### PR TITLE
Skip texture packing for tile sources. DEF-966

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
@@ -103,7 +103,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false);
+        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false, null);
         TextureSet textureSet = result.builder.setTexture("").build();
         BufferedImage image = result.image;
         assertThat(image.getWidth(), is(64));
@@ -127,7 +127,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false);
+        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false, null);
         BufferedImage image = result.image;
         assertThat(image.getWidth(), is(64));
         assertThat(image.getHeight(), is(16));
@@ -154,7 +154,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false);
+        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false, null);
 
         TextureSet textureSet = result.builder.setTexture("").build();
 
@@ -176,7 +176,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false);
+        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0, 0, 0, false, false, true, false, null);
 
         TextureSet textureSet = result.builder.setTexture("").build();
         assertUVTransform(0.0f, 0.0f, 0.25f, 1.0f, getUvTransforms(result.uvTransforms, textureSet, "anim1", 0));

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -26,7 +26,7 @@ public class TextureSetLayoutTest {
     }
 
     private static Layout layout(int margin, List<Rect> rectangles) {
-        return TextureSetLayout.layout(margin, rectangles, true, false);
+        return TextureSetLayout.layout(margin, rectangles, true);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetLayoutTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import com.dynamo.bob.textureset.TextureSetLayout;
 import com.dynamo.bob.textureset.TextureSetLayout.Layout;
 import com.dynamo.bob.textureset.TextureSetLayout.Rect;
+import com.dynamo.bob.textureset.TextureSetLayout.Grid;
 
 public class TextureSetLayoutTest {
 
@@ -25,8 +26,12 @@ public class TextureSetLayoutTest {
         assertThat(r.id, is(id));
     }
 
-    private static Layout layout(int margin, List<Rect> rectangles) {
-        return TextureSetLayout.layout(margin, rectangles, true);
+    private static Layout packedLayout(int margin, List<Rect> rectangles) {
+        return TextureSetLayout.packedLayout(margin, rectangles, true);
+    }
+
+    private static Layout gridLayout(int margin, List<Rect> rectangles, Grid gridSize) {
+        return TextureSetLayout.gridLayout(margin, rectangles, gridSize);
     }
 
     @Test
@@ -34,7 +39,7 @@ public class TextureSetLayoutTest {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList();
 
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
         assertThat(layout.getWidth(), is(1));
         assertThat(layout.getHeight(), is(1));
         assertThat(layout.getRectangles().size(), is(0));
@@ -48,7 +53,7 @@ public class TextureSetLayoutTest {
                             rect(2, 16, 16),
                             rect(3, 16, 16));
 
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
         assertThat(layout.getWidth(), is(64));
         assertThat(layout.getHeight(), is(16));
         assertRect(layout, 0, 0, 0, 0);
@@ -68,7 +73,7 @@ public class TextureSetLayoutTest {
                             rect(5, 8, 8),
                             rect(6, 8, 8));
 
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
         assertThat(layout.getWidth(), is(64));
         assertThat(layout.getHeight(), is(16));
         assertRect(layout, 0, 0, 0, 0);
@@ -85,7 +90,7 @@ public class TextureSetLayoutTest {
         List<TextureSetLayout.Rect> rectangles
             = Arrays.asList(rect(0, 512, 128));
 
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
         assertThat(layout.getWidth(), is(512));
         assertThat(layout.getHeight(), is(128));
         assertRect(layout, 0, 0, 0, 0);
@@ -98,7 +103,7 @@ public class TextureSetLayoutTest {
                             rect(1, 16, 2),
                             rect(2, 16, 2));
 
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
         assertThat(layout.getWidth(), is(32));
         assertThat(layout.getHeight(), is(16));
         assertRect(layout, 0, 0, 0, 0);
@@ -114,7 +119,7 @@ public class TextureSetLayoutTest {
                             rect(2, 16, 16),
                             rect(3, 16, 16));
 
-        Layout layout = layout(2, rectangles);
+        Layout layout = packedLayout(2, rectangles);
         assertThat(layout.getWidth(), is(128));
         assertThat(layout.getHeight(), is(32));
         assertRect(layout, 0, 0, 0, 0);
@@ -131,7 +136,7 @@ public class TextureSetLayoutTest {
                             rect(2, 15, 15),
                             rect(3, 15, 15));
 
-        Layout layout = layout(2, rectangles);
+        Layout layout = packedLayout(2, rectangles);
         assertThat(layout.getWidth(), is(128));
         assertThat(layout.getHeight(), is(32));
         assertRect(layout, 0, 0, 0, 0);
@@ -144,7 +149,7 @@ public class TextureSetLayoutTest {
     public void testThinStrip() {
         List<TextureSetLayout.Rect> rectangles = Arrays.asList(rect(0, 1, 16));
 
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
         assertThat(layout.getWidth(), is(1));
         assertThat(layout.getHeight(), is(16));
         assertRect(layout, 0, 0, 0, 0);
@@ -183,7 +188,7 @@ public class TextureSetLayoutTest {
     @Test
     public void testAllIncluded() {
         List<Rect> rectangles = createSampleRectangles(1);
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
 
         HashSet<Integer> recordedIds = new HashSet<Integer>();
 
@@ -215,7 +220,52 @@ public class TextureSetLayoutTest {
     @Test
     public void testNoOverlaps() {
         List<Rect> rectangles = createSampleRectangles(1);
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
+        List<Rect> outputRectangles = layout.getRectangles();
+        int numRectangles = outputRectangles.size();
+
+        for (int i=0; i<numRectangles; ++i) {
+            for (int j=i+1; j<numRectangles; ++j) {
+                assertFalse(isOverlapping(outputRectangles.get(i), outputRectangles.get(j)));
+            }
+        }
+    }
+
+    @Test
+    public void testGridLayout1() {
+
+        List<Rect> rectangles
+            = Arrays.asList(rect(0, 16, 4),
+                            rect(1, 16, 4),
+                            rect(2, 16, 4),
+                            rect(3, 16, 4));
+
+        Layout layout = gridLayout(0, rectangles, new Grid(2,2) );
+
+        assertEquals( layout.getWidth(), 32 );
+        assertEquals( layout.getHeight(), 8 );
+    }
+
+    @Test
+    public void testGridLayout2() {
+
+        List<Rect> rectangles
+            = Arrays.asList(rect(0, 32, 16));
+
+        Layout layout = gridLayout(0, rectangles, new Grid(2,2) );
+
+        assertEquals( layout.getWidth(), 64 );
+        assertEquals( layout.getHeight(), 32 );
+    }
+
+    @Test
+    public void testGridNoOverlaps() {
+        List<Rect> rectangles
+            = Arrays.asList(rect(0, 16, 4),
+                            rect(1, 16, 4),
+                            rect(2, 16, 4),
+                            rect(3, 16, 4));
+        Layout layout = gridLayout(0, rectangles, new Grid(2,2) );
         List<Rect> outputRectangles = layout.getRectangles();
         int numRectangles = outputRectangles.size();
 
@@ -229,7 +279,7 @@ public class TextureSetLayoutTest {
     @Test
     public void testLargeLayout() {
         List<Rect> rectangles = Arrays.asList(rect(0, 1000, 800), rect(1, 800, 1000), rect(2, 1000, 100), rect(3, 800, 100));
-        Layout layout = layout(0, rectangles);
+        Layout layout = packedLayout(0, rectangles);
 
         assertEquals(layout.getWidth(), 2048);
         assertEquals(layout.getHeight(), 1024);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/TileSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/TileSetGeneratorTest.java
@@ -107,19 +107,19 @@ public class TileSetGeneratorTest {
         TextureSet textureSet = result.builder.setTexture("").build();
         BufferedImage texture = result.image;
 
-        assertEquals(1024, texture.getWidth());
-        assertEquals(256, texture.getHeight());
+        assertEquals(512, texture.getWidth());
+        assertEquals(512, texture.getHeight());
 
         ByteString vertices = textureSet.getVertices();
         ByteBuffer v = ByteBuffer.wrap(vertices.toByteArray());
         // Vertex buffers is in little endian (java big)
         v.order(ByteOrder.LITTLE_ENDIAN);
-        float[] us = { 0.0f, 0.125f, 0.25f, 0.375f, 0.5f, 0.625f, 0.725f, 1f};
-        float[] vs = { 0.0f, 0.5f, 1f };
+        float[] us = { 0.0f, 0.25f, 0.5f, 0.75f, 1f};
+        float[] vs = { 0.0f, 0.25f, 0.5f, 0.75f, 1f};
         // Verify vertices
         for (int i = 0; i < tileCount; ++i) {
-            int x = i / 2;
-            int y = i % 2;
+            int x = i % 3;
+            int y = i / 3;
             assertQuad(v, tileWidth, tileHeight, us[x], us[x + 1], vs[y], vs[y + 1]);
         }
 
@@ -129,8 +129,8 @@ public class TileSetGeneratorTest {
         // Verify tex coords
         assertThat(textureSet.getTexCoords().size(), is(8 * 4 * tileCount));
         for (int i = 0; i < tileCount; ++i) {
-            int x = i / 2;
-            int y = i % 2;
+            int x = i % 3;
+            int y = i / 3;
             assertQuadTexCoords(uv, us[x], us[x + 1], vs[y], vs[y + 1], false);
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -167,6 +167,6 @@ public class AtlasUtil {
         return TextureSetGenerator.generate(images, iterator,
                 Math.max(0, atlas.getMargin()),
                 Math.max(0,  atlas.getInnerPadding()),
-                Math.max(0, atlas.getExtrudeBorders()), false, false, true, false);
+                Math.max(0, atlas.getExtrudeBorders()), false, false, true, false, null);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -3,7 +3,6 @@ package com.dynamo.bob.textureset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 import java.util.Comparator;
 
 import com.dynamo.bob.textureset.TextureSetLayout.Layout;
@@ -38,7 +37,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
 
     @Override
     public List<Layout> createLayout(List<Rect> srcRects) {
-        Vector<RectNode> srcNodes = new Vector<RectNode>(srcRects.size());
+        ArrayList<RectNode> srcNodes = new ArrayList<RectNode>(srcRects.size());
         for(Rect r : srcRects) {
             RectNode n = new RectNode(r);
             n.rect.width += settings.paddingX;
@@ -46,7 +45,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             srcNodes.add(n);
         }
 
-        Vector<Page> pages = new Vector<Page>();
+        ArrayList<Page> pages = new ArrayList<Page>();
         while (0 < srcNodes.size()) {
             Page result = packPage(srcNodes);
             pages.add(result);
@@ -69,7 +68,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         return result;
     }
 
-    private Page packPage(Vector<RectNode> inputRects) {
+    private Page packPage(ArrayList<RectNode> inputRects) {
         // Find min size.
         int minWidth = Integer.MAX_VALUE;
         int minHeight = Integer.MAX_VALUE;
@@ -154,13 +153,13 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     /** @param fully If true, the only results that pack all rects will be considered. If false, all results are considered, not all
      *           rects may be packed.
      **/
-    private Page packAtSize (boolean fully, int width, int height, Vector<RectNode> inputRects) {
+    private Page packAtSize (boolean fully, int width, int height, ArrayList<RectNode> inputRects) {
         Page bestResult = null;
         for (int i = 0, n = methods.length; i < n; i++) {
             maxRects.init(width, height);
             Page result;
 
-            Vector<RectNode> remaining = new Vector<RectNode>();
+            ArrayList<RectNode> remaining = new ArrayList<RectNode>();
             for (int ii = 0, nn = inputRects.size(); ii < nn; ii++) {
                 RectNode rect = inputRects.get(ii);
                 if (maxRects.insert(rect, methods[i]) == null) {
@@ -259,7 +258,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     }
 
     static class Page {
-        public Vector<RectNode> outputRects, remainingRects;
+        public ArrayList<RectNode> outputRects, remainingRects;
         public float occupancy;
         public int width, height;
     }
@@ -271,8 +270,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
     class MaxRects {
         private int binWidth;
         private int binHeight;
-        private final Vector<RectNode> usedRectangles = new Vector<RectNode>();
-        private final Vector<RectNode> freeRectangles = new Vector<RectNode>();
+        private final ArrayList<RectNode> usedRectangles = new ArrayList<RectNode>();
+        private final ArrayList<RectNode> freeRectangles = new ArrayList<RectNode>();
 
         public void init (int width, int height) {
             binWidth = width;
@@ -311,8 +310,8 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         }
 
         /** For each rectangle, packs each one then chooses the best and packs that. Slow! */
-        public Page pack (Vector<RectNode> rects, FreeRectChoiceHeuristic method) {
-            rects = new Vector<RectNode>(rects);
+        public Page pack (ArrayList<RectNode> rects, FreeRectChoiceHeuristic method) {
+            rects = new ArrayList<RectNode>(rects);
             while (rects.size() > 0) {
                 int bestRectIndex = -1;
                 RectNode bestNode = new RectNode(new Rect(null, 0, 0, 0, 0));
@@ -354,7 +353,7 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
                 h = Math.max(h, node.rect.y + node.rect.height);
             }
             Page result = new Page();
-            result.outputRects = new Vector<RectNode>(usedRectangles);
+            result.outputRects = new ArrayList<RectNode>(usedRectangles);
             result.occupancy = getOccupancy();
             result.width = w;
             result.height = h;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -25,7 +25,6 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         public int paddingX;
         public int paddingY;
         public boolean rotation;
-        public boolean fast;
         public boolean square;
     }
 
@@ -45,26 +44,6 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
             n.rect.width += settings.paddingX;
             n.rect.height += settings.paddingY;
             srcNodes.add(n);
-        }
-
-        if (settings.fast){
-            if (settings.rotation) {
-                // Sort by longest side if rotation is enabled.
-                Collections.sort(srcNodes, new Comparator<RectNode>() {
-                    public int compare (RectNode o1, RectNode o2) {
-                        int n1 = o1.rect.width > o1.rect.height ? o1.rect.width : o1.rect.height;
-                        int n2 = o2.rect.width > o2.rect.height ? o2.rect.width : o2.rect.height;
-                        return n2 - n1;
-                    }
-                });
-            } else {
-                // Sort only by width (largest to smallest) if rotation is disabled.
-                Collections.sort(srcNodes, new Comparator<RectNode>() {
-                    public int compare (RectNode o1, RectNode o2) {
-                        return o2.rect.width - o1.rect.width;
-                    }
-                });
-            }
         }
 
         Vector<Page> pages = new Vector<Page>();
@@ -180,21 +159,19 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         for (int i = 0, n = methods.length; i < n; i++) {
             maxRects.init(width, height);
             Page result;
-            if (!settings.fast) {
-                result = maxRects.pack(inputRects, methods[i]);
-            } else {
-                Vector<RectNode> remaining = new Vector<RectNode>();
-                for (int ii = 0, nn = inputRects.size(); ii < nn; ii++) {
-                    RectNode rect = inputRects.get(ii);
-                    if (maxRects.insert(rect, methods[i]) == null) {
-                        while (ii < nn) {
-                            remaining.add(inputRects.get(ii++));
-                        }
+
+            Vector<RectNode> remaining = new Vector<RectNode>();
+            for (int ii = 0, nn = inputRects.size(); ii < nn; ii++) {
+                RectNode rect = inputRects.get(ii);
+                if (maxRects.insert(rect, methods[i]) == null) {
+                    while (ii < nn) {
+                        remaining.add(inputRects.get(ii++));
                     }
                 }
-                result = maxRects.getResult();
-                result.remainingRects = remaining;
             }
+            result = maxRects.getResult();
+            result.remainingRects = remaining;
+
             if (fully && result.remainingRects.size() > 0) {
                 continue;
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -142,8 +142,7 @@ public class TextureSetGenerator {
         images = extrudeBorders(images, extrudeBorders);
 
         Layout layout;
-        if (useTileGrid)
-        {
+        if (useTileGrid) {
             layout = TextureSetLayout.gridLayout(margin, rectanglesFromImages(images), gridSize);
         } else {
             layout = packedImageLayout(margin, images, rotate);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -9,6 +9,22 @@ import java.util.List;
  *
  */
 public class TextureSetLayout {
+
+    public static class Grid {
+        public int columns;
+        public int rows;
+
+        public Grid( int columns, int rows ) {
+            this.columns = columns;
+            this.rows    = rows;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%d columns, %d rows", columns, rows);
+        }
+    }
+
     public static class Rect {
         public Object id;
         public int x, y, width, height;
@@ -73,12 +89,55 @@ public class TextureSetLayout {
 
     }
 
-    public static Layout layout(int margin, List<Rect> rectangles, boolean rotate) {
+    public static Layout packedLayout(int margin, List<Rect> rectangles, boolean rotate) {
         if (rectangles.size() == 0) {
             return new Layout(1, 1, new ArrayList<TextureSetLayout.Rect>());
         }
 
         return createMaxRectsLayout(margin, rectangles, rotate);
+    }
+
+    private static int getExponentNextOrMatchingPowerOfTwo(int value) {
+        int exponent = 0;
+        while (value > (1<<exponent)) {
+            ++exponent;
+        }
+        return exponent;
+    }
+
+    public static Layout gridLayout(int margin, List<Rect> rectangles, Grid gridSize ) {
+
+        // We assume here that all images have the same size,
+        // since they will be "packed" into a uniformly sized grid.
+        int cellWidth  = rectangles.get(0).width;
+        int cellHeight = rectangles.get(0).height;
+
+        // Scale layout area so it's a power of two
+        int inputWidth  = gridSize.columns * cellWidth + margin*2;
+        int inputHeight = gridSize.rows * cellHeight + margin*2;
+        int layoutWidth = 1 << getExponentNextOrMatchingPowerOfTwo(inputWidth);
+        int layoutHeight = 1 << getExponentNextOrMatchingPowerOfTwo(inputHeight);
+
+        int x = margin;
+        int y = margin;
+
+        // Loop through all images and put them right after each other
+        Layout layout = new Layout(layoutWidth, layoutHeight, rectangles);
+        for (Rect r : layout.getRectangles()) {
+
+            r.x = x;
+            r.y = y;
+
+             if (x + cellWidth >= inputWidth) {
+                 x = margin;
+                 y += cellHeight;
+             } else {
+                 x += cellWidth;
+             }
+
+        }
+
+        return layout;
     }
 
     public static Layout createMaxRectsLayout(int margin, List<Rect> rectangles, boolean rotate) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -73,14 +73,15 @@ public class TextureSetLayout {
 
     }
 
-    public static Layout layout(int margin, List<Rect> rectangles, boolean rotate, boolean fast) {
+    public static Layout layout(int margin, List<Rect> rectangles, boolean rotate) {
         if (rectangles.size() == 0) {
             return new Layout(1, 1, new ArrayList<TextureSetLayout.Rect>());
         }
-        return createMaxRectsLayout(margin, rectangles, rotate, fast);
+
+        return createMaxRectsLayout(margin, rectangles, rotate);
     }
 
-    public static Layout createMaxRectsLayout(int margin, List<Rect> rectangles, boolean rotate, boolean fast) {
+    public static Layout createMaxRectsLayout(int margin, List<Rect> rectangles, boolean rotate) {
         int defaultMaxPageSize = 1024;
         final int defaultMinPageSize = 16;
 
@@ -92,7 +93,6 @@ public class TextureSetLayout {
         settings.paddingX = margin;
         settings.paddingY = margin;
         settings.rotation = rotate;
-        settings.fast = fast;
         settings.square = false;
 
         // Ensure the longest length found in all of the images will fit within one page, irrespective of orientation.

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -128,7 +128,7 @@ public class TextureSetLayout {
             r.x = x;
             r.y = y;
 
-             if (x + cellWidth >= inputWidth) {
+             if (x + cellWidth >= inputWidth - margin) {
                  x = margin;
                  y += cellHeight;
              } else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
@@ -9,7 +9,7 @@ import com.dynamo.bob.textureset.TextureSetGenerator;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimDesc;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimIterator;
 import com.dynamo.bob.textureset.TextureSetGenerator.TextureSetResult;
-import com.dynamo.bob.textureset.TextureSetLayout.Rect;
+import com.dynamo.bob.textureset.TextureSetLayout.Grid;
 import com.dynamo.bob.tile.TileSetUtil.ConvexHulls;
 import com.dynamo.bob.util.TextureUtil;
 import com.dynamo.textureset.proto.TextureSetProto.TextureSet;
@@ -100,7 +100,7 @@ public class TileSetGenerator {
 
         // Since all the images already are positioned optimally in a grid,
         // we tell TextureSetGenerator to NOT do its own packing and use this grid directly.
-        Rect grid_size = new Rect(0, metrics.tilesPerRow, metrics.tilesPerColumn);
+        Grid grid_size = new Grid(metrics.tilesPerRow, metrics.tilesPerColumn);
         TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0,
                 tileSet.getInnerPadding(),
                 tileSet.getExtrudeBorders(), genOutlines, genAtlasVertices, false, true, grid_size );

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
@@ -9,6 +9,7 @@ import com.dynamo.bob.textureset.TextureSetGenerator;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimDesc;
 import com.dynamo.bob.textureset.TextureSetGenerator.AnimIterator;
 import com.dynamo.bob.textureset.TextureSetGenerator.TextureSetResult;
+import com.dynamo.bob.textureset.TextureSetLayout.Rect;
 import com.dynamo.bob.tile.TileSetUtil.ConvexHulls;
 import com.dynamo.bob.util.TextureUtil;
 import com.dynamo.textureset.proto.TextureSetProto.TextureSet;
@@ -97,9 +98,12 @@ public class TileSetGenerator {
 
         AnimIterator iterator = createAnimIterator(tileSet, images.size());
 
+        // Since all the images already are positioned optimally in a grid,
+        // we tell TextureSetGenerator to NOT do its own packing and use this grid directly.
+        Rect grid_size = new Rect(0, metrics.tilesPerRow, metrics.tilesPerColumn);
         TextureSetResult result = TextureSetGenerator.generate(images, iterator, 0,
                 tileSet.getInnerPadding(),
-                tileSet.getExtrudeBorders(), genOutlines, genAtlasVertices, false, true);
+                tileSet.getExtrudeBorders(), genOutlines, genAtlasVertices, false, true, grid_size );
 
         TextureSet.Builder builder = result.builder;
 

--- a/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasNode.java
@@ -168,7 +168,7 @@ public class AtlasNode extends TextureSetNode {
                 TextureSetResult result = TextureSetGenerator.generate(images, iterator,
                         Math.max(0, margin),
                         Math.max(0, innerPadding),
-                        Math.max(0, extrudeBorders), true, true, true, false);
+                        Math.max(0, extrudeBorders), true, true, true, false, null);
                 TextureSet textureSet = result.builder.setTexture("").build();
                 runtimeTextureSet.update(textureSet, result.uvTransforms);
 


### PR DESCRIPTION
- Removed “fast” option in TextureSetLayout/MaxRectsLayoutStrategy.
- Added naive grid layout option for TextureSetGenerator (skips texture
  packing).
