### PR TITLE
DEF-1163 - Ongoing HTTP requests hangs application

### DIFF
--- a/engine/dlib/src/dlib/connection_pool.h
+++ b/engine/dlib/src/dlib/connection_pool.h
@@ -28,6 +28,7 @@ namespace dmConnectionPool
         RESULT_OUT_OF_RESOURCES = -1,//!< RESULT_OUT_OF_RESOURCES
         RESULT_SOCKET_ERROR = -2,    //!< RESULT_SOCKET_ERROR
         RESULT_HANDSHAKE_FAILED = -3,//!< RESULT_HANDSHAKE_FAILED
+        RESULT_SHUT_DOWN = -4,       //<! RESULT_SHUT_DOWN
     };
 
     /**
@@ -136,6 +137,23 @@ namespace dmConnectionPool
      * @return reuse count
      */
     uint32_t GetReuseCount(HPool pool, HConnection connection);
+
+    /**
+     * Shuts down all open sockets in the pool and block new connection attempts. The function can be
+     * called repeatedly on the same pool until it returns no more connections in use.
+     *
+     * @param pool pool
+     * @param how shutdown type to pass to socket shutdown function
+     * @return current number of connections in use
+     */
+    uint32_t Shutdown(HPool pool, dmSocket::ShutdownType how);
+
+    /**
+     * Reopen the pool from a Shutdown call so it allows Dialing again. This function is here so the pool can be reset
+     * during testing, or subsequent tests will break when the pool has been put in shutdown mode.
+     */
+    void Reopen(HPool pool);
+
 }
 
 #endif // #ifndef DM_CONNECTION_POOL

--- a/engine/dlib/src/dlib/http_client.h
+++ b/engine/dlib/src/dlib/http_client.h
@@ -243,6 +243,21 @@ namespace dmHttpClient
      * @param client Client handle
      */
     void Delete(HClient client);
+
+    /**
+     * Close all sockets open by the internal pool and return how many connections
+     * are still in use. If the function returns zero, there are no remaining in-use
+     * connections and no new connections can be created.
+     *
+     * @return number of in-use connections
+     */
+    uint32_t ShutdownConnectionPool();
+
+    /**
+     * Reopen the internal connection pool. Implemented so testing the shutdown sequence is possible without
+     * permanently breaking for subsequent requests.
+    */
+    void ReopenConnectionPool();
 }
 
 #endif // DM_HTTP_CLIENT_H

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -12,6 +12,7 @@
 #include <dlib/math.h>
 #include <dlib/path.h>
 #include <dlib/sys.h>
+#include <dlib/http_client.h>
 #include <extension/extension.h>
 #include <gamesys/model_ddf.h>
 #include <gamesys/physics_ddf.h>
@@ -161,6 +162,8 @@ namespace dmEngine
         if (engine->m_MainCollection)
             dmResource::Release(engine->m_Factory, engine->m_MainCollection);
         dmGameObject::PostUpdate(engine->m_Register);
+
+        dmHttpClient::ShutdownConnectionPool();
 
         dmGameSystem::ScriptLibContext script_lib_context;
         script_lib_context.m_Factory = engine->m_Factory;


### PR DESCRIPTION
- Make connection pool possible to shut down
- Added test to try out this behavior
  (also with function to re-open it again)
- Added shutdown sequence to engine
- Corrected spelling mistake Resused -> Reused
