### PR TITLE
DEF-1462 Streaming/Dynamic font support

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/FontBuilderTest.java
@@ -29,12 +29,9 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         src.append("font: \"/Tuffy.ttf\"\n");
         src.append("material: \"/test.material\"\n");
         src.append("size: 16\n");
+
         FontMap fontMap = (FontMap)build("/test.font", src.toString()).get(0);
-
         assertEquals(fontMap.getMaterial(), "/test.materialc");
-        assertEquals(fontMap.getTexturesCount(), 1);
-        assertEquals(fontMap.getTextures(0), "/test_tex0.texturec");
-
     }
 
     @Test
@@ -47,8 +44,6 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         FontMap fontMap = (FontMap)build("/test.font", src.toString()).get(0);
 
         assertEquals(fontMap.getMaterial(), "/test.materialc");
-        assertEquals(fontMap.getTexturesCount(), 1);
-        assertEquals(fontMap.getTextures(0), "/test_tex0.texturec");
 
     }
 
@@ -65,8 +60,6 @@ public class FontBuilderTest extends AbstractProtoBuilderTest {
         FontMap fontMap = (FontMap)build("/subdir/test.font", src.toString()).get(0);
 
         assertEquals(fontMap.getMaterial(), "/test.materialc");
-        assertEquals(fontMap.getTexturesCount(), 1);
-        assertEquals(fontMap.getTextures(0), "/subdir/test_tex0.texturec");
 
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -25,6 +25,7 @@ import java.awt.image.Kernel;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -43,10 +44,6 @@ import org.apache.commons.io.FilenameUtils;
 
 import com.dynamo.bob.font.BMFont.BMFontFormatException;
 import com.dynamo.bob.font.BMFont.Char;
-import com.dynamo.bob.pipeline.TextureGenerator;
-import com.dynamo.bob.pipeline.TextureGeneratorException;
-import com.dynamo.bob.util.PathUtil;
-import com.dynamo.graphics.proto.Graphics.TextureImage;
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.FontMap;
 import com.dynamo.render.proto.Font.FontTextureFormat;
@@ -55,7 +52,7 @@ import com.google.protobuf.TextFormat;
 
 class Glyph {
     int index;
-    char c;
+    int c;
     int width;
     int advance;
     int leftBearing;
@@ -63,7 +60,10 @@ class Glyph {
     int descent;
     int x;
     int y;
+    int cache_entry_offset;
+    int cache_entry_size;
     GlyphVector vector;
+    BufferedImage image;
 };
 
 class OrderComparator implements Comparator<Glyph> {
@@ -113,59 +113,102 @@ public class Fontc {
         FORMAT_TRUETYPE, FORMAT_BMFONT
     };
 
-    private int imageWidth = 1024;
-    private int imageHeight = 2048; // Enough. Will be cropped later
     private InputFontFormat inputFormat = InputFontFormat.FORMAT_TRUETYPE;
     private Stroke outlineStroke = null;
-    private StringBuffer characters;
-    private FontRenderContext fontRendererContext;
-    private BufferedImage image;
+    private int channelCount = 3;
     private FontDesc fontDesc;
-    static final int imageType = BufferedImage.TYPE_3BYTE_BGR;
+    private FontMap.Builder fontMapBuilder;
+    private ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
 
-
+    private Font font;
+    private BMFont bmfont;
 
     public interface FontResourceResolver {
         public InputStream getResource(String resourceName) throws FileNotFoundException;
     }
 
     public Fontc() {
+
     }
 
     public InputFontFormat getInputFormat() {
         return inputFormat;
     }
 
-    public void builderTTF(InputStream fontStream, FontDesc fontDesc, FontMap.Builder builder) throws FontFormatException, IOException {
+    public void TTFBuilder(InputStream fontStream) throws FontFormatException, IOException {
 
-        // 7-bit ASCII. Note inclusive range [32,126]
-        for (int i = 32; i <= 126; ++i)
-            this.characters.append((char) i);
+        ArrayList<Integer> characters = new ArrayList<Integer>();
 
-        String extraCharacters = fontDesc.getExtraCharacters();
-        for (int i = 0; i < extraCharacters.length(); i++) {
-            char c = extraCharacters.charAt(i);
-            this.characters.append(c);
+        if (!fontDesc.getAllChars()) {
+
+            // 7-bit ASCII. Note inclusive range [32,126]
+            for (int i = 32; i <= 126; ++i) {
+                characters.add(i);
+            }
+
+            String extraCharacters = fontDesc.getExtraCharacters();
+            for (int i = 0; i < extraCharacters.length(); i++) {
+                char c = extraCharacters.charAt(i);
+                characters.add((int)c);
+            }
+
         }
 
-        this.fontRendererContext = new FontRenderContext(new AffineTransform(), fontDesc.getAntialias() != 0, fontDesc.getAntialias() != 0);
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
             outlineStroke = new BasicStroke(fontDesc.getOutlineWidth());
         }
 
-        Font font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+        font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
         font = font.deriveFont(Font.PLAIN, fontDesc.getSize());
-        for (int i = 0; i < this.characters.length(); ++i) {
-            char ch = this.characters.charAt(i);
-            if (!font.canDisplay(ch)) {
-                this.characters.deleteCharAt(i);
-                i--;
+
+
+        FontRenderContext fontRendererContext = new FontRenderContext(new AffineTransform(), fontDesc.getAntialias() != 0, fontDesc.getAntialias() != 0);
+
+        int loopEnd = characters.size();
+        if (fontDesc.getAllChars()) {
+            assert(0 == loopEnd);
+            loopEnd = 0x10FFFF;
+        }
+        for (int i = 0; i < loopEnd; ++i) {
+
+            int codePoint = i;
+            if (!fontDesc.getAllChars()) {
+                codePoint = characters.get(i);
+            }
+
+            if (font.canDisplay(codePoint)) {
+                String s = new String(Character.toChars(codePoint));
+
+                GlyphVector glyphVector = font.createGlyphVector(fontRendererContext, s);
+                Rectangle visualBounds = glyphVector.getOutline().getBounds();
+
+                GlyphMetrics metrics = glyphVector.getGlyphMetrics(0);
+
+                Glyph glyph = new Glyph();
+                glyph.ascent = (int)Math.ceil(-visualBounds.getMinY());
+                glyph.descent = (int)Math.ceil(visualBounds.getMaxY());
+
+                glyph.c = codePoint;
+                glyph.index = i;
+                glyph.advance = Math.round(metrics.getAdvance());
+                float leftBearing = metrics.getLSB();
+                glyph.leftBearing = (int)Math.floor(leftBearing);
+                glyph.width = visualBounds.width;
+                if (leftBearing != 0.0f) {
+                    glyph.width += 1;
+                }
+
+                glyph.vector = glyphVector;
+
+                glyphs.add(glyph);
             }
         }
 
-        image = new BufferedImage(this.imageWidth, this.imageHeight, Fontc.imageType);
-        Graphics2D g = image.createGraphics();
+        BufferedImage image;
+        Graphics2D g;
+        image = new BufferedImage(1024, 1024, BufferedImage.TYPE_3BYTE_BGR);
+        g = image.createGraphics();
         g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         setHighQuality(g);
@@ -173,39 +216,72 @@ public class Fontc {
         FontMetrics fontMetrics = g.getFontMetrics(font);
         int maxAscent = fontMetrics.getMaxAscent();
         int maxDescent = fontMetrics.getMaxDescent();
+        fontMapBuilder.setMaxAscent(maxAscent)
+                      .setMaxDescent(maxDescent)
+                      .setShadowX(fontDesc.getShadowX())
+                      .setShadowY(fontDesc.getShadowY());
 
-        ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
-        for (int i = 0; i < this.characters.length(); ++i) {
-            String s = this.characters.substring(i, i+1);
+    }
 
-            GlyphVector glyphVector = font.createGlyphVector(this.fontRendererContext, s);
-            Rectangle visualBounds = glyphVector.getOutline().getBounds();
-            GlyphMetrics metrics = glyphVector.getGlyphMetrics(0);
+
+    public void FNTBuilder(InputStream fontStream) throws FontFormatException, IOException {
+        this.inputFormat = InputFontFormat.FORMAT_BMFONT;
+
+        bmfont = new BMFont();
+
+        // parse BMFont file
+        try {
+            bmfont.parse(fontStream);
+        } catch (BMFontFormatException e) {
+            throw new FontFormatException(e.getMessage());
+        }
+
+        int maxAscent = 0;
+        int maxDescent = 0;
+        for (int i = 0; i < bmfont.charArray.size(); ++i) {
+
+            Char c = bmfont.charArray.get(i);
+
+            int ascent = bmfont.base - (int)c.yoffset;
+            int descent = c.height - ascent;
+
+            maxAscent = Math.max(ascent, maxAscent);
+            maxDescent = Math.max(descent, maxDescent);
 
             Glyph glyph = new Glyph();
-            glyph.ascent = (int)Math.ceil(-visualBounds.getMinY());
-            glyph.descent = (int)Math.ceil(visualBounds.getMaxY());
+            glyph.ascent = ascent;
+            glyph.descent = descent;
 
-            glyph.c = s.charAt(0);
+            glyph.x = c.x;
+            glyph.y = c.y;
+            glyph.c = c.id;
             glyph.index = i;
-            glyph.advance = Math.round(metrics.getAdvance());
-            float leftBearing = metrics.getLSB();
-            glyph.leftBearing = (int)Math.floor(leftBearing);
-            glyph.width = visualBounds.width;
-            if (leftBearing != 0.0f) {
-                glyph.width += 1;
-            }
-
-            glyph.vector = glyphVector;
+            glyph.advance = (int) c.xadvance;
+            glyph.leftBearing = (int) c.xoffset;
+            glyph.width = c.width;
 
             glyphs.add(glyph);
         }
 
-        int i = 0;
-        float totalY = 0.0f;
-        // Margin is set to 1 since the font map is an atlas, this removes sampling artifacts (neighbouring texels outside the sample-area being used)
-        int margin = 1;
+        fontMapBuilder.setMaxAscent(maxAscent)
+                      .setMaxDescent(maxDescent);
+    }
+
+    // We use repeatedWrite to create a (cell) padding around the glyph bitmap data
+    private void repeatedWrite(ByteArrayOutputStream dataOut, int repeat, int value) {
+        for (int i = 0; i < repeat; i++) {
+            dataOut.write(value);
+        }
+    }
+
+    public BufferedImage generateGlyphData(boolean preview, final FontResourceResolver resourceResolver) throws FontFormatException {
+
+        ByteArrayOutputStream glyphDataBank = new ByteArrayOutputStream(1024*1024*4);
+
+        // Padding is the pixel amount needed to get a good antialiasing around the glyphs, while cell padding
+        // is the extra padding added to the bitmap data to avoid filtering glitches when rendered.
         int padding = 0;
+        int cell_padding = 1;
         float sdf_scale = 0;
         float sdf_offset = 0;
         if (fontDesc.getAntialias() != 0)
@@ -215,14 +291,14 @@ public class Fontc {
             // need sqrt(2) on either side of the range [0, outlineWidth + 1] to prevent clamped values being used
             // for interpolation across texels in the output. The extra is for smoothstep room.
             float sqrt2 = 1.4142f;
-            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + this.fontDesc.getOutlineWidth());
+            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + fontDesc.getOutlineWidth());
             sdf_offset = sdf_scale * sqrt2; // where glyph ends
         }
-        Color faceColor = new Color(this.fontDesc.getAlpha(), 0.0f, 0.0f);
-        Color outlineColor = new Color(0.0f, this.fontDesc.getOutlineAlpha(), 0.0f);
+        Color faceColor = new Color(fontDesc.getAlpha(), 0.0f, 0.0f);
+        Color outlineColor = new Color(0.0f, fontDesc.getOutlineAlpha(), 0.0f);
         ConvolveOp shadowConvolve = null;
         Composite blendComposite = new BlendComposite();
-        if (this.fontDesc.getShadowAlpha() > 0.0f) {
+        if (fontDesc.getShadowAlpha() > 0.0f) {
             float[] kernelData = {
                     0.0625f, 0.1250f, 0.0625f,
                     0.1250f, 0.2500f, 0.1250f,
@@ -234,68 +310,203 @@ public class Fontc {
             hints.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_DISABLE);
             shadowConvolve = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, hints);
         }
-        while (i < this.characters.length()) {
-            float x = margin;
-            float maxY = 0.0f;
-            int j = i;
-            while (j < this.characters.length() && x < this.imageWidth ) {
-                Glyph glyph = glyphs.get(j);
-                int width = glyph.width + margin + padding * 2;
-                if (x + width < this.imageWidth) {
-                    maxY = Math.max(maxY, glyph.ascent + glyph.descent);
-                    x += width;
-                } else {
-                    break;
-                }
-                ++j;
-            }
-
-            g.translate(0, margin);
-
-            for (int k = i; k < j; ++k) {
-                Glyph glyph = glyphs.get(k);
-
-                g.translate(margin, 0);
-
-                if (glyph.width > 0.0f) {
-                    BufferedImage glyphImage;
-                    if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP)
-                        glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
-                    else
-                        glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
-                    g.drawImage(glyphImage, 0, 0, null);
-                    glyph.x += g.getTransform().getTranslateX();
-                    glyph.y += g.getTransform().getTranslateY();
-
-                    g.translate(glyphImage.getWidth(), 0);
-                }
-            }
-            g.translate(-g.getTransform().getTranslateX(), maxY + padding * 2);
-            totalY += maxY + margin + 2 * padding;
-            i = j;
-        }
-        totalY += margin;
-
-        int newHeight = (int) (Math.log(totalY) / Math.log(2));
-        newHeight = (int) Math.pow(2, newHeight + 1);
-        this.image = this.image.getSubimage(0, 0, this.imageWidth, newHeight);
-
-        builder.setShadowX(fontDesc.getShadowX())
-               .setShadowY(fontDesc.getShadowY())
-               .setMaxAscent(maxAscent)
-               .setMaxDescent(maxDescent);
-
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             // sdf_scale has up until now been the value to scale with.
             // Now recompute their inverses to be used for unpacking it.
-            builder.setSdfScale(1.0f / sdf_scale);
-            builder.setSdfOffset(-sdf_offset / sdf_scale);
-            builder.setSdfOutline(this.fontDesc.getOutlineWidth());
+            fontMapBuilder.setSdfScale(1.0f / sdf_scale);
+            fontMapBuilder.setSdfOffset(-sdf_offset / sdf_scale);
+            fontMapBuilder.setSdfOutline(this.fontDesc.getOutlineWidth());
+        }
+
+        // Load external image resource for BMFont files
+        BufferedImage imageBMFont = null;
+        if (inputFormat == InputFontFormat.FORMAT_BMFONT) {
+            String origPath = Paths.get(FilenameUtils.normalize(bmfont.page.get(0))).getFileName().toString();
+            InputStream inputImageStream = null;
+            try {
+                inputImageStream = resourceResolver.getResource(origPath);
+                imageBMFont = ImageIO.read(inputImageStream);
+                inputImageStream.close();
+            } catch (FileNotFoundException e) {
+                throw new FontFormatException("Could not find BMFont image resource: " + origPath);
+            } catch (IOException e) {
+                throw new FontFormatException("Error while reading BMFont image resource: " + e.getMessage());
+            }
+        }
+
+        // Calculate channel count depending on both input and output format
+        if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+            inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+
+            // If font has outline, we need all three channels
+            if (fontDesc.getOutlineWidth() > 0.0f && this.fontDesc.getOutlineAlpha() > 0.0f) {
+                channelCount = 3;
+            } else {
+                channelCount = 1;
+            }
+
+        } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                   inputFormat == InputFontFormat.FORMAT_BMFONT) {
+            channelCount = 4;
+        } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
+                   inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+            channelCount = 1;
+        }
+
+        // We keep track of offset into the glyph data bank,
+        // this is saved for each glyph to know where their bitmap data is stored.
+        int dataOffset = 0;
+
+        // Find max width, height for each glyph to lock down cache cell sizes,
+        // this includes cell padding.
+        int cell_width = 0;
+        int cell_height = 0;
+        for (int i = 0; i < glyphs.size(); i++) {
+            Glyph glyph = glyphs.get(i);
+            if (glyph.width <= 0.0f) {
+                continue;
+            }
+            int width = glyph.width + padding * 2 + cell_padding * 2;
+            int height = glyph.ascent + glyph.descent + padding * 2 + cell_padding * 2;
+            cell_width = Math.max(cell_width, width);
+            cell_height = Math.max(cell_height, height);
+        }
+
+        // We do an early cache size calculation before we create the glyph bitmaps
+        // This is so that we can know when we have created enough glyphs to fill
+        // the cache when creating a preview image.
+        int cache_width = 1024;
+        int cache_height = 0;
+        if (fontDesc.getCacheWidth() > 0) {
+            cache_width = fontDesc.getCacheWidth();
+        }
+        int cache_columns = cache_width / cell_width;
+
+        if (fontDesc.getCacheHeight() > 0) {
+            cache_height = fontDesc.getCacheHeight();
+        } else {
+            // No "static" height set, guess height size for all to fit
+            int tot_rows = (int)Math.ceil((double)glyphs.size() / (double)cache_columns);
+            int tot_height = tot_rows * cell_height;
+            tot_height = (int) (Math.log(tot_height) / Math.log(2));
+            tot_height = (int) Math.pow(2, tot_height + 1);
+            cache_height = Math.min(tot_height,  2048);
+        }
+        int cache_rows = cache_height / cell_height;
+
+        int include_glyph_count = glyphs.size();
+        if (preview) {
+            include_glyph_count = Math.min(glyphs.size(), cache_rows * cache_columns);
+        }
+        for (int i = 0; i < include_glyph_count; i++) {
+
+            Glyph glyph = glyphs.get(i);
+            if (glyph.width <= 0 || glyph.ascent + glyph.descent <= 0) {
+                continue;
+            }
+            glyph.cache_entry_offset = dataOffset;
+
+            // Generate bitmap for each glyph depending on format
+            BufferedImage glyphImage = null;
+            int clearData = 0;
+            if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
+            } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                       inputFormat == InputFontFormat.FORMAT_BMFONT) {
+                glyphImage = drawBMFontGlyph(glyph, imageBMFont);
+            } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
+                       inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
+                clearData = 255;
+            } else {
+                throw new FontFormatException("Invalid font format combination!");
+            }
+
+            if (preview) {
+
+                glyph.image = glyphImage;
+
+            } else {
+
+                // Get raster data from rendered glyph and store in glyph data bank
+                int dataSizeOut = (glyphImage.getWidth() + cell_padding * 2) * (glyphImage.getHeight() + cell_padding * 2) * channelCount;
+                for (int y = 0; y < glyphImage.getHeight(); y++) {
+
+                    if (y == 0) {
+                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
+                    }
+                    for (int x = 0; x < glyphImage.getWidth(); x++) {
+
+                        if (x == 0) {
+                            repeatedWrite(glyphDataBank, channelCount, clearData);
+                        }
+
+                        int color = glyphImage.getRGB(x, y);
+                        int blue  = (color) & 0xff;
+                        int green = (color >> 8) & 0xff;
+                        int red   = (color >> 16) & 0xff;
+                        int alpha = (color >> 24) & 0xff;
+                        blue = (blue * alpha) / 255;
+                        green = (green * alpha) / 255;
+                        red = (red * alpha) / 255;
+                        
+
+                        glyphDataBank.write((byte)red);
+
+                        if (channelCount > 1) {
+                            glyphDataBank.write((byte)green);
+                            glyphDataBank.write((byte)blue);
+
+                            if (channelCount > 3) {
+                                
+                                glyphDataBank.write((byte)alpha);
+                            }
+                        }
+
+                        if (x == glyphImage.getWidth()-1) {
+                            repeatedWrite(glyphDataBank, channelCount, clearData);
+                        }
+
+                    }
+                    if (y == glyphImage.getHeight()-1) {
+                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
+                    }
+                }
+                dataOffset += dataSizeOut;
+                glyph.cache_entry_size = dataOffset - glyph.cache_entry_offset;
+            }
 
         }
 
-        i = 0;
-        for (Glyph glyph : glyphs) {
+        // Sanity check;
+        // Some fonts don't include ASCII range and trying to compile a font without
+        // setting "all_chars" could result in an empty glyph list.
+        if (glyphs.size() == 0) {
+            throw new FontFormatException("No character glyphs where included! Maybe turn on 'all_chars'?");
+        }
+
+        // Start filling the rest of FontMap
+        fontMapBuilder.setGlyphPadding(cell_padding);
+        fontMapBuilder.setCacheWidth(cache_width);
+        fontMapBuilder.setCacheHeight(cache_height);
+        fontMapBuilder.setGlyphData(ByteString.copyFrom(glyphDataBank.toByteArray()));
+        fontMapBuilder.setCacheCellWidth(cell_width);
+        fontMapBuilder.setCacheCellHeight(cell_height);
+        fontMapBuilder.setGlyphChannels(channelCount);
+
+
+        BufferedImage previewImage = null;
+        if (preview) {
+            try {
+                previewImage = generatePreviewImage();
+            } catch (IOException e) {
+                throw new FontFormatException("Could not generate font preview: " + e.getMessage());
+            }
+        }
+
+        for (int i = 0; i < include_glyph_count; i++) {
+            Glyph glyph = glyphs.get(i);
             FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
                 .setCharacter(glyph.c)
                 .setWidth(glyph.width + (glyph.width > 0 ? padding * 2 : 0))
@@ -303,79 +514,24 @@ public class Fontc {
                 .setLeftBearing(glyph.leftBearing - padding)
                 .setAscent(glyph.ascent + padding)
                 .setDescent(glyph.descent + padding)
-                .setX(glyph.x)
-                .setY(glyph.y);
-            builder.addGlyphs(glyphBuilder);
+                .setGlyphDataOffset(glyph.cache_entry_offset)
+                .setGlyphDataSize(glyph.cache_entry_size);
+
+            // "Static" cache positions is only used for previews currently
+            if (preview) {
+                glyphBuilder.setX(glyph.x);
+                glyphBuilder.setY(glyph.y);
+            }
+
+            fontMapBuilder.addGlyphs(glyphBuilder);
         }
+
+        return previewImage;
 
     }
 
-    public void builderFNT(InputStream fontStream, FontDesc fontDesc, FontMap.Builder builder, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        this.inputFormat = InputFontFormat.FORMAT_BMFONT;
-
-        BMFont bmfont = new BMFont();
-
-        // parse BMFont file
-        try {
-            bmfont.parse(fontStream);
-        } catch (BMFontFormatException e) {
-            throw new FontFormatException(e.getMessage());
-        }
-
-        // fill glyphs
-        int maxAscent = 0;
-        int maxDescent = 0;
-        for (int i = 0; i < bmfont.charArray.size(); ++i) {
-            Char c = bmfont.charArray.get(i);
-
-            int ascent = bmfont.base - (int)c.yoffset;
-            int descent = c.height - ascent;
-
-            maxAscent = Math.max(ascent, maxAscent);
-            maxDescent = Math.max(descent, maxDescent);
-
-            FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
-                .setCharacter(c.id)
-                .setWidth(c.width)
-                .setAdvance(c.xadvance)
-                .setLeftBearing(c.xoffset)
-                .setAscent(ascent)
-                .setDescent(descent)
-                .setX(c.x - (int)c.xoffset)
-                .setY(c.y + ascent);
-            builder.addGlyphs(glyphBuilder);
-        }
-
-        // fill FontMap
-        builder.setMaxAscent(maxAscent)
-               .setMaxDescent(maxDescent);
-
-        // copy to new texture
-        String origPath = Paths.get(FilenameUtils.normalize(bmfont.page.get(0))).getFileName().toString();
-        InputStream inputImageStream = null;
-        try {
-            inputImageStream = resourceResolver.getResource(origPath);
-        } catch (FileNotFoundException e) {
-            throw new IOException("Could not find BMFont image resource: " + origPath);
-        }
-        BufferedImage origImage = ImageIO.read(inputImageStream);
-        inputImageStream.close();
-        this.image = origImage;
-    }
-
-    public BufferedImage compile(InputStream fontStream, FontDesc fontDesc, FontMap.Builder fontMapBuilder, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        this.characters = new StringBuffer();
-        this.fontDesc = fontDesc;
-
-        if (fontDesc.getFont().toLowerCase().endsWith("fnt")) {
-            builderFNT(fontStream, fontDesc, fontMapBuilder, resourceResolver);
-        } else {
-            builderTTF(fontStream, fontDesc, fontMapBuilder);
-        }
-        fontMapBuilder.setMaterial(fontDesc.getMaterial() + "c");
-        fontMapBuilder.setImageFormat(fontDesc.getOutputFormat());
-
-        return this.image;
+    private BufferedImage drawBMFontGlyph(Glyph glyph, BufferedImage imageBMFontInput) {
+        return imageBMFontInput.getSubimage(glyph.x, glyph.y, glyph.width, glyph.ascent + glyph.descent);
     }
 
     private BufferedImage makeDistanceField(Glyph glyph, int padding, float sdf_scale, float sdf_offset, Font font) {
@@ -430,7 +586,7 @@ public class Fontc {
         double kx = 1 / (double)width;
         double ky = 1 / (double)height;
 
-        BufferedImage image = new BufferedImage(width, height, Fontc.imageType);
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         for (int v=0;v<height;v++) {
             int ofs = v * width;
             for (int u=0;u<width;u++) {
@@ -463,7 +619,7 @@ public class Fontc {
         glyph.x = dx;
         glyph.y = dy;
 
-        BufferedImage image = new BufferedImage(width, height, Fontc.imageType);
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         Graphics2D g = image.createGraphics();
         setHighQuality(g);
         g.setBackground(Color.BLACK);
@@ -502,7 +658,7 @@ public class Fontc {
         } else {
             g.setPaint(faceColor);
             g.setFont(font);
-            g.drawString(Character.toString(glyph.c), 0, 0);
+            g.drawString(new String(Character.toChars(glyph.c)), 0, 0);
         }
 
         return image;
@@ -540,10 +696,63 @@ public class Fontc {
        }
     }
 
-    public static BufferedImage compileToImage(InputStream fontStream, FontDesc fontDesc, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        Fontc fontc = new Fontc();
-        FontMap.Builder builder = FontMap.newBuilder();
-        return fontc.compile(fontStream, fontDesc, builder, resourceResolver);
+    public BufferedImage compile(InputStream fontStream, FontDesc fontDesc, boolean preview, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
+        this.fontDesc = fontDesc;
+        this.fontMapBuilder = FontMap.newBuilder();
+
+        if (fontDesc.getFont().toLowerCase().endsWith("fnt")) {
+            FNTBuilder(fontStream);
+        } else {
+            TTFBuilder(fontStream);
+        }
+        fontMapBuilder.setMaterial(fontDesc.getMaterial() + "c");
+        fontMapBuilder.setImageFormat(fontDesc.getOutputFormat());
+
+        return generateGlyphData(preview, resourceResolver);
+    }
+
+    public FontMap getFontMap() {
+        return fontMapBuilder.build();
+    }
+
+    public BufferedImage generatePreviewImage() throws IOException {
+
+        Graphics2D g;
+        BufferedImage previewImage = new BufferedImage(fontMapBuilder.getCacheWidth(), fontMapBuilder.getCacheHeight(), BufferedImage.TYPE_3BYTE_BGR);
+        g = previewImage.createGraphics();
+        g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
+        g.clearRect(0, 0, previewImage.getWidth(), previewImage.getHeight());
+        setHighQuality(g);
+
+        int cache_columns = fontMapBuilder.getCacheWidth() / fontMapBuilder.getCacheCellWidth();
+        int cache_rows = fontMapBuilder.getCacheHeight() / fontMapBuilder.getCacheCellHeight();
+
+        BufferedImage glyphImage;
+        for (int i = 0; i < glyphs.size(); i++) {
+
+            Glyph glyph = glyphs.get(i);
+
+            int col = i % cache_columns;
+            int row = i / cache_columns;
+
+            if (row >= cache_rows) {
+                break;
+            }
+
+            int x = col * fontMapBuilder.getCacheCellWidth();
+            int y = row * fontMapBuilder.getCacheCellHeight();
+
+            glyph.x = x;
+            glyph.y = y;
+
+            g.translate(x, y);
+            glyphImage = glyph.image;
+            g.drawImage(glyphImage, 0, 0, null);
+            g.translate(-x, -y);
+
+        }
+
+        return previewImage;
     }
 
     public static void main(String[] args) throws FontFormatException {
@@ -588,8 +797,7 @@ public class Fontc {
             Fontc fontc = new Fontc();
             String fontInputFile = basedir + File.separator + fontDesc.getFont();
             BufferedInputStream fontInputStream = new BufferedInputStream(new FileInputStream(fontInputFile));
-            FontMap.Builder fontmapBuilder = FontMap.newBuilder();
-            BufferedImage image = fontc.compile(fontInputStream, fontDesc, fontmapBuilder, new FontResourceResolver() {
+            fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
 
                 @Override
                 public InputStream getResource(String resourceName) throws FileNotFoundException {
@@ -601,26 +809,11 @@ public class Fontc {
             });
             fontInputStream.close();
 
-            // Construct "internal" project root relative path, ie. /builtins/fonts/foobar_tex0.texturec
-            String internalPath = args[0].substring(basedir.length());
-            internalPath = FilenameUtils.removeExtension(internalPath) + "_tex0.texturec";
-            fontmapBuilder.addTextures(FilenameUtils.separatorsToUnix(internalPath));
-
-            // Generate texture (and save to disk) from font image
-            String textureFilename = FilenameUtils.removeExtension(Paths.get(outfile).normalize().toString()) + "_tex0.texturec";
-            TextureImage texture = TextureGenerator.generate(image, null);
-            FileOutputStream textureOutputStream = new FileOutputStream( textureFilename );
-            texture.writeTo(textureOutputStream);
-            textureOutputStream.close();
-
             // Write fontmap file
             FileOutputStream fontMapOutputStream = new FileOutputStream(outfile);
-            fontmapBuilder.build().writeTo(fontMapOutputStream);
+            fontc.getFontMap().writeTo(fontMapOutputStream);
             fontMapOutputStream.close();
 
-        } catch (TextureGeneratorException e) {
-            System.err.println(e.getMessage());
-            System.exit(1);
         } catch (IOException e) {
             System.err.println(e.getMessage());
             System.exit(1);

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/FontEditor.java
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/FontEditor.java
@@ -76,7 +76,9 @@ public class FontEditor extends DdfEditor {
                             }
                         }
 
-                        final BufferedImage awtImage = Fontc.compileToImage(new ByteArrayInputStream(cachedFont), fontDesc, new FontResourceResolver() {
+                        //final BufferedImage awtImage = Fontc.generatePreviewImage(new ByteArrayInputStream(cachedFont), fontDesc, new FontResourceResolver() {
+                        Fontc fontc = new Fontc();
+                        final BufferedImage awtImage = fontc.compile(new ByteArrayInputStream(cachedFont), fontDesc, true, new FontResourceResolver() {
 
                             @Override
                             public InputStream getResource(String resourceName)

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -298,10 +298,10 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
                     if (g != null) {
                         if (g.getWidth() > 0) {
 
-                            double u_min = sU * (g.getX() + g.getLeftBearing());
-                            double v_min = sV * (g.getY() - g.getAscent());
-                            double u_max = u_min + sU * g.getWidth();
-                            double v_max = v_min + sV * (g.getAscent() + g.getDescent());
+                            double u_min = sU * (g.getX() + fontMap.getGlyphPadding());
+                            double v_min = sV * (g.getY() + fontMap.getGlyphPadding());
+                            double u_max = sU * (g.getX() + fontMap.getGlyphPadding() + g.getWidth());
+                            double v_max = sV * (g.getY() + fontMap.getGlyphPadding() + g.getAscent() + g.getDescent());
 
                             double x_min = x + g.getLeftBearing();
                             double x_max = x_min + g.getWidth();

--- a/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
+++ b/com.dynamo.cr/com.dynamo.cr.sceneed/src/com/dynamo/cr/sceneed/core/SceneModel.java
@@ -495,14 +495,13 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
         }
 
         // Compile to FontMap
-        FontMap.Builder fontMapBuilder = FontMap.newBuilder();
         final IFile fontInputFile = contentRoot.getFile(new Path(fontDesc.getFont()));
         final String searchPath = new Path(fontDesc.getFont()).removeLastSegments(1).toString();
         BufferedImage image;
         Fontc fontc = new Fontc();
 
         try {
-            image = fontc.compile(fontInputFile.getContents(), fontDesc, fontMapBuilder, new FontResourceResolver() {
+            image = fontc.compile(fontInputFile.getContents(), fontDesc, true, new FontResourceResolver() {
 
                 @Override
                 public InputStream getResource(String resourceName)
@@ -522,7 +521,7 @@ public class SceneModel implements IAdaptable, IOperationHistoryListener, IScene
             throw new IOException(e.getMessage());
         }
 
-        handle.setFont(fontMapBuilder.build(), image, fontc.getInputFormat());
+        handle.setFont(fontc.getFontMap(), image, fontc.getInputFormat());
 
     }
 

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -599,18 +599,6 @@ public class Fontc {
             });
             fontInputStream.close();
 
-            // Construct "internal" project root relative path, ie. /builtins/fonts/foobar_tex0.texturec
-            String internalPath = args[0].substring(basedir.length());
-            internalPath = FilenameUtils.removeExtension(internalPath) + "_tex0.texturec";
-            fontmapBuilder.addTextures(FilenameUtils.separatorsToUnix(internalPath));
-
-            // Generate texture (and save to disk) from font image
-            String textureFilename = FilenameUtils.removeExtension(Paths.get(outfile).normalize().toString()) + "_tex0.texturec";
-            TextureImage texture = TextureGenerator.generate(image, null);
-            FileOutputStream textureOutputStream = new FileOutputStream( textureFilename );
-            texture.writeTo(textureOutputStream);
-            textureOutputStream.close();
-
             // Write fontmap file
             FileOutputStream fontMapOutputStream = new FileOutputStream(outfile);
             fontmapBuilder.build().writeTo(fontMapOutputStream);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -977,6 +977,7 @@ bail:
 
                     dmRender::ClearRenderObjects(engine->m_RenderContext);
 
+
                     dmMessage::Dispatch(engine->m_SystemSocket, Dispatch, engine);
                 }
 

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -294,6 +294,9 @@ namespace dmGraphics
         , m_MipMap(0)
         , m_Width(0)
         , m_Height(0)
+        , m_SubUpdate(false)
+        , m_X(0)
+        , m_Y(0)
         {}
 
         TextureFormat m_Format;
@@ -306,6 +309,11 @@ namespace dmGraphics
         uint16_t m_MipMap;
         uint16_t m_Width;
         uint16_t m_Height;
+
+        // For sub texture updates
+        bool m_SubUpdate;
+        uint32_t m_X;
+        uint32_t m_Y;
     };
 
     // Parameters structure for OpenWindow
@@ -549,6 +557,7 @@ namespace dmGraphics
      * @param params
      */
     void SetTexture(HTexture texture, const TextureParams& params);
+    uint8_t* GetTextureData(HTexture texture);
     void SetTextureParams(HTexture texture, TextureFilter minfilter, TextureFilter magfilter, TextureWrap uwrap, TextureWrap vwrap);
     uint16_t GetTextureWidth(HTexture texture);
     uint16_t GetTextureHeight(HTexture texture);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -802,6 +802,10 @@ namespace dmGraphics
         memcpy(texture->m_Data, params.m_Data, params.m_DataSize);
     }
 
+    uint8_t* GetTextureData(HTexture texture) {
+        return 0x0;
+    }
+
     uint16_t GetTextureWidth(HTexture texture)
     {
         return texture->m_Width;

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -27,6 +27,10 @@ message FontDesc
     optional float shadow_y = 11 [default = 0.0];
     optional string extra_characters = 12 [default = ""];
     optional FontTextureFormat output_format = 13 [default = TYPE_BITMAP];
+
+    optional bool all_chars = 14 [default = false];
+    optional uint32 cache_width = 15 [default = 0];
+    optional uint32 cache_height = 16 [default = 0];
 }
 
 message FontMap
@@ -41,6 +45,9 @@ message FontMap
         optional uint32 descent = 6 [default = 0];
         optional int32 x = 7 [default = 0];
         optional int32 y = 8 [default = 0];
+
+        optional uint64 glyph_data_offset = 9;
+        optional uint64 glyph_data_size = 10;
     }
 
     repeated Glyph glyphs = 1;
@@ -54,5 +61,16 @@ message FontMap
     optional float sdf_scale = 11 [default = 1];
     optional float sdf_offset = 12 [default = 0];
     optional float sdf_outline = 13 [default = 0];
-    repeated string textures = 14 [(resource)=true];
+
+    optional uint32 cache_width = 14 [default = 0];
+    optional uint32 cache_height = 15 [default = 0];
+    optional uint64 glyph_padding = 16;
+
+    optional uint32 cache_cell_width = 17;
+    optional uint32 cache_cell_height = 18;
+
+    optional uint32 glyph_channels = 19;
+
+    optional bytes glyph_data = 20; // glyph data may be compressed
+
 }

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -31,6 +31,13 @@ namespace dmRender
     , m_SdfScale(1.0f)
     , m_SdfOffset(0)
     , m_SdfOutline(0)
+    , m_CacheWidth(0)
+    , m_CacheHeight(0)
+    , m_GlyphData(0)
+    , m_CacheCellWidth(0)
+    , m_CacheCellHeight(0)
+    , m_GlyphChannels(1)
+    , m_CacheCellPadding(0)
     {
 
     }
@@ -45,18 +52,34 @@ namespace dmRender
         , m_ShadowY(0.0f)
         , m_MaxAscent(0.0f)
         , m_MaxDescent(0.0f)
+        , m_CacheWidth(0)
+        , m_CacheHeight(0)
+        , m_GlyphData(0)
+        , m_Cache(0)
+        , m_CacheCursor(0)
+        , m_CacheColumns(0)
+        , m_CacheRows(0)
+        , m_CacheCellWidth(0)
+        , m_CacheCellHeight(0)
+        , m_CacheCellPadding(0)
         {
 
         }
 
         ~FontMap()
         {
-
+            if (m_GlyphData) {
+                free(m_GlyphData);
+            }
+            if (m_Cache) {
+                free(m_Cache);
+            }
+            dmGraphics::DeleteTexture(m_Texture);
         }
 
         dmGraphics::HTexture    m_Texture;
         HMaterial               m_Material;
-        dmHashTable16<Glyph>    m_Glyphs;
+        dmHashTable32<Glyph>    m_Glyphs;
         float                   m_ShadowX;
         float                   m_ShadowY;
         float                   m_MaxAscent;
@@ -64,6 +87,21 @@ namespace dmRender
         float                   m_SdfScale;
         float                   m_SdfOffset;
         float                   m_SdfOutline;
+
+        uint32_t                m_CacheWidth;
+        uint32_t                m_CacheHeight;
+        void*                   m_GlyphData;
+
+        Glyph**                 m_Cache;
+        uint32_t                m_CacheCursor;
+        dmGraphics::TextureFormat m_CacheFormat;
+
+        uint32_t                m_CacheColumns;
+        uint32_t                m_CacheRows;
+
+        uint32_t                m_CacheCellWidth;
+        uint32_t                m_CacheCellHeight;
+        uint8_t                 m_CacheCellPadding;
     };
 
     struct GlyphVertex
@@ -98,6 +136,56 @@ namespace dmRender
         font_map->m_SdfOffset = params.m_SdfOffset;
         font_map->m_SdfOutline = params.m_SdfOutline;
 
+        font_map->m_CacheWidth = params.m_CacheWidth;
+        font_map->m_CacheHeight = params.m_CacheHeight;
+        font_map->m_GlyphData = params.m_GlyphData;
+
+        font_map->m_CacheCellWidth = params.m_CacheCellWidth;
+        font_map->m_CacheCellHeight = params.m_CacheCellHeight;
+        font_map->m_CacheCellPadding = params.m_CacheCellPadding;
+
+        font_map->m_CacheColumns = params.m_CacheWidth / params.m_CacheCellWidth;
+        font_map->m_CacheRows = params.m_CacheHeight / params.m_CacheCellHeight;
+        uint32_t cell_count = font_map->m_CacheColumns * font_map->m_CacheRows;
+
+        switch (params.m_GlyphChannels)
+        {
+            case 1:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+            break;
+            case 3:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGB;
+            break;
+            case 4:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGBA;
+            break;
+            default:
+                dmLogError("Invalid channel count for glyph data!");
+                delete font_map;
+                return 0x0;
+        };
+
+        font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
+        memset(font_map->m_Cache, 0, sizeof(Glyph*) * cell_count);
+
+        // create new texture to be used as a cache
+        dmGraphics::TextureCreationParams tex_create_params;
+        dmGraphics::TextureParams tex_params;
+        tex_create_params.m_Width = params.m_CacheWidth;
+        tex_create_params.m_Height = params.m_CacheHeight;
+        tex_create_params.m_OriginalWidth = params.m_CacheWidth;
+        tex_create_params.m_OriginalHeight = params.m_CacheHeight;
+        tex_params.m_Format = font_map->m_CacheFormat;
+
+        tex_params.m_Data = 0;
+        tex_params.m_DataSize = 0;
+        tex_params.m_Width = params.m_CacheWidth;
+        tex_params.m_Height = params.m_CacheHeight;
+        tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+        tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+        font_map->m_Texture = dmGraphics::NewTexture(graphics_context, tex_create_params);
+        dmGraphics::SetTexture(font_map->m_Texture, tex_params);
+
         return font_map;
     }
 
@@ -109,11 +197,17 @@ namespace dmRender
     void SetFontMap(HFontMap font_map, FontMapParams& params)
     {
         const dmArray<Glyph>& glyphs = params.m_Glyphs;
-        font_map->m_Glyphs.SetCapacity((3 * glyphs.Size()) / 2, glyphs.Size());
         font_map->m_Glyphs.Clear();
+        font_map->m_Glyphs.SetCapacity((3 * glyphs.Size()) / 2, glyphs.Size());
         for (uint32_t i = 0; i < glyphs.Size(); ++i) {
             const Glyph& g = glyphs[i];
             font_map->m_Glyphs.Put(g.m_Character, g);
+        }
+
+        // release previous glyph data bank
+        if (font_map->m_GlyphData) {
+            free(font_map->m_GlyphData);
+            free(font_map->m_Cache);
         }
 
         font_map->m_ShadowX = params.m_ShadowX;
@@ -124,11 +218,46 @@ namespace dmRender
         font_map->m_SdfOffset = params.m_SdfOffset;
         font_map->m_SdfOutline = params.m_SdfOutline;
 
-    }
+        font_map->m_CacheWidth = params.m_CacheWidth;
+        font_map->m_CacheHeight = params.m_CacheHeight;
+        font_map->m_GlyphData = params.m_GlyphData;
 
-    void SetFontMapTexture(HFontMap font_map, dmGraphics::HTexture texture)
-    {
-        font_map->m_Texture = texture;
+        font_map->m_CacheCellWidth = params.m_CacheCellWidth;
+        font_map->m_CacheCellHeight = params.m_CacheCellHeight;
+        font_map->m_CacheCellPadding = params.m_CacheCellPadding;
+
+        font_map->m_CacheColumns = params.m_CacheWidth / params.m_CacheCellWidth;
+        font_map->m_CacheRows = params.m_CacheHeight / params.m_CacheCellHeight;
+        uint32_t cell_count = font_map->m_CacheColumns * font_map->m_CacheRows;
+
+        switch (params.m_GlyphChannels)
+        {
+            case 1:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+            break;
+            case 3:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGB;
+            break;
+            case 4:
+                font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGBA;
+            break;
+            default:
+                dmLogError("Invalid channel count for glyph data!");
+                delete font_map;
+                return;
+        };
+
+        font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
+        memset(font_map->m_Cache, 0, sizeof(Glyph*) * cell_count);
+
+        dmGraphics::TextureParams tex_params;
+        tex_params.m_Format = font_map->m_CacheFormat;
+        tex_params.m_Data = 0x0;
+        tex_params.m_DataSize = 0x0;
+        tex_params.m_Width = params.m_CacheWidth;
+        tex_params.m_Height = params.m_CacheHeight;
+        dmGraphics::SetTexture(font_map->m_Texture, tex_params);
+
     }
 
     dmGraphics::HTexture GetFontMapTexture(HFontMap font_map)
@@ -156,6 +285,7 @@ namespace dmRender
         text_context.m_ClientBuffer = new char[buffer_size];
         text_context.m_VertexIndex = 0;
         text_context.m_VerticesFlushed = 0;
+        text_context.m_Frame = 0;
 
         dmGraphics::VertexElement ve[] =
         {
@@ -265,12 +395,12 @@ namespace dmRender
         }
 
         uint32_t text_len = strlen(params.m_Text);
-        if (text_context->m_TextBuffer.Capacity() < (text_len + 1)) {
+        uint32_t offset = text_context->m_TextBuffer.Size();
+        if (text_context->m_TextBuffer.Capacity() < (offset + text_len + 1)) {
             dmLogWarning("Out of text-render buffer");
             return;
         }
 
-        uint32_t offset = text_context->m_TextBuffer.Size();
         text_context->m_TextBuffer.PushArray(params.m_Text, text_len);
         text_context->m_TextBuffer.Push('\0');
 
@@ -339,8 +469,8 @@ namespace dmRender
         }
     }
 
-    static const Glyph* GetGlyph(HFontMap font_map, uint16_t c) {
-        const Glyph* g = font_map->m_Glyphs.Get(c);
+    static Glyph* GetGlyph(HFontMap font_map, uint32_t c) {
+        Glyph* g = font_map->m_Glyphs.Get(c);
         if (!g)
             g = font_map->m_Glyphs.Get(126U); // Fallback to ~
 
@@ -388,6 +518,9 @@ namespace dmRender
 
         const uint32_t max_lines = 128;
         TextLine lines[max_lines];
+
+        Glyph* missing_glyphs[256];
+        uint16_t missing_cursor = 0;
 
         while (entry_key != -1) {
             const TextEntry& te = text_context.m_TextEntries[entry_key];
@@ -443,9 +576,9 @@ namespace dmRender
                 int n = l.m_Count;
                 for (int j = 0; j < n; ++j)
                 {
-                    uint16_t c = (uint16_t) dmUtf8::NextChar(&cursor);
+                    uint32_t c = dmUtf8::NextChar(&cursor);
 
-                    const Glyph* g =  GetGlyph(font_map, c);
+                    Glyph* g =  GetGlyph(font_map, c);
                     if (!g) {
                         continue;
                     }
@@ -458,60 +591,127 @@ namespace dmRender
 
                     if (g->m_Width > 0)
                     {
-                        GlyphVertex& v1 = vertices[text_context.m_VertexIndex];
-                        GlyphVertex& v2 = *(&v1 + 1);
-                        GlyphVertex& v3 = *(&v1 + 2);
-                        GlyphVertex& v4 = *(&v1 + 3);
-                        GlyphVertex& v5 = *(&v1 + 4);
-                        GlyphVertex& v6 = *(&v1 + 5);
-                        text_context.m_VertexIndex += 6;
 
-                        int16_t width = (int16_t)g->m_Width;
-                        int16_t descent = (int16_t)g->m_Descent;
-                        int16_t ascent = (int16_t)g->m_Ascent;
+                        if (!g->m_InCache) {
+                            if (missing_cursor < 256) {
+                                missing_glyphs[missing_cursor++] = g;
+                            }
+                        } else {
+                            g->m_Frame = text_context.m_Frame;
 
-                        // TODO: 16 bytes alignment and simd (when enabled in vector-math library)
-                        //       Legal cast? (strict aliasing)
-                        (Vector4&) v1.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y - descent, 0, 1);
-                        (Vector4&) v2.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y + ascent, 0, 1);
-                        (Vector4&) v3.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y - descent, 0, 1);
-                        (Vector4&) v6.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y + ascent, 0, 1);
+                            GlyphVertex& v1 = vertices[text_context.m_VertexIndex];
+                            GlyphVertex& v2 = *(&v1 + 1);
+                            GlyphVertex& v3 = *(&v1 + 2);
+                            GlyphVertex& v4 = *(&v1 + 3);
+                            GlyphVertex& v5 = *(&v1 + 4);
+                            GlyphVertex& v6 = *(&v1 + 5);
+                            text_context.m_VertexIndex += 6;
 
-                        v1.m_UV[0] = (g->m_X + g->m_LeftBearing) * im_recip;
-                        v1.m_UV[1] = (g->m_Y + descent) * ih_recip;
+                            int16_t width = (int16_t)g->m_Width;
+                            int16_t descent = (int16_t)g->m_Descent;
+                            int16_t ascent = (int16_t)g->m_Ascent;
 
-                        v2.m_UV[0] = (g->m_X + g->m_LeftBearing) * im_recip;
-                        v2.m_UV[1] = (g->m_Y - ascent) * ih_recip;
+                            // TODO: 16 bytes alignment and simd (when enabled in vector-math library)
+                            //       Legal cast? (strict aliasing)
+                            (Vector4&) v1.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y - descent, 0, 1);
+                            (Vector4&) v2.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing, y + ascent, 0, 1);
+                            (Vector4&) v3.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y - descent, 0, 1);
+                            (Vector4&) v6.m_Position = te.m_Transform * Vector4(x + g->m_LeftBearing + width, y + ascent, 0, 1);
 
-                        v3.m_UV[0] = (g->m_X + g->m_LeftBearing + g->m_Width) * im_recip;
-                        v3.m_UV[1] = (g->m_Y + descent) * ih_recip;
+                            v1.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding) * im_recip;
+                            v1.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding + ascent + descent) * ih_recip;
 
-                        v6.m_UV[0] = (g->m_X + g->m_LeftBearing + g->m_Width) * im_recip;
-                        v6.m_UV[1] = (g->m_Y - ascent) * ih_recip;
+                            v2.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding) * im_recip;
+                            v2.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding) * ih_recip;
 
-                        #define SET_VERTEX_PARAMS(v) \
-                            v.m_FaceColor = face_color; \
-                            v.m_OutlineColor = outline_color; \
-                            v.m_ShadowColor = shadow_color; \
-                            v.m_SdfParams[0] = sdf_scale; \
-                            v.m_SdfParams[1] = sdf_offset; \
-                            v.m_SdfParams[2] = sdf_outline; \
-                            v.m_SdfParams[3] = sdf_smoothing; \
+                            v3.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding + g->m_Width) * im_recip;
+                            v3.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding + ascent + descent) * ih_recip;
 
-                        SET_VERTEX_PARAMS(v1)
-                        SET_VERTEX_PARAMS(v2)
-                        SET_VERTEX_PARAMS(v3)
-                        SET_VERTEX_PARAMS(v6)
+                            v6.m_UV[0] = (g->m_X + font_map->m_CacheCellPadding + g->m_Width) * im_recip;
+                            v6.m_UV[1] = (g->m_Y + font_map->m_CacheCellPadding) * ih_recip;
 
-                        #undef SET_VERTEX_PARAMS
+                            #define SET_VERTEX_PARAMS(v) \
+                                v.m_FaceColor = face_color; \
+                                v.m_OutlineColor = outline_color; \
+                                v.m_ShadowColor = shadow_color; \
+                                v.m_SdfParams[0] = sdf_scale; \
+                                v.m_SdfParams[1] = sdf_offset; \
+                                v.m_SdfParams[2] = sdf_outline; \
+                                v.m_SdfParams[3] = sdf_smoothing; \
 
-                        v4 = v3;
-                        v5 = v2;
+                            SET_VERTEX_PARAMS(v1)
+                            SET_VERTEX_PARAMS(v2)
+                            SET_VERTEX_PARAMS(v3)
+                            SET_VERTEX_PARAMS(v6)
+
+                            #undef SET_VERTEX_PARAMS
+
+                            v4 = v3;
+                            v5 = v2;
+                        }
                     }
                     x += (int16_t)g->m_Advance;
                 }
             }
             entry_key = te.m_Next;
+        }
+
+        // Upload missing glyphs
+        if (missing_cursor > 0) {
+            uint32_t prev_cache_cursor = font_map->m_CacheCursor;
+            dmGraphics::TextureParams tex_params;
+            tex_params.m_SubUpdate = true;
+            tex_params.m_MipMap = 0;
+            tex_params.m_Format = font_map->m_CacheFormat;
+            tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+            tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
+
+            while (missing_cursor > 0) {
+                Glyph* g = missing_glyphs[--missing_cursor];
+
+                // Check if glyph is already uploaded
+                if (g->m_InCache) {
+                    continue;
+                }
+
+                // Locate a cache cell candidate
+                do {
+                    uint32_t cur = font_map->m_CacheCursor++;
+                    Glyph* candidate = font_map->m_Cache[cur];
+                    font_map->m_CacheCursor = font_map->m_CacheCursor % (font_map->m_CacheColumns * font_map->m_CacheRows);
+
+                    if (candidate == 0x0 || text_context.m_Frame != candidate->m_Frame) {
+
+                        if (candidate) {
+                            candidate->m_InCache = false;
+                        }
+                        font_map->m_Cache[cur] = g;
+
+                        uint32_t col = cur % font_map->m_CacheColumns;
+                        uint32_t row = cur / font_map->m_CacheColumns;
+
+                        g->m_X = col * font_map->m_CacheCellWidth;
+                        g->m_Y = row * font_map->m_CacheCellHeight;
+                        g->m_Frame = text_context.m_Frame;
+                        g->m_InCache = true;
+
+                        // Upload glyph data to GPU
+                        tex_params.m_X = g->m_X;
+                        tex_params.m_Y = g->m_Y;
+                        tex_params.m_Width = g->m_Width + font_map->m_CacheCellPadding*2;
+                        tex_params.m_Height = g->m_Ascent + g->m_Descent + font_map->m_CacheCellPadding*2;
+                        tex_params.m_Data = (uint8_t*)font_map->m_GlyphData + g->m_GlyphDataOffset;
+                        SetTexture(font_map->m_Texture, tex_params);
+                        break;
+                    }
+
+                } while (prev_cache_cursor != font_map->m_CacheCursor);
+
+                if (prev_cache_cursor == font_map->m_CacheCursor) {
+                    dmLogError("Out of available cache cells! Consider increasing cache_width or cache_height for the font.");
+                    break;
+                }
+            }
         }
 
         ro->m_VertexCount = text_context.m_VertexIndex - ro->m_VertexStart;

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -16,7 +16,7 @@ namespace dmRender
      */
     struct Glyph
     {
-        uint16_t    m_Character;
+        uint32_t    m_Character;
         /// Width of the glyph
         uint32_t    m_Width;
         /// Total advancement of the glyph, measured from left to the next glyph
@@ -31,6 +31,11 @@ namespace dmRender
         int32_t     m_X;
         /// Y coordinate of the glyph in the map
         int32_t     m_Y;
+
+        bool        m_InCache;
+        uint64_t    m_GlyphDataOffset;
+        uint64_t    m_GlyphDataSize;
+        uint32_t    m_Frame;
     };
 
     /**
@@ -57,6 +62,15 @@ namespace dmRender
         float m_SdfOffset;
         /// Distance value where outline should end
         float m_SdfOutline;
+        ///
+        uint32_t m_CacheWidth;
+        uint32_t m_CacheHeight;
+        uint8_t m_GlyphChannels;
+        void* m_GlyphData;
+
+        uint32_t m_CacheCellWidth;
+        uint32_t m_CacheCellHeight;
+        uint8_t m_CacheCellPadding;
     };
 
     /**
@@ -92,13 +106,6 @@ namespace dmRender
      * @param params Parameters to update
      */
     void SetFontMap(HFontMap font_map, FontMapParams& params);
-
-    /**
-     * Set font map texture
-     * @param font_map Font map handle
-     * @param texture Texture handle
-     */
-    void SetFontMapTexture(HFontMap font_map, dmGraphics::HTexture texture);
 
     /**
      * Get texture from a font map

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -305,6 +305,7 @@ namespace dmRender
         context->m_TextContext.m_RenderObjectIndex = 0;
         context->m_TextContext.m_VertexIndex = 0;
         context->m_TextContext.m_VerticesFlushed = 0;
+        context->m_TextContext.m_Frame += 1;
         context->m_TextContext.m_TextBuffer.SetSize(0);
         context->m_TextContext.m_Batches.Clear();
         context->m_TextContext.m_TextEntries.SetSize(0);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -135,6 +135,7 @@ namespace dmRender
         // Map from batch id (hash of font-map etc) to index into m_TextEntries
         dmHashTable64<int32_t>              m_Batches;
         dmArray<TextEntry>                  m_TextEntries;
+        uint32_t                            m_Frame;
     };
 
     struct RenderTargetSetup

--- a/engine/render/src/waf_render.py
+++ b/engine/render/src/waf_render.py
@@ -29,5 +29,3 @@ def font_file(self, node):
     obj_ext = '.fontc'
     out = node.change_ext(obj_ext)
     fontmap.set_outputs(out)
-    out_tex = node.change_ext("_tex0.texturec")
-    fontmap.set_outputs(out_tex)


### PR DESCRIPTION
- All fonts/glyphs are chached and streamed on demand.
- Glyph chars are now 32bit full unicode code points. (Changed engine hashtable to 32bit hash for glyph lookup. Protobufs were already 32bit.)
- Fixed bug with DrawText where it didn't correctly check if it was out of text-render buffer.
- Optimised preview image rendering to not include glyphs that does not fit into cache.
