### PR TITLE
DEF-1436 - Out of scopes error for the profiler

### DIFF
--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -50,11 +50,12 @@
 #else
 #define DM_PROFILE(scope_name, name) \
     static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = 0; \
-    if (DM_PROFILE_PASTE2(scope, __LINE__) == 0) \
+    if (dmProfile::g_IsInitialized && DM_PROFILE_PASTE2(scope, __LINE__) == 0) \
     {\
         DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::AllocateScope(#scope_name);\
     }\
     dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(DM_PROFILE_PASTE2(scope, __LINE__), name);\
+
 
     #define DM_COUNTER(name, amount) \
     dmProfile::AddCounter(name, amount);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -994,7 +994,7 @@ bail:
                     dmMessage::Dispatch(engine->m_SystemSocket, Dispatch, engine);
                 }
 
-                if (engine->m_ShowProfile)
+                if (dLib::IsDebugMode() && engine->m_ShowProfile)
                 {
                     DM_PROFILE(Profile, "Draw");
                     dmProfile::Pause(true);
@@ -1008,6 +1008,7 @@ bail:
                     dmRender::ClearRenderObjects(engine->m_RenderContext);
                     dmProfile::Pause(false);
                 }
+
                 dmGraphics::Flip(engine->m_GraphicsContext);
 
                 RecordData* record_data = &engine->m_RecordData;


### PR DESCRIPTION
- Do not try to allocate scopes if profiler not active
- Disable profile drawing in engine if not in debug mode
