### PR TITLE
DEFEDIT-813 Use platform support path when unpacking/logging

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -16,9 +16,8 @@ jre = ${bootstrap.resourcespath}/packages/jre
 java = ${launcher.jre}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.sha1}.jar
 main = com.defold.editor.Start
-log = ${bootstrap.supportpath}/editor2.log
 debug = 1
-vmargs = -Ddefold.editor2.log=${launcher.log},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.supportpath=${bootstrap.supportpath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
+vmargs = -Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.supportpath=${bootstrap.supportpath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -1,8 +1,11 @@
 [bootstrap]
-# This field does not support replacements.
-# It will probably only be used for testing purposes.
+# These fields do not support replacements.
+# They are only here for testing purposes.
+
 # If left unset, it defaults to the installation resources path.
 resourcespath =
+# If left unset, it defaults to the platform application support path
+supportpath = 
 [build]
 # These fields are filled in by bundle.py
 version = 2.0.0
@@ -13,9 +16,9 @@ jre = ${bootstrap.resourcespath}/packages/jre
 java = ${launcher.jre}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.sha1}.jar
 main = com.defold.editor.Start
-log =
+log = ${bootstrap.supportpath}/editor2.log
 debug = 1
-vmargs = -Ddefold.editor2.log=${launcher.log},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
+vmargs = -Ddefold.editor2.log=${launcher.log},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.supportpath=${bootstrap.supportpath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -19,8 +19,7 @@
                      [prismatic/plumbing                          "0.5.2"]
                      [at.bestsolution.eclipse/org.eclipse.fx.code.editor.fx "2.2.0"]
                      [com.google.protobuf/protobuf-java           "2.3.0"]
-                     [org.slf4j/slf4j-api                         "1.7.14"]
-                     [ch.qos.logback/logback-classic              "1.1.3"]
+                     [ch.qos.logback/logback-classic              "1.2.1"]
                      [joda-time/joda-time                         "2.9.2"]
                      [commons-io/commons-io                       "2.4"]
                      [commons-configuration/commons-configuration "1.10"

--- a/editor/resources/logback.xml
+++ b/editor/resources/logback.xml
@@ -6,7 +6,7 @@
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>${defold.editor2.log:-editor2.log}</file>
+    <file>${defold.supportpath:-.}/editor2.log</file>
     <append>true</append>
     <encoder>
 	<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>

--- a/editor/resources/logback.xml
+++ b/editor/resources/logback.xml
@@ -5,11 +5,18 @@
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>${defold.supportpath:-.}/editor2.log</file>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <append>true</append>
+    <prudent>true</prudent>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${defold.supportpath:-.}/editor2.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+
     <encoder>
-	<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -25,6 +25,8 @@ import com.defold.editor.Platform;
 public class ResourceUnpacker {
 
     public static final String DEFOLD_UNPACK_PATH_KEY = "defold.unpack.path";
+    public static final String DEFOLD_SUPPORT_PATH_KEY = "defold.supportpath";
+    public static final String DEFOLD_SHA1_KEY = "defold.sha1";
 
     private static boolean isInitialized = false;
     private static Logger logger = LoggerFactory.getLogger(ResourceUnpacker.class);
@@ -95,18 +97,24 @@ public class ResourceUnpacker {
     }
 
     private static Path getUnpackPath() throws IOException {
-        String unpackPath = System.getProperty(DEFOLD_UNPACK_PATH_KEY);
-        if (unpackPath != null) {
-            Path p = Paths.get(unpackPath);
-            File f = p.toFile();
-            if (f.exists()) {
-                FileUtils.cleanDirectory(f);
-            } else {
-                f.mkdirs();
-            }
-            return p;
+        if (System.getProperty(DEFOLD_UNPACK_PATH_KEY) != null) {
+            return ensureEmptyDirectory(Paths.get(System.getProperty(DEFOLD_UNPACK_PATH_KEY)));
+        } else if (System.getProperty(DEFOLD_SUPPORT_PATH_KEY) != null && System.getProperty(DEFOLD_SHA1_KEY) != null)) {
+            return ensureEmptyDirectory(Paths.get(System.getProperty(DEFOLD_SUPPORT_PATH_KEY),
+                                                  "unpack",
+                                                  System.getProperty(DEFOLD_SHA1_KEY)));
         } else {
             return Files.createTempDirectory("defold-unpack");
         }
+    }
+
+    private static Path ensureEmptyDirectory(Path path) throws IOException {
+        File f = path.toFile();
+        if (f.exists()) {
+            FileUtils.cleanDirectory(f);
+        } else {
+            f.mkdirs();
+        }
+        return path;
     }
 }

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -99,7 +99,7 @@ public class ResourceUnpacker {
     private static Path getUnpackPath() throws IOException {
         if (System.getProperty(DEFOLD_UNPACK_PATH_KEY) != null) {
             return ensureEmptyDirectory(Paths.get(System.getProperty(DEFOLD_UNPACK_PATH_KEY)));
-        } else if (System.getProperty(DEFOLD_SUPPORT_PATH_KEY) != null && System.getProperty(DEFOLD_SHA1_KEY) != null)) {
+        } else if (System.getProperty(DEFOLD_SUPPORT_PATH_KEY) != null && System.getProperty(DEFOLD_SHA1_KEY) != null) {
             return ensureEmptyDirectory(Paths.get(System.getProperty(DEFOLD_SUPPORT_PATH_KEY),
                                                   "unpack",
                                                   System.getProperty(DEFOLD_SHA1_KEY)));

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -81,8 +81,12 @@ public class ResourceUnpacker {
                     if (dest.equals(target)) {
                         continue;
                     }
-                    logger.debug("unpacking '{}' to '{}'", source, dest);
-                    Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
+                    if (Files.exists(dest)) {
+                        logger.debug("skipping already unpacked '{}'", source);
+                    } else {
+                        logger.debug("unpacking '{}' to '{}'", source, dest);
+                        Files.copy(source, dest);
+                    }
                 }
             }
         }
@@ -98,21 +102,19 @@ public class ResourceUnpacker {
 
     private static Path getUnpackPath() throws IOException {
         if (System.getProperty(DEFOLD_UNPACK_PATH_KEY) != null) {
-            return ensureEmptyDirectory(Paths.get(System.getProperty(DEFOLD_UNPACK_PATH_KEY)));
+            return ensureDirectory(Paths.get(System.getProperty(DEFOLD_UNPACK_PATH_KEY)));
         } else if (System.getProperty(DEFOLD_SUPPORT_PATH_KEY) != null && System.getProperty(DEFOLD_SHA1_KEY) != null) {
-            return ensureEmptyDirectory(Paths.get(System.getProperty(DEFOLD_SUPPORT_PATH_KEY),
-                                                  "unpack",
-                                                  System.getProperty(DEFOLD_SHA1_KEY)));
+            return ensureDirectory(Paths.get(System.getProperty(DEFOLD_SUPPORT_PATH_KEY),
+                                             "unpack",
+                                             System.getProperty(DEFOLD_SHA1_KEY)));
         } else {
             return Files.createTempDirectory("defold-unpack");
         }
     }
 
-    private static Path ensureEmptyDirectory(Path path) throws IOException {
+    private static Path ensureDirectory(Path path) throws IOException {
         File f = path.toFile();
-        if (f.exists()) {
-            FileUtils.cleanDirectory(f);
-        } else {
+        if (!f.exists()) {
             f.mkdirs();
         }
         return path;

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -24,7 +24,7 @@
 
 // bootstrap.resourcespath must default to resourcespath of the installation
 #define RESOURCES_PATH_KEY ("bootstrap.resourcespath")
-#define LOG_PATH_KEY ("launcher.log")
+#define SUPPORT_PATH_KEY ("bootstrap.supportpath")
 #define MAX_ARGS_SIZE (10 * DMPATH_MAX_PATH)
 
 struct ReplaceContext
@@ -32,8 +32,8 @@ struct ReplaceContext
     dmConfigFile::HConfig m_Config;
     // Will be set to either bootstrap.resourcespath (if set) or the default installation resources path
     const char* m_ResourcesPath;
-    // Will be set to launcher.log or default log path
-    const char* m_LogPath;
+    // Will be set to either bootstrap.supportpath (if set) or the platform application support path
+    const char* m_SupportPath;
 };
 
 static const char* ReplaceCallback(void* user_data, const char* key)
@@ -44,9 +44,9 @@ static const char* ReplaceCallback(void* user_data, const char* key)
     {
         return context->m_ResourcesPath;
     }
-    else if (dmStrCaseCmp(key, LOG_PATH_KEY) == 0)
+    else if (dmStrCaseCmp(key, SUPPORT_PATH_KEY) == 0)
     {
-        return context->m_LogPath;
+        return context->m_SupportPath;
     }
 
     return dmConfigFile::GetString(context->m_Config, key, 0x0);
@@ -91,7 +91,6 @@ int Launch(int argc, char **argv) {
     char default_resources_path[DMPATH_MAX_PATH];
     char config_path[DMPATH_MAX_PATH];
     char application_support_path[DMPATH_MAX_PATH];
-    char default_logfile_path[DMPATH_MAX_PATH];
     char java_path[DMPATH_MAX_PATH];
     char jar_path[DMPATH_MAX_PATH];
     char os_args[MAX_ARGS_SIZE];
@@ -111,9 +110,6 @@ int Launch(int argc, char **argv) {
         dmLogFatal("Failed to locate application support path (%d)", r);
         return 5;
     }
-
-    dmStrlCpy(default_logfile_path, application_support_path, sizeof(default_logfile_path));
-    dmStrlCat(default_logfile_path, "/editor2.log", sizeof(default_logfile_path));
 
     dmConfigFile::HConfig config;
     dmConfigFile::Result cr = dmConfigFile::Load(config_path, argc, (const char**) argv, &config);
@@ -135,10 +131,10 @@ int Launch(int argc, char **argv) {
         context.m_ResourcesPath = default_resources_path;
     }
 
-    context.m_LogPath = dmConfigFile::GetString(config, LOG_PATH_KEY, default_logfile_path);
-    if (*context.m_LogPath == '\0')
+    context.m_SupportPath = dmConfigFile::GetString(config, SUPPORT_PATH_KEY, application_support_path);
+    if (*context.m_SupportPath == '\0')
     {
-        context.m_LogPath = default_logfile_path;
+        context.m_SupportPath = application_support_path;
     }
 
     const char* main = dmConfigFile::GetString(config, "launcher.main", "Main");
@@ -259,4 +255,5 @@ int main(int argc, char **argv) {
 }
 
 #undef RESOURCES_PATH_KEY
+#undef SUPPORT_PATH_KEY
 #undef MAX_ARGS_SIZE

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -108,11 +108,12 @@ static dmSys::Result GetLocalApplicationSupportPath(const char* application_name
             return dmSys::RESULT_INVAL;
         if (dmStrlCat(path, application_name, path_len) >= path_len)
             return dmSys::RESULT_INVAL;
-
-        if (mkdir(path) == 0)
+        
+        dmSys::Result r =  dmSys::Mkdir(path, 0755);
+        if (r == dmSys::RESULT_EXIST)
             return dmSys::RESULT_OK;
         else
-	    return dmSys::RESULT_IO;
+            return r;
     }
     else
     {
@@ -141,7 +142,7 @@ int Launch(int argc, char **argv) {
     dmStrlCpy(config_path, default_resources_path, sizeof(config_path));
     dmStrlCat(config_path, "/config", sizeof(config_path));
 
-    r = dmSys::GetApplicationSupportPath("Defold", application_support_path, sizeof(application_support_path));
+    r = GetLocalApplicationSupportPath("Defold", application_support_path, sizeof(application_support_path));
     if (r != dmSys::RESULT_OK) {
         dmLogFatal("Failed to locate application support path (%d)", r);
         return 5;


### PR DESCRIPTION
- update launcher to pass application support path (as determined by `dmSys::GetApplicationSupportPath`) through `bootstrap.supportpath` config key
- update resource unpacker to unpack to:
  - `${defold.unpack.path}` if set
  - `${defold.supportpath}/unpack/${defold.sha1}` if both properties set
  -  temp directory otherwise 
- update logging config:
  - use `defold.supportpath` to store logfiles if available
  - cap total log volume to 1GB and roll files daily