### PR TITLE
Added class "text" to the text editor text nodes

### DIFF
--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextNode.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextNode.java
@@ -282,6 +282,7 @@ public class DefoldStyledTextNode extends Region {
 		this.originalText = text;
 
 		this.textNode = new Text(processText(text));
+		this.textNode.getStyleClass().add("text");
 		this.textNode.setBoundsType(TextBoundsType.LOGICAL_VERTICAL_CENTER);
 		this.textNode.fillProperty().bind(fillProperty());
 		getChildren().add(this.textNode);


### PR DESCRIPTION
This allows for styling of the code editor text nodes. Fixes font smoothing for code since modena.css sets lcd font smoothing on class "text" (text nodes).
