### PR TITLE
DEF-1422 Editor crashed on GUIs with invalid font-paths

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/FontNode.java
@@ -8,6 +8,7 @@ import com.dynamo.cr.guied.Activator;
 import com.dynamo.cr.properties.NotEmpty;
 import com.dynamo.cr.properties.Property;
 import com.dynamo.cr.properties.Property.EditorType;
+import com.dynamo.cr.sceneed.core.ISceneModel;
 import com.dynamo.cr.sceneed.core.Identifiable;
 import com.dynamo.cr.sceneed.core.Node;
 import com.dynamo.cr.sceneed.core.validators.Unique;

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiTextureNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/GuiTextureNode.java
@@ -41,6 +41,10 @@ public class GuiTextureNode {
         if(this.IsValidResource(texturePath)) {
             try {
                 Node n = node.getModel().loadNode(texturePath);
+                if (n == null) {
+                    logger.error("Failed loading resource: " + texturePath);
+                    return;
+                }
                 n.setModel(node.getModel());
                 this.textureSetNode = (TextureSetNode) n;
             } catch (Exception e) {

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TexturesNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/core/TexturesNode.java
@@ -45,6 +45,11 @@ public class TexturesNode extends LabelNode {
                     continue;
                 }
 
+                if (textureSetNode == null) {
+                    logger.error("Failed loading resource: " + textureNode.getTexture());
+                    continue;
+                }
+
                 List<String> animationsIds = textureSetNode.getAnimationIds();
                 for(String animationsId : animationsIds) {
                     textures.add(textureNode.getId() + "/" + animationsId);

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -12,10 +12,7 @@ import javax.media.opengl.GL2;
 import javax.vecmath.Point3d;
 
 import org.eclipse.swt.graphics.RGB;
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.dynamo.bob.font.Fontc.InputFontFormat;
 import com.dynamo.cr.guied.core.ClippingNode;
@@ -37,8 +34,6 @@ import com.dynamo.render.proto.Font.FontTextureFormat;
 import com.jogamp.opengl.util.texture.Texture;
 
 public class TextNodeRenderer implements INodeRenderer<TextNode> {
-
-    private static Logger logger = LoggerFactory.getLogger(TextNodeRenderer.class);
 
     private static final EnumSet<Pass> passes = EnumSet.of(Pass.OUTLINE, Pass.TRANSPARENT, Pass.SELECTION);
 
@@ -190,16 +185,16 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
         String actualText = node.getText();
 
         FontRendererHandle textRenderHandle = null;
-        try {
-            textRenderHandle = node.getTextRendererHandle();
+        textRenderHandle = node.getFontRendererHandle(gl);
 
-            //
-            if (textRenderHandle == null) {
-                textRenderHandle = node.getDefaultTextRendererHandle();
-                actualText = String.format("Error: Font '%s' not found", node.getFont());
-            }
-        } catch (Exception e) {
-            logger.error("Failed to load default font.", e);
+        if (textRenderHandle == null || !textRenderHandle.isValid()) {
+            textRenderHandle = node.getDefaultFontRendererHandle();
+            actualText = String.format("Error: Font '%s' not found", node.getFont());
+        }
+
+        if (textRenderHandle == null || !textRenderHandle.isValid()) {
+            // Failed to load default font renderer
+            return;
         }
 
         boolean clipping = renderData.getUserData() != null;

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/.classpath
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/.settings/org.eclipse.jdt.core.prefs
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,7 @@
-#Thu Nov 03 15:46:07 CET 2011
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.source=1.7

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/ISceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/ISceneModel.java
@@ -44,6 +44,9 @@ public interface ISceneModel extends IPropertyObjectWorld {
 
     BufferedImage getImage(String path);
     TextureHandle getTexture(String path);
+    FontRendererHandle getFont(String path);
+    
+    FontRendererHandle getDefaultFontRendererHandle();
 
     ProjectProperties getProjectProperties();
 }

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
@@ -1,7 +1,13 @@
 package com.dynamo.cr.sceneed.core;
 
+import java.awt.FontFormatException;
 import java.awt.image.BufferedImage;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,6 +21,7 @@ import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.core.commands.operations.OperationHistoryEvent;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
@@ -31,6 +38,8 @@ import org.eclipse.swt.widgets.Display;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.dynamo.bob.font.Fontc;
+import com.dynamo.bob.font.Fontc.FontResourceResolver;
 import com.dynamo.cr.editor.core.EditorUtil;
 import com.dynamo.cr.editor.core.ProjectProperties;
 import com.dynamo.cr.editor.ui.IImageProvider;
@@ -39,7 +48,10 @@ import com.dynamo.cr.properties.IPropertyModel;
 import com.dynamo.cr.properties.PropertyIntrospector;
 import com.dynamo.cr.properties.PropertyIntrospectorModel;
 import com.dynamo.cr.sceneed.core.operations.SelectOperation;
+import com.dynamo.render.proto.Font;
+import com.dynamo.render.proto.Font.FontMap;
 import com.google.inject.Inject;
+import com.google.protobuf.TextFormat;
 
 @Entity(commandFactory = SceneUndoableCommandFactory.class)
 public class SceneModel implements IAdaptable, IOperationHistoryListener, ISceneModel {
@@ -64,6 +76,8 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
     // Issue for this: https://defold.fogbugz.com/default.asp?1052
     private final Map<String, BufferedImage> imageCache = new HashMap<String, BufferedImage>();
     private final Map<String, TextureHandle> textureCache = new HashMap<String, TextureHandle>();
+    private final Map<String, FontRendererHandle> fontCache = new HashMap<String, FontRendererHandle>();
+    private FontRendererHandle defaultFontRendererHandle = null;
 
     private static PropertyIntrospector<SceneModel, SceneModel> introspector = new PropertyIntrospector<SceneModel, SceneModel>(SceneModel.class);
 
@@ -120,7 +134,26 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
     @Inject
     public void init() {
         this.history.addOperationHistoryListener(this);
+
     }
+
+    public FontRendererHandle getDefaultFontRendererHandle() {
+
+        if (this.defaultFontRendererHandle == null) {
+            this.defaultFontRendererHandle = new FontRendererHandle();
+            try {
+                loadFont("/builtins/fonts/system_font.font", this.defaultFontRendererHandle);
+            } catch (CoreException | IOException e) {
+                logger.error("Could not load default font");
+            }
+        }
+
+        if (this.defaultFontRendererHandle.isValid()) {
+            return this.defaultFontRendererHandle;
+        }
+        return null;
+    }
+
 
     public void dispose(GL2 gl) {
         if (this.root != null) {
@@ -129,6 +162,12 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
         this.history.removeOperationHistoryListener(this);
         for (TextureHandle texture : this.textureCache.values()) {
             texture.clear(gl);
+        }
+        for (FontRendererHandle font : this.fontCache.values()) {
+            font.clear(gl);
+        }
+        if (this.defaultFontRendererHandle != null) {
+            this.defaultFontRendererHandle.clear(gl);
         }
     }
 
@@ -277,6 +316,7 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
         @Override
         public boolean visit(IResourceDelta delta) throws CoreException {
             IResource resource = delta.getResource();
+
             if (resource instanceof IFile) {
                 String path = EditorUtil.makeResourcePath(contentRoot, resource);
                 // Remove from cache so we guarantee reload
@@ -288,7 +328,20 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
                         // Clearing image means texture will be disposed at next access
                         texture.setImage(null);
                     }
+
                 }
+
+                if (fontCache.containsKey(path)) {
+                    FontRendererHandle font = fontCache.get(path);
+                    fontCache.remove(path);
+                    fontCache.put(path, null);
+
+                    // Need to wait to clear font, needs active GL to dispose of texture
+                    if (font != null) {
+                        font.setDeferredClear();
+                    }
+                }
+
                 if (loaderContext != null) {
                     loaderContext.removeFromCache(path);
                 }
@@ -418,6 +471,76 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
             this.textureCache.put(path, texture);
         }
         return texture;
+    }
+
+    private void loadFont(String fontPath, FontRendererHandle handle) throws CoreException, IOException {
+        IProject project = EditorUtil.getProject();
+        final IContainer contentRoot = EditorUtil.getContentRoot(project);
+        IFile fontFile = contentRoot.getFile(new Path(fontPath));
+        InputStream is = fontFile.getContents();
+        Font.FontDesc fontDesc = null;
+
+        // Parse font description
+        try {
+            Reader reader = new InputStreamReader(is);
+            Font.FontDesc.Builder fontDescBuilder = Font.FontDesc.newBuilder();
+            TextFormat.merge(reader, fontDescBuilder);
+            fontDesc = fontDescBuilder.build();
+        } finally {
+            is.close();
+        }
+
+        if (fontDesc == null) {
+            throw new IOException("Could not load font: " + fontPath);
+        }
+
+        // Compile to FontMap
+        FontMap.Builder fontMapBuilder = FontMap.newBuilder();
+        final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
+        final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
+        BufferedImage image;
+        Fontc fontc = new Fontc();
+
+        try {
+            image = fontc.compile(fontInputFile.getContents(), fontDesc, fontMapBuilder, new FontResourceResolver() {
+
+                @Override
+                public InputStream getResource(String resourceName)
+                        throws FileNotFoundException {
+
+                    String resPath = Paths.get(searchPath, resourceName).toString();
+                    IFile resFile = contentRoot.getFile(new Path(resPath));
+
+                    try {
+                        return resFile.getContents();
+                    } catch (CoreException e) {
+                        throw new FileNotFoundException(e.getMessage());
+                    }
+                }
+            });
+        } catch (FontFormatException e) {
+            throw new IOException(e.getMessage());
+        }
+
+        handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
+
+    }
+
+    @Override
+    public FontRendererHandle getFont(String path) {
+        FontRendererHandle font = this.fontCache.get(path);
+        if (font == null) {
+            font = new FontRendererHandle();
+            this.fontCache.put(path, font);
+
+            try {
+                loadFont(path, font);
+            } catch (CoreException | IOException e) {
+                logger.error("Could not load font " + path, e);
+            }
+
+        }
+        return font;
     }
 
     @Override


### PR DESCRIPTION
- Better error handling for when font files specified in GUI font nodes does not exist.
- Added a minor error check for when texture files specified in GUI texture nodes does not exist.
- Moved font renderer handle creation and usage into font cache inside SceneModel, this lowers the resource usage.
