### PR TITLE
DEFEDIT-686 Fix lua require statement parsing

### DIFF
--- a/editor/src/java/com/defold/editor/pipeline/LuaScanner.java
+++ b/editor/src/java/com/defold/editor/pipeline/LuaScanner.java
@@ -18,23 +18,25 @@ public class LuaScanner {
     private static Pattern multiLineCommentPattern = Pattern.compile("--\\[\\[.*?--\\]\\]",
             Pattern.DOTALL | Pattern.MULTILINE);
 
-    private static Pattern requirePattern1 = Pattern.compile(".*?require\\s*?\"(.*?)\"$",
+    private static String commentAfterRequire = "\\s*?(-{2,}.*?)?$";
+
+    private static Pattern requirePattern1 = Pattern.compile(".*?require\\s*?\"(.*?)\"\\s*,{0,1}" + commentAfterRequire,
              Pattern.DOTALL | Pattern.MULTILINE);
 
-    private static Pattern requirePattern2 = Pattern.compile(".*?require\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)$",
+    private static Pattern requirePattern2 = Pattern.compile(".*?require\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)\\s*,{0,1}" + commentAfterRequire,
              Pattern.DOTALL | Pattern.MULTILINE);
 
-    private static Pattern requirePattern3 = Pattern.compile(".*?require\\s*?'(.*?)'$",
+    private static Pattern requirePattern3 = Pattern.compile(".*?require\\s*?'(.*?)'\\s*,{0,1}" + commentAfterRequire,
              Pattern.DOTALL | Pattern.MULTILINE);
 
     /**
      * Note: we need four different patterns here to match the same beginning and ending character for
      * a string (eg " or '). We can't match on [\"']. If we do we'd have a false positive for the
      * following line:
-     * 
+     *
      * local s = 'require "should_not_match"'
      */
-    private static Pattern requirePattern4 = Pattern.compile(".*?require\\s*?\\(\\s*?'(.*?)'\\s*?\\)$",
+    private static Pattern requirePattern4 = Pattern.compile(".*?require\\s*?\\(\\s*?'(.*?)'\\s*?\\)\\s*,{0,1}" + commentAfterRequire,
              Pattern.DOTALL | Pattern.MULTILINE);
 
     private static Pattern propertyDeclPattern = Pattern.compile("go.property\\((.*?)\\);?(\\s*?--.*?)?$");


### PR DESCRIPTION
Update LuaScanner from bob so we also get the fix for
https://jira.int.midasplayer.com/browse/DEF-1364.

This bug caused builds to fail when such require statements were used,
because we'd try to find a module using an invalid path, and on
windows we crashed when trying to load project because of an
InvalidPathException.

Fixes https://github.com/defold/editor2-issues/issues/389