### PR TITLE
DEFEDIT-765 Simplify debug output of Resources

### DIFF
--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -85,7 +85,7 @@
      :children  (:children r)})))
 
 (defmethod print-method FileResource [file-resource ^java.io.Writer w]
-  (.write w (format "FileResource{:workspace %s :file %s :children %s}" (:workspace file-resource) (:file file-resource) (str (:children file-resource)))))
+  (.write w (format "{:FileResource %s}" (pr-str (proj-path file-resource)))))
 
 (defrecord MemoryResource [workspace ext data]
   Resource
@@ -112,7 +112,7 @@
 (core/register-record-type! MemoryResource)
 
 (defmethod print-method MemoryResource [memory-resource ^java.io.Writer w]
-  (.write w (format "MemoryResource{:workspace %s :data %s}" (:workspace memory-resource) (:data memory-resource))))
+  (.write w (format "{:MemoryResource %s}" (pr-str (ext memory-resource)))))
 
 (defn make-memory-resource [workspace resource-type data]
   (MemoryResource. workspace (:ext resource-type) data))
@@ -165,7 +165,7 @@
      :children  (:children r)})))
 
 (defmethod print-method ZipResource [zip-resource ^java.io.Writer w]
-  (.write w (format "ZipResource{:workspace %s :path %s :children %s}" (:workspace zip-resource) (:path zip-resource) (str (:children zip-resource)))))
+  (.write w (format "{:ZipResource %s}" (pr-str (proj-path zip-resource)))))
 
 (defn- read-zip-entry [^ZipInputStream zip ^ZipEntry e]
   (let [os (ByteArrayOutputStream.)


### PR DESCRIPTION
Resources are represented as Clojure maps with a single key-value pair. The key signifies the type of resource, and the value is a quoted string representation of its `proj-path`. Children are not listed, and neither is the workspace as it is almost never relevant. For MemoryResources we show its `ext` in place of a `proj-path`. The fact that the new format is valid Clojure syntax allows smart REPLs to format output nicely, whereas before any data structure that contained a Resource would break formatting.
```clj
{:FileResource "/main/main.collection"}
{:ZipResource "/builtins/fonts/label.material"}
{:MemoryResource "model"}
```
### Before
![print-resource-before](https://cloud.githubusercontent.com/assets/22448941/22745338/7bb91442-ee20-11e6-81bd-41c2f7e9a91b.png)
### After
![print-resource-after](https://cloud.githubusercontent.com/assets/22448941/22745346/828b4704-ee20-11e6-9c3f-de20b15b6fc3.png)