### PR TITLE
- DEF-875 Broken build system

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -73,6 +73,7 @@ public class GameProjectBuilder extends Builder<Void> {
         extToMessageClass.put(".guic", Gui.SceneDesc.class);
         extToMessageClass.put(".scriptc", LuaModule.class);
         extToMessageClass.put(".gui_scriptc", LuaModule.class);
+        extToMessageClass.put(".render_scriptc", LuaModule.class);
         extToMessageClass.put(".luac", LuaModule.class);
         extToMessageClass.put(".tilegridc", TileGrid.class);
         extToMessageClass.put(".collisionobjectc", CollisionObjectDesc.class);
@@ -98,7 +99,6 @@ public class GameProjectBuilder extends Builder<Void> {
         leafResourceTypes.add(".fpc");
         leafResourceTypes.add(".wavc");
         leafResourceTypes.add(".oggc");
-        leafResourceTypes.add(".render_scriptc");
         leafResourceTypes.add(".meshc");
     }
 


### PR DESCRIPTION
Register render_scriptc as LuaModule for dependencies to be properly registered.
Fixes issue where Lua resources are left out from darc.
