### PR TITLE
DEF-587 - Tables with integer keys > 0xffff can't be serialized

### DIFF
--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -169,7 +169,7 @@ namespace dmScript
         else
         {
             lua_Number index = lua_tonumber(L, -2);
-            if (index > 0xfffffff) {
+            if (index > 0xffffffff) {
                 luaL_error(L, "index out of bounds, max is %d", 0xffffffff);
             }
             uint32_t key = (uint32_t)index;


### PR DESCRIPTION
- Added test to serialize various large 32-bit numbers
- Fixed incorrect range test, added 4 more bits
