### PR TITLE
DEFEDIT-571 Sync push fixes

### DIFF
--- a/editor/resources/sync-dialog.fxml
+++ b/editor/resources/sync-dialog.fxml
@@ -8,7 +8,7 @@
 <?import java.net.*?>
 <?import javafx.scene.layout.*?>
 
-<BorderPane prefHeight="200.0" prefWidth="468.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<BorderPane styleClass="sync-dialog" prefHeight="200.0" prefWidth="468.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <stylesheets>
     <URL value="@editor.css" />
   </stylesheets>

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -70,17 +70,10 @@
 
 (handler/defhandler :diff :changes-view
   (enabled? [selection]
-            (and (= 1 (count selection))
-                 (not= :add (:change-type (first selection)))
-                 (not= :delete (:change-type (first selection)))))
+            (git/selection-diffable? selection))
   (run [selection ^Git git list-view]
-       (let [status (first selection)
-             old-name (or (:old-path status) (:new-path status) )
-             new-name (or (:new-path status) (:old-path status) )
-             work-tree (.getWorkTree (.getRepository git))
-             old (String. ^bytes (git/show-file git old-name))
-             new (slurp (io/file work-tree new-name))]
-         (diff-view/make-diff-viewer old-name old new-name new))))
+       (let [{:keys [new new-path old old-path]} (git/selection-diff-data git selection)]
+         (diff-view/make-diff-viewer old-path old new-path new))))
 
 (handler/defhandler :synchronize :global
   (enabled? [changes-view]

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -5,10 +5,11 @@
             [editor.diff-view :as diff-view]
             [editor.git :as git]
             [editor.handler :as handler]
+            [editor.sync :as sync]
             [editor.ui :as ui]
             [editor.resource :as resource]
+            [editor.vcs-status :as vcs-status]
             [editor.workspace :as workspace]
-            [editor.sync :as sync]
             [service.log :as log])
   (:import [javafx.scene Parent]
            [javafx.scene.control SelectionMode ListView]
@@ -25,26 +26,8 @@
         list-view (g/node-value changes-view :list-view)]
     (refresh-list-view! git list-view)))
 
-(def ^:const status-icons
-  {:add    "icons/32/Icons_M_07_plus.png"
-   :modify "icons/32/Icons_S_06_arrowup.png"
-   :delete "icons/32/Icons_M_06_trash.png"
-   :rename "icons/32/Icons_S_08_arrow-d-right.png"})
-
-(def ^:const status-styles
-  {:add    #{"added-file"}
-   :modify #{"modified-file"}
-   :delete #{"deleted-file"}
-   :rename #{"renamed-file"}})
-
-(defn- status-render [status]
-  {:text (format "%s" (or (:new-path status)
-                          (:old-path status)))
-   :icon (get status-icons (:change-type status))
-   :style (get status-styles (:change-type status) #{})})
-
 (ui/extend-menu ::changes-menu nil
-                [{:label "Diff"
+                [{:label "View Diff"
                   :icon "icons/32/Icons_S_06_arrowup.png"
                   :command :diff}
                  {:label "Revert"
@@ -115,7 +98,7 @@
       (ui/context! parent :changes-view {:git git :list-view list-view :workspace workspace} (ui/->selection-provider list-view) {}
                    {resource/Resource (fn [status] (status->resource workspace status))})
       (ui/register-context-menu list-view ::changes-menu)
-      (ui/cell-factory! list-view status-render)
+      (ui/cell-factory! list-view vcs-status/render)
       (ui/bind-action! diff-button :diff)
       (ui/bind-action! revert-button :revert)
       (ui/disable! diff-button true)

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -228,3 +228,23 @@
      (onEndTask
        ([taskName workCurr])
        ([taskName workCurr workTotal percentDone])))))
+
+;; =================================================================================
+
+(defn selection-diffable? [selection]
+  (and (= 1 (count selection))
+       (let [change-type (:change-type (first selection))]
+         (and (keyword? change-type)
+              (not= :add change-type)
+              (not= :delete change-type)))))
+
+(defn selection-diff-data [git selection]
+  (let [change (first selection)
+        old-path (or (:old-path change) (:new-path change) )
+        new-path (or (:new-path change) (:old-path change) )
+        old (String. ^bytes (show-file git old-path))
+        new (slurp (file git new-path))]
+    {:new new
+     :new-path new-path
+     :old old
+     :old-path old-path}))

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -57,7 +57,7 @@
      :missing                 (set (.getMissing s))
      :modified                (set (.getModified s))
      :removed                 (set (.getRemoved s))
-     :uncommited-changes      (set (.getUncommittedChanges s))
+     :uncommitted-changes     (set (.getUncommittedChanges s))
      :untracked               (set (.getUntracked s))
      :untracked-folders       (set (.getUntrackedFolders s))
      :conflicting-stage-state (apply hash-map
@@ -136,13 +136,8 @@
 (defn make-rename-change [old-path new-path]
   {:change-type :rename :old-path old-path :new-path new-path})
 
-(defn- guess-change [git file-path]
-  "DEPRECATED. TODO: Remove remaining calls to this function."
-  ; The stage-change! and unstage-change! functions behave the same for :add
-  ; and :modify changes, so make-modify-change will work for added files.
-  (if (.exists (file git file-path))
-    (make-modify-change file-path)
-    (make-delete-change file-path)))
+(defn change-path [{:keys [old-path new-path]}]
+  (or new-path old-path))
 
 (defn stage-change! [^Git git {:keys [change-type old-path new-path]}]
   (case change-type
@@ -157,14 +152,6 @@
     :delete        (-> git .reset (.addPath old-path) .call)
     :rename        (do (-> git .reset (.addPath new-path) .call)
                        (-> git .reset (.addPath old-path) .call))))
-
-(defn stage-file! [git file-path]
-  "DEPRECATED. TODO: Remove remaining calls to this function."
-  (stage-change! git (guess-change git file-path)))
-
-(defn unstage-file! [git file-path]
-  "DEPRECATED. TODO: Remove remaining calls to this function."
-  (unstage-change! git (guess-change git file-path)))
 
 (defn hard-reset [^Git git ^RevCommit start-ref]
   (-> (.reset git)

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -90,6 +90,9 @@
           (->> (.compute rd (.getObjectReader tw) nil)
                (mapv diff-entry->map)))))))
 
+(defn file ^java.io.File [^Git git file-path]
+  (io/file (str (worktree git) "/" file-path)))
+
 (defn show-file
   ([^Git git name]
    (show-file git name "HEAD"))
@@ -133,10 +136,11 @@
 (defn make-rename-change [old-path new-path]
   {:change-type :rename :old-path old-path :new-path new-path})
 
-(defn guess-change [git file-path]
+(defn- guess-change [git file-path]
+  "DEPRECATED. TODO: Remove remaining calls to this function."
   ; The stage-change! and unstage-change! functions behave the same for :add
   ; and :modify changes, so make-modify-change will work for added files.
-  (if (.exists (io/file (str (worktree git) "/" file-path)))
+  (if (.exists (file git file-path))
     (make-modify-change file-path)
     (make-delete-change file-path)))
 
@@ -216,7 +220,7 @@
   (let [s (status git)]
     (doseq [f files]
       (when (contains? (:untracked s) f)
-        (io/delete-file (str (.getWorkTree (.getRepository git)) "/" f))))))
+        (io/delete-file (file git f))))))
 
 (defn make-clone-monitor [^ProgressBar progress-bar]
   (let [tasks (atom {"remote: Finding sources" 0

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -1,14 +1,14 @@
 (ns editor.sync
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.set :as set]
             [editor
              [dialogs :as dialogs]
              [diff-view :as diff-view]
              [git :as git]
              [handler :as handler]
              [login :as login]
-             [ui :as ui]]
+             [ui :as ui]
+             [vcs-status :as vcs-status]]
             [editor.progress :as progress])
   (:import [org.eclipse.jgit.api Git PullResult]
            [org.eclipse.jgit.revwalk RevCommit]
@@ -216,7 +216,7 @@
     :push/done      flow))
 
 (ui/extend-menu ::conflicts-menu nil
-                [{:label "Show Diff"
+                [{:label "View Diff"
                   :command :show-diff}
                  {:label "Use Ours"
                   :command :use-ours}
@@ -224,13 +224,13 @@
                   :command :use-theirs}])
 
 (ui/extend-menu ::staging-menu nil
-                [{:label "Show Diff"
+                [{:label "View Diff"
                   :command :show-change-diff}
                  {:label "Stage Change"
                   :command :stage-change}])
 
 (ui/extend-menu ::unstaging-menu nil
-                [{:label "Show Diff"
+                [{:label "View Diff"
                   :command :show-change-diff}
                  {:label "Unstage Change"
                   :command :unstage-change}])
@@ -470,7 +470,7 @@
       (ui/context! (:stage push-controls) :sync {:!flow !flow} (ui/->selection-provider list-view))
       (ui/bind-action! (:stage push-controls) :stage-change)
       (ui/register-context-menu list-view ::staging-menu)
-      (ui/cell-factory! list-view (fn [e] {:text (git/change-path e)})))
+      (ui/cell-factory! list-view vcs-status/render-verbose))
 
     (let [^ListView list-view (:staged push-controls)]
       (.setSelectionMode (.getSelectionModel list-view) SelectionMode/MULTIPLE)
@@ -478,7 +478,7 @@
       (ui/context! (:unstage push-controls) :sync {:!flow !flow} (ui/->selection-provider list-view))
       (ui/bind-action! (:unstage push-controls) :unstage-change)
       (ui/register-context-menu list-view ::unstaging-menu)
-      (ui/cell-factory! list-view (fn [e] {:text (git/change-path e)})))
+      (ui/cell-factory! list-view vcs-status/render-verbose))
 
     (.addEventFilter scene KeyEvent/KEY_PRESSED
                      (ui/event-handler event

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -153,15 +153,22 @@
        (assoc :state new-state)
        (update :progress #(progress/advance % n)))))
 
+(defn- find-changes [status unified-status status-keys]
+  (into #{}
+        (comp (filter (fn [change]
+                          (some #(contains? (status %)
+                                            (git/change-path change))
+                                status-keys)))
+              (map #(dissoc % :score)))
+        unified-status))
+
+(defn find-git-state [status unified-status]
+  {:staged   (find-changes status unified-status [:added :changed :removed])
+   :modified (find-changes status unified-status [:missing :modified :untracked])})
+
 (defn refresh-git-state [{:keys [git] :as flow}]
-  (let [st (git/status git)]
-    (merge flow
-           {:staged   (set/union (:added st)
-                                 (:removed st)
-                                 (:changed st))
-            :modified (set/union (:missing st)
-                                 (:untracked st)
-                                 (:modified st))})))
+  (merge flow (find-git-state (git/status git)
+                              (git/unified-status git))))
 
 (defn advance-flow [{:keys [git state progress creds conflicts stash-ref message] :as flow} render-progress]
   (render-progress progress)
@@ -196,9 +203,9 @@
 
     :push/start     (advance-flow (tick (refresh-git-state flow) :push/staging) render-progress)
     :push/staging   flow
-    :push/comitting (do
-                      (git/commit git message)
-                      (advance-flow (tick flow :push/pushing) render-progress))
+    :push/committing (do
+                       (git/commit git message)
+                       (advance-flow (tick flow :push/pushing) render-progress))
     :push/pushing   (do
                       (try
                         (git/push git creds)
@@ -209,24 +216,24 @@
     :push/done      flow))
 
 (ui/extend-menu ::conflicts-menu nil
-                [{:label "Show diff"
+                [{:label "Show Diff"
                   :command :show-diff}
-                 {:label "Use ours"
+                 {:label "Use Ours"
                   :command :use-ours}
-                 {:label "Use theirs"
+                 {:label "Use Theirs"
                   :command :use-theirs}])
 
 (ui/extend-menu ::staging-menu nil
-                [{:label "Show diff"
-                  :command :show-file-diff}
-                 {:label "Stage files"
-                  :command :stage-file}])
+                [{:label "Show Diff"
+                  :command :show-change-diff}
+                 {:label "Stage Change"
+                  :command :stage-change}])
 
 (ui/extend-menu ::unstaging-menu nil
-                [{:label "Show diff"
-                  :command :show-file-diff}
-                 {:label "Unstage files"
-                  :command :unstage-file}])
+                [{:label "Show Diff"
+                  :command :show-change-diff}
+                 {:label "Unstage Change"
+                  :command :unstage-change}])
 
 (defn get-theirs [{:keys [git] :as flow} file]
   (String. ^bytes (git/show-file git file)))
@@ -256,10 +263,11 @@
         (diff-view/make-diff-viewer (str "Theirs '" file "'") theirs
                                     (str "Ours '" file "'") ours)))))
 
-(handler/defhandler :show-file-diff :sync
+(handler/defhandler :show-change-diff :sync
   (enabled? [selection] (= 1 (count selection)))
   (run [selection !flow]
-    (let [file   (first selection)
+    (let [change (first selection)
+          file   (git/change-path change)
           ours   (try (slurp (io/file (git/worktree (:git @!flow)) file)) (catch Exception _))
           theirs (try (get-theirs @!flow file) (catch Exception _))]
       (when (and ours theirs)
@@ -282,18 +290,18 @@
         (spit (io/file (git/worktree (:git @!flow)) f) theirs)
         (resolve-file! !flow f)))))
 
-(handler/defhandler :stage-file :sync
+(handler/defhandler :stage-change :sync
   (enabled? [selection] (pos? (count selection)))
   (run [selection !flow]
-    (doseq [f selection]
-      (git/stage-file! (:git @!flow) f))
+    (doseq [change selection]
+      (git/stage-change! (:git @!flow) change))
     (swap! !flow refresh-git-state)))
 
-(handler/defhandler :unstage-file :sync
+(handler/defhandler :unstage-change :sync
   (enabled? [selection] (pos? (count selection)))
   (run [selection !flow]
-    (doseq [f selection]
-      (git/unstage-file! (:git @!flow) f))
+    (doseq [change selection]
+      (git/unstage-change! (:git @!flow) change))
     (swap! !flow refresh-git-state)))
 
 ;; =================================================================================
@@ -383,8 +391,8 @@
                                                    staged-view ^ListView (:staged push-controls)
                                                    changed-selection (vec (ui/selection changed-view))
                                                    staged-selection (vec (ui/selection staged-view))]
-                                               (ui/items! changed-view (sort modified))
-                                               (ui/items! staged-view (sort staged))
+                                               (ui/items! changed-view (sort-by git/change-path modified))
+                                               (ui/items! staged-view (sort-by git/change-path staged))
                                                (ui/disable! (:ok dialog-controls)
                                                             (or (empty? staged)
                                                                 (empty? (ui/text (:message push-controls)))))
@@ -423,7 +431,7 @@
                                              (= :push/staging (:state @!flow))
                                              (swap! !flow #(advance-flow
                                                             (merge %
-                                                                   {:state   :push/comitting
+                                                                   {:state   :push/committing
                                                                     :message (ui/text (:message push-controls))})
                                                             render-progress))
 
@@ -435,7 +443,7 @@
                                                                    :progress (progress/make "push" 4)}))
                                              (swap! !flow advance-flow render-progress)))
 
-    (ui/bind-action! (:diff push-controls) :show-file-diff)
+    (ui/bind-action! (:diff push-controls) :show-change-diff)
 
     (ui/observe (.focusOwnerProperty scene)
                 (fn [_ _ new]
@@ -465,17 +473,17 @@
       (.setSelectionMode (.getSelectionModel list-view) SelectionMode/MULTIPLE)
       (ui/context! list-view :sync {:!flow !flow} (ui/->selection-provider list-view))
       (ui/context! (:stage push-controls) :sync {:!flow !flow} (ui/->selection-provider list-view))
-      (ui/bind-action! (:stage push-controls) :stage-file)
+      (ui/bind-action! (:stage push-controls) :stage-change)
       (ui/register-context-menu list-view ::staging-menu)
-      (ui/cell-factory! list-view (fn [e] {:text e})))
+      (ui/cell-factory! list-view (fn [e] {:text (git/change-path e)})))
 
     (let [^ListView list-view (:staged push-controls)]
       (.setSelectionMode (.getSelectionModel list-view) SelectionMode/MULTIPLE)
       (ui/context! list-view :sync {:!flow !flow} (ui/->selection-provider list-view))
       (ui/context! (:unstage push-controls) :sync {:!flow !flow} (ui/->selection-provider list-view))
-      (ui/bind-action! (:unstage push-controls) :unstage-file)
+      (ui/bind-action! (:unstage push-controls) :unstage-change)
       (ui/register-context-menu list-view ::unstaging-menu)
-      (ui/cell-factory! list-view (fn [e] {:text e})))
+      (ui/cell-factory! list-view (fn [e] {:text (git/change-path e)})))
 
     (.addEventFilter scene KeyEvent/KEY_PRESSED
                      (ui/event-handler event

--- a/editor/src/clj/editor/vcs_status.clj
+++ b/editor/src/clj/editor/vcs_status.clj
@@ -1,0 +1,34 @@
+(ns editor.vcs-status)
+
+(def ^:const change-type-icons
+  {:add    "icons/32/Icons_M_07_plus.png"
+   :modify "icons/32/Icons_S_06_arrowup.png"
+   :delete "icons/32/Icons_M_06_trash.png"
+   :rename "icons/32/Icons_S_08_arrow-d-right.png"})
+
+(def ^:const change-type-styles
+  {:add    #{"added-file"}
+   :modify #{"modified-file"}
+   :delete #{"deleted-file"}
+   :rename #{"renamed-file"}})
+
+(defn- text [change]
+  (format "%s" (or (:new-path change)
+                   (:old-path change))))
+
+(defn- verbose-text [change]
+  (if (= :rename (:change-type change))
+    (format "%s \u2192 %s" ; "->" (RIGHTWARDS ARROW)
+            (:old-path change)
+            (:new-path change))
+    (text change)))
+
+(defn render [change]
+  {:text (text change)
+   :icon (get change-type-icons (:change-type change))
+   :style (get change-type-styles (:change-type change) #{})})
+
+(defn render-verbose [change]
+  {:text (verbose-text change)
+   :icon (get change-type-icons (:change-type change))
+   :style (get change-type-styles (:change-type change) #{})})

--- a/editor/styling/stylesheets/main.sass
+++ b/editor/styling/stylesheets/main.sass
@@ -49,6 +49,7 @@
 @import 'modules/_progress-bar';
 @import 'modules/_right-split';
 @import 'modules/_script-editor';
+@import 'modules/_sync-dialog';
 @import 'modules/_tool-tabs';
 @import 'modules/_toolbar';
 @import 'modules/_toolbar-status';

--- a/editor/styling/stylesheets/modules/_sync-dialog.scss
+++ b/editor/styling/stylesheets/modules/_sync-dialog.scss
@@ -1,0 +1,6 @@
+.sync-dialog {
+  #message {
+    -fx-border-color: $dark-grey-border;
+    -fx-prompt-text-fill: $tree-view-icon;
+  }
+}

--- a/editor/test/editor/git_test.clj
+++ b/editor/test/editor/git_test.clj
@@ -107,10 +107,10 @@
       (is (= #{} (:untracked (git/status git))))
       (create-file git "/src/util.cpp" "// stuff")
       (is (= #{"src/util.cpp"} (:modified (git/status git))))
-      (is (= #{"src/util.cpp"} (:uncommited-changes (git/status git))))
+      (is (= #{"src/util.cpp"} (:uncommitted-changes (git/status git))))
       (autostage git)
       (is (= #{} (:modified (git/status git))))
-      (is (= #{"src/util.cpp"} (:uncommited-changes (git/status git)))))
+      (is (= #{"src/util.cpp"} (:uncommitted-changes (git/status git)))))
 
     (testing "Create new.cpp"
       (create-file git "/src/new.cpp" "")

--- a/editor/test/editor/git_test.clj
+++ b/editor/test/editor/git_test.clj
@@ -7,17 +7,14 @@
            org.apache.commons.io.FileUtils
            [org.eclipse.jgit.api Git]))
 
-(defn- git-file [^Git git path]
-  (io/file (str (.getWorkTree (.getRepository git)) "/" path)))
-
 (defn create-file [git path content]
-  (let [f (git-file git path)]
+  (let [f (git/file git path)]
     (io/make-parents f)
     (spit f content)))
 
 (defn move-file [git old-path new-path]
-  (let [old-file (git-file git old-path)
-        new-file (git-file git new-path)]
+  (let [old-file (git/file git old-path)
+        new-file (git/file git new-path)]
     (io/make-parents new-file)
     (.renameTo old-file new-file)))
 
@@ -43,10 +40,10 @@
   (FileUtils/deleteDirectory (.getWorkTree (.getRepository git))))
 
 (defn delete-file [git file]
-  (io/delete-file (git-file git file)))
+  (io/delete-file (git/file git file)))
 
 (defn slurp-file [git file]
-  (slurp (git-file git file)))
+  (slurp (git/file git file)))
 
 (defn- add-src [git]
   (-> git (.add) (.addFilepattern "src") (.call)))

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -129,7 +129,7 @@
         (swap! !flow sync/advance-flow progress/null-render-progress!)
         (is (= :push/staging (:state @!flow)))
         (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
-        (git/stage-change! local-git (git/make-modified-change "src/main.cpp"))
+        (git/stage-change! local-git (git/make-modify-change "src/main.cpp"))
         (swap! !flow sync/refresh-git-state)
         (is (= #{"src/main.cpp"} (:staged @!flow)))
         (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -129,7 +129,7 @@
         (swap! !flow sync/advance-flow progress/null-render-progress!)
         (is (= :push/staging (:state @!flow)))
         (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))
-        (git/stage-file local-git "src/main.cpp")
+        (git/stage-change! local-git (git/make-modified-change "src/main.cpp"))
         (swap! !flow sync/refresh-git-state)
         (is (= #{"src/main.cpp"} (:staged @!flow)))
         (is (flow-equal? @!flow @(sync/resume-flow local-git prefs)))


### PR DESCRIPTION
Fixes DEFEDIT-565
Fixes DEFEDIT-571
Fixes DEFEDIT-572
Fixes DEFEDIT-581
Fixes defold/editor2-issues#159

* The Push stage of the Synchronize dialog now displays changes the same way as the Changed Files panel, except we use the extra space to also show source and destination paths of moved files.
* Deleted files are now committed and pushed correctly during Synchronize.
* Moved or renamed files are now committed and pushed correctly during Synchronize.
* Every context menu action and button that opens the diff dialog is now labelled **View Diff**, except the **Diff** button in the Changed Files panel, where space is limited.
* We now use the same logic for **View Diff** from the Push stage of the Synchronize dialog as in the Changed Files panel.
* Context menu actions in the Synchronize dialog are now properly capitalized.
* Fixed typos in `sync.clj` keywords.