### PR TITLE
DEFEDIT-381 Editor for sound

### DIFF
--- a/editor/resources/test_project/sounds/new.sound
+++ b/editor/resources/test_project/sounds/new.sound
@@ -1,0 +1,4 @@
+sound: ""
+looping: 0
+group: "master"
+gain: 1.0

--- a/editor/resources/test_project/sounds/tink.sound
+++ b/editor/resources/test_project/sounds/tink.sound
@@ -1,0 +1,4 @@
+sound: "/sounds/tink.wav"
+looping: 1
+group: "fx"
+gain: 0.5

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -55,12 +55,10 @@
    :rotation (math/vecmath->clj rotation-q4)
    :data (or (:content save-data) "")})
 
-(def sound-exts (into #{} (map :ext sound/sound-defs)))
-
 (defn- wrap-if-raw-sound [_node-id target]
   (let [source-path (resource/proj-path (:resource (:resource target)))
         ext (FilenameUtils/getExtension source-path)]
-    (if (sound-exts ext)
+    (if (sound/supported-audio-formats ext)
       (let [workspace (project/workspace (project/get-project _node-id))
             res-type  (workspace/get-resource-type workspace "sound")
             pb        {:sound source-path}

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -323,7 +323,8 @@
         (project/select project [comp-node])))))
 
 (defn add-component-handler [workspace go-id]
-  (let [component-exts (map :ext (workspace/get-resource-types workspace :component))]
+  (let [component-exts (map :ext (concat (workspace/get-resource-types workspace :component)
+                                         (workspace/get-resource-types workspace :embeddable)))]
     (when-let [resource (first (dialogs/make-resource-dialog workspace {:ext component-exts :title "Select Component File"}))]
       (add-component-file go-id resource))))
 

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -1,19 +1,33 @@
 (ns editor.sound
   (:require [clojure.java.io :as io]
             [dynamo.graph :as g]
-            [editor.workspace :as workspace]
-            [editor.defold-project :as project])
+            [editor.defold-project :as project]
+            [editor.graph-util :as gu]
+            [editor.outline :as outline]
+            [editor.properties :as properties]
+            [editor.protobuf :as protobuf]
+            [editor.resource :as resource]
+            [editor.types :as types]
+            [editor.validation :as validation]
+            [editor.workspace :as workspace])
   (:import [java.io ByteArrayOutputStream]
+           [com.dynamo.sound.proto Sound$SoundDesc]
            [org.apache.commons.io IOUtils]))
 
 (set! *warn-on-reflection* true)
 
-(def sound-defs [{:ext "wav"
-                  :icon "icons/32/Icons_26-AT-Sound.png"}
-                 {:ext "ogg"
-                  :icon "icons/32/Icons_26-AT-Sound.png"}])
+(defmacro spy
+  [& body]
+  `(let [ret# (try ~@body (catch Throwable t# (prn t#) (throw t#)))]
+     (prn ret#)
+     ret#))
 
-(defn- build-sound [self basis resource dep-resources user-data]
+(def sound-icon "icons/32/Icons_26-AT-Sound.png")
+
+(def supported-audio-formats #{"wav" "ogg"})
+
+(defn- build-sound-source
+  [self basis resource dep-resources user-data]
   (let [source (:resource resource)
         in (io/input-stream source)
         out (ByteArrayOutputStream.)
@@ -21,22 +35,135 @@
         content (.toByteArray out)]
     {:resource resource :content content}))
 
-(g/defnk produce-build-targets [_node-id resource]
+(g/defnk produce-source-build-targets [_node-id resource]
   [{:node-id _node-id
     :resource (workspace/make-build-resource resource)
-    :build-fn build-sound}])
+    :build-fn build-sound-source}])
 
 (g/defnode SoundSourceNode
   (inherits project/ResourceNode)
 
-  (output build-targets g/Any produce-build-targets))
+  (output build-targets g/Any produce-source-build-targets))
 
-(defn- register [workspace def]
-  (workspace/register-resource-type workspace
-                                   :ext (:ext def)
-                                   :node-type SoundSourceNode
-                                   :icon (:icon def)))
+;;--------------------------------------------------------------------
 
-(defn register-resource-types [workspace]
-  (for [def sound-defs]
-    (register workspace def)))
+(g/defnk produce-outline-data
+  [_node-id]
+  {:node-id _node-id
+   :label "Sound"
+   :icon sound-icon})
+
+(g/defnk produce-form-data
+  [_node-id sound looping group gain]
+  {:form-ops {:user-data {}
+              :set (fn [v [property] val]
+                     (g/set-property! _node-id property val))
+              :clear (fn [property]
+                       (g/clear-property! _node-id property))}
+   :sections [{:title "Sound"
+               :fields [{:path [:sound]
+                         :label "Sound"
+                         :type :resource
+                         :filter supported-audio-formats}
+                        {:path [:looping]
+                         :label "Loop"
+                         :type :boolean}
+                        {:path [:group]
+                         :label "Group"
+                         :type :number}
+                        {:path [:gain]
+                         :label "Gain"
+                         :type :number}]}]
+   :values {[:sound] (resource/resource->proj-path sound)
+            [:looping] looping
+            [:group] group
+            [:gain] gain}})
+
+(g/defnk produce-pb-msg
+  [_node-id sound-resource looping group gain]
+  {:sound (resource/resource->proj-path sound-resource)
+   :looping (if looping 1 0)
+   :group group
+   :gain gain})
+
+(g/defnk produce-save-data
+  [resource pb-msg]
+  {:resource resource
+   :content (protobuf/map->str Sound$SoundDesc pb-msg)})
+
+(defn build-sound
+  [self basis resource dep-resources user-data]
+  (let [pb-msg (reduce #(assoc %1 (first %2) (second %2))
+                       (:pb-msg user-data)
+                       (map (fn [[label res]] [label (resource/proj-path (get dep-resources res))]) (:dep-resources user-data)))]
+    {:resource resource
+     :content (protobuf/map->bytes Sound$SoundDesc pb-msg)}))
+
+(g/defnk produce-build-targets
+  [_node-id resource sound dep-build-targets pb-msg]
+  (let [dep-build-targets (flatten dep-build-targets)
+        deps-by-resource (into {} (map (juxt (comp :resource :resource) :resource) dep-build-targets))
+        dep-resources (map (fn [[label resource]]
+                             [label (get deps-by-resource resource)])
+                           [[:sound sound]])]
+    [{:node-id _node-id
+      :resource (workspace/make-build-resource resource)
+      :build-fn build-sound
+      :user-data {:pb-msg pb-msg
+                  :dep-resources dep-resources}
+      :deps dep-build-targets}]))
+
+(defn load-sound
+  [project self resource]
+  (let [sound (protobuf/read-text Sound$SoundDesc resource)]
+    (g/set-property self
+                    :sound (workspace/resolve-resource resource (:sound sound))
+                    :looping (not (zero? (:looping sound)))
+                    :group (:group sound)
+                    :gain (:gain sound))))
+
+(g/defnode SoundNode
+  (inherits project/ResourceNode)
+
+  (input dep-build-targets g/Any)
+  (input sound-resource resource/Resource)
+
+  (property sound resource/Resource
+            (value (gu/passthrough sound-resource))
+            (set (fn [basis self old-value new-value]
+                   (project/resource-setter basis self old-value new-value
+                                            [:resource :sound-resource]
+                                            [:build-targets :dep-build-targets])))
+            (validate (validation/validate-resource sound "Missing sound"))
+            (dynamic edit-type (g/always {:type resource/Resource :ext supported-audio-formats})))
+
+  (property looping g/Bool (default false))
+  (property group g/Str (default "master"))
+  (property gain g/Num (default 1.0)
+            (validate (g/fnk [gain]
+                        (when-not (<= 0.0 gain 1.0)
+                          (g/error-warning "Gain must be between 0.0 and 1.0")))))
+
+  (output form-data g/Any :cached produce-form-data)
+  (output node-outline outline/OutlineData :cached produce-outline-data)
+  (output pb-msg g/Any :cached produce-pb-msg)
+  (output save-data g/Any :cached produce-save-data)
+  (output build-targets g/Any :cached produce-build-targets))
+
+(defn register-resource-types
+  [workspace]
+  (concat
+   (workspace/register-resource-type workspace
+                                     :ext "sound"
+                                     :node-type SoundNode
+                                     :load-fn load-sound
+                                     :icon sound-icon
+                                     :view-types [:form-view :text]
+                                     :view-opts {}
+                                     :tags #{:component}
+                                     :label "Sound")
+   (for [format supported-audio-formats]
+     (workspace/register-resource-type workspace
+                                       :ext format
+                                       :node-type SoundSourceNode
+                                       :icon sound-icon))))

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -166,4 +166,5 @@
      (workspace/register-resource-type workspace
                                        :ext format
                                        :node-type SoundSourceNode
-                                       :icon sound-icon))))
+                                       :icon sound-icon
+                                       :tags #{:embeddable}))))

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -42,7 +42,9 @@
                  "**/spineboy.spinescene"
                  "**/spineboy.spinemodel"
                  "**/new.factory"
-                 "**/with_prototype.factory"]]
+                 "**/with_prototype.factory"
+                 "**/new.sound"
+                 "**/tink.sound"]]
     (with-clean-system
       (let [workspace (test-util/setup-workspace! world)
             project   (test-util/setup-project! workspace)

--- a/editor/test/integration/sound_test.clj
+++ b/editor/test/integration/sound_test.clj
@@ -1,0 +1,36 @@
+(ns integration.sound-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [support.test-support :refer [with-clean-system]]
+            [editor.collection :as collection]
+            [editor.sound :as sound]
+            [editor.handler :as handler]
+            [editor.defold-project :as project]
+            [editor.types :as types]
+            [editor.properties :as properties]
+            [integration.test-util :as test-util]))
+
+(deftest new-sound-object
+  (testing "A new sound object"
+    (with-clean-system
+      (let [workspace (test-util/setup-workspace! world)
+            project   (test-util/setup-project! workspace)
+            node-id   (test-util/resource-node project "/sounds/new.sound")
+            outline   (g/node-value node-id :node-outline)
+            form-data (g/node-value node-id :form-data)]
+        (is (= "Sound" (:label outline)))
+        (is (empty? (:children outline)))
+        (is (= nil (get-in form-data [:values [:sound]])))))))
+
+(deftest sound-object-with-sound
+  (testing "A sound object with a sound set"
+    (with-clean-system
+      (let [workspace (test-util/setup-workspace! world)
+            project   (test-util/setup-project! workspace)
+            node-id   (test-util/resource-node project "/sounds/tink.sound")
+            outline   (g/node-value node-id :node-outline)
+            form-data (g/node-value node-id :form-data)]
+        (is (= "Sound" (:label outline)))
+        (is (empty? (:children outline)))
+        (is (= "/sounds/tink.wav" (get-in form-data [:values [:sound]])))))))
+


### PR DESCRIPTION
WIP
- [x] validation
- [x] tests
- [x] embedding raw audio files in game-objects?
  - it seems like we allow embedding raw audio files in game objects, but under the cover wrap them up in a sound component: https://github.com/defold/defold/blob/master/editor/src/clj/editor/game_object.clj#L60
  - Doesn't look like you can actually use that as a user yet though. In old editor you can add a "wav" or "ogg" file to a game object, but we don't show those extensions in new editor.
  - Could easily show them in new editor, not sure what desired behaviour/intention is with this
