### PR TITLE
Collision editor fixes

### DIFF
--- a/editor/resources/test_project/collision_object/tile_map_collision_shape.collisionobject
+++ b/editor/resources/test_project/collision_object/tile_map_collision_shape.collisionobject
@@ -1,0 +1,10 @@
+collision_shape: "/tilegrid/test.tilegrid"
+type: COLLISION_OBJECT_TYPE_DYNAMIC
+mass: 42.0
+friction: 2.3
+restitution: 1.5
+group: "default"
+mask: "default"
+linear_damping: 0.0
+angular_damping: 0.0
+locked_rotation: false

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -474,6 +474,7 @@
   (let [co (protobuf/read-text Physics$CollisionObjectDesc resource)]
     (concat
      (g/set-property self
+                     :collision-shape (workspace/resolve-resource resource (:collision-shape co))
                      :type (:type co)
                      :mass (:mass co)
                      :friction (:friction co)

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -604,7 +604,7 @@
 
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-data g/Any :cached produce-save-data)
-  (output build-targets g/Any #_:cached produce-build-targets))
+  (output build-targets g/Any :cached produce-build-targets))
 
 (defn register-resource-types [workspace]
   (workspace/register-resource-type workspace

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -34,7 +34,8 @@
                  "**/scene.gui"
                  "**/fireworks_big.particlefx"
                  "**/new.collisionobject"
-                 "**/three_shapes.collisionobject"]]
+                 "**/three_shapes.collisionobject"
+                 "**/tile_map_collision_shape.collisionobject"]]
     (with-clean-system
       (let [workspace (test-util/setup-workspace! world)
             project   (test-util/setup-project! workspace)


### PR DESCRIPTION
- referenced collision shapes from tile maps weren't loaded properly, fixed and added test
- cache `build-targets` output 
