### PR TITLE
DEF-1187 - GUI rendering forces new batching / sorting

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1199,6 +1199,8 @@ namespace dmGameSystem
             write_ptr->m_Order = dmGui::GetRenderOrder(c->m_Scene);
             write_ptr->m_UserData = (uintptr_t) c;
             write_ptr->m_BatchKey = i;
+            write_ptr->m_TagMask = dmRender::GetMaterialTagMask(((dmRender::HMaterial)dmGui::GetMaterial(c->m_Scene)));
+
             write_ptr->m_Dispatch = dispatch;
             ++write_ptr;
         }

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -162,6 +162,7 @@ namespace dmGameSystem
 
             write_ptr->m_WorldPosition = dmGameObject::GetWorldPosition(component.m_Instance);
             write_ptr->m_UserData = (uintptr_t) &component;
+            write_ptr->m_TagMask = dmRender::GetMaterialTagMask(component.m_Model->m_Material);
             write_ptr->m_BatchKey = 0;
             write_ptr->m_Dispatch = dispatch;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -223,7 +223,10 @@ namespace dmGameSystem
         if (params.m_Operation == dmRender::RENDER_LIST_OPERATION_BATCH)
         {
             for (uint32_t *i=params.m_Begin;i!=params.m_End;i++)
+            {
+                dmRender::RenderObject *ro = (dmRender::RenderObject*) params.m_Buf[*i].m_UserData;
                 dmRender::AddToRender(params.m_Context, (dmRender::RenderObject*) params.m_Buf[*i].m_UserData);
+            }
         }
     }
 
@@ -245,6 +248,7 @@ namespace dmGameSystem
             write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());
             write_ptr->m_UserData = (uintptr_t) &render_objects[i];
             write_ptr->m_BatchKey = 0;
+            write_ptr->m_TagMask = dmRender::GetMaterialTagMask(render_objects[i].m_Material);
             write_ptr->m_Dispatch = dispatch;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;
@@ -423,7 +427,6 @@ namespace dmGameSystem
             ro.m_VertexBuffer = world->m_VertexBuffer;
             ro.m_VertexDeclaration = world->m_VertexDeclaration;
             ro.m_PrimitiveType = dmGraphics::PRIMITIVE_TRIANGLES;
-            ro.m_CalculateDepthKey = 1;
             ro.m_WorldTransform = world_transform;
             ro.m_SetBlendFactors = 1;
             SetBlendFactors(&ro, blend_mode);

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -1075,6 +1075,7 @@ namespace dmGameSystem
             write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());
             write_ptr->m_UserData = (uintptr_t) &component;
             write_ptr->m_BatchKey = component.m_MixedHash;
+            write_ptr->m_TagMask = dmRender::GetMaterialTagMask(component.m_Resource->m_Material);
             write_ptr->m_Dispatch = dispatch;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -678,6 +678,7 @@ namespace dmGameSystem
             write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());
             write_ptr->m_UserData = (uintptr_t) &component;
             write_ptr->m_BatchKey = component.m_MixedHash;
+            write_ptr->m_TagMask = dmRender::GetMaterialTagMask(component.m_Resource->m_Material);
             write_ptr->m_Dispatch = sprite_dispatch;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -187,7 +187,6 @@ namespace dmGameSystem
             ro->m_VertexBuffer = 0;
             ro->m_PrimitiveType = dmGraphics::PRIMITIVE_TRIANGLES;
             ro->m_Material = material;
-            ro->m_CalculateDepthKey = 1;
         }
 
         world->m_TileGrids.Push(component);
@@ -477,6 +476,7 @@ namespace dmGameSystem
             const Vector4 trans = tile_grid->m_RenderWorldTransform.getCol(3);
             write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());
             write_ptr->m_UserData = (uintptr_t) tile_grid;
+            write_ptr->m_TagMask = dmRender::GetMaterialTagMask(tile_grid->m_TileGridResource->m_Material);
             write_ptr->m_BatchKey = i;
             write_ptr->m_Dispatch = dispatch;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -127,8 +127,6 @@ namespace dmRender
         uint8_t                         m_FragmentConstantMask;
         uint8_t                         m_SetBlendFactors : 1;
         uint8_t                         m_SetStencilTest : 1;
-        // Set to true if RenderKey.m_Depth should be filled in
-        uint8_t                         m_CalculateDepthKey : 1;
     };
 
     struct RenderContextParams
@@ -165,6 +163,7 @@ namespace dmRender
         Point3 m_WorldPosition;
         uint32_t m_Order;
         uint32_t m_BatchKey;
+        uint32_t m_TagMask;
         uintptr_t m_UserData;
         uint32_t m_MajorOrder:2;
         uint32_t m_Dispatch:8;

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -187,10 +187,8 @@ namespace dmRender
         dmArray<RenderListEntry>    m_RenderList;
         dmArray<RenderListDispatch> m_RenderListDispatch;
         dmArray<RenderListSortValue>m_RenderListSortValues;
-        dmArray<uint32_t>           m_RenderListSortBuffers[2];
-        uint32_t                    m_RenderListSortTarget;
+        dmArray<uint32_t>           m_RenderListSortBuffer;
         dmArray<uint32_t>           m_RenderListSortIndices;
-        Matrix4                     m_RenderListDispatchedForViewProj;
 
         HFontMap                    m_SystemFontMap;
 

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -231,6 +231,7 @@ TEST_F(dmRenderTest, TestRenderListDraw)
         dmRender::RenderListEntry & entry = out[i];
         entry.m_WorldPosition = Point3(0,0,orders[i]);
         entry.m_MajorOrder = majors[i % 3];
+        entry.m_TagMask = 0;
         entry.m_Order = orders[i];
         entry.m_BatchKey = i & 3; // no particular system
         entry.m_Dispatch = dispatch;


### PR DESCRIPTION
- Add m_TagMask to render list so we can build a limited
  set of batches/render objects based on the current request
- Caching of sorting is now not really necessary unless drawing
  the same thing multiple times (unlikely), so remove that
- Remove some other stuff too
