### PR TITLE
DEFEDIT-547 Improve error dialog

### DIFF
--- a/editor/resources/error.fxml
+++ b/editor/resources/error.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.text.*?>
+<?import java.lang.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<VBox prefWidth="500.0" spacing="12.0" stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <Label text="An error occurred:" />
+      <TextArea id="message" editable="false" prefHeight="60.0" styleClass="copyable-text-area" wrapText="true" />
+      <Label text="You can help us fix this problem by reporting it and providing more information about what you were doing when it happened." wrapText="true" />
+      <HBox>
+         <children>
+            <Button id="dismiss" minWidth="80.0" mnemonicParsing="false" text="Dismiss" />
+            <Region HBox.hgrow="ALWAYS" />
+           <Button id="report" alignment="CENTER" minWidth="80.0" mnemonicParsing="false" text="Report" />
+         </children>
+      </HBox>
+   </children>
+   <padding>
+     <Insets bottom="12.0" left="12.0" right="12.0" top="12.0" />
+   </padding>
+</VBox>

--- a/editor/sidecar/aot.clj
+++ b/editor/sidecar/aot.clj
@@ -41,7 +41,8 @@
          clojure.walk
          clojure.xml
          clojure.zip
-         schema.core]))
+         schema.core
+         schema.utils]))
 
 (defn compile-order
   [srcdirs]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -43,7 +43,6 @@
            [javafx.stage Stage FileChooser WindowEvent]
            [javafx.util Callback]
            [java.io File ByteArrayOutputStream]
-           [java.net URI]
            [java.nio.file Paths]
            [java.util.prefs Preferences]
            [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]))
@@ -310,13 +309,13 @@
     (ui/show! stage)))
 
 (handler/defhandler :documentation :global
-  (run [] (.browse (Desktop/getDesktop) (URI. "http://www.defold.com/learn/"))))
+  (run [] (ui/browse-url "http://www.defold.com/learn/")))
 
 (handler/defhandler :report-issue :global
-  (run [] (.browse (Desktop/getDesktop) (github/new-issue-link))))
+  (run [] (ui/browse-url (github/new-issue-link))))
 
 (handler/defhandler :report-praise :global
-  (run [] (.browse (Desktop/getDesktop) (github/new-praise-link))))
+  (run [] (ui/browse-url (github/new-praise-link))))
 
 (handler/defhandler :about :global
   (run [] (make-about-dialog)))

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -110,13 +110,17 @@
     (let [sentry-id (deref sentry-id-promise 100 nil)
           fields (cond-> {}
                    sentry-id
-                   (assoc "Error" (format "<a href='https://sentry.io/defold/editor2/%s'>%s</a>"
+                   (assoc "Error" (format "<a href='https://sentry.io/defold/editor2/?query=%s'>%s</a>"
                                           sentry-id sentry-id)))]
       (ui/browse-url (github/new-issue-link fields)))))
 
 (defn- messages
   [ex-map]
-  (str/join ": " (keep :message (tree-seq :via :via ex-map))))
+  (->> (tree-seq :via :via ex-map)
+       (drop 1)
+       (map (fn [{:keys [message ^Class type]}]
+              (format "%s: %s" (.getName type) (or message "Unknown"))))
+       (str/join "\n")))
 
 (defn make-error-dialog
   [ex-map sentry-id-promise]

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -9,6 +9,7 @@
             [editor.resource :as resource]
             [editor.defold-project :as project]
             [editor.defold-project-search :as project-search]
+            [editor.github :as github]
             [service.log :as log])
   (:import [java.io File]
            [java.nio.file Path Paths]
@@ -103,6 +104,38 @@
     (.setScene stage scene)
     (ui/show-and-wait! stage)
     @result))
+
+(handler/defhandler ::report-error :dialog
+  (run [sentry-id-promise]
+    (let [sentry-id (deref sentry-id-promise 100 nil)
+          fields (cond-> {}
+                   sentry-id
+                   (assoc "Error" (format "<a href='https://sentry.io/defold/editor2/%s'>%s</a>"
+                                          sentry-id sentry-id)))]
+      (ui/browse-url (github/new-issue-link fields)))))
+
+(defn- messages
+  [ex-map]
+  (str/join ": " (keep :message (tree-seq :via :via ex-map))))
+
+(defn make-error-dialog
+  [ex-map sentry-id-promise]
+  (let [root     ^Parent (ui/load-fxml "error.fxml")
+        stage    (ui/make-stage)
+        scene    (Scene. root)
+        controls (ui/collect-controls root ["message" "dismiss" "report"])]
+    (observe-focus stage)
+    (ui/context! root :dialog {:stage stage :sentry-id-promise sentry-id-promise} nil)
+    (ui/title! stage "Error")
+    (ui/text! (:message controls) (messages ex-map))
+    (ui/bind-action! (:dismiss controls) ::close)
+    (ui/bind-action! (:report controls) ::report-error)
+    (ui/bind-keys! root {KeyCode/ESCAPE ::close})
+    (ui/request-focus! (:report controls))
+    (.initModality stage Modality/APPLICATION_MODAL)
+    (.setResizable stage false)
+    (.setScene stage scene)
+    (ui/show-and-wait! stage)))
 
 (defn make-task-dialog [dialog-fxml options]
   (let [root ^Parent (ui/load-fxml "task-dialog.fxml")

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -1,0 +1,101 @@
+(ns editor.error-reporting
+  (:require
+   [clojure.string :as str]
+   [editor.sentry :as sentry]
+   [service.log :as log])
+  (:import
+   (java.util.concurrent LinkedBlockingQueue)))
+
+(set! *warn-on-reflection* true)
+
+;;--------------------------------------------------------------------
+;; user notification
+
+(defonce ^:private ^:redef exception-notifier
+  ;; default noop notifier
+  (fn
+    ([])
+    ([ex-map sentry-id-promise])))
+
+(defn make-exception-notifier
+  [notify-fn]
+  (let [queue       (LinkedBlockingQueue. 32)
+        notifier-fn (fn []
+                      (try
+                        (while true
+                          (when-let [[ex-map sentry-id-promise] (.take queue)]
+                            (notify-fn ex-map sentry-id-promise)))
+                        (catch InterruptedException _ nil)))
+        thread      (doto (Thread. notifier-fn)
+                      (.setDaemon true)
+                      (.setName "exception-notifier-thread")
+                      (.start))]
+    (fn
+      ([]
+       (.interrupt thread))
+      ([exception sentry-id-promise]
+       (.offer queue [exception sentry-id-promise])))))
+
+(defn init-exception-notifier!
+  [notify-fn]
+  (alter-var-root #'exception-notifier
+                  (fn [val]
+                    (when val (val))
+                    (make-exception-notifier notify-fn))))
+
+;;--------------------------------------------------------------------
+;; sentry
+
+(defonce ^:private ^:redef sentry-reporter
+  ;; default noop reporter
+  (fn
+    ([])
+    ([exception thread] (promise))))
+
+(defn init-sentry-reporter!
+  [options]
+  (alter-var-root #'sentry-reporter
+                  (fn [val]
+                    (when val (val))
+                    (sentry/make-exception-reporter options))))
+
+;;--------------------------------------------------------------------
+
+(defonce ^:private exception-stats (atom {}))
+
+(def ^:const suppress-exception-threshold-ms 1000)
+
+(defn- update-stats
+  [{:keys [last-seen] :as stats}]
+  (let [now (System/currentTimeMillis)]
+    {:last-seen now
+     :suppressed? (and last-seen (< (- now last-seen) suppress-exception-threshold-ms))}))
+
+(defn- record-exception!
+  [exception]
+  (let [ex-map (Throwable->map exception)
+        ex-identity (select-keys ex-map [:cause :trace])
+        ret (swap! exception-stats update ex-identity update-stats)]
+    (assoc (get ret ex-identity) :ex-map ex-map)))
+
+(defn report-exception!
+  ([exception]
+   (report-exception! exception (Thread/currentThread)))
+  ([exception thread]
+   (try
+     (log/error :exception exception)
+     (let [{:keys [ex-map suppressed?]} (record-exception! exception)]
+       (when-not suppressed?
+         (let [sentry-id-promise (sentry-reporter exception thread)]
+           (exception-notifier ex-map sentry-id-promise))))
+     (catch Throwable t
+       (println (format "Fatal error reporting unhandled exception: '%s'\n%s" (.getMessage t) (pr-str (Throwable->map t))))))))
+
+(defn setup-error-reporting!
+  [{:keys [sentry notifier]}]
+  (when sentry (init-sentry-reporter! sentry))
+  (when notifier (init-exception-notifier! (:notify-fn notifier)))
+  (Thread/setDefaultUncaughtExceptionHandler
+    (reify Thread$UncaughtExceptionHandler
+      (uncaughtException [_ thread exception]
+        (report-exception! exception thread)))))

--- a/editor/src/clj/editor/github.clj
+++ b/editor/src/clj/editor/github.clj
@@ -20,23 +20,22 @@
 
 (defn- issue-body
   ([fields]
-   (let [fields (merge (default-fields) fields)]
-     (->> ["<!-- NOTE! The information you specify will be publicly accessible. -->"
-           "### Expected behaviour"
-           ""
-           "### Actual behaviour"
-           ""
-           "### Steps to reproduce"
-           ""
-           "<hr/>"
-           ""
-           (when (seq fields)
-             ["<table>"
-              (for [[name value] fields]
-                (format "<tr><td>%s</td><td>%s</td></tr>" name value))
-              "<table>"])]
-          flatten
-          (string/join "\n")))))
+   (->> ["<!-- NOTE! The information you specify will be publicly accessible. -->"
+         "### Expected behaviour"
+         ""
+         "### Actual behaviour"
+         ""
+         "### Steps to reproduce"
+         ""
+         "<hr/>"
+         ""
+         (when (seq fields)
+           ["<table>"
+            (for [[name value] fields]
+              (format "<tr><td>%s</td><td>%s</td></tr>" name value))
+            "<table>"])]
+        flatten
+        (string/join "\n"))))
 
 (defn new-issue-link
   ([]

--- a/editor/src/clj/editor/github.clj
+++ b/editor/src/clj/editor/github.clj
@@ -9,27 +9,42 @@
 
 (def issue-repo "https://github.com/defold/editor2-issues")
 
-(defn issue-body
+(defn- default-fields
   []
-  (string/join "\n"
-               ["<!-- NOTE! The information you specify will be publicly accessible. -->"
-                "### Expected behaviour"
-                ""
-                "### Actual behaviour"
-                ""
-                "### Steps to reproduce"
-                ""
-                "<hr/>"
-                (format "Defold version: %s" (or (system/defold-version) "dev"))
-                (format "Defold sha: %s" (or (system/defold-sha1) ""))
-                (format "Platform: %s %s (%s)" (system/os-name) (system/os-version) (system/os-arch))
-                (format "Java version: %s" (system/java-runtime-version))]))
+  {"Defold version" (or (system/defold-version) "dev")
+   "Defold sha"     (or (system/defold-sha1) "")
+   "OS name"        (system/os-name)
+   "OS version"     (system/os-version)
+   "OS arch"        (system/os-arch)
+   "Java version"   (system/java-runtime-version)})
+
+(defn- issue-body
+  ([fields]
+   (let [fields (merge (default-fields) fields)]
+     (->> ["<!-- NOTE! The information you specify will be publicly accessible. -->"
+           "### Expected behaviour"
+           ""
+           "### Actual behaviour"
+           ""
+           "### Steps to reproduce"
+           ""
+           "<hr/>"
+           ""
+           (when (seq fields)
+             ["<table>"
+              (for [[name value] fields]
+                (format "<tr><td>%s</td><td>%s</td></tr>" name value))
+              "<table>"])]
+          flatten
+          (string/join "\n")))))
 
 (defn new-issue-link
-  []
-  (URI. (str issue-repo "/issues/new?title=&body="
-             (URLEncoder/encode (issue-body)))))
+  ([]
+   (new-issue-link {}))
+  ([fields]
+      (str issue-repo "/issues/new?title=&labels=new&body="
+           (URLEncoder/encode (issue-body (merge (default-fields) fields))))))
 
 (defn new-praise-link
   []
-  (URI. (format "%s/issues/new?title=%s&body=%s" issue-repo (URLEncoder/encode "[PRAISE] ") (URLEncoder/encode "<!-- NOTE! The information you specify will be publicly accessible. -->"))))
+  (format "%s/issues/new?title=%s&body=%s" issue-repo (URLEncoder/encode "[PRAISE] ") (URLEncoder/encode "<!-- NOTE! The information you specify will be publicly accessible. -->")))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as string]
+   [editor.error-reporting :as error-reporting]
    [editor.handler :as handler]
    [editor.jfx :as jfx]
    [editor.progress :as progress]
@@ -15,6 +16,8 @@
    [com.defold.control LongField]
    [com.defold.control ListCell]
    [com.defold.control TreeCell]
+   [java.awt Desktop]
+   [java.net URI]
    [javafx.animation AnimationTimer Timeline KeyFrame KeyValue]
    [javafx.application Platform]
    [javafx.beans.value ChangeListener ObservableValue]
@@ -687,10 +690,10 @@
           ^Tab tab (.getSelectedItem (.getSelectionModel tab-pane))]
       (or (and tab (.getContent tab) (user-data (.getContent tab) ::context))
           (user-data node ::context)))
-    
+
     (instance? TextInputControl node)
     (make-text-input-control-context node)
-    
+
     :else
     (user-data node ::context)))
 
@@ -1203,8 +1206,7 @@ command."
   ([fps name tick-fn]
    (let [last       (atom (System/nanoTime))
          interval   (when fps
-                      (long (* 1e9 (/ 1 (double fps)))))
-         last-error (atom nil)]
+                      (long (* 1e9 (/ 1 (double fps)))))]
      {:last  last
       :timer (proxy [AnimationTimer] []
                (handle [now]
@@ -1213,15 +1215,11 @@ command."
                                      (when (or (nil? interval) (> delta interval))
                                        (try
                                          (tick-fn this (* delta 1e-9))
-                                         (reset! last-error nil)
                                          (reset! last (- now (if interval
                                                                (- delta interval)
                                                                0)))
-                                         (catch Exception e
-                                           (let [clj-ex (Throwable->map e)]
-                                             (when (not= @last-error clj-ex)
-                                               (println clj-ex)
-                                               (reset! last-error clj-ex))))))))))})))
+                                         (catch Throwable t
+                                           (error-reporting/report-exception! t))))))))})))
 
 (defn timer-start! [timer]
   (.start ^AnimationTimer (:timer timer)))
@@ -1232,23 +1230,21 @@ command."
 (defn anim! [duration anim-fn end-fn]
   (let [duration   (long (* 1e9 duration))
         start      (System/nanoTime)
-        end        (+ start (long duration))
-        last-error (atom nil)]
+        end        (+ start (long duration))]
     (doto (proxy [AnimationTimer] []
             (handle [now]
               (if (< now end)
                 (let [t (/ (double (- now start)) duration)]
                   (try
                     (anim-fn t)
-                    (reset! last-error nil)
-                    (catch Exception e
-                      (let [clj-ex (Throwable->map e)]
-                        (when (not= @last-error clj-ex)
-                          (println clj-ex)
-                          (reset! last-error clj-ex))))))
-                (do
+                    (catch Throwable t
+                      (error-reporting/report-exception! t))))
+                (try
                   (end-fn)
-                  (.stop ^AnimationTimer this)))))
+                  (catch Throwable t
+                    (error-reporting/report-exception! t))
+                  (finally
+                    (.stop ^AnimationTimer this))))))
       (.start))))
 
 (defn anim-stop! [^AnimationTimer anim]
@@ -1291,9 +1287,13 @@ command."
   [closeable timer]
   (on-closed! closeable (fn [_]
                          (timer-stop! timer))))
-                         
+
 (defn drag-internal? [^DragEvent e]
   (some? (.getGestureSource e)))
 
 (defn parent->stage ^Stage [^Parent parent]
   (.. parent getScene getWindow))
+
+(defn browse-url
+  [url]
+  (.browse (Desktop/getDesktop) (URI. url)))

--- a/editor/styling/stylesheets/base/_typography.scss
+++ b/editor/styling/stylesheets/base/_typography.scss
@@ -20,4 +20,3 @@
 
 $default-font: 'Source Sans Pro';
 $default-font-size: 12px;
-$default-mono-font: 'Dejavu Sans Mono';

--- a/editor/styling/stylesheets/base/_typography.scss
+++ b/editor/styling/stylesheets/base/_typography.scss
@@ -17,3 +17,7 @@
 @font-face {
   font-family: 'Dejavu Sans Mono Bold';
   src: url("DejaVuSansMono-Bold.ttf"); }
+
+$default-font: 'Source Sans Pro';
+$default-font-size: 12px;
+$default-mono-font: 'Dejavu Sans Mono';

--- a/editor/styling/stylesheets/components/_text-area.scss
+++ b/editor/styling/stylesheets/components/_text-area.scss
@@ -1,0 +1,39 @@
+.text-area {
+  -fx-font-size: 9pt;
+  -fx-font-family: "Dejavu Sans Mono"; }
+
+/*
+ * A shadow/borderless text-area that can be used when you want a
+ * multi-line label component where the text can be selected for copy &
+ * paste
+ */
+.copyable-text-area {
+    -fx-font-family: $default-font;
+    -fx-font-size: $default-font-size;
+    -fx-padding: 0;
+    -fx-cursor: default;
+    -fx-background-color: $dark-grey;
+}
+.copyable-text-area > .scroll-pane {
+    -fx-background-color: null;
+}
+.copyable-text-area > .scroll-pane > .scroll-bar:horizontal {
+    -fx-background-radius: 0 0 0 0;
+}
+.copyable-text-area > .scroll-pane > .scroll-bar:vertical {
+    -fx-background-radius: 0 0 0 0;
+}
+.copyable-text-area > .scroll-pane > .corner {
+    -fx-background-radius: 0 0 0 0;
+}
+.copyable-text-area .content {
+    -fx-padding: 0 0 0 0;
+    -fx-cursor: text;
+    -fx-background-color: $dark-grey;
+    -fx-background-radius: 0;
+}
+.copyable-text-area:focused .content {
+    -fx-background-color: $dark-grey;
+    -fx-background-insets: 0 0 0 0;
+    -fx-background-radius: 0 0 0 0;
+}

--- a/editor/styling/stylesheets/editor.scss
+++ b/editor/styling/stylesheets/editor.scss
@@ -35,8 +35,8 @@ Links:
   -fx-hover-base: $mid-grey;
   -fx-pressed-base: $bright-grey;
   -fx-accent_: $defold-red;
-  -fx-font-family: "Source Sans Pro";
-  -fx-font-size: 12px;
+  -fx-font-family: $default-font;
+  -fx-font-size: $default-font-size;
   -fx-font-weight: normal;
   }
 
@@ -72,9 +72,6 @@ Links:
   -fx-control-inner-background: $bright-black-light;
   -fx-hover-base: $defold-red; }
 
-.text-area {
-  -fx-font-size: 9pt;
-  -fx-font-family: "Dejavu Sans Mono"; }
 
 /* Modules - Major panes in the editor */
 #properties HBox {

--- a/editor/styling/stylesheets/main.sass
+++ b/editor/styling/stylesheets/main.sass
@@ -34,6 +34,7 @@
 @import 'components/_split-pane';
 @import 'components/_tab';
 @import 'components/_table-view';
+@import 'components/_text-area';
 @import 'components/_text-field';
 @import 'components/_titled-pane';
 @import 'components/_tree-view';


### PR DESCRIPTION
- new dialog for unhandled exceptions with ability to report as github issue
  - includes link to sentry issue, if available
- always log
- suppress sentry reporting and user notification of exceptions that repeat with less than 1s time in between

Fixes: https://github.com/defold/editor2-issues/issues/281