### PR TITLE
DEFEDIT-534 Nodes from deleted files remain in the graph

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -489,13 +489,10 @@
             old->new (atom {})]
         ;; Internal resources to reload
         (let [in-use? (fn [resource-node-id]
-                        (reduce (fn [_ [target _]]
-                                  (if (and (not= project target)
-                                           (= project-graph (g/node-id->graph-id target)))
-                                    (reduced true)
-                                    false))
-                                false
-                                (gt/targets (g/now) resource-node-id)))
+                        (some (fn [[target _]]
+                                (and (not= project target)
+                                     (= project-graph (g/node-id->graph-id target))))
+                              (gt/targets (g/now) resource-node-id)))
               should-create-node? (fn [[operation resource]]
                                     (or (not= :removed operation)
                                         (-> resource


### PR DESCRIPTION
Fixes DEFEDIT-534

* When a file that does not have any outputs in the project graph is deleted, we do not create a "missing" resource node for it.