### PR TITLE
DEF-657 - Expose non-uniform scaling in editor

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -184,10 +184,11 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 s = MathUtil.ddfToVecmath(collInst.getScale3());
             } else {
                 double scale = collInst.getScale();
-                if (subCollBuilder.getScaleAlongZ() != 0)
+                if (subCollBuilder.getScaleAlongZ() != 0) {
                     s = new Vector3d(scale, scale, scale);
-                else
+                } else {
                     s = new Vector3d(scale, scale, 1);
+                }
             }
 
             for (InstanceDesc inst : subCollBuilder.getInstancesList()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import javax.vecmath.Point3d;
 import javax.vecmath.Quat4d;
+import javax.vecmath.Vector3d;
 
 import org.apache.commons.io.FilenameUtils;
 
@@ -29,6 +30,7 @@ import com.dynamo.gameobject.proto.GameObject.InstanceDesc;
 import com.dynamo.gameobject.proto.GameObject.InstancePropertyDesc;
 import com.dynamo.gameobject.proto.GameObject.PropertyDesc;
 import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarations;
+import com.dynamo.proto.DdfMath;
 
 @ProtoParams(messageClass = CollectionDesc.class)
 @BuilderParams(name="Collection", inExts=".collection", outExt=".collectionc")
@@ -176,7 +178,18 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
             }
             Point3d p = MathUtil.ddfToVecmath(collInst.getPosition());
             Quat4d r = MathUtil.ddfToVecmath(collInst.getRotation());
-            double s = collInst.getScale();
+
+            Vector3d s;
+            if (collInst.hasScale3()) {
+                s = MathUtil.ddfToVecmath(collInst.getScale3());
+            } else {
+                double scale = collInst.getScale();
+                if (subCollBuilder.getScaleAlongZ() != 0)
+                    s = new Vector3d(scale, scale, scale);
+                else
+                    s = new Vector3d(scale, scale, 1);
+            }
+
             for (InstanceDesc inst : subCollBuilder.getInstancesList()) {
                 InstanceDesc.Builder instBuilder = InstanceDesc.newBuilder(inst);
                 BuilderUtil.checkResource(this.project, owner, "prototype", inst.getPrototype());
@@ -190,21 +203,29 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     instBuilder.clearComponentProperties();
                     instBuilder.addAllComponentProperties(mergeComponentProperties(sourceProperties, overrideProperties));
                 }
+
                 // merge transform for non-children
                 if (!childIds.contains(inst.getId())) {
-                    Point3d instP = MathUtil.ddfToVecmath(inst.getPosition());
-                    if (subCollBuilder.getScaleAlongZ() != 0) {
-                        instP.scale(s);
+
+                    Vector3d instS;
+                    if (inst.hasScale3()) {
+                        instS = MathUtil.ddfToVecmath(inst.getScale3());
                     } else {
-                        instP.set(s * instP.getX(), s * instP.getY(), instP.getZ());
+                        double scale = inst.getScale();
+                        instS = new Vector3d(scale, scale, scale);
                     }
+                    instS.set(instS.getX() * s.getX(), instS.getY() * s.getY(), instS.getZ() * s.getZ());
+
+                    Point3d instP = MathUtil.ddfToVecmath(inst.getPosition());
+                    instP.set(s.getX() * instP.getX(), s.getY() * instP.getY(), s.getZ() * instP.getZ());
+
                     MathUtil.rotate(r, instP);
                     instP.add(p);
                     instBuilder.setPosition(MathUtil.vecmathToDDF(instP));
                     Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
                     instR.mul(r, instR);
                     instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
-                    instBuilder.setScale((float)(s * inst.getScale()));
+                    instBuilder.setScale3(MathUtil.vecmathToDDF(instS));
                 }
                 // adjust child ids
                 for (int i = 0; i < instBuilder.getChildrenCount(); ++i) {
@@ -227,11 +248,20 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 }
                 // merge transform for non-children
                 if (!childIds.contains(inst.getId())) {
+                    Vector3d instS;
+                    if (inst.hasScale3()) {
+                        instS = MathUtil.ddfToVecmath(inst.getScale3());
+                    } else {
+                        double scale = inst.getScale();
+                        instS = new Vector3d(scale, scale, scale);
+                    }
+                    instS.set(instS.getX() * s.getX(), instS.getY() * s.getY(), instS.getZ() * s.getZ());
+
                     Point3d instP = MathUtil.ddfToVecmath(inst.getPosition());
                     if (subCollBuilder.getScaleAlongZ() != 0) {
-                        instP.scale(s);
+                        instP.set(s.getX() * instP.getX(), s.getY() * instP.getY(), s.getZ() * instP.getZ());
                     } else {
-                        instP.set(s * instP.getX(), s * instP.getY(), instP.getZ());
+                        instP.set(s.getX() * instP.getX(), s.getY() * instP.getY(), instP.getZ());
                     }
                     MathUtil.rotate(r, instP);
                     instP.add(p);
@@ -239,7 +269,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                     Quat4d instR = MathUtil.ddfToVecmath(inst.getRotation());
                     instR.mul(r, instR);
                     instBuilder.setRotation(MathUtil.vecmathToDDF(instR));
-                    instBuilder.setScale((float)(s * inst.getScale()));
+                    instBuilder.setScale3(MathUtil.vecmathToDDF(instS));
                 }
                 // adjust child ids
                 for (int i = 0; i < instBuilder.getChildrenCount(); ++i) {
@@ -273,8 +303,15 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 .addAllChildren(desc.getChildrenList())
                 .setPosition(desc.getPosition())
                 .setRotation(desc.getRotation())
-                .setScale(desc.getScale())
                 .addAllComponentProperties(desc.getComponentPropertiesList());
+
+            // Promote to scale3
+            if (desc.hasScale3()) {
+                instBuilder.setScale3(desc.getScale3());
+            } else {
+                double s = desc.getScale();
+                instBuilder.setScale3(MathUtil.vecmathToDDF(new Vector3d(s, s, s)));
+            }
 
             messageBuilder.addInstances(instBuilder);
             ++embedIndex;
@@ -287,6 +324,13 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
             for (int j = 0; j < b.getChildrenCount(); ++j) {
                 b.setChildren(j, "/" + b.getChildren(j));
             }
+
+            // Promote to scale3
+            if (!b.hasScale3()) {
+                double s = b.getScale();
+                b.setScale3(MathUtil.vecmathToDDF(new Vector3d(s, s, s)));
+            }
+
             b.setPrototype(BuilderUtil.replaceExt(b.getPrototype(), ".go", ".goc"));
             for (int j = 0; j < b.getComponentPropertiesCount(); ++j) {
                 ComponentPropertyDesc.Builder compPropBuilder = ComponentPropertyDesc.newBuilder(b.getComponentProperties(j));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/MathUtil.java
@@ -14,6 +14,10 @@ public class MathUtil {
         return new Point3d(p.getX(), p.getY(), p.getZ());
     }
 
+    public static Vector3d ddfToVecmath(Vector3 p) {
+        return new Vector3d(p.getX(), p.getY(), p.getZ());
+    }
+
     public static Quat4d ddfToVecmath(Quat q) {
         return new Quat4d(q.getX(), q.getY(), q.getZ(), q.getW());
     }

--- a/com.dynamo.cr/com.dynamo.cr.go/src/com/dynamo/cr/go/core/CollectionLoader.java
+++ b/com.dynamo.cr/com.dynamo.cr.go/src/com/dynamo/cr/go/core/CollectionLoader.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import javax.vecmath.Vector3d;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
@@ -32,6 +34,7 @@ import com.dynamo.gameobject.proto.GameObject.EmbeddedInstanceDesc;
 import com.dynamo.gameobject.proto.GameObject.InstanceDesc;
 import com.dynamo.gameobject.proto.GameObject.InstancePropertyDesc;
 import com.dynamo.gameobject.proto.GameObject.PropertyDesc;
+import com.dynamo.proto.DdfMath;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
 
@@ -56,7 +59,13 @@ public class CollectionLoader implements INodeLoader<CollectionNode> {
             RefGameObjectInstanceNode instanceNode = new RefGameObjectInstanceNode(gameObjectNode);
             instanceNode.setTranslation(LoaderUtil.toPoint3d(instanceDesc.getPosition()));
             instanceNode.setRotation(LoaderUtil.toQuat4(instanceDesc.getRotation()));
-            instanceNode.setScale(instanceDesc.getScale());
+            if (instanceDesc.hasScale3()) {
+                instanceNode.setScale(LoaderUtil.toVector3(instanceDesc.getScale3()));
+            } else {
+                double s = instanceDesc.getScale();
+                instanceNode.setScale(new Vector3d(s, s, s));
+            }
+
             instanceNode.setId(instanceDesc.getId());
             instanceNode.setGameObject(path);
             idToInstance.put(instanceDesc.getId(), instanceNode);
@@ -79,7 +88,12 @@ public class CollectionLoader implements INodeLoader<CollectionNode> {
             GameObjectNode instanceNode = (GameObjectNode)context.loadNode("go", new ByteArrayInputStream(instanceDesc.getData().getBytes()));
             instanceNode.setTranslation(LoaderUtil.toPoint3d(instanceDesc.getPosition()));
             instanceNode.setRotation(LoaderUtil.toQuat4(instanceDesc.getRotation()));
-            instanceNode.setScale(instanceDesc.getScale());
+            if (instanceDesc.hasScale3()) {
+                instanceNode.setScale(LoaderUtil.toVector3(instanceDesc.getScale3()));
+            } else {
+                double s = instanceDesc.getScale();
+                instanceNode.setScale(new Vector3d(s, s, s));
+            }
             instanceNode.setId(instanceDesc.getId());
             idToInstance.put(instanceDesc.getId(), instanceNode);
             remainingInstances.add(instanceNode);
@@ -117,7 +131,12 @@ public class CollectionLoader implements INodeLoader<CollectionNode> {
             CollectionInstanceNode instanceNode = new CollectionInstanceNode(collectionNode);
             instanceNode.setTranslation(LoaderUtil.toPoint3d(instanceDesc.getPosition()));
             instanceNode.setRotation(LoaderUtil.toQuat4(instanceDesc.getRotation()));
-            instanceNode.setScale(instanceDesc.getScale());
+            if (instanceDesc.hasScale3()) {
+                instanceNode.setScale(LoaderUtil.toVector3(instanceDesc.getScale3()));
+            } else {
+                double s = instanceDesc.getScale();
+                instanceNode.setScale(new Vector3d(s, s, s));
+            }
             instanceNode.setId(instanceDesc.getId());
             instanceNode.setCollection(path);
             for (InstancePropertyDesc instancePropDesc : instanceDesc.getInstancePropertiesList()) {
@@ -154,7 +173,7 @@ public class CollectionLoader implements INodeLoader<CollectionNode> {
                 InstanceDesc.Builder instanceBuilder = InstanceDesc.newBuilder();
                 instanceBuilder.setPosition(LoaderUtil.toPoint3(instance.getTranslation()));
                 instanceBuilder.setRotation(LoaderUtil.toQuat(instance.getRotation()));
-                instanceBuilder.setScale((float)instance.getScale());
+                instanceBuilder.setScale3(LoaderUtil.toVector3(instance.getScale()));
                 instanceBuilder.setId(instance.getId());
                 instanceBuilder.setPrototype(instance.getGameObject());
                 for (Node grandChild : child.getChildren()) {
@@ -175,7 +194,7 @@ public class CollectionLoader implements INodeLoader<CollectionNode> {
                     EmbeddedInstanceDesc.Builder instanceBuilder = EmbeddedInstanceDesc.newBuilder();
                     instanceBuilder.setPosition(LoaderUtil.toPoint3(instance.getTranslation()));
                     instanceBuilder.setRotation(LoaderUtil.toQuat(instance.getRotation()));
-                    instanceBuilder.setScale((float)instance.getScale());
+                    instanceBuilder.setScale3(LoaderUtil.toVector3(instance.getScale()));
                     instanceBuilder.setId(instance.getId());
                     ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
                     SubMonitor partProgress = progress.newChild(1).setWorkRemaining(2);
@@ -199,7 +218,7 @@ public class CollectionLoader implements INodeLoader<CollectionNode> {
                 CollectionInstanceDesc.Builder instanceBuilder = CollectionInstanceDesc.newBuilder();
                 instanceBuilder.setPosition(LoaderUtil.toPoint3(instance.getTranslation()));
                 instanceBuilder.setRotation(LoaderUtil.toQuat(instance.getRotation()));
-                instanceBuilder.setScale((float)instance.getScale());
+                instanceBuilder.setScale3(LoaderUtil.toVector3(instance.getScale()));
                 instanceBuilder.setId(instance.getId());
                 instanceBuilder.setCollection(instance.getCollection());
                 instanceBuilder.addAllInstanceProperties(buildInstanceProperties(instance));

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiSceneLoader.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiSceneLoader.java
@@ -64,7 +64,7 @@ public class GuiSceneLoader implements INodeLoader<GuiSceneNode> {
         node.setId(desc.getId());
         node.setTranslation(LoaderUtil.toPoint3d(desc.getPosition()));
         node.setEuler(LoaderUtil.toVector3(desc.getRotation()));
-        node.setComponentScale(LoaderUtil.toVector3(desc.getScale()));
+        node.setScale(LoaderUtil.toVector3(desc.getScale()));
         node.setSize(LoaderUtil.toVector3(desc.getSize()));
         node.setColor(LoaderUtil.toRGB(desc.getColor()));
         node.setAlpha(desc.getColor().getW());
@@ -189,7 +189,7 @@ public class GuiSceneLoader implements INodeLoader<GuiSceneNode> {
         builder.setId(node.getId());
         builder.setPosition(LoaderUtil.toVector4(node.getTranslation()));
         builder.setRotation(LoaderUtil.toVector4(node.getEuler()));
-        builder.setScale(LoaderUtil.toVector4(node.getComponentScale()));
+        builder.setScale(LoaderUtil.toVector4(node.getScale()));
         builder.setSize(LoaderUtil.toVector4(node.getSize()));
         builder.setColor(LoaderUtil.toVector4(node.getColor(), node.getAlpha()));
         builder.setBlendMode(node.getBlendMode());

--- a/com.dynamo.cr/com.dynamo.cr.sceneed.test/src/com/dynamo/cr/sceneed/core/test/NodeTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed.test/src/com/dynamo/cr/sceneed/core/test/NodeTest.java
@@ -85,7 +85,7 @@ public class NodeTest extends AbstractNodeTest {
         assertEquals(new Vector3d(0, 180, 0), node.getEuler());
     }
 
-    void assertWorld(Node node, Point3d translation, Quat4d rotation, double scale) {
+    void assertWorld(Node node, Point3d translation, Quat4d rotation, Vector3d scale) {
         Matrix4d world = new Matrix4d();
         node.getWorldTransform(world);
         Vector3d t = new Vector3d();
@@ -96,7 +96,7 @@ public class NodeTest extends AbstractNodeTest {
         double epsilon = 0.0000000001;
         assertTrue(translation.epsilonEquals(new Point3d(t.x, t.y, t.z), epsilon));
         assertTrue(rotation.epsilonEquals(r, epsilon));
-        assertThat(s, is(scale));
+        assertThat(new Vector3d(s, s, s), is(scale));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class NodeTest extends AbstractNodeTest {
         Point3d translation = new Point3d(1, 0, 0);
         Quat4d rotation = new Quat4d();
         rotation.set(new AxisAngle4d(new Vector3d(0.0, 0.0, 1.0), Math.PI * 0.5));
-        double scale = 2.0;
+        Vector3d scale = new Vector3d(2.0, 2.0, 2.0);
 
         parent.setTranslation(translation);
         parent.setRotation(rotation);
@@ -125,7 +125,7 @@ public class NodeTest extends AbstractNodeTest {
         Point3d worldTranslation = new Point3d(1.0, 2.0, 0.0);
         Quat4d worldRotation = new Quat4d(rotation);
         worldRotation.mul(rotation);
-        double worldScale = scale * scale;
+        Vector3d worldScale = new Vector3d(scale.x * scale.x, scale.y * scale.y, scale.z * scale.z);
         assertWorld(child, worldTranslation, worldRotation, worldScale);
 
     }
@@ -143,7 +143,7 @@ public class NodeTest extends AbstractNodeTest {
         Point3d translation = new Point3d(1, 0, 0);
         Quat4d rotation = new Quat4d();
         rotation.set(new AxisAngle4d(new Vector3d(0.0, 0.0, 1.0), Math.PI * 0.5));
-        double scale = 2.0;
+        Vector3d scale = new Vector3d(2.0, 2.0, 2.0);
 
         parent.setTranslation(translation);
         parent.setRotation(rotation);
@@ -161,7 +161,7 @@ public class NodeTest extends AbstractNodeTest {
         Point3d worldTranslationNoScale = new Point3d(1.0, 1.0, 0.0);
         Quat4d worldRotation = new Quat4d(rotation);
         worldRotation.mul(rotation);
-        double worldScale = scale * scale;
+        Vector3d worldScale = new Vector3d(scale.x * scale.x, scale.y * scale.y, scale.z * scale.z);
 
         assertWorld(childNoRotation, worldTranslationNoRotation, rotation, worldScale);
         assertWorld(childNoScale, worldTranslationNoScale, worldRotation, scale);
@@ -178,7 +178,7 @@ public class NodeTest extends AbstractNodeTest {
         Point3d translation = new Point3d(0, 0, 1);
         Quat4d rotation = new Quat4d();
         rotation.set(new AxisAngle4d(new Vector3d(0.0, 1.0, 0.0), Math.PI * 0.5));
-        double scale = 2.0;
+        Vector3d scale = new Vector3d(2.0, 2.0, 2.0);
 
         parent.setTranslation(translation);
         parent.setRotation(rotation);
@@ -196,7 +196,7 @@ public class NodeTest extends AbstractNodeTest {
         Point3d worldTranslationNoScale = new Point3d(1.0, 0.0, 1.0);
         Quat4d worldRotation = new Quat4d(rotation);
         worldRotation.mul(rotation);
-        double worldScale = scale * scale;
+        Vector3d worldScale = new Vector3d(scale.x * scale.x, scale.y * scale.y, scale.z * scale.z);
 
         assertWorld(childScale, worldTranslationScale, worldRotation, worldScale);
         assertWorld(childNoScale, worldTranslationNoScale, worldRotation, worldScale);

--- a/com.dynamo.cr/com.dynamo.cr.sceneed.test/src/com/dynamo/cr/sceneed/core/test/NodeTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed.test/src/com/dynamo/cr/sceneed/core/test/NodeTest.java
@@ -262,7 +262,7 @@ public class NodeTest extends AbstractNodeTest {
         refMat.mul(tmpMat);
         assertTrue(transform.epsilonEquals(refMat, epsilon));
 
-        node.setComponentScale(new Vector3d(0.25, 0.5, 0.75));
+        node.setScale(new Vector3d(0.25, 0.5, 0.75));
         node.getWorldTransform(transform);
         tmpMat.setIdentity();
         tmpMat.setElement(0, 0, 0.25);

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/Node.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/Node.java
@@ -67,8 +67,7 @@ public abstract class Node implements IAdaptable, Serializable {
     protected Vector3d euler = new Vector3d(0, 0, 0);
 
     @Property
-    @GreaterThanZero
-    private double scale = 1.0;
+    private Vector3d scale = new Vector3d(1.0, 1.0, 1.0);
 
     @Property(displayName = "scale")
     private Vector3d componentScale = new Vector3d(1.0, 1.0, 1.0);
@@ -250,13 +249,13 @@ public abstract class Node implements IAdaptable, Serializable {
         return new Vector3d(euler);
     }
 
-    public void setScale(double scale) {
+    public void setScale(Vector3d scale) {
         this.scale = scale;
         setAABBDirty();
         transformChanged();
     }
 
-    public double getScale() {
+    public Vector3d getScale() {
         return this.scale;
     }
 
@@ -336,9 +335,9 @@ public abstract class Node implements IAdaptable, Serializable {
         rotationScale.set(rotation);
         Matrix3d scale = new Matrix3d();
         scale.setIdentity();
-        scale.setElement(0, 0, this.scale * this.componentScale.getX());
-        scale.setElement(1, 1, this.scale * this.componentScale.getY());
-        scale.setElement(2, 2, this.scale * this.componentScale.getZ());
+        scale.setElement(0, 0, this.scale.x * this.componentScale.getX());
+        scale.setElement(1, 1, this.scale.y * this.componentScale.getY());
+        scale.setElement(2, 2, this.scale.z * this.componentScale.getZ());
         rotationScale.mul(scale);
         transform.setRotationScale(rotationScale);
     }
@@ -390,9 +389,9 @@ public abstract class Node implements IAdaptable, Serializable {
             localRotationScale.set(rotation);
             Matrix3d scale = new Matrix3d();
             scale.setIdentity();
-            scale.setElement(0, 0, this.scale * this.componentScale.getX());
-            scale.setElement(1, 1, this.scale * this.componentScale.getY());
-            scale.setElement(2, 2, this.scale * this.componentScale.getZ());
+            scale.setElement(0, 0, this.scale.x * this.componentScale.getX());
+            scale.setElement(1, 1, this.scale.y * this.componentScale.getY());
+            scale.setElement(2, 2, this.scale.z * this.componentScale.getZ());
             localRotationScale.mul(scale);
             local.setRotationScale(localRotationScale);
             transform.mul(local);
@@ -604,11 +603,23 @@ public abstract class Node implements IAdaptable, Serializable {
         return super.toString();
     }
 
+    public static Vector3d get3dScaleFromMatrix(Matrix4d mtx) {
+        Vector4d tmp = new Vector4d();
+        Vector3d out = new Vector3d();
+        mtx.getColumn(0, tmp);
+        out.x = tmp.length();
+        mtx.getColumn(1, tmp);
+        out.y = tmp.length();
+        mtx.getColumn(2, tmp);
+        out.z = tmp.length();
+        return out;
+    }
+
     public void setLocalTransform(Matrix4d transform) {
         Vector3d translation = new Vector3d();
         transform.get(translation);
         this.translation.set(translation);
-        this.scale = transform.getScale();
+        this.scale = get3dScaleFromMatrix(transform);
         transform.get(this.rotation);
         quatToEuler(this.rotation, euler);
         setAABBDirty();
@@ -624,7 +635,7 @@ public abstract class Node implements IAdaptable, Serializable {
         out.writeObject(this.translation);
         out.writeObject(this.rotation);
         out.writeObject(this.euler);
-        out.writeDouble(this.scale);
+        out.writeObject(this.scale);
         out.writeObject(this.componentScale);
     }
 
@@ -644,7 +655,7 @@ public abstract class Node implements IAdaptable, Serializable {
         this.translation = (Point3d)in.readObject();
         this.rotation = (Quat4d)in.readObject();
         this.euler = (Vector3d)in.readObject();
-        this.scale = in.readDouble();
+        this.scale = (Vector3d)in.readObject();
         this.componentScale = (Vector3d) in.readObject();
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/Node.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/Node.java
@@ -250,7 +250,12 @@ public abstract class Node implements IAdaptable, Serializable {
     }
 
     public void setScale(Vector3d scale) {
-        this.scale = scale;
+        if (scale.x > 0)
+            this.scale.x = scale.x;
+        if (scale.y > 0)
+            this.scale.y = scale.y;
+        if (scale.z >= 0)
+            this.scale.z = scale.z;
         setAABBDirty();
         transformChanged();
     }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/Node.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/Node.java
@@ -66,11 +66,8 @@ public abstract class Node implements IAdaptable, Serializable {
     @Property(displayName="rotation")
     protected Vector3d euler = new Vector3d(0, 0, 0);
 
-    @Property
-    private Vector3d scale = new Vector3d(1.0, 1.0, 1.0);
-
     @Property(displayName = "scale")
-    private Vector3d componentScale = new Vector3d(1.0, 1.0, 1.0);
+    private Vector3d scale = new Vector3d(1.0, 1.0, 1.0);
 
     // Used to preserve order when adding/removing child nodes
     private transient int childIndex = -1;
@@ -156,14 +153,6 @@ public abstract class Node implements IAdaptable, Serializable {
 
     public boolean isScaleVisible() {
         return isScalable();
-    }
-
-    public final boolean isComponentScalable() {
-        return flags.contains(Flags.COMPONENT_SCALABLE);
-    }
-
-    public boolean isComponentScaleVisible() {
-        return isComponentScalable();
     }
 
     public final boolean isEditable() {
@@ -254,7 +243,7 @@ public abstract class Node implements IAdaptable, Serializable {
             this.scale.x = scale.x;
         if (scale.y > 0)
             this.scale.y = scale.y;
-        if (scale.z >= 0)
+        if (scale.z > 0)
             this.scale.z = scale.z;
         setAABBDirty();
         transformChanged();
@@ -262,16 +251,6 @@ public abstract class Node implements IAdaptable, Serializable {
 
     public Vector3d getScale() {
         return this.scale;
-    }
-
-    public Vector3d getComponentScale() {
-        return this.componentScale;
-    }
-
-    public void setComponentScale(Vector3d componentScale) {
-        this.componentScale = componentScale;
-        setAABBDirty();
-        transformChanged();
     }
 
     public static void eulerToQuat(Tuple3d euler, Quat4d quat) {
@@ -340,9 +319,9 @@ public abstract class Node implements IAdaptable, Serializable {
         rotationScale.set(rotation);
         Matrix3d scale = new Matrix3d();
         scale.setIdentity();
-        scale.setElement(0, 0, this.scale.x * this.componentScale.getX());
-        scale.setElement(1, 1, this.scale.y * this.componentScale.getY());
-        scale.setElement(2, 2, this.scale.z * this.componentScale.getZ());
+        scale.setElement(0, 0, this.scale.x);
+        scale.setElement(1, 1, this.scale.y);
+        scale.setElement(2, 2, this.scale.z);
         rotationScale.mul(scale);
         transform.setRotationScale(rotationScale);
     }
@@ -394,9 +373,9 @@ public abstract class Node implements IAdaptable, Serializable {
             localRotationScale.set(rotation);
             Matrix3d scale = new Matrix3d();
             scale.setIdentity();
-            scale.setElement(0, 0, this.scale.x * this.componentScale.getX());
-            scale.setElement(1, 1, this.scale.y * this.componentScale.getY());
-            scale.setElement(2, 2, this.scale.z * this.componentScale.getZ());
+            scale.setElement(0, 0, this.scale.x);
+            scale.setElement(1, 1, this.scale.y);
+            scale.setElement(2, 2, this.scale.z);
             localRotationScale.mul(scale);
             local.setRotationScale(localRotationScale);
             transform.mul(local);
@@ -641,7 +620,6 @@ public abstract class Node implements IAdaptable, Serializable {
         out.writeObject(this.rotation);
         out.writeObject(this.euler);
         out.writeObject(this.scale);
-        out.writeObject(this.componentScale);
     }
 
     @SuppressWarnings("unchecked")
@@ -661,6 +639,5 @@ public abstract class Node implements IAdaptable, Serializable {
         this.rotation = (Quat4d)in.readObject();
         this.euler = (Vector3d)in.readObject();
         this.scale = (Vector3d)in.readObject();
-        this.componentScale = (Vector3d) in.readObject();
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/util/LoaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/util/LoaderUtil.java
@@ -14,6 +14,7 @@ import org.eclipse.swt.graphics.RGB;
 
 import com.dynamo.proto.DdfMath.Point3;
 import com.dynamo.proto.DdfMath.Quat;
+import com.dynamo.proto.DdfMath.Vector3;
 import com.dynamo.proto.DdfMath.Vector4;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
@@ -26,6 +27,10 @@ public class LoaderUtil {
 
     public static Vector4d toVector4(Vector4 p) {
         return new Vector4d(p.getX(), p.getY(), p.getZ(), p.getW());
+    }
+
+    public static Vector3d toVector3(Vector3 p) {
+        return new Vector3d(p.getX(), p.getY(), p.getZ());
     }
 
     public static Vector3d toVector3(Vector4 p) {
@@ -48,6 +53,10 @@ public class LoaderUtil {
             .setX((float) v.getX())
             .setY((float) v.getY())
             .setZ((float) v.getZ()).build();
+    }
+
+    public static Vector3 toVector3(Vector3d p) {
+        return Vector3.newBuilder().setX((float) p.getX()).setY((float) p.getY()).setZ((float) p.getZ()).build();
     }
 
     public static Vector4 toVector4(RGB rgb, double alpha) {

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/ui/ScaleManipulator.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/ui/ScaleManipulator.java
@@ -2,36 +2,78 @@ package com.dynamo.cr.sceneed.ui;
 
 import java.util.List;
 
+import javax.vecmath.Matrix3d;
+import javax.vecmath.Matrix4d;
+import javax.vecmath.Quat4d;
+import javax.vecmath.Quat4f;
+import javax.vecmath.Vector3d;
+import javax.vecmath.Vector4d;
+
+import org.eclipse.swt.events.MouseEvent;
+
 import com.dynamo.cr.sceneed.core.Manipulator;
 import com.dynamo.cr.sceneed.core.Node;
 import com.dynamo.cr.sceneed.core.operations.TransformNodeOperation.ITransformer;
 
 @SuppressWarnings("serial")
-public class ScaleManipulator extends TransformManipulator<Double> {
+public class ScaleManipulator extends TransformManipulator<Vector3d> {
 
-    private class ScaleTransformer implements ITransformer<Double> {
+    private class ScaleTransformer implements ITransformer<Vector3d> {
         @Override
-        public Double get(Node n) {
+        public Vector3d get(Node n) {
             return n.getScale();
         }
 
         @Override
-        public void set(Node n, Double value) {
+        public void set(Node n, Vector3d value) {
             n.setScale(value);
         }
     }
 
-    private ScaleAxisManipulator scaleManipulator;
+    private ScaleAxisManipulator xManipulator;
+    private ScaleAxisManipulator yManipulator;
+
     private ScaleTransformer transformer = new ScaleTransformer();
 
     public ScaleManipulator() {
-        scaleManipulator = new ScaleAxisManipulator(this, new float[] {1, 0, 0, 1});
-        addChild(scaleManipulator);
+        xManipulator = new ScaleAxisManipulator(this,  new float[] {1, 0, 0, 1});
+        yManipulator = new ScaleAxisManipulator(this,  new float[] {0, 1, 0, 1});
+        addChild(xManipulator);
+        addChild(yManipulator);
+    }
+
+    @Override
+    protected void selectionChanged() {
+        super.selectionChanged();
+
+        // align with selected objects
+        List<Node> sel = getSelection();
+        Quat4d rotation = new Quat4d();
+        if (sel.size() > 0)
+        {
+            rotation = sel.get(0).getRotation();
+            if (sel.size() > 1)
+            {
+                // blend in the rest
+                double interp = 1.0f / (sel.size());
+                for (int i=1;i<sel.size();i++)
+                    rotation.interpolate(sel.get(i).getRotation(), interp);
+            }
+            xManipulator.setRotation(rotation);
+            Quat4d yrot = new Quat4d(0, 0, 0.707, 0.707);
+            yrot.mul(rotation);
+            yManipulator.setRotation(yrot);
+        }
     }
 
     @Override
     protected String getOperation() {
         return "Scale";
+    }
+
+    @Override
+    public void manipulatorChanged(Manipulator manipulator) {
+        this.transformChanged();
     }
 
     @Override
@@ -45,26 +87,25 @@ public class ScaleManipulator extends TransformManipulator<Double> {
     }
 
     @Override
-    protected void applyTransform(List<Node> selection, List<Double> originalLocalTransforms) {
-        double distance = this.scaleManipulator.getDistance();
-        double factor = 0.05;
+    protected void applyTransform(List<Node> selection, List<Vector3d> originalLocalTransforms) {
+        double distX = this.xManipulator.getDistance();
+        double distY = this.yManipulator.getDistance();
+        double factor = 0.025;
         int n = selection.size();
         for (int i = 0; i < n; ++i) {
             Node instance = selection.get(i);
-            double scale = originalLocalTransforms.get(i);
-            scale += factor * distance;
-            scale = Math.abs(scale);
-            instance.setScale(scale);
-        }
+            Vector3d scale = originalLocalTransforms.get(i);
+            Vector3d newScale = new Vector3d(
+                    Math.abs(scale.x + factor * distX),
+                    Math.abs(scale.y + factor * distY),
+                    scale.z
+            );
+            instance.setScale(newScale);
+       }
     }
 
     @Override
-    public void manipulatorChanged(Manipulator manipulator) {
-        transformChanged();
-    }
-
-    @Override
-    protected ITransformer<Double> getTransformer() {
+    protected ITransformer<Vector3d> getTransformer() {
         return this.transformer;
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.spine/src/com/dynamo/cr/spine/scene/SpineModelNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.spine/src/com/dynamo/cr/spine/scene/SpineModelNode.java
@@ -322,7 +322,7 @@ public class SpineModelNode extends ComponentTypeNode {
                     node = new SpineBoneNode(b.name);
                     node.setTranslation(b.localT.position);
                     node.setRotation(b.localT.rotation);
-                    node.setComponentScale(b.localT.scale);
+                    node.setScale(b.localT.scale);
                     nodes.put(b.name, node);
                 }
                 Node parent = this;

--- a/engine/dlib/src/dlib/transform.h
+++ b/engine/dlib/src/dlib/transform.h
@@ -394,6 +394,7 @@ namespace dmTransform
     /**
      * Eliminate the scaling components in a matrix
      * @param mtx Matrix to operate on
+     * @return Vector containing the scaling by component
      */
     inline Vector3 ResetScale(Matrix4 *mtx)
     {

--- a/engine/dlib/src/dlib/transform.h
+++ b/engine/dlib/src/dlib/transform.h
@@ -379,7 +379,7 @@ namespace dmTransform
     }
 
     /**
-     * Extract the scale component from a matrix
+     * Extract the absolute values of the scale component from a matrix.
      * @param mtx Source matrix
      * @return Vector3 with scale values for x,y,z
      */
@@ -392,28 +392,33 @@ namespace dmTransform
     }
 
     /**
+     * Eliminate the scaling components in a matrix
+     * @param mtx Matrix to operate on
+     */
+    inline Vector3 ResetScale(Matrix4 *mtx)
+    {
+        const float limit = 0.000001f;
+        Vector3 scale = ExtractScale(*mtx);
+        assert(scale.getX() * scale.getX() > limit);
+        assert(scale.getY() * scale.getY() > limit);
+        assert(scale.getZ() * scale.getZ() > limit);
+        mtx->setCol(0, mtx->getCol(0) * (1.0f / scale.getX()));
+        mtx->setCol(1, mtx->getCol(1) * (1.0f / scale.getY()));
+        mtx->setCol(2, mtx->getCol(2) * (1.0f / scale.getZ()));
+        return scale;
+    }
+
+    /**
      * Convert a matrix into a transform
      * @param mtx Matrix4 to convert
      * @return Transform representing the same transform
      */
     inline Transform ToTransform(const Matrix4& mtx)
     {
-        Vector3 scale = ExtractScale(mtx);
+        Matrix4 tmp(mtx);
         Vector4 col3(mtx.getCol(3));
-        return dmTransform::Transform(Vector3(col3.getX(), col3.getY(), col3.getZ()), Quat(mtx.getUpper3x3()), scale);
-    }
-
-    /**
-     * Eliminate the scaling components in a matrix
-     * @param mtx Matrix to operate on
-     */
-    inline Vector3 ResetScale(Matrix4 *mtx)
-    {
-        Vector3 scale = ExtractScale(*mtx);
-        mtx->setCol(0, mtx->getCol(0) * (1.0f / scale.getX()));
-        mtx->setCol(1, mtx->getCol(1) * (1.0f / scale.getX()));
-        mtx->setCol(2, mtx->getCol(2) * (1.0f / scale.getX()));
-        return scale;
+        Vector3 scale = ResetScale(&tmp);
+        return dmTransform::Transform(Vector3(col3.getX(), col3.getY(), col3.getZ()), Quat(tmp.getUpper3x3()), scale);
     }
 
     /**

--- a/engine/dlib/src/dlib/transform.h
+++ b/engine/dlib/src/dlib/transform.h
@@ -397,11 +397,10 @@ namespace dmTransform
      */
     inline Vector3 ResetScale(Matrix4 *mtx)
     {
-        const float limit = 0.000001f;
         Vector3 scale = ExtractScale(*mtx);
-        assert(scale.getX() * scale.getX() > limit);
-        assert(scale.getY() * scale.getY() > limit);
-        assert(scale.getZ() * scale.getZ() > limit);
+        if (scale.getX() == 0 || scale.getY() == 0 || scale.getZ() == 0)
+            return Vector3(1, 1, 1);
+
         mtx->setCol(0, mtx->getCol(0) * (1.0f / scale.getX()));
         mtx->setCol(1, mtx->getCol(1) * (1.0f / scale.getY()));
         mtx->setCol(2, mtx->getCol(2) * (1.0f / scale.getZ()));

--- a/engine/dlib/src/test/test_transform.cpp
+++ b/engine/dlib/src/test/test_transform.cpp
@@ -100,6 +100,65 @@ TEST(dmTransform, MultiplyNoScaleZ)
     ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), res.GetTranslation());
 }
 
+TEST(dmTransform, MultiplyNoScaleZMatrix)
+{
+    Transform ts10(Vector3(0.0f, 0.0f, 1.0f),
+            Quat::identity(),
+            Vector3(2.0f, 2.0f, 2.0f));
+
+    Matrix4 ts10mtx = ToMatrix4(ts10);
+    Matrix4 ress1 = ts10mtx * ts10mtx;
+    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 3.0f), ress1.getCol(3));
+    ress1 = MulNoScaleZ(ts10mtx, ts10mtx);
+    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), ress1.getCol(3));
+
+    Transform t0(Vector3(0.0f, 0.0f, 1.0f),
+            Quat::identity(),
+            Vector3(2.0f, 2.0f, 2.0f));
+
+    Matrix4 t0mtx = ToMatrix4(t0);
+    Matrix4 res = t0mtx * t0mtx;
+    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 3.0f), res.getCol(3));
+    res = MulNoScaleZ(t0mtx, t0mtx);
+    ASSERT_V3_NEAR(Vector3(0.0f, 0.0f, 2.0f), res.getCol(3));
+}
+
+TEST(dmTransform, Conversion)
+{
+    const int count = 4;
+    Vector3 vecs[count] = {
+        Vector3(-1, -2, -3),
+        Vector3(5, 0.3f, 3),
+        Vector3(0.09f, -3, 1),
+        Vector3(1, 2, 0.5f)
+    };
+
+    // try all the combinations of above vectors as pos, rot and scale
+    // and make sure transformation transform->matrix->transform generates
+    // the same transfrom
+    for (int i=0;i<count;i++) // pos
+    {
+        for (int j=0;j<count;j++) // rotaxis
+        {
+            for (int k=0;k<count;k++) // scale
+            {
+                Vector3 axis = vecs[j] * (1.0f / length(vecs[j]));
+                Vector3 scale(dmMath::Abs(vecs[k].getX()), dmMath::Abs(vecs[k].getY()), dmMath::Abs(vecs[k].getZ()));
+                Transform t0(vecs[i], normalize(Quat(axis, 1.0f)), scale);
+
+                Matrix4 mtx = ToMatrix4(t0);
+                Transform t1 = ToTransform(mtx);
+
+                Vector3 test(-10,20,-30);
+                Vector4 res = mtx * test;
+                Vector3 res3(res.getX(), res.getY(), res.getZ());
+                ASSERT_V3_NEAR(Apply(t0, test), res3);
+                ASSERT_V3_NEAR(Apply(t0, test), Apply(t1, test));
+            }
+        }
+    }
+}
+
 TEST(dmTransform, Inverse)
 {
     TransformS1 is1;

--- a/engine/gameobject/proto/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject_ddf.proto
@@ -69,6 +69,7 @@ message InstanceDesc
     optional dmMath.Quat    rotation    = 5;
     repeated ComponentPropertyDesc component_properties = 6;
     optional float          scale       = 7 [default = 1.0];
+    optional dmMath.Vector3 scale3      = 8;
 }
 
 message EmbeddedInstanceDesc
@@ -80,6 +81,7 @@ message EmbeddedInstanceDesc
     optional dmMath.Quat    rotation    = 5;
     repeated ComponentPropertyDesc component_properties = 6;
     optional float          scale       = 7 [default = 1.0];
+    optional dmMath.Vector3 scale3      = 8;
 }
 
 message InstancePropertyDesc
@@ -95,6 +97,7 @@ message CollectionInstanceDesc
     optional dmMath.Point3  position    = 3;
     optional dmMath.Quat    rotation    = 4;
     optional float          scale       = 5 [default = 1.0];
+    optional dmMath.Vector3 scale3      = 7;
     repeated InstancePropertyDesc instance_properties = 6;
 }
 
@@ -224,7 +227,9 @@ message TransformResponse
     required dmMath.Point3  world_position  = 3;
     required dmMath.Quat    world_rotation  = 4;
     optional float          scale           = 5 [default = 1.0];
+    optional dmMath.Vector3 scale3          = 7;
     optional float          world_scale     = 6 [default = 1.0];
+    optional dmMath.Vector3 world_scale3    = 8;
 }
 
 /*# sets the parent of the receiving instance

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -963,7 +963,7 @@ namespace dmGameObject
                 }
 
                 // world transforms need to be up to date in time for the script init calls
-                collection->m_WorldTransforms[new_instances[i]->m_Index] = new_instances[i]->m_Transform;
+                collection->m_WorldTransforms[new_instances[i]->m_Index] = dmTransform::ToMatrix4(new_instances[i]->m_Transform);
             }
         }
 

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -758,7 +758,7 @@ namespace dmGameObject
      * return true on success
      */
     bool SpawnFromCollection(HCollection collection, const char* path, InstancePropertyBuffers *property_buffers,
-                             const Point3& position, const Quat& rotation, float scale,
+                             const Point3& position, const Quat& rotation, const Vector3& scale,
                              InstanceIdMap *instances);
 
     /**

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -725,7 +725,7 @@ namespace dmGameObject
      * @param scale Scale of the spawned object
      * return the spawned instance, 0 at failure
      */
-    HInstance Spawn(HCollection collection, const char* prototype_name, dmhash_t id, uint8_t* property_buffer, uint32_t property_buffer_size, const Point3& position, const Quat& rotation, float scale);
+    HInstance Spawn(HCollection collection, const char* prototype_name, dmhash_t id, uint8_t* property_buffer, uint32_t property_buffer_size, const Point3& position, const Quat& rotation, const Vector3& scale);
 
     struct InstancePropertyBuffer
     {
@@ -1032,7 +1032,14 @@ namespace dmGameObject
      * @param instance Gameobject instance
      * @return Uniform scale
      */
-    float GetScale(HInstance instance);
+    float GetUniformScale(HInstance instance);
+
+    /**
+     * Get gameobject instance scale
+     * @param instance Gameobject instance
+     * @return Uniform scale
+     */
+    Vector3 GetScale(HInstance instance);
 
     /**
      * Get gameobject instance world position
@@ -1051,16 +1058,30 @@ namespace dmGameObject
     /**
      * Get game object instance world transform
      * @param instance Game object instance
-     * @return World uniform scale
+     * @return World scale
      */
-    float GetWorldScale(HInstance instance);
+    Vector3 GetWorldScale(HInstance instance);
 
     /**
-     * Get game object instance world uniform scale
+     * Get game object instance uniform scale
      * @param instance Game object instance
      * @return World uniform scale
      */
-    const dmTransform::Transform& GetWorldTransform(HInstance instance);
+    float GetWorldUniformScale(HInstance instance);
+
+    /**
+     * Get game object instance world transform
+     * @param instance Game object instance
+     * @return World transform
+     */
+    const dmTransform::Transform GetWorldTransform(HInstance instance);
+
+    /**
+     * Get game object instance world transform as Matrix4.
+     * @param instance Game object instance
+     * @return World transform matrix.
+     */
+    const Matrix4 & GetWorldMatrix(HInstance instance);
 
     /**
      * Set parent instance to child

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -1037,7 +1037,7 @@ namespace dmGameObject
     /**
      * Get gameobject instance scale
      * @param instance Gameobject instance
-     * @return Uniform scale
+     * @return Non-uniform scale
      */
     Vector3 GetScale(HInstance instance);
 

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -97,6 +97,7 @@ namespace dmGameObject
         }
 
         dmTransform::Transform m_Transform;
+        
         // Shadowed rotation expressed in euler coordinates
         Vector3 m_EulerRotation;
         // Previous euler rotation, used to detect if the euler rotation has changed and should overwrite the real rotation (needed by animation)
@@ -257,7 +258,7 @@ namespace dmGameObject
         dmArray<uint16_t>        m_LevelIndices[MAX_HIERARCHICAL_DEPTH];
 
         // Array of world transforms. Calculated using m_LevelIndices above
-        dmArray<dmTransform::Transform> m_WorldTransforms;
+        dmArray<Matrix4> m_WorldTransforms;
 
         // Identifier to Instance mapping
         dmHashTable64<Instance*> m_IDToInstance;

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -718,7 +718,12 @@ namespace dmGameObject
         // Supports both vector and number
         if (dmScript::IsVector3(L, 1))
         {
-            dmGameObject::SetScale(instance, *dmScript::CheckVector3(L, 1));
+            Vector3 scale = *dmScript::CheckVector3(L, 1);
+            if (scale.getX() <= 0.0f || scale.getY() <= 0.0f || scale.getZ() <= 0.0f)
+            {
+                return luaL_error(L, "Vector passed to go.set_scale contains components that are below or equal to zero");
+            }
+            dmGameObject::SetScale(instance, scale);
             return 0;
         }
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -612,7 +612,30 @@ namespace dmGameObject
     int Script_GetScale(lua_State* L)
     {
         Instance* instance = ResolveInstance(L, 1);
-        lua_pushnumber(L, dmGameObject::GetScale(instance));
+        lua_pushnumber(L, dmGameObject::GetUniformScale(instance));
+        return 1;
+    }
+
+    /*# gets the 3d scale factor of the instance
+     * The scale is relative the parent (if any). Use <code>go.get_world_scale</code> to retrieve the global world scale factor.
+     *
+     * @name go.get_scale_vector
+     * @param [id] optional id of the instance to get the scale for, by default the instance of the calling script (hash|string|url)
+     * @return scale factor (vector)
+     * @examples
+     * <p>Get the scale of the instance the script is attached to:</p>
+     * <pre>
+     * local s = go.get_scale_vector()
+     * </pre>
+     * <p>Get the scale of another instance "x":</p>
+     * <pre>
+     * local s = go.get_scale_vector("x")
+     * </pre>
+     */
+    int Script_GetScaleVector(lua_State* L)
+    {
+        Instance* instance = ResolveInstance(L, 1);
+        dmScript::PushVector3(L, dmGameObject::GetScale(instance));
         return 1;
     }
 
@@ -674,7 +697,7 @@ namespace dmGameObject
      * NOTE! Physics are currently not affected when setting scale from this function.
      *
      * @name go.set_scale
-     * @param scale uniform scale factor, must be greater than 0 (number)
+     * @param scale vector or uniform scale factor, must be greater than 0 (number)
      * @param [id] optional id of the instance to get the scale for, by default the instance of the calling script (hash|string|url)
      * @examples
      * <p>Set the scale of the instance the script is attached to:</p>
@@ -691,6 +714,14 @@ namespace dmGameObject
     int Script_SetScale(lua_State* L)
     {
         Instance* instance = ResolveInstance(L, 2);
+
+        // Supports both vector and number
+        if (dmScript::IsVector3(L, 1))
+        {
+            dmGameObject::SetScale(instance, *dmScript::CheckVector3(L, 1));
+            return 0;
+        }
+
         lua_Number v = luaL_checknumber(L, 1);
         if (v <= 0.0)
         {
@@ -765,7 +796,7 @@ namespace dmGameObject
     int Script_GetWorldScale(lua_State* L)
     {
         Instance* instance = ResolveInstance(L, 1);
-        lua_pushnumber(L, dmGameObject::GetWorldScale(instance));
+        lua_pushnumber(L, dmGameObject::GetWorldUniformScale(instance));
         return 1;
     }
 
@@ -1271,6 +1302,7 @@ namespace dmGameObject
         {"get_position",        Script_GetPosition},
         {"get_rotation",        Script_GetRotation},
         {"get_scale",           Script_GetScale},
+        {"get_scale_vector",    Script_GetScaleVector},
         {"set_position",        Script_SetPosition},
         {"set_rotation",        Script_SetRotation},
         {"set_scale",           Script_SetScale},

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -60,7 +60,13 @@ namespace dmGameObject
             if (instance != 0x0)
             {
                 instance->m_ScaleAlongZ = collection_desc->m_ScaleAlongZ;
-                instance->m_Transform = dmTransform::Transform(Vector3(instance_desc.m_Position), instance_desc.m_Rotation, instance_desc.m_Scale);
+
+                // support legacy pipeline which outputs 0 for Scale3 and scale in Scale
+                Vector3 scale = instance_desc.m_Scale3;
+                if (scale.getX() == 0 && scale.getY() == 0 && scale.getZ() == 0)
+                        scale = Vector3(instance_desc.m_Scale, instance_desc.m_Scale, instance_desc.m_Scale);
+
+                instance->m_Transform = dmTransform::Transform(Vector3(instance_desc.m_Position), instance_desc.m_Rotation, scale);
 
                 dmHashInit64(&instance->m_CollectionPathHashState, true);
                 const char* path_end = strrchr(instance_desc.m_Id, *ID_SEPARATOR);

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -495,7 +495,7 @@ TEST_F(AnimTest, ScriptedRestart)
 {
     m_UpdateContext.m_DT = 0.25f;
     dmGameObject::PropertyVar var(1.0f);
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/restart.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/restart.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     for (uint32_t i = 0; i < 10; ++i)
@@ -508,7 +508,7 @@ TEST_F(AnimTest, ScriptedCancel)
 {
     m_UpdateContext.m_DT = 0.25f;
     dmGameObject::PropertyVar var(1.0f);
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/cancel.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/cancel.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     for (uint32_t i = 0; i < 10; ++i)
@@ -519,13 +519,13 @@ TEST_F(AnimTest, ScriptedCancel)
 
 TEST_F(AnimTest, ScriptedAnimBadURL)
 {
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/anim_bad_url.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/anim_bad_url.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_EQ(0, go);
 }
 
 TEST_F(AnimTest, ScriptedCancelBadURL)
 {
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/cancel_bad_url.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/cancel_bad_url.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_EQ(0, go);
 }
 
@@ -533,7 +533,7 @@ TEST_F(AnimTest, ScriptedChainOtherProp)
 {
     m_UpdateContext.m_DT = 0.25f;
     dmGameObject::PropertyVar var(1.0f);
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/chain_other_prop.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/chain_other_prop.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     for (uint32_t i = 0; i < 12; ++i)
@@ -546,7 +546,7 @@ TEST_F(AnimTest, ScriptedChainDelayBug)
 {
     m_UpdateContext.m_DT = 0.25f;
     dmGameObject::PropertyVar var(1.0f);
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/chain_delay_bug.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/chain_delay_bug.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     for (uint32_t i = 0; i < 12; ++i)
@@ -563,10 +563,10 @@ TEST_F(AnimTest, ScriptedDemo)
     for (uint32_t i = 0; i < count; ++i)
     {
         DM_SNPRINTF(id, 8, "box%d", i + 1);
-        dmGameObject::HInstance box = dmGameObject::Spawn(m_Collection, "/demo_box.goc", hash(id), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+        dmGameObject::HInstance box = dmGameObject::Spawn(m_Collection, "/demo_box.goc", hash(id), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
         ASSERT_NE((void*)0, box);
     }
-    dmGameObject::HInstance demo = dmGameObject::Spawn(m_Collection, "/demo.goc", hash("demo"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance demo = dmGameObject::Spawn(m_Collection, "/demo.goc", hash("demo"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, demo);
 
     uint32_t frame_count = 1000;
@@ -582,7 +582,7 @@ TEST_F(AnimTest, ScriptedInvalidType)
 {
     m_UpdateContext.m_DT = 0.25f;
     dmGameObject::PropertyVar var(1.0f);
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/invalid_type.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/invalid_type.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_EQ((void*)0, go);
 }
 
@@ -590,7 +590,7 @@ TEST_F(AnimTest, ScriptedDelayedCompositeCallback)
 {
     m_UpdateContext.m_DT = 0.25f;
     dmGameObject::PropertyVar var(1.0f);
-    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/composite_delay.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1);
+    dmGameObject::HInstance go = dmGameObject::Spawn(m_Collection, "/composite_delay.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     for (uint32_t i = 0; i < 10; ++i)
@@ -615,7 +615,7 @@ TEST_F(AnimTest, UniformScale)
 
     dmGameObject::Update(m_Collection, &m_UpdateContext);
 
-    ASSERT_NEAR(2.0f, dmGameObject::GetScale(go), 0.000001f);
+    ASSERT_NEAR(2.0f, dmGameObject::GetUniformScale(go), 0.000001f);
 
     dmGameObject::Delete(m_Collection, go);
 }

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
@@ -153,7 +153,7 @@ TEST_F(CollectionTest, CollectionSpawning)
 
     Vectormath::Aos::Point3 pos(0,0,0);
     Vectormath::Aos::Quat rot(0,0,0,1);
-    const float scale = 1.0f;
+    Vectormath::Aos::Vector3 scale(1,1,1);
 
     bool ret;
     ret = dmGameObject::Update(coll, &m_UpdateContext);
@@ -189,7 +189,7 @@ TEST_F(CollectionTest, CollectionSpawningToFail)
 
     Vectormath::Aos::Point3 pos(0,0,0);
     Vectormath::Aos::Quat rot(0,0,0,1);
-    const float scale = 1.0f;
+    Vectormath::Aos::Vector3 scale(1,1,1);
 
     // Spawn until failure
     bool filled = false;
@@ -215,7 +215,7 @@ TEST_F(CollectionTest, CollectionSpawningToFail)
 
     ASSERT_TRUE(filled);
     dmGameObject::PostUpdate(m_Register);
-    
+
     ASSERT_TRUE(true);
 }
 

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -115,7 +115,7 @@ TEST_F(FactoryTest, Factory)
     {
         dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
         ASSERT_NE(0u, id);
-        dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), 1.0f);
+        dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), Vector3(1, 1, 1));
         ASSERT_NE(0u, (uintptr_t)instance);
     }
 }
@@ -124,19 +124,19 @@ TEST_F(FactoryTest, FactoryScale)
 {
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
     ASSERT_NE(0u, id);
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), 2.0f);
-    ASSERT_EQ(2.0f, dmGameObject::GetScale(instance));
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), Vector3(2, 2, 2));
+    ASSERT_EQ(2.0f, dmGameObject::GetUniformScale(instance));
 }
 
 TEST_F(FactoryTest, FactoryScaleAlongZ)
 {
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
     m_Collection->m_ScaleAlongZ = 1;
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), 2.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_TRUE(dmGameObject::ScaleAlongZ(instance));
     id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
     m_Collection->m_ScaleAlongZ = 0;
-    instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), 2.0f);
+    instance = dmGameObject::Spawn(m_Collection, "/test.goc", id, 0x0, 0, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_FALSE(dmGameObject::ScaleAlongZ(instance));
 }
 
@@ -170,10 +170,10 @@ TEST_F(FactoryTest, FactoryProperties)
     uint32_t buffer_size = dmScript::CheckTable(L, buffer, 256, -1);
     lua_pop(L, 1);
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), 2.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
     id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
-    instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), 2.0f);
+    instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }
 
@@ -188,7 +188,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     uint32_t buffer_size = dmScript::CheckTable(L, buffer, 256, -1);
     lua_pop(L, 1);
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), 2.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 }
 
@@ -203,14 +203,14 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     uint32_t buffer_size = dmScript::CheckTable(L, buffer, 256, -1);
     lua_pop(L, 1);
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), 2.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_props.goc", id, (unsigned char*)buffer, buffer_size, Point3(), Quat(), Vector3(2, 2, 2));
     ASSERT_EQ((void*)0, instance);
 }
 
 TEST_F(FactoryTest, FactoryCreateCallback)
 {
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(m_Collection);
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_create.goc", id, 0x0, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), 2.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/test_create.goc", id, 0x0, 0, Point3(2.0f, 0.0f, 0.0f), Quat(), Vector3(2, 2, 2));
     ASSERT_NE((void*)0, instance);
 }
 

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -592,6 +592,27 @@ TEST_F(HierarchyTest, TestHierarchyScale)
     dmGameObject::Delete(m_Collection, parent);
 }
 
+TEST_F(HierarchyTest, TestHierarchyNonUniformScale)
+{
+    dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child = dmGameObject::New(m_Collection, "/go.goc");
+
+    const Vector3 scale(4,5,6);
+    dmGameObject::SetScale(parent, scale);
+    dmGameObject::SetPosition(child, Point3(7.0f, 8.0f, 9.0f));
+    dmGameObject::SetParent(child, parent);
+    
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    
+    dmTransform::Transform world = dmGameObject::GetWorldTransform(child);
+    ASSERT_EQ(world.GetScale().getX(), scale.getX());
+    ASSERT_EQ(world.GetScale().getY(), scale.getY());
+    ASSERT_EQ(world.GetScale().getZ(), scale.getZ());
+
+    dmGameObject::Delete(m_Collection, child);
+    dmGameObject::Delete(m_Collection, parent);
+}
+
 TEST_F(HierarchyTest, TestHierarchyInheritScale)
 {
     dmGameObject::HInstance parent = dmGameObject::New(m_Collection, "/go.goc");

--- a/engine/gameobject/src/gameobject/test/message/test_gameobject_message.cpp
+++ b/engine/gameobject/src/gameobject/test/message/test_gameobject_message.cpp
@@ -413,10 +413,10 @@ TEST_F(MessageTest, TestGameObjectTransform)
 
     Vectormath::Aos::Point3 position = dmGameObject::GetPosition(go);
     Vectormath::Aos::Quat rotation = dmGameObject::GetRotation(go);
-    float scale = dmGameObject::GetScale(go);
+    float scale = dmGameObject::GetUniformScale(go);
     Vectormath::Aos::Point3 world_position = dmGameObject::GetWorldPosition(go);
     Vectormath::Aos::Quat world_rotation = dmGameObject::GetWorldRotation(go);
-    float world_scale = dmGameObject::GetWorldScale(go);
+    float world_scale = dmGameObject::GetWorldUniformScale(go);
 
     ASSERT_EQ(position.getX(), context.m_Position.getX());
     ASSERT_EQ(rotation.getX(), context.m_Rotation.getX());

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -212,14 +212,14 @@ TEST_F(PropsTest, PropsSpawn)
     ASSERT_EQ(top, lua_gettop(L));
     ASSERT_LT(0u, size_used);
     ASSERT_LT(size_used, buffer_size);
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/props_spawn.goc", dmHashString64("test_id"), buffer, buffer_size, Point3(0.0f, 0.0f, 0.0f), Quat(0.0f, 0.0f, 0.0f, 1.0f), 1.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/props_spawn.goc", dmHashString64("test_id"), buffer, buffer_size, Point3(0.0f, 0.0f, 0.0f), Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     // Script init is run in spawn which verifies the properties
     ASSERT_NE((void*)0u, instance);
 }
 
 TEST_F(PropsTest, PropsSpawnNoProperties)
 {
-    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/props_go.goc", dmHashString64("test_id"), 0x0, 0, Point3(0.0f, 0.0f, 0.0f), Quat(0.0f, 0.0f, 0.0f, 1.0f), 1.0f);
+    dmGameObject::HInstance instance = dmGameObject::Spawn(m_Collection, "/props_go.goc", dmHashString64("test_id"), 0x0, 0, Point3(0.0f, 0.0f, 0.0f), Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     // Script init is run in spawn which verifies the properties
     ASSERT_NE((void*)0u, instance);
 }
@@ -478,7 +478,7 @@ TEST_F(PropsTest, PropsGetSetScript)
 }
 
 #define ASSERT_SPAWN_FAILS(path)\
-    dmGameObject::HInstance i = dmGameObject::Spawn(m_Collection, path, dmHashString64("id"), (uint8_t*)0x0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), 1.0f);\
+    dmGameObject::HInstance i = dmGameObject::Spawn(m_Collection, path, dmHashString64("id"), (uint8_t*)0x0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));\
     ASSERT_EQ(0, i);
 
 TEST_F(PropsTest, PropsGetBadURL)

--- a/engine/gameobject/src/gameobject/test/script/go1.script
+++ b/engine/gameobject/src/gameobject/test/script/go1.script
@@ -41,7 +41,17 @@ function update(self, dt)
 
         go.set_scale(i, v)
         local s = go.get_scale(v)
+        local sv = go.get_scale_vector(v)
         assert_near(i, s, epsilon)
+        assert_near(i, sv.x, epsilon)
+        assert_near(i, sv.y, epsilon)
+        assert_near(i, sv.z, epsilon)
+
+        go.set_scale(vmath.vector3(2*i,3*i,4*i), v)
+        sv = go.get_scale_vector(v)
+        assert_near(sv.x, 2*i, epsilon)
+        assert_near(sv.y, 3*i, epsilon)
+        assert_near(sv.z, 4*i, epsilon)
     end
 
     msg.post("@system:", "factory", {prototype = "test", pos = vmath.vector3(1, 2, 3)})

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -21,7 +21,7 @@ static int Lua_Spawn(lua_State* L) {
     dmGameObject::HInstance instance = dmGameObject::GetInstanceFromLua(L);
     dmGameObject::HCollection collection = dmGameObject::GetCollection(instance);
     dmhash_t id = dmGameObject::GenerateUniqueInstanceId(collection);
-    dmGameObject::HInstance spawned = dmGameObject::Spawn(collection, prototype, id, 0x0, 0, Vectormath::Aos::Point3(0.0f, 0.0f, 0.0f), Vectormath::Aos::Quat(0.0f, 0.0f, 0.0f, 1.0f), 1.0f);
+    dmGameObject::HInstance spawned = dmGameObject::Spawn(collection, prototype, id, 0x0, 0, Vectormath::Aos::Point3(0.0f, 0.0f, 0.0f), Vectormath::Aos::Quat(0.0f, 0.0f, 0.0f, 1.0f), Vector3(1, 1, 1));
     if (spawned == 0x0) {
         luaL_error(L, "failed to spawn");
         return 1;

--- a/engine/gamesys/proto/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys_ddf.proto
@@ -22,6 +22,7 @@ message Create
     required dmMath.Quat    rotation = 2;
     optional uint64         id       = 3 [default=0];
     optional float          scale    = 4 [default=1];
+    optional dmMath.Vector3 scale3   = 5; // if zero, 'scale' is used instead
 }
 
 message CollectionProxyDesc

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -95,8 +95,20 @@ namespace dmGameSystem
             {
                 id = dmGameObject::GenerateUniqueInstanceId(collection);
             }
+
+            // m_Scale is legacy, so use it if Scale3 is all zeroes
+            Vector3 scale;
+            if (create->m_Scale3.getX() == 0 && create->m_Scale3.getY() == 0 && create->m_Scale3.getZ() == 0)
+            {
+                scale = Vector3(create->m_Scale, create->m_Scale, create->m_Scale);
+            }
+            else
+            {
+                scale = create->m_Scale3;
+            }
+
             dmGameObject::Spawn(collection, fc->m_Resource->m_FactoryDesc->m_Prototype, id, property_buffer, property_buffer_size,
-                    create->m_Position, create->m_Rotation, create->m_Scale);
+                    create->m_Position, create->m_Rotation, scale);
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -118,15 +118,17 @@ namespace dmGameSystem
             Mesh* mesh = model->m_Mesh;
 
             dmRender::RenderObject& ro = component.m_RenderObject;
-            dmTransform::Transform world = dmGameObject::GetWorldTransform(component.m_Instance);
-            dmTransform::Transform local(Vector3(component.m_Position), component.m_Rotation, 1.0f);
+
+            Matrix4 local(component.m_Rotation, Vector3(component.m_Position));
+
+            const Matrix4& go_world = dmGameObject::GetWorldMatrix(component.m_Instance);
             if (dmGameObject::ScaleAlongZ(component.m_Instance))
             {
-                world = dmTransform::Mul(world, local);
+                ro.m_WorldTransform = go_world * local;
             }
             else
             {
-                world = dmTransform::MulNoScaleZ(world, local);
+                ro.m_WorldTransform = dmTransform::MulNoScaleZ(go_world, local);
             }
 
             ro.m_Material = model->m_Material;
@@ -138,7 +140,6 @@ namespace dmGameSystem
             ro.m_VertexStart = 0;
             ro.m_VertexCount = mesh->m_VertexCount;
             ro.m_TextureTransform = Matrix4::identity();
-            ro.m_WorldTransform = dmTransform::ToMatrix4(world);
             dmRender::AddToRender(params.m_Context, &component.m_RenderObject);
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -542,19 +542,16 @@ namespace dmGameSystem
 
             if (c->m_MeshEntry != 0x0)
             {
-                dmTransform::Transform world = dmGameObject::GetWorldTransform(c->m_Instance);
+                const Matrix4& go_world = dmGameObject::GetWorldMatrix(c->m_Instance);
+                const Matrix4 local = dmTransform::ToMatrix4(c->m_Transform);
                 if (dmGameObject::ScaleAlongZ(c->m_Instance))
                 {
-                    world = dmTransform::Mul(world, c->m_Transform);
+                    c->m_World = go_world * local;
                 }
                 else
                 {
-                    world = dmTransform::MulNoScaleZ(world, c->m_Transform);
+                    c->m_World = dmTransform::MulNoScaleZ(go_world, local);
                 }
-                Matrix4 w = dmTransform::ToMatrix4(world);
-                Vector4 position = w.getCol3();
-                w.setCol3(position);
-                c->m_World = w;
             }
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -453,17 +453,19 @@ namespace dmGameSystem
             uint32_t* anim_id = texture_set->m_AnimationIds.Get(c->m_CurrentAnimation);
             if (anim_id)
             {
-                dmTransform::Transform world = dmGameObject::GetWorldTransform(c->m_Instance);
-                dmTransform::Transform local(Vector3(c->m_Position), c->m_Rotation, 1.0f);
+                Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(Vector3(c->m_Position), c->m_Rotation, 1.0f));
+                Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
+                Matrix4 w;
+
                 if (dmGameObject::ScaleAlongZ(c->m_Instance))
                 {
-                    world = dmTransform::Mul(world, local);
+                    w = world * local;
                 }
                 else
                 {
-                    world = dmTransform::MulNoScaleZ(world, local);
+                    w = dmTransform::MulNoScaleZ(world, local);
                 }
-                Matrix4 w = dmTransform::ToMatrix4(world);
+
                 w = appendScale(w, ComputeScaledSize(c));
                 Vector4 position = w.getCol3();
                 if (!sub_pixels)

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -409,8 +409,6 @@ namespace dmGameSystem
 
     static void RenderListDispatch(dmRender::RenderListDispatchParams const &params)
     {
-        TileGridWorld *world = (TileGridWorld *) params.m_UserData;
-
         if (params.m_Operation == dmRender::RENDER_LIST_OPERATION_BATCH)
         {
             assert((params.m_End - params.m_Begin) == 1);
@@ -460,19 +458,16 @@ namespace dmGameSystem
                 continue;
             }
 
-            dmTransform::Transform world = dmGameObject::GetWorldTransform(tile_grid->m_Instance);
-            dmTransform::Transform local(tile_grid->m_Translation, tile_grid->m_Rotation, 1.0f);
-
+            Matrix4 local(tile_grid->m_Rotation, Vector3(tile_grid->m_Translation));
+            const Matrix4& go_world = dmGameObject::GetWorldMatrix(tile_grid->m_Instance);
             if (dmGameObject::ScaleAlongZ(tile_grid->m_Instance))
             {
-                world = dmTransform::Mul(world, local);
+                tile_grid->m_RenderWorldTransform = go_world * local;
             }
             else
             {
-                world = dmTransform::MulNoScaleZ(world, local);
+                tile_grid->m_RenderWorldTransform = dmTransform::MulNoScaleZ(go_world, local);
             }
-
-            tile_grid->m_RenderWorldTransform = dmTransform::ToMatrix4(world);
 
             const Vector4 trans = tile_grid->m_RenderWorldTransform.getCol(3);
             write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());

--- a/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
@@ -50,14 +50,14 @@ namespace dmGameSystem
      * Spawning is instant, but spawned game objects get their first update calls the following frame. The supplied parameters for position, rotation and scale
      * will be applied to the whole collection when spawned.
      *
-     * Script properties in the created game objects can be overridden through 
+     * Script properties in the created game objects can be overridden through
      * a properties-parameter table. The table should contain game object ids
      * (hash) as keys and property tables as values to be used when initiating each
      * spawned game object.
      *
      * See go.property for more information on script properties.
      *
-     * The function returns a table that contains a key for each game object 
+     * The function returns a table that contains a key for each game object
      * id (hash), as addressed if the collection file was top level, and the
      * corresponding spawned instance id (hash) as value with a unique path
      * prefix added to each instance.
@@ -68,7 +68,7 @@ namespace dmGameSystem
      * @param [rotation] rotation to assign to the newly spawned collection (quat)
      * @param [properties] table of script properties to propagate to any new game object instances (table)
      * @param [scale] uniform scaling to apply to the newly spawned collection (must be greater than 0). (number)
-     * @return a table mapping the id:s from the collection to the new instance id:s 
+     * @return a table mapping the id:s from the collection to the new instance id:s
      * @examples
      * <p>
      * How to spawn a collection of game objects:
@@ -82,21 +82,21 @@ namespace dmGameSystem
      *   local props = {}
      *   props[hash("/enemy_leader")] = { health = 1000.0 }
      *   props[hash("/enemy_1")] = { health = 200.0 }
-     *   props[hash("/enemy_2")] = { health = 400.0, color = hash("green") } 
+     *   props[hash("/enemy_2")] = { health = 400.0, color = hash("green") }
      *
      *   local self.enemy_ids = collectionfactory.create("#enemyfactory", pos, rot, props, scale)
      *   -- enemy_ids now map to the spawned instance ids:
      *   --
      *   -- pprint(self.enemy_ids)
      *   --
-     *   -- DEBUG:SCRIPT: 
+     *   -- DEBUG:SCRIPT:
      *   -- {
      *   --   hash: [/enemy_leader] = hash: [/collection0/enemy_leader],
      *   --   hash: [/enemy_1] = hash: [/collection0/enemy_1],
      *   --   hash: [/enemy_2] = hash: [/collection0/enemy_2]
      *   -- }
-     *   
-     *   -- Send "attack" message to the leader. First look up its instance id. 
+     *
+     *   -- Send "attack" message to the leader. First look up its instance id.
      *   local leader_id = self.enemy_ids[hash("/enemy_leader")]
      *   msg.post(leader_id, "attack")
      * end
@@ -180,13 +180,21 @@ namespace dmGameSystem
             }
         }
 
-        float scale;
+        Vector3 scale;
         if (top >= 5 && !lua_isnil(L, 5))
         {
-            scale = luaL_checknumber(L, 5);
-            if (scale <= 0.0f)
+            if (dmScript::IsVector3(L, 5))
             {
-                return luaL_error(L, "The scale supplied to factory.create must be greater than 0.");
+                scale = *dmScript::CheckVector3(L, 5);
+            }
+            else
+            {
+                float val = luaL_checknumber(L, 5);
+                if (val <= 0.0f)
+                {
+                    return luaL_error(L, "The scale supplied to factory.create must be greater than 0.");
+                }
+                scale = Vector3(val, val, val);
             }
         }
         else

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -33,7 +33,7 @@ namespace dmGameSystem
      * @param [position] the position of the new game object, the position of the game object containing the factory is used by default (vector3)
      * @param [rotation] the rotation of the new game object, the rotation of the game object containing the factory is used by default (quat)
      * @param [properties] the properties defined in a script attached to the new game object (table)
-     * @param [scale] the scale of the new game object (must be greater than 0), the scale of the game object containing the factory is used by default (number)
+     * @param [scale] the scale of the new game object (must be greater than 0), the scale of the game object containing the factory is used by default (number or vector3)
      * @return the global id of the spawned game object (hash)
      * @examples
      * <p>
@@ -104,13 +104,22 @@ namespace dmGameSystem
             if (actual_prop_buffer_size > prop_buffer_size)
                 return luaL_error(L, "the properties supplied to factory.create are too many.");
         }
-        float scale;
+
+        Vector3 scale;
         if (top >= 5 && !lua_isnil(L, 5))
         {
-            scale = luaL_checknumber(L, 5);
-            if (scale <= 0.0f)
+            if (dmScript::IsVector3(L, 5))
             {
-                return luaL_error(L, "The scale supplied to factory.create must be greater than 0.");
+                scale = *dmScript::CheckVector3(L, 5);
+            }
+            else
+            {
+                float val = luaL_checknumber(L, 5);
+                if (val <= 0.0f)
+                {
+                    return luaL_error(L, "The scale supplied to factory.create must be greater than 0.");
+                }
+                scale = Vector3(val, val, val);
             }
         }
         else
@@ -124,7 +133,7 @@ namespace dmGameSystem
             create_msg->m_Id = id;
             create_msg->m_Position = position;
             create_msg->m_Rotation = rotation;
-            create_msg->m_Scale = scale;
+            create_msg->m_Scale3 = scale;
             dmMessage::URL sender;
             if (!dmScript::GetURL(L, &sender)) {
                 luaL_error(L, "factory.create can not be called from this script type");


### PR DESCRIPTION
- Added parallell scale3 property for xyz scaling
- Change internal API:s to use Vector3
- Update collection builder to transfer scaling to scale3 property
- Update loading/saving code to load both but always save scale3
- Change world transforms to be Matrix4
- Add functionality to dlib for NoScaleZ related transformation
- New scaling manipulator for editor
