### PR TITLE
DEF-1500 Better error codes to FB callbacks.

### DIFF
--- a/engine/facebook/src/facebook.h
+++ b/engine/facebook/src/facebook.h
@@ -33,6 +33,13 @@ namespace dmFacebook {
         AUDIENCE_EVERYONE = 4,
     };
 
+    enum Error {
+        ERROR_NONE                 = 0,
+        ERROR_SDK                  = 1,
+        ERROR_DIALOG_CANCELED      = 2,
+        ERROR_DIALOG_NOT_SUPPORTED = 3,
+    };
+
 
 /*
     Notes on facebook.show_dialog in regards to FB SDK 4.

--- a/engine/facebook/src/facebook.h
+++ b/engine/facebook/src/facebook.h
@@ -36,8 +36,7 @@ namespace dmFacebook {
     enum Error {
         ERROR_NONE                 = 0,
         ERROR_SDK                  = 1,
-        ERROR_DIALOG_CANCELED      = 2,
-        ERROR_DIALOG_NOT_SUPPORTED = 3,
+        ERROR_DIALOG_NOT_SUPPORTED = 2,
     };
 
 

--- a/engine/facebook/src/facebook.mm
+++ b/engine/facebook/src/facebook.mm
@@ -99,7 +99,7 @@ static void RunDialogResultCallback(lua_State*L, NSDictionary* result, NSError* 
     - (void)sharerDidCancel:(id<FBSDKSharing>)sharer {
         NSDictionary *errorDetail = @{ NSLocalizedDescriptionKey : @"Share dialog was cancelled" };
         NSError *error = [NSError errorWithDomain:@"facebook" code:0 userInfo:errorDetail];
-        RunDialogResultCallback(g_Facebook.m_MainThread, nil, error, dmFacebook::ERROR_DIALOG_CANCELED);
+        RunDialogResultCallback(g_Facebook.m_MainThread, nil, error, dmFacebook::ERROR_SDK);
     }
 
     // App invite related methods
@@ -153,7 +153,7 @@ static void RunDialogResultCallback(lua_State*L, NSDictionary* result, NSError* 
     - (void)gameRequestDialogDidCancel:(FBSDKGameRequestDialog *)gameRequestDialog {
         NSDictionary *errorDetail = @{ NSLocalizedDescriptionKey : @"Game request dialog was cancelled" };
         NSError *error = [NSError errorWithDomain:@"facebook" code:0 userInfo:errorDetail];
-        RunDialogResultCallback(g_Facebook.m_MainThread, nil, error, dmFacebook::ERROR_DIALOG_CANCELED);
+        RunDialogResultCallback(g_Facebook.m_MainThread, nil, error, dmFacebook::ERROR_SDK);
     }
 
 
@@ -521,7 +521,7 @@ int Facebook_Login(lua_State* L)
             } else if (result.isCancelled) {
                 NSMutableDictionary *errorDetail = [NSMutableDictionary dictionary];
                 [errorDetail setValue:@"Login was cancelled" forKey:NSLocalizedDescriptionKey];
-                RunStateCallback(main_thread, dmFacebook::STATE_CLOSED_LOGIN_FAILED, [NSError errorWithDomain:@"facebook" code:0 userInfo:errorDetail], dmFacebook::ERROR_DIALOG_CANCELED);
+                RunStateCallback(main_thread, dmFacebook::STATE_CLOSED_LOGIN_FAILED, [NSError errorWithDomain:@"facebook" code:0 userInfo:errorDetail], dmFacebook::ERROR_SDK);
             } else {
 
                 if ([result.grantedPermissions containsObject:@"public_profile"] &&
@@ -1054,7 +1054,6 @@ dmExtension::Result InitializeFacebook(dmExtension::Params* params)
     SETCONSTANT(AUDIENCE_EVERYONE, dmFacebook::AUDIENCE_EVERYONE);
 
     SETCONSTANT(ERROR_SDK,                  dmFacebook::ERROR_SDK);
-    SETCONSTANT(ERROR_DIALOG_CANCELED,      dmFacebook::ERROR_DIALOG_CANCELED);
     SETCONSTANT(ERROR_DIALOG_NOT_SUPPORTED, dmFacebook::ERROR_DIALOG_NOT_SUPPORTED);
 
 #undef SETCONSTANT

--- a/engine/facebook/src/facebook_android.cpp
+++ b/engine/facebook/src/facebook_android.cpp
@@ -592,7 +592,7 @@ int Facebook_ShowDialog(lua_State* L)
     char params_json[1024];
     params_json[0] = '{';
     params_json[1] = '\0';
-    char tmp[256];
+    char tmp[1024];
 
     lua_pushnil(L);
     int i = 0;
@@ -609,7 +609,7 @@ int Facebook_ShowDialog(lua_State* L)
         }
 
         // escape string characters such as "
-        char k_escaped[128];
+        char k_escaped[1024];
         char v_escaped[1024];
         escape_json_str(k, k_escaped, k_escaped+sizeof(k_escaped));
         escape_json_str(vp, v_escaped, v_escaped+sizeof(v_escaped));
@@ -722,7 +722,6 @@ dmExtension::Result InitializeFacebook(dmExtension::Params* params)
     SETCONSTANT(AUDIENCE_EVERYONE, dmFacebook::AUDIENCE_EVERYONE);
 
     SETCONSTANT(ERROR_SDK,                  dmFacebook::ERROR_SDK);
-    SETCONSTANT(ERROR_DIALOG_CANCELED,      dmFacebook::ERROR_DIALOG_CANCELED);
     SETCONSTANT(ERROR_DIALOG_NOT_SUPPORTED, dmFacebook::ERROR_DIALOG_NOT_SUPPORTED);
 
 #undef SETCONSTANT

--- a/engine/facebook/src/facebook_emscripten.cpp
+++ b/engine/facebook/src/facebook_emscripten.cpp
@@ -587,6 +587,9 @@ dmExtension::Result InitializeFacebook(dmExtension::Params* params)
     SETCONSTANT(AUDIENCE_FRIENDS,  dmFacebook::AUDIENCE_FRIENDS);
     SETCONSTANT(AUDIENCE_EVERYONE, dmFacebook::AUDIENCE_EVERYONE);
 
+    SETCONSTANT(ERROR_SDK,                  dmFacebook::ERROR_SDK);
+    SETCONSTANT(ERROR_DIALOG_NOT_SUPPORTED, dmFacebook::ERROR_DIALOG_NOT_SUPPORTED);
+
 #undef SETCONSTANT
 
     lua_pop(L, 1);

--- a/engine/facebook/src/facebook_emscripten.cpp
+++ b/engine/facebook/src/facebook_emscripten.cpp
@@ -217,7 +217,7 @@ static void RunDialogResultCallback(lua_State* L, const char *result_json, const
         else
         {
             dmLogError("Got empty dialog result JSON (or FB error).");
-            lua_newtable((lua_State *)L);
+            lua_pushnil(L);
         }
 
         PushError(L, error, error_code);
@@ -414,7 +414,7 @@ int Facebook_Permissions(lua_State* L)
     {
         dmLogError("Got empty Facebook_Permissions response (or FB error).");
         // This follows the iOS implementation...
-        lua_newtable((lua_State *)L);
+        lua_pushnil(L);
     }
 
     assert(top + 1 == lua_gettop(L));

--- a/engine/facebook/src/java/com/dynamo/android/facebook/Facebook.java
+++ b/engine/facebook/src/java/com/dynamo/android/facebook/Facebook.java
@@ -38,6 +38,7 @@ public class Facebook implements Handler.Callback {
     public static final String MSG_KEY_ACTION           = "defold.fb.msg.action";
     public static final String MSG_KEY_SUCCESS          = "defold.fb.msg.success";
     public static final String MSG_KEY_ERROR            = "defold.fb.msg.error";
+    public static final String MSG_KEY_ERROR_CODE       = "defold.fb.msg.error_code";
     public static final String MSG_KEY_STATE            = "defold.fb.msg.state";
     public static final String MSG_KEY_USER             = "defold.fb.msg.user";
     public static final String MSG_KEY_ACCESS_TOKEN     = "defold.fb.msg.access_token";
@@ -59,15 +60,15 @@ public class Facebook implements Handler.Callback {
     private Activity activity;
 
     public interface Callback {
-        void onDone(String error);
+        void onDone(String error, int error_code);
     }
 
     public interface StateCallback {
-        void onDone(int state, String error);
+        void onDone(int state, String error, int error_code);
     }
 
     public interface DialogCallback {
-        void onDone(Bundle result, String error);
+        void onDone(Bundle result, String error, int error_code);
     }
 
     public Facebook(Activity activity, String appId) {
@@ -160,9 +161,13 @@ public class Facebook implements Handler.Callback {
         boolean handled = false;
         Bundle data = msg.getData();
         String error = null;
+        int error_code = 0;
         boolean success = data.containsKey(MSG_KEY_SUCCESS);
         if (data.containsKey(MSG_KEY_ERROR)) {
             error = data.getString(MSG_KEY_ERROR);
+        }
+        if (data.containsKey(MSG_KEY_ERROR_CODE)) {
+            error_code = data.getInt(MSG_KEY_ERROR_CODE);
         }
         String action = data.getString(MSG_KEY_ACTION);
         if (action.equals(ACTION_LOGIN)) {
@@ -184,13 +189,13 @@ public class Facebook implements Handler.Callback {
                 }
             }
 
-            this.stateCallback.onDone(data.getInt(MSG_KEY_STATE), error);
+            this.stateCallback.onDone(data.getInt(MSG_KEY_STATE), error, error_code);
 
         } else if (action.equals(ACTION_REQ_READ_PERMS) || action.equals(ACTION_REQ_PUB_PERMS)) {
-            this.callback.onDone(error);
+            this.callback.onDone(error, error_code);
 
         } else if (action.equals(ACTION_SHOW_DIALOG)) {
-            this.dialogCallback.onDone(data.getBundle(MSG_KEY_DIALOG_RESULT), error);
+            this.dialogCallback.onDone(data.getBundle(MSG_KEY_DIALOG_RESULT), error, error_code);
 
         }
         return handled;

--- a/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
+++ b/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
@@ -62,6 +62,18 @@ public class FacebookActivity implements PseudoActivity {
 
     }
 
+    public enum Error {
+        ERROR_NONE                 (0),
+        ERROR_SDK                  (1),
+        ERROR_DIALOG_CANCELED      (2),
+        ERROR_DIALOG_NOT_SUPPORTED (3);
+
+        private final int value;
+        private Error(int value) { this.value = value; };
+        public int getValue() { return this.value; };
+
+    }
+
     /*
      * Functions to convert Lua enums to corresponding Facebook enums.
      * Switch values are from enums defined in facebook_android.cpp.
@@ -112,6 +124,7 @@ public class FacebookActivity implements PseudoActivity {
             Bundle data = new Bundle();
             data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
             data.putString(Facebook.MSG_KEY_ERROR, "Dialog canceled");
+            data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_CANCELED.getValue());
             respond(Facebook.ACTION_SHOW_DIALOG, data);
         }
 
@@ -120,6 +133,7 @@ public class FacebookActivity implements PseudoActivity {
             Bundle data = new Bundle();
             data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
             data.putString(Facebook.MSG_KEY_ERROR, error.toString());
+            data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
             respond(Facebook.ACTION_SHOW_DIALOG, data);
         }
 
@@ -160,6 +174,7 @@ public class FacebookActivity implements PseudoActivity {
                        data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                        data.putInt(Facebook.MSG_KEY_STATE, State.STATE_CLOSED_LOGIN_FAILED.getValue());
                        data.putString(Facebook.MSG_KEY_ERROR, response.getError().getErrorMessage());
+                       data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
                    }
                    respond(Facebook.ACTION_LOGIN, data);
                 }
@@ -188,6 +203,7 @@ public class FacebookActivity implements PseudoActivity {
                     data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                     data.putInt(Facebook.MSG_KEY_STATE, State.STATE_CLOSED_LOGIN_FAILED.getValue());
                     data.putString(Facebook.MSG_KEY_ERROR, "Login canceled");
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_CANCELED.getValue());
                     respond(Facebook.ACTION_LOGIN, data);
                 }
 
@@ -197,6 +213,7 @@ public class FacebookActivity implements PseudoActivity {
                     data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                     data.putInt(Facebook.MSG_KEY_STATE, State.STATE_CLOSED_LOGIN_FAILED.getValue());
                     data.putString(Facebook.MSG_KEY_ERROR, error.toString());
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
                     respond(Facebook.ACTION_LOGIN, data);
                 }
 
@@ -226,6 +243,7 @@ public class FacebookActivity implements PseudoActivity {
                     Bundle data = new Bundle();
                     data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                     data.putString(Facebook.MSG_KEY_ERROR, "Login canceled");
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_CANCELED.getValue());
                     respond(action, data);
                 }
 
@@ -234,6 +252,7 @@ public class FacebookActivity implements PseudoActivity {
                     Bundle data = new Bundle();
                     data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                     data.putString(Facebook.MSG_KEY_ERROR, error.toString());
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
                     respond(action, data);
                 }
 
@@ -250,6 +269,7 @@ public class FacebookActivity implements PseudoActivity {
         } else {
             Bundle data = new Bundle();
             data.putString(Facebook.MSG_KEY_ERROR, "User is not logged in");
+            data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
             respond(action, data);
         }
     }
@@ -285,6 +305,7 @@ public class FacebookActivity implements PseudoActivity {
             } else {
                 Bundle data = new Bundle();
                 data.putString(Facebook.MSG_KEY_ERROR, "Dialog not available");
+                data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_NOT_SUPPORTED.getValue());
                 respond(Facebook.ACTION_SHOW_DIALOG, data);
             }
 
@@ -295,6 +316,7 @@ public class FacebookActivity implements PseudoActivity {
 
                 Bundle data = new Bundle();
                 data.putString(Facebook.MSG_KEY_ERROR, "User is not logged in");
+                data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
                 respond(Facebook.ACTION_SHOW_DIALOG, data);
 
             } else {
@@ -402,6 +424,7 @@ public class FacebookActivity implements PseudoActivity {
                 } else {
                     Bundle data = new Bundle();
                     data.putString(Facebook.MSG_KEY_ERROR, "Unknown dialog type");
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_NOT_SUPPORTED.getValue());
                     respond(Facebook.ACTION_SHOW_DIALOG, data);
                 }
             }
@@ -425,6 +448,7 @@ public class FacebookActivity implements PseudoActivity {
         Bundle abortedData = new Bundle();
         abortedData.putString(Facebook.MSG_KEY_ACTION, action);
         abortedData.putString(Facebook.MSG_KEY_ERROR, "Aborted");
+        abortedData.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
         onAbortedMessage = new Message();
         onAbortedMessage.setData(abortedData);
 
@@ -440,6 +464,7 @@ public class FacebookActivity implements PseudoActivity {
         } catch (Exception e) {
             Bundle data = new Bundle();
             data.putString(Facebook.MSG_KEY_ERROR, e.getMessage());
+            data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
             respond(action, data);
         }
     }

--- a/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
+++ b/engine/facebook/src/java/com/dynamo/android/facebook/FacebookActivity.java
@@ -65,8 +65,7 @@ public class FacebookActivity implements PseudoActivity {
     public enum Error {
         ERROR_NONE                 (0),
         ERROR_SDK                  (1),
-        ERROR_DIALOG_CANCELED      (2),
-        ERROR_DIALOG_NOT_SUPPORTED (3);
+        ERROR_DIALOG_NOT_SUPPORTED (2);
 
         private final int value;
         private Error(int value) { this.value = value; };
@@ -124,7 +123,7 @@ public class FacebookActivity implements PseudoActivity {
             Bundle data = new Bundle();
             data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
             data.putString(Facebook.MSG_KEY_ERROR, "Dialog canceled");
-            data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_CANCELED.getValue());
+            data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
             respond(Facebook.ACTION_SHOW_DIALOG, data);
         }
 
@@ -203,7 +202,7 @@ public class FacebookActivity implements PseudoActivity {
                     data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                     data.putInt(Facebook.MSG_KEY_STATE, State.STATE_CLOSED_LOGIN_FAILED.getValue());
                     data.putString(Facebook.MSG_KEY_ERROR, "Login canceled");
-                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_CANCELED.getValue());
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
                     respond(Facebook.ACTION_LOGIN, data);
                 }
 
@@ -243,7 +242,7 @@ public class FacebookActivity implements PseudoActivity {
                     Bundle data = new Bundle();
                     data.putBoolean(Facebook.MSG_KEY_SUCCESS, false);
                     data.putString(Facebook.MSG_KEY_ERROR, "Login canceled");
-                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_DIALOG_CANCELED.getValue());
+                    data.putInt(Facebook.MSG_KEY_ERROR_CODE, Error.ERROR_SDK.getValue());
                     respond(action, data);
                 }
 

--- a/engine/facebook/src/js/library_facebook.js
+++ b/engine/facebook/src/js/library_facebook.js
@@ -3,6 +3,12 @@ var LibraryFacebook = {
 
         },
 
+        dmFacebookError: {
+            ERROR_NONE                 : 0,
+            ERROR_SDK                  : 1,
+            ERROR_DIALOG_CANCELED      : 2,
+            ERROR_DIALOG_NOT_SUPPORTED : 3},
+
         dmFacebookInitialize: function(app_id) {
             // We assume that the Facebook javascript SDK is loaded by now.
             // This should be done via a script tag (synchronously) in the html page:
@@ -94,10 +100,10 @@ var LibraryFacebook = {
                     if(e == 0) {
                         var res_data = JSON.stringify(response);
                         var res_buf = allocate(intArrayFromString(res_data), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viii', callback, [lua_state, res_buf, e]);
+                        Runtime.dynCall('viiii', callback, [lua_state, res_buf, e, dmFacebookError.ERROR_NONE]);
                     } else {
                         var error = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viii', callback, [lua_state, 0, error]);
+                        Runtime.dynCall('viiii', callback, [lua_state, 0, error, dmFacebookError.ERROR_SDK]);
                     }
                 });
             } catch (e) {
@@ -119,26 +125,26 @@ var LibraryFacebook = {
                                     if (e == 0) {
                                         var me_buf = allocate(intArrayFromString(me_data), 'i8', ALLOC_STACK);
                                         var permissions_buf = allocate(intArrayFromString(permissions_data), 'i8', ALLOC_STACK);
-                                        Runtime.dynCall('viiiii', callback, [lua_state, state_open, 0, me_buf, permissions_buf]);
+                                        Runtime.dynCall('viiiiii', callback, [lua_state, state_open, 0, dmFacebookError.ERROR_NONE, me_buf, permissions_buf]);
                                     } else {
                                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                        Runtime.dynCall('viiiii', callback, [lua_state, state_failed, err_buf, 0, 0]);
+                                        Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, dmFacebookError.ERROR_SDK, 0, 0]);
                                     }
                                 });
                             } else {
                                 var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viiiii', callback, [lua_state, state_failed, err_buf, 0, 0]);
+                                Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, dmFacebookError.ERROR_SDK, 0, 0]);
                             }
                         });
 
                     } else if (e != 0) {
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiiii', callback, [lua_state, state_closed, err_buf, 0, 0]);
+                        Runtime.dynCall('viiiiii', callback, [lua_state, state_closed, err_buf, dmFacebookError.ERROR_SDK, 0, 0]);
                     } else {
                         // No authResponse. Below text is from facebook's own example of this case.
                         e = 'User cancelled login or did not fully authorize.';
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiiii', callback, [lua_state, state_failed, err_buf, 0, 0]);
+                        Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, dmFacebookError.ERROR_DIALOG_CANCELED, 0, 0]);
                     }
                 }, {scope: 'public_profile,user_friends'});
             } catch (e) {
@@ -168,21 +174,21 @@ var LibraryFacebook = {
                         window._dmFacebookUpdatePermissions(function(e, permissions_data) {
                             if (e == 0) {
                                 var permissions_buf = allocate(intArrayFromString(permissions_data), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viii', callback, [lua_state, 0, permissions_buf]);
+                                Runtime.dynCall('viiii', callback, [lua_state, 0, dmFacebookError.ERROR_NONE, permissions_buf]);
                             } else {
                                 var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viii', callback, [lua_state, err_buf, 0]);
+                                Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
                             }
                         });
 
                     } else if (e != 0) {
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viii', callback, [lua_state, err_buf, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
                     } else {
                         // No authResponse. Below text is from facebook's own example of this case.
                         e = 'User cancelled login or did not fully authorize.';
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viii', callback, [lua_state, err_buf, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_DIALOG_CANCELED, 0]);
                     }
                 }, {scope: Pointer_stringify(permissions)});
             } catch (e){
@@ -202,21 +208,21 @@ var LibraryFacebook = {
                         window._dmFacebookUpdatePermissions(function(e, permissions_data) {
                             if (e == 0) {
                                 var permissions_buf = allocate(intArrayFromString(permissions_data), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viii', callback, [lua_state, 0, permissions_buf]);
+                                Runtime.dynCall('viiii', callback, [lua_state, 0, dmFacebookError.ERROR_NONE, permissions_buf]);
                             } else {
                                 var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viii', callback, [lua_state, err_buf, 0]);
+                                Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
                             }
                         });
 
                     } else if (e != 0) {
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viii', callback, [lua_state, err_buf, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
                     } else {
                         // No authResponse. Below text is from facebook's own example of this case.
                         e = 'User cancelled login or did not fully authorize.';
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viii', callback, [lua_state, err_buf, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_DIALOG_CANCELED, 0]);
                     }
                 }, {scope: Pointer_stringify(permissions)});
             } catch (e){

--- a/engine/facebook/src/js/library_facebook.js
+++ b/engine/facebook/src/js/library_facebook.js
@@ -1,13 +1,10 @@
 var LibraryFacebook = {
         $FBinner: {
-
-        },
-
-        dmFacebookError: {
+            dmFacebookError: {
             ERROR_NONE                 : 0,
             ERROR_SDK                  : 1,
-            ERROR_DIALOG_CANCELED      : 2,
-            ERROR_DIALOG_NOT_SUPPORTED : 3},
+            ERROR_DIALOG_NOT_SUPPORTED : 2}
+        },
 
         dmFacebookInitialize: function(app_id) {
             // We assume that the Facebook javascript SDK is loaded by now.
@@ -100,10 +97,10 @@ var LibraryFacebook = {
                     if(e == 0) {
                         var res_data = JSON.stringify(response);
                         var res_buf = allocate(intArrayFromString(res_data), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, res_buf, e, dmFacebookError.ERROR_NONE]);
+                        Runtime.dynCall('viiii', callback, [lua_state, res_buf, e, FBinner.dmFacebookError.ERROR_NONE]);
                     } else {
                         var error = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, 0, error, dmFacebookError.ERROR_SDK]);
+                        Runtime.dynCall('viiii', callback, [lua_state, 0, error, FBinner.dmFacebookError.ERROR_SDK]);
                     }
                 });
             } catch (e) {
@@ -125,26 +122,26 @@ var LibraryFacebook = {
                                     if (e == 0) {
                                         var me_buf = allocate(intArrayFromString(me_data), 'i8', ALLOC_STACK);
                                         var permissions_buf = allocate(intArrayFromString(permissions_data), 'i8', ALLOC_STACK);
-                                        Runtime.dynCall('viiiiii', callback, [lua_state, state_open, 0, dmFacebookError.ERROR_NONE, me_buf, permissions_buf]);
+                                        Runtime.dynCall('viiiiii', callback, [lua_state, state_open, 0, FBinner.dmFacebookError.ERROR_NONE, me_buf, permissions_buf]);
                                     } else {
                                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                        Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, dmFacebookError.ERROR_SDK, 0, 0]);
+                                        Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0, 0]);
                                     }
                                 });
                             } else {
                                 var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, dmFacebookError.ERROR_SDK, 0, 0]);
+                                Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0, 0]);
                             }
                         });
 
                     } else if (e != 0) {
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiiiii', callback, [lua_state, state_closed, err_buf, dmFacebookError.ERROR_SDK, 0, 0]);
+                        Runtime.dynCall('viiiiii', callback, [lua_state, state_closed, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0, 0]);
                     } else {
                         // No authResponse. Below text is from facebook's own example of this case.
                         e = 'User cancelled login or did not fully authorize.';
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, dmFacebookError.ERROR_DIALOG_CANCELED, 0, 0]);
+                        Runtime.dynCall('viiiiii', callback, [lua_state, state_failed, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0, 0]);
                     }
                 }, {scope: 'public_profile,user_friends'});
             } catch (e) {
@@ -174,21 +171,21 @@ var LibraryFacebook = {
                         window._dmFacebookUpdatePermissions(function(e, permissions_data) {
                             if (e == 0) {
                                 var permissions_buf = allocate(intArrayFromString(permissions_data), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viiii', callback, [lua_state, 0, dmFacebookError.ERROR_NONE, permissions_buf]);
+                                Runtime.dynCall('viiii', callback, [lua_state, 0, FBinner.dmFacebookError.ERROR_NONE, permissions_buf]);
                             } else {
                                 var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
+                                Runtime.dynCall('viiii', callback, [lua_state, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0]);
                             }
                         });
 
                     } else if (e != 0) {
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0]);
                     } else {
                         // No authResponse. Below text is from facebook's own example of this case.
                         e = 'User cancelled login or did not fully authorize.';
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_DIALOG_CANCELED, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0]);
                     }
                 }, {scope: Pointer_stringify(permissions)});
             } catch (e){
@@ -208,21 +205,21 @@ var LibraryFacebook = {
                         window._dmFacebookUpdatePermissions(function(e, permissions_data) {
                             if (e == 0) {
                                 var permissions_buf = allocate(intArrayFromString(permissions_data), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viiii', callback, [lua_state, 0, dmFacebookError.ERROR_NONE, permissions_buf]);
+                                Runtime.dynCall('viiii', callback, [lua_state, 0, FBinner.dmFacebookError.ERROR_NONE, permissions_buf]);
                             } else {
                                 var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                                Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
+                                Runtime.dynCall('viiii', callback, [lua_state, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0]);
                             }
                         });
 
                     } else if (e != 0) {
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_SDK, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0]);
                     } else {
                         // No authResponse. Below text is from facebook's own example of this case.
                         e = 'User cancelled login or did not fully authorize.';
                         var err_buf = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, dmFacebookError.ERROR_DIALOG_CANCELED, 0]);
+                        Runtime.dynCall('viiii', callback, [lua_state, err_buf, FBinner.dmFacebookError.ERROR_SDK, 0]);
                     }
                 }, {scope: Pointer_stringify(permissions)});
             } catch (e){

--- a/engine/facebook/src/js/library_facebook.js
+++ b/engine/facebook/src/js/library_facebook.js
@@ -89,22 +89,30 @@ var LibraryFacebook = {
             var par = JSON.parse(Pointer_stringify(params));
             par.method = Pointer_stringify(mth);
 
-            try {
-                FB.ui(par, function(response) {
-                    // https://developers.facebook.com/docs/graph-api/using-graph-api/v2.0
-                    //   (Section 'Handling Errors')
-                    var e = (response && response.error ? response.error.message : 0);
-                    if(e == 0) {
-                        var res_data = JSON.stringify(response);
-                        var res_buf = allocate(intArrayFromString(res_data), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, res_buf, e, FBinner.dmFacebookError.ERROR_NONE]);
-                    } else {
-                        var error = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
-                        Runtime.dynCall('viiii', callback, [lua_state, 0, error, FBinner.dmFacebookError.ERROR_SDK]);
-                    }
-                });
-            } catch (e) {
-                console.error("Facebook show dialog failed " + e);
+            // We only officially support "feed", "appinvite" and "apprequest(s)".
+            // On HTML5 we only support "feed" and "apprequest".
+            if (par.method == "feed" || par.method == "apprequests" || par.method == "apprequest") {
+                try {
+                    FB.ui(par, function(response) {
+                        // https://developers.facebook.com/docs/graph-api/using-graph-api/v2.0
+                        //   (Section 'Handling Errors')
+                        var e = (response && response.error ? response.error.message : 0);
+                        if(e == 0) {
+                            var res_data = JSON.stringify(response);
+                            var res_buf = allocate(intArrayFromString(res_data), 'i8', ALLOC_STACK);
+                            Runtime.dynCall('viiii', callback, [lua_state, res_buf, e, FBinner.dmFacebookError.ERROR_NONE]);
+                        } else {
+                            var error = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
+                            Runtime.dynCall('viiii', callback, [lua_state, 0, error, FBinner.dmFacebookError.ERROR_SDK]);
+                        }
+                    });
+                } catch (e) {
+                    console.error("Facebook show dialog failed " + e);
+                }
+            } else {
+                var e = 'Dialog not supported.';
+                var error = allocate(intArrayFromString(e), 'i8', ALLOC_STACK);
+                Runtime.dynCall('viiii', callback, [lua_state, 0, error, FBinner.dmFacebookError.ERROR_DIALOG_NOT_SUPPORTED]);
             }
         },
 


### PR DESCRIPTION
- Added a error_code field to the error-table for FB callbacks. The default value here is `ERROR_SDK` indicating FB SDK reported the error. There is also `ERROR_DIALOG_NOT_SUPPORTED` when we can determine that the dialog could not be shown.
