### PR TITLE
DEF-1148 - Multitouch: single input does not work as expected on Android

### DIFF
--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -260,33 +260,20 @@ static GLFWTouch* touchById(void *ref)
 
 static GLFWTouch* touchGetOrAlloc(void *ref)
 {
-    // If it already exists, not expected but then just overwrite it.
-    GLFWTouch *new_touch = touchById(ref);
-    if (!new_touch && _glfwInput.TouchCount < GLFW_MAX_TOUCH)
-    {
-        new_touch = &_glfwInput.Touch[_glfwInput.TouchCount++];
+    // Return existing touch or a memset:ed new.
+    GLFWTouch *touch = touchById(ref);
+    if (touch) {
+        return touch;
     }
-    if (new_touch)
-    {
-        memset(new_touch, 0x00, sizeof(GLFWTouch));
-        new_touch->Reference = ref;
-    }
-    return new_touch;
-}
 
-static void touchFree(void *ref)
-{
-    int32_t i, j;
-    for (i=0;i!=_glfwInput.TouchCount;i++)
-    {
-        if (_glfwInput.Touch[i].Reference == ref)
-        {
-            _glfwInput.TouchCount--;
-            for (j=i;j<_glfwInput.TouchCount;j++)
-                _glfwInput.Touch[j] = _glfwInput.Touch[j+1];
-            return;
-        }
+    if (_glfwInput.TouchCount < GLFW_MAX_TOUCH) {
+        touch = &_glfwInput.Touch[_glfwInput.TouchCount++];
+        memset(touch, 0x00, sizeof(GLFWTouch));
+        touch->Reference = ref;
+        return touch;
     }
+
+    return 0;
 }
 
 static void touchStart(void *ref, int32_t x, int32_t y)
@@ -348,9 +335,6 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
 
         int32_t action_action = action & AMOTION_EVENT_ACTION_MASK;
 
-        // which to remove after updating
-        void *rm_pointer = 0;
-
         switch (action_action)
         {
             case AMOTION_EVENT_ACTION_DOWN:
@@ -359,16 +343,16 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
                 break;
             case AMOTION_EVENT_ACTION_UP:
                 _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE );
-                rm_pointer = touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
+                touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
                 break;;
             case AMOTION_EVENT_ACTION_POINTER_DOWN:
                 touchStart(pointer_ref, x, y);
                 break;
             case AMOTION_EVENT_ACTION_POINTER_UP:
-                rm_pointer = touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
+                touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
                 break;
             case AMOTION_EVENT_ACTION_CANCEL:
-                rm_pointer = touchUpdate(pointer_ref, x, y, GLFW_PHASE_CANCELLED);
+                touchUpdate(pointer_ref, x, y, GLFW_PHASE_CANCELLED);
                 break;
             case AMOTION_EVENT_ACTION_MOVE:
                 {
@@ -389,14 +373,9 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
                 break;
         }
 
-        if (_glfwWin.touchCallback)
+        if (_glfwWin.touchCallback && _glfwInput.TouchCount > 0)
         {
             _glfwWin.touchCallback(_glfwInput.Touch, _glfwInput.TouchCount);
-        }
-
-        if (rm_pointer)
-        {
-            touchFree(rm_pointer);
         }
 
         return 1;
@@ -477,6 +456,7 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
 
     return 0;
 }
+
 
 void _glfwPreMain(struct android_app* state)
 {


### PR DESCRIPTION
- Made it so that touch array is adjusted on read, to keep a consistent
  view where BEGAN/ENDED/CANCELLED are only reported once
- Fixed an embarassing error in android touch update where it would
  erase structs between updates
