### PR TITLE
Improving performance of text editor on large files

### DIFF
--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -151,12 +151,12 @@
       (.evaluate this scanner false))
     (evaluate [this scanner resume]
       (let [^DefoldRuleBasedScanner sc scanner
-            result (scanner-fn (.readString sc))]
-        (if result
-          (let [len (:length result)]
-            (when (pos? len) (.moveForward sc len))
-            token)
-          Token/UNDEFINED)))
+            ch-seq (.readSequence sc)]
+        (let [result (scanner-fn ch-seq)]
+          (if (and result (pos? (:length result)))
+            (do (.moveForward sc (:length result))
+                token)
+            Token/UNDEFINED))))
     (getSuccessToken ^IToken [this] token)))
 
 (defmethod make-rule :custom [{:keys [scanner]} token]

--- a/editor/src/java/com/defold/editor/eclipse/DefoldRuleBasedScanner.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldRuleBasedScanner.java
@@ -2,25 +2,72 @@ package com.defold.editor.eclipse;
 
 import org.eclipse.jface.text.rules.RuleBasedScanner;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import java.util.Iterator;
 
 public class DefoldRuleBasedScanner extends RuleBasedScanner {
+    public class DocumentCharSequence implements Iterable, CharSequence {
+        int start;
+        int end;
 
-    //Reads from offset all at once to the end of the doc as a peek
-    public String readString() {
-        try {
-        	int docLen = fDocument.getLength();
-        	// This is a performance fix to handle large documents
-        	// should be revisited to see if we can handle regexes better in the Eclipse way of doing things
-            if (fOffset < docLen && (docLen < 1000)){
-                 int len = docLen - fOffset;
-                 return fDocument.get(fOffset, len);
-            }else{
-                return "";
-            }
-        } catch (BadLocationException e) {
-            System.out.println("Bad Location in Document" + "offset:" + fOffset +  "length:" + fDocument.getLength());
-            return "";
+        public DocumentCharSequence(int start, int end) {
+            this.start = start;
+            this.end = end;
         }
+
+        public char charAt(int index) {
+            try {
+                return fDocument.getChar(start + index);
+            }
+            catch (BadLocationException e) {
+                System.out.println("Bad Location in Document" + "offset:" + (start + index) +  "length:" + fDocument.getLength());
+	       return '\0';
+            }
+        }
+
+        public int length() {
+            return end - start;
+        }
+
+        public CharSequence subSequence(int subStart, int subEnd) {
+            return new DocumentCharSequence(start + subStart, start + subEnd);
+        }
+
+        public boolean matchString(String s) {
+            int len = s.length();
+
+            if (len > length())
+                return false;
+
+            try {
+                return s.equals(fDocument.get(start, len));
+            }
+            catch (BadLocationException e) {
+                return false;
+            }
+        }
+
+        public String toString() {
+            return new StringBuilder(this).toString();
+        }
+
+        private class CharIterator implements Iterator {
+            int index;
+            public CharIterator() { index = 0; }
+            public boolean hasNext() {
+                return index < length();
+            }
+            public Object next() { return charAt(index++); }
+            public void remove() { throw new UnsupportedOperationException(); }
+        }
+
+        public Iterator iterator() {
+            return new CharIterator();
+        }
+    }
+
+    public CharSequence readSequence() {
+        return new DocumentCharSequence(fOffset, fRangeEnd);
     }
 
     // increments the offset by a given amount - this is from a match found


### PR DESCRIPTION
- Removing capture groups from constant/operator patterns  apparently
  speeds up highlighting
- Explicit use of CharSequence instead of pretty seq'y or string'y api
- Custom matchString on DocumentCharSequence
