### PR TITLE
Introduce :_overridden-properties intrinsic.

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -588,6 +588,10 @@
   (assert node-id)
   (it/clear-property node-id p))
 
+(defn clear-property!
+  [node-id p]
+  (transact (clear-property node-id p)))
+
 (defn update-graph-value [graph-id k f & args]
   (it/update-graph-value graph-id update (into [k f] args)))
 

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -16,10 +16,11 @@
   (produce-value       [this label evaluation-context] "Pull a value using an evaluation context"))
 
 (defprotocol Node
-  (node-id             [this]                          "Return an ID that can be used to get this node (or a future value of it).")
-  (node-type           [this basis]                    "Return the node type that created this node.")
-  (get-property        [this basis property]           "Return the value of the named property")
-  (set-property        [this basis property value]     "Set the named property"))
+  (node-id               [this]                          "Return an ID that can be used to get this node (or a future value of it).")
+  (node-type             [this basis]                    "Return the node type that created this node.")
+  (get-property          [this basis property]           "Return the value of the named property")
+  (set-property          [this basis property value]     "Set the named property")
+  (overridden-properties [this basis]                    "Return a map of property name to override value"))
 
 (defprotocol OverrideNode
   (clear-property      [this basis property]           "Clear the named property (this is only valid for override nodes)")

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -859,3 +859,37 @@
 
 (deftest declared-properties-is-cached
   (is (contains? (in/cached-outputs CustomPropertiesOutput) :_declared-properties)))
+
+(defn- override [node-id]
+  (-> (g/override node-id {})
+    :tx-data
+    tx-nodes))
+
+(deftest overridden-properties
+  (testing "is empty for an original node"
+    (with-clean-system
+      (let [[n] (tx-nodes (g/make-node world BasicNode))]
+        (is (empty? (g/node-value n :_overridden-properties))))))
+
+  (testing "is empty for an override node with no properties set"
+    (with-clean-system
+      (let [[n] (tx-nodes (g/make-node world BasicNode))
+            [onode] (override n)]
+        (is (empty? (g/node-value onode :_overridden-properties))))))
+
+  (testing "contains only properties with an override value"
+    (with-clean-system
+      (let [[n]     (tx-nodes (g/make-node world BasicNode))
+            [onode] (override n)
+            _       (g/set-property! onode :dynamic-property 99)
+            v1      (g/node-value onode :_overridden-properties)
+            _       (g/set-property! onode :background-color "cornflower blue")
+            v2      (g/node-value onode :_overridden-properties)
+            _       (g/clear-property! onode :dynamic-property)
+            v3      (g/node-value onode :_overridden-properties)
+            _       (g/clear-property! onode :background-color)
+            v4      (g/node-value onode :_overridden-properties)]
+        (is (= v1 {:dynamic-property 99} ))
+        (is (= v2 {:dynamic-property 99 :background-color "cornflower blue"} ))
+        (is (= v3 {:background-color "cornflower blue"}))
+        (is (= v4 {}))))))

--- a/editor/test/internal/node_type_test.clj
+++ b/editor/test/internal/node_type_test.clj
@@ -21,7 +21,7 @@
   (inherits SubType))
 
 (deftest type-fns
-  (is (= #{:_declared-properties :sub-out :sub-prop :_output-jammers :_properties :super-out :super-prop :_node-id}
+  (is (= #{:_declared-properties :_overridden-properties :sub-out :sub-prop :_output-jammers :_properties :super-out :super-prop :_node-id}
          (util/key-set (g/declared-outputs SubType))))
   (is (= #{:super-in :sub-in} (util/key-set (g/declared-inputs SubType))))
   (is (= #{:super-prop :sub-prop} (util/key-set (g/declared-properties SubType)))))

--- a/editor/test/internal/transaction_test.clj
+++ b/editor/test/internal/transaction_test.clj
@@ -170,7 +170,7 @@
           real-id          (first (g/tx-nodes-added tx-result))
           outputs-modified (:outputs-modified tx-result)]
       (is (some #{real-id} (map first outputs-modified)))
-      (is (= #{:_declared-properties :_properties :_node-id :_output-jammers :self-dependent :a-property :ordinary} (into #{} (map second outputs-modified))))
+      (is (= #{:_declared-properties :_properties :_overridden-properties :_node-id :_output-jammers :self-dependent :a-property :ordinary} (into #{} (map second outputs-modified))))
       (let [tx-data          [(it/update-property real-id :a-property (constantly "new-value") [])]
             tx-result        (g/transact tx-data)
             outputs-modified (:outputs-modified tx-result)]


### PR DESCRIPTION
- For an ordinary node, always produces an empty map.
- For an override node, produces a map of overridden properties to their values.
