### PR TITLE
Text editor fix undo redo

### DIFF
--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -352,9 +352,13 @@
                    (mapv style-fn style-ranges)))
   cvx/TextUndo
   (changes! [this]
-    (let [code-node-id (-> this (.getTextWidget) (code-node))]
-      (g/transact [(g/set-property code-node-id :code (cvx/text this))
-                   (g/set-property code-node-id :caret-position (cvx/caret this)) ]))))
+    (let [code-node-id (-> this (.getTextWidget) (code-node))
+          code-changed? (not= (cvx/text this) (g/node-value code-node-id :code))
+          caret-changed? (not= (cvx/caret this) (g/node-value code-node-id :caret-position))]
+      (when (or code-changed? caret-changed?)
+        (g/transact (remove nil?
+                            [(when code-changed? (g/set-property code-node-id :code (cvx/text this)))
+                             (when caret-changed? (g/set-property code-node-id :caret-position (cvx/caret this))) ]))))))
 
 (defn make-view [graph ^Parent parent code-node opts]
   (let [source-viewer (setup-source-viewer opts true)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -213,7 +213,7 @@
     (remember-caret-col source-viewer pos)
     (changes! source-viewer)
     (when cf (handler/run
-               cf
+               (:command cf)
                [{:name :code-view :env {:selection source-viewer :clipboard (Clipboard/getSystemClipboard)}}]
                e))))
 

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -27,6 +27,9 @@
 (defprotocol TextStyles
   (styles [this]))
 
+(defprotocol TextUndo
+  (changes! [this]))
+
 (def mappings
   {
   ;;;movement
@@ -162,7 +165,8 @@
       (handler/run
         (:command kf)
         [{:name :code-view :env {:selection source-viewer :clipboard (Clipboard/getSystemClipboard)}}]
-        k-info))))
+        k-info)
+      (changes! source-viewer))))
 
 (defn- is-mac-os? []
   (= "Mac OS X" (System/getProperty "os.name")))
@@ -177,7 +181,8 @@
       (handler/run
         :key-typed
         [{:name :code-view :env {:selection source-viewer :key-typed key-typed}}]
-        e))))
+        e)
+      (changes! source-viewer))))
 
 
 (defn- adjust-bounds [s pos]
@@ -206,6 +211,7 @@
         cf (click-fn click-count)
         pos (caret source-viewer)]
     (remember-caret-col source-viewer pos)
+    (changes! source-viewer)
     (when cf (handler/run
                cf
                [{:name :code-view :env {:selection source-viewer :clipboard (Clipboard/getSystemClipboard)}}]
@@ -753,3 +759,15 @@
     (when (editable? selection)
       (let [line-seperator (System/getProperty "line.separator")]
         (enter-key-text selection line-seperator)))))
+
+(handler/defhandler :undo :code-view
+  (enabled? [selection] selection)
+  (run [view-node code-node]
+    (g/undo! (g/node-id->graph-id code-node))
+    (g/node-value view-node :new-content)))
+
+(handler/defhandler :redo :code-view
+  (enabled? [selection] selection)
+  (run [view-node code-node]
+    (g/redo! (g/node-id->graph-id code-node))
+    (g/node-value view-node :new-content)))

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -76,14 +76,10 @@
       (caret! source-viewer 5 false)
       (testing "moving right"
         (right! source-viewer)
-        (g/node-value viewer-node :new-content)
-        (is (= 6 (caret source-viewer)))
-        (is (= 6 (g/node-value code-node :caret-position))))
+        (is (= 6 (caret source-viewer))))
       (testing "moving left"
         (left! source-viewer)
-        (g/node-value viewer-node :new-content)
-        (is (= 5 (caret source-viewer)))
-        (is (= 5 (g/node-value code-node :caret-position))))
+        (is (= 5 (caret source-viewer))))
       (testing "out of bounds right"
         (caret! source-viewer (count code) false)
         (right! source-viewer)
@@ -127,14 +123,12 @@
        (select-right! source-viewer)
        (select-right! source-viewer)
        (is (= 2 (caret source-viewer)))
-       (is (= 2 (g/node-value code-node :caret-position)))
        (is (= "he" (text-selection source-viewer))))
      (testing "selecting left"
        (caret! source-viewer 5 false)
        (select-left! source-viewer)
        (select-left! source-viewer)
        (is (= 3 (caret source-viewer)))
-       (is (= 3 (g/node-value code-node :caret-position)))
        (is (= "lo" (text-selection source-viewer))))
      (testing "out of bounds right"
        (caret! source-viewer (count code) false)
@@ -192,8 +186,7 @@
         (is (= \l (get-char-at-caret source-viewer))))
       (testing "respects tab spacing"
         (let [new-code "line1\n\t2345"]
-          (g/transact (g/set-property code-node :code new-code))
-          (g/node-value viewer-node :new-content)
+          (text! source-viewer new-code)
           (caret! source-viewer 3 false)
           (preferred-offset! 4)
           (is (= \e (get-char-at-caret source-viewer)))
@@ -501,9 +494,8 @@
         (paste! source-viewer clipboard)
         (is (= " duckblue" (text source-viewer))))
       (testing "cutting without selection cuts the line"
-        (g/transact (g/set-property code-node :code "line1\nline2"))
-        (g/node-value viewer-node :new-content)
-        (text-selection! source-viewer 0 0)
+        (text! source-viewer "line1\nline2")
+       (text-selection! source-viewer 0 0)
         (caret! source-viewer 9 false)
         (is (= \e (get-char-at-caret source-viewer)))
         (cut! source-viewer clipboard)
@@ -531,8 +523,7 @@
         (is (= "ck" (text source-viewer)))
         (is (= \c  (get-char-at-caret source-viewer))))
       (testing "deleting next"
-        (g/transact (g/set-property code-node :code code))
-        (g/node-value viewer-node :new-content)
+        (text! source-viewer code)
         (caret! source-viewer 2 false)
         (is (= \u (get-char-at-caret source-viewer)))
         (delete-next-word! source-viewer)
@@ -561,8 +552,7 @@
         (is (= "blue du" (text source-viewer)))
         (is (= nil (get-char-at-caret source-viewer))))
       (testing "deleting to start of the line"
-        (g/transact (g/set-property code-node :code code))
-        (g/node-value viewer-node :new-content)
+        (text! source-viewer code)
         (caret! source-viewer 7 false)
         (is (= \c (get-char-at-caret source-viewer)))
         (delete-to-start-of-line! source-viewer)
@@ -665,9 +655,8 @@
         (is (= "the red red ducks" (text source-viewer)))
         (is (= 11 (caret source-viewer))))
       (testing "when caret is beyond match, will not replace"
-         (g/transact (g/set-property code-node :code code))
-         (g/node-value viewer-node :new-content)
-         (caret! source-viewer 7 false)
+        (text! source-viewer code)
+        (caret! source-viewer 7 false)
         (replace-next! source-viewer)
         (is (= "the blue red ducks" (text source-viewer)))
         (is (= 12 (caret source-viewer)))))))
@@ -697,3 +686,27 @@
       (testing "basic enter"
         (enter! source-viewer)
         (is (= "\nhi" (text source-viewer)))))))
+
+(defn- undo! [source-viewer view-node code-node]
+  (handler/run :undo [{:name :code-view :env {:selection source-viewer :view-node view-node :code-node code-node}}]{}))
+
+(defn- redo! [source-viewer view-node code-node]
+  (handler/run :redo [{:name :code-view :env {:selection source-viewer :view-node view-node :code-node code-node}}]{}))
+
+(deftest undo-redo-test
+  (with-clean-system
+    (let [pgraph-id  (g/make-graph! :history true)
+          code ""
+          opts lua/lua
+          source-viewer (setup-source-viewer opts false)
+          [code-node viewer-node] (setup-code-view-nodes pgraph-id source-viewer code script/ScriptNode)]
+      (testing "text editing"
+        (key-typed! source-viewer "h")
+        (changes! source-viewer)
+        (key-typed! source-viewer "i")
+        (changes! source-viewer)
+        (is (= "hi" (g/node-value code-node :code)))
+        (undo! source-viewer viewer-node code-node)
+        (is (= "h" (g/node-value code-node :code)))
+        (redo! source-viewer viewer-node code-node)
+        (is (= "hi" (g/node-value code-node :code)))))))


### PR DESCRIPTION
Since we are now handling all the undoable events with our code, we can simplify the transactions of the properties by handling the caret and text changes together within our actions. 

A protocol TextUndo with a changes! method is called when there is a command to execute for keyPressed, keyTyped, or mouseClicked.  It takes care of making the transaction of the two set-property for code and and caret-position, if they've changed.

For undo, and redo, we sync the node values to the source-viewer with a call to node's new-content
