### PR TITLE
DEF-1689: Android N support

### DIFF
--- a/engine/engine/wscript
+++ b/engine/engine/wscript
@@ -76,7 +76,7 @@ namespace dmEngineVersion
         # For IAP
         conf.env.append_value('LINKFLAGS', ['-framework', 'StoreKit'])
     elif operating_sys == 'android':
-        conf.env.append_value('LINKFLAGS', ['-lEGL', '-lGLESv1_CM', '-lGLESv2', '-landroid'])
+        conf.env.append_value('LINKFLAGS', ['-lEGL', '-lGLESv1_CM', '-lGLESv2', '-landroid', '-Wl,-soname=libdmengine.so'])
     elif operating_sys == "linux":
         conf.env['LIB_X'] = ['Xext', 'X11', 'Xi', 'GL', 'GLU']
     elif operating_sys == "win" and architecture == 'x86':


### PR DESCRIPTION
> In Unix and Unix-like operating systems, a soname is a field of data in a shared object file. The soname is a string, which is used as a "logical name" describing the functionality of the object (typically, that name is equal to the filename of the library, or to a prefix thereof, e.g. libc.so.6).

https://en.wikipedia.org/wiki/Soname

> Each ELF shared object (“native library”) must have a SONAME (Shared Object Name) attribute. The NDK toolchain adds this attribute by default, so its absence indicates either a misconfigured alternative toolchain or a misconfiguration in your build system. A missing SONAME may lead to runtime issues such as the wrong library being loaded: the filename is used instead when this attribute is missing.

http://android-developers.blogspot.se/2016/06/android-changes-for-ndk-developers.html
