### PR TITLE
Logging: When running locally, only log to console.

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -3,7 +3,6 @@
 /tmp
 /build
 /src/generated
-/server*.log
 /derby.log
 /*.iml
 /local

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,36 +1,11 @@
 <configuration>
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>WARN</level>
-    </filter>
-
-    <file>server.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <!-- daily rollover -->
-      <fileNamePattern>server.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <!-- keep 30 days' worth of history -->
-      <maxHistory>30</maxHistory>
-    </rollingPolicy>
-
-    <encoder>
-      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-    </encoder>
-  </appender>
-
   <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>WARN</level>
-    </filter>
-
     <encoder>
-      <!-- NOTE: %nopex suppress stack-trace output -->
-      <pattern>%date %level [%thread] %logger{10} [%file:%line] %nopex %msg%n</pattern>
+      <pattern>%date %level [%thread] %logger{10} %msg%n</pattern>
     </encoder>
-    <target>System.err</target>
   </appender>
 
   <root level="info">
-    <appender-ref ref="FILE" />
     <appender-ref ref="STDERR" />
   </root>
 </configuration>


### PR DESCRIPTION
Updates the logback configuration to only log to console when
running locally in development. Also updates .gitignore to not exclude
local logfiles anymore.
