### PR TITLE
DEFEDIT-821 Update dialog displayed as child of main window

### DIFF
--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -11,15 +11,15 @@
    [editor.progress :as progress]
    [editor.sentry :as sentry]
    [editor.ui :as ui]
+   [editor.updater :as updater]
    [service.log :as log])
   (:import
    [com.defold.control ListCell]
    [java.io File]
-   [javafx.scene Scene Parent]
+   [javafx.scene Scene]
    [javafx.scene.control Button Control Label ListView]
    [javafx.scene.input MouseEvent]
    [javafx.scene.layout VBox]
-   [javafx.stage Stage]
    [javafx.util Callback]))
 
 (set! *warn-on-reflection* true)
@@ -67,6 +67,7 @@
         ^ListView recent-projects (.lookup root "#recent-projects")
         ^Button open-project (.lookup root "#open-project")
         import-project (.lookup root "#import-project")]
+    (updater/install-pending-update-check! stage nil)
     (ui/set-main-stage stage)
     (ui/on-action! open-project (fn [_] (when-let [file-name (ui/choose-file "Open Project" "Project Files" ["*.project"])]
                                           (ui/close! stage)

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -1,0 +1,60 @@
+(ns editor.updater
+  (:require [editor.ui :as ui]
+            [editor.defold-project :as project]
+            [service.log :as log])
+  (:import [com.defold.editor EditorApplication Updater$PendingUpdate]
+           [java.io IOException]
+           [javafx.animation AnimationTimer]
+           [javafx.scene Scene Parent]
+           [javafx.stage Stage]))
+
+(set! *warn-on-reflection* true)
+
+(defn show-pending-update-dialog!
+  [^Stage owner]
+  (let [root ^Parent (ui/load-fxml "update-alert.fxml")
+        stage (ui/make-dialog-stage owner)
+        scene (Scene. root)
+        result (atom false)]
+    (ui/title! stage "Update Available")
+    (ui/with-controls root [ok cancel]
+      (ui/on-action! ok (fn on-ok! [_] (reset! result true) (.close stage)))
+      (ui/on-action! cancel (fn on-cancel! [_] (.close stage))))
+    (.setScene stage scene)
+    (ui/show-and-wait! stage)
+    @result))
+
+(defn- ask-update-and-restart!
+  [^Stage owner ^Updater$PendingUpdate pending-update project]
+  (when (show-pending-update-dialog! owner)
+    (log/info :message "update installation requested")
+
+    ;; If we have a project, save it before restarting the editor.
+    (when (some? project)
+      ;; If a build or save was in progress, wait for it to complete.
+      (while (project/ongoing-build-save?)
+        (Thread/sleep 300))
+
+      ;; Save the project and block until complete.
+      (let [save-future (project/save-all! project nil)]
+        (when (future? save-future)
+          (deref save-future))))
+
+    ;; Install update and restart the editor.
+    (try
+      (.install pending-update)
+      (log/info :message "update installed - restarting")
+      (System/exit 17)
+      (catch IOException e
+        (log/debug :message "update installation failed" :exception e)))))
+
+(defn install-pending-update-check!
+  [^Stage stage project]
+  (let [tick-fn (fn [^AnimationTimer timer _dt]
+                  (when-let [pending-update (EditorApplication/getPendingUpdate)]
+                    (.stop timer)
+                    (ui/run-later
+                      (ask-update-and-restart! stage pending-update project))))
+        timer (ui/->timer 1 "pending-update-check" tick-fn)]
+    (.setOnShown stage (ui/event-handler event (ui/timer-start! timer)))
+    (.setOnHiding stage (ui/event-handler event (ui/timer-stop! timer)))))

--- a/editor/src/java/com/defold/editor/EditorApplication.java
+++ b/editor/src/java/com/defold/editor/EditorApplication.java
@@ -30,10 +30,10 @@ public class EditorApplication {
         openEditor.invoke(startInstance, new Object[] { args });
     }
 
-    public static void registerPreUpdateAction(Runnable action) throws Exception {
+    public static Object getPendingUpdate() throws Exception {
         // See comment next to startInstance why we use reflection here
-        Method registerPreUpdateAction = startInstance.getClass().getMethod("registerPreUpdateAction", Runnable.class);
-        registerPreUpdateAction.invoke(startInstance, action);
+        Method getPendingUpdate = startInstance.getClass().getMethod("getPendingUpdate");
+        return getPendingUpdate.invoke(startInstance);
     }
 
     public void run(String[] args) {

--- a/editor/src/java/com/defold/editor/Updater.java
+++ b/editor/src/java/com/defold/editor/Updater.java
@@ -78,6 +78,10 @@ public class Updater {
         this.resourcesPath = new File(resourcesPath);
         this.currentSha1 = currentSha1;
         this.mapper = new ObjectMapper();
+
+        // Delete temp files at shutdown.
+        File tempDirectory = this.tempDirectory.toFile();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(tempDirectory)));
     }
 
     private File download(String packagesUrl, String url) throws IOException {


### PR DESCRIPTION
Fixes defold/editor2-issues#538

* Open Update dialog as child window of main window.
* Delete downloaded temp files at shutdown.