### PR TITLE
- Follow-up fixes for DEF-1187 - GUI rendering forces new batching / …

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui.h
@@ -53,14 +53,20 @@ namespace dmGameSystem
         uint32_t m_Color;
     };
 
+    struct GuiRenderObject
+    {
+        dmRender::RenderObject m_RenderObject;
+        uint32_t m_SortOrder;
+    };
+
     struct GuiWorld
     {
+        dmArray<GuiRenderObject>         m_GuiRenderObjects;
         dmArray<GuiComponent*>           m_Components;
         dmGraphics::HVertexDeclaration   m_VertexDeclaration;
         dmGraphics::HVertexBuffer        m_VertexBuffer;
         dmArray<BoxVertex>               m_ClientVertexBuffer;
         dmGraphics::HTexture             m_WhiteTexture;
-        dmArray<dmRender::RenderObject>  m_GuiRenderObjects;
     };
 
     dmGameObject::CreateResult CompGuiNewWorld(const dmGameObject::ComponentNewWorldParams& params);

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -225,7 +225,7 @@ namespace dmGameSystem
             for (uint32_t *i=params.m_Begin;i!=params.m_End;i++)
             {
                 dmRender::RenderObject *ro = (dmRender::RenderObject*) params.m_Buf[*i].m_UserData;
-                dmRender::AddToRender(params.m_Context, (dmRender::RenderObject*) params.m_Buf[*i].m_UserData);
+                dmRender::AddToRender(params.m_Context, ro);
             }
         }
     }

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -171,15 +171,16 @@ namespace dmRender
     void DrawText(HRenderContext render_context, HFontMap font_map, const DrawTextParams& params);
 
     /**
-     * Produces render objects for all the previously DrawText:ed texts.
+     * Produces render list entries for all the previously DrawText:ed texts.
      * Multiple calls can be made with final=false, but one (last) call
      * with final=true must be made, so that the vertex buffers will be
      * written.
      *
      * @param final If this is the last call.
+     * @param render_order Render order to write for the rendering
      * @param render_context Context to use when rendering
      */
-    void FlushTexts(HRenderContext render_context, bool final);
+    void FlushTexts(HRenderContext render_context, uint32_t render_order, bool final);
 
     /**
      * Get text metrics for string

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -205,6 +205,10 @@ namespace dmRender
 
     void RenderListEnd(HRenderContext render_context)
     {
+        // Whatever text has not been flushed now has the last chance
+        // now. We put it in with a high 2^24-1 sort value so it is last.
+        FlushTexts(render_context, 0xffffff, true);
+
         // These will be sorted into when dispatched.
         render_context->m_RenderListSortBuffer.SetCapacity(render_context->m_RenderListSortIndices.Capacity());
         render_context->m_RenderListSortBuffer.SetSize(0);
@@ -471,10 +475,8 @@ namespace dmRender
         dmGraphics::HContext context = dmRender::GetGraphicsContext(render_context);
 
         // TODO: Move to "BeginFrame()" or similar? See case 2261
+        // TODO: Should really fix this.
         FlushDebug(render_context);
-
-        // Write vertex buffer
-        FlushTexts(render_context, true);
 
         for (uint32_t i = 0; i < render_context->m_RenderObjects.Size(); ++i)
         {

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -593,7 +593,7 @@ TEST_F(dmRenderScriptTest, TestDrawText)
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
-    dmRender::FlushTexts(m_Context, true);
+    dmRender::FlushTexts(m_Context, 0, true);
 
     ASSERT_NE(0u, m_Context->m_TextContext.m_VertexIndex);
 


### PR DESCRIPTION
…sorting
- Perform dmGui::Render in the Render() call instead of lazily
  waiting until the render objects need to be produced.
- Fixes case where gui scenes contain materials with different
  tags than the gui scene itself, and thus do not get rendered.
