### PR TITLE
No Keep-alive in target xml requests - dlib http server header parse fix - http async preloader fix

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.target/src/com/dynamo/cr/target/core/DefaultUrlFetcher.java
+++ b/com.dynamo.cr/com.dynamo.cr.target/src/com/dynamo/cr/target/core/DefaultUrlFetcher.java
@@ -15,6 +15,7 @@ public class DefaultUrlFetcher implements IURLFetcher {
     public String fetch(String url) throws IOException {
         int timeout = 2000;
         URLConnection connection = new URL(url).openConnection();
+        connection.setRequestProperty("Connection",  "close");
         connection.setConnectTimeout(timeout);
         connection.setReadTimeout(timeout);
         InputStream input = connection.getInputStream();

--- a/engine/dlib/src/dlib/http_server.cpp
+++ b/engine/dlib/src/dlib/http_server.cpp
@@ -194,7 +194,7 @@ namespace dmHttpServer
         {
             req->m_Request.m_ContentLength = strtol(value, 0, 10);
         }
-        else if (dmStrCaseCmp(key, "Connection") == 0 && dmStrCaseCmp(key, "close") == 0)
+        else if (dmStrCaseCmp(key, "Connection") == 0 && dmStrCaseCmp(value, "close") == 0)
         {
             req->m_CloseConnection = 1;
         }

--- a/engine/resource/src/async/load_queue_threaded.cpp
+++ b/engine/resource/src/async/load_queue_threaded.cpp
@@ -90,6 +90,8 @@ namespace dmLoadQueue
                 GetCanonicalPath(queue->m_Factory, current->m_Name, canonical_path);
 
                 uint32_t size;
+
+                current->m_Buffer.SetSize(0);
                 result.m_LoadResult = DoLoadResource(queue->m_Factory, canonical_path, current->m_Name, &size, &current->m_Buffer);
                 result.m_PreloadResult = dmResource::RESULT_PENDING;
                 result.m_PreloadData = 0;


### PR DESCRIPTION
A few small fixes after testing and debugging
