### PR TITLE
Increase server session time from 1 to 5 days.

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/auth/AccessTokenAuthenticator.java
+++ b/server/src/main/java/com/dynamo/cr/server/auth/AccessTokenAuthenticator.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class AccessTokenAuthenticator {
-    private static final Duration SESSION_PROLONG_DURATION = Duration.of(24, ChronoUnit.HOURS);
+    private static final Duration SESSION_PROLONG_DURATION = Duration.of(5, ChronoUnit.DAYS);
     private final AccessTokenFactory accessTokenFactory = new AccessTokenFactory();
     private final AccessTokenStore accessTokenStore;
     private TimeSource timeSource = new SystemTimeSource();


### PR DESCRIPTION
The reasoning behind this is a combination of that users feel that they need to login
too often and that the editor handles this poorly.
