### PR TITLE
DEFEDIT-616 Re-order asset browser context menu

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -84,6 +84,13 @@
                  {:label "Dependencies"
                   :command :dependencies}
                  {:label :separator}
+                 {:label "New"
+                  :command :new-file
+                  :icon "icons/64/Icons_29-AT-Unknown.png"}
+                 {:label "New Folder"
+                  :command :new-folder
+                  :icon "icons/32/Icons_01-Folder-closed.png"}
+                 {:label :separator}
                  {:label "Copy"
                   :command :copy
                   :acc "Shortcut+C"}
@@ -98,14 +105,7 @@
                  {:label "Delete"
                   :command :delete
                   :icon "icons/32/Icons_M_06_trash.png"
-                  :acc "Shortcut+BACKSPACE"}
-                 {:label :separator}
-                 {:label "New"
-                  :command :new-file
-                  :icon "icons/64/Icons_29-AT-Unknown.png"}
-                 {:label "New Folder"
-                  :command :new-folder
-                  :icon "icons/32/Icons_01-Folder-closed.png"}])
+                  :acc "Shortcut+BACKSPACE"}])
 
 (defn- is-resource [x] (satisfies? resource/Resource x))
 (defn- is-deletable-resource [x] (and (satisfies? resource/Resource x)


### PR DESCRIPTION
- put "New" and "New folder" at top (when clicking on folder) because
  they are most used

Fixes https://github.com/defold/editor2-issues/issues/162