### PR TITLE
DEFEDIT-491 Synchronize dialog fixes

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -50,6 +50,7 @@
             [editor.ui :as ui]
             [editor.web-profiler :as web-profiler]
             [editor.workspace :as workspace]
+            [editor.sync :as sync]
             [editor.system :as system]
             [util.http-server :as http-server])
   (:import  [java.io File]
@@ -240,7 +241,15 @@
           (g/update-property app-view :auto-pulls conj [properties-view :pane])))
       (if (system/defold-dev?)
         (graph-view/setup-graph-view root)
-        (.removeAll (.getTabs tool-tabs) (to-array (mapv #(find-tab tool-tabs %) ["graph-tab" "css-tab"])))))
+        (.removeAll (.getTabs tool-tabs) (to-array (mapv #(find-tab tool-tabs %) ["graph-tab" "css-tab"]))))
+
+      ; If project sync was in progress when we shut down the editor, re-open the sync dialog at startup.
+      (let [git   (g/node-value changes-view :git)
+            prefs (g/node-value changes-view :prefs)]
+        (when (sync/flow-in-progress? git)
+          (ui/run-later
+            (sync/open-sync-dialog (sync/resume-flow git prefs))))))
+
     (reset! the-root root)
     root))
 

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -74,7 +74,7 @@
   (run [changes-view]
     (let [git   (g/node-value changes-view :git)
           prefs (g/node-value changes-view :prefs)]
-      (sync/open-sync-dialog (sync/make-flow git prefs)))))
+      (sync/open-sync-dialog (sync/begin-flow! git prefs)))))
 
 (defn changes-view-post-create
   [this basis event]

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -92,7 +92,7 @@
     (refresh! git list-view)))
 
 (ui/extend-menu ::menubar :editor.app-view/open
-                [{:label "Synchronize"
+                [{:label "Synchronize..."
                   :id ::synchronize
                   :acc "Shortcut+U"
                   :command :synchronize}])

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -16,7 +16,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- get-commit [^Repository repository revision]
+(defn get-commit [^Repository repository revision]
   (let [walk (RevWalk. repository)]
     (.setRetainBody walk true)
     (.parseCommit walk (.resolve repository revision))))

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -298,7 +298,6 @@
         pull-root       ^Parent (ui/load-fxml "sync-pull.fxml")
         push-root       ^Parent (ui/load-fxml "sync-push.fxml")
         stage           (ui/make-stage)
-        old-stage       (ui/main-stage)
         scene           (Scene. root)
         dialog-controls (ui/collect-controls root [ "ok" "push" "cancel" "dialog-area" "progress-bar"])
         pull-controls   (ui/collect-controls pull-root ["conflicting" "resolved" "conflict-box" "main-label"])
@@ -357,7 +356,7 @@
 
                              nil)))]
     (dialogs/observe-focus stage)
-    (ui/set-main-stage stage)
+    (.initOwner stage (ui/main-stage))
     (update-controls @!flow)
     (add-watch !flow :updater (fn [_ _ _ flow]
                                 (update-controls flow)))
@@ -424,6 +423,4 @@
       (ui/show-and-wait-throwing! stage)
       (catch Exception e
         (cancel-flow! !flow)
-        (throw e))
-      (finally
-        (ui/set-main-stage old-stage)))))
+        (throw e)))))

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -347,5 +347,11 @@
 
     (.initModality stage Modality/APPLICATION_MODAL)
     (.setScene stage scene)
-    (ui/show-and-wait! stage)
-    (ui/set-main-stage old-stage)))
+
+    (try
+      (ui/show-and-wait-throwing! stage)
+      (catch Exception e
+        (cancel-flow @!flow)
+        (throw e))
+      (finally
+        (ui/set-main-stage old-stage)))))

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -1,8 +1,7 @@
 (ns editor.sync
-  (:require [clojure
-             [set :as set]
-             [string :as string]]
+  (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
+            [clojure.set :as set]
             [editor
              [dialogs :as dialogs]
              [diff-view :as diff-view]
@@ -11,17 +10,13 @@
              [login :as login]
              [ui :as ui]]
             [editor.progress :as progress])
-  (:import javafx.geometry.Pos
-           [org.eclipse.jgit.api Git PullResult]
-           [org.eclipse.jgit.revwalk RevCommit RevWalk]
+  (:import [org.eclipse.jgit.api Git PullResult]
+           [org.eclipse.jgit.revwalk RevCommit]
            [org.eclipse.jgit.api.errors StashApplyFailureException]
-           [javafx.scene Parent Scene Node]
-           [javafx.scene.control ContentDisplay Label MenuButton SelectionMode ListView TextArea]
+           [javafx.scene Parent Scene]
+           [javafx.scene.control SelectionMode ListView TextArea]
            [javafx.scene.input KeyCode KeyEvent]
-           javafx.scene.layout.BorderPane
-           [javafx.stage Modality Stage]
-           [org.eclipse.jgit.api ResetCommand$ResetType CheckoutCommand$Stage]
-           org.eclipse.jgit.api.errors.CheckoutConflictException))
+           [javafx.stage Modality]))
 
 (set! *warn-on-reflection* true)
 
@@ -46,14 +41,32 @@
 ;;          <-----------------------------------------------    -> :cancel
 
 
-(defn make-flow [^Git git prefs]
-  (when *login*
-    (login/login prefs))
+(defn- serialize-ref [^RevCommit ref]
+  (some->> ref .getName))
+
+(defn- deserialize-ref [revision ^Git git]
+  (some->> revision (git/get-commit (.getRepository git))))
+
+(defn- serialize-flow [flow]
+  (-> flow
+      (dissoc :git)
+      (dissoc :creds)
+      (update :start-ref serialize-ref)
+      (update :stash-ref serialize-ref)))
+
+(defn- deserialize-flow [serialized-flow ^Git git creds]
+  (-> serialized-flow
+      (assoc :git git)
+      (assoc :creds creds)
+      (update :start-ref deserialize-ref git)
+      (update :stash-ref deserialize-ref git)))
+
+(defn- make-flow! [^Git git creds]
   (let [start-ref (git/get-current-commit-ref git)
         stash-ref (git/stash git)]
     {:state     :pull/start
      :git       git
-     :creds     (git/credentials prefs)
+     :creds     creds
      :start-ref start-ref
      :stash-ref stash-ref
      :progress  (progress/make "pull" 4)
@@ -62,7 +75,41 @@
      :staged    #{}
      :modified  #{}}))
 
-(defn cancel-flow [{:keys [git start-ref stash-ref] :as flow}]
+(defn- flow-journal-file ^java.io.File [^Git git]
+  (io/file (.. git getRepository getWorkTree) ".internal/.sync-in-progress"))
+
+(defn- write-flow-journal! [{:keys [git] :as flow}]
+  (let [file (flow-journal-file git)
+        data (serialize-flow flow)]
+    (println "Writing journal:" (:state flow) (str file))
+    (io/make-parents file)
+    (spit file (pr-str data))))
+
+(defn flow-in-progress? [^Git git]
+  (.exists (flow-journal-file git)))
+
+(defn begin-flow! [^Git git prefs]
+  (when *login*
+    (login/login prefs))
+  (let [creds (git/credentials prefs)
+        flow  (make-flow! git creds)]
+    (write-flow-journal! flow)
+    flow))
+
+(defn resume-flow [^Git git prefs]
+  (when *login*
+    (login/login prefs))
+  (let [creds (git/credentials prefs)
+        file  (flow-journal-file git)
+        data  (with-open [reader (java.io.PushbackReader. (io/reader file))]
+                (edn/read reader))]
+    (deserialize-flow data git creds)))
+
+(defn cancel-flow! [{:keys [git start-ref stash-ref] :as flow}]
+  (let [file (flow-journal-file git)]
+    (when (.exists file)
+      (println "Deleting journal:" (:state flow) (str file))
+      (io/delete-file file :silently)))
   (git/hard-reset git start-ref)
   (when stash-ref
     (git/stash-apply git stash-ref)
@@ -76,15 +123,28 @@
        (assoc :state new-state)
        (update :progress #(progress/advance % n)))))
 
-(defn refresh-git-state [{:keys [git] :as flow}]
-  (let [st (git/status git)]
-    (merge flow
-           {:staged   (set/union (:added st)
-                                 (:deleted st)
-                                 (set/difference (:uncommited-changes st)
-                                                 (:modified st)))
-            :modified (set/union (:modified st)
-                                 (:untracked st))})))
+(defn- should-update-journal? [old-flow new-flow]
+  (or (not= (:state old-flow) (:state new-flow))
+      (not= (:staged old-flow) (:staged new-flow))
+      (not= (:modified old-flow) (:modified new-flow))
+      (let [old-progress (:progress old-flow)
+            new-progress (:progress new-flow)]
+        (not= (:message old-progress) (:message new-progress))
+        (and (= (:pos new-progress) (:size new-progress))
+             (not= (:pos old-progress) (:size old-progress))))))
+
+(defn refresh-git-state [{:keys [git] :as old-flow}]
+  (let [st (git/status git)
+        new-flow (merge old-flow
+                        {:staged   (set/union (:added st)
+                                              (:deleted st)
+                                              (set/difference (:uncommited-changes st)
+                                                              (:modified st)))
+                         :modified (set/union (:modified st)
+                                              (:untracked st))})]
+    (when (should-update-journal? old-flow new-flow)
+      (write-flow-journal! new-flow))
+    new-flow))
 
 (defn advance-flow [{:keys [git state progress creds conflicts stash-ref message] :as flow} render-progress]
   (render-progress progress)
@@ -131,6 +191,12 @@
                           (advance-flow (tick flow :pull/start) render-progress))))
     :push/done      flow))
 
+(defn advance-flow-and-write-journal! [flow render-progress!]
+  (let [updated-flow (advance-flow flow render-progress!)]
+    (when (should-update-journal? flow updated-flow)
+      (write-flow-journal! updated-flow))
+    updated-flow))
+
 (ui/extend-menu ::conflicts-menu nil
                 [{:label "Show diff"
                   :command :show-diff}
@@ -164,7 +230,8 @@
     (git/unstage-file (:git @!flow) file)
     (swap! !flow #(-> %
                       (update :conflicts dissoc file)
-                      (update :resolved assoc file entry)))))
+                      (update :resolved assoc file entry)))
+    (write-flow-journal! @!flow)))
 
 (handler/defhandler :show-diff :sync
   (enabled? [selection] (= 1 (count selection)))
@@ -290,7 +357,7 @@
                                 (update-controls flow)))
 
     (ui/on-action! (:cancel dialog-controls) (fn [_]
-                                               (cancel-flow @!flow)
+                                               (cancel-flow! @!flow)
                                                (.close stage)))
     (ui/on-action! (:ok dialog-controls) (fn [_]
                                            (cond
@@ -301,19 +368,19 @@
                                                (.close stage))
 
                                              (= :push/staging (:state @!flow))
-                                             (swap! !flow #(advance-flow
+                                             (swap! !flow #(advance-flow-and-write-journal!
                                                             (merge %
                                                                    {:state :push/comitting
                                                                     :message (ui/text (:message push-controls))})
                                                             render-progress))
 
                                              :else
-                                             (swap! !flow advance-flow render-progress))))
+                                             (swap! !flow advance-flow-and-write-journal! render-progress))))
     (ui/on-action! (:push dialog-controls) (fn [_]
                                              (swap! !flow #(merge %
                                                                   {:state    :push/start
                                                                    :progress (progress/make "push" 4)}))
-                                             (swap! !flow advance-flow render-progress)))
+                                             (swap! !flow advance-flow-and-write-journal! render-progress)))
 
     (ui/observe (.textProperty ^TextArea (:message push-controls))
                 (fn [_ _ _]
@@ -342,7 +409,7 @@
                      (ui/event-handler event
                                        (let [code (.getCode ^KeyEvent event)]
                                          (when (= code KeyCode/ESCAPE) true
-                                               (cancel-flow @!flow)
+                                               (cancel-flow! @!flow)
                                                (.close stage)))))
 
     (.initModality stage Modality/APPLICATION_MODAL)
@@ -351,7 +418,7 @@
     (try
       (ui/show-and-wait-throwing! stage)
       (catch Exception e
-        (cancel-flow @!flow)
+        (cancel-flow! @!flow)
         (throw e))
       (finally
         (ui/set-main-stage old-stage)))))

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -151,9 +151,9 @@
        (assoc :state new-state)
        (update :progress #(progress/advance % n)))))
 
-(defn refresh-git-state [{:keys [git] :as old-flow}]
+(defn refresh-git-state [{:keys [git] :as flow}]
   (let [st (git/status git)]
-    (merge old-flow
+    (merge flow
            {:staged   (set/union (:added st)
                                  (:deleted st)
                                  (set/difference (:uncommited-changes st)
@@ -179,13 +179,13 @@
                                              (println e))))
                           status    (git/status git)]
                       (cond
-                        (nil? stash-ref) (advance-flow (tick flow :pull/done 2) render-progress)
+                        (nil? stash-ref)        (advance-flow (tick flow :pull/done 2) render-progress)
                         (= :conflict stash-res) (advance-flow (-> flow
                                                                   (tick :pull/conflicts)
                                                                   (assoc :conflicts (:conflicting-stage-state status)))
                                                               render-progress)
-                        stash-res (advance-flow (tick flow :pull/done 2) render-progress)
-                        :else (advance-flow (tick flow :pull/error) render-progress)))
+                        stash-res               (advance-flow (tick flow :pull/done 2) render-progress)
+                        :else                   (advance-flow (tick flow :pull/error) render-progress)))
     :pull/conflicts (if (empty? conflicts)
                       (advance-flow (tick flow :pull/done) render-progress)
                       flow)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -602,9 +602,8 @@
     dynamics
     (update :env merge (into {} (map (fn [[k [node v]]] [k (g/node-value (get-in context [:env node]) v)]) dynamics)))))
 
-(defn- contexts []
-  (let [main-scene (.getScene ^Stage @*main-stage*)
-        initial-node (or (.getFocusOwner main-scene) (.getRoot main-scene))]
+(defn- contexts [^Scene scene]
+  (let [initial-node (or (.getFocusOwner scene) (.getRoot scene))]
     (loop [^Node node initial-node
            ctxs []]
       (if-not node
@@ -709,7 +708,7 @@
   (.addEventHandler control ContextMenuEvent/CONTEXT_MENU_REQUESTED
     (event-handler event
                    (when-not (.isConsumed event)
-                     (let [cm (make-context-menu (make-menu-items (realize-menu menu-id) (contexts)))]
+                     (let [cm (make-context-menu (make-menu-items (realize-menu menu-id) (contexts (.getScene control))))]
                        ;; Required for autohide to work when the event originates from the anchor/source control
                        ;; See RT-15160 and Control.java
                        (.setImpl_showRelativeToWindow cm true)
@@ -717,7 +716,7 @@
                        (.consume event))))))
 
 (defn register-tab-context-menu [^Tab tab menu-id]
-  (let [cm (make-context-menu (make-menu-items (realize-menu menu-id) (contexts)))]
+  (let [cm (make-context-menu (make-menu-items (realize-menu menu-id) (contexts (.getScene (.getTabPane tab)))))]
     (.setImpl_showRelativeToWindow cm true)
     (.setContextMenu tab cm)))
 
@@ -857,7 +856,7 @@
               (.select state))))))))
 
 (defn refresh
-  ([^Scene scene] (refresh scene (contexts)))
+  ([^Scene scene] (refresh scene (contexts scene)))
   ([^Scene scene command-contexts]
    (let [root (.getRoot scene)
          toolbar-descs (vals (user-data root ::toolbars))]

--- a/editor/test/editor/git_test.clj
+++ b/editor/test/editor/git_test.clj
@@ -1,13 +1,11 @@
 (ns editor.git-test
-  (:require [clojure
-             [set :as set]
-             [test :refer :all]]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [editor.git :as git])
   (:import java.nio.file.attribute.FileAttribute
            java.nio.file.Files
            org.apache.commons.io.FileUtils
-           [org.eclipse.jgit.api Git MergeResult MergeResult$MergeStatus]))
+           [org.eclipse.jgit.api Git]))
 
 (defn create-file [git path content]
   (let [f (io/file (str (.getWorkTree (.getRepository git)) "/" path))]
@@ -62,10 +60,36 @@
     (doseq [f (:missing s)]
       (-> git (.rm) (.addFilepattern f) (.call)))))
 
+(def ^:private assert-args #'clojure.core/assert-args)
+
+(defmacro with-git
+  "bindings => [name init ...]
+
+  Helper for cleaning up temporary git repositories created during testing.
+  Semantics and implementaiton are based on clojure.core/with-open.
+
+  Evaluates body in a try expression with names bound to the values
+  of the inits, and a finally clause that calls (delete-git name) on each
+  name that was bount to a Git value in reverse order."
+  [bindings & body]
+  (assert-args
+    (vector? bindings) "a vector for its binding"
+    (even? (count bindings)) "an even number of forms in binding vector")
+  (cond
+    (= (count bindings) 0) `(do ~@body)
+    (symbol? (bindings 0)) `(let ~(subvec bindings 0 2)
+                              (try
+                                (with-git ~(subvec bindings 2) ~@body)
+                                (finally
+                                  (when (instance? Git ~(bindings 0))
+                                    (delete-git ~(bindings 0))))))
+    :else (throw (IllegalArgumentException.
+                   "with-git only allows Symbols in bindings"))))
+
 ;; ============================================================================================
 
 (deftest autostage-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (testing "create files"
       (create-file git "/src/main.cpp" "void main() {}")
       (create-file git "/src/util.cpp" ""))
@@ -93,22 +117,18 @@
       (is (= #{"src/main.cpp"} (:missing (git/status git))))
       (autostage git)
       (is (= #{} (:missing (git/status git))))
-      (is (= #{"src/main.cpp"} (:removed (git/status git)))))
-
-    (delete-git git)))
+      (is (= #{"src/main.cpp"} (:removed (git/status git)))))))
 
 (deftest worktree-test
-  (let [git (new-git)]
-    (is (instance? java.io.File (git/worktree git)))
-    (delete-git git)))
+  (with-git [git (new-git)]
+    (is (instance? java.io.File (git/worktree git)))))
 
 (deftest get-current-commit-ref-test
-  (let [git (new-git)]
-    (is (instance? org.eclipse.jgit.revwalk.RevCommit (git/get-current-commit-ref git)))
-    (delete-git git)))
+  (with-git [git (new-git)]
+    (is (instance? org.eclipse.jgit.revwalk.RevCommit (git/get-current-commit-ref git)))))
 
 (deftest status-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (testing "untracked"
       (create-file git "/src/main.cpp" "void main() {}")
       (is (= #{"/src/main.cpp" (:untracked (git/status git))}))
@@ -119,28 +139,26 @@
       (is (= #{"src" (:uncommnited-changes (git/status git))})))
 
     (testing "conflicts"
-      (let [local-git (clone git)]
+      (with-git [local-git (clone git)]
         (create-file git "/src/main.cpp" "void main() {BAR}")
         (create-file local-git "/src/main.cpp" "void main() {FOO}")
         (commit-src git)
         (commit-src local-git)
         (-> local-git .pull .call)
         (is (= #{"src/main.cpp"} (:conflicting (git/status local-git))))
-        (is (= {"src/main.cpp" :both-added} (:conflicting-stage-state (git/status local-git))))))
-    (delete-git git)))
+        (is (= {"src/main.cpp" :both-added} (:conflicting-stage-state (git/status local-git))))))))
 
 (deftest unified-status-test
   (testing "new file; unstaged and staged"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (is (= [{:score 0, :change-type :add, :old-path nil, :new-path "src/main.cpp"}] (git/unified-status git)))
       (add-src git)
-      (is (= [{:score 0, :change-type :add, :old-path nil, :new-path "src/main.cpp"}] (git/unified-status git)))
-      (delete-git git)))
+      (is (= [{:score 0, :change-type :add, :old-path nil, :new-path "src/main.cpp"}] (git/unified-status git)))))
 
   (testing "changed file; unstaged and staged and partially staged"
-    (let [git (new-git)
-          expect {:score 0, :change-type :modify, :old-path "src/main.cpp", :new-path "src/main.cpp"}]
+    (with-git [git (new-git)
+               expect {:score 0, :change-type :modify, :old-path "src/main.cpp", :new-path "src/main.cpp"}]
 
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
@@ -153,12 +171,10 @@
 
       (create-file git "/src/main.cpp" "void main2() {}\nint x;")
       (add-src git)
-      (is (= [expect] (git/unified-status git)))
-
-      (delete-git git)))
+      (is (= [expect] (git/unified-status git)))))
 
   (testing "delete and related"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
 
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
@@ -170,12 +186,10 @@
 
       ;; recreate src/main.cpp and expect in modified state
       (create-file git "/src/main.cpp" "void main2() {}")
-      (is (= [{:score 0, :change-type :modify, :old-path "src/main.cpp", :new-path "src/main.cpp"}] (git/unified-status git)))
-
-      (delete-git git)))
+      (is (= [{:score 0, :change-type :modify, :old-path "src/main.cpp", :new-path "src/main.cpp"}] (git/unified-status git)))))
 
   (testing "rename in work tree"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
       (is (= [] (git/unified-status git)))
@@ -183,12 +197,10 @@
       (create-file git "/src/foo.cpp" "void main() {}")
       (delete-file git "src/main.cpp")
 
-      (is (= [{:score 100, :change-type :rename, :old-path "src/main.cpp", :new-path "src/foo.cpp"}] (git/unified-status git)))
-
-      (delete-git git)))
+      (is (= [{:score 100, :change-type :rename, :old-path "src/main.cpp", :new-path "src/foo.cpp"}] (git/unified-status git)))))
 
   (testing "rename deleted and staged file"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
       (is (= [] (git/unified-status git)))
@@ -196,13 +208,11 @@
       (create-file git "/src/foo.cpp" "void main() {}")
       (-> git (.rm) (.addFilepattern "src/main.cpp") (.call))
 
-      (is (= [{:score 100, :change-type :rename, :old-path "src/main.cpp", :new-path "src/foo.cpp"}] (git/unified-status git)))
-
-      (delete-git git)))
+      (is (= [{:score 100, :change-type :rename, :old-path "src/main.cpp", :new-path "src/foo.cpp"}] (git/unified-status git)))))
 
   (testing "honor .gitignore"
-    (let [git (new-git)
-          expect {:score 0, :change-type :modify, :old-path "src/main.cpp", :new-path "src/main.cpp"}]
+    (with-git [git (new-git)
+               expect {:score 0, :change-type :modify, :old-path "src/main.cpp", :new-path "src/main.cpp"}]
 
       (create-file git "/.gitignore" "*.cpp")
       (-> git (.add) (.addFilepattern ".gitignore") (.call))
@@ -211,106 +221,94 @@
       (is (= [] (git/unified-status git)))
 
       (create-file git "/src/main.cpp" "void main() {}")
-      (is (= [] (git/unified-status git)))
-
-      (delete-git git))))
+      (is (= [] (git/unified-status git))))))
 
 (deftest show-file-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "/src/main.cpp" "void main() {}")
     (let [ref (commit-src git)]
       (is (= "void main() {}" (String. (git/show-file git "src/main.cpp"))))
-      (is (= "void main() {}" (String. (git/show-file git "src/main.cpp" (.name ref))))))
-    (delete-git git)))
+      (is (= "void main() {}" (String. (git/show-file git "src/main.cpp" (.name ref))))))))
 
 (deftest stage-file-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "src/main.cpp" "void main() {}")
     (git/stage-file git "src/main.cpp")
     (is (= #{"src/main.cpp"} (:added (git/status git))))
-    (is (= #{} (:untracked (git/status git))))
-    (delete-git git)))
+    (is (= #{} (:untracked (git/status git))))))
 
 (deftest unstage-file-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "src/main.cpp" "void main() {}")
     (git/stage-file git "src/main.cpp")
     (is (= #{"src/main.cpp"} (:added (git/status git))))
     (git/unstage-file git "src/main.cpp")
     (is (= #{} (:added (git/status git))))
-    (is (= #{"src/main.cpp"} (:untracked (git/status git))))
-    (delete-git git)))
+    (is (= #{"src/main.cpp"} (:untracked (git/status git))))))
 
 (deftest hard-reset-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "src/main.cpp" "void main() {}")
     (let [ref (commit-src git)]
       (create-file git "src/main.cpp" "void main() {FOO}")
       (is (= #{"src/main.cpp"} (:modified (git/status git))))
       (git/hard-reset git ref)
-      (is (= #{} (:modified (git/status git)))))
-    (delete-git git)))
+      (is (= #{} (:modified (git/status git)))))))
 
 (deftest stash-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "src/main.cpp" "void main() {}")
     (is (= #{"src/main.cpp"} (:untracked (git/status git))))
     (git/stash git)
-    (is (= #{} (:untracked (git/status git))))
-    (delete-git git)))
+    (is (= #{} (:untracked (git/status git))))))
 
 (deftest stash-apply-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "src/main.cpp" "void main() {}")
     (is (= #{"src/main.cpp"} (:untracked (git/status git))))
     (let [ref (git/stash git)]
       (is (= #{} (:untracked (git/status git))))
       (git/stash-apply git ref)
-      (is (= #{"src/main.cpp"} (:untracked (git/status git)))))
-    (delete-git git)))
+      (is (= #{"src/main.cpp"} (:untracked (git/status git)))))))
 
 (deftest stash-drop-test
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "src/main.cpp" "void main() {}")
     (let [ref (git/stash git)]
       (git/stash-drop git ref)
       (git/stash-apply git ref)
       ;; ref still is reflog
-      (is (= #{"src/main.cpp"} (:untracked (git/status git)))))
-    (delete-git git)))
+      (is (= #{"src/main.cpp"} (:untracked (git/status git)))))))
 
 (deftest revert-test
   (testing "untracked"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (is (= #{"src/main.cpp"} (:untracked (git/status git))))
       (git/revert git ["src/main.cpp"])
-      (is (= #{} (all-files (git/status git))))
-      (delete-git git)))
+      (is (= #{} (all-files (git/status git))))))
 
   (testing "new and staged"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
 
       (autostage git)
       (is (= #{"src/main.cpp"} (:added (git/status git))))
       (git/revert git ["src/main.cpp"])
-      (is (= #{} (all-files (git/status git))))
-      (delete-git git)))
+      (is (= #{} (all-files (git/status git))))))
 
   (testing "changed"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
       (create-file git "/src/main.cpp" "void main2() {}")
 
       (is (= #{"src/main.cpp"} (:modified (git/status git))))
       (git/revert git ["src/main.cpp"])
-      (is (= #{} (all-files (git/status git))))
-      (delete-git git)))
+      (is (= #{} (all-files (git/status git))))))
 
   (testing "changed and staged"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
       (create-file git "/src/main.cpp" "void main2() {}")
@@ -318,11 +316,10 @@
       (is (= #{"src/main.cpp"} (:modified (git/status git))))
       (autostage git)
       (git/revert git ["src/main.cpp"])
-      (is (= #{} (all-files (git/status git))))
-      (delete-git git)))
+      (is (= #{} (all-files (git/status git))))))
 
   (testing "renamed and staged"
-    (let [git (new-git)]
+    (with-git [git (new-git)]
       (create-file git "/src/main.cpp" "void main() {}")
       (commit-src git)
 
@@ -333,10 +330,9 @@
       (is (= #{"src/foo.cpp"} (:untracked (git/status git))))
                                         ;(git/autostage git)
       (git/revert git ["src/foo.cpp"])
-      (is (= #{} (all-files (git/status git))))
-      (delete-git git)))
+      (is (= #{} (all-files (git/status git))))))
 
-  (let [git (new-git)]
+  (with-git [git (new-git)]
     (create-file git "/src/main.cpp" "void main() {}")
     (commit-src git)
 
@@ -347,5 +343,4 @@
     (is (= #{"src/foo.cpp"} (:untracked (git/status git))))
     (autostage git)
     (git/revert git ["src/foo.cpp"])
-    (is (= #{} (all-files (git/status git))))
-    (delete-git git)))
+    (is (= #{} (all-files (git/status git))))))

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -64,7 +64,7 @@
       (sync/finish-flow! !flow)
       (is (false? (sync/flow-in-progress? git))))))
 
-(deftest advance-flow-and-write-journal-test
+(deftest advance-flow-test
   (testing ":pull/done"
     (with-git [git       (new-git)
                local-git (clone git)

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -24,47 +24,56 @@
        (= (instance? org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider (:creds a))
           (instance? org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider (:creds b)))))
 
-(deftest serialize-flow-test
-  (with-git [git (new-git)]
-    (create-file git "/existing.txt" "A file that already existed in the repo.")
-    (commit-src git)
-    (create-file git "/existing.txt" "A file that already existed in the repo, with unstaged changes.")
-    (create-file git "/added.txt" "A file that has been added but not staged.")
-    (let [prefs (make-prefs)
-          flow (sync/begin-flow! git prefs)]
-      (is (flow-equal? flow (sync/resume-flow git prefs))))))
-
-(deftest cancel-flow-test
-  (with-git [git (new-git)]
-    (create-file git "/src/main.cpp" "void main() {}")
-    (commit-src git)
-    (let [flow (sync/begin-flow! git (make-prefs))]
-      (create-file git "/src/main.cpp" "void main() {FOO}")
-      (sync/cancel-flow! flow)
-      (is (= "void main() {}" (slurp-file git "/src/main.cpp")))
-      (is (false? (sync/flow-in-progress? git))))))
-
-(deftest make-flow-and-write-journal-test
-  (with-git [git (new-git)
+(deftest begin-flow-test
+  (with-git [git   (new-git)
              prefs (make-prefs)
-             flow (sync/begin-flow! git prefs)]
+             flow  @(sync/begin-flow! git prefs)]
     (is (= :pull/start (:state flow)))
     (is (= git (:git flow)))
     (is (instance? org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider (:creds flow)))
     (is (instance? org.eclipse.jgit.revwalk.RevCommit (:start-ref flow)))
     (is (nil? (:stash-ref flow)))
     (is (true? (sync/flow-in-progress? git)))
-    (is (flow-equal? flow (sync/resume-flow git prefs)))))
+    (is (flow-equal? flow @(sync/resume-flow git prefs)))))
+
+(deftest resume-flow-test
+  (with-git [git (new-git)]
+    (create-file git "/existing.txt" "A file that already existed in the repo.")
+    (commit-src git)
+    (create-file git "/existing.txt" "A file that already existed in the repo, with unstaged changes.")
+    (create-file git "/added.txt" "A file that has been added but not staged.")
+    (let [prefs (make-prefs)
+          !flow (sync/begin-flow! git prefs)]
+      (is (flow-equal? @!flow @(sync/resume-flow git prefs))))))
+
+(deftest cancel-flow-test
+  (with-git [git (new-git)]
+    (create-file git "/src/main.cpp" "void main() {}")
+    (commit-src git)
+    (let [!flow (sync/begin-flow! git (make-prefs))]
+      (is (true? (sync/flow-in-progress? git)))
+      (create-file git "/src/main.cpp" "void main() {FOO}")
+      (sync/cancel-flow! !flow)
+      (is (= "void main() {}" (slurp-file git "/src/main.cpp")))
+      (is (false? (sync/flow-in-progress? git))))))
+
+(deftest finish-flow-test
+  (with-git [git (new-git)]
+    (let [!flow (sync/begin-flow! git (make-prefs))]
+      (is (true? (sync/flow-in-progress? git)))
+      (sync/finish-flow! !flow)
+      (is (false? (sync/flow-in-progress? git))))))
 
 (deftest advance-flow-and-write-journal-test
   (testing ":pull/done"
     (with-git [git       (new-git)
                local-git (clone git)
                prefs     (make-prefs)
-               flow      (sync/begin-flow! local-git prefs)
-               res       (sync/advance-flow-and-write-journal! flow progress/null-render-progress!)]
-      (is (= :pull/done (:state res)))
-      (is (flow-equal? res (sync/resume-flow local-git prefs)))))
+               !flow     (sync/begin-flow! local-git prefs)]
+      (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
+      (swap! !flow sync/advance-flow progress/null-render-progress!)
+      (is (= :pull/done (:state @!flow)))
+      (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))))
 
   (testing ":pull/conflicts"
     (with-git [git (new-git)]
@@ -75,33 +84,33 @@
         (commit-src git)
         (create-file local-git "/src/main.cpp" "void main() {BAR}")
         (let [prefs (make-prefs)
-              !flow (atom (sync/begin-flow! local-git prefs))
-              res   (swap! !flow sync/advance-flow-and-write-journal! progress/null-render-progress!)]
+              !flow (sync/begin-flow! local-git prefs)
+              res   (swap! !flow sync/advance-flow progress/null-render-progress!)]
           (is (= #{"src/main.cpp"} (:conflicting (git/status local-git))))
           (is (= :pull/conflicts (:state res)))
-          (is (flow-equal? res (sync/resume-flow local-git prefs)))
+          (is (flow-equal? res @(sync/resume-flow local-git prefs)))
           (let [flow2 @!flow]
             (testing "theirs"
               (create-file local-git "/src/main.cpp" (sync/get-theirs @!flow "src/main.cpp"))
-              (sync/resolve-file !flow "src/main.cpp")
+              (sync/resolve-file! !flow "src/main.cpp")
               (is (= {"src/main.cpp" :both-modified} (:resolved @!flow)))
               (is (= #{} (:staged @!flow)))
-              (is (flow-equal? @!flow (sync/resume-flow local-git prefs)))
-              (let [res2 (sync/advance-flow-and-write-journal! @!flow progress/null-render-progress!)]
-                (is (= :pull/done (:state res2)))
-                (is (= "void main() {FOO}" (slurp-file local-git "/src/main.cpp")))
-                (is (flow-equal? res2 (sync/resume-flow local-git prefs)))))
+              (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
+              (swap! !flow sync/advance-flow progress/null-render-progress!)
+              (is (= :pull/done (:state @!flow)))
+              (is (= "void main() {FOO}" (slurp-file local-git "/src/main.cpp")))
+              (is (flow-equal? @!flow @(sync/resume-flow local-git prefs))))
             (testing "ours"
               (reset! !flow flow2)
               (create-file local-git "/src/main.cpp" (sync/get-ours @!flow "src/main.cpp"))
-              (sync/resolve-file !flow "src/main.cpp")
+              (sync/resolve-file! !flow "src/main.cpp")
               (is (= {"src/main.cpp" :both-modified} (:resolved @!flow)))
               (is (= #{} (:staged @!flow)))
-              (is (flow-equal? @!flow (sync/resume-flow local-git prefs)))
-              (let [res2 (sync/advance-flow-and-write-journal! @!flow progress/null-render-progress!)]
-                (is (= :pull/done (:state res2)))
-                (is (= "void main() {BAR}" (slurp-file local-git "/src/main.cpp")))
-                (is (flow-equal? res2 (sync/resume-flow local-git prefs))))))))))
+              (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
+              (swap! !flow sync/advance-flow progress/null-render-progress!)
+              (is (= :pull/done (:state @!flow)))
+              (is (= "void main() {BAR}" (slurp-file local-git "/src/main.cpp")))
+              (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))))))))
 
   (testing ":push-staging -> :push/done"
     (with-git [git (new-git)]
@@ -109,18 +118,19 @@
       (commit-src git)
       (with-git [local-git (clone git)
                  prefs     (make-prefs)
-                 !flow     (atom (assoc (sync/begin-flow! local-git prefs) :state :push/start))]
+                 !flow     (sync/begin-flow! local-git prefs)]
+        (swap! !flow assoc :state :push/start)
         (create-file local-git "/src/main.cpp" "void main() {BAR}")
-        (swap! !flow sync/advance-flow-and-write-journal! progress/null-render-progress!)
+        (swap! !flow sync/advance-flow progress/null-render-progress!)
         (is (= :push/staging (:state @!flow)))
-        (is (flow-equal? @!flow (sync/resume-flow local-git prefs)))
+        (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
         (git/stage-file local-git "src/main.cpp")
         (swap! !flow sync/refresh-git-state)
         (is (= #{"src/main.cpp"} (:staged @!flow)))
-        (is (flow-equal? @!flow (sync/resume-flow local-git prefs)))
+        (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
         (swap! !flow merge {:state   :push/comitting
                             :message "foobar"})
-        (is (flow-equal? @!flow (sync/resume-flow local-git prefs)))
-        (swap! !flow sync/advance-flow-and-write-journal! progress/null-render-progress!)
+        (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
+        (swap! !flow sync/advance-flow progress/null-render-progress!)
         (is (= :push/done (:state @!flow)))
-        (is (false? (sync/flow-in-progress? local-git)))))))
+        (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))))))


### PR DESCRIPTION
Fixes DEFEDIT-491 - Lost my work when an exception was thrown during Synchronize

Fixes https://github.com/defold/editor2-issues/issues/69 - Selecting the synchronize window from out-of-focus causes an exception

Changes:
- Revert files to pre-sync state if an unhandled exception occurs during Synchronize.
- Keep track of where we are in the sync flow and save it in a `.sync-in-progress` file below the `.internal` dir in the project.
- Reopen the Synchronize dialog at startup if the editor was shut down during an in-progress sync.
- Fixed a bug where 
- The `contexts` function now takes an explicit Scene parameter.
- Added ellipsis (...) to the Synchronize menu item to indicate that it opens a dialog.
- Integration tests that throw an exception will now clean up their temporary git repos.
