### PR TITLE
DEF-874 - LuaJIT: bob.jar from CI only contains libexec/linux

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.xml
@@ -70,18 +70,27 @@
         </parallel>
 
         <copy todir="libexec" overwrite="true">
-            <cutdirsmapper dirs="1"/>
-            <tarfileset includes="bin/linux/luajit">
+            <chainedmapper>
+                <cutdirsmapper dirs="1"/>
+                <compositemapper>
+                    <!-- Symlinks do not seem to make it through this process, so we map from versioned name
+                         to the final name. Only files that are matched by either glob below are included in
+                         the copy -->
+                    <globmapper from="*/luajit-2.0.3" to="*/luajit"/>
+                    <globmapper from="*/luajit.exe" to="*/luajit.exe"/>
+                </compositemapper>
+            </chainedmapper>
+            <tarfileset includes="bin/linux/**">
                 <gzipresource>
                     <file file="../../packages/luajit-2.0.3-linux.tar.gz" />
                 </gzipresource>
             </tarfileset>
-            <tarfileset includes="bin/win32/luajit.exe">
+            <tarfileset includes="bin/win32/**">
                 <gzipresource>
                     <file file="../../packages/luajit-2.0.3-win32.tar.gz" />
                 </gzipresource>
             </tarfileset>
-            <tarfileset includes="bin/darwin/luajit">
+            <tarfileset includes="bin/darwin/**">
                 <gzipresource>
                     <file file="../../packages/luajit-2.0.3-darwin.tar.gz" />
                 </gzipresource>


### PR DESCRIPTION
- Factored out any symlink of the luajit/libexec equation since
  the copy/tarfileset combo produces 0 byte size files instead
  of anything useful.
