### PR TITLE
Fix a couple of text editor issues.

### DIFF
--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -362,8 +362,8 @@
        (.setSkin text-area skin)
        (.addEventHandler  ^ListView (.getListView skin)
                           MouseEvent/MOUSE_CLICKED
-                          (ui/event-handler e (cvx/handle-mouse-clicked e source-viewer))))
-
+                          (ui/event-handler e (cvx/handle-mouse-clicked e source-viewer)))
+       (.setMinWidth (.getLineRuler skin) 50)) ; make it fit reasonably large line numbers to avoid jumps when scrolling
 
       (ui/user-data! text-area ::behavior styled-text-behavior)
       (ui/user-data! source-viewer ::assist (:assist opts))

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -196,7 +196,7 @@
         (code/combine-matches match-open match-body)))))
 
 (defn increase-indent? [s]
-  (re-find #"^\s*(else|elseif|for|(local\s+)?function|if|while)\b((?!end).)*$|\{\s*$" s))
+  (re-find #"^\s*(else|elseif|for|(local\s+)?function|if|while)\b((?!end\b).)*$|\{\s*$" s))
 
 (defn decrease-indent? [s]
   (re-find #"^\s*(elseif|else|end|\}).*$" s))
@@ -211,8 +211,7 @@
 (def lua {:language "lua"
           :syntax
           {:line-comment "-- "
-           :indentation {:indent-chars "\t"
-                         :increase? increase-indent?
+           :indentation {:increase? increase-indent?
                          :decrease? decrease-indent?}
            :scanner
            [#_{:partition "__multicomment"

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -284,6 +284,10 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 		return contentView;
 	}
 
+	public LineRuler getLineRuler() {
+	    return lineRuler;
+	}
+
 	DefoldStyledTextBehavior getBehavior() {
 		return this.behavior;
 	}

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -163,9 +163,9 @@
                                                expect)
       "foo|"                   "food_glorious_food" "food_glorious_food|"
       "go.set|"                "go.set_property()"  "go.set_property()|"
-      "  go.set|"              "go.set_property()"  "  go.set_property()|"
-      "  assert(math.a|"       "math.abs()"         "  assert(math.abs()|"
-      "    go.set_prop = vma|" "vmath"              "    go.set_prop = vmath|"
+      "  go.set|"              "go.set_property()"  "go.set_property()|"
+      "  assert(math.a|"       "math.abs()"         "assert(math.abs()|"
+      "    go.set_prop = vma|" "vmath"              "go.set_prop = vmath|"
       "vmat| = go.set"         "vmath"              "vmath| = go.set"
       "vmatches = vm|"         "vmath"              "vmatches = vmath|")))
 
@@ -350,6 +350,22 @@
                          (should-be  "function test(x)"
                                      "end"
                                      "|")))
+      (testing "nested function immedate end deindents"
+        (buffer-commands (load-buffer world script/ScriptNode lua/lua)
+                         (should-be "function test(x)"
+                                    "\tfunction nested(y)"
+                                    "\t\tend|")
+                         (enter!)
+                         (should-be "function test(x)"
+                                    "\tfunction nested(y)"
+                                    "\tend"
+                                    "\t|")))
+      (testing "enter after function signature containing end still indents"
+        (buffer-commands (load-buffer world script/ScriptNode lua/lua)
+                         (should-be "function foo(sender)|")
+                         (enter!)
+                         (should-be "function foo(sender)"
+                                    "\t|")))
       (testing "no enter identation if not at an end of the line"
         (buffer-commands (load-buffer world script/ScriptNode lua/lua)
                          (should-be "fu|nction test(x)")

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -719,6 +719,19 @@
         (cut-to-end-of-line! source-viewer clipboard)
         (is (= "\nline3" (text source-viewer)))))))
 
+(deftest copy-paste-selection-preserves-caret
+  (with-clean-system
+    (let [code "line1\nline2\nline3"
+          clipboard (new TestClipboard (atom ""))
+          opts lua/lua
+          source-viewer (setup-source-viewer opts)
+          [code-node viewer-node] (setup-code-view-nodes world source-viewer code script/ScriptNode)]
+      (testing "copy-paste-preserves-caret"
+        (text-selection! source-viewer 2 8)
+        (copy! source-viewer clipboard)
+        (paste! source-viewer clipboard)
+        (is (= 10 (caret source-viewer)))))))
+
 (defn- find-text! [source-viewer text]
   ;; bypassing handler for the dialog handling
   (find-text source-viewer text))


### PR DESCRIPTION
Treat 4*space as indentation.
Only deindent scope-end lines.
Indent after function signatures containing end, line function foo(sender).
Change proposal tests as indentation policy changed.
Fix copy-paste caret pos bug.
Make line ruler fit reasonably large line numbers

This should fix:
https://github.com/defold/editor2-issues/issues/31
https://github.com/defold/editor2-issues/issues/21
https://github.com/defold/editor2-issues/issues/7
