### PR TITLE
Text editor fix cursor column position when jumping

### DIFF
--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -345,7 +345,8 @@
         np (adjust-bounds doc c)
         next-word-move (next-word-move doc np)
         next-pos (+ np (count next-word-move))]
-    (caret! selection next-pos select?)))
+    (caret! selection next-pos select?)
+    (remember-caret-col selection next-pos)))
 
 (defn prev-word-move [doc np]
   (re-find word-regex (->> (subs doc 0 np) (reverse) (apply str))))
@@ -356,7 +357,8 @@
         np (adjust-bounds doc c)
         next-word-move (prev-word-move doc np)
         next-pos (- np (count next-word-move))]
-    (caret! selection next-pos select?)))
+    (caret! selection next-pos select?)
+    (remember-caret-col selection next-pos)))
 
 (handler/defhandler :next-word :code-view
   (enabled? [selection] selection)
@@ -388,7 +390,8 @@
 
 (defn line-begin [selection select?]
   (let [next-pos (line-begin-pos selection)]
-    (caret! selection next-pos select?)))
+    (caret! selection next-pos select?)
+    (remember-caret-col selection next-pos)))
 
 (defn line-end-pos [selection]
   (let [c (caret selection)
@@ -400,7 +403,8 @@
 
 (defn line-end [selection select?]
   (let [next-pos (line-end-pos selection)]
-    (caret! selection next-pos select?)))
+    (caret! selection next-pos select?)
+    (remember-caret-col selection next-pos)))
 
 (handler/defhandler :line-begin :code-view
   (enabled? [selection] selection)

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -264,7 +264,18 @@
         (prev-word! source-viewer)
         (is (= \q (get-char-at-caret source-viewer)))
         (prev-word! source-viewer)
-        (is (= \t (get-char-at-caret source-viewer)))))))
+        (is (= \t (get-char-at-caret source-viewer))))
+      (testing "moving by word remembers col position"
+        (text! source-viewer "aed.111\nbcf 222")
+        (caret! source-viewer 0 false)
+        (next-word! source-viewer)
+        (is (= \. (get-char-at-caret source-viewer)))
+        (down! source-viewer)
+        (is (= \space (get-char-at-caret source-viewer)))
+        (prev-word! source-viewer)
+        (is (= \b (get-char-at-caret source-viewer)))
+        (up! source-viewer)
+        (is (= \a (get-char-at-caret source-viewer)))))))
 
 (defn- select-next-word! [source-viewer]
   (handler/run :select-next-word [{:name :code-view :env {:selection source-viewer}}]{}))
@@ -316,7 +327,16 @@
         (is (= nil (get-char-at-caret source-viewer)))
         (is (= 11 (caret source-viewer)))
         (line-end! source-viewer)
-        (is (= 11 (caret source-viewer)))))))
+        (is (= 11 (caret source-viewer))))
+      (testing "moving remembers col position"
+        (text! source-viewer "line1\nline2")
+        (caret! source-viewer 0 false)
+        (line-end! source-viewer)
+        (down! source-viewer)
+        (is (= 11 (caret source-viewer)))
+        (line-begin! source-viewer)
+        (up! source-viewer)
+        (is (= 0 (caret source-viewer)))))))
 
 (defn- select-line-begin! [source-viewer]
   (handler/run :select-line-begin [{:name :code-view :env {:selection source-viewer}}]{}))


### PR DESCRIPTION
This fixes bug when the cursor column position was not stored when moving by word or moving to end/start of line.
