### PR TITLE
DEF-1331 Better handling of to and recipients fields on FB API

### DIFF
--- a/engine/facebook/src/facebook.mm
+++ b/engine/facebook/src/facebook.mm
@@ -750,6 +750,7 @@ int Facebook_Me(lua_State* L)
  *   <li><code>data</code> (string)</li>
  *   <li><code>object_id</code> (string)</li>
  *   <li><code>suggestions</code> (table)</li>
+ *   <li><code>recipients</code> (table)</li>
  *   <li><code>to</code> (string)</li>
  * </ul>
  *
@@ -835,12 +836,20 @@ static int Facebook_ShowDialog(lua_State* L)
         content.filters    = convertGameRequestFilters([GetTableValue(L, 2, @[@"filters"], LUA_TNUMBER) unsignedIntValue]);
         content.data       = GetTableValue(L, 2, @[@"data"], LUA_TSTRING);
         content.objectID   = GetTableValue(L, 2, @[@"object_id"], LUA_TSTRING);
-        content.recipientSuggestions = GetTableValue(L, 2, @[@"suggestions"], LUA_TTABLE);
+
+        NSArray* suggestions = GetTableValue(L, 2, @[@"suggestions"], LUA_TTABLE);
+        if (suggestions != nil) {
+            content.recipientSuggestions = suggestions;
+        }
 
         // comply with JS way of specifying recipients/to
-        NSString* recipients = GetTableValue(L, 2, @[@"to"], LUA_TTABLE);
-        if (recipients != nil && [recipients respondsToSelector:@selector(componentsSeparatedByString:)]) {
-            content.recipients = [recipients componentsSeparatedByString:@","];
+        NSString* to = GetTableValue(L, 2, @[@"to"], LUA_TSTRING);
+        if (to != nil && [to respondsToSelector:@selector(componentsSeparatedByString:)]) {
+            content.recipients = [to componentsSeparatedByString:@","];
+        }
+        NSArray* recipients = GetTableValue(L, 2, @[@"recipients"], LUA_TTABLE);
+        if (recipients != nil) {
+            content.recipients = recipients;
         }
 
         [FBSDKGameRequestDialog showWithContent:content delegate:g_Facebook.m_Delegate];

--- a/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
+++ b/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
@@ -342,19 +342,18 @@ public class FacebookActivity implements PseudoActivity {
                     }
 
                     // comply with JS way of specifying recipients/to
-                    String recipientsString = null;
-                    String[] recipients = null;
-                    // FB SDK is weird, special case on Android, recipients/to
-                    // can only be one person. We pick the first one in the list,
-                    // if multiple are supplied...
-                    if (dialogParams.getString("to") != null) {
-                        recipients = dialogParams.getString("to").split(",");
+                    String toString = null;
+
+                    // Recipients field does not exist in FB SDK 4.3 for Android.
+                    // For now we fill the "to" field with the comma separated user ids,
+                    // but when we upgrade to a newer version with the recipients field
+                    // we should fill the correct recipients field instead.
+                    if (dialogParams.getString("to", null) != null) {
+                        toString = dialogParams.getString("to");
                     }
-                    if (recipients != null) {
-                        recipientsString = recipients[0];
-                        if (recipients.length > 1) {
-                            Log.d(TAG, "Facebook SDK for Android only supports one recipient ('to' field) for GameRequestDialog, only the first one will be used.");
-                        }
+
+                    if (dialogParams.getString("recipients", null) != null) {
+                        toString = dialogParams.getString("recipients");
                     }
 
                     GameRequestContent.Builder content = new GameRequestContent.Builder()
@@ -373,8 +372,8 @@ public class FacebookActivity implements PseudoActivity {
 
                     // recipients, filters and suggestions are mutually exclusive
                     int filters = Integer.parseInt(dialogParams.getString("filters", "-1"));
-                    if (recipientsString != null) {
-                        content.setTo(recipientsString);
+                    if (toString != null) {
+                        content.setTo(toString);
                     } else if (filters != -1) {
                         content.setFilters(convertGameRequestFilters(filters));
                     } else {


### PR DESCRIPTION
- Fixed old "to" field is handled correctly on both iOS and Android, a comma separated string. (Internally assign to "recipient" field on iOS since it's deprecated there.)
- Added "recipient" field for both iOS and Android (that takes a table/array instead of a comma separated string).
