### PR TITLE
DEFEDIT-799 Initially setting toolbar choicebox items should not invo…

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -736,7 +736,9 @@
   ([^Scene scene]
     (contexts scene true))
   ([^Scene scene all-selections?]
-    (node-contexts (or (.getFocusOwner scene) (.getRoot scene)) all-selections?)))
+    (if scene
+      (node-contexts (or (.getFocusOwner scene) (.getRoot scene)) all-selections?)
+      [])))
 
 (defn extend-menu [id location menu]
   (menu/extend-menu id location menu))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1080,6 +1080,7 @@
                                                             (.setConverter (proxy [StringConverter] []
                                                                              (fromString [str] (some #{str} (map :label opts)))
                                                                              (toString [v] (:label v)))))]
+                                                   (.setAll (.getItems cb) ^java.util.Collection opts)
                                                    (observe (.valueProperty cb) (fn [this old new]
                                                                                   (when new
                                                                                     (let [scene (.getScene control)
@@ -1088,8 +1089,6 @@
                                                                                         (when (handler/enabled? handler-ctx)
                                                                                           (handler/run handler-ctx)
                                                                                           (refresh scene)))))))
-                                                   (doseq [opt opts]
-                                                     (.add (.getItems cb) opt))
                                                    (.add (.getChildren hbox) (jfx/get-image-view (:icon menu-item) 16))
                                                    (.add (.getChildren hbox) cb)
                                                    hbox)


### PR DESCRIPTION
…ke observer

* The original issue could not be reproduced
* It looked like the observer was called (as a result from setting the items) before the control was added to the scene
* The fix is to set the items before adding the observer, which seems more correct anyway