### PR TITLE
DEF-1422 Editor crashed on GUIs with invalid font-paths

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
@@ -35,11 +35,6 @@ public class FontNode extends Node implements Identifiable {
     }
 
     @Override
-    public void setModel(ISceneModel model) {
-        super.setModel(model);
-    }
-
-    @Override
     public String getId() {
         return this.id;
     }

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
@@ -1,46 +1,20 @@
 package com.dynamo.cr.guied.core;
 
-import java.awt.FontFormatException;
-import java.awt.image.BufferedImage;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.file.Paths;
-
-import javax.media.opengl.GL2;
-
-import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.graphics.Image;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.dynamo.bob.font.Fontc;
-import com.dynamo.bob.font.Fontc.FontResourceResolver;
-import com.dynamo.cr.editor.core.EditorUtil;
 import com.dynamo.cr.guied.Activator;
 import com.dynamo.cr.properties.NotEmpty;
 import com.dynamo.cr.properties.Property;
 import com.dynamo.cr.properties.Property.EditorType;
-import com.dynamo.cr.sceneed.core.FontRendererHandle;
 import com.dynamo.cr.sceneed.core.ISceneModel;
 import com.dynamo.cr.sceneed.core.Identifiable;
 import com.dynamo.cr.sceneed.core.Node;
 import com.dynamo.cr.sceneed.core.validators.Unique;
-import com.dynamo.render.proto.Font;
-import com.dynamo.render.proto.Font.FontMap;
-import com.google.protobuf.TextFormat;
 
 @SuppressWarnings("serial")
 public class FontNode extends Node implements Identifiable {
-
-    private static Logger logger = LoggerFactory.getLogger(FontNode.class);
 
     @Property
     @NotEmpty(severity = IStatus.ERROR)
@@ -50,132 +24,19 @@ public class FontNode extends Node implements Identifiable {
     @Property(editorType = EditorType.RESOURCE, extensions = { "font" })
     private String font;
 
-    private transient FontRendererHandle fontRendererHandle = null;
-    private transient FontRendererHandle defaultFontRendererHandle = null;
-
     public FontNode() {
         this.font = "";
         this.id = "";
-        updateFontRendererHandle(); // Will load default font
     }
 
     public FontNode(String font) {
         this.font = font;
         this.id = new Path(font).removeFileExtension().lastSegment();
-        updateFontRendererHandle();
-    }
-
-    public void dispose(GL2 gl) {
-        super.dispose(gl);
-        if (this.fontRendererHandle != null) {
-            this.fontRendererHandle.clear(gl);
-        }
-        if (this.defaultFontRendererHandle != null) {
-            this.defaultFontRendererHandle.clear(gl);
-        }
     }
 
     @Override
     public void setModel(ISceneModel model) {
         super.setModel(model);
-        updateFontRendererHandle();
-    }
-
-    private void loadFont(String fontPath, FontRendererHandle handle) throws CoreException, IOException {
-        IProject project = EditorUtil.getProject();
-        final IContainer contentRoot = EditorUtil.getContentRoot(project);
-        IFile fontFile = contentRoot.getFile(new Path(fontPath));
-        InputStream is = fontFile.getContents();
-        Font.FontDesc fontDesc = null;
-
-        // Parse font description
-        try {
-            Reader reader = new InputStreamReader(is);
-            Font.FontDesc.Builder fontDescBuilder = Font.FontDesc.newBuilder();
-            TextFormat.merge(reader, fontDescBuilder);
-            fontDesc = fontDescBuilder.build();
-        } finally {
-            is.close();
-        }
-
-        if (fontDesc == null) {
-            throw new IOException("Could not load font: " + fontPath);
-        }
-
-        // Compile to FontMap
-        FontMap.Builder fontMapBuilder = FontMap.newBuilder();
-        final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
-        final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
-        BufferedImage image;
-        Fontc fontc = new Fontc();
-
-        try {
-            image = fontc.compile(fontInputFile.getContents(), fontDesc, fontMapBuilder, new FontResourceResolver() {
-
-                @Override
-                public InputStream getResource(String resourceName)
-                        throws FileNotFoundException {
-
-                    String resPath = Paths.get(searchPath, resourceName).toString();
-                    IFile resFile = contentRoot.getFile(new Path(resPath));
-
-                    try {
-                        return resFile.getContents();
-                    } catch (CoreException e) {
-                        throw new FileNotFoundException(e.getMessage());
-                    }
-                }
-            });
-        } catch (FontFormatException e) {
-            throw new IOException(e.getMessage());
-        }
-
-        handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
-
-    }
-
-    private void updateFontRendererHandle() {
-
-        if (getModel() == null)
-            return;
-
-        // Reset current handle
-        this.fontRendererHandle = null;
-
-        if (!this.font.isEmpty()) {
-            try {
-                FontRendererHandle tmpFontRendererHandle = new FontRendererHandle();
-                loadFont(this.font, tmpFontRendererHandle);
-                this.fontRendererHandle = tmpFontRendererHandle;
-                this.defaultFontRendererHandle = null;
-            } catch (CoreException e) {
-                logger.error("Could not load font " + this.font, e);
-            } catch (IOException e) {
-                logger.error("Could not load font " + this.font, e);
-            }
-        }
-
-        if (this.fontRendererHandle == null && this.defaultFontRendererHandle == null) {
-            this.defaultFontRendererHandle = new FontRendererHandle();
-
-            try {
-                this.loadFont("/builtins/fonts/system_font.font", this.defaultFontRendererHandle);
-            } catch (CoreException e) {
-                logger.error("Could not load default font.", e);
-            } catch (IOException e) {
-                logger.error("Could not load default font.", e);
-            }
-        }
-
-
-    }
-
-    public FontRendererHandle getFontRendererHandle() {
-        return this.fontRendererHandle;
-    }
-
-    public FontRendererHandle getDefaultFontRendererHandle() {
-        return this.defaultFontRendererHandle;
     }
 
     @Override
@@ -194,7 +55,6 @@ public class FontNode extends Node implements Identifiable {
 
     public void setFont(String font) {
         this.font = font;
-        updateFontRendererHandle();
     }
 
     @Override

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
@@ -1,19 +1,46 @@
 package com.dynamo.cr.guied.core;
 
+import java.awt.FontFormatException;
+import java.awt.image.BufferedImage;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Paths;
+
+import javax.media.opengl.GL2;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.graphics.Image;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.dynamo.bob.font.Fontc;
+import com.dynamo.bob.font.Fontc.FontResourceResolver;
+import com.dynamo.cr.editor.core.EditorUtil;
 import com.dynamo.cr.guied.Activator;
 import com.dynamo.cr.properties.NotEmpty;
 import com.dynamo.cr.properties.Property;
 import com.dynamo.cr.properties.Property.EditorType;
+import com.dynamo.cr.sceneed.core.FontRendererHandle;
+import com.dynamo.cr.sceneed.core.ISceneModel;
 import com.dynamo.cr.sceneed.core.Identifiable;
 import com.dynamo.cr.sceneed.core.Node;
 import com.dynamo.cr.sceneed.core.validators.Unique;
+import com.dynamo.render.proto.Font;
+import com.dynamo.render.proto.Font.FontMap;
+import com.google.protobuf.TextFormat;
 
 @SuppressWarnings("serial")
 public class FontNode extends Node implements Identifiable {
+
+    private static Logger logger = LoggerFactory.getLogger(FontNode.class);
 
     @Property
     @NotEmpty(severity = IStatus.ERROR)
@@ -23,14 +50,132 @@ public class FontNode extends Node implements Identifiable {
     @Property(editorType = EditorType.RESOURCE, extensions = { "font" })
     private String font;
 
+    private transient FontRendererHandle fontRendererHandle = null;
+    private transient FontRendererHandle defaultFontRendererHandle = null;
+
     public FontNode() {
         this.font = "";
         this.id = "";
+        updateFontRendererHandle(); // Will load default font
     }
 
     public FontNode(String font) {
         this.font = font;
         this.id = new Path(font).removeFileExtension().lastSegment();
+        updateFontRendererHandle();
+    }
+
+    public void dispose(GL2 gl) {
+        super.dispose(gl);
+        if (this.fontRendererHandle != null) {
+            this.fontRendererHandle.clear(gl);
+        }
+        if (this.defaultFontRendererHandle != null) {
+            this.defaultFontRendererHandle.clear(gl);
+        }
+    }
+
+    @Override
+    public void setModel(ISceneModel model) {
+        super.setModel(model);
+        updateFontRendererHandle();
+    }
+
+    private void loadFont(String fontPath, FontRendererHandle handle) throws CoreException, IOException {
+        IProject project = EditorUtil.getProject();
+        final IContainer contentRoot = EditorUtil.getContentRoot(project);
+        IFile fontFile = contentRoot.getFile(new Path(fontPath));
+        InputStream is = fontFile.getContents();
+        Font.FontDesc fontDesc = null;
+
+        // Parse font description
+        try {
+            Reader reader = new InputStreamReader(is);
+            Font.FontDesc.Builder fontDescBuilder = Font.FontDesc.newBuilder();
+            TextFormat.merge(reader, fontDescBuilder);
+            fontDesc = fontDescBuilder.build();
+        } finally {
+            is.close();
+        }
+
+        if (fontDesc == null) {
+            throw new IOException("Could not load font: " + fontPath);
+        }
+
+        // Compile to FontMap
+        FontMap.Builder fontMapBuilder = FontMap.newBuilder();
+        final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
+        final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
+        BufferedImage image;
+        Fontc fontc = new Fontc();
+
+        try {
+            image = fontc.compile(fontInputFile.getContents(), fontDesc, fontMapBuilder, new FontResourceResolver() {
+
+                @Override
+                public InputStream getResource(String resourceName)
+                        throws FileNotFoundException {
+
+                    String resPath = Paths.get(searchPath, resourceName).toString();
+                    IFile resFile = contentRoot.getFile(new Path(resPath));
+
+                    try {
+                        return resFile.getContents();
+                    } catch (CoreException e) {
+                        throw new FileNotFoundException(e.getMessage());
+                    }
+                }
+            });
+        } catch (FontFormatException e) {
+            throw new IOException(e.getMessage());
+        }
+
+        handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
+
+    }
+
+    private void updateFontRendererHandle() {
+
+        if (getModel() == null)
+            return;
+
+        // Reset current handle
+        this.fontRendererHandle = null;
+
+        if (!this.font.isEmpty()) {
+            try {
+                FontRendererHandle tmpFontRendererHandle = new FontRendererHandle();
+                loadFont(this.font, tmpFontRendererHandle);
+                this.fontRendererHandle = tmpFontRendererHandle;
+                this.defaultFontRendererHandle = null;
+            } catch (CoreException e) {
+                logger.error("Could not load font " + this.font, e);
+            } catch (IOException e) {
+                logger.error("Could not load font " + this.font, e);
+            }
+        }
+
+        if (this.fontRendererHandle == null && this.defaultFontRendererHandle == null) {
+            this.defaultFontRendererHandle = new FontRendererHandle();
+
+            try {
+                this.loadFont("/builtins/fonts/system_font.font", this.defaultFontRendererHandle);
+            } catch (CoreException e) {
+                logger.error("Could not load default font.", e);
+            } catch (IOException e) {
+                logger.error("Could not load default font.", e);
+            }
+        }
+
+
+    }
+
+    public FontRendererHandle getFontRendererHandle() {
+        return this.fontRendererHandle;
+    }
+
+    public FontRendererHandle getDefaultFontRendererHandle() {
+        return this.defaultFontRendererHandle;
     }
 
     @Override
@@ -49,6 +194,7 @@ public class FontNode extends Node implements Identifiable {
 
     public void setFont(String font) {
         this.font = font;
+        updateFontRendererHandle();
     }
 
     @Override

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiTextureNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiTextureNode.java
@@ -41,6 +41,10 @@ public class GuiTextureNode {
         if(this.IsValidResource(texturePath)) {
             try {
                 Node n = node.getModel().loadNode(texturePath);
+                if (n == null) {
+                    logger.error("Failed loading resource: " + texturePath);
+                    return;
+                }
                 n.setModel(node.getModel());
                 this.textureSetNode = (TextureSetNode) n;
             } catch (Exception e) {

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TextNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TextNode.java
@@ -223,8 +223,14 @@ public class TextNode extends GuiNode {
                 }
             }
 
-            if (this.fontNode != null &&
-                !this.fontNode.getFont().equals(this.fontPath)) {
+            if ( this.fontNode != null &&
+                !this.fontNode.getId().equals(this.font)) {
+                this.fontRendererHandle = null;
+                this.fontPath = "";
+                updateFont();
+            }
+
+            if (this.fontNode != null && !this.fontNode.getFont().equals(this.fontPath)) {
                 this.fontRendererHandle = null;
                 this.fontPath = this.fontNode.getFont();
             }

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TextNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TextNode.java
@@ -269,7 +269,7 @@ public class TextNode extends GuiNode {
                 newFontPath = "";
             }
 
-            if (!this.fontPath.equals(newFontPath)) {
+            if (this.fontPath != null && !this.fontPath.equals(newFontPath)) {
                 this.fontRendererHandle = null;
             }
 

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TextNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TextNode.java
@@ -1,27 +1,13 @@
 package com.dynamo.cr.guied.core;
 
-import java.awt.FontFormatException;
-import java.awt.image.BufferedImage;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
+import javax.media.opengl.GL2;
+
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.RGB;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.dynamo.bob.font.Fontc;
-import com.dynamo.bob.font.Fontc.FontResourceResolver;
 import com.dynamo.cr.guied.Activator;
 import com.dynamo.cr.guied.util.GuiNodeStateBuilder;
 import com.dynamo.cr.properties.Property;
@@ -32,14 +18,9 @@ import com.dynamo.cr.sceneed.core.Node;
 import com.dynamo.cr.sceneed.core.FontRendererHandle;
 import com.dynamo.cr.sceneed.core.util.LoaderUtil;
 import com.dynamo.proto.DdfMath.Vector4;
-import com.dynamo.render.proto.Font;
-import com.dynamo.render.proto.Font.FontMap;
-import com.google.protobuf.TextFormat;
 
 @SuppressWarnings("serial")
 public class TextNode extends GuiNode {
-
-    private static Logger logger = LoggerFactory.getLogger(TextNode.class);
 
     @Property
     private String text = "";
@@ -64,8 +45,18 @@ public class TextNode extends GuiNode {
     @Range(min = 0.0, max = 1.0)
     private double shadowAlpha = 1.0;
 
-    private transient FontRendererHandle fontRendererHandle = null;
-    private transient FontRendererHandle textDefaultRendererHandle = null;
+    private transient FontNode fontNode = null;
+
+    public TextNode() {
+        super();
+        updateFont();
+    }
+
+    public void dispose(GL2 gl) {
+        if (this.fontNode != null) {
+            this.fontNode.dispose(gl);
+        }
+    }
 
     public String getText() {
         return text;
@@ -141,7 +132,7 @@ public class TextNode extends GuiNode {
     }
 
     public void resetOutline() {
-        this. outline = LoaderUtil.toRGB((Vector4)GuiNodeStateBuilder.resetField(this, "Outline"));
+        this.outline = LoaderUtil.toRGB((Vector4)GuiNodeStateBuilder.resetField(this, "Outline"));
     }
 
     public boolean isOutlineOverridden() {
@@ -201,78 +192,26 @@ public class TextNode extends GuiNode {
         return GuiNodeStateBuilder.isFieldOverridden(this, "ShadowAlpha", (float)this.shadowAlpha);
     }
 
-    public FontRendererHandle getDefaultTextRendererHandle() throws CoreException, IOException {
-        if (this.textDefaultRendererHandle == null) {
-            this.textDefaultRendererHandle = new FontRendererHandle();
-            this.loadFont("/builtins/fonts/system_font.font", this.textDefaultRendererHandle);
-        }
-
-        return this.textDefaultRendererHandle;
-    }
-
-    public FontRendererHandle getTextRendererHandle() {
-        return this.fontRendererHandle;
-    }
-
-    private void loadFont(String fontPath, FontRendererHandle fontRendererHandle) throws CoreException, IOException {
-
-        final IContainer contentRoot = getModel().getContentRoot();
-        IFile fontFile = contentRoot.getFile(new Path(fontPath));
-        InputStream is = fontFile.getContents();
-        Font.FontDesc fontDesc = null;
-
-        // Parse font description
-        try {
-            Reader reader = new InputStreamReader(is);
-            Font.FontDesc.Builder fontDescBuilder = Font.FontDesc.newBuilder();
-            TextFormat.merge(reader, fontDescBuilder);
-            fontDesc = fontDescBuilder.build();
-        } finally {
-            is.close();
-        }
-
-        if (fontDesc == null) {
-            throw new IOException("Could not load font: " + fontPath);
-        }
-
-        // Compile to FontMap
-        FontMap.Builder fontMapBuilder = FontMap.newBuilder();
-        final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
-        final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
-        BufferedImage image;
-        Fontc fontc = new Fontc();
-
-        try {
-            image = fontc.compile(fontInputFile.getContents(), fontDesc, fontMapBuilder, new FontResourceResolver() {
-
-                @Override
-                public InputStream getResource(String resourceName)
-                        throws FileNotFoundException {
-
-                    String resPath = Paths.get(searchPath, resourceName).toString();
-                    IFile resFile = contentRoot.getFile(new Path(resPath));
-
-                    try {
-                        return resFile.getContents();
-                    } catch (CoreException e) {
-                        throw new FileNotFoundException(e.getMessage());
-                    }
-                }
-            });
-        } catch (FontFormatException e) {
-            throw new IOException(e.getMessage());
-        }
-
-        fontRendererHandle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
-
-    }
-
-    private String findFontByName(List<Node> fontNodes) {
+    private FontNode findFontNodeByName(List<Node> fontNodes) {
         for (Node n : fontNodes) {
             FontNode fontNode = (FontNode) n;
             if (fontNode.getId().equals(this.font)) {
-                return fontNode.getFont();
+                return fontNode;
             }
+        }
+        return null;
+    }
+
+    public FontRendererHandle getFontRendererHandle() {
+        if (this.fontNode != null) {
+            return this.fontNode.getFontRendererHandle();
+        }
+        return null;
+    }
+
+    public FontRendererHandle getDefaultFontRendererHandle() {
+        if (this.fontNode != null) {
+            return this.fontNode.getDefaultFontRendererHandle();
         }
         return null;
     }
@@ -280,21 +219,11 @@ public class TextNode extends GuiNode {
     private void updateFont() {
         if (!this.font.isEmpty() && getModel() != null) {
             GuiSceneNode scene = getScene();
-            String fontPath = this.findFontByName(scene.getFontsNode().getChildren());
-            if(fontPath == null) {
+            this.fontNode = this.findFontNodeByName(scene.getFontsNode().getChildren());
+            if(this.fontNode == null) {
                 TemplateNode parentTemplate = this.getParentTemplateNode();
                 if(parentTemplate != null && parentTemplate.getTemplateScene() != null) {
-                    fontPath = this.findFontByName(parentTemplate.getTemplateScene().getFontsNode().getChildren());
-                }
-            }
-            if (fontPath != null) {
-                try {
-                    this.fontRendererHandle = new FontRendererHandle();
-                    loadFont(fontPath, this.fontRendererHandle);
-                } catch (CoreException e) {
-                    logger.error("Could not load font " + fontPath, e);
-                } catch (IOException e) {
-                    logger.error("Could not load font " + fontPath, e);
+                    this.fontNode = this.findFontNodeByName(parentTemplate.getTemplateScene().getFontsNode().getChildren());
                 }
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TexturesNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TexturesNode.java
@@ -45,6 +45,11 @@ public class TexturesNode extends LabelNode {
                     continue;
                 }
 
+                if (textureSetNode == null) {
+                    logger.error("Failed loading resource: " + textureNode.getTexture());
+                    continue;
+                }
+
                 List<String> animationsIds = textureSetNode.getAnimationIds();
                 for(String animationsId : animationsIds) {
                     textures.add(textureNode.getId() + "/" + animationsId);

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -13,8 +13,6 @@ import javax.vecmath.Point3d;
 
 import org.eclipse.swt.graphics.RGB;
 import org.osgi.framework.FrameworkUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.dynamo.bob.font.Fontc.InputFontFormat;
 import com.dynamo.cr.guied.core.ClippingNode;
@@ -36,8 +34,6 @@ import com.dynamo.render.proto.Font.FontTextureFormat;
 import com.jogamp.opengl.util.texture.Texture;
 
 public class TextNodeRenderer implements INodeRenderer<TextNode> {
-
-    private static Logger logger = LoggerFactory.getLogger(TextNodeRenderer.class);
 
     private static final EnumSet<Pass> passes = EnumSet.of(Pass.OUTLINE, Pass.TRANSPARENT, Pass.SELECTION);
 
@@ -189,14 +185,14 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
         String actualText = node.getText();
 
         FontRendererHandle textRenderHandle = null;
-        textRenderHandle = node.getFontRendererHandle();
+        textRenderHandle = node.getFontRendererHandle(gl);
 
-        if (textRenderHandle == null) {
+        if (textRenderHandle == null || !textRenderHandle.isLoaded()) {
             textRenderHandle = node.getDefaultFontRendererHandle();
             actualText = String.format("Error: Font '%s' not found", node.getFont());
         }
 
-        if (textRenderHandle == null) {
+        if (textRenderHandle == null || !textRenderHandle.isLoaded()) {
             // Failed to load default font renderer
             return;
         }

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -187,12 +187,12 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
         FontRendererHandle textRenderHandle = null;
         textRenderHandle = node.getFontRendererHandle(gl);
 
-        if (textRenderHandle == null || !textRenderHandle.isLoaded()) {
+        if (textRenderHandle == null || !textRenderHandle.isValid()) {
             textRenderHandle = node.getDefaultFontRendererHandle();
             actualText = String.format("Error: Font '%s' not found", node.getFont());
         }
 
-        if (textRenderHandle == null || !textRenderHandle.isLoaded()) {
+        if (textRenderHandle == null || !textRenderHandle.isValid()) {
             // Failed to load default font renderer
             return;
         }

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -12,7 +12,6 @@ import javax.media.opengl.GL2;
 import javax.vecmath.Point3d;
 
 import org.eclipse.swt.graphics.RGB;
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,16 +189,16 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
         String actualText = node.getText();
 
         FontRendererHandle textRenderHandle = null;
-        try {
-            textRenderHandle = node.getTextRendererHandle();
+        textRenderHandle = node.getFontRendererHandle();
 
-            //
-            if (textRenderHandle == null) {
-                textRenderHandle = node.getDefaultTextRendererHandle();
-                actualText = String.format("Error: Font '%s' not found", node.getFont());
-            }
-        } catch (Exception e) {
-            logger.error("Failed to load default font.", e);
+        if (textRenderHandle == null) {
+            textRenderHandle = node.getDefaultFontRendererHandle();
+            actualText = String.format("Error: Font '%s' not found", node.getFont());
+        }
+
+        if (textRenderHandle == null) {
+            // Failed to load default font renderer
+            return;
         }
 
         boolean clipping = renderData.getUserData() != null;

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/.classpath
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/.settings/org.eclipse.jdt.core.prefs
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,7 @@
-#Thu Nov 03 15:46:07 CET 2011
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.source=1.7

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
@@ -24,6 +24,8 @@ public class FontRendererHandle {
     private Fontc.InputFontFormat inputFormat = InputFontFormat.FORMAT_TRUETYPE;
     private Texture texture;
     private boolean reloadTexture = false;
+    private boolean loaded = false;
+    private boolean awaitClear = false;
 
     private HashMap<Integer, FontMap.Glyph> glyphLookup;
 
@@ -41,6 +43,8 @@ public class FontRendererHandle {
             this.texture.destroy(gl);
             this.texture = null;
         }
+        this.loaded = false;
+        this.awaitClear = false;
     }
 
     public void setFont(FontMap fontMap, BufferedImage image, Fontc.InputFontFormat inputFormat) {
@@ -55,9 +59,12 @@ public class FontRendererHandle {
             FontMap.Glyph g = this.fontMap.getGlyphs(i);
             this.glyphLookup.put(g.getCharacter(), g);
         }
+        
+        this.loaded = true;
     }
 
     public Texture getTexture(GL2 gl) {
+        
         try {
 
             if (this.reloadTexture) {
@@ -80,7 +87,19 @@ public class FontRendererHandle {
         }
         return g;
     }
+    
+    public void setShoudClear() {
+        this.awaitClear = true;
+    }
+    
+    public boolean getShoudClear() {
+        return this.awaitClear;
+    }
 
+    public boolean isLoaded() {
+        return this.loaded;
+    }
+    
     public FontMap getFontMap() {
         return fontMap;
     }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
@@ -35,6 +35,14 @@ public class FontRendererHandle {
         }
     }
 
+    public void clear(GL2 gl) {
+        this.image = null;
+        if (this.texture != null) {
+            this.texture.destroy(gl);
+            this.texture = null;
+        }
+    }
+
     public void setFont(FontMap fontMap, BufferedImage image, Fontc.InputFontFormat inputFormat) {
         this.fontMap = fontMap;
         this.image = image;

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
@@ -19,12 +19,11 @@ public class FontRendererHandle {
 
     private static Logger logger = LoggerFactory.getLogger(FontRendererHandle.class);
 
-    private FontMap fontMap;
-    private BufferedImage image;
+    private FontMap fontMap = null;
+    private BufferedImage image = null;
     private Fontc.InputFontFormat inputFormat = InputFontFormat.FORMAT_TRUETYPE;
-    private Texture texture;
+    private Texture texture = null;
     private boolean reloadTexture = false;
-    private boolean loaded = false;
     private boolean awaitClear = false;
 
     private HashMap<Integer, FontMap.Glyph> glyphLookup;
@@ -43,7 +42,6 @@ public class FontRendererHandle {
             this.texture.destroy(gl);
             this.texture = null;
         }
-        this.loaded = false;
         this.awaitClear = false;
     }
 
@@ -59,8 +57,6 @@ public class FontRendererHandle {
             FontMap.Glyph g = this.fontMap.getGlyphs(i);
             this.glyphLookup.put(g.getCharacter(), g);
         }
-
-        this.loaded = true;
     }
 
     public Texture getTexture(GL2 gl) {
@@ -99,8 +95,8 @@ public class FontRendererHandle {
         return this.awaitClear;
     }
 
-    public boolean isLoaded() {
-        return this.loaded;
+    public boolean isValid() {
+        return (this.image != null && this.fontMap != null);
     }
 
     public FontMap getFontMap() {

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/FontRendererHandle.java
@@ -59,17 +59,20 @@ public class FontRendererHandle {
             FontMap.Glyph g = this.fontMap.getGlyphs(i);
             this.glyphLookup.put(g.getCharacter(), g);
         }
-        
+
         this.loaded = true;
     }
 
     public Texture getTexture(GL2 gl) {
-        
+
         try {
 
             if (this.reloadTexture) {
                 this.reloadTexture = false;
 
+                if (this.texture != null) {
+                    this.texture.destroy(gl);
+                }
                 generateTexture(gl);
             }
 
@@ -87,19 +90,19 @@ public class FontRendererHandle {
         }
         return g;
     }
-    
-    public void setShoudClear() {
+
+    public void setDeferredClear() {
         this.awaitClear = true;
     }
-    
-    public boolean getShoudClear() {
+
+    public boolean getDeferredClear() {
         return this.awaitClear;
     }
 
     public boolean isLoaded() {
         return this.loaded;
     }
-    
+
     public FontMap getFontMap() {
         return fontMap;
     }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/ISceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/ISceneModel.java
@@ -44,6 +44,9 @@ public interface ISceneModel extends IPropertyObjectWorld {
 
     BufferedImage getImage(String path);
     TextureHandle getTexture(String path);
+    FontRendererHandle getFont(String path);
+    
+    FontRendererHandle getDefaultFontRendererHandle();
 
     ProjectProperties getProjectProperties();
 }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
@@ -143,14 +143,12 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
             this.defaultFontRendererHandle = new FontRendererHandle();
             try {
                 loadFont("/builtins/fonts/system_font.font", this.defaultFontRendererHandle);
-            } catch (CoreException e) {
-                logger.error("Could not load default font");
-            } catch (IOException e) {
+            } catch (CoreException | IOException e) {
                 logger.error("Could not load default font");
             }
         }
 
-        if (this.defaultFontRendererHandle.isLoaded()) {
+        if (this.defaultFontRendererHandle.isValid()) {
             return this.defaultFontRendererHandle;
         }
         return null;
@@ -537,9 +535,7 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
 
             try {
                 loadFont(path, font);
-            } catch (CoreException e) {
-                logger.error("Could not load font " + path, e);
-            } catch (IOException e) {
+            } catch (CoreException | IOException e) {
                 logger.error("Could not load font " + path, e);
             }
 


### PR DESCRIPTION
- Better error handling for when font files specified in GUI font nodes does not exist.
- Added a minor error check for when texture files specified in GUI texture nodes does not exist.
- Moved font renderer handle creation into FontNodes, this lowers the resource usage.
