### PR TITLE
Text editor enhancements

### DIFF
--- a/editor/resources/editor.css
+++ b/editor/resources/editor.css
@@ -1024,7 +1024,7 @@ Defold Orange       #fd6623             Guides etc
 }
 
 .styled-text-area .selection-marker {
-	-fx-background-color:  rgba(172,148,120,0.3)
+	-fx-background-color: rgba(172,148,120,0.3)
 }
 
 /*

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -265,10 +265,6 @@
       (.impl_setCaretOffset this offset select?)
       (catch Exception e
         (println "caret! failure")
-        ;;do nothing there is a bug in the StyledTextSkin that creates
-        ;;null pointers due to the skin rendered completely yet not being created yet (the skin
-        ;;is created on the ui pulse) Eventually we should consider
-        ;;rewriting the Skin class and porting it to Clojure
         )))
   (caret [this] (.getCaretOffset this)))
 
@@ -395,7 +391,10 @@
   cvx/TextCaret
   (caret! [this offset select?]
     (source-viewer-set-caret! this offset select?))
-  (caret [this] (cvx/caret(.getTextWidget this)))
+  (caret [this]
+    (let [c (cvx/caret (.getTextWidget this))
+          doc (cvx/text this)]
+      (cvx/adjust-bounds doc c)))
   cvx/TextView
   (selection-offset [this]
     (.-offset ^TextSelection (-> this (.getTextWidget) (.getSelection))))

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -467,6 +467,17 @@
       (if (neg? prev-line-num)
         ""
         (.getLine text-area-content prev-line-num))))
+  (next-line [this]
+    (let [text-area-content (.getContent (.getTextWidget this))
+          offset (cvx/caret this)
+          line-no (.getLineAtOffset text-area-content offset)
+          line-offset (.getOffsetAtLine text-area-content line-no)
+          line-length (count (.getLine text-area-content line-no))
+          doc-length (count(cvx/text this))
+          end-of-doc? (<= doc-length (+ line-offset line-length))]
+      (if end-of-doc?
+        ""
+        (.getLine text-area-content (inc line-no)))))
   (line-offset [this]
     (let [text-area-content (.getContent (.getTextWidget this))
           offset (cvx/caret this)
@@ -481,6 +492,9 @@
   (line-offset-at-num [this line-num]
     (let [text-area-content (.getContent (.getTextWidget this))]
       (.getOffsetAtLine text-area-content line-num)))
+  (line-count [this]
+    (let [text-area-content (.getContent (.getTextWidget this))]
+      (.getLineCount text-area-content)))
   cvx/TextProposals
   (propose [this]
     (when-let [assist-fn (assist this)]

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -490,7 +490,7 @@
   (snippet-tab-triggers [this] (when-let [tt (tab-triggers this)]
                                  @tt))
   (snippet-tab-triggers! [this val] (reset! (tab-triggers this) val))
-  (has-snippet-tab-trigger? [this] (tab-triggers this))
+  (has-snippet-tab-trigger? [this] (cvx/snippet-tab-triggers this))
   (next-snippet-tab-trigger! [this]
     (let [tt (tab-triggers this)
           trigger (or (first @tt) :end)]

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -472,6 +472,15 @@
           offset (cvx/caret this)
           line-no (.getLineAtOffset text-area-content offset)]
       (.getOffsetAtLine text-area-content line-no)))
+  (line-num-at-offset [this offset]
+    (let [text-area-content (.getContent (.getTextWidget this))]
+      (.getLineAtOffset text-area-content offset)))
+  (line-at-num [this line-num]
+    (let [text-area-content (.getContent (.getTextWidget this))]
+      (.getLine text-area-content line-num)))
+  (line-offset-at-num [this line-num]
+    (let [text-area-content (.getContent (.getTextWidget this))]
+      (.getOffsetAtLine text-area-content line-num)))
   cvx/TextProposals
   (propose [this]
     (when-let [assist-fn (assist this)]

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -41,6 +41,12 @@
 (defn- syntax [selection]
   (ui/user-data selection ::syntax))
 
+(defn- prefer-offset [selection]
+  (ui/user-data selection ::prefer-offset))
+
+(defn- tab-triggers [selection]
+  (ui/user-data selection ::tab-triggers))
+
 (defmacro binding-atom [a val & body]
   `(let [old-val# (deref ~a)]
      (try
@@ -49,7 +55,7 @@
        (finally
          (reset! ~a old-val#)))))
 
-(g/defnk update-source-viewer [^SourceViewer source-viewer code-node code caret-position selection-offset selection-length active-tab]
+(g/defnk update-source-viewer [^SourceViewer source-viewer code-node code caret-position selection-offset selection-length active-tab prefer-offset tab-triggers]
   (ui/user-data! (.getTextWidget source-viewer) ::code-node code-node)
     (when (not= code (cvx/text source-viewer))
     (try
@@ -57,6 +63,8 @@
       (catch Throwable e
         (println "exception during .set!")
         (.printStackTrace e))))
+    (cvx/preferred-offset! source-viewer prefer-offset)
+    (cvx/snippet-tab-triggers! source-viewer tab-triggers)
   (if (pos? selection-length)
     (do
       ;; There is a bug somewhere in the e(fx)clipse that doesn't
@@ -319,7 +327,9 @@
 
       (ui/user-data! text-area ::behavior styled-text-behavior)
       (ui/user-data! source-viewer ::assist (:assist opts))
-      (ui/user-data! source-viewer ::syntax (:syntax opts)))
+      (ui/user-data! source-viewer ::syntax (:syntax opts))
+      (ui/user-data! source-viewer ::prefer-offset (atom 0))
+      (ui/user-data! source-viewer ::tab-triggers (atom nil)))
 
   source-viewer))
 
@@ -328,6 +338,8 @@
   (input code-node g/Int)
   (input code g/Str)
   (input caret-position g/Int)
+  (input prefer-offset g/Int)
+  (input tab-triggers g/Any)
   (input selection-offset g/Int)
   (input selection-length g/Int)
   (input active-tab Tab)
@@ -342,10 +354,14 @@
     (g/connect code-node :_node-id view-id :code-node)
     (g/connect code-node :code view-id :code)
     (g/connect code-node :caret-position view-id :caret-position)
+    (g/connect code-node :prefer-offset view-id :prefer-offset)
+    (g/connect code-node :tab-triggers view-id :tab-triggers)
     (g/connect code-node :selection-offset view-id :selection-offset)
     (g/connect code-node :selection-length view-id :selection-length)
     (g/connect app-view-id :active-tab view-id :active-tab)
     (g/set-property code-node :caret-position initial-caret-position)
+    (g/set-property code-node :prefer-offset 0)
+    (g/set-property code-node :tab-triggers nil)
     (g/set-property code-node :selection-offset 0)
     (g/set-property code-node :selection-length 0)))
   view-id)
@@ -420,18 +436,24 @@
           selection-length (cvx/selection-length this)
           code (cvx/text this)
           caret (cvx/caret this)
+          prefer-offset (cvx/preferred-offset this)
+          tab-triggers (cvx/snippet-tab-triggers this)
           code-changed? (not= code (g/node-value code-node-id :code))
           caret-changed? (not= caret (g/node-value code-node-id :caret-position))
           selection-changed? (or (not= selection-offset (g/node-value code-node-id :selection-offset))
-                                 (not= selection-length (g/node-value code-node-id :selection-length)))]
-      (when (or code-changed? caret-changed? selection-changed?)
+                                 (not= selection-length (g/node-value code-node-id :selection-length)))
+          prefer-offset-changed? (not= prefer-offset (g/node-value code-node-id :prefer-offset))
+          tab-triggers-changed? (not= tab-triggers (g/node-value code-node-id :tab-triggers))]
+      (when (or code-changed? caret-changed? selection-changed? prefer-offset-changed? tab-triggers-changed?)
         (g/transact (remove nil?
                             (concat
                              (when code-changed?  [(g/set-property code-node-id :code code)])
                              (when caret-changed? [(g/set-property code-node-id :caret-position caret)])
                              (when selection-changed?
                                [(g/set-property code-node-id :selection-offset selection-offset)
-                                (g/set-property code-node-id :selection-length selection-length)])))))))
+                                (g/set-property code-node-id :selection-length selection-length)])
+                             (when prefer-offset-changed? [(g/set-property code-node-id :prefer-offset prefer-offset)])
+                             (when tab-triggers-changed? [(g/set-property code-node-id :tab-triggers tab-triggers)])))))))
   cvx/TextLine
   (line [this]
     (let [text-area-content (.getContent (.getTextWidget this))
@@ -458,7 +480,26 @@
             line (cvx/line this)
             code-node-id (-> this (.getTextWidget) (code-node))
             completions (g/node-value code-node-id :completions)]
-        (assist-fn completions (cvx/text this) offset line)))))
+        (assist-fn completions (cvx/text this) offset line))))
+  cvx/TextOffset
+  (preferred-offset [this]
+    @(prefer-offset this))
+  (preferred-offset! [this val]
+    (reset! (prefer-offset this) val))
+  cvx/TextSnippet
+  (snippet-tab-triggers [this] (when-let [tt (tab-triggers this)]
+                                 @tt))
+  (snippet-tab-triggers! [this val] (reset! (tab-triggers this) val))
+  (has-snippet-tab-trigger? [this] (tab-triggers this))
+  (next-snippet-tab-trigger! [this]
+    (let [tt (tab-triggers this)
+          trigger (or (first @tt) :end)]
+      (if (= trigger :end)
+        (reset! tt nil)
+        (swap! tt rest))
+      trigger))
+  (clear-snippet-tab-triggers! [this]
+    (reset! (tab-triggers this) nil)))
 
 (defn make-view [graph ^Parent parent code-node opts]
   (let [source-viewer (setup-source-viewer opts true)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -137,7 +137,7 @@
   :Ctrl+Space            {:command :proposals}
 
   ;;Indentation
-  :Shortcut+I            {:command :indent}
+  :Shortcut+I            {:command :indent                  :label "Indent"                           :group "Indent" :order 1}
 
 })
 
@@ -154,7 +154,8 @@
         find-commands (filter (fn [[k v]] (= "Find" (:group v))) mappings)
         replace-commands (filter (fn [[k v]] (= "Replace" (:group v))) mappings)
         delete-commands (filter (fn [[k v]] (= "Delete" (:group v))) mappings)
-        comment-commands (filter (fn [[k v]] (= "Comment" (:group v))) mappings)]
+        comment-commands (filter (fn [[k v]] (= "Comment" (:group v))) mappings)
+        indent-commands (filter (fn [[k v]] (= "Indent" (:group v))) mappings)]
     [{:label "Text Edit"
        :id ::text-edit
        :children (concat
@@ -166,7 +167,9 @@
                   [{:label :separator}]
                   (sort-by :order (map menu-data delete-commands))
                   [{:label :separator}]
-                  (sort-by :order (map menu-data comment-commands)))}]))
+                  (sort-by :order (map menu-data comment-commands))
+                  [{:label :separator}]
+                  (sort-by :order (map menu-data indent-commands)))}]))
 
 (def tab-size 4)
 (def last-find-text (atom ""))
@@ -748,11 +751,12 @@
     (let [np (caret selection)
           doc (text selection)
           ftext @last-find-text
-          found-idx (.indexOf ^String doc ^String ftext ^int np)
+          found-idx (string/index-of doc ftext np)
           tlen (count ftext)
           rtext @last-replace-text
           tlen-new (count rtext)]
-      (do-replace selection doc found-idx rtext tlen tlen-new np))))
+      (when found-idx
+        (do-replace selection doc found-idx rtext tlen tlen-new np)))))
 
 (defn toggle-comment [text line-comment]
   (let [pattern (re-pattern (str "^" line-comment))]

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -77,6 +77,7 @@
 
   ;; select
   :Double-Click          {:command :select-word}
+  :Triple-Click          {:command :select-line}
   :Shortcut+A            {:command :select-all}
 
   ;;movement with select
@@ -181,7 +182,10 @@
     (get mappings code)))
 
 (defn- click-fn [click-count]
-  (let [code (if (= click-count 2) :Double-Click :Single-Click)]
+  (let [code (case (int click-count)
+               3 :Triple-Click
+               2 :Double-Click
+               :Single-Click)]
     (get mappings code)))
 
 (defn- is-mac-os? []
@@ -210,7 +214,7 @@
         [{:name :code-view :env {:selection source-viewer :key-typed key-typed}}]
         e))))
 
-(defn- adjust-bounds [s pos]
+(defn adjust-bounds [s pos]
   (if (neg? pos) 0 (min (count s) pos)))
 
 (defn tab-count [s]
@@ -551,6 +555,14 @@
           end-pos (+ np (count word-end))
           len (- end-pos start-pos)]
       (text-selection! selection start-pos len))))
+
+(handler/defhandler :select-line :code-view
+  (enabled? [selection] selection)
+  (run [selection]
+    (let [regex #"^\w+"
+          line (line selection)
+          line-offset (line-offset selection)]
+      (text-selection! selection line-offset (count line)))))
 
 (handler/defhandler :select-all :code-view
   (enabled? [selection] selection)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -411,9 +411,8 @@
   (re-find word-regex (subs doc np)))
 
 (defn next-word [selection select?]
-  (let [c (caret selection)
+  (let [np (caret selection)
         doc (text selection)
-        np (adjust-bounds doc c)
         next-word-move (next-word-move doc np)
         next-pos (+ np (count next-word-move))]
     (caret! selection next-pos select?)
@@ -423,9 +422,8 @@
   (re-find word-regex (->> (subs doc 0 np) (reverse) (apply str))))
 
 (defn prev-word [selection select?]
-  (let [c (caret selection)
+  (let [np (caret selection)
         doc (text selection)
-        np (adjust-bounds doc c)
         next-word-move (prev-word-move doc np)
         next-pos (- np (count next-word-move))]
     (caret! selection next-pos select?)
@@ -452,9 +450,8 @@
     (prev-word selection true)))
 
 (defn line-begin-pos [selection]
-  (let [c (caret selection)
+  (let [np (caret selection)
         doc (text selection)
-        np (adjust-bounds doc c)
         lines-before (lines-before doc np)
         len-before (-> lines-before last count)]
         (- np len-before)))
@@ -465,9 +462,8 @@
     (remember-caret-col selection next-pos)))
 
 (defn line-end-pos [selection]
-  (let [c (caret selection)
+  (let [np (caret selection)
         doc (text selection)
-        np (adjust-bounds doc c)
         lines-after (lines-after doc np)
         len-after (-> lines-after first count)]
     (+ np len-after)))
@@ -546,9 +542,8 @@
   (enabled? [selection] selection)
   (run [selection]
     (let [regex #"^\w+"
-          c (caret selection)
+          np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           word-end (re-find regex (subs doc np))
           text-before (->> (subs doc 0 (adjust-bounds doc (inc np))) (reverse) (rest) (apply str))
           word-begin (re-find regex text-before)
@@ -563,9 +558,8 @@
     (text-selection! selection 0 (count (text selection)))))
 
 (defn delete [selection]
-  (let [c (caret selection)
-        doc (text selection)
-        np (adjust-bounds doc c)]
+  (let [np (caret selection)
+        doc (text selection)]
     (if (pos? (selection-length selection))
       (replace-text-selection selection "")
       (when-not (zero? np)
@@ -582,9 +576,8 @@
   (replace-text-selection selection ""))
 
 (defn cut-line [selection clipboard]
-  (let [c (caret selection)
+  (let [np (caret selection)
         doc (text selection)
-        np (adjust-bounds doc c)
         line-begin-offset (line-begin-pos selection)
         line-end-offset (line-end-pos selection)
         consume-pos (if (= line-end-offset (count doc))
@@ -607,9 +600,8 @@
 (handler/defhandler :delete-prev-word :code-view
   (enabled? [selection] (editable? selection))
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           next-word-move (prev-word-move doc np)
           new-pos (- np (count next-word-move))
           new-doc (str (subs doc 0 new-pos)
@@ -620,9 +612,8 @@
 (handler/defhandler :delete-next-word :code-view
   (enabled? [selection] (editable? selection))
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           next-word-move (next-word-move doc np)
           next-word-pos (+ np (count next-word-move))
           new-doc (str (subs doc 0 np)
@@ -632,9 +623,8 @@
 (handler/defhandler :delete-to-end-of-line :code-view
   (enabled? [selection] (editable? selection))
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           line-end-offset (line-end-pos selection)
           new-doc (str (subs doc 0 np)
                        (subs doc line-end-offset))]
@@ -643,9 +633,8 @@
 (handler/defhandler :delete-to-start-of-line :code-view
   (enabled? [selection] (editable? selection))
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           line-begin-offset (line-begin-pos selection)
           new-doc (str (subs doc 0 line-begin-offset)
                        (subs doc np))]
@@ -678,9 +667,8 @@
 (handler/defhandler :find-next :code-view
   (enabled? [selection] selection)
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           search-text (text-selection selection)
           found-idx (.indexOf ^String doc ^String search-text ^int np)
           tlen (count search-text)]
@@ -689,9 +677,8 @@
 (handler/defhandler :find-prev :code-view
   (enabled? [selection] selection)
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           search-text (text-selection selection)
           tlen (count search-text)
           found-idx (.lastIndexOf ^String doc ^String search-text ^int (adjust-bounds doc (- np (inc tlen))))]
@@ -731,9 +718,8 @@
 (handler/defhandler :replace-next :code-view
   (enabled? [selection] (editable? selection))
   (run [selection]
-    (let [c (caret selection)
+    (let [np (caret selection)
           doc (text selection)
-          np (adjust-bounds doc c)
           ftext @last-find-text
           found-idx (.indexOf ^String doc ^String ftext ^int np)
           tlen (count ftext)
@@ -756,9 +742,8 @@
     (toggle-comment (str text-before text-after) line-comment)))
 
 (defn toggle-line-comment [selection]
-  (let [c (caret selection)
+  (let [np (caret selection)
         doc (text selection)
-        np (adjust-bounds doc c)
         line-comment (:line-comment (syntax selection))
         line-text (line selection)
         loffset (line-offset selection)]
@@ -801,9 +786,8 @@
       (toggle-line-comment selection))))
 
 (defn enter-key-text [selection key-typed]
-  (let [c (caret selection)
-        doc (text selection)
-        np (adjust-bounds doc c)]
+  (let [np (caret selection)
+        doc (text selection)]
     (if (pos? (selection-length selection))
       (replace-text-selection selection key-typed)
       (replace-text-and-caret selection np 0 key-typed (+ np (count key-typed))))))
@@ -863,9 +847,8 @@
   (run [selection]
     (when (editable? selection)
       (if (has-snippet-tab-trigger? selection)
-        (let [caret (caret selection)
-              doc (text selection)
-              np (adjust-bounds doc caret)]
+        (let [np (caret selection)
+              doc (text selection)]
           (next-tab-trigger selection np))
         (enter-key-text selection "\t")))))
 

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -830,9 +830,12 @@
 (defn next-tab-trigger [selection pos]
   (when (has-snippet-tab-trigger? selection)
     (let [doc (text selection)
+          np (caret selection)
           search-text (next-snippet-tab-trigger! selection)]
       (if (= :end search-text)
-        (right selection)
+        (do
+          (text-selection! selection np 0)
+          (right selection))
         (let [found-idx (string/index-of doc search-text pos)
               tlen (count search-text)]
           (when found-idx

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -589,6 +589,8 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
   (property code g/Str (dynamic visible (g/always false)))
   (property def g/Any (dynamic visible (g/always false)))
   (property caret-position g/Int (dynamic visible (g/always false)) (default 0))
+  (property prefer-offset g/Int (dynamic visible (g/always false)) (default 0))
+  (property tab-triggers g/Any (dynamic visible (g/always false)) (default nil))
   (property selection-offset g/Int (dynamic visible (g/always false)) (default 0))
   (property selection-length g/Int (dynamic visible (g/always false)) (default 0))
 

--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -124,6 +124,8 @@
 
   (property code g/Str (dynamic visible (g/always false)))
   (property caret-position g/Int (dynamic visible (g/always false)) (default 0))
+  (property prefer-offset g/Int (dynamic visible (g/always false)) (default 0))
+  (property tab-triggers g/Any (dynamic visible (g/always false)) (default nil))
   (property selection-offset g/Int (dynamic visible (g/always false)) (default 0))
   (property selection-length g/Int (dynamic visible (g/always false)) (default 0))
 

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -108,6 +108,9 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 			@Override
 			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
 				int lineIndex = getSkinnable().getContent().getLineAtOffset(newValue.intValue());
+                                if (lineIndex < 0){
+                                    return;
+                                 }
 				Line lineObject = DefoldStyledTextSkin.this.lineList.get(lineIndex);
                                 if (lineObject == null){
                                     return;

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -777,6 +777,10 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 						children.remove(lineInfo);
 					}
 				}
+				if (c.getGraphic() != null) {
+					DefoldStyledTextLayoutContainer block = (DefoldStyledTextLayoutContainer) c.getGraphic();
+					block.requestLayout();
+				}
 			}
 
 			for (LineInfo l : layouted) {
@@ -835,16 +839,12 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 
 				@Override
 				public void run() {
-					for (LineCell c : lineInfoMap.keySet()) {
-						if (c.getGraphic() != null) {
-							DefoldStyledTextLayoutContainer block = (DefoldStyledTextLayoutContainer) c.getGraphic();
-							block.requestLayout();
-						}
-					}
-
+					DefoldStyledTextSkin.this.lineRuler.requestLayout();
 				}
 			});
+
 		}
+
 
 		@Override
 		protected void positionCell(LineCell cell, double position) {
@@ -854,13 +854,6 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 				lineInfo.setDomainElement(cell.domainElement);
 				lineInfo.setLayoutY(cell.getLayoutY());
 			}
-			Platform.runLater(new Runnable() {
-
-				@Override
-				public void run() {
-					DefoldStyledTextSkin.this.lineRuler.requestLayout();
-				}
-			});
 
 		}
 

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -118,7 +118,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 
 				getFlow().show(lineIndex);
 
-				for (LineCell c : getCurrentVisibleCells()) {
+				for (LineCell c : lineInfoMap.keySet()) {
 					if (c.domainElement == lineObject) {
 						// Adjust the selection
 						if (DefoldStyledTextSkin.this.contentView.getSelectionModel().getSelectedItem() != c.domainElement) {
@@ -141,7 +141,6 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 
 			@Override
 			public void changed(ObservableValue<? extends TextSelection> observable, TextSelection oldValue, TextSelection newValue) {
-				List<LineCell> vcells = getCurrentVisibleCells();
 				Map<LineCell,LineInfo > mymap = lineInfoMap;
 				Set<LineCell> mymapcells = mymap.keySet();
 

--- a/editor/test/editor/code_view_test.clj
+++ b/editor/test/editor/code_view_test.clj
@@ -7,13 +7,16 @@
             [editor.lua :as lua]
             [editor.script :as script]
             [editor.gl.shader :as shader]
+            [integration.test-util :refer [DummyAppView]]
             [support.test-support :refer [with-clean-system tx-nodes]]))
 
 (defn setup-code-view-nodes [world source-viewer code code-node-type]
-  (let [[code-node viewer-node] (tx-nodes (g/make-node world code-node-type)
+  (let [[app-view code-node viewer-node] (tx-nodes
+                                          (g/make-node world DummyAppView)
+                                          (g/make-node world code-node-type)
                                           (g/make-node world CodeView :source-viewer source-viewer))]
     (do (g/transact (g/set-property code-node :code code))
-        (setup-code-view viewer-node code-node 0)
+        (setup-code-view app-view viewer-node code-node 0)
         (g/node-value viewer-node :new-content)
         [code-node viewer-node])))
 

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -243,7 +243,9 @@
         (tab! source-viewer)
         (is (= "--do things" (text-selection source-viewer)))
         (tab! source-viewer)
-        (is (= "end" (text-selection source-viewer)))))))
+        (is (= "end" (text-selection source-viewer)))
+        (tab! source-viewer)
+        (is (= "" (text-selection source-viewer)))))))
 
 (defn- enter! [source-viewer]
   (handler/run :enter [{:name :code-view :env {:selection source-viewer}}]{}))

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -262,9 +262,9 @@
           (enter! source-viewer)
           (is (= "function test(x)\n\t" (text source-viewer))))
         (testing "some indentation exists"
-          (set-code-and-caret! source-viewer "\tfunction test(x)")
+          (set-code-and-caret! source-viewer "if true then\n\tfunction test(x)")
           (enter! source-viewer)
-          (is (= "\tfunction test(x)\n\t\t" (text source-viewer))))
+          (is (= "if true then\n\tfunction test(x)\n\t\t" (text source-viewer))))
         (testing "maintains level in the function"
           (set-code-and-caret! source-viewer "function test(x)\n\tfoo")
           (enter! source-viewer)

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -181,7 +181,11 @@
       (testing "single result gets automatically inserted"
         (set-code-and-caret! source-viewer "math.ab")
         (propose! source-viewer)
-        (is (= "math.abs(x)" (text source-viewer)))))))
+        (is (= "math.abs(x)" (text source-viewer))))
+      (testing "proper indentation is put in"
+        (set-code-and-caret! source-viewer "function foo(x)\n\tif")
+        (propose! source-viewer)
+        (is (= "function foo(x)\n\tif cond then\n\t\t--do things\n\tend" (text source-viewer)))))))
 
 (defn- tab! [source-viewer]
   (handler/run :tab [{:name :code-view :env {:selection source-viewer}}]{}))
@@ -329,3 +333,23 @@
           (set-code-and-caret! source-viewer "x = {\n\t1\n\t}")
           (enter! source-viewer)
           (is (= "x = {\n\t1\n}\n" (text source-viewer))))))))
+
+(defn- indent! [source-viewer]
+  (handler/run :indent [{:name :code-view :env {:selection source-viewer}}]{}))
+
+(deftest lua-enter-indent-line-and-region
+  (with-clean-system
+    (let [code ""
+          opts lua/lua
+          source-viewer (setup-source-viewer opts false)
+          [code-node viewer-node] (setup-code-view-nodes world source-viewer code script/ScriptNode)]
+      (testing "indent line"
+        (set-code-and-caret! source-viewer "if true then\nreturn 1")
+        (indent! source-viewer)
+        (is (= "if true then\n\treturn 1" (text source-viewer))))
+      (testing "indent region"
+        (let [code "if true then\nreturn 1\nif false then\nreturn 2\nend\nend"]
+          (set-code-and-caret! source-viewer code)
+          (text-selection! source-viewer 0 (count code))
+          (indent! source-viewer)
+          (is (= "if true then\n\treturn 1\n\tif false then\n\t\treturn 2\n\tend\nend" (text source-viewer))))))))

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -601,7 +601,7 @@
 (defn- delete-to-start-of-line! [source-viewer]
   (handler/run :delete-to-start-of-line [{:name :code-view :env {:selection source-viewer}}]{}))
 
-(deftest delete-to-start-end-line
+(deftest delete-to-start-end-line-test
   (with-clean-system
     (let [code "blue duck"
           opts lua/lua
@@ -620,6 +620,31 @@
         (delete-to-start-of-line! source-viewer)
         (is (= "ck" (text source-viewer)))
         (is (= \c (get-char-at-caret source-viewer)))))))
+
+(defn- cut-to-end-of-line! [source-viewer clipboard]
+  (handler/run :cut-to-end-of-line [{:name :code-view :env {:selection source-viewer :clipboard clipboard}}]{}))
+
+(deftest cut-to-end-line-test
+  (with-clean-system
+    (let [code "line1\nline2\nline3"
+          clipboard (new TestClipboard (atom ""))
+          opts lua/lua
+          source-viewer (setup-source-viewer opts false)
+          [code-node viewer-node] (setup-code-view-nodes world source-viewer code script/ScriptNode)]
+      (testing "cutting to end of the line"
+        (caret! source-viewer 2 false)
+        (cut-to-end-of-line! source-viewer clipboard)
+        (is (= "li\nline2\nline3" (text source-viewer)))
+        (paste! source-viewer clipboard)
+        (is (= "line1\nline2\nline3" (text source-viewer))))
+      (testing "multiple kill lines work"
+        (caret! source-viewer 0 false)
+        (cut-to-end-of-line! source-viewer clipboard)
+        (is (= "\nline2\nline3" (text source-viewer)))
+        (cut-to-end-of-line! source-viewer clipboard)
+        (is (= "line2\nline3" (text source-viewer)))
+        (cut-to-end-of-line! source-viewer clipboard)
+        (is (= "\nline3" (text source-viewer)))))))
 
 (defn- find-text! [source-viewer text]
   ;; bypassing handler for the dialog handling

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -486,6 +486,22 @@
         (select-word! source-viewer)
         (is (= "" (text-selection source-viewer)))))))
 
+(defn- select-line! [source-viewer]
+  (handler/run :select-line [{:name :code-view :env {:selection source-viewer}}]{}))
+
+(deftest select-line-test
+  (with-clean-system
+    (let [code "line1\nline2"
+          opts lua/lua
+          source-viewer (setup-source-viewer opts false)
+          [code-node viewer-node] (setup-code-view-nodes world source-viewer code script/ScriptNode)]
+      (testing "selects the line"
+        (select-line! source-viewer)
+        (is (= "line1" (text-selection source-viewer)))
+        (caret! source-viewer 7 false)
+        (select-line! source-viewer)
+        (is (= "line2" (text-selection source-viewer)))))))
+
 (defn- select-all! [source-viewer]
   (handler/run :select-all [{:name :code-view :env {:selection source-viewer}}]{}))
 

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -31,6 +31,7 @@
   (:import [java.io File FilenameFilter FileOutputStream FileInputStream ByteArrayOutputStream]
            [java.nio.file Files attribute.FileAttribute]
            [javax.imageio ImageIO]
+           [javafx.scene.control Tab]
            [org.apache.commons.io FilenameUtils FileUtils IOUtils]
            [java.util.zip ZipOutputStream ZipEntry]))
 
@@ -98,7 +99,8 @@
     (not (nil? (some #{tgt-node-id} sel)))))
 
 (g/defnode DummyAppView
-  (property active-tool g/Keyword))
+  (property active-tool g/Keyword)
+  (property active-tab Tab))
 
 (defn setup-app-view! []
   (let [view-graph (g/make-graph! :history false :volatility 2)


### PR DESCRIPTION
Various bug fixes and improvements
- Moving to next tab has the cursor appear immediately
- Move tab triggers and preferred offset to node properties and have them work with undo
- Triple click select line
- Emacs bindings Ctl-K to delete and Clt-Y to paste
- Bug fix for ending tab trigger out snippet blocks with text after
- Performance and bug fixes for layout rendering
- Indent line & Ident Region (command + I)
- Fix bug for snippets being inserted with wrong indentation
- Refactoring to use more efficient line protocol
