### PR TITLE
DEFEDIT-458 Right-clicking in Assets pane throws IllegalArgumentException when nothing is selected

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -106,12 +106,13 @@
                                  (= :file (resource/source-type x))))
 
 (handler/defhandler :open :asset-browser
-  (enabled? [selection] (every? is-resource-file selection))
+  (enabled? [selection] (and (seq selection) (every? is-resource-file selection)))
   (run [selection open-fn]
        (doseq [resource selection]
          (open-fn resource))))
 
 (handler/defhandler :open-as :asset-browser
+  (active? [selection] (some is-resource-file selection))
   (enabled? [selection] (= 1 (count selection)))
   (run [selection open-fn user-data]
     (let [resource (first selection)]
@@ -193,7 +194,7 @@
        (copy (-> selection roots fileify))))
 
 (handler/defhandler :cut :asset-browser
-  (enabled? [selection] (every? is-deletable-resource selection))
+  (enabled? [selection] (and (seq selection) (every? is-deletable-resource selection)))
   (run [selection on-delete-resource-fn]
        (let [tmp (doto (-> (Files/createTempDirectory "asset-cut" (into-array FileAttribute []))
                          (.toFile))
@@ -261,7 +262,7 @@
       (rename resource new-name))))
 
 (handler/defhandler :delete :asset-browser
-  (enabled? [selection] (every? is-deletable-resource selection))
+  (enabled? [selection] (and (seq selection) (every? is-deletable-resource selection)))
   (run [selection on-delete-resource-fn]
     (let [names (apply str (interpose ", " (map resource/resource-name selection)))]
       (and (dialogs/make-confirm-dialog (format "Are you sure you want to delete %s?" names))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -656,7 +656,7 @@
               check (:check item)]
           (when-let [handler-ctx (handler/active command command-contexts user-data)]
             (let [label (or (handler/label handler-ctx) item-label)]
-              (if-let [options (handler/options handler-ctx)]
+              (if-let [options (and (handler/enabled? handler-ctx) (handler/options handler-ctx))]
                 (make-submenu label icon (make-menu-items options command-contexts) on-open)
                 (make-menu-command label icon (:acc item) user-data command handler-ctx check)))))))))
 
@@ -769,7 +769,7 @@
                         (let [^Control child (if separator?
                                                (doto (Separator. Orientation/VERTICAL)
                                                  (add-style! "separator"))
-                                               (if-let [opts (handler/options handler-ctx)]
+                                               (if-let [opts (and (handler/enabled? handler-ctx) (handler/options handler-ctx))]
                                                  (let [hbox (doto (HBox.)
                                                               (add-style! "cell"))
                                                        cb (doto (ChoiceBox.)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -657,7 +657,7 @@
               check (:check item)]
           (when-let [handler-ctx (handler/active command command-contexts user-data)]
             (let [label (or (handler/label handler-ctx) item-label)]
-              (if-let [options (and (handler/enabled? handler-ctx) (handler/options handler-ctx))]
+              (if-let [options (handler/options handler-ctx)]
                 (make-submenu label icon (make-menu-items options command-contexts) on-open)
                 (make-menu-command label icon (:acc item) user-data command handler-ctx check)))))))))
 
@@ -770,7 +770,7 @@
                         (let [^Control child (if separator?
                                                (doto (Separator. Orientation/VERTICAL)
                                                  (add-style! "separator"))
-                                               (if-let [opts (and (handler/enabled? handler-ctx) (handler/options handler-ctx))]
+                                               (if-let [opts (handler/options handler-ctx)]
                                                  (let [hbox (doto (HBox.)
                                                               (add-style! "cell"))
                                                        cb (doto (ChoiceBox.)


### PR DESCRIPTION
- Do not invoke options callback for disabled handlers
