### PR TITLE
DEFEDIT-663 Mitigate some concurrency issues

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -484,14 +484,16 @@
       (.setTitle stage new-title))))
 
 (defn- refresh-ui! [^Stage stage project]
-  (ui/refresh (.getScene stage))
-  (refresh-app-title! stage project))
+  (when-not (ui/ui-disabled?)
+    (ui/refresh (.getScene stage))
+    (refresh-app-title! stage project)))
 
 (defn- refresh-views! [app-view]
-  (let [auto-pulls (g/node-value app-view :auto-pulls)]
-    (doseq [[node label] auto-pulls]
-      (profiler/profile "view" (:name @(g/node-type* node))
-                        (g/node-value node label)))))
+  (when-not (ui/ui-disabled?)
+    (let [auto-pulls (g/node-value app-view :auto-pulls)]
+      (doseq [[node label] auto-pulls]
+        (profiler/profile "view" (:name @(g/node-type* node))
+                          (g/node-value node label))))))
 
 ;; Here only because reports indicate that isDesktopSupported does
 ;; some kind of initialization behind the scenes on Linux:

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -18,7 +18,7 @@
            [javafx.event Event ActionEvent]
            [javafx.geometry Point2D]
            [javafx.scene Parent Scene]
-           [javafx.scene.control TextField TreeView TreeItem ListView]
+           [javafx.scene.control TextField TreeView TreeItem ListView ProgressBar]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.scene.input KeyEvent]
            [javafx.stage Stage StageStyle Modality DirectoryChooser]))
@@ -70,6 +70,24 @@
   (ui/observe (.focusedProperty stage)
               (fn [property old-val new-val]
                 (record-focus-change! new-val))))
+
+(defn make-progress-dialog [title message]
+  (let [root     ^Parent (ui/load-fxml "progress.fxml")
+        stage    (ui/make-stage)
+        scene    (Scene. root)
+        controls (ui/collect-controls root ["title" "message" "progress"])]
+    (observe-focus stage)
+    (ui/title! stage title)
+    (ui/text! (:title controls) title)
+    (ui/text! (:message controls) message)
+    (.setProgress ^ProgressBar (:progress controls) 0)
+    (.initModality stage Modality/APPLICATION_MODAL)
+    (.setScene stage scene)
+    (.setAlwaysOnTop stage true)
+    (.show stage)
+    {:stage              stage
+     :render-progress-fn (fn [progress]
+                           (ui/update-progress-controls! progress (:progress controls) (:message controls)))}))
 
 (defn make-alert-dialog [message]
   (let [root     ^Parent (ui/load-fxml "alert.fxml")

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1096,23 +1096,37 @@
           (throw @return)
           @return))))
 
-(def ^:private last-focused-node (atom nil))
+(defn ui-disabled?
+  []
+  (run-now (.. (main-stage) getScene getRoot isDisabled)))
 
-(defn disable-ui [disabled]
+(def disabled-ui-event-filter
+  (event-handler e (.consume e)))
+
+(defn disable-ui
+  []
   (let [scene       (.getScene (main-stage))
         focus-owner (.getFocusOwner scene)
         root        (.getRoot scene)]
-    (.setDisable root disabled)
-    (when-let [^Node node @last-focused-node]
-      (.requestFocus node))
-    (reset! last-focused-node focus-owner)))
+    (.setDisable root true)
+    (.addEventFilter scene javafx.event.EventType/ROOT disabled-ui-event-filter)
+    focus-owner))
+
+(defn enable-ui
+  [^Node focus-owner]
+  (let [scene       (.getScene (main-stage))
+        root        (.getRoot scene)]
+    (.removeEventFilter scene javafx.event.EventType/ROOT disabled-ui-event-filter)
+    (.setDisable root false)
+    (when focus-owner
+      (.requestFocus focus-owner))))
 
 (defmacro with-disabled-ui [& body]
-  `(try
-     (run-now (disable-ui true))
-     ~@body
-     (finally
-       (run-now (disable-ui false)))))
+  `(let [focus-owner# (run-now (disable-ui))]
+     (try
+       ~@body
+       (finally
+         (run-now (enable-ui focus-owner#))))))
 
 (defn mouse-type
   []


### PR DESCRIPTION
- move `resource-sync!` back to UI thread 😢  
- improve UX very slightly by showing a dialog when resources are being reloaded
- mitigate some cases where we interact with graph even though UI is disabled
  - we are no longer disabling the UI using this mechanism, but I think it is still useful so leaving it in for now 