### PR TITLE
Store if playable uploaded.

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/model/ProjectSite.java
+++ b/server/src/main/java/com/dynamo/cr/server/model/ProjectSite.java
@@ -36,6 +36,9 @@ public class ProjectSite {
     @Column
     private String reviewUrl;
 
+    @Column
+    private boolean playableUploaded;
+
     @OneToMany(cascade = CascadeType.ALL)
     private Set<AppStoreReference> appStoreReferences = new HashSet<>();
 
@@ -120,5 +123,13 @@ public class ProjectSite {
 
     public void setScreenshots(Set<Screenshot> screenShots) {
         this.screenshots = screenShots;
+    }
+
+    public boolean isPlayableUploaded() {
+        return playableUploaded;
+    }
+
+    public void setPlayableUploaded(boolean playableUploaded) {
+        this.playableUploaded = playableUploaded;
     }
 }

--- a/server/src/main/java/com/dynamo/cr/server/resources/mappers/ProjectSiteMapper.java
+++ b/server/src/main/java/com/dynamo/cr/server/resources/mappers/ProjectSiteMapper.java
@@ -25,13 +25,14 @@ public class ProjectSiteMapper {
     public static Protocol.ProjectSite map(Project project, MagazineClient magazineClient) {
         Protocol.ProjectSite.Builder builder = Protocol.ProjectSite.newBuilder();
 
-        // TODO: Keep track of if a playable has been uploaded?
-        builder.setPlayableUrl(magazineClient.createReadUrl("/projects/" + project.getId() + "/playable") + "/index.html");
-
         if (project.getProjectSite() != null) {
             ProjectSite projectSite = project.getProjectSite();
 
             builder.setProjectId(project.getId());
+
+            if (projectSite.isPlayableUploaded()) {
+                builder.setPlayableUrl(magazineClient.createReadUrl("/projects/" + project.getId() + "/playable") + "/index.html");
+            }
 
             if (projectSite.getName() != null) {
                 builder.setName(projectSite.getName());

--- a/server/src/main/java/com/dynamo/cr/server/services/ProjectService.java
+++ b/server/src/main/java/com/dynamo/cr/server/services/ProjectService.java
@@ -126,6 +126,7 @@ public class ProjectService {
         }
     }
 
+    @Transactional
     public void uploadPlayableFiles(String username, Long projectId, InputStream file) throws Exception {
         Path tempFile = null;
 
@@ -138,6 +139,8 @@ public class ProjectService {
 
             uploadPlayableFiles(username, projectId, playablePath);
 
+            ProjectSite projectSite = getProjectSite(projectId);
+            projectSite.setPlayableUploaded(true);
         } finally {
             if (tempFile != null) {
                 Files.deleteIfExists(tempFile);

--- a/server/src/test/java/com/dynamo/cr/server/resources/v2/ProjectSitesResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/v2/ProjectSitesResourceTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ProjectSitesResourceTest extends AbstractResourceTest {
 
@@ -193,6 +194,11 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
     public void uploadPlayable() throws URISyntaxException {
         Protocol.ProjectInfo project = createProject(TestUser.JAMES);
 
+        Protocol.ProjectSite projectSite = getProjectSite(TestUser.JAMES, project.getId());
+
+        // Project site should not have playable yet.
+        assertFalse(projectSite.hasPlayableUrl());
+
         File playableFile = new File(ClassLoader.getSystemResource("test_playable.zip").toURI());
 
         MultiPart multiPart = new MultiPart(MediaType.MULTIPART_FORM_DATA_TYPE);
@@ -204,7 +210,7 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
                 .type(MediaType.MULTIPART_FORM_DATA_TYPE)
                 .put(multiPart);
 
-        Protocol.ProjectSite projectSite = getProjectSite(TestUser.JAMES, project.getId());
+        projectSite = getProjectSite(TestUser.JAMES, project.getId());
         System.out.println(projectSite.getPlayableUrl());
     }
 }


### PR DESCRIPTION
This adds a boolean that keeps track of if a HTML5 playable has been
uploaded to the project site or not. IFF a playable has been uploaded,
the playable URL should be a part of the project site response.