### PR TITLE
DEFEDIT-377 Make sure loading starts after Javafx gfx has started

### DIFF
--- a/editor/src/java/com/defold/editor/Splash.java
+++ b/editor/src/java/com/defold/editor/Splash.java
@@ -6,11 +6,13 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.event.EventHandler;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
 import javafx.scene.control.Label;
 import javafx.scene.control.Button;
 
@@ -20,7 +22,7 @@ public class Splash {
     private Scene scene;
     private StringProperty launchError = new SimpleStringProperty();
     private BooleanProperty errorShowing = new SimpleBooleanProperty(false);
-    private BooleanProperty showing = new SimpleBooleanProperty(false);
+    private BooleanProperty shown = new SimpleBooleanProperty(false);
 
     public Splash() throws IOException {
     }
@@ -42,7 +44,12 @@ public class Splash {
                 System.exit(1);
             });
 
-        showing.bind(stage.showingProperty());
+        stage.setOnShown(new EventHandler<WindowEvent>() {
+            @Override
+            public void handle(WindowEvent event) {
+                shown.set(true);
+            }
+        });
         stage.show();
     }
 
@@ -74,7 +81,7 @@ public class Splash {
         return errorShowing;
     }
 
-    public BooleanProperty showingProperty() {
-        return showing;
+    public BooleanProperty shownProperty() {
+        return shown;
     }
 }

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -221,7 +221,7 @@ public class Start extends Application {
     @Override
     public void start(Stage primaryStage) throws Exception {
         final Splash splash = new Splash();
-        splash.showingProperty().addListener(new ChangeListener<Boolean>() {
+        splash.shownProperty().addListener(new ChangeListener<Boolean>() {
             @Override
             public void changed(ObservableValue<? extends Boolean> observable,
                     Boolean oldValue, Boolean newValue) {


### PR DESCRIPTION
- To avoid deadlock when classloaders load native libs concurrently
