### PR TITLE
DEFEDIT-439 Code-completion throws error

### DIFF
--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -136,8 +136,8 @@
   (try
     (let
         [{:keys [namespace function] :as parse-result} (or (code/parse-line line) (code/default-parse-result))
-         items (if namespace (get completions (string/lower-case namespace)) (get completions ""))
-         pattern (string/lower-case (code/proposal-filter-pattern namespace function))
+         items (if namespace (get completions namespace) (get completions ""))
+         pattern (code/proposal-filter-pattern namespace function)
          results (filter (fn [i] (string/starts-with? (:name i) pattern)) items)]
       (->> results (sort-by :display-string) (partition-by :display-string) (mapv first)))
     (catch Exception e

--- a/editor/test/editor/code_completion_test.clj
+++ b/editor/test/editor/code_completion_test.clj
@@ -56,11 +56,11 @@
           (is (=  #{"x" "foo" "y"} (set (filter  #{"x" "foo" "y"} var-names))))
           (is (= 1 @project-search-count))))
 
-      (testing "bare requires"
+      (testing "bare requires does not magically create module names"
         (g/transact (g/set-property script-node :code "require(\"mymath\")"))
         (let [completions  (with-redefs [find-module-node-in-project test-find-in-project
                                          resource-node-path (constantly "/mymath.lua")]
                                  (g/node-value script-node :completions))
               mymath-names (set (map :name (get completions "mymath")))]
-          (is (= #{"mymath.add" "mymath.sub"} mymath-names))
+          (is (= #{} mymath-names))
           (is (= 1 @project-search-count)))))))

--- a/editor/test/editor/code_view_ux_syntax_test.clj
+++ b/editor/test/editor/code_view_ux_syntax_test.clj
@@ -159,12 +159,14 @@
   (are [init completions] (completions-in? "/mymodule.lua"
                                            "local mymodule={} \n function mymodule.add(x,y) return x end \n return mymodule"
                                           init completions)
-    "require(\"mymodule\") \n mymodule.|"        [["mymodule.add" "mymodule.add(x,y)" "mymodule.add(x,y)"]]
     "foo = require(\"mymodule\") \n foo.|"       [["foo.add"      "foo.add(x,y)"      "foo.add(x,y)"]]
     "local bar = require(\"mymodule\") \n bar.|" [["bar.add"      "bar.add(x,y)"      "bar.add(x,y)"]]
-    "require(\"mymodule\") \n mymod|"            [["mymodule"     "mymodule"          "mymodule"]]
     "foo = require(\"mymodule\") \n foo|"        [["foo"          "foo"               "foo"]]
-    "local bar = require(\"mymodule\") \n ba|"   [["bar"          "bar"               "bar"]]))
+    "local bar = require(\"mymodule\") \n ba|"   [["bar"          "bar"               "bar"]])
+  (are [init completions] (completions-in? "/mymodule.lua"
+                                           "local M = {} \n function M.yield(...) \n end return M"
+                                           init completions)
+    "local foo = require(\"mymodule\") \n foo.|" [["foo.yield"    "foo.yield(...)"    "foo.yield(...)"]]))
 
 (deftest test-do-proposal-replacement
   (with-clean-system


### PR DESCRIPTION
Fixes defold/editor2-issues#111
- handle vararg module functions "M.yield(...)"
- don't lowercase namespace when looking for completions
- fuzz-tests for parser stability
