### PR TITLE
DEFEDIT-398 Packaging cleanup: Update JVM args

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -13,8 +13,8 @@ java = ${launcher.jre}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.sha1}.jar
 main = com.defold.editor.Start
 debug = 1
-vmargs = -Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true
+vmargs = -Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
 [platform]
-osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns
+osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =
 linux =


### PR DESCRIPTION
AFAICT, editor1 uses these JVM options (from https://github.com/defold/defold/blob/master/com.dynamo.cr/com.dynamo.cr.editor-product/template/cr.product#L16) :

``` xml
<vmArgs>-Declipse.p2.unsignedPolicy=allow -Dsun.net.client.defaultReadTimeout=30000 -XX:MaxPermSize=128M -Xmx1200M -Djogl.texture.notexrect=true -Djava.net.preferIPv4Stack=true</vmArgs>
<vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
```

| Option | Comment |
| --- | --- |
| `-Declipse.p2.unsignedPolicy=allow` | eclipse, ignore |
| `-Dsun.net.client.defaultReadTimeout=30000` | set this and defaultConnectTimeout too |
| `-XX:MaxPermSize=128M` | deprecated since java 1.8 |
| `-Xmx1200M` | probably too little, don't set this yet? would have to do some work to understand what our expected usage is |
| `-Djogl.texture.notexrect=true` | keep this |
| `-Djava.net.preferIPv4Stack=true` | we already set |

**OSX specific**:

| Option | Comment |
| --- | --- |
| `-XstartOnFirstThread` | "run the main() method on the first (AppKit) thread". Not sure if we need this as we're not using SWT anymore: https://jogamp.org/wiki/index.php/Using_JOGL_in_AWT_SWT_and_Swing |
| `-Dorg.eclipse.swt.internal.carbon.smallFonts` | eclipse, ignore |
