### PR TITLE
DEF-1629 - Setting char input callback on HTML5 silently fails

### DIFF
--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -27,6 +27,7 @@ var LibraryGLFW = {
 
     keyFunc: null,
     charFunc: null,
+    markedTextFunc: null,
     mouseButtonFunc: null,
     mousePosFunc: null,
     mouseWheelFunc: null,
@@ -584,6 +585,12 @@ var LibraryGLFW = {
 
   glfwSetCharCallback: function(cbfun) {
     GLFW.charFunc = cbfun;
+    return 1;
+  },
+
+  glfwSetMarkedTextCallback: function(cbfun) {
+    GLFW.markedTextFunc = cbfun;
+    return 1;
   },
 
   glfwSetMouseButtonCallback: function(cbfun) {


### PR DESCRIPTION
Minor fix for missing return in glfwSetChar/MarkedTextCallback
