### PR TITLE
DEFAN-80 - dmengine.apk downloaded at d.download.com (stable) is cras…

### DIFF
--- a/engine/dlib/src/dlib/spinlock.h
+++ b/engine/dlib/src/dlib/spinlock.h
@@ -90,7 +90,8 @@ namespace dmSpinlock
          __asm__ __volatile__(
  "1:     ldrex   %0, [%1]\n"
  "       teq     %0, #0\n"
- "       wfene\n"
+// "       wfene\n"  -- WFENE gives SIGILL for still unknown reasons on some 64-bit ARMs Aarch32 mode.
+//                      Disassembly of libc.so and pthread_mutex_lock shows no use of the instruction.
  "       strexeq %0, %2, [%1]\n"
  "       teqeq   %0, #0\n"
  "       bne     1b\n"


### PR DESCRIPTION
…hing at start
- Do not use wfene instruction on arm for spinlocks.

At least some android configurations with armv8 cpus crash on this
instruction; probably having the instruction trapped (speculation) through
control registers.

libc.so on these systems do not use the wfene instruction in implementations
of pthread_mutex_lock, instead just use a busy loop, so do the same here.
