### PR TITLE
More text editor fixes

### DIFF
--- a/editor/src/clj/editor/code.clj
+++ b/editor/src/clj/editor/code.clj
@@ -4,11 +4,12 @@
 
 (set! *warn-on-reflection* true)
 
-(defn not-ascii-or-delete [key-typed]
+(defn control-char-or-delete [key-typed]
  ;; ascii control chars like Enter are all below 32
   ;; delete is an exception and is 127
   (let [n (.charAt ^String key-typed 0)]
-    (and (> (int n) 31) (not= (int n) 127))))
+    (or (< (int n) 32)
+        (= (int n) 127))))
 
 (defn- remove-optional-params [s]
   (string/replace s #"\[.*\]" ""))

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -624,7 +624,7 @@
                                       (let [key-typed (.getCharacter ^KeyEvent event)]
                                         (cond
 
-                                          (and (not-empty key-typed) (code/not-ascii-or-delete key-typed))
+                                          (and (not-empty key-typed) (not (code/control-char-or-delete key-typed)))
                                           (do
                                             (swap! filter-text str key-typed)
                                             (update-items)

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -10,7 +10,10 @@
             [editor.gl.shader :as shader]
             [editor.code-view-test :as cvt :refer [setup-code-view-nodes load-buffer expect-buffer buffer-commands should-be]]
             [support.test-support :refer [with-clean-system tx-nodes]]
-            [clojure.string :as str]))
+            [clojure.string :as string])
+  (:import [com.sun.javafx.tk Toolkit]
+           [javafx.scene.input KeyEvent KeyCode]))
+
 
 ;; ----------------------------------------
 ;; Simulate commands
@@ -25,7 +28,15 @@
   (cvx/handler-run :backwards-tab-trigger [{:name :code-view :env {:selection source-viewer}}] {}))
 
 (defn- key-typed! [source-viewer key-typed]
-  (cvx/handler-run :key-typed [{:name :code-view :env {:selection source-viewer :key-typed key-typed}}] {}))
+  (cvx/handler-run :key-typed [{:name :code-view
+                                :env {:selection source-viewer :key-typed key-typed :key-event (KeyEvent. KeyEvent/KEY_TYPED
+                                                                                                          key-typed
+                                                                                                          ""
+                                                                                                          (KeyCode/getKeyCode key-typed)
+                                                                                                          false
+                                                                                                          false
+                                                                                                          false
+                                                                                                          false)}}] {}))
 
 (defn- toggle-comment! [source-viewer]
   (cvx/handler-run :toggle-comment [{:name :code-view :env {:selection source-viewer}}] {}))

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -1,5 +1,6 @@
 (ns editor.code-view-ux-test
   (:require [clojure.test :refer :all]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.code-view :as cv :refer :all]
             [editor.code-view-ux :as cvx :refer :all]
@@ -8,7 +9,8 @@
             [editor.script :as script]
             [editor.code-view-test :as cvt :refer [setup-code-view-nodes]]
             [support.test-support :refer [with-clean-system tx-nodes]])
-  (:import [com.sun.javafx.tk Toolkit]))
+  (:import [com.sun.javafx.tk Toolkit]
+           [javafx.scene.input KeyEvent KeyCode]))
 
 
 (defrecord TestClipboard [content]
@@ -18,7 +20,15 @@
   (replace! [this offset length s]))
 
 (defn- key-typed! [source-viewer key-typed]
-  (cvx/handler-run :key-typed [{:name :code-view :env {:selection source-viewer :key-typed key-typed}}] {}))
+  (cvx/handler-run :key-typed [{:name :code-view
+                                :env {:selection source-viewer :key-typed key-typed :key-event (KeyEvent. KeyEvent/KEY_TYPED
+                                                                                                          key-typed
+                                                                                                          ""
+                                                                                                          (KeyCode/getKeyCode key-typed)
+                                                                                                          false
+                                                                                                          false
+                                                                                                          false
+                                                                                                          false)}}] {}))
 
 (deftest key-typed-test
   (with-clean-system
@@ -910,7 +920,7 @@
         (propose! source-viewer)
         (is (= "string.sub(s,i)" (text source-viewer)))
         (is (= "s" (text-selection source-viewer)))
-      (typing-changes! source-viewer)
+        (typing-changes! source-viewer)
         (tab! source-viewer)
         (typing-changes! source-viewer)
         (is (= "i" (text-selection source-viewer)))


### PR DESCRIPTION
- Dont insert closing automatches when typing them explicitly
- Reorg preconds for key-typed/updating of last-command -> repeated
  ctrl+k works again
- Changed check for typable characters according to similar code in
  javafx & e(fx)clipse
- "Async" proposal replacement didn't create a transaction
