### PR TITLE
DEF-946: Geometry wars crashes on start up

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.h
+++ b/engine/graphics/src/opengl/graphics_opengl.h
@@ -77,6 +77,7 @@ namespace dmGraphics
     {
         TextureParams   m_BufferTextureParams[MAX_BUFFER_TYPE_COUNT];
         HTexture        m_BufferTextures[MAX_BUFFER_TYPE_COUNT];
+        GLuint          m_RenderBuffers[MAX_BUFFER_TYPE_COUNT];
         GLuint          m_Id;
     };
 


### PR DESCRIPTION
- Do not use texture2d:s for setting up depth buffer
