### PR TITLE
Fix native lib loading

### DIFF
--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -136,7 +136,7 @@ public class Start extends Application {
     private ClassLoader makeClassLoader() {
         ArrayList<URL> urls = extractURLs(System.getProperty("java.class.path"));
         // The "boot class-loader", i.e. for java.*, sun.*, etc
-        ClassLoader parent = ClassLoader.getSystemClassLoader().getParent();
+        ClassLoader parent = ClassLoader.getSystemClassLoader();
         // Per instance class-loader
         ClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), parent);
         return classLoader;
@@ -187,6 +187,10 @@ public class Start extends Application {
 	        Future<?> extractFuture = threadPool.submit(() -> {
 	            try {
 	                NativeArtifacts.extractNatives();
+                        ClassLoader parent = ClassLoader.getSystemClassLoader();
+                        Class<?> glprofile = parent.loadClass("javax.media.opengl.GLProfile");
+                        Method init = glprofile.getMethod("initSingleton");
+                        init.invoke(null);
 	            } catch (Exception e) {
 	                logger.error("failed to extract native libs", e);
 	            }


### PR DESCRIPTION
- Force the native libs to be loaded from the System class loader.
- Have all the Clojure "pods" subordinate to the System class
  loader. (Previously these were subordinate to the System class
  loader's parent, which is a bootstrap class loader.)

This way, any Clojure namespace that touches into
javax.media.opengl.GLProfile will find the GLProfile class from the
System class loader. It will already have the native libs linked into
the process.
