### PR TITLE
DEFEDIT-459 Fix commands being invoked multiple times

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -697,7 +697,11 @@
    (if-let [menubar (.lookup root menubar-id)]
      (let [desc (make-desc menubar menu-id)]
        (user-data! root ::menubar desc))
-     (log/warn :message (format "menubar %s not found" menubar-id)))))
+     (log/warn :message (format "menubar %s not found" menubar-id))))
+  (.addEventFilter scene KeyEvent/KEY_PRESSED
+    (event-handler event
+      (when (some (fn [^KeyCombination c] (.match c event)) @*menu-key-combos*)
+        (.consume event)))))
 
 (def ^:private invalidate-menus? (atom false))
 


### PR DESCRIPTION
- Re-add filtering of all KEY_PRESSED events with bound shortcuts

Fixes defold/editor2-issues#112, defold/editor2-issues#104
