### PR TITLE
DEFEDIT-689 Add per-extension style classes to elements representing resources

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -563,6 +563,7 @@
     (g/transact
       (select app-view resource-node [resource-node]))
     (.setGraphic tab (jfx/get-image-view (:icon resource-type "icons/64/Icons_29-AT-Unknown.png") 16))
+    (.addAll (.getStyleClass tab) ^Collection (resource/style-classes resource))
     (ui/register-tab-context-menu tab ::tab-menu)
     (let [close-handler (.getOnClosed tab)]
       (.setOnClosed tab (ui/event-handler

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -534,21 +534,17 @@
     (doto tree-view
       (ui/bind-double-click! :open)
       (.setOnDragDetected detected-handler)
-      (.setCellFactory (reify Callback (call ^TreeCell [this view]
-                                         (let [cell (proxy [TreeCell] []
-                                                    (updateItem [resource empty]
-                                                      (let [this ^TreeCell this]
-                                                        (proxy-super updateItem resource empty)
-                                                        (ui/update-tree-cell-style! this)
-                                                        (let [name (or (and (not empty) (not (nil? resource)) (resource/resource-name resource)) nil)]
-                                                          (proxy-super setText name))
-                                                        (proxy-super setGraphic (jfx/get-image-view (workspace/resource-icon resource) 16)))))]
-                                           (doto cell
-                                             (.setOnDragOver over-handler)
-                                             (.setOnDragDropped dropped-handler)
-                                             (.setOnDragEntered entered-handler)
-                                             (.setOnDragExited exited-handler))))))
-      
+      (ui/cell-factory! (fn [resource]
+                          (if (nil? resource)
+                            {}
+                            {:text (resource/resource-name resource)
+                             :icon (workspace/resource-icon resource)
+                             :style (into #{} (keep not-empty) [(some->> resource resource/ext not-empty (str "resource-ext-"))
+                                                                (when (resource/read-only? resource) "resource-read-only")])
+                             :over-handler over-handler
+                             :dropped-handler dropped-handler
+                             :entered-handler entered-handler
+                             :exited-handler exited-handler})))
       (ui/register-context-menu ::resource-menu)
       (ui/context! :asset-browser {:workspace workspace :asset-browser asset-browser} selection-provider))))
 

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -539,8 +539,7 @@
                             {}
                             {:text (resource/resource-name resource)
                              :icon (workspace/resource-icon resource)
-                             :style (into #{} (keep not-empty) [(some->> resource resource/ext not-empty (str "resource-ext-"))
-                                                                (when (resource/read-only? resource) "resource-read-only")])
+                             :style (resource/style-classes resource)
                              :over-handler over-handler
                              :dropped-handler dropped-handler
                              :entered-handler entered-handler

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -68,7 +68,8 @@
   [tree-item]
   (let [resource (-> tree-item :value :resource)]
     {:text (resource/proj-path resource)
-     :icon (workspace/resource-icon resource)}))
+     :icon (workspace/resource-icon resource)
+     :style (resource/style-classes resource)}))
 
 (defmethod make-tree-cell :default
   [{:keys [error] :as tree-item}]

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -355,6 +355,7 @@
                      :filter ""
                      :cell-fn (fn [r] {:text (resource/proj-path r)
                                        :icon (workspace/resource-icon r)
+                                       :style (resource/style-classes r)
                                        :tooltip (when-let [tooltip-gen (:tooltip-gen options)]
                                                   (tooltip-gen r))})
                      :filter-fn (fn [filter-value items]
@@ -448,9 +449,11 @@
 
     (ui/cell-factory! (:resources-tree controls) (fn [r] (if (instance? MatchContextResource r)
                                                            {:text (resource/resource-name r)
-                                                            :icon (workspace/resource-icon r)}
+                                                            :icon (workspace/resource-icon r)
+                                                            :style (resource/style-classes r)}
                                                            {:text (resource/proj-path r)
-                                                            :icon (workspace/resource-icon r)})))
+                                                            :icon (workspace/resource-icon r)
+                                                            :style (resource/style-classes r)})))
 
     (ui/observe (.textProperty term-field) on-input-changed!)
     (ui/observe (.textProperty exts-field) on-input-changed!)

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -221,3 +221,9 @@
                   out (io/output-stream f)]
         (IOUtils/copy in out))
       (.getAbsolutePath f))))
+
+(defn style-classes [resource]
+  (into #{}
+        (keep not-empty)
+        [(some->> resource ext not-empty (str "resource-ext-"))
+         (when (read-only? resource) "resource-read-only")]))


### PR DESCRIPTION
* Introduces two new CSS style classes:
  * `resource-ext-$FILE_EXTENSION` based on file type (e.g. `resource-ext-lua`).
  * `resource-read-only` for read-only resources.
* Add these style classes to UI elements representing resources:
  * Entries in the **Asset Browser**.
  * Entries in the **Search in Files** dialog.
  * Entries in **Resource Picker** dialogs.
  * Entries in the **Build Errors** view.
  * Open **File Tabs** in the editor.

In order to see a visual difference, CSS declarations must be added to target these style classes. This will be done in a separate PR.