### PR TITLE
DEFEDIT-474 Support for custom resources in game.project

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -375,8 +375,6 @@
                                           basis            (g/now)
                                           cache            (g/cache)}
                                      :as opts}]
-  (reset! (g/node-value project :build-cache {:basis basis :cache cache}) {})
-  (reset! (g/node-value project :fs-build-cache {:basis basis :cache cache}) {})
   (let [files-on-disk  (file-seq (io/file (workspace/build-path
                                            (g/node-value project :workspace {:basis basis :cache cache}))))
         fs-build-cache (g/node-value project :fs-build-cache {:basis basis :cache cache})
@@ -542,6 +540,7 @@
   (input selected-node-ids g/Any :array)
   (input selected-node-properties g/Any :array)
   (input resources g/Any)
+  (input resource-map g/Any)
   (input resource-types g/Any)
   (input save-data g/Any :array :substitute (fn [save-data] (vec (remove g/error? save-data))))
   (input node-resources resource/Resource :array)
@@ -554,6 +553,7 @@
   (output sub-selection g/Any :cached (g/fnk [selected-node-ids sub-selection]
                                              (let [nids (set selected-node-ids)]
                                                (filterv (comp nids first) sub-selection))))
+  (output resource-map g/Any (gu/passthrough resource-map))
   (output nodes-by-resource-path g/Any :cached (g/fnk [node-resources nodes] (into {} (map (fn [n] [(resource/proj-path (g/node-value n :resource)) n]) nodes))))
   (output save-data g/Any :cached (g/fnk [save-data] (filter #(and % (:content %)) save-data)))
   (output settings g/Any :cached (gu/passthrough settings))
@@ -748,6 +748,7 @@
               (g/make-nodes graph
                             [project [Project :workspace workspace-id :build-cache (atom {}) :fs-build-cache (atom {})]]
                             (g/connect workspace-id :resource-list project :resources)
+                            (g/connect workspace-id :resource-map project :resource-map)
                             (g/connect workspace-id :resource-types project :resource-types)
                             (g/set-graph-value graph :project-id project)))))]
     (workspace/add-resource-listener! workspace-id (ProjectResourceListener. project-id))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -134,7 +134,7 @@
    :resource (workspace/make-build-resource (CustomResource. resource))
    :build-fn build-custom-resource
    ;; NOTE! Break build cache when resource content changes.
-   :user-data {:hash (murmur/hash-bytes (resource-content resource))}})
+   :user-data {:hash (murmur/hash64-bytes (resource-content resource))}})
 
 (defn- with-leading-slash [path]
   (if (string/starts-with? path "/")

--- a/editor/src/clj/util/murmur.clj
+++ b/editor/src/clj/util/murmur.clj
@@ -3,3 +3,6 @@
 
 (defn hash64 [v]
   (MurmurHash/hash64 v))
+
+(defn hash-bytes [bytes]
+  (MurmurHash/hash64 bytes (alength bytes)))

--- a/editor/src/clj/util/murmur.clj
+++ b/editor/src/clj/util/murmur.clj
@@ -4,5 +4,5 @@
 (defn hash64 [v]
   (MurmurHash/hash64 v))
 
-(defn hash-bytes [bytes]
+(defn hash64-bytes [bytes]
   (MurmurHash/hash64 bytes (alength bytes)))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -1,5 +1,6 @@
 (ns integration.build-test
   (:require [clojure.test :refer :all]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [support.test-support :refer [with-clean-system]]
             [editor.math :as math]
@@ -247,6 +248,35 @@
           (is (> (count build-results) 0))
           (is (not-any? :cached first-build-results)))))))
 
+(defn- build-path [workspace proj-path]
+  (str (workspace/build-path workspace) proj-path))
+
+(defn- abs-project-path [workspace proj-path]
+  (str (workspace/project-path workspace) proj-path))
+
+(defn mtime [path]
+  (.lastModified (File. path)))
+
+(deftest build-and-write-cached
+  (testing "Verify the build cache works when building to disk"
+    (with-clean-system
+      (let [workspace (test-util/setup-scratch-workspace! world project-path)
+            project (test-util/setup-project! workspace)
+            path "/game.project"
+            game-project (test-util/resource-node project "/game.project")
+            main-collection (test-util/resource-node project "/main/main.collection")]
+        (project/build-and-write project game-project {})
+        (let [first-mtime (mtime (build-path workspace "/main/main.collectionc"))]
+          (Thread/sleep 1000)
+          (project/build-and-write project game-project {})
+          (let [test-mtime (mtime (build-path workspace "/main/main.collectionc"))]
+            (is (= first-mtime test-mtime)))
+          (g/transact (g/set-property main-collection :name "my-test-name"))
+          (Thread/sleep 1000)
+          (project/build-and-write project game-project {})
+          (let [test-mtime (mtime (build-path workspace "/main/main.collectionc"))]
+            (is (not (= first-mtime test-mtime)))))))))
+
 (deftest prune-build-cache
   (testing "Verify the build cache works as expected"
     (with-clean-system
@@ -421,3 +451,80 @@
                                                                     :render-error!    #(reset! build-error %)})]
       (is (nil? build-results))
       (is (instance? internal.graph.error_values.ErrorValue @build-error)))))
+
+(defmacro with-setting [path value & body]
+  ;; assumes game-project in scope
+  (let [path-list (string/split path #"/")]
+    `(let [initial-settings# (g/node-value ~'game-project :raw-settings)]
+           (g/transact (g/update-property ~'game-project :raw-settings conj {:path ~path-list :value ~value}))
+           (try
+             ~@body
+             (finally
+               (g/set-property ~'game-project :raw-settings initial-settings#))))))
+
+(defn- check-file-contents [workspace specs]
+  (doseq [[path content] specs]
+    (let [file (File. (build-path workspace path))]
+      (is (true? (.exists file)))
+      (is (= (slurp file) content)))))
+
+(deftest build-with-custom-resources
+  (with-clean-system
+    (let [workspace (test-util/setup-scratch-workspace! world "test/resources/custom_resources_project")
+          project (test-util/setup-project! workspace)
+          game-project (test-util/resource-node project "/game.project")]
+      (with-setting "project/custom_resources" "root.stuff"
+        (project/build-and-write project game-project {})
+        (check-file-contents workspace [["root.stuff" "root.stuff"]])
+      (with-setting "project/custom_resources" "/root.stuff"
+        (project/build-and-write project game-project {})
+        (check-file-contents workspace [["root.stuff" "root.stuff"]])
+      (with-setting "project/custom_resources" "assets"
+        (project/build-and-write project game-project {})
+        (check-file-contents workspace
+                             [["/assets/some.stuff" "some.stuff"]
+                              ["/assets/some2.stuff" "some2.stuff"]]))
+      (with-setting "project/custom_resources" "/assets"
+        (project/build-and-write project game-project {})
+        (check-file-contents workspace
+                             [["/assets/some.stuff" "some.stuff"]
+                              ["/assets/some2.stuff" "some2.stuff"]]))
+      (with-setting "project/custom_resources" "/assets, root.stuff"
+        (project/build-and-write project game-project {})
+        (check-file-contents workspace
+                             [["/assets/some.stuff" "some.stuff"]
+                              ["/assets/some2.stuff" "some2.stuff"]
+                              ["/root.stuff" "root.stuff"]]))
+      (with-setting "project/custom_resources" "assets, root.stuff, /more_assets/"
+        (project/build-and-write project game-project {})
+        (check-file-contents workspace
+                             [["/assets/some.stuff" "some.stuff"]
+                              ["/assets/some2.stuff" "some2.stuff"]
+                              ["/root.stuff" "root.stuff"]
+                              ["/more_assets/some_more.stuff" "some_more.stuff"]
+                              ["/more_assets/some_more2.stuff" "some_more2.stuff"]]))
+      (with-setting "project/custom_resources" "nonexistent_path"
+        (project/build-and-write project game-project {})
+        (doseq [path ["/assets/some.stuff" "/assets/some2.stuff"
+                      "/root.stuff"
+                      "/more_assets/some_more.stuff" "/more_assets/some_more2.stuff"]]
+          (is (false? (.exists (File. (build-path workspace path))))))))))))
+
+(deftest custom-resources-cached
+  (testing "Check custom resources are only rebuilt when source has changed"
+    (with-clean-system
+      (let [workspace (test-util/setup-scratch-workspace! world "test/resources/custom_resources_project")
+            project (test-util/setup-project! workspace)
+            game-project (test-util/resource-node project "/game.project")]
+        (with-setting "project/custom_resources" "assets"
+          (project/build-and-write project game-project {})
+          (let [initial-some-mtime (mtime (build-path workspace "/assets/some.stuff"))
+                initial-some2-mtime (mtime (build-path workspace "/assets/some2.stuff"))]
+            (Thread/sleep 1000)
+            (spit (File. (abs-project-path workspace "/assets/some.stuff")) "new stuff")
+            (workspace/resource-sync! workspace)
+            (project/build-and-write project game-project {})
+            (is (not (= initial-some-mtime (mtime (build-path workspace "/assets/some.stuff")))))
+            (is (= initial-some2-mtime (mtime (build-path workspace "/assets/some2.stuff"))))))))))
+
+                               

--- a/editor/test/resources/custom_resources_project/assets/some.stuff
+++ b/editor/test/resources/custom_resources_project/assets/some.stuff
@@ -1,0 +1,1 @@
+some.stuff

--- a/editor/test/resources/custom_resources_project/assets/some2.stuff
+++ b/editor/test/resources/custom_resources_project/assets/some2.stuff
@@ -1,0 +1,1 @@
+some2.stuff

--- a/editor/test/resources/custom_resources_project/game.project
+++ b/editor/test/resources/custom_resources_project/game.project
@@ -1,0 +1,10 @@
+[project]
+title = Custom resources project
+custom_resources =
+
+[bootstrap]
+main_collection = main.collectionc
+
+[input]
+game_binding = game.input_bindingc
+

--- a/editor/test/resources/custom_resources_project/main.collection
+++ b/editor/test/resources/custom_resources_project/main.collection
@@ -1,0 +1,1 @@
+name: "Main collection"

--- a/editor/test/resources/custom_resources_project/more_assets/some_more.stuff
+++ b/editor/test/resources/custom_resources_project/more_assets/some_more.stuff
@@ -1,0 +1,1 @@
+some_more.stuff

--- a/editor/test/resources/custom_resources_project/more_assets/some_more2.stuff
+++ b/editor/test/resources/custom_resources_project/more_assets/some_more2.stuff
@@ -1,0 +1,1 @@
+some_more2.stuff

--- a/editor/test/resources/custom_resources_project/root.stuff
+++ b/editor/test/resources/custom_resources_project/root.stuff
@@ -1,0 +1,1 @@
+root.stuff


### PR DESCRIPTION
Naive solution that does not use ResourceNode's to track changes, but
instead relies on resource list to be updated on sync.
Content hash used as build cache key.
