### PR TITLE
Defedit 523 perf regression

### DIFF
--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -244,7 +244,7 @@
                                             [:anim-ids :anim-ids]
                                             [:gpu-texture :gpu-texture]
                                             [:build-targets :dep-build-targets])))
-            (dynamic error (g/fnk [_node-id image]
+            (dynamic error (g/fnk [_node-id image anim-data]
                                   (or (validation/prop-error :info _node-id :image validation/prop-nil? image "Image")
                                       (validation/prop-error :fatal _node-id :image validation/prop-resource-not-exists? image "Image"))))
             (dynamic edit-type (g/constantly
@@ -253,9 +253,9 @@
 
   (property default-animation g/Str
             (value (g/fnk [default-animation anim-ids]
-                     (if-not (str/blank? default-animation)
-                       default-animation
-                       (first (sort-anim-ids anim-ids)))))
+                     (if (and (str/blank? default-animation) anim-ids)
+                       (first (sort-anim-ids anim-ids))
+                       default-animation)))
             (dynamic error (g/fnk [_node-id image anim-ids default-animation]
                              (when image
                                (let [anim-id-set (set anim-ids)]

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -53,7 +53,9 @@
          project   (test-util/setup-project! workspace)
          node-id   (test-util/resource-node project "/logic/main.gui")]
      (is (nil? (test-util/prop-error node-id :script)))
-     ; Script is not required, so nil would be ok
+     ;; Script is not required, so nil would be ok
+     (test-util/with-prop [node-id :script nil]
+       (is (nil? (test-util/prop-error node-id :script))))
      (test-util/with-prop [node-id :script (workspace/resolve-workspace-resource workspace "/not_found.script")]
        (is (g/error-fatal? (test-util/prop-error node-id :script))))
      (is (nil? (test-util/prop-error node-id :material)))


### PR DESCRIPTION
- anim-data is expensive to produce, use anim-ids instead and move defaulting behaviour from image property set fn to default-animation value fn.