### PR TITLE
Updated error message when GetComponentUserDataFromLua() DEF-1158

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -326,7 +326,7 @@ namespace dmGameObject
         {
             dmMessage::URL receiver;
             dmScript::ResolveURL(L, index, &receiver, &sender);
-            if (sender.m_Socket != dmGameObject::GetMessageSocket(collection) || receiver.m_Socket != dmGameObject::GetMessageSocket(collection))
+            if (sender.m_Socket != receiver.m_Socket || sender.m_Socket != dmGameObject::GetMessageSocket(collection))
             {
                 luaL_error(L, "function called can only access instances within the same collection.");
                 return; // Actually never reached

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -324,18 +324,18 @@ namespace dmGameObject
         dmMessage::URL sender;
         if (dmScript::GetURL(L, &sender))
         {
-            if (sender.m_Socket != dmGameObject::GetMessageSocket(collection))
+            dmMessage::URL receiver;
+            dmScript::ResolveURL(L, index, &receiver, &sender);
+            if (sender.m_Socket != dmGameObject::GetMessageSocket(collection) || receiver.m_Socket != dmGameObject::GetMessageSocket(collection))
             {
                 luaL_error(L, "function called can only access instances within the same collection.");
                 return; // Actually never reached
             }
 
-            dmMessage::URL receiver;
-            dmScript::ResolveURL(L, index, &receiver, &sender);
             HInstance instance = GetInstanceFromIdentifier(collection, receiver.m_Path);
             if (!instance)
             {
-                luaL_error(L, "Instance %s not found (function called can only access instances within the same collection).", lua_tostring(L, index));
+                luaL_error(L, "Instance %s not found", lua_tostring(L, index));
                 return; // Actually never reached
             }
 
@@ -1105,7 +1105,7 @@ namespace dmGameObject
      * An example how to delete game objects listed in a table
      * </p>
      * <pre>
-     * -- List the objects to be deleted 
+     * -- List the objects to be deleted
      * local ids = { hash("/my_object_1"), hash("/my_object_2"), hash("/my_object_3") }
      * go.delete_all(ids)
      * </pre>

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -335,7 +335,7 @@ namespace dmGameObject
             HInstance instance = GetInstanceFromIdentifier(collection, receiver.m_Path);
             if (!instance)
             {
-                luaL_error(L, "Instance %s not found", lua_tostring(L, index));
+                luaL_error(L, "Instance %s not found (function called can only access instances within the same collection).", lua_tostring(L, index));
                 return; // Actually never reached
             }
 


### PR DESCRIPTION
Updated error message for when GetComponentUserDataFromLua() (gameobject_script.cpp) can't find the instance; hints that the function being called can't access instance instances outside the current collection.

As decided in meeting, described here: https://docs.google.com/document/d/1gWeuJDO9UrG8vauLvkqJYSFoXWzrqmhnm_RAk6zyo9U/
