### PR TITLE
DEFEDIT-570 Can't View Diff from the Sync dialog Push stage

### DIFF
--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -336,10 +336,10 @@
                                  (ui/disable! (:unstage push-controls) (not (:unstage enabled)))
 
                                  (when (:diff enabled)
-                                   (if-let [selection-provider (cond (ui/focus? changed-view) changed-view
-                                                                     (ui/focus? staged-view) staged-view
-                                                                     :else nil)]
-                                     (ui/context! (:diff push-controls) :sync {:!flow !flow} selection-provider)))))
+                                   (if-let [focused-list-view (cond (ui/focus? changed-view) changed-view
+                                                                    (ui/focus? staged-view) staged-view
+                                                                    :else nil)]
+                                     (ui/context! (:diff push-controls) :sync {:!flow !flow} (ui/->selection-provider focused-list-view))))))
         update-controls (fn [{:keys [state conflicts resolved modified staged] :as flow}]
                           (ui/run-later
                            (if (= "pull" (namespace state))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -152,20 +152,20 @@
   Supports both single and multi-selection. In both cases the selected items
   will be provided in a vector."
   [node listen-fn]
-  `(let [selection-provider# ~node
+  `(let [selection-owner# ~node
          selection-listener# ~listen-fn
-         selection-model# (.getSelectionModel selection-provider#)]
+         selection-model# (.getSelectionModel selection-owner#)]
      (condp instance? selection-model#
        MultipleSelectionModel
-       (observe-list selection-provider#
+       (observe-list selection-owner#
                      (.getSelectedItems ^MultipleSelectionModel selection-model#)
                      (fn [_# selected-items#]
-                       (selection-listener# selection-provider# selected-items#)))
+                       (selection-listener# selection-owner# selected-items#)))
 
        SelectionModel
        (observe (.selectedItemProperty ^SelectionModel selection-model#)
                 (fn [_# _# selected-item#]
-                  (selection-listener# selection-provider# [selected-item#]))))))
+                  (selection-listener# selection-owner# [selected-item#]))))))
 
 (defn remove-list-observers
   [^Node node ^ObservableList observable]


### PR DESCRIPTION
Fixes DEFEDIT-570

* Fixed exception when clicking the **View Diff** button in the Sync dialog.
* Fixed misleading binding name in the `ui/observe-selection` macro