### PR TITLE
DEF-1030 - Render order bug between spine and sprites

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_spine_model.h
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.h
@@ -17,8 +17,8 @@ namespace dmGameSystem
         struct
         {
             uint64_t m_Index : 16;  // Index is used to ensure stable sort
-            uint64_t m_MixedHash : 32;
             uint64_t m_Z : 16; // Quantified relative z
+            uint64_t m_MixedHash : 32;
         };
         uint64_t     m_Key;
     };


### PR DESCRIPTION
- Fixes batch breaking when it should not, to avoid inconsistencies.
