### PR TITLE
Added missing GL error check in dmGraphics::SetSampler

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1123,7 +1123,9 @@ static void LogFrameBufferError(GLenum status)
 
     void SetSampler(HContext context, int32_t location, int32_t unit)
     {
+        assert(context);
         glUniform1i(location, unit);
+        CHECK_GL_ERROR
     }
 
     void SetDepthStencilRenderBuffer(RenderTarget* rt, bool update_current = false)


### PR DESCRIPTION
Found this while looking for possible GL error "leaking".
