### PR TITLE
DEFEDIT-460 Support tilemaps with old tilegrid extension

### DIFF
--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -1033,7 +1033,7 @@
 
 (defn register-resource-types [workspace]
   (workspace/register-resource-type workspace
-                                    :ext "tilemap"
+                                    :ext ["tilemap" "tilegrid"]
                                     :build-ext "tilegridc"
                                     :node-type TileMapNode
                                     :load-fn load-tile-map


### PR DESCRIPTION
Fixes defold/editor2-issues#93
