### PR TITLE
Use arrays instead of vectors for vertex buffer slices.

### DIFF
--- a/editor/src/clj/editor/buffers.clj
+++ b/editor/src/clj/editor/buffers.clj
@@ -45,10 +45,11 @@
 
 (defn slice [^ByteBuffer bb offsets]
   (let [dup (.duplicate bb)]
-    (mapv (fn [o] (do
-                   (.position dup o)
-                   (doto (.slice dup)
-                     (.order (.order bb))))) offsets)))
+    (into-array ByteBuffer (for [o offsets]
+                             (do (.position dup o)
+                                 (doto (.slice dup)
+                                   (.order (.order bb))))))))
+
 
 (extend-type ByteBuffer
   ByteStringCoding

--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -178,10 +178,10 @@ the `do-gl` macro from `editor.gl`."
         arglist         (into [] (concat ['slices 'idx] names))
         multiplications (indexers "idx" vsteps)
         references      (map (comp first multiplications) vsteps)]
-    `(fn [~'slices ~'idx [~@names]]
+    `(fn [~(with-meta 'slices {:tag "[Ljava.nio.ByteBuffer;"}) ~'idx [~@names]]
        (let ~(into [] (apply concat (vals multiplications)))
          ~@(map (fn [i nm setter refer]
-                 (list setter (with-meta (list `nth 'slices i) {:tag `ByteBuffer}) refer nm))
+                 (list setter (with-meta (list `aget 'slices i) {:tag `ByteBuffer}) refer nm))
                (range (count names)) names setters references)))))
 
 (defn- make-vertex-getter
@@ -190,10 +190,10 @@ the `do-gl` macro from `editor.gl`."
         vsteps          (attribute-vsteps  vertex-format)
         multiplications (indexers "idx" vsteps)
         references      (map (comp first multiplications) vsteps)]
-    `(fn [~'slices ~'idx]
+    `(fn [~(with-meta 'slices {:tag "[Ljava.nio.ByteBuffer;"}) ~'idx]
        (let ~(into [] (apply concat (vals multiplications)))
          [~@(map (fn [i getter refer]
-                   (list getter (with-meta (list `nth 'slices i) {:tag `ByteBuffer}) (list `int refer)))
+                   (list getter (with-meta (list `aget 'slices i) {:tag `ByteBuffer}) (list `int refer)))
                  (range (count getters)) getters references)]))))
 
 (declare new-persistent-vertex-buffer)


### PR DESCRIPTION
- can use `aget` instead of `nth` in hot get/set functions that need to
  look up slice

Each `conj!` operation on a vertex buffer will look up the underlying `ByteBuffer` slice once per attribute. Slices were previously a vector of `ByteBuffer` and `nth` was used to find the correct slice. These many `nth` calls showed up as a hotspot when creating vertex buffers for large (<= 50k tiles) tile-maps where many `conj!` calls are made. This PR improves the constant factor slightly by using arrays and `aget` instead, as slices are never modified after creation.

**Perf test**:

``` clojure
(defvertex pos-uv-vtx
  (vec3 pos)
  (vec2 uv))

(criterium.core/quick-bench
  (let [n 50000]
    (loop [i 0
           vbuf (->pos-uv-vtx (* 4 n))]
      (if (< i sz)
        (recur (inc i) (-> vbuf
                           (conj! [i i i i i])
                           (conj! [i i i i i])
                           (conj! [i i i i i])
                           (conj! [i i i i i])))
               (persistent! vbuf)))))
```

Before:

```
Evaluation count : 30 in 6 samples of 5 calls.
             Execution time mean : 22.546595 ms
    Execution time std-deviation : 1.164926 ms
   Execution time lower quantile : 21.271955 ms ( 2.5%)
   Execution time upper quantile : 23.665468 ms (97.5%)
                   Overhead used : 1.375955 ns
```

After:

```
Evaluation count : 48 in 6 samples of 8 calls.
             Execution time mean : 13.933222 ms
    Execution time std-deviation : 678.307369 µs
   Execution time lower quantile : 13.159518 ms ( 2.5%)
   Execution time upper quantile : 14.737350 ms (97.5%)
                   Overhead used : 1.350438 ns
```
