### PR TITLE
Added error check in swap buffers for Android. DEF-1219 + DEF-1275

### DIFF
--- a/engine/ddf/src/ddf/ddf.cpp
+++ b/engine/ddf/src/ddf/ddf.cpp
@@ -196,6 +196,7 @@ namespace dmDDF
         {
             if (fseek(f, 0, SEEK_END) != 0)
             {
+                fclose(f);
                 return RESULT_IO_ERROR;
             }
 
@@ -203,6 +204,7 @@ namespace dmDDF
 
             if (fseek(f, 0, SEEK_SET) != 0)
             {
+                fclose(f);
                 return RESULT_IO_ERROR;
             }
 
@@ -210,6 +212,7 @@ namespace dmDDF
             if ( fread(buffer, 1, size, f) != (size_t) size )
             {
                 free(buffer);
+                fclose(f);
                 return RESULT_IO_ERROR;
             }
 

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -472,6 +472,7 @@ namespace dmHttpCache
         if (f == 0)
         {
             dmLogError("Unable to open temporary file: '%s'", file_name);
+            fclose(f);
             free(file_name);
             cache->m_CacheCreatorsPool.Push(index);
             return RESULT_IO_ERROR;
@@ -690,6 +691,7 @@ namespace dmHttpCache
                 *file = f;
                 entry->m_ReadLockCount++;
                 *checksum = entry->m_Info.m_Checksum;
+                fclose(f);
                 return RESULT_OK;
             }
             else

--- a/engine/dlib/src/dlib/linux/socket_linux.cpp
+++ b/engine/dlib/src/dlib/linux/socket_linux.cpp
@@ -27,6 +27,7 @@ namespace dmSocket
         ifc.ifc_ifcu.ifcu_req = ifr;
         ifc.ifc_len = sizeof(buf);
         if (ioctl(s, SIOCGIFCONF, &ifc) < 0) {
+            close(s);
             return;
         }
 
@@ -73,6 +74,8 @@ namespace dmSocket
 
             *count = *count + 1;
         }
+
+        close(s);
         return;
     }
 }

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -340,7 +340,7 @@ namespace dmSSDP
 
         return socket;
 bail:
-        if (socket)
+        if (socket != dmSocket::INVALID_SOCKET_HANDLE)
             dmSocket::Delete(socket);
 
         return dmSocket::INVALID_SOCKET_HANDLE;

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -680,6 +680,7 @@ namespace dmSys
         if (asset) {
             uint32_t asset_size = (uint32_t) AAsset_getLength(asset);
             if (asset_size > buffer_size) {
+                AAsset_close(asset);
                 return RESULT_INVAL;
             }
             int nread = AAsset_read(asset, buffer, asset_size);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -836,9 +836,15 @@ bail:
                 dmTime::Sleep(1000 * 100);
                 // Update time again after the sleep to avoid big leaps after iconified.
                 // In practice, it makes the delta time 1/freq even though we slept for long
+
                 time = dmTime::GetTime();
-                engine->m_PreviousFrameTime = time - fixed_dt * 1000000;
-                dt = fixed_dt;
+                uint64_t i_dt = fixed_dt * 1000000;
+                if (i_dt > time) {
+                    engine->m_PreviousFrameTime = 0;
+                } else {
+                    engine->m_PreviousFrameTime = time - i_dt;
+                }
+
                 engine->m_WasIconified = true;
                 return;
             }

--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -178,7 +178,7 @@ static void computeIconifiedState()
     //
     // Therefore, base iconified status on both INIT_WINDOW and PAUSE/RESUME states
     // Iconified unless opened, active and resumed (not paused)
-    _glfwWin.iconified = !(_glfwWin.opened && _glfwWin.active && !_glfwWin.paused);
+    _glfwWin.iconified = !(_glfwWin.opened && _glfwWin.active && !_glfwWin.paused && _glfwWin.hasSurface);
 }
 
 static void handleCommand(struct android_app* app, int32_t cmd) {
@@ -191,6 +191,7 @@ static void handleCommand(struct android_app* app, int32_t cmd) {
         if (_glfwWin.opened)
         {
             create_gl_surface(&_glfwWin);
+            _glfwWin.hasSurface = 1;
         }
         _glfwWin.opened = 1;
         computeIconifiedState();
@@ -206,6 +207,8 @@ static void handleCommand(struct android_app* app, int32_t cmd) {
             g_appLaunchInterrupted = 1;
         }
         destroy_gl_surface(&_glfwWin);
+        _glfwWin.hasSurface = 0;
+        computeIconifiedState();
         break;
     case APP_CMD_GAINED_FOCUS:
         _glfwWin.active = 1;
@@ -243,6 +246,7 @@ static void handleCommand(struct android_app* app, int32_t cmd) {
     case APP_CMD_DESTROY:
         _glfwWin.opened = 0;
         final_gl(&_glfwWin);
+        computeIconifiedState();
         break;
     }
 }
@@ -468,6 +472,7 @@ void _glfwPreMain(struct android_app* state)
     state->onInputEvent = handleInput;
 
     _glfwWin.opened = 0;
+    _glfwWin.hasSurface = 0;
     // Wait for window to become ready (APP_CMD_INIT_WINDOW in handleCommand)
     while (_glfwWin.opened == 0)
     {
@@ -541,7 +546,7 @@ int _glfwPlatformInit( void )
     _glfwWin.context = EGL_NO_CONTEXT;
     _glfwWin.surface = EGL_NO_SURFACE;
     _glfwWin.iconified = 1;
-    _glfwWin.paused = 1;
+    _glfwWin.paused = 0;
     _glfwWin.app = g_AndroidApp;
 
     int result = pipe(_glfwWin.m_Pipefd);

--- a/engine/glfw/lib/android/android_native_app_glue.c
+++ b/engine/glfw/lib/android/android_native_app_glue.c
@@ -270,7 +270,7 @@ static struct android_app* android_app_create(ANativeActivity* activity,
     android_app->msgread = msgpipe[0];
     android_app->msgwrite = msgpipe[1];
 
-    pthread_attr_t attr; 
+    pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     pthread_create(&android_app->thread, &attr, android_app_entry, android_app);

--- a/engine/glfw/lib/android/android_util.c
+++ b/engine/glfw/lib/android/android_util.c
@@ -233,6 +233,7 @@ void create_gl_surface(_GLFWwin* win)
         }
 
         win->surface = surface;
+        win->hasSurface = 1;
 
         win->width = w;
         win->height = h;

--- a/engine/glfw/lib/android/android_window.c
+++ b/engine/glfw/lib/android/android_window.c
@@ -139,7 +139,7 @@ void _glfwPlatformRestoreWindow( void )
 
 void _glfwPlatformSwapBuffers( void )
 {
-    if (_glfwWin.display == EGL_NO_DISPLAY || _glfwWin.surface == EGL_NO_SURFACE)
+    if (_glfwWin.display == EGL_NO_DISPLAY || _glfwWin.surface == EGL_NO_SURFACE || _glfwWin.iconified == 1)
     {
         return;
     }
@@ -157,8 +157,10 @@ void _glfwPlatformSwapBuffers( void )
                 return;
             } else if (error == EGL_BAD_SURFACE) {
                 // Recreate surface
-                LOGE("eglSwapBuffers failed due to EGL_BAD_SURFACE, trying to recreate surface!");
-                create_gl_surface(&_glfwWin);
+                LOGE("eglSwapBuffers failed due to EGL_BAD_SURFACE, destroy surface and wait for recreation.");
+                destroy_gl_surface(&_glfwWin);
+                _glfwWin.iconified = 1;
+                _glfwWin.hasSurface = 0;
                 return;
             } else {
                 // Other errors typically mean that the current surface is bad,

--- a/engine/glfw/lib/android/android_window.c
+++ b/engine/glfw/lib/android/android_window.c
@@ -155,6 +155,11 @@ void _glfwPlatformSwapBuffers( void )
                 LOGE("eglSwapBuffers failed due to EGL_CONTEXT_LOST!");
                 assert(0);
                 return;
+            } else if (error == EGL_BAD_SURFACE) {
+                // Recreate surface
+                LOGE("eglSwapBuffers failed due to EGL_BAD_SURFACE, trying to recreate surface!");
+                create_gl_surface(&_glfwWin);
+                return;
             } else {
                 // Other errors typically mean that the current surface is bad,
                 // probably because the SurfaceView surface has been destroyed,

--- a/engine/glfw/lib/android/android_window.c
+++ b/engine/glfw/lib/android/android_window.c
@@ -144,8 +144,27 @@ void _glfwPlatformSwapBuffers( void )
         return;
     }
 
-    eglSwapBuffers(_glfwWin.display, _glfwWin.surface);
-    CHECK_EGL_ERROR
+    if (!eglSwapBuffers(_glfwWin.display, _glfwWin.surface))
+    {
+        // Error checking inspired by Android implementation of GLSurfaceView:
+        // http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/5.1.0_r1/android/opengl/GLSurfaceView.java?av=f
+        EGLint error = eglGetError();
+        if (error != EGL_SUCCESS) {
+
+            if (error == EGL_CONTEXT_LOST) {
+                LOGE("eglSwapBuffers failed due to EGL_CONTEXT_LOST!");
+                assert(0);
+                return;
+            } else {
+                // Other errors typically mean that the current surface is bad,
+                // probably because the SurfaceView surface has been destroyed,
+                // but we haven't been notified yet.
+                // Ignore error, but log for debugging purpose.
+                LOGW("eglSwapBuffers failed, eglGetError: %X", error);
+                return;
+            }
+        }
+    }
 
     /*
      The preferred way of handling orientation changes is probably

--- a/engine/glfw/lib/android/platform.h
+++ b/engine/glfw/lib/android/platform.h
@@ -132,6 +132,7 @@ struct _GLFWwin_struct {
     // pipe used to go from java thread to native (JNI)
     int m_Pipefd[2];
     int paused;
+    int hasSurface;
 };
 
 GLFWGLOBAL _GLFWwin _glfwWin;


### PR DESCRIPTION
- Added specific error check for swap buffers based on how it
  is done in the Android/Java implementation of GLSurfaceView.
- Added new hasSurface flag to keep track when there is a
  rendering surface. This flag is included in the iconified check.
