### PR TITLE
DEFEDIT-639 Save all when opening Synchronize dialog

### DIFF
--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -3,6 +3,7 @@
             [dynamo.graph :as g]
             [editor.core :as core]
             [editor.diff-view :as diff-view]
+            [editor.defold-project :as project]
             [editor.git :as git]
             [editor.handler :as handler]
             [editor.sync :as sync]
@@ -61,11 +62,12 @@
 (handler/defhandler :synchronize :global
   (enabled? [changes-view]
             (g/node-value changes-view :git))
-  (run [changes-view workspace]
-    (let [git   (g/node-value changes-view :git)
-          prefs (g/node-value changes-view :prefs)]
-      (sync/open-sync-dialog (sync/begin-flow! git prefs))
-      (workspace/resource-sync! workspace))))
+  (run [changes-view workspace project]
+       (let [git   (g/node-value changes-view :git)
+             prefs (g/node-value changes-view :prefs)]
+         (project/save-all! project (fn []
+                                      (sync/open-sync-dialog (sync/begin-flow! git prefs))
+                                      (workspace/resource-sync! workspace))))))
 
 (ui/extend-menu ::menubar :editor.app-view/open
                 [{:label "Synchronize..."


### PR DESCRIPTION
Fixes defold/editor2-issues#215
Fixes defold/editor2-issues#273

* Save all changed files before opening the Synchronize dialog.