### PR TITLE
DEF-1759 - Changed editor update URLs to point to CDN domain.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/ApplicationWorkbenchWindowAdvisor.java
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/ApplicationWorkbenchWindowAdvisor.java
@@ -155,6 +155,15 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
                 }
             }
 
+            // Remove AWS URIs since our move to d.defold.com
+            List<URI> awsURIs = getReposContaining(metadataManager, "d.defold.com.s3-website-eu-west-1.amazonaws.com");
+            awsURIs.addAll(getReposContaining(artifactManager, "d.defold.com.s3-website-eu-west-1.amazonaws.com"));
+            for (URI repoURI : awsURIs) {
+                System.out.println(String.format("Removing URI: %s", repoURI.toString()));
+                metadataManager.removeRepository(repoURI);
+                artifactManager.removeRepository(repoURI);
+            }
+
         } catch (URISyntaxException e) {
             logger.error("Unexpected error", e);
         }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -579,7 +579,7 @@ instructions.configure=\
 
         self._build_cr('editor')
 
-    def _archive_cr(self, product, channel, build_dir):
+    def _archive_cr(self, product, build_dir):
         sha1 = self._git_sha1()
         full_archive_path = join(self.archive_path, sha1, self.channel, product).replace('\\', '/') + '/'
         host, path = full_archive_path.split(':', 1)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -833,7 +833,7 @@ instructions.configure=\
     type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository'
     version='1.0.0'>
   <children size='1'>
-      <child location='http://%(host)s/archive/%(sha1)s/editor/repository'/>
+      <child location='http://%(host)s/archive/%(sha1)s/%(channel)s/editor/repository'/>
   </children>
 </repository>"""
 
@@ -843,7 +843,7 @@ instructions.configure=\
     type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository'
     version='1.0.0'>
   <children size='1'>
-      <child location='http://%(host)s/archive/%(sha1)s/editor/repository'/>
+      <child location='http://%(host)s/archive/%(sha1)s/%(channel)s/editor/repository'/>
   </children>
 </repository>
 """
@@ -914,7 +914,8 @@ instructions.configure=\
             key = bucket.new_key(full_name)
             key.content_type = 'text/xml'
             key.set_contents_from_string(template % {'host': host,
-                                                     'sha1': release_sha1})
+                                                     'sha1': release_sha1,
+                                                     'channel': self.channel})
 
     def _get_s3_archive_prefix(self):
         u = urlparse.urlparse(self.archive_path)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -570,8 +570,8 @@ class Configuration(object):
 
         p2 = """
 instructions.configure=\
-  addRepository(type:0,location:http${#58}//d.defold.com.s3-website-eu-west-1.amazonaws.com/%(channel)s/update/);\
-  addRepository(type:1,location:http${#58}//d.defold.com.s3-website-eu-west-1.amazonaws.com/%(channel)s/update/);
+  addRepository(type:0,location:http${#58}//d.defold.com/%(channel)s/update/);\
+  addRepository(type:1,location:http${#58}//d.defold.com/%(channel)s/update/);
 """
 
         with open('com.dynamo.cr/com.dynamo.cr.editor-product/cr-generated.p2.inf', 'w') as f:
@@ -579,9 +579,9 @@ instructions.configure=\
 
         self._build_cr('editor')
 
-    def _archive_cr(self, product, build_dir):
+    def _archive_cr(self, product, channel, build_dir):
         sha1 = self._git_sha1()
-        full_archive_path = join(self.archive_path, sha1, product).replace('\\', '/') + '/'
+        full_archive_path = join(self.archive_path, sha1, self.channel, product).replace('\\', '/') + '/'
         host, path = full_archive_path.split(':', 1)
         for p in glob(join(build_dir, 'target/products/*.zip')):
             self.upload_file(p, full_archive_path)
@@ -903,7 +903,7 @@ instructions.configure=\
         # Create redirection keys for editor
         for name in ['Defold-macosx.cocoa.x86_64.zip', 'Defold-win32.win32.x86.zip', 'Defold-linux.gtk.x86.zip']:
             key_name = '%s/%s' % (self.channel, name)
-            redirect = '/archive/%s/editor/%s' % (release_sha1, name)
+            redirect = '/archive/%s/%s/editor/%s' % (release_sha1, self.channel, name)
             self._log('Creating link from %s -> %s' % (key_name, redirect))
             key = bucket.new_key(key_name)
             key.set_redirect(redirect)


### PR DESCRIPTION
- Changed the release step in build.py so it uses the correct domain when creating the editor update file.
- Changed so that editor releases are uploaded into:
  .../archive/{SHA1}/{CHANNEL_NAME}/editor/Defold.*.zip
- Changed ApplicationWorkbenchWindowAdvisor so it removes "old" AWS domains from the update repositories. This is to make sure new users don't have any old AWS urls lingering in their update repositories.
