### PR TITLE
Output fnks should preserve the type of seqs

### DIFF
--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -36,7 +36,8 @@
 (defn use-original-value
   [x]
   (cond
-    (sequential? x)          (mapv use-original-value x)
+    (vector? x)              (mapv use-original-value x)
+    (list? x)                (into (empty x) (map use-original-value x))
     (instance? ErrorValue x) (:value x)
     :else                    x))
 

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1290,11 +1290,10 @@
 (defn input-error-check [self-name ctx-name description label nodeid-sym input-sym tail]
   (if (contains? internal-keys label)
     tail
-    `(let [serious-input-errors# (filter-error-vals (:ignore-errors ~ctx-name) ~input-sym)]
+    `(let [serious-input-errors# (filter ie/error? (vals ~input-sym))]
        (if (empty? serious-input-errors#)
-         (let [~input-sym (util/map-vals ie/use-original-value ~input-sym)]
-           ~tail)
-         (ie/error-aggregate serious-input-errors# :_node-id ~nodeid-sym :_label ~label)))))
+         ~tail
+         (ie/error-aggregate (filter-error-vals (:ignore-errors ~ctx-name) ~input-sym) :_node-id ~nodeid-sym :_label ~label)))))
 
 (defn call-production-function [self-name ctx-name description transform input-sym nodeid-sym output-sym forms]
   `(let [~output-sym ((var ~(symbol (dollar-name (:name description) [:output transform]))) ~input-sym)]

--- a/editor/test/internal/value_test.clj
+++ b/editor/test/internal/value_test.clj
@@ -430,6 +430,7 @@
                                                               (g/connect sender3 :a-property receiver :multi)))
             _                                  (g/mark-defective! sender2 (g/error-fatal "Bad things have happened"))
             error-value                        (g/node-value receiver :multi-output)]
+        (def e* error-value)
         (is (g/error? error-value))
         (is (= 1 (count       (:causes  error-value))))
         (is (= receiver       (:_node-id error-value)))
@@ -454,6 +455,10 @@
   (input list-input       g/Any)
   (input inner-list-input g/Any))
 
+(g/defnode ConstantOutputNode
+  (property real-val g/Any (default (list 1)))
+  (output val g/Any (g/fnk [real-val] real-val)))
+
 (deftest seq-values-are-preserved
   (with-clean-system
     (let [list-type      (type (list 1))
@@ -467,3 +472,13 @@
       (is (= list-type (type (g/node-value input  :list-input))))
       (is (= list-type (type (first (g/node-value output :inner-recycle)))))
       (is (= list-type (type (first (g/node-value input :inner-list-input))))))))
+
+(deftest values-are-not-reconstructed-on-happy-path
+  (with-clean-system
+    (let [[const input] (tx-nodes
+                         (g/make-nodes world
+                                       [const  ConstantOutputNode
+                                        input  ListInput]
+                                       (g/connect const :val input :list-input)))]
+      (is (identical? (g/node-value const :val) (g/node-value const :val)))
+      (is (identical? (g/node-value const :val) (g/node-value input :list-input))))))


### PR DESCRIPTION
Previously, error filtering code would silently turn lists into vectors for any fnk arguments. This no longer occurs.
