### PR TITLE
Remove SSL-support from server.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.common/proto/cr_ddf.proto
+++ b/com.dynamo.cr/com.dynamo.cr.common/proto/cr_ddf.proto
@@ -12,9 +12,6 @@ message ProjectTemplate {
 message Configuration
 {
     required int32 service_port = 4;
-    optional int32 ssl_service_port = 41;
-    optional string keystore = 42;
-    optional string keystore_password = 43;
     // Exposed port to the client, i.e. editor
     required int32 git_port = 40;
     required string persistence_unit_name = 6;

--- a/server/src/main/java/com/dynamo/cr/server/Server.java
+++ b/server/src/main/java/com/dynamo/cr/server/Server.java
@@ -39,8 +39,6 @@ import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.glassfish.grizzly.http.server.StaticHttpHandler;
 import org.glassfish.grizzly.servlet.ServletHandler;
-import org.glassfish.grizzly.ssl.SSLContextConfigurator;
-import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -172,27 +170,6 @@ public class Server {
             listener.getKeepAlive().setIdleTimeoutInSeconds(configuration.getGrizzlyIdleTimeout());
         }
         server.addListener(listener);
-
-        if (configuration.hasSslServicePort() && configuration.hasKeystore()) {
-            SSLContextConfigurator sslCon = new SSLContextConfigurator();
-            sslCon.setKeyStoreFile(configuration.getKeystore());
-            String password = "defold";
-            if (configuration.hasKeystorePassword()) {
-                password = configuration.getKeystorePassword();
-            }
-            sslCon.setKeyStorePass(password);
-            NetworkListener sslListener = new NetworkListener("ssl_grizzly", NetworkListener.DEFAULT_NETWORK_HOST,
-                    new PortRange(configuration.getSslServicePort()));
-            sslListener.setSecure(true);
-            SSLEngineConfigurator ssle = new SSLEngineConfigurator(sslCon);
-            sslListener.setSSLEngineConfig(ssle);
-            ssle.setClientMode(false);
-
-            if (configuration.hasGrizzlyIdleTimeout()) {
-                sslListener.getKeepAlive().setIdleTimeoutInSeconds(configuration.getGrizzlyIdleTimeout());
-            }
-            server.addListener(sslListener);
-        }
 
         Config config = new Config(this);
         ServletHandler handler = new GuiceHandler(config);


### PR DESCRIPTION
- Removes the SSL-support (listener) from the server, because SSL is
  now terminated in the loadbalancer.
- Removes the keystore configuration, because the keystore is no longer
  needed.
