### PR TITLE
DEFEDIT-519 Error when loading project that is not a Git repository

### DIFF
--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -84,7 +84,7 @@
                    (not= (:pos old-progress) (:size old-progress))))))))
 
 (defn- flow-journal-file ^java.io.File [^Git git]
-  (io/file (.. git getRepository getWorkTree) ".internal/.sync-in-progress"))
+  (some-> git .getRepository .getWorkTree (io/file ".internal/.sync-in-progress")))
 
 (defn- write-flow-journal! [{:keys [git] :as flow}]
   (let [file (flow-journal-file git)
@@ -97,7 +97,9 @@
     (write-flow-journal! new-flow)))
 
 (defn flow-in-progress? [^Git git]
-  (.exists (flow-journal-file git)))
+  (if-let [file (flow-journal-file git)]
+    (.exists file)
+    false))
 
 (defn begin-flow! [^Git git prefs]
   (when *login*

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -24,6 +24,11 @@
        (= (instance? org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider (:creds a))
           (instance? org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider (:creds b)))))
 
+(deftest flow-in-progress-test
+  (is (false? (sync/flow-in-progress? nil)))
+  (with-git [git (new-git)]
+    (is (false? (sync/flow-in-progress? git)))))
+
 (deftest begin-flow-test
   (with-git [git   (new-git)
              prefs (make-prefs)


### PR DESCRIPTION
Fixes DEFEDIT-519

* Return `nil` from `sync/flow-journal-file` if given a `nil` `Git` argument.
* Return `false` from `sync/flow-in-progress?` if given a `nil` `Git` argument.
* Added `flow-in-progress-test`.