### PR TITLE
Copy correct OpenAL32 library for Win32 bundling. DEF-1112

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -132,10 +132,9 @@ public class Bob {
         }
     }
 
-    public static String getLib(String name) throws IOException {
+    public static String getLib(Platform platform, String name) throws IOException {
         init();
 
-        Platform platform = Platform.getJavaPlatform();
         String libName = platform.getPair() + "/" + platform.getLibPrefix() + name + platform.getLibSuffix();
         URL url = Bob.class.getResource("/lib/" + libName);
         if (url == null) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
@@ -9,7 +9,7 @@ import com.sun.jna.Pointer;
 public class TexcLibrary {
     static {
         try {
-            File lib = new File(Bob.getLib("texc_shared"));
+            File lib = new File(Bob.getLib(Platform.getJavaPlatform(), "texc_shared"));
             System.setProperty("jna.library.path", lib.getParent());
             Bob.verbose("Added '%s' to 'jna.library.path'", lib.getParent());
             Native.register("texc_shared");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
@@ -36,8 +36,8 @@ public class Win32Bundler implements IBundler {
         }
 
         // Touch both OpenAL32.dll and wrap_oal.dll so they get included in the step below
-        Bob.getLib("OpenAL32");
-        Bob.getLib("wrap_oal");
+        Bob.getLib(Platform.X86Win32, "OpenAL32");
+        Bob.getLib(Platform.X86Win32, "wrap_oal");
 
         // Copy Executable and DLL:s
         File exeOut = new File(appDir, String.format("%s.exe", title));


### PR DESCRIPTION
Win32Bundler breaks on non-Win32 platforms since the `Bob.getLib(...)` call gets the OpenAL32 library by host platform naming convention (i.e. libOpenAL32.dylib on OSX, but should bundle OpenAL32.dll).

Fixed: Bob.getLib now takes an additional Platform parameter, the same way getExe works.
