### PR TITLE
DEFEDIT-587 Fixed some issues with numeric expressions in property fields

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -46,23 +46,23 @@
 (def ^{:private true :const true} grid-vgap 6)
 (def ^{:private true :const true} all-available 5000)
 
-(defn- evaluate-expression [parse-fn text]
-  (if-let [matches (re-find #"(.+?)\s*([\+\-*/])\s*(.+?)" text)]
+(defn- evaluate-expression [parse-fn precision text]
+  (if-let [matches (re-find #"(.+?)\s*([\+\-*/])\s*(.+)" text)]
     (let [a (parse-fn (matches 1))
           b (parse-fn (matches 3))
           op (resolve (symbol (matches 2)))]
-      (math/round-with-precision (op a b) 0.01))
+      (math/round-with-precision (op a b) precision))
     (parse-fn text)))
 
 (defn- to-int [s]
   (try
-    (evaluate-expression #(Integer/parseInt %) s)
+    (int (evaluate-expression #(Integer/parseInt %) 1.0 s))
     (catch Throwable _
       nil)))
 
 (defn- to-double [s]
  (try
-   (evaluate-expression #(Double/parseDouble %) s)
+   (evaluate-expression #(Double/parseDouble %) 0.01 s)
    (catch Throwable _
      nil)))
 


### PR DESCRIPTION
Fixes DEFEDIT-587
Fixes DEFEDIT-588

* Fixes a schema validation error for fractional expression results in numeric property editor fields.
* Fixes only using the first digit of a multi-digit final term.