### PR TITLE
DEFEDIT-725 Fix non-git project regression

### DIFF
--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -95,8 +95,9 @@
   (property list-view g/Any)
   (property unconfigured-git g/Any)
   (output git g/Any (g/fnk [unconfigured-git prefs]
-                      (doto unconfigured-git
-                        (git/ensure-user-configured! prefs))))
+                      (when unconfigured-git
+                        (doto unconfigured-git
+                          (git/ensure-user-configured! prefs)))))
   (property prefs g/Any))
 
 (defn- status->resource [workspace status]


### PR DESCRIPTION
Check if we have a git repo before trying to configure it.

Fixes https://github.com/defold/editor2-issues/issues/436