### PR TITLE
- DEF-1472 Facebook softlock when switching from facebook

### DIFF
--- a/engine/gamesys/src/java/com/dynamo/android/DispatcherActivity.java
+++ b/engine/gamesys/src/java/com/dynamo/android/DispatcherActivity.java
@@ -14,6 +14,7 @@ public class DispatcherActivity extends Activity {
 
     public interface PseudoActivity {
         void onCreate(Bundle savedInstanceState, Activity parent);
+        void onDestroy();
 
         void onActivityResult(int requestCode, int resultCode, Intent data);
     }
@@ -60,6 +61,9 @@ public class DispatcherActivity extends Activity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        if (this.activity != null) {
+            this.activity.onDestroy();
+        }
         Log.v(TAG, "onDestroy");
     }
 


### PR DESCRIPTION
Forward onDestroy() events to FacebookAcitivty and there, send
a 'cancelled' message if activity is terminated before result
is had.
