### PR TITLE
DEFEDIT-772 Create and sign DMG when bundling for osx

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -862,8 +862,11 @@ instructions.configure=\
     def archive_editor2(self):
         sha1 = self._git_sha1()
         full_archive_path = join(self.archive_path, sha1, 'editor2')
-        for p in glob(join(self.defold_root, 'editor', 'target', 'editor', 'Defold*.zip')):
-            self.upload_file(p, '%s/%s' % (full_archive_path, basename(p)))
+
+        for ext in ['zip', 'dmg']:
+            for p in glob(join(self.defold_root, 'editor', 'target', 'editor', 'Defold*.%s' % ext)):
+                self.upload_file(p, '%s/%s' % (full_archive_path, basename(p)))
+
         for p in glob(join(self.defold_root, 'editor', 'target', 'editor', 'update', '*')):
             self.upload_file(p, '%s/%s' % (full_archive_path, basename(p)))
 


### PR DESCRIPTION
Avoids issues with Gatekeeper in macOS Sierra.

- Create DMG when bundling for osx, sign if certificate is available
- Upload both zip and dmg to s3 when archiving.

Fixes https://github.com/defold/editor2-issues/issues/475