### PR TITLE
DEFEDIT-810 Exception when changing name of go.property

### DIFF
--- a/editor/src/clj/editor/script.clj
+++ b/editor/src/clj/editor/script.clj
@@ -3,6 +3,7 @@
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [editor.code-completion :as code-completion]
+            [internal.util :as iutil]
             [editor.types :as t]
             [editor.geom :as geom]
             [editor.gl :as gl]
@@ -165,7 +166,11 @@
 
   ;; todo replace this with the lua-parser modules
   (output modules g/Any :cached (g/fnk [code] (lua-scan/src->modules code)))
-  (output script-properties g/Any :cached (g/fnk [code] (lua-scan/src->properties code)))
+  (output script-properties g/Any :cached (g/fnk [code]
+                                                 (->> (lua-scan/src->properties code)
+                                                      (filter #(not (string/blank? (:name %))))
+                                                      (iutil/distinct-by :name)
+                                                      vec)))
   (output user-properties g/Properties :cached produce-user-properties)
   (output _properties g/Properties :cached (g/fnk [_declared-properties user-properties]
                                                   ;; TODO - fix this when corresponding graph issue has been fixed

--- a/editor/test/editor/properties_test.clj
+++ b/editor/test/editor/properties_test.clj
@@ -33,7 +33,7 @@
   (into {} (map (fn [[k v]]
                   [k (assoc v
                             :node-id _node-id
-                            :type v)])
+                            :type (type (:value v)))])
                 p)))
 
 (g/defnode UserProps


### PR DESCRIPTION
* filter out duplicate/unnamed script properties
* only use override properties if the value matches the underlying
  property type
* fix apparently broken properties_tests with properties missing/with
  wrong type