### PR TITLE
DEFEDIT-541 Staging files to commit is unintuitive

### DIFF
--- a/editor/resources/editor.css
+++ b/editor/resources/editor.css
@@ -245,7 +245,11 @@ Defold Orange       #fd6623             Guides etc
   -fx-control-inner-background: #323232;
   -fx-hover-base: #c80000; }
 
+.text-input {
+  -fx-prompt-text-fill: #484d54; }
+
 .text-area {
+  -fx-border-color: #484d54;
   -fx-font-size: 9pt;
   -fx-font-family: "Dejavu Sans Mono"; }
 

--- a/editor/resources/sync-push.fxml
+++ b/editor/resources/sync-push.fxml
@@ -33,7 +33,24 @@
                <children>
                   <Label id="changed-files" text="Changed Files" />
                   <ListView id="changed" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS" />
-                  <Label text="Files to Commit">
+                  <HBox BorderPane.alignment="CENTER">
+                     <padding>
+                        <Insets top="16.0" />
+                     </padding>
+                     <children>
+                        <Pane HBox.hgrow="ALWAYS">
+                           <children>
+                              <Button id="diff" mnemonicParsing="false" prefWidth="80.0" text="View Diff" />
+                           </children>
+                        </Pane>
+                        <Button id="stage" mnemonicParsing="false" prefWidth="80.0" text="&#x25bc; Stage" />
+                        <Button id="unstage" mnemonicParsing="false" prefWidth="80.0" text="&#x25b2; Unstage" />
+                     </children>
+                     <padding>
+                        <Insets bottom="0.0" left="16.0" right="16.0" top="26.0" />
+                     </padding>
+                  </HBox>
+                  <Label text="Files Staged for Commit">
                      <padding>
                         <Insets top="16.0" />
                      </padding>
@@ -44,7 +61,7 @@
                         <Insets top="16.0" />
                      </padding>
                   </Label>
-                  <TextArea id="message" prefHeight="200.0" prefWidth="200.0" />
+                  <TextArea id="message" prefHeight="200.0" prefWidth="200.0" promptText="Describe Your Changes" />
                </children>
             </VBox>
          </children>

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -14,7 +14,7 @@
            [org.eclipse.jgit.revwalk RevCommit]
            [org.eclipse.jgit.api.errors StashApplyFailureException]
            [javafx.scene Parent Scene]
-           [javafx.scene.control SelectionMode ListView TextArea]
+           [javafx.scene.control Button SelectionMode ListView TextArea]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.stage Modality]))
 
@@ -303,10 +303,43 @@
         scene           (Scene. root)
         dialog-controls (ui/collect-controls root [ "ok" "push" "cancel" "dialog-area" "progress-bar"])
         pull-controls   (ui/collect-controls pull-root ["conflicting" "resolved" "conflict-box" "main-label"])
-        push-controls   (ui/collect-controls push-root ["changed" "staged" "message" "content-box" "main-label"])
+        push-controls   (ui/collect-controls push-root ["changed" "staged" "message" "content-box" "main-label" "diff" "stage" "unstage"])
         render-progress (fn [progress]
                           (ui/run-later
-                           (ui/update-progress-controls! progress (:progress-bar dialog-controls) nil)))
+                            (ui/update-progress-controls! progress (:progress-bar dialog-controls) nil)))
+        update-push-buttons! (fn []
+                               ;; The stage, unstage and diff buttons are enabled
+                               ;; if the changed or staged views have input focus
+                               ;; and something selected. The diff button is
+                               ;; disabled if more than one item is selected.
+                               (let [changed-view      (:changed push-controls)
+                                     changed-selection (ui/selection changed-view)
+                                     staged-view       (:staged push-controls)
+                                     staged-selection  (ui/selection staged-view)
+                                     enabled           (cond
+                                                         (and (ui/focus? changed-view)
+                                                              (seq changed-selection))
+                                                         (if (next changed-selection)
+                                                           #{:stage}
+                                                           #{:stage :diff})
+
+                                                         (and (ui/focus? staged-view)
+                                                              (seq staged-selection))
+                                                         (if (next staged-selection)
+                                                           #{:unstage}
+                                                           #{:unstage :diff})
+
+                                                         :else
+                                                         #{})]
+                                 (ui/disable! (:diff push-controls) (not (:diff enabled)))
+                                 (ui/disable! (:stage push-controls) (not (:stage enabled)))
+                                 (ui/disable! (:unstage push-controls) (not (:unstage enabled)))
+
+                                 (when (:diff enabled)
+                                   (if-let [selection-provider (cond (ui/focus? changed-view) changed-view
+                                                                     (ui/focus? staged-view) staged-view
+                                                                     :else nil)]
+                                     (ui/context! (:diff push-controls) :sync {:!flow !flow} selection-provider)))))
         update-controls (fn [{:keys [state conflicts resolved modified staged] :as flow}]
                           (ui/run-later
                            (if (= "pull" (namespace state))
@@ -343,14 +376,25 @@
                                                 (ui/visible! (:push dialog-controls) false)
                                                 (ui/visible! (:conflict-box pull-controls) false)
                                                 (ui/text! (:ok dialog-controls) "Close"))
-
-                             :push/staging   (do
-                                               (ui/items! (:changed push-controls) (sort modified))
-                                               (ui/items! (:staged push-controls) (sort staged))
+                             :push/staging   (let [changed-view ^ListView (:changed push-controls)
+                                                   staged-view ^ListView (:staged push-controls)
+                                                   changed-selection (vec (ui/selection changed-view))
+                                                   staged-selection (vec (ui/selection staged-view))]
+                                               (ui/items! changed-view (sort modified))
+                                               (ui/items! staged-view (sort staged))
                                                (ui/disable! (:ok dialog-controls)
                                                             (or (empty? staged)
-                                                                (empty? (ui/text (:message push-controls))))))
+                                                                (empty? (ui/text (:message push-controls)))))
 
+                                               ;; The stage, unstage and diff buttons start off disabled, but
+                                               ;; might be enabled by the event handler triggered by select!
+                                               (ui/disable! (:diff push-controls) true)
+                                               (ui/disable! (:stage push-controls) true)
+                                               (ui/disable! (:unstage push-controls) true)
+                                               (doseq [item changed-selection]
+                                                 (ui/select! changed-view item))
+                                               (doseq [item staged-selection]
+                                                 (ui/select! staged-view item)))
                              :push/done    (do
                                              (ui/text! (:main-label push-controls) "Done!")
                                              (ui/visible! (:content-box push-controls) false)
@@ -388,6 +432,21 @@
                                                                    :progress (progress/make "push" 4)}))
                                              (swap! !flow advance-flow render-progress)))
 
+    (ui/bind-action! (:diff push-controls) :show-file-diff)
+
+    (ui/observe (.focusOwnerProperty scene)
+                (fn [_ _ new]
+                  (when-not (instance? Button new)
+                    (update-push-buttons!))))
+
+    (ui/observe (.. ^ListView (:changed push-controls) getSelectionModel selectedItemProperty)
+                (fn [_ _ _]
+                  (update-push-buttons!)))
+
+    (ui/observe (.. ^ListView (:staged push-controls) getSelectionModel selectedItemProperty)
+                (fn [_ _ _]
+                  (update-push-buttons!)))
+
     (ui/observe (.textProperty ^TextArea (:message push-controls))
                 (fn [_ _ _]
                   (update-controls @!flow)))
@@ -402,12 +461,16 @@
     (let [^ListView list-view (:changed push-controls)]
       (.setSelectionMode (.getSelectionModel list-view) SelectionMode/MULTIPLE)
       (ui/context! list-view :sync {:!flow !flow} list-view)
+      (ui/context! (:stage push-controls) :sync {:!flow !flow} list-view)
+      (ui/bind-action! (:stage push-controls) :stage-file)
       (ui/register-context-menu list-view ::staging-menu)
       (ui/cell-factory! list-view (fn [e] {:text e})))
 
     (let [^ListView list-view (:staged push-controls)]
       (.setSelectionMode (.getSelectionModel list-view) SelectionMode/MULTIPLE)
       (ui/context! list-view :sync {:!flow !flow} list-view)
+      (ui/context! (:unstage push-controls) :sync {:!flow !flow} list-view)
+      (ui/bind-action! (:unstage push-controls) :unstage-file)
       (ui/register-context-menu list-view ::unstaging-menu)
       (ui/cell-factory! list-view (fn [e] {:text e})))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#11
Fixes DEFEDIT-541

* Added buttons for Stage, Unstage and View Diff to the Push stage of the Sync dialog.
* Added prompt text to Commit Message field.
* Styled `TextArea` controls to have a thin grey border similar to `ListView` controls.

![stage-local-changes](https://cloud.githubusercontent.com/assets/22448941/20058710/982aead2-a4f2-11e6-90e5-720cadb39be0.png)