### PR TITLE
Detect x86_64-darwin host platform

### DIFF
--- a/editor/src/java/com/defold/editor/Platform.java
+++ b/editor/src/java/com/defold/editor/Platform.java
@@ -83,7 +83,11 @@ public enum Platform {
         if (os_name.indexOf("win") != -1) {
             return Platform.X86Win32;
         } else if (os_name.indexOf("mac") != -1) {
-            return Platform.X86Darwin;
+            if (arch.equals("x86_64") || arch.equals("amd64")) {
+                return Platform.X86_64Darwin;
+            } else {
+                return Platform.X86Darwin;
+            }
         } else if (os_name.indexOf("linux") != -1) {
             if (arch.equals("x86_64") || arch.equals("amd64")) {
                 return Platform.X86_64Linux;


### PR DESCRIPTION
Fixes finding engine on 64-bit mac.
