### PR TITLE
DEF-1998: Add "mesh" support to spine

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/RigScene.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/RigScene.java
@@ -843,8 +843,8 @@ public class RigScene {
                         mesh.slot = slot;
                         mesh.visible = attName.equals(slot.attachment);
 
-                        if ((spineVersion != null) && (spineVersion.compareTo("3.4.02") >= 0)) {
-                            // spineVersion >= 3.4.02
+                        if ((spineVersion != null) && (spineVersion.compareTo("3.3.07") >= 0)) {
+                            // spineVersion >= 3.3.07
                             if (type.equals("region")) {
                                 scene.loadRegion(attNode, mesh, bone);
                             } else if (type.equals("mesh")) {


### PR DESCRIPTION
Somewhere down the road when I was working on this issue I mistakenly started to use 3.4.02 as the earliest version where this error occurred even though it was initially reported to occur for versions as early as 3.3.07. I have no recollection or explanation for why this happened, but it should be 3.3.07 since people are still experiencing the problem.

A small discussion has continued here: https://forum.defold.com/t/problem-with-new-version-of-spine-json-format-changed-def-1998/2398

There is no documentation from Spine as to when the export format changed.
http://esotericsoftware.com/spine-changelog/archive
