### PR TITLE
Override properties invalidate _properties

### DIFF
--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -2,8 +2,7 @@
   (:require [clojure.set :as set]
             [internal.graph.types :as gt]
             [schema.core :as s]
-            [internal.util :as util]
-            [internal.node :as in]))
+            [internal.util :as util]))
 
 (set! *warn-on-reflection* true)
 
@@ -396,7 +395,6 @@
           tgt-node      (node tgt-graph tgt-id)
           tgt-type      (gt/node-type tgt-node this)]
       (assert (<= (:_volatility src-graph 0) (:_volatility tgt-graph 0)))
-      (assert (in/has-input? tgt-type tgt-label) (str "No label " tgt-label " exists on node " tgt-node))
       (if (= src-gid tgt-gid)
         (update this :graphs assoc
                 src-gid (-> src-graph
@@ -456,8 +454,10 @@
 
 (defn- input-deps [basis node-id]
   (or (some-> (gt/node-by-id-at basis node-id)
-        (gt/node-type basis)
-        in/input-dependencies) {}))
+              (gt/node-type basis)
+              deref
+              :input-dependencies)
+      {}))
 
 (defn update-successors
   [basis changes]

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -6,6 +6,8 @@
             [internal.cache :as c]
             [internal.graph.types :as gt]
             [internal.graph.error-values :as ie]
+            [internal.state :as state]
+            [internal.system :as is]
             [plumbing.core :as pc]
             [plumbing.fnk.pfnk :as pf]
             [schema.core :as s]
@@ -1474,7 +1476,9 @@
   (set-property        [this basis property value]
     (if (= :_output-jammers property)
       (throw (ex-info "Not possible to mark override nodes as defective" {}))
-      (assoc-in this [:properties property] value)))
+      (do
+        (c/cache-invalidate (is/system-cache @state/*the-system*) (gt/dependencies basis [[node-id :_properties]]))
+        (assoc-in this [:properties property] value))))
 
   gt/Evaluation
   (produce-value       [this output evaluation-context]
@@ -1525,7 +1529,9 @@
               (node-value* original output evaluation-context)))))))
 
   gt/OverrideNode
-  (clear-property [this basis property] (update this :properties dissoc property))
+  (clear-property [this basis property]
+    (c/cache-invalidate (is/system-cache @state/*the-system*) (gt/dependencies basis [[node-id :_properties]]))
+    (update this :properties dissoc property))
   (override-id    [this]                override-id)
   (original       [this]                original-id)
   (set-original   [this original-id]    (assoc this :original-id original-id)))

--- a/editor/src/clj/internal/state.clj
+++ b/editor/src/clj/internal/state.clj
@@ -1,0 +1,4 @@
+(ns internal.state)
+
+;; Only marked dynamic so tests can rebind. Should never be rebound "for real".
+(defonce ^:dynamic *the-system* (atom nil))

--- a/editor/test/benchmark/graph_benchmark.clj
+++ b/editor/test/benchmark/graph_benchmark.clj
@@ -8,6 +8,7 @@
             [integration.test-util :as test-util]
             [internal.graph :as ig]
             [internal.graph.types :as gt]
+            [internal.state :as state]
             [internal.system :as isys]))
 
 
@@ -139,7 +140,7 @@
 (defn set-property-some-nodes []
   (with-clean-system
     (let [r               (load-test-project! world)
-          project-graph   (isys/graph @g/*the-system* (:project-graph r))
+          project-graph   (isys/graph @state/*the-system* (:project-graph r))
           affected-num    100
           chosen-node-ids (repeatedly affected-num (partial rand-nth (ig/node-ids project-graph)))
           chosen-props    (mapv (fn [node-id]  (safe-rand-nth (vec (disj (set (keys (-> node-id g/node-type g/public-properties))) :id)))) chosen-node-ids)]

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -5,17 +5,18 @@
             [support.test-support :as ts]
             [internal.util :as u]
             [internal.graph.types :as gt]
+            [internal.state :as state]
             [internal.system :as is]))
 
 (g/defnode Root
   (property where g/Str)
   (property touched g/Num))
 
-(defn graphs        []    (is/graphs        @g/*the-system*))
-(defn graph         [gid] (is/graph         @g/*the-system* gid))
-(defn graph-ref     [gid] (is/graph-ref     @g/*the-system* gid))
-(defn graph-time    [gid] (is/graph-time    @g/*the-system* gid))
-(defn graph-history [gid] (is/graph-history @g/*the-system* gid))
+(defn graphs        []    (is/graphs        @state/*the-system*))
+(defn graph         [gid] (is/graph         @state/*the-system* gid))
+(defn graph-ref     [gid] (is/graph-ref     @state/*the-system* gid))
+(defn graph-time    [gid] (is/graph-time    @state/*the-system* gid))
+(defn graph-history [gid] (is/graph-history @state/*the-system* gid))
 
 (defn history-states
   [gid]
@@ -88,7 +89,7 @@
                                       (g/operation-label "Increment touch count")])
             undos-after  (is/undo-stack (graph-history pgraph-id))
             redos-after  (is/redo-stack (graph-history pgraph-id))
-            snapshot     @g/*the-system*]
+            snapshot     @state/*the-system*]
         (is (= ["Build root" "Increment touch count"] (mapv :label undos-after)))
         (is (= []                                     (mapv :label redos-after)))
         (is/undo-history (graph-history pgraph-id) snapshot)

--- a/editor/test/support/test_support.clj
+++ b/editor/test/support/test_support.clj
@@ -1,6 +1,7 @@
 (ns support.test-support
   (:require [dynamo.graph :as g]
-            [internal.system :as is]))
+            [internal.system :as is]
+            [internal.state :as state]))
 
 (defmacro with-clean-system
   [& forms]
@@ -9,7 +10,7 @@
     `(let [~'system      (is/make-system ~configuration)
            ~'cache       (:cache ~'system)
            ~'world       (first (keys (is/graphs ~'system)))]
-       (binding [g/*the-system* (atom ~'system)]
+       (binding [state/*the-system* (atom ~'system)]
          ~@forms))))
 
 (defn tx-nodes [& txs]
@@ -35,8 +36,8 @@
 
 (defn undo-stack
   [graph]
-  (is/undo-stack (is/graph-history @g/*the-system* graph)))
+  (is/undo-stack (is/graph-history @state/*the-system* graph)))
 
 (defn redo-stack
   [graph]
-  (is/redo-stack (is/graph-history @g/*the-system* graph)))
+  (is/redo-stack (is/graph-history @state/*the-system* graph)))


### PR DESCRIPTION
Setting or clearing a property on an override node (as one does with
instances of scripts in a collection) will cause the node's _properties
output to be invalidated.

The visible behavior of this is in the properties view. Open a
collection, select a script node that is referenced in the
collection. Change a property that was defined in the script code and
observe that the label immediately turns blue on hitting enter or
removing focus from the text field. The reset arrow also appears
immediately. Hitting the reset arrow immediately updated the view as
well.
