### PR TITLE
- DEF-803: Escape HTTP URLs

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/FileHandler.java
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/FileHandler.java
@@ -48,7 +48,7 @@ public class FileHandler extends ResourceHandler {
                     int i = line.indexOf(' ');
                     URI uri;
                     try {
-                        uri = new URI(URLDecoder.decode(line.substring(0, i), "UTF-8"));
+                        uri = new URI(line.substring(0, i));
                         uri = uri.normalize(); // http://foo.com//a -> http://foo.com/a
                     } catch (URISyntaxException e) {
                         logger.warn(e.getMessage(), e);

--- a/engine/dlib/src/dlib/http_client.h
+++ b/engine/dlib/src/dlib/http_client.h
@@ -243,23 +243,6 @@ namespace dmHttpClient
      * @param client Client handle
      */
     void Delete(HClient client);
-
-    /**
-     * Escape an URL string. Non unreserved characters are replaced with %XX where XX is the hexadecimal representation of the character.
-     * See http://en.wikipedia.org/wiki/Percent-encoding for list of unreserved characters
-     * @param src Source string
-     * @param dst Destination string. May *not* overlap with src
-     * @param dst_len Destination string length. Total buffer size
-     * @return RESULT_OK on success and RESULT_INVAL if destination buffer is too small.
-     */
-    Result Escape(const char* src, char* dst, uint32_t dst_len);
-
-    /**
-     * Unescape an url string
-     * @param src Source string
-     * @param dst Destination string (might be the same as src)
-     */
-    void Unescape(const char* src, char* dst);
 }
 
 #endif // DM_HTTP_CLIENT_H

--- a/engine/dlib/src/dlib/uri.h
+++ b/engine/dlib/src/dlib/uri.h
@@ -44,22 +44,20 @@ namespace dmURI
     Result Parse(const char* uri, Parts* parts);
 
     /**
-     * Encodes the provided URI into escaped format.
-     * @note This function currently only replaces spaces with '+'
-     * @param uri URI to encode
-     * @param out Decoded URI
-     * @param out_size size of the provided out buffer
+     * Performs URL encoding of the supplied buffer
+     * @param src String to encode
+     * @param dst Encoded string
+     * @param dst_size size of the provided out buffer
      */
-    void Encode(const char* uri, char* out, uint32_t out_size);
+    void Encode(const char* src, char* dst, uint32_t dst_size);
 
     /**
-     * Decodes the provided URI into escaped format.
-     * @note This function currently only replaces '+' with ' '
-     * @param uri URI to decode
-     * @param out Decoded URI
-     * @param out_size size of the provided out buffer
+     * Undoes URL decoding on a buffer.
+     * @note The output will never be larger than the input.
+     * @param src Input
+     * @param dst Decoded output
      */
-    void Decode(const char* uri, char* out, uint32_t out_size);
+    void Decode(const char* src, char* dst);
 }
 
 #endif // DM_URI_H

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -637,12 +637,17 @@ TEST_P(dmHttpClientTest, MaxAgeCache)
 
 TEST_P(dmHttpClientTest, PathWithSpaces)
 {
-    char buf[128];
+    char buf[128], uri[128];
 
+    // should fail since it is not properly encoded.
+    // NOTE: Really really should be only encoding the 'message' and not the whole path.
+    //       But Encode for now is kind to not encode '/'
     const char* message = "testing 1 2";
     snprintf(buf, 128, "/echo/%s", message);
+    dmURI::Encode(buf, uri, sizeof(uri));
+
     m_Content = "";
-    dmHttpClient::Result r = dmHttpClient::Get(m_Client, buf);
+    dmHttpClient::Result r = dmHttpClient::Get(m_Client, uri);
     ASSERT_EQ(dmHttpClient::RESULT_OK, r);
     ASSERT_STREQ(message, m_Content.c_str());
 }
@@ -870,103 +875,6 @@ TEST(dmHttpClient, ConnectionRefused)
     ASSERT_EQ(dmHttpClient::RESULT_SOCKET_ERROR, r);
     ASSERT_EQ(dmSocket::RESULT_CONNREFUSED, dmHttpClient::GetLastSocketResult(client));
     dmHttpClient::Delete(client);
-}
-
-TEST(dmHttpClient, Escape)
-{
-    char src[1024];
-    char dst[1024];
-#define CPY_TO_BUF(s) strcpy(src, s);
-
-    CPY_TO_BUF("")
-    dmHttpClient::Escape(src, dst, sizeof(dst));
-    ASSERT_STREQ("", dst);
-
-    CPY_TO_BUF(" ")
-    dmHttpClient::Escape(src, dst, sizeof(dst));
-    ASSERT_STREQ("%20", dst);
-
-    CPY_TO_BUF("foo")
-    dmHttpClient::Escape(src, dst, sizeof(dst));
-    ASSERT_STREQ("foo", dst);
-
-    CPY_TO_BUF("foo bar")
-    dmHttpClient::Escape(src, dst, sizeof(dst));
-    ASSERT_STREQ("foo%20bar", dst);
-
-    CPY_TO_BUF("to[0]")
-    dmHttpClient::Escape(src, dst, sizeof(dst));
-    ASSERT_STREQ("to%5B0%5D", dst);
-
-#undef CPY_TO_BUF
-}
-
-TEST(dmHttpClient, EscapeBufferSize)
-{
-    char src[1024];
-    char dst[1024];
-#define CPY_TO_BUF(s) strcpy(src, s);
-    dmHttpClient::Result r;
-
-    CPY_TO_BUF("")
-    r = dmHttpClient::Escape(src, dst, 1);
-    ASSERT_EQ(dmHttpClient::RESULT_OK, r);
-    ASSERT_STREQ("", dst);
-
-    dst[1] = '!';
-    CPY_TO_BUF(" ")
-    r = dmHttpClient::Escape(src, dst, 1);
-    ASSERT_EQ(dmHttpClient::RESULT_INVAL, r);
-    ASSERT_EQ('!', dst[1]);
-
-    dst[2] = '!';
-    CPY_TO_BUF(" ")
-    r = dmHttpClient::Escape(src, dst, 2);
-    ASSERT_EQ(dmHttpClient::RESULT_INVAL, r);
-    ASSERT_EQ('!', dst[2]);
-
-    dst[3] = '!';
-    CPY_TO_BUF(" ")
-    r = dmHttpClient::Escape(src, dst, 3);
-    ASSERT_EQ(dmHttpClient::RESULT_INVAL, r);
-    ASSERT_EQ('!', dst[3]);
-
-    dst[4] = '!';
-    CPY_TO_BUF(" ")
-    r = dmHttpClient::Escape(src, dst, 4);
-    ASSERT_EQ(dmHttpClient::RESULT_OK, r);
-    ASSERT_STREQ("%20", dst);
-    ASSERT_EQ('!', dst[4]);
-
-#undef CPY_TO_BUF
-}
-
-TEST(dmHttpClient, Unescape)
-{
-    char buf[1024];
-#define CPY_TO_BUF(s) strcpy(buf, s);
-
-    CPY_TO_BUF("")
-    dmHttpClient::Unescape(buf, buf);
-    ASSERT_STREQ("", buf);
-
-    CPY_TO_BUF("foo")
-    dmHttpClient::Unescape(buf, buf);
-    ASSERT_STREQ("foo", buf);
-
-    CPY_TO_BUF("%20")
-    dmHttpClient::Unescape(buf, buf);
-    ASSERT_STREQ(" ", buf);
-
-    CPY_TO_BUF("fbconnect://success?request=575262345875717&to%5B0%5D=100006469467942&to%5B1%5D=100006622931864&to%5B2%5D=100006677888489&to%5B3%5D=100006751147236&to%5B4%5D=100006793533882")
-    dmHttpClient::Unescape(buf, buf);
-    ASSERT_STREQ("fbconnect://success?request=575262345875717&to[0]=100006469467942&to[1]=100006622931864&to[2]=100006677888489&to[3]=100006751147236&to[4]=100006793533882", buf);
-
-    CPY_TO_BUF("foo+bar")
-    dmHttpClient::Unescape(buf, buf);
-    ASSERT_STREQ("foo bar", buf);
-
-#undef CPY_TO_BUF
 }
 
 int main(int argc, char **argv)

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -468,7 +468,10 @@ static Result DoLoadResource(HFactory factory, const char* path, const char* ori
         factory->m_HttpFactoryResult = RESULT_OK;
         factory->m_HttpStatus = -1;
 
-        dmHttpClient::Result http_result = dmHttpClient::Get(factory->m_HttpClient, path);
+        char uri[RESOURCE_PATH_MAX*2];
+        dmURI::Encode(path, uri, sizeof(uri));
+
+        dmHttpClient::Result http_result = dmHttpClient::Get(factory->m_HttpClient, uri);
         if (http_result != dmHttpClient::RESULT_OK)
         {
             if (factory->m_HttpStatus == 404)


### PR DESCRIPTION
- http_client now expects a properly formatted URI
- Remove escape/unescape from http_client, merged into
  uri/Encode and Decode functions
- Remove URI decoding in FileHandler since URI() needs a properly
  formatted URI, which it should already be in the requst line
