### PR TITLE
Access token: Fix access token resource issues.

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/Server.java
+++ b/server/src/main/java/com/dynamo/cr/server/Server.java
@@ -118,6 +118,7 @@ public class Server {
                     bind(LoginResource.class);
                     bind(LoginOAuthResource.class);
                     bind(ProspectsResource.class);
+                    bind(AccessTokenResource.class);
 
                     Map<String, String> params = new HashMap<>();
                     params.put("com.sun.jersey.config.property.resourceConfigClass",

--- a/server/src/main/java/com/dynamo/cr/server/resources/AccessTokenResource.java
+++ b/server/src/main/java/com/dynamo/cr/server/resources/AccessTokenResource.java
@@ -2,13 +2,16 @@ package com.dynamo.cr.server.resources;
 
 import com.dynamo.cr.server.auth.AccessTokenAuthenticator;
 
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 
 @Path("access_token")
+@RolesAllowed(value = {"user"})
 public class AccessTokenResource extends BaseResource {
 
     private final AccessTokenAuthenticator accessTokenAuthenticator;
@@ -20,7 +23,7 @@ public class AccessTokenResource extends BaseResource {
     }
 
     @POST
-    public String generateNewToken(@Context HttpServletRequest httpServletRequest) {
-        return accessTokenAuthenticator.createLifetimeToken(getUser(), httpServletRequest.getRemoteAddr());
+    public Response generateNewToken(@Context HttpServletRequest httpServletRequest) {
+        return okResponse(accessTokenAuthenticator.createLifetimeToken(getUser(), httpServletRequest.getRemoteAddr()));
     }
 }

--- a/server/src/test/java/com/dynamo/cr/server/resources/test/AbstractResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/test/AbstractResourceTest.java
@@ -156,6 +156,22 @@ public class AbstractResourceTest {
         return client.resource(uri);
     }
 
+    WebResource createBaseResource(User user, String password) {
+        DefaultClientConfig clientConfig = new DefaultClientConfig();
+        clientConfig.getClasses().add(JsonProviders.ProtobufMessageBodyReader.class);
+        clientConfig.getClasses().add(JsonProviders.ProtobufMessageBodyWriter.class);
+        clientConfig.getClasses().add(ProtobufProviders.ProtobufMessageBodyReader.class);
+        clientConfig.getClasses().add(ProtobufProviders.ProtobufMessageBodyWriter.class);
+
+        Client client = Client.create(clientConfig);
+        client.addFilter(new HTTPBasicAuthFilter(user.getEmail(), password));
+
+        int port = injector.getInstance(Configuration.class).getServicePort();
+
+        URI uri = UriBuilder.fromUri("http://localhost/").port(port).build();
+        return client.resource(uri);
+    }
+
     WebResource createAnonymousResource(String baseURI) {
         DefaultClientConfig clientConfig = new DefaultClientConfig();
         clientConfig.getClasses().add(JsonProviders.ProtobufMessageBodyReader.class);

--- a/server/src/test/java/com/dynamo/cr/server/resources/test/AccessTokenResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/test/AccessTokenResourceTest.java
@@ -1,0 +1,21 @@
+package com.dynamo.cr.server.resources.test;
+
+import com.dynamo.cr.server.model.User;
+import com.sun.jersey.api.client.WebResource;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class AccessTokenResourceTest extends AbstractResourceTest {
+
+    @Test
+    public void userShouldBeAbleToGenerateNewAccessToken() {
+        User bobUser = createUser("bob@foo.com", "bob", "Mr", "Bob", User.Role.USER);
+
+        WebResource resource = createBaseResource(bobUser, "bob");
+        String access_token = resource.path("access_token").post(String.class);
+
+        assertTrue(access_token != null && !access_token.isEmpty());
+    }
+
+}


### PR DESCRIPTION
- Access token resourse wasn't registered in server correctly.
- User wasn't authenticate when requesting access token, which resulted in NPE.
- Added basic resource test.
