### PR TITLE
DEFEDIT-670 Report unhandled exceptions in OnDragDropped event handlers

### DIFF
--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -99,3 +99,11 @@
     (reify Thread$UncaughtExceptionHandler
       (uncaughtException [_ thread exception]
         (report-exception! exception thread)))))
+
+(defmacro catch-all!
+  "Executes body, catching and reporting any unhandled exceptions."
+  [& body]
+  `(try
+     ~@body
+     (catch Throwable throwable#
+       (report-exception! throwable#))))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -2,6 +2,7 @@
   (:require
    [dynamo.graph :as g]
    [editor.app-view :as app-view]
+   [editor.error-reporting :as error-reporting]
    [editor.handler :as handler]
    [editor.jfx :as jfx]
    [editor.outline :as outline]
@@ -411,7 +412,7 @@
       (.. getSelectionModel (setSelectionMode SelectionMode/MULTIPLE))
       (.setOnDragDetected (ui/event-handler e (drag-detected proj-graph outline-view e)))
       (.setOnDragOver (ui/event-handler e (drag-over proj-graph outline-view e)))
-      (.setOnDragDropped (ui/event-handler e (drag-dropped proj-graph app-view outline-view e)))
+      (.setOnDragDropped (ui/event-handler e (error-reporting/catch-all! (drag-dropped proj-graph app-view outline-view e))))
       (.setCellFactory (reify Callback (call ^TreeCell [this view] (make-tree-cell view drag-entered-handler drag-exited-handler))))
       (ui/observe-selection #(propagate-selection %2 app-view))
       (ui/bind-double-click! :open)


### PR DESCRIPTION
Fixes defold/editor2-issues#300

Exceptions thrown from inside the `OnDragDropped` handler of the JavaFX `TreeView` control do not reach the `DefaultUncaughtExceptionHandler` for the thread. Instead, the string "Java Messsge:" (sic) followed by the exception message is printed to stderr.

This change ensures errors thrown from within all places we use the `OnDragDropped` handler are reported, so we can investigate why the behavior reported in defold/editor2-issues#300 can happen.