### PR TITLE
DEFEDIT-466 Spine build breaks when attachment is missing corresponding animation

### DIFF
--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -275,12 +275,14 @@
                              0 weights)]
     (mapv (fn [w] (update w :weight #(/ % total-weight))) weights)))
 
+(def ^:private ^TextureSetGenerator$UVTransform uv-identity (TextureSetGenerator$UVTransform.))
+
 (defn- attachment->mesh [attachment att-name slot-data anim-data bones-remap bone-index->world]
   (when anim-data
     (let [type (get attachment "type" "region")
           world ^SpineScene$Transform (:bone-world slot-data)
           anim-id (get attachment "name" att-name)
-          uv-trans ^TextureSetGenerator$UVTransform (first (get-in anim-data [anim-id :uv-transforms]))
+          uv-trans (or ^TextureSetGenerator$UVTransform (first (get-in anim-data [anim-id :uv-transforms])) uv-identity)
           mesh (case type
                  "region"
                  (let [local (doto (SpineScene$Transform.)


### PR DESCRIPTION
Use identity transform when animation + transform missing.
