### PR TITLE
Fix for Android hang when accessing the notification bar.

### DIFF
--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -541,7 +541,7 @@ int _glfwPlatformInit( void )
     _glfwWin.context = EGL_NO_CONTEXT;
     _glfwWin.surface = EGL_NO_SURFACE;
     _glfwWin.iconified = 1;
-    _glfwWin.paused = 1;
+    _glfwWin.paused = 0;
     _glfwWin.app = g_AndroidApp;
 
     int result = pipe(_glfwWin.m_Pipefd);


### PR DESCRIPTION
Change initial value of paused flag on Android to false, which
otherwise was true until a APP_CMD_RESUME was received
(i.e a full pause -> resume cycle was performed).
