### PR TITLE
DEF-1626 Set the number of default http/GET retries to 1

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -250,7 +250,7 @@ namespace dmHttpClient
         client->m_HttpSendContentLength = params->m_HttpSendContentLength;
         client->m_HttpWrite = params->m_HttpWrite;
         client->m_HttpWriteHeaders = params->m_HttpWriteHeaders;
-        client->m_MaxGetRetries = 4;
+        client->m_MaxGetRetries = 1;
         client->m_RequestTimeout = 0;
         client->m_RequestStart = 0;
         memset(&client->m_Statistics, 0, sizeof(client->m_Statistics));

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -196,7 +196,7 @@ namespace dmHttpService
             params.m_HttpCache = worker->m_Service->m_HttpCache;
             worker->m_Client = dmHttpClient::New(&params, url.m_Hostname, url.m_Port, strcmp(url.m_Scheme, "https") == 0);
             if (worker->m_Client) {
-                dmHttpClient::SetOptionInt(worker->m_Client, dmHttpClient::OPTION_MAX_GET_RETRIES, 3);
+                dmHttpClient::SetOptionInt(worker->m_Client, dmHttpClient::OPTION_MAX_GET_RETRIES, 1);
             }
             memcpy(&worker->m_CurrentURL, &url, sizeof(url));
         }

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -98,7 +98,7 @@ int ReadSerializedTable(lua_State* L, uint8_t* source, uint32_t source_length, T
         }
         double value_read = lua_tonumber(L, -1);
         double value_expected = fn(2.0 * M_PI * (double)i / (double)0xffff);
-        double diff = abs(value_read - value_expected);
+        double diff = fabs(value_read - value_expected);
         EXPECT_GT(epsilon, diff);
         lua_pop(L, 1);
 


### PR DESCRIPTION
This is in order to make the implementation similar to the html5 version,
which doesn't support retries.
