### PR TITLE
DEFEDIT-482 Update jogl/gluegen to 2.3.2

### DIFF
--- a/editor/dev/clj/jfx.clj
+++ b/editor/dev/clj/jfx.clj
@@ -3,5 +3,5 @@
 ;; These two lines initialize JavaFX and OpenGL when running from a pure REPL
 ;; It also messes up the menus
 
-(.toString (javax.media.opengl.GLProfile/getDefault))
+(.toString (com.jogamp.opengl.GLProfile/getDefault))
 (javafx.embed.swing.JFXPanel.)

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -39,8 +39,8 @@
                      [net.java.dev.jna/jna-platform               "4.1.0"]
 
                      ;; Keep jogl version in sync with bundle.py. See JOGL_VERSION
-                     [org.jogamp.gluegen/gluegen-rt-main          "2.0.2"]
-                     [org.jogamp.jogl/jogl-all-main               "2.0.2"]]
+                     [org.jogamp.gluegen/gluegen-rt-main          "2.3.2"]
+                     [org.jogamp.jogl/jogl-all-main               "2.3.2"]]
 
   :source-paths      ["src/clj"
                       "../com.dynamo.cr/com.dynamo.cr.sceneed2/src/clj"]

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -8,6 +8,7 @@ import tempfile
 import urllib
 import optparse
 import urlparse
+import re
 import shutil
 import subprocess
 import tarfile
@@ -15,7 +16,7 @@ import zipfile
 import ConfigParser
 
 # Keep this version in sync with project.clj
-JOGL_VERSION = "2.0.2"
+JOGL_VERSION = "2.3.2"
 JNA_VERSION = "4.1.0"
 
 platform_to_java = {'x86_64-linux': 'linux-x64',
@@ -111,9 +112,9 @@ def ziptree(path, outfile, directory = None):
 def add_native_libs(platform, in_jar_name, out_jar):
     with zipfile.ZipFile(in_jar_name, 'r') as in_jar:
         for zi in in_jar.infolist():
-            if not 'META-INF' in zi.filename:
+            if not re.search(r"META-INF|TAG\.class", zi.filename):
                 d = in_jar.read(zi)
-                n = 'lib/%s/%s' % (platform, zi.filename)
+                n = 'lib/%s/%s' % (platform, os.path.basename(zi.filename))
                 print "adding", n
                 out_jar.writestr(n, d)
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -19,7 +19,6 @@
             [util.http-server :as http-server])
   (:import [com.defold.editor EditorApplication]
            [com.defold.editor Start]
-           [com.jogamp.opengl.util.awt Screenshot]
            [java.awt Desktop]
            [javafx.application Platform]
            [javafx.beans.value ChangeListener]
@@ -40,7 +39,7 @@
            [java.net URI]
            [java.nio.file Paths]
            [java.util.prefs Preferences]
-           [javax.media.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]))
+           [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -10,7 +10,6 @@
             [editor.dialogs :as dialogs])
   (:import [com.defold.editor Start]
            [editor.resource FileResource]
-           [com.jogamp.opengl.util.awt Screenshot]
            [java.awt Desktop]
            [javafx.application Platform]
            [javafx.collections FXCollections ObservableList]
@@ -31,7 +30,7 @@
            [java.io File]
            [java.nio.file Path Paths Files attribute.FileAttribute]
            [java.util.prefs Preferences]
-           [javax.media.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]
            [org.apache.commons.io FileUtils FilenameUtils IOUtils]
            [com.defold.control TreeCell]))
 

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -33,8 +33,8 @@
            [com.google.protobuf ByteString]
            [editor.types Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point3d Matrix4d]
            [java.nio ByteBuffer ByteOrder FloatBuffer]))
 

--- a/editor/src/clj/editor/background.clj
+++ b/editor/src/clj/editor/background.clj
@@ -4,7 +4,7 @@
             [editor.gl :as gl]
             [editor.colors :as colors]
             [editor.gl.pass :as p])
-  (:import [javax.media.opengl GL2]))
+  (:import [com.jogamp.opengl GL2]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -31,8 +31,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d Vector4d]
            [org.apache.commons.io FilenameUtils]))
 

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -29,7 +29,7 @@
     Physics$CollisionShape
     Physics$CollisionShape$Shape
     Physics$CollisionShape$Type]
-   [javax.media.opengl GL GL2]
+   [com.jogamp.opengl GL GL2]
    [javax.vecmath Point3d Matrix4d Quat4d Vector3d]
    [editor.types AABB]))
 

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -15,8 +15,8 @@
            [com.jogamp.opengl.util.awt TextRenderer]
            [editor.types Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point3d Matrix4d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/curve_grid.clj
+++ b/editor/src/clj/editor/curve_grid.clj
@@ -8,7 +8,7 @@
             [editor.validation :as validation]
             [editor.gl.pass :as pass])
   (:import [editor.types AABB Camera]
-           [javax.media.opengl GL GL2]
+           [com.jogamp.opengl GL GL2]
            [javax.vecmath Vector3d Vector4d Matrix3d Matrix4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -54,8 +54,8 @@
            [javafx.util Callback StringConverter]
            [java.lang Runnable Math]
            [java.nio IntBuffer ByteBuffer ByteOrder]
-           [javax.media.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point2i Point3d Quat4d Matrix4d Vector4d Matrix3d Vector3d]
            [sun.awt.image IntegerComponentRaster]
            [java.util.concurrent Executors]
@@ -579,7 +579,7 @@
                        (if-let [view-id (ui/user-data image-view ::view-id)]
                          (let [drawable ^GLOffscreenAutoDrawable (g/node-value view-id :drawable)]
                            (doto drawable
-                             (.setSize w h))
+                             (.setSurfaceSize w h))
                            (let [context (scene/make-current drawable)]
                              (doto ^AsyncCopier (g/node-value view-id :async-copier)
                                (.setSize ^GL2 (.getGL context) w h))

--- a/editor/src/clj/editor/display_profiles.clj
+++ b/editor/src/clj/editor/display_profiles.clj
@@ -30,8 +30,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Quat4d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -27,8 +27,8 @@
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
            [java.nio ByteBuffer]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Vector3d]
            [com.jogamp.opengl.util.texture Texture TextureData]
            [com.google.protobuf ByteString]))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -28,8 +28,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d]
            [org.apache.commons.io FilenameUtils]))
 

--- a/editor/src/clj/editor/gl.clj
+++ b/editor/src/clj/editor/gl.clj
@@ -5,10 +5,10 @@
   (:import [java.awt Font]
            [java.util WeakHashMap]
            [java.nio IntBuffer]
-           [javax.media.opengl GL GL2 GLDrawableFactory GLProfile]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLDrawableFactory GLProfile]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d]
-           [javax.media.opengl.awt GLCanvas]
+           [com.jogamp.opengl.awt GLCanvas]
            [com.jogamp.opengl.util.awt TextRenderer]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/gl/pass.clj
+++ b/editor/src/clj/editor/gl/pass.clj
@@ -2,8 +2,8 @@
   (:require [dynamo.graph :as g]
             [schema.core :as s]
             [editor.types :as types])
-  (:import [javax.media.opengl GL GL2]
-           [javax.media.opengl.glu GLU]))
+  (:import [com.jogamp.opengl GL GL2]
+           [com.jogamp.opengl.glu GLU]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -95,7 +95,7 @@ There are some examples in the testcases in dynamo.shader.translate-test."
           [editor.defold-project :as project]
           [editor.scene-cache :as scene-cache])
 (:import [java.nio IntBuffer ByteBuffer]
-         [javax.media.opengl GL GL2 GLContext]
+         [com.jogamp.opengl GL GL2 GLContext]
          [javax.vecmath Matrix4d Vector4f Vector4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -7,7 +7,7 @@
             [dynamo.graph :as g])
   (:import [java.awt.image BufferedImage DataBuffer DataBufferByte]
            [java.nio IntBuffer ByteBuffer]
-           [javax.media.opengl GL GL2 GL3 GLContext GLProfile]
+           [com.jogamp.opengl GL GL2 GL3 GLContext GLProfile]
            [com.jogamp.common.nio Buffers]
            [com.jogamp.opengl.util.texture Texture TextureIO TextureData]
            [com.jogamp.opengl.util.texture.awt AWTTextureIO]))

--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -33,7 +33,7 @@ the `do-gl` macro from `editor.gl`."
            [com.jogamp.common.nio Buffers]
            [java.nio ByteBuffer]
            [java.util.concurrent.atomic AtomicLong AtomicBoolean]
-           [javax.media.opengl GL GL2]))
+           [com.jogamp.opengl GL GL2]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/gl/vertex2.clj
+++ b/editor/src/clj/editor/gl/vertex2.clj
@@ -12,7 +12,7 @@
    [com.google.protobuf ByteString]
    [com.jogamp.common.nio Buffers]
    [java.nio ByteBuffer ByteOrder]
-   [javax.media.opengl GL GL2]))
+   [com.jogamp.opengl GL GL2]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -8,7 +8,7 @@
             [editor.validation :as validation]
             [editor.gl.pass :as pass])
   (:import [editor.types AABB Camera]
-           [javax.media.opengl GL GL2]
+           [com.jogamp.opengl GL GL2]
            [javax.vecmath Vector3d Vector4d Matrix3d Matrix4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -31,7 +31,7 @@
   (:import [com.dynamo.gui.proto Gui$SceneDesc Gui$SceneDesc$AdjustReference Gui$NodeDesc Gui$NodeDesc$Type Gui$NodeDesc$XAnchor Gui$NodeDesc$YAnchor
             Gui$NodeDesc$Pivot Gui$NodeDesc$AdjustMode Gui$NodeDesc$BlendMode Gui$NodeDesc$ClippingMode Gui$NodeDesc$PieBounds Gui$NodeDesc$SizeMode]
            [editor.types AABB]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d]
            [java.awt.image BufferedImage]
            [com.defold.editor.pipeline TextureSetGenerator$UVTransform]

--- a/editor/src/clj/editor/gui_clipping.clj
+++ b/editor/src/clj/editor/gui_clipping.clj
@@ -1,6 +1,6 @@
 (ns editor.gui-clipping
   (:require [dynamo.graph :as g])
-  (:import [javax.media.opengl GL GL2]
+  (:import [com.jogamp.opengl GL GL2]
            [clojure.lang ExceptionInfo]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/input.clj
+++ b/editor/src/clj/editor/input.clj
@@ -2,7 +2,7 @@
   (:require [dynamo.graph :as g]
             [schema.core :as s])
   (:import [com.defold.editor Start UIUtil]
-           [com.jogamp.opengl.util.awt TextRenderer Screenshot]
+           [com.jogamp.opengl.util.awt TextRenderer]
            [editor.types Camera AABB Region]
            [java.awt Font]
            [java.awt.image BufferedImage]

--- a/editor/src/clj/editor/json.clj
+++ b/editor/src/clj/editor/json.clj
@@ -15,8 +15,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -19,8 +19,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Vector4d Matrix4d Point3d Quat4d]
            [editor.gl.shader ShaderLifecycle]))
 

--- a/editor/src/clj/editor/menu.clj
+++ b/editor/src/clj/editor/menu.clj
@@ -2,7 +2,7 @@
   (:require [editor.jfx :as jfx]
             [editor.ui :as ui])
   (:import [com.defold.editor Start]
-           [com.jogamp.opengl.util.awt Screenshot]
+           
            [java.awt Desktop]
            [javafx.application Platform]
            [javafx.collections FXCollections ObservableList]
@@ -21,7 +21,7 @@
            [java.io File]
            [java.nio.file Paths]
            [java.util.prefs Preferences]
-           [javax.media.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]))
+           [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/mesh.clj
+++ b/editor/src/clj/editor/mesh.clj
@@ -22,8 +22,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -20,8 +20,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Quat4d]
            [editor.gl.shader ShaderLifecycle]))
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -29,7 +29,7 @@
            [com.dynamo.particle.proto Particle$ParticleFX Particle$Emitter Particle$PlayMode Particle$EmitterType
             Particle$EmitterKey Particle$ParticleKey Particle$ModifierKey
             Particle$EmissionSpace Particle$BlendMode Particle$ParticleOrientation Particle$ModifierType]
-           [javax.media.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [com.defold.libs ParticleLibrary]
            [com.sun.jna Pointer]

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -16,7 +16,7 @@
   (:import [com.defold.editor Start]
            [com.dynamo.proto DdfExtensions]
            [com.google.protobuf ProtocolMessageEnum]
-           [com.jogamp.opengl.util.awt Screenshot]
+           
            [javafx.application Platform]
            [javafx.beans.value ChangeListener]
            [javafx.collections FXCollections ObservableList]
@@ -35,7 +35,7 @@
            [java.io File]
            [java.nio.file Paths]
            [java.util.prefs Preferences]
-           [javax.media.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]
            [com.google.protobuf ProtocolMessageEnum]
            [editor.properties CurveSpread Curve]))
 

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -23,8 +23,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Quat4d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/rulers.clj
+++ b/editor/src/clj/editor/rulers.clj
@@ -12,7 +12,7 @@
             [editor.scene-cache :as scene-cache]
             [editor.scene-text :as scene-text]
             [editor.types :as types])
-  (:import  [javax.media.opengl GL GL2]
+  (:import  [com.jogamp.opengl GL GL2]
             [javax.vecmath Matrix4d Point3d]
             [editor.types Camera]))
 

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -47,8 +47,8 @@
            [javafx.scene.layout AnchorPane Pane StackPane]
            [java.lang Runnable Math]
            [java.nio IntBuffer ByteBuffer ByteOrder]
-           [javax.media.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point2i Point3d Quat4d Matrix4d Vector4d Matrix3d Vector3d]
            [sun.awt.image IntegerComponentRaster]
            [java.util.concurrent Executors]
@@ -161,8 +161,10 @@
                   (.setOnscreen false)
                   (.setPBuffer true)
                   (.setDoubleBuffered false)
-                  (.setStencilBits 8))]
-    ^GLOffscreenAutoDrawable (.createOffscreenAutoDrawable factory nil caps nil w h nil)))
+                  (.setStencilBits 8))
+        drawable (.createOffscreenAutoDrawable factory nil caps nil w h)]
+    (doto drawable
+      (.setContext (.createContext drawable nil) true))))
 
 (defn make-copier [^ImageView image-view ^GLAutoDrawable drawable ^Region viewport]
   (let [context ^GLContext (make-current drawable)
@@ -628,7 +630,7 @@
                        (if-let [view-id (ui/user-data image-view ::view-id)]
                          (let [drawable ^GLOffscreenAutoDrawable (g/node-value view-id :drawable)]
                            (doto drawable
-                             (.setSize w h))
+                             (.setSurfaceSize w h))
                            (let [context (make-current drawable)]
                              (doto ^AsyncCopier (g/node-value view-id :async-copier)
                                (.setSize ^GL2 (.getGL context) w h))

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -36,8 +36,8 @@
            [javafx.scene.layout AnchorPane Pane]
            [java.lang Runnable Math]
            [java.nio IntBuffer ByteBuffer ByteOrder]
-           [javax.media.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GL2GL3 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point2i Point3d Quat4d Matrix4d Vector4d Matrix3d Vector3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/scene_text.clj
+++ b/editor/src/clj/editor/scene_text.clj
@@ -4,7 +4,7 @@
   (:import [com.jogamp.opengl.util.awt TextRenderer]
            [java.awt Font]
            [java.awt.geom Rectangle2D]
-           [javax.media.opengl GL2]))
+           [com.jogamp.opengl GL2]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -10,7 +10,7 @@
             [editor.gl.pass :as pass]
             [editor.types :as types])
   (:import [com.defold.editor Start UIUtil]
-           [com.jogamp.opengl.util.awt TextRenderer Screenshot]
+           [com.jogamp.opengl.util.awt TextRenderer]
            [editor.types Camera AABB Region Rect]
            [java.awt Font]
            [java.awt.image BufferedImage]
@@ -27,8 +27,8 @@
            [javafx.scene.layout AnchorPane Pane]
            [java.lang Runnable Math]
            [java.nio IntBuffer ByteBuffer ByteOrder]
-           [javax.media.opengl GL GL2 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLProfile GLAutoDrawable GLOffscreenAutoDrawable GLDrawableFactory GLCapabilities]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point2i Point3d Quat4d Matrix4d Vector4d Matrix3d Vector3d AxisAngle4d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -23,8 +23,8 @@
            [com.google.protobuf ByteString]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -30,8 +30,8 @@
            [com.defold.editor.pipeline BezierUtil SpineScene$Transform TextureSetGenerator$UVTransform]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point2d Point3d Quat4d Vector2d Vector3d Vector4d Tuple3d Tuple4d]
            [editor.gl.shader ShaderLifecycle]))
 

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -19,8 +19,8 @@
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
-           [javax.media.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.media.opengl.glu GLU]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d]))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -33,7 +33,7 @@
   (:import
    (com.dynamo.tile.proto Tile$TileGrid Tile$TileGrid$BlendMode Tile$TileLayer)
    (editor.gl.shader ShaderLifecycle)
-   (javax.media.opengl GL GL2)
+   (com.jogamp.opengl GL GL2)
    (javax.vecmath Point3d Matrix4d Quat4d Vector3d Vector4d)))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/tile_map_grid.clj
+++ b/editor/src/clj/editor/tile_map_grid.clj
@@ -10,7 +10,7 @@
    [editor.types :as types])
   (:import
    (editor.types AABB Camera)
-   (javax.media.opengl GL GL2)
+   (com.jogamp.opengl GL GL2)
    (javax.vecmath Vector3d Vector4d Matrix3d Matrix4d Point3d)))
 
 (set! *warn-on-reflection* true)

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -31,7 +31,7 @@
    [com.google.protobuf ByteString]
    [editor.types AABB]
    [javax.vecmath Point3d Matrix4d]
-   [javax.media.opengl GL GL2]
+   [com.jogamp.opengl GL GL2]
    [java.awt.image BufferedImage]
    [java.nio ByteBuffer ByteOrder FloatBuffer]))
 

--- a/editor/src/java/com/defold/editor/AsyncCopier.java
+++ b/editor/src/java/com/defold/editor/AsyncCopier.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.media.opengl.GL2;
+import com.jogamp.opengl.GL2;
 
 import com.defold.util.Profiler;
 import com.defold.util.Profiler.Sample;

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -193,7 +193,7 @@ public class Start extends Application {
                 Thread.sleep(200);
                 NativeArtifacts.extractNatives();
                 ClassLoader parent = ClassLoader.getSystemClassLoader();
-                Class<?> glprofile = parent.loadClass("javax.media.opengl.GLProfile");
+                Class<?> glprofile = parent.loadClass("com.jogamp.opengl.GLProfile");
                 Method init = glprofile.getMethod("initSingleton");
                 init.invoke(null);
             } catch (Exception e) {


### PR DESCRIPTION
- `javax.media.opengl` is now `com.jogamp.opengl`
- `GLOffscreenAutoDrawable.setSize` is now `GLOffscreenAutoDrawable.setSurfaceSize`
- `GLDrawableFactory.createOffscreenAutoDrawable` has changed initialization semantics for its `GLContext`:
  - 2.0.2: "The GLOffscreenAutoDrawable's GLDrawable is realized and it's GLContext assigned but not yet made current." [javadoc](https://jogamp.org/deployment/v2.0.2/javadoc/jogl/javadoc/javax/media/opengl/GLDrawableFactory.html#createOffscreenAutoDrawable%28javax.media.nativewindow.AbstractGraphicsDevice, javax.media.opengl.GLCapabilitiesImmutable, javax.media.opengl.GLCapabilitiesChooser, int, int, javax.media.opengl.GLContext%29)
  - 2.3.2: "The GLOffscreenAutoDrawable's GLDrawable is realized without an assigned GLContext, hence not initialized completely.
    The GLContext can be assigned later manually via setContext(ctx) or it will be created lazily at the 1st display() method call." [javadoc](https://jogamp.org/deployment/v2.3.2/javadoc/jogl/javadoc/com/jogamp/opengl/GLDrawableFactory.html#createOffscreenAutoDrawable%28com.jogamp.nativewindow.AbstractGraphicsDevice, com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser, int, int%29)
  - Changed to set `GLContext` manually after creating drawable, see `editor.scene`
- update `bundle.py` to use correct locations jogl/gluegen natives
