### PR TITLE
DEFEDIT-456 Logic to stop timers on tab close do not trigger on cmd-w

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -152,20 +152,11 @@
     (ui/set-main-stage stage)
     (.setScene stage scene)
 
-    (when-let [dims (prefs/get-prefs prefs app-view/prefs-window-dimensions nil)]
-      (.setX stage (:x dims))
-      (.setY stage (:y dims))
-      (.setWidth stage (:width dims))
-      (.setHeight stage (:height dims)))
+    (app-view/restore-window-dimensions stage prefs)
 
     (ui/init-progress!)
     (ui/show! stage)
     (targets/start)
-
-    (ui/on-close-request! stage
-                          (fn [_]
-                            (g/transact
-                              (g/delete-node project))))
 
     (let [^MenuBar menu-bar    (.lookup root "#menu-bar")
           ^TabPane editor-tabs (.lookup root "#editor-tabs")
@@ -177,10 +168,6 @@
           next-console         (.lookup root "#next-console")
           clear-console        (.lookup root "#clear-console")
           search-console       (.lookup root "#search-console")
-          splits               [(.lookup root "#main-split")
-                                (.lookup root "#center-split")
-                                (.lookup root "#right-split")
-                                (.lookup root "#assets-split")]
           app-view             (app-view/make-app-view *view-graph* *project-graph* project stage menu-bar editor-tabs prefs)
           outline-view         (outline-view/make-outline-view *view-graph* outline (fn [nodes] (project/select! project nodes)) project)
           properties-view      (properties-view/make-properties-view workspace project *view-graph* (.lookup root "#properties"))
@@ -214,11 +201,16 @@
                                                       (.lookup root "#curve-editor-view")
                                                       {:tab (find-tab tool-tabs "curve-editor-tab")})]
 
-      (when-let [div-pos (prefs/get-prefs prefs app-view/prefs-split-positions nil)]
-        (doall (map (fn [^SplitPane sp pos]
-                      (when (and sp pos)
-                        (.setDividerPositions sp (into-array Double/TYPE pos))))
-                    splits div-pos)))
+      (app-view/restore-split-positions stage prefs)
+
+      (ui/on-closing! stage (fn [_]
+                              (or (not (workspace/version-on-disk-outdated? workspace))
+                                  (dialogs/make-confirm-dialog "Unsaved changes exists, are you sure you want to quit?"))))
+    
+      (ui/on-closed! stage (fn [_]
+                             (app-view/store-window-dimensions stage prefs)
+                             (app-view/store-split-positions stage prefs)
+                             (g/transact (g/delete-node project))))
 
       (console/setup-console! {:text   console
                                :search search-console
@@ -236,8 +228,7 @@
                          :web-server        web-server
                          :build-errors-view build-errors-view
                          :changes-view      changes-view
-                         :main-stage        stage
-                         :splits            splits}]
+                         :main-stage        stage}]
         (ui/context! (.getRoot (.getScene stage)) :global context-env (project/selection-provider project) {:active-resource [:app-view :active-resource]}))
       (g/transact
         (concat

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -664,8 +664,8 @@
                                                          (ui/run-later (cvx/refresh! source-viewer)))))
     (cvx/refresh! source-viewer)
     (ui/timer-start! repainter)
-    (ui/timer-stop-on-close! ^Tab (:tab opts) repainter)
-    (ui/timer-stop-on-close! (ui/parent->stage parent) repainter)
+    (ui/timer-stop-on-closed! ^Tab (:tab opts) repainter)
+    (ui/timer-stop-on-closed! (ui/parent->stage parent) repainter)
     view-id))
 
 (defn register-view-types [workspace]

--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -594,9 +594,9 @@
                                                     (update-image-view! image-view dt)
                                                     (g/node-value view-id :update-list-view))))]
                              (ui/user-data! view ::repainter repainter)
-                             (ui/on-close tab
-                                          (fn [e]
-                                            (ui/timer-stop! repainter)))
+                             (ui/on-closed! tab
+                                            (fn [e]
+                                              (ui/timer-stop! repainter)))
                              (ui/timer-start! repainter))
                            (let [drawable (scene/make-drawable w h)]
                              (g/transact

--- a/editor/src/clj/editor/form_view.clj
+++ b/editor/src/clj/editor/form_view.clj
@@ -691,8 +691,8 @@
       (concat
         (g/connect resource-node :form-data view-id :form-data)))
     (ui/timer-start! repainter)
-    (ui/timer-stop-on-close! ^Tab (:tab opts) repainter)
-    (ui/timer-stop-on-close! (ui/parent->stage parent) repainter)
+    (ui/timer-stop-on-closed! ^Tab (:tab opts) repainter)
+    (ui/timer-stop-on-closed! (ui/parent->stage parent) repainter)
     view-id))
 
 (defn- make-form-view [graph ^Parent parent resource-node opts]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -641,11 +641,11 @@
                                                 (fn [dt]
                                                   (when (.isSelected tab)
                                                     (update-image-view! image-view dt))))]
-                             (ui/on-close tab
-                                          (fn [e]
-                                            (ui/timer-stop! repainter)
-                                            (scene-view-dispose view-id)
-                                            (scene-cache/drop-context! nil true)))
+                             (ui/on-closed! tab
+                                            (fn [e]
+                                              (ui/timer-stop! repainter)
+                                              (scene-view-dispose view-id)
+                                              (scene-cache/drop-context! nil true)))
                              (ui/timer-start! repainter))
                            (let [drawable (make-drawable w h)]
                              (g/transact

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -207,6 +207,6 @@
                                                        (.setScrollTop ta Double/MAX_VALUE)
                                                        (.deselect ta)
                                                        (.setScrollLeft ta left)))))))
-    (ui/on-hiding! stage (fn [_]
+    (ui/on-closed! stage (fn [_]
                            (remove-watch event-log :dialog)))
     (ui/show! stage)))


### PR DESCRIPTION
- Timers were closed on "close request" event which only happens if
  you click the close button. Changed to onClosed event.
- Other cleanup calls were dependent on close request for main stage,
  these were changed to use onHidden, which is onClosed for stages.
- Prefs saving etc in :quit defhandler was moved to new close handler
  so it also happen when using the close button.
- :quit now only requests close.
