### PR TITLE
Server: Extend db-tables when needed.

### DIFF
--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -25,7 +25,7 @@
             <property name="eclipselink.logging.level" value="WARNING"/>
 
             <!-- EclipseLink should create the database schema automatically -->
-            <property name="eclipselink.ddl-generation" value="create-tables" />
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables" />
             <property name="eclipselink.ddl-generation.output-mode" value="database" />
         </properties>
 
@@ -53,7 +53,7 @@
             <property name="eclipselink.logging.level" value="WARNING"/>
 
             <!-- EclipseLink should create the database schema automatically -->
-            <property name="eclipselink.ddl-generation" value="create-tables" />
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables" />
             <property name="eclipselink.ddl-generation.output-mode" value="database" />
         </properties>
 


### PR DESCRIPTION
This changes how EclipseLink handles database schema updates. Instead
of just creating new tables when needed, it will now also extend
existing tables with new columns.