### PR TITLE
DEF-1739 - Fixed bug with scale animations on sprite components.

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -832,15 +832,17 @@ namespace dmGameSystem
     {
         dmGameObject::PropertyResult result = dmGameObject::PROPERTY_RESULT_OK;
 
-        // We deliberately do not provide a value pointer in the case of read only variables,
-        // in order to ensure that it is not used in any write optimisation (see animation system).
+        // We deliberately do not provide a value pointer, two reasons:
+        // 1. The value pointers will not correctly be updated in the animation system
+        //    if a gameobject is deleted. This is due to the actual gameobject
+        //    instance can be swapped in the gameobject pool but the actual
+        //    animation value pointer will not update and point to an old location.
+        // 2. If it's a read only variable, we can't do it in order to ensure that it
+        //    is not used in any write optimisation (see animation system).
         out_value.m_ReadOnly = property.m_ReadOnly;
+        out_value.m_ValuePtr = 0x0;
         if (get_property == property.m_Vector)
         {
-            if (!property.m_ReadOnly)
-            {
-                out_value.m_ValuePtr = (float*)&ref_value;
-            }
             out_value.m_ElementIds[0] = property.m_X;
             out_value.m_ElementIds[1] = property.m_Y;
             out_value.m_ElementIds[2] = property.m_Z;
@@ -848,26 +850,14 @@ namespace dmGameSystem
         }
         else if (get_property == property.m_X)
         {
-            if (!property.m_ReadOnly)
-            {
-                out_value.m_ValuePtr = (float*)&ref_value;
-            }
             out_value.m_Variant = dmGameObject::PropertyVar(ref_value.getX());
         }
         else if (get_property == property.m_Y)
         {
-            if (!property.m_ReadOnly)
-            {
-                out_value.m_ValuePtr = (float*)&ref_value + 1;
-            }
             out_value.m_Variant = dmGameObject::PropertyVar(ref_value.getY());
         }
         else if (get_property == property.m_Z)
         {
-            if (!property.m_ReadOnly)
-            {
-                out_value.m_ValuePtr = (float*)&ref_value + 2;
-            }
             out_value.m_Variant = dmGameObject::PropertyVar(ref_value.getZ());
         }
         else

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -833,10 +833,10 @@ namespace dmGameSystem
         dmGameObject::PropertyResult result = dmGameObject::PROPERTY_RESULT_OK;
 
         // We deliberately do not provide a value pointer, two reasons:
-        // 1. The value pointers will not correctly be updated in the animation system
-        //    if a gameobject is deleted. This is due to the actual gameobject
-        //    instance can be swapped in the gameobject pool but the actual
-        //    animation value pointer will not update and point to an old location.
+        // 1. Deleting a gameobject (that included sprite(s)) will rearrange the
+        //    object pool for components (due to EraseSwap in the Free for the object pool);
+        //    this result in the original animation value pointer will still point
+        //    to the original memory location in the component object pool.
         // 2. If it's a read only variable, we can't do it in order to ensure that it
         //    is not used in any write optimisation (see animation system).
         out_value.m_ReadOnly = property.m_ReadOnly;

--- a/engine/gamesys/src/gamesys/test/sprite/sprite_anim.go
+++ b/engine/gamesys/src/gamesys/test/sprite/sprite_anim.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/sprite/sprite_anim.script"
+}

--- a/engine/gamesys/src/gamesys/test/sprite/sprite_anim.script
+++ b/engine/gamesys/src/gamesys/test/sprite/sprite_anim.script
@@ -1,0 +1,15 @@
+function init(self)
+    go.animate("go1#sprite", "scale.x", go.PLAYBACK_ONCE_FORWARD, 0.0, go.EASING_LINEAR, 2/60.0, 0, function() go.delete("go1") end)
+    go.animate("go2#sprite", "scale.x", go.PLAYBACK_ONCE_FORWARD, 0.0, go.EASING_LINEAR, 2/60.0, 1/60.0, function() go.delete("go2") end)
+    go.animate("go3#sprite", "scale.x", go.PLAYBACK_ONCE_FORWARD, 0.0, go.EASING_LINEAR, 4/60.0, 1/60.0)
+
+    self.last_scale_x = 1.0
+end
+
+function update(self, dt)
+    local s = go.get("go3#sprite", "scale")
+    if (s.x < 1.0 and s.x > 0.0) then
+        assert(s.x < self.last_scale_x)
+        self.last_scale_x = s.x
+    end
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -75,6 +75,12 @@ public:
     virtual ~ComponentFailTest() {}
 };
 
+class SpriteAnimTest : public GamesysTest<const char*>
+{
+public:
+    virtual ~SpriteAnimTest() {}
+};
+
 bool CopyResource(const char* src, const char* dst);
 bool UnlinkResource(const char* name);
 


### PR DESCRIPTION
- Changed so that GetProperty for sprite components does not
  return the value pointer to the animation system.
