### PR TITLE
DEFEDIT-197 Partial fix for Geometry Wars, tilesources still broken

### DIFF
--- a/editor/src/clj/editor/mesh.clj
+++ b/editor/src/clj/editor/mesh.clj
@@ -52,7 +52,7 @@
 
 (defn- source->floats [source]
   (let [floats (first (-> source (element :float_array) (:content)))]
-    (mapv #(Float/parseFloat %) (str/split floats #"\s"))))
+    (mapv #(Float/parseFloat %) (str/split (str/triml floats) #"\s+"))))
 
 (defn- extract [input source comp-count tri-count tri-indices stride factor default]
   (let [factor (or factor 1.0)
@@ -92,7 +92,7 @@
         normal-source (source sources-map normal-input)
         texcoord-source (source sources-map texcoord-input)
         tri-count (Integer/parseInt (get-in triangles [:attrs :count] "0"))
-        tri-indices (mapv #(Integer/parseInt %) (str/split (first (-> triangles (element :p) (:content))) #"\s"))
+        tri-indices (mapv #(Integer/parseInt %) (str/split (str/triml (first (-> triangles (element :p) (:content)))) #"\s+"))
         positions (extract vertex-input pos-source 3 tri-count tri-indices stride meter [0 0 0])
         normals (extract normal-input normal-source 3 tri-count tri-indices stride nil [0 0 1])
         texcoords (extract texcoord-input texcoord-source 2 tri-count tri-indices stride nil [0 0 1])]

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -66,7 +66,7 @@
               {:ext "render"
                :icon "icons/32/Icons_30-Render.png"
                :pb-class Render$RenderPrototypeDesc
-               :resource-fields [:script]
+               :resource-fields [:script [:materials :material]]
                :view-types [:form-view]
                :label "Render"}
               {:ext "material"


### PR DESCRIPTION
mesh: string splitting should ignore leading and consecutive whitespace
protobuf_types: render materials/material not flagged as resource
font: missing build deps
