### PR TITLE
DEF-878 - Async engine service update

### DIFF
--- a/engine/dlib/src/dlib/socket.cpp
+++ b/engine/dlib/src/dlib/socket.cpp
@@ -120,6 +120,16 @@ namespace dmSocket
         return RESULT_OK;
     }
 
+    Result SetMulticastIf(Socket socket, Address address)
+    {
+        struct in_addr if_addr;
+        if_addr.s_addr = htonl(address);
+        int ret = setsockopt(socket, IPPROTO_IP, IP_MULTICAST_IF, &if_addr, sizeof(if_addr));
+        if (ret != 0)
+            return NativeToResult(DM_SOCKET_ERRNO);
+        return RESULT_OK;
+    }
+
     Result Delete(Socket socket)
     {
 #if defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__) || defined(__AVM2__)
@@ -528,11 +538,11 @@ namespace dmSocket
     static Result SetSockoptTime(Socket socket, int level, int name, uint64_t time)
     {
 #ifdef WIN32
-		DWORD timeval = time / 1000;
-		if (time > 0 && timeval == 0) {
-		    dmLogWarning("Socket timeout requested less than 1ms. Timeout set to 1ms.");
-		    timeval = 1;
-		}
+        DWORD timeval = time / 1000;
+        if (time > 0 && timeval == 0) {
+            dmLogWarning("Socket timeout requested less than 1ms. Timeout set to 1ms.");
+            timeval = 1;
+        }
 #else
         struct timeval timeval;
         timeval.tv_sec = time / 1000000;

--- a/engine/dlib/src/dlib/socket.h
+++ b/engine/dlib/src/dlib/socket.h
@@ -263,6 +263,14 @@ namespace dmSocket
     Result AddMembership(Socket socket, Address multi_addr, Address interface_addr, int ttl);
 
     /**
+     * Set address for outgoing multicast datagrams
+     * @param socket socket to set multicast address for
+     * @param address address of network interface to use
+     * @return RESULT_OK
+     */
+    Result SetMulticastIf(Socket socket, Address address);
+
+    /**
      * Accept a connection on a socket
      * @param socket Socket to accept connections on
      * @param address Result address parameter

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <algorithm>
+#include <string.h>
+
 #include "ssdp.h"
 
 #include "array.h"
@@ -62,11 +65,19 @@ namespace dmSSDP
         "ST: upnp:rootdevice\r\n\r\n";
 
     const uint32_t SSDP_LOCAL_ADDRESS_EXPIRATION = 4U;
+    const uint32_t SSDP_MAX_LOCAL_ADDRESSES = 32U;
 
     struct Device
     {
         // Only available for registered devices
         const DeviceDesc*   m_DeviceDesc;
+
+        struct IfAddrState {
+            uint64_t m_Expires;
+            dmSocket::Address m_Address;
+        } m_IfAddrState[SSDP_MAX_LOCAL_ADDRESSES];
+
+        uint32_t m_IfAddrStateCount;
 
         // Time when the device expires
         // For registered devices: a notification should be sent
@@ -95,7 +106,6 @@ namespace dmSSDP
             memset(this, 0, sizeof(*this));
             m_DiscoveredDevices.SetCapacity(983, 1024);
             m_RegistredEntries.SetCapacity(17, 32);
-            m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
             m_MCastSocket = dmSocket::INVALID_SOCKET_HANDLE;
         }
 
@@ -121,19 +131,21 @@ namespace dmSSDP
         // All registered devices
         dmHashTable64<Device*>  m_RegistredEntries;
 
-        // Socket for unicast send/receive and for multicast send
-        dmSocket::Socket        m_Socket;
         // Port for m_Socket
         uint16_t                m_Port;
 
         // Socket for multicast receive
         dmSocket::Socket        m_MCastSocket;
 
-        // Hostname (local) in ip-format (x.y.z.w)
-        char                    m_Hostname[32];
-        // Local IP Address
-        dmSocket::Address       m_Address;
-        uint64_t                m_AddressExpires;
+        // Addresses & sockets for each available network address.
+        // Mutex lock is held during Update() calls and from addr. update thread.
+        dmSocket::IfAddr        m_LocalAddr[SSDP_MAX_LOCAL_ADDRESSES];
+        dmSocket::Socket        m_LocalAddrSocket[SSDP_MAX_LOCAL_ADDRESSES];
+        uint32_t                m_LocalAddrCount;
+        uint64_t                m_LocalAddrExpires;
+
+        // Hostname for the current request being processed.
+        char                    m_HttpHost[64];
 
         // Http server for device descriptions
         dmHttpServer::HServer   m_HttpServer;
@@ -240,15 +252,33 @@ namespace dmSSDP
         }
     };
 
+    static const char* ReplaceIfAddrVar(void *user_data, const char *key)
+    {
+        static char tmp[32];
+        dmSocket::Address saddr = *((dmSocket::Address*) user_data);
+        if (strcmp(key, "HOSTNAME") == 0)
+        {
+            DM_SNPRINTF(tmp, sizeof(tmp), "%u.%u.%u.%u", (saddr >> 24) & 0xff, (saddr >> 16) & 0xff, (saddr >> 8) & 0xff, (saddr >> 0) & 0xff);
+            return tmp;
+        }
+        return 0;
+    }
+
+    static const char* ReplaceHttpHostVar(void *user_data, const char *key)
+    {
+        SSDP* ssdp = (SSDP*) user_data;
+        if (strcmp(key, "HTTP-HOST") == 0)
+        {
+            return ssdp->m_HttpHost;
+        }
+        return 0;
+    }
+
     static const char* ReplaceSSDPVar(void* user_data, const char* key)
     {
         SSDP* ssdp = (SSDP*) user_data;
 
-        if (strcmp(key, "HOSTNAME") == 0)
-        {
-            return ssdp->m_Hostname;
-        }
-        else if (strcmp(key, "HTTPPORT") == 0)
+        if (strcmp(key, "HTTPPORT") == 0)
         {
             return ssdp->m_HttpPortText;
         }
@@ -316,6 +346,108 @@ bail:
         return dmSocket::INVALID_SOCKET_HANDLE;
     }
 
+
+    static bool AddressSortPred(dmSocket::IfAddr const &a, dmSocket::IfAddr const &b)
+    {
+        return a.m_Address < b.m_Address;
+    }
+
+    // Internally used only; clean up the LocalAddrSocket entry at index 'slot'
+    static void DestroyListeningSocket(SSDP *ssdp, uint32_t slot)
+    {
+        if (ssdp->m_LocalAddrSocket[slot] != dmSocket::INVALID_SOCKET_HANDLE)
+        {
+            const uint32_t la = ssdp->m_LocalAddr[slot].m_Address;
+            dmLogInfo("SSDP: Done on address %u.%u.%u.%u", (la >> 24) & 0xff, (la >> 16) & 0xff, (la >> 8) & 0xff, (la >> 0) & 0xff);
+            dmSocket::Delete(ssdp->m_LocalAddrSocket[slot]);
+        }
+    }
+
+    // Make sure we have sockets bound to all local if addresses
+    static void UpdateListeningSockets(SSDP *ssdp, dmSocket::IfAddr *if_addr, uint32_t if_addr_count)
+    {
+        dmSocket::Socket new_socket[SSDP_MAX_LOCAL_ADDRESSES];
+
+        // Here, the new list of network addresses is compared with the new list provide with the if_addr* argumenst.
+        // Both lists are sorted by address, and the loop compares them side by side to detect
+        // 1) Addresses that are no longer present (=> destroy socket)
+        // 2) Addresses that are still here (=> keep socket)
+        // 3) Addresses that are new (=> new socket)
+        uint32_t j=0;
+        for (uint32_t i=0;i!=if_addr_count;i++)
+        {
+            // i = new list idx, j = old list idx
+            const dmSocket::Address addr = if_addr[i].m_Address;
+
+            // Skip past all non-matching entries (that must have been destroyed)
+            while (j < ssdp->m_LocalAddrCount && ssdp->m_LocalAddr[j].m_Address < addr)
+            {
+                DestroyListeningSocket(ssdp, j++);
+            }
+
+            // If matches address and the socket is valid, keep it. Otherwise make a new.
+            if (j < ssdp->m_LocalAddrCount && ssdp->m_LocalAddr[j].m_Address == addr && ssdp->m_LocalAddrSocket[j] != dmSocket::INVALID_SOCKET_HANDLE)
+            {
+                new_socket[i] = ssdp->m_LocalAddrSocket[j];
+                j++;
+            }
+            else
+            {
+                new_socket[i] = dmSocket::INVALID_SOCKET_HANDLE;
+
+                dmSocket::Socket s = NewSocket();
+                if (s == dmSocket::INVALID_SOCKET_HANDLE)
+                    continue;
+
+                if (dmSocket::RESULT_OK != dmSocket::SetMulticastIf(s, addr))
+                {
+                    dmSocket::Delete(s);
+                    continue;
+                }
+
+                if (dmSocket::RESULT_OK != dmSocket::Bind(s, addr, 0))
+                {
+                    dmSocket::Delete(s);
+                    continue;
+                }
+
+                uint32_t la = addr;
+                dmLogInfo("SSDP: Started on address %u.%u.%u.%u", (la >> 24) & 0xff, (la >> 16) & 0xff, (la >> 8) & 0xff, (la >> 0) & 0xff);
+                new_socket[i] = s;
+            }
+        }
+
+        // Cleanup remaining unused
+        while (j < ssdp->m_LocalAddrCount)
+        {
+            DestroyListeningSocket(ssdp, j++);
+        }
+
+        // The temporary list of new_socket becomes the new list.
+        ssdp->m_LocalAddrCount = if_addr_count;
+        memcpy(ssdp->m_LocalAddr, if_addr, sizeof(dmSocket::IfAddr) * if_addr_count);
+        memcpy(ssdp->m_LocalAddrSocket, new_socket, sizeof(dmSocket::Socket) * if_addr_count);
+    }
+
+    static void HttpHeader(void* user_data, const char* key, const char* value)
+    {
+        // Catch the 'Host' header value to know through what address the client
+        // is connecting using. This same host will be used as replace var to
+        // provide a matching address.
+        SSDP* ssdp = (SSDP*) user_data;
+        if (!dmStrCaseCmp(key, "Host"))
+        {
+            dmStrlCpy(ssdp->m_HttpHost, value, sizeof(ssdp->m_HttpHost));
+
+            // Strip possible port number included here
+            char *delim = strchr(ssdp->m_HttpHost, ':');
+            if (delim)
+            {
+                *delim = 0;
+            }
+        }
+    }
+
     static void HttpResponse(void* user_data, const dmHttpServer::Request* request)
     {
         SSDP* ssdp = (SSDP*) user_data;
@@ -340,18 +472,22 @@ bail:
             return;
         }
 
-        const char* device_desc = (*device)->m_DeviceDesc->m_DeviceDescription;
-        dmHttpServer::Send(request, device_desc, strlen(device_desc));
+        char buffer[1024];
+        Replacer replacer(0, ssdp, ReplaceHttpHostVar);
+        dmTemplate::Result tr = dmTemplate::Format(&replacer, buffer, sizeof(buffer), (*device)->m_DeviceDesc->m_DeviceDescription, Replacer::Replace);
+        if (tr != dmTemplate::RESULT_OK)
+        {
+            dmLogError("Error formating http response (%d)", tr);
+            const char *s = "Internal error";
+            dmHttpServer::Send(request, s, strlen(s));
+            return;
+        }
+
+        dmHttpServer::Send(request, buffer, strlen(buffer));
     }
 
     static void Disconnect(SSDP* ssdp)
     {
-        if (ssdp->m_Socket != dmSocket::INVALID_SOCKET_HANDLE)
-        {
-            dmSocket::Delete(ssdp->m_Socket);
-            ssdp->m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
-        }
-
         if (ssdp->m_MCastSocket != dmSocket::INVALID_SOCKET_HANDLE)
         {
             dmSocket::Delete(ssdp->m_MCastSocket);
@@ -363,49 +499,27 @@ bail:
     {
         Disconnect(ssdp);
 
-        dmSocket::Socket sock = dmSocket::INVALID_SOCKET_HANDLE;
         dmSocket::Socket mcast_sock = dmSocket::INVALID_SOCKET_HANDLE;
         dmSocket::Result sr;
-        dmSocket::Address address;
-
-        sr = dmSocket::GetLocalAddress(&address);
-        if (sr != dmSocket::RESULT_OK) goto bail;
-
-        sock = NewSocket();
-        if (sock == dmSocket::INVALID_SOCKET_HANDLE) goto bail;
-        sr = dmSocket::Bind(sock, 0, 0);
-        if (sr != dmSocket::RESULT_OK) goto bail;
-        dmSocket::Address sock_addr;
-        uint16_t sock_port;
-        sr = dmSocket::GetName(sock, &sock_addr, &sock_port);
-        if (sr != dmSocket::RESULT_OK) goto bail;
 
         mcast_sock = NewSocket();
         if (mcast_sock == dmSocket::INVALID_SOCKET_HANDLE) goto bail;
         sr = dmSocket::Bind(mcast_sock, 0, SSDP_MCAST_PORT);
         if (sr != dmSocket::RESULT_OK) goto bail;
-
         sr = dmSocket::AddMembership(mcast_sock,
-                                    dmSocket::AddressFromIPString(SSDP_MCAST_ADDR),
-                                    0,
-                                    SSDP_MCAST_TTL);
+                                     dmSocket::AddressFromIPString(SSDP_MCAST_ADDR),
+                                     0,
+                                     SSDP_MCAST_TTL);
 
         if (sr != dmSocket::RESULT_OK)
         {
             dmLogError("Unable to add broadcast membership for ssdp socket. No network connection? (%d)", sr);
         }
 
-        ssdp->m_Socket = sock;
-        ssdp->m_Address = address;
-        ssdp->m_Port = sock_port;
         ssdp->m_MCastSocket = mcast_sock;
-
         return RESULT_OK;
 
 bail:
-        if (sock != dmSocket::INVALID_SOCKET_HANDLE)
-            dmSocket::Delete(sock);
-
         if (mcast_sock != dmSocket::INVALID_SOCKET_HANDLE)
             dmSocket::Delete(mcast_sock);
 
@@ -434,11 +548,10 @@ bail:
         DM_SNPRINTF(ssdp->m_MaxAgeText, sizeof(ssdp->m_MaxAgeText), "%u", params->m_MaxAge);
         ssdp->m_Announce = params->m_Announce;
         ssdp->m_AnnounceInterval = params->m_AnnounceInterval;
-        ssdp->m_AddressExpires = dmTime::GetTime() + SSDP_LOCAL_ADDRESS_EXPIRATION * uint64_t(1000000U);
 
         *hssdp = ssdp;
 
-        http_params.m_HttpHeader = 0;
+        http_params.m_HttpHeader = HttpHeader;
         http_params.m_HttpResponse = HttpResponse;
         http_params.m_Userdata = ssdp;
         hsr = dmHttpServer::New(&http_params, 0, &http_server);
@@ -452,18 +565,6 @@ bail:
         dmHttpServer::GetName(http_server, &http_address, &http_port);
 
         DM_SNPRINTF(ssdp->m_HttpPortText, sizeof(ssdp->m_HttpPortText), "%u", http_port);
-
-        DM_SNPRINTF(ssdp->m_Hostname, sizeof(ssdp->m_Hostname), "%u.%u.%u.%u",
-                (ssdp->m_Address >> 24) & 0xff, (ssdp->m_Address >> 16) & 0xff, (ssdp->m_Address >> 8) & 0xff, (ssdp->m_Address >> 0) & 0xff);
-
-        dmLogInfo("SSDP started (ssdp://%s:%u, http://%u.%u.%u.%u:%u)",
-                ssdp->m_Hostname,
-                ssdp->m_Port,
-                (http_address >> 24) & 0xff,
-                (http_address >> 16) & 0xff,
-                (http_address >> 8) & 0xff,
-                (http_address >> 0) & 0xff,
-                http_port);
 
         return RESULT_OK;
 
@@ -480,18 +581,22 @@ bail:
 
     Result Delete(HSSDP ssdp)
     {
+        UpdateListeningSockets(ssdp, 0, 0);
         dmHttpServer::Delete(ssdp->m_HttpServer);
         Disconnect(ssdp);
         delete ssdp;
         return RESULT_OK;
     }
 
-    static void SendAnnounce(HSSDP ssdp, Device* device)
+    static void SendAnnounce(HSSDP ssdp, Device* device, uint32_t interface)
     {
-        dmLogDebug("SSDP Announcing '%s'", device->m_DeviceDesc->m_Id);
+        assert(interface < ssdp->m_LocalAddrCount);
+        dmLogDebug("SSDP Announcing '%s' on interface %s", device->m_DeviceDesc->m_Id, ssdp->m_LocalAddr[interface].m_Name);
         Replacer replacer1(0, device, ReplaceDeviceVar);
         Replacer replacer2(&replacer1, ssdp, ReplaceSSDPVar);
-        dmTemplate::Result tr = dmTemplate::Format(&replacer2, (char*) ssdp->m_Buffer, sizeof(ssdp->m_Buffer), SSDP_ALIVE_TMPL, Replacer::Replace);
+        Replacer replacer3(&replacer2, &ssdp->m_LocalAddr[interface].m_Address, ReplaceIfAddrVar);
+
+        dmTemplate::Result tr = dmTemplate::Format(&replacer3, (char*) ssdp->m_Buffer, sizeof(ssdp->m_Buffer), SSDP_ALIVE_TMPL, Replacer::Replace);
         if (tr != dmTemplate::RESULT_OK)
         {
             dmLogError("Error formating announce message (%d)", tr);
@@ -499,14 +604,14 @@ bail:
         }
 
         int sent_bytes;
-        dmSocket::Result sr = dmSocket::SendTo(ssdp->m_Socket, ssdp->m_Buffer, strlen((char*) ssdp->m_Buffer), &sent_bytes, dmSocket::AddressFromIPString(SSDP_MCAST_ADDR), SSDP_MCAST_PORT);
+        dmSocket::Result sr = dmSocket::SendTo(ssdp->m_LocalAddrSocket[interface], ssdp->m_Buffer, strlen((char*) ssdp->m_Buffer), &sent_bytes, dmSocket::AddressFromIPString(SSDP_MCAST_ADDR), SSDP_MCAST_PORT);
         if (sr != dmSocket::RESULT_OK)
         {
             dmLogWarning("Failed to send announce message (%d)", sr);
         }
     }
 
-    static void SendUnannounce(HSSDP ssdp, Device* device)
+    static void SendUnannounce(HSSDP ssdp, Device* device, uint32_t interface)
     {
         Replacer replacer(0, device, ReplaceDeviceVar);
         dmTemplate::Result tr = dmTemplate::Format(&replacer, (char*) ssdp->m_Buffer, sizeof(ssdp->m_Buffer), SSDP_BYEBYE_TMPL, Replacer::Replace);
@@ -517,7 +622,7 @@ bail:
         }
 
         int sent_bytes;
-        dmSocket::Result sr = dmSocket::SendTo(ssdp->m_Socket, ssdp->m_Buffer, strlen((char*) ssdp->m_Buffer), &sent_bytes, dmSocket::AddressFromIPString(SSDP_MCAST_ADDR), SSDP_MCAST_PORT);
+        dmSocket::Result sr = dmSocket::SendTo(ssdp->m_LocalAddrSocket[interface], ssdp->m_Buffer, strlen((char*) ssdp->m_Buffer), &sent_bytes, dmSocket::AddressFromIPString(SSDP_MCAST_ADDR), SSDP_MCAST_PORT);
         if (sr != dmSocket::RESULT_OK)
         {
             dmLogWarning("Failed to send unannounce message (%d)", sr);
@@ -553,7 +658,12 @@ bail:
         }
 
         Device** d  = ssdp->m_RegistredEntries.Get(id_hash);
-        SendUnannounce(ssdp, *d);
+
+        for (uint32_t i=0;i!=ssdp->m_LocalAddrCount;i++)
+        {
+            if (ssdp->m_LocalAddrSocket[i] != dmSocket::INVALID_SOCKET_HANDLE)
+                SendUnannounce(ssdp, *d, i);
+        }
         delete *d;
         ssdp->m_RegistredEntries.Erase(id_hash);
         dmLogDebug("SSDP device '%s' deregistered", id);
@@ -676,17 +786,42 @@ bail:
 
     static void SearchCallback(SearchResponseContext* ctx, const dmhash_t* key, Device** device)
     {
-        dmLogDebug("Sending search response: %s", (*device)->m_DeviceDesc->m_UDN);
-
         if (strcmp(ctx->m_ST, (*device)->m_DeviceDesc->m_DeviceType) != 0) {
             return;
         }
 
         SSDP* ssdp = ctx->m_State->m_SSDP;
+
+        // To know which socket to use for the response, pick the one with the highest
+        // number of matching bits. Ideally, netmask would be available to make a correct
+        // decision, but it is unfortunately not so easy to read out on all platforms.
+        dmSocket::Address local_address = 0;
+        dmSocket::Socket output_socket = dmSocket::INVALID_SOCKET_HANDLE;
+        uint32_t best_match_value = ~0;
+        for (uint32_t i=0;i!=ssdp->m_LocalAddrCount;i++)
+        {
+            uint32_t non_matching_bits = ssdp->m_LocalAddr[i].m_Address ^ ctx->m_FromAddress;
+            if (i == 0 || non_matching_bits < best_match_value)
+            {
+                best_match_value = non_matching_bits;
+                local_address = ssdp->m_LocalAddr[i].m_Address;
+                output_socket = ssdp->m_LocalAddrSocket[i];
+            }
+        }
+
+        if (output_socket == dmSocket::INVALID_SOCKET_HANDLE)
+        {
+            dmLogError("No output socket available for ssdp search response");
+            return;
+        }
+
+        dmLogDebug("Sending search response: %s", (*device)->m_DeviceDesc->m_UDN);
+
         Replacer replacer1(0, *device, ReplaceDeviceVar);
         Replacer replacer2(&replacer1, ctx, ReplaceSearchResponseVar);
         Replacer replacer3(&replacer2, ssdp, ReplaceSSDPVar);
-        dmTemplate::Result tr = dmTemplate::Format(&replacer3, (char*) ssdp->m_Buffer, sizeof(ssdp->m_Buffer), SEARCH_RESULT_FMT, Replacer::Replace);
+        Replacer replacer4(&replacer3, &local_address, ReplaceIfAddrVar);
+        dmTemplate::Result tr = dmTemplate::Format(&replacer4, (char*) ssdp->m_Buffer, sizeof(ssdp->m_Buffer), SEARCH_RESULT_FMT, Replacer::Replace);
         if (tr != dmTemplate::RESULT_OK)
         {
             dmLogError("Error formating search response message (%d)", tr);
@@ -694,7 +829,7 @@ bail:
         }
 
         int sent_bytes;
-        dmSocket::SendTo(ssdp->m_Socket, ssdp->m_Buffer, strlen((char*) ssdp->m_Buffer), &sent_bytes, ctx->m_FromAddress, ctx->m_FromPort);
+        dmSocket::SendTo(output_socket, ssdp->m_Buffer, strlen((char*) ssdp->m_Buffer), &sent_bytes, ctx->m_FromAddress, ctx->m_FromPort);
     }
 
     static void HandleSearch(RequestParseState* state, dmSocket::Address from_address, uint16_t from_port)
@@ -765,13 +900,6 @@ bail:
         uint8_t comps[4];
         comps[0] = (from_addr >> 24) & 0xff; comps[1] = (from_addr >> 16) & 0xff;
         comps[2] = (from_addr >> 8) & 0xff; comps[3] = (from_addr >> 0) & 0xff;
-
-        if (from_addr == ssdp->m_Address && from_port == ssdp->m_Port)
-        {
-            dmLogDebug("Ignoring package from self (%u.%u.%u.%u:%d)", comps[0],comps[1],comps[2],comps[3], from_port);
-            return true;
-        }
-
         dmLogDebug("Multicast SSDP message from %u.%u.%u.%u:%d", comps[0],comps[1],comps[2],comps[3], from_port);
 
         RequestParseState state(ssdp);
@@ -868,11 +996,46 @@ bail:
 
     static void VisitRegistredAnnounceDevice(SSDP* ssdp, const dmhash_t* key, Device** device)
     {
-        uint64_t now = dmTime::GetTime();
-        if (now >= (*device)->m_Expires)
+        const uint64_t now = dmTime::GetTime();
+        const uint64_t next = now + ssdp->m_AnnounceInterval * uint64_t(1000000);
+        Device *dev = *device;
+
+        // Each device keeps a list of the interface address states; address and timeout. It is a sorted
+        // list and so is m_LocalAddrs, so side-by-side comparison allows easy matching with the sockes
+        // and addresses in m_LocalAddr.
+        uint64_t new_expires[SSDP_MAX_LOCAL_ADDRESSES];
+        for (uint32_t i=0,j=0;i!=ssdp->m_LocalAddrCount;i++)
         {
-            SendAnnounce(ssdp, *device);
-            (*device)->m_Expires = now + ssdp->m_AnnounceInterval * 1000000;
+            while (j < dev->m_IfAddrStateCount && dev->m_IfAddrState[j].m_Address < ssdp->m_LocalAddr[i].m_Address)
+                ++j;
+
+            if (j < dev->m_IfAddrStateCount && dev->m_IfAddrState[j].m_Address == ssdp->m_LocalAddr[i].m_Address)
+            {
+                // Found previous expiry time for this interface
+                new_expires[i] = dev->m_IfAddrState[j++].m_Expires;
+            }
+            else
+            {
+                // This address has no expiry time (new interface), send right away
+                new_expires[i] = now;
+            }
+        }
+
+        // Send announces on all interfaces.
+        dev->m_IfAddrStateCount = ssdp->m_LocalAddrCount;
+        for (uint32_t i=0;i!=ssdp->m_LocalAddrCount;i++)
+        {
+            Device::IfAddrState *dst = &dev->m_IfAddrState[i];
+            dst->m_Address = ssdp->m_LocalAddr[i].m_Address;
+            if (new_expires[i] <= now)
+            {
+                SendAnnounce(ssdp, dev, i);
+                dst->m_Expires = next;
+            }
+            else
+            {
+                dst->m_Expires = new_expires[i];
+            }
         }
     }
 
@@ -890,21 +1053,29 @@ bail:
             ssdp->m_Reconnect = 0;
         }
 
-        dmSocket::Address address;
-
-        uint64_t current_time = dmTime::GetTime();
-        if (current_time > ssdp->m_AddressExpires)
+        const uint64_t now = dmTime::GetTime();
+        if (now > ssdp->m_LocalAddrExpires)
         {
-            dmLogDebug("Update SSDP address");
-            // Update address. It might have change. 3G -> wifi etc
-            if (dmSocket::GetLocalAddress(&address) == dmSocket::RESULT_OK)
-            {
-                ssdp->m_Address = address;
-            }
-            ssdp->m_AddressExpires = current_time + SSDP_LOCAL_ADDRESS_EXPIRATION * uint64_t(1000000U);
+            // Grab a sorted list of network addresses, with all the wildcard addresses (0) removed
+            // and make sure there are sockets for each of these
+            ssdp->m_LocalAddrExpires = now + SSDP_LOCAL_ADDRESS_EXPIRATION * uint64_t(1000000);
+
+            uint32_t if_addr_count;
+            dmSocket::IfAddr if_addr[SSDP_MAX_LOCAL_ADDRESSES];
+            dmSocket::GetIfAddresses(if_addr, SSDP_MAX_LOCAL_ADDRESSES, &if_addr_count);
+            std::sort(if_addr, if_addr + if_addr_count, AddressSortPred);
+
+            // Remove zeroes which are all at the starts
+            dmSocket::IfAddr *begin = &if_addr[0];
+            dmSocket::IfAddr *end = begin + if_addr_count;
+            while (begin < end && !begin->m_Address)
+                ++begin;
+
+            UpdateListeningSockets(ssdp, begin, end - begin);
         }
 
         ExpireDiscovered(ssdp);
+
         if (ssdp->m_Announce)
         {
             AnnounceRegistred(ssdp);
@@ -919,7 +1090,11 @@ bail:
             dmSocket::Selector selector;
             dmSocket::SelectorZero(&selector);
             dmSocket::SelectorSet(&selector, dmSocket::SELECTOR_KIND_READ, ssdp->m_MCastSocket);
-            dmSocket::SelectorSet(&selector, dmSocket::SELECTOR_KIND_READ, ssdp->m_Socket);
+            for (uint32_t i=0;i<ssdp->m_LocalAddrCount;i++)
+            {
+                if (ssdp->m_LocalAddrSocket[i] != dmSocket::INVALID_SOCKET_HANDLE)
+                    dmSocket::SelectorSet(&selector, dmSocket::SELECTOR_KIND_READ, ssdp->m_LocalAddrSocket[i]);
+            }
             dmSocket::Select(&selector, 0);
 
             if (dmSocket::SelectorIsSet(&selector, dmSocket::SELECTOR_KIND_READ, ssdp->m_MCastSocket))
@@ -933,34 +1108,41 @@ bail:
                     ssdp->m_Reconnect = 1;
                 }
             }
-            if (dmSocket::SelectorIsSet(&selector, dmSocket::SELECTOR_KIND_READ, ssdp->m_Socket))
+
+            for (uint32_t i=0;i<ssdp->m_LocalAddrCount;i++)
             {
-                if (DispatchSocket(ssdp, ssdp->m_Socket, true))
+                if (ssdp->m_LocalAddrSocket[i] == dmSocket::INVALID_SOCKET_HANDLE)
+                    continue;
+
+                if (dmSocket::SelectorIsSet(&selector, dmSocket::SELECTOR_KIND_READ, ssdp->m_LocalAddrSocket[i]))
                 {
-                    incoming_data = true;
-                }
-                else
-                {
-                    ssdp->m_Reconnect = 1;
+                    if (DispatchSocket(ssdp, ssdp->m_LocalAddrSocket[i], true))
+                        incoming_data = true;
                 }
             }
         } while (incoming_data);
 
         if (search)
         {
-            int sent_bytes;
-            dmSocket::Result sr;
-            sr = dmSocket::SendTo(ssdp->m_Socket,
-                             M_SEARCH_FMT,
-                             strlen(M_SEARCH_FMT),
-                             &sent_bytes,
-                             dmSocket::AddressFromIPString(SSDP_MCAST_ADDR),
-                             SSDP_MCAST_PORT);
-
-            dmLogDebug("SSDP M-SEARCH");
-            if (sr != dmSocket::RESULT_OK)
+            for (uint32_t i=0;i!=ssdp->m_LocalAddrCount;i++)
             {
-                dmLogWarning("Failed to send SSDP search package (%d)", sr);
+                if (ssdp->m_LocalAddrSocket[i] == dmSocket::INVALID_SOCKET_HANDLE)
+                    continue;
+
+                int sent_bytes;
+                dmSocket::Result sr;
+                sr = dmSocket::SendTo(ssdp->m_LocalAddrSocket[i],
+                                 M_SEARCH_FMT,
+                                 strlen(M_SEARCH_FMT),
+                                 &sent_bytes,
+                                 dmSocket::AddressFromIPString(SSDP_MCAST_ADDR),
+                                 SSDP_MCAST_PORT);
+
+                dmLogDebug("SSDP M-SEARCH");
+                if (sr != dmSocket::RESULT_OK)
+                {
+                    dmLogWarning("Failed to send SSDP search package (%d)", sr);
+                }
             }
         }
     }
@@ -976,5 +1158,6 @@ bail:
         ssdp->m_DiscoveredDevices.Iterate(call_back, context);
     }
 
-}  // namespace dmSSPD
+}  // namespace dmSSDP
+
 

--- a/engine/dlib/src/dlib/ssdp.h
+++ b/engine/dlib/src/dlib/ssdp.h
@@ -43,7 +43,8 @@ namespace dmSSDP
         /// UPnP device type
         const char* m_DeviceType;
 
-        /// Device description in XML form
+        /// Device description template in XML form.
+        /// This can include the variable ${HTTP-HOST} in the url
         const char* m_DeviceDescription;
 
         /// Unique Device Name, eg uuid:0509f95d-3d4f-339c-8c4d-f7c6da6771c8

--- a/engine/dlib/src/java/com/dynamo/upnp/SSDP.java
+++ b/engine/dlib/src/java/com/dynamo/upnp/SSDP.java
@@ -165,7 +165,7 @@ public class SSDP implements ISSDP {
                             discoveredDevices.put(usn, device);
                             ++changeCount;
                         } else {
-                            // The port might have changed (for identical usn) so we check
+                            // The address might have changed (for identical usn) so we check
                             // for equality here (equals in DeviceInfo compares headers)
                             if (!discDevice.equals(device)) {
                                 discoveredDevices.put(usn, device);

--- a/engine/dlib/src/test/test_ssdp.cpp
+++ b/engine/dlib/src/test/test_ssdp.cpp
@@ -22,7 +22,7 @@ static const char* DEVICE_DESC =
 "        <friendlyName>Defold System</friendlyName>\n"
 "        <manufacturer>Defold</manufacturer>\n"
 "        <modelName>Defold Engine 1.0</modelName>\n"
-"        <UDN>${UDN}</UDN>\n"
+"        <UDN>uuid:0509f95d-3d4f-339c-8c4d-f7c6da6771c8</UDN>\n"
 "    </device>\n"
 "</root>\n";
 

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -206,7 +206,8 @@ namespace dmEngineService
             }
             else if (strcmp(key, "HOSTNAME") == 0)
             {
-                return self->m_LocalAddress;
+                // this will be filled in by the SSDP response
+                return "${HTTP-HOST}";
             }
             else if (strcmp(key, "ENGINE_VERSION") == 0)
             {


### PR DESCRIPTION
- Implement threaded update of network interfaces
- Dynamically create and destroy sockets to respond to interface changes
- Allow ${HTTP-HOST} for replacement in SSDP http response blob to make
  xml response always point to matching hostname
- Remove the 'packet from self' check since it is tricky to do this way
  (setsockopt IP_MULTICAST_LOOP would probably work but not needed anyway)
- Add changing the multicast if through socket interface to set interface
  for outgoing packets (useful for announce in particular)
