### PR TITLE
DEFEDIT-653 Native extensions pref warning

### DIFF
--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -173,10 +173,11 @@
           (io/make-parents out-path)
           (copy-file (.getPath f) out-path )
           (.setExecutable (io/file out-path) true)
-          (do-launch out-path launch-dir prefs))
-        )
+          (do-launch out-path launch-dir prefs)))
       (catch Throwable e
-        (console/append-console-message! (str e "\n"))))))
+        (throw (RuntimeException.
+                 "Unable to launch custom engine. You have selected \"Enable Extensions\" in preferences. This is currently an experimental feature that requires additional, not yet released software."
+                 e))))))
 
 (defn launch [prefs workspace launch-dir]
   (if (prefs/get-prefs prefs "enable-extensions" false)

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -85,7 +85,7 @@
 
 (defpage "General"
   {:label "Enable Texture Profiles" :type :boolean :key "general-enable-texture-profiles" :default true}
-  {:label "Enable Extensions" :type :boolean :key "enable-extensions" :default false}
+  {:label "Enable Extensions (only enable if you have the required setup)" :type :boolean :key "enable-extensions" :default false}
   {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false})
 
 (defpage "Scene"


### PR DESCRIPTION
- make it clearer that you should only "Enable Extensions" if you know
  what you are doing
- let exceptions propoagate to standard error reporting when launching custom engine

Fixes https://github.com/defold/editor2-issues/issues/202