### PR TITLE
Acquire focus when clicking in scene view.

### DIFF
--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -584,6 +584,10 @@
                                                   y (:y action)
                                                   pos [x y 0.0]
                                                   picking-rect (selection/calc-picking-rect pos pos)]
+                                              (when (= :mouse-pressed (:type action))
+                                                ;; request focus and consume event to prevent someone else from stealing focus
+                                                (.requestFocus parent)
+                                                (.consume e))
                                               ; Only look for tool selection when the mouse is moving with no button pressed
                                               (when (and (= :mouse-moved (:type action)) (= 0 (:click-count action)))
                                                 (let [s (g/node-value view-id :selected-tool-renderables)]
@@ -595,9 +599,7 @@
                                               (dispatch-input (g/sources-of view-id :input-handlers) action @tool-user-data))))]
     (ui/on-mouse! parent (fn [type e] (cond
                                         (= type :exit)
-                                        (g/set-property! view-id :cursor-pos nil)
-                                        (= type :enter)
-                                        (.requestFocus parent))))
+                                        (g/set-property! view-id :cursor-pos nil))))
     (.setOnMousePressed parent event-handler)
     (.setOnMouseReleased parent event-handler)
     (.setOnMouseClicked parent event-handler)


### PR DESCRIPTION
- removes need to requestFocus on mouse enter for curve view
