### PR TITLE
DEFEDIT-508 Links to deleted file are broken even after restoring it

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -179,7 +179,7 @@
             (FileUtils/deleteDirectory f)
             (.delete (File. (resource/abs-path resource))))))
       (on-delete-resource-fn resources)
-      (workspace/resource-sync! workspace false))))
+      (workspace/resource-sync! workspace))))
 
 (defn- copy [files]
   (let [cb (Clipboard/getSystemClipboard)

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -170,7 +170,7 @@
           (FileUtils/moveFile srcf dstf))
         (workspace/resource-sync! workspace true [[srcf dstf]])))))
 
-(defn delete [resources on-delete-resource-fn]
+(defn delete [resources]
   (when (not (empty? resources))
     (let [workspace (resource/workspace (first resources))]
       (doseq [resource resources]
@@ -178,7 +178,6 @@
           (if (.isDirectory f)
             (FileUtils/deleteDirectory f)
             (.delete (File. (resource/abs-path resource))))))
-      (on-delete-resource-fn resources)
       (workspace/resource-sync! workspace))))
 
 (defn- copy [files]
@@ -194,12 +193,12 @@
 
 (handler/defhandler :cut :asset-browser
   (enabled? [selection] (and (seq selection) (every? is-deletable-resource selection)))
-  (run [selection on-delete-resource-fn]
+  (run [selection]
        (let [tmp (doto (-> (Files/createTempDirectory "asset-cut" (into-array FileAttribute []))
                          (.toFile))
                    (.deleteOnExit))]
          (copy (mapv #(tmp-file tmp %) (roots selection))))
-    (delete selection on-delete-resource-fn)))
+    (delete selection)))
 
 (defn- unique [^File f]
   (if (.exists f)
@@ -262,10 +261,10 @@
 
 (handler/defhandler :delete :asset-browser
   (enabled? [selection] (and (seq selection) (every? is-deletable-resource selection)))
-  (run [selection on-delete-resource-fn]
+  (run [selection]
     (let [names (apply str (interpose ", " (map resource/resource-name selection)))]
       (and (dialogs/make-confirm-dialog (format "Are you sure you want to delete %s?" names))
-           (delete selection on-delete-resource-fn)))))
+           (delete selection)))))
 
 (handler/defhandler :show-in-desktop :asset-browser
   (enabled? [selection] (and (= 1 (count selection)) (not= nil (resource/abs-path (first selection)))) )
@@ -497,14 +496,13 @@
 
   (output tree-view TreeView :cached produce-tree-view))
 
-(defn make-asset-browser [graph workspace tree-view open-resource-fn on-delete-resource-fn]
+(defn make-asset-browser [graph workspace tree-view open-resource-fn]
   (let [asset-browser (first
                         (g/tx-nodes-added
                           (g/transact
                             (g/make-nodes graph
                                           [asset-browser [AssetBrowser :tree-view tree-view]]
                                           (g/connect workspace :resource-tree asset-browser :resource-tree)))))]
-    (ui/context! tree-view :asset-browser {:tree-view tree-view :workspace workspace :open-fn open-resource-fn
-                                           :on-delete-resource-fn on-delete-resource-fn} tree-view)
+    (ui/context! tree-view :asset-browser {:tree-view tree-view :workspace workspace :open-fn open-resource-fn} tree-view)
     (setup-asset-browser workspace tree-view open-resource-fn)
     asset-browser))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -179,10 +179,7 @@
           properties-view      (properties-view/make-properties-view workspace project *view-graph* (.lookup root "#properties"))
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets
                                                                  (fn [resource & [opts]]
-                                                                   (app-view/open-resource app-view workspace project resource (or opts {})))
-                                                                 (fn [_]
-                                                                   ; Nothing.
-                                                                   ))
+                                                                   (app-view/open-resource app-view workspace project resource (or opts {}))))
           web-server           (-> (http-server/->server 0 {"/profiler" web-profiler/handler
                                                             project/hot-reload-url-prefix (partial hotload/build-handler project)})
                                    http-server/start!)

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -58,7 +58,8 @@
 (handler/defhandler :diff :asset-browser
   (enabled? [selection]
             (and (= 1 (count selection))
-                 (not= :add (:change-type (first selection)))))
+                 (not= :add (:change-type (first selection)))
+                 (not= :delete (:change-type (first selection)))))
   (run [selection ^Git git list-view]
        (let [status (first selection)
              old-name (or (:old-path status) (:new-path status) )

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -128,13 +128,7 @@
   (with-clean-system
     (let [[workspace project] (setup-scratch world)
           atlas-id (test-util/resource-node project "/switcher/switcher.atlas")]
-      (asset-browser/delete [(g/node-value atlas-id :resource)]
-                            (fn [resources]
-                              (let [nodes (keep #(project/get-resource-node project %) resources)]
-                                (when (not-empty nodes)
-                                  (g/transact
-                                    (for [n nodes]
-                                      (g/delete-node n)))))))
+      (asset-browser/delete [(g/node-value atlas-id :resource)])
       (is (not (g/error? (project/save-data project)))))))
 
 (deftest save-after-external-delete []


### PR DESCRIPTION
Fixes DEFEDIT-508
- We now handle deleting a file from the Assets panel the same way as if it was deleted externally.
- Removed the `on-delete-resource-fn` callback parameter from the `make-asset-browser` and `delete` functions in the `asset-browser` module.
- Disabled the Diff action for deleted files in the changes view, since attempting to diff a deleted file would result in an error.
