### PR TITLE
Crash fix:

### DIFF
--- a/engine/iap/src/iap_ios.mm
+++ b/engine/iap/src/iap_ios.mm
@@ -60,6 +60,7 @@ static void PushError(lua_State*L, NSError* error)
 
 @interface SKProductsRequestDelegate : NSObject<SKProductsRequestDelegate>
     @property lua_State* m_LuaState;
+    @property (assign) SKProductsRequest* m_Request;
 @end
 
 @implementation SKProductsRequestDelegate
@@ -140,7 +141,6 @@ static void PushError(lua_State*L, NSError* error)
     g_IAP.m_Self = LUA_NOREF;
 
     assert(top == lua_gettop(L));
-    [self release];
 }
 
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error{
@@ -184,6 +184,11 @@ static void PushError(lua_State*L, NSError* error)
     g_IAP.m_Self = LUA_NOREF;
 
     assert(top == lua_gettop(L));
+}
+
+- (void)requestDidFinish:(SKRequest *)request
+{
+    [self.m_Request release];
     [self release];
 }
 
@@ -355,6 +360,7 @@ int IAP_List(lua_State* L)
     SKProductsRequest* products_request = [[SKProductsRequest alloc] initWithProductIdentifiers: product_identifiers];
     SKProductsRequestDelegate* delegate = [SKProductsRequestDelegate alloc];
     delegate.m_LuaState = dmScript::GetMainThread(L);
+    delegate.m_Request = products_request;
     products_request.delegate = delegate;
     [products_request start];
 


### PR DESCRIPTION
- Implement requestDidFinish for iap product request, where both delegate
  and request are released.

Fixes crash caused by OS calling requestDidFinish on released delegate
