### PR TITLE
DEFEDIT-476 Rename and change semantics of `always` macro

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -1,6 +1,6 @@
 (ns dynamo.graph
   "Main api for graph and node"
-  (:refer-clojure :exclude [deftype])
+  (:refer-clojure :exclude [deftype constantly])
   (:require [clojure.set :as set]
             [clojure.tools.macro :as ctm]
             [cognitect.transit :as transit]
@@ -222,7 +222,7 @@
     (assert (symbol? name) (str "Name for defnk is not a symbol:" name))
     `(def ~name (fnk ~@args))))
 
-(defmacro always [v] `(dynamo.graph/fnk [] ~v))
+(defmacro constantly [v] `(let [ret# ~v] (dynamo.graph/fnk [] ret#)))
 
 (defmacro deftype
   [symb & body]
@@ -581,7 +581,7 @@
   (assert node-id)
   (mapcat
    (fn [[p v]]
-     (it/update-property node-id p (constantly v) []))
+     (it/update-property node-id p (clojure.core/constantly v) []))
    (partition-all 2 kvs)))
 
 (defn set-property!
@@ -691,7 +691,7 @@
      (list
       (set-property node-id :_output-jammers
                     (zipmap (remove externs outputs)
-                            (repeat (constantly defective-value))))
+                            (repeat (clojure.core/constantly defective-value))))
       (invalidate node-id)))))
 
 (defn mark-defective!
@@ -990,7 +990,7 @@
                      :serializer (some-fn custom-serializer default-node-serializer %)})"
   ([root-ids opts]
    (copy (now) root-ids opts))
-  ([basis root-ids {:keys [traverse? serializer] :or {traverse? (constantly false) serializer default-node-serializer} :as opts}]
+  ([basis root-ids {:keys [traverse? serializer] :or {traverse? (clojure.core/constantly false) serializer default-node-serializer} :as opts}]
     (s/validate opts-schema opts)
    (let [serializer     #(assoc (serializer basis (gt/node-by-id-at basis %2)) :serial-id %1)
          original-ids   (input-traverse basis traverse? root-ids)
@@ -1060,7 +1060,7 @@
     (override root-id {}))
   ([root-id opts]
     (override (now) root-id opts))
-  ([basis root-id {:keys [traverse?] :or {traverse? (constantly true)}}]
+  ([basis root-id {:keys [traverse?] :or {traverse? (clojure.core/constantly true)}}]
     (let [graph-id (node-id->graph-id root-id)
           preds [traverse-cascade-delete traverse?]
           traverse-fn (partial predecessors preds)

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -127,7 +127,7 @@
 (g/defnode AtlasImage
   (inherits outline/OutlineNode)
 
-  (property order g/Int (dynamic visible (g/always false)) (default 0))
+  (property order g/Int (dynamic visible (g/constantly false)) (default 0))
 
   (input src-resource resource/Resource)
   (input src-image BufferedImage)
@@ -208,7 +208,7 @@
   (property flip-horizontal g/Bool)
   (property flip-vertical   g/Bool)
   (property playback        types/AnimationPlayback
-            (dynamic edit-type (g/always
+            (dynamic edit-type (g/constantly
                                  (let [options (protobuf/enum-values Tile$Playback)]
                                    {:type :choicebox
                                     :options (zipmap (map first options)

--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -411,7 +411,7 @@
   (output viewport Region (gu/passthrough viewport))
   (output camera Camera :cached produce-camera)
 
-  (output input-handler Runnable :cached (g/always handle-input)))
+  (output input-handler Runnable :cached (g/constantly handle-input)))
 
 (defn- lerp [a b t]
   (let [d (- b a)]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -92,7 +92,7 @@
                                   (validation/prop-error :fatal _node-id :id (partial prop-id-duplicate? id-counts) id))))
   (property url g/Str
             (value (g/fnk [base-url id] (format "%s/%s" (or base-url "") id)))
-            (dynamic read-only? (g/always true)))
+            (dynamic read-only? (g/constantly true)))
   (input base-url g/Str)
   (input source-id g/NodeID :cascade-delete)
   (input id-counts g/Any))
@@ -203,7 +203,7 @@
                                        [(assoc target :instance-data {:resource (:resource target)
                                                                       :instance-msg ddf-message
                                                                       :transform transform})])))
-  (output build-error g/Err (g/always nil))
+  (output build-error g/Err (g/constantly nil))
 
   (output scene g/Any :cached (g/fnk [_node-id transform scene child-scenes]
                                      (let [aabb (reduce #(geom/aabb-union %1 (:aabb %2)) (or (:aabb scene) (geom/null-aabb)) child-scenes)
@@ -221,7 +221,7 @@
   (inherits GameObjectInstanceNode)
 
   (property overrides g/Any
-              (dynamic visible (g/always false))
+              (dynamic visible (g/constantly false))
               (value (gu/passthrough ddf-component-properties))
               (set (fn [basis self old-value new-value]
                      (let [go (g/node-value self :source-id {:basis basis})
@@ -447,7 +447,7 @@
   ;; This property is legacy and purposefully hidden
   ;; The feature is only useful for uniform scaling, we use non-uniform now
   (property scale-along-z g/Bool
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
 
   (input ref-inst-ddf g/Any :array)
   (input embed-inst-ddf g/Any :array)

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -63,7 +63,7 @@
   (input color g/Any)
   
   (property shape-type g/Any
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
 
   (output shape-data g/Any :abstract)
   (output scene g/Any :abstract)
@@ -393,7 +393,7 @@
                                                       (fn [d _] (when (some #(<= % 0.0) d)
                                                                   "All dimensions must be greater than zero"))
                                                       dimensions))
-            (dynamic edit-type (g/always {:type types/Vec3 :labels ["W" "H" "D"]})))
+            (dynamic edit-type (g/constantly {:type types/Vec3 :labels ["W" "H" "D"]})))
 
   (display-order [Shape :dimensions])
 
@@ -608,13 +608,13 @@
                    (project/resource-setter basis self old-value new-value
                                             [:resource :collision-shape-resource]
                                             [:build-targets :dep-build-targets])))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "tilemap"}))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "tilemap"}))
             (dynamic error (g/fnk [_node-id collision-shape]
                                   (when collision-shape
                                     (validation/prop-error :fatal _node-id :collision-shape validation/prop-resource-not-exists? collision-shape "Collision Shape")))))
 
   (property type g/Any
-            (dynamic edit-type (g/always (properties/->pb-choicebox Physics$CollisionObjectType))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Physics$CollisionObjectType))))
 
   (property mass g/Num
             (value (g/fnk [mass type]

--- a/editor/src/clj/editor/core.clj
+++ b/editor/src/clj/editor/core.clj
@@ -67,7 +67,7 @@ Inheritors are required to supply a production function for the :save output."
 
 (g/defnode ResourceNode
   "Mixin. Any node loaded from the filesystem should inherit this."
-  (property filename types/PathManipulation (dynamic visible (g/always false)))
+  (property filename types/PathManipulation (dynamic visible (g/constantly false)))
 
   (output content g/Any :abstract))
 
@@ -79,9 +79,9 @@ Inputs:
 
 Outputs:
 - tree `OutlineItem` - A single value that contains the display info for this node and all its children."
-  (output outline-children [types/OutlineItem] (g/always []))
+  (output outline-children [types/OutlineItem] (g/constantly []))
   (output outline-label    g/Str :abstract)
-  (output outline-commands [types/OutlineCommand] (g/always []))
+  (output outline-commands [types/OutlineCommand] (g/constantly []))
   (output outline-tree     types/OutlineItem
           (g/fnk [this outline-label outline-commands outline-children]
                {:label outline-label

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -116,7 +116,7 @@
 
   (output gpu-texture g/Any :cached produce-gpu-texture)
   (output save-data   g/Any :cached produce-save-data)
-  (output aabb        AABB  :cached (g/always geom/unit-bounding-box))
+  (output aabb        AABB  :cached (g/constantly geom/unit-bounding-box))
   (output scene       g/Any :cached produce-scene))
 
 (defn load-cubemap [project self resource]

--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -372,7 +372,7 @@
   (property select-fn Runnable)
   (input sub-selection g/Any)
   (input curve-handle g/Any)
-  (output input-handler Runnable :cached (g/always handle-input)))
+  (output input-handler Runnable :cached (g/constantly handle-input)))
 
 (defn- pick-control-points [curves picking-rect camera viewport]
   (let [aabb (geom/rect->aabb picking-rect)]

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -46,7 +46,7 @@
   (inherits resource/ResourceNode)
 
   (output save-data g/Any (g/fnk [resource] {:resource resource}))
-  (output build-targets g/Any (g/always []))
+  (output build-targets g/Any (g/constantly []))
   (output node-outline outline/OutlineData :cached
     (g/fnk [_node-id resource source-outline child-outlines]
            (let [rt (resource/resource-type resource)
@@ -558,7 +558,7 @@
   (output save-data g/Any :cached (g/fnk [save-data] (filter #(and % (:content %)) save-data)))
   (output settings g/Any :cached (gu/passthrough settings))
   (output display-profiles g/Any :cached (gu/passthrough display-profiles))
-  (output nil-resource resource/Resource (g/always nil))
+  (output nil-resource resource/Resource (g/constantly nil))
   (output collision-groups-data g/Any :cached produce-collision-groups-data))
 
 (defn get-resource-type [resource-node]

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -91,7 +91,7 @@
   (input prototype-resource resource/Resource)
 
   (property factory-type g/Any
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
 
   (property prototype resource/Resource
             (value (gu/passthrough prototype-resource))

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -373,7 +373,7 @@
             (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
                                                            (or (= type :defold) (= type :distance-field)))))
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? size)))
-  (property antialias g/Int (dynamic visible (g/always false)))
+  (property antialias g/Int (dynamic visible (g/constantly false)))
   (property alpha g/Num
             (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
                                                            (= type :defold))))
@@ -403,7 +403,7 @@
   (property extra-characters g/Str (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
                                                                                   (or (= type :defold) (= type :distance-field))))))
   (property output-format g/Keyword
-    (dynamic edit-type (g/always (properties/->pb-choicebox Font$FontTextureFormat))))
+    (dynamic edit-type (g/constantly (properties/->pb-choicebox Font$FontTextureFormat))))
 
   (property all-chars g/Bool)
   (property cache-width g/Int
@@ -411,7 +411,7 @@
   (property cache-height g/Int
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? cache-height)))
 
-  (property pb g/Any (dynamic visible (g/always false)))
+  (property pb g/Any (dynamic visible (g/constantly false)))
 
   (input dep-build-targets g/Any :array)
   (input font-resource resource/Resource)

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -95,7 +95,7 @@
                                       (validation/prop-error :fatal _node-id :id (partial prop-id-duplicate? id-counts) id)))))
   (property url g/Str
             (value (g/fnk [base-url id] (format "%s#%s" (or base-url "") id)))
-            (dynamic read-only? (g/always true)))
+            (dynamic read-only? (g/constantly true)))
 
   (display-order [:id :url :path scene/SceneNode])
 

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -197,7 +197,7 @@
 
 (g/defnode GameProjectRefs
   (property display-profiles resource/Resource
-          (dynamic visible (g/always false))
+          (dynamic visible (g/constantly false))
           (value (gu/passthrough display-profiles-resource))
           (set (fn [basis self old-value new-value]
                  (project/resource-setter basis self old-value new-value
@@ -205,35 +205,35 @@
                                               [:build-targets :dep-build-targets]
                                               [:profile-data :display-profiles-data]))))
   (property main-collection resource/Resource
-            (dynamic visible (g/always false))
+            (dynamic visible (g/constantly false))
             (value (gu/passthrough main-collection-resource))
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
                                                 [:resource :main-collection-resource]
                                                 [:build-targets :dep-build-targets]))))
   (property render resource/Resource
-            (dynamic visible (g/always false))
+            (dynamic visible (g/constantly false))
             (value (gu/passthrough render-resource))
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
                                                 [:resource :render-resource]
                                                 [:build-targets :dep-build-targets]))))
   (property texture-profiles resource/Resource
-            (dynamic visible (g/always false))
+            (dynamic visible (g/constantly false))
             (value (gu/passthrough texture-profiles-resource))
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
                                                 [:resource :texture-profiles-resource]
                                                 [:build-targets :dep-build-targets]))))
   (property gamepads resource/Resource
-            (dynamic visible (g/always false))
+            (dynamic visible (g/constantly false))
             (value (gu/passthrough gamepads-resource))
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
                                                 [:resource :gamepads-resource]
                                                 [:build-targets :dep-build-targets]))))
   (property input-binding resource/Resource
-            (dynamic visible (g/always false))
+            (dynamic visible (g/constantly false))
             (value (gu/passthrough input-binding-resource))
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
@@ -259,8 +259,8 @@
   (inherits project/ResourceNode)
   (inherits GameProjectRefs)
 
-  (property raw-settings g/Any (dynamic visible (g/always false)))
-  (property meta-info g/Any (dynamic visible (g/always false)))
+  (property raw-settings g/Any (dynamic visible (g/constantly false)))
+  (property meta-info g/Any (dynamic visible (g/constantly false)))
 
   (output raw-settings g/Any
           (g/fnk [raw-settings meta-info ref-settings]

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -590,13 +590,13 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
 (g/defnode ShaderNode
   (inherits project/ResourceNode)
 
-  (property code g/Str (dynamic visible (g/always false)))
-  (property def g/Any (dynamic visible (g/always false)))
-  (property caret-position g/Int (dynamic visible (g/always false)) (default 0))
-  (property prefer-offset g/Int (dynamic visible (g/always false)) (default 0))
-  (property tab-triggers g/Any (dynamic visible (g/always false)) (default nil))
-  (property selection-offset g/Int (dynamic visible (g/always false)) (default 0))
-  (property selection-length g/Int (dynamic visible (g/always false)) (default 0))
+  (property code g/Str (dynamic visible (g/constantly false)))
+  (property def g/Any (dynamic visible (g/constantly false)))
+  (property caret-position g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property prefer-offset g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property tab-triggers g/Any (dynamic visible (g/constantly false)) (default nil))
+  (property selection-offset g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property selection-length g/Int (dynamic visible (g/constantly false)) (default 0))
 
   (output build-targets g/Any produce-build-targets)
   (output full-source g/Str (g/fnk [code def] (str (get def :prefix) code))))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -392,26 +392,26 @@
   (inherits scene/ScalableSceneNode)
   (inherits outline/OutlineNode)
 
-  (property index g/Int (dynamic visible (g/always false)) (default 0))
-  (property type g/Keyword (dynamic visible (g/always false)))
-  (property animation g/Str (dynamic visible (g/always false)) (default ""))
+  (property index g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property type g/Keyword (dynamic visible (g/constantly false)))
+  (property animation g/Str (dynamic visible (g/constantly false)) (default ""))
 
   (input id-prefix g/Str)
   (property id g/Str (default "")
             (dynamic visible no-override?))
   (property generated-id g/Str
-            (dynamic label (g/always "Id"))
+            (dynamic label (g/constantly "Id"))
             (value (gu/passthrough id))
-            (dynamic read-only? (g/always true))
+            (dynamic read-only? (g/constantly true))
             (dynamic visible override?))
   (property size types/Vec3 (default [0 0 0])
             (dynamic visible (g/fnk [type] (not= type :type-template))))
   (property color types/Color (default [1 1 1 1])
             (dynamic visible (g/fnk [type] (not= type :type-template)))
-            (dynamic edit-type (g/always {:type types/Color
+            (dynamic edit-type (g/constantly {:type types/Color
                                           :ignore-alpha? true})))
   (property alpha g/Num (default 1.0)
-            (dynamic edit-type (g/always {:type :slider
+            (dynamic edit-type (g/constantly {:type :slider
                                           :min 0.0
                                           :max 1.0
                                           :precision 0.01})))
@@ -487,15 +487,15 @@
   (inherits GuiNode)
 
   (property blend-mode g/Keyword (default :blend-mode-alpha)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$BlendMode))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$BlendMode))))
   (property adjust-mode g/Keyword (default :adjust-mode-fit)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$AdjustMode))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$AdjustMode))))
   (property pivot g/Keyword (default :pivot-center)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$Pivot))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$Pivot))))
   (property x-anchor g/Keyword (default :xanchor-none)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$XAnchor))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$XAnchor))))
   (property y-anchor g/Keyword (default :yanchor-none)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$YAnchor))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$YAnchor))))
 
   (input material-shader ShaderLifecycle)
   (input gpu-texture g/Any)
@@ -535,7 +535,7 @@
                                                              (= :size-mode-auto size-mode)))))
   (property size-mode g/Keyword (default :size-mode-auto)
             (dynamic visible (g/fnk [type] (or (= type :type-box) (= type :type-pie))))
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$SizeMode))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$SizeMode))))
   (property texture g/Str
             (dynamic edit-type (g/fnk [texture-ids] (properties/->choicebox (cons "" (keys texture-ids)))))
             (value (g/fnk [texture-input animation]
@@ -555,7 +555,7 @@
                          []))))))
 
   (property clipping-mode g/Keyword (default :clipping-mode-none)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$ClippingMode))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$ClippingMode))))
   (property clipping-visible g/Bool (default true))
   (property clipping-inverted g/Bool (default false))
 
@@ -615,7 +615,7 @@
   (inherits ShapeNode)
 
   (property outer-bounds g/Keyword (default :piebounds-ellipse)
-            (dynamic edit-type (g/always (properties/->pb-choicebox Gui$NodeDesc$PieBounds))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$PieBounds))))
   (property inner-radius g/Num (default 0.0))
   (property perimeter-vertices g/Num (default 10.0))
   (property pie-fill-angle g/Num (default 360.0))
@@ -704,18 +704,18 @@
   (property text-leading g/Num (default 1.0))
   (property text-tracking g/Num (default 0.0))
   (property outline types/Color (default [1 1 1 1])
-            (dynamic edit-type (g/always {:type types/Color
+            (dynamic edit-type (g/constantly {:type types/Color
                                           :ignore-alpha? true})))
   (property outline-alpha g/Num (default 1.0)
-    (dynamic edit-type (g/always {:type :slider
+    (dynamic edit-type (g/constantly {:type :slider
                                   :min 0.0
                                   :max 1.0
                                   :precision 0.01})))
   (property shadow types/Color (default [1 1 1 1])
-            (dynamic edit-type (g/always {:type types/Color
+            (dynamic edit-type (g/constantly {:type types/Color
                                           :ignore-alpha? true})))
   (property shadow-alpha g/Num (default 1.0)
-    (dynamic edit-type (g/always {:type :slider
+    (dynamic edit-type (g/constantly {:type :slider
                                   :min 0.0
                                   :max 1.0
                                   :precision 0.01})))
@@ -776,7 +776,7 @@
 
   (property template TemplateData
             (dynamic read-only? override?)
-            (dynamic edit-type (g/always {:type resource/Resource
+            (dynamic edit-type (g/constantly {:type resource/Resource
                                           :ext "gui"
                                           :to-type (fn [v] (:resource v))
                                           :from-type (fn [r] {:resource r :overrides {}})}))
@@ -853,7 +853,7 @@
   (output outline-overridden? g/Bool :cached (g/fnk [template-outline]
                                                     (let [children (get-in template-outline [:children 0 :children])]
                                                       (boolean (some :outline-overridden? children)))))
-  (output node-outline-reqs g/Any :cached (g/always []))
+  (output node-outline-reqs g/Any :cached (g/constantly []))
   (output pb-msgs g/Any :cached (g/fnk [id pb-msg scene-pb-msg]
                                        (into [pb-msg] (map #(-> %
                                                               (assoc :template-node-child true)
@@ -985,7 +985,7 @@
 (g/defnode LayerNode
   (inherits outline/OutlineNode)
   (property name g/Str)
-  (property index g/Int (dynamic visible (g/always false)) (default 0))
+  (property index g/Int (dynamic visible (g/constantly false)) (default 0))
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id name index]
                                                           {:node-id _node-id
                                                            :label name
@@ -1011,7 +1011,7 @@
   (inherits outline/OutlineNode)
   (property name g/Str)
   (property nodes g/Any
-            (dynamic visible (g/always false))
+            (dynamic visible (g/constantly false))
             (value (gu/passthrough layout-overrides))
             (set (fn [basis self _ new-value]
                    (let [scene (ffirst (g/targets-of basis self :_node-id))
@@ -1070,8 +1070,8 @@
                        'child-outlines)}))
 
 (g/defnode NodeTree
-  (property id g/Str (default (g/always ""))
-            (dynamic visible (g/always false)))
+  (property id g/Str (default (g/constantly ""))
+            (dynamic visible (g/constantly false)))
 
   (inherits outline/OutlineNode)
 
@@ -1265,12 +1265,12 @@
     (dynamic error (g/fnk [_node-id material]
                           (prop-resource-error _node-id :material material "Material"))))
 
-  (property adjust-reference g/Keyword (dynamic edit-type (g/always (properties/->pb-choicebox Gui$SceneDesc$AdjustReference))))
-  (property pb g/Any (dynamic visible (g/always false)))
-  (property def g/Any (dynamic visible (g/always false)))
-  (property background-color types/Color (dynamic visible (g/always false)) (default [1 1 1 1]))
-  (property visible-layout g/Str (default (g/always ""))
-            (dynamic visible (g/always false))
+  (property adjust-reference g/Keyword (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$SceneDesc$AdjustReference))))
+  (property pb g/Any (dynamic visible (g/constantly false)))
+  (property def g/Any (dynamic visible (g/constantly false)))
+  (property background-color types/Color (dynamic visible (g/constantly false)) (default [1 1 1 1]))
+  (property visible-layout g/Str (default (g/constantly ""))
+            (dynamic visible (g/constantly false))
             (dynamic edit-type (g/fnk [layout-msgs] {:type :choicebox
                                                      :options (into {"" "Default"} (map (fn [l] [(:name l) (:name l)]) layout-msgs))})))
   (property max-nodes g/Int

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -182,10 +182,10 @@
 (g/defnode MaterialNode
   (inherits project/ResourceNode)
 
-  (property pb g/Any (dynamic visible (g/always false)))
-  (property def g/Any (dynamic visible (g/always false)))
+  (property pb g/Any (dynamic visible (g/constantly false)))
+  (property def g/Any (dynamic visible (g/constantly false)))
   (property vertex-program resource/Resource
-    (dynamic visible (g/always false))
+    (dynamic visible (g/constantly false))
     (value (gu/passthrough vertex-resource))
     (set (fn [basis self old-value new-value]
            (project/resource-setter basis self old-value new-value
@@ -195,7 +195,7 @@
                           (prop-resource-error _node-id :vertex-program vertex-program "Vertex Program"))))
 
   (property fragment-program resource/Resource
-    (dynamic visible (g/always false))
+    (dynamic visible (g/constantly false))
     (value (gu/passthrough fragment-resource))
     (set (fn [basis self old-value new-value]
            (project/resource-setter basis self old-value new-value
@@ -214,7 +214,7 @@
 
   (output save-data g/Any :cached produce-save-data)
   (output build-targets g/Any :cached produce-build-targets)
-  (output scene g/Any (g/always {}))
+  (output scene g/Any (g/constantly {}))
   (output shader ShaderLifecycle :cached (g/fnk [_node-id vertex-source fragment-source pb]
                                            (let [uniforms (into {} (map (fn [constant] [(:name constant) (constant->val constant)]) (concat (:vertex-constants pb) (:fragment-constants pb))))]
                                              (shader/make-shader _node-id vertex-source fragment-source uniforms))))

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -90,7 +90,7 @@
 (g/defnode ModelNode
   (inherits project/ResourceNode)
 
-  (property name g/Str (dynamic visible (g/always false)))
+  (property name g/Str (dynamic visible (g/constantly false)))
   (property mesh resource/Resource
             (value (gu/passthrough mesh-resource))
             (set (fn [basis self old-value new-value]
@@ -102,7 +102,7 @@
                                             [:scene :scene])))
             (dynamic error (g/fnk [_node-id mesh]
                                   (prop-resource-error :info _node-id :mesh mesh "Mesh")))
-            (dynamic edit-type (g/always {:type resource/Resource
+            (dynamic edit-type (g/constantly {:type resource/Resource
                                           :ext "dae"})))
   (property material resource/Resource
             (value (gu/passthrough material-resource))
@@ -114,7 +114,7 @@
                                             [:shader :shader])))
             (dynamic error (g/fnk [_node-id material]
                                   (prop-resource-error :fatal _node-id :material material "Material")))
-            (dynamic edit-type (g/always {:type resource/Resource
+            (dynamic edit-type (g/constantly {:type resource/Resource
                                           :ext "material"})))
   (property textures resource/ResourceVec
             (value (gu/passthrough texture-resources))
@@ -132,7 +132,7 @@
                          (if r
                            (project/connect-resource-node project r self connections)
                            (g/connect project :nil-resource self :texture-resources)))))))
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
 
   (input mesh-resource resource/Resource)
   (input mesh-pb g/Any)

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -276,9 +276,9 @@
   (inherits scene/SceneNode)
   (inherits outline/OutlineNode)
 
-  (property type g/Keyword (dynamic visible (g/always false)))
+  (property type g/Keyword (dynamic visible (g/constantly false)))
   (property use-direction g/Bool (default false)
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
   (property magnitude CurveSpread)
   (property max-distance Curve (dynamic visible (g/fnk [type] (contains? #{:modifier-type-radial :modifier-type-vortex} type))))
 
@@ -287,7 +287,7 @@
     (g/fnk [_node-id type]
       (let [mod-type (mod-types type)]
         {:node-id _node-id :label (:label mod-type) :icon modifier-icon})))
-  (output aabb AABB (g/always (geom/aabb-incorporate (geom/null-aabb) 0 0 0)))
+  (output aabb AABB (g/constantly (geom/aabb-incorporate (geom/null-aabb) 0 0 0)))
   (output scene g/Any :cached produce-modifier-scene))
 
 (def ^:private circle-steps 32)
@@ -364,26 +364,26 @@
      :children child-scenes}))
 
 (g/defnode EmitterProperties
-  (property emitter-key-spawn-rate CurveSpread (dynamic label (g/always "Spawn Rate")))
-  (property emitter-key-size-x CurveSpread (dynamic label (g/always "Emitter Size X")))
-  (property emitter-key-size-y CurveSpread (dynamic label (g/always "Emitter Size Y")))
-  (property emitter-key-size-z CurveSpread (dynamic label (g/always "Emitter Size Z")))
-  (property emitter-key-particle-life-time CurveSpread (dynamic label (g/always "Particle Life Time")))
-  (property emitter-key-particle-speed CurveSpread (dynamic label (g/always "Initial Speed")))
-  (property emitter-key-particle-size CurveSpread (dynamic label (g/always "Initial Size")))
-  (property emitter-key-particle-red CurveSpread (dynamic label (g/always "Initial Red")))
-  (property emitter-key-particle-green CurveSpread (dynamic label (g/always "Initial Green")))
-  (property emitter-key-particle-blue CurveSpread (dynamic label (g/always "Initial Blue")))
-  (property emitter-key-particle-alpha CurveSpread (dynamic label (g/always "Initial Alpha")))
-  (property emitter-key-particle-rotation CurveSpread (dynamic label (g/always "Initial Rotation"))))
+  (property emitter-key-spawn-rate CurveSpread (dynamic label (g/constantly "Spawn Rate")))
+  (property emitter-key-size-x CurveSpread (dynamic label (g/constantly "Emitter Size X")))
+  (property emitter-key-size-y CurveSpread (dynamic label (g/constantly "Emitter Size Y")))
+  (property emitter-key-size-z CurveSpread (dynamic label (g/constantly "Emitter Size Z")))
+  (property emitter-key-particle-life-time CurveSpread (dynamic label (g/constantly "Particle Life Time")))
+  (property emitter-key-particle-speed CurveSpread (dynamic label (g/constantly "Initial Speed")))
+  (property emitter-key-particle-size CurveSpread (dynamic label (g/constantly "Initial Size")))
+  (property emitter-key-particle-red CurveSpread (dynamic label (g/constantly "Initial Red")))
+  (property emitter-key-particle-green CurveSpread (dynamic label (g/constantly "Initial Green")))
+  (property emitter-key-particle-blue CurveSpread (dynamic label (g/constantly "Initial Blue")))
+  (property emitter-key-particle-alpha CurveSpread (dynamic label (g/constantly "Initial Alpha")))
+  (property emitter-key-particle-rotation CurveSpread (dynamic label (g/constantly "Initial Rotation"))))
 
 (g/defnode ParticleProperties
-  (property particle-key-scale Curve (dynamic label (g/always "Life Scale")))
-  (property particle-key-red Curve (dynamic label (g/always "Life Red")))
-  (property particle-key-green Curve (dynamic label (g/always "Life Green")))
-  (property particle-key-blue Curve (dynamic label (g/always "Life Blue")))
-  (property particle-key-alpha Curve (dynamic label (g/always "Life Alpha")))
-  (property particle-key-rotation Curve (dynamic label (g/always "Life Rotation"))))
+  (property particle-key-scale Curve (dynamic label (g/constantly "Life Scale")))
+  (property particle-key-red Curve (dynamic label (g/constantly "Life Red")))
+  (property particle-key-green Curve (dynamic label (g/constantly "Life Green")))
+  (property particle-key-blue Curve (dynamic label (g/constantly "Life Blue")))
+  (property particle-key-alpha Curve (dynamic label (g/constantly "Life Alpha")))
+  (property particle-key-rotation Curve (dynamic label (g/constantly "Life Rotation"))))
 
 (defn- get-property [properties kw]
   (let [v (get-in properties [kw :value])]
@@ -446,15 +446,15 @@
 
   (property id g/Str)
   (property mode g/Keyword
-            (dynamic edit-type (g/always (->choicebox Particle$PlayMode)))
-            (dynamic label (g/always "Play Mode")))
+            (dynamic edit-type (g/constantly (->choicebox Particle$PlayMode)))
+            (dynamic label (g/constantly "Play Mode")))
   (property duration g/Num)
   (property space g/Keyword
-            (dynamic edit-type (g/always (->choicebox Particle$EmissionSpace)))
-            (dynamic label (g/always "Emission Space")))
+            (dynamic edit-type (g/constantly (->choicebox Particle$EmissionSpace)))
+            (dynamic label (g/constantly "Emission Space")))
 
   (property tile-source resource/Resource
-            (dynamic label (g/always "Image"))
+            (dynamic label (g/constantly "Image"))
             (value (gu/passthrough tile-source-resource))
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
@@ -483,14 +483,14 @@
 
   (property blend-mode g/Keyword
             (dynamic tip (validation/blend-mode-tip blend-mode Particle$BlendMode))
-            (dynamic edit-type (g/always (->choicebox Particle$BlendMode))))
+            (dynamic edit-type (g/constantly (->choicebox Particle$BlendMode))))
 
-  (property particle-orientation g/Keyword (dynamic edit-type (g/always (->choicebox Particle$ParticleOrientation))))
+  (property particle-orientation g/Keyword (dynamic edit-type (g/constantly (->choicebox Particle$ParticleOrientation))))
   (property inherit-velocity g/Num)
   (property max-particle-count g/Int)
   (property type g/Keyword
-            (dynamic edit-type (g/always (->choicebox Particle$EmitterType)))
-            (dynamic label (g/always "Emitter Type")))
+            (dynamic edit-type (g/constantly (->choicebox Particle$EmitterType)))
+            (dynamic label (g/constantly "Emitter Type")))
   (property start-delay g/Num)
 
   (display-order [:id scene/SceneNode :mode :space :duration :start-delay :tile-source :animation :material :blend-mode

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -110,8 +110,8 @@
 (g/defnode ProtobufNode
   (inherits project/ResourceNode)
 
-  (property pb g/Any (dynamic visible (g/always false)))
-  (property def g/Any (dynamic visible (g/always false)))
+  (property pb g/Any (dynamic visible (g/constantly false)))
+  (property def g/Any (dynamic visible (g/constantly false)))
 
   (output form-data g/Any :cached produce-form-data)
 
@@ -119,7 +119,7 @@
 
   (output save-data g/Any :cached produce-save-data)
   (output build-targets g/Any :cached produce-build-targets)
-  (output scene g/Any (g/always {})))
+  (output scene g/Any (g/constantly {})))
 
 (defn- connect-build-targets [project self resource path]
   (let [resource (workspace/resolve-resource resource path)]

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -180,7 +180,7 @@
           (mapv (fn [x] (->zip-resources workspace "" x)))))))
 
 (g/defnode ResourceNode
-  (extern resource Resource (dynamic visible (g/always false))))
+  (extern resource Resource (dynamic visible (g/constantly false))))
 
 (defn- seq-children [resource]
   (seq (children resource)))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -408,7 +408,7 @@
   (inherits SceneRenderer)
 
   (property image-view ImageView)
-  (property viewport Region (default (g/always (types/->Region 0 0 0 0))))
+  (property viewport Region (default (g/constantly (types/->Region 0 0 0 0))))
   (property active-updatable-ids g/Any)
   (property play-mode g/Keyword)
   (property drawable GLAutoDrawable)
@@ -805,13 +805,13 @@
 (g/defnode SceneNode
   (property position types/Vec3 (default [0.0 0.0 0.0]))
   (property rotation types/Vec4 (default [0.0 0.0 0.0 1.0])
-            (dynamic edit-type (g/always (properties/quat->euler))))
+            (dynamic edit-type (g/constantly (properties/quat->euler))))
 
   (output position-v3 Vector3d :cached (g/fnk [^types/Vec3 position] (doto (Vector3d.) (math/clj->vecmath position))))
   (output rotation-q4 Quat4d :cached (g/fnk [^types/Vec4 rotation] (doto (Quat4d.) (math/clj->vecmath rotation))))
   (output transform Matrix4d :cached (g/fnk [^Vector3d position-v3 ^Quat4d rotation-q4] (math/->mat4-uniform position-v3 rotation-q4 1.0)))
   (output scene g/Any :cached (g/fnk [^g/NodeID _node-id ^Matrix4d transform] {:node-id _node-id :transform transform}))
-  (output aabb AABB :cached (g/always (geom/null-aabb))))
+  (output aabb AABB :cached (g/constantly (geom/null-aabb))))
 
 (defmethod scene-tools/manip-move ::SceneNode [basis node-id delta]
   (let [orig-p ^Vector3d (doto (Vector3d.) (math/clj->vecmath (g/node-value node-id :position {:basis basis})))

--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -156,4 +156,4 @@
   (output renderable pass/RenderData :cached (g/fnk [start current] {pass/overlay [{:world-transform (Matrix4d. geom/Identity4d)
                                                                                     :render-fn render-selection-box
                                                                                     :user-data {:start start :current current}}]}))
-  (output input-handler Runnable :cached (g/always handle-selection-input)))
+  (output input-handler Runnable :cached (g/constantly handle-selection-input)))

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -527,4 +527,4 @@
   (input selected-renderables g/Any)
 
   (output renderables pass/RenderData :cached produce-renderables)
-  (output input-handler Runnable :cached (g/always handle-input)))
+  (output input-handler Runnable :cached (g/constantly handle-input)))

--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -138,12 +138,12 @@
 (g/defnode ScriptNode
   (inherits project/ResourceNode)
 
-  (property code g/Str (dynamic visible (g/always false)))
-  (property caret-position g/Int (dynamic visible (g/always false)) (default 0))
-  (property prefer-offset g/Int (dynamic visible (g/always false)) (default 0))
-  (property tab-triggers g/Any (dynamic visible (g/always false)) (default nil))
-  (property selection-offset g/Int (dynamic visible (g/always false)) (default 0))
-  (property selection-length g/Int (dynamic visible (g/always false)) (default 0))
+  (property code g/Str (dynamic visible (g/constantly false)))
+  (property caret-position g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property prefer-offset g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property tab-triggers g/Any (dynamic visible (g/constantly false)) (default nil))
+  (property selection-offset g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property selection-length g/Int (dynamic visible (g/constantly false)) (default 0))
 
   (input module-nodes g/Any :array)
 

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -137,7 +137,7 @@
             (dynamic error (g/fnk [_node-id sound]
                                   (or (validation/prop-error :info _node-id :sound validation/prop-nil? sound "Sound")
                                       (validation/prop-error :fatal _node-id :sound validation/prop-resource-not-exists? sound "Sound"))))
-            (dynamic edit-type (g/always {:type resource/Resource :ext supported-audio-formats})))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext supported-audio-formats})))
 
   (property looping g/Bool (default false))
   (property group g/Str (default "master"))

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -628,7 +628,7 @@
                                                 [:content :spine-scene]
                                                 [:structure :scene-structure]
                                                 [:node-outline :source-outline])))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "json"}))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "json"}))
             (dynamic error (g/fnk [_node-id spine-json]
                                   (prop-resource-error _node-id :spine-json spine-json "Spine Json"))))
 
@@ -640,7 +640,7 @@
                                                 [:anim-data :anim-data]
                                                 [:gpu-texture :gpu-texture]
                                                 [:build-targets :dep-build-targets])))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "atlas"}))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "atlas"}))
             (dynamic error (g/fnk [_node-id atlas]
                                   (prop-resource-error _node-id :atlas atlas "Atlas"))))
 
@@ -717,12 +717,12 @@
                                                   [:node-outline :source-outline]
                                                   [:anim-data :anim-data]
                                                   [:scene-structure :scene-structure])))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "spinescene"}))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "spinescene"}))
             (dynamic error (g/fnk [_node-id spine-scene]
                                   (prop-resource-error _node-id :spine-scene spine-scene "Spine Scene"))))
   (property blend-mode g/Any (default :blend_mode_alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Spine$SpineModelDesc$BlendMode))
-            (dynamic edit-type (g/always (properties/->pb-choicebox Spine$SpineModelDesc$BlendMode))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Spine$SpineModelDesc$BlendMode))))
   (property material resource/Resource
             (value (gu/passthrough material-resource))
             (set (fn [basis self old-value new-value]
@@ -731,7 +731,7 @@
                                                 [:shader :material-shader]
                                                 [:sampler-data :sampler-data]
                                                 [:build-targets :dep-build-targets])))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "material"}))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "material"}))
             (dynamic error (g/fnk [_node-id material]
                                   (prop-resource-error _node-id :material material "Material"))))
   (property default-animation g/Str
@@ -808,14 +808,14 @@
 
 (g/defnode SpineBone
   (inherits outline/OutlineNode)
-  (property name g/Str (dynamic read-only? (g/always true)))
+  (property name g/Str (dynamic read-only? (g/constantly true)))
   (property position types/Vec3
-            (dynamic edit-type (g/always (properties/vec3->vec2 0.0)))
-            (dynamic read-only? (g/always true)))
-  (property rotation g/Num (dynamic read-only? (g/always true)))
+            (dynamic edit-type (g/constantly (properties/vec3->vec2 0.0)))
+            (dynamic read-only? (g/constantly true)))
+  (property rotation g/Num (dynamic read-only? (g/constantly true)))
   (property scale types/Vec3
-            (dynamic edit-type (g/always (properties/vec3->vec2 1.0)))
-            (dynamic read-only? (g/always true)))
+            (dynamic edit-type (g/constantly (properties/vec3->vec2 1.0)))
+            (dynamic read-only? (g/constantly true)))
 
   (input child-bones g/Any :array)
 

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -263,7 +263,7 @@
 
   (property blend-mode g/Any (default :blend_mode_alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Sprite$SpriteDesc$BlendMode))
-            (dynamic edit-type (g/always
+            (dynamic edit-type (g/constantly
                                 (let [options (protobuf/enum-values Sprite$SpriteDesc$BlendMode)]
                                   {:type :choicebox
                                    :options (zipmap (map first options)

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -240,7 +240,7 @@
   (input blend-mode g/Any)
 
   (property cell-map g/Any
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
 
   (property id g/Str)
   (property z g/Num
@@ -354,7 +354,7 @@
 
   ;; TODO: better way?
   (property tool-controller g/Any
-            (dynamic visible (g/always false)))
+            (dynamic visible (g/constantly false)))
 
   (input layer-ids g/Any :array)
   (input layer-msgs g/Any :array)
@@ -379,7 +379,7 @@
                                             [:gpu-texture :gpu-texture])))
             (dynamic error (g/fnk [_node-id tile-source]
                                   (prop-resource-error :info _node-id :tile-source tile-source "Tile Source")))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "tilesource"})))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "tilesource"})))
 
   ;; material
   (property material resource/Resource
@@ -391,10 +391,10 @@
                                             [:shader :material-shader])))
             (dynamic error (g/fnk [_node-id material]
                                   (prop-resource-error :fatal _node-id :material material "Material")))
-            (dynamic edit-type (g/always {:type resource/Resource :ext "material"})))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext "material"})))
 
   (property blend-mode g/Any
-            (dynamic edit-type (g/always (properties/->pb-choicebox Tile$TileGrid$BlendMode))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Tile$TileGrid$BlendMode))))
 
 
   (output tile-source-attributes g/Any (gu/passthrough tile-source-attributes))
@@ -945,7 +945,7 @@
   (output editor-renderables pass/RenderData produce-editor-renderables)
   (output palette-renderables pass/RenderData produce-palette-renderables)
   (output renderables pass/RenderData :cached produce-tool-renderables)
-  (output input-handler Runnable :cached (g/always (make-input-handler))))
+  (output input-handler Runnable :cached (g/constantly (make-input-handler))))
 
 (defmethod scene/attach-tool-controller ::TileMapController
   [_ tool-id view-id resource-id]

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -188,7 +188,7 @@
                                   (validation/prop-error :fatal _node-id :end-tile (partial prop-tile-range? tile-count) end-tile "End Tile"))))
   (property playback types/AnimationPlayback
             (default :playback-once-forward)
-            (dynamic edit-type (g/always
+            (dynamic edit-type (g/constantly
                                 (let [options (protobuf/enum-values Tile$Playback)]
                                   {:type :choicebox
                                    :options (zipmap (map first options)
@@ -197,7 +197,7 @@
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? fps)))
   (property flip-horizontal g/Bool (default false))
   (property flip-vertical g/Bool (default false))
-  (property cues g/Any (dynamic visible (g/always false)))
+  (property cues g/Any (dynamic visible (g/constantly false)))
 
   (input tile-count g/Int)
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id id] {:node-id _node-id :label id :icon animation-icon}))
@@ -522,9 +522,9 @@
             (dynamic error (g/fnk [_node-id collision image-dim-error tile-width-error tile-height-error]
                                   (validation/prop-error :fatal _node-id :collision validation/prop-resource-not-exists? collision "Collision"))))
 
-  (property material-tag g/Str (default "tile") (dynamic visible (g/always false)))
-  (property original-convex-hulls g/Any (dynamic visible (g/always false)))
-  (property tile->collision-group-node g/Any (dynamic visible (g/always false)))
+  (property material-tag g/Str (default "tile") (dynamic visible (g/constantly false)))
+  (property original-convex-hulls g/Any (dynamic visible (g/constantly false)))
+  (property tile->collision-group-node g/Any (dynamic visible (g/constantly false)))
 
   (input collision-groups g/Any :array)
   (input animation-ddfs g/Any :array)
@@ -743,7 +743,7 @@
   (output active-tile-idx g/Any :cached produce-active-tile-idx)
   (output selected-collision-group-node g/Any produce-selected-collision-group-node)
   (output renderables pass/RenderData :cached produce-tool-renderables)
-  (output input-handler Runnable :cached (g/always handle-input)))
+  (output input-handler Runnable :cached (g/constantly handle-input)))
 
 (defmethod scene/attach-tool-controller ::ToolController
   [_ tool-id view-id resource-id]

--- a/editor/test/dynamo/integration/error_substitute_values.clj
+++ b/editor/test/dynamo/integration/error_substitute_values.clj
@@ -8,7 +8,7 @@
 (g/deftype StrArray [(s/maybe s/Str)])
 
 (g/defnode SimpleOutputNode
-  (output my-output g/Str (g/always "scones")))
+  (output my-output g/Str (g/constantly "scones")))
 
 (g/defnode SimpleTestNode
   (input my-input g/Str)
@@ -52,7 +52,7 @@
         (is (= ["scones"] (g/node-value atnode2 :passthrough)))))))
 
 (g/defnode NilOutputNode
-  (output my-output g/Str (g/always nil)))
+  (output my-output g/Str (g/constantly nil)))
 
 (deftest test-producing-values-with-nils
   (testing "values with nils"
@@ -88,7 +88,7 @@
         (is (= [nil] (g/node-value atnode2 :passthrough)))))))
 
 (g/defnode ErrorOutputNode
-  (output my-output g/Str (g/always (g/error-fatal "I am an error!"))))
+  (output my-output g/Str (g/constantly (g/error-fatal "I am an error!"))))
 
 (defn thrown-for-reason?
   [node output reason]

--- a/editor/test/dynamo/integration/graph_functions.clj
+++ b/editor/test/dynamo/integration/graph_functions.clj
@@ -5,7 +5,7 @@
 
 (g/defnode SourceNode
   (property a-property g/Str)
-  (output an-output g/Str (g/always "An output")))
+  (output an-output g/Str (g/constantly "An output")))
 
 (g/defnode SinkNode
   (input an-input g/Str)
@@ -14,7 +14,7 @@
   (output an-array-output [g/Str] (g/fnk [an-array-input] an-array-input)))
 
 (g/defnode OutputOnlyNode
-  (output an-ouput g/Str (g/always "empty")))
+  (output an-ouput g/Str (g/constantly "empty")))
 
 (g/defnode ChainedOutputNode
   (property foo g/Str (default "c"))

--- a/editor/test/dynamo/integration/node_become.clj
+++ b/editor/test/dynamo/integration/node_become.clj
@@ -5,8 +5,8 @@
             [dynamo.integration.node-become-support :refer :all]))
 
 (g/defnode InputOutputNode
-  (output output-a g/Str (g/always "Cake is tasty"))
-  (output output-b g/Str (g/always "Bread is tasty"))
+  (output output-a g/Str (g/constantly "Cake is tasty"))
+  (output output-b g/Str (g/constantly "Bread is tasty"))
   (input input-a g/Str)
   (output passthrough-a g/Str (g/fnk [input-a] (str "passthrough: " input-a))))
 
@@ -25,7 +25,7 @@
   (output output-a g/Str (g/fnk [input-a] (str "new: " input-a))))
 
 (g/defnode CachedOutputNode
-  (property number g/Any (default (g/always (atom 0))))
+  (property number g/Any (default (g/constantly (atom 0))))
   (output output-a g/Str :cached (g/fnk [number] (str "val" (swap! number inc)))))
 
 (deftest test-become

--- a/editor/test/dynamo/integration/node_become_support.clj
+++ b/editor/test/dynamo/integration/node_become_support.clj
@@ -5,7 +5,7 @@
 
 (g/defnode NodeA
   (input input-a g/Str)
-  (output output-a g/Str (g/always "a")))
+  (output output-a g/Str (g/constantly "a")))
 
 (g/defnode NodeB
   (input input-b g/Str)

--- a/editor/test/dynamo/integration/schema_validation.clj
+++ b/editor/test/dynamo/integration/schema_validation.clj
@@ -10,11 +10,11 @@
   (input sub-str-input g/Str :substitute "String substitute")
   (input sub-int-input g/Int :substitute 2675)
 
-  (output str-output g/Str (g/always "I am a string."))
-  (output int-output g/Int (g/always 99))
+  (output str-output g/Str (g/constantly "I am a string."))
+  (output int-output g/Int (g/constantly 99))
 
-  (output bad-str-output g/Str (g/always 133))
-  (output bad-int-output g/Int (g/always "I should be an Int."))
+  (output bad-str-output g/Str (g/constantly 133))
+  (output bad-int-output g/Int (g/constantly "I should be an Int."))
 
   (output str-pass-through g/Str (g/fnk [str-input] str-input))
   (output int-pass-through g/Int (g/fnk [int-input] int-input))

--- a/editor/test/dynamo/integration/visibility_enablement.clj
+++ b/editor/test/dynamo/integration/visibility_enablement.clj
@@ -6,13 +6,13 @@
 
 (g/defnode OutputNode
   (property can-change-prop g/Bool (default false))
-  (output true-output g/Bool (g/always true))
-  (output false-output g/Bool (g/always false)))
+  (output true-output g/Bool (g/constantly true))
+  (output false-output g/Bool (g/constantly false)))
 
 (g/defnode VisibilityTestNode
   (input a-input g/Bool)
-  (property hidden-prop g/Str (dynamic visible (g/always false)))
-  (property visible-prop g/Str (dynamic visible (g/always true)))
+  (property hidden-prop g/Str (dynamic visible (g/constantly false)))
+  (property visible-prop g/Str (dynamic visible (g/constantly true)))
   (property a-prop g/Str (dynamic visible (g/fnk [a-input] a-input))))
 
 (defn- property-visible [node key]
@@ -51,8 +51,8 @@
 
 (g/defnode EnablementTestNode
   (input a-input g/Bool)
-  (property disabled-prop g/Str (dynamic enabled (g/always false)))
-  (property enabled-prop g/Str (dynamic enabled (g/always true)))
+  (property disabled-prop g/Str (dynamic enabled (g/constantly false)))
+  (property enabled-prop g/Str (dynamic enabled (g/constantly true)))
   (property a-prop g/Str (dynamic enabled (g/fnk [a-input] a-input))))
 
 (defn- property-enabled [node key]

--- a/editor/test/editor/properties_test.clj
+++ b/editor/test/editor/properties_test.clj
@@ -19,7 +19,7 @@
 
 (g/defnode StrPropReadOnly
   (property my-prop g/Str
-            (dynamic read-only? (g/always true))))
+            (dynamic read-only? (g/constantly true))))
 
 (g/defnode LinkedProps
   (property multi-properties g/Any
@@ -228,7 +228,7 @@
 
 (g/defnode QuatAsEuler
   (property rotation t/Vec4
-            (dynamic edit-type (g/always (properties/quat->euler)))))
+            (dynamic edit-type (g/constantly (properties/quat->euler)))))
 
 (deftest value-conversion
   (with-clean-system

--- a/editor/test/internal/copy_paste_test.clj
+++ b/editor/test/internal/copy_paste_test.clj
@@ -244,7 +244,7 @@
 
 (g/defnode RichNode
   (property deep-value StructuredValue
-            (default (g/always (->StructuredValue 1 2 3)))))
+            (default (g/constantly (->StructuredValue 1 2 3)))))
 
 (defn rich-value-fragment [world]
   (let [[node] (ts/tx-nodes (g/make-node world RichNode))]

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -803,7 +803,7 @@
   (input input-three g/Any)
 
   (property a-property g/Any
-            (default  (g/always false))
+            (default  (g/constantly false))
             (validate (g/fnk [input-three] (nil? input-three)))
             (value    (g/fnk [input-two] (inc input-two))))
 


### PR DESCRIPTION
`always` previously evaluated its arguments on each invocation of the generated fnk. This is rarely desired. It has now been renamed to `constantly` and evaluates its argument once.

The caching in the properties view was broken for some node types because those types used non-pure functions (for example `(properties/quat->euler)`) for dynamics. Previous definition of `always` meant we'd generate new values each time, meaning:

``` clojure
(= (g/node-value node-id :_properties)
   (g/node-value node-id :_properties))
```

would not be true.
