### PR TITLE
DEFEDIT-540 Fix memory leak in code editor

### DIFF
--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
@@ -15,6 +15,7 @@ import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.WeakChangeListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
@@ -159,11 +160,11 @@ public class DefoldStyledTextLayoutContainer extends Region {
 		Bindings.bindContent(this.textLayoutNode.getChildren(), this.textNodes);
 		getChildren().setAll(this.selectionMarker, this.textLayoutNode, this.caret);
 		selectionProperty().addListener(this::handleSelectionChange);
-		ownerFocusedProperty.addListener( o -> {
-			if( ! ownerFocusedProperty.get() ) {
-				this.caret.setVisible(false);
+		ownerFocusedProperty.addListener(new WeakChangeListener<>((observable, oldValue, newValue) -> {
+			if (!newValue) {
+                            this.caret.setVisible(false);
 			}
-		});
+                }));
 	}
 
 	private int getEndOffset() {

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextLayoutContainer.java
@@ -15,6 +15,7 @@ import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -110,6 +111,7 @@ public class DefoldStyledTextLayoutContainer extends Region {
 	int caretIndex = -1;
 
 	private final ReadOnlyBooleanProperty ownerFocusedProperty;
+	private final ChangeListener<Boolean> ownerFocusedChangedListener;
 
 	/**
 	 * Create a container to layout text and allows to show e.g. a selection
@@ -160,11 +162,13 @@ public class DefoldStyledTextLayoutContainer extends Region {
 		Bindings.bindContent(this.textLayoutNode.getChildren(), this.textNodes);
 		getChildren().setAll(this.selectionMarker, this.textLayoutNode, this.caret);
 		selectionProperty().addListener(this::handleSelectionChange);
-		ownerFocusedProperty.addListener(new WeakChangeListener<>((observable, oldValue, newValue) -> {
-			if (!newValue) {
-                            this.caret.setVisible(false);
+
+		this.ownerFocusedChangedListener = (observable, oldValue, newValue) -> {
+			if(!newValue) {
+				this.caret.setVisible(false);
 			}
-                }));
+		};
+		this.ownerFocusedProperty.addListener(new WeakChangeListener<>(this.ownerFocusedChangedListener));
 	}
 
 	private int getEndOffset() {


### PR DESCRIPTION
Prevent keeping `DefoldStyledTextLayoutContainer` instances around by using a weak listener when listening to owning `DefoldStyledTextArea` focused property.

Fixes https://github.com/defold/editor2-issues/issues/143