### PR TITLE
DEF-1393 Fixed suggestion field in FB game request

### DIFF
--- a/engine/facebook/src/facebook.mm
+++ b/engine/facebook/src/facebook.mm
@@ -826,7 +826,7 @@ static int Facebook_ShowDialog(lua_State* L)
 
         [FBSDKAppInviteDialog showWithContent:content delegate:g_Facebook.m_Delegate];
 
-    } else if (dialog == dmHashString64("apprequests")) {
+    } else if (dialog == dmHashString64("apprequests") || dialog == dmHashString64("apprequest")) {
 
         FBSDKGameRequestContent* content = [[FBSDKGameRequestContent alloc] init];
         content.title      = GetTableValue(L, 2, @[@"title"], LUA_TSTRING);

--- a/engine/facebook/src/facebook_android.cpp
+++ b/engine/facebook/src/facebook_android.cpp
@@ -387,11 +387,11 @@ void AppendArray(lua_State* L, char* buffer, uint32_t buffer_size, int idx)
     while (lua_next(L, idx) != 0)
     {
         if (!lua_isstring(L, -1))
-            luaL_error(L, "permissions can only be strings (not %s)", lua_typename(L, lua_type(L, -1)));
+            luaL_error(L, "array arguments can only be strings (not %s)", lua_typename(L, lua_type(L, -1)));
         if (*buffer != 0)
             dmStrlCat(buffer, ",", buffer_size);
-        const char* permission = lua_tostring(L, -1);
-        dmStrlCat(buffer, permission, buffer_size);
+        const char* entry_str = lua_tostring(L, -1);
+        dmStrlCat(buffer, entry_str, buffer_size);
         lua_pop(L, 1);
     }
 }
@@ -505,20 +505,57 @@ int Facebook_Me(lua_State* L)
     return 1;
 }
 
-void AppendTableArray(lua_State* L, char* buffer, uint32_t buffer_size, int idx)
-{
-    lua_pushnil(L);
-    *buffer = 0;
-    while (lua_next(L, idx) != 0)
-    {
-        if (!lua_isstring(L, -1))
-            luaL_error(L, "table concat can only be strings (not %s)", lua_typename(L, lua_type(L, -1)));
-        if (*buffer != 0)
-            dmStrlCat(buffer, ",", buffer_size);
-        const char* permission = lua_tostring(L, -1);
-        dmStrlCat(buffer, permission, buffer_size);
-        lua_pop(L, 1);
+
+static void escape_json_str(const char* unescaped, char* escaped, char* end_ptr) {
+
+    // keep going through the unescaped until null terminating
+    // always need at least 3 chars left in escaped buffer,
+    // 2 for char expanding + 1 for null term
+    while (*unescaped && escaped < end_ptr - 3) {
+
+        switch (*unescaped) {
+
+            case '\x22':
+                *escaped++ = '\\';
+                *escaped++ = '"';
+                break;
+            case '\x5C':
+                *escaped++ = '\\';
+                *escaped++ = '\\';
+                break;
+            case '\x08':
+                *escaped++ = '\\';
+                *escaped++ = '\b';
+                break;
+            case '\x0C':
+                *escaped++ = '\\';
+                *escaped++ = '\f';
+                break;
+            case '\x0A':
+                *escaped++ = '\\';
+                *escaped++ = '\n';
+                break;
+            case '\x0D':
+                *escaped++ = '\\';
+                *escaped++ = '\r';
+                break;
+            case '\x09':
+                *escaped++ = '\\';
+                *escaped++ = '\t';
+                break;
+
+            default:
+                *escaped++ = *unescaped;
+                break;
+
+        }
+
+        unescaped++;
+
     }
+
+    *escaped = 0;
+
 }
 
 int Facebook_ShowDialog(lua_State* L)
@@ -549,13 +586,19 @@ int Facebook_ShowDialog(lua_State* L)
         const char* k = luaL_checkstring(L, -2);
 
         if (lua_istable(L, -1)) {
-            AppendTableArray(L, v, 1024, lua_gettop(L));
+            AppendArray(L, v, 1024, lua_gettop(L));
             vp = v;
         } else {
             vp = luaL_checkstring(L, -1);
         }
 
-        DM_SNPRINTF(tmp, sizeof(tmp), "\"%s\": \"%s\"", k, vp);
+        // escape string characters such as "
+        char k_escaped[128];
+        char v_escaped[1024];
+        escape_json_str(k, k_escaped, k_escaped+sizeof(k_escaped));
+        escape_json_str(vp, v_escaped, v_escaped+sizeof(v_escaped));
+
+        DM_SNPRINTF(tmp, sizeof(tmp), "\"%s\": \"%s\"", k_escaped, v_escaped);
         if (i > 0) {
             dmStrlCat(params_json, ",", sizeof(params_json));
         }

--- a/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
+++ b/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
@@ -330,7 +330,7 @@ public class FacebookActivity implements PseudoActivity {
 
                     shareDialog.show(parent, content.build());
 
-                } else if (dialogType.equals("apprequests")) {
+                } else if (dialogType.equals("apprequests") || dialogType.equals("apprequest")) {
 
                     GameRequestDialog appInviteDialog = new GameRequestDialog(parent);
 

--- a/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
+++ b/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
@@ -309,8 +309,9 @@ public class FacebookActivity implements PseudoActivity {
                         .setPlaceId(dialogParams.getString("place_id", ""))
                         .setRef(dialogParams.getString("ref", ""));
 
-                    if (dialogParams.getStringArray("people_ids") != null) {
-                        content.setPeopleIds(Arrays.asList(dialogParams.getStringArray("people_ids")));
+                    String peopleIdsString = dialogParams.getString("people_ids", null);
+                    if (peopleIdsString != null) {
+                        content.setPeopleIds(Arrays.asList(peopleIdsString.split(",")));
                     }
 
                     shareDialog.registerCallback(callbackManager, new DefaultDialogCallback<Sharer.Result>() {
@@ -334,8 +335,9 @@ public class FacebookActivity implements PseudoActivity {
                     GameRequestDialog appInviteDialog = new GameRequestDialog(parent);
 
                     ArrayList<String> suggestionsArray = new ArrayList<String>();
-                    String[] suggestions = dialogParams.getStringArray("suggestions");
-                    if (suggestions != null) {
+                    String suggestionsString = dialogParams.getString("suggestions", null);
+                    if (suggestionsString != null) {
+                        String [] suggestions = suggestionsString.split(",");
                         suggestionsArray.addAll(Arrays.asList(suggestions));
                     }
 


### PR DESCRIPTION
- Android did not correctly handle the "suggestion" and
  "people_ids" fields. These are now sent as a list of strings
  separated with commas from C++ and split in Java.
- iOS crashed when sending strings for some fields to the
  game request dialog. Added some type checking of the
  expected field types before setting them.
