### PR TITLE
Fix a couple of text editor issues.

### DIFF
--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -362,8 +362,8 @@
        (.setSkin text-area skin)
        (.addEventHandler  ^ListView (.getListView skin)
                           MouseEvent/MOUSE_CLICKED
-                          (ui/event-handler e (cvx/handle-mouse-clicked e source-viewer))))
-
+                          (ui/event-handler e (cvx/handle-mouse-clicked e source-viewer)))
+       (.setMinWidth (.getLineRuler skin) 50)) ; make it fit reasonably large line numbers to avoid jumps when scrolling
 
       (ui/user-data! text-area ::behavior styled-text-behavior)
       (ui/user-data! source-viewer ::assist (:assist opts))

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -299,13 +299,13 @@
         sel-len (selection-length source-viewer)]
     (text-selection! source-viewer 0 0)
     (replace! source-viewer np sel-len s)
-    (caret! source-viewer (+ np sel-len) false)
+    (caret! source-viewer (+ np (count s)) false)
     (show-line source-viewer)))
 
 (defn- replace-text-and-caret [source-viewer offset length s new-caret-pos]
   (let [doc (text source-viewer)
         pos (adjust-bounds doc offset)
-        new-len (adjust-replace-length (text source-viewer) pos length)
+        new-len (adjust-replace-length doc pos length)
         new-pos (adjust-bounds doc new-caret-pos)]
     (replace! source-viewer pos new-len s)
     (caret! source-viewer (adjust-bounds (text source-viewer) new-caret-pos) false)

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -186,7 +186,10 @@
                   [{:label :separator}]
                   (sort-by :order (map menu-data indent-commands)))}]))
 
+;; keep regex's in split-indentation etc in sync with these
 (def tab-size 4)
+(def default-indentation "\t")
+
 (def last-find-text (atom ""))
 (def last-replace-text (atom ""))
 (def last-command (atom nil))
@@ -291,13 +294,13 @@
     0
     n))
 
-(defn- replace-text-selection [selection s]
-  (let [np (selection-offset selection)
-        sel-len (selection-length selection)]
-    (text-selection! selection 0 0)
-    (replace! selection np sel-len s)
-    (caret! selection (inc np) false)
-    (show-line selection)))
+(defn- replace-text-selection [source-viewer s]
+  (let [np (selection-offset source-viewer)
+        sel-len (selection-length source-viewer)]
+    (text-selection! source-viewer 0 0)
+    (replace! source-viewer np sel-len s)
+    (caret! source-viewer (+ np sel-len) false)
+    (show-line source-viewer)))
 
 (defn- replace-text-and-caret [selection offset length s new-caret-pos]
   (let [doc (text selection)
@@ -1043,31 +1046,103 @@
               doc (text selection)]
           (prev-tab-trigger selection np))))))
 
+(defn- trim-indentation [line]
+  (second (re-find #"^[\t ]*(.*)" line)))
+
 (defn- get-indentation [line]
-  (re-find #"^\s+" line))
+  (re-find #"^[\t ]*" line))
+
+(defn- untabify [whitespace]
+  (string/replace whitespace #"\t" "    "))
+
+(defn- split-indentation [indentation]
+  (let [[_ indents remains] (re-find #"^((?:    |\t)*)([\t ]*)" indentation)]
+    (if (< (count (untabify remains)) tab-size)
+      [indents remains]
+      (split-indentation (untabify indentation)))))
+
+(defn- increase-indents [indent-split indentation]
+  (update indent-split 0 str indentation))
+
+(defn- decrease-indents [indent-split]
+  (update indent-split 0 string/replace #"(    |\t)$" ""))
+
+(defn- make-indented-line [indent-split line]
+  (str (first indent-split) (second indent-split) (trim-indentation line)))
+
+(defn- keep-indentation [line line-above]
+  (-> (get-indentation line-above)
+      (split-indentation)
+      (make-indented-line line)))
 
 (defn indent-line [selection line line-above]
   (when-let [indentation-data (:indentation (syntax selection))]
-    (let [{:keys [indent-chars increase? decrease?]} indentation-data
-          current-indentation (get-indentation line)]
+    (let [{:keys [increase? decrease?]} indentation-data]
       (cond
-        (decrease? line)
-        (let [line-above-indent (or (get-indentation line-above) "")
-              new-indent (string/replace-first line-above-indent (re-pattern indent-chars) "")
-              line-without-indent (string/replace-first line (re-pattern (str indent-chars "*")) "")]
-          (str new-indent line-without-indent))
+        ;; function asdf()
+        ;; end|
+        (and (decrease? line) (increase? line-above))
+        (keep-indentation line line-above)
 
+        ;; if foo
+        ;;     ...
+        ;;     ...
+        ;;     end|
+        (decrease? line)
+        (-> (get-indentation line-above)
+            (split-indentation)
+            (decrease-indents)
+            (make-indented-line line))
+
+        ;; function foo()
+        ;; |
         (increase? line-above)
-        (let [line-above-indent (get-indentation line-above)
-              line-without-indent (string/replace-first line (re-pattern (str indent-chars "*")) "")]
-          (str line-above-indent indent-chars line-without-indent))
+        (-> (get-indentation line-above)
+            (split-indentation)
+            (increase-indents default-indentation)
+            (make-indented-line line))
+
+        ;; function foo()
+        ;;     ...
+        ;;     ...
+        ;; |
+        :else
+        (keep-indentation line line-above)))))
+
+(defn unindent-line [selection line line-above]
+  (when-let [indentation-data (:indentation (syntax selection))]
+    (let [{:keys [increase? decrease?]} indentation-data]
+      (cond
+        ;; if foo
+        ;;     ...
+        ;;     end|
+        (and (decrease? line) (not (increase? line-above)))
+        (-> (get-indentation line-above)
+            (split-indentation)
+            (decrease-indents)
+            (make-indented-line line))
+
+        ;; if foo
+        ;;     end|
+        (decrease? line)
+        (keep-indentation line line-above)
 
         :else
-        (let [line-above-indent (get-indentation line-above)
-              line-without-indent (string/replace-first line (re-pattern (str indent-chars "*")) "")
-              line-above-increase? (increase? line-above)
-              new-indent (if line-above-increase? (str line-above-indent indent-chars) line-above-indent)]
-          (str new-indent line-without-indent))))))
+        line))))
+
+(defn do-unindent-line [selection line-num]
+  (let [current-line (line-at-num selection line-num)
+        line-offset (line-offset-at-num selection line-num)
+        caret-offset (caret selection)
+        prev-line (if (= 0 line-num) "" (line-at-num selection (dec line-num)))
+        unindent-text (unindent-line selection current-line prev-line)
+        caret-delta (- (count unindent-text) (count current-line))]
+    (if unindent-text
+      (do
+        (replace! selection (adjust-bounds (text selection) line-offset) (count current-line) unindent-text)
+        (caret! selection (+ caret-offset caret-delta) false)
+        caret-delta)
+      0)))
 
 (defn do-indent-line [selection line-num]
   (let [current-line (line-at-num selection line-num)
@@ -1122,7 +1197,7 @@
       (clear-snippet-tab-triggers! selection)
       (if (= (caret selection) (line-end-pos selection))
         (do
-          (do-indent-line selection (line-num-at-offset selection (caret selection)))
+          (do-unindent-line selection (line-num-at-offset selection (caret selection)))
           (enter-key-text selection (System/getProperty "line.separator"))
           (do-indent-line selection (line-num-at-offset selection (caret selection)))
           (caret! selection (+ (line-offset selection) (count (line selection))) false)

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -196,7 +196,7 @@
         (code/combine-matches match-open match-body)))))
 
 (defn increase-indent? [s]
-  (re-find #"^\s*(else|elseif|for|(local\s+)?function|if|while)\b((?!end).)*$|\{\s*$" s))
+  (re-find #"^\s*(else|elseif|for|(local\s+)?function|if|while)\b((?!end\b).)*$|\{\s*$" s))
 
 (defn decrease-indent? [s]
   (re-find #"^\s*(elseif|else|end|\}).*$" s))
@@ -211,8 +211,7 @@
 (def lua {:language "lua"
           :syntax
           {:line-comment "-- "
-           :indentation {:indent-chars "\t"
-                         :increase? increase-indent?
+           :indentation {:increase? increase-indent?
                          :decrease? decrease-indent?}
            :scanner
            [#_{:partition "__multicomment"

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -284,6 +284,10 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 		return contentView;
 	}
 
+	public LineRuler getLineRuler() {
+	    return lineRuler;
+	}
+
 	DefoldStyledTextBehavior getBehavior() {
 		return this.behavior;
 	}

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -163,9 +163,9 @@
                                                expect)
       "foo|"                   "food_glorious_food" "food_glorious_food|"
       "go.set|"                "go.set_property()"  "go.set_property()|"
-      "  go.set|"              "go.set_property()"  "  go.set_property()|"
-      "  assert(math.a|"       "math.abs()"         "  assert(math.abs()|"
-      "    go.set_prop = vma|" "vmath"              "    go.set_prop = vmath|"
+      "  go.set|"              "go.set_property()"  "go.set_property()|"
+      "  assert(math.a|"       "math.abs()"         "assert(math.abs()|"
+      "    go.set_prop = vma|" "vmath"              "go.set_prop = vmath|"
       "vmat| = go.set"         "vmath"              "vmath| = go.set"
       "vmatches = vm|"         "vmath"              "vmatches = vmath|")))
 
@@ -350,6 +350,22 @@
                          (should-be  "function test(x)"
                                      "end"
                                      "|")))
+      (testing "nested function immedate end deindents"
+        (buffer-commands (load-buffer world script/ScriptNode lua/lua)
+                         (should-be "function test(x)"
+                                    "\tfunction nested(y)"
+                                    "\t\tend|")
+                         (enter!)
+                         (should-be "function test(x)"
+                                    "\tfunction nested(y)"
+                                    "\tend"
+                                    "\t|")))
+      (testing "enter after function signature containing end still indents"
+        (buffer-commands (load-buffer world script/ScriptNode lua/lua)
+                         (should-be "function foo(sender)|")
+                         (enter!)
+                         (should-be "function foo(sender)"
+                                    "\t|")))
       (testing "no enter identation if not at an end of the line"
         (buffer-commands (load-buffer world script/ScriptNode lua/lua)
                          (should-be "fu|nction test(x)")

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -719,6 +719,19 @@
         (cut-to-end-of-line! source-viewer clipboard)
         (is (= "\nline3" (text source-viewer)))))))
 
+(deftest copy-paste-selection-preserves-caret
+  (with-clean-system
+    (let [code "line1\nline2\nline3"
+          clipboard (new TestClipboard (atom ""))
+          opts lua/lua
+          source-viewer (setup-source-viewer opts)
+          [code-node viewer-node] (setup-code-view-nodes world source-viewer code script/ScriptNode)]
+      (testing "copy-paste-preserves-caret"
+        (text-selection! source-viewer 2 8)
+        (copy! source-viewer clipboard)
+        (paste! source-viewer clipboard)
+        (is (= 10 (caret source-viewer)))))))
+
 (defn- find-text! [source-viewer text]
   ;; bypassing handler for the dialog handling
   (find-text source-viewer text))


### PR DESCRIPTION
Treat 4*space as indentation.
Only deindent scope-end lines.
Indent after function signatures containing end, line function foo(sender).
Change proposal tests as indentation policy changed.
Fix copy-paste caret pos bug.
Make line ruler fit reasonably large line numbers
