### PR TITLE
DEFEDIT-558 Allow simple arithmetic in numeric input fields

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -51,7 +51,7 @@
     (let [a (parse-fn (matches 1))
           b (parse-fn (matches 3))
           op (resolve (symbol (matches 2)))]
-      (math/round-with-precision (op a b) 0.01)
+      (math/round-with-precision (op a b) 0.01))
     (parse-fn text)))
 
 (defn- to-int [s]

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -46,15 +46,23 @@
 (def ^{:private true :const true} grid-vgap 6)
 (def ^{:private true :const true} all-available 5000)
 
+(defn- evaluate-expression [parse-fn text]
+  (if-let [matches (re-find #"(.+?)\s*([\+\-*/])\s*(.+?)" text)]
+    (let [a (parse-fn (matches 1))
+          b (parse-fn (matches 3))
+          op (resolve (symbol (matches 2)))]
+      (math/round-with-precision (op a b) 0.01)
+    (parse-fn text)))
+
 (defn- to-int [s]
   (try
-    (Integer/parseInt s)
+    (evaluate-expression #(Integer/parseInt %) s)
     (catch Throwable _
       nil)))
 
 (defn- to-double [s]
  (try
-   (Double/parseDouble s)
+   (evaluate-expression #(Double/parseDouble %) s)
    (catch Throwable _
      nil)))
 


### PR DESCRIPTION
* Allow users to type simple expressions such as `1280 / 2` or `17.5*4` into numeric text input fields, setting the property to the evaluated value.