### PR TITLE
DEFEDIT-665-glcontext

### DIFF
--- a/editor/src/clj/editor/gl.clj
+++ b/editor/src/clj/editor/gl.clj
@@ -115,17 +115,6 @@
        (finally
          (.swapBuffers ~canvas)))))
 
-(defmacro with-context
-  [ctx bindings & body]
-  (assert (= 2 (count bindings)) "Bindings vector must provide names to bind to the GL2 and GLU objects")
-  `(try
-     (.makeCurrent ~ctx)
-     (let [~(first bindings)  (.. ~ctx getGL getGL2)
-           ~(second bindings) (GLU.)]
-       ~@body)
-     (finally
-       (.release ~ctx))))
-
 (defmacro with-gl-bindings
   [glsymb render-args-symb gl-stuff & body]
   (assert (vector? gl-stuff) (str "GL objects must be a vector of values that satisfy GlBind" gl-stuff))

--- a/editor/src/java/com/defold/editor/AsyncCopier.java
+++ b/editor/src/java/com/defold/editor/AsyncCopier.java
@@ -179,7 +179,6 @@ public class AsyncCopier {
 
                         Profiler.end(setPixels);
 
-                        gl.glBindBuffer(GL2.GL_PIXEL_PACK_BUFFER, readTo.pbo);
                         gl.glUnmapBuffer(GL2.GL_PIXEL_PACK_BUFFER);
                         gl.glBindBuffer(GL2.GL_PIXEL_PACK_BUFFER, 0);
 
@@ -201,8 +200,7 @@ public class AsyncCopier {
                     } finally {
                         gl.getContext().release();
                     }
-                }
-                else {
+                } else {
                     logger.warn("makeCurrent() failed in endFrame/task");
                 }
 


### PR DESCRIPTION
Don't attempt gl ops when makeCurrent() fails
Log makeCurrent failures
Postpone resizing of buffers to beginning of next frame to reduce calls to makeCurrent