### PR TITLE
- DEF-1077: Pie-node related crash

### DIFF
--- a/engine/engine/src/test/def-1077/def-1077.collection
+++ b/engine/engine/src/test/def-1077/def-1077.collection
@@ -1,0 +1,16 @@
+name: "main"
+instances {
+  id: "main"
+  prototype: "/def-1077/def-1077.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/engine/src/test/def-1077/def-1077.go
+++ b/engine/engine/src/test/def-1077/def-1077.go
@@ -1,0 +1,4 @@
+components {
+  id: "gui"
+  component: "/def-1077/def-1077.gui"
+}

--- a/engine/engine/src/test/def-1077/def-1077.gui
+++ b/engine/engine/src/test/def-1077/def-1077.gui
@@ -1,0 +1,38 @@
+script: "/def-1077/def-1077.gui_script"
+nodes {
+  position { 
+	x:0
+	y:0
+	z:0
+	w:0 
+  }
+  rotation { 
+	x:0
+	y:0
+	z:0
+	w:0
+  }
+  scale { 
+	x:1
+	y:1
+	z:1
+	w:0 
+  }
+  size { 
+	x:100
+	y:100
+	z:0
+	w:1 
+  }
+  color { 
+	x:1
+	y:1
+	z:1
+	w:1 
+  }
+  type: TYPE_PIE
+  outerBounds: PIEBOUNDS_RECTANGLE
+  pieFillAngle: 360
+  perimeterVertices: 251
+  id: "pie1"
+}

--- a/engine/engine/src/test/def-1077/def-1077.gui_script
+++ b/engine/engine/src/test/def-1077/def-1077.gui_script
@@ -1,0 +1,4 @@
+function update(self)
+    msg.post("@system:", "exit", {code = 0})
+end
+

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -157,6 +157,14 @@ TEST_F(EngineTest, DEF_841)
     ASSERT_EQ(0, dmEngine::Launch(3, (char**)argv, 0, 0, 0));
 }
 
+TEST_F(EngineTest, DEF_1077)
+{
+    // DEF-1077: Crash triggered by gui scene containing a fully filled pie node with rectangular bounds that precisely fills up the remaining
+    //           capacity in the vertex buffer, fails to allocate memory.
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/def-1077/def-1077.collectionc", CONTENT_ROOT "/game.projectc"};
+    ASSERT_EQ(0, dmEngine::Launch(3, (char**)argv, 0, 0, 0));
+}
+
 TEST_F(EngineTest, SpineAnim)
 {
     const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/spine_anim/spine.collectionc", CONTENT_ROOT "/game.projectc"};


### PR DESCRIPTION
- Added test that requires precisely 2 more vertices than available in the
  vertex buffer
