### PR TITLE
DEF-2010 Fixed test_profile to more accurately measure profiling time

### DIFF
--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -670,11 +670,6 @@ namespace dmProfile
         }
     }
 
-    static inline bool CounterPred(const Counter& c1, const Counter& c2)
-    {
-        return c1.m_NameHash < c2.m_NameHash;
-    }
-
     void AddCounter(const char* name, uint32_t amount)
     {
         uint32_t name_hash = dmHashBufferNoReverse32(name, strlen(name));

--- a/engine/dlib/src/dlib/time.h
+++ b/engine/dlib/src/dlib/time.h
@@ -7,7 +7,8 @@
 namespace dmTime
 {
     /**
-     * Sleep thread
+     * Sleep thread with low precision (~10 milliseconds).
+     * This function has a very low precision, expect it to be 10s of milliseconds.
      * @param useconds Time to sleep in microseconds
      */
     void Sleep(uint32_t useconds);
@@ -17,6 +18,15 @@ namespace dmTime
      * @return
      */
     uint64_t GetTime();
+
+    /**
+     * Busy wait thread with high precision (~10 microseconds).
+     * @param useconds Time to wait in microseconds
+     */
+    inline void BusyWait(uint32_t useconds) {
+        uint64_t end = dmTime::GetTime() + (uint64_t)useconds;
+        while (dmTime::GetTime() < end);
+    }
 }
 
 #endif // DM_TIME_H


### PR DESCRIPTION
- Introduced dmTime::BusyWait for higher precision waiting
- Fixed warning (unused function dmProfile::CounterPred)
- Cleaned up ProfileScope and removed unused variables
- Changed test TOL to 1 msec, which is close to the expected time (still too high)
