### PR TITLE
Improved error message when a resource exception is caught

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -266,7 +266,7 @@ public class GameProjectBuilder extends Builder<Void> {
                 findResources(project, (Message) message, resources);
 
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException("A problem occurred when trying to find resource '" + resource.getPath() + "'. " + e.getMessage());
             }
         } else {
             throw new CompileExceptionError(resource, -1, "No mapping for " + ext);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -261,16 +261,18 @@ public class GameProjectBuilder extends Builder<Void> {
             try {
                 Method newBuilder = klass.getDeclaredMethod("newBuilder");
                 builder = (GeneratedMessage.Builder<?>) newBuilder.invoke(null);
-                builder.mergeFrom(resource.output().getContent());
+                final byte[] content = resource.output().getContent();
+                if(content == null) {
+                	throw new CompileExceptionError(resource, 0, "Unable to find resource " + resource.getPath());
+                }
+                builder.mergeFrom(content);
                 Object message = builder.build();
                 findResources(project, (Message) message, resources);
 
-            } catch(NullPointerException e) {
-            	throw new CompileExceptionError(resource, 0, "Unable to find and build resource " + resource.getPath());
             } catch(CompileExceptionError e) {
-            	throw e;
+                throw e;
             } catch(Exception e) {
-            	throw new RuntimeException(e);
+                throw new RuntimeException(e);
             }
         } else {
             throw new CompileExceptionError(resource, -1, "No mapping for " + ext);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -265,8 +265,12 @@ public class GameProjectBuilder extends Builder<Void> {
                 Object message = builder.build();
                 findResources(project, (Message) message, resources);
 
-            } catch (Exception e) {
-                throw new RuntimeException("A problem occurred when trying to find resource '" + resource.getPath() + "'. " + e.getMessage());
+            } catch(NullPointerException e) {
+            	throw new CompileExceptionError(resource, 0, "Unable to find and build resource " + resource.getPath());
+            } catch(CompileExceptionError e) {
+            	throw e;
+            } catch(Exception e) {
+            	throw new RuntimeException(e);
             }
         } else {
             throw new CompileExceptionError(resource, -1, "No mapping for " + ext);


### PR DESCRIPTION
I got the following very non specific error when trying to build a project where a gui scene was referencing a non existing texture:

java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.NullPointerException

With my suggested fix filenames are also included in the error. This makes it significantly easier to find which file is causing a problem:

A problem occurred when trying to find resource 'saga/loader/loader.collectionc'. A problem occurred when trying to find resource 'saga/loader/loader_generated_1.goc'. A problem occurred when trying to find resource 'saga/loader/loader_generated_1_generated_0.collectionproxyc'. A problem occurred when trying to find resource 'saga/saga.collectionc'. A problem occurred when trying to find resource 'saga/saga_generated_0.goc'. A problem occurred when trying to find resource 'saga/saga_generated_0_generated_0.collectionproxyc'. A problem occurred when trying to find resource 'game/game.collectionc'. A problem occurred when trying to find resource 'game/game_generated_1.goc'. A problem occurred when trying to find resource 'saga/postgame/postgame.guic'. A problem occurred when trying to find resource 'saga/map/pregame/pregame.texturesetc'. null
