### PR TITLE
DEF-1330 Better socket error code handling

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -329,7 +329,7 @@ namespace dmHttpClient
             int r = ssl_write(response->m_SSLConnection, (const uint8_t*) buffer, length);
 
             // In order to mimic the http code path, we return the same error number
-            if( HasRequestTimedOut(response->m_Client) )
+            if( (r == length) && HasRequestTimedOut(response->m_Client) )
             {
                 return dmSocket::RESULT_WOULDBLOCK;
             }
@@ -349,7 +349,7 @@ namespace dmHttpClient
                 {
                     r = dmSocket::RESULT_TRY_AGAIN;
                 }
-                if( HasRequestTimedOut(response->m_Client) )
+                if( (r == dmSocket::RESULT_OK || r == dmSocket::RESULT_TRY_AGAIN) && HasRequestTimedOut(response->m_Client) )
                 {
                     r = dmSocket::RESULT_WOULDBLOCK;
                 }
@@ -495,7 +495,7 @@ namespace dmHttpClient
             {
                 r = dmSocket::RESULT_TRY_AGAIN;
             }
-            if( HasRequestTimedOut(client) )
+            if( (r == dmSocket::RESULT_OK || r == dmSocket::RESULT_TRY_AGAIN) && HasRequestTimedOut(client) )
             {
                 r = dmSocket::RESULT_WOULDBLOCK;
             }
@@ -685,7 +685,7 @@ bail:
             {
                 sock_res = dmSocket::RESULT_TRY_AGAIN;
             }
-            if( HasRequestTimedOut(response->m_Client) )
+            if( (sock_res == dmSocket::RESULT_OK || sock_res == dmSocket::RESULT_TRY_AGAIN) && HasRequestTimedOut(client) )
             {
                 sock_res = dmSocket::RESULT_WOULDBLOCK;
             }
@@ -850,7 +850,7 @@ bail:
                     {
                         sock_r = dmSocket::RESULT_TRY_AGAIN;
                     }
-                    if( HasRequestTimedOut(response->m_Client) )
+                    if( (sock_r == dmSocket::RESULT_OK || sock_r == dmSocket::RESULT_TRY_AGAIN) && HasRequestTimedOut(client) )
                     {
                         sock_r = dmSocket::RESULT_WOULDBLOCK;
                     }

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -174,6 +174,11 @@ namespace dmScript
         {0, 0}
     };
 
+    void SetHttpRequestTimeout(uint64_t timeout)
+    {
+        g_Timeout = timeout;
+    }
+
     void InitializeHttp(lua_State* L, dmConfigFile::HConfig config_file)
     {
 // TODO: Port

--- a/engine/script/src/script_http.h
+++ b/engine/script/src/script_http.h
@@ -5,6 +5,7 @@ namespace dmScript
 {
     void InitializeHttp(lua_State* L, dmConfigFile::HConfig config_file);
     void FinalizeHttp(lua_State* L);
+    void SetHttpRequestTimeout(uint64_t timeout);
 }
 
 #endif // DM_SCRIPT_HTTP_H

--- a/engine/script/src/test/test.config
+++ b/engine/script/src/test/test.config
@@ -1,4 +1,4 @@
 [foo]
 value=123
 [network]
-http_timeout = 0.3
+http_timeout = 0

--- a/engine/script/src/test/test_http_timeout.lua
+++ b/engine/script/src/test/test_http_timeout.lua
@@ -1,7 +1,7 @@
 function callback(response)
 end
 
-requests_left = 1
+requests_left = 2
 
 -- NOTE: We test timeout in a separate file as the test-server is single threaded
 -- and could potentially timeout other requests
@@ -16,6 +16,15 @@ function test_http_timeout()
             requests_left = requests_left - 1
         end,
     headers, '', options)
+
+    -- The config file also specifies a timeout value, let's test that too
+    http.request("http://localhost:" .. PORT .. "/sleep", "GET",
+        function(response)
+            assert(response.status == 0)
+            requests_left = requests_left - 1
+        end,
+    headers)
+
 end
 
 functions = { test_http_timeout = test_http_timeout }

--- a/engine/script/src/test/test_script_http.cpp
+++ b/engine/script/src/test/test_script_http.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "script.h"
+#include "script_http.h" // to set the timeout
 
 #include <dlib/configfile.h>
 #include <dlib/dstrings.h>
@@ -54,6 +55,7 @@ public:
     lua_State* L;
     dmMessage::URL m_DefaultURL;
     dmConfigFile::HConfig m_ConfigFile;
+    int m_NumberOfFails;
 
 protected:
 
@@ -86,7 +88,7 @@ protected:
         assert(top == lua_gettop(L));
 
         m_WebServerPort = 9001;
-
+        m_NumberOfFails = 0;
     }
 
     virtual void TearDown()
@@ -142,6 +144,7 @@ void DispatchCallbackDDF(dmMessage::Message *message, void* user_ptr)
 
     dmScript::PushDDF(L, descriptor, (const char*)&message->m_Data[0]);
     int ret = dmScript::PCall(L, 1, 0);
+    test->m_NumberOfFails += ret == 0 ? 0 : 1;
     ASSERT_EQ(0, ret);
 }
 
@@ -184,11 +187,21 @@ TEST_F(ScriptHttpTest, TestPost)
             break;
         }
 
+        // One issue causing intermittent failures (SOCKET_ERROR+WOULDBLOCK), was the fact that the connection creation times
+        // could peak above 250ms. However, this was when we had the config script timeout set at 0.3 seconds.
+        // Increasing that timeout value should make it robust again. /MAWE
+        if( m_NumberOfFails )
+        {
+            break;
+        }
+
         dmTime::Sleep(10 * 1000);
 
         uint64_t now = dmTime::GetTime();
         uint64_t elapsed = now - start;
+
         if (elapsed / 1000000 > 4) {
+            dmLogError("The test timed out\n");
             ASSERT_TRUE(0);
         }
     }
@@ -196,8 +209,22 @@ TEST_F(ScriptHttpTest, TestPost)
     ASSERT_EQ(top, lua_gettop(L));
 }
 
+struct SHttpRequestTimeoutGuard // Makes sure it gets reset after gtest returns
+{
+    SHttpRequestTimeoutGuard(uint64_t timeout)
+    {
+        dmScript::SetHttpRequestTimeout(timeout);
+    }
+    ~SHttpRequestTimeoutGuard()
+    {
+        dmScript::SetHttpRequestTimeout(0);
+    }
+};
+
 TEST_F(ScriptHttpTest, TestTimeout)
 {
+    SHttpRequestTimeoutGuard timeoutguard(1000 * 1000);
+
     int top = lua_gettop(L);
 
     ASSERT_TRUE(RunFile(L, "test_http_timeout.luac"));
@@ -234,11 +261,17 @@ TEST_F(ScriptHttpTest, TestTimeout)
             break;
         }
 
+        if( m_NumberOfFails )
+        {
+            break;
+        }
+
         dmTime::Sleep(10 * 1000);
 
         uint64_t now = dmTime::GetTime();
         uint64_t elapsed = now - start;
         if (elapsed / 1000000 > 4) {
+            dmLogError("The test timed out\n");
             ASSERT_TRUE(0);
         }
     }
@@ -248,6 +281,8 @@ TEST_F(ScriptHttpTest, TestTimeout)
 
 TEST_F(ScriptHttpTest, TestDeletedSocket)
 {
+    SHttpRequestTimeoutGuard timeoutguard(300 * 1000);
+
     int top = lua_gettop(L);
 
     ASSERT_TRUE(RunFile(L, "test_http.luac"));


### PR DESCRIPTION
- The http request now respects the received socket errors
- Made the ScriptHttpTest.TestPost test (and others) more robust by using 0 as timeout value
- Added dmScript:: SetHttpRequestTimeout for easier unit testing
