### PR TITLE
DEF-1089 - DF font, alpha missmatch vs "Normal" fonts

### DIFF
--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -37,15 +37,13 @@ void main_supersample()
                    + eval_borders(dt.zw); // bottom right
 
     borders = (1.0/6.0) * borders;
-    lowp vec4 outline_color = vec4(var_outline_color.xyz * var_outline_color.w, var_outline_color.w);
-    gl_FragColor = mix(mix(var_face_color, outline_color, borders.y), vec4(0), borders.x);
+    gl_FragColor = mix(mix(var_face_color, var_outline_color, borders.y), vec4(0), borders.x);
 }
 
 void main_default()
 {
     lowp vec2 borders = eval_borders(var_texcoord0);
-    lowp vec4 outline_color = vec4(var_outline_color.xyz * var_outline_color.w, var_outline_color.w);
-    gl_FragColor = mix(mix(var_face_color, outline_color, borders.y), vec4(0), borders.x);
+    gl_FragColor = mix(mix(var_face_color, var_outline_color, borders.y), vec4(0), borders.x);
 }
 
 void main()

--- a/engine/engine/content/builtins/fonts/font-df.vp
+++ b/engine/engine/content/builtins/fonts/font-df.vp
@@ -16,8 +16,8 @@ attribute lowp vec4 shadow_color;
 void main()
 {
     var_texcoord0 = texcoord0;
-    var_face_color = face_color;
-    var_outline_color = outline_color;
+    var_face_color = vec4(face_color.xyz * face_color.w, face_color.w);
+    var_outline_color = vec4(outline_color.xyz * outline_color.w, outline_color.w);
     var_sdf_params = sdf_params;
     gl_Position = view_proj * vec4(position.x, position.y, position.z, 1.0);
 }


### PR DESCRIPTION
- Fixed vertex/pixel shader to premultiply properly both
  face and outline color
