### PR TITLE
GUI Node Adjust mode parent referencing. DEF-1206

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/plugin.xml
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/plugin.xml
@@ -401,7 +401,7 @@
             name="Gui"
             proto-message-class="com.dynamo.gui.proto.Gui$SceneDesc"
             resource-refactor-participant-class="com.dynamo.cr.ddfeditor.refactoring.GuiRefactorParticipant"
-            template-data="script: &apos;&apos;"
+            template-data="script: &apos;&apos; adjust_reference: ADJUST_REFERENCE_PARENT"
             type-class="component">
          <references>
             <reference-type-class

--- a/com.dynamo.cr/com.dynamo.cr.guied/plugin.xml
+++ b/com.dynamo.cr/com.dynamo.cr.guied/plugin.xml
@@ -802,7 +802,7 @@
             name="Gui"
             proto-message-class="com.dynamo.gui.proto.Gui$SceneDesc"
             resource-refactor-participant-class="com.dynamo.cr.guied.refactoring.GuiSceneRefactorParticipant"
-            template-data="script: &apos;&apos;"
+            template-data="script: &apos;&apos; adjust_reference: ADJUST_REFERENCE_PARENT"
             type-class="component">
          <references>
             <reference-type-class

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiSceneLoader.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiSceneLoader.java
@@ -155,6 +155,7 @@ public class GuiSceneLoader implements INodeLoader<GuiSceneNode> {
         GuiSceneNode node = new GuiSceneNode();
         node.setScript(sceneDesc.getScript());
         node.setMaterial(sceneDesc.getMaterial());
+        node.setAdjustReference(sceneDesc.getAdjustReference());
         if (sceneDesc.hasBackgroundColor()) {
             node.setBackgroundColor(LoaderUtil.toRGB(sceneDesc.getBackgroundColor()));
         }
@@ -310,6 +311,7 @@ public class GuiSceneLoader implements INodeLoader<GuiSceneNode> {
         Builder b = SceneDesc.newBuilder();
         b.setScript(node.getScript());
         b.setMaterial(node.getMaterial());
+        b.setAdjustReference(node.getAdjustReference());
         b.setBackgroundColor(LoaderUtil.toVector4(node.getBackgroundColor(), 1.0));
         for (Node n : node.getTexturesNode().getChildren()) {
             TextureNode texNode = (TextureNode) n;

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiSceneNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiSceneNode.java
@@ -24,6 +24,7 @@ import com.dynamo.cr.properties.Property;
 import com.dynamo.cr.properties.Property.EditorType;
 import com.dynamo.cr.sceneed.core.AABB;
 import com.dynamo.cr.sceneed.core.Node;
+import com.dynamo.gui.proto.Gui.SceneDesc.AdjustReference;
 
 @SuppressWarnings("serial")
 public class GuiSceneNode extends ComponentTypeNode {
@@ -35,6 +36,9 @@ public class GuiSceneNode extends ComponentTypeNode {
 
     @Property(editorType = EditorType.RESOURCE, extensions = { "material" })
     private String material;
+
+    @Property(editorType = EditorType.DROP_DOWN)
+    private AdjustReference adjustReference = AdjustReference.ADJUST_REFERENCE_PARENT;
 
     private RGB backgroundColor = new RGB(0, 0, 0);
 
@@ -82,6 +86,14 @@ public class GuiSceneNode extends ComponentTypeNode {
 
     public void setMaterial(String material) {
         this.material = material;
+    }
+
+    public AdjustReference getAdjustReference() {
+        return adjustReference;
+    }
+
+    public void setAdjustReference( AdjustReference adjustReference) {
+        this.adjustReference = adjustReference;
     }
 
     public RGB getBackgroundColor() {

--- a/engine/gamesys/proto/gui_ddf.proto
+++ b/engine/gamesys/proto/gui_ddf.proto
@@ -116,6 +116,12 @@ message NodeDesc
 
 message SceneDesc
 {
+    enum AdjustReference
+    {
+        ADJUST_REFERENCE_LEGACY = 0 [(displayName) = "Scene (Legacy)"];
+        ADJUST_REFERENCE_PARENT = 1 [(displayName) = "Parent Node"];
+    };
+
     message FontDesc
     {
         required string name    = 1;
@@ -147,6 +153,8 @@ message SceneDesc
     optional string      material                = 8 [(resource)=true, default="/builtins/materials/gui.material"];
 
     repeated LayoutDesc  layouts                 = 9;
+
+    optional AdjustReference adjust_reference    = 10 [default = ADJUST_REFERENCE_LEGACY];
 }
 
 /*# reports a layout change
@@ -154,13 +162,13 @@ message SceneDesc
  * This message is broadcast to every GUI component when a layout change has been initiated
  * on device.
  * </p>
- * 
+ *
  * @message
  * @name layout_changed
  * @param id the id of the layout the engine is changing to (hash)
  * @param previous_id the id of the layout the engine is changing from (hash)
  * @examples
- * 
+ *
  * <pre>
  * function on_message(self, message_id, message, sender)
  *    if message_id == hash("layout_changed") and message.id == hash("Landscape") then

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -301,6 +301,7 @@ namespace dmGameSystem
         bool result = true;
 
         dmGui::SetMaterial(scene, scene_resource->m_Material);
+        dmGui::SetSceneAdjustReference(scene, (dmGui::AdjustReference)scene_desc->m_AdjustReference);
 
         for (uint32_t i = 0; i < scene_resource->m_FontMaps.Size(); ++i)
         {

--- a/engine/gamesys/src/gamesys/resources/res_gui.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui.cpp
@@ -21,13 +21,13 @@ namespace dmGameSystem
         dmDDF::Result e = dmDDF::LoadMessage<dmLuaDDF::LuaModule>(buffer, buffer_size, &lua_module);
         if ( e != dmDDF::RESULT_OK )
             return dmResource::RESULT_FORMAT_ERROR;
-            
+
         uint32_t n_modules = lua_module->m_Modules.m_Count;
         for (uint32_t i = 0; i < n_modules; ++i)
         {
             dmResource::PreloadHint(hint_info, lua_module->m_Resources[i]);
         }
-        
+
         *preload_data = lua_module;
         return dmResource::RESULT_OK;
     }

--- a/engine/gamesys/src/gamesys/resources/res_gui.h
+++ b/engine/gamesys/src/gamesys/resources/res_gui.h
@@ -27,8 +27,8 @@ namespace dmGameSystem
         dmGui::HContext                 m_GuiContext;
         dmRender::HMaterial             m_Material;
     };
-    
-    dmResource::Result ResPreloadSceneDesc(dmResource::HFactory factory, 
+
+    dmResource::Result ResPreloadSceneDesc(dmResource::HFactory factory,
                                           dmResource::HPreloadHintInfo hint_info,
                                           void* context,
                                           const void* buffer, uint32_t buffer_size,

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -670,8 +670,7 @@ namespace dmGui
         float scale_x = 1.0f;
         float scale_y = 1.0f;
 
-        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || node == 0x0 || node->m_ParentIndex == INVALID_INDEX)
-        {
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || node == 0x0 || node->m_ParentIndex == INVALID_INDEX) {
             scale_x = (float) scene->m_Context->m_PhysicalWidth / (float) scene->m_Width;
             scale_y = (float) scene->m_Context->m_PhysicalHeight / (float) scene->m_Height;
         } else {
@@ -1879,8 +1878,7 @@ namespace dmGui
         Context* context = scene->m_Context;
         Vector4 parent_dims;
 
-        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || n->m_ParentIndex == INVALID_INDEX)
-        {
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || n->m_ParentIndex == INVALID_INDEX) {
             parent_dims = Vector4((float) scene->m_Width, (float) scene->m_Height, 0.0f, 1.0f);
         } else {
             InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
@@ -1889,9 +1887,8 @@ namespace dmGui
 
         Vector4 offset = Vector4(0.0f, 0.0f, 0.0f, 0.0f);
         Vector4 adjusted_dims = mulPerElem(parent_dims, adjust_scale);
-        Vector4 ref_size = Vector4(1.0f, 1.0f, 0.0f, 1.0f);
-        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || n->m_ParentIndex == INVALID_INDEX)
-        {
+        Vector4 ref_size;
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || n->m_ParentIndex == INVALID_INDEX) {
             ref_size = Vector4((float) context->m_PhysicalWidth, (float) context->m_PhysicalHeight, 0.0f, 1.0f);
 
             // need to calculate offset for root nodes, since (0,0) is in middle of scene

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -12,6 +12,7 @@
 #include <dlib/hashtable.h>
 #include <dlib/math.h>
 #include <dlib/vmath.h>
+#include <dlib/transform.h>
 #include <dlib/message.h>
 #include <dlib/profile.h>
 #include <dlib/trig_lookup.h>
@@ -40,7 +41,7 @@ namespace dmGui
     const uint32_t INDEX_SHIFT = CLIPPER_SHIFT + CLIPPER_RANGE;
     const uint32_t LAYER_SHIFT = INDEX_SHIFT + INDEX_RANGE;
 
-    inline void CalculateNodeTransformAndColorCached(HScene scene, InternalNode* n, const Vector4& reference_scale, const CalculateNodeTransformFlags flags, Matrix4& out_transform, Vector4& out_color);
+    inline void CalculateNodeTransformAndColorCached(HScene scene, InternalNode* n, const CalculateNodeTransformFlags flags, Matrix4& out_transform, Vector4& out_color);
     static inline void UpdateTextureSetAnimData(HScene scene, InternalNode* n);
 
     static const char* SCRIPT_FUNCTION_NAMES[] =
@@ -219,6 +220,11 @@ namespace dmGui
         return scene->m_Context->m_DisplayProfiles;
     }
 
+    AdjustReference GetSceneAdjustReference(HScene scene)
+    {
+        return scene->m_AdjustReference;
+    }
+
     void SetDisplayProfiles(HContext context, void* display_profiles)
     {
         context->m_DisplayProfiles = display_profiles;
@@ -227,6 +233,11 @@ namespace dmGui
     void SetDefaultFont(HContext context, void* font)
     {
         context->m_DefaultFont = font;
+    }
+
+    void SetSceneAdjustReference(HScene scene, AdjustReference adjust_reference)
+    {
+        scene->m_AdjustReference = adjust_reference;
     }
 
     void SetDefaultNewSceneParams(NewSceneParams* params)
@@ -239,6 +250,7 @@ namespace dmGui
         params->m_MaxFonts = 4;
         // 8 is hard cap for the same reason as above
         params->m_MaxLayers = 8;
+        params->m_AdjustReference = dmGui::ADJUST_REFERENCE_LEGACY;
     }
 
     static void ResetScene(HScene scene) {
@@ -281,6 +293,7 @@ namespace dmGui
         scene->m_Fonts.SetCapacity(params->m_MaxFonts*2, params->m_MaxFonts);
         scene->m_Layers.SetCapacity(params->m_MaxLayers*2, params->m_MaxLayers);
         scene->m_Layouts.SetCapacity(1);
+        scene->m_AdjustReference = params->m_AdjustReference;
         scene->m_DefaultFont = 0;
         scene->m_UserData = params->m_UserData;
         scene->m_RenderHead = INVALID_INDEX;
@@ -652,10 +665,18 @@ namespace dmGui
         return ((uint32_t) node->m_Version) << 16 | node->m_Index;
     }
 
-    Vector4 CalculateReferenceScale(HScene scene)
+    Vector4 CalculateReferenceScale(HScene scene, InternalNode* node)
     {
-        float scale_x = (float) scene->m_Context->m_PhysicalWidth / (float) scene->m_Width;
-        float scale_y = (float) scene->m_Context->m_PhysicalHeight / (float) scene->m_Height;
+        float scale_x = 1.0f;
+        float scale_y = 1.0f;
+
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || node == 0x0 || node->m_ParentIndex == INVALID_INDEX)
+        {
+            scale_x = (float) scene->m_Context->m_PhysicalWidth / (float) scene->m_Width;
+            scale_y = (float) scene->m_Context->m_PhysicalHeight / (float) scene->m_Height;
+        } else {
+            return scene->m_Nodes[node->m_ParentIndex].m_Node.m_LocalScale;
+        }
         return Vector4(scale_x, scale_y, 1, 1);
     }
 
@@ -1005,7 +1026,6 @@ namespace dmGui
         UpdateDynamicTextures(scene, params, context);
         DeferredDeleteDynamicTextures(scene, params, context);
 
-        Vector4 scale = CalculateReferenceScale(scene);
         c->m_RenderNodes.SetSize(0);
         c->m_RenderTransforms.SetSize(0);
         c->m_RenderColors.SetSize(0);
@@ -1042,7 +1062,7 @@ namespace dmGui
             const RenderEntry& entry = c->m_RenderNodes[i];
             uint16_t index = entry.m_Node & 0xffff;
             InternalNode* n = &scene->m_Nodes[index];
-            CalculateNodeTransformAndColorCached(scene, n, scale, CalculateNodeTransformFlags(CALCULATE_NODE_INCLUDE_SIZE | CALCULATE_NODE_RESET_PIVOT), transform, color);
+            CalculateNodeTransformAndColorCached(scene, n, CalculateNodeTransformFlags(CALCULATE_NODE_INCLUDE_SIZE | CALCULATE_NODE_RESET_PIVOT), transform, color);
             c->m_RenderTransforms.Push(transform);
             c->m_RenderColors.Push(color);
             if (n->m_ClipperIndex != INVALID_INDEX) {
@@ -1835,69 +1855,103 @@ namespace dmGui
 
     static void AdjustPosScale(HScene scene, InternalNode* n, const Vector4& reference_scale, Vector4& position, Vector4& scale)
     {
-        if (n->m_ParentIndex == INVALID_INDEX)
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY && n->m_ParentIndex != INVALID_INDEX)
         {
-            Node& node = n->m_Node;
-            // Apply ref-scaling to scale uniformly, select the smallest scale component to make sure everything fits
-            Vector4 adjust_scale = reference_scale;
-            if (node.m_AdjustMode == dmGui::ADJUST_MODE_FIT)
-            {
-                float uniform = dmMath::Min(reference_scale.getX(), reference_scale.getY());
-                adjust_scale.setX(uniform);
-                adjust_scale.setY(uniform);
-            }
-            else if (node.m_AdjustMode == dmGui::ADJUST_MODE_ZOOM)
-            {
-                float uniform = dmMath::Max(reference_scale.getX(), reference_scale.getY());
-                adjust_scale.setX(uniform);
-                adjust_scale.setY(uniform);
-            }
-
-            Context* context = scene->m_Context;
-            Vector4 screen_dims((float) scene->m_Width, (float) scene->m_Height, 0.0f, 1.0f);
-            Vector4 adjusted_dims = mulPerElem(screen_dims, adjust_scale);
-            Vector4 offset = (Vector4((float) context->m_PhysicalWidth, (float) context->m_PhysicalHeight, 0.0f, 1.0f) - adjusted_dims) * 0.5f;
-            // Apply anchoring
-            Vector4 scaled_position = mulPerElem(position, adjust_scale);
-            if (node.m_XAnchor == XANCHOR_LEFT)
-            {
-                offset.setX(0.0f);
-                scaled_position.setX(position.getX() * reference_scale.getX());
-            }
-            else if (node.m_XAnchor == XANCHOR_RIGHT)
-            {
-                offset.setX(0.0f);
-                float distance = (scene->m_Width - position.getX()) * reference_scale.getX();
-                scaled_position.setX(context->m_PhysicalWidth - distance);
-            }
-            if (node.m_YAnchor == YANCHOR_TOP)
-            {
-                offset.setY(0.0f);
-                float distance = (scene->m_Height - position.getY()) * reference_scale.getY();
-                scaled_position.setY(context->m_PhysicalHeight - distance);
-            }
-            else if (node.m_YAnchor == YANCHOR_BOTTOM)
-            {
-                offset.setY(0.0f);
-                scaled_position.setY(position.getY() * reference_scale.getY());
-            }
-            position = scaled_position + offset;
-            scale = mulPerElem(adjust_scale, scale);
+            return;
         }
+
+        Node& node = n->m_Node;
+        // Apply ref-scaling to scale uniformly, select the smallest scale component to make sure everything fits
+        Vector4 adjust_scale = reference_scale;
+        if (node.m_AdjustMode == dmGui::ADJUST_MODE_FIT)
+        {
+            float uniform = dmMath::Min(reference_scale.getX(), reference_scale.getY());
+            adjust_scale.setX(uniform);
+            adjust_scale.setY(uniform);
+        }
+        else if (node.m_AdjustMode == dmGui::ADJUST_MODE_ZOOM)
+        {
+            float uniform = dmMath::Max(reference_scale.getX(), reference_scale.getY());
+            adjust_scale.setX(uniform);
+            adjust_scale.setY(uniform);
+        }
+
+        Context* context = scene->m_Context;
+        Vector4 parent_dims;
+
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || n->m_ParentIndex == INVALID_INDEX)
+        {
+            parent_dims = Vector4((float) scene->m_Width, (float) scene->m_Height, 0.0f, 1.0f);
+        } else {
+            InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
+            parent_dims = Vector4(parent->m_Node.m_Properties[dmGui::PROPERTY_SIZE].getX(), parent->m_Node.m_Properties[dmGui::PROPERTY_SIZE].getY(), 0.0f, 1.0f);
+        }
+
+        Vector4 offset = Vector4(0.0f, 0.0f, 0.0f, 0.0f);
+        Vector4 adjusted_dims = mulPerElem(parent_dims, adjust_scale);
+        Vector4 ref_size = Vector4(1.0f, 1.0f, 0.0f, 1.0f);
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_LEGACY || n->m_ParentIndex == INVALID_INDEX)
+        {
+            ref_size = Vector4((float) context->m_PhysicalWidth, (float) context->m_PhysicalHeight, 0.0f, 1.0f);
+
+            // need to calculate offset for root nodes, since (0,0) is in middle of scene
+            offset = (ref_size - adjusted_dims) * 0.5f;
+        } else {
+            InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
+            ref_size = Vector4(parent->m_Node.m_Properties[dmGui::PROPERTY_SIZE].getX() * reference_scale.getX(), parent->m_Node.m_Properties[dmGui::PROPERTY_SIZE].getY() * reference_scale.getY(), 0.0f, 1.0f);
+        }
+
+        // Apply anchoring
+        Vector4 scaled_position = mulPerElem(position, adjust_scale);
+        if (node.m_XAnchor == XANCHOR_LEFT)
+        {
+            offset.setX(0.0f);
+            scaled_position.setX(position.getX() * reference_scale.getX());
+        }
+        else if (node.m_XAnchor == XANCHOR_RIGHT)
+        {
+            offset.setX(0.0f);
+            float distance = (parent_dims.getX() - position.getX()) * reference_scale.getX();
+            scaled_position.setX(ref_size.getX() - distance);
+        }
+        if (node.m_YAnchor == YANCHOR_TOP)
+        {
+            offset.setY(0.0f);
+            float distance = (parent_dims.getY() - position.getY()) * reference_scale.getY();
+            scaled_position.setY(ref_size.getY() - distance);
+        }
+        else if (node.m_YAnchor == YANCHOR_BOTTOM)
+        {
+            offset.setY(0.0f);
+            scaled_position.setY(position.getY() * reference_scale.getY());
+        }
+
+        position = scaled_position + offset;
+        scale = mulPerElem(adjust_scale, scale);
     }
 
-    static void UpdateLocalTransform(HScene scene, InternalNode* n, const Vector4& reference_scale)
+    static void UpdateLocalTransform(HScene scene, InternalNode* n)
     {
         Node& node = n->m_Node;
 
         Vector4 position = node.m_Properties[dmGui::PROPERTY_POSITION];
-        Vector4 scale = node.m_Properties[dmGui::PROPERTY_SCALE];
-        AdjustPosScale(scene, n, reference_scale, position, scale);
+        node.m_LocalScale = node.m_Properties[dmGui::PROPERTY_SCALE];
+        Vector4 reference_scale = CalculateReferenceScale(scene, n);
+        AdjustPosScale(scene, n, reference_scale, position, node.m_LocalScale);
         const Vector3& rotation = node.m_Properties[dmGui::PROPERTY_ROTATION].getXYZ();
         Quat r = dmVMath::EulerToQuat(rotation);
         r = normalize(r);
-        node.m_LocalTransform.setUpper3x3(Matrix3::rotation(r) * Matrix3::scale(scale.getXYZ()));
+
+        node.m_LocalTransform.setUpper3x3(Matrix3::rotation(r) * Matrix3::scale(node.m_LocalScale.getXYZ()) );
         node.m_LocalTransform.setTranslation(position.getXYZ());
+
+        if (scene->m_AdjustReference == ADJUST_REFERENCE_PARENT && n->m_ParentIndex != INVALID_INDEX)
+        {
+            // undo parent scale (if node has parent)
+            Vector3 inv_ref_scale = Vector3(1.0f / reference_scale.getX(), 1.0f / reference_scale.getY(), 1.0f / reference_scale.getZ());
+            node.m_LocalTransform = Matrix4::scale( inv_ref_scale ) * node.m_LocalTransform;
+        }
+
         node.m_DirtyLocal = 0;
     }
 
@@ -2643,7 +2697,7 @@ namespace dmGui
                 (float) scene->m_Context->m_PhysicalHeight / (float) scene->m_Context->m_DefaultProjectHeight, 1, 1);
         Matrix4 transform;
         InternalNode* n = GetNode(scene, node);
-        CalculateNodeTransform(scene, n, scale, CalculateNodeTransformFlags(CALCULATE_NODE_BOUNDARY | CALCULATE_NODE_INCLUDE_SIZE | CALCULATE_NODE_RESET_PIVOT), transform);
+        CalculateNodeTransform(scene, n, CalculateNodeTransformFlags(CALCULATE_NODE_BOUNDARY | CALCULATE_NODE_INCLUDE_SIZE | CALCULATE_NODE_RESET_PIVOT), transform);
         transform = inverse(transform);
         Vector4 screen_pos(x * scale.getX(), y * scale.getY(), 0.0f, 1.0f);
         Vector4 node_pos = transform * screen_pos;
@@ -2832,7 +2886,7 @@ namespace dmGui
         }
     }
 
-    inline void CalculateParentNodeTransformAndAlphaCached(HScene scene, InternalNode* n, const Vector4& reference_scale, Matrix4& out_transform, float& out_alpha, SceneTraversalCache& traversal_cache)
+    inline void CalculateParentNodeTransformAndAlphaCached(HScene scene, InternalNode* n, Matrix4& out_transform, float& out_alpha, SceneTraversalCache& traversal_cache)
     {
         const Node& node = n->m_Node;
         uint16_t cache_index;
@@ -2853,7 +2907,7 @@ namespace dmGui
 
         if (node.m_DirtyLocal || scene->m_ResChanged)
         {
-            UpdateLocalTransform(scene, n, reference_scale);
+            UpdateLocalTransform(scene, n);
         }
         else if(cached)
         {
@@ -2868,7 +2922,7 @@ namespace dmGui
             Matrix4 parent_trans;
             float parent_alpha;
             InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
-            CalculateParentNodeTransformAndAlphaCached(scene, parent, reference_scale, parent_trans, parent_alpha, traversal_cache);
+            CalculateParentNodeTransformAndAlphaCached(scene, parent, parent_trans, parent_alpha, traversal_cache);
             out_transform = parent_trans * out_transform;
             out_alpha = n->m_Node.m_Properties[dmGui::PROPERTY_COLOR].getW();
             if (node.m_InheritAlpha)
@@ -2885,12 +2939,12 @@ namespace dmGui
         cache_data.m_Alpha = out_alpha;
     }
 
-    inline void CalculateNodeTransformAndColorCached(HScene scene, InternalNode* n, const Vector4& reference_scale, const CalculateNodeTransformFlags flags, Matrix4& out_transform, Vector4& out_color)
+    inline void CalculateNodeTransformAndColorCached(HScene scene, InternalNode* n, const CalculateNodeTransformFlags flags, Matrix4& out_transform, Vector4& out_color)
     {
         const Node& node = n->m_Node;
         if (node.m_DirtyLocal || scene->m_ResChanged)
         {
-            UpdateLocalTransform(scene, n, reference_scale);
+            UpdateLocalTransform(scene, n);
         }
         out_transform = node.m_LocalTransform;
         CalculateNodeExtents(node, flags, out_transform);
@@ -2900,7 +2954,7 @@ namespace dmGui
             Matrix4 parent_trans;
             float parent_alpha;
             InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
-            CalculateParentNodeTransformAndAlphaCached(scene, parent, reference_scale, parent_trans, parent_alpha, scene->m_Context->m_SceneTraversalCache);
+            CalculateParentNodeTransformAndAlphaCached(scene, parent, parent_trans, parent_alpha, scene->m_Context->m_SceneTraversalCache);
             out_transform = parent_trans * out_transform;
             if (node.m_InheritAlpha)
             {
@@ -2918,12 +2972,12 @@ namespace dmGui
         }
     }
 
-    inline void CalculateParentNodeTransform(HScene scene, InternalNode* n, const Vector4& reference_scale, Matrix4& out_transform)
+    inline void CalculateParentNodeTransform(HScene scene, InternalNode* n, Matrix4& out_transform)
     {
         const Node& node = n->m_Node;
         if (node.m_DirtyLocal || scene->m_ResChanged)
         {
-            UpdateLocalTransform(scene, n, reference_scale);
+            UpdateLocalTransform(scene, n);
         }
         out_transform = node.m_LocalTransform;
 
@@ -2931,17 +2985,17 @@ namespace dmGui
         {
             Matrix4 parent_trans;
             InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
-            CalculateParentNodeTransform(scene, parent, reference_scale, parent_trans);
+            CalculateParentNodeTransform(scene, parent, parent_trans);
             out_transform = parent_trans * out_transform;
         }
     }
 
-    void CalculateNodeTransform(HScene scene, InternalNode* n, const Vector4& reference_scale, const CalculateNodeTransformFlags flags, Matrix4& out_transform)
+    void CalculateNodeTransform(HScene scene, InternalNode* n, const CalculateNodeTransformFlags flags, Matrix4& out_transform)
     {
         const Node& node = n->m_Node;
         if (node.m_DirtyLocal || scene->m_ResChanged)
         {
-            UpdateLocalTransform(scene, n, reference_scale);
+            UpdateLocalTransform(scene, n);
         }
         out_transform = node.m_LocalTransform;
         CalculateNodeExtents(node, flags, out_transform);
@@ -2950,7 +3004,7 @@ namespace dmGui
         {
             Matrix4 parent_trans;
             InternalNode* parent = &scene->m_Nodes[n->m_ParentIndex];
-            CalculateParentNodeTransform(scene, parent, reference_scale, parent_trans);
+            CalculateParentNodeTransform(scene, parent, parent_trans);
             out_transform = parent_trans * out_transform;
         }
     }

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -64,6 +64,12 @@ namespace dmGui
         PLAYBACK_COUNT = 7,
     };
 
+    enum AdjustReference
+    {
+        ADJUST_REFERENCE_LEGACY  = 0,
+        ADJUST_REFERENCE_PARENT = 1
+    };
+
     /**
      * Textureset animation
      */
@@ -139,6 +145,7 @@ namespace dmGui
         void*    m_UserData;
         FetchTextureSetAnimCallback m_FetchTextureSetAnimCallback;
         OnWindowResizeCallback m_OnWindowResizeCallback;
+        AdjustReference m_AdjustReference;
 
         NewSceneParams()
         {
@@ -442,6 +449,8 @@ namespace dmGui
 
     void SetDefaultFont(HContext context, void* font);
 
+    void SetSceneAdjustReference(HScene scene, AdjustReference adjust_reference);
+
     HScene NewScene(HContext context, const NewSceneParams* params);
 
     void DeleteScene(HScene scene);
@@ -459,6 +468,8 @@ namespace dmGui
     uint32_t GetDisplayDpi(HScene scene);
 
     void* GetDisplayProfiles(HScene scene);
+
+    AdjustReference GetSceneAdjustReference(HScene scene);
 
     /**
      * Adds a texture and optional textureset with the specified name to the scene.

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -93,6 +93,7 @@ namespace dmGui
         Vector4     m_Properties[PROPERTY_COUNT];
         Vector4     m_ResetPointProperties[PROPERTY_COUNT];
         Matrix4     m_LocalTransform;
+        Vector4     m_LocalScale;
         uint32_t    m_ResetPointState;
 
         uint32_t m_PerimeterVertices;
@@ -232,6 +233,7 @@ namespace dmGui
         dmArray<dmhash_t>       m_Layouts;
         dmArray<void*>          m_LayoutsNodeDescs;
         dmhash_t                m_LayoutId;
+        AdjustReference         m_AdjustReference;
         dmArray<dmhash_t>       m_DeletedDynamicTextures;
         void*                   m_DefaultFont;
         void*                   m_UserData;
@@ -263,15 +265,16 @@ namespace dmGui
      * @param flags CalculateNodeTransformFlags enumerated behaviour flags
      * @param out_transform out-parameter to write the calculated transform to
      */
-    void CalculateNodeTransform(HScene scene, InternalNode* node, const Vector4& reference_scale, const CalculateNodeTransformFlags flags, Matrix4& out_transform);
+    void CalculateNodeTransform(HScene scene, InternalNode* node, const CalculateNodeTransformFlags flags, Matrix4& out_transform);
 
-    /** calculates the reference scale for a scene
+    /** calculates the reference scale for a node
      * The reference scale is defined as scaling from the predefined screen space to the actual screen space.
      *
-     * @param scene scene for which to calculate the reference scale
+     * @param scene scene for which the node exists in
+     * @param node node for which the reference scale should be calculated
      * @return a scaling vector (ref_scale, ref_scale, 1, 1)
      */
-    Vector4 CalculateReferenceScale(HScene scene);
+    Vector4 CalculateReferenceScale(HScene scene, InternalNode* node);
 
     HNode GetNodeHandle(InternalNode* node);
 }

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -2964,10 +2964,9 @@ namespace dmGui
     {
         InternalNode* n = LuaCheckNode(L, 1, 0);
         Scene* scene = GuiScriptInstance_Check(L);
-        Vector4 scale = CalculateReferenceScale(scene);
         Matrix4 node_transform;
         Vector4 center(0.5f, 0.5f, 0.0f, 1.0f);
-        CalculateNodeTransform(scene, n, scale, CalculateNodeTransformFlags(CALCULATE_NODE_BOUNDARY | CALCULATE_NODE_INCLUDE_SIZE | CALCULATE_NODE_RESET_PIVOT), node_transform);
+        CalculateNodeTransform(scene, n, CalculateNodeTransformFlags(CALCULATE_NODE_BOUNDARY | CALCULATE_NODE_INCLUDE_SIZE | CALCULATE_NODE_RESET_PIVOT), node_transform);
         Vector4 p = node_transform * center;
         dmScript::PushVector3(L, Vector3(p.getX(), p.getY(), p.getZ()));
         return 1;

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -39,6 +39,8 @@ extern uint32_t BUG352_LUA_SIZE;
  *
  * Render
  *
+ * Adjust reference
+ *
  */
 
 #define MAX_NODES 64U
@@ -2208,7 +2210,7 @@ TEST_F(dmGuiTest, Anchoring)
     dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
     dmGui::SetSceneResolution(m_Scene, width, height);
 
-    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene);
+    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene, 0);
 
     const char* n1_name = "n1";
     dmGui::HNode n1 = dmGui::NewNode(m_Scene, Point3(10, 10, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX);
@@ -2245,7 +2247,7 @@ TEST_F(dmGuiTest, ScriptAnchoring)
     dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
     dmGui::SetSceneResolution(m_Scene, width, height);
 
-    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene);
+    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene, 0);
 
     const char* s = "function init(self)\n"
                     "    assert (1024 == gui.get_width())\n"
@@ -2312,7 +2314,11 @@ TEST_F(dmGuiTest, AdjustMode)
     dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
     dmGui::SetSceneResolution(m_Scene, width, height);
 
-    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene);
+    // Verify that if we haven't specifically set adjust reference we should get
+    // the legacy/old behaviour -> scene resolution should be adjust reference.
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_LEGACY, dmGui::GetSceneAdjustReference(m_Scene));
+
+    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene, 0);
     float min_ref_scale = dmMath::Min(ref_scale.getX(), ref_scale.getY());
     float max_ref_scale = dmMath::Max(ref_scale.getX(), ref_scale.getY());
 
@@ -3412,6 +3418,295 @@ TEST_F(dmGuiTest, NewDeleteScene)
     dmGui::DeleteScene(scene2);
 
     ASSERT_EQ(1u, m_Context->m_Scenes.Size());
+}
+
+TEST_F(dmGuiTest, AdjustReference)
+{
+    uint32_t width = 100;
+    uint32_t height = 50;
+
+    uint32_t physical_width = 200;
+    uint32_t physical_height = 50;
+
+    dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
+    dmGui::SetSceneResolution(m_Scene, width, height);
+
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_LEGACY, dmGui::GetSceneAdjustReference(m_Scene));
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_PARENT);
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_PARENT, dmGui::GetSceneAdjustReference(m_Scene));
+
+    // create nodes
+    dmGui::HNode node_level0 = dmGui::NewNode(m_Scene, Point3(10, 10, 0), Vector3(80, 30, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level0, "node_level0");
+    dmGui::SetNodePivot(m_Scene, node_level0, dmGui::PIVOT_SW);
+    dmGui::SetNodeXAnchor(m_Scene, node_level0, dmGui::XANCHOR_LEFT);
+    dmGui::SetNodeYAnchor(m_Scene, node_level0, dmGui::YANCHOR_BOTTOM);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level0, dmGui::ADJUST_MODE_STRETCH);
+
+    dmGui::HNode node_level1 = dmGui::NewNode(m_Scene, Point3(10, 10, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level1, "node_level1");
+    dmGui::SetNodePivot(m_Scene, node_level1, dmGui::PIVOT_SW);
+    dmGui::SetNodeXAnchor(m_Scene, node_level1, dmGui::XANCHOR_LEFT);
+    dmGui::SetNodeYAnchor(m_Scene, node_level1, dmGui::YANCHOR_BOTTOM);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level1, dmGui::ADJUST_MODE_FIT);
+
+    dmGui::SetNodeParent(m_Scene, node_level1, node_level0);
+
+    // update
+    dmGui::RenderScene(m_Scene, &RenderNodes, this);
+
+
+    /*
+        before resize:
+        a----------------------+
+        |                      |
+        |  b---------------+   |
+        |  |[c]  <-80->    |   |
+        |10+---------------+   |
+        | 10                   |
+        +----------------------+
+
+        after resize:
+        a---------------------------------------------+
+        |                                             |
+        |    b----------------------------------+     |
+        |    |[c]           <-160->             |     |
+        | 20 +----------------------------------+     |
+        |   10                                        |
+        +---------------------------------------------+
+
+
+        a: window (ADJUST_REFERENCE_PARENT)
+        b: node_level_0 (ADJUST_MOD_STRETCH)
+        c: node_level_1 (parent: b, ADJUST_MODE_FIT)
+
+        => node c should not resize or offset inside b
+
+     */
+
+
+    Point3 node_level0_p = m_NodeTextToRenderedPosition["node_level0"];
+    Point3 node_level1_p = m_NodeTextToRenderedPosition["node_level1"];
+    Vector3 node_level0_s = m_NodeTextToRenderedSize["node_level0"];
+    Vector3 node_level1_s = m_NodeTextToRenderedSize["node_level1"];
+
+    ASSERT_EQ( 20, node_level0_p.getX());
+    ASSERT_EQ( 10, node_level0_p.getY());
+
+    ASSERT_EQ(160, node_level0_s.getX());
+    ASSERT_EQ( 30, node_level0_s.getY());
+
+    ASSERT_EQ( 10, node_level1_s.getX());
+    ASSERT_EQ( 10, node_level1_s.getY());
+
+    ASSERT_EQ( 40, node_level1_p.getX());
+    ASSERT_EQ( 20, node_level1_p.getY());
+
+    // clean up
+    dmGui::DeleteNode(m_Scene, node_level1);
+    dmGui::DeleteNode(m_Scene, node_level0);
+
+}
+
+TEST_F(dmGuiTest, AdjustReferenceMultiLevel)
+{
+    uint32_t width = 100;
+    uint32_t height = 50;
+
+    uint32_t physical_width = 200;
+    uint32_t physical_height = 50;
+
+    dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
+    dmGui::SetSceneResolution(m_Scene, width, height);
+
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_LEGACY, dmGui::GetSceneAdjustReference(m_Scene));
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_PARENT);
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_PARENT, dmGui::GetSceneAdjustReference(m_Scene));
+
+    // create nodes
+    dmGui::HNode node_level0 = dmGui::NewNode(m_Scene, Point3(0, 0, 0), Vector3(100, 50, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level0, "node_level0");
+    dmGui::SetNodePivot(m_Scene, node_level0, dmGui::PIVOT_SW);
+    dmGui::SetNodeXAnchor(m_Scene, node_level0, dmGui::XANCHOR_LEFT);
+    dmGui::SetNodeYAnchor(m_Scene, node_level0, dmGui::YANCHOR_BOTTOM);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level0, dmGui::ADJUST_MODE_STRETCH);
+
+    dmGui::HNode node_level1 = dmGui::NewNode(m_Scene, Point3(10, 10, 0), Vector3(80, 30, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level1, "node_level1");
+    dmGui::SetNodePivot(m_Scene, node_level1, dmGui::PIVOT_SW);
+    dmGui::SetNodeXAnchor(m_Scene, node_level1, dmGui::XANCHOR_LEFT);
+    dmGui::SetNodeYAnchor(m_Scene, node_level1, dmGui::YANCHOR_BOTTOM);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level1, dmGui::ADJUST_MODE_STRETCH);
+    dmGui::SetNodeParent(m_Scene, node_level1, node_level0);
+
+    dmGui::HNode node_level2 = dmGui::NewNode(m_Scene, Point3(10, 10, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level2, "node_level2");
+    dmGui::SetNodePivot(m_Scene, node_level2, dmGui::PIVOT_SW);
+    dmGui::SetNodeXAnchor(m_Scene, node_level2, dmGui::XANCHOR_LEFT);
+    dmGui::SetNodeYAnchor(m_Scene, node_level2, dmGui::YANCHOR_BOTTOM);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level2, dmGui::ADJUST_MODE_FIT);
+    dmGui::SetNodeParent(m_Scene, node_level2, node_level1);
+
+    // update
+    dmGui::RenderScene(m_Scene, &RenderNodes, this);
+
+    Point3 node_level0_p = m_NodeTextToRenderedPosition["node_level0"];
+    Point3 node_level1_p = m_NodeTextToRenderedPosition["node_level1"];
+    Point3 node_level2_p = m_NodeTextToRenderedPosition["node_level2"];
+    Vector3 node_level0_s = m_NodeTextToRenderedSize["node_level0"];
+    Vector3 node_level1_s = m_NodeTextToRenderedSize["node_level1"];
+    Vector3 node_level2_s = m_NodeTextToRenderedSize["node_level2"];
+
+    ASSERT_EQ(  0, node_level0_p.getX());
+    ASSERT_EQ(  0, node_level0_p.getY());
+
+    ASSERT_EQ(200, node_level0_s.getX());
+    ASSERT_EQ( 50, node_level0_s.getY());
+
+    ASSERT_EQ( 20, node_level1_p.getX());
+    ASSERT_EQ( 10, node_level1_p.getY());
+
+    ASSERT_EQ(160, node_level1_s.getX());
+    ASSERT_EQ( 30, node_level1_s.getY());
+
+    ASSERT_EQ( 10, node_level2_s.getX());
+    ASSERT_EQ( 10, node_level2_s.getY());
+
+    ASSERT_EQ( 40, node_level2_p.getX());
+    ASSERT_EQ( 20, node_level2_p.getY());
+
+    // clean up
+    dmGui::DeleteNode(m_Scene, node_level2);
+    dmGui::DeleteNode(m_Scene, node_level1);
+    dmGui::DeleteNode(m_Scene, node_level0);
+
+}
+
+TEST_F(dmGuiTest, AdjustReferenceOffset)
+{
+    uint32_t width = 100;
+    uint32_t height = 50;
+
+    uint32_t physical_width = 10;
+    uint32_t physical_height = 50;
+
+    dmGui::SetDefaultResolution(m_Context, width, height);
+    dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
+    dmGui::SetSceneResolution(m_Scene, width, height);
+
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_LEGACY, dmGui::GetSceneAdjustReference(m_Scene));
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_PARENT);
+    ASSERT_EQ(dmGui::ADJUST_REFERENCE_PARENT, dmGui::GetSceneAdjustReference(m_Scene));
+
+    // create nodes
+    dmGui::HNode node_level0 = dmGui::NewNode(m_Scene, Point3(50.0f, 25.0f, 0), Vector3(100, 50, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level0, "node_level0");
+    dmGui::SetNodePivot(m_Scene, node_level0, dmGui::PIVOT_CENTER);
+    dmGui::SetNodeXAnchor(m_Scene, node_level0, dmGui::XANCHOR_NONE);
+    dmGui::SetNodeYAnchor(m_Scene, node_level0, dmGui::YANCHOR_NONE);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level0, dmGui::ADJUST_MODE_STRETCH);
+
+    dmGui::HNode node_level1 = dmGui::NewNode(m_Scene, Point3(0, 0, 0), Vector3(50, 50, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level1, "node_level1");
+    dmGui::SetNodePivot(m_Scene, node_level1, dmGui::PIVOT_CENTER);
+    dmGui::SetNodeXAnchor(m_Scene, node_level1, dmGui::XANCHOR_NONE);
+    dmGui::SetNodeYAnchor(m_Scene, node_level1, dmGui::YANCHOR_NONE);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level1, dmGui::ADJUST_MODE_FIT);
+    dmGui::SetNodeParent(m_Scene, node_level1, node_level0);
+
+    dmGui::HNode node_level2 = dmGui::NewNode(m_Scene, Point3(0, 0, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, node_level2, "node_level2");
+    dmGui::SetNodePivot(m_Scene, node_level2, dmGui::PIVOT_CENTER);
+    dmGui::SetNodeXAnchor(m_Scene, node_level2, dmGui::XANCHOR_NONE);
+    dmGui::SetNodeYAnchor(m_Scene, node_level2, dmGui::YANCHOR_NONE);
+    dmGui::SetNodeAdjustMode(m_Scene, node_level2, dmGui::ADJUST_MODE_FIT);
+    dmGui::SetNodeParent(m_Scene, node_level2, node_level1);
+
+    // update
+    dmGui::RenderScene(m_Scene, &RenderNodes, this);
+
+    // get render positions and sizes
+    Point3 node_level0_p = m_NodeTextToRenderedPosition["node_level0"];
+    Point3 node_level1_p = m_NodeTextToRenderedPosition["node_level1"];
+    Point3 node_level2_p = m_NodeTextToRenderedPosition["node_level2"];
+    Vector3 node_level0_s = m_NodeTextToRenderedSize["node_level0"];
+    Vector3 node_level1_s = m_NodeTextToRenderedSize["node_level1"];
+    Vector3 node_level2_s = m_NodeTextToRenderedSize["node_level2"];
+
+    Vector4 screen_origo = Vector4(5.0f, 25.0f, 0.0f, 0.0f);
+
+    // validate
+    ASSERT_EQ( screen_origo.getX(), node_level0_p.getX() + node_level0_s.getX() / 2.0f);
+    ASSERT_EQ( screen_origo.getY(), node_level0_p.getY() + node_level0_s.getY() / 2.0f);
+
+    ASSERT_EQ( 10.0f, node_level0_s.getX());
+    ASSERT_EQ( 50.0f, node_level0_s.getY());
+
+    ASSERT_EQ( screen_origo.getX(), node_level1_p.getX() + node_level1_s.getX() / 2.0f);
+    ASSERT_EQ( screen_origo.getY(), node_level1_p.getY() + node_level1_s.getY() / 2.0f);
+
+    ASSERT_EQ( 5.0f, node_level1_s.getX());
+    ASSERT_EQ( 5.0f, node_level1_s.getY());
+
+    ASSERT_EQ( screen_origo.getX(), node_level2_p.getX() + node_level2_s.getX() / 2.0f);
+    ASSERT_EQ( screen_origo.getY(), node_level2_p.getY() + node_level2_s.getY() / 2.0f);
+
+    ASSERT_EQ( 1.0f, node_level2_s.getX());
+    ASSERT_EQ( 1.0f, node_level2_s.getY());
+
+    // clean up
+    dmGui::DeleteNode(m_Scene, node_level2);
+    dmGui::DeleteNode(m_Scene, node_level1);
+    dmGui::DeleteNode(m_Scene, node_level0);
+    dmGui::ClearFonts(m_Scene);
+
+}
+
+TEST_F(dmGuiTest, AdjustReferenceAnchoring)
+{
+    uint32_t width = 1024;
+    uint32_t height = 768;
+
+    uint32_t physical_width = 640;
+    uint32_t physical_height = 320;
+
+    dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
+    dmGui::SetSceneResolution(m_Scene, width, height);
+    dmGui::SetSceneAdjustReference(m_Scene, dmGui::ADJUST_REFERENCE_PARENT);
+
+    Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene, 0);
+
+    dmGui::HNode root_node = dmGui::NewNode(m_Scene, Point3(0.0f, 0.0f, 0), Vector3(1024, 768, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, root_node, "root_node");
+    dmGui::SetNodePivot(m_Scene, root_node, dmGui::PIVOT_SW);
+    dmGui::SetNodeXAnchor(m_Scene, root_node, dmGui::XANCHOR_NONE);
+    dmGui::SetNodeYAnchor(m_Scene, root_node, dmGui::YANCHOR_NONE);
+    dmGui::SetNodeAdjustMode(m_Scene, root_node, dmGui::ADJUST_MODE_STRETCH);
+
+    const char* n1_name = "n1";
+    dmGui::HNode n1 = dmGui::NewNode(m_Scene, Point3(10, 10, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, n1, n1_name);
+    dmGui::SetNodeXAnchor(m_Scene, n1, dmGui::XANCHOR_LEFT);
+    dmGui::SetNodeYAnchor(m_Scene, n1, dmGui::YANCHOR_BOTTOM);
+    dmGui::SetNodeParent(m_Scene, n1, root_node);
+
+    const char* n2_name = "n2";
+    dmGui::HNode n2 = dmGui::NewNode(m_Scene, Point3(width - 10.0f, height - 10.0f, 0), Vector3(10, 10, 0), dmGui::NODE_TYPE_BOX);
+    dmGui::SetNodeText(m_Scene, n2, n2_name);
+    dmGui::SetNodeXAnchor(m_Scene, n2, dmGui::XANCHOR_RIGHT);
+    dmGui::SetNodeYAnchor(m_Scene, n2, dmGui::YANCHOR_TOP);
+    dmGui::SetNodeParent(m_Scene, n2, root_node);
+
+    dmGui::RenderScene(m_Scene, &RenderNodes, this);
+
+    Point3 pos1 = m_NodeTextToRenderedPosition[n1_name] + m_NodeTextToRenderedSize[n1_name] * 0.5f;
+    const float EPSILON = 0.0001f;
+    ASSERT_NEAR(10 * ref_scale.getX(), pos1.getX(), EPSILON);
+    ASSERT_NEAR(10 * ref_scale.getY(), pos1.getY(), EPSILON);
+
+    Point3 pos2 = m_NodeTextToRenderedPosition[n2_name] + m_NodeTextToRenderedSize[n2_name] * 0.5f;
+    ASSERT_NEAR(physical_width - 10 * ref_scale.getX(), pos2.getX(), EPSILON);
+    ASSERT_NEAR(physical_height - 10 * ref_scale.getY(), pos2.getY(), EPSILON);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
(Kärt barn har många namn, "Adjust mode inheritance" etc)
- Added a new optional field to GUI scenes called `adjust_reference`, with two possible settings `ADJUST_REFERENCE_PARENT` and `ADJUST_REFERENCE_LEGACY`. This setting indicate what node scale/position adjustments should be relative to.
- `ADJUST_REFERENCE_LEGACY`: Current/old way; all nodes are adjusted relative to the scene size. Childs of nodes will inherit the parent adjust mode.
- `ADJUST_REFERENCE_PARENT`: New mode; nodes adjust their position and size depending on the size of their parent. If a node has no parent node, it will act as if the scene is the parent.
- The default value is `ADJUST_REFERENCE_LEGACY`, this means old scenes that don't have the àdjust_reference` field set will still use the old legacy mode.
- The template for GUI scenes sets `ADJUST_REFERENCE_PARENT`, so new scenes will have the new behaviour by default.
