### PR TITLE
Decrease number of calls to dmGameObject::UpdateTransforms.

### DIFF
--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -260,6 +260,21 @@ namespace dmMessage
         return false;
     }
 
+    bool HasMessages(HSocket socket)
+    {
+        uint16_t id;
+        MessageSocket*s = GetSocketInternal(socket, id);
+        dmMutex::Lock(s->m_Mutex);
+        bool has_messages = false;
+        if (s->m_Header)
+        {
+            has_messages = true;
+        }
+        dmMutex::Unlock(s->m_Mutex);
+
+        return has_messages;
+    }
+
     void ResetURL(const URL& url)
     {
         memset((void*)&url, 0, sizeof(URL));

--- a/engine/dlib/src/dlib/message.h
+++ b/engine/dlib/src/dlib/message.h
@@ -128,6 +128,13 @@ namespace dmMessage
     bool IsSocketValid(HSocket socket);
 
     /**
+     * Test if a socket has any messages
+     * @param socket Socket
+     * @return if the socket has messages or not
+     */
+    bool HasMessages(HSocket socket);
+
+    /**
      * Resets the given URL to default values.
      * @note Previously the URL wasn't reset in the constructor and certain calls
      *       to ResetURL might currently be redundant

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1971,13 +1971,17 @@ namespace dmGameObject
             {
                 if (dmMessage::IsSocketValid(sockets[i]))
                 {
-                    if (dmMessage::HasMessages(sockets[i]))
+                    if (dmMessage::HasMessages(sockets[i]) && collection->m_DirtyTransforms)
                     {
                         UpdateTransforms(collection);
                     }
                     uint32_t message_count = dmMessage::Dispatch(sockets[i], &DispatchMessagesFunction, (void*) &ctx);
                     if (message_count > 0)
+                    {
+                        collection->m_DirtyTransforms = true;
                         iterate = true;
+                    }
+
                 }
             }
             ++iteration_count;
@@ -2003,11 +2007,6 @@ namespace dmGameObject
     {
         DM_PROFILE(GameObject, "UpdateTransforms");
 
-        if (!collection->m_DirtyTransforms)
-        {
-            return;
-        }
-
         // Calculate world transforms
         // First root-level instances
         dmArray<uint16_t>& root_level = collection->m_LevelIndices[0];
@@ -2023,6 +2022,7 @@ namespace dmGameObject
         }
 
         // World-transform for levels 1..MAX_HIERARCHICAL_DEPTH-1
+        Matrix4 own;
         for (uint32_t level_i = 1; level_i < MAX_HIERARCHICAL_DEPTH; ++level_i)
         {
             dmArray<uint16_t>& level = collection->m_LevelIndices[level_i];
@@ -2038,22 +2038,21 @@ namespace dmGameObject
                 assert(parent_index != INVALID_INSTANCE_INDEX);
 
                 Matrix4* parent_trans = &collection->m_WorldTransforms[parent_index];
+                own = dmTransform::ToMatrix4(instance->m_Transform);
 
                 if (instance->m_ScaleAlongZ)
                 {
-                    *trans = *parent_trans * dmTransform::ToMatrix4(instance->m_Transform);
+                    *trans = *parent_trans * own;
                 }
                 else
                 {
-                    *trans = dmTransform::MulNoScaleZ(*parent_trans, dmTransform::ToMatrix4(instance->m_Transform));
+                    *trans = dmTransform::MulNoScaleZ(*parent_trans, own);
                 }
 
                 if (instance->m_NoInheritScale)
                 {
-                    Matrix4 parent = (*parent_trans);
-                    Vector3 scale = dmTransform::ExtractScale(parent);
-                    Matrix4 own = dmTransform::ToMatrix4(instance->m_Transform);
-                    own.setUpper3x3(Matrix3::scale(Vector3(1/scale.getX(), 1/scale.getY(), 1/scale.getZ())) * own.getUpper3x3());
+                    Vector3 scale = dmTransform::ExtractScale(*parent_trans);
+                    own.setUpper3x3(Matrix3::scale(Vector3(1.0f/scale.getX(), 1.0f/scale.getY(), 1.0f/scale.getZ())) * own.getUpper3x3());
                     *trans = (*parent_trans) * own;
                 }
             }
@@ -2084,6 +2083,10 @@ namespace dmGameObject
 
             DM_COUNTER(component_type->m_Name, collection->m_ComponentInstanceCount[update_index]);
 
+            if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {
+                UpdateTransforms(collection);
+            }
+
             if (component_type->m_UpdateFunction)
             {
                 DM_PROFILE(GameObject, component_type->m_Name);
@@ -2100,15 +2103,15 @@ namespace dmGameObject
             // demands updated child-transforms. Many redundant calculations. This could be solved by splitting the component Update-callback
             // into UpdateTrasform, then Update or similar
             collection->m_DirtyTransforms |= component_type->m_WritesTransforms;
-            if (component_type->m_ReadsTransforms) {
-                UpdateTransforms(collection);
-            }
 
             if (!DispatchMessages(collection, &collection->m_ComponentSocket, 1))
                 ret = false;
         }
 
         collection->m_InUpdate = 0;
+        if (collection->m_DirtyTransforms) {
+            UpdateTransforms(collection);
+        }
 
         return ret;
     }

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1971,6 +1971,7 @@ namespace dmGameObject
             {
                 if (dmMessage::IsSocketValid(sockets[i]))
                 {
+                    // Make sure the transforms are updated if we are about to dispatch messages
                     if (dmMessage::HasMessages(sockets[i]) && collection->m_DirtyTransforms)
                     {
                         UpdateTransforms(collection);
@@ -2058,7 +2059,7 @@ namespace dmGameObject
             }
         }
 
-        collection->m_DirtyTransforms = 0;
+        collection->m_DirtyTransforms = false;
     }
 
     bool Update(HCollection collection, const UpdateContext* update_context)
@@ -2083,6 +2084,7 @@ namespace dmGameObject
 
             DM_COUNTER(component_type->m_Name, collection->m_ComponentInstanceCount[update_index]);
 
+            // Avoid to call UpdateTransforms for each/all component types.
             if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {
                 UpdateTransforms(collection);
             }
@@ -2099,9 +2101,9 @@ namespace dmGameObject
                 if (res != UPDATE_RESULT_OK)
                     ret = false;
             }
-            // TODO: Solve this better! Right now the worst is assumed, which is that every component updates some transforms as well as
-            // demands updated child-transforms. Many redundant calculations. This could be solved by splitting the component Update-callback
-            // into UpdateTrasform, then Update or similar
+
+            // Mark the collections transforms as dirty if this component could have updated
+            // them in its update function.
             collection->m_DirtyTransforms |= component_type->m_WritesTransforms;
 
             if (!DispatchMessages(collection, &collection->m_ComponentSocket, 1))

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -619,7 +619,9 @@ namespace dmGameObject
         ComponentGetProperty    m_GetPropertyFunction;
         ComponentSetProperty    m_SetPropertyFunction;
         uint32_t                m_InstanceHasUserData : 1;
-        uint32_t                m_Reserved : 31;
+        uint32_t                m_ReadsTransforms : 1;
+        uint32_t                m_WritesTransforms : 1;
+        uint32_t                m_Reserved : 29;
         uint16_t                m_UpdateOrderPrio;
     };
 

--- a/engine/gameobject/src/gameobject/gameobject_comp.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_comp.cpp
@@ -26,6 +26,8 @@ namespace dmGameObject
         script_component.m_SetPropertyFunction = &CompScriptSetProperty;
         script_component.m_InstanceHasUserData = true;
         script_component.m_UpdateOrderPrio = 200;
+        script_component.m_ReadsTransforms = 1;
+        script_component.m_WritesTransforms = 1;
         Result result = RegisterComponentType(regist, script_component);
         if (result != dmGameObject::RESULT_OK)
             return result;
@@ -36,6 +38,8 @@ namespace dmGameObject
         anim_component.m_NewWorldFunction = &CompAnimNewWorld;
         anim_component.m_DeleteWorldFunction = &CompAnimDeleteWorld;
         anim_component.m_AddToUpdateFunction = &CompAnimAddToUpdate;
+        anim_component.m_ReadsTransforms = 1;
+        anim_component.m_WritesTransforms = 1;
         anim_component.m_UpdateFunction = &CompAnimUpdate;
         anim_component.m_UpdateOrderPrio = 250;
         return RegisterComponentType(regist, anim_component);

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -97,7 +97,7 @@ namespace dmGameObject
         }
 
         dmTransform::Transform m_Transform;
-        
+
         // Shadowed rotation expressed in euler coordinates
         Vector3 m_EulerRotation;
         // Previous euler rotation, used to detect if the euler rotation has changed and should overwrite the real rotation (needed by animation)
@@ -215,6 +215,7 @@ namespace dmGameObject
             m_InUpdate = 0;
             m_ToBeDeleted = 0;
             m_ScaleAlongZ = 0;
+            m_DirtyTransforms = 1;
 
             m_InstancesToDeleteHead = INVALID_INSTANCE_INDEX;
             m_InstancesToDeleteTail = INVALID_INSTANCE_INDEX;
@@ -296,6 +297,7 @@ namespace dmGameObject
         uint32_t                 m_ToBeDeleted : 1;
         // If the game object dynamically created in this collection should have the Z component of the position affected by scale
         uint32_t                 m_ScaleAlongZ : 1;
+        uint32_t                 m_DirtyTransforms : 1;
     };
 
     ComponentType* FindComponentType(Register* regist, uint32_t resource_type, uint32_t* index);

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -136,7 +136,7 @@ namespace dmGameSystem
         dmResource::Result factory_result;
         dmGameObject::Result go_result;
 
-#define REGISTER_COMPONENT_TYPE(extension, prio, context, new_world_func, delete_world_func, create_func, destroy_func, init_func, final_func, add_to_update_func, update_func, render_func, post_update_func, on_message_func, on_input_func, on_reload_func, get_property_func, set_property_func)\
+#define REGISTER_COMPONENT_TYPE(extension, prio, context, new_world_func, delete_world_func, create_func, destroy_func, init_func, final_func, add_to_update_func, update_func, render_func, post_update_func, on_message_func, on_input_func, on_reload_func, get_property_func, set_property_func, set_reads_transforms, set_writes_transforms)\
     factory_result = dmResource::GetTypeFromExtension(factory, extension, &type);\
     if (factory_result != dmResource::RESULT_OK)\
     {\
@@ -162,6 +162,8 @@ namespace dmGameSystem
     component_type.m_OnReloadFunction = on_reload_func;\
     component_type.m_GetPropertyFunction = get_property_func;\
     component_type.m_SetPropertyFunction = set_property_func;\
+    component_type.m_ReadsTransforms = set_reads_transforms;\
+    component_type.m_WritesTransforms = set_writes_transforms;\
     component_type.m_InstanceHasUserData = (uint32_t)true;\
     component_type.m_UpdateOrderPrio = prio;\
     go_result = dmGameObject::RegisterComponentType(regist, component_type);\
@@ -177,74 +179,88 @@ namespace dmGameSystem
                 &CompCollectionProxyNewWorld, &CompCollectionProxyDeleteWorld,
                 &CompCollectionProxyCreate, &CompCollectionProxyDestroy, 0, 0,
                 &CompCollectionProxyAddToUpdate, &CompCollectionProxyUpdate, &CompCollectionProxyRender, &CompCollectionProxyPostUpdate,
-                &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput, 0, 0, 0);
+                &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput, 0, 0, 0,
+                0, 0);
 
         // Priority 200 is reserved for script
 
         REGISTER_COMPONENT_TYPE("guic", 300, gui_context,
                 CompGuiNewWorld, CompGuiDeleteWorld,
                 CompGuiCreate, CompGuiDestroy, CompGuiInit, CompGuiFinal, CompGuiAddToUpdate,
-                CompGuiUpdate, CompGuiRender, 0, CompGuiOnMessage, CompGuiOnInput, CompGuiOnReload, 0, 0);
+                CompGuiUpdate, CompGuiRender, 0, CompGuiOnMessage, CompGuiOnInput, CompGuiOnReload, 0, 0,
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("collisionobjectc", 400, physics_context,
                 &CompCollisionObjectNewWorld, &CompCollisionObjectDeleteWorld,
                 &CompCollisionObjectCreate, &CompCollisionObjectDestroy, 0, &CompCollisionObjectFinal, &CompCollisionObjectAddToUpdate,
-                &CompCollisionObjectUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0, &CompCollisionObjectOnReload, CompCollisionObjectGetProperty, CompCollisionObjectSetProperty);
+                &CompCollisionObjectUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0, &CompCollisionObjectOnReload, CompCollisionObjectGetProperty, CompCollisionObjectSetProperty,
+                1, 1);
 
         REGISTER_COMPONENT_TYPE("camerac", 500, render_context,
                 &CompCameraNewWorld, &CompCameraDeleteWorld,
                 &CompCameraCreate, &CompCameraDestroy, 0, 0, &CompCameraAddToUpdate,
-                &CompCameraUpdate, 0, 0, &CompCameraOnMessage, 0, &CompCameraOnReload, 0, 0);
+                &CompCameraUpdate, 0, 0, &CompCameraOnMessage, 0, &CompCameraOnReload, 0, 0,
+                1, 0);
 
         REGISTER_COMPONENT_TYPE("soundc", 600, 0x0,
                 CompSoundNewWorld, CompSoundDeleteWorld,
                 CompSoundCreate, CompSoundDestroy, 0, 0, CompSoundAddToUpdate,
-                CompSoundUpdate, 0, 0, CompSoundOnMessage, 0, 0, 0, 0);
+                CompSoundUpdate, 0, 0, CompSoundOnMessage, 0, 0, 0, 0,
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("modelc", 700, render_context,
                 CompModelNewWorld, CompModelDeleteWorld,
                 CompModelCreate, CompModelDestroy, 0, 0, CompModelAddToUpdate,
-                CompModelUpdate, CompModelRender, 0, CompModelOnMessage, 0, 0, CompModelGetProperty, CompModelSetProperty);
+                CompModelUpdate, CompModelRender, 0, CompModelOnMessage, 0, 0, CompModelGetProperty, CompModelSetProperty,
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("emitterc", 750, 0x0,
                 &CompEmitterNewWorld, &CompEmitterDeleteWorld,
                 &CompEmitterCreate, &CompEmitterDestroy, 0, 0, 0,
-                0, 0, 0, CompEmitterOnMessage, 0, 0, 0, 0);
+                0, 0, 0, CompEmitterOnMessage, 0, 0, 0, 0,
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("particlefxc", 800, particlefx_context,
                 &CompParticleFXNewWorld, &CompParticleFXDeleteWorld,
                 &CompParticleFXCreate, &CompParticleFXDestroy, 0, 0, &CompParticleFXAddToUpdate,
-                &CompParticleFXUpdate, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0, &CompParticleFXOnReload, 0, 0);
+                &CompParticleFXUpdate, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0, &CompParticleFXOnReload, 0, 0,
+                1, 0);
 
         REGISTER_COMPONENT_TYPE("factoryc", 900, factory_context,
                 CompFactoryNewWorld, CompFactoryDeleteWorld,
                 CompFactoryCreate, CompFactoryDestroy, 0, 0, 0,
-                0, 0, 0, CompFactoryOnMessage, 0, 0, 0, 0);
+                0, 0, 0, CompFactoryOnMessage, 0, 0, 0, 0,
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("collectionfactoryc", 950, collectionfactory_context,
                 CompCollectionFactoryNewWorld, CompCollectionFactoryDeleteWorld,
                 CompCollectionFactoryCreate, CompCollectionFactoryDestroy, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0);
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("lightc", 1000, render_context,
                 CompLightNewWorld, CompLightDeleteWorld,
                 CompLightCreate, CompLightDestroy, 0, 0, CompLightAddToUpdate,
-                CompLightUpdate, 0, 0, CompLightOnMessage, 0, 0, 0, 0);
+                CompLightUpdate, 0, 0, CompLightOnMessage, 0, 0, 0, 0,
+                1, 0);
 
         REGISTER_COMPONENT_TYPE("spritec", 1100, sprite_context,
                 CompSpriteNewWorld, CompSpriteDeleteWorld,
                 CompSpriteCreate, CompSpriteDestroy, 0, 0, CompSpriteAddToUpdate,
-                CompSpriteUpdate, CompSpriteRender, 0, CompSpriteOnMessage, 0, CompSpriteOnReload, CompSpriteGetProperty, CompSpriteSetProperty);
+                CompSpriteUpdate, CompSpriteRender, 0, CompSpriteOnMessage, 0, CompSpriteOnReload, CompSpriteGetProperty, CompSpriteSetProperty,
+                1, 0);
 
         REGISTER_COMPONENT_TYPE(TILE_MAP_EXT, 1200, render_context,
                 CompTileGridNewWorld, CompTileGridDeleteWorld,
                 CompTileGridCreate, CompTileGridDestroy, 0, 0, CompTileGridAddToUpdate,
-                CompTileGridUpdate, CompTileGridRender, 0, CompTileGridOnMessage, 0, CompTileGridOnReload, CompTileGridGetProperty, CompTileGridSetProperty);
+                CompTileGridUpdate, CompTileGridRender, 0, CompTileGridOnMessage, 0, CompTileGridOnReload, CompTileGridGetProperty, CompTileGridSetProperty,
+                1, 0);
 
         REGISTER_COMPONENT_TYPE(SPINE_MODEL_EXT, 1300, spine_model_context,
                 CompSpineModelNewWorld, CompSpineModelDeleteWorld,
                 CompSpineModelCreate, CompSpineModelDestroy, 0, 0, CompSpineModelAddToUpdate,
-                CompSpineModelUpdate, CompSpineModelRender, 0, CompSpineModelOnMessage, 0, CompSpineModelOnReload, CompSpineModelGetProperty, CompSpineModelSetProperty);
+                CompSpineModelUpdate, CompSpineModelRender, 0, CompSpineModelOnMessage, 0, CompSpineModelOnReload, CompSpineModelGetProperty, CompSpineModelSetProperty,
+                1, 1);
 
         #undef REGISTER_COMPONENT_TYPE
 


### PR DESCRIPTION
- Added m_Reads/m_WritesTransforms flags to ComponentType.
- Added m_DirtyTransforms flag to Collection.

UpdateTransforms should not be called every component type,
but instead only for component types that potentially updates
and/or reads the transforms.
