### PR TITLE
DEF-1462 Dynamic/Streaming fonts

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -368,7 +368,7 @@ def codesign(task):
     entitlements_path = os.path.join(task.env['DYNAMO_HOME'], 'share', entitlements)
     resource_rules_plist_file = task.resource_rules_plist.bldpath(task.env)
 
-    ret = bld.exec_command('CODESIGN_ALLOCATE=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate codesign -f -s "%s" --resource-rules=%s --entitlements %s %s' % (identity, resource_rules_plist_file, entitlements_path, signed_exe_dir))
+    ret = bld.exec_command('CODESIGN_ALLOCATE=%s/usr/bin/codesign_allocate codesign -f -s "%s" --resource-rules=%s --entitlements %s %s' % (IOS_TOOLCHAIN_ROOT, identity, resource_rules_plist_file, entitlements_path, signed_exe_dir))
     if ret != 0:
         error('Error running codesign')
         return 1

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -368,7 +368,7 @@ def codesign(task):
     entitlements_path = os.path.join(task.env['DYNAMO_HOME'], 'share', entitlements)
     resource_rules_plist_file = task.resource_rules_plist.bldpath(task.env)
 
-    ret = bld.exec_command('CODESIGN_ALLOCATE=%s/usr/bin/codesign_allocate codesign -f -s "%s" --resource-rules=%s --entitlements %s %s' % (IOS_TOOLCHAIN_ROOT, identity, resource_rules_plist_file, entitlements_path, signed_exe_dir))
+    ret = bld.exec_command('CODESIGN_ALLOCATE=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate codesign -f -s "%s" --resource-rules=%s --entitlements %s %s' % (identity, resource_rules_plist_file, entitlements_path, signed_exe_dir))
     if ret != 0:
         error('Error running codesign')
         return 1

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
@@ -22,24 +22,6 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         addFile("/test.material", src.toString());
     }
 
-    // TODO need to fix this since Fontc will not generate a texture!
-    /*
-    @Test
-    public void testTTF() throws Exception {
-
-        StringBuilder src = new StringBuilder();
-        src.append("font: \"/Tuffy.ttf\"\n");
-        src.append("material: \"/test.material\"\n");
-        src.append("size: 16\n");
-        FontMap fontMap = (FontMap)build("/test.font", src.toString()).get(0);
-
-        assertEquals(fontMap.getMaterial(), "/test.materialc");
-        assertEquals(fontMap.getTexturesCount(), 1);
-        assertEquals(fontMap.getTextures(0), "/test_tex0.texturec");
-
-    }
-    */
-
     @Test
     public void testTTF() throws Exception {
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
@@ -22,6 +22,8 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         addFile("/test.material", src.toString());
     }
 
+    // TODO need to fix this since Fontc will not generate a texture!
+    /*
     @Test
     public void testTTF() throws Exception {
 
@@ -36,6 +38,19 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(fontMap.getTextures(0), "/test_tex0.texturec");
 
     }
+    */
+
+    @Test
+    public void testTTF() throws Exception {
+
+        StringBuilder src = new StringBuilder();
+        src.append("font: \"/Tuffy.ttf\"\n");
+        src.append("material: \"/test.material\"\n");
+        src.append("size: 16\n");
+
+        FontMap fontMap = (FontMap)build("/test.font", src.toString()).get(0);
+        assertEquals(fontMap.getMaterial(), "/test.materialc");
+    }
 
     @Test
     public void testFNT() throws Exception {
@@ -47,8 +62,6 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         FontMap fontMap = (FontMap)build("/test.font", src.toString()).get(0);
 
         assertEquals(fontMap.getMaterial(), "/test.materialc");
-        assertEquals(fontMap.getTexturesCount(), 1);
-        assertEquals(fontMap.getTextures(0), "/test_tex0.texturec");
 
     }
 
@@ -65,8 +78,6 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         FontMap fontMap = (FontMap)build("/subdir/test.font", src.toString()).get(0);
 
         assertEquals(fontMap.getMaterial(), "/test.materialc");
-        assertEquals(fontMap.getTexturesCount(), 1);
-        assertEquals(fontMap.getTextures(0), "/subdir/test_tex0.texturec");
 
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -349,14 +349,10 @@ public class FontTest {
 
         // For previews we don't inlcude all glyphs
         assertTrue(fontMap.getGlyphsCount() < 1519);
-        System.out.println("fontMap.getGlyphsCount(): " + fontMap.getGlyphsCount());
 
         // Check that all glyphs are inside cache space
         for (int i = 0; i < fontMap.getGlyphsCount(); i++) {
             Glyph g = fontMap.getGlyphs(i);
-            System.out.println("i: " + i);
-            System.out.println("x: " + g.getX());
-            System.out.println("y: " + g.getY());
             assertTrue(g.getX() >= 0);
             assertTrue(g.getY() >= 0);
             assertTrue(g.getX() + g.getWidth() < fontMap.getCacheWidth());
@@ -445,5 +441,8 @@ public class FontTest {
         // verify glyphs
         BufferedInputStream fontcStream = new BufferedInputStream(new FileInputStream(outfile));
         fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
+
+        int expectedCharCount = 96; // Taken from bmfont.fnt
+        assertEquals(expectedCharCount, fontMap.getGlyphsCount());
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -201,26 +201,25 @@ public class FontTest {
 
         // compile font
         Fontc fontc = new Fontc();
-        InputStream fontDescStream = getClass().getResourceAsStream(fontDesc.getFont());
+        InputStream fontInputStream = getClass().getResourceAsStream(fontDesc.getFont());
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
         final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
-        FontMap.Builder fontmapBuilder = FontMap.newBuilder();
 
-        fontc.compile(fontDescStream, fontDesc, fontmapBuilder, new FontResourceResolver() {
+        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
                     return new FileInputStream(Paths.get(searchPath, resourceName).toString());
                 }
             });
-        fontmapBuilder.build().writeTo(fontOutputStream);
+        fontMap.writeTo(fontOutputStream);
 
-        fontDescStream.close();
+        fontInputStream.close();
         fontOutputStream.close();
 
         // verify output
         BufferedInputStream fontcStream = new BufferedInputStream(new FileInputStream(outfile));
-        FontMap fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
+        fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
 
         // glyph count
         int expectedCharCount = (127 - 32) + 7; // (127 - 32) default chars, 7 extra åäöÅÄÖ
@@ -228,6 +227,90 @@ public class FontTest {
 
         // unicode chars
         assertEquals(0xF8FF, fontMap.getGlyphs(fontMap.getGlyphsCount() - 1).getCharacter());
+    }
+
+    @Test
+    public void testTTFJapaneseAllChars() throws Exception {
+        
+        // create "font file"
+        FontDesc fontDesc = FontDesc.newBuilder()
+            .setFont("DroidSansJapanese.ttf")
+            .setMaterial("font.material")
+            .setSize(24)
+            .setAllChars(true)
+            .build();
+
+        // temp output file
+        File outfile = File.createTempFile("font-output", ".fontc");
+        outfile.deleteOnExit();
+
+        // compile font
+        Fontc fontc = new Fontc();
+        InputStream fontInputStream = getClass().getResourceAsStream(fontDesc.getFont());
+        FileOutputStream fontOutputStream = new FileOutputStream(outfile);
+        final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
+
+        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
+                @Override
+                public InputStream getResource(String resourceName)
+                        throws FileNotFoundException {
+                    return new FileInputStream(Paths.get(searchPath, resourceName).toString());
+                }
+            });
+        fontMap.writeTo(fontOutputStream);
+
+        fontInputStream.close();
+        fontOutputStream.close();
+
+        // verify output
+        BufferedInputStream fontcStream = new BufferedInputStream(new FileInputStream(outfile));
+        fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
+
+        // glyph count
+        int expectedCharCount = 6639; // Taken from font information of DroidSansJapanese.ttf
+        assertEquals(expectedCharCount, fontMap.getGlyphsCount());
+    }
+
+    @Test
+    public void testTTFAllChars() throws Exception {
+
+        // create "font file"
+        FontDesc fontDesc = FontDesc.newBuilder()
+            .setFont("Tuffy.ttf")
+            .setMaterial("font.material")
+            .setSize(24)
+            .setAllChars(true)
+            .build();
+
+        // temp output file
+        File outfile = File.createTempFile("font-output", ".fontc");
+        outfile.deleteOnExit();
+
+        // compile font
+        Fontc fontc = new Fontc();
+        InputStream fontInputStream = getClass().getResourceAsStream(fontDesc.getFont());
+        FileOutputStream fontOutputStream = new FileOutputStream(outfile);
+        final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
+
+        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
+                @Override
+                public InputStream getResource(String resourceName)
+                        throws FileNotFoundException {
+                    return new FileInputStream(Paths.get(searchPath, resourceName).toString());
+                }
+            });
+        fontMap.writeTo(fontOutputStream);
+
+        fontInputStream.close();
+        fontOutputStream.close();
+
+        // verify output
+        BufferedInputStream fontcStream = new BufferedInputStream(new FileInputStream(outfile));
+        fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
+
+        // glyph count
+        int expectedCharCount = 1519; // Taken from font information of Tuffy.ttf
+        assertEquals(expectedCharCount, fontMap.getGlyphsCount());
     }
 
     @Test
@@ -245,24 +328,23 @@ public class FontTest {
         // compile font
         boolean success = true;
         Fontc fontc = new Fontc();
-        InputStream fontDescStream = getClass().getResourceAsStream(fontDesc.getFont());
+        InputStream fontInputStream = getClass().getResourceAsStream(fontDesc.getFont());
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
         final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
-        FontMap.Builder fontmapBuilder = FontMap.newBuilder();
         try {
-            fontc.compile(fontDescStream, fontDesc, fontmapBuilder, new FontResourceResolver() {
+            FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
                     return new FileInputStream(Paths.get(searchPath, resourceName).toString());
                 }
             });
-            fontmapBuilder.build().writeTo(fontOutputStream);
+            fontMap.writeTo(fontOutputStream);
         } catch (FontFormatException e) {
             success = false;
         }
 
-        fontDescStream.close();
+        fontInputStream.close();
         fontOutputStream.close();
 
 
@@ -293,10 +375,9 @@ public class FontTest {
 
         // compile font
         Fontc fontc = new Fontc();
-        FileInputStream fontDescStream = new FileInputStream(fontDesc.getFont());
+        FileInputStream fontInputStream = new FileInputStream(fontDesc.getFont());
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
-        FontMap.Builder fontmapBuilder = FontMap.newBuilder();
-        BufferedImage image = fontc.compile(fontDescStream, fontDesc, fontmapBuilder, new FontResourceResolver() {
+        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
 
             @Override
             public InputStream getResource(String resourceName)
@@ -305,19 +386,23 @@ public class FontTest {
             }
         });
 
-        fontmapBuilder.build().writeTo(fontOutputStream);
-        fontDescStream.close();
+        fontMap.writeTo(fontOutputStream);
+        fontInputStream.close();
         fontOutputStream.close();
 
         // verify data
+        /*
         assertTrue(image != null);
         assertTrue(image.getHeight() > 0);
         assertTrue(image.getWidth() > 0);
+        */
 
         // verify glyphs
         BufferedInputStream fontcStream = new BufferedInputStream(new FileInputStream(outfile));
-        FontMap fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
+        fontMap = FontMap.newBuilder().mergeFrom(fontcStream).build();
 
+        // TODO need to change this to work with streaming fonts (will not generate a preview texture by default)
+        /*
         assertEquals(96, fontMap.getGlyphsCount());
         for (int i = 0; i < fontMap.getGlyphsCount(); i++) {
             Glyph g = fontMap.getGlyphs(i);
@@ -329,5 +414,6 @@ public class FontTest {
             assertTrue( g.getX() + g.getLeftBearing() + g.getWidth() <= image.getWidth());
             assertTrue( g.getY() + g.getDescent() <= image.getHeight());
         }
+        */
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -346,7 +346,7 @@ public class FontTest {
         // Check "old" texture sizes
         assertEquals(previewImage.getWidth(), 1024);
         assertEquals(previewImage.getHeight(), 2048);
-        
+
         // For previews we don't inlcude all glyphs
         assertTrue(fontMap.getGlyphsCount() < 1519);
         System.out.println("fontMap.getGlyphsCount(): " + fontMap.getGlyphsCount());

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -205,13 +205,14 @@ public class FontTest {
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
         final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
 
-        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
+        fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
                     return new FileInputStream(Paths.get(searchPath, resourceName).toString());
                 }
             });
+        FontMap fontMap = fontc.getFontMap();
         fontMap.writeTo(fontOutputStream);
 
         fontInputStream.close();
@@ -250,13 +251,14 @@ public class FontTest {
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
         final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
 
-        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
+        fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
                     return new FileInputStream(Paths.get(searchPath, resourceName).toString());
                 }
             });
+        FontMap fontMap = fontc.getFontMap();
         fontMap.writeTo(fontOutputStream);
 
         fontInputStream.close();
@@ -292,13 +294,14 @@ public class FontTest {
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
         final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
 
-        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
+        fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
                     return new FileInputStream(Paths.get(searchPath, resourceName).toString());
                 }
             });
+        FontMap fontMap = fontc.getFontMap();
         fontMap.writeTo(fontOutputStream);
 
         fontInputStream.close();
@@ -332,13 +335,14 @@ public class FontTest {
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
         final String searchPath = FilenameUtils.getBaseName(fontDesc.getFont());
         try {
-            FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
-                @Override
-                public InputStream getResource(String resourceName)
-                        throws FileNotFoundException {
-                    return new FileInputStream(Paths.get(searchPath, resourceName).toString());
-                }
-            });
+            fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
+                    @Override
+                    public InputStream getResource(String resourceName)
+                            throws FileNotFoundException {
+                        return new FileInputStream(Paths.get(searchPath, resourceName).toString());
+                    }
+                });
+            FontMap fontMap = fontc.getFontMap();
             fontMap.writeTo(fontOutputStream);
         } catch (FontFormatException e) {
             success = false;
@@ -377,7 +381,7 @@ public class FontTest {
         Fontc fontc = new Fontc();
         FileInputStream fontInputStream = new FileInputStream(fontDesc.getFont());
         FileOutputStream fontOutputStream = new FileOutputStream(outfile);
-        FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
+        fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
 
             @Override
             public InputStream getResource(String resourceName)
@@ -385,7 +389,7 @@ public class FontTest {
                 return new FileInputStream(Paths.get(tmpDir.toString(), resourceName).toString());
             }
         });
-
+        FontMap fontMap = fontc.getFontMap();
         fontMap.writeTo(fontOutputStream);
         fontInputStream.close();
         fontOutputStream.close();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -119,7 +119,7 @@ public class Fontc {
     private FontDesc fontDesc;
     private FontMap.Builder fontMapBuilder;
     private ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
-    
+
     private Font font;
     private BMFont bmfont;
 
@@ -128,7 +128,7 @@ public class Fontc {
     }
 
     public Fontc() {
-        
+
     }
 
     public InputFontFormat getInputFormat() {
@@ -200,11 +200,11 @@ public class Fontc {
                 }
 
                 glyph.vector = glyphVector;
-                
+
                 glyphs.add(glyph);
             }
         }
-        
+
         BufferedImage image;
         Graphics2D g;
         image = new BufferedImage(1024, 1024, BufferedImage.TYPE_3BYTE_BGR);
@@ -212,7 +212,7 @@ public class Fontc {
         g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         setHighQuality(g);
-        
+
         FontMetrics fontMetrics = g.getFontMetrics(font);
         int maxAscent = fontMetrics.getMaxAscent();
         int maxDescent = fontMetrics.getMaxDescent();
@@ -222,7 +222,7 @@ public class Fontc {
                       .setShadowY(fontDesc.getShadowY());
 
     }
-    
+
 
     public void FNTBuilder(InputStream fontStream) throws FontFormatException, IOException {
         this.inputFormat = InputFontFormat.FORMAT_BMFONT;
@@ -235,13 +235,13 @@ public class Fontc {
         } catch (BMFontFormatException e) {
             throw new FontFormatException(e.getMessage());
         }
-        
+
         int maxAscent = 0;
         int maxDescent = 0;
         for (int i = 0; i < bmfont.charArray.size(); ++i) {
 
             Char c = bmfont.charArray.get(i);
-            
+
             int ascent = bmfont.base - (int)c.yoffset;
             int descent = c.height - ascent;
 
@@ -262,12 +262,12 @@ public class Fontc {
 
             glyphs.add(glyph);
         }
-        
+
         fontMapBuilder.setMaxAscent(maxAscent)
                       .setMaxDescent(maxDescent);
     }
-    
-    // We use repeatedWrite to create a (cell) padding around the glyph bitmap data 
+
+    // We use repeatedWrite to create a (cell) padding around the glyph bitmap data
     private void repeatedWrite(ByteArrayOutputStream dataOut, int repeat, int value) {
         for (int i = 0; i < repeat; i++) {
             dataOut.write(value);
@@ -277,7 +277,7 @@ public class Fontc {
     public BufferedImage generateGlyphData(boolean preview, final FontResourceResolver resourceResolver) throws FontFormatException {
 
         ByteArrayOutputStream glyphDataBank = new ByteArrayOutputStream(1024*1024*4);
-        
+
         // Padding is the pixel amount needed to get a good antialiasing around the glyphs, while cell padding
         // is the extra padding added to the bitmap data to avoid filtering glitches when rendered.
         int padding = 0;
@@ -317,7 +317,7 @@ public class Fontc {
             fontMapBuilder.setSdfOffset(-sdf_offset / sdf_scale);
             fontMapBuilder.setSdfOutline(this.fontDesc.getOutlineWidth());
         }
-        
+
         // Load external image resource for BMFont files
         BufferedImage imageBMFont = null;
         if (inputFormat == InputFontFormat.FORMAT_BMFONT) {
@@ -333,18 +333,18 @@ public class Fontc {
                 throw new FontFormatException("Error while reading BMFont image resource: " + e.getMessage());
             }
         }
-        
+
         // Calculate channel count depending on both input and output format
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
             inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
-            
+
             // If font has outline, we need all three channels
             if (fontDesc.getOutlineWidth() > 0.0f && this.fontDesc.getOutlineAlpha() > 0.0f) {
                 channelCount = 3;
             } else {
-                channelCount = 1;                
+                channelCount = 1;
             }
-            
+
         } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
                    inputFormat == InputFontFormat.FORMAT_BMFONT) {
             channelCount = 4;
@@ -356,7 +356,7 @@ public class Fontc {
         // We keep track of offset into the glyph data bank,
         // this is saved for each glyph to know where their bitmap data is stored.
         int dataOffset = 0;
-        
+
         // Find max width, height for each glyph to lock down cache cell sizes,
         // this includes cell padding.
         int cell_width = 0;
@@ -371,19 +371,19 @@ public class Fontc {
             cell_width = Math.max(cell_width, width);
             cell_height = Math.max(cell_height, height);
         }
-        
+
         // We do an early cache size calculation before we create the glyph bitmaps
         // This is so that we can know when we have created enough glyphs to fill
         // the cache when creating a preview image.
         int cache_width = 1024;
         int cache_height = 0;
         if (fontDesc.getCacheWidth() > 0) {
-            cache_width = fontDesc.getCacheWidth(); 
+            cache_width = fontDesc.getCacheWidth();
         }
         int cache_columns = cache_width / cell_width;
-        
+
         if (fontDesc.getCacheHeight() > 0) {
-            cache_height = fontDesc.getCacheHeight(); 
+            cache_height = fontDesc.getCacheHeight();
         } else {
             // No "static" height set, guess height size for all to fit
             int tot_rows = (int)Math.ceil((double)glyphs.size() / (double)cache_columns);
@@ -393,7 +393,7 @@ public class Fontc {
             cache_height = Math.min(tot_height,  2048);
         }
         int cache_rows = cache_height / cell_height;
-        
+
         int include_glyph_count = glyphs.size();
         if (preview) {
             include_glyph_count = cache_rows * cache_columns;
@@ -422,26 +422,26 @@ public class Fontc {
             } else {
                 throw new FontFormatException("Invalid font format combination!");
             }
-            
+
             if (preview) {
-                
+
                 glyph.image = glyphImage;
-                
+
             } else {
 
                 // Get raster data from rendered glyph and store in glyph data bank
                 int dataSizeOut = (glyphImage.getWidth() + cell_padding * 2) * (glyphImage.getHeight() + cell_padding * 2) * channelCount;
                 for (int y = 0; y < glyphImage.getHeight(); y++) {
-                    
+
                     if (y == 0) {
                         repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
                     }
                     for (int x = 0; x < glyphImage.getWidth(); x++) {
-                        
+
                         if (x == 0) {
                             repeatedWrite(glyphDataBank, channelCount, clearData);
                         }
-                        
+
                         int color = glyphImage.getRGB(x, y);
                         int blue  = (color);
                         int green = (blue >> 8);
@@ -452,13 +452,13 @@ public class Fontc {
                         if (channelCount > 1) {
                             glyphDataBank.write((byte)(green & 0x000000ff));
                             glyphDataBank.write((byte)(blue & 0x000000ff));
-                            
+
                             if (channelCount > 3) {
                                 int alpha = (red >> 8);
                                 glyphDataBank.write((byte)(alpha & 0x000000ff));
                             }
                         }
-                        
+
                         if (x == glyphImage.getWidth()-1) {
                             repeatedWrite(glyphDataBank, channelCount, clearData);
                         }
@@ -471,16 +471,16 @@ public class Fontc {
                 dataOffset += dataSizeOut;
                 glyph.cache_entry_size = dataOffset - glyph.cache_entry_offset;
             }
-            
+
         }
-        
+
         // Sanity check;
         // Some fonts don't include ASCII range and trying to compile a font without
         // setting "all_chars" could result in an empty glyph list.
         if (glyphs.size() == 0) {
             throw new FontFormatException("No character glyphs where included! Maybe turn on 'all_chars'?");
         }
-        
+
         // Start filling the rest of FontMap
         fontMapBuilder.setGlyphPadding(cell_padding);
         fontMapBuilder.setCacheWidth(cache_width);
@@ -489,8 +489,8 @@ public class Fontc {
         fontMapBuilder.setCacheCellWidth(cell_width);
         fontMapBuilder.setCacheCellHeight(cell_height);
         fontMapBuilder.setGlyphChannels(channelCount);
-        
-        
+
+
         BufferedImage previewImage = null;
         if (preview) {
             try {
@@ -499,7 +499,7 @@ public class Fontc {
                 throw new FontFormatException("Could not generate font preview: " + e.getMessage());
             }
         }
-        
+
         for (int i = 0; i < include_glyph_count; i++) {
             Glyph glyph = glyphs.get(i);
             FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
@@ -511,20 +511,20 @@ public class Fontc {
                 .setDescent(glyph.descent + padding)
                 .setGlyphDataOffset(glyph.cache_entry_offset)
                 .setGlyphDataSize(glyph.cache_entry_size);
-            
+
             // "Static" cache positions is only used for previews currently
             if (preview) {
                 glyphBuilder.setX(glyph.x);
                 glyphBuilder.setY(glyph.y);
             }
-            
+
             fontMapBuilder.addGlyphs(glyphBuilder);
         }
-        
+
         return previewImage;
 
     }
-    
+
     private BufferedImage drawBMFontGlyph(Glyph glyph, BufferedImage imageBMFontInput) {
         return imageBMFontInput.getSubimage(glyph.x, glyph.y, glyph.width, glyph.ascent + glyph.descent);
     }
@@ -702,14 +702,14 @@ public class Fontc {
         }
         fontMapBuilder.setMaterial(fontDesc.getMaterial() + "c");
         fontMapBuilder.setImageFormat(fontDesc.getOutputFormat());
-        
+
         return generateGlyphData(preview, resourceResolver);
     }
-    
+
     public FontMap getFontMap() {
         return fontMapBuilder.build();
     }
-    
+
     public BufferedImage generatePreviewImage() throws IOException {
 
         Graphics2D g;
@@ -718,35 +718,35 @@ public class Fontc {
         g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
         g.clearRect(0, 0, previewImage.getWidth(), previewImage.getHeight());
         setHighQuality(g);
-        
+
         int cache_columns = fontMapBuilder.getCacheWidth() / fontMapBuilder.getCacheCellWidth();
         int cache_rows = fontMapBuilder.getCacheHeight() / fontMapBuilder.getCacheCellHeight();
-        
+
         BufferedImage glyphImage;
         for (int i = 0; i < glyphs.size(); i++) {
-            
+
             Glyph glyph = glyphs.get(i);
-            
+
             int col = i % cache_columns;
             int row = i / cache_columns;
-            
+
             if (row >= cache_rows) {
                 break;
             }
-            
+
             int x = col * fontMapBuilder.getCacheCellWidth();
             int y = row * fontMapBuilder.getCacheCellHeight();
-            
+
             glyph.x = x;
             glyph.y = y;
-            
+
             g.translate(x, y);
             glyphImage = glyph.image;
             g.drawImage(glyphImage, 0, 0, null);
             g.translate(-x, -y);
-            
+
         }
-        
+
         return previewImage;
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -396,7 +396,7 @@ public class Fontc {
 
         int include_glyph_count = glyphs.size();
         if (preview) {
-            include_glyph_count = cache_rows * cache_columns;
+            include_glyph_count = Math.min(glyphs.size(), cache_rows * cache_columns);
         }
         for (int i = 0; i < include_glyph_count; i++) {
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -443,19 +443,19 @@ public class Fontc {
                         }
 
                         int color = glyphImage.getRGB(x, y);
-                        int blue  = (color);
-                        int green = (blue >> 8);
-                        int red   = (green >> 8);
+                        int blue  = (color) & 0xff;
+                        int green = (color >> 8) & 0xff;
+                        int red   = (color >> 16) & 0xff;
 
-                        glyphDataBank.write((byte)(red & 0x000000ff));
+                        glyphDataBank.write((byte)red);
 
                         if (channelCount > 1) {
-                            glyphDataBank.write((byte)(green & 0x000000ff));
-                            glyphDataBank.write((byte)(blue & 0x000000ff));
+                            glyphDataBank.write((byte)green);
+                            glyphDataBank.write((byte)blue);
 
                             if (channelCount > 3) {
-                                int alpha = (red >> 8);
-                                glyphDataBank.write((byte)(alpha & 0x000000ff));
+                                int alpha = (color >> 24) & 0xff;
+                                glyphDataBank.write((byte)alpha);
                             }
                         }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -25,6 +25,7 @@ import java.awt.image.Kernel;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -43,10 +44,6 @@ import org.apache.commons.io.FilenameUtils;
 
 import com.dynamo.bob.font.BMFont.BMFontFormatException;
 import com.dynamo.bob.font.BMFont.Char;
-import com.dynamo.bob.pipeline.TextureGenerator;
-import com.dynamo.bob.pipeline.TextureGeneratorException;
-import com.dynamo.bob.util.PathUtil;
-import com.dynamo.graphics.proto.Graphics.TextureImage;
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.FontMap;
 import com.dynamo.render.proto.Font.FontTextureFormat;
@@ -55,7 +52,7 @@ import com.google.protobuf.TextFormat;
 
 class Glyph {
     int index;
-    char c;
+    int c;
     int width;
     int advance;
     int leftBearing;
@@ -63,6 +60,8 @@ class Glyph {
     int descent;
     int x;
     int y;
+    int cache_entry_offset;
+    int cache_entry_size;
     GlyphVector vector;
 };
 
@@ -113,99 +112,176 @@ public class Fontc {
         FORMAT_TRUETYPE, FORMAT_BMFONT
     };
 
-    private int imageWidth = 1024;
-    private int imageHeight = 2048; // Enough. Will be cropped later
     private InputFontFormat inputFormat = InputFontFormat.FORMAT_TRUETYPE;
     private Stroke outlineStroke = null;
-    private StringBuffer characters;
-    private FontRenderContext fontRendererContext;
-    private BufferedImage image;
     private FontDesc fontDesc;
-    static final int imageType = BufferedImage.TYPE_3BYTE_BGR;
-
-
+    private FontMap.Builder fontMapBuilder;
+    private ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
+    
+    private Font font;
+    private BMFont bmfont;
 
     public interface FontResourceResolver {
         public InputStream getResource(String resourceName) throws FileNotFoundException;
     }
 
     public Fontc() {
+        
     }
 
     public InputFontFormat getInputFormat() {
         return inputFormat;
     }
 
-    public void builderTTF(InputStream fontStream, FontDesc fontDesc, FontMap.Builder builder) throws FontFormatException, IOException {
+    public void TTFBuilder(InputStream fontStream) throws FontFormatException, IOException {
 
-        // 7-bit ASCII. Note inclusive range [32,126]
-        for (int i = 32; i <= 126; ++i)
-            this.characters.append((char) i);
+        ArrayList<Integer> characters = new ArrayList<Integer>();
 
-        String extraCharacters = fontDesc.getExtraCharacters();
-        for (int i = 0; i < extraCharacters.length(); i++) {
-            char c = extraCharacters.charAt(i);
-            this.characters.append(c);
+        if (!fontDesc.getAllChars()) {
+
+            // 7-bit ASCII. Note inclusive range [32,126]
+            for (int i = 32; i <= 126; ++i) {
+                characters.add(i);
+            }
+
+            String extraCharacters = fontDesc.getExtraCharacters();
+            for (int i = 0; i < extraCharacters.length(); i++) {
+                char c = extraCharacters.charAt(i);
+                characters.add((int)c);
+            }
+
         }
 
-        this.fontRendererContext = new FontRenderContext(new AffineTransform(), fontDesc.getAntialias() != 0, fontDesc.getAntialias() != 0);
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
             outlineStroke = new BasicStroke(fontDesc.getOutlineWidth());
         }
 
-        Font font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+        font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
         font = font.deriveFont(Font.PLAIN, fontDesc.getSize());
-        for (int i = 0; i < this.characters.length(); ++i) {
-            char ch = this.characters.charAt(i);
-            if (!font.canDisplay(ch)) {
-                this.characters.deleteCharAt(i);
-                i--;
+
+
+        FontRenderContext fontRendererContext = new FontRenderContext(new AffineTransform(), fontDesc.getAntialias() != 0, fontDesc.getAntialias() != 0);
+
+        int loopEnd = characters.size();
+        if (fontDesc.getAllChars()) {
+            assert(0 == loopEnd);
+            loopEnd = 0x10FFFF;
+        }
+        for (int i = 0; i < loopEnd; ++i) {
+
+            int codePoint = i;
+            if (!fontDesc.getAllChars()) {
+                codePoint = characters.get(i);
+            }
+
+            if (font.canDisplay(codePoint)) {
+                String s = new String(Character.toChars(codePoint));
+
+                GlyphVector glyphVector = font.createGlyphVector(fontRendererContext, s);
+                Rectangle visualBounds = glyphVector.getOutline().getBounds();
+
+                GlyphMetrics metrics = glyphVector.getGlyphMetrics(0);
+
+                Glyph glyph = new Glyph();
+                glyph.ascent = (int)Math.ceil(-visualBounds.getMinY());
+                glyph.descent = (int)Math.ceil(visualBounds.getMaxY());
+
+                glyph.c = codePoint;
+                glyph.index = i;
+                glyph.advance = Math.round(metrics.getAdvance());
+                float leftBearing = metrics.getLSB();
+                glyph.leftBearing = (int)Math.floor(leftBearing);
+                glyph.width = visualBounds.width;
+                if (leftBearing != 0.0f) {
+                    glyph.width += 1;
+                }
+
+                glyph.vector = glyphVector;
+
+                glyphs.add(glyph);
             }
         }
-
-        image = new BufferedImage(this.imageWidth, this.imageHeight, Fontc.imageType);
-        Graphics2D g = image.createGraphics();
+        
+        BufferedImage image;
+        Graphics2D g;
+        image = new BufferedImage(1024, 1024, BufferedImage.TYPE_3BYTE_BGR);
+        g = image.createGraphics();
         g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         setHighQuality(g);
-
+        
         FontMetrics fontMetrics = g.getFontMetrics(font);
         int maxAscent = fontMetrics.getMaxAscent();
         int maxDescent = fontMetrics.getMaxDescent();
+        fontMapBuilder.setMaxAscent(maxAscent)
+                      .setMaxDescent(maxDescent)
+                      .setShadowX(fontDesc.getShadowX())
+                      .setShadowY(fontDesc.getShadowY());
 
-        ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
-        for (int i = 0; i < this.characters.length(); ++i) {
-            String s = this.characters.substring(i, i+1);
+    }
+    
 
-            GlyphVector glyphVector = font.createGlyphVector(this.fontRendererContext, s);
-            Rectangle visualBounds = glyphVector.getOutline().getBounds();
-            GlyphMetrics metrics = glyphVector.getGlyphMetrics(0);
+    public void FNTBuilder(InputStream fontStream) throws FontFormatException, IOException {
+        this.inputFormat = InputFontFormat.FORMAT_BMFONT;
+
+        bmfont = new BMFont();
+
+        // parse BMFont file
+        try {
+            bmfont.parse(fontStream);
+        } catch (BMFontFormatException e) {
+            throw new FontFormatException(e.getMessage());
+        }
+        
+        int maxAscent = 0;
+        int maxDescent = 0;
+        for (int i = 0; i < bmfont.charArray.size(); ++i) {
+
+            Char c = bmfont.charArray.get(i);
+            
+            int ascent = bmfont.base - (int)c.yoffset;
+            int descent = c.height - ascent;
+
+            maxAscent = Math.max(ascent, maxAscent);
+            maxDescent = Math.max(descent, maxDescent);
 
             Glyph glyph = new Glyph();
-            glyph.ascent = (int)Math.ceil(-visualBounds.getMinY());
-            glyph.descent = (int)Math.ceil(visualBounds.getMaxY());
+            glyph.ascent = ascent;
+            glyph.descent = descent;
 
-            glyph.c = s.charAt(0);
+            glyph.x = c.x;
+            glyph.y = c.y;
+            glyph.c = c.id;
             glyph.index = i;
-            glyph.advance = Math.round(metrics.getAdvance());
-            float leftBearing = metrics.getLSB();
-            glyph.leftBearing = (int)Math.floor(leftBearing);
-            glyph.width = visualBounds.width;
-            if (leftBearing != 0.0f) {
-                glyph.width += 1;
-            }
-
-            glyph.vector = glyphVector;
+            glyph.advance = (int) c.xadvance;
+            glyph.leftBearing = (int) c.xoffset;
+            glyph.width = c.width;
 
             glyphs.add(glyph);
         }
+        
+        fontMapBuilder.setMaxAscent(maxAscent)
+                      .setMaxDescent(maxDescent);
+    }
+    
+    private void repeatedWrite(ByteArrayOutputStream dataOut, int repeat, int value) {
+        for (int i = 0; i < repeat; i++) {
+            dataOut.write(value);
+        }
+    }
 
-        int i = 0;
-        float totalY = 0.0f;
+    public void generateGlyphData(boolean preview, final FontResourceResolver resourceResolver) throws FontFormatException {
+
+        ByteArrayOutputStream glyphDataBank = new ByteArrayOutputStream(1024*1024*4);
+        
+        int cellWidth = 0;
+        int cellHeight = 0;
+        
         // Margin is set to 1 since the font map is an atlas, this removes sampling artifacts (neighbouring texels outside the sample-area being used)
         int margin = 1;
         int padding = 0;
+        int cell_padding = 1;
         float sdf_scale = 0;
         float sdf_offset = 0;
         if (fontDesc.getAntialias() != 0)
@@ -215,14 +291,14 @@ public class Fontc {
             // need sqrt(2) on either side of the range [0, outlineWidth + 1] to prevent clamped values being used
             // for interpolation across texels in the output. The extra is for smoothstep room.
             float sqrt2 = 1.4142f;
-            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + this.fontDesc.getOutlineWidth());
+            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + fontDesc.getOutlineWidth());
             sdf_offset = sdf_scale * sqrt2; // where glyph ends
         }
-        Color faceColor = new Color(this.fontDesc.getAlpha(), 0.0f, 0.0f);
-        Color outlineColor = new Color(0.0f, this.fontDesc.getOutlineAlpha(), 0.0f);
+        Color faceColor = new Color(fontDesc.getAlpha(), 0.0f, 0.0f);
+        Color outlineColor = new Color(0.0f, fontDesc.getOutlineAlpha(), 0.0f);
         ConvolveOp shadowConvolve = null;
         Composite blendComposite = new BlendComposite();
-        if (this.fontDesc.getShadowAlpha() > 0.0f) {
+        if (fontDesc.getShadowAlpha() > 0.0f) {
             float[] kernelData = {
                     0.0625f, 0.1250f, 0.0625f,
                     0.1250f, 0.2500f, 0.1250f,
@@ -234,67 +310,212 @@ public class Fontc {
             hints.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_DISABLE);
             shadowConvolve = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, hints);
         }
-        while (i < this.characters.length()) {
-            float x = margin;
-            float maxY = 0.0f;
-            int j = i;
-            while (j < this.characters.length() && x < this.imageWidth ) {
-                Glyph glyph = glyphs.get(j);
-                int width = glyph.width + margin + padding * 2;
-                if (x + width < this.imageWidth) {
-                    maxY = Math.max(maxY, glyph.ascent + glyph.descent);
-                    x += width;
-                } else {
-                    break;
-                }
-                ++j;
-            }
-
-            g.translate(0, margin);
-
-            for (int k = i; k < j; ++k) {
-                Glyph glyph = glyphs.get(k);
-
-                g.translate(margin, 0);
-
-                if (glyph.width > 0.0f) {
-                    BufferedImage glyphImage;
-                    if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP)
-                        glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
-                    else
-                        glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
-                    g.drawImage(glyphImage, 0, 0, null);
-                    glyph.x += g.getTransform().getTranslateX();
-                    glyph.y += g.getTransform().getTranslateY();
-
-                    g.translate(glyphImage.getWidth(), 0);
-                }
-            }
-            g.translate(-g.getTransform().getTranslateX(), maxY + padding * 2);
-            totalY += maxY + margin + 2 * padding;
-            i = j;
-        }
-        totalY += margin;
-
-        int newHeight = (int) (Math.log(totalY) / Math.log(2));
-        newHeight = (int) Math.pow(2, newHeight + 1);
-        this.image = this.image.getSubimage(0, 0, this.imageWidth, newHeight);
-
-        builder.setShadowX(fontDesc.getShadowX())
-               .setShadowY(fontDesc.getShadowY())
-               .setMaxAscent(maxAscent)
-               .setMaxDescent(maxDescent);
-
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             // sdf_scale has up until now been the value to scale with.
             // Now recompute their inverses to be used for unpacking it.
-            builder.setSdfScale(1.0f / sdf_scale);
-            builder.setSdfOffset(-sdf_offset / sdf_scale);
-            builder.setSdfOutline(this.fontDesc.getOutlineWidth());
-
+            fontMapBuilder.setSdfScale(1.0f / sdf_scale);
+            fontMapBuilder.setSdfOffset(-sdf_offset / sdf_scale);
+            fontMapBuilder.setSdfOutline(this.fontDesc.getOutlineWidth());
+        }
+        
+        // Load external image resource for BMFont files
+        BufferedImage imageBMFont = null;
+        if (inputFormat == InputFontFormat.FORMAT_BMFONT) {
+            String origPath = Paths.get(FilenameUtils.normalize(bmfont.page.get(0))).getFileName().toString();
+            InputStream inputImageStream = null;
+            try {
+                inputImageStream = resourceResolver.getResource(origPath);
+                imageBMFont = ImageIO.read(inputImageStream);
+                inputImageStream.close();
+            } catch (FileNotFoundException e) {
+                throw new FontFormatException("Could not find BMFont image resource: " + origPath);
+            } catch (IOException e) {
+                throw new FontFormatException("Error while reading BMFont image resource: " + e.getMessage());
+            }
+        }
+        
+        // Calculate channel count depending on both input and output format
+        int channelCount = 3;
+        if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+            inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+            
+            // If font has outline, we need all three channels
+            if (fontDesc.getOutlineWidth() > 0.0f && this.fontDesc.getOutlineAlpha() > 0.0f) {
+                channelCount = 3;
+            } else {
+                channelCount = 1;                
+            }
+            
+        } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                   inputFormat == InputFontFormat.FORMAT_BMFONT) {
+            channelCount = 4;
+        } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
+                   inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+            channelCount = 1;
         }
 
-        i = 0;
+        
+        // Generate "old style" texture preview
+        if (preview) {
+
+            /*
+            while (i < this.characters.length()) {
+                float x = margin;
+                float maxY = 0.0f;
+                int j = i;
+                while (j < this.characters.length() && x < imageWidth ) {
+                    Glyph glyph = glyphs.get(j);
+                    int width = glyph.width + margin + padding * 2;
+                    if (x + width < imageWidth) {
+                        maxY = Math.max(maxY, glyph.ascent + glyph.descent);
+                        x += width;
+                    } else {
+                        break;
+                    }
+                    ++j;
+                }
+
+                g.translate(0, margin);
+
+                for (int k = i; k < j; ++k) {
+                    Glyph glyph = glyphs.get(k);
+
+                    g.translate(margin, 0);
+
+                    if (glyph.width > 0.0f) {
+                        BufferedImage glyphImage;
+                        if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP)
+                            glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
+                        else
+                            glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
+                        g.drawImage(glyphImage, 0, 0, null);
+                        glyph.x += g.getTransform().getTranslateX();
+                        glyph.y += g.getTransform().getTranslateY();
+
+                        g.translate(glyphImage.getWidth(), 0);
+                    }
+                }
+                g.translate(-g.getTransform().getTranslateX(), maxY + padding * 2);
+                totalY += maxY + margin + 2 * padding;
+                i = j;
+
+            }
+            totalY += margin;
+
+            int newHeight = (int) (Math.log(totalY) / Math.log(2));
+            newHeight = (int) Math.pow(2, newHeight + 1);
+            image = image.getSubimage(0, 0, this.imageWidth, newHeight);
+            */
+
+        // Generate glyph data bank
+        } else {
+
+            // Keep track of offset into the glyph data bank
+            int dataOffset = 0;
+            
+            for (int i = 0; i < glyphs.size(); i++) {
+
+                Glyph glyph = glyphs.get(i);
+                if (glyph.width <= 0.0f) {
+                    continue;
+                }
+                glyph.cache_entry_offset = dataOffset;
+
+                // Find max width, height for each glyph to lock down cache cell sizes
+                // Includes cell padding
+                int width = glyph.width + padding * 2 + cell_padding * 2;
+                int height = glyph.ascent + glyph.descent + padding * 2 + cell_padding * 2;
+                cellWidth = Math.max(cellWidth, width);
+                cellHeight = Math.max(cellHeight, height);
+
+                // Generate bitmap for each glyph depending on format
+                BufferedImage glyphImage = null;
+                int clearData = 0;
+                if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                    inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                    glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
+                } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                           inputFormat == InputFontFormat.FORMAT_BMFONT) {
+                    glyphImage = drawBMFontGlyph(glyph, imageBMFont);
+                } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
+                           inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                    glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
+                    clearData = 255;
+                } else {
+                    throw new FontFormatException("Invalid font format combination!");
+                }
+
+                // Get raster data from rendered glyph and store in glyph data bank
+                int dataSizeOut = (glyphImage.getWidth() + cell_padding * 2) * (glyphImage.getHeight() + cell_padding * 2) * channelCount;
+                for (int y = 0; y < glyphImage.getHeight(); y++) {
+                    if (y == 0) {
+                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
+                    }
+                    for (int x = 0; x < glyphImage.getWidth(); x++) {
+                        
+                        if (x == 0) {
+                            repeatedWrite(glyphDataBank, channelCount, clearData);
+                        }
+                        
+                        int color = glyphImage.getRGB(x, y);
+                        int blue  = (color);
+                        int green = (blue >> 8);
+                        int red   = (green >> 8);
+
+                        glyphDataBank.write((byte)(red & 0x000000ff));
+
+                        if (channelCount > 1) {
+                            glyphDataBank.write((byte)(green & 0x000000ff));
+                            glyphDataBank.write((byte)(blue & 0x000000ff));
+                            
+                            if (channelCount > 3) {
+                                int alpha = (red >> 8);
+                                glyphDataBank.write((byte)(alpha & 0x000000ff));
+                            }
+                        }
+                        
+                        if (x == glyphImage.getWidth()-1) {
+                            repeatedWrite(glyphDataBank, channelCount, clearData);
+                        }
+
+                    }
+                    if (y == glyphImage.getHeight()-1) {
+                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
+                    }
+                }
+                dataOffset += dataSizeOut;
+                glyph.cache_entry_size = dataOffset - glyph.cache_entry_offset;
+
+            }
+
+        }
+        
+        
+        // Start filling the rest of FontMap        
+        int cache_width = 1024;
+        int cache_height = 2048;
+        if (fontDesc.getCacheWidth() > 0) {
+            cache_width = fontDesc.getCacheWidth(); 
+        }
+        if (fontDesc.getCacheHeight() > 0) {
+            cache_height = fontDesc.getCacheHeight(); 
+        }
+        
+        fontMapBuilder.setGlyphPadding(cell_padding);
+        fontMapBuilder.setCacheWidth(cache_width);
+        fontMapBuilder.setCacheHeight(cache_height);
+        fontMapBuilder.setGlyphData(ByteString.copyFrom(glyphDataBank.toByteArray()));
+        fontMapBuilder.setCacheCellWidth(cellWidth);
+        fontMapBuilder.setCacheCellHeight(cellHeight);
+        fontMapBuilder.setGlyphChannels(channelCount);
+
+        // Sanity check
+        // Some fonts don't include ASCII range and trying to compile a font without
+        // setting "all_chars" could result in an empty glyph list.
+        if (glyphs.size() == 0) {
+            throw new FontFormatException("No character glyphs where included! Maybe turn on 'all_chars'?");
+        }
+        
         for (Glyph glyph : glyphs) {
             FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
                 .setCharacter(glyph.c)
@@ -303,79 +524,33 @@ public class Fontc {
                 .setLeftBearing(glyph.leftBearing - padding)
                 .setAscent(glyph.ascent + padding)
                 .setDescent(glyph.descent + padding)
-                .setX(glyph.x)
-                .setY(glyph.y);
-            builder.addGlyphs(glyphBuilder);
+                .setGlyphDataOffset(glyph.cache_entry_offset)
+                .setGlyphDataSize(glyph.cache_entry_size);
+            fontMapBuilder.addGlyphs(glyphBuilder);
         }
 
     }
 
-    public void builderFNT(InputStream fontStream, FontDesc fontDesc, FontMap.Builder builder, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        this.inputFormat = InputFontFormat.FORMAT_BMFONT;
 
-        BMFont bmfont = new BMFont();
-
-        // parse BMFont file
-        try {
-            bmfont.parse(fontStream);
-        } catch (BMFontFormatException e) {
-            throw new FontFormatException(e.getMessage());
-        }
-
-        // fill glyphs
-        int maxAscent = 0;
-        int maxDescent = 0;
-        for (int i = 0; i < bmfont.charArray.size(); ++i) {
-            Char c = bmfont.charArray.get(i);
-
-            int ascent = bmfont.base - (int)c.yoffset;
-            int descent = c.height - ascent;
-
-            maxAscent = Math.max(ascent, maxAscent);
-            maxDescent = Math.max(descent, maxDescent);
-
-            FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
-                .setCharacter(c.id)
-                .setWidth(c.width)
-                .setAdvance(c.xadvance)
-                .setLeftBearing(c.xoffset)
-                .setAscent(ascent)
-                .setDescent(descent)
-                .setX(c.x - (int)c.xoffset)
-                .setY(c.y + ascent);
-            builder.addGlyphs(glyphBuilder);
-        }
-
-        // fill FontMap
-        builder.setMaxAscent(maxAscent)
-               .setMaxDescent(maxDescent);
-
-        // copy to new texture
-        String origPath = Paths.get(FilenameUtils.normalize(bmfont.page.get(0))).getFileName().toString();
-        InputStream inputImageStream = null;
-        try {
-            inputImageStream = resourceResolver.getResource(origPath);
-        } catch (FileNotFoundException e) {
-            throw new IOException("Could not find BMFont image resource: " + origPath);
-        }
-        BufferedImage origImage = ImageIO.read(inputImageStream);
-        inputImageStream.close();
-        this.image = origImage;
-    }
-
-    public BufferedImage compile(InputStream fontStream, FontDesc fontDesc, FontMap.Builder fontMapBuilder, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        this.characters = new StringBuffer();
+    public FontMap compile(InputStream fontStream, FontDesc fontDesc, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
         this.fontDesc = fontDesc;
+        this.fontMapBuilder = FontMap.newBuilder();
 
         if (fontDesc.getFont().toLowerCase().endsWith("fnt")) {
-            builderFNT(fontStream, fontDesc, fontMapBuilder, resourceResolver);
+            FNTBuilder(fontStream);
         } else {
-            builderTTF(fontStream, fontDesc, fontMapBuilder);
+            TTFBuilder(fontStream);
         }
         fontMapBuilder.setMaterial(fontDesc.getMaterial() + "c");
         fontMapBuilder.setImageFormat(fontDesc.getOutputFormat());
 
-        return this.image;
+        generateGlyphData(false, resourceResolver);
+
+        return this.fontMapBuilder.build(); // TODO
+    }
+    
+    private BufferedImage drawBMFontGlyph(Glyph glyph, BufferedImage imageBMFontInput) {
+        return imageBMFontInput.getSubimage(glyph.x, glyph.y, glyph.width, glyph.ascent + glyph.descent);
     }
 
     private BufferedImage makeDistanceField(Glyph glyph, int padding, float sdf_scale, float sdf_offset, Font font) {
@@ -430,7 +605,7 @@ public class Fontc {
         double kx = 1 / (double)width;
         double ky = 1 / (double)height;
 
-        BufferedImage image = new BufferedImage(width, height, Fontc.imageType);
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY);
         for (int v=0;v<height;v++) {
             int ofs = v * width;
             for (int u=0;u<width;u++) {
@@ -463,7 +638,7 @@ public class Fontc {
         glyph.x = dx;
         glyph.y = dy;
 
-        BufferedImage image = new BufferedImage(width, height, Fontc.imageType);
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         Graphics2D g = image.createGraphics();
         setHighQuality(g);
         g.setBackground(Color.BLACK);
@@ -502,7 +677,7 @@ public class Fontc {
         } else {
             g.setPaint(faceColor);
             g.setFont(font);
-            g.drawString(Character.toString(glyph.c), 0, 0);
+            g.drawString(new String(Character.toChars(glyph.c)), 0, 0);
         }
 
         return image;
@@ -541,9 +716,10 @@ public class Fontc {
     }
 
     public static BufferedImage compileToImage(InputStream fontStream, FontDesc fontDesc, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        Fontc fontc = new Fontc();
-        FontMap.Builder builder = FontMap.newBuilder();
-        return fontc.compile(fontStream, fontDesc, builder, resourceResolver);
+//        Fontc fontc = new Fontc();
+//        FontMap.Builder builder = FontMap.newBuilder();
+        //return fontc.compile(fontStream, fontDesc, builder, resourceResolver);
+        return null; // TODO
     }
 
     public static void main(String[] args) throws FontFormatException {
@@ -588,8 +764,7 @@ public class Fontc {
             Fontc fontc = new Fontc();
             String fontInputFile = basedir + File.separator + fontDesc.getFont();
             BufferedInputStream fontInputStream = new BufferedInputStream(new FileInputStream(fontInputFile));
-            FontMap.Builder fontmapBuilder = FontMap.newBuilder();
-            BufferedImage image = fontc.compile(fontInputStream, fontDesc, fontmapBuilder, new FontResourceResolver() {
+            FontMap fontMap = fontc.compile(fontInputStream, fontDesc, new FontResourceResolver() {
 
                 @Override
                 public InputStream getResource(String resourceName) throws FileNotFoundException {
@@ -601,26 +776,11 @@ public class Fontc {
             });
             fontInputStream.close();
 
-            // Construct "internal" project root relative path, ie. /builtins/fonts/foobar_tex0.texturec
-            String internalPath = args[0].substring(basedir.length());
-            internalPath = FilenameUtils.removeExtension(internalPath) + "_tex0.texturec";
-            fontmapBuilder.addTextures(FilenameUtils.separatorsToUnix(internalPath));
-
-            // Generate texture (and save to disk) from font image
-            String textureFilename = FilenameUtils.removeExtension(Paths.get(outfile).normalize().toString()) + "_tex0.texturec";
-            TextureImage texture = TextureGenerator.generate(image, null);
-            FileOutputStream textureOutputStream = new FileOutputStream( textureFilename );
-            texture.writeTo(textureOutputStream);
-            textureOutputStream.close();
-
             // Write fontmap file
             FileOutputStream fontMapOutputStream = new FileOutputStream(outfile);
-            fontmapBuilder.build().writeTo(fontMapOutputStream);
+            fontMap.writeTo(fontMapOutputStream);
             fontMapOutputStream.close();
 
-        } catch (TextureGeneratorException e) {
-            System.err.println(e.getMessage());
-            System.exit(1);
         } catch (IOException e) {
             System.err.println(e.getMessage());
             System.exit(1);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -446,6 +446,11 @@ public class Fontc {
                         int blue  = (color) & 0xff;
                         int green = (color >> 8) & 0xff;
                         int red   = (color >> 16) & 0xff;
+                        int alpha = (color >> 24) & 0xff;
+                        blue = (blue * alpha) / 255;
+                        green = (green * alpha) / 255;
+                        red = (red * alpha) / 255;
+                        
 
                         glyphDataBank.write((byte)red);
 
@@ -454,7 +459,7 @@ public class Fontc {
                             glyphDataBank.write((byte)blue);
 
                             if (channelCount > 3) {
-                                int alpha = (color >> 24) & 0xff;
+                                
                                 glyphDataBank.write((byte)alpha);
                             }
                         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -1,15 +1,11 @@
 package com.dynamo.bob.pipeline;
 
 import java.awt.FontFormatException;
-import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-
-import org.apache.commons.io.FilenameUtils;
 
 import com.dynamo.bob.Builder;
 import com.dynamo.bob.BuilderParams;
@@ -18,11 +14,7 @@ import com.dynamo.bob.Task;
 import com.dynamo.bob.font.Fontc;
 import com.dynamo.bob.font.Fontc.FontResourceResolver;
 import com.dynamo.bob.fs.IResource;
-import com.dynamo.bob.util.TextureUtil;
-import com.dynamo.graphics.proto.Graphics.TextureImage;
-import com.dynamo.graphics.proto.Graphics.TextureProfile;
 import com.dynamo.render.proto.Font.FontDesc;
-import com.dynamo.render.proto.Font.FontMap;
 
 @BuilderParams(name = "Font", inExts = ".font", outExt = ".fontc")
 public class FontBuilder extends Builder<Void>  {
@@ -56,7 +48,6 @@ public class FontBuilder extends Builder<Void>  {
 
         Fontc fontc = new Fontc();
         BufferedInputStream fontStream = new BufferedInputStream(new ByteArrayInputStream(inputFontFile.getContent()));
-        BufferedImage outputImage = null;
         try {
 
             // Run fontc, fills the fontmap builder and returns an image

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -60,7 +60,7 @@ public class FontBuilder extends Builder<Void>  {
         try {
 
             // Run fontc, fills the fontmap builder and returns an image
-            FontMap fontMap = fontc.compile(fontStream, fontDesc, new FontResourceResolver() {
+            fontc.compile(fontStream, fontDesc, false, new FontResourceResolver() {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
@@ -78,7 +78,7 @@ public class FontBuilder extends Builder<Void>  {
             });
 
             // Save fontmap file
-            task.output(0).setContent(fontMap.toByteArray());
+            task.output(0).setContent(fontc.getFontMap().toByteArray());
 
         } catch (FontFormatException e) {
             task.output(0).remove();

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/FontEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/FontEditor.java
@@ -76,7 +76,9 @@ public class FontEditor extends DdfEditor {
                             }
                         }
 
-                        final BufferedImage awtImage = Fontc.compileToImage(new ByteArrayInputStream(cachedFont), fontDesc, new FontResourceResolver() {
+                        //final BufferedImage awtImage = Fontc.generatePreviewImage(new ByteArrayInputStream(cachedFont), fontDesc, new FontResourceResolver() {
+                        Fontc fontc = new Fontc();
+                        final BufferedImage awtImage = fontc.compile(new ByteArrayInputStream(cachedFont), fontDesc, true, new FontResourceResolver() {
 
                             @Override
                             public InputStream getResource(String resourceName)

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -298,10 +298,10 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
                     if (g != null) {
                         if (g.getWidth() > 0) {
 
-                            double u_min = sU * (g.getX() + g.getLeftBearing());
-                            double v_min = sV * (g.getY() - g.getAscent());
-                            double u_max = u_min + sU * g.getWidth();
-                            double v_max = v_min + sV * (g.getAscent() + g.getDescent());
+                            double u_min = sU * (g.getX() + fontMap.getGlyphPadding());
+                            double v_min = sV * (g.getY() + fontMap.getGlyphPadding());
+                            double u_max = sU * (g.getX() + fontMap.getGlyphPadding() + g.getWidth());
+                            double v_max = sV * (g.getY() + fontMap.getGlyphPadding() + g.getAscent() + g.getDescent());
 
                             double x_min = x + g.getLeftBearing();
                             double x_max = x_min + g.getWidth();

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
@@ -495,14 +495,14 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
         }
 
         // Compile to FontMap
-        FontMap.Builder fontMapBuilder = FontMap.newBuilder();
         final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
         final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
-        BufferedImage image;
+        //BufferedImage image;
+        FontMap fontMap = null;
         Fontc fontc = new Fontc();
 
         try {
-            image = fontc.compile(fontInputFile.getContents(), fontDesc, fontMapBuilder, new FontResourceResolver() {
+            fontMap = fontc.compile(fontInputFile.getContents(), fontDesc, new FontResourceResolver() {
 
                 @Override
                 public InputStream getResource(String resourceName)
@@ -522,7 +522,8 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
             throw new IOException(e.getMessage());
         }
 
-        handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
+        //handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
+        // TODO FIXME!!!!
 
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
@@ -497,12 +497,11 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
         // Compile to FontMap
         final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
         final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
-        //BufferedImage image;
-        FontMap fontMap = null;
+        BufferedImage image;
         Fontc fontc = new Fontc();
 
         try {
-            fontMap = fontc.compile(fontInputFile.getContents(), fontDesc, new FontResourceResolver() {
+            image = fontc.compile(fontInputFile.getContents(), fontDesc, true, new FontResourceResolver() {
 
                 @Override
                 public InputStream getResource(String resourceName)
@@ -522,8 +521,7 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
             throw new IOException(e.getMessage());
         }
 
-        //handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
-        // TODO FIXME!!!!
+        handle.setFont(fontc.getFontMap(), image, fontc.getInputFormat());
 
     }
 

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -599,18 +599,6 @@ public class Fontc {
             });
             fontInputStream.close();
 
-            // Construct "internal" project root relative path, ie. /builtins/fonts/foobar_tex0.texturec
-            String internalPath = args[0].substring(basedir.length());
-            internalPath = FilenameUtils.removeExtension(internalPath) + "_tex0.texturec";
-            fontmapBuilder.addTextures(FilenameUtils.separatorsToUnix(internalPath));
-
-            // Generate texture (and save to disk) from font image
-            String textureFilename = FilenameUtils.removeExtension(Paths.get(outfile).normalize().toString()) + "_tex0.texturec";
-            TextureImage texture = TextureGenerator.generate(image, null);
-            FileOutputStream textureOutputStream = new FileOutputStream( textureFilename );
-            texture.writeTo(textureOutputStream);
-            textureOutputStream.close();
-
             // Write fontmap file
             FileOutputStream fontMapOutputStream = new FileOutputStream(outfile);
             fontmapBuilder.build().writeTo(fontMapOutputStream);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -977,6 +977,7 @@ bail:
 
                     dmRender::ClearRenderObjects(engine->m_RenderContext);
 
+
                     dmMessage::Dispatch(engine->m_SystemSocket, Dispatch, engine);
                 }
 

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -75,7 +75,6 @@ namespace dmGameSystem
 
         dmRender::SetFontMapMaterial(font_map, material);
 
-        // free(params.m_GlyphData);
         dmDDF::FreeMessage(ddf);
 
         *font_map_out = font_map;

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -53,7 +53,6 @@ namespace dmGameSystem
 
         params.m_CacheWidth = ddf->m_CacheWidth;
         params.m_CacheHeight = ddf->m_CacheHeight;
-        params.m_GlyphDataSize = ddf->m_GlyphDataSize;
 
         params.m_GlyphChannels = ddf->m_GlyphChannels;
 

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -16,30 +16,8 @@ namespace dmGameSystem
     {
         *font_map_out = 0;
 
-        if (reload)
-        {
-            // Will pick up the actual pointer when running get. This is a poor man's rebuild dependency
-            // tracking. The editor could in theory send a reload command for the texture as well, but for
-            // now trigger it manually here.
-            dmResource::Result r = dmResource::ReloadResource(factory, ddf->m_Textures[0], 0);
-            if (r != dmResource::RESULT_OK)
-            {
-                dmDDF::FreeMessage(ddf);
-                return r;
-            }
-        }
-
         dmRender::HMaterial material;
         dmResource::Result result = dmResource::Get(factory, ddf->m_Material, (void**) &material);
-        if (result != dmResource::RESULT_OK)
-        {
-            dmDDF::FreeMessage(ddf);
-            return result;
-        }
-
-        dmGraphics::HTexture texture;
-        assert(ddf->m_Textures.m_Count > 0);
-        result = dmResource::Get(factory, ddf->m_Textures[0], (void**) &texture);
         if (result != dmResource::RESULT_OK)
         {
             dmDDF::FreeMessage(ddf);
@@ -59,8 +37,11 @@ namespace dmGameSystem
             o_g.m_Descent = i_g.m_Descent;
             o_g.m_LeftBearing = i_g.m_LeftBearing;
             o_g.m_Width = i_g.m_Width;
-            o_g.m_X = i_g.m_X;
-            o_g.m_Y = i_g.m_Y;
+
+            o_g.m_InCache = false;
+            o_g.m_GlyphDataOffset = i_g.m_GlyphDataOffset;
+            o_g.m_GlyphDataSize = i_g.m_GlyphDataSize;
+
         }
         params.m_ShadowX = ddf->m_ShadowX;
         params.m_ShadowY = ddf->m_ShadowY;
@@ -70,18 +51,31 @@ namespace dmGameSystem
         params.m_SdfScale = ddf->m_SdfScale;
         params.m_SdfOutline = ddf->m_SdfOutline;
 
+        params.m_CacheWidth = ddf->m_CacheWidth;
+        params.m_CacheHeight = ddf->m_CacheHeight;
+        params.m_GlyphDataSize = ddf->m_GlyphDataSize;
+
+        params.m_GlyphChannels = ddf->m_GlyphChannels;
+
+        params.m_CacheCellWidth = ddf->m_CacheCellWidth;
+        params.m_CacheCellHeight = ddf->m_CacheCellHeight;
+        params.m_CacheCellPadding = ddf->m_GlyphPadding;
+
+        // Copy and unpack glyphdata
+        params.m_GlyphData = malloc(ddf->m_GlyphData.m_Count);
+        memcpy(params.m_GlyphData, ddf->m_GlyphData.m_Data, ddf->m_GlyphData.m_Count);
+
         if (font_map == 0)
             font_map = dmRender::NewFontMap(dmRender::GetGraphicsContext(context), params);
         else
         {
             dmRender::SetFontMap(font_map, params);
             dmResource::Release(factory, dmRender::GetFontMapMaterial(font_map));
-            dmResource::Release(factory, dmRender::GetFontMapTexture(font_map));
         }
 
-        dmRender::SetFontMapTexture(font_map, texture);
         dmRender::SetFontMapMaterial(font_map, material);
 
+        // free(params.m_GlyphData);
         dmDDF::FreeMessage(ddf);
 
         *font_map_out = font_map;
@@ -103,8 +97,6 @@ namespace dmGameSystem
         }
 
         dmResource::PreloadHint(hint_info, ddf->m_Material);
-        assert(ddf->m_Textures.m_Count > 0);
-        dmResource::PreloadHint(hint_info, ddf->m_Textures[0]);
 
         *preload_data = ddf;
         return dmResource::RESULT_OK;
@@ -139,7 +131,6 @@ namespace dmGameSystem
     {
         dmRender::HFontMap font_map = (dmRender::HFontMap)resource->m_Resource;
         dmResource::Release(factory, (void*)dmRender::GetFontMapMaterial(font_map));
-        dmResource::Release(factory, (void*)dmRender::GetFontMapTexture(font_map));
         dmRender::DeleteFontMap(font_map);
 
         return dmResource::RESULT_OK;

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -294,6 +294,9 @@ namespace dmGraphics
         , m_MipMap(0)
         , m_Width(0)
         , m_Height(0)
+        , m_SubUpdate(false)
+        , m_X(0)
+        , m_Y(0)
         {}
 
         TextureFormat m_Format;
@@ -306,6 +309,11 @@ namespace dmGraphics
         uint16_t m_MipMap;
         uint16_t m_Width;
         uint16_t m_Height;
+
+        // For sub texture updates
+        bool m_SubUpdate;
+        uint32_t m_X;
+        uint32_t m_Y;
     };
 
     // Parameters structure for OpenWindow
@@ -549,6 +557,7 @@ namespace dmGraphics
      * @param params
      */
     void SetTexture(HTexture texture, const TextureParams& params);
+    uint8_t* GetTextureData(HTexture texture);
     void SetTextureParams(HTexture texture, TextureFilter minfilter, TextureFilter magfilter, TextureWrap uwrap, TextureWrap vwrap);
     uint16_t GetTextureWidth(HTexture texture);
     uint16_t GetTextureHeight(HTexture texture);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -802,6 +802,10 @@ namespace dmGraphics
         memcpy(texture->m_Data, params.m_Data, params.m_DataSize);
     }
 
+    uint8_t* GetTextureData(HTexture texture) {
+        return 0x0;
+    }
+
     uint16_t GetTextureWidth(HTexture texture)
     {
         return texture->m_Width;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1516,7 +1516,8 @@ static void LogFrameBufferError(GLenum status)
             if (params.m_DataSize > 0) {
                 if (texture->m_Type == TEXTURE_TYPE_2D) {
                     if (params.m_SubUpdate) {
-                    } else {
+                        glCompressedTexSubImage2D(GL_TEXTURE_2D, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, params.m_Data);
+                    } else {
                         glCompressedTexImage2D(GL_TEXTURE_2D, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, params.m_Data);
                     }
                     CHECK_GL_ERROR
@@ -1553,16 +1554,6 @@ static void LogFrameBufferError(GLenum status)
             glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
             CHECK_GL_ERROR
         }
-    }
-
-    uint8_t* GetTextureData(HTexture texture)
-    {
-        uint8_t* asd = (uint8_t*)malloc(sizeof(uint8_t) * texture->m_Width * texture->m_Height * 3);
-        // glBindTexture(TEXTURE_TYPE_2D, texture->m_Texture);
-        // glGetTexImage(TEXTURE_TYPE_2D, 0, DMGRAPHICS_TEXTURE_FORMAT_RGB, DMGRAPHICS_TYPE_UNSIGNED_BYTE, (void*)asd);
-        // glBindTexture(TEXTURE_TYPE_2D, 0);
-
-        return asd;
     }
 
     uint16_t GetTextureWidth(HTexture texture)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1486,18 +1486,33 @@ static void LogFrameBufferError(GLenum status)
                 }
             } else if (texture->m_Type == TEXTURE_TYPE_CUBE_MAP) {
                 const char* p = (const char*) params.m_Data;
-                glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 0);
-                CHECK_GL_ERROR
-                glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 1);
-                CHECK_GL_ERROR
-                glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 2);
-                CHECK_GL_ERROR
-                glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 3);
-                CHECK_GL_ERROR
-                glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 4);
-                CHECK_GL_ERROR
-                glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 5);
-                CHECK_GL_ERROR
+                if (params.m_SubUpdate) {
+                    glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, gl_type, p + params.m_DataSize * 0);
+                    CHECK_GL_ERROR
+                    glTexSubImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, gl_type, p + params.m_DataSize * 1);
+                    CHECK_GL_ERROR
+                    glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, gl_type, p + params.m_DataSize * 2);
+                    CHECK_GL_ERROR
+                    glTexSubImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, gl_type, p + params.m_DataSize * 3);
+                    CHECK_GL_ERROR
+                    glTexSubImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, gl_type, p + params.m_DataSize * 4);
+                    CHECK_GL_ERROR
+                    glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, gl_type, p + params.m_DataSize * 5);
+                    CHECK_GL_ERROR
+                } else {
+                    glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 0);
+                    CHECK_GL_ERROR
+                    glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 1);
+                    CHECK_GL_ERROR
+                    glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 2);
+                    CHECK_GL_ERROR
+                    glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 3);
+                    CHECK_GL_ERROR
+                    glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 4);
+                    CHECK_GL_ERROR
+                    glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 5);
+                    CHECK_GL_ERROR
+                }
 
             } else {
                 assert(0);
@@ -1523,18 +1538,33 @@ static void LogFrameBufferError(GLenum status)
                     CHECK_GL_ERROR
                 } else if (texture->m_Type == TEXTURE_TYPE_CUBE_MAP) {
                     const char* p = (const char*) params.m_Data;
-                    glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 0);
-                    CHECK_GL_ERROR
-                    glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 1);
-                    CHECK_GL_ERROR
-                    glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 2);
-                    CHECK_GL_ERROR
-                    glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 3);
-                    CHECK_GL_ERROR
-                    glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 4);
-                    CHECK_GL_ERROR
-                    glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 5);
-                    CHECK_GL_ERROR
+                    if (params.m_SubUpdate) {
+                        glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, p + params.m_DataSize * 0);
+                        CHECK_GL_ERROR
+                        glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, p + params.m_DataSize * 1);
+                        CHECK_GL_ERROR
+                        glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, p + params.m_DataSize * 2);
+                        CHECK_GL_ERROR
+                        glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, p + params.m_DataSize * 3);
+                        CHECK_GL_ERROR
+                        glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, p + params.m_DataSize * 4);
+                        CHECK_GL_ERROR
+                        glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, params.m_X, params.m_Y, params.m_Width, params.m_Height, gl_format, params.m_DataSize, p + params.m_DataSize * 5);
+                        CHECK_GL_ERROR
+                    } else {
+                        glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, p + params.m_DataSize * 0);
+                        CHECK_GL_ERROR
+                        glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, p + params.m_DataSize * 1);
+                        CHECK_GL_ERROR
+                        glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, p + params.m_DataSize * 2);
+                        CHECK_GL_ERROR
+                        glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, p + params.m_DataSize * 3);
+                        CHECK_GL_ERROR
+                        glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, p + params.m_DataSize * 4);
+                        CHECK_GL_ERROR
+                        glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, gl_format, params.m_Width, params.m_Height, 0, params.m_DataSize, p + params.m_DataSize * 5);
+                        CHECK_GL_ERROR
+                    }
                 } else {
                     assert(0);
                 }

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -27,6 +27,10 @@ message FontDesc
     optional float shadow_y = 11 [default = 0.0];
     optional string extra_characters = 12 [default = ""];
     optional FontTextureFormat output_format = 13 [default = TYPE_BITMAP];
+
+    optional bool all_chars = 14 [default = false];
+    optional uint32 cache_width = 15 [default = 0];
+    optional uint32 cache_height = 16 [default = 0];
 }
 
 message FontMap
@@ -41,6 +45,9 @@ message FontMap
         optional uint32 descent = 6 [default = 0];
         optional int32 x = 7 [default = 0];
         optional int32 y = 8 [default = 0];
+
+        optional uint64 glyph_data_offset = 9;
+        optional uint64 glyph_data_size = 10;
     }
 
     repeated Glyph glyphs = 1;
@@ -54,5 +61,20 @@ message FontMap
     optional float sdf_scale = 11 [default = 1];
     optional float sdf_offset = 12 [default = 0];
     optional float sdf_outline = 13 [default = 0];
-    repeated string textures = 14 [(resource)=true];
+    //repeated string textures = 14 [(resource)=true];
+
+    optional uint32 cache_width = 14 [default = 0];
+    optional uint32 cache_height = 15 [default = 0];
+    optional uint64 glyph_padding = 16; // total uncompressed size
+
+    optional uint32 cache_cell_width = 17;
+    optional uint32 cache_cell_height = 18;
+
+    optional uint32 glyph_channels = 19;
+
+    optional bytes glyph_data = 20; // glyph data may be compressed
+    optional uint64 glyph_data_size = 21; // total uncompressed size
+
+
+
 }

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -61,11 +61,10 @@ message FontMap
     optional float sdf_scale = 11 [default = 1];
     optional float sdf_offset = 12 [default = 0];
     optional float sdf_outline = 13 [default = 0];
-    //repeated string textures = 14 [(resource)=true];
 
     optional uint32 cache_width = 14 [default = 0];
     optional uint32 cache_height = 15 [default = 0];
-    optional uint64 glyph_padding = 16; // total uncompressed size
+    optional uint64 glyph_padding = 16;
 
     optional uint32 cache_cell_width = 17;
     optional uint32 cache_cell_height = 18;
@@ -73,8 +72,5 @@ message FontMap
     optional uint32 glyph_channels = 19;
 
     optional bytes glyph_data = 20; // glyph data may be compressed
-    optional uint64 glyph_data_size = 21; // total uncompressed size
-
-
 
 }

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -34,7 +34,6 @@ namespace dmRender
     , m_CacheWidth(0)
     , m_CacheHeight(0)
     , m_GlyphData(0)
-    , m_GlyphDataSize(0)
     , m_CacheCellWidth(0)
     , m_CacheCellHeight(0)
     , m_GlyphChannels(1)
@@ -56,7 +55,6 @@ namespace dmRender
         , m_CacheWidth(0)
         , m_CacheHeight(0)
         , m_GlyphData(0)
-        , m_GlyphDataSize(0)
         , m_Cache(0)
         , m_CacheCursor(0)
         , m_CacheColumns(0)
@@ -93,7 +91,6 @@ namespace dmRender
         uint32_t                m_CacheWidth;
         uint32_t                m_CacheHeight;
         void*                   m_GlyphData;
-        uint64_t                m_GlyphDataSize;
 
         Glyph**                 m_Cache;
         uint32_t                m_CacheCursor;
@@ -142,7 +139,6 @@ namespace dmRender
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
         font_map->m_GlyphData = params.m_GlyphData;
-        font_map->m_GlyphDataSize = params.m_GlyphDataSize;
 
         font_map->m_CacheCellWidth = params.m_CacheCellWidth;
         font_map->m_CacheCellHeight = params.m_CacheCellHeight;
@@ -167,7 +163,6 @@ namespace dmRender
                 dmLogError("Invalid channel count for glyph data!");
                 delete font_map;
                 return 0x0;
-            break;
         };
 
         font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
@@ -202,8 +197,8 @@ namespace dmRender
     void SetFontMap(HFontMap font_map, FontMapParams& params)
     {
         const dmArray<Glyph>& glyphs = params.m_Glyphs;
-        font_map->m_Glyphs.SetCapacity((3 * glyphs.Size()) / 2, glyphs.Size());
         font_map->m_Glyphs.Clear();
+        font_map->m_Glyphs.SetCapacity((3 * glyphs.Size()) / 2, glyphs.Size());
         for (uint32_t i = 0; i < glyphs.Size(); ++i) {
             const Glyph& g = glyphs[i];
             font_map->m_Glyphs.Put(g.m_Character, g);
@@ -226,7 +221,6 @@ namespace dmRender
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
         font_map->m_GlyphData = params.m_GlyphData;
-        font_map->m_GlyphDataSize = params.m_GlyphDataSize;
 
         font_map->m_CacheCellWidth = params.m_CacheCellWidth;
         font_map->m_CacheCellHeight = params.m_CacheCellHeight;
@@ -251,7 +245,6 @@ namespace dmRender
                 dmLogError("Invalid channel count for glyph data!");
                 delete font_map;
                 return;
-            break;
         };
 
         font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
@@ -687,15 +680,11 @@ namespace dmRender
                     Glyph* candidate = font_map->m_Cache[cur];
                     font_map->m_CacheCursor = font_map->m_CacheCursor % (font_map->m_CacheColumns * font_map->m_CacheRows);
 
-                    // Empty cell
-                    if (candidate == 0x0) {
-                        candidate = g;
-                        candidate->m_Frame = !text_context.m_Frame;
-                    }
+                    if (candidate == 0x0 || text_context.m_Frame != candidate->m_Frame) {
 
-                    if (text_context.m_Frame != candidate->m_Frame) {
-
-                        candidate->m_InCache = false;
+                        if (candidate) {
+                            candidate->m_InCache = false;
+                        }
                         font_map->m_Cache[cur] = g;
 
                         uint32_t col = cur % font_map->m_CacheColumns;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -31,6 +31,14 @@ namespace dmRender
     , m_SdfScale(1.0f)
     , m_SdfOffset(0)
     , m_SdfOutline(0)
+    , m_CacheWidth(0)
+    , m_CacheHeight(0)
+    , m_GlyphData(0)
+    , m_GlyphDataSize(0)
+    , m_CacheCellWidth(0)
+    , m_CacheCellHeight(0)
+    , m_GlyphChannels(1)
+    , m_CacheCellPadding(0)
     {
 
     }
@@ -45,18 +53,35 @@ namespace dmRender
         , m_ShadowY(0.0f)
         , m_MaxAscent(0.0f)
         , m_MaxDescent(0.0f)
+        , m_CacheWidth(0)
+        , m_CacheHeight(0)
+        , m_GlyphData(0)
+        , m_GlyphDataSize(0)
+        , m_Cache(0)
+        , m_CacheCursor(0)
+        , m_CacheColumns(0)
+        , m_CacheRows(0)
+        , m_CacheCellWidth(0)
+        , m_CacheCellHeight(0)
+        , m_CacheCellPadding(0)
         {
 
         }
 
         ~FontMap()
         {
-
+            if (m_GlyphData) {
+                free(m_GlyphData);
+            }
+            if (m_Cache) {
+                free(m_Cache);
+            }
+            dmGraphics::DeleteTexture(m_Texture);
         }
 
         dmGraphics::HTexture    m_Texture;
         HMaterial               m_Material;
-        dmHashTable16<Glyph>    m_Glyphs;
+        dmHashTable32<Glyph>    m_Glyphs;
         float                   m_ShadowX;
         float                   m_ShadowY;
         float                   m_MaxAscent;
@@ -64,6 +89,24 @@ namespace dmRender
         float                   m_SdfScale;
         float                   m_SdfOffset;
         float                   m_SdfOutline;
+
+        uint32_t                m_CacheWidth;
+        uint32_t                m_CacheHeight;
+        void*                   m_GlyphData;
+        uint64_t                m_GlyphDataSize;
+
+        Glyph**                 m_Cache;
+        uint32_t                m_CacheCursor;
+        dmGraphics::TextureFormat m_CacheFormat;
+
+        uint32_t                m_CacheColumns;
+        uint32_t                m_CacheRows;
+
+        uint32_t                m_CacheCellWidth;
+        uint32_t                m_CacheCellHeight;
+        uint8_t                 m_CacheCellPadding;
+
+        // uint32_t                m_Frame; // frame usage id
     };
 
     struct GlyphVertex
@@ -98,6 +141,68 @@ namespace dmRender
         font_map->m_SdfOffset = params.m_SdfOffset;
         font_map->m_SdfOutline = params.m_SdfOutline;
 
+        font_map->m_CacheWidth = params.m_CacheWidth;
+        font_map->m_CacheHeight = params.m_CacheHeight;
+        font_map->m_GlyphData = params.m_GlyphData;
+        font_map->m_GlyphDataSize = params.m_GlyphDataSize;
+
+        font_map->m_CacheCellWidth = params.m_CacheCellWidth;
+        font_map->m_CacheCellHeight = params.m_CacheCellHeight;
+        font_map->m_CacheCellPadding = params.m_CacheCellPadding;
+
+        font_map->m_CacheColumns = params.m_CacheWidth / params.m_CacheCellWidth;
+        font_map->m_CacheRows = params.m_CacheHeight / params.m_CacheCellHeight;
+        uint32_t cell_count = font_map->m_CacheColumns * font_map->m_CacheRows;
+
+        switch (params.m_GlyphChannels)
+        {
+            case 1:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+            break;
+            case 3:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGB;
+            break;
+            case 4:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGBA;
+            break;
+            default:
+                dmLogError("Invalid channel count for glyph data!");
+                delete font_map;
+                return 0x0;
+            break;
+        };
+
+        font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
+        memset(font_map->m_Cache, 0, sizeof(Glyph*) * cell_count);
+
+        // create new texture to be used as a cache
+        dmGraphics::TextureCreationParams tex_create_params;
+        dmGraphics::TextureParams tex_params;
+        tex_create_params.m_Width = params.m_CacheWidth;
+        tex_create_params.m_Height = params.m_CacheHeight;
+        tex_create_params.m_OriginalWidth = params.m_CacheWidth;
+        tex_create_params.m_OriginalHeight = params.m_CacheHeight;
+        tex_params.m_Format = font_map->m_CacheFormat;
+
+        uint32_t tmp_size = sizeof(uint8_t) * params.m_CacheWidth * params.m_CacheHeight * params.m_GlyphChannels;
+        uint8_t* tmp_data = (uint8_t*)malloc(tmp_size);
+        if (params.m_GlyphChannels == 1) {
+            memset(tmp_data, 255, tmp_size);
+        } else {
+            memset(tmp_data, 0, tmp_size);
+        }
+
+        tex_params.m_Data = tmp_data;
+        tex_params.m_DataSize = tmp_size;
+        tex_params.m_Width = params.m_CacheWidth;
+        tex_params.m_Height = params.m_CacheHeight;
+        tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+        tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+        font_map->m_Texture = dmGraphics::NewTexture(graphics_context, tex_create_params);
+        dmGraphics::SetTexture(font_map->m_Texture, tex_params);
+
+        free(tmp_data);
+
         return font_map;
     }
 
@@ -116,6 +221,13 @@ namespace dmRender
             font_map->m_Glyphs.Put(g.m_Character, g);
         }
 
+        // release previous glyph data bank
+        if (font_map->m_GlyphData) {
+            free(font_map->m_GlyphData);
+            free(font_map->m_Cache);
+            dmGraphics::DeleteTexture(font_map->m_Texture);
+        }
+
         font_map->m_ShadowX = params.m_ShadowX;
         font_map->m_ShadowY = params.m_ShadowY;
         font_map->m_MaxAscent = params.m_MaxAscent;
@@ -124,11 +236,48 @@ namespace dmRender
         font_map->m_SdfOffset = params.m_SdfOffset;
         font_map->m_SdfOutline = params.m_SdfOutline;
 
-    }
+        font_map->m_CacheWidth = params.m_CacheWidth;
+        font_map->m_CacheHeight = params.m_CacheHeight;
+        font_map->m_GlyphData = params.m_GlyphData;
+        font_map->m_GlyphDataSize = params.m_GlyphDataSize;
 
-    void SetFontMapTexture(HFontMap font_map, dmGraphics::HTexture texture)
-    {
-        font_map->m_Texture = texture;
+        font_map->m_CacheCellWidth = params.m_CacheCellWidth;
+        font_map->m_CacheCellHeight = params.m_CacheCellHeight;
+        font_map->m_CacheCellPadding = params.m_CacheCellPadding;
+
+        font_map->m_CacheColumns = params.m_CacheWidth / params.m_CacheCellWidth;
+        font_map->m_CacheRows = params.m_CacheHeight / params.m_CacheCellHeight;
+        uint32_t cell_count = font_map->m_CacheColumns * font_map->m_CacheRows;
+
+        switch (params.m_GlyphChannels)
+        {
+            case 1:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+            break;
+            case 3:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGB;
+            break;
+            case 4:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGBA;
+            break;
+            default:
+                dmLogError("Invalid channel count for glyph data!");
+                delete font_map;
+                return;
+            break;
+        };
+
+        font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
+        memset(font_map->m_Cache, 0, sizeof(Glyph*) * cell_count);
+
+        dmGraphics::TextureParams tex_params;
+        tex_params.m_Format = font_map->m_CacheFormat;
+        tex_params.m_Data = 0x0;
+        tex_params.m_DataSize = 0x0;
+        tex_params.m_Width = params.m_CacheWidth;
+        tex_params.m_Height = params.m_CacheHeight;
+        dmGraphics::SetTexture(font_map->m_Texture, tex_params);
+
     }
 
     dmGraphics::HTexture GetFontMapTexture(HFontMap font_map)
@@ -156,6 +305,7 @@ namespace dmRender
         text_context.m_ClientBuffer = new char[buffer_size];
         text_context.m_VertexIndex = 0;
         text_context.m_VerticesFlushed = 0;
+        text_context.m_Frame = 0;
 
         dmGraphics::VertexElement ve[] =
         {
@@ -339,8 +489,8 @@ namespace dmRender
         }
     }
 
-    static const Glyph* GetGlyph(HFontMap font_map, uint16_t c) {
-        const Glyph* g = font_map->m_Glyphs.Get(c);
+    static Glyph* GetGlyph(HFontMap font_map, uint32_t c) {
+        Glyph* g = font_map->m_Glyphs.Get(c);
         if (!g)
             g = font_map->m_Glyphs.Get(126U); // Fallback to ~
 
@@ -388,6 +538,9 @@ namespace dmRender
 
         const uint32_t max_lines = 128;
         TextLine lines[max_lines];
+
+        Glyph* missing_glyphs[256];
+        uint16_t missing_cursor = 0;
 
         while (entry_key != -1) {
             const TextEntry& te = text_context.m_TextEntries[entry_key];
@@ -443,9 +596,9 @@ namespace dmRender
                 int n = l.m_Count;
                 for (int j = 0; j < n; ++j)
                 {
-                    uint16_t c = (uint16_t) dmUtf8::NextChar(&cursor);
+                    uint32_t c = dmUtf8::NextChar(&cursor);
 
-                    const Glyph* g =  GetGlyph(font_map, c);
+                    Glyph* g =  GetGlyph(font_map, c);
                     if (!g) {
                         continue;
                     }
@@ -458,60 +611,133 @@ namespace dmRender
 
                     if (g->m_Width > 0)
                     {
-                        GlyphVertex& v1 = vertices[text_context.m_VertexIndex];
-                        GlyphVertex& v2 = *(&v1 + 1);
-                        GlyphVertex& v3 = *(&v1 + 2);
-                        GlyphVertex& v4 = *(&v1 + 3);
-                        GlyphVertex& v5 = *(&v1 + 4);
-                        GlyphVertex& v6 = *(&v1 + 5);
-                        text_context.m_VertexIndex += 6;
 
-                        int16_t width = (int16_t)g->m_Width;
-                        int16_t descent = (int16_t)g->m_Descent;
-                        int16_t ascent = (int16_t)g->m_Ascent;
+                        if (!g->m_InCache) {
+                            if (missing_cursor < 256) {
+                                missing_glyphs[missing_cursor++] = g;
+                            } else {
+                                dmLogError("Too many missing glyphs!");
+                            }
+                        } else {
+                            g->m_Frame = text_context.m_Frame;
 
-                        // TODO: 16 bytes alignment and simd (when enabled in vector-math library)
-                        //       Legal cast? (strict aliasing)
-                        (Vector4&) v1.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y - descent, 0, 1);
-                        (Vector4&) v2.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y + ascent, 0, 1);
-                        (Vector4&) v3.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y - descent, 0, 1);
-                        (Vector4&) v6.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y + ascent, 0, 1);
+                            GlyphVertex& v1 = vertices[text_context.m_VertexIndex];
+                            GlyphVertex& v2 = *(&v1 + 1);
+                            GlyphVertex& v3 = *(&v1 + 2);
+                            GlyphVertex& v4 = *(&v1 + 3);
+                            GlyphVertex& v5 = *(&v1 + 4);
+                            GlyphVertex& v6 = *(&v1 + 5);
+                            text_context.m_VertexIndex += 6;
 
-                        v1.m_UV[0] = (g->m_X + g->m_LeftBearing) * im_recip;
-                        v1.m_UV[1] = (g->m_Y + descent) * ih_recip;
+                            int16_t width = (int16_t)g->m_Width;
+                            int16_t descent = (int16_t)g->m_Descent;
+                            int16_t ascent = (int16_t)g->m_Ascent;
 
-                        v2.m_UV[0] = (g->m_X + g->m_LeftBearing) * im_recip;
-                        v2.m_UV[1] = (g->m_Y - ascent) * ih_recip;
+                            // TODO: 16 bytes alignment and simd (when enabled in vector-math library)
+                            //       Legal cast? (strict aliasing)
+                            (Vector4&) v1.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y - descent, 0, 1);
+                            (Vector4&) v2.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y + ascent, 0, 1);
+                            (Vector4&) v3.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y - descent, 0, 1);
+                            (Vector4&) v6.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y + ascent, 0, 1);
 
-                        v3.m_UV[0] = (g->m_X + g->m_LeftBearing + g->m_Width) * im_recip;
-                        v3.m_UV[1] = (g->m_Y + descent) * ih_recip;
+                            v1.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding) * im_recip;
+                            v1.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding + ascent + descent) * ih_recip;
 
-                        v6.m_UV[0] = (g->m_X + g->m_LeftBearing + g->m_Width) * im_recip;
-                        v6.m_UV[1] = (g->m_Y - ascent) * ih_recip;
+                            v2.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding) * im_recip;
+                            v2.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding) * ih_recip;
 
-                        #define SET_VERTEX_PARAMS(v) \
-                            v.m_FaceColor = face_color; \
-                            v.m_OutlineColor = outline_color; \
-                            v.m_ShadowColor = shadow_color; \
-                            v.m_SdfParams[0] = sdf_scale; \
-                            v.m_SdfParams[1] = sdf_offset; \
-                            v.m_SdfParams[2] = sdf_outline; \
-                            v.m_SdfParams[3] = sdf_smoothing; \
+                            v3.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding + g->m_Width) * im_recip;
+                            v3.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding + ascent + descent) * ih_recip;
 
-                        SET_VERTEX_PARAMS(v1)
-                        SET_VERTEX_PARAMS(v2)
-                        SET_VERTEX_PARAMS(v3)
-                        SET_VERTEX_PARAMS(v6)
+                            v6.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding + g->m_Width) * im_recip;
+                            v6.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding) * ih_recip;
 
-                        #undef SET_VERTEX_PARAMS
+                            #define SET_VERTEX_PARAMS(v) \
+                                v.m_FaceColor = face_color; \
+                                v.m_OutlineColor = outline_color; \
+                                v.m_ShadowColor = shadow_color; \
+                                v.m_SdfParams[0] = sdf_scale; \
+                                v.m_SdfParams[1] = sdf_offset; \
+                                v.m_SdfParams[2] = sdf_outline; \
+                                v.m_SdfParams[3] = sdf_smoothing; \
 
-                        v4 = v3;
-                        v5 = v2;
+                            SET_VERTEX_PARAMS(v1)
+                            SET_VERTEX_PARAMS(v2)
+                            SET_VERTEX_PARAMS(v3)
+                            SET_VERTEX_PARAMS(v6)
+
+                            #undef SET_VERTEX_PARAMS
+
+                            v4 = v3;
+                            v5 = v2;
+                        }
                     }
                     x += (int16_t)g->m_Advance;
                 }
             }
             entry_key = te.m_Next;
+        }
+
+        // Upload missing glyphs
+        if (missing_cursor > 0) {
+            uint32_t prev_cache_cursor = font_map->m_CacheCursor;
+            dmGraphics::TextureParams tex_params;
+            tex_params.m_SubUpdate = true;
+            tex_params.m_MipMap = 0;
+            tex_params.m_Format = font_map->m_CacheFormat;
+            tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+            tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+
+            while (missing_cursor > 0) {
+                Glyph* g = missing_glyphs[--missing_cursor];
+
+                // Check if glyph is already uploaded
+                if (g->m_InCache) {
+                    continue;
+                }
+
+                // Locate a cache cell candidate
+                do {
+                    uint32_t cur = font_map->m_CacheCursor++;
+                    Glyph* candidate = font_map->m_Cache[cur];
+                    font_map->m_CacheCursor = font_map->m_CacheCursor % (font_map->m_CacheColumns * font_map->m_CacheRows);
+
+                    // Empty cell
+                    if (candidate == 0x0) {
+                        candidate = g;
+                        candidate->m_Frame = !text_context.m_Frame;
+                    }
+
+                    if (text_context.m_Frame != candidate->m_Frame) {
+
+                        candidate->m_InCache = false;
+                        font_map->m_Cache[cur] = g;
+
+                        uint32_t col = cur % font_map->m_CacheColumns;
+                        uint32_t row = cur / font_map->m_CacheColumns;
+
+                        g->m_X = col * font_map->m_CacheCellWidth;
+                        g->m_Y = row * font_map->m_CacheCellHeight;
+                        g->m_Frame = text_context.m_Frame;
+                        g->m_InCache = true;
+
+                        // Upload glyph data to GPU
+                        tex_params.m_X = g->m_X;
+                        tex_params.m_Y = g->m_Y;
+                        tex_params.m_Width = g->m_Width + font_map->m_CacheCellPadding*2;
+                        tex_params.m_Height = g->m_Ascent + g->m_Descent + font_map->m_CacheCellPadding*2;
+                        tex_params.m_Data = (uint8_t*)font_map->m_GlyphData + g->m_GlyphDataOffset;
+                        SetTexture(font_map->m_Texture, tex_params);
+                        break;
+                    }
+
+                } while (prev_cache_cursor != font_map->m_CacheCursor);
+
+                if (prev_cache_cursor == font_map->m_CacheCursor) {
+                    dmLogError("Out of available cache cells! Consider increasing cache_width or cache_height for the font.");
+                    break;
+                }
+            }
         }
 
         ro->m_VertexCount = text_context.m_VertexIndex - ro->m_VertexStart;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -213,7 +213,6 @@ namespace dmRender
         if (font_map->m_GlyphData) {
             free(font_map->m_GlyphData);
             free(font_map->m_Cache);
-            dmGraphics::DeleteTexture(font_map->m_Texture);
         }
 
         font_map->m_ShadowX = params.m_ShadowX;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -105,8 +105,6 @@ namespace dmRender
         uint32_t                m_CacheCellWidth;
         uint32_t                m_CacheCellHeight;
         uint8_t                 m_CacheCellPadding;
-
-        // uint32_t                m_Frame; // frame usage id
     };
 
     struct GlyphVertex
@@ -184,24 +182,14 @@ namespace dmRender
         tex_create_params.m_OriginalHeight = params.m_CacheHeight;
         tex_params.m_Format = font_map->m_CacheFormat;
 
-        uint32_t tmp_size = sizeof(uint8_t) * params.m_CacheWidth * params.m_CacheHeight * params.m_GlyphChannels;
-        uint8_t* tmp_data = (uint8_t*)malloc(tmp_size);
-        if (params.m_GlyphChannels == 1) {
-            memset(tmp_data, 255, tmp_size);
-        } else {
-            memset(tmp_data, 0, tmp_size);
-        }
-
-        tex_params.m_Data = tmp_data;
-        tex_params.m_DataSize = tmp_size;
+        tex_params.m_Data = 0;
+        tex_params.m_DataSize = 0;
         tex_params.m_Width = params.m_CacheWidth;
         tex_params.m_Height = params.m_CacheHeight;
         tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
         tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
         font_map->m_Texture = dmGraphics::NewTexture(graphics_context, tex_create_params);
         dmGraphics::SetTexture(font_map->m_Texture, tex_params);
-
-        free(tmp_data);
 
         return font_map;
     }
@@ -415,12 +403,12 @@ namespace dmRender
         }
 
         uint32_t text_len = strlen(params.m_Text);
-        if (text_context->m_TextBuffer.Capacity() < (text_len + 1)) {
+        uint32_t offset = text_context->m_TextBuffer.Size();
+        if (text_context->m_TextBuffer.Capacity() < (offset + text_len + 1)) {
             dmLogWarning("Out of text-render buffer");
             return;
         }
 
-        uint32_t offset = text_context->m_TextBuffer.Size();
         text_context->m_TextBuffer.PushArray(params.m_Text, text_len);
         text_context->m_TextBuffer.Push('\0');
 
@@ -615,8 +603,6 @@ namespace dmRender
                         if (!g->m_InCache) {
                             if (missing_cursor < 256) {
                                 missing_glyphs[missing_cursor++] = g;
-                            } else {
-                                dmLogError("Too many missing glyphs!");
                             }
                         } else {
                             g->m_Frame = text_context.m_Frame;

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -67,7 +67,6 @@ namespace dmRender
         uint32_t m_CacheHeight;
         uint8_t m_GlyphChannels;
         void* m_GlyphData;
-        uint64_t m_GlyphDataSize;
 
         uint32_t m_CacheCellWidth;
         uint32_t m_CacheCellHeight;

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -16,7 +16,7 @@ namespace dmRender
      */
     struct Glyph
     {
-        uint16_t    m_Character;
+        uint32_t    m_Character;
         /// Width of the glyph
         uint32_t    m_Width;
         /// Total advancement of the glyph, measured from left to the next glyph
@@ -31,6 +31,11 @@ namespace dmRender
         int32_t     m_X;
         /// Y coordinate of the glyph in the map
         int32_t     m_Y;
+
+        bool        m_InCache;
+        uint64_t    m_GlyphDataOffset;
+        uint64_t    m_GlyphDataSize;
+        uint32_t    m_Frame;
     };
 
     /**
@@ -57,6 +62,16 @@ namespace dmRender
         float m_SdfOffset;
         /// Distance value where outline should end
         float m_SdfOutline;
+        ///
+        uint32_t m_CacheWidth;
+        uint32_t m_CacheHeight;
+        uint8_t m_GlyphChannels;
+        void* m_GlyphData;
+        uint64_t m_GlyphDataSize;
+
+        uint32_t m_CacheCellWidth;
+        uint32_t m_CacheCellHeight;
+        uint8_t m_CacheCellPadding;
     };
 
     /**
@@ -92,13 +107,6 @@ namespace dmRender
      * @param params Parameters to update
      */
     void SetFontMap(HFontMap font_map, FontMapParams& params);
-
-    /**
-     * Set font map texture
-     * @param font_map Font map handle
-     * @param texture Texture handle
-     */
-    void SetFontMapTexture(HFontMap font_map, dmGraphics::HTexture texture);
 
     /**
      * Get texture from a font map

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -305,6 +305,7 @@ namespace dmRender
         context->m_TextContext.m_RenderObjectIndex = 0;
         context->m_TextContext.m_VertexIndex = 0;
         context->m_TextContext.m_VerticesFlushed = 0;
+        context->m_TextContext.m_Frame += 1;
         context->m_TextContext.m_TextBuffer.SetSize(0);
         context->m_TextContext.m_Batches.Clear();
         context->m_TextContext.m_TextEntries.SetSize(0);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -135,6 +135,7 @@ namespace dmRender
         // Map from batch id (hash of font-map etc) to index into m_TextEntries
         dmHashTable64<int32_t>              m_Batches;
         dmArray<TextEntry>                  m_TextEntries;
+        uint32_t                            m_Frame;
     };
 
     struct RenderTargetSetup

--- a/engine/render/src/waf_render.py
+++ b/engine/render/src/waf_render.py
@@ -29,5 +29,3 @@ def font_file(self, node):
     obj_ext = '.fontc'
     out = node.change_ext(obj_ext)
     fontmap.set_outputs(out)
-    out_tex = node.change_ext("_tex0.texturec")
-    fontmap.set_outputs(out_tex)


### PR DESCRIPTION
- All fonts/glyphs are chached and streamed on demand.
- Glyph chars are now 32bit full unicode code points. (Changed engine hashtable to 32bit hash for glyph lookup. Protobufs were already 32bit.)
- Fixed bug with DrawText where it didn't correctly check if it was out of text-render buffer.
- Optimised preview image rendering to not include glyphs that does not fit into cache.

Not included in this PR:
- Memory mapped font glyph banks
- Streaming fonts in the editor ("static cache" version for now, will behave like previous fonts)
