### PR TITLE
DEFEDIT-361 Improve application focus/unfocus detection

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -3,6 +3,7 @@
             [editor.progress :as progress]
             [editor.workspace :as workspace]
             [editor.ui :as ui]
+            [editor.dialogs :as dialogs]
             [editor.changes-view :as changes-view]
             [editor.properties-view :as properties-view]
             [editor.text :as text]
@@ -115,18 +116,36 @@
     (workspace/resource-sync! workspace)
     workspace))
 
-(defn load-stage [workspace project prefs]
 
+;; Slight hack to work around the fact that we have not yet found a
+;; reliable way of detecting when the application loses focus.
+
+;; If no application-owned windows have had focus within this
+;; threshold, we consider the application to have lost focus.
+(def application-unfocused-threshold-ms 500)
+
+(defn- watch-focus-state! [workspace]
+  (add-watch dialogs/focus-state :main-stage
+             (fn [key ref old new]
+               (when (and old
+                          (not (:focused? old))
+                          (:focused? new))
+                 (let [unfocused-ms (- (:t new) (:t old))]
+                   (when (< application-unfocused-threshold-ms unfocused-ms)
+                     (future
+                       (ui/with-disabled-ui
+                         (ui/with-progress [render-fn ui/default-render-progress!]
+                           (editor.workspace/resource-sync! workspace true [] render-fn))))))))))
+
+
+(defn load-stage [workspace project prefs]
   (let [^VBox root (ui/load-fxml "editor.fxml")
         stage      (Stage.)
         scene      (Scene. root)]
     (ui/observe (.focusedProperty stage)
                 (fn [property old-val new-val]
-                  (when (true? new-val)
-                    (future
-                      (ui/with-disabled-ui
-                        (ui/with-progress [render-fn ui/default-render-progress!]
-                          (editor.workspace/resource-sync! workspace true [] render-fn)))))))
+                  (dialogs/record-focus-change! new-val)))
+    (watch-focus-state! workspace)
 
     (ui/set-main-stage stage)
     (.setScene stage scene)


### PR DESCRIPTION
JavaFX nor Java provides a reliable way to detect when the application
as a whole loses focus.

This commit provides a (questionable) solution that detects when the
time no application window has had focus goes above a threshold (500ms).
