### PR TITLE
DEF-1412 Option to specify Android push fields

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -7,11 +7,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -26,7 +23,6 @@ import com.dynamo.bob.Bob;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Platform;
 import com.dynamo.bob.Project;
-import com.dynamo.bob.pipeline.GameProjectBuilder;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
 import com.dynamo.bob.util.Exec.Result;
@@ -42,6 +38,11 @@ public class AndroidBundler implements IBundler {
             return true;
         }
         return false;
+    }
+
+    private boolean copyIconDPI(BobProjectProperties projectProperties, String projectRoot, File resDir, String name, String outName, String dpi)
+            throws IOException {
+            return copyIcon(projectProperties, projectRoot, resDir, name + "_" + dpi, "drawable-" + dpi + "/" + outName);
     }
 
     @Override
@@ -93,6 +94,20 @@ public class AndroidBundler implements IBundler {
             iconCount++;
         if (copyIcon(projectProperties, projectRoot, resDir, "app_icon_192x192", "drawable-xxxhdpi/icon.png"))
             iconCount++;
+
+        // Copy push notification icons
+        if (copyIcon(projectProperties, projectRoot, resDir, "push_icon_small", "drawable/push_icon_small.png"))
+            iconCount++;
+        if (copyIcon(projectProperties, projectRoot, resDir, "push_icon_large", "drawable/push_icon_large.png"))
+            iconCount++;
+
+        String[] dpis = new String[] { "ldpi", "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi" };
+        for (String dpi : dpis) {
+            if (copyIconDPI(projectProperties, projectRoot, resDir, "push_icon_small", "push_icon_small.png", dpi))
+                iconCount++;
+            if (copyIconDPI(projectProperties, projectRoot, resDir, "push_icon_large", "push_icon_large.png", dpi))
+                iconCount++;
+        }
 
         File manifestFile = new File(appDir, "AndroidManifest.xml");
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/android/AndroidManifest.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/android/AndroidManifest.xml
@@ -35,6 +35,16 @@
                 android:launchMode="singleTask">
             <meta-data android:name="android.app.lib_name"
                     android:value="{{exe-name}}" />
+            {{#android.push_field_title}}
+            <meta-data
+                android:name="com.defold.push.field_title"
+                android:value="{{android.push_field_title}}" />
+            {{/android.push_field_title}}
+            {{#android.push_field_text}}
+            <meta-data
+                android:name="com.defold.push.field_text"
+                android:value="{{android.push_field_text}}" />
+            {{/android.push_field_text}}
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -275,6 +275,42 @@ app_icon_144x144.help = Android xxhdpi icon file (.png)
 app_icon_192x192.type = resource
 app_icon_192x192.help = Android xxxhdpi icon file (.png)
 
+push_icon_small.type = resource
+push_icon_small.help = Small push notification icon (.png)
+push_icon_large.type = resource
+push_icon_large.help = Large push notification icon (.png)
+
+push_icon_small_ldpi.type = resource
+push_icon_small_ldpi.help = Small ldpi push notification icon file (.png)
+push_icon_small_mdpi.type = resource
+push_icon_small_mdpi.help = Small mdpi push notification icon file (.png)
+push_icon_small_hdpi.type = resource
+push_icon_small_hdpi.help = Small hdpi push notification icon file (.png)
+push_icon_small_xhdpi.type = resource
+push_icon_small_xhdpi.help = Small xhdpi push notification icon file (.png)
+push_icon_small_xxhdpi.type = resource
+push_icon_small_xxhdpi.help = Small xxhdpi push notification icon file (.png)
+push_icon_small_xxxhdpi.type = resource
+push_icon_small_xxxhdpi.help = Small xxxhdpi push notification icon file (.png)
+
+push_icon_large_ldpi.type = resource
+push_icon_large_ldpi.help = Large ldpi push notification icon file (.png)
+push_icon_large_mdpi.type = resource
+push_icon_large_mdpi.help = Large mdpi push notification icon file (.png)
+push_icon_large_hdpi.type = resource
+push_icon_large_hdpi.help = Large hdpi push notification icon file (.png)
+push_icon_large_xhdpi.type = resource
+push_icon_large_xhdpi.help = Large xhdpi push notification icon file (.png)
+push_icon_large_xxhdpi.type = resource
+push_icon_large_xxhdpi.help = Large xxhdpi push notification icon file (.png)
+push_icon_large_xxxhdpi.type = resource
+push_icon_large_xxxhdpi.help = Large xxxhdpi push notification icon file (.png)
+
+push_field_title.type = string
+push_field_title.help = JSON field name in push payload to use as notification title
+push_field_text.type = string
+push_field_text.help = JSON field name in push payload to use as notification text
+
 version_code.type = integer
 version_code.help = android version code (android:versionCode)
 version_code.default = 1

--- a/engine/push/src/java/com/defold/push/LocalNotificationReceiver.java
+++ b/engine/push/src/java/com/defold/push/LocalNotificationReceiver.java
@@ -36,20 +36,32 @@ public class LocalNotificationReceiver extends WakefulBroadcastReceiver {
         try {
             PendingIntent contentIntent = PendingIntent.getActivity(context, id, new_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
 
-            // get application icon
             ApplicationInfo info = context.getApplicationInfo();
-            PackageManager pm = context.getPackageManager();
-            Resources resources = pm.getResourcesForApplication(info);
-            Bitmap appIconBitmap = BitmapFactory.decodeResource(resources, info.icon);
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
-                .setLargeIcon(appIconBitmap)
-                .setSmallIcon(info.icon)
                 .setContentTitle(extras.getString("title"))
                 .setContentText(extras.getString("message"))
                 .setWhen(System.currentTimeMillis())
                 .setContentIntent(contentIntent)
                 .setPriority(extras.getInt("priority"));
+
+            // Find icons, if they were supplied
+            int smallIconId = extras.getInt("smallIcon");
+            int largeIconId = extras.getInt("largeIcon");
+            if (smallIconId == 0) {
+                smallIconId = info.icon;
+            }
+            if (largeIconId == 0) {
+                largeIconId = info.icon;
+            }
+
+            // Get bitmap for large icon resource
+            PackageManager pm = context.getPackageManager();
+            Resources resources = pm.getResourcesForApplication(info);
+            Bitmap largeIconBitmap = BitmapFactory.decodeResource(resources, largeIconId);
+
+            builder.setSmallIcon(smallIconId);
+            builder.setLargeIcon(largeIconBitmap);
 
             Notification notification = builder.build();
             notification.defaults = Notification.DEFAULT_ALL;


### PR DESCRIPTION
- Added game.project options to specify which fields in the remote push payload to use as notification title and text.
- Added game.project options to specify specific notification icons (small and large) on Android, this fixes DEF-1411.
- Skipping remote push that has the "from" set to "google.com/iid" which relates to DEF-1354.
