### PR TITLE
DEFEDIT-605 Particlefx playable when emitters/modifiers are selected

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -391,10 +391,10 @@
                   :children [{:label "Profiler"
                               :children [{:label "Measure"
                                           :command :profile
-                                          :acc "Shortcut+P"}
+                                          :acc "Shortcut+Alt+X"}
                                          {:label "Measure and Show"
                                           :command :profile-show
-                                          :acc "Shift+Shortcut+P"}]}
+                                          :acc "Shift+Shortcut+Alt+X"}]}
                              {:label "Reload Stylesheet"
                               :acc "F5"
                               :command :reload-stylesheet}

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -72,10 +72,13 @@
    :scale3 scale
    :component-properties ddf-component-properties})
 
-(defn- assoc-deep [scene keyword new-value]
-  (let [new-scene (assoc scene keyword new-value)]
+(defn- claim-scene [scene node-id]
+  (let [prev-node-id (:node-id scene)
+        new-scene (-> scene
+                    (assoc :node-id node-id)
+                    (update :node-path (fn [p] (cons prev-node-id (or p [])))))]
     (if (:children scene)
-      (assoc new-scene :children (mapv #(assoc-deep % keyword new-value) (:children scene)))
+      (assoc new-scene :children (mapv #(claim-scene % node-id) (:children scene)))
       new-scene)))
 
 (defn- prop-id-duplicate? [id-counts id]
@@ -207,7 +210,7 @@
   (output scene g/Any :cached (g/fnk [_node-id transform scene child-scenes]
                                      (let [aabb (reduce #(geom/aabb-union %1 (:aabb %2)) (or (:aabb scene) (geom/null-aabb)) child-scenes)
                                            aabb (geom/aabb-transform (geom/aabb-incorporate aabb 0 0 0) transform)]
-                                       (-> (assoc-deep scene :node-id _node-id)
+                                       (-> (claim-scene scene _node-id)
                                          (assoc :transform transform
                                                 :aabb aabb
                                                 :renderable {:passes [pass/selection]})
@@ -588,7 +591,7 @@
                                             :scale3 scale
                                             :instance-properties ddf-properties}))
   (output scene g/Any :cached (g/fnk [_node-id transform scene]
-                                     (assoc (assoc-deep scene :node-id _node-id)
+                                     (assoc (claim-scene scene _node-id)
                                            :transform transform
                                            :aabb (geom/aabb-transform (or (:aabb scene) (geom/null-aabb)) transform)
                                            :renderable {:passes [pass/selection]})))

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -76,7 +76,7 @@
   (let [prev-node-id (:node-id scene)
         new-scene (-> scene
                     (assoc :node-id node-id)
-                    (update :node-path (fn [p] (cons prev-node-id (or p [])))))]
+                    (update :node-path (fn [p] (into [prev-node-id] p))))]
     (if (:children scene)
       (assoc new-scene :children (mapv #(claim-scene % node-id) (:children scene)))
       new-scene)))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -130,7 +130,7 @@
                                        (assoc :node-id _node-id
                                               :transform transform
                                               :aabb (geom/aabb-transform (geom/aabb-incorporate (get scene :aabb (geom/null-aabb)) 0 0 0) transform))
-                                       (update :node-path (partial cons _node-id)))))
+                                       (update :node-path (partial into [_node-id])))))
   (output build-resource resource/Resource (g/fnk [source-build-targets] (:resource (first source-build-targets))))
   (output build-targets g/Any :cached (g/fnk [_node-id source-build-targets build-resource rt-ddf-message transform]
                                              (if-let [target (first source-build-targets)]

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -258,7 +258,7 @@
                                                                     (geom/scale [max-distance max-distance 1] dash-circle))}})
 
 (g/defnk produce-modifier-scene
-  [_node-id transform aabb type magnitude max-distance]
+  [_node-id transform aabb type magnitude max-distance scene-updatable]
   (let [mod-type (mod-types type)
         magnitude (props/sample magnitude)
         max-distance (props/sample max-distance)]
@@ -270,7 +270,8 @@
                   :select-batch-key _node-id
                   :user-data {:geom-data-screen ((:geom-data-screen mod-type) magnitude max-distance)
                               :geom-data-world ((:geom-data-world mod-type) magnitude max-distance)}
-                  :passes [pass/outline pass/selection]}}))
+                  :passes [pass/outline pass/selection]}
+     :updatable scene-updatable}))
 
 (g/defnode ModifierNode
   (inherits scene/SceneNode)
@@ -281,6 +282,8 @@
             (dynamic visible (g/constantly false)))
   (property magnitude CurveSpread)
   (property max-distance Curve (dynamic visible (g/fnk [type] (contains? #{:modifier-type-radial :modifier-type-vortex} type))))
+
+  (input scene-updatable g/Any)
 
   (output pb-msg g/Any :cached produce-modifier-pb)
   (output node-outline outline/OutlineData :cached
@@ -349,7 +352,7 @@
                                                      (geom/scale [size-x size-y 1] box-geom-data))}})
 
 (g/defnk produce-emitter-scene
-  [_node-id transform aabb type emitter-key-size-x emitter-key-size-y emitter-key-size-z child-scenes]
+  [_node-id transform aabb type emitter-key-size-x emitter-key-size-y emitter-key-size-z child-scenes scene-updatable]
   (let [emitter-type (emitter-types type)]
     {:node-id _node-id
      :transform transform
@@ -361,6 +364,7 @@
                               :geom-data-world (apply (:geom-data-world emitter-type)
                                                  (mapv props/sample [emitter-key-size-x emitter-key-size-y emitter-key-size-z]))}
                   :passes [pass/outline pass/selection]}
+     :updatable scene-updatable
      :children child-scenes}))
 
 (g/defnode EmitterProperties
@@ -421,9 +425,10 @@
 
 (defn- attach-modifier [self-id parent-id modifier-id]
   (concat
-    (let [conns [[:_node-id :nodes]]]
-      (for [[from to] conns]
-        (g/connect modifier-id from self-id to)))
+    (for [[from to] [[:_node-id :nodes]]]
+      (g/connect modifier-id from self-id to))
+    (for [[from to] [[:scene-updatable :scene-updatable]]]
+      (g/connect self-id from modifier-id to))
     (let [conns [[:node-outline :child-outlines]
                  [:scene :child-scenes]
                  [:pb-msg :modifier-msgs]]]
@@ -529,6 +534,7 @@
   (input anim-ids g/Any)
   (input child-scenes g/Any :array)
   (input modifier-msgs g/Any :array)
+  (input scene-updatable g/Any)
 
   (output scene g/Any :cached produce-emitter-scene)
   (output pb-msg g/Any :cached produce-emitter-pb)
@@ -633,14 +639,10 @@
                         (.mul (camera/camera-projection-matrix camera) (camera/camera-view-matrix camera)))]
         (plib/render pfx-sim (partial render-emitter-fn gl render-args vtx-binding view-proj))))))
 
-(g/defnk produce-scene [_node-id child-scenes rt-pb-data fetch-anim-fn render-emitter-fn]
+(g/defnk produce-scene [_node-id child-scenes render-emitter-fn scene-updatable]
   {:node-id _node-id
    :node-path [_node-id]
-   :updatable {:update-fn (g/fnk [dt world-transform]
-                                 (let [data [max-emitter-count max-particle-count rt-pb-data world-transform]
-                                       pfx-sim-ref (:pfx-sim (scene-cache/request-object! ::pfx-sim _node-id nil data))]
-                                   (swap! pfx-sim-ref plib/simulate dt fetch-anim-fn [world-transform])))
-               :name "ParticleFX"}
+   :updatable scene-updatable
    :renderable {:render-fn render-pfx
                 :batch-key nil
                 :user-data {:render-emitter-fn render-emitter-fn}
@@ -648,16 +650,26 @@
    :aabb (reduce geom/aabb-union (geom/null-aabb) (filter #(not (nil? %)) (map :aabb child-scenes)))
    :children child-scenes})
 
+(g/defnk produce-scene-updatable [_node-id rt-pb-data fetch-anim-fn]
+  {:node-id _node-id
+   :name "ParticleFX"
+   :update-fn (g/fnk [dt world-transform]
+                (let [data [max-emitter-count max-particle-count rt-pb-data world-transform]
+                      pfx-sim-ref (:pfx-sim (scene-cache/request-object! ::pfx-sim _node-id nil data))]
+                  (swap! pfx-sim-ref plib/simulate dt fetch-anim-fn [world-transform])))})
+
 (defn- attach-emitter [self-id emitter-id]
-  (let [conns [[:_node-id :nodes]
-               [:node-outline :child-outlines]
-               [:scene :child-scenes]
-               [:pb-msg :emitter-msgs]
-               [:emitter-sim-data :emitter-sim-data]
-               [:id :ids]
-               [:build-targets :dep-build-targets]]]
-    (for [[from to] conns]
-      (g/connect emitter-id from self-id to))))
+  (concat
+    (for [[from to] [[:_node-id :nodes]
+                     [:node-outline :child-outlines]
+                     [:scene :child-scenes]
+                     [:pb-msg :emitter-msgs]
+                     [:emitter-sim-data :emitter-sim-data]
+                     [:id :ids]
+                     [:build-targets :dep-build-targets]]]
+      (g/connect emitter-id from self-id to))
+    (for [[from to] [[:scene-updatable :scene-updatable]]]
+      (g/connect self-id from emitter-id to))))
 
 (g/defnode ParticleFXNode
   (inherits project/ResourceNode)
@@ -676,6 +688,7 @@
   (output emitter-sim-data g/Any :cached (gu/passthrough emitter-sim-data))
   (output build-targets g/Any :cached produce-build-targets)
   (output scene g/Any :cached produce-scene)
+  (output scene-updatable g/Any :cached produce-scene-updatable)
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id child-outlines]
                                                      (let [[mod-outlines emitter-outlines] (let [outlines (group-by #(g/node-instance? ModifierNode (:node-id %)) child-outlines)]
                                                                                              [(get outlines true) (get outlines false)])]

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -201,3 +201,17 @@
                (is (= 0.0 (.x (pos go-node))))
                (test-util/mouse-drag! view 64 64 68 64)
                (is (not= 0.0 (.x (pos go-node))))))))
+
+(deftest select-component-part-in-collection
+  (testing "Transform tools and manipulator interactions"
+           (with-clean-system
+             (let [workspace     (test-util/setup-workspace! world)
+                   project       (test-util/setup-project! workspace)
+                   app-view      (test-util/setup-app-view!)
+                   path          "/collection/go_pfx.collection"
+                   resource-node (test-util/resource-node project path)
+                   view          (test-util/open-scene-view! project app-view resource-node 128 128)
+                   emitter       (:node-id (test-util/outline resource-node [0 0 0]))]
+               (is (test-util/empty-selection? project))
+               (project/select! project [emitter])
+               (is (seq (g/node-value view :selected-renderables)))))))

--- a/editor/test/resources/test_project/collection/go_pfx.collection
+++ b/editor/test/resources/test_project/collection/go_pfx.collection
@@ -1,0 +1,21 @@
+name: "go_pfx"
+embedded_instances {
+    id: "go"
+    data: "components {\n"
+    "  id: \"particlefx\"\n"
+    "  component: \"/particlefx/fireworks_big.particlefx\"\n"
+    "  position {\n"
+    "    x: 0.0\n"
+    "    y: 0.0\n"
+    "    z: 0.0\n"
+    "  }\n"
+    "  rotation {\n"
+    "    x: 0.0\n"
+    "    y: 0.0\n"
+    "    z: 0.0\n"
+    "    w: 1.0\n"
+    "  }\n"
+    "}\n"
+    ""
+    scale3 {x: 1.0 y: 1.0 z: 1.0}
+}


### PR DESCRIPTION
* Also in collections
* Remapped profiler commands to more obscure keyboard combos
* Updatable part of particlefx produced separately and supplied to emitters/modifiers
* game object instances keep track of :node-path so that components can be manipulated in collections
  - Also fixes problem of moving collision shapes with the manipulators
* Simplified updatables production fns in scene ns
* Added test to verify that components can be selected when rendering collections