### PR TITLE
DEF-2219 - Fixed Mesh, Skeleton and Animation bone indices discrepancy.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/bonelist_anim_test.dae
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/bonelist_anim_test.dae
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <contributor>
+      <author>Blender User</author>
+      <authoring_tool>Blender 2.73.0 commit date:2015-01-20, commit time:18:16, hash:bbf09d9</authoring_tool>
+    </contributor>
+    <created>2016-10-14T13:38:27</created>
+    <modified>2016-10-14T13:38:27</modified>
+    <unit name="meter" meter="1"/>
+    <up_axis>Z_UP</up_axis>
+  </asset>
+  <library_images/>
+  <library_effects>
+    <effect id="Material_001-effect">
+      <profile_COMMON>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <ambient>
+              <color sid="ambient">0 0 0 1</color>
+            </ambient>
+            <diffuse>
+              <color sid="diffuse">0.64 0.64 0.64 1</color>
+            </diffuse>
+            <specular>
+              <color sid="specular">0.125 0.125 0.125 1</color>
+            </specular>
+            <shininess>
+              <float sid="shininess">50</float>
+            </shininess>
+            <index_of_refraction>
+              <float sid="index_of_refraction">1</float>
+            </index_of_refraction>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_materials>
+    <material id="Material_001-material" name="Material_001">
+      <instance_effect url="#Material_001-effect"/>
+    </material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="Cube_001-mesh" name="Cube.001">
+      <mesh>
+        <source id="Cube_001-mesh-positions">
+          <float_array id="Cube_001-mesh-positions-array" count="96">-0.5 -0.5 -0.5 -0.5 0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5 0.5 -0.5 0.5 -2.9 -0.5 -0.5 -2.9 0.5 -0.5 -1.9 0.5 -0.5 -1.9 -0.5 -0.5 -2.9 -0.5 0.5 -2.9 0.5 0.5 -1.9 0.5 0.5 -1.9 -0.5 0.5 -5.5 -0.5 -0.5 -5.5 0.5 -0.5 -4.5 0.5 -0.5 -4.5 -0.5 -0.5 -5.5 -0.5 0.5 -5.5 0.5 0.5 -4.5 0.5 0.5 -4.5 -0.5 0.5 -7.9 -0.5 -0.5 -7.9 0.5 -0.5 -6.9 0.5 -0.5 -6.9 -0.5 -0.5 -7.9 -0.5 0.5 -7.9 0.5 0.5 -6.9 0.5 0.5 -6.9 -0.5 0.5</float_array>
+          <technique_common>
+            <accessor source="#Cube_001-mesh-positions-array" count="32" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube_001-mesh-normals">
+          <float_array id="Cube_001-mesh-normals-array" count="144">-1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Cube_001-mesh-normals-array" count="48" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube_001-mesh-map-0">
+          <float_array id="Cube_001-mesh-map-0-array" count="288">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <technique_common>
+            <accessor source="#Cube_001-mesh-map-0-array" count="144" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube_001-mesh-vertices">
+          <input semantic="POSITION" source="#Cube_001-mesh-positions"/>
+        </vertices>
+        <polylist material="Material_001-material" count="48">
+          <input semantic="VERTEX" source="#Cube_001-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube_001-mesh-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#Cube_001-mesh-map-0" offset="2" set="0"/>
+          <vcount>3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 </vcount>
+          <p>5 0 0 1 0 1 0 0 2 6 1 3 2 1 4 1 1 5 7 2 6 3 2 7 2 2 8 4 3 9 0 3 10 3 3 11 1 4 12 2 4 13 3 4 14 6 5 15 5 5 16 4 5 17 13 6 18 9 6 19 8 6 20 14 7 21 10 7 22 9 7 23 15 8 24 11 8 25 10 8 26 12 9 27 8 9 28 11 9 29 9 10 30 10 10 31 11 10 32 14 11 33 13 11 34 12 11 35 21 12 36 17 12 37 16 12 38 22 13 39 18 13 40 17 13 41 23 14 42 19 14 43 18 14 44 20 15 45 16 15 46 19 15 47 17 16 48 18 16 49 19 16 50 22 17 51 21 17 52 20 17 53 29 18 54 25 18 55 24 18 56 30 19 57 26 19 58 25 19 59 31 20 60 27 20 61 26 20 62 28 21 63 24 21 64 27 21 65 25 22 66 26 22 67 27 22 68 30 23 69 29 23 70 28 23 71 4 24 72 5 24 73 0 24 74 5 25 75 6 25 76 1 25 77 6 26 78 7 26 79 2 26 80 7 27 81 4 27 82 3 27 83 0 28 84 1 28 85 3 28 86 7 29 87 6 29 88 4 29 89 12 30 90 13 30 91 8 30 92 13 31 93 14 31 94 9 31 95 14 32 96 15 32 97 10 32 98 15 33 99 12 33 100 11 33 101 8 34 102 9 34 103 11 34 104 15 35 105 14 35 106 12 35 107 20 36 108 21 36 109 16 36 110 21 37 111 22 37 112 17 37 113 22 38 114 23 38 115 18 38 116 23 39 117 20 39 118 19 39 119 16 40 120 17 40 121 19 40 122 23 41 123 22 41 124 20 41 125 28 42 126 29 42 127 24 42 128 29 43 129 30 43 130 25 43 131 30 44 132 31 44 133 26 44 134 31 45 135 28 45 136 27 45 137 24 46 138 25 46 139 27 46 140 31 47 141 30 47 142 28 47 143</p>
+        </polylist>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_animations>
+    <animation id="Armature_Bone_pose_matrix">
+      <source id="Armature_Bone_pose_matrix-input">
+        <float_array id="Armature_Bone_pose_matrix-input-array" count="2">0 1.666667</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-input-array" count="2" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_pose_matrix-output">
+        <float_array id="Armature_Bone_pose_matrix-output-array" count="32">6.87838e-5 -0.9999656 0.008295654 1.33878e-9 0.9999657 -2.49375e-8 -0.008295939 7.82311e-8 0.008295655 0.008295939 0.9999312 2.14204e-8 0 0 0 1 6.87838e-5 -0.9999656 0.008295654 1.33878e-9 0.9999657 -2.49375e-8 -0.008295939 7.82311e-8 0.008295655 0.008295939 0.9999312 2.14204e-8 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-output-array" count="2" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_pose_matrix-interpolation-array" count="2">LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-interpolation-array" count="2" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_pose_matrix-sampler" target="Bone/transform"/>
+    </animation>
+    <animation id="Armature_Bone_001_pose_matrix">
+      <source id="Armature_Bone_001_pose_matrix-input">
+        <float_array id="Armature_Bone_001_pose_matrix-input-array" count="2">0 1.666667</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-input-array" count="2" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_001_pose_matrix-output">
+        <float_array id="Armature_Bone_001_pose_matrix-output-array" count="32">0.9999656 -6.87763e-5 0.008295656 2.86349e-11 -4.62889e-8 0.9999655 0.008295939 2.390159 -0.008295939 -0.008295652 0.9999311 5.29598e-9 0 0 0 1 0.7659739 -0.6428182 0.008295656 2.86349e-11 0.6427655 0.766018 0.008295938 2.390159 -0.0116874 -0.001022311 0.9999311 5.29598e-9 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-output-array" count="2" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_001_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_001_pose_matrix-interpolation-array" count="2">LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-interpolation-array" count="2" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_001_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_001_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_001_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_001_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_001_pose_matrix-sampler" target="Bone_001/transform"/>
+    </animation>
+    <animation id="Armature_Bone_002_pose_matrix">
+      <source id="Armature_Bone_002_pose_matrix-input">
+        <float_array id="Armature_Bone_002_pose_matrix-input-array" count="2">0 1.666667</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_002_pose_matrix-input-array" count="2" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_002_pose_matrix-output">
+        <float_array id="Armature_Bone_002_pose_matrix-output-array" count="32">1 0 2.90955e-9 1.19209e-7 0 1 -4.65663e-10 2.617677 -2.57687e-9 -2.47772e-10 1 -1.86265e-9 0 0 0 1 1 -9.01513e-10 -2.47689e-9 1.19209e-7 0 0.9396926 -0.3420201 2.617677 3.12665e-9 0.3420201 0.9396926 -1.86265e-9 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_002_pose_matrix-output-array" count="2" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_002_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_002_pose_matrix-interpolation-array" count="2">LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_002_pose_matrix-interpolation-array" count="2" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_002_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_002_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_002_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_002_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_002_pose_matrix-sampler" target="Bone_002/transform"/>
+    </animation>
+  </library_animations>
+  <library_controllers>
+    <controller id="Armature_Cube_001-skin" name="Armature">
+      <skin source="#Cube_001-mesh">
+        <bind_shape_matrix>1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</bind_shape_matrix>
+        <source id="Armature_Cube_001-skin-joints">
+          <Name_array id="Armature_Cube_001-skin-joints-array" count="3">Bone_002 Bone_001 Bone</Name_array>
+          <technique_common>
+            <accessor source="#Armature_Cube_001-skin-joints-array" count="3" stride="1">
+              <param name="JOINT" type="name"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Armature_Cube_001-skin-bind_poses">
+          <float_array id="Armature_Cube_001-skin-bind_poses-array" count="48">6.87977e-5 0.9999656 0.008295655 0 -0.9999656 0 0.008295893 0 0.008295595 -0.008295893 0.9999312 0 0 0 0 1 0 1 0 0 -1 0 0 -2.390077 0 0 1 -0.01982861 0 0 0 1 0 1 0 0 -1 0 0 -5.007753 0 0 1 -0.01982861 0 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Armature_Cube_001-skin-bind_poses-array" count="3" stride="16">
+              <param name="TRANSFORM" type="float4x4"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Armature_Cube_001-skin-weights">
+          <float_array id="Armature_Cube_001-skin-weights-array" count="62">0.9982073 0.001792669 1 0 1 1 0 0.9999979 2.19895e-6 0.9951928 0.004807233 0.9999917 8.33525e-6 1 0 0 0.9998548 1.45206e-4 1.27879e-4 0.9998721 0 1 0 0 0.9999999 0 8.74824e-5 0.9999125 0 0 1 0 2.12114e-4 0.9996866 1.01293e-4 0 1 0 0 1 0 1 0 1 0 1 0 1 0 1 0.03359806 0.9664019 0 0.9999999 1 1 1 1 1 1 1 1</float_array>
+          <technique_common>
+            <accessor source="#Armature_Cube_001-skin-weights-array" count="62" stride="1">
+              <param name="WEIGHT" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <joints>
+          <input semantic="JOINT" source="#Armature_Cube_001-skin-joints"/>
+          <input semantic="INV_BIND_MATRIX" source="#Armature_Cube_001-skin-bind_poses"/>
+        </joints>
+        <vertex_weights count="32">
+          <input semantic="JOINT" source="#Armature_Cube_001-skin-joints" offset="0"/>
+          <input semantic="WEIGHT" source="#Armature_Cube_001-skin-weights" offset="1"/>
+          <vcount>2 2 1 2 2 2 2 2 3 2 3 3 3 3 3 3 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 </vcount>
+          <v>0 0 1 1 0 2 1 3 0 4 0 5 1 6 0 7 1 8 0 9 1 10 0 11 1 12 0 13 1 14 0 15 1 16 2 17 0 18 1 19 0 20 1 21 2 22 0 23 1 24 2 25 0 26 1 27 2 28 0 29 1 30 2 31 0 32 1 33 2 34 0 35 1 36 2 37 0 38 2 39 0 40 2 41 0 42 2 43 0 44 2 45 0 46 2 47 0 48 2 49 0 50 2 51 0 52 2 53 2 54 2 55 2 56 2 57 2 58 2 59 2 60 2 61</v>
+        </vertex_weights>
+      </skin>
+    </controller>
+  </library_controllers>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Armature" name="Armature" type="NODE">
+        <translate sid="location">0 0 0</translate>
+        <rotate sid="rotationZ">0 0 1 0</rotate>
+        <rotate sid="rotationY">0 1 0 0</rotate>
+        <rotate sid="rotationX">1 0 0 0</rotate>
+        <scale sid="scale">1 1 1</scale>
+        <node id="Bone" name="Bone" sid="Bone" type="JOINT">
+          <matrix sid="transform">6.87838e-5 -0.9999656 0.008295654 1.33878e-9 0.9999656 -2.49375e-8 -0.008295939 7.82311e-8 0.008295654 0.008295939 0.9999312 2.14204e-8 0 0 0 1</matrix>
+          <node id="Bone_001" name="Bone.001" sid="Bone_001" type="JOINT">
+            <matrix sid="transform">0.9999656 -6.87763e-5 0.008295657 4.31797e-11 -4.62894e-8 0.9999656 0.00829594 2.390159 -0.008295939 -0.008295653 0.9999312 5.29598e-9 0 0 0 1</matrix>
+            <node id="Bone_002" name="Bone.002" sid="Bone_002" type="JOINT">
+              <matrix sid="transform">1 -2.13469e-8 -2.79397e-9 7.10543e-15 2.13469e-8 1 0 2.617677 2.79397e-9 0 1 0 0 0 0 1</matrix>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node id="Cube_001" name="Cube_001" type="NODE">
+        <translate sid="location">0 0 0</translate>
+        <rotate sid="rotationZ">0 0 1 0</rotate>
+        <rotate sid="rotationY">0 1 0 0</rotate>
+        <rotate sid="rotationX">1 0 0 0</rotate>
+        <scale sid="scale">1 1 1</scale>
+        <instance_controller url="#Armature_Cube_001-skin">
+          <skeleton>#Bone</skeleton>
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="Material_001-material" target="#Material_001-material"/>
+            </technique_common>
+          </bind_material>
+        </instance_controller>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/bonelist_mesh_test.dae
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/bonelist_mesh_test.dae
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <contributor>
+      <author>Blender User</author>
+      <authoring_tool>Blender 2.73.0 commit date:2015-01-20, commit time:18:16, hash:bbf09d9</authoring_tool>
+    </contributor>
+    <created>2016-10-14T13:38:27</created>
+    <modified>2016-10-14T13:38:27</modified>
+    <unit name="meter" meter="1"/>
+    <up_axis>Z_UP</up_axis>
+  </asset>
+  <library_images/>
+  <library_effects>
+    <effect id="Material_001-effect">
+      <profile_COMMON>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <ambient>
+              <color sid="ambient">0 0 0 1</color>
+            </ambient>
+            <diffuse>
+              <color sid="diffuse">0.64 0.64 0.64 1</color>
+            </diffuse>
+            <specular>
+              <color sid="specular">0.125 0.125 0.125 1</color>
+            </specular>
+            <shininess>
+              <float sid="shininess">50</float>
+            </shininess>
+            <index_of_refraction>
+              <float sid="index_of_refraction">1</float>
+            </index_of_refraction>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_materials>
+    <material id="Material_001-material" name="Material_001">
+      <instance_effect url="#Material_001-effect"/>
+    </material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="Cube_001-mesh" name="Cube.001">
+      <mesh>
+        <source id="Cube_001-mesh-positions">
+          <float_array id="Cube_001-mesh-positions-array" count="96">-0.5 -0.5 -0.5 -0.5 0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5 0.5 -0.5 0.5 -2.9 -0.5 -0.5 -2.9 0.5 -0.5 -1.9 0.5 -0.5 -1.9 -0.5 -0.5 -2.9 -0.5 0.5 -2.9 0.5 0.5 -1.9 0.5 0.5 -1.9 -0.5 0.5 -5.5 -0.5 -0.5 -5.5 0.5 -0.5 -4.5 0.5 -0.5 -4.5 -0.5 -0.5 -5.5 -0.5 0.5 -5.5 0.5 0.5 -4.5 0.5 0.5 -4.5 -0.5 0.5 -7.9 -0.5 -0.5 -7.9 0.5 -0.5 -6.9 0.5 -0.5 -6.9 -0.5 -0.5 -7.9 -0.5 0.5 -7.9 0.5 0.5 -6.9 0.5 0.5 -6.9 -0.5 0.5</float_array>
+          <technique_common>
+            <accessor source="#Cube_001-mesh-positions-array" count="32" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube_001-mesh-normals">
+          <float_array id="Cube_001-mesh-normals-array" count="144">-1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1 -1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Cube_001-mesh-normals-array" count="48" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube_001-mesh-map-0">
+          <float_array id="Cube_001-mesh-map-0-array" count="288">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <technique_common>
+            <accessor source="#Cube_001-mesh-map-0-array" count="144" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube_001-mesh-vertices">
+          <input semantic="POSITION" source="#Cube_001-mesh-positions"/>
+        </vertices>
+        <polylist material="Material_001-material" count="48">
+          <input semantic="VERTEX" source="#Cube_001-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube_001-mesh-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#Cube_001-mesh-map-0" offset="2" set="0"/>
+          <vcount>3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 </vcount>
+          <p>5 0 0 1 0 1 0 0 2 6 1 3 2 1 4 1 1 5 7 2 6 3 2 7 2 2 8 4 3 9 0 3 10 3 3 11 1 4 12 2 4 13 3 4 14 6 5 15 5 5 16 4 5 17 13 6 18 9 6 19 8 6 20 14 7 21 10 7 22 9 7 23 15 8 24 11 8 25 10 8 26 12 9 27 8 9 28 11 9 29 9 10 30 10 10 31 11 10 32 14 11 33 13 11 34 12 11 35 21 12 36 17 12 37 16 12 38 22 13 39 18 13 40 17 13 41 23 14 42 19 14 43 18 14 44 20 15 45 16 15 46 19 15 47 17 16 48 18 16 49 19 16 50 22 17 51 21 17 52 20 17 53 29 18 54 25 18 55 24 18 56 30 19 57 26 19 58 25 19 59 31 20 60 27 20 61 26 20 62 28 21 63 24 21 64 27 21 65 25 22 66 26 22 67 27 22 68 30 23 69 29 23 70 28 23 71 4 24 72 5 24 73 0 24 74 5 25 75 6 25 76 1 25 77 6 26 78 7 26 79 2 26 80 7 27 81 4 27 82 3 27 83 0 28 84 1 28 85 3 28 86 7 29 87 6 29 88 4 29 89 12 30 90 13 30 91 8 30 92 13 31 93 14 31 94 9 31 95 14 32 96 15 32 97 10 32 98 15 33 99 12 33 100 11 33 101 8 34 102 9 34 103 11 34 104 15 35 105 14 35 106 12 35 107 20 36 108 21 36 109 16 36 110 21 37 111 22 37 112 17 37 113 22 38 114 23 38 115 18 38 116 23 39 117 20 39 118 19 39 119 16 40 120 17 40 121 19 40 122 23 41 123 22 41 124 20 41 125 28 42 126 29 42 127 24 42 128 29 43 129 30 43 130 25 43 131 30 44 132 31 44 133 26 44 134 31 45 135 28 45 136 27 45 137 24 46 138 25 46 139 27 46 140 31 47 141 30 47 142 28 47 143</p>
+        </polylist>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_animations>
+    <animation id="Armature_Bone_pose_matrix">
+      <source id="Armature_Bone_pose_matrix-input">
+        <float_array id="Armature_Bone_pose_matrix-input-array" count="2">0 1.666667</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-input-array" count="2" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_pose_matrix-output">
+        <float_array id="Armature_Bone_pose_matrix-output-array" count="32">6.87838e-5 -0.9999656 0.008295654 1.33878e-9 0.9999657 -2.49375e-8 -0.008295939 7.82311e-8 0.008295655 0.008295939 0.9999312 2.14204e-8 0 0 0 1 6.87838e-5 -0.9999656 0.008295654 1.33878e-9 0.9999657 -2.49375e-8 -0.008295939 7.82311e-8 0.008295655 0.008295939 0.9999312 2.14204e-8 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-output-array" count="2" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_pose_matrix-interpolation-array" count="2">LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-interpolation-array" count="2" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_pose_matrix-sampler" target="Bone/transform"/>
+    </animation>
+    <animation id="Armature_Bone_001_pose_matrix">
+      <source id="Armature_Bone_001_pose_matrix-input">
+        <float_array id="Armature_Bone_001_pose_matrix-input-array" count="2">0 1.666667</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-input-array" count="2" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_001_pose_matrix-output">
+        <float_array id="Armature_Bone_001_pose_matrix-output-array" count="32">0.9999656 -6.87763e-5 0.008295656 2.86349e-11 -4.62889e-8 0.9999655 0.008295939 2.390159 -0.008295939 -0.008295652 0.9999311 5.29598e-9 0 0 0 1 0.7659739 -0.6428182 0.008295656 2.86349e-11 0.6427655 0.766018 0.008295938 2.390159 -0.0116874 -0.001022311 0.9999311 5.29598e-9 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-output-array" count="2" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_001_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_001_pose_matrix-interpolation-array" count="2">LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-interpolation-array" count="2" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_001_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_001_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_001_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_001_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_001_pose_matrix-sampler" target="Bone_001/transform"/>
+    </animation>
+    <animation id="Armature_Bone_002_pose_matrix">
+      <source id="Armature_Bone_002_pose_matrix-input">
+        <float_array id="Armature_Bone_002_pose_matrix-input-array" count="2">0 1.666667</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_002_pose_matrix-input-array" count="2" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_002_pose_matrix-output">
+        <float_array id="Armature_Bone_002_pose_matrix-output-array" count="32">1 0 2.90955e-9 1.19209e-7 0 1 -4.65663e-10 2.617677 -2.57687e-9 -2.47772e-10 1 -1.86265e-9 0 0 0 1 1 -9.01513e-10 -2.47689e-9 1.19209e-7 0 0.9396926 -0.3420201 2.617677 3.12665e-9 0.3420201 0.9396926 -1.86265e-9 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_002_pose_matrix-output-array" count="2" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_002_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_002_pose_matrix-interpolation-array" count="2">LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_002_pose_matrix-interpolation-array" count="2" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_002_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_002_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_002_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_002_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_002_pose_matrix-sampler" target="Bone_002/transform"/>
+    </animation>
+  </library_animations>
+  <library_controllers>
+    <controller id="Armature_Cube_001-skin" name="Armature">
+      <skin source="#Cube_001-mesh">
+        <bind_shape_matrix>1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</bind_shape_matrix>
+        <source id="Armature_Cube_001-skin-joints">
+          <Name_array id="Armature_Cube_001-skin-joints-array" count="3">Bone Bone_001 Bone_002</Name_array>
+          <technique_common>
+            <accessor source="#Armature_Cube_001-skin-joints-array" count="3" stride="1">
+              <param name="JOINT" type="name"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Armature_Cube_001-skin-bind_poses">
+          <float_array id="Armature_Cube_001-skin-bind_poses-array" count="48">6.87977e-5 0.9999656 0.008295655 0 -0.9999656 0 0.008295893 0 0.008295595 -0.008295893 0.9999312 0 0 0 0 1 0 1 0 0 -1 0 0 -2.390077 0 0 1 -0.01982861 0 0 0 1 0 1 0 0 -1 0 0 -5.007753 0 0 1 -0.01982861 0 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Armature_Cube_001-skin-bind_poses-array" count="3" stride="16">
+              <param name="TRANSFORM" type="float4x4"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Armature_Cube_001-skin-weights">
+          <float_array id="Armature_Cube_001-skin-weights-array" count="62">0.9982073 0.001792669 1 0 1 1 0 0.9999979 2.19895e-6 0.9951928 0.004807233 0.9999917 8.33525e-6 1 0 0 0.9998548 1.45206e-4 1.27879e-4 0.9998721 0 1 0 0 0.9999999 0 8.74824e-5 0.9999125 0 0 1 0 2.12114e-4 0.9996866 1.01293e-4 0 1 0 0 1 0 1 0 1 0 1 0 1 0 1 0.03359806 0.9664019 0 0.9999999 1 1 1 1 1 1 1 1</float_array>
+          <technique_common>
+            <accessor source="#Armature_Cube_001-skin-weights-array" count="62" stride="1">
+              <param name="WEIGHT" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <joints>
+          <input semantic="JOINT" source="#Armature_Cube_001-skin-joints"/>
+          <input semantic="INV_BIND_MATRIX" source="#Armature_Cube_001-skin-bind_poses"/>
+        </joints>
+        <vertex_weights count="32">
+          <input semantic="JOINT" source="#Armature_Cube_001-skin-joints" offset="0"/>
+          <input semantic="WEIGHT" source="#Armature_Cube_001-skin-weights" offset="1"/>
+          <vcount>2 2 1 2 2 2 2 2 3 2 3 3 3 3 3 3 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 </vcount>
+          <v>0 0 1 1 0 2 1 3 0 4 0 5 1 6 0 7 1 8 0 9 1 10 0 11 1 12 0 13 1 14 0 15 1 16 2 17 0 18 1 19 0 20 1 21 2 22 0 23 1 24 2 25 0 26 1 27 2 28 0 29 1 30 2 31 0 32 1 33 2 34 0 35 1 36 2 37 0 38 2 39 0 40 2 41 0 42 2 43 0 44 2 45 0 46 2 47 0 48 2 49 0 50 2 51 0 52 2 53 2 54 2 55 2 56 2 57 2 58 2 59 2 60 2 61</v>
+        </vertex_weights>
+      </skin>
+    </controller>
+  </library_controllers>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Armature" name="Armature" type="NODE">
+        <translate sid="location">0 0 0</translate>
+        <rotate sid="rotationZ">0 0 1 0</rotate>
+        <rotate sid="rotationY">0 1 0 0</rotate>
+        <rotate sid="rotationX">1 0 0 0</rotate>
+        <scale sid="scale">1 1 1</scale>
+        <node id="Bone" name="Bone" sid="Bone" type="JOINT">
+          <matrix sid="transform">6.87838e-5 -0.9999656 0.008295654 1.33878e-9 0.9999656 -2.49375e-8 -0.008295939 7.82311e-8 0.008295654 0.008295939 0.9999312 2.14204e-8 0 0 0 1</matrix>
+          <node id="Bone_001" name="Bone.001" sid="Bone_001" type="JOINT">
+            <matrix sid="transform">0.9999656 -6.87763e-5 0.008295657 4.31797e-11 -4.62894e-8 0.9999656 0.00829594 2.390159 -0.008295939 -0.008295653 0.9999312 5.29598e-9 0 0 0 1</matrix>
+            <node id="Bone_002" name="Bone.002" sid="Bone_002" type="JOINT">
+              <matrix sid="transform">1 -2.13469e-8 -2.79397e-9 7.10543e-15 2.13469e-8 1 0 2.617677 2.79397e-9 0 1 0 0 0 0 1</matrix>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node id="Cube_001" name="Cube_001" type="NODE">
+        <translate sid="location">0 0 0</translate>
+        <rotate sid="rotationZ">0 0 1 0</rotate>
+        <rotate sid="rotationY">0 1 0 0</rotate>
+        <rotate sid="rotationX">1 0 0 0</rotate>
+        <scale sid="scale">1 1 1</scale>
+        <instance_controller url="#Armature_Cube_001-skin">
+          <skeleton>#Bone</skeleton>
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="Material_001-material" target="#Material_001-material"/>
+            </technique_common>
+          </bind_material>
+        </instance_controller>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaModelBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaModelBuilder.java
@@ -41,22 +41,16 @@ public class ColladaModelBuilder extends Builder<Void>  {
 
         // MeshSet
         ByteArrayInputStream mesh_is = new ByteArrayInputStream(task.input(0).getContent());
-        Mesh.Builder meshBuilder = Mesh.newBuilder();
+        MeshSet.Builder meshSetBuilder = MeshSet.newBuilder();
         AnimationSet.Builder animSetBuilder = AnimationSet.newBuilder();
         Skeleton.Builder skeletonBuilder = Skeleton.newBuilder();
         try {
-            ColladaUtil.load(mesh_is, meshBuilder, animSetBuilder, skeletonBuilder);
+            ColladaUtil.load(mesh_is, meshSetBuilder, animSetBuilder, skeletonBuilder);
         } catch (XMLStreamException e) {
             throw new CompileExceptionError(task.input(0), e.getLocation().getLineNumber(), "Failed to compile mesh: " + e.getLocalizedMessage(), e);
         } catch (LoaderException e) {
             throw new CompileExceptionError(task.input(0), -1, "Failed to compile mesh: " + e.getLocalizedMessage(), e);
         }
-        Mesh mesh = meshBuilder.build();
-        MeshSet.Builder meshSetBuilder = MeshSet.newBuilder();
-        MeshEntry.Builder meshEntryBuilder = MeshEntry.newBuilder();
-        meshEntryBuilder.addMeshes(mesh);
-        meshEntryBuilder.setId(0);
-        meshSetBuilder.addMeshEntries(meshEntryBuilder);
         out = new ByteArrayOutputStream(64 * 1024);
         meshSetBuilder.build().writeTo(out);
         out.close();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
@@ -670,7 +670,7 @@ public class ColladaUtil {
         com.dynamo.rig.proto.Rig.Bone.Builder b = com.dynamo.rig.proto.Rig.Bone.newBuilder();
 
         b.setParent(parentIndex);
-        b.setId(MurmurHash.hash64(bone.getName()));
+        b.setId(MurmurHash.hash64(bone.getSourceId()));
 
         Matrix4d matrix = MathUtil.floatToDouble(MathUtil.vecmath2ToVecmath1(bone.bindMatrix));
 

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/MeshLoader.java
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/MeshLoader.java
@@ -14,6 +14,7 @@ import com.dynamo.cr.sceneed.core.INodeLoader;
 import com.google.protobuf.Message;
 import com.dynamo.rig.proto.Rig.AnimationSet;
 import com.dynamo.rig.proto.Rig.Mesh;
+import com.dynamo.rig.proto.Rig.MeshSet;
 import com.dynamo.rig.proto.Rig.Skeleton;
 
 public class MeshLoader implements INodeLoader<MeshNode> {
@@ -23,11 +24,12 @@ public class MeshLoader implements INodeLoader<MeshNode> {
             throws IOException, CoreException {
 
         try {
-            Mesh.Builder meshBuilder = Mesh.newBuilder();
+            MeshSet.Builder meshSetBuilder = MeshSet.newBuilder();
             Skeleton.Builder skeletonBuilder = Skeleton.newBuilder();
             AnimationSet.Builder animSetBuilder = AnimationSet.newBuilder();
-            ColladaUtil.load(contents, meshBuilder, animSetBuilder, skeletonBuilder);
-            return new MeshNode(meshBuilder.build());
+            ColladaUtil.load(contents, meshSetBuilder, animSetBuilder, skeletonBuilder);
+            Mesh mesh = meshSetBuilder.getMeshEntries(0).getMeshes(0);
+            return new MeshNode(mesh);
         } catch (XMLStreamException e) {
             return invalidMeshNode(e);
         } catch (LoaderException e) {

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/ModelNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/ModelNode.java
@@ -198,7 +198,7 @@ public class ModelNode extends ComponentTypeNode {
         ArrayList<String> boneIds = new ArrayList<String>();
         try {
             IFile skeletonFile = getModel().getFile(this.skeleton.isEmpty() ? this.mesh : this.skeleton);
-            ColladaUtil.loadSkeleton(skeletonFile.getContents(), skeletonBuilder, boneIds, null);
+            ColladaUtil.loadSkeleton(skeletonFile.getContents(), skeletonBuilder, boneIds);
         } catch (Exception e) {
             updateStatus();
             return;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1417,6 +1417,8 @@ namespace dmGameSystem
         out_data->m_AnimationSet = rig_res->m_AnimationSetRes->m_AnimationSet;
         out_data->m_Texture = rig_res->m_TextureSet->m_Texture;
         out_data->m_TextureSet = rig_res->m_TextureSet->m_TextureSet;
+        out_data->m_PoseIdxToInfluence = &rig_res->m_PoseIdxToInfluence;
+        out_data->m_TrackIdxToPose     = &rig_res->m_TrackIdxToPose;
 
         return true;
     }

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -286,6 +286,8 @@ namespace dmGameSystem
         create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes == 0x0 ? 0x0 : rig_resource->m_AnimationSetRes->m_AnimationSet;
         create_params.m_Skeleton         = rig_resource->m_SkeletonRes == 0x0 ? 0x0 : rig_resource->m_SkeletonRes->m_Skeleton;
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;
+        create_params.m_PoseIdxToInfluence = &rig_resource->m_PoseIdxToInfluence;
+        create_params.m_TrackIdxToPose     = &rig_resource->m_TrackIdxToPose;
         create_params.m_MeshId           = 0; // not implemented for models
         create_params.m_DefaultAnimation = dmHashString64(component->m_Resource->m_Model->m_DefaultAnimation);
 
@@ -698,6 +700,8 @@ namespace dmGameSystem
         create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes == 0x0 ? 0x0 : rig_resource->m_AnimationSetRes->m_AnimationSet;
         create_params.m_Skeleton         = rig_resource->m_SkeletonRes == 0x0 ? 0x0 : rig_resource->m_SkeletonRes->m_Skeleton;
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;
+        create_params.m_PoseIdxToInfluence = &rig_resource->m_PoseIdxToInfluence;
+        create_params.m_TrackIdxToPose     = &rig_resource->m_TrackIdxToPose;
         create_params.m_MeshId           = 0; // not implemented for models
         create_params.m_DefaultAnimation = dmHashString64(component->m_Resource->m_Model->m_DefaultAnimation);
 

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -320,6 +320,8 @@ namespace dmGameSystem
         create_params.m_Skeleton         = rig_resource->m_SkeletonRes->m_Skeleton;
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;
         create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes->m_AnimationSet;
+        create_params.m_PoseIdxToInfluence = &rig_resource->m_PoseIdxToInfluence;
+        create_params.m_TrackIdxToPose     = &rig_resource->m_TrackIdxToPose;
         create_params.m_MeshId           = dmHashString64(component->m_Resource->m_Model->m_Skin);
         create_params.m_DefaultAnimation = dmHashString64(component->m_Resource->m_Model->m_DefaultAnimation);
 
@@ -724,6 +726,8 @@ namespace dmGameSystem
         create_params.m_Skeleton         = rig_resource->m_SkeletonRes->m_Skeleton;
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;
         create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes->m_AnimationSet;
+        create_params.m_PoseIdxToInfluence = &rig_resource->m_PoseIdxToInfluence;
+        create_params.m_TrackIdxToPose     = &rig_resource->m_TrackIdxToPose;
         create_params.m_MeshId           = dmHashString64(component->m_Resource->m_Model->m_Skin);
         create_params.m_DefaultAnimation = dmHashString64(component->m_Resource->m_Model->m_DefaultAnimation);
 

--- a/engine/gamesys/src/gamesys/resources/res_rig_scene.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_rig_scene.cpp
@@ -70,6 +70,7 @@ namespace dmGameSystem
         if (result == dmResource::RESULT_OK && resource->m_SkeletonRes)
         {
             dmRig::CreateBindPose(*resource->m_SkeletonRes->m_Skeleton, resource->m_BindPose);
+            dmRig::CreateLookUpArrays(*resource->m_MeshSetRes->m_MeshSet, *resource->m_AnimationSetRes->m_AnimationSet, *resource->m_SkeletonRes->m_Skeleton, resource->m_TrackIdxToPose, resource->m_PoseIdxToInfluence);
         }
         return result;
     }

--- a/engine/gamesys/src/gamesys/resources/res_rig_scene.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_rig_scene.cpp
@@ -70,7 +70,7 @@ namespace dmGameSystem
         if (result == dmResource::RESULT_OK && resource->m_SkeletonRes)
         {
             dmRig::CreateBindPose(*resource->m_SkeletonRes->m_Skeleton, resource->m_BindPose);
-            dmRig::CreateLookUpArrays(*resource->m_MeshSetRes->m_MeshSet, *resource->m_AnimationSetRes->m_AnimationSet, *resource->m_SkeletonRes->m_Skeleton, resource->m_TrackIdxToPose, resource->m_PoseIdxToInfluence);
+            dmRig::FillBoneListArrays(*resource->m_MeshSetRes->m_MeshSet, *resource->m_AnimationSetRes->m_AnimationSet, *resource->m_SkeletonRes->m_Skeleton, resource->m_TrackIdxToPose, resource->m_PoseIdxToInfluence);
         }
         return result;
     }

--- a/engine/gamesys/src/gamesys/resources/res_rig_scene.h
+++ b/engine/gamesys/src/gamesys/resources/res_rig_scene.h
@@ -24,6 +24,9 @@ namespace dmGameSystem
         MeshSetResource*        m_MeshSetRes;
         AnimationSetResource*   m_AnimationSetRes;
         TextureSetResource*     m_TextureSet;
+
+        dmArray<uint32_t>       m_PoseIdxToInfluence;
+        dmArray<uint32_t>       m_TrackIdxToPose;
     };
 
     dmResource::Result ResRigScenePreload(const dmResource::ResourcePreloadParams& params);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2345,6 +2345,8 @@ namespace dmGui
         create_params.m_Skeleton         = rig_data.m_Skeleton;
         create_params.m_MeshSet          = rig_data.m_MeshSet;
         create_params.m_AnimationSet     = rig_data.m_AnimationSet;
+        create_params.m_PoseIdxToInfluence = rig_data.m_PoseIdxToInfluence;
+        create_params.m_TrackIdxToPose     = rig_data.m_TrackIdxToPose;
         create_params.m_MeshId           = skin_id;
         create_params.m_DefaultAnimation = default_animation_id;
 

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -126,6 +126,8 @@ namespace dmGui
         dmRigDDF::Skeleton*      m_Skeleton;
         dmRigDDF::MeshSet*       m_MeshSet;
         dmRigDDF::AnimationSet*  m_AnimationSet;
+        const dmArray<uint32_t>* m_PoseIdxToInfluence;
+        const dmArray<uint32_t>* m_TrackIdxToPose;
         void*                    m_Texture;
         void*                    m_TextureSet;
     };

--- a/engine/rig/proto/rig/rig_ddf.proto
+++ b/engine/rig/proto/rig/rig_ddf.proto
@@ -97,6 +97,7 @@ message RigAnimation
 message AnimationSet
 {
     repeated RigAnimation animations = 1;
+    repeated uint64 bone_list = 2;
 }
 
 message Mesh
@@ -128,6 +129,10 @@ message MeshEntry
 message MeshSet
 {
     repeated MeshEntry mesh_entries = 1;
+
+    // List of bone names that represent the order of the bone influences.
+    // Not used for Spine rigs since they don't have support for external skeletons.
+    repeated uint64 bone_list = 2;
 }
 
 message RigScene
@@ -136,4 +141,7 @@ message RigScene
     optional string animation_set = 2 [(resource)=true];
     required string mesh_set = 3 [(resource)=true];
     optional string texture_set = 4 [(resource)=true];
+
+    repeated uint32 pose_idx_to_influence = 5;
+    repeated uint32 track_idx_to_pose = 6;
 }

--- a/engine/rig/proto/rig/rig_ddf.proto
+++ b/engine/rig/proto/rig/rig_ddf.proto
@@ -141,7 +141,4 @@ message RigScene
     optional string animation_set = 2 [(resource)=true];
     required string mesh_set = 3 [(resource)=true];
     optional string texture_set = 4 [(resource)=true];
-
-    repeated uint32 pose_idx_to_influence = 5;
-    repeated uint32 track_idx_to_pose = 6;
 }

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -1414,22 +1414,34 @@ namespace dmRig
         pose_idx_to_influence.SetCapacity(bone_count);
         pose_idx_to_influence.SetSize(bone_count);
 
+        uint32_t anim_bone_list_count = animationset.m_BoneList.m_Count;
+        uint32_t mesh_bone_list_count = meshset.m_BoneList.m_Count;
+
         for (int bi = 0; bi < bone_count; ++bi)
         {
             uint64_t bone_id = skeleton.m_Bones[bi].m_Id;
-            uint32_t track_idx = FindBoneInList(animationset.m_BoneList.m_Data, animationset.m_BoneList.m_Count, bone_id);
-            uint32_t influence_idx = FindBoneInList(meshset.m_BoneList.m_Data, meshset.m_BoneList.m_Count, bone_id);
 
-            if (track_idx != INVALID_BONE_IDX) {
-                track_idx_to_pose[track_idx] = bi;
-            }
-            if (influence_idx != INVALID_BONE_IDX) {
-                pose_idx_to_influence[bi] = influence_idx;
+            if (anim_bone_list_count) {
+                uint32_t track_idx = FindBoneInList(animationset.m_BoneList.m_Data, animationset.m_BoneList.m_Count, bone_id);
+                if (track_idx != INVALID_BONE_IDX) {
+                    track_idx_to_pose[track_idx] = bi;
+                }
             } else {
-                // If there is no influence index for the current bone
-                // we still need to put the pose matrix somewhere during
-                // pose-to-influence rearrangement so just put it last.
-                pose_idx_to_influence[bi] = bone_count - 1;
+                track_idx_to_pose[bi] = bi;
+            }
+
+            if (mesh_bone_list_count) {
+                uint32_t influence_idx = FindBoneInList(meshset.m_BoneList.m_Data, meshset.m_BoneList.m_Count, bone_id);
+                if (influence_idx != INVALID_BONE_IDX) {
+                    pose_idx_to_influence[bi] = influence_idx;
+                } else {
+                    // If there is no influence index for the current bone
+                    // we still need to put the pose matrix somewhere during
+                    // pose-to-influence rearrangement so just put it last.
+                    pose_idx_to_influence[bi] = bone_count - 1;
+                }
+            } else {
+                pose_idx_to_influence[bi] = bi;
             }
         }
     }

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -1415,6 +1415,8 @@ namespace dmRig
 
         track_idx_to_pose.SetCapacity(bone_count);
         track_idx_to_pose.SetSize(bone_count);
+        memset((void*)track_idx_to_pose.Begin(), 0x0, track_idx_to_pose.Size()*sizeof(uint32_t));
+
         pose_idx_to_influence.SetCapacity(bone_count);
         pose_idx_to_influence.SetSize(bone_count);
 

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -1191,11 +1191,15 @@ namespace dmRig
             // Bump scratch buffer capacity to handle current vertex count
             uint32_t index_count = mesh->m_Indices.m_Count;
             if (positions.Capacity() < index_count) {
-                int offset_capacity = index_count - positions.Capacity();
-                positions.OffsetCapacity(offset_capacity);
-                if (vertex_format == RIG_VERTEX_FORMAT_MODEL && mesh->m_NormalsIndices.m_Count) {
-                    normals.OffsetCapacity(offset_capacity);
+                positions.OffsetCapacity(index_count - positions.Capacity());
+            }
+            positions.SetSize(index_count);
+
+            if (vertex_format == RIG_VERTEX_FORMAT_MODEL && mesh->m_NormalsIndices.m_Count) {
+                if (normals.Capacity() < index_count) {
+                    normals.OffsetCapacity(index_count - normals.Capacity());
                 }
+                normals.SetSize(index_count);
             }
 
             // Fill scratch buffers for positions, and normals if applicable, using pose matrices.

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -1402,7 +1402,7 @@ namespace dmRig
         return INVALID_BONE_IDX;
     }
 
-    void CreateLookUpArrays(const dmRigDDF::MeshSet& meshset, const dmRigDDF::AnimationSet& animationset, const dmRigDDF::Skeleton& skeleton, dmArray<uint32_t>& track_idx_to_pose, dmArray<uint32_t>& pose_idx_to_influence)
+    void FillBoneListArrays(const dmRigDDF::MeshSet& meshset, const dmRigDDF::AnimationSet& animationset, const dmRigDDF::Skeleton& skeleton, dmArray<uint32_t>& track_idx_to_pose, dmArray<uint32_t>& pose_idx_to_influence)
     {
         // Create lookup arrays
         // - track-to-pose, used to convert animation track bonde index into correct pose transform index

--- a/engine/rig/src/rig.h
+++ b/engine/rig/src/rig.h
@@ -188,6 +188,7 @@ namespace dmRig
         // Temporary scratch buffers used for store pose as transform and matrices
         // (avoids modifying the real pose transform data during rendering).
         dmArray<dmTransform::Transform> m_ScratchPoseTransformBuffer;
+        dmArray<Matrix4>                m_ScratchInfluenceMatrixBuffer;
         dmArray<Matrix4>                m_ScratchPoseMatrixBuffer;
         // Temporary scratch buffers used when transforming the vertex buffer,
         // used to creating primitives from indices.
@@ -212,6 +213,8 @@ namespace dmRig
         const dmRigDDF::Skeleton*     m_Skeleton;
         const dmRigDDF::MeshSet*      m_MeshSet;
         const dmRigDDF::AnimationSet* m_AnimationSet;
+        const dmArray<uint32_t>*      m_PoseIdxToInfluence;
+        const dmArray<uint32_t>*      m_TrackIdxToPose;
         RigPoseCallback               m_PoseCallback;
         void*                         m_PoseCBUserData1;
         void*                         m_PoseCBUserData2;
@@ -255,6 +258,10 @@ namespace dmRig
         const dmRigDDF::Skeleton*     m_Skeleton;
         const dmRigDDF::MeshSet*      m_MeshSet;
         const dmRigDDF::AnimationSet* m_AnimationSet;
+
+        const dmArray<uint32_t>*      m_PoseIdxToInfluence;
+        const dmArray<uint32_t>*      m_TrackIdxToPose;
+
         RigPoseCallback               m_PoseCallback;
         void*                         m_PoseCBUserData1;
         void*                         m_PoseCBUserData2;
@@ -298,6 +305,7 @@ namespace dmRig
     // Util function used to fill a bind pose array from skeleton data
     // used in rig tests and loading rig resources.
     void CreateBindPose(dmRigDDF::Skeleton& skeleton, dmArray<RigBone>& bind_pose);
+    void CreateLookUpArrays(const dmRigDDF::MeshSet& meshset, const dmRigDDF::AnimationSet& animationset, const dmRigDDF::Skeleton& skeleton, dmArray<uint32_t>& track_idx_to_pose, dmArray<uint32_t>& pose_idx_to_influence);
 }
 
 #endif // DM_RIG_H

--- a/engine/rig/src/rig.h
+++ b/engine/rig/src/rig.h
@@ -305,7 +305,7 @@ namespace dmRig
     // Util function used to fill a bind pose array from skeleton data
     // used in rig tests and loading rig resources.
     void CreateBindPose(dmRigDDF::Skeleton& skeleton, dmArray<RigBone>& bind_pose);
-    void CreateLookUpArrays(const dmRigDDF::MeshSet& meshset, const dmRigDDF::AnimationSet& animationset, const dmRigDDF::Skeleton& skeleton, dmArray<uint32_t>& track_idx_to_pose, dmArray<uint32_t>& pose_idx_to_influence);
+    void FillBoneListArrays(const dmRigDDF::MeshSet& meshset, const dmRigDDF::AnimationSet& animationset, const dmRigDDF::Skeleton& skeleton, dmArray<uint32_t>& track_idx_to_pose, dmArray<uint32_t>& pose_idx_to_influence);
 }
 
 #endif // DM_RIG_H

--- a/engine/rig/src/test/test_rig.cpp
+++ b/engine/rig/src/test/test_rig.cpp
@@ -436,7 +436,7 @@ private:
             m_MeshSet->m_BoneList.m_Data[i] = bone_count-i-1;
         }
 
-        dmRig::CreateLookUpArrays(*m_MeshSet, *m_AnimationSet, *m_Skeleton, m_TrackIdxToPose, m_PoseIdxToInfluence);
+        dmRig::FillBoneListArrays(*m_MeshSet, *m_AnimationSet, *m_Skeleton, m_TrackIdxToPose, m_PoseIdxToInfluence);
 
     }
 


### PR DESCRIPTION
* ColladaUtil::load() now fills a MeshSet.Builder instead of Mesh.Builder.
* dmRigDDF::MeshSet and dmRigDDF::AnimationSet now include bone lists to specify in what order their bone indices are defined.
* Use dmRig::FillBoneListArrays to fill bone indices lookup arrays during rig scene loading.
* Added a new scratch Matrix4 buffer used to rearrange pose matrices into the order expected by vertex influences.