### PR TITLE
DEF-1134 - Texture scaling / 9-slicing using atlases

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
@@ -143,6 +143,33 @@ public class TextureSetGeneratorTest {
     }
 
     @Test
+    public void testAtlasGeneratorMaxRectMargin() throws Exception {
+        // These are 11x11 and with 5x5 padding added during generation, the output should be 64x16
+        List<BufferedImage> images = Arrays.asList(newImage(11, 11), newImage(11, 11), newImage(11, 11),
+                newImage(11, 11));
+
+        List<String> ids = Arrays.asList("1", "2", "3", "4");
+
+        List<MappedAnimDesc> animations = new ArrayList<MappedAnimDesc>();
+        animations.add(newAnim("anim1", Arrays.asList("1", "2", "3")));
+        animations.add(newAnim("anim2", Arrays.asList("2", "4")));
+
+        MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
+
+        TextureSetResult result = TextureSetGenerator.generate(images, iterator, 5, 0, 0, false, false, true, false, null);
+        BufferedImage image = result.image;
+        assertThat(image.getWidth(), is(64));
+        assertThat(image.getHeight(), is(16));
+
+        for (UVTransform uv : result.uvTransforms)
+        {
+            // Same as original
+            assertThat((int)(uv.scale.x * image.getWidth()), is(11));
+            assertThat((int)(uv.scale.y * image.getHeight()), is(11));
+        }
+    }
+
+    @Test
     public void testRotatedAnimations() {
         List<BufferedImage> images = Arrays.asList(newImage(64,32), newImage(64,32), newImage(32,64), newImage(32,64));
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/MaxRectsLayoutStrategy.java
@@ -57,7 +57,9 @@ public class MaxRectsLayoutStrategy implements TextureSetLayoutStrategy {
         for(Page page : pages) {
             ArrayList<Rect> rects = new ArrayList<Rect>(page.outputRects.size());
             for(RectNode node : page.outputRects) {
-                rects.add(node.rect);
+                Rect finalRect = new Rect(node.rect.id, node.rect.x, node.rect.y, node.rect.width - settings.paddingX, node.rect.height - settings.paddingY);
+                finalRect.rotated = node.rect.rotated;
+                rects.add(finalRect);
             }
             int layoutWidth = 1 << getExponentNextOrMatchingPowerOfTwo(page.width);
             int layoutHeight = 1 << getExponentNextOrMatchingPowerOfTwo(page.height);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetLayout.java
@@ -157,8 +157,8 @@ public class TextureSetLayout {
         // Ensure the longest length found in all of the images will fit within one page, irrespective of orientation.
         int maxLengthScale = 0;
         for (Rect r : rectangles) {
-            maxLengthScale = Math.max(maxLengthScale, r.width + 2 * margin);
-            maxLengthScale = Math.max(maxLengthScale, r.height + 2 * margin);
+            maxLengthScale = Math.max(maxLengthScale, r.width + margin);
+            maxLengthScale = Math.max(maxLengthScale, r.height + margin);
         }
         settings.maxPageHeight = Math.max(settings.maxPageHeight, maxLengthScale);
         settings.maxPageWidth = Math.max(settings.maxPageWidth, maxLengthScale);

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/BoxNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/BoxNodeRenderer.java
@@ -200,12 +200,12 @@ public class BoxNodeRenderer implements INodeRenderer<BoxNode> {
         if(uvRotated)
         {
             us[vI[0]] = u0;
-            us[vI[1]] = u0 + (sV * node.getSlice9().w);
-            us[vI[2]] = u1 - (sV * node.getSlice9().y);
+            us[vI[1]] = u0 + (sU * node.getSlice9().w);
+            us[vI[2]] = u1 - (sU * node.getSlice9().y);
             us[vI[3]] = u1;
             vs[uI[0]] = v0;
-            vs[uI[1]] = v0 + (sU * node.getSlice9().x);
-            vs[uI[2]] = v1 - (sU * node.getSlice9().z);
+            vs[uI[1]] = v0 + (sV * node.getSlice9().x);
+            vs[uI[2]] = v1 - (sV * node.getSlice9().z);
             vs[uI[3]] = v1;
             for (int i=0;i<3;i++)
             {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -617,12 +617,12 @@ namespace dmGameSystem
                     const uint32_t *uI = flip_v ? uvIndex[1] : uvIndex[0];
                     const uint32_t *vI = flip_u ? uvIndex[1] : uvIndex[0];
                     us[uI[0]] = tc[0];
-                    us[uI[1]] = tc[0] + (sv * slice9.getW());
-                    us[uI[2]] = tc[2] - (sv * slice9.getY());
+                    us[uI[1]] = tc[0] + (su * slice9.getW());
+                    us[uI[2]] = tc[2] - (su * slice9.getY());
                     us[uI[3]] = tc[2];
                     vs[vI[0]] = tc[1];
-                    vs[vI[1]] = tc[1] + (su * slice9.getX());
-                    vs[vI[2]] = tc[5] - (su * slice9.getZ());
+                    vs[vI[1]] = tc[1] + (sv * slice9.getX());
+                    vs[vI[2]] = tc[5] - (sv * slice9.getZ());
                     vs[vI[3]] = tc[5];
                 }
                 else


### PR DESCRIPTION
- Add test to verify that rects after layouting are the same size as before
- Fix U/V confusion in calculations for slice9 nodes (bug when rotated)
