### PR TITLE
Output fnks should preserve the type of seqs

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -23,7 +23,7 @@
 
 (namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id produce-value node-by-id-at])
 
-(namespaces/import-vars [internal.graph.error-values INFO WARNING SEVERE FATAL error-info error-warning error-severe error-fatal error? error-info? error-warning? error-severe? error-fatal? most-serious error-aggregate worse-than])
+(namespaces/import-vars [internal.graph.error-values INFO WARNING SEVERE FATAL error-info error-warning error-severe error-fatal error? error-info? error-warning? error-severe? error-fatal? error-aggregate worse-than])
 
 (namespaces/import-vars [internal.node value-type-schema value-type? value-type-dispatch-value has-input? has-output? has-property? type-compatible? merge-display-order NodeType supertypes transforms transform-types internal-properties declared-properties public-properties externs declared-inputs injectable-inputs declared-outputs cached-outputs input-dependencies input-cardinality cascade-deletes substitute-for input-type output-type input-labels output-labels property-labels property-display-order])
 

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -28,18 +28,7 @@
 
 (defn worse-than
   [severity x]
-  (cond
-    (sequential? x)          (filter #(sev? severity %) x)
-    (instance? ErrorValue x) (when (sev? severity x) x)
-    :else                    nil))
-
-(defn use-original-value
-  [x]
-  (cond
-    (vector? x)              (mapv use-original-value x)
-    (list? x)                (into (empty x) (map use-original-value x))
-    (instance? ErrorValue x) (:value x)
-    :else                    x))
+  (when (instance? ErrorValue x) (sev? severity x)))
 
 (defn severity? [level e]  (= level (:severity e)))
 
@@ -47,8 +36,6 @@
 (def  error-warning? (partial severity? WARNING))
 (def  error-severe?  (partial severity? SEVERE))
 (def  error-fatal?   (partial severity? FATAL))
-
-(defn most-serious    [es] (first (reverse (sort-by :severity es))))
 
 (defn error-aggregate
   ([es]

--- a/editor/test/internal/value_test.clj
+++ b/editor/test/internal/value_test.clj
@@ -4,7 +4,9 @@
             [internal.util :as util]
             [internal.node :as in]
             [internal.transaction :as it]
-            [support.test-support :refer :all]))
+            [support.test-support :refer :all]
+            [internal.graph.error-values :as ie])
+  (:import [internal.graph.error_values ErrorValue]))
 
 (def ^:dynamic *calls*)
 
@@ -376,6 +378,10 @@
 (g/defnode ConstantPropertyNode
   (property a-property g/Any))
 
+(defn- cause [ev]
+  (when (instance? ErrorValue ev)
+    (first (:causes ev))))
+
 (deftest error-values-are-not-wrapped-from-properties
   (with-clean-system
     (let [[node]      (tx-nodes (g/make-node world ConstantPropertyNode))
@@ -404,18 +410,10 @@
                                              (g/connect sender :a-property receiver :single)))
             _                 (g/mark-defective! sender (g/error-fatal "Bad news, my friend."))
             error-value       (g/node-value receiver :single-output)]
-        (is (g/error? error-value))
-        (is (= 1 (count       (:causes  error-value))))
-        (is (= receiver       (:_node-id error-value)))
-        (is (= :single-output (:_label   error-value)))
-        (is (= g/FATAL        (:severity error-value)))
-
-        (let [cause (first (:causes error-value))]
-          (is (g/error? cause))
-          (is (empty?        (:causes   cause)))
-          (is (= sender      (:_node-id cause)))
-          (is (= :a-property (:_label   cause)))
-          (is (= g/FATAL     (:severity cause)))))))
+        (are [node label sev e] (and (= node (:_node-id e)) (= label (:_label e)) (= sev (:severity error-value)))
+          receiver :single-output g/FATAL   error-value
+          receiver :single        g/FATAL   (cause error-value)
+          sender   :a-property    g/FATAL   (cause (cause error-value))))))
 
   (testing "multi-valued input with an error results in a single error out."
     (with-clean-system
@@ -430,20 +428,10 @@
                                                               (g/connect sender3 :a-property receiver :multi)))
             _                                  (g/mark-defective! sender2 (g/error-fatal "Bad things have happened"))
             error-value                        (g/node-value receiver :multi-output)]
-        (def e* error-value)
-        (is (g/error? error-value))
-        (is (= 1 (count       (:causes  error-value))))
-        (is (= receiver       (:_node-id error-value)))
-        (is (= :multi-output  (:_label   error-value)))
-        (is (= g/FATAL        (:severity error-value)))
-
-
-        (let [cause (first (:causes error-value))]
-          (is (g/error? cause))
-          (is (empty?        (:causes   cause)))
-          (is (= sender2     (:_node-id cause)))
-          (is (= :a-property (:_label   cause)))
-          (is (= g/FATAL     (:severity cause))))))))
+        (are [node label sev e] (and (= node (:_node-id e)) (= label (:_label e)) (= sev (:severity error-value)))
+          receiver :multi-output g/FATAL   error-value
+          receiver :multi        g/FATAL   (cause error-value)
+          sender2  :a-property   g/FATAL   (cause (cause error-value)))))))
 
 (g/defnode ListOutput
   (output list-output       g/Any (g/fnk []                  (list 1)))


### PR DESCRIPTION
**This is a replacement for #782**

Previously, error filtering code would silently turn lists into vectors for any fnk arguments. This no longer occurs.

This PR also fixes bugs with ignoring and aggregating errors:

Aggregated errors now return the _entire_ error chain in their causes. This often looks like "output error caused by input error caused by output error on some other node." This improves tracing.
