### PR TITLE
Fixes DEF-7 IAP - Add purchase cancelled error code

### DIFF
--- a/engine/iap/src/iap_android.cpp
+++ b/engine/iap/src/iap_android.cpp
@@ -26,7 +26,7 @@ enum TransactionState
 
 enum ErrorReason
 {
-	REASON_ERROR = 0,
+	REASON_UNSPECIFIED = 0,
 	REASON_USER_CANCELED = 1,
 };
 
@@ -379,13 +379,13 @@ void HandleProductResult(const Command* cmd)
         } else {
             dmLogError("Failed to parse product response (%d)", r);
             lua_pushnil(L);
-            PushError(L, "failed to parse product response", REASON_ERROR);
+            PushError(L, "failed to parse product response", REASON_UNSPECIFIED);
         }
         dmJson::Free(&doc);
     } else {
         dmLogError("Google Play error %d", cmd->m_ResponseCode);
         lua_pushnil(L);
-        PushError(L, "failed to fetch product", REASON_ERROR);
+        PushError(L, "failed to fetch product", REASON_UNSPECIFIED);
     }
 
     dmScript::PCall(L, 3, LUA_MULTRET);
@@ -433,7 +433,7 @@ void HandlePurchaseResult(const Command* cmd)
         } else {
             dmLogError("Failed to parse purchase response (%d)", r);
             lua_pushnil(L);
-            PushError(L, "failed to parse purchase response", REASON_ERROR);
+            PushError(L, "failed to parse purchase response", REASON_UNSPECIFIED);
         }
         dmJson::Free(&doc);
     } else if (cmd->m_ResponseCode == BILLING_RESPONSE_RESULT_USER_CANCELED) {
@@ -442,7 +442,7 @@ void HandlePurchaseResult(const Command* cmd)
     } else {
         dmLogError("Google Play error %d", cmd->m_ResponseCode);
         lua_pushnil(L);
-        PushError(L, "failed to buy product", REASON_ERROR);
+        PushError(L, "failed to buy product", REASON_UNSPECIFIED);
     }
 
     dmScript::PCall(L, 3, LUA_MULTRET);
@@ -539,7 +539,7 @@ dmExtension::Result InitializeIAP(dmExtension::Params* params)
     SETCONSTANT(TRANS_STATE_FAILED)
     SETCONSTANT(TRANS_STATE_RESTORED)
 
-    SETCONSTANT(REASON_ERROR)
+    SETCONSTANT(REASON_UNSPECIFIED)
     SETCONSTANT(REASON_USER_CANCELED)
 
 #undef SETCONSTANT

--- a/engine/iap/src/iap_android.cpp
+++ b/engine/iap/src/iap_android.cpp
@@ -24,6 +24,12 @@ enum TransactionState
     TRANS_STATE_RESTORED,
 };
 
+enum ErrorReason
+{
+	REASON_ERROR = 0,
+	REASON_USER_CANCELED = 1,
+};
+
 enum BillingResponse
 {
     BILLING_RESPONSE_RESULT_OK = 0,
@@ -277,13 +283,15 @@ static int ToLua(lua_State*L, dmJson::Document* doc, int index)
 extern "C" {
 #endif
 
-static void PushError(lua_State*L, const char* error)
+static void PushError(lua_State*L, const char* error, int reason)
 {
-    // Could be extended with error codes etc
     if (error != 0) {
         lua_newtable(L);
         lua_pushstring(L, "error");
         lua_pushstring(L, error);
+        lua_rawset(L, -3);
+        lua_pushstring(L, "reason");
+        lua_pushinteger(L, reason);
         lua_rawset(L, -3);
     } else {
         lua_pushnil(L);
@@ -371,14 +379,13 @@ void HandleProductResult(const Command* cmd)
         } else {
             dmLogError("Failed to parse product response (%d)", r);
             lua_pushnil(L);
-            PushError(L, "failed to parse product response");
+            PushError(L, "failed to parse product response", REASON_ERROR);
         }
         dmJson::Free(&doc);
     } else {
         dmLogError("Google Play error %d", cmd->m_ResponseCode);
         lua_pushnil(L);
-        // TODO: Add error code to table
-        PushError(L, "failed to fetch product");
+        PushError(L, "failed to fetch product", REASON_ERROR);
     }
 
     dmScript::PCall(L, 3, LUA_MULTRET);
@@ -426,14 +433,16 @@ void HandlePurchaseResult(const Command* cmd)
         } else {
             dmLogError("Failed to parse purchase response (%d)", r);
             lua_pushnil(L);
-            PushError(L, "failed to parse purchase response");
+            PushError(L, "failed to parse purchase response", REASON_ERROR);
         }
         dmJson::Free(&doc);
+    } else if (cmd->m_ResponseCode == BILLING_RESPONSE_RESULT_USER_CANCELED) {
+        lua_pushnil(L);
+        PushError(L, "user canceled purchase", REASON_USER_CANCELED);
     } else {
         dmLogError("Google Play error %d", cmd->m_ResponseCode);
         lua_pushnil(L);
-        // TODO: Add error code to table
-        PushError(L, "failed to buy product");
+        PushError(L, "failed to buy product", REASON_ERROR);
     }
 
     dmScript::PCall(L, 3, LUA_MULTRET);
@@ -529,6 +538,9 @@ dmExtension::Result InitializeIAP(dmExtension::Params* params)
     SETCONSTANT(TRANS_STATE_PURCHASED)
     SETCONSTANT(TRANS_STATE_FAILED)
     SETCONSTANT(TRANS_STATE_RESTORED)
+
+    SETCONSTANT(REASON_ERROR)
+    SETCONSTANT(REASON_USER_CANCELED)
 
 #undef SETCONSTANT
 

--- a/engine/iap/src/iap_ios.mm
+++ b/engine/iap/src/iap_ios.mm
@@ -47,7 +47,7 @@ IAP g_IAP;
 
 NS_ENUM(NSInteger, ErrorReason)
 {
-    REASON_ERROR = 0,
+    REASON_UNSPECIFIED = 0,
     REASON_USER_CANCELED = 1,
 };
 
@@ -178,7 +178,7 @@ static void PushError(lua_State*L, NSError* error, NSInteger reason)
     }
 
     lua_pushnil(L);
-    PushError(L, error, REASON_ERROR);
+    PushError(L, error, REASON_UNSPECIFIED);
 
     int ret = lua_pcall(L, 3, LUA_MULTRET, 0);
     if (ret != 0) {
@@ -264,7 +264,7 @@ void RunTransactionCallback(lua_State* L, int cb, int self, SKPaymentTransaction
         if (transaction.error.code == SKErrorPaymentCancelled) {
             PushError(L, transaction.error, REASON_USER_CANCELED);
         } else {
-            PushError(L, transaction.error, REASON_ERROR);
+            PushError(L, transaction.error, REASON_UNSPECIFIED);
         }
     } else {
         lua_pushnil(L);
@@ -516,9 +516,9 @@ static const luaL_reg IAP_methods[] =
  * @variable
  */
 
-/*# generic error reason
+/*# unspecified error reason
  *
- * @name iap.REASON_ERROR
+ * @name iap.REASON_UNSPECIFIED
  * @variable
  */
 
@@ -549,7 +549,7 @@ dmExtension::Result InitializeIAP(dmExtension::Params* params)
     SETCONSTANT(TRANS_STATE_FAILED, SKPaymentTransactionStateFailed);
     SETCONSTANT(TRANS_STATE_RESTORED, SKPaymentTransactionStateRestored);
 
-    SETCONSTANT(REASON_ERROR, REASON_ERROR);
+    SETCONSTANT(REASON_UNSPECIFIED, REASON_UNSPECIFIED);
     SETCONSTANT(REASON_USER_CANCELED, REASON_USER_CANCELED);
 
 #undef SETCONSTANT

--- a/engine/iap/src/java/com/defold/iap/Iap.java
+++ b/engine/iap/src/java/com/defold/iap/Iap.java
@@ -46,6 +46,7 @@ public class Iap implements Handler.Callback {
 
     public static final int BILLING_RESPONSE_RESULT_OK = 0;
     public static final int BILLING_RESPONSE_RESULT_USER_CANCELED = 1;
+    public static final int BILLING_RESPONSE_RESULT_SERVICE_UNAVAILABLE = 2;
     public static final int BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE = 3;
     public static final int BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE = 4;
     public static final int BILLING_RESPONSE_RESULT_DEVELOPER_ERROR = 5;
@@ -363,12 +364,10 @@ public class Iap implements Handler.Callback {
             if (purchaseData != null && dataSignature != null) {
                 purchaseData = convertPurchase(purchaseData, dataSignature);
             } else {
-                responseCode = BILLING_RESPONSE_RESULT_ERROR;
                 purchaseData = "";
             }
 
             purchaseListener.onPurchaseResult(responseCode, purchaseData);
-            this.purchaseListener = null;
         } else if (action == Action.RESTORE) {
             Bundle items = bundle.getBundle("items");
             ArrayList<String> ownedSkus = items.getStringArrayList(RESPONSE_INAPP_ITEM_LIST);


### PR DESCRIPTION
Added iap.REASON_ERROR and iap.REASON_USER_CANCELED as well as a
“reason” field on the error table returned in the iap.buy listener
callback.
