### PR TITLE
DEF-1455 Fixed local push schedule bug on Android

### DIFF
--- a/engine/push/src/push_android.cpp
+++ b/engine/push/src/push_android.cpp
@@ -223,7 +223,7 @@ int Push_Schedule(lua_State* L)
     }
 
     sn.id        = g_Push.m_ScheduleLastID++;
-    sn.timestamp = dmTime::GetTime() + seconds * 1000000; // in microseconds
+    sn.timestamp = dmTime::GetTime() + ((uint64_t)seconds) * 1000000L; // in microseconds
     sn.title     = strdup(title);
     sn.message   = strdup(message);
     sn.payload   = strdup(payload);


### PR DESCRIPTION
- Using a large value for the seconds argument would
  overflow since we internally use microseconds on Android.
