### PR TITLE
DEFEDIT-449 Write NREPL port to .nrepl-port file

### DIFF
--- a/editor/src/clj/editor/debug.clj
+++ b/editor/src/clj/editor/debug.clj
@@ -3,6 +3,19 @@
 (set! *warn-on-reflection* true)
 
 (defonce ^:private repl-server (agent nil))
+(defonce should-write-nrepl-port-file (atom true))
+
+(defn ^:private write-nrepl-port-file
+  [port]
+  (when @should-write-nrepl-port-file
+    (reset! should-write-nrepl-port-file false)
+    (let [nrepl-port-file (java.io.File. ".nrepl-port")]
+      (try
+        (spit nrepl-port-file (str port))
+        (.deleteOnExit nrepl-port-file)
+        (catch Exception e
+          (println (format "Failed to write NREPL port file to `%s`" (.getAbsolutePath nrepl-port-file)))
+          (prn e))))))
 
 ;; Try/catching the requires here because the dependencies might be missing
 
@@ -21,6 +34,7 @@
                   (apply start-server (mapcat identity config))
                   (start-server))]
         (println (format "Started REPL at nrepl://127.0.0.1:%s\n" (:port srv)))
+        (write-nrepl-port-file (:port srv))
         srv)
       (catch Exception e
         (println "Failed to start NREPL server")

--- a/editor/src/clj/editor/debug.clj
+++ b/editor/src/clj/editor/debug.clj
@@ -1,9 +1,10 @@
-(ns editor.debug)
+(ns editor.debug
+  (:require [editor.system :as system]))
 
 (set! *warn-on-reflection* true)
 
 (defonce ^:private repl-server (agent nil))
-(defonce should-write-nrepl-port-file (atom true))
+(defonce should-write-nrepl-port-file (atom (system/defold-dev?)))
 
 (defn ^:private write-nrepl-port-file
   [port]


### PR DESCRIPTION
- When we start the first NREPL instance, we write the selected port number to a `.nrepl-port` file. This file will be read by some development tools such as the Cursive plugin for IntelliJ IDEA and allows us to connect a Remote Clojure REPL after starting the Defold editor. The `.nrepl-port` file will be deleted when the JVM shuts down.
