### PR TITLE
DEF-958 - Previewing flipbook animations does not consider auto-rotated ...

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasRenderer.java
@@ -96,8 +96,17 @@ public class AtlasRenderer implements INodeRenderer<AtlasNode> {
             time += renderContext.getDt();
             AtlasAnimationNode playBackNode = node.getPlayBackNode();
             if (playBackNode != null) {
-                renderAnimation(runtimeTextureSet, playBackNode, gl, texture);
                 renderTiles(runtimeTextureSet, gl, 0.1f, texture);
+
+                // AtlasVertexBuffer contains vertices that will display the bitmaps rotated as layed out in the atlas.
+                // Switch here to VertexBuffer for presenting the animation so it is rendered the way it will actually appear.
+                this.vertexFormat.disable(gl, shader);
+                vertexBuffer.disable(gl);
+                vertexBuffer = node.getRuntimeTextureSet().getVertexBuffer();
+                vertexBuffer.enable(gl);
+                this.vertexFormat.enable(gl, shader);
+
+                renderAnimation(runtimeTextureSet, playBackNode, gl, texture);
             } else {
                 renderTiles(runtimeTextureSet, gl, 1, texture);
             }


### PR DESCRIPTION
...atlas images
- Use the 'real' vertex buffer for rendering the animation preview for atlases.
