### PR TITLE
DEFEDIT-401-417-420

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -61,7 +61,7 @@
              :icon gui-icon
              :pb-class Gui$SceneDesc
              :resource-fields [:script :material [:fonts :font] [:textures :texture]]
-             :tags #{:component}})
+             :tags #{:component :non-embeddable}})
 
 ; Line shader
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -824,7 +824,7 @@
                                      :node-type ParticleFXNode
                                      :load-fn load-particle-fx
                                      :icon particle-fx-icon
-                                     :tags #{:component}
+                                     :tags #{:component :non-embeddable}
                                      :view-types [:scene :text]
                                      :view-opts {:scene {:grid true}}))
 

--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -43,7 +43,7 @@
                    :icon "icons/32/Icons_12-Script-type.png"
                    :view-types [:code :default]
                    :view-opts lua-code-opts
-                   :tags #{:component :overridable-properties}}
+                   :tags #{:component :non-embeddable :overridable-properties}}
                   {:ext "render_script"
                    :label "Render Script"
                    :icon "icons/32/Icons_12-Script-type.png"

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -730,17 +730,21 @@
                                   (prop-resource-error _node-id :material material "Material"))))
   (property default-animation g/Str
             (value (g/fnk [default-animation spine-anim-ids] (or (not-empty default-animation) (first spine-anim-ids))))
-            (dynamic error (g/fnk [_node-id spine-anim-ids default-animation]
-                                  (validation/prop-error :fatal _node-id :default-animation (fn [anim ids] (when (not (contains? ids anim))
-                                                                                                             (format "animation '%s' could not be found in the specified scene" anim))) default-animation (set spine-anim-ids))))
+            (dynamic error (g/fnk [_node-id spine-anim-ids default-animation spine-scene]
+                                  (when spine-scene
+                                    (validation/prop-error :fatal _node-id
+                                                           :default-animation (fn [anim ids]
+                                                                                (when (not (contains? ids anim))
+                                                                                  (format "animation '%s' could not be found in the specified scene" anim))) default-animation (set spine-anim-ids)))))
             (dynamic edit-type (g/fnk [anim-ids] (properties/->choicebox anim-ids))))
   (property skin g/Str
             (value (g/fnk [skin scene-structure] (or (not-empty skin) (first (:skins scene-structure)))))
-            (dynamic error (g/fnk [_node-id skin scene-structure]
-                                  (validation/prop-error :fatal _node-id :skin
+            (dynamic error (g/fnk [_node-id skin scene-structure spine-scene]
+                                  (when spine-scene
+                                    (validation/prop-error :fatal _node-id :skin
                                                          (fn [skin skins]
                                                            (when (not (contains? skins skin))
-                                                             (format "skin '%s' could not be found in the specified scene" skin))) skin (set (:skins scene-structure)))))
+                                                             (format "skin '%s' could not be found in the specified scene" skin))) skin (set (:skins scene-structure))))))
             (dynamic edit-type (g/fnk [scene-structure]
                                       (properties/->choicebox (:skins scene-structure)))))
 

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -1041,5 +1041,5 @@
                                     :view-types [:scene :text]
                                     :view-opts {:scene {:grid tile-map-grid/TileMapGrid
                                                         :tool-controller TileMapController}}
-                                    :tags #{:component}
+                                    :tags #{:component :non-embeddable}
                                     :label "Tile Map"))


### PR DESCRIPTION
- fix for material in embedded sprite
- only validate spine skin & default anim if scene set
- don't show non embeddable components under Add Component
