### PR TITLE
Experimental changes to support regex syntax highlighting on large files

### DIFF
--- a/editor/resources/editor.css
+++ b/editor/resources/editor.css
@@ -944,7 +944,7 @@ Defold Orange       #fd6623             Guides etc
     -styled-text-color: #fd6623;
 }
 
-.lua.styled-text-area .constant {
+.lua.styled-text-area .constant-keywords {
     -styled-text-color: #FFBBFF;
 }
 

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -163,11 +163,9 @@
 (def defold-keywords #{"final" "init" "on_input" "on_message" "on_reload" "update" "acquire_input_focus" "disable" "enable"
                        "release_input_focus" "request_transform" "set_parent" "transform_response"})
 
-(def constant-pattern #"^(?<![^.]\.|:)\b(false|nil|true|_G|_VERSION|math\.(pi|huge))\b|(?<![.])\.{3}(?!\.)")
-(def operator-pattern #"^(\+|\-|\%|\#|\*|\/|\^|\=|\=\=|\~\=|\<\=|\>\=)")
+(def constant-keywords #{"false" "nil" "true" "_G" "VERSION"})
 
-(defn match-constant [s]
-  (code/match-regex constant-pattern s))
+(def operator-pattern #"^(\+|\-|\%|\#|\*|\/|\^|\=|\=\=|\~\=|\<\=|\>\=)")
 
 (defn match-operator [s]
   (code/match-regex operator-pattern s))
@@ -249,10 +247,10 @@
               {:type :keyword :start? is-word-start :part? is-word-part :keywords self-keyword :class "self-keyword"}
               {:type :keyword :start? is-word-start :part? is-word-part :keywords logic-keywords :class "logic-keywords"}
               {:type :keyword :start? is-word-start :part? is-word-part :keywords control-flow-keywords :class "control-flow-keyword"}
+              {:type :keyword :start? is-word-start :part? is-word-part :keywords constant-keywords :class "constant-keywords"}
               {:type :word :start? is-word-start :part? is-word-part :class "default"}
               {:type :singleline :start "\"" :end "\"" :esc \\ :class "string"}
               {:type :singleline :start "'" :end "'" :esc \\ :class "string"}
-              {:type :custom :scanner match-constant :class "constant"}
               {:type :custom :scanner code/match-number :class "number"}
               {:type :custom :scanner match-operator :class "operator"}
               {:type :number :class "number"}

--- a/editor/src/java/com/defold/editor/eclipse/DefoldRuleBasedScanner.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldRuleBasedScanner.java
@@ -8,8 +8,9 @@ public class DefoldRuleBasedScanner extends RuleBasedScanner {
     //Reads from offset all at once to the end of the doc as a peek
     public String readString() {
         try {
-            if (fOffset < fDocument.getLength()){
-                 int len = fDocument.getLength() - fOffset;
+            int docLen = fDocument.getLength();
+            if (fOffset < docLen){
+                 int len = docLen - fOffset;
                  return fDocument.get(fOffset, len);
             }else{
                 return "";

--- a/editor/src/java/com/defold/editor/eclipse/Document.java
+++ b/editor/src/java/com/defold/editor/eclipse/Document.java
@@ -1,7 +1,10 @@
 package com.defold.editor.eclipse;
 
+import java.nio.CharBuffer;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.GapTextStore;
+import org.eclipse.jface.text.ITextStore;
 import org.eclipse.jface.text.GapTextStore;
 import org.eclipse.jface.text.CopyOnWriteTextStore;
 import org.eclipse.jface.text.DefaultLineTracker;
@@ -11,12 +14,65 @@ import org.eclipse.jface.text.DefaultLineTracker;
  *SafeRunner and org/osgi/framework/BundleActivator
  */
 public class Document extends AbstractDocument {
+	
+	private static class CharArrayTextStore implements ITextStore {
+
+		public char[] fContent;
+
+		/**
+		 * Creates a new string text store with the given content.
+		 *
+		 * @param content the content
+		 */
+
+		public CharArrayTextStore() {
+		}
+
+		@Override
+		public char get(int offset) {
+			return fContent[offset];
+		}
+
+		@Override
+		public String get(int offset, int length) {
+			return CharBuffer.wrap(fContent, offset, length).toString();
+		}
+
+		@Override
+		public int getLength() {
+			return fContent.length;
+		}
+
+		@Override
+		public void replace(int offset, int length, String text) {
+			try{
+			StringBuffer sb = new StringBuffer(new String(fContent));
+			sb.replace(offset, offset + length, text);
+			fContent = sb.toString().toCharArray();
+			}
+			catch (Exception e){
+				e.printStackTrace();
+			}
+
+		}
+
+		@Override
+		public void set(String text) {
+			fContent = text.toCharArray();
+
+		}
+
+	}
+		
+
+
 	/**
 	 * Creates a new empty document.
 	 */
 	public Document() {
+		
 		super();
-		setTextStore(new CopyOnWriteTextStore(new GapTextStore()));
+		setTextStore(new CharArrayTextStore());
 		setLineTracker(new DefaultLineTracker());
 		completeInitialization();
 	}
@@ -28,7 +84,7 @@ public class Document extends AbstractDocument {
 	 */
 	public Document(String initialContent) {
 		super();
-		setTextStore(new CopyOnWriteTextStore(new GapTextStore()));
+		setTextStore(new CharArrayTextStore());
 		setLineTracker(new DefaultLineTracker());
 		getStore().set(initialContent);
 		getTracker().set(initialContent);


### PR DESCRIPTION
**DO NOT MERGE!**

This pull request is to share potential thoughts on supporting large file syntax highlighting with good performance.

**Background:**  The eclipse java classes only support syntax highlighting by looking one char at a time.  We would like to get the "substring" of a particular place in the document, rather than the char so that we can use regexes for pattern matching.  Regexes are much nicer to deal with.  Sublime uses them for their syntax plugins and would be nice to have that as an option for eventual plugin development in our editor as well.  In the current version of the text editor, we do have regex support, but the performance degrades with large files.

After profiling and experimenting, there are two performance problem areas with the current approach:
- The text store's get method is very slow for large files.  Even with _no_ syntax code, just getting the text from a large file is very laggy for large files.
- Some of the regexs can be improved for performance

The code on the pull request is an experiment with changing the data store to be more efficient on the get method and reworking one of the problematic regexes.   However, more thought needs to go in it to see if this is the right solution or not.  Maybe subclassing GapTexStore is a better option.

The current work around in the https://github.com/defold/defold/pull/735 pull request is to disable custom scanners for large files.
