### PR TITLE
Nygard/fix property dependencies

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -219,10 +219,7 @@
                              s/Keyword                             s/Any}}
      (s/optional-key :display-order) [(s/either s/Keyword [(s/one String "category") s/Keyword])]})
 
-(def node-intrinsics
-  [(list 'extern '_node-id :dynamo.graph/NodeID)
-   (list 'output '_properties :dynamo.graph/Properties `(dynamo.graph/fnk [~'_declared-properties] ~'_declared-properties))
-   (list 'extern '_output-jammers :dynamo.graph/KeywordMap)])
+
 
 ;; ---------------------------------------------------------------------------
 ;; Definition
@@ -324,7 +321,7 @@
   [symb & body]
   (let [[symb forms]  (ctm/name-with-attributes symb body)
         fqs           (symbol (str *ns*) (str symb))
-        node-type-def (in/process-node-type-forms fqs (concat node-intrinsics forms))
+        node-type-def (in/process-node-type-forms fqs forms)
         fn-paths      (in/extract-functions node-type-def)
         fn-defs       (for [[path func] fn-paths]
                         (list `def (in/dollar-name symb path) func))

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -618,17 +618,6 @@
   [description]
   (assoc description :input-dependencies (description->input-dependencies description)))
 
-(defn input-dependencies-non-transitive
-  "Return a map from input to affected outputs, but without including
-  the transitive effects on other outputs within the same node
-  type. This is a specialized case and if it's not apparent what it
-  means, you should probably call input-dependencies instead."
-  [node-type]
-  (let [transforms (transforms node-type)]
-    (invert-map
-     (zipmap (keys transforms)
-             (map util/inputs-needed (vals transforms))))))
-
 (declare node-output-value-function)
 (declare declared-properties-function)
 (declare node-input-value-function)

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -863,9 +863,9 @@
   ([l r & more]
    (reduce node-type-merge (node-type-merge l r) more)))
 
-(defn merge-left
-  [tree selector]
-  (let [supertypes (map deref (get tree selector []))]
+(defn merge-supertypes
+  [tree]
+  (let [supertypes (map deref (get tree :supertypes []))]
     (node-type-merge (apply node-type-merge supertypes) tree)))
 
 (defn defer-display-order-resolution
@@ -952,7 +952,7 @@
   [fqs forms]
   (-> (maybe-inject-intrinsics forms)
       group-node-type-forms
-      (merge-left :supertypes)
+      merge-supertypes
       (assoc :name (str fqs))
       (assoc :key (keyword fqs))
       wrap-constant-fns

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -827,3 +827,24 @@
       :input-one
       :_properties
       :_declared-properties)))
+
+(g/defnode CustomPropertiesOutput
+  (output _properties g/Properties :cached
+          (g/fnk [_declared-properties]
+                 (assoc-in _declared-properties [:properties :from-custom-output] {:node-id 0
+                                                                                   :type    g/Bool
+                                                                                   :value true}))))
+
+(g/defnode InheritFromCustomProperties
+  (inherits CustomPropertiesOutput))
+
+(deftest inheriting-properties-output
+  (testing "custom _properties function is invoked"
+    (with-clean-system
+      (let [[n] (tx-nodes (g/make-node world CustomPropertiesOutput))]
+        (is (some-> n (g/node-value :_properties) :properties :from-custom-output :value)))))
+
+  (testing "inherited function is invoked"
+    (with-clean-system
+      (let [[n] (tx-nodes (g/make-node world InheritFromCustomProperties))]
+        (is (some-> n (g/node-value :_properties) :properties :from-custom-output :value))))))

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -838,6 +838,10 @@
 (g/defnode InheritFromCustomProperties
   (inherits CustomPropertiesOutput))
 
+(g/defnode InheritAndOverrideProperties
+  (output _properties g/Properties
+          (g/fnk [_declared-properties] _declared-properties)))
+
 (deftest inheriting-properties-output
   (testing "custom _properties function is invoked"
     (with-clean-system
@@ -847,4 +851,8 @@
   (testing "inherited function is invoked"
     (with-clean-system
       (let [[n] (tx-nodes (g/make-node world InheritFromCustomProperties))]
-        (is (some-> n (g/node-value :_properties) :properties :from-custom-output :value))))))
+        (is (some-> n (g/node-value :_properties) :properties :from-custom-output :value)))))
+
+  (testing "cached flag is not inherited"
+    (is (contains? (-> @CustomPropertiesOutput :output :_properties :flags) :cached))
+    (is (not (contains? (-> @InheritAndOverrideProperties :output :_properties :flags) :cached)))))

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -170,7 +170,7 @@
                                                        (g/connect source :foo target :bar)))
           tx-result                     (g/set-property! source :foo "hi")
           properties-modified-on-target (set (keep #(when (= (first %) target) (second %)) (:outputs-modified tx-result)))]
-      (is (= #{:_declared-properties :_properties} properties-modified-on-target)))))
+      (is (= #{:_declared-properties :baz :_properties} properties-modified-on-target)))))
 
 (deftest visibility-properties
   (with-clean-system
@@ -189,7 +189,7 @@
       (let [tx-result     (g/transact (g/set-property snode :foo 1))
             enode-results (filter #(= (first %) enode) (:outputs-modified tx-result))
             modified      (into #{} (map second enode-results))]
-        (is (= #{:_declared-properties :_properties} modified))))))
+        (is (= #{:_declared-properties :baz :_properties} modified))))))
 
 (deftest enablement-properties
   (with-clean-system


### PR DESCRIPTION
Properties now depend on their own inputs

Previously, if a property had a validation or dynamic attribute with inputs, those inputs were not used to invalidate that property itself. (Oddly enough, downstream outputs _were_ properly invalidated.)

Now, a property depends on its own inputs for validates, getters, and any number of dynamics.

Also, node intrinsics were being injected into every node definition. This
meant that overriding the _properties function would not be inherited,
because a fresh copy of the default function got injected into the
derived node types.

Now, we treat intrinsics as something to inject _only_ when there are no
`inherits` clauses in the node definition. This acts more like a
"universal base type" but without polluting the supertype hierarchy.

When overriding a function from a supertype, the :cached flag is not
inherited. This PR adds a test to verify that.
