### PR TITLE
DEFEDIT-235 MVP text editor

### DIFF
--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -37,6 +37,7 @@
             [editor.particlefx :as particlefx]
             [editor.gui :as gui]
             [editor.text :as text]
+            [editor.code-view :as code-view]
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [service.log :as log])
@@ -137,6 +138,7 @@
     (g/transact
       (concat
         (text/register-view-types workspace)
+        (code-view/register-view-types workspace)
         (scene/register-view-types workspace)
         (form-view/register-view-types workspace)))
     (g/transact

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -1,0 +1,104 @@
+(ns editor.code-view
+  (:require [dynamo.graph :as g]
+            [internal.system :as is]
+            [editor.core :as core]
+            [editor.ui :as ui]
+            [editor.workspace :as workspace])
+  (:import [javafx.scene Parent]
+           [javafx.scene.control TextArea]
+           [javafx.animation AnimationTimer]
+           [com.defold.control UndolessTextArea]))
+
+(defn- opseqs [text-area]
+  (ui/user-data text-area ::opseqs))
+
+(defn- new-opseq [text-area]
+  (swap! (opseqs text-area) rest))
+
+(defn- opseq [text-area]
+  (first @(opseqs text-area)))
+
+(defn- programmatic-change [text-area]
+  (ui/user-data text-area ::programmatic-change))
+
+(defn- code-node [text-area]
+  (ui/user-data text-area ::code-node))
+
+(defn- restart-opseq-timer [text-area]
+  (if-let [timer (ui/user-data text-area ::opseq-timer)]
+    (.playFromStart timer)
+    (ui/user-data! text-area ::opseq-timer (ui/->future 0.5 #(new-opseq text-area)))))
+
+(defmacro binding-atom [a val & body]
+  `(let [old-val# (deref ~a)]
+     (try
+       (reset! ~a ~val)
+       ~@body
+       (finally
+         (reset! ~a old-val#)))))
+
+(defn- setup-text-area [text-area]
+  (ui/user-data! text-area ::opseqs (atom (repeatedly gensym)))
+  (ui/user-data! text-area ::programmatic-change (atom nil))
+  (ui/observe (.textProperty text-area)
+    (fn [_ _ new-code]
+      (restart-opseq-timer text-area)
+      (when-not @(programmatic-change text-area)
+        (g/transact
+          (concat
+            (g/operation-sequence (opseq text-area))
+            (g/operation-label (str "Text Change: " new-code))
+            (g/set-property (code-node text-area) :code new-code))))))
+  (ui/observe (.caretPositionProperty text-area)
+    (fn [_ _ new-caret-position]
+      (when-not @(programmatic-change text-area)
+        (g/transact
+          (concat
+            (g/operation-sequence (opseq text-area))
+            ;; we dont supply an operation label here, because the caret position events comes just after the text change, and it seems
+            ;; when merging transactions the latest label wins
+            (g/set-property (code-node text-area) :caret-position new-caret-position))))))
+  text-area)
+
+(g/defnk update-text-area [^TextArea text-area code-node code caret-position]
+  (ui/user-data! text-area ::code-node code-node)
+  (when (not= code (.getText text-area))
+    (new-opseq text-area)
+    (binding-atom (programmatic-change text-area) true
+      (.setText text-area code)))
+  (when (not= caret-position (.getCaretPosition text-area))
+    (new-opseq text-area)
+    (binding-atom (programmatic-change text-area) true
+      (.positionCaret text-area caret-position)))
+  [code-node code caret-position])
+
+(g/defnode CodeView
+  (property text-area TextArea)
+  (input code-node g/Int)
+  (input code g/Str)
+  (input caret-position g/Int)
+  (output new-content g/Any :cached update-text-area))
+
+(defn- setup-code-view [view-id code-node]
+  (g/transact
+    (concat
+      (g/connect code-node :_node-id view-id :code-node)
+      (g/connect code-node :code view-id :code)
+      (g/connect code-node :caret-position view-id :caret-position)))
+  view-id)
+
+(defn make-view [graph ^Parent parent code-node opts]
+  (let [text-area (setup-text-area (UndolessTextArea.))
+        view-id (setup-code-view (g/make-node! graph CodeView :text-area text-area) code-node)]
+    (ui/children! parent [text-area])
+    (ui/fill-control text-area)
+    (let [refresh-timer (ui/->timer 10 (fn [_] (g/node-value view-id :new-content)))
+          stage (.. parent getScene getWindow)]
+      (ui/timer-stop-on-close! stage refresh-timer)
+      (ui/timer-start! refresh-timer)
+      view-id)))
+
+(defn register-view-types [workspace]
+  (workspace/register-view-type workspace
+                                :id :code
+                                :make-view-fn make-view))

--- a/editor/src/clj/editor/pipeline/lua_scan.clj
+++ b/editor/src/clj/editor/pipeline/lua_scan.clj
@@ -21,7 +21,9 @@
 
 (defn- prop->clj [^LuaScanner$Property property]
   (let [status (status->clj (.status property))
-        type (protobuf/pb-enum->val (.getValueDescriptor (.type property)))]
+        type (some-> (.type property)
+               (.getValueDescriptor)
+               (protobuf/pb-enum->val))]
     {:name (.name property)
      :type type
      :raw-value (.rawValue property)

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -254,11 +254,14 @@
 
 (defmethod create-property-control! :default [_ _ _]
   (let [text (TextField.)
+        wrapper (HBox.)
         update-ui-fn (fn [values message]
                        (ui/text! text (properties/unify-values (map str values)))
-                       (update-field-message [text] message))]
+                       (update-field-message [wrapper] message))]
+    (HBox/setHgrow text Priority/ALWAYS)
+    (ui/children! wrapper [text])
     (.setDisable text true)
-    [text update-ui-fn]))
+    [wrapper update-ui-fn]))
 
 (defn- ^Point2D node-screen-coords [^Node node ^Point2D offset]
   (let [scene (.getScene node)

--- a/editor/src/java/com/defold/control/UndolessTextArea.java
+++ b/editor/src/java/com/defold/control/UndolessTextArea.java
@@ -1,0 +1,47 @@
+package com.defold.control;
+
+import java.util.Optional;
+
+import javafx.event.EventHandler;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.control.TextArea;
+
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import com.sun.javafx.scene.control.behavior.TextAreaBehavior;
+
+public class UndolessTextArea extends TextArea {
+
+    public UndolessTextArea() {
+	super();
+	undoBinding = BindingAccessor.findBinding("Undo");
+	redoBinding = BindingAccessor.findBinding("Redo");
+	addEventHandler(KeyEvent.ANY, keyEventListener);
+    }
+
+    static class BindingAccessor extends TextAreaBehavior {
+	BindingAccessor(final TextArea textArea) {
+	    super(textArea);
+	}
+	static KeyBinding findBinding(String action) {
+	    return TEXT_AREA_BINDINGS.stream().filter(b -> b.getAction() == action).findAny().orElse(null);
+	}
+    }
+    
+    private final EventHandler<KeyEvent> keyEventListener =
+	new EventHandler<KeyEvent>() {
+	    @Override public void handle(KeyEvent event) {
+		if (!event.isConsumed()) {
+		    if (matchBinding(undoBinding, event) || matchBinding(redoBinding, event)) {
+			event.consume();
+		    }
+		}
+	    }
+	};
+
+    private static boolean matchBinding(KeyBinding binding, KeyEvent keyEvent) {
+	return binding != null && binding.getCode() == keyEvent.getCode();
+    }
+	
+    private KeyBinding undoBinding;
+    private KeyBinding redoBinding;
+}


### PR DESCRIPTION
- TextArea with shortcuts for undo/redo disabled. Still
  visible in context menu - using these will create
  a confusing global undo stack :)
- Fix for lua-scan assuming found properties had proper types
- Fix for disabled/invalid properties not reacting to mouse
  movement (to display tooltips)
