### PR TITLE
DEFEDIT-521 Import project drop-down list in wrong position

### DIFF
--- a/editor/resources/import.fxml
+++ b/editor/resources/import.fxml
@@ -28,7 +28,8 @@
                   <Insets />
                </GridPane.margin>
             </Label>
-            <ComboBox id="projects" prefWidth="800.0" GridPane.columnIndex="1" />
+            <!-- NOTE: a value for visibleRowCount is important here, "fixes" bug with drop-down list position on Linux --> 
+            <ComboBox id="projects" prefWidth="800.0" visibleRowCount="10" GridPane.columnIndex="1" />
             <HBox prefHeight="100.0" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="1">
                <children>
                   <TextField id="location" editable="false" HBox.hgrow="ALWAYS" />


### PR DESCRIPTION
This appears to be a bug in the JavaFX implementation for Linux. Setting
"visibleRowCount" to a value dodges it.

Fixes https://github.com/defold/editor2-issues/issues/48