### PR TITLE
DEF-1395 Invalid touch position on some Android devices.

### DIFF
--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -313,6 +313,12 @@ inline void *pointerIdToRef(int32_t id)
     return (void*)(0x1 + id);
 }
 
+static void updateGlfwMousePos(int32_t x, int32_t y)
+{
+    _glfwInput.MousePosX = x;
+    _glfwInput.MousePosY = y;
+}
+
 // return 1 to handle the event, 0 for default handling
 static int32_t handleInput(struct android_app* app, AInputEvent* event)
 {
@@ -334,32 +340,37 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
 
         int32_t x = AMotionEvent_getX(event, pointer_index);
         int32_t y = AMotionEvent_getY(event, pointer_index);
-        _glfwInput.MousePosX = x;
-        _glfwInput.MousePosY = y;
 
         int32_t action_action = action & AMOTION_EVENT_ACTION_MASK;
 
         switch (action_action)
         {
             case AMOTION_EVENT_ACTION_DOWN:
+                updateGlfwMousePos(x,y);
                 _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_PRESS );
                 touchStart(pointer_ref, x, y);
                 break;
             case AMOTION_EVENT_ACTION_UP:
+                updateGlfwMousePos(x,y);
                 _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE );
                 touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
                 break;;
             case AMOTION_EVENT_ACTION_POINTER_DOWN:
+                updateGlfwMousePos(x,y);
                 touchStart(pointer_ref, x, y);
                 break;
             case AMOTION_EVENT_ACTION_POINTER_UP:
+                updateGlfwMousePos(x,y);
                 touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
                 break;
             case AMOTION_EVENT_ACTION_CANCEL:
+                updateGlfwMousePos(x,y);
                 touchUpdate(pointer_ref, x, y, GLFW_PHASE_CANCELLED);
                 break;
             case AMOTION_EVENT_ACTION_MOVE:
                 {
+                    updateGlfwMousePos(x,y);
+
                     // these events contain updates for all pointers.
                     int i, max = AMotionEvent_getPointerCount(event);
                     for (i=0;i<max;i++)
@@ -667,4 +678,3 @@ int _glfwPlatformTerminate( void )
 
     return GL_TRUE;
 }
-


### PR DESCRIPTION
On some Android devices we (wrongly) set _glfwInput.MousePosX and Y
to invalid values for input actions that we don't really want
(such as *_HOVER and *_SCROLL).

Moved the assignment into a separate function and only call this
function for cases we actually want to update the mouse position.
