### PR TITLE
Once-ping-pong in atlas anim should behave same as regular loop-ping-pong

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasRenderer.java
@@ -129,6 +129,7 @@ public class AtlasRenderer implements INodeRenderer<AtlasNode> {
         case PLAYBACK_ONCE_BACKWARD:
             frame = (nFrames-1) - (frameTime % nFrames);
             break;
+        case PLAYBACK_ONCE_PINGPONG:
         case PLAYBACK_LOOP_PINGPONG:
             // Unwrap to nFrames + (nFrames - 2)
             frame = frameTime % (nFrames * 2 - 2);


### PR DESCRIPTION
Worlds tiniest pull-request. :-)

(My original solution included "correctly" only previewing the animation once (including fixes for other once-playback modes). However, it's unclear if this is actually desired when previewing animations... Play/pause-ing to keep previewing a once-animation could be frustrating, so reverted to this much easier fix.)
