### PR TITLE
DEFEDIT-737 Particle system orientation fixes

### DIFF
--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -139,12 +139,13 @@
 
 (defn inv-transform
   ([^Point3d position ^Quat4d rotation ^Point3d p]
-    (let [q (doto (Quat4d. rotation) (.conjugate))]
-      (.sub p position)
-      (rotate q p)))
+    (let [q (doto (Quat4d. rotation) (.conjugate))
+          p1 (doto (Point3d. p) (.sub position))]
+      (rotate q p1)))
   ([^Quat4d rotation ^Quat4d q]
     (let [q1 (doto (Quat4d. rotation) (.conjugate))]
-      (.mul q1 q))))
+      (.mul q1 q)
+      q1)))
 
 (defn from-to->quat [^Vector3d unit-from ^Vector3d unit-to]
   (let [dot (.dot unit-from unit-to)]

--- a/editor/test/resources/build_project/SideScroller/main/main.go
+++ b/editor/test/resources/build_project/SideScroller/main/main.go
@@ -59,6 +59,21 @@ components {
   }
 }
 components {
+  id: "pfx2"
+  component: "/main/tail.particlefx"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}
+components {
   id: "sound"
   component: "/main/sound.sound"
   position {

--- a/editor/test/resources/build_project/SideScroller/main/tail.particlefx
+++ b/editor/test/resources/build_project/SideScroller/main/tail.particlefx
@@ -1,0 +1,332 @@
+emitters {
+  id: "emitter"
+  mode: PLAY_MODE_LOOP
+  duration: 6.0
+  space: EMISSION_SPACE_WORLD
+  position {
+    x: 10.0
+    y: 20.0
+    z: 30.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.70710677
+    w: 0.70710677
+  }
+  tile_source: "/builtins/graphics/particle_blob.tilesource"
+  animation: "anim"
+  material: "/builtins/materials/particlefx.material"
+  blend_mode: BLEND_MODE_ADD
+  particle_orientation: PARTICLE_ORIENTATION_DEFAULT
+  inherit_velocity: 0
+  max_particle_count: 128
+  type: EMITTER_TYPE_CONE
+  properties {
+    key: EMITTER_KEY_SPAWN_RATE
+    points {
+      x: 0.0
+      y: 50
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_X
+    points {
+      x: 0.0
+      y: 4.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_Y
+    points {
+      x: 0.0
+      y: 12.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_Z
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_LIFE_TIME
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SPEED
+    points {
+      x: 0.0
+      y: 150.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SIZE
+    points {
+      x: 0.0
+      y: 20.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_RED
+    points {
+      x: 0.0
+      y: 0.98889387
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.16088632
+      y: 1.0017536
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.3362235
+      y: 0.011552867
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.5009634
+      y: 0.011552867
+      t_x: 0.99999565
+      t_y: -0.0029591909
+    }
+    points {
+      x: 0.6628131
+      y: -0.0013068834
+      t_x: 0.9999922
+      t_y: -0.0039447504
+    }
+    points {
+      x: 0.84393066
+      y: 1.0017536
+      t_x: 0.9999958
+      t_y: -0.0028895843
+    }
+    points {
+      x: 1.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_GREEN
+    points {
+      x: 0.0
+      y: 0.011552867
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.15895954
+      y: 1.0017536
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.3381503
+      y: 1.0017536
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.5
+      y: 1.0017536
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.66088635
+      y: -0.0013068834
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.8477842
+      y: -0.0013068834
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 1.0
+      y: 0.011552867
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_BLUE
+    points {
+      x: 0.0
+      y: 0.037272368
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.15703276
+      y: 0.024412617
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.3371869
+      y: 0.011552867
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.5019268
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.6628131
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 0.84489405
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    points {
+      x: 1.0
+      y: -0.0013068834
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_ALPHA
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  particle_properties {
+    key: PARTICLE_KEY_SCALE
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_RED
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_GREEN
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_BLUE
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_ALPHA
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 0.07194582
+      t_y: 0.99740857
+    }
+    points {
+      x: 0.11320755
+      y: 0.99277455
+      t_x: 0.99418455
+      t_y: 0.10768964
+    }
+    points {
+      x: 0.7112546
+      y: 0.555656
+      t_x: 0.5694311
+      t_y: -0.82203907
+    }
+    points {
+      x: 1.0
+      y: 0.0072254334
+      t_x: 0.4737472
+      t_y: -0.8806609
+    }
+  }
+  size_mode: SIZE_MODE_AUTO
+}
+modifiers {
+  type: MODIFIER_TYPE_DRAG
+  use_direction: 0
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  properties {
+    key: MODIFIER_KEY_MAGNITUDE
+    points {
+      x: 0.0
+      y: 0.7
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+}

--- a/editor/test/resources/test_project/editor1/ship_thruster_trail.particlefx
+++ b/editor/test/resources/test_project/editor1/ship_thruster_trail.particlefx
@@ -251,6 +251,7 @@ emitters {
       t_y: 0.0
     }
   }
+  size_mode: SIZE_MODE_MANUAL
 }
 emitters {
   id: "jetcore2"
@@ -505,4 +506,5 @@ emitters {
       t_y: 0.0
     }
   }
+  size_mode: SIZE_MODE_MANUAL
 }

--- a/editor/test/resources/test_project/editor1/test.particlefx
+++ b/editor/test/resources/test_project/editor1/test.particlefx
@@ -252,6 +252,7 @@ emitters {
       spread: 10.0
     }
   }
+  size_mode: SIZE_MODE_MANUAL
 }
 modifiers {
   type: MODIFIER_TYPE_DRAG


### PR DESCRIPTION
Fixes defold/editor2-issues#195

* ParticleFX build step produced curves without keys, confusing the runtime.
* `math/inv-transform` was broken, and also broke its inputs. It is now pure.
* The Size Mode property was not respected by the new editor, and was in fact stripped out if set.
* We now have tests for all of the above.