### PR TITLE
DEFEDIT-617 Color change on the diff window

### DIFF
--- a/editor/resources/diff.fxml
+++ b/editor/resources/diff.fxml
@@ -7,42 +7,42 @@
 <?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 
-<VBox stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox styleClass="diff-view" stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <AnchorPane>
          <children>
             <HBox AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                <children>
-                  <Label id="left-file" maxWidth="1.7976931348623157E308" text="Left file" HBox.hgrow="ALWAYS" />
+                  <Label id="left-file" styleClass="code-view-header" maxWidth="1.7976931348623157E308" text="Left file" HBox.hgrow="ALWAYS" />
                   <Pane prefWidth="40.0" />
-                  <Label id="right-file" maxWidth="1.7976931348623157E308" text="Right file" HBox.hgrow="ALWAYS" />
+                  <Label id="right-file" styleClass="code-view-header" maxWidth="1.7976931348623157E308" text="Right file" HBox.hgrow="ALWAYS" />
                </children>
             </HBox>
          </children>
       </AnchorPane>
-      <ScrollPane fitToWidth="true" hbarPolicy="NEVER" prefHeight="768.0" prefWidth="1024.0" VBox.vgrow="ALWAYS">
+      <ScrollPane styleClass="edge-to-edge" fitToWidth="true" hbarPolicy="NEVER" prefHeight="768.0" prefWidth="1024.0" VBox.vgrow="ALWAYS">
          <content>
             <AnchorPane>
                <children>
                   <HBox id="foo" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
-                        <AnchorPane prefWidth="300.0" HBox.hgrow="ALWAYS">
+                        <AnchorPane HBox.hgrow="ALWAYS">
                            <children>
-                              <Pane id="left" minHeight="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-background-color: white;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                              <Pane id="left" styleClass="code-view" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                            </children>
                         </AnchorPane>
                         <VBox>
                            <children>
                               <AnchorPane VBox.vgrow="ALWAYS">
                                  <children>
-                                    <Pane id="markers" maxWidth="40.0" minWidth="40.0" prefWidth="40.0" style="-fx-background-color: #cccccc;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                                    <Pane id="markers" maxWidth="40.0" minWidth="40.0" prefWidth="40.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                                  </children>
                               </AnchorPane>
                            </children>
                         </VBox>
-                        <AnchorPane prefWidth="300.0" HBox.hgrow="ALWAYS">
+                        <AnchorPane HBox.hgrow="ALWAYS">
                            <children>
-                              <Pane id="right" minHeight="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-background-color: white;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                              <Pane id="right" styleClass="code-view" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                            </children>
                         </AnchorPane>
                      </children>

--- a/editor/resources/diff.fxml
+++ b/editor/resources/diff.fxml
@@ -1,56 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.shape.*?>
-<?import javafx.scene.text.*?>
-<?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
-<?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 
-<VBox styleClass="diff-view" stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-   <children>
-      <AnchorPane>
-         <children>
-            <HBox AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-               <children>
-                  <Label id="left-file" styleClass="code-view-header" maxWidth="1.7976931348623157E308" text="Left file" HBox.hgrow="ALWAYS" />
-                  <Pane prefWidth="40.0" />
-                  <Label id="right-file" styleClass="code-view-header" maxWidth="1.7976931348623157E308" text="Right file" HBox.hgrow="ALWAYS" />
-               </children>
-            </HBox>
-         </children>
-      </AnchorPane>
-      <ScrollPane styleClass="edge-to-edge" fitToWidth="true" hbarPolicy="NEVER" prefHeight="768.0" prefWidth="1024.0" VBox.vgrow="ALWAYS">
-         <content>
-            <AnchorPane>
-               <children>
-                  <HBox id="foo" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                     <children>
-                        <AnchorPane HBox.hgrow="ALWAYS">
-                           <children>
-                              <Pane id="left" styleClass="code-view" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                           </children>
-                        </AnchorPane>
-                        <VBox>
-                           <children>
-                              <AnchorPane VBox.vgrow="ALWAYS">
-                                 <children>
-                                    <Pane id="markers" maxWidth="40.0" minWidth="40.0" prefWidth="40.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                                 </children>
-                              </AnchorPane>
-                           </children>
-                        </VBox>
-                        <AnchorPane HBox.hgrow="ALWAYS">
-                           <children>
-                              <Pane id="right" styleClass="code-view" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                           </children>
-                        </AnchorPane>
-                     </children>
-                  </HBox>
-               </children>
-            </AnchorPane>
-         </content>
-      </ScrollPane>
-      <ScrollBar id="hscroll" />
-   </children>
+<VBox styleClass="diff-view" stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8">
+   <HBox>
+      <Label id="left-file" styleClass="code-view-header" maxWidth="1.7976931348623157E308" text="Left file" HBox.hgrow="ALWAYS"/>
+      <Pane prefWidth="40.0"/>
+      <Label id="right-file" styleClass="code-view-header" maxWidth="1.7976931348623157E308" text="Right file" HBox.hgrow="ALWAYS"/>
+   </HBox>
+   <ScrollPane styleClass="edge-to-edge" fitToWidth="true" fitToHeight="true" hbarPolicy="NEVER" prefWidth="1024.0" prefHeight="768.0" VBox.vgrow="ALWAYS">
+      <HBox minHeight="-Infinity">
+         <Pane id="left" styleClass="code-view" HBox.hgrow="ALWAYS"/>
+         <Pane id="markers"/>
+         <Pane id="right" styleClass="code-view" HBox.hgrow="ALWAYS"/>
+      </HBox>
+   </ScrollPane>
+   <ScrollBar id="hscroll"/>
 </VBox>

--- a/editor/src/clj/editor/diff_view.clj
+++ b/editor/src/clj/editor/diff_view.clj
@@ -73,7 +73,7 @@
     (if (= begin end) (Rectangle. 10 0) t)))
 
 (defn- make-texts [^Group box lines edits selector]
-  (let [font (Font. "Courier New" 13)
+  (let [font (Font. "Dejavu Sans Mono" 13)
         texts (mapv (fn [e] (make-text font lines (selector e))) edits)
         heights (reductions (fn [sum t] (+ sum (:height (ui/local-bounds t)))) 0 texts)]
     (doseq [[t y] (map vector texts heights)]

--- a/editor/src/clj/editor/diff_view.clj
+++ b/editor/src/clj/editor/diff_view.clj
@@ -102,7 +102,7 @@
   (let [lines
         (for [[t-left t-right edit] (map vector texts-left texts-right edits)
               :when (not= (:type edit) :nop)]
-          (make-line t-left t-right 1 40))]
+          (make-line t-left t-right 0 40))]
     (ui/children! box lines)))
 
 (defn- clip-control! [^Control control]

--- a/editor/styling/stylesheets/editor.scss
+++ b/editor/styling/stylesheets/editor.scss
@@ -76,12 +76,6 @@ Links:
   -fx-font-size: 9pt;
   -fx-font-family: "Dejavu Sans Mono"; }
 
-/* diff viewer */
-.diff-box {
-  -fx-fill: rgba(204, 204, 204, 0.2);
-  -fx-stroke: #000000;
-}
-
 /* Modules - Major panes in the editor */
 #properties HBox {
   -fx-spacing: 0; }

--- a/editor/styling/stylesheets/main.sass
+++ b/editor/styling/stylesheets/main.sass
@@ -46,6 +46,7 @@
 @import 'modules/_changes-container';
 @import 'modules/_console';
 @import 'modules/_curve-view';
+@import 'modules/_diff-view';
 @import 'modules/_progress-bar';
 @import 'modules/_right-split';
 @import 'modules/_script-editor';

--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -8,6 +8,9 @@
   }
 
   #markers {
+    -fx-min-width: 40px;
+    -fx-max-width: 40px;
+    -fx-pref-width: 40px;
     -fx-background-color: $dark-grey;
   }
 

--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -12,6 +12,7 @@
   }
 
   .code-view {
+    -fx-pref-width: 300px;
     -fx-background-color: $bright-black;
   }
 

--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -1,0 +1,35 @@
+.diff-view {
+  Line {
+    -fx-stroke: $mid-grey;
+  }
+
+  Text {
+    -fx-fill: $bright-grey-light;
+  }
+
+  AnchorPane {
+    -fx-border-width: 0;
+  }
+
+  #markers {
+    -fx-background-color: $dark-grey;
+  }
+
+  .code-view {
+    -fx-min-height: 300px;
+    -fx-pref-width: 300px;
+    -fx-background-color: $bright-black;
+  }
+
+  .code-view-header {
+    -fx-font-weight: bold;
+    -fx-text-fill: $bright-grey;
+    -fx-min-height: 40px;
+    -fx-alignment: center;
+  }
+
+  .diff-box {
+    -fx-fill: $mid-grey;
+    -fx-stroke: $mid-grey;
+  }
+}

--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -7,17 +7,11 @@
     -fx-fill: $bright-grey-light;
   }
 
-  AnchorPane {
-    -fx-border-width: 0;
-  }
-
   #markers {
     -fx-background-color: $dark-grey;
   }
 
   .code-view {
-    -fx-min-height: 300px;
-    -fx-pref-width: 300px;
     -fx-background-color: $bright-black;
   }
 


### PR DESCRIPTION
Fixes defold/editor2-issues#221

* Use color scheme and typeface consistent with the rest of the application.
* Stretch code views to the full height of the window.
* Refactored most of the styling into the stylesheet.

![diff-window-colors](https://cloud.githubusercontent.com/assets/22448941/20806983/624f7c8e-b7fd-11e6-911d-74a512e1f5ea.png)