### PR TITLE
Text editor snippet tab trigger ux

### DIFF
--- a/editor/resources/editor.css
+++ b/editor/resources/editor.css
@@ -989,11 +989,6 @@ Defold Orange       #fd6623             Guides etc
     -styled-text-color: #aaaaff;
 }
 
-.lua.selection-marker,
-.glsl.selection-marker {
-    -fx-background-color: #8f9296;
-}
-
 .glsl.styled-text-area .directive {
     -styled-text-color: #fd6623;
 }
@@ -1026,6 +1021,10 @@ Defold Orange       #fd6623             Guides etc
 .styled-text-area .text-caret {
 	-fx-fill: white;
 	-fx-stroke: white;
+}
+
+.styled-text-area .selection-marker {
+	-fx-background-color:  rgba(172,148,120,0.3)
 }
 
 /*

--- a/editor/src/clj/editor/code.clj
+++ b/editor/src/clj/editor/code.clj
@@ -12,12 +12,13 @@
 
 (defn create-hint
   ([name]
-   (create-hint name name name ""))
-  ([name display-string insert-string doc]
+   (create-hint name name name "" nil))
+  ([name display-string insert-string doc tab-triggers]
    {:name name
     :display-string display-string
     :insert-string insert-string
-    :doc doc}))
+    :doc doc
+    :tab-triggers (or tab-triggers [])}))
 
 (defn match-while [body p]
   (loop [body body

--- a/editor/src/clj/editor/code_completion.clj
+++ b/editor/src/clj/editor/code_completion.clj
@@ -20,7 +20,7 @@
         fns  (map (fn [[fname {:keys [params]}]]
                     (let [n (if namespace-alias (replace-alias fname namespace-alias) fname)
                           display-string (str n "(" (string/join "," params)  ")")]
-                      (code/create-hint n display-string display-string "")))
+                      (code/create-hint n display-string display-string "" params)))
                   fn-info)]
     (set (concat vars fns))))
 

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -283,24 +283,26 @@
                                     ;;do nothing we are handling all the events
                                     )
                                   (defoldUpdateCursor [^MouseEvent event visible-cells selection]
-                                    (let [vcells (into [] visible-cells)
-                                          doc-len (.getCharCount ^StyledTextArea text-area)
-                                          event-y (.getY event)
-                                          scene-event-x (.getSceneX event)
-                                          scene-event-y (.getSceneY event)
-                                          caret-cells (sort-by :min-y (mapv #(caret-at-point % scene-event-x scene-event-y) vcells))
-                                          found-cells (filter #(when-let [idx (:caret-idx %)]
-                                                                 (not= -1 idx)) caret-cells)]
-                                      (if-let [fcell (first found-cells)]
-                                        (cvx/caret! text-area (+ (:start-offset fcell) (:caret-idx fcell)) selection)
-                                        (let [closest-cell (some #(when (>= (:max-y %) event-y) %) caret-cells)]
-                                          (cond
+                                    (try
+                                      (let [vcells (into [] visible-cells)
+                                           doc-len (.getCharCount ^StyledTextArea text-area)
+                                           event-y (.getY event)
+                                           scene-event-x (.getSceneX event)
+                                           scene-event-y (.getSceneY event)
+                                           caret-cells (sort-by :min-y (mapv #(caret-at-point % scene-event-x scene-event-y) vcells))
+                                           found-cells (filter #(when-let [idx (:caret-idx %)]
+                                                                  (not= -1 idx)) caret-cells)]
+                                       (if-let [fcell (first found-cells)]
+                                         (cvx/caret! text-area (+ (:start-offset fcell) (:caret-idx fcell)) selection)
+                                         (let [closest-cell (some #(when (>= (:max-y %) event-y) %) caret-cells)]
+                                           (cond
 
-                                            (:line-offset closest-cell)
-                                            (cvx/caret! text-area (+ (:line-offset closest-cell) (:line-length closest-cell)) selection)
+                                             (:line-offset closest-cell)
+                                             (cvx/caret! text-area (+ (:line-offset closest-cell) (:line-length closest-cell)) selection)
 
-                                            true
-                                            (cvx/caret! text-area doc-len selection)))))))]
+                                             true
+                                             (cvx/caret! text-area doc-len selection)))))
+                                      (catch Exception e (println "error updating cursor")))))]
       (.addEventHandler ^StyledTextArea text-area
                         KeyEvent/KEY_PRESSED
                         (ui/event-handler e (cvx/handle-key-pressed e source-viewer)))

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -7,7 +7,7 @@
             [editor.ui :as ui]
             [editor.workspace :as workspace])
   (:import [com.defold.editor.eclipse DefoldRuleBasedScanner Document DefoldStyledTextSkin DefoldStyledTextSkin$LineCell
-            DefoldStyledTextBehavior DefoldStyledTextArea DefoldSourceViewer]
+            DefoldStyledTextBehavior DefoldStyledTextArea DefoldSourceViewer DefoldStyledTextLayoutContainer]
            [javafx.scene Parent]
            [javafx.scene.input Clipboard ClipboardContent KeyEvent MouseEvent]
            [javafx.scene.image Image ImageView]
@@ -235,7 +235,7 @@
   (caret-at-point [this x y]
     (let [bip (.getBoundsInParent this)
           de (.getDomainElement ^DefoldStyledTextSkin$LineCell this)
-          ^StyledTextLayoutContainer n (.getGraphic this)
+          ^DefoldStyledTextLayoutContainer n (.getGraphic this)
           base {:min-x (.getMinX bip)
                 :min-y (.getMinY bip)
                 :max-x (.getMaxX bip)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -834,7 +834,9 @@
                   replacement
                  (code/proposal-filter-pattern (:namespace parsed-line) (:function parsed-line)))
         new-line-text (string/replace-first line-text pattern replacement)
-        snippet-tab-start (or (string/index-of new-line-text "(") 0)]
+        snippet-tab-start (or (string/index-of new-line-text "function_name")
+                              (string/index-of new-line-text "(")
+                              0)]
     (replace! selection (line-offset selection) (count line-text) new-line-text)
     (snippet-tab-triggers! tab-triggers)
     (next-tab-trigger selection (+ loffset snippet-tab-start))))

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -161,6 +161,7 @@
       (reset! tab-triggers nil)
       (swap! tab-triggers rest))
     trigger))
+(defn clear-snippet-tab-triggers! [] (reset! tab-triggers nil))
 
 (defn- info [e]
   {:event e
@@ -239,6 +240,7 @@
         cf (click-fn click-count)
         pos (caret source-viewer)]
     (remember-caret-col source-viewer pos)
+    (clear-snippet-tab-triggers!)
     (when cf (handler/run
                (:command cf)
                [{:name :code-view :env {:selection source-viewer :clipboard (Clipboard/getSystemClipboard)}}]
@@ -276,16 +278,18 @@
         next-pos (if (pos? (count selected-text))
                    (adjust-bounds doc (+ c (count selected-text)))
                    (adjust-bounds doc (inc c)))]
-      (caret! selection next-pos false)
-      (remember-caret-col selection next-pos)))
+    (clear-snippet-tab-triggers!)
+    (caret! selection next-pos false)
+    (remember-caret-col selection next-pos)))
 
 (defn select-right [selection]
   (let [c (caret selection)
         doc (text selection)
         selected-text (text-selection selection)
         next-pos (adjust-bounds doc (inc c))]
-      (caret! selection next-pos true)
-      (remember-caret-col selection next-pos)))
+    (clear-snippet-tab-triggers!)
+    (caret! selection next-pos true)
+    (remember-caret-col selection next-pos)))
 
 (defn left [selection]
   (let [c (caret selection)
@@ -294,16 +298,18 @@
         next-pos (if (pos? (count selected-text))
                    (adjust-bounds doc (- c (count selected-text)))
                    (adjust-bounds doc (dec c)))]
-      (caret! selection next-pos false)
-      (remember-caret-col selection next-pos)))
+    (clear-snippet-tab-triggers!)
+    (caret! selection next-pos false)
+    (remember-caret-col selection next-pos)))
 
 (defn select-left [selection]
   (let [c (caret selection)
         doc (text selection)
         selected-text (text-selection selection)
         next-pos (adjust-bounds doc (dec c))]
-      (caret! selection next-pos true)
-      (remember-caret-col selection next-pos)))
+    (clear-snippet-tab-triggers!)
+    (caret! selection next-pos true)
+    (remember-caret-col selection next-pos)))
 
 (handler/defhandler :right :code-view
   (enabled? [selection] selection)
@@ -858,6 +864,7 @@
   (enabled? [selection] (editable? selection))
   (run [selection]
     (when (editable? selection)
+      (println "Carin " (has-snippet-tab-trigger?) @tab-triggers)
       (if (has-snippet-tab-trigger?)
         (let [caret (caret selection)
               doc (text selection)
@@ -892,6 +899,7 @@
   (enabled? [selection] (editable? selection))
   (run [selection]
     (when (editable? selection)
+      (clear-snippet-tab-triggers!)
       (let [line-seperator (System/getProperty "line.separator")
             current-line (line selection)
             line-offset (line-offset selection)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -864,7 +864,6 @@
   (enabled? [selection] (editable? selection))
   (run [selection]
     (when (editable? selection)
-      (println "Carin " (has-snippet-tab-trigger?) @tab-triggers)
       (if (has-snippet-tab-trigger?)
         (let [caret (caret selection)
               doc (text selection)

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -127,9 +127,9 @@
        (code/create-hint "elseif" "elseif" "elseif cond\n\t--do things\nend" "" ["cond" "--do things" "end"])
        (code/create-hint "while" "while" "while cond\n\t--do things\nend" "" ["cond" "--do things"])
        (code/create-hint "repeat" "repeat" "repeat\n\t--do things\nuntil cond" "" ["--do things" "cond"])
-       (code/create-hint "function" "function" "function function_name(params)\n\t--do things\nend" "" ["function_name" "params" "--do things"])
+       (code/create-hint "function" "function" "function function_name(params)\n\t--do things\nend" "" ["function_name" "params" "--do things" "end"])
        (code/create-hint "local" "local" "local local_name = local_value" "" ["local_name" "local_value"])
-       (code/create-hint "for" "for" "for i=1,10 do\n\t--do things\nend" "" ["i" "1" "10" "--do things"])]})
+       (code/create-hint "for" "for" "for i=1,10 do\n\t--do things\nend" "" ["i" "1" "10" "--do things" "end"])]})
 
 (def lua-std-libs-docs (atom (merge-with into (lua-base-documentation) (lua-std-libs-documentation))))
 

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -110,12 +110,15 @@
                         slurp
                         edn/read-string)
         hints (for [item base-items]
-                (code/create-hint
-                 (first (string/split item #"\("))
-                 item
-                 (string/replace item #"\[.*\]" "")
-                 ""
-                 nil))
+                (let [insert-string (string/replace item #"\[.*\]" "")
+                      params (re-find #"(\()(.*)(\))" insert-string)
+                      tab-triggers (when (< 3 (count params)) (remove #(= "" %) (string/split (nth params 2) #",")))]
+                  (code/create-hint
+                   (first (string/split item #"\("))
+                   item
+                   insert-string
+                   ""
+                   tab-triggers)))
         completions (group-by #(let [names (string/split (:name %) #"\.")]
                                          (if (= 2 (count names)) (first names) "")) hints)
         package-completions {"" (map code/create-hint (remove #(= "" %) (keys completions)))}]

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
@@ -1,0 +1,360 @@
+package com.defold.editor.eclipse;
+
+import org.eclipse.fx.ui.controls.styledtext.TextSelection;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.beans.Observable;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.geometry.Point2D;
+import javafx.scene.layout.Region;
+import javafx.scene.shape.Line;
+import javafx.scene.text.TextFlow;
+import javafx.util.Duration;
+
+/**
+ * A text layout container who is able to show selection
+ *
+ * @since 2.0
+ */
+public class DefoldStyledTextLayoutContainer extends Region {
+	@SuppressWarnings("null")
+	@NonNull
+	private final ObservableList<@NonNull DefoldStyledTextNode> textNodes = FXCollections.observableArrayList();
+
+	@NonNull
+	private final IntegerProperty startOffset = new SimpleIntegerProperty(this, "startOffset"); //$NON-NLS-1$
+
+	/**
+	 * The start offset if used in a bigger context like {@link StyledTextArea}
+	 *
+	 * @return the offset property to observe
+	 */
+	public final IntegerProperty startOffsetProperty() {
+		return this.startOffset;
+	}
+
+	/**
+	 * The start offset if used in a bigger context like {@link StyledTextArea}
+	 *
+	 * @return the offset
+	 */
+	public final int getStartOffset() {
+		return this.startOffsetProperty().get();
+	}
+
+	/**
+	 * The start offset if used in a bigger context like {@link StyledTextArea}
+	 *
+	 * @param startOffset
+	 *            the start offset
+	 */
+	public final void setStartOffset(final int startOffset) {
+		this.startOffsetProperty().set(startOffset);
+	}
+
+	@NonNull
+	private final ObjectProperty<@NonNull TextSelection> selection = new SimpleObjectProperty<>(this, "selection", TextSelection.EMPTY); //$NON-NLS-1$
+
+	/**
+	 * The selection currently shown
+	 *
+	 * @return the selection property to observe
+	 */
+	public final ObjectProperty<@NonNull TextSelection> selectionProperty() {
+		return this.selection;
+	}
+
+	/**
+	 * @return the text selection
+	 */
+	public final @NonNull TextSelection getSelection() {
+		return this.selectionProperty().get();
+	}
+
+	/**
+	 * The selection to be shown
+	 *
+	 * @param selection
+	 *            the new selection
+	 */
+	public final void setSelection(final @NonNull TextSelection selection) {
+		this.selectionProperty().set(selection);
+	}
+
+	private final Region selectionMarker = new Region();
+	final Line caret = new Line();
+	private final TextFlow textLayoutNode = new TextFlow();
+
+	private DefoldStyledTextNode selectionStartNode;
+	private DefoldStyledTextNode selectionEndNode;
+
+	private double selectionStartX;
+	private double selectionEndX;
+
+	private Timeline flashTimeline;
+	int caretIndex = -1;
+
+	private final ReadOnlyBooleanProperty ownerFocusedProperty;
+
+	/**
+	 * Create a container to layout text and allows to show e.g. a selection
+	 * range
+	 */
+	public DefoldStyledTextLayoutContainer() {
+		this(new SimpleBooleanProperty(true));
+	}
+
+	/**
+	 * Create a container to layout text and allows to show e.g. a selection
+	 * range
+	 *
+	 * @param ownerFocusedProperty
+	 *            property identifing if the owner of the text container has the
+	 *            input focus
+	 */
+	@SuppressWarnings("null")
+	public DefoldStyledTextLayoutContainer(ReadOnlyBooleanProperty ownerFocusedProperty) {
+		this.ownerFocusedProperty = ownerFocusedProperty;
+		getStyleClass().add("styled-text-layout-container"); //$NON-NLS-1$
+		this.textNodes.addListener(this::recalculateOffset);
+		this.selectionMarker.setVisible(false);
+		this.selectionMarker.setManaged(false);
+		this.selectionMarker.getStyleClass().add("selection-marker"); //$NON-NLS-1$
+		this.caret.setVisible(false);
+		this.caret.setStrokeWidth(2);
+		this.caret.setManaged(false);
+		this.caret.getStyleClass().add("text-caret"); //$NON-NLS-1$
+
+		this.flashTimeline = new Timeline();
+		this.flashTimeline.setCycleCount(Animation.INDEFINITE);
+
+		EventHandler<ActionEvent> startEvent = e -> {
+			if( ! ownerFocusedProperty.get() ) {
+				DefoldStyledTextLayoutContainer.this.caret.setVisible(false);
+			} else {
+				DefoldStyledTextLayoutContainer.this.caret.setVisible(DefoldStyledTextLayoutContainer.this.caretIndex != -1);
+			}
+		};
+
+		EventHandler<ActionEvent> endEvent = e -> {
+			DefoldStyledTextLayoutContainer.this.caret.setVisible(false);
+		};
+
+		this.flashTimeline.getKeyFrames().addAll(new KeyFrame(Duration.ZERO, startEvent), new KeyFrame(Duration.millis(500), endEvent), new KeyFrame(Duration.millis(1000)));
+
+		Bindings.bindContent(this.textLayoutNode.getChildren(), this.textNodes);
+		getChildren().setAll(this.selectionMarker, this.textLayoutNode, this.caret);
+		selectionProperty().addListener(this::handleSelectionChange);
+		ownerFocusedProperty.addListener( o -> {
+			if( ! ownerFocusedProperty.get() ) {
+				this.caret.setVisible(false);
+			}
+		});
+	}
+
+	private int getEndOffset() {
+		return getStartOffset() + getText().length();
+	}
+
+	/**
+	 * Check if the offset is between the start and end
+	 *
+	 * @param start
+	 *            the start
+	 * @param end
+	 *            the end
+	 * @return <code>true</code> if intersects the offset
+	 */
+	public boolean intersectOffset(int start, int end) {
+		if (getStartOffset() > end) {
+			return false;
+		} else if (getEndOffset() < start) {
+			return false;
+		}
+		return true;
+	}
+
+	private void recalculateOffset(Observable o) {
+		int offset = 0;
+		for (DefoldStyledTextNode t : this.textNodes) {
+			t.setStartOffset(offset);
+			offset = t.getEndOffset();
+		}
+	}
+
+	private void handleSelectionChange(Observable o, TextSelection oldSelection, TextSelection newSelection) {
+		if (newSelection.length == 0) {
+			this.selectionMarker.setVisible(false);
+			this.selectionMarker.resize(0, 0);
+		} else {
+			this.selectionMarker.setVisible(true);
+			int start = newSelection.offset;
+			int end = newSelection.offset + newSelection.length;
+
+			this.selectionStartNode = null;
+			this.selectionEndNode = null;
+			for (DefoldStyledTextNode t : this.textNodes) {
+				if (t.intersectOffset(start, end)) {
+					if (this.selectionStartNode == null) {
+						this.selectionStartNode = t;
+					}
+					this.selectionEndNode = t;
+				}
+			}
+
+			if (this.selectionStartNode != null && this.selectionEndNode != null) {
+				int charIndex = start - this.selectionStartNode.getStartOffset();
+				this.selectionStartX = this.selectionStartNode.getCharLocation(charIndex);
+				charIndex = end - this.selectionEndNode.getStartOffset();
+				this.selectionEndX = this.selectionEndNode.getCharLocation(charIndex);
+				requestLayout();
+			}
+		}
+	}
+
+	@Override
+	protected double computePrefHeight(double width) {
+		double d = super.computePrefHeight(width);
+		return d;
+	}
+
+	@Override
+	protected void layoutChildren() {
+		super.layoutChildren();
+
+		this.textLayoutNode.relocate(getInsets().getLeft(), getInsets().getTop());
+
+		if (this.selectionStartNode != null && this.selectionEndNode != null) {
+			double x1 = this.textLayoutNode.localToParent(this.selectionStartNode.getBoundsInParent().getMinX(), 0).getX() + this.selectionStartX;
+			double x2 = this.textLayoutNode.localToParent(this.selectionEndNode.getBoundsInParent().getMinX(), 0).getX() + this.selectionEndX;
+			this.selectionMarker.resizeRelocate(x1, 0, x2 - x1, getHeight());
+		}
+
+		if (this.caretIndex >= 0) {
+			this.textLayoutNode.layout();
+			this.textLayoutNode.applyCss();
+			for (DefoldStyledTextNode t : this.textNodes) {
+				t.applyCss();
+				if (t.getStartOffset() <= this.caretIndex && (t.getEndOffset() > this.caretIndex || this.textNodes.get(this.textNodes.size() - 1) == t)) {
+					double caretX = t.getCharLocation(this.caretIndex - t.getStartOffset());
+					double x = this.textLayoutNode.localToParent(t.getBoundsInParent().getMinX(), 0).getX() + caretX;
+					double h = t.prefHeight(-1);
+
+					this.caret.setStartX(x);
+					this.caret.setEndX(x);
+					this.caret.setStartY(getInsets().getTop() + 1);
+					this.caret.setEndY(h + getInsets().getTop() + 1);
+					this.caret.toFront();
+					return;
+				}
+			}
+
+			this.caret.setStartX(0);
+			this.caret.setEndX(0);
+			this.caret.setStartY(0);
+			this.caret.setEndY(15);
+
+		} else {
+			this.caret.setStartX(0);
+			this.caret.setEndX(0);
+			this.caret.setStartY(0);
+			this.caret.setEndY(getHeight());
+		}
+	}
+
+	/**
+	 * @return list of text nodes rendered
+	 */
+	public @NonNull ObservableList<@NonNull DefoldStyledTextNode> getTextNodes() {
+		return this.textNodes;
+	}
+
+	/**
+	 * Find the caret index at the give point
+	 *
+	 * @param point
+	 *            the point relative to coordinate system of this node
+	 * @return the index or <code>-1</code> if not found
+	 */
+	public int getCaretIndexAtPoint(Point2D point) {
+		Point2D scenePoint = localToScene(point);
+		for (DefoldStyledTextNode t : this.textNodes) {
+			if (t.localToScene(t.getBoundsInLocal()).contains(scenePoint)) {
+				return t.getCaretIndexAtPoint(t.sceneToLocal(scenePoint)) + t.getStartOffset();
+			}
+		}
+
+		return -1;
+	}
+
+	private String getText() {
+		StringBuilder b = new StringBuilder();
+		for (DefoldStyledTextNode t : this.textNodes) {
+			b.append(t.getText());
+		}
+		return b.toString();
+	}
+
+	/**
+	 * Set the caret to show at the given index
+	 *
+	 * @param index
+	 *            the index or <code>-1</code> if caret is to be hidden
+	 */
+	public void setCaretIndex(int index) {
+		if (index >= 0) {
+			this.caretIndex = index;
+			if( this.ownerFocusedProperty.get() ) {
+				this.caret.setVisible(true);
+			} else {
+				this.caret.setVisible(false);
+			}
+			this.flashTimeline.play();
+			requestLayout();
+		} else {
+			this.caretIndex = -1;
+			this.flashTimeline.stop();
+			this.caret.setVisible(false);
+			requestLayout();
+		}
+	}
+
+	/**
+	 * Find the position of a the caret at a given index
+	 *
+	 * @param index
+	 *            the index
+	 * @return the location relative to this node or <code>null</code>
+	 */
+	public @Nullable Point2D getCareLocation(int index) {
+		for (DefoldStyledTextNode t : this.textNodes) {
+			if (t.getStartOffset() <= index && t.getEndOffset() >= index) {
+				double x = t.getCharLocation(index);
+				return sceneToLocal(t.localToScene(x, 0));
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Releases resources immediately
+	 */
+	public void dispose() {
+		this.flashTimeline.stop();
+		this.flashTimeline.getKeyFrames().clear();
+	}
+}

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
@@ -216,6 +216,7 @@ public class DefoldStyledTextLayoutContainer extends Region {
 				}
 			}
 
+			this.selectionEndNode.applyCss();
 			if (this.selectionStartNode != null && this.selectionEndNode != null) {
 				int charIndex = start - this.selectionStartNode.getStartOffset();
 				this.selectionStartX = this.selectionStartNode.getCharLocation(charIndex);

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextNode.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextNode.java
@@ -1,0 +1,441 @@
+package com.defold.editor.eclipse;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.ObservableList;
+import javafx.css.CssMetaData;
+import javafx.css.ParsedValue;
+import javafx.css.SimpleStyleableIntegerProperty;
+import javafx.css.SimpleStyleableObjectProperty;
+import javafx.css.StyleConverter;
+import javafx.css.Styleable;
+import javafx.css.StyleableProperty;
+import javafx.geometry.Point2D;
+import javafx.scene.Node;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.PathElement;
+import javafx.scene.text.Font;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextBoundsType;
+
+import org.eclipse.fx.core.Util;
+import org.eclipse.fx.ui.controls.styledtext.DecorationStrategyFactory;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.sun.javafx.css.converters.PaintConverter;
+import com.sun.javafx.scene.text.HitInfo;
+
+/**
+ * A node who allows to decorate the text
+ *
+ * @since 2.0
+ */
+@SuppressWarnings("restriction")
+public class DefoldStyledTextNode extends Region {
+
+	/**
+	 * A strategy to decorate the text
+	 */
+	public interface DecorationStrategy {
+		/**
+		 * Attach the decoration on the text
+		 *
+		 * @param node
+		 *            the node the decoration is attached to
+		 * @param textNode
+		 *            the text node decorated
+		 */
+		public void attach(DefoldStyledTextNode node, Text textNode);
+
+		/**
+		 * Remove the decoration from the text
+		 *
+		 * @param node
+		 *            the node the decoration is attached to
+		 * @param textNode
+		 *            the text node decorated
+		 */
+		public void unattach(DefoldStyledTextNode node, Text textNode);
+
+		/**
+		 * Layout the decoration
+		 *
+		 * @param node
+		 *            the node the layout pass is done on
+		 * @param textNode
+		 *            the text node decorated
+		 */
+		public void layout(DefoldStyledTextNode node, Text textNode);
+	}
+
+	private final Text textNode;
+
+	@SuppressWarnings("null")
+	@NonNull
+	private static final CssMetaData<DefoldStyledTextNode, @NonNull Paint> FILL = new CssMetaData<DefoldStyledTextNode, @NonNull Paint>("-fx-fill", PaintConverter.getInstance(), Color.BLACK) { //$NON-NLS-1$
+
+		@Override
+		public boolean isSettable(DefoldStyledTextNode styleable) {
+			return !styleable.fillProperty().isBound();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public StyleableProperty<@NonNull Paint> getStyleableProperty(DefoldStyledTextNode styleable) {
+			return (StyleableProperty<@NonNull Paint>) styleable.fill;
+		}
+
+	};
+	@SuppressWarnings("null")
+	@NonNull
+	final ObjectProperty<@NonNull Paint> fill = new SimpleStyleableObjectProperty<>(FILL, this, "fill", Color.BLACK); //$NON-NLS-1$
+
+	/**
+	 * The paint used to fill the text
+	 *
+	 * @return the property to observe
+	 */
+	public final @NonNull ObjectProperty<@NonNull Paint> fillProperty() {
+		return (ObjectProperty<@NonNull Paint>) this.fill;
+	}
+
+	/**
+	 * @return the paint used to fill the text
+	 */
+	public final @NonNull Paint getFill() {
+		return this.fillProperty().get();
+	}
+
+	/**
+	 * Set a new paint
+	 *
+	 * @param color
+	 *            the paint used to fill the text
+	 */
+	public final void setFill(final @NonNull Paint color) {
+		this.fillProperty().set(color);
+	}
+
+	static class DecorationStyleConverter extends StyleConverter<ParsedValue<?, DecorationStrategy>, DecorationStrategy> {
+		private static Map<String, DecorationStrategyFactory> FACTORIES;
+
+		@SuppressWarnings("null")
+		@Override
+		public DecorationStrategy convert(ParsedValue<ParsedValue<?, DecorationStrategy>, DecorationStrategy> value, Font font) {
+			String definition = value.getValue() + ""; //$NON-NLS-1$
+
+			if (FACTORIES == null) {
+				FACTORIES = Util.lookupServiceList(getClass(), DecorationStrategyFactory.class).stream().sorted((f1, f2) -> -1 * Integer.compare(f1.getRanking(), f2.getRanking())).collect(Collectors.toMap(f -> f.getDecorationStrategyName(), f -> f));
+			}
+
+			String type;
+			if (definition.contains("(")) { //$NON-NLS-1$
+				type = definition.substring(0, definition.indexOf('('));
+			} else {
+				type = definition + ""; //$NON-NLS-1$
+			}
+
+			DecorationStrategyFactory strategy = FACTORIES.get(type);
+			if (strategy != null) {
+				return (DecorationStrategy) strategy.create(definition.contains("(") ? definition.substring(definition.indexOf('(') + 1, definition.lastIndexOf(')')) : null); //$NON-NLS-1$
+			}
+
+			return null;
+		}
+	}
+
+	@NonNull
+	private static final DecorationStyleConverter CONVERTER = new DecorationStyleConverter();
+
+	@SuppressWarnings("null")
+	@NonNull
+	private static final CssMetaData<DefoldStyledTextNode, @Nullable DecorationStrategy> DECORATIONSTRATEGY = new CssMetaData<DefoldStyledTextNode, @Nullable DecorationStrategy>("-efx-decoration", CONVERTER, null) { //$NON-NLS-1$
+
+		@Override
+		public boolean isSettable(DefoldStyledTextNode node) {
+			return !node.decorationStrategyProperty().isBound();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public StyleableProperty<@Nullable DecorationStrategy> getStyleableProperty(DefoldStyledTextNode node) {
+			return (StyleableProperty<@Nullable DecorationStrategy>) node.decorationStrategyProperty();
+		}
+
+	};
+
+	@SuppressWarnings("null")
+	@NonNull
+	private static final CssMetaData<DefoldStyledTextNode, @NonNull Number> TABCHARADANCE = new CssMetaData<DefoldStyledTextNode, @NonNull Number>("-efx-tab-char-advance", StyleConverter.getSizeConverter(), Integer.valueOf(4)) { //$NON-NLS-1$
+
+		@Override
+		public boolean isSettable(DefoldStyledTextNode styleable) {
+			return !styleable.tabCharAdvanceProperty().isBound();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public StyleableProperty<@NonNull Number> getStyleableProperty(DefoldStyledTextNode styleable) {
+			return (StyleableProperty<@NonNull Number>) styleable.tabCharAdvance;
+		}
+
+	};
+
+	private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
+
+	static {
+		final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<CssMetaData<? extends Styleable, ?>>(Region.getClassCssMetaData());
+		styleables.add(DECORATIONSTRATEGY);
+		styleables.add(FILL);
+		STYLEABLES = Collections.unmodifiableList(styleables);
+	}
+
+	public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+		return STYLEABLES;
+	}
+
+	@Override
+	public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+		return getClassCssMetaData();
+	}
+
+	private @NonNull ObjectProperty<@Nullable DecorationStrategy> decorationStrategy = new SimpleStyleableObjectProperty<@Nullable DecorationStrategy>(DECORATIONSTRATEGY, this, "decorationStrategy"); //$NON-NLS-1$
+
+	/**
+	 * The current strategy used for decoration
+	 *
+	 * @return the property to observe
+	 */
+	public final @NonNull ObjectProperty<@Nullable DecorationStrategy> decorationStrategyProperty() {
+		return this.decorationStrategy;
+	}
+
+	/**
+	 * @return strategy used for decoration
+	 */
+	public final @Nullable DecorationStrategy getDecorationStrategy() {
+		return this.decorationStrategyProperty().get();
+	}
+
+	/**
+	 * Set a new strategy used for decoration
+	 *
+	 * @param strategy
+	 *            the strategy
+	 */
+	public final void setDecorationStrategy(final @Nullable DecorationStrategy strategy) {
+		this.decorationStrategyProperty().set(strategy);
+	}
+
+	@NonNull
+	IntegerProperty tabCharAdvance = new SimpleStyleableIntegerProperty(TABCHARADANCE, this, "tabCharAdvance", Integer.valueOf(4)); //$NON-NLS-1$
+
+	/**
+	 * Number of chars to use for tab advance (default is 4)
+	 *
+	 * @return the property to observe
+	 */
+	public final IntegerProperty tabCharAdvanceProperty() {
+		return this.tabCharAdvance;
+	}
+
+	/**
+	 * @return the number of chars to use for tab advance (default is 4)
+	 */
+	public final int getTabCharAdvance() {
+		return this.tabCharAdvanceProperty().get();
+	}
+
+	/**
+	 * Set a new number for chars to advance for a tab
+	 *
+	 * @param tabCharAdvance
+	 *            the number of chars to use for tab advance (default is 4)
+	 */
+	public final void setTabCharAdvance(final int tabCharAdvance) {
+		this.tabCharAdvanceProperty().set(tabCharAdvance);
+	}
+
+	private int startOffset;
+	private List<Integer> tabPositions = new ArrayList<>();
+	private String originalText;
+
+	/**
+	 * Create a new styled text node
+	 *
+	 * @param text
+	 *            the text
+	 */
+	public DefoldStyledTextNode(String text) {
+		getStyleClass().add("styled-text-node"); //$NON-NLS-1$
+		this.originalText = text;
+
+		this.textNode = new Text(processText(text));
+		this.textNode.setBoundsType(TextBoundsType.LOGICAL_VERTICAL_CENTER);
+		this.textNode.fillProperty().bind(fillProperty());
+		getChildren().add(this.textNode);
+		this.decorationStrategy.addListener(this::handleDecorationChange);
+
+		this.tabCharAdvance.addListener(o -> {
+			this.textNode.setText(processText(text));
+		});
+	}
+
+	private String processText(String text) {
+		String tmp = text;
+		StringBuilder b = new StringBuilder();
+		for (int i = 0; i < this.tabCharAdvance.get(); i++) {
+			b.append(" "); //$NON-NLS-1$
+		}
+		int position = -1;
+		this.tabPositions.clear();
+		while ((position = tmp.indexOf('\t')) != -1) {
+			tmp = tmp.replaceFirst("\t", b.toString()); //$NON-NLS-1$
+			this.tabPositions.add(Integer.valueOf(position));
+		}
+		return tmp;
+	}
+
+	private void handleDecorationChange(ObservableValue<? extends DecorationStrategy> observable, DecorationStrategy oldValue, DecorationStrategy newValue) {
+		if (oldValue != null) {
+			oldValue.unattach(this, this.textNode);
+		}
+
+		if (newValue != null) {
+			newValue.attach(this, this.textNode);
+		}
+	}
+
+	void setStartOffset(int startOffset) {
+		this.startOffset = startOffset;
+	}
+
+	/**
+	 * @return the start offset in the file
+	 */
+	public int getStartOffset() {
+		return this.startOffset;
+	}
+
+	/**
+	 * @return the end offset in the file
+	 */
+	public int getEndOffset() {
+		return this.startOffset + getText().length();
+	}
+
+	/**
+	 * Check if the text node intersects with the start and end locations
+	 *
+	 * @param start
+	 *            the start
+	 * @param end
+	 *            the end
+	 * @return <code>true</code> if intersects
+	 */
+	public boolean intersectOffset(int start, int end) {
+		if (getStartOffset() > end) {
+			return false;
+		} else if (getEndOffset() < start) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return this.originalText;
+	}
+
+	@Override
+	public ObservableList<Node> getChildren() {
+		return super.getChildren();
+	}
+
+	/**
+	 * @return the text
+	 */
+	public String getText() {
+		return this.originalText;
+	}
+
+	@Override
+	protected void layoutChildren() {
+		super.layoutChildren();
+		this.textNode.relocate(0, 0);
+		DecorationStrategy decorationStrategy2 = this.decorationStrategy.get();
+		if (decorationStrategy2 != null) {
+			decorationStrategy2.layout(this, this.textNode);
+		}
+
+	}
+
+	/**
+	 * Get the caret index at the given point
+	 *
+	 * @param point
+	 *            the point relative to this node
+	 * @return the index or <code>-1</code>
+	 */
+	public int getCaretIndexAtPoint(Point2D point) {
+		@SuppressWarnings("deprecation")
+		HitInfo info = this.textNode.impl_hitTestChar(this.textNode.sceneToLocal(localToScene(point)));
+		if (info != null) {
+			int idx = info.getInsertionIndex();
+			int toRemove = 0;
+			for (Integer i : this.tabPositions) {
+				if (i.intValue() <= idx && idx < i.intValue() + this.tabCharAdvance.get()) {
+					toRemove += idx - i.intValue();
+					// If we are in the 2nd half of the tab we
+					// simply move one past the value
+					if ((idx - i.intValue()) % this.tabCharAdvance.get() >= this.tabCharAdvance.get() / 2) {
+						idx += 1;
+					}
+					break;
+				} else if (i.intValue() < idx) {
+					toRemove += this.tabCharAdvance.get() - 1;
+				}
+			}
+			idx -= toRemove;
+			return idx;
+		}
+		return -1;
+	}
+
+	/**
+	 * Find the x coordinate where we the character for the given index starts
+	 *
+	 * @param index
+	 *            the index
+	 * @return the location or <code>0</code> if not found
+	 */
+	@SuppressWarnings("deprecation")
+	public double getCharLocation(int index) {
+		int realIndex = index;
+		for (Integer i : this.tabPositions) {
+			if (i.intValue() < realIndex) {
+				realIndex += this.tabCharAdvance.get() - 1;
+			}
+		}
+		this.textNode.setImpl_caretPosition(realIndex);
+		PathElement[] pathElements = this.textNode.getImpl_caretShape();
+		for (PathElement e : pathElements) {
+			if (e instanceof MoveTo) {
+				return this.textNode.localToParent(((MoveTo) e).getX(), 0).getX();
+			}
+		}
+
+		return 0.0;
+	}
+}

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import org.eclipse.fx.ui.controls.styledtext.StyleRange;
 import org.eclipse.fx.ui.controls.styledtext.StyledTextArea;
 import org.eclipse.fx.ui.controls.styledtext.StyledTextArea.StyledTextLine;
-import org.eclipse.fx.ui.controls.styledtext.StyledTextLayoutContainer;
-import org.eclipse.fx.ui.controls.styledtext.StyledTextNode;
 import org.eclipse.fx.ui.controls.styledtext.TextSelection;
 import org.eclipse.jdt.annotation.NonNull;
 
@@ -124,7 +122,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 							DefoldStyledTextSkin.this.contentView.getSelectionModel().select(lineObject);
 						}
 
-						StyledTextLayoutContainer p = (StyledTextLayoutContainer) c.getGraphic();
+						DefoldStyledTextLayoutContainer p = (DefoldStyledTextLayoutContainer) c.getGraphic();
 						p.setCaretIndex(newValue.intValue() - p.getStartOffset());
 						p.requestLayout();
 
@@ -147,7 +145,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 				if (newValue == null || newValue.length == 0) {
 					for (LineCell c : mymapcells) {
 						if (c.getGraphic() != null) {
-							StyledTextLayoutContainer block = (StyledTextLayoutContainer) c.getGraphic();
+							DefoldStyledTextLayoutContainer block = (DefoldStyledTextLayoutContainer) c.getGraphic();
 							block.setSelection(new TextSelection(0, 0));
 						}
 					}
@@ -156,7 +154,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 					for (LineCell c : mymapcells) {
 						if (c.getGraphic() != null) {
 							Line arg0 = c.domainElement;
-							StyledTextLayoutContainer block = (StyledTextLayoutContainer) c.getGraphic();
+							DefoldStyledTextLayoutContainer block = (DefoldStyledTextLayoutContainer) c.getGraphic();
 							if (selection.length > 0 && block.intersectOffset(selection.offset, selection.offset + selection.length)) {
 								int start = Math.max(0, selection.offset - arg0.getLineOffset());
 
@@ -237,9 +235,9 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 		});
 	}
 
-	private StyledTextLayoutContainer currentActiveNode;
+	private DefoldStyledTextLayoutContainer currentActiveNode;
 
-	void updateCurrentCursorNode(StyledTextLayoutContainer node) {
+	void updateCurrentCursorNode(DefoldStyledTextLayoutContainer node) {
 		if (this.currentActiveNode != node) {
 			if (this.currentActiveNode != null) {
 				this.currentActiveNode.setCaretIndex(-1);
@@ -298,7 +296,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 		Line lineObject = this.lineList.get(lineIndex);
 		for (LineCell c : getCurrentVisibleCells()) {
 			if (c.domainElement == lineObject) {
-				StyledTextLayoutContainer b = (StyledTextLayoutContainer) c.getGraphic();
+				DefoldStyledTextLayoutContainer b = (DefoldStyledTextLayoutContainer) c.getGraphic();
 				Point2D careLocation = b.getCareLocation(caretPosition - b.getStartOffset());
 				Point2D tmp = getSkinnable().sceneToLocal(b.localToScene(careLocation));
 				return new Point2D(tmp.getX(), getSkinnable().sceneToLocal(b.localToScene(0, b.getHeight())).getY());
@@ -426,12 +424,12 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 				}
 				lineInfo.setLayoutY(getLayoutY());
 
-				StyledTextLayoutContainer block = (StyledTextLayoutContainer) getGraphic();
+				DefoldStyledTextLayoutContainer block = (DefoldStyledTextLayoutContainer) getGraphic();
 
 				if (block == null) {
 					// System.err.println("CREATING NEW GRAPHIC BLOCK: " + this
 					// + " => " + this.domainElement);
-					block = new StyledTextLayoutContainer(getSkinnable().focusedProperty());
+					block = new DefoldStyledTextLayoutContainer(getSkinnable().focusedProperty());
 					block.getStyleClass().add("source-segment-container"); //$NON-NLS-1$
 					setGraphic(block);
 					// getSkinnable().requestLayout();
@@ -450,10 +448,10 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 
 				this.currentSegments = segments;
 
-				List<@NonNull StyledTextNode> texts = new ArrayList<>();
+				List<@NonNull DefoldStyledTextNode> texts = new ArrayList<>();
 
 				for (final Segment seg : this.currentSegments) {
-					StyledTextNode t = new StyledTextNode(seg.text);
+					DefoldStyledTextNode t = new DefoldStyledTextNode(seg.text);
 					if (seg.style.stylename != null) {
 						if (seg.style.stylename.contains(".")) { //$NON-NLS-1$
 							List<String> styles = new ArrayList<String>(Arrays.asList(seg.style.stylename.split("\\."))); //$NON-NLS-1$
@@ -474,7 +472,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 				}
 
 				if (segments.isEmpty()) {
-					StyledTextNode t = new StyledTextNode(""); //$NON-NLS-1$
+					DefoldStyledTextNode t = new DefoldStyledTextNode(""); //$NON-NLS-1$
 					t.getStyleClass().setAll("source-segment"); //$NON-NLS-1$
 					block.getTextNodes().setAll(t);
 				} else {
@@ -836,7 +834,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 				public void run() {
 					for (LineCell c : lineInfoMap.keySet()) {
 						if (c.getGraphic() != null) {
-							StyledTextLayoutContainer block = (StyledTextLayoutContainer) c.getGraphic();
+							DefoldStyledTextLayoutContainer block = (DefoldStyledTextLayoutContainer) c.getGraphic();
 							block.requestLayout();
 						}
 					}


### PR DESCRIPTION
When a completion is made and the snippet inserted, the first parameter is selected so that the user can immediately replace the field with a value.  
Example  `go.set(url,id,value)` will have `url` selected.

Tab will take the user to the next field and select it.  When the end has been reached, tab will move the user out of the last paren.  From then on, tab will act as normal.  This replicates the Sublime completion ux.

This tab snippet triggers also work in other templates like `if`.
In this case the snippet expands to 

```
if cond then
    --do things
end
```

`cond` is initially selected then `--do things` then `end`

Tab triggers are manually defined in lua.clj for base lua functions like `if` and `for`

Otherwise, the triggers are extracted from the non-optional parameters of the functions.

Other fixes
- fix for weird selection highlight bug
- improvement in selection css color with opacity reduced so that the text can be seen better
