### PR TITLE
- Corrected broken file glob for luajit sharefiles for bob.jar: DEF-621

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.xml
@@ -171,7 +171,7 @@
             </fileset>
             <fileset dir=".">
                 <include name="libexec/*/*luajit*"/>
-                <include name="share/luajit/**.*"/>
+                <include name="share/luajit/**"/>
             </fileset>
             <zipfileset src="lib/builtins.zip"/>
             <zipfileset src="tmp/external-libs-builtins.jar">


### PR DESCRIPTION
This error was breaking command line builds
