### PR TITLE
Improved property value dependencies

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -30,8 +30,6 @@
 
 (namespaces/import-vars [internal.graph.types always PropertyType property-value-type property-default-value property-validate property-valid-value? property-tags property-type? Properties])
 
-(namespaces/import-vars [internal.property property-default-setter property-default-getter])
-
 (namespaces/import-vars [internal.graph arc type-compatible? node-by-id-at node-ids])
 
 (namespaces/import-macro schema.core/defn      s-defn)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -620,7 +620,7 @@
     (g/make-nodes view-graph
                   [renderer   SceneRenderer
                    background background/Gradient
-                   camera     [c/CameraController :camera (or (:camera opts) (c/make-camera :orthographic)) :reframe true]
+                   camera     [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic)) :reframe true]
                    grid       grid/Grid
                    tool-controller scene-tools/ToolController]
                   (g/update-property camera  :movements-enabled disj :tumble) ; TODO - pass in to constructor

--- a/editor/test/dynamo/integration/property_setters.clj
+++ b/editor/test/dynamo/integration/property_setters.clj
@@ -12,12 +12,19 @@
   (input source g/Str)
 
   (property reference g/Int
-            (get (fn [basis this prop]
-                   (ffirst (g/basis-sources basis (g/node-id this) :source))))
-            (set (fn [basis this prop value]
-                   (g/basis-connect basis value :contents (g/node-id this) :source))))
+            (value (g/fnk [this]
+                   (ffirst (g/sources-of (g/node-id this) :source))))
+            (set (fn [basis this value]
+                   (if value
+                     (g/connect value :contents (g/node-id this) :source)
+                      (when-let [old-source (ffirst (g/sources-of (g/node-id this) :source))]
+                        (g/disconnect old-source :contents (g/node-id this) :source))))))
 
-  (output transformed g/Str (g/fnk [source] (and source (.toUpperCase source))))
+  (property derived-property g/Str
+            (value (g/fnk [source]
+                          (and source (.toUpperCase source)))))
+
+  (output transformed g/Str :cached (g/fnk [source] (and source (.toUpperCase source))))
   (output upstream    g/Int (g/fnk [reference] reference)))
 
 (deftest fronting-a-connection-via-a-property
@@ -38,3 +45,32 @@
       (is (= provider (g/node-value user :reference)))
       (is (= provider (get-in (g/node-value user :_properties) [:properties :reference :value])))
       (is (= provider (g/node-value user :upstream))))))
+
+(defn- modified? [tx-report node property] (some #{[node property]} (:outputs-modified tx-report)))
+
+(deftest dependencies-through-properties
+  (testing "an output uses a property with a getter, changing the upstream node affects the output"
+    (ts/with-clean-system
+      (let [[provider user] (g/tx-nodes-added
+                             (g/transact
+                              (g/make-nodes world
+                                            [provider [ResourceNode :path "/images/something.png"]
+                                             user     ResourceUser])))]
+        (is (= [] (g/basis-sources (g/now) user :source)))
+        (is (instance? Long provider))
+
+        (g/set-property! user :reference provider)
+
+        (let [tx-report (g/set-property! provider :path "/a/new/path")]
+          (is      (modified? tx-report provider :path))
+          (is      (modified? tx-report provider :_properties))
+          (is      (modified? tx-report user     :derived-property))
+          (is      (modified? tx-report user     :transformed))
+          (is (not (modified? tx-report user     :upstream))))
+
+        (let [tx-report (g/set-property! user :reference nil)]
+          (is (not (modified? tx-report provider :path)))
+          (is (not (modified? tx-report provider :_properties)))
+          (is      (modified? tx-report user     :derived-property))
+          (is      (modified? tx-report user     :transformed))
+          (is      (modified? tx-report user     :upstream)))))))

--- a/editor/test/dynamo/transaction_test.clj
+++ b/editor/test/dynamo/transaction_test.clj
@@ -18,6 +18,8 @@
 (g/defnode Downstream
   (input consumer g/Keyword))
 
+(defn safe+ [x y] (int (or (and x (+ x y)) y)))
+
 (deftest low-level-transactions
   (testing "one node"
     (with-clean-system
@@ -44,8 +46,8 @@
 
   (testing "simple update"
     (with-clean-system
-      (let [[resource] (tx-nodes (g/make-node world Resource :marker 0))
-            tx-result  (g/transact (it/update-property resource :marker (fnil + 0) [42]))]
+      (let [[resource] (tx-nodes (g/make-node world Resource :marker (int 0)))
+            tx-result  (g/transact (it/update-property resource :marker safe+ [42]))]
         (is (= :ok (:status tx-result)))
         (is (= 42 (g/node-value resource :marker))))))
 

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -9,7 +9,7 @@
 
 (g/defnode Root
   (property where g/Str)
-  (property touched g/Int))
+  (property touched Number))
 
 (defn graphs        []    (is/graphs        @g/*the-system*))
 (defn graph         [gid] (is/graph         @g/*the-system* gid))


### PR DESCRIPTION
- `value` clause in property is now an fnk.
- it's arguments are handled just like production function arguments.
- `set` clause used to take a basis and return a modified basis. Now it returns a collection of transaction steps.
- some updates to editor.camera were needed to avoid an infinite loop when reframing the camera.

[Finishes #101147724]
