### PR TITLE
Fix NPEs when dragging in asset browser and outline view

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -382,11 +382,12 @@
 (defn- drag-done [^DragEvent e selection])
 
 (defn- drag-entered [^DragEvent e]
-  (when-let [^TreeCell cell (target (.getTarget e))]
-    (let [resource (.getValue (.getTreeItem cell))]
-      (when (and (= :folder (resource/source-type resource))
-                 (not (resource/read-only? resource)))
-        (ui/add-style! cell "drop-target")))))
+  (let [^TreeCell cell (target (.getTarget e))]
+    (when (and cell (not (.isEmpty cell)))
+      (let [resource (.getValue (.getTreeItem cell))]
+        (when (and (= :folder (resource/source-type resource))
+                   (not (resource/read-only? resource)))
+          (ui/add-style! cell "drop-target"))))))
 
 (defn- drag-exited [^DragEvent e]
   (when-let [cell (target (.getTarget e))]


### PR DESCRIPTION
- fixes defold/editor2-issues#37 defold/editor2-issues#18
- also extracted `make-tree-cell` from `setup-tree-view` to make it a bit easier to read (hopefully) and work with in repl
