### PR TITLE
Fixes for LiveUpdate API after design meeting discussion

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/liveupdate/LiveUpdateDialog.java
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/liveupdate/LiveUpdateDialog.java
@@ -238,13 +238,13 @@ public class LiveUpdateDialog extends TitleAreaDialog {
         // -------------------------------------------------------------------
         // Defold Service
         // -------------------------------------------------------------------
-        CreateHorizontalSpacing(container);
-        CreateRadioButton(container, "Upload to Defold AWS service", false, new IRadioAction() {
-            @Override
-            public void select() {
-                presenter.setMode(PublisherSettings.PublishMode.Defold);
-            }
-        });
+        // CreateHorizontalSpacing(container);
+        // CreateRadioButton(container, "Upload to Defold AWS service", false, new IRadioAction() {
+        //     @Override
+        //     public void select() {
+        //         presenter.setMode(PublisherSettings.PublishMode.Defold);
+        //     }
+        // });
 
 
         // -------------------------------------------------------------------

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -267,9 +267,7 @@ static const luaL_reg Module_methods[] =
     {"get_current_manifest", dmLiveUpdate::Resource_GetCurrentManifest},
     {"create_manifest", dmLiveUpdate::Resource_CreateManifest},
     {"destroy_manifest", dmLiveUpdate::Resource_DestroyManifest},
-    {"verify_resource", dmLiveUpdate::Resource_VerifyResource},
     {"store_resource", dmLiveUpdate::Resource_StoreResource},
-    {"verify_manifest", dmLiveUpdate::Resource_VerifyManifest},
     {"store_manifest", dmLiveUpdate::Resource_StoreManifest},
 
     {0, 0}

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
@@ -133,14 +133,26 @@ namespace dmLiveUpdate
             return luaL_error(L, "The manifest identifier does not exist");
         }
 
-        // BEGIN Temporary solution until async
         StoreResourceEntry entry;
         entry.m_L = dmScript::GetMainThread(L);
         dmScript::GetInstance(L);
         entry.m_Self = dmScript::Ref(L, LUA_REGISTRYINDEX);
         entry.m_Callback = callback;
         entry.m_HexDigest = hexDigest;
-        entry.m_Status = dmLiveUpdate::StoreResource(manifest, hexDigest, hexDigestLength, &resource);
+
+        if (buflen >= sizeof(dmResourceArchive::LiveUpdateResourceHeader))
+        {
+            // BEGIN Temporary solution until async
+            entry.m_Status = dmLiveUpdate::StoreResource(manifest, hexDigest, hexDigestLength, &resource);
+            // END Temporary solution until async
+        }
+        else
+        {
+            dmLogError("The resource could not be verified, header information is missing: %s", hexDigest);
+            entry.m_Status = false;
+        }
+
+        // BEGIN Temporary solution until async
         Callback_StoreResource(&entry);
         // END Temporary solution until async
 

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
@@ -2,9 +2,24 @@
 #include <liveupdate/liveupdate.h>
 
 #include <script/script.h>
+#include <dlib/log.h>
 
 namespace dmLiveUpdate
 {
+
+    struct StoreResourceEntry
+    {
+
+        StoreResourceEntry() {
+            memset(this, 0x0, sizeof(*this));
+        }
+
+        lua_State*  m_L;
+        int         m_Callback;
+        int         m_Self;
+        const char* m_HexDigest;
+        bool        m_Status;
+    };
 
     int Resource_GetCurrentManifest(lua_State* L)
     {
@@ -64,32 +79,33 @@ namespace dmLiveUpdate
         return 0;
     }
 
-    int Resource_VerifyResource(lua_State* L)
+    static void Callback_StoreResource(StoreResourceEntry* entry)
     {
-        int top = lua_gettop(L);
+        lua_State* L = entry->m_L;
+        DM_LUA_STACK_CHECK(L, 0);
 
-        int manifestIndex = luaL_checkint(L, 1);
+        lua_rawgeti(L, LUA_REGISTRYINDEX, entry->m_Callback);
+        lua_rawgeti(L, LUA_REGISTRYINDEX, entry->m_Self);
+        lua_pushvalue(L, -1);
 
-        size_t hexDigestLength = 0;
-        const char* hexDigest = luaL_checklstring(L, 2, &hexDigestLength);
+        dmScript::SetInstance(L);
 
-        size_t buflen = 0;
-        const char* buf = luaL_checklstring(L, 3, &buflen);
-        dmResourceArchive::LiveUpdateResource resource((const uint8_t*)buf, buflen);
-
-        dmResource::Manifest* manifest = dmLiveUpdate::GetManifest(manifestIndex);
-
-        if (manifest == 0x0)
+        if (!dmScript::IsInstanceValid(L))
         {
-            assert(top == lua_gettop(L));
-            return luaL_error(L, "The manifest identifier does not exist");
+            dmLogError("Could not run store_resource callback since the instance has been deleted.");
+            lua_pop(L, 2);
+            return;
         }
 
-        bool validResource = dmLiveUpdate::VerifyResource(manifest, hexDigest, hexDigestLength, &resource);
-        lua_pushboolean(L, (int) validResource);
+        lua_pushstring(L, entry->m_HexDigest);
+        lua_pushboolean(L, entry->m_Status);
 
-        assert(lua_gettop(L) == (top + 1));
-        return 1;
+        int ret = lua_pcall(L, 3, 0, 0);
+        if (ret != 0)
+        {
+            dmLogError("Error while running store_resource callback: %s", lua_tostring(L, -1));
+            lua_pop(L, 1);
+        }
     }
 
     int Resource_StoreResource(lua_State* L)
@@ -98,12 +114,16 @@ namespace dmLiveUpdate
 
         int manifestIndex = luaL_checkint(L, 1);
 
-        size_t hexDigestLength = 0;
-        const char* hexDigest = luaL_checklstring(L, 2, &hexDigestLength);
-
         size_t buflen = 0;
-        const char* buf = luaL_checklstring(L, 3, &buflen);
-        dmResourceArchive::LiveUpdateResource resource((const uint8_t*)buf, buflen);
+        const char* buf = luaL_checklstring(L, 2, &buflen);
+        dmResourceArchive::LiveUpdateResource resource((const uint8_t*) buf, buflen);
+
+        size_t hexDigestLength = 0;
+        const char* hexDigest = luaL_checklstring(L, 3, &hexDigestLength);
+
+        luaL_checktype(L, 4, LUA_TFUNCTION);
+        lua_pushvalue(L, 4);
+        int callback = dmScript::Ref(L, LUA_REGISTRYINDEX);
 
         dmResource::Manifest* manifest = dmLiveUpdate::GetManifest(manifestIndex);
 
@@ -112,18 +132,19 @@ namespace dmLiveUpdate
             assert(top == lua_gettop(L));
             return luaL_error(L, "The manifest identifier does not exist");
         }
-        
-        bool resourceStored = dmLiveUpdate::StoreResource(manifest, hexDigest, hexDigestLength, &resource);
-        lua_pushboolean(L, (int) resourceStored);
 
-        assert(lua_gettop(L) == top + 1);
-        return 1;
-    }
+        // BEGIN Temporary solution until async
+        StoreResourceEntry entry;
+        entry.m_L = dmScript::GetMainThread(L);
+        dmScript::GetInstance(L);
+        entry.m_Self = dmScript::Ref(L, LUA_REGISTRYINDEX);
+        entry.m_Callback = callback;
+        entry.m_HexDigest = hexDigest;
+        entry.m_Status = dmLiveUpdate::StoreResource(manifest, hexDigest, hexDigestLength, &resource);
+        Callback_StoreResource(&entry);
+        // END Temporary solution until async
 
-    int Resource_VerifyManifest(lua_State* L)
-    {
-        DM_LUA_STACK_CHECK(L, 0);
-
+        assert(lua_gettop(L) == top);
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
@@ -30,7 +30,8 @@ namespace dmLiveUpdate
      */
     int Resource_GetCurrentManifest(lua_State* L);
 
-    /*# create a new manifest from a buffer
+    // DOCUMENTATION NOT CURRENTLY EXPOSED
+    /* create a new manifest from a buffer
      *
      * Create a new manifest from a buffer and return a reference to the
      * manifest. Before storing a manifest that has been downloaded it is
@@ -61,7 +62,8 @@ namespace dmLiveUpdate
      */
     int Resource_CreateManifest(lua_State* L);
 
-    /*# remove a manifest that has been created
+    // DOCUMENTATION NOT CURRENTLY EXPOSED
+    /* remove a manifest that has been created
      *
      * remove a manifest that has been created using `create_manifest`. This will
      * free up the memory that was allocated when creating the manifest. The
@@ -83,114 +85,65 @@ namespace dmLiveUpdate
      */
     int Resource_DestroyManifest(lua_State* L);
 
-    /*# checks whether a resource matches the expected resource hash or not
-     *
-     * checks whether a resource matches the expected resource hash or not. This
-     * function can be used before storing a resource using the
-     * function store_resource to ensure that the resource was not corrupted,
-
-     * or modified by a third party, during transfer.
-     *
-     * @name resource.verify_resource
-     * @param manifest_reference [type:number] the manifest to check against
-     * @param expected_hash [type:string] the expected hash for the resource,
-     * retrieved through `collectionproxy.missing_resources`.
-     * @param buffer [type:string] the resource data to verify.
-     * @return matches [type:boolean] `true` if the resource matches the expected hash, `false`
-     * otherwise.
-     * @error An error occurs if the manifest_reference is invalid.
-     * @examples
-     *
-     * ```lua
-     * function init(self)
-     *     self.manifest = resource.get_current_manifest()
-     * end
-     *
-     * local function store_resource(self, expected_hash, buffer)
-     *     if resource.verify_resource(self.manifest, expected_hash, buffer) then
-     *         resource.store_resource(self.manifest, expected_hash, buffer)
-     *     end
-     * end
-     * ```
-     */
-    int Resource_VerifyResource(lua_State* L);
-
     /*# add a resource to the data archive and runtime index
      *
      * add a resource to the data archive and runtime index. The resource that
      * is added must already exist in the manifest, and can be verified using
      * verify_resource. The resource will also be verified internally before being
      * added to the data archive.
-
      *
      * @name resource.store_resource
-     * @param manifest_reference (int) The manifest to check against.
-     * @param expected_hash (string) The expected hash for the resource,
+     * @param manifest_reference [type:number] The manifest to check against.
+     * @param data [type:string] The resource data that should be stored.
+     * @param hexdigest [type:string] The expected hash for the resource,
      * retrieved through collectionproxy.missing_resources.
-     * @param buffer (string) The resource data to store.
+     * @param callback [type:function(self, hexdigest, status)] The callback
+     * function that is executed once the engine has been attempted to store
+     * the resource.
+     *
+     * `self`
+     * : [type:object] The current object.
+     *
+     * `hexdigest`
+     * : [type:string] The hexdigest of the resource.
+     *
+     * `status`
+     * : [type:boolean] Whether or not the resource was successfully stored.
      * @return (bool) True if the resource could be stored, False otherwise.
-
-     */
-    int Resource_StoreResource(lua_State* L);
-
-    /*# check if a manifest has been created with the correct private key
-     *
-     * Check if a manifest has been created with the correct private key. This
-     * function should always be used before storing a new manifest using the
-     * function `store_manifest` to ensure that the manifest was not corrupted,
-     * or modified by a third party, during transfer.
-     *
-     * @name resource.verify_manifest
-     * @param manifest_reference [type:number] the reference that should be verified.
-     * @return verified [type:boolean] `true` if the manifest signature could be correctly
-     * verified, `false` otherwise.
      *
      * @examples
-     *
-     * ```lua
-     * local function callback_update_manifest(self, id, response)
-     *     if response.status == 200 then
-     *         local manifest = resource.create_manifest(response.response)
-     *         if resource.verify_manifest(manifest) then
-     *             resource.store_manifest(manifest)
-     *             msg.post("@system", "reboot")
-     *         else
-     *             print("Manifest could not be verified")
-     *             -- error handling
-     *         end
-     *         resource.destroy_manifest(manifest)
-     *     else
-     *         print("Could not retrieve new manifest from server")
-     *         -- error handling
-     *     end
+     * ```
+     * function init(self)
+     *     self.manifest = resource.get_current_manifest()
      * end
      *
-     * local function callback_manifest_info(self, id, response)
-     *     if response.status == 200 then
-     *         error, data = pcall(json.decode, response.response)
-     *         if not error then
-     *             if data.version > self.version then
-     *                 http.request(data.uri, "GET", callback_update_manifest)
-     *             end
-     *         else
-     *             print("Could not parse manifest information from server")
-     *             -- error handling
-     *         end
-     *     else
-     *         print("Could not retrieve manifest information from server")
-     *         -- error handling
-     *     end
+     * local function callback_store_resource(self, hexdigest, status)
+     *      if status == true then
+     *           print("Successfully stored resource: " .. hexdigest)
+     *      else
+     *           print("Failed to store resource: " .. hexdigest)
+     *      end
      * end
      *
-     * local function check_new_manifest(self)
-     *     local uri = "http://example.defold.com/latest_manifest.json"
-     *     http.request(uri, "GET", callback_manifest_info)
+     * local function load_resources(self, target)
+     *      local resources = collectionproxy.missing_resources(target)
+     *      for _, resource_hash in ipairs(resources) do
+     *           local baseurl = "http://example.defold.com:8000/"
+     *           http.request(baseurl .. resource_hash, "GET", function(self, id, response)
+     *                if response.status == 200 then
+     *                     resource.store_resource(self.manifest, response.response, resource_hash, callback_store_resource)
+     *                else
+     *                     print("Failed to download resource: " .. resource_hash)
+     *                end
+     *           end)
+     *      end
      * end
      * ```
      */
-    int Resource_VerifyManifest(lua_State* L);
+    int Resource_StoreResource(lua_State* L);
 
-    /*# store a manifest to device
+    // DOCUMENTATION NOT CURRENTLY EXPOSED
+    /* store a manifest to device
      *
      * Store a manifest to device. The manifest that is stored should be
      * verified using `verify_manifest` before the manifest is stored. The next

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -61,10 +61,23 @@ namespace dmLiveUpdate
         dmLiveUpdateDDF::HashAlgorithm algorithm = manifest->m_DDF->m_Data.m_Header.m_ResourceHashAlgorithm;
         uint32_t digestLength = dmResource::HashLength(algorithm);
         uint8_t* digest = (uint8_t*) malloc(digestLength * sizeof(uint8_t));
+        if (digest == 0x0)
+        {
+            dmLogError("Failed to allocate memory for hash calculation.");
+            return false;
+        }
+
         CreateResourceHash(algorithm, (const char*)resource->m_Data, resource->m_Count, digest);
 
         uint32_t hexDigestLength = digestLength * 2 + 1;
         char* hexDigest = (char*) malloc(hexDigestLength * sizeof(char));
+        if (hexDigest == 0x0)
+        {
+            dmLogError("Failed to allocate memory for hash calculation.");
+            free(digest);
+            return false;
+        }
+
         dmResource::HashToString(algorithm, digest, hexDigest, hexDigestLength);
 
         if (expectedLength == (hexDigestLength - 1))
@@ -106,6 +119,12 @@ namespace dmLiveUpdate
         dmLiveUpdateDDF::HashAlgorithm algorithm = manifest->m_DDF->m_Data.m_Header.m_ResourceHashAlgorithm;
         uint32_t digestLength = dmResource::HashLength(algorithm);
         uint8_t* digest = (uint8_t*) malloc(digestLength * sizeof(uint8_t));
+        if (digest == 0x0)
+        {
+            dmLogError("Failed to allocate memory for hash calculation.");
+            return false;
+        }
+
         CreateResourceHash(algorithm, (const char*)resource->m_Data, resource->m_Count, digest);
 
         char proj_id[dmResource::MANIFEST_PROJ_ID_LEN];

--- a/engine/liveupdate/src/liveupdate_private.cpp
+++ b/engine/liveupdate/src/liveupdate_private.cpp
@@ -73,7 +73,7 @@ namespace dmLiveUpdate
         return resources;
     }
 
-    void CreateResourceHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const char* buf, uint32_t buflen, uint8_t* digest)
+    void CreateResourceHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const char* buf, size_t buflen, uint8_t* digest)
     {
         if (algorithm == dmLiveUpdateDDF::HASH_MD5)
         {

--- a/engine/liveupdate/src/liveupdate_private.h
+++ b/engine/liveupdate/src/liveupdate_private.h
@@ -24,7 +24,7 @@ namespace dmLiveUpdate
 
     uint32_t MissingResources(dmResource::Manifest* manifest, const dmhash_t urlHash, uint8_t* entries[], uint32_t entries_size);
 
-    void CreateResourceHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const char* buf, uint32_t buflen, uint8_t* digest);
+    void CreateResourceHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const char* buf, size_t buflen, uint8_t* digest);
 
 };
 

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -361,7 +361,7 @@ namespace dmResourceArchive
         }
     }
 
-    Result WriteResourceToArchive(HArchiveIndexContainer& archive, const uint8_t* buf, uint32_t buf_len, uint32_t& bytes_written, uint32_t& offset)
+    Result WriteResourceToArchive(HArchiveIndexContainer& archive, const uint8_t* buf, size_t buf_len, uint32_t& bytes_written, uint32_t& offset)
     {
         fseek(archive->m_LiveUpdateFileResourceData, 0, SEEK_END);
         uint32_t offs = (uint32_t)ftell(archive->m_LiveUpdateFileResourceData);

--- a/engine/resource/src/resource_archive.h
+++ b/engine/resource/src/resource_archive.h
@@ -65,7 +65,7 @@ namespace dmResourceArchive
         }
 
         const uint8_t* m_Data;
-        uint32_t m_Count;
+        size_t m_Count;
         LiveUpdateResourceHeader* m_Header;
     };
 


### PR DESCRIPTION
Design meeting fixes for LiveUpdate API
- Updated resource.store_resource to execute a callback after the resource has been stored to prepare for threaded storage of resources
- Updated documentation to reflect the API, temporarily disabled documentation for features we’re not ready to expose
- Updated LiveUpdate Settings dialog not to display the Defold Service setting since it’s not ready