### PR TITLE
Ensure com.dynamo.script.proto is generated during build.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.common/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.common/build.xml
@@ -58,7 +58,7 @@
             <proto dir="../../engine/render/proto/render" file="render_ddf.proto"/>
             <proto dir="../../engine/resource/proto" file="resource_ddf.proto"/>
             <proto dir="../../engine/script/src/script" file="script_doc_ddf.proto"/>
-            <proto dir="../../engine/script/src" file="script/lua_source_ddf.proto"/>
+            <proto dir="../../engine/script/src/script" file="lua_source_ddf.proto"/>
             <proto dir="../../engine/vscript/proto" file="vscript_ddf.proto"/>
         </parallel>
     </target>


### PR DESCRIPTION
- Path in build.xml was different, seemed to prevent Java sources from
  being generated.
