### PR TITLE
DEFEDIT-820 Nodes attached on spine-nodes are not working

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -345,7 +345,6 @@
    [:scene :child-scenes]
    [:node-msgs :node-msgs]
    [:node-rt-msgs :node-rt-msgs]
-   [:node-ids :node-ids]
    [:node-overrides :node-overrides]
    [:build-errors :build-errors]
    [:template-build-targets :template-build-targets]])
@@ -1014,9 +1013,9 @@
           (not= :clipping-mode-none clipping-mode)
           (assoc :clipping {:mode clipping-mode :inverted clipping-inverted :visible clipping-visible})))))
   (output node-rt-msgs g/Any :cached
-    (g/fnk [node-msgs spine-scene-structure adjust-mode spine-skin-ids]
+    (g/fnk [node-msgs node-rt-msgs spine-scene-structure adjust-mode spine-skin-ids]
       (let [pb-msg (first node-msgs)
-            rt-pb-msgs [(update pb-msg :spine-skin (fn [skin] (if (str/blank? skin) (first spine-skin-ids) skin)))]
+            rt-pb-msgs (into node-rt-msgs [(update pb-msg :spine-skin (fn [skin] (if (str/blank? skin) (first spine-skin-ids) skin)))])
             gui-node-id (:id pb-msg)
             bones (tree-seq :children :children (:skeleton spine-scene-structure))
             child-to-parent (reduce (fn [m b] (into m (map (fn [c] [(:name c) b]) (:children b)))) {} bones)

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -195,10 +195,10 @@
                  :pb-class Gui$SceneDesc
                  :resource-fields [[:spine-scenes :spine-scene]]
                  :test-fn (fn [pb targets]
-                            (let [main-node (first (:nodes pb))
+                            (let [main-node (first (filter #(= "spine" (:id %)) (:nodes pb)))
                                   nodes (into #{} (map :id (:nodes pb)))]
                               (is (= "default" (:spine-skin main-node)))
-                              (is (every? nodes ["spine" "spine/root"]))))}]})
+                              (is (every? nodes ["spine" "spine/root" "box"]))))}]})
 
 (defn- run-pb-case [case content-by-source content-by-target]
   (testing (str "Testing " (:label case))

--- a/editor/test/resources/build_project/SideScroller/gui/spine.gui
+++ b/editor/test/resources/build_project/SideScroller/gui/spine.gui
@@ -49,6 +49,61 @@ nodes {
   spine_default_animation: "idle"
   spine_skin: ""
 }
+nodes {
+  position {
+    x: 337.939
+    y: 237.207
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "spine"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_AUTO
+}
 background_color {
   x: 0.0
   y: 0.0


### PR DESCRIPTION
Include children of spine nodes in node-rt-msgs, which will feed into
build-targets.