### PR TITLE
DEF-1450 - Engine does not fall back on NullSoundDevice on android

### DIFF
--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -16,7 +16,7 @@ def build(bld):
     bld.install_files('${PREFIX}/share/proto', '../proto/engine_ddf.proto')
 
     additional_libs = ['CRASH']
-    exported_symbols = ['DefaultSoundDevice', 'AudioDecoderWav', 'CrashExt']
+    exported_symbols = ['DefaultSoundDevice', 'NullSoundDevice', 'AudioDecoderWav', 'CrashExt']
 
     # Add stb_vorbis and/or tremolo depending on platform
     if 'js-web' in bld.env['PLATFORM'] or 'win32' in bld.env['PLATFORM']:
@@ -41,7 +41,6 @@ def build(bld):
         exported_symbols.append('FacebookExt')
     elif 'js-web' in bld.env['PLATFORM']:
         sound_lib = 'SOUND OPENAL'
-        exported_symbols.append('NullSoundDevice')
         exported_symbols.append('FacebookExt')
     else:
         sound_lib = 'SOUND OPENAL'

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -8,7 +8,7 @@ def build(bld):
     bld.add_subdirs('openal')
 
     source =  'sound_common.cpp sound.cpp sound_codec.cpp sound_decoder.cpp'.split()
-    source2 =  'sound_common.cpp sound2.cpp sound_codec.cpp sound_decoder.cpp'.split()
+    source2 =  'devices/device_null.cpp sound_common.cpp sound2.cpp sound_codec.cpp sound_decoder.cpp'.split()
     source_null = 'devices/device_null.cpp sound_common.cpp sound_null.cpp sound_decoder.cpp sound_codec.cpp sound_generic.cpp'.split()
 
     stb_vorbis = 'decoders/decoder_stb_vorbis.cpp stb_vorbis/stb_vorbis.c'.split()


### PR DESCRIPTION
- Fixed wscript so null sound device is actually present in engine
- Added exported symbol for null symbol always in engine builds
- Made OpenSL device able to clean up and return error code instead
  of assert(false):ing on error.

Tested above by hand by forcing failures to individual function
calls.
