### PR TITLE
DEFEDIT-739 Allow pasting files into any writable directory

### DIFF
--- a/editor/test/integration/asset_browser_test.clj
+++ b/editor/test/integration/asset_browser_test.clj
@@ -1,17 +1,12 @@
 (ns integration.asset-browser-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [support.test-support :refer [with-clean-system]]
-            [editor.atlas :as atlas]
-            [editor.collection :as collection]
-            [editor.cubemap :as cubemap]
-            [editor.game-object :as game-object]
-            [editor.image :as image]
+            [editor.asset-browser :as asset-browser]
             [editor.defold-project :as project]
-            [editor.scene :as scene]
-            [editor.sprite :as sprite]
             [editor.resource :as resource]
-            [integration.test-util :as test-util]))
+            [integration.test-util :as test-util]
+            [support.test-support :refer [with-clean-system]]))
 
 (deftest workspace-tree
   (testing "The file system can be retrieved as a tree"
@@ -40,3 +35,43 @@
                   view (make-preview-fn view-graph resource-node view-opts 128 128)]
               (let [image (g/node-value view :frame)]
                 (is (not (nil? image)))))))))))
+
+(deftest allow-resource-move-test
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          root-path "projects/game"
+          make-file (fn [proj-path]
+                      (io/file root-path proj-path))
+          make-dir-resource (fn [proj-path opts]
+                              (test-util/make-fake-file-resource workspace root-path (make-file proj-path) nil opts))]
+
+      (testing "Returns false for readonly destination"
+        (let [readonly-dir (make-dir-resource "readonly" {:read-only? true})]
+          (is (false? (asset-browser/allow-resource-move? readonly-dir [])))
+          (is (false? (asset-browser/allow-resource-move? readonly-dir [(make-file "a.txt")])))))
+
+      (testing "Returns false if destination is below source"
+        (let [src-path "player"
+              dst-path "player/scripts"
+              src-dir (make-file src-path)
+              dst-dir (make-dir-resource dst-path {})]
+          (is (false? (asset-browser/allow-resource-move? dst-dir [src-dir])))))
+
+      (testing "Returns false if destination is the same as the source"
+        (let [dir-path "player/scripts"]
+          (is (false? (asset-browser/allow-resource-move? (make-dir-resource dir-path {})
+                                                          [(make-file dir-path)]))))
+        (let [dir-path "player"
+              file-path "player/player.go"]
+          (is (false? (asset-browser/allow-resource-move? (make-dir-resource dir-path {})
+                                                          [(make-file file-path)])))))
+
+      (testing "Returns true for writable destination"
+        (is (true? (asset-browser/allow-resource-move? (make-dir-resource "dest" {})
+                                                       [(make-file "a.txt")
+                                                        (make-file "b.txt")]))))
+
+      (testing "Returns true for conflicting files"
+        (is (true? (asset-browser/allow-resource-move? (make-dir-resource "dest" {})
+                                                       [(make-file "a.txt")
+                                                        (make-file "readonly/a.txt")])))))))


### PR DESCRIPTION
Fixes defold/editor2-issues#170

* Allow pasting files into any writable directory.
  * This should be safe since we have code in place to make up unique file names in case of conflicts.
* Renamed `allow-resource-transfer?` function to `allow-resource-move?` to clarify its new role.
* Added unit tests for `allow-resource-move?` function. It's behavior remains the same.