### PR TITLE
DEFEDIT-783 Customise font size for demo purposes

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -334,9 +334,9 @@
 
 (defn ^Parent load-fxml [path]
   (let [root ^Parent (FXMLLoader/load (io/resource path))
-        css (io/file "editor.css")]
-    (when (and (.exists css) (seq (.getStylesheets root)))
-      (.setAll (.getStylesheets root) ^java.util.Collection (vec [(str (.toURI css))])))
+        css (io/file (System/getProperty "user.home") ".defold" "editor.css")]
+    (when (.exists css)
+      (.. root getStylesheets (add (str (.toURI css)))))
     root))
 
 (extend-type Window

--- a/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
+++ b/editor/src/java/com/defold/editor/eclipse/DefoldStyledTextSkin.java
@@ -329,8 +329,7 @@ public class DefoldStyledTextSkin extends SkinBase<StyledTextArea> {
 		});
 		contentView.setMinHeight(0);
 		contentView.setMinWidth(0);
-		// this.contentView.setFixedCellSize(value);
-		// this.contentView.setFixedCellSize(15);
+		contentView.setFixedCellSize(0); // size cells after content
 		contentView.setOnMousePressed(new EventHandler<MouseEvent>() {
 
 			@Override


### PR DESCRIPTION
This will allow @britzl to change font sizes for GDC demo.

To test, put something like the following in `~/.defold/editor.css`:

```css
.root {
    -fx-font-size: 18px;
}

.styled-text-area .source-segment, .styled-text-area .plain-source-segment {
    -fx-font-size: 18px;
}

.line-ruler-text {
    -fx-font-size: 18px;
}

.titled-pane > .title {
    -fx-font-size: 18px;
}

.button, .button-small, .button-large {
  -fx-font-size: 18px;
}

```