### PR TITLE
DEFEDIT-654 Fix build error navigation

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -189,11 +189,12 @@
                                                             hot-reload/url-prefix (partial hot-reload/build-handler project)})
                                    http-server/start!)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
-                                                                         (fn [resource node-id]
+                                                                         (fn [resource node-id opts]
                                                                            (app-view/open-resource app-view
                                                                                                    (g/node-value project :workspace)
                                                                                                    project
-                                                                                                   resource)
+                                                                                                   resource
+                                                                                                   opts)
                                                                            (app-view/select! app-view node-id)))
           changes-view         (changes-view/make-changes-view *view-graph* workspace prefs
                                                                (.lookup root "#changes-container"))

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -57,7 +57,6 @@
     {:label "root"
      :children items}))
 
-
 (defn error-line
   [error]
   (-> error :value ex-data :line))

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -676,8 +676,9 @@
 
 (defn focus-view
   [code-view-node {:keys [line]}]
-  (when line
-    (when-let [source-viewer (g/node-value code-view-node :source-viewer)]
+  (when-let [^SourceViewer source-viewer (g/node-value code-view-node :source-viewer)]
+    (cvx/refresh! source-viewer)
+    (when line
       (cvx/go-to-line source-viewer line))))
 
 (defn register-view-types [workspace]

--- a/editor/src/clj/editor/code_view.clj
+++ b/editor/src/clj/editor/code_view.clj
@@ -671,10 +671,18 @@
     (ui/timer-start! repainter)
     (ui/timer-stop-on-closed! ^Tab (:tab opts) repainter)
     (ui/timer-stop-on-closed! (ui/parent->stage parent) repainter)
+    (g/node-value view-id :new-content)
     view-id))
+
+(defn focus-view
+  [code-view-node {:keys [line]}]
+  (when line
+    (when-let [source-viewer (g/node-value code-view-node :source-viewer)]
+      (cvx/go-to-line source-viewer line))))
 
 (defn register-view-types [workspace]
   (workspace/register-view-type workspace
                                 :id :code
                                 :label "Code"
-                                :make-view-fn (fn [graph ^Parent parent code-node opts] (make-view graph parent code-node opts))))
+                                :make-view-fn (fn [graph ^Parent parent code-node opts] (make-view graph parent code-node opts))
+                                :focus-fn focus-view))

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -726,19 +726,16 @@
       (remember-caret-col source-viewer (caret source-viewer))
       (state-changes! source-viewer))))
 
-(defn go-to-line [source-viewer line-number]
-  (when line-number
-    (try
-     (let [line (Integer/parseInt line-number)
-           line-count (line-count source-viewer)
-           line-num (if (> 1 line) 0 (dec line))
-           np (if (>= line-count line-num)
-                (line-offset-at-num source-viewer line-num)
-                (count (text source-viewer)))]
-       (caret! source-viewer np false)
-       (remember-caret-col source-viewer np)
-       (show-line source-viewer))
-     (catch Throwable  e (println "Not a valid line number" line-number (.getMessage e))))))
+(defn go-to-line [source-viewer line]
+  (when line
+    (let [line-count (line-count source-viewer)
+          line-num (if (> 1 line) 0 (dec line))
+          np (if (>= line-count line-num)
+               (line-offset-at-num source-viewer line-num)
+               (count (text source-viewer)))]
+      (caret! source-viewer np false)
+      (remember-caret-col source-viewer np)
+      (show-line source-viewer))))
 
 (handler/defhandler :goto-line :code-view
   (enabled? [source-viewer] source-viewer)

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -630,7 +630,9 @@
                       (ui/event-handler e
                            (let [key (.getCode ^KeyEvent e)]
                              (when (= key KeyCode/ENTER)
-                               (close (ui/text (:line controls))))
+                               (close (try
+                                        (Integer/parseInt (ui/text (:line controls)))
+                                        (catch Exception _))))
                              (when (= key KeyCode/ESCAPE)
                                (close nil)))))
     (.initModality stage Modality/NONE)

--- a/editor/src/clj/editor/luajit.clj
+++ b/editor/src/clj/editor/luajit.clj
@@ -10,7 +10,8 @@
 
 (defn- parse-compilation-error
   [s]
-  (zipmap [:exec :filename :line :message] (map str/trim (str/split s #":"))))
+  (-> (zipmap [:exec :filename :line :message] (map str/trim (str/split s #":")))
+      (update :line #(try (Integer/parseInt %) (catch Exception _)))))
 
 (defn- luajit-exec-path
   []

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -517,18 +517,18 @@
 (deftest goto-line-test
   (with-code lua/lua "a\nb\nc"
     (testing "goto line"
-      (go-to-line! source-viewer "2")
+      (go-to-line! source-viewer 2)
       (is (= \b (get-char-at-caret source-viewer)))
-      (go-to-line! source-viewer "3")
+      (go-to-line! source-viewer 3)
       (is (= \c (get-char-at-caret source-viewer)))
-      (go-to-line! source-viewer "1")
+      (go-to-line! source-viewer 1)
       (is (= \a (get-char-at-caret source-viewer))))
     (testing "goto line bounds"
-      (go-to-line! source-viewer "0")
+      (go-to-line! source-viewer 0)
       (is (= \a (get-char-at-caret source-viewer)))
-      (go-to-line! source-viewer "-2")
+      (go-to-line! source-viewer -2)
       (is (= \a (get-char-at-caret source-viewer)))
-      (go-to-line! source-viewer "100")
+      (go-to-line! source-viewer 100)
       (is (= nil (get-char-at-caret source-viewer)))
       (is (= 5 (caret source-viewer))))))
 


### PR DESCRIPTION
- double-clicking on error should open resource
- navigate to correct line for code if line is known

Fixes https://github.com/defold/editor2-issues/issues/307, https://github.com/defold/editor2-issues/issues/330