### PR TITLE
DEFEDIT-676 Reduce error spam

### DIFF
--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -71,12 +71,18 @@
     {:last-seen now
      :suppressed? (and last-seen (< (- now last-seen) suppress-exception-threshold-ms))}))
 
+(defn- ex-identity
+  [{:keys [cause trace]}]
+  {:cause cause
+   :trace (when (and trace (pos? (count trace)))
+            (subvec trace 0 1))})
+
 (defn- record-exception!
   [exception]
   (let [ex-map (Throwable->map exception)
-        ex-identity (select-keys ex-map [:cause :trace])
-        ret (swap! exception-stats update ex-identity update-stats)]
-    (assoc (get ret ex-identity) :ex-map ex-map)))
+        ex-id (ex-identity ex-map)
+        ret (swap! exception-stats update ex-id update-stats)]
+    (assoc (get ret ex-id) :ex-map ex-map)))
 
 (defn report-exception!
   ([exception]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -298,10 +298,11 @@
    :content (protobuf/map->str Font$FontDesc pb-msg)})
 
 (g/defnk produce-font-map [_node-id font pb-msg]
-  (let [project (project/get-project _node-id)
-        workspace (project/workspace project)
-        resolver (partial workspace/resolve-workspace-resource workspace)]
-    (font-gen/generate pb-msg font resolver)))
+  (or (validation/prop-error :fatal _node-id :font validation/prop-resource-not-exists? font "Font")
+      (let [project (project/get-project _node-id)
+            workspace (project/workspace project)
+            resolver (partial workspace/resolve-workspace-resource workspace)]
+        (font-gen/generate pb-msg font resolver))))
 
 (defn- build-font [self basis resource dep-resources user-data]
   (let [project (project/get-project self)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -76,7 +76,11 @@
 (defn- render-error
   [gl render-args renderables nrenderables]
   (when (= pass/overlay (:pass render-args))
-    (let [errors (set (mapcat root-causes (map (comp :error :user-data) renderables)))]
+    (let [errors (->> renderables
+                      (map (comp :error :user-data))
+                      (mapcat root-causes)
+                      (map #(select-keys % [:_node-id :message]))
+                      set)]
       (scene-text/overlay gl "Render error:" 24.0 -22.0)
       (doseq [[n error] (partition 2 (interleave (range) errors))]
         (let [message (format "- %s: %s"


### PR DESCRIPTION
- reduce error spam by only looking at message and top stack frame when considering which exceptions to report
- fix unrelated minor bug where same error was rendered multiple times in scene view
- fix unrelated bug where we tried to generate font data when font resource was not found
