### PR TITLE
DEF-264 Made SSDP tests more definitive

### DIFF
--- a/engine/dlib/src/java_test/com/dynamo/upnp/SSDPTest.java
+++ b/engine/dlib/src/java_test/com/dynamo/upnp/SSDPTest.java
@@ -45,7 +45,8 @@ public class SSDPTest {
         assertNotDevice(USN2);
 
         for (int i = 0; i < 5; ++i) {
-            ssdp.update(true);
+            // Search in the first iteration
+            ssdp.update(i == 0);
             Thread.sleep(100);
         }
         assertDevice(USN2);
@@ -53,7 +54,6 @@ public class SSDPTest {
 
     @Test
     public void testAnnounce() throws Exception {
-        ssdp.update(false);
         assertNotDevice(USN1);
 
         for (int i = 0; i < 15; ++i) {


### PR DESCRIPTION
- Tests failed because CI found a device at the start of testAnnounce, where there was not supposed to be any
- testSearch: no point in broadcasting search more than once
  *\* To avoid sending out more searches than necessary
- testAnnounce: avoid updating SSDP before entry condition: no devices
  *\* The success case is to update SSDP to see the device, so don't do it before the test starts
