### PR TITLE
DEFEDIT-491 Plugged some holes in the Sync process

### DIFF
--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -305,7 +305,7 @@
         push-root       ^Parent (ui/load-fxml "sync-push.fxml")
         stage           (ui/make-stage)
         scene           (Scene. root)
-        dialog-controls (ui/collect-controls root [ "ok" "push" "cancel" "dialog-area" "progress-bar"])
+        dialog-controls (ui/collect-controls root ["ok" "push" "cancel" "dialog-area" "progress-bar"])
         pull-controls   (ui/collect-controls pull-root ["conflicting" "resolved" "conflict-box" "main-label"])
         push-controls   (ui/collect-controls push-root ["changed" "staged" "message" "content-box" "main-label" "diff" "stage" "unstage"])
         render-progress (fn [progress]
@@ -379,7 +379,8 @@
                                                 (ui/text! (:main-label pull-controls) "Error getting changes")
                                                 (ui/visible! (:push dialog-controls) false)
                                                 (ui/visible! (:conflict-box pull-controls) false)
-                                                (ui/text! (:ok dialog-controls) "Close"))
+                                                (ui/text! (:ok dialog-controls) "Done")
+                                                (ui/disable! (:ok dialog-controls) true))
                              :push/staging   (let [changed-view ^ListView (:changed push-controls)
                                                    staged-view ^ListView (:staged push-controls)
                                                    changed-selection (vec (ui/selection changed-view))

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -411,6 +411,10 @@
     (add-watch !flow :updater (fn [_ _ _ flow]
                                 (update-controls flow)))
 
+    ; Disable the window close button, since it is unclear what it means.
+    ; This forces the user to make an active choice between Done or Cancel.
+    (ui/on-closing! stage (fn [_] false))
+
     (ui/on-action! (:cancel dialog-controls) (fn [_]
                                                (cancel-flow! !flow)
                                                (.close stage)))

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -1,5 +1,6 @@
 (ns editor.sync-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [editor.git-test :refer :all]
             [editor.prefs :as prefs]
             [editor.git :as git]
@@ -40,6 +41,36 @@
     (is (nil? (:stash-ref flow)))
     (is (true? (sync/flow-in-progress? git)))
     (is (flow-equal? flow @(sync/resume-flow git prefs)))))
+
+(deftest begin-flow-critical-failure-test
+  (testing "Local changes are restored in case an error occurs inside begin-flow!"
+    (with-git [git (new-git)
+               prefs (make-prefs)
+               added-path "/added.txt"
+               added-contents "A file that has been added but not staged."
+               existing-path "/existing.txt"
+               existing-contents "A file that already existed in the repo, with unstaged changes."
+               deleted-path "/deleted.txt"]
+      ; Create some local changes.
+      (create-file git existing-path "A file that already existed in the repo.")
+      (create-file git deleted-path "A file that existed in the repo, but will be deleted.")
+      (commit-src git)
+      (create-file git existing-path existing-contents)
+      (create-file git added-path added-contents)
+      (delete-file git deleted-path)
+
+      ; Create a directory where the flow journal file is expected to be
+      ; in order to cause an Exception inside the begin-flow! function.
+      ; Verify that the local changes remain afterwards.
+      (let [journal-file (sync/flow-journal-file git)
+            status-before (git/status git)]
+        (.mkdirs journal-file)
+        (is (thrown? java.io.IOException (sync/begin-flow! git prefs)))
+        (io/delete-file (str (git/worktree git) "/.internal") :silently)
+        (is (= status-before (git/status git)))
+        (when (= status-before (git/status git))
+          (is (= added-contents (slurp-file git added-path)))
+          (is (= existing-contents (slurp-file git existing-path))))))))
 
 (deftest resume-flow-test
   (with-git [git (new-git)]


### PR DESCRIPTION
Fixes DEFEDIT-491
Fixes defold/editor2-issues#201

* Disable the window close button, forcing the user to make an active choice between **Done** and **Cancel** at each stage of the sync process.
* Disable OK button in Sync dialog if an error occurred - **Cancel** is the only valid action.
* Restore local changes if exception thrown inside sync/begin-flow!
* Added `begin-flow-critical-failure-test`.