### PR TITLE
DEFEDIT-539 Label Component

### DIFF
--- a/editor/resources/templates/template.label
+++ b/editor/resources/templates/template.label
@@ -1,0 +1,13 @@
+text: 'Label'
+font: '/builtins/fonts/system_font.font'
+material: '/builtins/fonts/label.material'
+scale { x: 1 y: 1 z: 1 }
+size { x: 128 y: 32 z: 0 }
+color { x: 1 y: 1 z: 1 w: 1 }
+outline { x: 0 y: 0 z: 0 w: 1 }
+shadow { x: 0 y: 0 z: 0 w: 1 }
+leading: 1.0
+tracking: 0.0
+pivot: PIVOT_CENTER
+blend_mode: BLEND_MODE_ALPHA
+line_break: false

--- a/editor/resources/templates/template.light
+++ b/editor/resources/templates/template.light
@@ -1,0 +1,6 @@
+id: "light"
+type: 0
+intensity: 0.0
+color { x: 0.0 y: 0.0 z: 0.0 }
+range: 0.0
+decay: 0.0

--- a/editor/resources/templates/template.light
+++ b/editor/resources/templates/template.light
@@ -1,6 +1,0 @@
-id: "light"
-type: 0
-intensity: 0.0
-color { x: 0.0 y: 0.0 z: 0.0 }
-range: 0.0
-decay: 0.0

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -1159,6 +1159,12 @@
   (let [undo-stack (is/undo-stack (is/graph-history @*the-system* graph-id))]
     (not (empty? undo-stack))))
 
+(defn undo-stack-count
+  "Returns the number of entries in the undo stack for `graph-id`"
+  [graph-id]
+  (let [undo-stack (is/undo-stack (is/graph-history @*the-system* graph-id))]
+    (count undo-stack)))
+
 (defn redo!
   "Given a `graph-id` reverts an undo of the graph
 

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -27,6 +27,7 @@
             [editor.hot-reload :as hotload]
             [editor.image :as image]
             [editor.json :as json]
+            [editor.label :as label]
             [editor.login :as login]
             [editor.material :as material]
             [editor.mesh :as mesh]
@@ -102,6 +103,7 @@
         (gui/register-resource-types workspace)
         (image/register-resource-types workspace)
         (json/register-resource-types workspace)
+        (label/register-resource-types workspace)
         (material/register-resource-types workspace)
         (mesh/register-resource-types workspace)
         (model/register-resource-types workspace)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -241,11 +241,13 @@
   (let [user-data (get (first renderables) :user-data)
         gpu-texture (:texture user-data)
         font-map (:font-map user-data)
-        vertex-buffer (gen-vertex-buffer gl user-data [{:text (:text user-data)
+        max-width (:cache-width font-map)
+        text-layout (layout-text font-map (:text user-data) true max-width 0 1)
+        vertex-buffer (gen-vertex-buffer gl user-data [{:text-layout text-layout
+                                                        :align :left
                                                         :offset [0.0 0.0]
                                                         :world-transform (doto (Matrix4d.) (.setIdentity))
-                                                        :color [1.0 1.0 1.0 1.0] :outline [0.0 0.0 0.0 1.0] :shadow [0.0 0.0 0.0 0.0]
-                                                        :line-break true :max-width (:cache-width font-map)}])
+                                                        :color [1.0 1.0 1.0 1.0] :outline [0.0 0.0 0.0 1.0] :shadow [0.0 0.0 0.0 0.0]}])
         material-shader (:shader user-data)
         type (:type user-data)
         vcount (count vertex-buffer)]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -307,14 +307,19 @@
         font-map (assoc (:font-map user-data) :textures [(resource/proj-path (second (first dep-resources)))])]
     {:resource resource :content (protobuf/map->bytes Font$FontMap font-map)}))
 
-(g/defnk produce-build-targets [_node-id resource font-resource font-map dep-build-targets]
-  (let [project        (project/get-project _node-id)
-        workspace      (project/workspace project)]
-    [{:node-id _node-id
-      :resource (workspace/make-build-resource resource)
-      :build-fn build-font
-      :user-data {:font-map font-map}
-      :deps (flatten dep-build-targets)}]))
+(g/defnk produce-build-targets [_node-id resource font-resource font-map material dep-build-targets]
+  (or (when-let [errors (->> [[material :material "Material"]]
+                          (keep (fn [[v prop-kw name]]
+                                  (validation/prop-error :fatal _node-id prop-kw validation/prop-nil? v name)))
+                          not-empty)]
+        (g/error-aggregate errors))
+      (let [project        (project/get-project _node-id)
+           workspace      (project/workspace project)]
+       [{:node-id _node-id
+         :resource (workspace/make-build-resource resource)
+         :build-fn build-font
+         :user-data {:font-map font-map}
+         :deps (flatten dep-build-targets)}])))
 
 (g/defnode FontSourceNode
   (inherits project/ResourceNode))
@@ -434,11 +439,12 @@
                                  (geom/aabb-incorporate (Point3d. w (- h-offset h) 0))))
                              (geom/null-aabb))))
   (output gpu-texture g/Any :cached (g/fnk [_node-id font-map material-samplers]
-                                           (let [w (:cache-width font-map)
-                                                 h (:cache-height font-map)
-                                                 channels (:glyph-channels font-map)]
-                                             (texture/empty-texture _node-id w h channels
-                                                                   (material/sampler->tex-params (first material-samplers)) 0))))
+                                           (when font-map
+                                             (let [w (:cache-width font-map)
+                                                   h (:cache-height font-map)
+                                                   channels (:glyph-channels font-map)]
+                                               (texture/empty-texture _node-id w h channels
+                                                                      (material/sampler->tex-params (first material-samplers)) 0)))))
   (output material-shader ShaderLifecycle (gu/passthrough material-shader))
   (output type g/Keyword produce-font-type)
   (output font-data FontData :cached (g/fnk [type gpu-texture font-map]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -201,7 +201,7 @@
                                       (= type :distance-field) (into sdf-params)))
                      text-layout (:text-layout entry)
                      text-tracking (* line-height (:text-tracking text-layout 0))
-                     text-leading (:text-leading text-layout 0)
+                     text-leading (:text-leading text-layout 1)
                      offset (:offset entry)
                      xform (doto (Matrix4d.)
                              (.set (let [[x y] offset]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -406,9 +406,15 @@
     (let [rt (:resource-type user-data)]
       (or (:label rt) (:ext rt)))))
 
+(defn embeddable-component-resource-types [workspace]
+  (->> (workspace/get-resource-types workspace :component)
+       (filter (fn [resource-type]
+                 (and (not (contains? (:tags resource-type) :non-embeddable))
+                      (workspace/has-template? resource-type))))))
+
 (defn add-embedded-component-options [self workspace user-data]
   (when (not user-data)
-    (->> (remove (comp :non-embeddable :tags) (workspace/get-resource-types workspace :component))
+    (->> (embeddable-component-resource-types workspace)
          (map (fn [res-type] {:label (or (:label res-type) (:ext res-type))
                               :icon (:icon res-type)
                               :command :add

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -398,7 +398,7 @@
     (g/transact
      (concat
       (g/operation-label "Add Component")
-      (add-embedded-component self project (:ext component-type) template id [0 0 0] [0 0 0 1] true)))))
+      (add-embedded-component self project (:ext component-type) template id [0.0 0.0 0.0] [0.0 0.0 0.0 1.0] true)))))
 
 (defn add-embedded-component-label [user-data]
   (if-not user-data

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -241,7 +241,7 @@
                                   {:type :choicebox
                                    :options (zipmap (map first options)
                                                     (map (comp :display-name second) options))}))))
-  (property blend-mode g/Any (default :blend_mode_alpha)
+  (property blend-mode g/Any (default :blend-mode-alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Label$LabelDesc$BlendMode))
             (dynamic edit-type (g/constantly
                                 (let [options (protobuf/enum-values Label$LabelDesc$BlendMode)]

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -192,7 +192,7 @@
             offset (pivot-offset pivot size)
             lines (mapv conj (apply concat (take 4 (partition 2 1 (cycle (geom/transl offset [[0 0] [w 0] [w h] [0 h]]))))) (repeat 0))]
         (assoc scene :renderable {:render-fn render-labels
-                                  :batch-key {:gpu-texture gpu-texture :blend-mode blend-mode}
+                                  :batch-key {:blend-mode blend-mode :gpu-texture gpu-texture :material-shader material-shader}
                                   :select-batch-key _node-id
                                   :user-data {:material-shader material-shader
                                               :blend-mode blend-mode

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -1,0 +1,450 @@
+(ns editor.label
+  (:require [clojure.string :as str]
+            [editor.protobuf :as protobuf]
+            [dynamo.graph :as g]
+            [editor.font :as font]
+            [editor.graph-util :as gu]
+            [editor.geom :as geom]
+            [editor.gl :as gl]
+            [editor.gl.shader :as shader]
+            [editor.gl.vertex :as vtx]
+            [editor.defold-project :as project]
+            [editor.scene :as scene]
+            [editor.workspace :as workspace]
+            [editor.validation :as validation]
+            [editor.resource :as resource]
+            [editor.gl.pass :as pass]
+            [editor.gl.texture :as texture]
+            [editor.types :as types]
+            [editor.material :as material])
+  (:import [com.dynamo.label.proto Label$LabelDesc Label$LabelDesc$BlendMode Label$LabelDesc$Pivot]
+           [com.jogamp.opengl.util.awt TextRenderer]
+           [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
+           [java.awt.image BufferedImage]
+           [java.io PushbackReader]
+           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
+           [com.jogamp.opengl.glu GLU]
+           [javax.vecmath Matrix4d Point3d]
+           [editor.gl.shader ShaderLifecycle]))
+
+(set! *warn-on-reflection* true)
+
+(def label-icon "icons/32/Icons_39-GUI-Text-node.png")
+
+; Render assets
+
+(vtx/defvertex color-vtx
+  (vec3 position)
+  (vec4 color))
+
+(shader/defshader vertex-shader
+  (attribute vec4 position)
+  (attribute vec4 color)
+  (varying vec4 var_color)
+  (defn void main []
+    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
+    (setq var_color color)))
+
+(shader/defshader fragment-shader
+  (varying vec4 var_color)
+  (defn void main []
+    (setq gl_FragColor var_color)))
+
+; TODO - macro of this
+(def shader (shader/make-shader ::shader vertex-shader fragment-shader))
+
+(shader/defshader line-vertex-shader
+  (attribute vec4 position)
+  (attribute vec4 color)
+  (varying vec4 var_color)
+  (defn void main []
+    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
+    (setq var_color color)))
+
+(shader/defshader line-fragment-shader
+  (varying vec4 var_color)
+  (defn void main []
+    (setq gl_FragColor var_color)))
+
+(def line-shader (shader/make-shader ::line-shader line-vertex-shader line-fragment-shader))
+
+; Vertex generation
+
+#_(defn- gen-vertex [^Matrix4d wt ^Point3d pt x y u v]
+   (.set pt x y 0)
+   (.transform wt pt)
+   [(.x pt) (.y pt) (.z pt) u v])
+
+#_(defn- conj-quad! [vbuf ^Matrix4d wt ^Point3d pt width height anim-uvs]
+   (let [x1 (* 0.5 width)
+         y1 (* 0.5 height)
+         x0 (- x1)
+         y0 (- y1)
+         [[u0 v0] [u1 v1] [u2 v2] [u3 v3]] anim-uvs]
+     (-> vbuf
+       (conj! (gen-vertex wt pt x0 y0 u0 v0))
+       (conj! (gen-vertex wt pt x1 y0 u3 v3))
+       (conj! (gen-vertex wt pt x0 y1 u1 v1))
+       (conj! (gen-vertex wt pt x1 y0 u3 v3))
+       (conj! (gen-vertex wt pt x1 y1 u2 v2))
+       (conj! (gen-vertex wt pt x0 y1 u1 v1)))))
+
+#_(defn- gen-vertex-buffer
+   [renderables count]
+   (let [tmp-point (Point3d.)]
+     (loop [renderables renderables
+           vbuf (->texture-vtx (* count 6))]
+       (if-let [renderable (first renderables)]
+         (let [world-transform (:world-transform renderable)
+               user-data (:user-data renderable)
+               anim-uvs (:anim-uvs user-data)
+               anim-width (:anim-width user-data)
+               anim-height (:anim-height user-data)]
+           (recur (rest renderables) (conj-quad! vbuf world-transform tmp-point anim-width anim-height anim-uvs)))
+         (persistent! vbuf)))))
+
+#_(defn- gen-outline-vertex [^Matrix4d wt ^Point3d pt x y cr cg cb]
+   (.set pt x y 0)
+   (.transform wt pt)
+   [(.x pt) (.y pt) (.z pt) cr cg cb 1])
+
+#_(defn- conj-outline-quad! [vbuf ^Matrix4d wt ^Point3d pt width height cr cg cb]
+   (let [x1 (* 0.5 width)
+         y1 (* 0.5 height)
+         x0 (- x1)
+         y0 (- y1)
+         v0 (gen-outline-vertex wt pt x0 y0 cr cg cb)
+         v1 (gen-outline-vertex wt pt x1 y0 cr cg cb)
+         v2 (gen-outline-vertex wt pt x1 y1 cr cg cb)
+         v3 (gen-outline-vertex wt pt x0 y1 cr cg cb)]
+     (-> vbuf (conj! v0) (conj! v1) (conj! v1) (conj! v2) (conj! v2) (conj! v3) (conj! v3) (conj! v0))))
+
+(def outline-color (scene/select-color pass/outline false [1.0 1.0 1.0]))
+(def selected-outline-color (scene/select-color pass/outline true [1.0 1.0 1.0]))
+
+(defn- ->color-vtx-vb [vs colors vcount]
+  (let [vb (->color-vtx vcount)
+        vs (mapv (comp vec concat) vs colors)]
+    (doseq [v vs]
+      (conj! vb v))
+    (persistent! vb)))
+
+#_(defn- gen-outline-vertex-buffer
+   [renderables count]
+   (let [tmp-point (Point3d.)]
+     (loop [renderables renderables
+            vbuf (->color-vtx (* count 8))]
+       (if-let [renderable (first renderables)]
+         (let [color (if (:selected renderable) selected-outline-color outline-color)
+               cr (get color 0)
+               cg (get color 1)
+               cb (get color 2)
+               world-transform (:world-transform renderable)
+               user-data (:user-data renderable)
+               anim-width (:anim-width user-data)
+               anim-height (:anim-height user-data)]
+           (recur (rest renderables) (conj-outline-quad! vbuf world-transform tmp-point anim-width anim-height cr cg cb)))
+         (persistent! vbuf)))))
+
+; Rendering
+
+(defn render-lines [^GL2 gl render-args renderables rcount]
+  (let [[vs colors] (reduce (fn [[vs colors] renderable]
+                              (let [world-transform (:world-transform renderable)
+                                    user-data (:user-data renderable)
+                                    line-data (:line-data user-data)
+                                    vcount (count line-data)
+                                    color (get user-data :line-color (if (:selected renderable) selected-outline-color outline-color))]
+                                [(into vs (geom/transf-p world-transform (:line-data user-data)))
+                                 (into colors (repeat vcount color))]))
+                      [[] []] renderables)
+        vcount (count vs)]
+    (when (> vcount 0)
+      (let [vertex-binding (vtx/use-with ::lines (->color-vtx-vb vs colors vcount) line-shader)]
+        (gl/with-gl-bindings gl render-args [line-shader vertex-binding]
+          (gl/gl-draw-arrays gl GL/GL_LINES 0 vcount))))))
+
+(defn- gen-vb [^GL2 gl renderables]
+  (let [user-data (get-in renderables [0 :user-data])]
+    (font/gen-vertex-buffer gl (get-in user-data [:text-data :font-data])
+                            (map (fn [r] (let [text-data (get-in r [:user-data :text-data])
+                                               alpha (get-in text-data [:color 3])]
+                                           (-> text-data
+                                             (assoc :world-transform (:world-transform r))
+                                             (update-in [:outline 3] * alpha)
+                                             (update-in [:shadow 3] * alpha))))
+                                 renderables))))
+
+(defn render-tris [^GL2 gl render-args renderables rcount]
+  (let [user-data (get-in renderables [0 :user-data])
+        gpu-texture (or (get user-data :gpu-texture) texture/white-pixel)
+        material-shader (get user-data :material-shader)
+        blend-mode (get user-data :blend-mode)
+        vb (gen-vb gl renderables)
+        vcount (count vb)]
+    (when (> vcount 0)
+      (let [shader material-shader #_(if (types/selection? (:pass render-args))
+                     shader ;; TODO - Always use the hard-coded shader for selection, DEFEDIT-231 describes a fix for this
+                     (or material-shader shader))
+            vertex-binding (vtx/use-with ::tris vb shader)]
+        (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
+          (case blend-mode
+            :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
+            (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
+            :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+          (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 vcount)
+          (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA))))))
+
+(defn render-labels [^GL2 gl render-args renderables rcount]
+  (let [pass (:pass render-args)]
+    (if (= pass pass/outline)
+      (render-lines gl render-args renderables rcount)
+      (render-tris gl render-args renderables rcount))))
+
+#_(defn render-sprites [^GL2 gl render-args renderables count]
+   (let [pass (:pass render-args)]
+     (cond
+       (= pass pass/outline)
+       (let [outline-vertex-binding (vtx/use-with ::sprite-outline (gen-outline-vertex-buffer renderables count) outline-shader)]
+         (gl/with-gl-bindings gl render-args [outline-shader outline-vertex-binding]
+           (gl/gl-draw-arrays gl GL/GL_LINES 0 (* count 8))))
+
+       (= pass pass/transparent)
+       (let [vertex-binding (vtx/use-with ::sprite-trans (gen-vertex-buffer renderables count) shader)
+             user-data (:user-data (first renderables))
+             gpu-texture (:gpu-texture user-data)
+             blend-mode (:blend-mode user-data)]
+         (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
+           (case blend-mode
+             :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
+             (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
+             :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+           (shader/set-uniform shader gl "texture" 0)
+           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* count 6))
+           (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))
+
+       (= pass pass/selection)
+       (let [vertex-binding (vtx/use-with ::sprite-selection (gen-vertex-buffer renderables count) shader)]
+         (gl/with-gl-bindings gl render-args [shader vertex-binding]
+           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* count 6)))))))
+
+; Node defs
+
+(defn- pivot->h-align [pivot]
+  (case pivot
+    (:pivot-e :pivot-ne :pivot-se) :right
+    (:pivot-center :pivot-n :pivot-s) :center
+    (:pivot-w :pivot-nw :pivot-sw) :left))
+
+(defn- pivot->v-align [pivot]
+  (case pivot
+    (:pivot-ne :pivot-n :pivot-nw) :top
+    (:pivot-e :pivot-center :pivot-w) :middle
+    (:pivot-se :pivot-s :pivot-sw) :bottom))
+
+(defn- pivot-offset [pivot size]
+  (let [h-align (pivot->h-align pivot)
+        v-align (pivot->v-align pivot)
+        xs (case h-align
+             :right -1.0
+             :center -0.5
+             :left 0.0)
+        ys (case v-align
+             :top -1.0
+             :middle -0.5
+             :bottom 0.0)]
+    (mapv * size [xs ys 1])))
+
+(defn- v3->v4 [v]
+  (conj v 0))
+
+(defn- v4->v3 [v4]
+  (subvec v4 0 3))
+
+(g/defnk produce-pb-msg [text size scale color outline shadow leading tracking pivot blend-mode line-break font material]
+  {:text text
+   :size (v3->v4 size)
+   :scale (v3->v4 scale)
+   :color color
+   :outline outline
+   :shadow shadow
+   :leading leading
+   :tracking tracking
+   :pivot pivot
+   :blend-mode blend-mode
+   :line-break line-break
+   :font (resource/resource->proj-path font)
+   :material (resource/resource->proj-path material)})
+
+(g/defnk produce-save-data [_node-id resource pb-msg]
+  {:resource resource
+   :content (protobuf/map->str Label$LabelDesc pb-msg)})
+
+(g/defnk produce-scene
+  [_node-id aabb gpu-texture material-shader blend-mode pivot text-data]
+  (let [scene {:node-id _node-id
+               :aabb aabb}]
+    (if text-data
+      (let [min (types/min-p aabb)
+            max (types/max-p aabb)
+            size [(- (.x max) (.x min)) (- (.y max) (.y min)) 0]
+            [w h _] size
+            offset (pivot-offset pivot size)
+            lines (mapv conj (apply concat (take 4 (partition 2 1 (cycle (geom/transl offset [[0 0] [w 0] [w h] [0 h]]))))) (repeat 0))]
+        (assoc scene :renderable {:render-fn render-labels
+                                  :batch-key {:gpu-texture gpu-texture :blend-mode blend-mode}
+                                  :select-batch-key _node-id
+                                  :user-data {:material-shader material-shader
+                                              :blend-mode blend-mode
+                                              :gpu-texture gpu-texture
+                                              :line-data lines
+                                              :text-data text-data}
+                                  :passes [pass/transparent pass/selection pass/outline]}))
+      scene)))
+
+(defn- build-label [self basis resource dep-resources user-data]
+  (let [pb (:proto-msg user-data)
+        pb (reduce #(assoc %1 (first %2) (second %2)) pb (map (fn [[label res]] [label (resource/proj-path (get dep-resources res))]) (:dep-resources user-data)))]
+    {:resource resource :content (protobuf/map->bytes Label$LabelDesc pb)}))
+
+(g/defnk produce-build-targets [_node-id resource font material pb-msg dep-build-targets]
+  (or (when-let [errors (->> [[font :font "Font"]
+                              [material :material "Material"]]
+                          (keep (fn [[v prop-kw name]]
+                                  (validation/prop-error :fatal _node-id prop-kw validation/prop-nil? v name)))
+                          not-empty)]
+        (g/error-aggregate errors))
+      (let [dep-build-targets (flatten dep-build-targets)
+            deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
+            dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:font font] [:material material]])]
+        [{:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-label
+          :user-data {:proto-msg pb-msg
+                      :dep-resources dep-resources}
+          :deps dep-build-targets}])))
+
+(g/defnode LabelNode
+  (inherits project/ResourceNode)
+
+  (property text g/Str)
+  (property size types/Vec3)
+  (property scale types/Vec3)
+  (property color types/Color)
+  (property outline types/Color)
+  (property shadow types/Color)
+  (property leading g/Num)
+  (property tracking g/Num)
+  (property pivot g/Keyword (default :pivot-center)
+            (dynamic edit-type (g/constantly
+                                (let [options (protobuf/enum-values Label$LabelDesc$Pivot)]
+                                  {:type :choicebox
+                                   :options (zipmap (map first options)
+                                                    (map (comp :display-name second) options))}))))
+  (property blend-mode g/Any (default :blend_mode_alpha)
+            (dynamic tip (validation/blend-mode-tip blend-mode Label$LabelDesc$BlendMode))
+            (dynamic edit-type (g/constantly
+                                (let [options (protobuf/enum-values Label$LabelDesc$BlendMode)]
+                                  {:type :choicebox
+                                   :options (zipmap (map first options)
+                                                    (map (comp :display-name second) options))}))))
+  (property line-break g/Bool)
+    
+  (property font resource/Resource
+            (value (gu/passthrough font-resource))
+            (set (fn [basis self old-value new-value]
+                   (project/resource-setter basis self old-value new-value
+                                            [:resource :font-resource]
+                                            [:gpu-texture :gpu-texture]
+                                            [:font-map :font-map]
+                                            [:font-data :font-data]
+                                            [:build-targets :dep-build-targets])))
+            (dynamic error (g/fnk [_node-id font]
+                                  (or (validation/prop-error :info _node-id :image validation/prop-nil? font "Font")
+                                      (validation/prop-error :fatal _node-id :image validation/prop-resource-not-exists? font "Font"))))
+            (dynamic edit-type (g/constantly
+                                 {:type resource/Resource
+                                  :ext ["font"]})))
+  (property material resource/Resource
+            (value (gu/passthrough material-resource))
+            (set (fn [basis self old-value new-value]
+                   (project/resource-setter basis self old-value new-value
+                                            [:resource :material-resource]
+                                            [:shader :material-shader]
+                                            [:samplers :material-samplers]
+                                            [:build-targets :dep-build-targets])))
+            (dynamic error (g/fnk [_node-id material]
+                                  (or (validation/prop-error :info _node-id :image validation/prop-nil? material "Material")
+                                      (validation/prop-error :fatal _node-id :image validation/prop-resource-not-exists? material "Material"))))
+            (dynamic edit-type (g/constantly
+                                 {:type resource/Resource
+                                  :ext ["material"]})))
+
+  (input font-resource resource/Resource)
+  (input material-resource resource/Resource)
+  (input dep-build-targets g/Any :array)
+  (input gpu-texture g/Any)
+  (input font-map g/Any)
+  (input font-data font/FontData)
+  (input material-shader ShaderLifecycle)
+  (input material-samplers g/Any)
+
+  (output pb-msg g/Any :cached produce-pb-msg)
+  (output text-layout g/Any :cached (g/fnk [size font-map text line-break leading tracking]
+                                           (font/layout-text font-map text line-break (first size) tracking leading)))
+  (output text-data g/KeywordMap (g/fnk [text-layout font-data line-break color outline shadow aabb-size pivot]
+                                        (cond-> {:text-layout text-layout
+                                                 :font-data font-data
+                                                 :color color
+                                                 :outline outline
+                                                 :shadow shadow
+                                                 :align (pivot->h-align pivot)}
+                                          font-data (assoc :offset (let [[x y] (pivot-offset pivot aabb-size)
+                                                                         h (second aabb-size)]
+                                                                     [x (+ y (- h (get-in font-data [:font-map :max-ascent])))])))))
+  (output aabb-size g/Any :cached (g/fnk [text-layout]
+                                         [(:width text-layout) (:height text-layout) 0]))
+  (output aabb g/Any :cached (g/fnk [pivot aabb-size]
+                                    (let [offset-fn (partial mapv + (pivot-offset pivot aabb-size))
+                                          [min-x min-y _] (offset-fn [0 0 0])
+                                          [max-x max-y _] (offset-fn aabb-size)]
+                                      (-> (geom/null-aabb)
+                                        (geom/aabb-incorporate min-x min-y 0)
+                                        (geom/aabb-incorporate max-x max-y 0)))))
+  (output save-data g/Any :cached produce-save-data)
+  (output scene g/Any :cached produce-scene)
+  (output build-targets g/Any :cached produce-build-targets)
+  (output gpu-texture g/Any :cached (g/fnk [_node-id gpu-texture material-samplers]
+                                           (->> (material/sampler->tex-params (first material-samplers))
+                                             (texture/set-params gpu-texture)))))
+
+(defn load-label [project self resource]
+  (let [label (protobuf/read-text Label$LabelDesc resource)
+        label (reduce (fn [label k] (update label k v4->v3)) label [:size :scale])
+        font (workspace/resolve-resource resource (:font label))
+        material (workspace/resolve-resource resource (:material label))]
+    (concat
+      (g/set-property self
+                      :text (:text label)
+                      :size (:size label)
+                      :scale (:scale label)
+                      :color (:color label)
+                      :outline (:outline label)
+                      :shadow (:shadow label)
+                      :leading (:leading label)
+                      :tracking (:tracking label)
+                      :pivot (:pivot label)
+                      :blend-mode (:blend-mode label)
+                      :line-break (:line-break label)
+                      :font font
+                      :material material))))
+
+(defn register-resource-types [workspace]
+  (workspace/register-resource-type workspace
+                                    :ext "label"
+                                    :node-type LabelNode
+                                    :load-fn load-label
+                                    :icon label-icon
+                                    :view-types [:scene :text]
+                                    :tags #{:component}
+                                    :label "Label"))

--- a/editor/src/clj/editor/pipeline/font_gen.clj
+++ b/editor/src/clj/editor/pipeline/font_gen.clj
@@ -8,13 +8,14 @@
 (set! *warn-on-reflection* true)
 
 (defn generate [font-desc font-path resolver]
-  (let [^Font$FontDesc font-desc (protobuf/map->pb Font$FontDesc font-desc)
-        font-map-builder (Font$FontMap/newBuilder)
-        font-res-resolver (reify Fontc$FontResourceResolver
-                            (getResource [this resource-name]
-                              (io/input-stream (resolver (str "/" resource-name)))))]
-    (with-open [font-stream (io/input-stream font-path)]
-      (let [^Font$FontMap font-map (-> (doto (Fontc.)
-                                         (.compile font-stream font-desc false font-res-resolver))
-                                     (.getFontMap))]
-        (protobuf/pb->map font-map)))))
+  (when font-path
+    (let [^Font$FontDesc font-desc (protobuf/map->pb Font$FontDesc font-desc)
+          font-map-builder (Font$FontMap/newBuilder)
+          font-res-resolver (reify Fontc$FontResourceResolver
+                              (getResource [this resource-name]
+                                (io/input-stream (resolver (str "/" resource-name)))))]
+      (with-open [font-stream (io/input-stream font-path)]
+        (let [^Font$FontMap font-map (-> (doto (Fontc.)
+                                           (.compile font-stream font-desc false font-res-resolver))
+                                       (.getFontMap))]
+          (protobuf/pb->map font-map))))))

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -1,5 +1,6 @@
 (ns editor.spine
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [util.murmur :as murmur]
@@ -677,10 +678,10 @@
                     :sample-rate (:sample-rate spine))))
 
 (g/defnk produce-model-pb [spine-scene-resource default-animation skin material-resource blend-mode]
-  {:spine-scene (resource/proj-path spine-scene-resource)
+  {:spine-scene (resource/resource->proj-path spine-scene-resource)
    :default-animation default-animation
    :skin skin
-   :material (resource/proj-path material-resource)
+   :material (resource/resource->proj-path material-resource)
    :blend-mode blend-mode})
 
 (g/defnk produce-model-save-data [resource model-pb]
@@ -704,6 +705,10 @@
                   :dep-resources dep-resources}
       :deps dep-build-targets}]))
 
+(defn- sort-spine-anim-ids
+  [spine-anim-ids]
+  (sort-by str/lower-case spine-anim-ids))
+
 (g/defnode SpineModelNode
   (inherits project/ResourceNode)
 
@@ -722,7 +727,7 @@
             (dynamic edit-type (g/constantly {:type resource/Resource :ext "spinescene"}))
             (dynamic error (g/fnk [_node-id spine-scene]
                                   (prop-resource-error _node-id :spine-scene spine-scene "Spine Scene"))))
-  (property blend-mode g/Any (default :blend_mode_alpha)
+  (property blend-mode g/Any (default :blend-mode-alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Spine$SpineModelDesc$BlendMode))
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Spine$SpineModelDesc$BlendMode))))
   (property material resource/Resource
@@ -737,7 +742,10 @@
             (dynamic error (g/fnk [_node-id material]
                                   (prop-resource-error _node-id :material material "Material"))))
   (property default-animation g/Str
-            (value (g/fnk [default-animation spine-anim-ids] (or (not-empty default-animation) (first spine-anim-ids))))
+            (value (g/fnk [default-animation spine-anim-ids]
+                     (if (and (str/blank? default-animation) spine-anim-ids)
+                       (first (sort-spine-anim-ids spine-anim-ids))
+                       default-animation)))
             (dynamic error (g/fnk [_node-id spine-anim-ids default-animation spine-scene]
                                   (when spine-scene
                                     (validation/prop-error :fatal _node-id

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -26,7 +26,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def sprite-icon "icons/16/Icons_14-Sprite.png")
+(def sprite-icon "icons/32/Icons_14-Sprite.png")
 
 ; Render assets
 
@@ -275,7 +275,7 @@
                                   (or (validation/prop-error :fatal _node-id :material validation/prop-nil? material "Material")
                                       (validation/prop-error :fatal _node-id :material validation/prop-resource-not-exists? material "Material")))))
 
-  (property blend-mode g/Any (default :blend_mode_alpha)
+  (property blend-mode g/Any (default :blend-mode-alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Sprite$SpriteDesc$BlendMode))
             (dynamic edit-type (g/constantly
                                 (let [options (protobuf/enum-values Sprite$SpriteDesc$BlendMode)]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -131,8 +131,15 @@ ordinary paths."
   ([workspace tag]
     (filter #(contains? (:tags %) tag) (map second (g/node-value workspace :resource-types)))))
 
+(defn- template-path [resource-type]
+  (or (:template resource-type)
+      (some->> resource-type :ext (str "templates/template."))))
+
+(defn has-template? [resource-type]
+  (some? (some-> resource-type template-path io/resource)))
+
 (defn template [resource-type]
-  (when-let [template-path (or (:template resource-type) (str "templates/template." (:ext resource-type)))]
+  (when-let [template-path (template-path resource-type)]
     (when-let [resource (io/resource template-path)]
       (with-open [f (io/reader resource)]
         (slurp f)))))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -22,6 +22,7 @@
            [com.dynamo.model.proto Model$ModelDesc]
            [com.dynamo.physics.proto Physics$CollisionObjectDesc]
            [com.dynamo.properties.proto PropertiesProto$PropertyDeclarations]
+           [com.dynamo.label.proto Label$LabelDesc]
            [com.dynamo.lua.proto Lua$LuaModule]
            [com.dynamo.script.proto Lua$LuaSource]
            [com.dynamo.gui.proto Gui$SceneDesc]
@@ -91,7 +92,26 @@
                {:label "Spine Model"
                 :path "/player/spineboy.spinemodel"
                 :pb-class Spine$SpineModelDesc
-                :resource-fields [:spine-scene :material]}])
+                :resource-fields [:spine-scene :material]}
+               {:label "Label"
+                :path "/main/label.label"
+                :pb-class Label$LabelDesc
+                :resource-fields [:font :material]
+                :test-fn (fn [pb targets]
+                           (is (= {:color [1.0 1.0 1.0 1.0],
+                                   :line-break false,
+                                   :scale [1.0 1.0 1.0 0.0],
+                                   :blend-mode :blend-mode-alpha,
+                                   :leading 1.0,
+                                   :font "/builtins/fonts/system_font.fontc",
+                                   :size [128.0 32.0 0.0 0.0],
+                                   :tracking 0.0,
+                                   :material "/builtins/fonts/label.materialc",
+                                   :outline [0.0 0.0 0.0 1.0],
+                                   :pivot :pivot-center,
+                                   :shadow [0.0 0.0 0.0 1.0],
+                                   :text "Label"}
+                                  pb)))}])
 
 (defn- run-pb-case [case content-by-source content-by-target]
   (testing (str "Testing " (:label case))
@@ -120,7 +140,7 @@
                                              ~'build-results))]
        ~@forms)))
 
-(deftest build-game-project
+(deftest build-game-project-pb-cases
   (with-build-results "/game.project"
     (let [target-exts (into #{} (map #(:build-ext (resource/resource-type (:resource %))) build-results))
           exp-paths   [path

--- a/editor/test/integration/game_object_test.clj
+++ b/editor/test/integration/game_object_test.clj
@@ -37,11 +37,6 @@
                      (is (g/error? (test-util/prop-error comp-id :id)))
                      (is (build-error? go-id)))))))))
 
-(defn- embeddable-component-resource-types
-  [workspace]
-  (filterv #(not (contains? (:tags %) :non-embeddable))
-           (workspace/get-resource-types workspace :component)))
-
 (defn- save-data
   [project resource]
   (first (filter #(= resource (:resource %))
@@ -51,7 +46,7 @@
   (with-clean-system
     (let [workspace (test-util/setup-workspace! world)
           project (test-util/setup-project! workspace)
-          resource-types (embeddable-component-resource-types workspace)
+          resource-types (game-object/embeddable-component-resource-types workspace)
           save-data (partial save-data project)
           make-restore-point! #(test-util/make-graph-reverter (project/graph project))
           add-component! (partial test-util/add-embedded-component! project)

--- a/editor/test/integration/game_object_test.clj
+++ b/editor/test/integration/game_object_test.clj
@@ -1,20 +1,15 @@
 (ns integration.game-object-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.data :as data]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
             [support.test-support :refer [with-clean-system]]
-            [editor.collection :as collection]
             [editor.game-object :as game-object]
-            [editor.handler :as handler]
             [editor.defold-project :as project]
+            [editor.protobuf :as protobuf]
             [editor.workspace :as workspace]
-            [editor.types :as types]
-            [editor.properties :as properties]
             [integration.test-util :as test-util])
-  (:import [editor.types Region]
-           [java.awt.image BufferedImage]
-           [java.io File]
-           [javax.imageio ImageIO]
-           [javax.vecmath Point3d Matrix4d]))
+  (:import (com.dynamo.gameobject.proto GameObject$PrototypeDesc)
+           (java.io StringReader)))
 
 (defn- build-error? [node-id]
   (g/error? (g/node-value node-id :build-targets)))
@@ -41,3 +36,34 @@
                      (is (g/error? (test-util/prop-error factory :id)))
                      (is (g/error? (test-util/prop-error comp-id :id)))
                      (is (build-error? go-id)))))))))
+
+(defn- embeddable-component-resource-types
+  [workspace]
+  (filterv #(not (contains? (:tags %) :non-embeddable))
+           (workspace/get-resource-types workspace :component)))
+
+(defn- save-data
+  [project resource]
+  (first (filter #(= resource (:resource %))
+                 (project/save-data project))))
+
+(deftest embedded-components
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          resource-types (embeddable-component-resource-types workspace)
+          save-data (partial save-data project)
+          make-restore-point! #(test-util/make-graph-reverter (project/graph project))
+          add-component! (partial test-util/add-embedded-component! project)
+          go-id (project/get-resource-node project "/game_object/test.go")
+          go-resource (g/node-value go-id :resource)]
+      (doseq [resource-type resource-types]
+        (testing (:label resource-type)
+          (with-open [_ (make-restore-point!)]
+            (add-component! resource-type go-id)
+            (let [saved-string (:content (save-data go-resource))
+                  saved-embedded-components (g/node-value go-id :embed-ddf)
+                  loaded-embedded-components (:embedded-components (protobuf/read-text GameObject$PrototypeDesc (StringReader. saved-string)))
+                  [only-in-saved only-in-loaded] (data/diff saved-embedded-components loaded-embedded-components)]
+              (is (nil? only-in-saved))
+              (is (nil? only-in-loaded)))))))))

--- a/editor/test/integration/hot_reload_test.clj
+++ b/editor/test/integration/hot_reload_test.clj
@@ -64,6 +64,6 @@
         data (protobuf/bytes->map GameObject$CollectionDesc (->bytes (:body res)))]
     (is (= 200 (:status res)))
     (is (= "parallax" (:name data)))
-    (is (= 11 (count (:instances data)))))
+    (is (= 12 (count (:instances data)))))
 
   (is (= 404 (:status (handler-get (partial hotload/build-handler *project*) "foobar")))))

--- a/editor/test/integration/label_test.clj
+++ b/editor/test/integration/label_test.clj
@@ -1,12 +1,16 @@
 (ns integration.label-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
             [editor.defold-project :as project]
+            [editor.game-object :as game-object]
+            [editor.gl.pass :as pass]
+            [editor.label :as label]
             [editor.math :as math]
+            [editor.scene :as scene]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :refer [with-clean-system]]
-            [clojure.string :as string]))
+            [support.test-support :refer [with-clean-system]]))
 
 (deftest label-validation
   (with-clean-system
@@ -47,3 +51,97 @@
         (is (= "Label" (some-> scene :renderable :user-data :text-data :text-layout :lines first)))
         (is (string/includes? (some-> scene :renderable :user-data :material-shader :verts) "gl_Position"))
         (is (string/includes? (some-> scene :renderable :user-data :material-shader :frags) "gl_FragColor"))))))
+
+(defn- get-render-calls-by-pass
+  [scene camera selection key-fn]
+  (let [render-data (scene/produce-render-data scene selection [] camera)
+        renderables (:renderables render-data)]
+    (into {}
+          (keep (fn [pass]
+                  (let [calls (test-util/with-logged-calls [label/render-lines label/render-tris]
+                                (scene/batch-render nil {:pass pass} (get renderables pass) false key-fn))]
+                    (when (seq calls)
+                      [pass calls]))))
+          pass/render-passes)))
+
+(defn- map-render-calls
+  [transform-calls-fn render-calls-by-pass]
+  (into {}
+        (map (fn [[pass calls-by-fn]]
+               [pass (into {}
+                           (map (fn [[fn calls]]
+                                  [fn (transform-calls-fn calls)]))
+                           calls-by-fn)]))
+        render-calls-by-pass))
+
+(deftest label-batch-render
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          go (project/get-resource-node project "/game_object/test.go")
+          add-label-component! (let [resource-type (workspace/get-resource-type workspace "label")]
+                                 (fn [go]
+                                   (game-object/add-embedded-component-handler {:_node-id go :resource-type resource-type})
+                                   (first (test-util/selection project))))
+          render-calls (let [app-view (test-util/setup-app-view!)
+                             view (test-util/open-scene-view! project app-view go 128 128)]
+                         (fn [selection key-fn]
+                           (get-render-calls-by-pass (g/node-value go :scene)
+                                                     (g/node-value view :camera)
+                                                     selection
+                                                     key-fn)))
+          render-call-counts (comp (partial map-render-calls count)
+                                   render-calls)]
+
+      (testing "Single label"
+        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+          (add-label-component! go)
+          (is (= {pass/outline {label/render-lines 1}
+                  pass/transparent {label/render-tris 1}}
+                 (render-call-counts #{} :batch-key)))
+          (is (= {pass/outline {label/render-lines 1}
+                  pass/transparent {label/render-tris 1}}
+                 (render-call-counts #{} :select-batch-key)))))
+
+      (testing "Identical labels"
+        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+          (add-label-component! go)
+          (add-label-component! go)
+          (add-label-component! go)
+          (add-label-component! go)
+          (is (= {pass/outline {label/render-lines 1}
+                  pass/transparent {label/render-tris 1}}
+                 (render-call-counts #{} :batch-key)))
+          (is (= {pass/outline {label/render-lines 4}
+                  pass/transparent {label/render-tris 4}}
+                 (render-call-counts #{} :select-batch-key)))))
+
+      (testing "Blend mode differs"
+        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+          (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-add)
+          (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-add)
+          (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-mult)
+          (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-mult)
+          (is (= {pass/outline {label/render-lines 2}
+                  pass/transparent {label/render-tris 2}}
+                 (render-call-counts #{} :batch-key)))))
+
+      (testing "Font differs"
+        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+          (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/active_menu_item.font"))
+          (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/active_menu_item.font"))
+          (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/big_score.font"))
+          (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/big_score.font"))
+          (is (= {pass/outline {label/render-lines 2}
+                  pass/transparent {label/render-tris 2}}
+                 (render-call-counts #{} :batch-key)))))
+
+      (testing "Material differs"
+        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+          (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/active_menu_item.material"))
+          (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/active_menu_item.material"))
+          (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/big_score_font.material"))
+          (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/big_score_font.material"))
+          (is (= {pass/outline {label/render-lines 2}
+                  pass/transparent {label/render-tris 2}}
+                 (render-call-counts #{} :batch-key))))))))

--- a/editor/test/integration/label_test.clj
+++ b/editor/test/integration/label_test.clj
@@ -5,7 +5,8 @@
             [editor.math :as math]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :refer [with-clean-system]]))
+            [support.test-support :refer [with-clean-system]]
+            [clojure.string :as string]))
 
 (deftest label-validation
   (with-clean-system
@@ -18,8 +19,8 @@
                                         "unknown material" "/materials/unknown.material"}]]
               [case path] cases]
         (testing case
-                (test-util/with-prop [node-id prop (workspace/resolve-workspace-resource workspace path)]
-                  (is (g/error? (test-util/prop-error node-id prop)))))))))
+          (test-util/with-prop [node-id prop (workspace/resolve-workspace-resource workspace path)]
+                               (is (g/error? (test-util/prop-error node-id prop)))))))))
 
 (deftest label-aabb
   (with-clean-system
@@ -31,3 +32,18 @@
         (is (< 0.0 x))
         (is (< 0.0 y))
         (is (= 0.0 z))))))
+
+(deftest label-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/label/test.label")]
+      (let [scene (g/node-value node-id :scene)
+            aabb (g/node-value node-id :aabb)]
+        (is (= aabb (:aabb scene)))
+        (is (= node-id (:node-id scene)))
+        (is (= node-id (some-> scene :renderable :select-batch-key)))
+        (is (= :blend-mode-alpha (some-> scene :renderable :batch-key :blend-mode)))
+        (is (= "Label" (some-> scene :renderable :user-data :text-data :text-layout :lines first)))
+        (is (string/includes? (some-> scene :renderable :user-data :material-shader :verts) "gl_Position"))
+        (is (string/includes? (some-> scene :renderable :user-data :material-shader :frags) "gl_FragColor"))))))

--- a/editor/test/integration/label_test.clj
+++ b/editor/test/integration/label_test.clj
@@ -79,10 +79,8 @@
     (let [workspace (test-util/setup-workspace! world)
           project (test-util/setup-project! workspace)
           go (project/get-resource-node project "/game_object/test.go")
-          add-label-component! (let [resource-type (workspace/get-resource-type workspace "label")]
-                                 (fn [go]
-                                   (game-object/add-embedded-component-handler {:_node-id go :resource-type resource-type})
-                                   (first (test-util/selection project))))
+          make-restore-point! #(test-util/make-graph-reverter (project/graph project))
+          add-label-component! (partial test-util/add-embedded-component! project (workspace/get-resource-type workspace "label"))
           render-calls (let [app-view (test-util/setup-app-view!)
                              view (test-util/open-scene-view! project app-view go 128 128)]
                          (fn [selection key-fn]
@@ -94,7 +92,7 @@
                                    render-calls)]
 
       (testing "Single label"
-        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+        (with-open [_ (make-restore-point!)]
           (add-label-component! go)
           (is (= {pass/outline {label/render-lines 1}
                   pass/transparent {label/render-tris 1}}
@@ -104,7 +102,7 @@
                  (render-call-counts #{} :select-batch-key)))))
 
       (testing "Identical labels"
-        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+        (with-open [_ (make-restore-point!)]
           (add-label-component! go)
           (add-label-component! go)
           (add-label-component! go)
@@ -117,7 +115,7 @@
                  (render-call-counts #{} :select-batch-key)))))
 
       (testing "Blend mode differs"
-        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+        (with-open [_ (make-restore-point!)]
           (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-add)
           (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-add)
           (test-util/prop! (add-label-component! go) :blend-mode :blend-mode-mult)
@@ -127,7 +125,7 @@
                  (render-call-counts #{} :batch-key)))))
 
       (testing "Font differs"
-        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+        (with-open [_ (make-restore-point!)]
           (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/active_menu_item.font"))
           (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/active_menu_item.font"))
           (test-util/prop! (add-label-component! go) :font (workspace/find-resource workspace "/fonts/big_score.font"))
@@ -137,7 +135,7 @@
                  (render-call-counts #{} :batch-key)))))
 
       (testing "Material differs"
-        (with-open [_ (test-util/make-graph-reverter (project/graph project))]
+        (with-open [_ (make-restore-point!)]
           (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/active_menu_item.material"))
           (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/active_menu_item.material"))
           (test-util/prop! (add-label-component! go) :material (workspace/find-resource workspace "/fonts/big_score_font.material"))

--- a/editor/test/integration/label_test.clj
+++ b/editor/test/integration/label_test.clj
@@ -1,0 +1,45 @@
+(ns integration.label-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [support.test-support :refer [with-clean-system]]
+            [editor.workspace :as workspace]
+            [editor.defold-project :as project]
+            [editor.math :as math]
+            [editor.types :as types]
+            [editor.properties :as properties]
+            [integration.test-util :as test-util]))
+
+(deftest label-validation
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/label/test.label")]
+      (doseq [[prop cases] [[:font {"no font" ""
+                                    "unknown font" "/fonts/unknown.font"}]
+                            [:material {"no material" ""
+                                        "unknown material" "/materials/unknown.material"}]]
+              [case path] cases]
+        (testing case
+                (test-util/with-prop [node-id prop (workspace/resolve-workspace-resource workspace path)]
+                  (is (g/error? (test-util/prop-error node-id prop)))))))))
+
+(deftest label-aabb
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/label/test.label")]
+      (let [aabb (g/node-value node-id :aabb)
+            [x y z] (mapv - (math/vecmath->clj (:max aabb)) (math/vecmath->clj (:min aabb)))]
+        (is (< 0.0 x))
+        (is (< 0.0 y))
+        (is (= 0.0 z))))))
+
+(deftest label-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/label/test.label")]
+      (let [scene (g/node-value node-id :scene)]
+        (prn "s" scene)))))
+
+(label-scene)

--- a/editor/test/integration/label_test.clj
+++ b/editor/test/integration/label_test.clj
@@ -1,13 +1,11 @@
 (ns integration.label-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [support.test-support :refer [with-clean-system]]
-            [editor.workspace :as workspace]
             [editor.defold-project :as project]
             [editor.math :as math]
-            [editor.types :as types]
-            [editor.properties :as properties]
-            [integration.test-util :as test-util]))
+            [editor.workspace :as workspace]
+            [integration.test-util :as test-util]
+            [support.test-support :refer [with-clean-system]]))
 
 (deftest label-validation
   (with-clean-system
@@ -33,13 +31,3 @@
         (is (< 0.0 x))
         (is (< 0.0 y))
         (is (= 0.0 z))))))
-
-(deftest label-scene
-  (with-clean-system
-    (let [workspace (test-util/setup-workspace! world)
-          project (test-util/setup-project! workspace)
-          node-id (project/get-resource-node project "/label/test.label")]
-      (let [scene (g/node-value node-id :scene)]
-        (prn "s" scene)))))
-
-(label-scene)

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -332,6 +332,31 @@
       (write-file workspace "/gui/sub_scene.gui" (read-file workspace "/gui/new_sub_scene.gui"))
       (is (some? (gui-node node-id "sub_scene/sub_box2"))))))
 
+(deftest label
+  (with-clean-system
+    (let [[workspace project] (setup-scratch world)]
+      (let [node-id (project/get-resource-node project "/label/label.label")]
+        (is (= "Original" (g/node-value node-id :text)))
+        (is (= [1.0 1.0 1.0] (g/node-value node-id :scale)))
+        (is (= [1.0 1.0 1.0 1.0] (g/node-value node-id :color)))
+        (is (= [0.0 0.0 0.0 1.0] (g/node-value node-id :outline)))
+        (is (= 1.0 (g/node-value node-id :leading)))
+        (is (= 0.0 (g/node-value node-id :tracking)))
+        (is (= :pivot-center (g/node-value node-id :pivot)))
+        (is (= :blend-mode-alpha (g/node-value node-id :blend-mode)))
+        (is (false? (g/node-value node-id :line-break))))
+      (write-file workspace "/label/label.label" (read-file workspace "/label/new_label.label"))
+      (let [node-id (project/get-resource-node project "/label/label.label")]
+        (is (= "Modified" (g/node-value node-id :text)))
+        (is (= [2.0 3.0 4.0] (g/node-value node-id :scale)))
+        (is (= [1.0 0.0 0.0 1.0] (g/node-value node-id :color)))
+        (is (= [1.0 1.0 1.0 1.0] (g/node-value node-id :outline)))
+        (is (= 2.0 (g/node-value node-id :leading)))
+        (is (= 1.0 (g/node-value node-id :tracking)))
+        (is (= :pivot-n (g/node-value node-id :pivot)))
+        (is (= :blend-mode-add (g/node-value node-id :blend-mode)))
+        (is (true? (g/node-value node-id :line-break)))))))
+
 (deftest game-project
   (with-clean-system
     (let [[workspace project] (setup-scratch world)

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -14,6 +14,7 @@
            [com.dynamo.render.proto Font$FontDesc]
            [com.dynamo.gameobject.proto GameObject$PrototypeDesc GameObject$CollectionDesc]
            [com.dynamo.gui.proto Gui$SceneDesc]
+           [com.dynamo.label.proto Label$LabelDesc]
            [com.dynamo.model.proto Model$ModelDesc]
            [com.dynamo.particle.proto Particle$ParticleFX]
            [com.dynamo.spine.proto Spine$SpineSceneDesc Spine$SpineModelDesc Spine$SpineModelDesc$BlendMode]
@@ -23,6 +24,7 @@
                            "go" GameObject$PrototypeDesc
                            "collection" GameObject$CollectionDesc
                            "gui" Gui$SceneDesc
+                           "label" Label$LabelDesc
                            "model" Model$ModelDesc
                            "particlefx" Particle$ParticleFX
                            "spinescene" Spine$SpineSceneDesc
@@ -59,7 +61,8 @@
                  "**/new.tilemap"
                  "**/with_layers.tilemap"
                  "**/test.model"
-                 "**/empty_mesh.model"]]
+                 "**/empty_mesh.model"
+                 "**/test.label"]]
     (with-clean-system
       (let [workspace (test-util/setup-workspace! world)
             project   (test-util/setup-project! workspace)

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -34,11 +34,11 @@
             [editor.handler :as handler]
             [editor.display-profiles :as display-profiles]
             [util.http-server :as http-server])
-  (:import [java.io File FilenameFilter FileOutputStream FileInputStream ByteArrayOutputStream]
+  (:import [java.io File FilenameFilter FileInputStream ByteArrayOutputStream]
            [java.nio.file Files attribute.FileAttribute]
            [javax.imageio ImageIO]
            [javafx.scene.control Tab]
-           [org.apache.commons.io FilenameUtils FileUtils IOUtils]
+           [org.apache.commons.io FileUtils IOUtils]
            [java.util.zip ZipOutputStream ZipEntry]))
 
 (def project-path "test/resources/test_project")
@@ -197,10 +197,10 @@
   (get-in (g/node-value node-id :_properties) [:properties label :node-id]))
 
 (defn prop! [node-id label val]
-  (g/transact (g/set-property node-id label val)))
+  (g/transact (g/set-property (prop-node-id node-id label) label val)))
 
 (defn prop-clear! [node-id label]
-  (g/transact (g/clear-property node-id label)))
+  (g/transact (g/clear-property (prop-node-id node-id label) label)))
 
 (defn prop-read-only? [node-id label]
   (get-in (g/node-value node-id :_properties) [:properties label :read-only?]))
@@ -284,7 +284,45 @@
 
 (defn call-logger-calls
   "Given a function obtained from make-call-logger, returns a
-  vector of vectors containing the arguments for every time it
+  vector of sequences containing the arguments for every time it
   was called."
   [call-logger]
   (-> call-logger meta ::calls deref))
+
+(defmacro with-logged-calls
+  "Temporarily redefines the specified functions into call-loggers
+  while executing the body. Returns a map of functions to the
+  result of (call-logger-calls fn). Non-invoked functions will not
+  be included in the returned map.
+
+  Example:
+  (with-logged-calls [print println]
+    (println :a)
+    (println :a :b))
+  => {#object[clojure.core$println] [(:a)
+                                     (:a :b)]}"
+  [var-symbols & body]
+  `(let [binding-map# ~(into {}
+                             (map (fn [var-symbol]
+                                    `[(var ~var-symbol) (make-call-logger)]))
+                             var-symbols)]
+     (with-redefs-fn binding-map# (fn [] ~@body))
+     (into {}
+           (keep (fn [[var# call-logger#]]
+                   (let [calls# (call-logger-calls call-logger#)]
+                     (when (seq calls#)
+                       [(deref var#) calls#]))))
+           binding-map#)))
+
+(defn make-graph-reverter
+  "Returns an AutoCloseable that reverts the specified graph to
+  the state it was at construction time when its close method
+  is invoked. Suitable for use with the (with-open) macro."
+  [graph-id]
+  (let [initial-undo-stack-count (g/undo-stack-count graph-id)]
+    (reify java.lang.AutoCloseable
+      (close [_]
+        (loop [undo-stack-count (g/undo-stack-count graph-id)]
+          (when (< initial-undo-stack-count undo-stack-count)
+            (g/undo! graph-id)
+            (recur (g/undo-stack-count graph-id))))))))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -326,3 +326,11 @@
           (when (< initial-undo-stack-count undo-stack-count)
             (g/undo! graph-id)
             (recur (g/undo-stack-count graph-id))))))))
+
+(defn add-embedded-component!
+  "Adds a new instance of an embedded component to the specified
+  game object node inside a transaction and makes it the current
+  selection. Returns the id of the added EmbeddedComponent node."
+  [project resource-type go-id]
+  (game-object/add-embedded-component-handler {:_node-id go-id :resource-type resource-type})
+  (first (selection project)))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -10,6 +10,7 @@
             [editor.game-object :as game-object]
             [editor.game-project :as game-project]
             [editor.image :as image]
+            [editor.label :as label]
             [editor.defold-project :as project]
             [editor.scene :as scene]
             [editor.scene-selection :as scene-selection]
@@ -65,6 +66,7 @@
         (gui/register-resource-types workspace)
         (image/register-resource-types workspace)
         (json/register-resource-types workspace)
+        (label/register-resource-types workspace)
         (material/register-resource-types workspace)
         (mesh/register-resource-types workspace)
         (model/register-resource-types workspace)

--- a/editor/test/resources/build_project/SideScroller/main/blob.particlefx
+++ b/editor/test/resources/build_project/SideScroller/main/blob.particlefx
@@ -1,16 +1,225 @@
-emitters
-{
-	mode: PLAY_MODE_ONCE
-	space: EMISSION_SPACE_WORLD
-	position {x: 10 y: 0 z: 0}
-	rotation {x: 0 y: 0 z: 0 w: 1}
-	tile_source: "/builtins/graphics/particle_blob.tilesource"
-	animation: "anim"
-	material: "/builtins/materials/sprite.material"
-	max_particle_count: 1
-	type: EMITTER_TYPE_CIRCLE
+emitters {
+  id: "emitter"
+  mode: PLAY_MODE_ONCE
+  duration: 0.0
+  space: EMISSION_SPACE_WORLD
+  position {
+    x: 10.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  tile_source: "/builtins/graphics/particle_blob.tilesource"
+  animation: "anim"
+  material: "/builtins/materials/sprite.material"
+  blend_mode: BLEND_MODE_ALPHA
+  particle_orientation: PARTICLE_ORIENTATION_DEFAULT
+  inherit_velocity: 0.0
+  max_particle_count: 1
+  type: EMITTER_TYPE_CIRCLE
+  start_delay: 0.0
+  properties {
+    key: EMITTER_KEY_SPAWN_RATE
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_X
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_Y
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_Z
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_LIFE_TIME
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SPEED
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SIZE
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_RED
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_GREEN
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_BLUE
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_ALPHA
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_ROTATION
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  particle_properties {
+    key: PARTICLE_KEY_SCALE
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_RED
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_GREEN
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_BLUE
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_ALPHA
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_ROTATION
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
 }
-modifiers
-{
-	type: MODIFIER_TYPE_ACCELERATION
+modifiers {
+  type: MODIFIER_TYPE_ACCELERATION
+  use_direction: 0
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  properties {
+    key: MODIFIER_KEY_MAGNITUDE
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
 }

--- a/editor/test/resources/build_project/SideScroller/main/label.label
+++ b/editor/test/resources/build_project/SideScroller/main/label.label
@@ -1,0 +1,38 @@
+size {
+  x: 128.0
+  y: 32.0
+  z: 0.0
+  w: 0.0
+}
+scale {
+  x: 1.0
+  y: 1.0
+  z: 1.0
+  w: 0.0
+}
+color {
+  x: 1.0
+  y: 1.0
+  z: 1.0
+  w: 1.0
+}
+outline {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+shadow {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+leading: 1.0
+tracking: 0.0
+pivot: PIVOT_CENTER
+blend_mode: BLEND_MODE_ALPHA
+line_break: false
+text: "Label"
+font: "/builtins/fonts/system_font.font"
+material: "/builtins/fonts/label.material"

--- a/editor/test/resources/build_project/SideScroller/main/main.collection
+++ b/editor/test/resources/build_project/SideScroller/main/main.collection
@@ -1,8 +1,4 @@
 name: "parallax"
-collection_instances {
-  id: "player"
-  collection: "/player/player.collection"
-}
 instances {
   id: "factory"
   prototype: "/stars/factory.go"
@@ -17,7 +13,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
 instances {
   id: "large_clouds1"
@@ -33,7 +33,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
 instances {
   id: "large_clouds2"
@@ -49,7 +53,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
 instances {
   id: "main"
@@ -65,7 +73,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
 instances {
   id: "small_clouds1"
@@ -81,7 +93,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 0.3
+  scale3 {
+    x: 0.3
+    y: 0.3
+    z: 0.3
+  }
 }
 instances {
   id: "small_clouds2"
@@ -97,7 +113,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 0.3
+  scale3 {
+    x: 0.3
+    y: 0.3
+    z: 0.3
+  }
 }
 instances {
   id: "spaceship"
@@ -113,7 +133,11 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
 instances {
   id: "spaceship_tile"
@@ -129,7 +153,31 @@ instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}
+collection_instances {
+  id: "player"
+  collection: "/player/player.collection"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
 scale_along_z: 0
 embedded_instances {
@@ -166,5 +214,44 @@ embedded_instances {
     z: 0.0
     w: 1.0
   }
-  scale: 1.0
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}
+embedded_instances {
+  id: "label"
+  data: "components {\n"
+  "  id: \"label\"\n"
+  "  component: \"/main/label.label\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 300.0
+    y: 600.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 3.0
+    y: 3.0
+    z: 1.0
+  }
 }

--- a/editor/test/resources/reload_project/label/label.label
+++ b/editor/test/resources/reload_project/label/label.label
@@ -1,0 +1,38 @@
+size {
+  x: 128.0
+  y: 32.0
+  z: 0.0
+  w: 0.0
+}
+scale {
+  x: 1.0
+  y: 1.0
+  z: 1.0
+  w: 0.0
+}
+color {
+  x: 1.0
+  y: 1.0
+  z: 1.0
+  w: 1.0
+}
+outline {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+shadow {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+leading: 1.0
+tracking: 0.0
+pivot: PIVOT_CENTER
+blend_mode: BLEND_MODE_ALPHA
+line_break: false
+text: "Original"
+font: "/builtins/fonts/system_font.font"
+material: "/builtins/fonts/label.material"

--- a/editor/test/resources/reload_project/label/new_label.label
+++ b/editor/test/resources/reload_project/label/new_label.label
@@ -1,0 +1,38 @@
+size {
+  x: 128.0
+  y: 32.0
+  z: 0.0
+  w: 0.0
+}
+scale {
+  x: 2.0
+  y: 3.0
+  z: 4.0
+  w: 0.0
+}
+color {
+  x: 1.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+outline {
+  x: 1.0
+  y: 1.0
+  z: 1.0
+  w: 1.0
+}
+shadow {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+leading: 2.0
+tracking: 1.0
+pivot: PIVOT_N
+blend_mode: BLEND_MODE_ADD
+line_break: true
+text: "Modified"
+font: "/builtins/fonts/system_font.font"
+material: "/builtins/fonts/label.material"

--- a/editor/test/resources/test_project/fonts/invalid_material.font
+++ b/editor/test/resources/test_project/fonts/invalid_material.font
@@ -1,0 +1,7 @@
+font: "/fonts/justov.ttf"
+material: "/material/missing_name.material"
+size: 14
+antialias: 1
+alpha: 1.0
+shadow_alpha: 1.0
+shadow_blur: 2

--- a/editor/test/resources/test_project/label/test.label
+++ b/editor/test/resources/test_project/label/test.label
@@ -1,0 +1,13 @@
+text: 'Label'
+font: '/builtins/fonts/system_font.font'
+material: '/builtins/fonts/label.material'
+scale { x: 1 y: 1 z: 1 }
+size { x: 128 y: 32 z: 0 }
+color { x: 1 y: 1 z: 1 w: 1 }
+outline { x: 0 y: 0 z: 0 w: 1 }
+shadow { x: 0 y: 0 z: 0 w: 1 }
+leading: 1.0
+tracking: 0.0
+pivot: PIVOT_CENTER
+blend_mode: BLEND_MODE_ALPHA
+line_break: false


### PR DESCRIPTION
* Adds support for the Label component inside game objects.
* Fixes broken previewing of fonts in the scene view.
* Fixes exception thrown when attempting to add a Light to a game object.
* Fixes exception thrown when saving a Spine Model with an unspecified Material or Spine Scene.
* Fixed blurry icon for Sprite components.
* Restores various ProtoBuf build tests that had been disabled by mistake.
* Adds generic testing of instantiating, saving and loading for present and future embedded components.
* The `test-util/prop!` and `test-util/prop-clear!` functions will now resolve the owning node of the property like the other property helpers.
* Adds some useful helpers to the `test-util` module:
  * The `with-logged-calls` macro lets you replace existing functions with mock implementations that keep track of their calls.
  * The `make-graph-reverter` function returns an `AutoCloseable` for use with `(with-open ...)` that reverts a graph to a prior point.
* Fixes some bad content in the `build_project` test project that prevented certain files from opening in the editor.