### PR TITLE
Change of password hash algorithm.

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/auth/PasswordHashGenerator.java
+++ b/server/src/main/java/com/dynamo/cr/server/auth/PasswordHashGenerator.java
@@ -1,0 +1,27 @@
+package com.dynamo.cr.server.auth;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+public class PasswordHashGenerator {
+
+    /**
+     * Generates a hash for a clear text password using bcrypt.
+     *
+     * @param password Clear text password.
+     * @return Hashed password.
+     */
+    public static String generateHash(String password) {
+        return BCrypt.hashpw(password, BCrypt.gensalt());
+    }
+
+    /**
+     * Validates a clear text password towards hashed password.
+     *
+     * @param password Clear text password.
+     * @param passwordHash Password hash.
+     * @return True if the password hash was generated from the same clear text password as provided, false otherwise.
+     */
+    public static boolean validatePassword(String password, String passwordHash) {
+        return BCrypt.checkpw(password, passwordHash);
+    }
+}

--- a/server/src/main/java/com/dynamo/cr/server/model/User.java
+++ b/server/src/main/java/com/dynamo/cr/server/model/User.java
@@ -1,14 +1,14 @@
 package com.dynamo.cr.server.model;
 
+import com.dynamo.cr.server.auth.PasswordHashGenerator;
+
 import javax.persistence.*;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Table(name="users")
+@Table(name = "users")
 @NamedQueries({
         @NamedQuery(name = "User.findByEmail", query = "SELECT u FROM User u WHERE u.email = :email")
 })
@@ -44,27 +44,11 @@ public class User {
     @Temporal(TemporalType.TIMESTAMP)
     private Date registrationDate = new Date();
 
-    @OneToMany(cascade={CascadeType.PERSIST})
+    @OneToMany(cascade = {CascadeType.PERSIST})
     private Set<Project> projects = new HashSet<>();
 
     @OneToMany
     private Set<User> connections = new HashSet<>();
-
-    private static String digest(String password) {
-        MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        md.update(password.getBytes());
-        byte[] digest = md.digest();
-        StringBuilder sb = new StringBuilder();
-        for (byte b : digest) {
-            sb.append(Integer.toHexString(0xff & b));
-        }
-        return sb.toString();
-    }
 
     public Long getId() {
         return id;
@@ -78,12 +62,23 @@ public class User {
         this.email = email;
     }
 
+    /**
+     * Calculates the password hash and stores that in order to never store clear text passwords in the database.
+     *
+     * @param password Clear text password.
+     */
     public void setPassword(String password) {
-        this.password = digest(password);
+        this.password = PasswordHashGenerator.generateHash(password);
     }
 
+    /**
+     * Validates a clear text password towards hashed password retrieved from the database.
+     *
+     * @param password Clear text password.
+     * @return True if password is correct, false otherwise.
+     */
     public boolean authenticate(String password) {
-        return digest(password).equals(this.password);
+        return PasswordHashGenerator.validatePassword(password, this.password);
     }
 
     public String getFirstName() {
@@ -110,14 +105,6 @@ public class User {
         this.role = role;
     }
 
-    public Date getRegistrationDate() {
-        return registrationDate;
-    }
-
-    public void setRegistrationDate(Date registrationDate) {
-        this.registrationDate = registrationDate;
-    }
-
     public Set<Project> getProjects() {
         return projects;
     }
@@ -134,5 +121,4 @@ public class User {
             return String.format("%s (%d)", email, getId());
         }
     }
-
 }

--- a/server/src/main/java/com/dynamo/cr/server/resources/UsersResource.java
+++ b/server/src/main/java/com/dynamo/cr/server/resources/UsersResource.java
@@ -1,6 +1,5 @@
 package com.dynamo.cr.server.resources;
 
-import com.dynamo.cr.protocol.proto.Protocol.RegisterUser;
 import com.dynamo.cr.protocol.proto.Protocol.UserInfo;
 import com.dynamo.cr.protocol.proto.Protocol.UserInfoList;
 import com.dynamo.cr.server.ServerException;
@@ -133,27 +132,6 @@ public class UsersResource extends BaseResource {
                 throw new ServerException(String.format("Could not delete git repo for project %s", project.getName()), Status.INTERNAL_SERVER_ERROR);
             }
         }
-    }
-
-    @POST
-    @RolesAllowed(value = {"admin"})
-    @Transactional
-    public UserInfo registerUser(RegisterUser registerUser) {
-        /*
-         * NOTE: Old registration method as admin role
-         * OpenID registration is the only supported method. We should
-         * probably remove this and related tests soon
-         */
-
-        User user = new User();
-        user.setEmail(registerUser.getEmail());
-        user.setFirstName(registerUser.getFirstName());
-        user.setLastName(registerUser.getLastName());
-        user.setPassword(registerUser.getPassword());
-        em.persist(user);
-        em.flush();
-
-        return createUserInfo(user);
     }
 }
 

--- a/server/src/test/java/com/dynamo/cr/server/auth/PasswordHashGeneratorTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/auth/PasswordHashGeneratorTest.java
@@ -1,0 +1,18 @@
+package com.dynamo.cr.server.auth;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PasswordHashGeneratorTest {
+
+    @Test
+    public void passwordHashShouldBeValid() {
+        String password = "super secret sauce!";
+        String passwordHash = PasswordHashGenerator.generateHash(password);
+        assertTrue(PasswordHashGenerator.validatePassword(password, passwordHash));
+        assertFalse(PasswordHashGenerator.validatePassword("wrong password", passwordHash));
+    }
+
+}

--- a/server/src/test/java/com/dynamo/cr/server/resources/test/UsersResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/test/UsersResourceTest.java
@@ -19,13 +19,11 @@ import com.sun.jersey.api.client.filter.ClientFilter;
 import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.persistence.EntityManager;
 import javax.ws.rs.core.*;
-import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -250,63 +248,6 @@ public class UsersResourceTest extends AbstractResourceTest {
         UserInfoList userList = response.getEntity(UserInfoList.class);
         assertEquals(1, userList.getUsersCount());
         assertEquals(bobEmail, userList.getUsers(0).getEmail());
-    }
-
-    @Test
-    public void testRegister() throws Exception {
-        ObjectMapper m = new ObjectMapper();
-        ObjectNode user = m.createObjectNode();
-        user.put("email", "test@foo.com");
-        user.put("first_name", "mr");
-        user.put("last_name", "test");
-        user.put("password", "verysecret");
-
-        UserInfo userInfo = adminUsersWebResource
-            .accept(MediaType.APPLICATION_JSON_TYPE)
-            .type(MediaType.APPLICATION_JSON_TYPE)
-            .post(UserInfo.class, user.toString());
-
-        assertEquals("test@foo.com", userInfo.getEmail());
-        assertEquals("mr", userInfo.getFirstName());
-        assertEquals("test", userInfo.getLastName());
-    }
-
-    @Test
-    public void testRegisterTextAccept() throws Exception {
-        ObjectMapper m = new ObjectMapper();
-        ObjectNode user = m.createObjectNode();
-        user.put("email", "test@foo.com");
-        user.put("first_name", "mr");
-        user.put("last_name", "test");
-        user.put("password", "verysecret");
-
-        String userInfoText = adminUsersWebResource
-            .accept(MediaType.APPLICATION_JSON_TYPE)
-            .type(MediaType.APPLICATION_JSON_TYPE)
-            .post(String.class, user.toString());
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.readValue(new ByteArrayInputStream(userInfoText.getBytes()), JsonNode.class);
-
-        assertEquals("test@foo.com", node.get("email").getTextValue());
-        assertEquals("mr", node.get("first_name").getTextValue());
-        assertEquals("test", node.get("last_name").getTextValue());
-    }
-
-    @Test
-    public void testRegisterAsJoe() throws Exception {
-        ObjectMapper m = new ObjectMapper();
-        ObjectNode user = m.createObjectNode();
-        user.put("email", "test@foo.com");
-        user.put("first_name", "mr");
-        user.put("last_name", "test");
-        user.put("password", "verysecret");
-
-        ClientResponse response = joeUsersWebResource
-            .accept(MediaType.APPLICATION_JSON_TYPE)
-            .type(MediaType.APPLICATION_JSON_TYPE)
-            .post(ClientResponse.class, user.toString());
-        assertEquals(403, response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Using the MD5 algorithm without salt is not secure a enougg method for generating
hashed passwords. This change replaces that with BCrypt in order to increase
security before opening up for e-mail and password accounts (as a complement to OAuth).

Note: This also removes the possibility to register new accounts as admin (and the corresponding tests).
