### PR TITLE
DEF-1743: http.request() and ETag cache error

### DIFF
--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -23,7 +23,7 @@ namespace dmHttpCache
     // Magic file header for index file
     const uint32_t MAGIC = 0xCAAAAAAC;
     // Current index file version
-    const uint32_t VERSION = 5;
+    const uint32_t VERSION = 6;
 
     // Maximum number of cache entry creations in flight
     const uint32_t MAX_CACHE_CREATORS = 16;
@@ -62,7 +62,7 @@ namespace dmHttpCache
         // ETag string
         char     m_ETag[MAX_TAG_LEN];
         // Path string
-        char     m_URI[256];
+        char     m_URI[2048];
         // The content hash is the hash of URI and ETag.
         uint64_t m_IdentifierHash;
         // Last accessed time

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -62,7 +62,7 @@ namespace dmHttpCache
         // ETag string
         char     m_ETag[MAX_TAG_LEN];
         // Path string
-        char     m_URI[2048];
+        char     m_URI[MAX_URI_LEN];
         // The content hash is the hash of URI and ETag.
         uint64_t m_IdentifierHash;
         // Last accessed time

--- a/engine/dlib/src/dlib/http_cache.h
+++ b/engine/dlib/src/dlib/http_cache.h
@@ -38,6 +38,9 @@ namespace dmHttpCache
     /// Maximum length of tags
     const uint32_t MAX_TAG_LEN = 64;
 
+    // Maximum length of an URI
+    const uint32_t MAX_URI_LEN = 2048;
+
     /**
      * Cache entry info
      */

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -9,6 +9,7 @@
 #include <dlib/hash.h>
 #include <dlib/log.h>
 #include <dlib/math.h>
+#include <dlib/http_cache.h>
 
 #include "script.h"
 #include "http_ddf.h"
@@ -67,11 +68,10 @@ namespace dmScript
             const char* url = luaL_checkstring(L, 1);
             uint32_t url_len = strlen(url);
 
-            // NOTE: This magic number has to be the same as the URI buffer length for the HTTP Cache struct FileEntry.
-            if (url_len > 2048)
+            if (url_len > dmHttpCache::MAX_URI_LEN)
             {
                 assert(top == lua_gettop(L));
-                return luaL_error(L, "http.request does not support URI longer than 2048 characters.");
+                return luaL_error(L, "http.request does not support URI longer than %d characters.", dmHttpCache::MAX_URI_LEN);
             }
             const char* method = luaL_checkstring(L, 2);
             luaL_checktype(L, 3, LUA_TFUNCTION);

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -66,6 +66,13 @@ namespace dmScript
 
             const char* url = luaL_checkstring(L, 1);
             uint32_t url_len = strlen(url);
+
+            // NOTE: This magic number has to be the same as the URI buffer length for the HTTP Cache struct FileEntry.
+            if (url_len > 2048)
+            {
+                assert(top == lua_gettop(L));
+                return luaL_error(L, "http.request does not support URI longer than 2048 characters.");
+            }
             const char* method = luaL_checkstring(L, 2);
             luaL_checktype(L, 3, LUA_TFUNCTION);
             lua_pushvalue(L, 3);


### PR DESCRIPTION
Cache error due to missing ETag resolved, allowed cached URI length extended to 2048 characters.
