### PR TITLE
DEF-1635 - Collection factory limit project setting.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -204,6 +204,12 @@ max_count.type = integer
 max_count.help = max number of collection proxies, 8 by default
 max_count.default = 8
 
+[collectionfactory]
+help = Collection factory related settings
+max_count.type = integer
+max_count.help = max number of collection factories, 128 by default
+max_count.default = 128
+
 [factory]
 help = GameObject factory related settings
 max_count.type = integer


### PR DESCRIPTION
https://jira.int.midasplayer.com/browse/DEF-1635

Exposed the already existing collectionfactory.max_count in games.project. The functionality has been verified through `lldb` via the following commands.

```
$ lldb
(lldb) process attach --name dmengine --waitfor
(lldb) breakpoint set --file engine.cpp --line 682
(lldb) c
-- Step into the GetInt function that's run as part of dmEngine::Init(...)
(lldb) fr v
-- Verify the value of ret
```
