### PR TITLE
DEFEDIT-815 Fixed various issues when moving folders in the Asset Browser

### DIFF
--- a/editor/test/integration/asset_browser_test.clj
+++ b/editor/test/integration/asset_browser_test.clj
@@ -75,3 +75,73 @@
         (is (true? (asset-browser/allow-resource-move? (make-dir-resource "dest" {})
                                                        [(make-file "a.txt")
                                                         (make-file "readonly/a.txt")])))))))
+
+(deftest move-entry-test
+  (testing "File rename"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir ["old-name.txt"])
+      (let [src (io/file dir "old-name.txt")
+            tgt (io/file dir "new-name.txt")]
+        (is (= [[src tgt]] (asset-browser/move-entry! src tgt)))
+        (is (= ["new-name.txt"] (test-util/file-tree dir))))))
+
+  (testing "File move"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir ["file.txt" {"directory" []}])
+      (let [src (io/file dir "file.txt")
+            tgt (io/file dir "directory" "file.txt")]
+        (is (= [[src tgt]] (asset-browser/move-entry! src tgt)))
+        (is (= [{"directory" ["file.txt"]}] (test-util/file-tree dir))))))
+
+  (testing "Directory rename"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir [{"old-name" ["file.txt"]}])
+      (is (= [[(io/file dir "old-name" "file.txt") (io/file dir "new-name" "file.txt")]]
+             (asset-browser/move-entry! (io/file dir "old-name") (io/file dir "new-name"))))
+      (is (= [{"new-name" ["file.txt"]}] (test-util/file-tree dir)))))
+
+  (testing "Directory move"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir [{"project" []} {"archive" []}])
+      (is (= [] (asset-browser/move-entry! (io/file dir "project") (io/file dir "archive" "project"))))
+      (is (= [{"archive" [{"project" []}]}] (test-util/file-tree dir)))))
+
+  (testing "Directory hierarchy"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir [{"test" []}
+                                      {"assets" [{"images" [{"atlas" ["myatlas.atlas"]}
+                                                            {"game" [{"items" ["coin.png" "heart.png"]}]}]}]}])
+      (is (= [[(io/file dir "assets" "images" "atlas" "myatlas.atlas") (io/file dir "test" "assets" "images" "atlas" "myatlas.atlas")]
+              [(io/file dir "assets" "images" "game" "items" "coin.png") (io/file dir "test" "assets" "images" "game" "items" "coin.png")]
+              [(io/file dir "assets" "images" "game" "items" "heart.png") (io/file dir "test" "assets" "images" "game" "items" "heart.png")]]
+             (asset-browser/move-entry! (io/file dir "assets") (io/file dir "test" "assets"))))
+      (is (= [{"test" [{"assets" [{"images" [{"atlas" ["myatlas.atlas"]}
+                                             {"game" [{"items" ["coin.png" "heart.png"]}]}]}]}]}]
+             (test-util/file-tree dir)))))
+
+  (testing "File overwrite"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir ["source.txt" "destination.txt"])
+      (let [src (io/file dir "source.txt")
+            tgt (io/file dir "destination.txt")
+            src-contents (slurp src)]
+        (is (= [[src tgt]] (asset-browser/move-entry! src tgt)))
+        (is (= ["destination.txt"] (test-util/file-tree dir)))
+        (is (= src-contents (slurp tgt))))))
+
+  (testing "Directory merge"
+    (test-util/with-temp-dir! dir
+      (test-util/make-file-tree! dir [{"assets" [{"images" [{"atlas" ["myatlas.atlas"]}
+                                                            {"game" [{"items" ["coin.png" "heart.png"]}]}]}]}
+                                      {"images" [{"atlas" ["myatlas.atlas"]}
+                                                 {"empty" []}
+                                                 {"game" [{"items" ["cloud.png"]}]}]}])
+      (let [src-atlas-contents (slurp (io/file dir "images" "atlas" "myatlas.atlas"))]
+        (is (= [[(io/file dir "images" "atlas" "myatlas.atlas") (io/file dir "assets" "images" "atlas" "myatlas.atlas")]
+                [(io/file dir "images" "game" "items" "cloud.png") (io/file dir "assets" "images" "game" "items" "cloud.png")]]
+               (asset-browser/move-entry! (io/file dir "images") (io/file dir "assets" "images"))))
+        (is (= [{"assets" [{"images" [{"atlas" ["myatlas.atlas"]}
+                                      {"empty" []}
+                                      {"game" [{"items" ["cloud.png" "coin.png" "heart.png"]}]}]}]}]
+               (test-util/file-tree dir)))
+        (is (= src-atlas-contents (slurp (io/file dir "assets" "images" "atlas" "myatlas.atlas"))))))))


### PR DESCRIPTION
* Empty folders can now be moved in the Asset Browser.
* Empty folders are no longer left in the project when moving deep folder hierarchies in the Asset Browser.
* Added tests for various file and folder move scenarios.