### PR TITLE
DEFEDIT-792 Prevent dialog resize

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -304,7 +304,7 @@
 
 (defn make-about-dialog []
   (let [root ^Parent (ui/load-fxml "about.fxml")
-        stage (ui/make-stage)
+        stage (ui/make-dialog-stage)
         scene (Scene. root)
         controls (ui/collect-controls root ["version" "sha1" "time"])]
     (ui/text! (:version controls) (str "Version: " (System/getProperty "defold.version" "NO VERSION")))

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -62,7 +62,7 @@
 
 (defn open-welcome [prefs cont]
   (let [^VBox root (ui/load-fxml "welcome.fxml")
-        stage (ui/make-stage)
+        stage (ui/make-dialog-stage)
         scene (Scene. root)
         ^ListView recent-projects (.lookup root "#recent-projects")
         ^Button open-project (.lookup root "#open-project")
@@ -101,7 +101,6 @@
                    (into-array File))]
       (.addAll (.getItems recent-projects) ^"[Ljava.io.File;" recent))
     (.setScene stage scene)
-    (.setResizable stage false)
     (ui/show! stage)))
 
 (defn- load-namespaces-in-background

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -99,7 +99,8 @@
 
 (defn load-stage [workspace project prefs]
   (let [^VBox root (ui/load-fxml "editor.fxml")
-        stage      (ui/make-stage)
+        stage      (doto (ui/make-stage)
+                     (.. getIcons (add ui/application-icon-image)))
         scene      (Scene. root)]
     (ui/observe (.focusedProperty stage)
                 (fn [property old-val new-val]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -99,8 +99,7 @@
 
 (defn load-stage [workspace project prefs]
   (let [^VBox root (ui/load-fxml "editor.fxml")
-        stage      (doto (ui/make-stage)
-                     (.. getIcons (add ui/application-icon-image)))
+        stage      (ui/make-stage)
         scene      (Scene. root)]
     (ui/observe (.focusedProperty stage)
                 (fn [property old-val new-val]

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -1429,7 +1429,7 @@
           result (promise)
           current-line (line source-viewer)
           target (completion-pattern nil (line-offset source-viewer) current-line offset)
-          ^Stage stage (dialogs/make-proposal-dialog result screen-position proposals target (text-area source-viewer))
+          ^Stage stage (dialogs/make-proposal-popup result screen-position proposals target (text-area source-viewer))
           replace-text-fn (fn [] (when (and (realized? result) @result)
                                    (do-proposal-replacement source-viewer (first @result))
                                    (typing-changes! source-viewer)))]

--- a/editor/src/clj/editor/diff_view.clj
+++ b/editor/src/clj/editor/diff_view.clj
@@ -122,7 +122,8 @@
 
 (defn make-diff-viewer [left-name raw-str-left right-name raw-str-right]
   (let [root ^Parent (ui/load-fxml "diff.fxml")
-        stage (ui/make-stage)
+        stage (doto (ui/make-stage)
+                (.initOwner (ui/main-stage)))
         scene (Scene. root)
         str-left (text-util/crlf->lf raw-str-left)
         str-right (text-util/crlf->lf raw-str-right)

--- a/editor/src/clj/editor/login.clj
+++ b/editor/src/clj/editor/login.clj
@@ -38,7 +38,7 @@
 
 (defn- open-login-dialog [prefs client]
   (let [root ^Parent (ui/load-fxml "login.fxml")
-        stage (ui/make-stage)
+        stage (ui/make-dialog-stage)
         scene (Scene. root)
         web-view ^WebView (.lookup root "#web")
         engine (.getEngine web-view)
@@ -57,7 +57,6 @@
                        (log/error :exception e)))
                    (ui/run-later (ui/close! stage))
                    (NanoHTTPD$Response. "")))]
-    (.initModality stage Modality/APPLICATION_MODAL)
     (.setTitle stage "Login")
     (.start server)
     (.setOnHidden stage (ui/event-handler event (.stop server)))

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -92,15 +92,13 @@
 
 (defn open-prefs [prefs]
   (let [root ^Parent (ui/load-fxml "prefs.fxml")
-        stage (ui/make-stage)
+        stage (ui/make-dialog-stage (ui/main-stage))
         scene (Scene. root)]
 
     (doseq [p (pref-pages)]
       (add-page! prefs root p))
 
-    (.initOwner stage (ui/main-stage))
     (ui/title! stage "Preferences")
-    (.initModality stage Modality/WINDOW_MODAL)
     (.setScene stage scene)
 
     (.addEventFilter scene KeyEvent/KEY_PRESSED

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -340,7 +340,7 @@
   (let [root            ^Parent (ui/load-fxml "sync-dialog.fxml")
         pull-root       ^Parent (ui/load-fxml "sync-pull.fxml")
         push-root       ^Parent (ui/load-fxml "sync-push.fxml")
-        stage           (ui/make-stage)
+        stage           (ui/make-dialog-stage (ui/main-stage))
         scene           (Scene. root)
         dialog-controls (ui/collect-controls root ["ok" "push" "cancel" "dialog-area" "progress-bar"])
         pull-controls   (ui/collect-controls pull-root ["conflicting" "resolved" "conflict-box" "main-label"])
@@ -444,7 +444,6 @@
 
                              nil)))]
     (dialogs/observe-focus stage)
-    (.initOwner stage (ui/main-stage))
     (update-controls @!flow)
     (add-watch !flow :updater (fn [_ _ _ flow]
                                 (update-controls flow)))
@@ -526,8 +525,6 @@
                                          (when (= code KeyCode/ESCAPE) true
                                                (cancel-flow! !flow)
                                                (.close stage)))))
-
-    (.initModality stage Modality/APPLICATION_MODAL)
     (.setScene stage scene)
 
     (try

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -212,7 +212,6 @@
 (defn make-target-log-dialog []
   (let [root        ^Parent (ui/load-fxml "target-log.fxml")
         stage       (doto (ui/make-stage)
-                      (.setAlwaysOnTop true)
                       (.initOwner (ui/main-stage)))
         scene       (Scene. root)
         controls    (ui/collect-controls root ["message" "ok" "clear" "restart"])

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -21,6 +21,7 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.ButtonBase;
 import javafx.stage.Modality;
+import javafx.stage.StageStyle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,8 +111,10 @@ public class Start extends Application {
             stage.close();
         });
 
-        stage.setTitle("Update Available");
+        stage.initStyle(StageStyle.DECORATED);
         stage.initModality(Modality.APPLICATION_MODAL);
+        stage.setTitle("Update Available");
+        stage.setResizable(false);
         stage.setScene(scene);
         stage.showAndWait();
 


### PR DESCRIPTION
* Prevent resizing of dialogs.
* Get rid of application icon in title bars on macOS.
* Avoid application-modal dialogs whenever possible. Use window-modal with the main-stage as the owner instead. Only application-modal windows can enter full-screen mode on macOS, so this stops dialogs from entering full-screen.