### PR TITLE
DEFEDIT-679 Handle null curve values in Spine scenes

### DIFF
--- a/editor/test/integration/spine_test.clj
+++ b/editor/test/integration/spine_test.clj
@@ -21,6 +21,25 @@
 (defn- outline-label [nid path]
   (get (test-util/outline nid path) :label))
 
+(deftest key->curve-data-test
+  (testing "well-formed input"
+    (are [expected input]
+      (= expected (spine/key->curve-data {"curve" input}))
+      [0 0 1 1] "linear"
+      [0 0 1 0] "stepped"
+      [0.1 0.2 0.3 0.4] [0.1, 0.2, 0.3, 0.4]))
+  (testing "malformed input falls back to linear"
+    (are [expected input]
+      (= expected (spine/key->curve-data {"curve" input}))
+      [0 0 1 1] nil
+      [0 0 1 1] ""
+      [0 0 1 1] "other"
+      [0 0 1 1] []
+      [0 0 1 1] [0 0 0]
+      [0 0 1 1] [0 0 0 0 0]
+      [0 0 1 1] #{0.1 0.2 0.3 0.4}
+      [0 0 1 1] {:a 1 :b 2 :c 3 :d 4})))
+
 (deftest load-spine-scene-json
   (with-clean-system
     (let [workspace (test-util/setup-workspace! world)


### PR DESCRIPTION
Fixes defold/editor2-issues#375
Fixes defold/editor2-issues#376

It seems DragonBones as per version 4.9.5 will export curves with step interpolation (called "none" in DragonBones) as a `null` value for the `"curve"` property in the exported JSON:
```
"rotate": [
  {
    "angle": 0,
    "time": 0,
    "curve": null
  },
  {
    "time": 0.4166,
    "angle": -15
  }
]
```
According to [the spec](http://esotericsoftware.com/spine-json-format#Bone-timelines), step interpolation should be represented as the string `"stepped"`. I've used the DragonBones bug reporter to report the issue.

After this change, editor2 will treat this the same way editor1 does. This also seems to be the approach that [the official Spine runtime](https://github.com/EsotericSoftware/spine-runtimes/blob/2e6d84aa2538c9c319cb17ed5ad9fb8977be9c3f/spine-c/spine-c/src/spine/SkeletonJson.c#L109) has taken. We treat `null` as if the value is unspecified, and fall back on the default of linear interpolation.