### PR TITLE
Line endings fix

### DIFF
--- a/editor/src/clj/editor/code.clj
+++ b/editor/src/clj/editor/code.clj
@@ -11,6 +11,14 @@
     (or (< (int n) 32)
         (= (int n) 127))))
 
+
+(defn lf-normalize-line-endings [string]
+  (loop [normalized string]
+    (let [next (string/replace normalized "\r\n" "\n")]
+      (if (= next normalized)
+        (string/replace normalized "\r" "\n")
+        (recur next)))))
+
 (defn- remove-optional-params [s]
   (string/replace s #"\[.*\]" ""))
 

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -1250,7 +1250,8 @@
   (enabled? [selection] (editable? selection))
   (run [selection]
     ;; e(fx)clipse doesn't like \r\n
-    (let [line-separator "\n" #_(System/getProperty "line.separator")]
+    ;; should really be (System/getProperty "line.separator")
+    (let [line-separator "\n"]
       (when (editable? selection)
         (clear-snippet-tab-triggers! selection)
         (if (= (caret selection) (line-end-pos selection))

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -335,7 +335,7 @@
   (enabled? [selection] (editable? selection))
   (run [selection clipboard]
     (when-let [clipboard-text (text clipboard)]
-      (let [code (text selection)
+      (let [code (code/lf-normalize-line-endings (text selection))
             caret (caret selection)]
         (if (pos? (selection-length selection))
           (replace-text-selection selection clipboard-text)
@@ -372,7 +372,7 @@
         doc (text source-viewer)
         selected-text (text-selection source-viewer)
         next-pos (if (and (pos? (count selected-text))
-                      (not (caret-at-left-of-selection? source-viewer)))
+                          (not (caret-at-left-of-selection? source-viewer)))
                    (adjust-bounds doc (- c (count selected-text)))
                    (adjust-bounds doc (dec c)))]
     (clear-snippet-tab-triggers! source-viewer)
@@ -1249,18 +1249,20 @@
 (handler/defhandler :enter :code-view
   (enabled? [selection] (editable? selection))
   (run [selection]
-    (when (editable? selection)
-      (clear-snippet-tab-triggers! selection)
-      (if (= (caret selection) (line-end-pos selection))
-        (do
-          (do-unindent-line selection (line-num-at-offset selection (caret selection)))
-          (enter-key-text selection (System/getProperty "line.separator"))
-          (do-indent-line selection (line-num-at-offset selection (caret selection)))
-          (caret! selection (+ (line-offset selection) (count (line selection))) false)
-          (remember-caret-col selection (caret selection))
-          (show-line selection))
-        (enter-key-text selection (System/getProperty "line.separator")))
-      (typing-changes! selection))))
+    ;; e(fx)clipse doesn't like \r\n
+    (let [line-separator "\n" #_(System/getProperty "line.separator")]
+      (when (editable? selection)
+        (clear-snippet-tab-triggers! selection)
+        (if (= (caret selection) (line-end-pos selection))
+          (do
+            (do-unindent-line selection (line-num-at-offset selection (caret selection)))
+            (enter-key-text selection line-separator)
+            (do-indent-line selection (line-num-at-offset selection (caret selection)))
+            (caret! selection (+ (line-offset selection) (count (line selection))) false)
+            (remember-caret-col selection (caret selection))
+            (show-line selection))
+          (enter-key-text selection line-separator))
+        (typing-changes! selection)))))
 
 (defn- completion-pattern [replacement loffset line-text offset]
   (let [fragment (subs line-text 0 (- offset loffset))

--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -3,6 +3,7 @@
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [editor.code-completion :as code-completion]
+            [editor.code :as code]
             [editor.types :as t]
             [editor.geom :as geom]
             [editor.gl :as gl]
@@ -152,7 +153,7 @@
                                                                                 module-nodes))))
 
 (defn load-script [project self resource]
-  (g/set-property self :code (slurp resource)))
+  (g/set-property self :code (code/lf-normalize-line-endings (slurp resource))))
 
 (defn- register [workspace def]
   (let [args (merge def


### PR DESCRIPTION
- always insert \n for newline
- normalize line endings, \r\n -> \n & \r -> \n, when loading scripts
  and pasting from clipboard
