### PR TITLE
DEF-1094: Cap expiry date of http responses to 30 days instead of ignore caching of them

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -27,6 +27,8 @@ namespace dmHttpClient
     // Be careful with this buffer. See comment in Receive about ssl_read.
     const int BUFFER_SIZE = 64 * 1024;
 
+    const unsigned int HTTP_CLIENT_MAXIMUM_CACHE_AGE = 30U * 24U * 60U * 60U; // 30 days
+
     const uint32_t MAX_POOL_CONNECTIONS = 32;
 
     const int SOCKET_TIMEOUT = 500 * 1000;
@@ -441,11 +443,10 @@ namespace dmHttpClient
             const char* max_age = strstr(value, "max-age=");
             if (max_age) {
                 max_age += strlen(substr);
-                resp->m_MaxAge = atoi(max_age);
-                // This logic is questionable...
-                if (resp->m_MaxAge > 60U * 60U * 24U * 30U) {
-                    dmLogWarning("max-age > 30 days - ignoring. Bad response?");
-                    resp->m_MaxAge = 0;
+                resp->m_MaxAge = dmMath::Max(0, atoi(max_age));
+                if (resp->m_MaxAge > HTTP_CLIENT_MAXIMUM_CACHE_AGE)
+                {
+                    resp->m_MaxAge = HTTP_CLIENT_MAXIMUM_CACHE_AGE;
                 }
             }
         }


### PR DESCRIPTION
…30 days instead of being reset if it were greater than 30 days.
