### PR TITLE
- Use default engine width & height for initial gui scene sizes

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -562,6 +562,8 @@ namespace dmEngine
         gui_params.m_GetTextMetricsCallback = dmGameSystem::GuiGetTextMetricsCallback;
         gui_params.m_PhysicalWidth = physical_width;
         gui_params.m_PhysicalHeight = physical_height;
+        gui_params.m_DefaultProjectWidth = engine->m_Width;
+        gui_params.m_DefaultProjectHeight = engine->m_Height;
         gui_params.m_Dpi = physical_dpi;
         gui_params.m_HidContext = engine->m_HidContext;
         engine->m_GuiContext.m_GuiContext = dmGui::NewContext(&gui_params);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -459,10 +459,6 @@ namespace dmGameSystem
         scene_params.m_UserData = gui_component;
         scene_params.m_MaxFonts = 64;
         scene_params.m_MaxTextures = 128;
-        uint32_t scene_width, scene_height;
-        dmGui::GetPhysicalResolution((dmGui::HContext) scene_resource->m_GuiContext, scene_width, scene_height);
-        scene_params.m_Width = scene_width;
-        scene_params.m_Height = scene_height;
         scene_params.m_FetchTextureSetAnimCallback = &FetchTextureSetAnimCallback;
         scene_params.m_OnWindowResizeCallback = &OnWindowResizeCallback;
         gui_component->m_Scene = dmGui::NewScene(scene_resource->m_GuiContext, &scene_params);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -132,6 +132,8 @@ namespace dmGui
         context->m_GetUserDataCallback = params->m_GetUserDataCallback;
         context->m_ResolvePathCallback = params->m_ResolvePathCallback;
         context->m_GetTextMetricsCallback = params->m_GetTextMetricsCallback;
+        context->m_DefaultProjectWidth = params->m_DefaultProjectWidth;
+        context->m_DefaultProjectHeight = params->m_DefaultProjectHeight;
         context->m_PhysicalWidth = params->m_PhysicalWidth;
         context->m_PhysicalHeight = params->m_PhysicalHeight;
         context->m_Dpi = params->m_Dpi;
@@ -273,8 +275,8 @@ namespace dmGui
         scene->m_RenderTail = INVALID_INDEX;
         scene->m_NextVersionNumber = 0;
         scene->m_RenderOrder = 0;
-        scene->m_Width = params->m_Width;
-        scene->m_Height = params->m_Height;
+        scene->m_Width = context->m_DefaultProjectWidth;
+        scene->m_Height = context->m_DefaultProjectHeight;
         scene->m_FetchTextureSetAnimCallback = params->m_FetchTextureSetAnimCallback;
         scene->m_OnWindowResizeCallback = params->m_OnWindowResizeCallback;
 

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -137,8 +137,6 @@ namespace dmGui
         uint32_t m_MaxFonts;
         uint32_t m_MaxLayers;
         void*    m_UserData;
-        uint32_t m_Width;
-        uint32_t m_Height;
         FetchTextureSetAnimCallback m_FetchTextureSetAnimCallback;
         OnWindowResizeCallback m_OnWindowResizeCallback;
 
@@ -206,6 +204,8 @@ namespace dmGui
         GetTextMetricsCallback  m_GetTextMetricsCallback;
         uint32_t                m_PhysicalWidth;
         uint32_t                m_PhysicalHeight;
+        uint32_t                m_DefaultProjectWidth;
+        uint32_t                m_DefaultProjectHeight;
         uint32_t                m_Dpi;
         dmHID::HContext         m_HidContext;
         dmResource::HFactory    m_Factory;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -72,6 +72,8 @@ namespace dmGui
         GetTextMetricsCallback          m_GetTextMetricsCallback;
         uint32_t                        m_PhysicalWidth;
         uint32_t                        m_PhysicalHeight;
+        uint32_t                        m_DefaultProjectWidth;
+        uint32_t                        m_DefaultProjectHeight;
         uint32_t                        m_Dpi;
         dmArray<HScene>                 m_Scenes;
         dmArray<RenderEntry>            m_RenderNodes;

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -119,9 +119,8 @@ public:
         params.m_UserData = this;
         params.m_FetchTextureSetAnimCallback = FetchTextureSetAnimCallback;
         params.m_OnWindowResizeCallback = OnWindowResizeCallback;
-        params.m_Width = 1;
-        params.m_Height = 1;
         m_Scene = dmGui::NewScene(m_Context, &params);
+        dmGui::SetSceneResolution(m_Scene, 1, 1);
         m_Script = dmGui::NewScript(m_Context);
         dmGui::SetSceneScript(m_Scene, m_Script);
     }

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -96,9 +96,8 @@ TEST_F(dmGuiScriptTest, GetScreenPos)
     params.m_MaxNodes = 64;
     params.m_MaxAnimations = 32;
     params.m_UserData = this;
-    params.m_Width = 1;
-    params.m_Height = 1;
     dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    dmGui::SetSceneResolution(scene, 1, 1);
     dmGui::SetSceneScript(scene, script);
 
     const char* src = "function init(self)\n"
@@ -419,9 +418,8 @@ TEST_F(dmGuiScriptTest, TestLocalTransformSetPos)
     params.m_MaxNodes = 64;
     params.m_MaxAnimations = 32;
     params.m_UserData = this;
-    params.m_Width = 1;
-    params.m_Height = 1;
     dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    dmGui::SetSceneResolution(scene, 1, 1);
     dmGui::SetSceneScript(scene, script);
 
     // Set position
@@ -458,9 +456,8 @@ TEST_F(dmGuiScriptTest, TestLocalTransformAnim)
     params.m_MaxNodes = 64;
     params.m_MaxAnimations = 32;
     params.m_UserData = this;
-    params.m_Width = 1;
-    params.m_Height = 1;
     dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    dmGui::SetSceneResolution(scene, 1, 1);
     dmGui::SetSceneScript(scene, script);
 
     // Set position
@@ -506,10 +503,9 @@ TEST_F(dmGuiScriptTest, TestCustomEasingAnimation)
 	params.m_MaxNodes = 64;
 	params.m_MaxAnimations = 32;
 	params.m_UserData = this;
-	params.m_Width = 1;
-	params.m_Height = 1;
 
 	dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+	dmGui::SetSceneResolution(scene, 1, 1);
 	dmGui::SetSceneScript(scene, script);
 
 	// Create custom curve from vmath.vector and pass along to gui.animate


### PR DESCRIPTION
  instead of physical width.
