### PR TITLE
DEF-2008 Don't run lz4 python tests in parallel

### DIFF
--- a/engine/dlib/src/dlib/lz4.cpp
+++ b/engine/dlib/src/dlib/lz4.cpp
@@ -51,7 +51,7 @@ namespace dmLZ4
         *compressed_size = LZ4_compress_HC((const char *)buffer, (char *)compressed_buffer, buffer_size, LZ4_compressBound(buffer_size), 9);
 
         Result r;
-        if(compressed_size == 0)
+        if(*compressed_size == 0)
             r = dmLZ4::RESULT_COMPRESSION_FAILED;
         else
             r = dmLZ4::RESULT_OK;

--- a/engine/dlib/src/test/test_lz4.cpp
+++ b/engine/dlib/src/test/test_lz4.cpp
@@ -86,7 +86,7 @@ TEST(dmLZ4, Stress)
     for (int i = 0; i < 100; ++i) {
         int ref_len;
         char *ref = RandomCharArray(max_size, &ref_len);
-        int max_compressed_size, compressed_size, decompressed_size;
+        int max_compressed_size, compressed_size;
         dmLZ4::Result r = dmLZ4::MaxCompressedSize(ref_len, &max_compressed_size);
         ASSERT_EQ(dmLZ4::RESULT_OK, r);
 

--- a/engine/resource/src/test/wscript
+++ b/engine/resource/src/test/wscript
@@ -23,14 +23,16 @@ new_copy_task('script', '.script', '.scriptc')
 def build(bld):
     resources = bld.new_task_gen(source = ['test.cont_pb'])
 
-    archive = bld.new_task_gen(features = 'archive',
+    archive = bld.new_task_gen(name = 'uncompressed_archive',
+                               features = 'archive',
                                archive_target='test.arc',
                                source = 'archive_data/file4.ad archive_data/file1.ad archive_data/file3.ad archive_data/file2.ad archive_data/file5.script')
 
     compressed_archive = bld.new_task_gen(features = 'archive',
                                archive_target='test_compressed.arc',
                                use_compression=True,
-                               source = 'archive_data/file4.ad archive_data/file1.ad archive_data/file3.ad archive_data/file2.ad archive_data/file5.script')
+                               source = 'archive_data/file4.ad archive_data/file1.ad archive_data/file3.ad archive_data/file2.ad archive_data/file5.script',
+                               after = 'uncompressed_archive')
 
     # Same as above but created with the java-based archive builder
     jarchive = bld.new_task_gen(features = 'jarchive',


### PR DESCRIPTION
- Fixed waf rules to separate the two lz4 python tests
- The assumption is that they compete for resources some how
- Fixed tiny issue in lz4 which is not likely to be a practical issue, but still a bug
- Fixed compile warning
