### PR TITLE
DEFEDIT-717 Fix resource-sync when multiple files added

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -582,7 +582,9 @@
                            (first (:view-types resource-type))
                            (workspace/get-view-type workspace :text))]
      (if-let [make-view-fn (:make-view-fn view-type)]
-       (let [resource-node     (project/get-resource-node project resource)
+       (let [resource-node     (or (project/get-resource-node project resource)
+                                   (throw (ex-info (format "No resource node found for resource '%s'" (resource/proj-path resource))
+                                                   {})))
              ^TabPane tab-pane (g/node-value app-view :tab-pane)
              tabs              (.getTabs tab-pane)
              tab               (or (some #(when (and (= (tab->resource-node %) resource-node)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -77,9 +77,8 @@
           (g/mark-defective node-id node-type (g/error-fatal (format "The file '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found})))
         []))
     (catch Throwable t
-      (throw (ex-info (format "Error when loading resource '%'" (resource/resource->proj-path))
+      (throw (ex-info (format "Error when loading resource '%s'" (resource/resource->proj-path resource))
                       {:node-type node-type
-                       :resource resource
                        :resource-path (resource/resource->proj-path resource)}
                       t)))))
 


### PR DESCRIPTION
When multiple files are added to project and loaded in one
resource-sync!, we previously loaded each added resource eagerly. This
fails if added resources have inter-dependencies and dependant resources have not
been loaded yet. This happens, for example, with GUI scenes that have
templates.

Fixes https://github.com/defold/editor2-issues/issues/423, https://github.com/defold/editor2-issues/issues/422, https://github.com/defold/editor2-issues/issues/414