### PR TITLE
DEF-923 - Improve property field navigation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.properties/src/com/dynamo/cr/properties/util/SelectAllOnFocus.java
+++ b/com.dynamo.cr/com.dynamo.cr.properties/src/com/dynamo/cr/properties/util/SelectAllOnFocus.java
@@ -1,0 +1,19 @@
+package com.dynamo.cr.properties.util;
+
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.widgets.Text;
+
+// A focus listener that selects all in the text field when selected.
+// See DEF-923
+//
+public class SelectAllOnFocus implements FocusListener {
+    public void focusGained(FocusEvent e) {
+        if (e.getSource() instanceof Text) {
+            ((Text)e.getSource()).selectAll();
+        }
+    }
+
+    public void focusLost(FocusEvent e) {
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/handlers/SelectAllHandler.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/handlers/SelectAllHandler.java
@@ -7,11 +7,23 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.handlers.HandlerUtil;
 
 import com.dynamo.cr.sceneed.core.ISceneEditor;
+import org.eclipse.swt.widgets.*;
 
 public class SelectAllHandler extends AbstractHandler {
 
     @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
+
+        // This command handles selectAll event, which means they are eaten for any selected
+        // text object, which is somewhat unintentional. So if a text control has focus, execute select all
+        // there manually instead.
+        Control focusControl = Display.getCurrent().getFocusControl();
+        if (focusControl != null && focusControl instanceof Text) {
+            Text textControl = (Text)focusControl;
+            textControl.selectAll();
+            return null;
+        }
+
         IEditorPart editorPart = HandlerUtil.getActiveEditor(event);
         if (editorPart instanceof ISceneEditor) {
             ISceneEditor editor = (ISceneEditor) editorPart;


### PR DESCRIPTION
- Select whole text field content on tab press
- Only call setText() on text fields when actually changing content
- Call selectAll() on active textfield from sceneed SelectAllHandler
  since it will otherwise be silently dropped.
