### PR TITLE
- DEF-1438 SecurityException VIBRATE on push notification

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/android/AndroidManifest.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/android/AndroidManifest.xml
@@ -109,7 +109,7 @@
     <uses-permission android:name="{{android.package}}.permission.C2D_MESSAGE" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-
+    <uses-permission android:name="android.permission.VIBRATE" />
 
 </manifest>
 <!-- END_INCLUDE(manifest) -->


### PR DESCRIPTION
Add VIBRATE permission to AndroidManifest.xml along with the other
required ones for local push. Workaround for old Android versions
behavior.
