### PR TITLE
Bump core.cache with performance fixes and use

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -9,7 +9,7 @@
 
   :pedantic?        :abort
   :dependencies     [[org.clojure/clojure                         "1.8.0"]
-                     [org.clojure/core.cache                      "0.6.4"]
+                     [org.clojure/core.cache                      "0.6.5"]
                      [org.clojure/core.match                      "0.2.2"]
                      [org.clojure/tools.macro                     "0.1.5"]
                      [org.clojure/tools.namespace                 "0.2.10"]

--- a/editor/src/clj/internal/cache.clj
+++ b/editor/src/clj/internal/cache.clj
@@ -8,82 +8,17 @@
 ;; ----------------------------------------
 ;; Null cache for testing
 ;; ----------------------------------------
-(cc/defcache NullCache []
+(cc/defcache NullCache [cache]
   cc/CacheProtocol
-  (lookup [_ item] nil)
+  (lookup [_ item])
   (lookup [_ item not-found] not-found)
-  (has?   [_ item] false)
-  (hit    [this item] this)
-  (miss   [this item result] this)
-  (evict  [this key] this)
-  (seed   [_ base] base))
+  (has? [_ item] false)
+  (hit [this item] this)
+  (miss [this item result] this)
+  (evict [this key] this)
+  (seed [this base] base))
 
-(defn- null-cache [] (NullCache.))
-
-;; ----------------------------------------
-;; Faster LRU cache, (contains? cache key) rather than (= v ::miss) nonsense
-;; ----------------------------------------
-
-(defn- build-leastness-queue
-  [base limit start-at]
-  (into (clojure.data.priority-map/priority-map)
-        (concat (take (- limit (count base)) (for [k (range (- limit) 0)] [k k]))
-                (for [[k _] base] [k start-at]))))
-
-(cc/defcache LRUCache [cache lru tick limit]
-  cc/CacheProtocol
-  (lookup [_ item]
-    (get cache item))
-  (lookup [_ item not-found]
-    (get cache item not-found))
-  (has? [_ item]
-    (contains? cache item))
-  (hit [_ item]
-    (let [tick+ (inc tick)]
-      (LRUCache. cache
-                 (if (contains? cache item)
-                   (assoc lru item tick+)
-                   lru)
-                 tick+
-                 limit)))
-  (miss [_ item result]
-    (let [tick+ (inc tick)]
-      (if (>= (count lru) limit)
-        (let [k (if (contains? lru item)
-                  item
-                  (first (peek lru))) ;; minimum-key, maybe evict case
-              c (-> cache (dissoc k) (assoc item result))
-              l (-> lru (dissoc k) (assoc item tick+))]
-          (LRUCache. c l tick+ limit))
-        (LRUCache. (assoc cache item result)  ;; no change case
-                   (assoc lru item tick+)
-                   tick+
-                   limit))))
-  (evict [this key]
-    (if (contains? cache key)
-      (LRUCache. (dissoc cache key)
-                 (dissoc lru key)
-                 (inc tick)
-                 limit)
-      this))
-  (seed [_ base]
-    (LRUCache. base
-               (build-leastness-queue base limit 0)
-               0
-               limit))
-  Object
-  (toString [_]
-    (str cache \, \space lru \, \space tick \, \space limit)))
-
-(defn lru-cache-factory
-  "Returns an LRU cache with the cache and usage-table initialied to `base` --
-   each entry is initialized with the same usage value.
-   This function takes an optional `:threshold` argument that defines the maximum number
-   of elements in the cache before the LRU semantics apply (default is 32)."
-  [base & {threshold :threshold :or {threshold 32}}]
-  {:pre [(number? threshold) (< 0 threshold)
-         (map? base)]}
-  (clojure.core.cache/seed (LRUCache. {} (clojure.data.priority-map/priority-map) 0 threshold) base))
+(defn- null-cache [] (NullCache. {}))
 
 ;; ----------------------------------------
 ;; Mutators
@@ -118,7 +53,7 @@
    (atom
     (if (zero? limit)
       (null-cache)
-      (lru-cache-factory {} :threshold limit)))))
+      (cc/lru-cache-factory {} :threshold limit)))))
 
 (defn cache-snapshot
   [cache]


### PR DESCRIPTION
0.6.5 Has the performance fix to avoid equal comparison 
https://github.com/clojure/core.cache and use contains instead https://github.com/clojure/core.cache/commit/aab34676929c0d08eeb28e66d1233333c1a78aec
- Removed the internal.cache implementation of LRUCache and just use core.cache instead.
- Changed NullCache signature to make it work with new version defcache

Also ran the benchmarks which looked good.
