### PR TITLE
DEFEDIT-664 Fix crash in gui box selection

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -65,7 +65,22 @@
              :resource-fields [:script :material [:fonts :font] [:textures :texture]]
              :tags #{:component :non-embeddable}})
 
-; Line shader
+; Selection shader
+
+(shader/defshader selection-vert
+  (attribute vec4 position)
+  (defn void main []
+    (setq gl_Position (* gl_ModelViewProjectionMatrix position))))
+
+(shader/defshader selection-frag
+  (defn void main []
+    (setq gl_FragColor (vec4 1.0 1.0 1.0 1.0))))
+
+; TODO - macro of this
+(def selection-shader (shader/make-shader ::selection-shader selection-vert selection-frag))
+
+
+; Fallback shader
 
 (vtx/defvertex color-vtx
   (vec3 position)
@@ -187,7 +202,7 @@
         vcount (count vb)]
     (when (> vcount 0)
       (let [shader (if (types/selection? (:pass render-args))
-                     shader ;; TODO - Always use the hard-coded shader for selection, DEFEDIT-231 describes a fix for this
+                     selection-shader ;; TODO - Always use the hard-coded shader for selection, DEFEDIT-231 describes a fix for this
                      (or material-shader shader))
             vertex-binding (vtx/use-with ::tris vb shader)]
         (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]


### PR DESCRIPTION
Fixes defold/editor2-issues#370

* Crashed because we were reading vertex colors that were not present.
* Use a simplified position-only shader for selection hit testing.