### PR TITLE
Introduce a build-type option 

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -85,11 +85,11 @@
   :main ^:skip-aot   com.defold.editor.Start
 
   :profiles          {:test    {:injections [(defonce force-toolkit-init (javafx.embed.swing.JFXPanel.))]}
-                      :uberjar {:prep-tasks   ["clean" "protobuf" "javac" ["run" "-m" " aot"] "compile"]
-                                :jvm-opts     ["-Dclojure.compiler.direct-linking=true"]
+                      :uberjar {:prep-tasks   ["clean" "protobuf" "javac" ["run" "-m" "aot"] "compile"]
                                 :aot          :all
                                 :omit-source  true
                                 :source-paths ["sidecar"]}
+                      :release {:jvm-opts          ["-Ddefold.build=release"]}
                       :dev     {:dependencies      [[org.clojure/test.check   "0.9.0"]
                                                     [org.mockito/mockito-core "1.10.19"]
                                                     [org.clojure/tools.trace  "0.7.9"]

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -291,7 +291,7 @@ if __name__ == '__main__':
 
     print 'Building editor'
     exec_command('./scripts/lein clean')
-    exec_command('./scripts/lein uberjar')
+    exec_command('./scripts/lein with-profile +release uberjar')
 
     for platform in options.target_platform:
         bundle(platform, options)
@@ -304,4 +304,3 @@ if __name__ == '__main__':
                                   'action': 'copy'}]}
     with open('target/editor/update/manifest.json', 'w') as f:
         f.write(json.dumps(package_info, indent=4))
-

--- a/editor/sidecar/aot.clj
+++ b/editor/sidecar/aot.clj
@@ -60,11 +60,13 @@
 
 (def build->compiler-options
   {"development"
-   {:elide-meta     #{:file :line :column}}
+   {:elide-meta           #{:file :line :column}
+    :defold/check-schemas true}
 
    "release"
    {:elide-meta     #{:file :line :column}
-    :direct-linking true}})
+    :direct-linking true
+    :defold/check-schemas  false}})
 
 (def default-compiler-options (build->compiler-options "development"))
 

--- a/editor/sidecar/aot.clj
+++ b/editor/sidecar/aot.clj
@@ -56,19 +56,23 @@
   []
   (walk/keywordize-keys (into {} (System/getProperties))))
 
-(def build-type (atom (get (system-properties) :defold.build :development)))
+(def build-type (atom (get (system-properties) :defold.build "development")))
 
 (def build->compiler-options
-  {:development
-   {:elide-meta #{:file :line :column}}
+  {"development"
+   {:elide-meta     #{:file :line :column}}
 
-   :production
+   "release"
    {:elide-meta     #{:file :line :column}
     :direct-linking true}})
 
+(def default-compiler-options (build->compiler-options "development"))
+
 (defn compile-clj
   [namespaces]
-  (binding [*compiler-options* (build->compiler-options @build-type)]
+  (binding [*compiler-options* (build->compiler-options @build-type default-compiler-options)]
+    (println "Using build profile " @build-type)
+    (println "Compiler options: " *compiler-options*)
     (doseq [n namespaces]
       (println "Compiling " n)
       (compile n))))

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -21,8 +21,7 @@
 
 (set! *warn-on-reflection* true)
 
-;; todo - find a way to force this to nil when doing a production build.
-(def ^:dynamic *check-schemas* true)
+(def ^:dynamic *check-schemas* (get *compiler-options* :defold/check-schemas true))
 
 (def ^:dynamic *node-value-debug* nil)
 (def ^:dynamic ^:private *node-value-nesting* 0)

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -392,7 +392,7 @@
   (let [basis (:basis ctx)
         node-type (gt/node-type node basis)
         value-type (some-> (in/property-type node-type property) deref in/schema s/maybe)]
-   (if-let [validation-error (and value-type (s/check value-type new-value))]
+   (if-let [validation-error (and in/*check-schemas* value-type (s/check value-type new-value))]
      (do
        (in/warn-output-schema node-id node-type property new-value value-type validation-error)
        (throw (ex-info "SCHEMA-VALIDATION"


### PR DESCRIPTION
We now have a build flag that we can use for a release build. There are
a couple of links in the chain to get this activated:
- The AOT compiler looks for a Java system property calls
  "defold.build". If that is set to the string "release", then the
  release options are used (see below.)
- Any other option is equivalent to the default setting "development".
- The leiningen project enables the release build when you add in the
  profile "release", like so:

`lein with-profile +release uberjar`
- bundle.py will always build with the release profile.

A new compiler option is defined. When :defold/check-schemas is false,
schema checks are disabled for node output values and property values
being set.

Development compiler options:
- Elide metadata
- Enable schema checks

Release compiler options:
- Elide metadata
- Enable direct linking
- Disable schema checks
