### PR TITLE
DEFEDIT-446 Spine Model Default Animation dropdown choices are not animations

### DIFF
--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -738,7 +738,7 @@
                                                            :default-animation (fn [anim ids]
                                                                                 (when (not (contains? ids anim))
                                                                                   (format "animation '%s' could not be found in the specified scene" anim))) default-animation (set spine-anim-ids)))))
-            (dynamic edit-type (g/fnk [anim-ids] (properties/->choicebox anim-ids))))
+            (dynamic edit-type (g/fnk [spine-anim-ids] (properties/->choicebox spine-anim-ids))))
   (property skin g/Str
             (dynamic error (g/fnk [_node-id skin scene-structure spine-scene]
                                   (when spine-scene


### PR DESCRIPTION
- When editing properties on a Spine Model, the choices presented in the Default Animation dropdown were not animations from the selected Spine Model. Instead, it appeared to list the images in the Atlas used by the Spine Scene. This change lists the animations instead.
