### PR TITLE
Bugfix: This fixes endpoint override after added regexp.

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/resources/ProjectResource.java
+++ b/server/src/main/java/com/dynamo/cr/server/resources/ProjectResource.java
@@ -163,7 +163,7 @@ public class ProjectResource extends BaseResource {
     }
 
     @GET
-    @Path("/archive/{version: .*}")
+    @Path("/archive/{version: .+}")
     @RolesAllowed(value = { "member" })
     public Response getArchive(@PathParam("project") String project,
                                @PathParam("version") String version,


### PR DESCRIPTION
By added the regexp .\* to the archive endpoint, it overrides the
/archive endpoint. This fixes that by requiring at least one character
in the branch name.
