### PR TITLE
DEFEDIT-749 Native Extensions editors

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -4,6 +4,7 @@
             [dynamo.graph :as g]
             [editor.bundle :as bundle]
             [editor.changes-view :as changes-view]
+            [editor.console :as console]
             [editor.dialogs :as dialogs]
             [editor.engine :as engine]
             [editor.handler :as handler]
@@ -254,7 +255,8 @@
 
 (handler/defhandler :build :global
   (enabled? [] (not (project/ongoing-build-save?)))
-  (run [workspace project prefs web-server build-errors-view]
+  (run [project prefs web-server build-errors-view]
+    (console/clear-console!)
     (let [build (build-project project build-errors-view)]
       (when (and (future? build) @build)
         (or (when-let [target (prefs/get-prefs prefs "last-target" targets/local-target)]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -262,7 +262,7 @@
         (or (when-let [target (prefs/get-prefs prefs "last-target" targets/local-target)]
               (let [local-url (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix)]
                 (engine/reboot (:url target) local-url)))
-            (engine/launch prefs workspace (io/file (workspace/project-path (g/node-value project :workspace)))))))))
+            (engine/launch project prefs))))))
 
 (handler/defhandler :hot-reload :global
   (enabled? [app-view]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -24,7 +24,7 @@
               (str/lower-case @term)
               ^Long (inc (or (first @positions) -1)))))
 
-(defn- clear-console! [_]
+(defn clear-console! []
   (when-let [^TextArea node @node]
     (reset! term "")
     (reset! positions '())
@@ -72,7 +72,7 @@
   (alt-selection [this] []))
 
 (defn setup-console! [{:keys [^TextArea text ^TextField search ^Button prev ^Button next ^Button clear]}]
-  (ui/on-action! clear clear-console!)
+  (ui/on-action! clear (fn [_] (clear-console!)))
   (ui/on-action! next next-console!)
   (ui/on-action! prev prev-console!)
   (ui/observe (.textProperty search) search-console)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -36,8 +36,6 @@
 
 (def ^:private unknown-icon "icons/32/Icons_29-AT-Unknown.png")
 
-
-
 (g/defnode ResourceNode
   (inherits core/Scope)
   (inherits outline/OutlineNode)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -27,6 +27,7 @@
             [clojure.string :as str])
   (:import [java.io File]
            [java.nio.file FileSystem FileSystems PathMatcher]
+           [org.apache.commons.codec.digest DigestUtils]
            [editor.resource FileResource]))
 
 (set! *warn-on-reflection* true)
@@ -34,6 +35,8 @@
 (def ^:dynamic *load-cache* nil)
 
 (def ^:private unknown-icon "icons/32/Icons_29-AT-Unknown.png")
+
+
 
 (g/defnode ResourceNode
   (inherits core/Scope)
@@ -51,7 +54,14 @@
              {:node-id _node-id
               :label (or (:label rt) (:ext rt) "unknown")
               :icon (or (:icon rt) unknown-icon)
-              :children children}))))
+              :children children})))
+
+  (output sha256 g/Str :cached (g/fnk [resource save-data]
+                                 (let [content (get save-data :content ::no-content)]
+                                   (if (= ::no-content content)
+                                     (with-open [s (io/input-stream resource)]
+                                       (DigestUtils/sha256Hex ^java.io.InputStream s))
+                                     (DigestUtils/sha256Hex ^String content))))))
 
 (g/defnode PlaceholderResourceNode
   (inherits ResourceNode))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -102,7 +102,8 @@
 (defn get-engine [project prefs platform]
   (if-let [native-extension-roots (and (prefs/get-prefs prefs "enable-extensions" false)
                                        (native-extensions/extension-roots project))]
-    (native-extensions/get-engine project native-extension-roots platform (prefs/get-prefs prefs "extensions-server" nil))
+    (let [build-server (prefs/get-prefs prefs "extensions-server" native-extensions/defold-build-server-url)]
+      (native-extensions/get-engine project native-extension-roots platform build-server))
     (bundled-engine platform)))
 
 (defn launch [project prefs]

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -123,20 +123,8 @@
   [resource path]
   (reduce resource-child resource path))
 
-(defn extension-resources
-  [roots platform]
-  (let [paths (platform-extension-paths platform)]
-    (->> (for [root roots
-               path paths
-               :let [resource (resource-by-path root path)]
-               :when resource]
-           resource)
-         (mapcat resource/resource-seq)
-         (filter #(= :file (resource/source-type %))))))
-
 (defn extension-resource-nodes
   [project roots platform]
-  (def p project)
   (let [paths (platform-extension-paths platform)]
     (->> (for [root roots
                path paths

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -27,6 +27,7 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:const defold-build-server-url "https://build.defold.com")
 
 ;;; Caching
 

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [dynamo.graph :as g]
    [editor.prefs :as prefs]
+   [editor.defold-project :as project]
    [editor.resource :as resource]
    [editor.system :as system]
    [editor.workspace :as workspace])
@@ -15,7 +16,7 @@
    (javax.ws.rs.core MediaType)
    (org.apache.commons.codec.binary Hex)
    (org.apache.commons.codec.digest DigestUtils)
-   (org.apache.commons.io FileUtils FilenameUtils)
+   (org.apache.commons.io FileUtils FilenameUtils IOUtils)
    (com.sun.jersey.api.client Client ClientResponse WebResource WebResource$Builder)
    (com.sun.jersey.api.client.config ClientConfig DefaultClientConfig)
    (com.sun.jersey.core.impl.provider.entity InputStreamProvider StringProvider)
@@ -29,35 +30,18 @@
 
 ;;; Caching
 
-;; map from resource-path to {:hash, :timestamp} so we can avoid
-;; re-calculating file hashes if file hasn't been modified
-(def ^:private resource-hashes (atom {}))
-
-(defn- hash-resource ^String
-  [resource]
-  (let [proj-path (resource/proj-path resource)
-        resource-file (io/as-file resource)]
-    (or (when-let [cache-entry (get @resource-hashes proj-path)]
-          (when (= (:timestamp cache-entry) (.lastModified resource-file))
-            (:hash cache-entry)))
-        (let [hash (with-open [s (io/input-stream resource)]
-                     (DigestUtils/sha256Hex s))]
-          (swap! resource-hashes assoc proj-path {:timestamp (.lastModified resource-file)
-                                                  :hash      hash})
-          hash))))
-
 (defn- hash-resources! ^MessageDigest
-  [^MessageDigest md resources]
-  (run! #(DigestUtils/updateDigest md (hash-resource %))
-        (sort-by resource/proj-path resources))
+  [^MessageDigest md resource-nodes]
+  (run! #(DigestUtils/updateDigest md ^String (g/node-value % :sha256))
+        (sort resource-nodes))
   md)
 
 (defn- cache-key
-  [^String platform ^String sdk-version resources]
+  [^String platform ^String sdk-version resource-nodes]
   (-> (DigestUtils/getSha256Digest)
       (DigestUtils/updateDigest platform)
       (DigestUtils/updateDigest (or sdk-version ""))
-      (hash-resources! resources)
+      (hash-resources! resource-nodes)
       (.digest)
       (Hex/encodeHexString)))
 
@@ -125,8 +109,8 @@
   (some #(= "ext.manifest" (resource/resource-name %)) (resource/children resource)))
 
 (defn extension-roots
-  [workspace]
-  (->> (g/node-value workspace :resource-list)
+  [project]
+  (->> (g/node-value (project/workspace project) :resource-list)
        (filter extension-root?)
        (seq)))
 
@@ -150,15 +134,34 @@
          (mapcat resource/resource-seq)
          (filter #(= :file (resource/source-type %))))))
 
+(defn extension-resource-nodes
+  [project roots platform]
+  (def p project)
+  (let [paths (platform-extension-paths platform)]
+    (->> (for [root roots
+               path paths
+               :let [resource (resource-by-path root path)]
+               :when resource]
+           resource)
+         (mapcat resource/resource-seq)
+         (filter #(= :file (resource/source-type %)))
+         (map (fn [resource]
+                (project/get-resource-node project resource))))))
 
 ;;; Extender API
 
 (defn- build-url
   [platform sdk-version]
-  (format "/build/%s/%s" platform sdk-version))
+  (format "/build/%s/%s" platform (or sdk-version "")))
+
+(defn- resource-content-stream ^java.io.InputStream
+  [resource-node]
+  (if-let [content (some-> (g/node-value resource-node :save-data) :content)]
+    (IOUtils/toInputStream ^String content "UTF-8")
+    (io/input-stream (g/node-value resource-node :resource))))
 
 (defn- build-engine-archive ^File
-  [server-url platform sdk-version resources]
+  [server-url platform sdk-version resource-nodes]
   (let [cc (DefaultClientConfig.)
         ;; TODO: Random errors wihtout this... Don't understand why random!
         ;; For example No MessageBodyWriter for body part of type 'java.io.BufferedInputStream' and media type 'application/octet-stream"
@@ -170,22 +173,27 @@
         build-resource (.path api-root (build-url platform sdk-version))
         builder (.accept build-resource #^"[Ljavax.ws.rs.core.MediaType;" (into-array MediaType []))]
     (with-open [form (FormDataMultiPart.)]
-      (doseq [r resources]
-        (.bodyPart form (StreamDataBodyPart. (resource/proj-path r) (io/input-stream r))))
-      (let [^ClientResponse cr (.post ^WebResource$Builder (.type builder MediaType/MULTIPART_FORM_DATA_TYPE) ClientResponse form)
-            f (doto (File/createTempFile "defold-engine" ".zip")
-                (.deleteOnExit))]
-        (when-not (= 200 (.getStatus cr))
-          (throw (ex-info (format "Engine build failed: %s" (.getEntity cr String))
-                          {:status (.getStatus cr)})))
-        (FileUtils/copyInputStreamToFile (.getEntityInputStream cr) f)
-        f))))
+      (doseq [node resource-nodes]
+        (let [resource (g/node-value node :resource)]
+          (.bodyPart form (StreamDataBodyPart. (resource/proj-path resource) (resource-content-stream node)))))
+      (let [^ClientResponse cr (.post ^WebResource$Builder (.type builder MediaType/MULTIPART_FORM_DATA_TYPE) ClientResponse form)]
+        (case (.getStatus cr)
+          200 (let [f (doto (File/createTempFile "defold-engine" ".zip")
+                        (.deleteOnExit))]
+                (FileUtils/copyInputStreamToFile (.getEntityInputStream cr) f)
+                f)
+
+          422  (throw (ex-info (format "Compilation error: %s" (.getEntity cr String))
+                               {:status (.getStatus cr)}))
+
+          (throw (ex-info (format "Failed to build engine: %s" (.getEntity cr String))
+                          {:status (.getStatus cr)})))))))
 
 (defn- find-or-build-engine-archive
-  [cache-dir server-url platform sdk-version resources]
-  (let [key (cache-key platform sdk-version resources)]
+  [cache-dir server-url platform sdk-version resource-nodes]
+  (let [key (cache-key platform sdk-version resource-nodes)]
     (or (cached-engine-archive cache-dir platform key)
-        (let [engine-archive (build-engine-archive server-url platform sdk-version resources)]
+        (let [engine-archive (build-engine-archive server-url platform sdk-version resource-nodes)]
           (cache-engine-archive! cache-dir platform key engine-archive)))))
 
 (defn- unpack-dmengine
@@ -200,17 +208,11 @@
         (.setExecutable true)))))
 
 (defn get-engine
-  [workspace roots platform build-server]
+  [project roots platform build-server]
   (let [extender-platform (get-in extender-platforms [platform :platform])
-        engine-archive (find-or-build-engine-archive (cache-dir (workspace/project-path workspace))
+        engine-archive (find-or-build-engine-archive (cache-dir (workspace/project-path (project/workspace project)))
                                                      build-server
                                                      extender-platform
                                                      (system/defold-sha1)
-                                                     (extension-resources roots platform))]
+                                                     (extension-resource-nodes project roots platform))]
     (unpack-dmengine engine-archive)))
-
-
-
-
-
-

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -81,7 +81,7 @@
 ;;; Extension discovery/processing
 
 (def ^:private extender-platforms
-  {(.getPair Platform/X86Darwin)    {:platform      "x86_64-osx"
+  {(.getPair Platform/X86Darwin)    {:platform      "x86-osx"
                                      :library-paths #{"osx" "x86-osx"}}
    (.getPair Platform/X86_64Darwin) {:platform      "x86_64-osx"
                                      :library-paths #{"osx" "x86_64-osx"}}

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -111,7 +111,7 @@
 
 (defn extension-roots
   [project]
-  (->> (g/node-value (project/workspace project) :resource-list)
+  (->> (g/node-value project :resources)
        (filter extension-root?)
        (seq)))
 

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -2,7 +2,8 @@
   (:require [service.log :as log]
             [editor.ui :as ui]
             [editor.prefs :as prefs]
-            [editor.system :as system])
+            [editor.system :as system]
+            [editor.engine.native-extensions :as native-extensions])
   (:import [com.defold.control LongField]
            [javafx.scene Parent Scene]
            [javafx.scene.paint Color]
@@ -90,7 +91,7 @@
             {:label "Mouse Type" :type :choicebox :key "scene-mouse-type" :default :one-button :options [[:one-button "One Button"] [:three "Three Buttons"]]}]}
    {:name  "Extensions"
     :prefs [{:label "Enable Extensions" :type :boolean :key "enable-extensions" :default false}
-            {:label "Build Server" :type :string :key "extensions-server" :default "https://build.defold.com"}]}])
+            {:label "Build Server" :type :string :key "extensions-server" :default native-extensions/defold-build-server-url}]}])
 
 (defn open-prefs [prefs]
   (let [root ^Parent (ui/load-fxml "prefs.fxml")

--- a/editor/src/clj/editor/resource_types.clj
+++ b/editor/src/clj/editor/resource_types.clj
@@ -28,6 +28,7 @@
             [editor.sound :as sound]
             [editor.spine :as spine]
             [editor.sprite :as sprite]
+            [editor.text-file :as text-file]
             [editor.tile-map :as tile-map]
             [editor.tile-source :as tile-source]))
 
@@ -62,6 +63,7 @@
       (sound/register-resource-types workspace)
       (spine/register-resource-types workspace)
       (sprite/register-resource-types workspace)
+      (text-file/register-resource-types workspace)
       (tile-map/register-resource-types workspace)
       (tile-source/register-resource-types workspace))))
 

--- a/editor/src/clj/editor/text.clj
+++ b/editor/src/clj/editor/text.clj
@@ -17,6 +17,7 @@
 
 (defn make-view [graph ^Parent parent resource-node opts]
   (let [text-area (TextArea.)]
+    (.setEditable text-area false)
     (.setText text-area (slurp (g/node-value resource-node :resource)))
     (when-let [cp (:caret-position opts)]
       (.positionCaret text-area cp))

--- a/editor/src/clj/editor/text_file.clj
+++ b/editor/src/clj/editor/text_file.clj
@@ -15,12 +15,11 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- re-compile [s] (Pattern/compile s))
 (defn- re-quote [s] (Pattern/quote s))
 
 (defn- set->pattern
   [s]
-  (re-compile (str "^(?:"
+  (re-pattern (str "^(?:"
                    (clojure.string/join "|" (map re-quote (reverse (sort s))))
                    ")")))
 

--- a/editor/src/clj/editor/text_file.clj
+++ b/editor/src/clj/editor/text_file.clj
@@ -26,7 +26,7 @@
 
 ;;; Rudimentary syntax highlightning support for C/C++
 
-(def preprocessor-directives
+(def cpp-preprocessor-directives
   #{"#assert"
     "#define"
     "#elif"
@@ -193,8 +193,8 @@
     "^"
     "^="})
 
-(defn- is-word-start [^Character c] (or (Character/isLetter c) (= c \#) (= c \_) (= c \:)))
-(defn- is-word-part [^Character c] (or (is-word-start c) (Character/isDigit c) (= c \-)))
+(defn- is-word-start [^Character c] (or (Character/isLetter c) (= c \_)))
+(defn- is-word-part [^Character c] (or (is-word-start c) (Character/isDigit c)))
 
 (def operator-pattern (set->pattern cpp-operators))
 
@@ -215,11 +215,10 @@
                                      {:type :custom :scanner match-single-line-comment :class "comment"}
                                      {:type :custom :scanner match-multi-line-comment :class "comment"}
                                      {:type :keyword :start? is-word-start :part? is-word-part :keywords cpp-keywords :class "keyword"}
-                                     {:type :keyword :start? is-word-start :part? is-word-part :keywords preprocessor-directives :class "directive"}
+                                     {:type :keyword :start? is-word-start :part? is-word-part :keywords cpp-preprocessor-directives :class "directive"}
                                      {:type :word :start? is-word-start :part? is-word-part :class "default"}
                                      {:type :multiline :start "\"" :end "\"" :esc \\ :class "string"}
                                      {:type :multiline :start "'" :end "'" :esc \\ :class "string"}
-                                     #_{:type :singleline :start "<" :end ">" :esc \\ :class "string"}
                                      {:type :custom :scanner code/match-number :class "number"}
                                      {:type :custom :scanner match-operator :class "operator"}
                                      {:type :default :class "default"}]}]}})

--- a/editor/src/clj/editor/text_file.clj
+++ b/editor/src/clj/editor/text_file.clj
@@ -1,0 +1,290 @@
+(ns editor.text-file
+  (:require
+   [clojure.string :as str]
+   [dynamo.graph :as g]
+   [editor.code :as code]
+   [editor.types :as t]
+   [editor.graph-util :as gu]
+   [editor.defold-project :as project]
+   [editor.properties :as properties]
+   [editor.workspace :as workspace]
+   [editor.resource :as resource]
+   [util.text-util :as text-util])
+  (:import
+   (java.util.regex Pattern)))
+
+(set! *warn-on-reflection* true)
+
+(defn- re-compile [s] (Pattern/compile s))
+(defn- re-quote [s] (Pattern/quote s))
+
+(defn- set->pattern
+  [s]
+  (re-compile (str "^(?:"
+                   (clojure.string/join "|" (map re-quote (reverse (sort s))))
+                   ")")))
+
+
+;;; Rudimentary syntax highlightning support for C/C++
+
+(def preprocessor-directives
+  #{"#assert"
+    "#define"
+    "#elif"
+    "#else"
+    "#endif"
+    "#error"
+    "#ident"
+    "#if"
+    "#ifdef"
+    "#ifndef"
+    "#import"
+    "#include"
+    "#line"
+    "#pragma"
+    "#sccs"
+    "#unassert"
+    "#undef"
+    "#warning"})
+
+(def cpp-keywords
+  #{"alignas"
+    "alignof"
+    "asm"
+    "auto"
+    "bool"
+    "break"
+    "case"
+    "catch"
+    "char"
+    "char16_t"
+    "char32_t"
+    "class"
+    "const"
+    "const_cast"
+    "constexpr"
+    "continue"
+    "decltype"
+    "default"
+    "delete"
+    "do"
+    "double"
+    "dynamic_cast"
+    "else"
+    "enum"
+    "explicit"
+    "export"
+    "extern"
+    "false"
+    "float"
+    "for"
+    "friend"
+    "goto"
+    "if"
+    "inline"
+    "int"
+    "long"
+    "mutable"
+    "namespace"
+    "new"
+    "noexcept"
+    "nullptr"
+    "operator"
+    "private"
+    "protected"
+    "public"
+    "register"
+    "reinterpret_cast"
+    "return"
+    "short"
+    "signed"
+    "sizeof"
+    "static"
+    "static_assert"
+    "static_cast"
+    "struct"
+    "switch"
+    "template"
+    "this"
+    "thread_local"
+    "throw"
+    "true"
+    "try"
+    "typedef"
+    "typeid"
+    "typename"
+    "union"
+    "unsigned"
+    "using"
+    "virtual"
+    "void"
+    "volatile"
+    "wchar_t"
+    "while"})
+
+(def cpp-operators
+  #{"!"
+    "!="
+    "#"
+    "##"
+    "%"
+    "%:"
+    "%:%:"
+    "%="
+    "%>"
+    "&"
+    "&&"
+    "&="
+    "("
+    ")"
+    "*"
+    "*="
+    "+"
+    "++"
+    "+="
+    ","
+    "-"
+    "--"
+    "-="
+    "->"
+    "->*"
+    "."
+    ".*"
+    "..."
+    "/"
+    "/="
+    ":"
+    "::"
+    ":>"
+    ";"
+    "<"
+    "<%"
+    "<:"
+    "<<"
+    "<<="
+    "<="
+    "="
+    "=="
+    ">"
+    ">="
+    ">>"
+    ">>="
+    "?"
+    "["
+    "]"
+    "and"
+    "and_eq"
+    "bitand"
+    "bitor"
+    "compl"
+    "delete"
+    "new"
+    "not"
+    "not_eq"
+    "or"
+    "or_eq"
+    "xor"
+    "xor_eq"
+    "{"
+    "}"
+    "|"
+    "|="
+    "||"
+    "~"
+    "^"
+    "^="})
+
+(defn- is-word-start [^Character c] (or (Character/isLetter c) (= c \#) (= c \_) (= c \:)))
+(defn- is-word-part [^Character c] (or (is-word-start c) (Character/isDigit c) (= c \-)))
+
+(def operator-pattern (set->pattern c-operators))
+
+(defn match-operator [s]
+  (code/match-regex s operator-pattern))
+
+(defn match-single-line-comment [s]
+  (code/match-regex s #"^\Q//\E.*\n"))
+
+(defn match-multi-line-comment [s]
+  (code/match-regex s #"(?s)^\/\*.*?\*\/"))
+
+(def cpp-ish
+  {:language "c"
+   :syntax   {:scanner [{:partition :default
+                         :type      :default
+                         :rules     [{:type :whitespace :space? #{\space \tab \newline \return}}
+                                     {:type :custom :scanner match-single-line-comment :class "comment"}
+                                     {:type :custom :scanner match-multi-line-comment :class "comment"}
+                                     {:type :keyword :start? is-word-start :part? is-word-part :keywords c-keywords :class "keyword"}
+                                     {:type :keyword :start? is-word-start :part? is-word-part :keywords preprocessor-directives :class "directive"}
+                                     {:type :word :start? is-word-start :part? is-word-part :class "default"}
+                                     {:type :multiline :start "\"" :end "\"" :esc \\ :class "string"}
+                                     {:type :multiline :start "'" :end "'" :esc \\ :class "string"}
+                                     #_{:type :singleline :start "<" :end ">" :esc \\ :class "string"}
+                                     {:type :custom :scanner code/match-number :class "number"}
+                                     {:type :custom :scanner match-operator :class "operator"}
+                                     {:type :default :class "default"}]}]}})
+
+
+(def script-defs
+  [{:ext "cpp"
+    :label "C++"
+    :icon "icons/32/Icons_12-Script-type.png"
+    :view-types [:code :default]
+    :view-opts {:code cpp-ish}}
+   {:ext "h"
+    :label "C/C++ Header"
+    :icon "icons/32/Icons_12-Script-type.png"
+    :view-types [:code :default]
+    :view-opts {:code cpp-ish}}
+   {:ext "mm"
+    :label "Objective-C"
+    :icon "icons/32/Icons_12-Script-type.png"
+    :view-types [:code :default]
+    :view-opts {:code cpp-ish}}
+   {:ext "c"
+    :label "C"
+    :icon "icons/32/Icons_12-Script-type.png"
+    :view-types [:code :default]
+    :view-opts {:code cpp-ish}}
+   {:ext "manifest"
+    :label "Manifest"
+    :icon "icons/32/Icons_11-Script-general.png"
+    :view-types [:code :default]}])
+
+
+(g/defnode TextNode
+  (inherits project/ResourceNode)
+
+  (property code g/Str (dynamic visible (g/constantly false)))
+  (property caret-position g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property prefer-offset g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property tab-triggers g/Any (dynamic visible (g/constantly false)) (default nil))
+  (property selection-offset g/Int (dynamic visible (g/constantly false)) (default 0))
+  (property selection-length g/Int (dynamic visible (g/constantly false)) (default 0))
+
+  (output save-data g/Any :cached (g/fnk [resource code]
+                                    {:resource resource
+                                     :content code})))
+
+(defn load-text [project self resource]
+  (g/set-property self :code (text-util/crlf->lf (slurp resource))))
+
+(defn- register [workspace def]
+  (let [args (merge def
+               {:textual? true
+                :node-type TextNode
+                :load-fn load-text})]
+    (apply workspace/register-resource-type workspace (mapcat seq (seq args)))))
+
+(defn register-resource-types [workspace]
+  (for [def script-defs]
+    (register workspace def)))
+
+(comment
+  ;; Useful for re-registering resource types
+  (do (dynamo.graph/transact (register-resource-types 0)) nil)
+  
+  )
+
+

--- a/editor/src/clj/editor/text_file.clj
+++ b/editor/src/clj/editor/text_file.clj
@@ -197,7 +197,7 @@
 (defn- is-word-start [^Character c] (or (Character/isLetter c) (= c \#) (= c \_) (= c \:)))
 (defn- is-word-part [^Character c] (or (is-word-start c) (Character/isDigit c) (= c \-)))
 
-(def operator-pattern (set->pattern c-operators))
+(def operator-pattern (set->pattern cpp-operators))
 
 (defn match-operator [s]
   (code/match-regex s operator-pattern))
@@ -215,7 +215,7 @@
                          :rules     [{:type :whitespace :space? #{\space \tab \newline \return}}
                                      {:type :custom :scanner match-single-line-comment :class "comment"}
                                      {:type :custom :scanner match-multi-line-comment :class "comment"}
-                                     {:type :keyword :start? is-word-start :part? is-word-part :keywords c-keywords :class "keyword"}
+                                     {:type :keyword :start? is-word-start :part? is-word-part :keywords cpp-keywords :class "keyword"}
                                      {:type :keyword :start? is-word-start :part? is-word-part :keywords preprocessor-directives :class "directive"}
                                      {:type :word :start? is-word-start :part? is-word-part :class "default"}
                                      {:type :multiline :start "\"" :end "\"" :esc \\ :class "string"}

--- a/editor/styling/stylesheets/modules/_script-editor.scss
+++ b/editor/styling/stylesheets/modules/_script-editor.scss
@@ -23,6 +23,7 @@
     .source-segment, .plain-source-segment {
         -fx-font-family: "Dejavu Sans Mono";
         -fx-font-size: 9pt;
+        -styled-text-color: $defold-white;
     }
     .selection-marker {
             -fx-background-color: rgba(172,148,120,0.3)

--- a/editor/styling/stylesheets/modules/_script-editor.scss
+++ b/editor/styling/stylesheets/modules/_script-editor.scss
@@ -5,7 +5,7 @@
     -fx-background-color: $bright-black;
 
     .comment {
-        -styled-text-color: $script-comment; 
+        -styled-text-color: $script-comment;
         -fx-font-style: italic;
     }
     .list-view {
@@ -25,7 +25,7 @@
         -fx-font-size: 9pt;
     }
     .selection-marker {
-	    -fx-background-color: rgba(172,148,120,0.3)
+            -fx-background-color: rgba(172,148,120,0.3)
     }
     .text-caret {
         -fx-fill: white;
@@ -34,7 +34,7 @@
 }
 
 /* Script view colors */
-.lua, .glsl {
+.lua, .glsl, .c {
     &.styled-text-area {
         -styled-text-color: $script-comment;
 
@@ -49,7 +49,7 @@
         }
 
         .keyword {
-            -styled-text-color: $script-keyword;   
+            -styled-text-color: $script-keyword;
         }
 
         .operator {
@@ -102,20 +102,20 @@
 
 .glsl {
     &.styled-text-area {
-        .directive, .macro-keyword, .precision-keyword,
-        .storage-modifier-keyword, .support-function-keyword {
+        .keyword {
             -styled-text-color: $script-keyword;
-        }
-
-        .storage-type {
-            -styled-text-color: $script-function;
-        }
-
-        .support-variable-keyword {
-            -styled-text-color: $defold-white;
         }
     }
 }
+
+.c {
+    &.styled-text-area {
+        .directive {
+            -styled-text-color: $script-keyword;
+        }
+    }
+}
+
 
 /* text editor code completion popup */
 #proposals .list-cell:filled:selected {

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -13,9 +13,10 @@
 
 (deftest extension-roots-test
   (with-clean-system
-    (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")]
+    (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+          project (test-util/setup-project! workspace)]
       (is (= #{"/extension1" "/subdir/extension2"}
-             (set (map resource/proj-path (native-extensions/extension-roots workspace))))))))
+             (set (map resource/proj-path (native-extensions/extension-roots project))))))))
 
 (deftest extension-resource-nodes-test
   (letfn [(platform-resources [project platform]

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [integration.test-util :as test-util]
    [support.test-support :refer [with-clean-system]]
+   [dynamo.graph :as g]
    [editor.engine.native-extensions :as native-extensions]
    [editor.resource :as resource])
   (:import
@@ -16,15 +17,20 @@
       (is (= #{"/extension1" "/subdir/extension2"}
              (set (map resource/proj-path (native-extensions/extension-roots workspace))))))))
 
-(deftest extension-resources-test
-  (letfn [(platform-resources [workspace platform]
-            (set (map resource/proj-path
-                      (native-extensions/extension-resources
-                        (native-extensions/extension-roots workspace)
-                        platform))))]
+(deftest extension-resource-nodes-test
+  (letfn [(platform-resources [project platform]
+            (let [resource-nodes (native-extensions/extension-resource-nodes
+                                   project
+                                   (native-extensions/extension-roots project)
+                                   platform)]
+              (->> resource-nodes
+                   (map (comp resource/proj-path
+                              #(g/node-value % :resource)))
+                   set)))]
     (testing "x86_64-osx"
       (with-clean-system
-        (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")]
+        (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+              project (test-util/setup-project! workspace)]
           (is (= #{"/extension1/ext.manifest"
                    "/extension1/include/file"
                    "/extension1/include/subdir/file"
@@ -34,10 +40,11 @@
                    "/extension1/lib/x86_64-osx/file"
                    "/extension1/lib/osx/file"
                    "/subdir/extension2/ext.manifest"}
-                 (platform-resources workspace "x86_64-darwin"))))))
+                 (platform-resources project "x86_64-darwin"))))))
     (testing "x86_64-win32"
       (with-clean-system
-        (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")]
+        (let [workspace (test-util/setup-workspace! world "test/resources/extension_project")
+              project (test-util/setup-project! workspace)]
           (is (= #{"/extension1/ext.manifest"
                    "/extension1/include/file"
                    "/extension1/include/subdir/file"
@@ -47,7 +54,7 @@
                    "/extension1/lib/x86_64-windows/file"
                    "/extension1/lib/windows/file"
                    "/subdir/extension2/ext.manifest"}
-                 (platform-resources workspace "x86_64-win32"))))))))
+                 (platform-resources project "x86_64-win32"))))))))
 
 (defn- dummy-file
   []


### PR DESCRIPTION
- Refactor native extensions impl. to work with project and resource nodes instead of workspace and resources. This allows us to better work with resources that are edited in editor (such as .cpp files) where we don't want to rely on disk contents being up to date.
- Clear console when building: 
  - Fixes https://github.com/defold/editor2-issues/issues/308
- Basic text file editing using code editor:
  - Fixes https://github.com/defold/editor2-issues/issues/138
- Make default text view read-only
- Default to a good build server url:
  - Fixes https://github.com/defold/editor2-issues/issues/468