### PR TITLE
DEFEDIT-516 Several files reverted when only one was selected

### DIFF
--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -31,7 +31,7 @@
 
 (defn- find-original-for-renamed [ustatus file]
   (->> ustatus
-    (filter (fn [e] (= (:new-path file))))
+    (filter (fn [e] (= file (:new-path e))))
     (map :old-path)
     (first)))
 


### PR DESCRIPTION
Fixes DEFEDIT-516

* Fixed bug in `git/find-original-for-renamed` function that caused the first changed file to always be reverted along with the selected file.
* Added and updated tests to verify the bug was fixed.