### PR TITLE
DEFEDIT-380 Editor for camera

### DIFF
--- a/editor/resources/templates/template.camera
+++ b/editor/resources/templates/template.camera
@@ -1,0 +1,5 @@
+aspect_ratio: 1.0
+fov: 45.0
+near_z: 0.1
+far_z: 1000.0
+auto_aspect_ratio: 0

--- a/editor/resources/test_project/camera/new.camera
+++ b/editor/resources/test_project/camera/new.camera
@@ -1,0 +1,5 @@
+aspect_ratio: 1.0
+fov: 45.0
+near_z: 0.1
+far_z: 1000.0
+auto_aspect_ratio: 0

--- a/editor/resources/test_project/camera/non_default.camera
+++ b/editor/resources/test_project/camera/non_default.camera
@@ -1,0 +1,5 @@
+aspect_ratio: 42.0
+fov: 90.0
+near_z: 0.01
+far_z: 1234.0
+auto_aspect_ratio: 1

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -1,55 +1,54 @@
 (ns editor.boot-open-project
-  (:require [editor.defold-project :as project]
-            [editor.progress :as progress]
-            [editor.workspace :as workspace]
-            [editor.ui :as ui]
-            [editor.dialogs :as dialogs]
-            [editor.changes-view :as changes-view]
-            [editor.properties-view :as properties-view]
-            [editor.text :as text]
+  (:require [dynamo.graph :as g]
+            [editor.app-view :as app-view]
+            [editor.asset-browser :as asset-browser]
+            [editor.atlas :as atlas]
             [editor.build-errors-view :as build-errors-view]
+            [editor.camera-editor :as camera]
+            [editor.changes-view :as changes-view]
             [editor.code-view :as code-view]
+            [editor.collection :as collection]
             [editor.collision-object :as collision-object]
-            [editor.scene :as scene]
-            [editor.form-view :as form-view]
+            [editor.console :as console]
+            [editor.core :as core]
+            [editor.cubemap :as cubemap]
+            [editor.curve-view :as curve-view]
+            [editor.defold-project :as project]
+            [editor.dialogs :as dialogs]
+            [editor.display-profiles :as display-profiles]
             [editor.factory :as factory]
-            [editor.collection :as colleciton]
             [editor.font :as font]
+            [editor.form-view :as form-view]
             [editor.game-object :as game-object]
             [editor.game-project :as game-project]
+            [editor.gl.shader :as shader]
+            [editor.graph-view :as graph-view]
+            [editor.gui :as gui]
             [editor.hot-reload :as hotload]
-            [editor.console :as console]
-            [editor.cubemap :as cubemap]
             [editor.image :as image]
-            [editor.workspace :as workspace]
-            [editor.collection :as collection]
-            [editor.atlas :as atlas]
+            [editor.json :as json]
+            [editor.login :as login]
+            [editor.material :as material]
+            [editor.mesh :as mesh]
+            [editor.outline-view :as outline-view]
+            [editor.particlefx :as particlefx]
             [editor.platformer :as platformer]
             [editor.prefs :as prefs]
+            [editor.progress :as progress]
+            [editor.properties-view :as properties-view]
             [editor.protobuf-types :as protobuf-types]
+            [editor.scene :as scene]
             [editor.script :as script]
-            [editor.switcher :as switcher]
-            [editor.sprite :as sprite]
-            [editor.gl.shader :as shader]
-            [editor.tile-source :as tile-source]
-            [editor.targets :as targets]
             [editor.sound :as sound]
             [editor.spine :as spine]
-            [editor.json :as json]
-            [editor.mesh :as mesh]
-            [editor.material :as material]
-            [editor.particlefx :as particlefx]
-            [editor.gui :as gui]
-            [editor.app-view :as app-view]
-            [editor.outline-view :as outline-view]
-            [editor.asset-browser :as asset-browser]
-            [editor.graph-view :as graph-view]
-            [editor.core :as core]
-            [dynamo.graph :as g]
-            [editor.display-profiles :as display-profiles]
+            [editor.sprite :as sprite]
+            [editor.switcher :as switcher]
+            [editor.targets :as targets]
+            [editor.text :as text]
+            [editor.tile-source :as tile-source]
+            [editor.ui :as ui]
             [editor.web-profiler :as web-profiler]
-            [editor.curve-view :as curve-view]
-            [editor.login :as login]
+            [editor.workspace :as workspace]
             [util.http-server :as http-server])
   (:import  [java.io File]
             [javafx.scene.layout VBox]
@@ -79,37 +78,38 @@
 (defn setup-workspace [project-path]
   (let [workspace (workspace/make-workspace *workspace-graph* project-path)]
     (g/transact
-      (concat
-        (text/register-view-types workspace)
-        (code-view/register-view-types workspace)
-        (scene/register-view-types workspace)
-        (form-view/register-view-types workspace)))
+     (concat
+      (text/register-view-types workspace)
+      (code-view/register-view-types workspace)
+      (scene/register-view-types workspace)
+      (form-view/register-view-types workspace)))
     (g/transact
      (concat
+      (atlas/register-resource-types workspace)
+      (camera/register-resource-types workspace)
       (collection/register-resource-types workspace)
       (collision-object/register-resource-types workspace)
-      (font/register-resource-types workspace)
+      (cubemap/register-resource-types workspace)
+      (display-profiles/register-resource-types workspace)
       (factory/register-resource-types workspace)
+      (font/register-resource-types workspace)
       (game-object/register-resource-types workspace)
       (game-project/register-resource-types workspace)
-      (cubemap/register-resource-types workspace)
+      (gui/register-resource-types workspace)
       (image/register-resource-types workspace)
-      (atlas/register-resource-types workspace)
+      (json/register-resource-types workspace)
+      (material/register-resource-types workspace)
+      (mesh/register-resource-types workspace)
+      (particlefx/register-resource-types workspace)
       (platformer/register-resource-types workspace)
       (protobuf-types/register-resource-types workspace)
       (script/register-resource-types workspace)
-      (switcher/register-resource-types workspace)
-      (sprite/register-resource-types workspace)
       (shader/register-resource-types workspace)
-      (tile-source/register-resource-types workspace)
       (sound/register-resource-types workspace)
       (spine/register-resource-types workspace)
-      (json/register-resource-types workspace)
-      (mesh/register-resource-types workspace)
-      (material/register-resource-types workspace)
-      (particlefx/register-resource-types workspace)
-      (gui/register-resource-types workspace)
-      (display-profiles/register-resource-types workspace)))
+      (sprite/register-resource-types workspace)
+      (switcher/register-resource-types workspace)
+      (tile-source/register-resource-types workspace)))
     (workspace/resource-sync! workspace)
     workspace))
 

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -1,0 +1,114 @@
+(ns editor.camera-editor
+  (:require [clojure.string :as s]
+            [plumbing.core :as pc]
+            [dynamo.graph :as g]
+            [editor.defold-project :as project]
+            [editor.graph-util :as gu]
+            [editor.outline :as outline]
+            [editor.properties :as properties]
+            [editor.protobuf :as protobuf]
+            [editor.resource :as resource]
+            [editor.types :as types]
+            [editor.validation :as validation]
+            [editor.workspace :as workspace])
+  (:import [com.dynamo.camera.proto Camera$CameraDesc]))
+
+(set! *warn-on-reflection* true)
+
+(def camera-icon "icons/32/Icons_20-Camera.png")
+
+(g/defnk produce-form-data
+  [_node-id aspect-ratio fov near-z far-z auto-aspect-ratio]
+  {:form-ops {:user-data {}
+              :set (fn [v [property] val]
+                     (g/set-property! _node-id property val))
+              :clear (fn [property]
+                       (g/clear-property! _node-id property))}
+   :sections [{:title "Camera"
+               :fields [{:path [:aspect-ratio]
+                         :label "Aspect Ratio"
+                         :type :number}
+                        {:path [:fov]
+                         :label "FOV"
+                         :type :number}
+                        {:path [:near-z]
+                         :label "Near-Z"
+                         :type :number}
+                        {:path [:far-z]
+                         :label "Far-Z"
+                         :type :number}
+                        {:path [:auto-aspect-ratio]
+                         :label "Auto Aspect Ratio"
+                         :type :boolean}]}]
+   :values {[:aspect-ratio] aspect-ratio
+            [:fov] fov
+            [:near-z] near-z
+            [:far-z] far-z
+            [:auto-aspect-ratio] auto-aspect-ratio}})
+
+(g/defnk produce-pb-msg
+  [aspect-ratio fov near-z far-z auto-aspect-ratio]
+  {:aspect-ratio aspect-ratio
+   :fov fov
+   :near-z near-z
+   :far-z far-z
+   :auto-aspect-ratio (if (true? auto-aspect-ratio) 1 0)})
+
+(g/defnk produce-save-data [resource pb-msg]
+  {:resource resource
+   :content (protobuf/map->str Camera$CameraDesc pb-msg)})
+
+(defn build-camera
+  [self basis resource dep-resources user-data]
+  {:resource resource
+   :content (protobuf/map->bytes Camera$CameraDesc (:pb-msg user-data))})
+
+(g/defnk produce-build-targets
+  [_node-id resource pb-msg]
+  [{:node-id _node-id
+    :resource (workspace/make-build-resource resource)
+    :build-fn build-camera
+    :user-data {:pb-msg pb-msg}}])
+
+(defn load-camera
+  [project self resource]
+  (let [camera (protobuf/read-text Camera$CameraDesc resource)]
+    (g/set-property self
+                    :aspect-ratio (:aspect-ratio camera)
+                    :fov (:fov camera)
+                    :near-z (:near-z camera)
+                    :far-z (:far-z camera)
+                    :auto-aspect-ratio (not (zero? (:auto-aspect-ratio camera))))))
+
+(g/defnode CameraNode
+  (inherits project/ResourceNode)
+
+  (property aspect-ratio g/Num)
+  (property fov g/Num)
+  (property near-z g/Num)
+  (property far-z g/Num)
+  (property auto-aspect-ratio g/Bool)
+
+  (output form-data g/Any produce-form-data)
+
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id]
+                                                     {:node-id _node-id
+                                                      :label "Camera"
+                                                      :icon camera-icon}))
+
+  (output pb-msg g/Any :cached produce-pb-msg)
+  (output save-data g/Any :cached produce-save-data)
+  (output build-targets g/Any :cached produce-build-targets))
+
+
+(defn register-resource-types
+  [workspace]
+  (workspace/register-resource-type workspace
+                                    :ext "camera"
+                                    :node-type CameraNode
+                                    :load-fn load-camera
+                                    :icon camera-icon
+                                    :view-types [:form-view :text]
+                                    :view-opts {}
+                                    :tags #{:component}
+                                    :label "Camera Object"))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -107,7 +107,8 @@
         update-fn    (fn [_] (if-let [v (to-double (.getText text))]
                                (properties/set-values! (property-fn) (repeat v))
                                (update-ui-fn (properties/values (property-fn))
-                                             (properties/validation-message (property-fn)))))]
+                                             (properties/validation-message (property-fn))
+                                             (properties/read-only? (property-fn)))))]
     (doto text
       (.setPrefWidth Double/MAX_VALUE)
       (ui/on-action! update-fn)

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -18,7 +18,6 @@
            [com.dynamo.gamesystem.proto GameSystem$CollectionProxyDesc GameSystem$LightDesc]
            [com.dynamo.physics.proto Physics$CollisionObjectDesc Physics$ConvexShape]
            [com.dynamo.input.proto Input$GamepadMaps]
-           [com.dynamo.camera.proto Camera$CameraDesc]
            [com.dynamo.mesh.proto Mesh$MeshDesc]
            [com.dynamo.model.proto Model$ModelDesc]
            [com.dynamo.tile.proto Tile$TileGrid]
@@ -60,11 +59,6 @@
                :icon "icons/32/Icons_34-Gamepad.png"
                :pb-class Input$GamepadMaps
                :view-types [:form-view :text]}
-              {:ext "camera"
-               :label "Camera"
-               :icon "icons/32/Icons_20-Camera.png"
-               :pb-class Camera$CameraDesc
-               :tags #{:component}}
               {:ext "model"
                :label "Model"
                :icon "icons/32/Icons_22-Model.png"

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -42,7 +42,9 @@
                  "**/spineboy.spinescene"
                  "**/spineboy.spinemodel"
                  "**/new.factory"
-                 "**/with_prototype.factory"]]
+                 "**/with_prototype.factory"
+                 "**/new.camera"
+                 "**/non_default.camera"]]
     (with-clean-system
       (let [workspace (test-util/setup-workspace! world)
             project   (test-util/setup-project! workspace)

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [dynamo.graph :as g]
             [editor.atlas :as atlas]
+            [editor.camera-editor :as camera]
             [editor.collection :as collection]
             [editor.collision-object :as collision-object]
             [editor.cubemap :as cubemap]
@@ -46,34 +47,35 @@
   ([graph project-path]
     (let [workspace (workspace/make-workspace graph project-path)]
       (g/transact
-        (concat
-          (scene/register-view-types workspace)))
+       (concat
+         (scene/register-view-types workspace)))
       (g/transact
        (concat
+        (atlas/register-resource-types workspace)
+        (camera/register-resource-types workspace)
         (collection/register-resource-types workspace)
         (collision-object/register-resource-types workspace)
+        (cubemap/register-resource-types workspace)
+        (display-profiles/register-resource-types workspace)
         (factory/register-resource-types workspace)
         (font/register-resource-types workspace)
         (game-object/register-resource-types workspace)
         (game-project/register-resource-types workspace)
-        (cubemap/register-resource-types workspace)
+        (gui/register-resource-types workspace)
         (image/register-resource-types workspace)
-        (atlas/register-resource-types workspace)
-        (platformer/register-resource-types workspace)
-        (protobuf-types/register-resource-types workspace)
-        (switcher/register-resource-types workspace)
-        (sprite/register-resource-types workspace)
-        (script/register-resource-types workspace)
-        (shader/register-resource-types workspace)
-        (tile-source/register-resource-types workspace)
-        (sound/register-resource-types workspace)
-        (spine/register-resource-types workspace)
         (json/register-resource-types workspace)
+        (material/register-resource-types workspace)
         (mesh/register-resource-types workspace)
         (particlefx/register-resource-types workspace)
-        (gui/register-resource-types workspace)
-        (material/register-resource-types workspace)
-        (display-profiles/register-resource-types workspace)))
+        (platformer/register-resource-types workspace)
+        (protobuf-types/register-resource-types workspace)
+        (script/register-resource-types workspace)
+        (shader/register-resource-types workspace)
+        (sound/register-resource-types workspace)
+        (spine/register-resource-types workspace)
+        (sprite/register-resource-types workspace)
+        (switcher/register-resource-types workspace)
+        (tile-source/register-resource-types workspace)))
       (workspace/resource-sync! workspace)
       workspace)))
 


### PR DESCRIPTION
- We already have a `camera` namespace that is quite big and deals with camera stuff not related to the camera component so used `camera-editor` as namespace. Not ideal but maybe something we can revisit if we choose to re-organise our namespaces a bit?
