### PR TITLE
DEFEDIT-253 Dynamic/streaming fonts

### DIFF
--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -6,8 +6,10 @@
             [editor.gl :as gl]
             [editor.gl.shader :as shader]
             [editor.gl.vertex :as vtx]
+            [editor.gl.texture :as texture]
             [editor.project :as project]
             [editor.scene :as scene]
+            [editor.scene-cache :as scene-cache]
             [editor.workspace :as workspace]
             [editor.pipeline.font-gen :as font-gen]
             [editor.image :as image]
@@ -21,9 +23,14 @@
            [editor.gl.shader ShaderLifecycle]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
+           [java.nio ByteBuffer]
            [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
            [javax.media.opengl.glu GLU]
-           [javax.vecmath Matrix4d Point3d Vector3d]))
+           [javax.vecmath Matrix4d Point3d Vector3d]
+           [com.jogamp.opengl.util.texture Texture TextureData]
+           [com.google.protobuf ByteString]))
+
+(set! *warn-on-reflection* true)
 
 (def ^:private font-icon "icons/32/Icons_28-AT-Font.png")
 (def ^:private resource-fields #{:font :material})
@@ -43,23 +50,12 @@
   (vec4 outline_color)
   (vec4 shadow_color))
 
-(defn render-font [^GL2 gl render-args renderables rcount]
-  (let [user-data (get (first renderables) :user-data)
-        gpu-texture (:gpu-texture user-data)
-        vertex-buffer (:vertex-buffer user-data)
-        material-shader (:shader user-data)
-        type (:type user-data)
-        vcount (count vertex-buffer)]
-    (when (> vcount 0)
-      (let [vertex-binding (vtx/use-with ::vb vertex-buffer material-shader)]
-        (gl/with-gl-bindings gl render-args [material-shader vertex-binding gpu-texture]
-          (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 vcount))))))
-
 (def ^:private vertex-order [0 1 2 1 3 2])
 
-(defn- glyph->quad [su sv ^Matrix4d transform glyph]
-  (let [u0 (* su (+ (:x glyph) (:left-bearing glyph)))
-        v0 (* sv (- (:y glyph) (:ascent glyph)))
+(defn- glyph->quad [font-map su sv ^Matrix4d transform glyph]
+  (let [padding (:glyph-padding font-map)
+        u0 (* su (+ (:x glyph) padding))
+        v0 (* sv (+ (:y glyph) padding))
         u1 (+ u0 (* su (:width glyph)))
         v1 (+ v0 (* sv (+ (:ascent glyph) (:descent glyph))))
         x0 (:left-bearing glyph)
@@ -97,19 +93,24 @@
       (- (+ w (:left-bearing last) (:width last)) (:advance last))
       w)))
 
+(defn- split [s i]
+  (mapv s/trim [(subs s 0 i) (subs s i)]))
+
 (defn- break-line [^String line glyphs max-width]
-  (loop [b (dec (count line))]
+  (loop [b (dec (count line))
+         last-space nil]
     (if (> b 0)
       (let [c (.charAt line b)]
-        (if (= c \ )
-          (let [l1 (s/trim (subs line 0 b))
-                l2 (s/trim (subs line b))
+        (if (Character/isWhitespace c)
+          (let [[l1 l2] (split line b)
                 w (measure-line glyphs l1)]
             (if (> w max-width)
-              (recur (dec b))
+              (recur (dec b) b)
               [l1 l2]))
-          (recur (dec b))))
-      [line nil])))
+          (recur (dec b) last-space)))
+      (if last-space
+        (split line last-space)
+        [line nil]))))
 
 (defn- break-lines [lines glyphs max-width]
   (reduce (fn [result line]
@@ -132,7 +133,7 @@
   ([font-map text]
     (measure font-map text false 0))
   ([font-map text line-break? max-width]
-    (if (or (nil? font-map) (nil? text) (= (count text) 0))
+    (if (or (nil? font-map) (nil? text) (empty? text))
       [0 0]
       (let [glyphs (font-map->glyphs font-map)
             lines (split-text glyphs text line-break? max-width)
@@ -142,12 +143,28 @@
         [max-width (* (count lines) line-height)]))))
 
 (def FontData {:type g/Keyword
-               :font-map g/Any})
+               :font-map g/Any
+               :texture g/Any})
 
-(defn gen-vertex-buffer [{:keys [type font-map]} text-entries]
-  (let [w (:width font-map)
-        h (:height font-map)
-        glyph-fn (partial glyph->quad (/ 1 w) (/ 1 h))
+(defn- cell->coords [cell font-map]
+  (let [cw (:cache-cell-width font-map)
+        ch (:cache-cell-height font-map)
+        w (int (/ (:cache-width font-map) cw))
+        h (int (/ (:cache-height font-map) ch))]
+    [(* (mod cell w) cw)
+     (* (int (/ cell w)) ch)]))
+
+(defn- place-glyph [^GL2 gl cache font-map texture glyph]
+  (if-let [cell (scene-cache/request-object! ::glyph-cells [texture glyph] gl [cache font-map texture glyph])]
+    (let [[x y] (cell->coords cell font-map)]
+      (assoc glyph :x x :y y))
+    (assoc glyph :width 0)))
+
+(defn gen-vertex-buffer [^GL2 gl {:keys [type font-map texture]} text-entries]
+  (let [cache (scene-cache/request-object! ::glyph-caches texture gl [font-map])
+        w (:cache-width font-map)
+        h (:cache-height font-map)
+        glyph-fn (partial glyph->quad font-map (/ 1 w) (/ 1 h))
         glyphs (font-map->glyphs font-map)
         char->glyph (comp glyphs int)
         line-height (+ (:max-ascent font-map) (:max-descent font-map))
@@ -172,7 +189,8 @@
                                             glyphs (map char->glyph line)
                                             x 0.0]
                                        (if-let [glyph (first glyphs)]
-                                         (let [cursor (doto (Matrix4d.) (.set (Vector3d. x y 0.0)))
+                                         (let [glyph (place-glyph gl cache font-map texture glyph)
+                                               cursor (doto (Matrix4d.) (.set (Vector3d. x y 0.0)))
                                                cursor (doto cursor (.mul xform cursor))
                                                vs (reduce conj! vs (map into (glyph-fn cursor glyph) colors))]
                                            (recur vs (rest glyphs) (+ x (:advance glyph))))
@@ -183,42 +201,39 @@
                (persistent! vs)))]
     (vertex-buffer vs type font-map)))
 
-(g/defnk produce-scene [_node-id aabb gpu-texture font font-map ^BufferedImage font-image material-shader type]
-  (let [w (.getWidth font-image)
-        h (.getHeight font-image)
-        vs [[0 0 0 0 1]
-            [w 0 0 1 1]
-            [0 h 0 0 0]
-            [w h 0 1 0]]
-        vs (mapv #(get vs %) [0 1 2 1 3 2])
-        transform (doto
-                    (Matrix4d.)
-                    (.set (Vector3d. (- (* w 0.5)) (- (* h 0.5)) 0.0)))
-        glyph-fn (partial glyph->quad (/ 1 w) (/ 1 h))
-        glyphs (:glyphs font-map)
-        v3 (Vector3d.)
-        xforms (mapv (fn [g] (let [xform (doto (Matrix4d.)
-                                           (.set (do (.set v3 (:x g) (- h (:y g)) 0) v3)))]
-                               (.mul xform transform xform)
-                               xform))
-                     glyphs)
-        vs (concat (reduce into [] (map glyph-fn xforms glyphs)))
-        colors (cond->> [1.0 1.0 1.0 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0]
-                 (= type :distance-field) (into [(:sdf-scale font-map) (:sdf-offset font-map) (:sdf-outline font-map) 1.0]))
-        vs (mapv #(into % colors) vs)]
-    {:node-id _node-id
-     :aabb aabb
-     :renderable {:render-fn render-font
-                  :batch-key gpu-texture
-                  :select-batch-key _node-id
-                  :user-data {:type type
-                              :gpu-texture gpu-texture
-                              :vertex-buffer (vertex-buffer vs type font-map)
-                              :shader material-shader}
-                  :passes [pass/transparent]}}))
+(defn render-font [^GL2 gl render-args renderables rcount]
+  (let [user-data (get (first renderables) :user-data)
+        gpu-texture (:texture user-data)
+        font-map (:font-map user-data)
+        vertex-buffer (gen-vertex-buffer gl user-data [{:text (:text user-data)
+                                                        :offset [0.0 0.0]
+                                                        :world-transform (doto (Matrix4d.) (.setIdentity))
+                                                        :color [1.0 1.0 1.0 1.0] :outline [0.0 0.0 0.0 1.0] :shadow [0.0 0.0 0.0 0.0]
+                                                        :line-break true :max-width (:cache-width font-map)}])
+        material-shader (:shader user-data)
+        type (:type user-data)
+        vcount (count vertex-buffer)]
+    (when (> vcount 0)
+      (let [vertex-binding (vtx/use-with ::vb vertex-buffer material-shader)]
+        (gl/with-gl-bindings gl render-args [material-shader vertex-binding gpu-texture]
+          (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 vcount))))))
+
+(g/defnk produce-scene [_node-id aabb gpu-texture font font-map material-shader type preview-text]
+  {:node-id _node-id
+   :aabb aabb
+   :renderable {:render-fn render-font
+                :batch-key gpu-texture
+                :select-batch-key _node-id
+                :user-data {:type type
+                            :texture gpu-texture
+                            :font-map font-map
+                            :shader material-shader
+                            :text preview-text}
+                :passes [pass/transparent]}})
 
 (g/defnk produce-pb-msg [font material size antialias alpha outline-alpha outline-width
-                         shadow-alpha shadow-blur shadow-x shadow-y extra-characters output-format]
+                         shadow-alpha shadow-blur shadow-x shadow-y extra-characters output-format
+                         all-chars cache-width cache-height]
   {:font (resource/resource->proj-path font)
    :material (resource/resource->proj-path material)
    :size size
@@ -231,13 +246,16 @@
    :shadow-x shadow-x
    :shadow-y shadow-y
    :extra-characters extra-characters
-   :output-format output-format})
+   :output-format output-format
+   :all-chars all-chars
+   :cache-width cache-width
+   :cache-height cache-height})
 
 (g/defnk produce-save-data [resource pb-msg]
   {:resource resource
    :content (protobuf/map->str Font$FontDesc pb-msg)})
 
-(g/defnk produce-font-map-image [_node-id font pb-msg]
+(g/defnk produce-font-map [_node-id font pb-msg]
   (let [project (project/get-project _node-id)
         workspace (project/workspace project)
         resolver (partial workspace/resolve-workspace-resource workspace)]
@@ -249,21 +267,43 @@
         font-map (assoc (:font-map user-data) :textures [(workspace/proj-path (second (first dep-resources)))])]
     {:resource resource :content (protobuf/map->bytes Font$FontMap font-map)}))
 
-(g/defnk produce-build-targets [_node-id resource font-resource font-map font-image dep-build-targets]
+(g/defnk produce-build-targets [_node-id resource font-resource font-map dep-build-targets]
   (let [project        (project/get-project _node-id)
-        workspace      (project/workspace project)
-        texture-target (image/make-texture-build-target workspace _node-id font-image)]
+        workspace      (project/workspace project)]
     [{:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-font
       :user-data {:font-map font-map}
-      :deps (cons texture-target (flatten dep-build-targets))}]))
+      :deps (flatten dep-build-targets)}]))
 
 (g/defnode FontSourceNode
   (inherits project/ResourceNode))
 
 (g/defnk produce-font-type [font output-format]
   (font-type font output-format))
+
+(defn- char->string [c]
+  (String. (Character/toChars c)))
+
+(g/defnk produce-preview-text [font-map]
+  (let [char->glyph (into {} (map (fn [g] [(:character g) g]) (:glyphs font-map)))
+        chars (filter (fn [c] (and (contains? char->glyph c) (> (:width (get char->glyph c)) 0))) (range 255))
+        cache-width (:cache-width font-map)
+        lines (loop [lines []
+                     chars chars]
+                (if (not-empty chars)
+                  (let [[line chars] (loop [line []
+                                            chars chars
+                                            w 0]
+                                       (if (and (not-empty chars) (< w cache-width))
+                                         (let [c (first chars)
+                                               g (char->glyph c)]
+                                           (recur (conj line (first chars)) (rest chars) (+ w (int (:advance g)))))
+                                         [line chars]))]
+                    (recur (conj lines line) chars))
+                  lines))
+        text (s/join " " (map (fn [l] (s/join (map char->string l))) lines))]
+    text))
 
 (g/defnode FontNode
   (inherits project/ResourceNode)
@@ -277,7 +317,7 @@
     (value (g/fnk [material-resource] material-resource))
     (set (project/gen-resource-setter [[:resource :material-resource]
                                        [:build-targets :dep-build-targets]
-                                       [:sampler-data :material-sampler]
+                                       [:samplers :material-samplers]
                                        [:shader :material-shader]])))
   (property size g/Int (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
                                                                       (or (= type :defold) (= type :distance-field))))))
@@ -301,33 +341,43 @@
   (property output-format g/Keyword
     (dynamic edit-type (g/always (properties/->pb-choicebox Font$FontTextureFormat))))
 
+  (property all-chars g/Bool)
+  (property cache-width g/Int)
+  (property cache-height g/Int)
+
   (input dep-build-targets g/Any :array)
   (input font-resource (g/protocol resource/Resource))
   (input material-resource (g/protocol resource/Resource))
-  (input material-sampler {g/Keyword g/Any})
+  (input material-samplers [{g/Keyword g/Any}])
   (input material-shader ShaderLifecycle)
 
   (output outline g/Any :cached (g/fnk [_node-id] {:node-id _node-id :label "Font" :icon font-icon}))
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-data g/Any :cached produce-save-data)
   (output build-targets g/Any :cached produce-build-targets)
-  (output font-map-image g/Any :cached produce-font-map-image)
-  (output font-map g/Any (g/fnk [font-map-image] (:font-map font-map-image)))
-  (output font-image g/Any (g/fnk [font-map-image] (:image font-map-image)))
+  (output font-map g/Any :cached produce-font-map)
   (output scene g/Any :cached produce-scene)
-  (output aabb AABB (g/fnk [^BufferedImage font-image]
-                      (if font-image
-                        (let [hw (* 0.5 (.getWidth font-image))
-                              hh (* 0.5 (.getHeight font-image))]
-                          (-> (geom/null-aabb)
-                            (geom/aabb-incorporate (Point3d. (- hw) (- hh) 0))
-                            (geom/aabb-incorporate (Point3d. hw hh 0))))
-                        (geom/null-aabb))))
-  (output gpu-texture g/Any :cached (g/fnk [_node-id font-image material-sampler]
-                                      (first (material/make-textures [{:image-id _node-id :image font-image}] material-sampler))))
+  (output aabb AABB (g/fnk [font-map preview-text]
+                           (if font-map
+                             (let [[w h] (measure font-map preview-text true (:cache-width font-map))
+                                   h-offset (:max-ascent font-map)]
+                               (-> (geom/null-aabb)
+                                 (geom/aabb-incorporate (Point3d. 0 h-offset 0))
+                                 (geom/aabb-incorporate (Point3d. w (- h-offset h) 0))))
+                             (geom/null-aabb))))
+  (output gpu-texture g/Any :cached (g/fnk [_node-id font-map material-samplers]
+                                           (let [w (:cache-width font-map)
+                                                 h (:cache-height font-map)
+                                                 channels (:glyph-channels font-map)]
+                                             (texture/empty-texture _node-id w h channels
+                                                                   (material/sampler->tex-params (first material-samplers)) 0))))
   (output material-shader ShaderLifecycle (g/fnk [material-shader] material-shader))
   (output type g/Keyword produce-font-type)
-  (output font-data FontData :cached (g/fnk [type font-map] {:type type :font-map font-map})))
+  (output font-data FontData :cached (g/fnk [type gpu-texture font-map]
+                                            {:type type
+                                             :texture gpu-texture
+                                             :font-map font-map}))
+  (output preview-text g/Str :cached produce-preview-text))
 
 (defn load-font [project self resource]
   (let [font (protobuf/read-text Font$FontDesc resource)
@@ -352,3 +402,56 @@
                                       :node-type FontSourceNode
                                       :icon font-icon
                                       :view-types [:default])))
+
+(defn- make-glyph-cache [^GL2 gl params]
+  (let [[font-map] params
+        {:keys [cache-width cache-height cache-cell-width cache-cell-height]} font-map
+        size (* (int (/ cache-width cache-cell-width)) (int (/ cache-height cache-cell-height)))]
+    {:width cache-width
+     :height cache-height
+     :cell-width cache-cell-width
+     :cell-height cache-cell-height
+     :cache (atom {:free (range size)})}))
+
+(defn- update-glyph-cache [^GL2 gl glyph-cache params]
+  (make-glyph-cache gl params))
+
+(defn- destroy-glyph-caches [^GL2 gl font-caches _])
+
+(scene-cache/register-object-cache! ::glyph-caches make-glyph-cache update-glyph-cache destroy-glyph-caches)
+
+(defn- make-glyph-cell [^GL2 gl params]
+  (let [[cache font-map texture glyph] params
+        cache (:cache cache)
+        cw (:cache-cell-width font-map)
+        ch (:cache-cell-height font-map)
+        w (int (/ (:cache-width font-map) cw))
+        h (int (/ (:cache-height font-map) ch))]
+    (let [cell (first (:free @cache))]
+      (when cell
+        (let [x (* (mod cell w) cw)
+              y (* (int (/ cell w)) ch)
+              p (* 2 (:glyph-padding font-map))
+              w (+ (:width glyph) p)
+              h (+ (:ascent glyph) (:descent glyph) p)
+              ^ByteBuffer src-data (-> ^ByteBuffer (.asReadOnlyByteBuffer ^ByteString (:glyph-data font-map))
+                                     ^ByteBuffer (.position (:glyph-data-offset glyph))
+                                     (.slice)
+                                     (.limit (:glyph-data-size glyph)))
+              tgt-data (doto (ByteBuffer/allocateDirect (:glyph-data-size glyph))
+                         (.put src-data)
+                         (.flip))]
+          (when (> (:glyph-data-size glyph) 0)
+            (texture/tex-sub-image gl texture tgt-data x y w h (:glyph-channels font-map)))))
+      (swap! cache update :free rest)
+      cell)))
+
+(defn- update-glyph-cell [^GL2 gl cell params]
+  cell)
+
+(defn- destroy-glyph-cells [^GL2 gl glyphs params]
+  (doseq [[glyph params] (map vector glyphs params)
+          :let [[cache _ _ _] params]]
+    (swap! (:cache cache) update :free conj glyph)))
+
+(scene-cache/register-object-cache! ::glyph-cells make-glyph-cell update-glyph-cell destroy-glyph-cells)

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -486,7 +486,7 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
   (delete-shader gl program)
   (make-shader-program gl data))
 
-(defn- destroy-shader-programs [^GL2 gl programs]
+(defn- destroy-shader-programs [^GL2 gl programs _]
   (doseq [[program _] programs]
     (delete-shader gl program)))
 

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -6,11 +6,13 @@
             [editor.scene-cache :as scene-cache]
             [dynamo.graph :as g])
   (:import [java.awt.image BufferedImage]
-           [java.nio IntBuffer]
+           [java.nio IntBuffer ByteBuffer]
            [javax.media.opengl GL GL2 GL3 GLContext GLProfile]
            [com.jogamp.common.nio Buffers]
-           [com.jogamp.opengl.util.texture Texture TextureIO]
+           [com.jogamp.opengl.util.texture Texture TextureIO TextureData]
            [com.jogamp.opengl.util.texture.awt AWTTextureIO]))
+
+(set! *warn-on-reflection* true)
 
 (def
   ^{:doc "This map translates Clojure keywords into OpenGL constants.
@@ -43,19 +45,29 @@
         (.setTexParameteri texture gl p v)
         (println "WARNING: ignoring unknown texture parameter " p)))))
 
-(defrecord TextureLifecycle [request-id cache-id unit params img-data]
+(defprotocol TextureProxy
+  (->texture ^Texture [this ^GL2 gl]))
+
+(defrecord TextureLifecycle [request-id cache-id unit params texture-data]
+  TextureProxy
+  (->texture [this gl]
+    (scene-cache/request-object! cache-id request-id gl texture-data))
+
   GlBind
   (bind [this gl _]
-    (let [^Texture texture (scene-cache/request-object! cache-id request-id gl img-data)]
+    (let [tex (->texture this gl)]
       (.glActiveTexture ^GL2 gl unit)
-      (apply-params gl texture params)
-      (.enable texture gl)
-      (.bind texture gl)))
+      (.enable tex gl)
+      (.bind tex gl)
+      (apply-params gl tex params)))
 
   (unbind [this gl]
-    (let [^Texture texture (scene-cache/request-object! cache-id request-id gl img-data)]
-      (.disable texture gl))
+    (let [tex (->texture this gl)]
+      (.disable tex gl))
     (gl/gl-active-texture ^GL gl GL/GL_TEXTURE0)))
+
+(defn set-params [^TextureLifecycle tlc params]
+  (update tlc :params merge params))
 
 (def
   ^{:doc "If you do not supply parameters to `image-texture`, these will be used as defaults."}
@@ -83,12 +95,35 @@ If supplied, the unit must be an OpenGL texture unit enum. The default is GL_TEX
    (image-texture request-id img params 0))
   ([request-id ^BufferedImage img params unit-index]
     (assert (< unit-index GL2/GL_MAX_TEXTURE_IMAGE_UNITS) (format "the maximum number of texture units is %d" GL2/GL_MAX_TEXTURE_IMAGE_UNITS))
-    (let [unit (+ unit-index GL2/GL_TEXTURE0)]
-      (->TextureLifecycle request-id ::texture unit params (or img (:contents placeholder-image))))))
+    (let [texture-data (AWTTextureIO/newTextureData (GLProfile/getGL2GL3) (or img (:contents placeholder-image)) true)
+          unit (+ unit-index GL2/GL_TEXTURE0)]
+      (->TextureLifecycle request-id ::texture unit params texture-data))))
+
+(defn- channels->format [^long channels]
+  (case channels
+    1 GL2/GL_LUMINANCE
+    3 GL2/GL_RGB
+    4 GL2/GL_RGBA))
+
+(defn- ->texture-data [width height channels data]
+  (let [internal-format (channels->format channels)
+        _ (assert internal-format (format "Invalid channel count %d" channels))
+        type GL2/GL_UNSIGNED_BYTE
+        border 0]
+    (TextureData. (GLProfile/getGL2GL3) internal-format width height border internal-format type false false false data nil)))
+
+(defn empty-texture [request-id width height channels params unit-index]
+  (let [unit (+ unit-index GL2/GL_TEXTURE0)]
+    (->TextureLifecycle request-id ::texture unit params (->texture-data width height channels nil))))
 
 (def white-pixel (image-texture ::white (-> (img/blank-image 1 1) (img/flood 1.0 1.0 1.0)) (assoc default-image-texture-params
                                                                                              :min-filter GL2/GL_NEAREST
                                                                                              :mag-filter GL2/GL_NEAREST)))
+
+(defn tex-sub-image [^GL2 gl ^TextureLifecycle texture data x y w h channels]
+  (let [tex (->texture texture gl)
+        data (->texture-data w h channels data)]
+    (.updateSubImage tex gl data 0 x y)))
 
 (def default-cubemap-texture-params
   ^{:doc "If you do not supply parameters to `image-cubemap-texture`, these will be used as defaults."}
@@ -129,14 +164,14 @@ If supplied, the unit must be an OpenGL texture unit enum. The default is GL_TEX
   ([request-id unit params right left top bottom front back]
    (->TextureLifecycle request-id ::cubemap-texture unit params (map #(safe-texture %) [right left top bottom front back]))))
 
-(defn- make-texture [^GL2 gl ^BufferedImage img]
-  (AWTTextureIO/newTexture (GLProfile/getGL2GL3) img true))
+(defn- make-texture [^GL2 gl ^TextureData texture-data]
+  (Texture. gl texture-data))
 
-(defn- update-texture [^GL2 gl ^Texture texture ^BufferedImage img]
-  (.updateImage texture gl ^TextureData (AWTTextureIO/newTextureData (GLProfile/getGL2GL3) img true))
+(defn- update-texture [^GL2 gl ^Texture texture ^TextureData texture-data]
+  (.updateImage texture gl texture-data)
   texture)
 
-(defn- destroy-textures [^GL2 gl textures]
+(defn- destroy-textures [^GL2 gl textures _]
   (doseq [^Texture texture textures]
     (.destroy texture gl)))
 

--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -515,7 +515,7 @@ the `do-gl` macro from `editor.gl`."
   (let [vbo (first (gl/gl-gen-buffers gl 1))]
     (update-vbo gl vbo data)))
 
-(defn- destroy-vbos [^GL2 gl vbos]
+(defn- destroy-vbos [^GL2 gl vbos _]
   (apply gl/gl-delete-buffers gl vbos))
 
 (scene-cache/register-object-cache! ::vbo make-vbo update-vbo destroy-vbos)

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -798,7 +798,7 @@
       (swap! pfx-sim-ref plib/reload rt-pb-data))
     (assoc pfx-sim :protobuf-msg rt-pb-data)))
 
-(defn- destroy-pfx-sims [_ pfx-sims]
+(defn- destroy-pfx-sims [_ pfx-sims _]
   (doseq [pfx-sim pfx-sims]
     (plib/destroy-sim @(:pfx-sim pfx-sim))))
 

--- a/editor/src/clj/editor/pipeline/font_gen.clj
+++ b/editor/src/clj/editor/pipeline/font_gen.clj
@@ -12,9 +12,7 @@
                             (getResource [this resource-name]
                               (io/input-stream (resolver (str "/" resource-name)))))]
     (with-open [font-stream (io/input-stream font-path)]
-      (let [^BufferedImage image (-> (Fontc.)
-                                   (.compile font-stream font-desc font-map-builder font-res-resolver))]
-        {:image image
-         :font-map (-> (protobuf/pb->map (.build font-map-builder))
-                     (assoc :width (.getWidth image)
-                            :height (.getHeight image)))}))))
+      (let [^Font$FontMap font-map (-> (doto (Fontc.)
+                                         (.compile font-stream font-desc false font-res-resolver))
+                                     (.getFontMap))]
+        (protobuf/pb->map font-map)))))

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -10,7 +10,6 @@
             [editor.scene :as scene]
             [editor.workspace :as workspace]
             [editor.math :as math]
-            [editor.pipeline.font-gen :as font-gen]
             [internal.render.pass :as pass])
   (:import [com.dynamo.input.proto Input$InputBinding]
            [com.dynamo.render.proto Render$RenderPrototypeDesc]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -776,7 +776,7 @@
   (let [[font-family font-style font-size] data]
     (gl/text-renderer font-family font-style font-size)))
 
-(defn- destroy-text-renderers [^GL2 gl text-renderers]
+(defn- destroy-text-renderers [^GL2 gl text-renderers _]
   (doseq [^TextRenderer text-renderer text-renderers]
     (.dispose text-renderer)))
 

--- a/editor/src/clj/editor/scene_cache.clj
+++ b/editor/src/clj/editor/scene_cache.clj
@@ -40,9 +40,9 @@
                                            (when cache
                                              (let [pruned-cache (vcache/prune cache)
                                                    dead-entries (filter (fn [[request-id _]] (not (contains? pruned-cache request-id))) cache)
-                                                   dead-objects (mapv (fn [[_ [object _]]] object) dead-entries)]
+                                                   dead-objects (mapv (fn [[_ object]] object) dead-entries)]
                                                (when (not (empty? dead-objects))
-                                                 (destroy-batch-fn context dead-objects))
+                                                 (destroy-batch-fn context (map first dead-objects) (map second dead-objects)))
                                                pruned-cache))))]))
                 caches)))
 
@@ -55,7 +55,8 @@
                     [cache-id (if-let [cache (get-in meta [:caches context])]
                                 (do
                                   (when destroy-objects?
-                                    (destroy-batch-fn context (map #(first (second %)) cache)))
+                                    (let [entries (map second cache)]
+                                      (destroy-batch-fn context (map first entries) (map second entries))))
                                   (update meta :caches dissoc context))
                                 meta)]))
                 caches)))

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -25,6 +25,7 @@ import java.awt.image.Kernel;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -43,17 +44,15 @@ import org.apache.commons.io.FilenameUtils;
 
 import com.defold.editor.pipeline.BMFont.BMFontFormatException;
 import com.defold.editor.pipeline.BMFont.Char;
-import com.defold.editor.pipeline.TextureGenerator;
-import com.defold.editor.pipeline.TextureGeneratorException;
-import com.dynamo.graphics.proto.Graphics.TextureImage;
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.FontMap;
 import com.dynamo.render.proto.Font.FontTextureFormat;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
 
 class Glyph {
     int index;
-    char c;
+    int c;
     int width;
     int advance;
     int leftBearing;
@@ -61,7 +60,10 @@ class Glyph {
     int descent;
     int x;
     int y;
+    int cache_entry_offset;
+    int cache_entry_size;
     GlyphVector vector;
+    BufferedImage image;
 };
 
 class OrderComparator implements Comparator<Glyph> {
@@ -111,59 +113,102 @@ public class Fontc {
         FORMAT_TRUETYPE, FORMAT_BMFONT
     };
 
-    private int imageWidth = 1024;
-    private int imageHeight = 2048; // Enough. Will be cropped later
     private InputFontFormat inputFormat = InputFontFormat.FORMAT_TRUETYPE;
     private Stroke outlineStroke = null;
-    private StringBuffer characters;
-    private FontRenderContext fontRendererContext;
-    private BufferedImage image;
+    private int channelCount = 3;
     private FontDesc fontDesc;
-    static final int imageType = BufferedImage.TYPE_3BYTE_BGR;
+    private FontMap.Builder fontMapBuilder;
+    private ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
 
-
+    private Font font;
+    private BMFont bmfont;
 
     public interface FontResourceResolver {
         public InputStream getResource(String resourceName) throws FileNotFoundException;
     }
 
     public Fontc() {
+
     }
 
     public InputFontFormat getInputFormat() {
         return inputFormat;
     }
 
-    public void builderTTF(InputStream fontStream, FontDesc fontDesc, FontMap.Builder builder) throws FontFormatException, IOException {
+    public void TTFBuilder(InputStream fontStream) throws FontFormatException, IOException {
 
-    	// 7-bit ASCII. Note inclusive range [32,126]
-        for (int i = 32; i <= 126; ++i)
-            this.characters.append((char) i);
+        ArrayList<Integer> characters = new ArrayList<Integer>();
 
-        String extraCharacters = fontDesc.getExtraCharacters();
-        for (int i = 0; i < extraCharacters.length(); i++) {
-            char c = extraCharacters.charAt(i);
-            this.characters.append(c);
+        if (!fontDesc.getAllChars()) {
+
+            // 7-bit ASCII. Note inclusive range [32,126]
+            for (int i = 32; i <= 126; ++i) {
+                characters.add(i);
+            }
+
+            String extraCharacters = fontDesc.getExtraCharacters();
+            for (int i = 0; i < extraCharacters.length(); i++) {
+                char c = extraCharacters.charAt(i);
+                characters.add((int)c);
+            }
+
         }
 
-        this.fontRendererContext = new FontRenderContext(new AffineTransform(), fontDesc.getAntialias() != 0, fontDesc.getAntialias() != 0);
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
             outlineStroke = new BasicStroke(fontDesc.getOutlineWidth());
         }
 
-        Font font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+        font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
         font = font.deriveFont(Font.PLAIN, fontDesc.getSize());
-        for (int i = 0; i < this.characters.length(); ++i) {
-            char ch = this.characters.charAt(i);
-            if (!font.canDisplay(ch)) {
-                this.characters.deleteCharAt(i);
-                i--;
+
+
+        FontRenderContext fontRendererContext = new FontRenderContext(new AffineTransform(), fontDesc.getAntialias() != 0, fontDesc.getAntialias() != 0);
+
+        int loopEnd = characters.size();
+        if (fontDesc.getAllChars()) {
+            assert(0 == loopEnd);
+            loopEnd = 0x10FFFF;
+        }
+        for (int i = 0; i < loopEnd; ++i) {
+
+            int codePoint = i;
+            if (!fontDesc.getAllChars()) {
+                codePoint = characters.get(i);
+            }
+
+            if (font.canDisplay(codePoint)) {
+                String s = new String(Character.toChars(codePoint));
+
+                GlyphVector glyphVector = font.createGlyphVector(fontRendererContext, s);
+                Rectangle visualBounds = glyphVector.getOutline().getBounds();
+
+                GlyphMetrics metrics = glyphVector.getGlyphMetrics(0);
+
+                Glyph glyph = new Glyph();
+                glyph.ascent = (int)Math.ceil(-visualBounds.getMinY());
+                glyph.descent = (int)Math.ceil(visualBounds.getMaxY());
+
+                glyph.c = codePoint;
+                glyph.index = i;
+                glyph.advance = Math.round(metrics.getAdvance());
+                float leftBearing = metrics.getLSB();
+                glyph.leftBearing = (int)Math.floor(leftBearing);
+                glyph.width = visualBounds.width;
+                if (leftBearing != 0.0f) {
+                    glyph.width += 1;
+                }
+
+                glyph.vector = glyphVector;
+
+                glyphs.add(glyph);
             }
         }
 
-        image = new BufferedImage(this.imageWidth, this.imageHeight, Fontc.imageType);
-        Graphics2D g = image.createGraphics();
+        BufferedImage image;
+        Graphics2D g;
+        image = new BufferedImage(1024, 1024, BufferedImage.TYPE_3BYTE_BGR);
+        g = image.createGraphics();
         g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         setHighQuality(g);
@@ -171,39 +216,72 @@ public class Fontc {
         FontMetrics fontMetrics = g.getFontMetrics(font);
         int maxAscent = fontMetrics.getMaxAscent();
         int maxDescent = fontMetrics.getMaxDescent();
+        fontMapBuilder.setMaxAscent(maxAscent)
+                      .setMaxDescent(maxDescent)
+                      .setShadowX(fontDesc.getShadowX())
+                      .setShadowY(fontDesc.getShadowY());
 
-        ArrayList<Glyph> glyphs = new ArrayList<Glyph>();
-        for (int i = 0; i < this.characters.length(); ++i) {
-            String s = this.characters.substring(i, i+1);
+    }
 
-            GlyphVector glyphVector = font.createGlyphVector(this.fontRendererContext, s);
-            Rectangle visualBounds = glyphVector.getOutline().getBounds();
-            GlyphMetrics metrics = glyphVector.getGlyphMetrics(0);
+
+    public void FNTBuilder(InputStream fontStream) throws FontFormatException, IOException {
+        this.inputFormat = InputFontFormat.FORMAT_BMFONT;
+
+        bmfont = new BMFont();
+
+        // parse BMFont file
+        try {
+            bmfont.parse(fontStream);
+        } catch (BMFontFormatException e) {
+            throw new FontFormatException(e.getMessage());
+        }
+
+        int maxAscent = 0;
+        int maxDescent = 0;
+        for (int i = 0; i < bmfont.charArray.size(); ++i) {
+
+            Char c = bmfont.charArray.get(i);
+
+            int ascent = bmfont.base - (int)c.yoffset;
+            int descent = c.height - ascent;
+
+            maxAscent = Math.max(ascent, maxAscent);
+            maxDescent = Math.max(descent, maxDescent);
 
             Glyph glyph = new Glyph();
-            glyph.ascent = (int)Math.ceil(-visualBounds.getMinY());
-            glyph.descent = (int)Math.ceil(visualBounds.getMaxY());
+            glyph.ascent = ascent;
+            glyph.descent = descent;
 
-            glyph.c = s.charAt(0);
+            glyph.x = c.x;
+            glyph.y = c.y;
+            glyph.c = c.id;
             glyph.index = i;
-            glyph.advance = Math.round(metrics.getAdvance());
-            float leftBearing = metrics.getLSB();
-            glyph.leftBearing = (int)Math.floor(leftBearing);
-            glyph.width = visualBounds.width;
-            if (leftBearing != 0.0f) {
-                glyph.width += 1;
-            }
-
-            glyph.vector = glyphVector;
+            glyph.advance = (int) c.xadvance;
+            glyph.leftBearing = (int) c.xoffset;
+            glyph.width = c.width;
 
             glyphs.add(glyph);
         }
 
-        int i = 0;
-        float totalY = 0.0f;
-        // Margin is set to 1 since the font map is an atlas, this removes sampling artifacts (neighbouring texels outside the sample-area being used)
-        int margin = 1;
+        fontMapBuilder.setMaxAscent(maxAscent)
+                      .setMaxDescent(maxDescent);
+    }
+
+    // We use repeatedWrite to create a (cell) padding around the glyph bitmap data
+    private void repeatedWrite(ByteArrayOutputStream dataOut, int repeat, int value) {
+        for (int i = 0; i < repeat; i++) {
+            dataOut.write(value);
+        }
+    }
+
+    public BufferedImage generateGlyphData(boolean preview, final FontResourceResolver resourceResolver) throws FontFormatException {
+
+        ByteArrayOutputStream glyphDataBank = new ByteArrayOutputStream(1024*1024*4);
+
+        // Padding is the pixel amount needed to get a good antialiasing around the glyphs, while cell padding
+        // is the extra padding added to the bitmap data to avoid filtering glitches when rendered.
         int padding = 0;
+        int cell_padding = 1;
         float sdf_scale = 0;
         float sdf_offset = 0;
         if (fontDesc.getAntialias() != 0)
@@ -213,14 +291,14 @@ public class Fontc {
             // need sqrt(2) on either side of the range [0, outlineWidth + 1] to prevent clamped values being used
             // for interpolation across texels in the output. The extra is for smoothstep room.
             float sqrt2 = 1.4142f;
-            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + this.fontDesc.getOutlineWidth());
+            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + fontDesc.getOutlineWidth());
             sdf_offset = sdf_scale * sqrt2; // where glyph ends
         }
-        Color faceColor = new Color(this.fontDesc.getAlpha(), 0.0f, 0.0f);
-        Color outlineColor = new Color(0.0f, this.fontDesc.getOutlineAlpha(), 0.0f);
+        Color faceColor = new Color(fontDesc.getAlpha(), 0.0f, 0.0f);
+        Color outlineColor = new Color(0.0f, fontDesc.getOutlineAlpha(), 0.0f);
         ConvolveOp shadowConvolve = null;
         Composite blendComposite = new BlendComposite();
-        if (this.fontDesc.getShadowAlpha() > 0.0f) {
+        if (fontDesc.getShadowAlpha() > 0.0f) {
             float[] kernelData = {
                     0.0625f, 0.1250f, 0.0625f,
                     0.1250f, 0.2500f, 0.1250f,
@@ -232,68 +310,203 @@ public class Fontc {
             hints.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_DISABLE);
             shadowConvolve = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, hints);
         }
-        while (i < this.characters.length()) {
-            float x = margin;
-            float maxY = 0.0f;
-            int j = i;
-            while (j < this.characters.length() && x < this.imageWidth ) {
-                Glyph glyph = glyphs.get(j);
-                int width = glyph.width + margin + padding * 2;
-                if (x + width < this.imageWidth) {
-                    maxY = Math.max(maxY, glyph.ascent + glyph.descent);
-                    x += width;
-                } else {
-                    break;
-                }
-                ++j;
-            }
-
-            g.translate(0, margin);
-
-            for (int k = i; k < j; ++k) {
-                Glyph glyph = glyphs.get(k);
-
-                g.translate(margin, 0);
-
-                if (glyph.width > 0.0f) {
-                    BufferedImage glyphImage;
-                    if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP)
-                        glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
-                    else
-                        glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
-                    g.drawImage(glyphImage, 0, 0, null);
-                    glyph.x += g.getTransform().getTranslateX();
-                    glyph.y += g.getTransform().getTranslateY();
-
-                    g.translate(glyphImage.getWidth(), 0);
-                }
-            }
-            g.translate(-g.getTransform().getTranslateX(), maxY + padding * 2);
-            totalY += maxY + margin + 2 * padding;
-            i = j;
-        }
-        totalY += margin;
-
-        int newHeight = (int) (Math.log(totalY) / Math.log(2));
-        newHeight = (int) Math.pow(2, newHeight + 1);
-        this.image = this.image.getSubimage(0, 0, this.imageWidth, newHeight);
-
-        builder.setShadowX(fontDesc.getShadowX())
-               .setShadowY(fontDesc.getShadowY())
-               .setMaxAscent(maxAscent)
-               .setMaxDescent(maxDescent);
-
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             // sdf_scale has up until now been the value to scale with.
             // Now recompute their inverses to be used for unpacking it.
-            builder.setSdfScale(1.0f / sdf_scale);
-            builder.setSdfOffset(-sdf_offset / sdf_scale);
-            builder.setSdfOutline(this.fontDesc.getOutlineWidth());
+            fontMapBuilder.setSdfScale(1.0f / sdf_scale);
+            fontMapBuilder.setSdfOffset(-sdf_offset / sdf_scale);
+            fontMapBuilder.setSdfOutline(this.fontDesc.getOutlineWidth());
+        }
+
+        // Load external image resource for BMFont files
+        BufferedImage imageBMFont = null;
+        if (inputFormat == InputFontFormat.FORMAT_BMFONT) {
+            String origPath = Paths.get(FilenameUtils.normalize(bmfont.page.get(0))).getFileName().toString();
+            InputStream inputImageStream = null;
+            try {
+                inputImageStream = resourceResolver.getResource(origPath);
+                imageBMFont = ImageIO.read(inputImageStream);
+                inputImageStream.close();
+            } catch (FileNotFoundException e) {
+                throw new FontFormatException("Could not find BMFont image resource: " + origPath);
+            } catch (IOException e) {
+                throw new FontFormatException("Error while reading BMFont image resource: " + e.getMessage());
+            }
+        }
+
+        // Calculate channel count depending on both input and output format
+        if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+            inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+
+            // If font has outline, we need all three channels
+            if (fontDesc.getOutlineWidth() > 0.0f && this.fontDesc.getOutlineAlpha() > 0.0f) {
+                channelCount = 3;
+            } else {
+                channelCount = 1;
+            }
+
+        } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                   inputFormat == InputFontFormat.FORMAT_BMFONT) {
+            channelCount = 4;
+        } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
+                   inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+            channelCount = 1;
+        }
+
+        // We keep track of offset into the glyph data bank,
+        // this is saved for each glyph to know where their bitmap data is stored.
+        int dataOffset = 0;
+
+        // Find max width, height for each glyph to lock down cache cell sizes,
+        // this includes cell padding.
+        int cell_width = 0;
+        int cell_height = 0;
+        for (int i = 0; i < glyphs.size(); i++) {
+            Glyph glyph = glyphs.get(i);
+            if (glyph.width <= 0.0f) {
+                continue;
+            }
+            int width = glyph.width + padding * 2 + cell_padding * 2;
+            int height = glyph.ascent + glyph.descent + padding * 2 + cell_padding * 2;
+            cell_width = Math.max(cell_width, width);
+            cell_height = Math.max(cell_height, height);
+        }
+
+        // We do an early cache size calculation before we create the glyph bitmaps
+        // This is so that we can know when we have created enough glyphs to fill
+        // the cache when creating a preview image.
+        int cache_width = 1024;
+        int cache_height = 0;
+        if (fontDesc.getCacheWidth() > 0) {
+            cache_width = fontDesc.getCacheWidth();
+        }
+        int cache_columns = cache_width / cell_width;
+
+        if (fontDesc.getCacheHeight() > 0) {
+            cache_height = fontDesc.getCacheHeight();
+        } else {
+            // No "static" height set, guess height size for all to fit
+            int tot_rows = (int)Math.ceil((double)glyphs.size() / (double)cache_columns);
+            int tot_height = tot_rows * cell_height;
+            tot_height = (int) (Math.log(tot_height) / Math.log(2));
+            tot_height = (int) Math.pow(2, tot_height + 1);
+            cache_height = Math.min(tot_height,  2048);
+        }
+        int cache_rows = cache_height / cell_height;
+
+        int include_glyph_count = glyphs.size();
+        if (preview) {
+            include_glyph_count = Math.min(glyphs.size(), cache_rows * cache_columns);
+        }
+        for (int i = 0; i < include_glyph_count; i++) {
+
+            Glyph glyph = glyphs.get(i);
+            if (glyph.width <= 0 || glyph.ascent + glyph.descent <= 0) {
+                continue;
+            }
+            glyph.cache_entry_offset = dataOffset;
+
+            // Generate bitmap for each glyph depending on format
+            BufferedImage glyphImage = null;
+            int clearData = 0;
+            if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
+            } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
+                       inputFormat == InputFontFormat.FORMAT_BMFONT) {
+                glyphImage = drawBMFontGlyph(glyph, imageBMFont);
+            } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
+                       inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
+                clearData = 255;
+            } else {
+                throw new FontFormatException("Invalid font format combination!");
+            }
+
+            if (preview) {
+
+                glyph.image = glyphImage;
+
+            } else {
+
+                // Get raster data from rendered glyph and store in glyph data bank
+                int dataSizeOut = (glyphImage.getWidth() + cell_padding * 2) * (glyphImage.getHeight() + cell_padding * 2) * channelCount;
+                for (int y = 0; y < glyphImage.getHeight(); y++) {
+
+                    if (y == 0) {
+                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
+                    }
+                    for (int x = 0; x < glyphImage.getWidth(); x++) {
+
+                        if (x == 0) {
+                            repeatedWrite(glyphDataBank, channelCount, clearData);
+                        }
+
+                        int color = glyphImage.getRGB(x, y);
+                        int blue  = (color) & 0xff;
+                        int green = (color >> 8) & 0xff;
+                        int red   = (color >> 16) & 0xff;
+                        int alpha = (color >> 24) & 0xff;
+                        blue = (blue * alpha) / 255;
+                        green = (green * alpha) / 255;
+                        red = (red * alpha) / 255;
+                        
+
+                        glyphDataBank.write((byte)red);
+
+                        if (channelCount > 1) {
+                            glyphDataBank.write((byte)green);
+                            glyphDataBank.write((byte)blue);
+
+                            if (channelCount > 3) {
+                                
+                                glyphDataBank.write((byte)alpha);
+                            }
+                        }
+
+                        if (x == glyphImage.getWidth()-1) {
+                            repeatedWrite(glyphDataBank, channelCount, clearData);
+                        }
+
+                    }
+                    if (y == glyphImage.getHeight()-1) {
+                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
+                    }
+                }
+                dataOffset += dataSizeOut;
+                glyph.cache_entry_size = dataOffset - glyph.cache_entry_offset;
+            }
 
         }
 
-        i = 0;
-        for (Glyph glyph : glyphs) {
+        // Sanity check;
+        // Some fonts don't include ASCII range and trying to compile a font without
+        // setting "all_chars" could result in an empty glyph list.
+        if (glyphs.size() == 0) {
+            throw new FontFormatException("No character glyphs where included! Maybe turn on 'all_chars'?");
+        }
+
+        // Start filling the rest of FontMap
+        fontMapBuilder.setGlyphPadding(cell_padding);
+        fontMapBuilder.setCacheWidth(cache_width);
+        fontMapBuilder.setCacheHeight(cache_height);
+        fontMapBuilder.setGlyphData(ByteString.copyFrom(glyphDataBank.toByteArray()));
+        fontMapBuilder.setCacheCellWidth(cell_width);
+        fontMapBuilder.setCacheCellHeight(cell_height);
+        fontMapBuilder.setGlyphChannels(channelCount);
+
+
+        BufferedImage previewImage = null;
+        if (preview) {
+            try {
+                previewImage = generatePreviewImage();
+            } catch (IOException e) {
+                throw new FontFormatException("Could not generate font preview: " + e.getMessage());
+            }
+        }
+
+        for (int i = 0; i < include_glyph_count; i++) {
+            Glyph glyph = glyphs.get(i);
             FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
                 .setCharacter(glyph.c)
                 .setWidth(glyph.width + (glyph.width > 0 ? padding * 2 : 0))
@@ -301,79 +514,24 @@ public class Fontc {
                 .setLeftBearing(glyph.leftBearing - padding)
                 .setAscent(glyph.ascent + padding)
                 .setDescent(glyph.descent + padding)
-                .setX(glyph.x)
-                .setY(glyph.y);
-            builder.addGlyphs(glyphBuilder);
+                .setGlyphDataOffset(glyph.cache_entry_offset)
+                .setGlyphDataSize(glyph.cache_entry_size);
+
+            // "Static" cache positions is only used for previews currently
+            if (preview) {
+                glyphBuilder.setX(glyph.x);
+                glyphBuilder.setY(glyph.y);
+            }
+
+            fontMapBuilder.addGlyphs(glyphBuilder);
         }
+
+        return previewImage;
 
     }
 
-    public void builderFNT(InputStream fontStream, FontDesc fontDesc, FontMap.Builder builder, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        this.inputFormat = InputFontFormat.FORMAT_BMFONT;
-
-        BMFont bmfont = new BMFont();
-
-        // parse BMFont file
-        try {
-            bmfont.parse(fontStream);
-        } catch (BMFontFormatException e) {
-            throw new FontFormatException(e.getMessage());
-        }
-
-        // fill glyphs
-        int maxAscent = 0;
-        int maxDescent = 0;
-        for (int i = 0; i < bmfont.charArray.size(); ++i) {
-            Char c = bmfont.charArray.get(i);
-
-            int ascent = bmfont.base - (int)c.yoffset;
-            int descent = c.height - ascent;
-
-            maxAscent = Math.max(ascent, maxAscent);
-            maxDescent = Math.max(descent, maxDescent);
-
-            FontMap.Glyph.Builder glyphBuilder = FontMap.Glyph.newBuilder()
-                .setCharacter(c.id)
-                .setWidth(c.width)
-                .setAdvance(c.xadvance)
-                .setLeftBearing(c.xoffset)
-                .setAscent(ascent)
-                .setDescent(descent)
-                .setX(c.x - (int)c.xoffset)
-                .setY(c.y + ascent);
-            builder.addGlyphs(glyphBuilder);
-        }
-
-        // fill FontMap
-        builder.setMaxAscent(maxAscent)
-               .setMaxDescent(maxDescent);
-
-        // copy to new texture
-        String origPath = Paths.get(FilenameUtils.normalize(bmfont.page.get(0))).getFileName().toString();
-        InputStream inputImageStream = null;
-        try {
-            inputImageStream = resourceResolver.getResource(origPath);
-        } catch (FileNotFoundException e) {
-            throw new IOException("Could not find BMFont image resource: " + origPath);
-        }
-        BufferedImage origImage = ImageIO.read(inputImageStream);
-        inputImageStream.close();
-        this.image = origImage;
-    }
-
-    public BufferedImage compile(InputStream fontStream, FontDesc fontDesc, FontMap.Builder fontMapBuilder, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        this.characters = new StringBuffer();
-        this.fontDesc = fontDesc;
-
-        if (fontDesc.getFont().toLowerCase().endsWith("fnt")) {
-            builderFNT(fontStream, fontDesc, fontMapBuilder, resourceResolver);
-        } else {
-            builderTTF(fontStream, fontDesc, fontMapBuilder);
-        }
-        fontMapBuilder.setMaterial(fontDesc.getMaterial() + "c");
-        fontMapBuilder.setImageFormat(fontDesc.getOutputFormat());
-
-        return this.image;
+    private BufferedImage drawBMFontGlyph(Glyph glyph, BufferedImage imageBMFontInput) {
+        return imageBMFontInput.getSubimage(glyph.x, glyph.y, glyph.width, glyph.ascent + glyph.descent);
     }
 
     private BufferedImage makeDistanceField(Glyph glyph, int padding, float sdf_scale, float sdf_offset, Font font) {
@@ -428,7 +586,7 @@ public class Fontc {
         double kx = 1 / (double)width;
         double ky = 1 / (double)height;
 
-        BufferedImage image = new BufferedImage(width, height, Fontc.imageType);
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         for (int v=0;v<height;v++) {
             int ofs = v * width;
             for (int u=0;u<width;u++) {
@@ -461,7 +619,7 @@ public class Fontc {
         glyph.x = dx;
         glyph.y = dy;
 
-        BufferedImage image = new BufferedImage(width, height, Fontc.imageType);
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         Graphics2D g = image.createGraphics();
         setHighQuality(g);
         g.setBackground(Color.BLACK);
@@ -500,7 +658,7 @@ public class Fontc {
         } else {
             g.setPaint(faceColor);
             g.setFont(font);
-            g.drawString(Character.toString(glyph.c), 0, 0);
+            g.drawString(new String(Character.toChars(glyph.c)), 0, 0);
         }
 
         return image;
@@ -538,10 +696,63 @@ public class Fontc {
        }
     }
 
-    public static BufferedImage compileToImage(InputStream fontStream, FontDesc fontDesc, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
-        Fontc fontc = new Fontc();
-        FontMap.Builder builder = FontMap.newBuilder();
-        return fontc.compile(fontStream, fontDesc, builder, resourceResolver);
+    public BufferedImage compile(InputStream fontStream, FontDesc fontDesc, boolean preview, final FontResourceResolver resourceResolver) throws FontFormatException, IOException {
+        this.fontDesc = fontDesc;
+        this.fontMapBuilder = FontMap.newBuilder();
+
+        if (fontDesc.getFont().toLowerCase().endsWith("fnt")) {
+            FNTBuilder(fontStream);
+        } else {
+            TTFBuilder(fontStream);
+        }
+        fontMapBuilder.setMaterial(fontDesc.getMaterial() + "c");
+        fontMapBuilder.setImageFormat(fontDesc.getOutputFormat());
+
+        return generateGlyphData(preview, resourceResolver);
+    }
+
+    public FontMap getFontMap() {
+        return fontMapBuilder.build();
+    }
+
+    public BufferedImage generatePreviewImage() throws IOException {
+
+        Graphics2D g;
+        BufferedImage previewImage = new BufferedImage(fontMapBuilder.getCacheWidth(), fontMapBuilder.getCacheHeight(), BufferedImage.TYPE_3BYTE_BGR);
+        g = previewImage.createGraphics();
+        g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
+        g.clearRect(0, 0, previewImage.getWidth(), previewImage.getHeight());
+        setHighQuality(g);
+
+        int cache_columns = fontMapBuilder.getCacheWidth() / fontMapBuilder.getCacheCellWidth();
+        int cache_rows = fontMapBuilder.getCacheHeight() / fontMapBuilder.getCacheCellHeight();
+
+        BufferedImage glyphImage;
+        for (int i = 0; i < glyphs.size(); i++) {
+
+            Glyph glyph = glyphs.get(i);
+
+            int col = i % cache_columns;
+            int row = i / cache_columns;
+
+            if (row >= cache_rows) {
+                break;
+            }
+
+            int x = col * fontMapBuilder.getCacheCellWidth();
+            int y = row * fontMapBuilder.getCacheCellHeight();
+
+            glyph.x = x;
+            glyph.y = y;
+
+            g.translate(x, y);
+            glyphImage = glyph.image;
+            g.drawImage(glyphImage, 0, 0, null);
+            g.translate(-x, -y);
+
+        }
+
+        return previewImage;
     }
 
     public static void main(String[] args) throws FontFormatException {
@@ -586,8 +797,7 @@ public class Fontc {
             Fontc fontc = new Fontc();
             String fontInputFile = basedir + File.separator + fontDesc.getFont();
             BufferedInputStream fontInputStream = new BufferedInputStream(new FileInputStream(fontInputFile));
-            FontMap.Builder fontmapBuilder = FontMap.newBuilder();
-            BufferedImage image = fontc.compile(fontInputStream, fontDesc, fontmapBuilder, new FontResourceResolver() {
+            fontc.compile(fontInputStream, fontDesc, false, new FontResourceResolver() {
 
                 @Override
                 public InputStream getResource(String resourceName) throws FileNotFoundException {
@@ -601,12 +811,9 @@ public class Fontc {
 
             // Write fontmap file
             FileOutputStream fontMapOutputStream = new FileOutputStream(outfile);
-            fontmapBuilder.build().writeTo(fontMapOutputStream);
+            fontc.getFontMap().writeTo(fontMapOutputStream);
             fontMapOutputStream.close();
 
-        } catch (TextureGeneratorException e) {
-            System.err.println(e.getMessage());
-            System.exit(1);
         } catch (IOException e) {
             System.err.println(e.getMessage());
             System.exit(1);

--- a/editor/test/editor/scene_cache_test.clj
+++ b/editor/test/editor/scene_cache_test.clj
@@ -12,7 +12,7 @@
   (swap! context assoc key (inc data))
   key)
 
-(defn- destroy-fn [context keys]
+(defn- destroy-fn [context keys _]
   (doseq [key keys]
     (swap! context dissoc key)))
 

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -271,12 +271,9 @@
                      content-by-source (into {} (map #(do [(workspace/proj-path (:resource (:resource %))) (:content %)]) build-results))
                      content-by-target (into {} (map #(do [(workspace/proj-path (:resource %)) (:content %)]) build-results))
                      content (get content-by-source path)
-                     desc (protobuf/bytes->map Font$FontMap content)
-                     texture-content (get content-by-target (get-in desc [:textures 0]))
-                     texture (protobuf/bytes->map Graphics$TextureImage texture-content)
-                     first-tex (get-in texture [:alternatives 0])]
-                 (is (= 1024 (:width first-tex)))
-                 (is (= 128 (:height first-tex))))))))
+                     desc (protobuf/bytes->map Font$FontMap content)]
+                 (is (= 1024 (:cache-width desc)))
+                 (is (= 256 (:cache-height desc))))))))
 
 (deftest build-spine-scene
   (testing "Building spine scene"

--- a/editor/test/integration/font_test.clj
+++ b/editor/test/integration/font_test.clj
@@ -1,5 +1,6 @@
 (ns integration.font-test
   (:require [clojure.test :refer :all]
+            [clojure.string :as s]
             [dynamo.graph :as g]
             [support.test-support :refer [with-clean-system]]
             [integration.test-util :as test-util]
@@ -39,3 +40,18 @@
           (let [[w'' h''] (font/measure font-map "test test test" true w)]
           (is (= w'' w'))
           (is (> h'' h'))))))))
+
+(deftest preview-text
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project   (test-util/setup-project! workspace)
+          node-id   (test-util/resource-node project "/fonts/score.font")
+          font-map (g/node-value node-id :font-map)
+          pre-text (g/node-value node-id :preview-text)
+          no-break (s/replace pre-text " " "")
+          [w h] (font/measure font-map pre-text true (:cache-width font-map))
+          [ew eh] (font/measure font-map no-break true (:cache-width font-map))]
+      (is (.contains pre-text " "))
+      (is (not (.contains no-break " ")))
+      (is (< w ew))
+      (is (< eh h)))))

--- a/editor/test/integration/material_test.clj
+++ b/editor/test/integration/material_test.clj
@@ -20,6 +20,6 @@
     (let [workspace (test-util/setup-workspace! world)
           project   (test-util/setup-project! workspace)
           node-id   (test-util/resource-node project "/materials/test.material")
-          sampler-data (g/node-value node-id :sampler-data)]
+          samplers (g/node-value node-id :samplers)]
       (is (some? (g/node-value node-id :shader)))
-      (is (= 1 (count (:samplers sampler-data)))))))
+      (is (= 1 (count samplers))))))


### PR DESCRIPTION
- Two scene caches dealing with both the glyph-caches and the individual cells
- Ability to create empty textures, the glyph-cache is a texture which is filled in dynamically
- Fixed bugs in measuring fonts and splitting lines
- The font renders itself using the cache and existing ascii + extra chars
- Both font and gui use the same vertex buffers to render
- Separated material samplers from textures
  - Samplers are now added to TextureLifecycle objects as params
- Updated font AABB calc to consider the actual text block
