### PR TITLE
DEF-264 Additional wait in dmSSDPTest::Renew

### DIFF
--- a/engine/dlib/src/test/test_ssdp.cpp
+++ b/engine/dlib/src/test/test_ssdp.cpp
@@ -239,6 +239,7 @@ TEST_F(dmSSDPTest, Renew)
     Init(1);
     dmTime::Sleep(1000000);
     UpdateServer();
+    WaitPackage();
     UpdateClient();
     ASSERT_TRUE(TestDeviceDiscovered());
 }


### PR DESCRIPTION
- Failed on CI
- WaitPackage is called in other places to make sure that the communication has completed
- Added that to Renew as well
