### PR TITLE
DEFEDIT-817 Opening a project with unset GUI node template path fails

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1065,7 +1065,7 @@
                                   (prop-resource-error _node-id :texture texture "Texture")))
             (dynamic edit-type (g/constantly
                                  {:type resource/Resource
-                                  :ext ["atlas" "png"]})))
+                                  :ext ["atlas" "tilesource"]})))
 
   (input texture-resource resource/Resource)
   (input image BufferedImage)


### PR DESCRIPTION
Filter out empty template & texture paths.
Don't assume resources could be resolved.
Additionally set proper edit-type :ext on resource properties.