### PR TITLE
DEF-1050: Collections spawned from factories gets collision shapes wrong

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -946,6 +946,9 @@ namespace dmGameObject
                 {
                     new_instances[i]->m_Transform = dmTransform::Mul(transform, new_instances[i]->m_Transform);
                 }
+
+                // world transforms need to be up to date in time for the script init calls
+                collection->m_WorldTransforms[new_instances[i]->m_Index] = new_instances[i]->m_Transform;
             }
         }
 


### PR DESCRIPTION
- Update world transform table before calling init functions
