### PR TITLE
DEFEDIT-706 Only enable signing ios apps on osx

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -722,5 +722,6 @@
   (run [workspace project prefs] (fetch-libraries workspace project prefs)))
 
 (handler/defhandler :sign-ios-app :global
+  (active? [] (util/is-mac-os?))
   (run [workspace project prefs]
     (bundle/make-sign-dialog workspace prefs project)))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/384