### PR TITLE
Text editor polishing 

### DIFF
--- a/editor/resources/lua-base-snippets.edn
+++ b/editor/resources/lua-base-snippets.edn
@@ -33,7 +33,7 @@
    :display-string "local name = value",
    :insert-string "local name = value",
    :doc "",
-   :tab-triggers {:select ["local_name" "local_value"]}}
+   :tab-triggers {:select ["name" "value"]}}
   {:name "for",
    :display-string "for i=1,10",
    :insert-string "for i=1,10 do\n\t--do things\nend",

--- a/editor/resources/lua-base-snippets.edn
+++ b/editor/resources/lua-base-snippets.edn
@@ -1,0 +1,41 @@
+ [{:name "if",
+   :display-string "if cond then",
+   :insert-string "if cond then\n\t--do things\nend",
+   :doc "",
+   :tab-triggers {:select ["cond" "--do things" "end"]}}
+  {:name "else",
+   :display-string "else end",
+   :insert-string "else\n\t--do things\nend",
+   :doc "",
+   :tab-triggers {:select ["--do things"], :exit "end"}}
+  {:name "elsif",
+   :display-string "elseif cond end",
+   :insert-string "elseif cond then\n\t--do things\nend",
+   :doc "",
+   :tab-triggers {:select ["cond" "--do things" "end"]}}
+  {:name "while",
+   :display-string "while cond",
+   :insert-string "while cond\n\t--do things\nend",
+   :doc "",
+   :tab-triggers {:select ["cond" "--do things"], :exit "end"}}
+  {:name "repeat",
+   :display-string "repeat until cond",
+   :insert-string "repeat\n\t--do things\nuntil cond",
+   :doc "",
+   :tab-triggers {:select ["--do things" "cond"]}}
+  {:name "function",
+   :display-string "function",
+   :insert-string "function function_name(params)\n\t--do things\nend",
+   :doc "",
+   :tab-triggers
+   {:select ["function_name" "params" "--do things"], :exit "end"}}
+  {:name "local",
+   :display-string "local name = value",
+   :insert-string "local name = value",
+   :doc "",
+   :tab-triggers {:select ["local_name" "local_value"]}}
+  {:name "for",
+   :display-string "for i=1,10",
+   :insert-string "for i=1,10 do\n\t--do things\nend",
+   :doc "",
+   :tab-triggers {:select ["i" "1" "10" "--do things"], :exit "end"}}]

--- a/editor/src/clj/editor/code_completion.clj
+++ b/editor/src/clj/editor/code_completion.clj
@@ -20,7 +20,7 @@
         fns  (map (fn [[fname {:keys [params]}]]
                     (let [n (if namespace-alias (replace-alias fname namespace-alias) fname)
                           display-string (str n "(" (string/join "," params)  ")")]
-                      (code/create-hint n display-string display-string "" params)))
+                      (code/create-hint n display-string display-string "" {:select params})))
                   fn-info)]
     (set (concat vars fns))))
 

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -515,7 +515,6 @@
   (has-snippet-tab-trigger? [this] (cvx/snippet-tab-triggers this))
   (next-snippet-tab-trigger! [this]
     (let [tt (tab-triggers this)
-          _ (println "tt" @tt)
           triggers (:select @tt)
           trigger (or (first triggers) :end)
           exit-trigger (:exit @tt)]

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -510,9 +510,9 @@
     (reset! (prefer-offset this) val))
   cvx/TextSnippet
   (snippet-tab-triggers [this] (when-let [tt (tab-triggers this)]
-                                 (:select @tt)))
+                                 @tt))
   (snippet-tab-triggers! [this val] (reset! (tab-triggers this) val))
-  (has-snippet-tab-trigger? [this] (cvx/snippet-tab-triggers this))
+  (has-snippet-tab-trigger? [this] (:select (cvx/snippet-tab-triggers this)))
   (next-snippet-tab-trigger! [this]
     (let [tt (tab-triggers this)
           triggers (:select @tt)

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -510,16 +510,19 @@
     (reset! (prefer-offset this) val))
   cvx/TextSnippet
   (snippet-tab-triggers [this] (when-let [tt (tab-triggers this)]
-                                 @tt))
+                                 (:select @tt)))
   (snippet-tab-triggers! [this val] (reset! (tab-triggers this) val))
   (has-snippet-tab-trigger? [this] (cvx/snippet-tab-triggers this))
   (next-snippet-tab-trigger! [this]
     (let [tt (tab-triggers this)
-          trigger (or (first @tt) :end)]
+          _ (println "tt" @tt)
+          triggers (:select @tt)
+          trigger (or (first triggers) :end)
+          exit-trigger (:exit @tt)]
       (if (= trigger :end)
         (reset! tt nil)
-        (swap! tt rest))
-      trigger))
+        (swap! tt assoc :select (rest triggers)))
+      {:trigger trigger :exit exit-trigger}))
   (clear-snippet-tab-triggers! [this]
     (reset! (tab-triggers this) nil)))
 

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -580,7 +580,8 @@
     (if (pos? (selection-length selection))
       (replace-text-and-caret selection soffset slen "" soffset)
       (let [pos (adjust-bounds doc (dec np))]
-       (replace-text-and-caret selection pos 1 "" pos)))))
+       (when-not (zero? np)
+        (replace-text-and-caret selection pos 1 "" pos))))))
 
 (handler/defhandler :delete :code-view
   (enabled? [selection] (editable? selection))

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -815,7 +815,6 @@
           tab-trigger-info (next-snippet-tab-trigger! selection)
           search-text (:trigger tab-trigger-info)
           exit-text (:exit tab-trigger-info)]
-      (println :tab-trigger-info tab-trigger-info)
       (if (= :end search-text)
         (do
           (text-selection! selection pos 0)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -812,11 +812,18 @@
 (defn next-tab-trigger [selection pos]
   (when (has-snippet-tab-trigger? selection)
     (let [doc (text selection)
-          np (caret selection)
-          search-text (next-snippet-tab-trigger! selection)]
+          tab-trigger-info (next-snippet-tab-trigger! selection)
+          search-text (:trigger tab-trigger-info)
+          exit-text (:exit tab-trigger-info)]
+      (println :tab-trigger-info tab-trigger-info)
       (if (= :end search-text)
         (do
-          (text-selection! selection np 0)
+          (text-selection! selection pos 0)
+          (when exit-text
+            (let [found-idx (string/index-of doc exit-text pos)
+                  tlen (count exit-text)]
+              (when found-idx
+                (caret! selection (+ found-idx tlen) false))))
           (right selection))
         (let [found-idx (string/index-of doc search-text pos)
               tlen (count search-text)]

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -893,9 +893,12 @@
   (run [selection]
     (when (editable? selection)
       (clear-snippet-tab-triggers! selection)
-      (do-indent-line selection (line-num-at-offset selection (caret selection)))
-      (enter-key-text selection (System/getProperty "line.separator"))
-      (do-indent-line selection (line-num-at-offset selection (caret selection))))))
+      (if (= (caret selection) (line-end-pos selection))
+        (do
+          (do-indent-line selection (line-num-at-offset selection (caret selection)))
+          (enter-key-text selection (System/getProperty "line.separator"))
+          (do-indent-line selection (line-num-at-offset selection (caret selection))))
+        (enter-key-text selection (System/getProperty "line.separator"))))))
 
 (handler/defhandler :undo :code-view
   (enabled? [selection] selection)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -821,12 +821,12 @@
       (if (= :end search-text)
         (do
           (text-selection! selection pos 0)
-          (when exit-text
+          (if exit-text
             (let [found-idx (string/index-of doc exit-text pos)
                   tlen (count exit-text)]
               (when found-idx
-                (caret! selection (+ found-idx tlen) false))))
-          (right selection))
+                (caret! selection (+ found-idx tlen) false)))
+            (right selection)))
         (let [found-idx (string/index-of doc search-text pos)
               tlen (count search-text)]
           (when found-idx

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -574,11 +574,13 @@
 
 (defn delete [selection]
   (let [np (caret selection)
-        doc (text selection)]
+        doc (text selection)
+        slen (selection-length selection)
+        soffset (selection-offset selection)]
     (if (pos? (selection-length selection))
-      (replace-text-selection selection "")
-      (when-not (zero? np)
-       (replace-text-and-caret selection (dec np) 1 "" (dec np))))))
+      (replace-text-and-caret selection soffset slen "" soffset)
+      (let [pos (adjust-bounds doc (dec np))]
+       (replace-text-and-caret selection pos 1 "" pos)))))
 
 (handler/defhandler :delete :code-view
   (enabled? [selection] (editable? selection))

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -204,7 +204,7 @@
   (re-find #"^\s*(else|elseif|for|(local\s+)?function|if|while)\b((?!end).)*$|\{\s*$" s))
 
 (defn decrease-indent? [s]
-  (re-find #"^\s*(elseif|else|end|\})\s*$" s))
+  (re-find #"^\s*(elseif|else|end|\}).*$" s))
 
 ;; TODO: splitting into partitions using multiline (MultiLineRule) in combination with FastPartitioner does not work properly when
 ;; :eof is false. The initial "/*" does not start a comment partition, and when the ending "*/" is added (on another line) the document

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -88,7 +88,7 @@
   (when (= (.getType element) ScriptDoc$Type/FUNCTION)
     (let [params (for [^ScriptDoc$Parameter parameter (.getParametersList element)]
                    (.getName parameter))]
-      (remove #(= \[ (first %)) params))))
+      {:select (remove #(= \[ (first %)) params)})))
 
 (defn defold-documentation []
   (reduce
@@ -118,21 +118,21 @@
                    item
                    insert-string
                    ""
-                   tab-triggers)))
+                   {:select tab-triggers})))
         completions (group-by #(let [names (string/split (:name %) #"\.")]
                                          (if (= 2 (count names)) (first names) "")) hints)
         package-completions {"" (map code/create-hint (remove #(= "" %) (keys completions)))}]
     (merge-with into completions package-completions)))
 
 (defn lua-base-documentation []
-  {"" [(code/create-hint "if" "if" "if cond then\n\t--do things\nend" "" ["cond" "--do things" "end"])
-       (code/create-hint "else" "else" "else\n\t--do things\nend" "" ["--do things" "end"])
-       (code/create-hint "elseif" "elseif" "elseif cond\n\t--do things\nend" "" ["cond" "--do things" "end"])
-       (code/create-hint "while" "while" "while cond\n\t--do things\nend" "" ["cond" "--do things"])
-       (code/create-hint "repeat" "repeat" "repeat\n\t--do things\nuntil cond" "" ["--do things" "cond"])
-       (code/create-hint "function" "function" "function function_name(params)\n\t--do things\nend" "" ["function_name" "params" "--do things" "end"])
-       (code/create-hint "local" "local" "local local_name = local_value" "" ["local_name" "local_value"])
-       (code/create-hint "for" "for" "for i=1,10 do\n\t--do things\nend" "" ["i" "1" "10" "--do things" "end"])]})
+  {"" [(code/create-hint "if" "if" "if cond then\n\t--do things\nend" "" {:select ["cond" "--do things" "end"]})
+       (code/create-hint "else" "else" "else\n\t--do things\nend" "" {:select ["--do things"] :exit "end"})
+       (code/create-hint "elseif" "elseif" "elseif cond then\n\t--do things\nend" "" {:select ["cond" "--do things" "end"]})
+       (code/create-hint "while" "while" "while cond\n\t--do things\nend" "" {:select ["cond" "--do things"] :exit "end"})
+       (code/create-hint "repeat" "repeat" "repeat\n\t--do things\nuntil cond" "" {:select ["--do things" "cond"]})
+       (code/create-hint "function" "function" "function function_name(params)\n\t--do things\nend" "" {:select ["function_name" "params" "--do things"] :exit "end"})
+       (code/create-hint "local" "local" "local local_name = local_value" "" {:select ["local_name" "local_value"]})
+       (code/create-hint "for" "for" "for i=1,10 do\n\t--do things\nend" "" {:select ["i" "1" "10" "--do things"] :exit "end"})]})
 
 (def lua-std-libs-docs (atom (merge-with into (lua-base-documentation) (lua-std-libs-documentation))))
 

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -125,14 +125,9 @@
     (merge-with into completions package-completions)))
 
 (defn lua-base-documentation []
-  {"" [(code/create-hint "if" "if" "if cond then\n\t--do things\nend" "" {:select ["cond" "--do things" "end"]})
-       (code/create-hint "else" "else" "else\n\t--do things\nend" "" {:select ["--do things"] :exit "end"})
-       (code/create-hint "elseif" "elseif" "elseif cond then\n\t--do things\nend" "" {:select ["cond" "--do things" "end"]})
-       (code/create-hint "while" "while" "while cond\n\t--do things\nend" "" {:select ["cond" "--do things"] :exit "end"})
-       (code/create-hint "repeat" "repeat" "repeat\n\t--do things\nuntil cond" "" {:select ["--do things" "cond"]})
-       (code/create-hint "function" "function" "function function_name(params)\n\t--do things\nend" "" {:select ["function_name" "params" "--do things"] :exit "end"})
-       (code/create-hint "local" "local" "local local_name = local_value" "" {:select ["local_name" "local_value"]})
-       (code/create-hint "for" "for" "for i=1,10 do\n\t--do things\nend" "" {:select ["i" "1" "10" "--do things"] :exit "end"})]})
+  {"" (-> (io/resource "lua-base-snippets.edn")
+          slurp
+          edn/read-string)})
 
 (def lua-std-libs-docs (atom (merge-with into (lua-base-documentation) (lua-std-libs-documentation))))
 

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -83,7 +83,7 @@
         (set-code-and-caret! source-viewer "if")
         (let [result (propose source-viewer)]
          (is (= ["if"] (map :name result)))
-         (is (= ["if"] (map :display-string result)))
+         (is (= ["if cond then"] (map :display-string result)))
          (is (= ["if cond then\n\t--do things\nend"] (map :insert-string result)))))
       (testing "global defold package"
         (set-code-and-caret! source-viewer "go")
@@ -249,7 +249,19 @@
         (tab! source-viewer)
         (is (= "end" (text-selection source-viewer)))
         (tab! source-viewer)
-        (is (= "" (text-selection source-viewer)))))))
+        (is (= "" (text-selection source-viewer))))
+      (testing "with function template"
+        (set-code-and-caret! source-viewer "function")
+        (propose! source-viewer)
+        (is (= "function function_name(params)\n\t--do things\nend"(text source-viewer)))
+        (is (= "function_name" (text-selection source-viewer)))
+        (tab! source-viewer)
+        (is (= "params" (text-selection source-viewer)))
+        (tab! source-viewer)
+        (is (= "--do things" (text-selection source-viewer)))
+        (tab! source-viewer)
+        (is (= "" (text-selection source-viewer)))
+        (is (= (count "function function_name(params)\n\t--do things\nend") (caret source-viewer)))))))
 
 (defn- enter! [source-viewer]
   (handler/run :enter [{:name :code-view :env {:selection source-viewer}}]{}))

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -276,7 +276,12 @@
         (testing "end deindents"
           (set-code-and-caret! source-viewer "function test(x)\n\tend")
           (enter! source-viewer)
-          (is (= "function test(x)\nend\n" (text source-viewer))))))))
+          (is (= "function test(x)\nend\n" (text source-viewer))))
+        (testing "no enter identation if not at an end of the line"
+          (set-code-and-caret! source-viewer "function test(x)")
+          (caret! source-viewer 2 false)
+          (enter! source-viewer)
+          (is (= "fu\nnction test(x)" (text source-viewer))))))))
 
 (deftest lua-enter-indentation-if-else
   (with-clean-system


### PR DESCRIPTION
Bug fixes and enhancements
- Fix indentation taking into account text after elsif 
- Fix bug to limit enter indentation happening only at eol
- Fix tab triggers with snippets so that things like `function` go to the end of the snippet rather than highlighting the `end` word
- Move the lua base snippet data out to a resource file so that it can be used as a base for other lang snippets
- Other assorted bug fixes
