### PR TITLE
Potential memory overwrite fix. Better handling of handshake error status

### DIFF
--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -353,7 +353,7 @@ namespace dmConnectionPool
 
                 // Since the socket is non blocking (and the way axtls is implemented)
                 // we need do the hand shake ourselves
-                while( ssl_handshake_status(ssl) != SSL_OK )
+                while( ssl_handshake_status(ssl) == SSL_NOT_OK )
                 {
                     int ret = ssl_read(ssl, 0);
                     if( ret < 0 )


### PR DESCRIPTION
Failing test: dmHttpClientTest/dmHttpClientTest.ThreadStress/1
http://ci.defold.com/builders/engine-linux-test-dev/builds/1286/steps/compile/logs/stdio
