### PR TITLE
Archive cache: Only do atomic file move on same device/disk.

### DIFF
--- a/server/config/local-dev.config
+++ b/server/config/local-dev.config
@@ -24,7 +24,7 @@ invitation_count_map { key: 100 value: 5 }
 invitation_count_map { key: 5 value: 2 }
 invitation_count_map { key: 2 value: 1 }
 
-test_registration_key: "key"
+test_registration_key: "new"
 test_invitation_count: 1
 
 project_templates {
@@ -32,4 +32,5 @@ project_templates {
     path: "/tmp/foo"
     description: "Tutorial: Side-Scroller"
 }
+
 

--- a/server/src/main/java/com/dynamo/cr/archive/GitArchiveProvider.java
+++ b/server/src/main/java/com/dynamo/cr/archive/GitArchiveProvider.java
@@ -3,6 +3,7 @@ package com.dynamo.cr.archive;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Collection;
@@ -71,11 +72,12 @@ public class GitArchiveProvider {
                 throw new ServerException("Failed to checkout repo", e, Status.INTERNAL_SERVER_ERROR);
             }
 
-            temporaryZipFile = File.createTempFile("archive", ".zip");
+            Path targetZipFile = Paths.get(archivePathname);
+            temporaryZipFile = File.createTempFile("archive", ".zip", targetZipFile.getParent().toFile());
             zipFiles(cloneToDirectory, temporaryZipFile, fileKey);
 
             // Do atomic move of file to prevent serving incomplete files.
-            java.nio.file.Files.move(temporaryZipFile.toPath(), Paths.get(archivePathname), StandardCopyOption.ATOMIC_MOVE);
+            java.nio.file.Files.move(temporaryZipFile.toPath(), targetZipFile, StandardCopyOption.ATOMIC_MOVE);
 
         } catch (IOException e) {
             // Delete temporary file on error. If successful the file has been moved to an archive.


### PR DESCRIPTION
It's important when creating a zip archive that it's created with
one atomic file operation. Otherise we will start serving non-complete
files, which will be corrupt files. This fix ensures that the temporary
file used is created in the same directory as the final zip file in order
to make the atomic rename/move to work. Atomic move is not supported
between two seperate devices/disks.
