### PR TITLE
DEF-1488 Added request_id result field to iOS FB game request.

### DIFF
--- a/engine/facebook/src/facebook.mm
+++ b/engine/facebook/src/facebook.mm
@@ -117,6 +117,12 @@ static void RunDialogResultCallback(lua_State*L, NSDictionary* result, NSError* 
                 } else {
                     [new_res setObject:results[key] forKey:key];
                 }
+
+                // Alias request_id == request,
+                // want to have same result fields on both Android & iOS.
+                if ([key isEqualToString:@"request"]) {
+                    [new_res setObject:results[key] forKey:@"request_id"];
+                }
             }
             RunDialogResultCallback(g_Facebook.m_MainThread, new_res, 0);
         } else {

--- a/engine/facebook/src/facebook.mm
+++ b/engine/facebook/src/facebook.mm
@@ -760,8 +760,11 @@ int Facebook_Me(lua_State* L)
  *   <li><code>to</code> (string)</li>
  * </ul>
  *
- * <b>IMPORTANT</b>The Facebook SDK for Android allows just one recipient in the "to"-field.
- * Furthermore, the field has been deprecated on iOS. Use the "suggestions" field instead.
+ * On success, the "result" table parameter passed to the callback function will include the following fields:
+ * <ul>
+ *   <li><code>request_id</code> (string)</li>
+ *   <li><code>to</code> (table)</li>
+ * </ul>
  *
  * Details for each parameter: https://developers.facebook.com/docs/games/requests/v2.4#params
  *
@@ -777,6 +780,11 @@ int Facebook_Me(lua_State* L)
  *   <li><code>people_ids</code> (table)</li>
  *   <li><code>place_id</code> (string)</li>
  *   <li><code>ref</code> (string)</li>
+ * </ul>
+ *
+ * On success, the "result" table parameter passed to the callback function will include the following fields:
+ * <ul>
+ *   <li><code>post_id</code> (string)</li>
  * </ul>
  *
  * Details for each parameter: https://developers.facebook.com/docs/sharing/reference/feed-dialog/v2.4#params


### PR DESCRIPTION
- FB SDK for iOS did return "request" field, but the name was
  different to both JS and Android. Added an alias field such
  that 'request_id' is set to the content of 'request'. Keeping
  old result fields as well to keep backwards compatibility.
