### PR TITLE
DEFEDIT-445 Fixed merging of built embedded things

### DIFF
--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -179,7 +179,7 @@
   (inherits InstanceNode)
 
   (input properties g/Any)
-  (input build-targets g/Any)
+  (input source-build-targets g/Any)
   (input scene g/Any)
   (input child-scenes g/Any :array)
   (input child-ids g/Str :array)
@@ -191,10 +191,13 @@
   (output node-outline outline/OutlineData :cached produce-go-outline)
   (output ddf-message g/Any :abstract)
   (output node-outline-label g/Str (gu/passthrough id))
-  (output build-targets g/Any (g/fnk [build-targets build-error ddf-message transform] (let [target (first build-targets)]
-                                                                              [(assoc target :instance-data {:resource (:resource target)
-                                                                                                             :instance-msg ddf-message
-                                                                                                             :transform transform})])))
+  (output build-resource resource/Resource (g/fnk [source-build-targets] (:resource (first source-build-targets))))
+  (output build-targets g/Any (g/fnk [build-resource source-build-targets build-error ddf-message transform]
+                                     (let [target (assoc (first source-build-targets)
+                                                         :resource build-resource)]
+                                       [(assoc target :instance-data {:resource (:resource target)
+                                                                      :instance-msg ddf-message
+                                                                      :transform transform})])))
   (output build-error g/Err (g/always nil))
 
   (output scene g/Any :cached (g/fnk [_node-id transform scene child-scenes]
@@ -230,7 +233,12 @@
   (display-order [:id :url scene/ScalableSceneNode])
 
   (input proto-msg g/Any)
-
+  (input source-resource resource/Resource)
+  (input source-save-data g/Any)
+  (output build-resource resource/Resource (g/fnk [source-resource source-save-data]
+                                                  (some-> source-resource
+                                                     (assoc :data (:content source-save-data))
+                                                     workspace/make-build-resource)))
   (output ddf-message g/Any :cached (g/fnk [id child-ids position rotation scale proto-msg ddf-component-properties]
                                            (gen-embed-ddf id child-ids position rotation scale proto-msg ddf-component-properties))))
 
@@ -303,7 +311,7 @@
                                                                                  [:ddf-component-properties :ddf-component-properties]]
                                                                       :when (contains? outputs from)]
                                                                   (g/connect or-node from self to)))
-                                                              (for [[from to] [[:build-targets :build-targets]]]
+                                                              (for [[from to] [[:build-targets :source-build-targets]]]
                                                                 (g/connect go-node from self to))
                                                               (for [[from to] [[:url :base-url]]]
                                                                 (g/connect self from or-node to))
@@ -651,9 +659,11 @@
         [])
       (let [tx-data (project/make-resource-node graph project resource true
                                                 {go-node [[:_node-id :source-id]
+                                                          [:resource :source-resource]
                                                           [:node-outline :source-outline]
                                                           [:proto-msg :proto-msg]
-                                                          [:build-targets :build-targets]
+                                                          [:save-data :source-save-data]
+                                                          [:build-targets :source-build-targets]
                                                           [:scene :scene]
                                                           [:ddf-component-properties :ddf-component-properties]]
                                                  self [[:_node-id :nodes]]}

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -250,7 +250,7 @@
   (set-property [this basis property value]
     (assert (contains? (-> node-type deref :property util/key-set) property)
             (format "Attempting to use property %s from %s, but it does not exist"
-                    property (:name node-type)))
+                    property (:name @node-type)))
     (assoc this property value))
 
   (overridden-properties [this basis] {})


### PR DESCRIPTION
- The error was in producing build resources from embedded resources
- The build resource files would be suffixed by their hash, for embedded resources (MemoryResource) this would be the content
- The content was only set at load-time, and never changed as the node itself was being changed
- The fix is to re-generate build resources with the updated data to ensure they are separated for different data
- A better fix would be to think more about the actual problem and solve it deeper
