### PR TITLE
DEFEDIT-802 Tilemap with absent tilesource

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -512,7 +512,7 @@
   (input resources g/Any)
   (input resource-map g/Any)
   (input resource-types g/Any)
-  (input save-data g/Any :array :substitute (fn [save-data] (vec (remove g/error? save-data))))
+  (input save-data g/Any :array :substitute gu/array-subst-remove-errors)
   (input node-resources resource/Resource :array)
   (input settings g/Any :substitute (constantly (gpc/default-settings)))
   (input display-profiles g/Any)

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -17,3 +17,7 @@
 (defn disconnect-all [basis node-id label]
   (for [[src-node-id src-label] (g/sources-of basis node-id label)]
     (g/disconnect src-node-id src-label node-id label)))
+
+(defn array-subst-remove-errors [arr]
+  (vec (remove g/error? arr)))
+

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -318,7 +318,7 @@
   (input scene g/Any :substitute substitute-scene)
   (input selection g/Any)
   (input camera Camera)
-  (input aux-renderables pass/RenderData :array)
+  (input aux-renderables pass/RenderData :array :substitute gu/array-subst-remove-errors)
 
   (output viewport Region :abstract)
   (output all-renderables g/Any :abstract)

--- a/editor/src/clj/editor/tile_map_grid.clj
+++ b/editor/src/clj/editor/tile_map_grid.clj
@@ -105,7 +105,7 @@
 
 (g/defnode TileMapGrid
   (input camera Camera)
-  (input grid-size g/Any)
+  (input grid-size g/Any :substitute nil)
 
   (output grid       g/Any :cached update-grid)
   (output renderable pass/RenderData :cached grid-renderable))


### PR DESCRIPTION
A tile map referring to a tile source without image set would via the TileMapGrid :grid propagate an error value to the SceneRenderer's :aux-renderables. This in turn causes an NPE in update-image-view! because the active-updatables is now an error. Things like :selected-aabb also become errors, breaking for instance frame-selection. The fix prevents the error leaving TileMapGrid, and for good measure filters out error values from :aux-renderables. 

Fixes defold/editor2-issues#511