### PR TITLE
DEF-1928 Investigate SSDP issue on Android 6.0

### DIFF
--- a/engine/dlib/src/dlib/linux/socket_linux.cpp
+++ b/engine/dlib/src/dlib/linux/socket_linux.cpp
@@ -65,20 +65,15 @@ namespace dmSocket
                 memcpy(IPv6(&a->m_Address), &ia->sin6_addr, sizeof(struct in6_addr));
             }
 
-            unsigned char physical_adr[6] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-
-            if(ioctl(s, SIOCGIFHWADDR, r) >= 0) // success
+            if(ioctl(s, SIOCGIFHWADDR, r) >= 0)
             {
-                memcpy(&physical_adr, &r->ifr_hwaddr.sa_data[0], sizeof(unsigned char) * 6);
+                memcpy(a->m_MacAddress, &r->ifr_hwaddr.sa_data[0], sizeof(unsigned char) * 6);
                 a->m_Flags |= FLAGS_LINK;
             }
-
-            a->m_MacAddress[0] = physical_adr[0];
-            a->m_MacAddress[1] = physical_adr[1];
-            a->m_MacAddress[2] = physical_adr[2];
-            a->m_MacAddress[3] = physical_adr[3];
-            a->m_MacAddress[4] = physical_adr[4];
-            a->m_MacAddress[5] = physical_adr[5];
+            else
+            {
+                memset(a->m_MacAddress, 0x00, sizeof(unsigned char) * 6);
+            }
 
             if(ioctl(s, SIOCGIFFLAGS, r) < 0)
                 continue;

--- a/engine/dlib/src/dlib/linux/socket_linux.cpp
+++ b/engine/dlib/src/dlib/linux/socket_linux.cpp
@@ -70,8 +70,7 @@ namespace dmSocket
             if(ioctl(s, SIOCGIFHWADDR, r) < 0)
             {
 #ifdef ANDROID
-                // Android 6 and higher does not support getting HW adr programmatically. 
-                // Return const value of 02:00:00:00:00:00 instead (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
+                // Android 6 and higher does not support getting HW adr programmatically. Return const value of 02:00:00:00:00:00 instead (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
                 physical_adr[0] = 0x02;
 #else
                 continue;

--- a/engine/dlib/src/dlib/linux/socket_linux.cpp
+++ b/engine/dlib/src/dlib/linux/socket_linux.cpp
@@ -66,22 +66,13 @@ namespace dmSocket
             }
 
             unsigned char physical_adr[6] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-            
-            if(ioctl(s, SIOCGIFHWADDR, r) < 0)
-            {
-#ifdef ANDROID
-                // Android 6 and higher does not support getting HW adr programmatically. Return const value of 02:00:00:00:00:00 instead (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
-                physical_adr[0] = 0x02;
-#else
-                continue;
-#endif
-            }
-            else
+
+            if(ioctl(s, SIOCGIFHWADDR, r) >= 0) // success
             {
                 memcpy(&physical_adr, &r->ifr_hwaddr.sa_data[0], sizeof(unsigned char) * 6);
+                a->m_Flags |= FLAGS_LINK;
             }
 
-            a->m_Flags |= FLAGS_LINK;
             a->m_MacAddress[0] = physical_adr[0];
             a->m_MacAddress[1] = physical_adr[1];
             a->m_MacAddress[2] = physical_adr[2];

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -425,6 +425,27 @@ namespace dmScript
         return 1;
     }
 
+    // Android version 6 Marshmallow (API level 23) and up does not support getting hw adr programmatically (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
+    bool IsAndroidMarshmallowOrAbove()
+    {
+        const long android_marshmallow_api_level = 23;
+        bool is_android = false;
+        bool marshmallow_or_higher = false;
+        long api_level_android = 0;
+
+        dmSys::SystemInfo info;
+        dmSys::GetSystemInfo(&info);
+
+        is_android = strcmp("Android", info.m_SystemName) == 0;
+        if (is_android)
+        {
+            api_level_android = strtol(info.m_ApiVersion, 0, 10);
+            marshmallow_or_higher = (api_level_android >= android_marshmallow_api_level);
+        }
+
+        return is_android && marshmallow_or_higher;
+    }
+
     /*# enumerate network cards
      * returns an array of tables with the following members:
      * name, address (ip-string), mac (hardware address, colon separated string), up (bool), running (bool). NOTE: ip and mac might be nil if not available
@@ -434,24 +455,9 @@ namespace dmScript
      */
     int Sys_GetIfaddrs(lua_State* L)
     {
-        const long android_marshmallow_api_level = 23;
         int top = lua_gettop(L);
         const uint32_t max_count = 16;
         dmSocket::IfAddr addresses[max_count];
-        bool is_android = false;
-        bool hw_adr_support_android = false;
-        long api_level_android = 0;
-
-        dmSys::SystemInfo info;
-        dmSys::GetSystemInfo(&info);
-
-        // Android version 6 (API 23) and up does not support getting hw adr programmatically (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
-        is_android = strcmp("Android", info.m_SystemName) == 0;
-        if (is_android)
-        {
-            api_level_android = strtol(info.m_ApiVersion, 0, 10);
-            hw_adr_support_android = (api_level_android < android_marshmallow_api_level); // if Api version is lower than 23 there is hw adr support
-        }
 
         uint32_t count = 0;
         dmSocket::GetIfAddresses(addresses, max_count, &count);
@@ -493,17 +499,9 @@ namespace dmScript
                         ifa->m_MacAddress[5]);
                 lua_pushstring(L, tmp);
             } 
-            else if (is_android && !hw_adr_support_android)
+            else if (IsAndroidMarshmallowOrAbove()) // Marshmallow and above should return const value MAC address (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
             {
-                char tmp[64];
-                DM_SNPRINTF(tmp, sizeof(tmp), "%02x:%02x:%02x:%02x:%02x:%02x",
-                        0x02,
-                        0x00,
-                        0x00,
-                        0x00,
-                        0x00,
-                        0x00);
-                lua_pushstring(L, tmp);
+                lua_pushstring(L, "02:00:00:00:00:00");
             }
             else 
             {

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -440,7 +440,7 @@ namespace dmScript
         dmSocket::IfAddr addresses[max_count];
         bool is_android = false;
         bool hw_adr_support_android = false;
-        long android_api_level = 0;
+        long api_level_android = 0;
 
         dmSys::SystemInfo info;
         dmSys::GetSystemInfo(&info);
@@ -449,8 +449,8 @@ namespace dmScript
         is_android = strcmp("Android", info.m_SystemName) == 0;
         if (is_android)
         {
-            android_api_level = strtol(info.m_ApiVersion, 0, 10);
-            hw_adr_support_android = (android_api_level < android_marshmallow_api_level); // if Api version is lower than 23 there is hw adr support
+            api_level_android = strtol(info.m_ApiVersion, 0, 10);
+            hw_adr_support_android = (api_level_android < android_marshmallow_api_level); // if Api version is lower than 23 there is hw adr support
         }
 
         uint32_t count = 0;


### PR DESCRIPTION
Android 6 and up does no longer support getting physical (MAC) address programmatically. Instead we return constant value according to https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id
