### PR TITLE
Removed duplicate dmModelDDF::Set/ResetConstantModel.

### DIFF
--- a/engine/gamesys/proto/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys_ddf.proto
@@ -115,3 +115,9 @@ message SetConstant
     required uint64         name_hash   = 1;
     required dmMath.Vector4 value       = 2 [(field_align)=true];
 }
+
+/* Function wrapper documented in gamesys_script.cpp */
+message ResetConstant
+{
+    required uint64         name_hash   = 1;
+}

--- a/engine/gamesys/proto/model_ddf.proto
+++ b/engine/gamesys/proto/model_ddf.proto
@@ -51,17 +51,6 @@ message ModelCancelAnimation
 {
 }
 
-message SetConstantModel
-{
-    required uint64         name_hash   = 1;
-    required dmMath.Vector4 value       = 2;
-}
-
-message ResetConstantModel
-{
-    required uint64         name_hash   = 1;
-}
-
 message ModelAnimationDone
 {
     required uint64 animation_id = 1;

--- a/engine/gamesys/proto/sprite_ddf.proto
+++ b/engine/gamesys/proto/sprite_ddf.proto
@@ -60,10 +60,10 @@ message PlayAnimation
 }
 
 /*# reports that an animation has completed
- * <p>This message is sent to the sender of a <code>play_animation</code> message when the 
+ * <p>This message is sent to the sender of a <code>play_animation</code> message when the
  * animation has completed.</p>
  *
- * <p>Note that this message is sent only for animations that play with the following 
+ * <p>Note that this message is sent only for animations that play with the following
  * playback modes:</p>
  * <ul>
  * <li>Once Forward</li>
@@ -71,7 +71,7 @@ message PlayAnimation
  * <li>Once Ping Pong</li>
  * </ul>
  *
- * <p>See <code>play_animation</code> for more information and examples of how to use 
+ * <p>See <code>play_animation</code> for more information and examples of how to use
  * this message.</p>
  *
  * @message
@@ -95,12 +95,6 @@ message SetFlipHorizontal
 message SetFlipVertical
 {
     required uint32 flip = 1;
-}
-
-/* Function wrapper documented in gamesys_script.cpp */
-message ResetConstant
-{
-    required uint64         name_hash   = 1;
 }
 
 /* Function wrapper documented in gamesys_script.cpp */

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -20,6 +20,7 @@
 #include "../gamesys.h"
 #include "../gamesys_private.h"
 
+#include "gamesys_ddf.h"
 #include "model_ddf.h"
 #include "sprite_ddf.h"
 #include "tile_ddf.h"
@@ -685,9 +686,9 @@ namespace dmGameSystem
             {
                 dmRig::CancelAnimation(component->m_RigInstance);
             }
-            else if (params.m_Message->m_Id == dmModelDDF::SetConstantModel::m_DDFDescriptor->m_NameHash)
+            else if (params.m_Message->m_Id == dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash)
             {
-                dmModelDDF::SetConstantModel* ddf = (dmModelDDF::SetConstantModel*)params.m_Message->m_Data;
+                dmGameSystemDDF::SetConstant* ddf = (dmGameSystemDDF::SetConstant*)params.m_Message->m_Data;
                 dmGameObject::PropertyResult result = dmGameSystem::SetMaterialConstant(component->m_Resource->m_Material, ddf->m_NameHash,
                         dmGameObject::PropertyVar(ddf->m_Value), CompModelSetConstantCallback, component);
                 if (result == dmGameObject::PROPERTY_RESULT_NOT_FOUND)
@@ -700,9 +701,9 @@ namespace dmGameSystem
                             (const char*)dmHashReverse64(ddf->m_NameHash, 0x0));
                 }
             }
-            else if (params.m_Message->m_Id == dmModelDDF::ResetConstantModel::m_DDFDescriptor->m_NameHash)
+            else if (params.m_Message->m_Id == dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash)
             {
-                dmModelDDF::ResetConstantModel* ddf = (dmModelDDF::ResetConstantModel*)params.m_Message->m_Data;
+                dmGameSystemDDF::ResetConstant* ddf = (dmGameSystemDDF::ResetConstant*)params.m_Message->m_Data;
                 dmArray<dmRender::Constant>& constants = component->m_RenderConstants;
                 uint32_t size = constants.Size();
                 for (uint32_t i = 0; i < size; ++i)

--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -204,7 +204,7 @@ namespace dmGameSystem
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
         Vectormath::Aos::Vector4* value = dmScript::CheckVector4(L, 3);
 
-        dmModelDDF::SetConstantModel msg;
+        dmGameSystemDDF::SetConstant msg;
         msg.m_NameHash = name_hash;
         msg.m_Value = *value;
 
@@ -212,7 +212,7 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmModelDDF::SetConstantModel::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmModelDDF::SetConstantModel::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetConstant::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }
@@ -246,14 +246,14 @@ namespace dmGameSystem
         dmGameObject::HInstance instance = CheckGoInstance(L);
         dmhash_t name_hash = dmScript::CheckHashOrString(L, 2);
 
-        dmModelDDF::ResetConstantModel msg;
+        dmGameSystemDDF::ResetConstant msg;
         msg.m_NameHash = name_hash;
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        dmMessage::Post(&sender, &receiver, dmModelDDF::ResetConstantModel::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmModelDDF::ResetConstantModel::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::ResetConstant::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::ResetConstant::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(top == lua_gettop(L));
         return 0;
     }


### PR DESCRIPTION
- Removed dmModelDDF::Set/ResetConstantModel and changed usage to dmGameSystemDDF::Set/ResetConstant.
- Moved dmGameSystemDDF::ResetConstant from sprite_ddf.proto into gamesys_ddf.proto since it is used by both sprite and model now.
