### PR TITLE
DEFEDIT-647 Save project before installing updates

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -224,8 +224,9 @@
                                                                :cache            cache})
                             (workspace/update-version-on-disk! workspace)
                             (update-system-cache! old-cache-val cache))
-          (ui/run-later
-            (on-complete-fn))
+          (when (some? on-complete-fn)
+            (ui/run-later
+              (on-complete-fn)))
           (finally (reset! ongoing-build-save-atom false)))))))
 
 

--- a/editor/src/java/com/defold/editor/EditorApplication.java
+++ b/editor/src/java/com/defold/editor/EditorApplication.java
@@ -26,8 +26,14 @@ public class EditorApplication {
 
     public static void openEditor(String[] args) throws Exception {
         // See comment next to startInstance why we use reflection here
-        Method openEditor = startInstance.getClass().getMethod("openEditor", new Class[] { String[].class });
+        Method openEditor = startInstance.getClass().getMethod("openEditor", String[].class);
         openEditor.invoke(startInstance, new Object[] { args });
+    }
+
+    public static void registerPreUpdateAction(Runnable action) throws Exception {
+        // See comment next to startInstance why we use reflection here
+        Method registerPreUpdateAction = startInstance.getClass().getMethod("registerPreUpdateAction", Runnable.class);
+        registerPreUpdateAction.invoke(startInstance, action);
     }
 
     public void run(String[] args) {


### PR DESCRIPTION
* If the user chooses to install an update, save the project before applying the update and restarting the editor.
* If the users chooses to not install an update, we won't check for further updates during this session.