### PR TITLE
Added check in SetMaterialSampler if supplied sampler name is valid.

### DIFF
--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -326,7 +326,7 @@ namespace dmRender
 
         uint32_t n = samplers.Size();
         uint32_t i = unit;
-        if (unit < n && name_hash != 0)
+        if (unit < n && name_hash != 0 && material->m_NameHashToLocation.Get(name_hash) != 0)
         {
             Sampler& s = samplers[i];
             s.m_NameHash = name_hash;


### PR DESCRIPTION
If supplied sampler name/hash to SetMaterialSampler was an unknown, then `m_NameHashToLocation.Get(name_hash)` returned 0, dereferencing this would crash the engine. Added a check, along with the other sanity checks, to see so that non-NULL is returned...
