### PR TITLE
DEF-1088 - Atlas or tilesource textures are not correctly reloaded from ...

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_textureset.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_textureset.cpp
@@ -8,13 +8,25 @@
 namespace dmGameSystem
 {
     dmResource::Result AcquireResources(dmPhysics::HContext2D context, dmResource::HFactory factory, const void* buffer, uint32_t buffer_size,
-                                        TextureSetResource* tile_set, const char* filename)
+                                        TextureSetResource* tile_set, const char* filename, bool reload)
     {
         dmGameSystemDDF::TextureSet* texture_set_ddf;
         dmDDF::Result e  = dmDDF::LoadMessage(buffer, buffer_size, &texture_set_ddf);
         if ( e != dmDDF::RESULT_OK )
         {
             return dmResource::RESULT_FORMAT_ERROR;
+        }
+
+        if (reload)
+        {
+            // Will pick up the actual pointer when running get. This is a poor man's rebuild dependency
+            // tracking. The editor could in theory send a reload command for the texture as well, but for
+            // now trigger it manually here.
+            dmResource::Result r = dmResource::ReloadResource(factory, texture_set_ddf->m_Texture, 0);
+            if (r != dmResource::RESULT_OK)
+            {
+                return r;
+            }
         }
 
         dmResource::Result r = dmResource::Get(factory, texture_set_ddf->m_Texture, (void**)&tile_set->m_Texture);
@@ -90,7 +102,7 @@ namespace dmGameSystem
     {
         TextureSetResource* tile_set = new TextureSetResource();
 
-        dmResource::Result r = AcquireResources(((PhysicsContext*)context)->m_Context2D, factory, buffer, buffer_size, tile_set, filename);
+        dmResource::Result r = AcquireResources(((PhysicsContext*)context)->m_Context2D, factory, buffer, buffer_size, tile_set, filename, false);
         if (r == dmResource::RESULT_OK)
         {
             resource->m_Resource = (void*) tile_set;
@@ -121,7 +133,8 @@ namespace dmGameSystem
     {
         TextureSetResource* tile_set = (TextureSetResource*)resource->m_Resource;
         TextureSetResource tmp_tile_set;
-        dmResource::Result r = AcquireResources(((PhysicsContext*)context)->m_Context2D, factory, buffer, buffer_size, &tmp_tile_set, filename);
+
+        dmResource::Result r = AcquireResources(((PhysicsContext*)context)->m_Context2D, factory, buffer, buffer_size, &tmp_tile_set, filename, true);
         if (r == dmResource::RESULT_OK)
         {
             ReleaseResources(factory, tile_set);


### PR DESCRIPTION
...editor to run-time
- Trigger reload of the texture as well when reloading.
