### PR TITLE
DEFEDIT-734 Fix division by zero when using tab-switching shortcuts while no tabs are open

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -26,7 +26,8 @@
             [editor.view :as view]
             [util.profiler :as profiler]
             [util.http-server :as http-server])
-  (:import [com.defold.editor EditorApplication]
+  (:import [com.defold.control TabPaneBehavior]
+           [com.defold.editor EditorApplication]
            [com.defold.editor Start]
            [java.awt Desktop]
            [java.util Collection]
@@ -40,7 +41,7 @@
            [javafx.scene Scene Node Parent]
            [javafx.scene.control Button ColorPicker Label TextField TitledPane TextArea TreeItem Menu MenuItem MenuBar TabPane Tab ProgressBar Tooltip SplitPane]
            [javafx.scene.image Image ImageView WritableImage PixelWriter]
-           [javafx.scene.input MouseEvent]
+           [javafx.scene.input KeyEvent]
            [javafx.scene.layout AnchorPane GridPane StackPane HBox Priority]
            [javafx.scene.paint Color]
            [javafx.stage Stage FileChooser WindowEvent]
@@ -527,6 +528,13 @@
         (reify ListChangeListener
           (onChanged [this change]
             (ui/restyle-tabs! tab-pane)))))
+
+    ;; Workaround for JavaFX bug: https://bugs.openjdk.java.net/browse/JDK-8167282
+    ;; Consume key events that would select non-existing tabs in case we have none.
+    (.addEventFilter tab-pane KeyEvent/KEY_PRESSED (ui/event-handler event
+                                                     (when (and (empty? (.getTabs tab-pane))
+                                                                (TabPaneBehavior/isTraversalEvent event))
+                                                       (.consume event))))
 
     (ui/register-toolbar (.getScene stage) "#toolbar" :toolbar)
     (ui/register-menubar (.getScene stage) "#menu-bar" ::menubar)

--- a/editor/src/java/com/defold/control/TabPaneBehavior.java
+++ b/editor/src/java/com/defold/control/TabPaneBehavior.java
@@ -1,0 +1,21 @@
+package com.defold.control;
+
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import javafx.scene.control.TabPane;
+import javafx.scene.input.KeyEvent;
+
+public class TabPaneBehavior extends com.sun.javafx.scene.control.behavior.TabPaneBehavior {
+    public TabPaneBehavior(TabPane tabPane) {
+        super(tabPane);
+    }
+
+    public static boolean isTraversalEvent(KeyEvent event) {
+        for (KeyBinding keyBinding : TAB_PANE_BINDINGS) {
+            if (keyBinding.getSpecificity(null, event) > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes defold/editor2-issues#349

* Consume key events that would select non-existing tabs in case we have none.