### PR TITLE
DEFEDIT-659 Close tabs when resource is moved/deleted

### DIFF
--- a/editor/src/clj/editor/view.clj
+++ b/editor/src/clj/editor/view.clj
@@ -3,7 +3,7 @@
 
 (g/defnode WorkbenchView
   (input resource-node g/NodeID)
-  (input node-id+resource g/Any)
+  (input node-id+resource g/Any :substitute nil)
   (output view-data g/Any (g/fnk [_node-id node-id+resource] [_node-id (when node-id+resource
                                                                          {:resource-node (first node-id+resource)
                                                                           :resource (second node-id+resource)})])))

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1123,12 +1123,12 @@
 
 (defn maybe-ignore-error-in-value
   [self-name ctx-name nodeid-sym description input forms]
-  (let [sub       (get-in description [:input input :options :substitute])
+  (let [sub       (get-in description [:input input :options :substitute] ::no-sub)
         input-val (gensym)]
     `(let [~input-val ~forms]
        (if (instance? ErrorValue ~input-val)
          (if (ie/worse-than (:ignore-errors ~ctx-name) ~input-val)
-           ~(if sub
+           ~(if (not= ::no-sub sub)
               `(util/apply-if-fn ~sub ~input-val)
               `(ie/error-aggregate [~input-val] :_node-id ~nodeid-sym :_label ~input))
            (:value ~input-val))


### PR DESCRIPTION
Prevent defective resource nodes from breaking app view by substituting errors for nil so that view-data can always be produced.

Fixes https://github.com/defold/editor2-issues/issues/354