### PR TITLE
Text editor add selection offset and length to nodes & undo/redo

### DIFF
--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -57,6 +57,7 @@
       ;; display the text selection property after you change the text programatically
       ;; when it's resolved uncomment
       ;(cvx/text-selection! source-viewer selection-offset selection-length)
+      (cvx/caret! source-viewer caret-position false)
     )
     (cvx/caret! source-viewer caret-position false))
   [code-node code caret-position])

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -175,8 +175,8 @@
   (if (or (.isControlDown ^KeyEvent e) (.isAltDown ^KeyEvent e) (and (is-mac-os?) (.isMetaDown ^KeyEvent e)))
     (not (or (.isControlDown ^KeyEvent e) (and (is-mac-os?) (.isAltDown ^KeyEvent e))))))
 
-(defn handle-key-typed [e source-viewer]
-  (let [key-typed (.getCharacter ^KeyEvent e)]
+(defn handle-key-typed [^KeyEvent e source-viewer]
+  (let [key-typed (.getCharacter e)]
     (when-not (is-not-typable-modifier? e)
       (handler/run
         :key-typed
@@ -206,16 +206,17 @@
         caret-col (+ (count text-before) (* tab-count (dec tab-size)))]
     (preferred-offset! caret-col)))
 
-(defn handle-mouse-clicked [e source-viewer]
-  (let [click-count (.getClickCount ^MouseEvent e)
+(defn handle-mouse-clicked [^MouseEvent e source-viewer]
+  (let [click-count (.getClickCount e)
         cf (click-fn click-count)
         pos (caret source-viewer)]
     (remember-caret-col source-viewer pos)
-    (changes! source-viewer)
     (when cf (handler/run
                (:command cf)
                [{:name :code-view :env {:selection source-viewer :clipboard (Clipboard/getSystemClipboard)}}]
-               e))))
+               e))
+    (changes! source-viewer)
+    (.consume e)))
 
 (defn- replace-text-selection [selection s]
   (replace! selection (selection-offset selection) (selection-length selection) s)

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -537,6 +537,8 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
   (property code g/Str (dynamic visible (g/always false)))
   (property def g/Any (dynamic visible (g/always false)))
   (property caret-position g/Int (dynamic visible (g/always false)) (default 0))
+  (property selection-offset g/Int (dynamic visible (g/always false)) (default 0))
+  (property selection-length g/Int (dynamic visible (g/always false)) (default 0))
 
   (output build-targets g/Any produce-build-targets)
   (output full-source g/Str (g/fnk [code def] (str (get def :prefix) code))))

--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -117,6 +117,8 @@
 
   (property code g/Str (dynamic visible (g/always false)))
   (property caret-position g/Int (dynamic visible (g/always false)) (default 0))
+  (property selection-offset g/Int (dynamic visible (g/always false)) (default 0))
+  (property selection-length g/Int (dynamic visible (g/always false)) (default 0))
 
   (output modules g/Any :cached (g/fnk [code] (lua-scan/src->modules code)))
   (output script-properties g/Any :cached (g/fnk [code] (lua-scan/src->properties code)))


### PR DESCRIPTION
Added the selection offset and length to the code node and viewer nodes.

Everything is in place for them to be part of the undo/redo transaction.  Unfortunately there is a display bug somewhere in ex(fx)clipse code that is not reflecting any text selection changes after a programatic text change (rather than doing it with events).  

I wasn't able to track the source of it down yet, so commented out the text selection changes until we can devote time to fixing it.  Otherwise, the selected area will appear in random areas of the screen and looks really odd. There is the same problem with programmatic replace text.
