### PR TITLE
DEFEDIT-695 Ensure git user is configured

### DIFF
--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -8,6 +8,7 @@
             [editor.handler :as handler]
             [editor.sync :as sync]
             [editor.ui :as ui]
+            [editor.prefs :as prefs]
             [editor.resource :as resource]
             [editor.resource-watch :as resource-watch]
             [editor.vcs-status :as vcs-status]
@@ -93,6 +94,9 @@
   (inherits core/Scope)
   (property list-view g/Any)
   (property git g/Any)
+  (output git g/Any (g/fnk [git prefs]
+                      (doto git
+                        (git/ensure-user-configured! prefs))))
   (property prefs g/Any))
 
 (defn- status->resource [workspace status]

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -93,9 +93,9 @@
 (g/defnode ChangesView
   (inherits core/Scope)
   (property list-view g/Any)
-  (property git g/Any)
-  (output git g/Any (g/fnk [git prefs]
-                      (doto git
+  (property unconfigured-git g/Any)
+  (output git g/Any (g/fnk [unconfigured-git prefs]
+                      (doto unconfigured-git
                         (git/ensure-user-configured! prefs))))
   (property prefs g/Any))
 
@@ -109,7 +109,7 @@
         revert-button       (.lookup parent "#changes-revert")
         git                 (try (Git/open (io/file (g/node-value workspace :root)))
                                  (catch Exception _))
-        view-id             (g/make-node! view-graph ChangesView :list-view list-view :git git :prefs prefs)]
+        view-id             (g/make-node! view-graph ChangesView :list-view list-view :unconfigured-git git :prefs prefs)]
     ; TODO: try/catch to protect against project without git setup
     ; Show warning/error etc?
     (try

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -49,9 +49,9 @@
 
 (defn- git-name
   [prefs]
-  (let [name (format "%s %s"
-                     (prefs/get-prefs prefs "first-name" nil)
-                     (prefs/get-prefs prefs "last-name" nil))]
+  (let [name (str (prefs/get-prefs prefs "first-name" nil)
+                  " "
+                  (prefs/get-prefs prefs "last-name" nil))]
     (when-not (str/blank? name)
       name)))
 

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -1,6 +1,7 @@
 (ns editor.git
   (:require [camel-snake-kebab :as camel]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [editor
              [prefs :as prefs]
              [ui :as ui]]
@@ -40,10 +41,31 @@
 
 ;; =================================================================================
 
+
 (defn credentials [prefs]
   (let [email (prefs/get-prefs prefs "email" nil)
         token (prefs/get-prefs prefs "token" nil)]
     (UsernamePasswordCredentialsProvider. ^String email ^String token)))
+
+(defn- git-name
+  [prefs]
+  (let [name (format "%s %s"
+                     (prefs/get-prefs prefs "first-name" nil)
+                     (prefs/get-prefs prefs "last-name" nil))]
+    (when-not (str/blank? name)
+      name)))
+
+(defn ensure-user-configured!
+  [^Git git prefs]
+  (let [email            (prefs/get-prefs prefs "email" nil)
+        name             (or (git-name prefs) email "Unknown")
+        config           (.. git getRepository getConfig)
+        configured-name  (.getString config "user" nil "name")
+        configured-email (.getString config "user" nil "email")]
+    (when (str/blank? configured-name)
+      (.setString config "user" nil "name" name))
+    (when (str/blank? configured-email)
+      (.setString config "user" nil "email" email))))
 
 (defn worktree [^Git git]
   (.getWorkTree (.getRepository git)))

--- a/editor/src/clj/editor/login.clj
+++ b/editor/src/clj/editor/login.clj
@@ -48,6 +48,8 @@
                    (try
                      (let [exchange-info (handle-request prefs client session)]
                        (prefs/set-prefs prefs "email" (:email exchange-info))
+                       (prefs/set-prefs prefs "first-name" (:first-name exchange-info))
+                       (prefs/set-prefs prefs "last-name" (:last-name exchange-info))
                        (prefs/set-prefs prefs "token" (:auth-token exchange-info)))
                      (reset! return true)
                      (catch Exception e
@@ -74,4 +76,6 @@
 
 (defn logout [prefs]
   (prefs/set-prefs prefs "email" nil)
+  (prefs/set-prefs prefs "first-name" nil)
+  (prefs/set-prefs prefs "last-name" nil)
   (prefs/set-prefs prefs "token" nil))


### PR DESCRIPTION
If user has not configured a git `user.name` and/or `user.email`, try to set them based on user info obtained when logging in.

- In editor1, we write user.name and user.email to local repo config when cloning. Can't do this in editor2 as repo location is determined by user and can be used with different logins at different times. Instead, we try to fallback to login information if no user settings have been configured.

Fixes https://github.com/defold/editor2-issues/issues/390, https://github.com/defold/editor2-issues/issues/12