### PR TITLE
DEF-1198 Renamed sys.get_sys_info().system_name: Emscripten to HTML5

### DIFF
--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -537,7 +537,11 @@ namespace dmSys
         struct utsname uts;
         uname(&uts);
 
+#if defined(__EMSCRIPTEN__)
+        dmStrlCpy(info->m_SystemName, "HTML5", sizeof(info->m_SystemName));
+#else
         dmStrlCpy(info->m_SystemName, uts.sysname, sizeof(info->m_SystemName));
+#endif
         dmStrlCpy(info->m_SystemVersion, uts.release, sizeof(info->m_SystemVersion));
         info->m_DeviceModel[0] = '\0';
 

--- a/engine/tracking/src/lua/tracking.lua
+++ b/engine/tracking/src/lua/tracking.lua
@@ -75,6 +75,16 @@ function make_new_meta()
     return m
 end
 
+function convert_platform_name(system_name)
+    if system_name == "iPhone OS" then
+        return "ios"
+    end
+    if system_name == "HTML5" then
+        return "web"
+    end
+    return system_name
+end
+
 function start(save_directory, engine_version)
 
     tracking_enable = true
@@ -406,9 +416,17 @@ function send_events_file(idx)
         end
     end
 
+
+
     local post_data = "{";
     for k,v in pairs(sys_field_mapping) do
         local sv = sys_info[v]
+
+        -- A temporary compensation for the fact that we have another "fixup" in the defold/gather lib (https://github.com/defold/gather/blob/a05fa408b27abd52b69085654603b32bd4ac381a/src/main/java/com/king/gather/api/MessageConverter.java)
+        if v == "system_name" then
+            sv = convert_platform_name(sv)
+        end
+
         if sv and sv ~= "" then
             post_data = post_data .. json_str_field(k, sv) .. ","
         end


### PR DESCRIPTION
- Also patched tracking.lua to do conversions in the engine, as opposed to doing it in the defold/gather lib
