### PR TITLE
DEF-1758 - Fixed so that canvas size is handled similar to how other platforms handle window size.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -336,6 +336,14 @@ var Module = {
         }
     },
 
+    toggleFullscreen: function() {
+        if (GLFW.isFullscreen) {
+            GLFW.cancelFullScreen();
+        } else {
+            GLFW.requestFullScreen();
+        }
+    },
+
     preloadAll: function() {
         for (var i = 0; i < Module._filesToPreload.length; ++i) {
             var item = Module._filesToPreload[i];

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/engine_template.html
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/engine_template.html
@@ -9,22 +9,12 @@
 		<title>{{DEFOLD_APP_TITLE}}</title>
 		<style>
 			canvas {
-			  /* Full app dimensions. Fit in container */
-			  width: {{DEFOLD_DISPLAY_WIDTH}}px;
-			  height: {{DEFOLD_DISPLAY_HEIGHT}}px;
-			  max-width: 100%;
-			  max-height: 100%;
 			}
 
 			.canvas-app-container {
-			  width: {{DEFOLD_DISPLAY_WIDTH}}px;
-			  height: {{DEFOLD_DISPLAY_HEIGHT}}px;
 			  background: rgb(255,255,255) no-repeat center url("try_game.png");
 			  /* A positioned parent for loading visuals */
 			  position: relative;
-			  /* Firefox fullscreen will resize container to screen. */
-			  text-align: center;
-			  vertical-align: middle;
 			}
 
 			.canvas-app-container:-webkit-full-screen {
@@ -38,7 +28,7 @@
 			  background-color: rgb(245, 245, 245);
 			  height: 20px;
 			  /* Fill up container width. */
-			  width: 100%;
+			  width: {{DEFOLD_DISPLAY_WIDTH}}px;
 			  bottom: 0px;
 			}
 
@@ -66,7 +56,7 @@
     <div id="fb-root"></div>
 
 	<div id="app-container" class="canvas-app-container">
-	    <canvas id="canvas" class="canvas-app-canvas" tabindex="1"></canvas>
+	    <canvas id="canvas" class="canvas-app-canvas" tabindex="1" width="{{DEFOLD_DISPLAY_WIDTH}}" height="{{DEFOLD_DISPLAY_HEIGHT}}"></canvas>
 	</div>
 
 	<button id="fullscreen" class="button">Fullscreen</button>
@@ -86,15 +76,7 @@
 
 	    /* Fullscreen button */
 	    document.getElementById("fullscreen").onclick = function (e) {
-	      /* Enter fullscreen, don't lock pointer and don't resize canvas down. */
-	      var elem = document.getElementById("app-container");
-	      var rfs = elem.requestFullscreen ||
-	                elem.requestFullScreen ||
-	                elem.mozRequestFullScreen ||
-	                elem.webkitRequestFullscreen ||
-	                (function() {});
-	      rfs.apply(elem, []);
-	      document.getElementById("canvas").focus();
+	      Module.toggleFullscreen();
 	    };
 	</script>
 </body>

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/engine_template.html
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/engine_template.html
@@ -8,9 +8,6 @@
 
 		<title>{{DEFOLD_APP_TITLE}}</title>
 		<style>
-			canvas {
-			}
-
 			.canvas-app-container {
 			  background: rgb(255,255,255) no-repeat center url("try_game.png");
 			  /* A positioned parent for loading visuals */
@@ -27,7 +24,7 @@
 			  position: absolute;
 			  background-color: rgb(245, 245, 245);
 			  height: 20px;
-			  /* Fill up container width. */
+			  /* Progress same width as canvas. */
 			  width: {{DEFOLD_DISPLAY_WIDTH}}px;
 			  bottom: 0px;
 			}

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -46,6 +46,11 @@ var LibraryGLFW = {
     windowY: 0,
     windowWidth: 0,
     windowHeight: 0,
+    prevWidth: 0,
+    prevHeight: 0,
+    prevNonFSWidth: 0,
+    prevNonFSHeight: 0,
+    isFullscreen: false,
 
 /*******************************************************************************
  * DOM EVENT CALLBACKS
@@ -283,34 +288,37 @@ var LibraryGLFW = {
       }
     },
 
-    // TODO add fullscreen API ala:
-    // http://johndyer.name/native-fullscreen-javascript-api-plus-jquery-plugin/
     onFullScreenEventChange: function(event) {
       var width;
       var height;
-      if (document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
-        width = screen["width"];
-        height = screen["height"];
+      GLFW.isFullscreen = document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"] || document["msIsFullScreen"];
+      if (GLFW.isFullscreen) {
+        GLFW.prevNonFSWidth = GLFW.prevWidth;
+        GLFW.prevNonFSHeight = GLFW.prevHeight;
+        width = window.innerWidth;
+        height = window.innerHeight;
       } else {
-        width = GLFW.windowWidth;
-        height = GLFW.windowHeight;
-        // TODO set position
+        width = GLFW.prevNonFSWidth;
+        height = GLFW.prevNonFSHeight;
         document.removeEventListener('fullscreenchange', GLFW.onFullScreenEventChange, true);
         document.removeEventListener('mozfullscreenchange', GLFW.onFullScreenEventChange, true);
         document.removeEventListener('webkitfullscreenchange', GLFW.onFullScreenEventChange, true);
+        document.removeEventListener('msfullscreenchange', GLFW.onFullScreenEventChange, true);
       }
-      Browser.setCanvasSize(width, height);
-
-      if (GLFW.resizeFunc) {
-        Runtime.dynCall('vii', GLFW.resizeFunc, [width, height]);
-      }
+      Module["canvas"].width = width;
+      Module["canvas"].height = height;
     },
 
     requestFullScreen: function() {
+      document.addEventListener('fullscreenchange', GLFW.onFullScreenEventChange, true);
+      document.addEventListener('mozfullscreenchange', GLFW.onFullScreenEventChange, true);
+      document.addEventListener('webkitfullscreenchange', GLFW.onFullScreenEventChange, true);
+      document.addEventListener('msfullscreenchange', GLFW.onFullScreenEventChange, true);
       var RFS = Module["canvas"]['requestFullscreen'] ||
                 Module["canvas"]['requestFullScreen'] ||
                 Module["canvas"]['mozRequestFullScreen'] ||
                 Module["canvas"]['webkitRequestFullScreen'] ||
+                Module["canvas"]['msRequestFullScreen'] ||
                 (function() {});
       RFS.apply(Module["canvas"], []);
     },
@@ -320,6 +328,7 @@ var LibraryGLFW = {
                 document['cancelFullScreen'] ||
                 document['mozCancelFullScreen'] ||
                 document['webkitCancelFullScreen'] ||
+                document['msExitFullscreen'] ||
           (function() {});
       CFS.apply(document, []);
     }
@@ -427,8 +436,8 @@ var LibraryGLFW = {
     GLFW.params[0x0002000A] = stencilbits; // GLFW_STENCIL_BITS
 
     if (mode == 0x00010001) {// GLFW_WINDOW
-      Browser.setCanvasSize(GLFW.initWindowWidth = width,
-                            GLFW.initWindowHeight = height);
+      GLFW.initWindowWidth = width;
+      GLFW.initWindowHeight = height;
       GLFW.params[0x00030003] = true; // GLFW_STICKY_MOUSE_BUTTONS
     } else if (mode == 0x00010002) {// GLFW_FULLSCREEN
       GLFW.requestFullScreen();
@@ -469,7 +478,6 @@ var LibraryGLFW = {
   },
 
   glfwSetWindowSize: function(width, height) {
-    GLFW.cancelFullScreen();
       Browser.setCanvasSize(width, height);
       if (GLFW.resizeFunc) {
         Runtime.dynCall('vii', GLFW.resizeFunc, [width, height]);
@@ -482,7 +490,25 @@ var LibraryGLFW = {
 
   glfwRestoreWindow: function() {},
 
-  glfwSwapBuffers: function() {},
+  glfwSwapBuffers__deps: ['glfwSetWindowSize'],
+  glfwSwapBuffers: function() {
+
+    var width = Module['canvas'].width;
+    var height = Module['canvas'].height;
+
+    if (GLFW.isFullscreen) {
+      width = window.innerWidth;
+      height = window.innerHeight;
+    }
+
+    if (GLFW.prevWidth != width ||
+        GLFW.prevHeight != height) {
+
+      GLFW.prevWidth = width;
+      GLFW.prevHeight = height;
+      _glfwSetWindowSize(width, height);
+    }
+  },
 
   glfwSwapInterval: function(interval) {},
 
@@ -700,5 +726,4 @@ var LibraryGLFW = {
 
 autoAddDeps(LibraryGLFW, '$GLFW');
 mergeInto(LibraryManager.library, LibraryGLFW);
-
 


### PR DESCRIPTION
- Canvas size is checked each glfwSwapBuffers to see if size has changed.
  This is due to there not being any good way to get resize-events for
  canvas elements.
- Fixed fullscreen so it works on most browsers again and still being
  compatible with new canvas size fixes.
