### PR TITLE
DEFEDIT-788 Script component property saved in format not compatible with editor 1

### DIFF
--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -453,8 +453,7 @@
   (with-build-results "/script/props.collection"
     (doseq [[res-path pb decl-path] [["/script/props.script" Lua$LuaModule [:properties]]
                                      ["/script/props.go" GameObject$PrototypeDesc [:components 0 :property-decls]]
-                                     ["/script/props.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls]]
-                                     ["/script/props.collection" GameObject$CollectionDesc [:instances 1 :component-properties 0 :property-decls]]]]
+                                     ["/script/props.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls]]]]
       (let [content (get content-by-source res-path)
             desc (protobuf/bytes->map pb content)
             decl (get-in desc decl-path)]
@@ -467,7 +466,24 @@
         (is (not-empty (:bool-entries decl)))
         (is (not-empty (:float-values decl)))
         (is (not-empty (:hash-values decl)))
-        (is (not-empty (:string-values decl))))))
+        (is (not-empty (:string-values decl)))))
+    (let [collection-content (get content-by-source "/script/props.collection")
+          collection-desc (protobuf/bytes->map GameObject$CollectionDesc collection-content)
+          instance-map (into {} (map (juxt :id identity) (:instances collection-desc)))
+          embedded-props-target (:prototype (instance-map "/embedded_props"))
+          embedded-content (content-by-target embedded-props-target)
+          embedded-desc (protobuf/bytes->map GameObject$PrototypeDesc embedded-content)
+          decl (get-in embedded-desc [:components 0 :property-decls])]
+      (is (not-empty (:number-entries decl)))
+      (is (not-empty (:hash-entries decl)))
+      (is (not-empty (:url-entries decl)))
+      (is (not-empty (:vector3-entries decl)))
+      (is (not-empty (:vector4-entries decl)))
+      (is (not-empty (:quat-entries decl)))
+      (is (not-empty (:bool-entries decl)))
+      (is (not-empty (:float-values decl)))
+      (is (not-empty (:hash-values decl)))
+      (is (not-empty (:string-values decl)))))
   (with-build-results "/script/sub_props.collection"
     (doseq [[res-path pb decl-path] [["/script/sub_props.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls]]]]
       (let [content (get content-by-source res-path)

--- a/editor/test/resources/build_project/SideScroller/script/props.collection
+++ b/editor/test/resources/build_project/SideScroller/script/props.collection
@@ -1,46 +1,130 @@
 name: "props"
 instances {
-    id: "props"
-    prototype: "/script/props.go"
-    scale3 {x: 1.0 y: 1.0 z: 1.0}
-    component_properties {
-        id: "script"
-        properties {id: "number" value: "3.0" type: PROPERTY_TYPE_NUMBER}
-        properties {id: "hash" value: "hash3" type: PROPERTY_TYPE_HASH}
-        properties {id: "url" value: "/url2" type: PROPERTY_TYPE_URL}
-        properties {id: "vec3" value: "2.0,3.0,4.0" type: PROPERTY_TYPE_VECTOR3}
-        properties {id: "quat" value: "1.0,0.0,0.0,0.0" type: PROPERTY_TYPE_QUAT}
-        properties {id: "vec4" value: "1.0,2.0,3.0,4.0" type: PROPERTY_TYPE_VECTOR4}
-        properties {id: "bool" value: "true" type: PROPERTY_TYPE_BOOLEAN}
+  id: "props"
+  prototype: "/script/props.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  component_properties {
+    id: "script"
+    properties {
+      id: "number"
+      value: "3.0"
+      type: PROPERTY_TYPE_NUMBER
     }
+    properties {
+      id: "url"
+      value: "/url2"
+      type: PROPERTY_TYPE_URL
+    }
+    properties {
+      id: "hash"
+      value: "hash3"
+      type: PROPERTY_TYPE_HASH
+    }
+    properties {
+      id: "vec3"
+      value: "2.0,3.0,4.0"
+      type: PROPERTY_TYPE_VECTOR3
+    }
+    properties {
+      id: "vec4"
+      value: "1.0,2.0,3.0,4.0"
+      type: PROPERTY_TYPE_VECTOR4
+    }
+    properties {
+      id: "quat"
+      value: "1.0,0.0,0.0,0.0"
+      type: PROPERTY_TYPE_QUAT
+    }
+    properties {
+      id: "bool"
+      value: "true"
+      type: PROPERTY_TYPE_BOOLEAN
+    }
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
+scale_along_z: 0
 embedded_instances {
-    id: "embedded_props"
-    data: "components {\n"
-    "  id: \"script\"\n"
-    "  component: \"/script/props.script\"\n"
-    "  position {\n"
-    "    x: 0.0\n"
-    "    y: 0.0\n"
-    "    z: 0.0\n"
-    "  }\n"
-    "  rotation {\n"
-    "    x: 0.0\n"
-    "    y: 0.0\n"
-    "    z: 0.0\n"
-    "    w: 1.0\n"
-    "  }\n"
-    "}\n"
-    ""
-    scale3 {x: 1.0 y: 1.0 z: 1.0}
-    component_properties {
-        id: "script"
-        properties {id: "number" value: "3.0" type: PROPERTY_TYPE_NUMBER}
-        properties {id: "hash" value: "hash3" type: PROPERTY_TYPE_HASH}
-        properties {id: "url" value: "/url2" type: PROPERTY_TYPE_URL}
-        properties {id: "vec3" value: "2.0,3.0,4.0" type: PROPERTY_TYPE_VECTOR3}
-        properties {id: "quat" value: "1.0,0.0,0.0,0.0" type: PROPERTY_TYPE_QUAT}
-        properties {id: "vec4" value: "1.0,2.0,3.0,4.0" type: PROPERTY_TYPE_VECTOR4}
-        properties {id: "bool" value: "true" type: PROPERTY_TYPE_BOOLEAN}
-    }
+  id: "embedded_props"
+  data: "components {\n"
+  "  id: \"script\"\n"
+  "  component: \"/script/props.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"number\"\n"
+  "    value: \"3.0\"\n"
+  "    type: PROPERTY_TYPE_NUMBER\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"url\"\n"
+  "    value: \"url2\"\n"
+  "    type: PROPERTY_TYPE_URL\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"hash\"\n"
+  "    value: \"hash3\"\n"
+  "    type: PROPERTY_TYPE_HASH\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"vec3\"\n"
+  "    value: \"2.0,3.0,4.0\"\n"
+  "    type: PROPERTY_TYPE_VECTOR3\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"vec4\"\n"
+  "    value: \"1.0,2.0,3.0,4.0\"\n"
+  "    type: PROPERTY_TYPE_VECTOR4\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"quat\"\n"
+  "    value: \"0.0087265,0.0,0.0,0.9999619\"\n"
+  "    type: PROPERTY_TYPE_QUAT\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"bool\"\n"
+  "    value: \"true\"\n"
+  "    type: PROPERTY_TYPE_BOOLEAN\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }

--- a/editor/test/resources/test_project/collection/props.collection
+++ b/editor/test/resources/test_project/collection/props.collection
@@ -1,38 +1,90 @@
 name: "props"
 instances {
-    id: "props"
-    prototype: "/game_object/props.go"
-    scale3 {x: 1.0 y: 1.0 z: 1.0}
-    component_properties {
-        id: "script"
-        properties {id: "number" value: "3.0" type: PROPERTY_TYPE_NUMBER}
-        properties {id: "hash" value: "hash3" type: PROPERTY_TYPE_HASH}
-        properties {id: "url" value: "/url2" type: PROPERTY_TYPE_URL}
+  id: "props"
+  prototype: "/game_object/props.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  component_properties {
+    id: "script"
+    properties {
+      id: "number"
+      value: "3.0"
+      type: PROPERTY_TYPE_NUMBER
     }
+    properties {
+      id: "hash"
+      value: "hash3"
+      type: PROPERTY_TYPE_HASH
+    }
+    properties {
+      id: "url"
+      value: "/url2"
+      type: PROPERTY_TYPE_URL
+    }
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }
+scale_along_z: 0
 embedded_instances {
-    id: "props_embedded"
-    data: "components {\n"
-    "  id: \"script\"\n"
-    "  component: \"/script/props.script\"\n"
-    "  position {\n"
-    "    x: 0.0\n"
-    "    y: 0.0\n"
-    "    z: 0.0\n"
-    "  }\n"
-    "  rotation {\n"
-    "    x: 0.0\n"
-    "    y: 0.0\n"
-    "    z: 0.0\n"
-    "    w: 1.0\n"
-    "  }\n"
-    "}\n"
-    ""
-    scale3 {x: 1.0 y: 1.0 z: 1.0}
-    component_properties {
-        id: "script"
-        properties {id: "number" value: "3.0" type: PROPERTY_TYPE_NUMBER}
-        properties {id: "hash" value: "hash3" type: PROPERTY_TYPE_HASH}
-        properties {id: "url" value: "/url2" type: PROPERTY_TYPE_URL}
-    }
+  id: "props_embedded"
+  data: "components {\n"
+  "  id: \"script\"\n"
+  "  component: \"/script/props.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"number\"\n"
+  "    value: \"3.0\"\n"
+  "    type: PROPERTY_TYPE_NUMBER\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"hash\"\n"
+  "    value: \"hash3\"\n"
+  "    type: PROPERTY_TYPE_HASH\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"url\"\n"
+  "    value: \"/url2\"\n"
+  "    type: PROPERTY_TYPE_URL\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
 }


### PR DESCRIPTION
Overrides of script properties in embedded game objects were saved as
instance overrides in component_properties whereas editor 1 saves them
as part of the singleton prototype data string. This commit
essentially reverts parts of d6949a7322d46932dafc9744fd0cb4e64a99115b.