### PR TITLE
DEF-1270 - Android facebook crash

### DIFF
--- a/engine/adtruth/src/adtruth_android.cpp
+++ b/engine/adtruth/src/adtruth_android.cpp
@@ -294,4 +294,4 @@ dmExtension::Result FinalizeAdTruth(dmExtension::Params* params)
     return dmExtension::RESULT_OK;
 }
 
-DM_DECLARE_EXTENSION(AdTruthExt, "AdTruth", AppInitializeAdTruth, AppFinalizeAdTruth, InitializeAdTruth, FinalizeAdTruth)
+DM_DECLARE_EXTENSION(AdTruthExt, "AdTruth", AppInitializeAdTruth, AppFinalizeAdTruth, InitializeAdTruth, 0, FinalizeAdTruth)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -883,6 +883,22 @@ bail:
                         return;
                     }
 
+
+                    /* Extension updates */
+                    if (engine->m_SharedScriptContext) {
+                        dmScript::UpdateExtensions(engine->m_SharedScriptContext);
+                    } else {
+                        if (engine->m_GOScriptContext) {
+                            dmScript::UpdateExtensions(engine->m_GOScriptContext);
+                        }
+                        if (engine->m_RenderScriptContext) {
+                            dmScript::UpdateExtensions(engine->m_RenderScriptContext);
+                        }
+                        if (engine->m_GuiScriptContext) {
+                            dmScript::UpdateExtensions(engine->m_GuiScriptContext);
+                        }
+                    }
+
                     dmSound::Update();
 
                     dmHID::KeyboardPacket keybdata;

--- a/engine/extension/src/extension.h
+++ b/engine/extension/src/extension.h
@@ -58,6 +58,7 @@ namespace dmExtension
         Result (*AppInitialize)(AppParams* params);
         Result (*AppFinalize)(AppParams* params);
         Result (*Initialize)(Params* params);
+        Result (*Update)(Params* params);
         Result (*Finalize)(Params* params);
         const Desc* m_Next;
         bool        m_AppInitialzed;
@@ -131,12 +132,13 @@ namespace dmExtension
  * @param init init function. May not be 0
  * @param final final function. May not be 0
  */
-#define DM_DECLARE_EXTENSION(symbol, name, appinit, appfinal, init, final) \
+#define DM_DECLARE_EXTENSION(symbol, name, appinit, appfinal, init, update, final) \
         dmExtension::Desc DM_EXTENSION_PASTE2(symbol, __LINE__) = { \
                 name, \
                 appinit, \
                 appfinal, \
                 init, \
+                update, \
                 final, \
                 0, \
                 false, \

--- a/engine/extension/src/test/test_extension_lib.cpp
+++ b/engine/extension/src/test/test_extension_lib.cpp
@@ -29,9 +29,14 @@ dmExtension::Result InitializeTest(dmExtension::Params* params)
     return dmExtension::RESULT_OK;
 }
 
+dmExtension::Result UpdateTest(dmExtension::Params* params)
+{
+    return dmExtension::RESULT_OK;
+}
+
 dmExtension::Result FinalizeTest(dmExtension::Params* params)
 {
     return dmExtension::RESULT_OK;
 }
 
-DM_DECLARE_EXTENSION(TestExt, "test", AppInitializeTest, AppFinalizeTest, InitializeTest, FinalizeTest)
+DM_DECLARE_EXTENSION(TestExt, "test", AppInitializeTest, AppFinalizeTest, InitializeTest, UpdateTest, FinalizeTest)

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -209,6 +209,7 @@ namespace dmGameObject
                 }
             }
         }
+
         assert(top == lua_gettop(L));
         return result;
     }

--- a/engine/iap/src/iap_android.cpp
+++ b/engine/iap/src/iap_android.cpp
@@ -559,4 +559,4 @@ dmExtension::Result FinalizeIAP(dmExtension::Params* params)
     return dmExtension::RESULT_OK;
 }
 
-DM_DECLARE_EXTENSION(IAPExt, "IAP", 0, 0, InitializeIAP, FinalizeIAP)
+DM_DECLARE_EXTENSION(IAPExt, "IAP", 0, 0, InitializeIAP, 0, FinalizeIAP)

--- a/engine/iap/src/iap_ios.mm
+++ b/engine/iap/src/iap_ios.mm
@@ -558,4 +558,4 @@ dmExtension::Result FinalizeIAP(dmExtension::Params* params)
 }
 
 
-DM_DECLARE_EXTENSION(IAPExt, "IAP", 0, 0, InitializeIAP, FinalizeIAP)
+DM_DECLARE_EXTENSION(IAPExt, "IAP", 0, 0, InitializeIAP, 0, FinalizeIAP)

--- a/engine/push/src/push_android.cpp
+++ b/engine/push/src/push_android.cpp
@@ -717,4 +717,4 @@ dmExtension::Result FinalizePush(dmExtension::Params* params)
     return dmExtension::RESULT_OK;
 }
 
-DM_DECLARE_EXTENSION(PushExt, "Push", AppInitializePush, AppFinalizePush, InitializePush, FinalizePush)
+DM_DECLARE_EXTENSION(PushExt, "Push", AppInitializePush, AppFinalizePush, InitializePush, 0, FinalizePush)

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -177,6 +177,28 @@ namespace dmScript
         assert(top == lua_gettop(L));
     }
 
+    void UpdateExtensions(HContext context)
+    {
+        const dmExtension::Desc* ed = dmExtension::GetFirstExtension();
+        uint32_t i = 0;
+        while (ed) {
+            if (ed->Update)
+            {
+                dmExtension::Params p;
+                p.m_ConfigFile = context->m_ConfigFile;
+                p.m_L = context->m_LuaState;
+                if (context->m_InitializedExtensions[BIT_INDEX(i)] & (1 << BIT_OFFSET(i))) {
+                    dmExtension::Result r = ed->Update(&p);
+                    if (r != dmExtension::RESULT_OK) {
+                        dmLogError("Failed to update extension: %s", ed->m_Name);
+                    }
+                }
+            }
+            ++i;
+            ed = ed->m_Next;
+        }
+    }
+
     void Finalize(HContext context)
     {
         lua_State* L = context->m_LuaState;

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -101,7 +101,13 @@ namespace dmScript
      * Register the script libraries into the supplied script context.
      * @param context script context
      */
-    void Initialize(HContext m_Context);
+    void Initialize(HContext context);
+
+    /**
+     * Updates the extensions initalized in this script context.
+     * @param context script contetx
+     */
+    void UpdateExtensions(HContext context);
 
     /**
      * Finalize script libraries


### PR DESCRIPTION
- Add update method to extensions, add calls for these
  that only happen in non-iconified state
- Don't use looper for communication but instead a simple
  queue that is dispatched in the facebook extension update

Solves problem of when script callbacks invoke code that
touches the open gl surface for cases when it is not available.
