### PR TITLE
Revert "Output fnks should preserve the type of seqs"

### DIFF
--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -36,8 +36,7 @@
 (defn use-original-value
   [x]
   (cond
-    (vector? x)              (mapv use-original-value x)
-    (list? x)                (into (empty x) (map use-original-value x))
+    (sequential? x)          (mapv use-original-value x)
     (instance? ErrorValue x) (:value x)
     :else                    x))
 

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1290,10 +1290,11 @@
 (defn input-error-check [self-name ctx-name description label nodeid-sym input-sym tail]
   (if (contains? internal-keys label)
     tail
-    `(let [serious-input-errors# (filter ie/error? (vals ~input-sym))]
+    `(let [serious-input-errors# (filter-error-vals (:ignore-errors ~ctx-name) ~input-sym)]
        (if (empty? serious-input-errors#)
-         ~tail
-         (ie/error-aggregate (filter-error-vals (:ignore-errors ~ctx-name) ~input-sym) :_node-id ~nodeid-sym :_label ~label)))))
+         (let [~input-sym (util/map-vals ie/use-original-value ~input-sym)]
+           ~tail)
+         (ie/error-aggregate serious-input-errors# :_node-id ~nodeid-sym :_label ~label)))))
 
 (defn call-production-function [self-name ctx-name description transform input-sym nodeid-sym output-sym forms]
   `(let [~output-sym ((var ~(symbol (dollar-name (:name description) [:output transform]))) ~input-sym)]


### PR DESCRIPTION
Reverts defold/defold#782 as it broke some tests that currently block a new beta release.

Looked briefly at the failing tests but am unsure about solution so reverting for now.
