### PR TITLE
DEFEDIT-813 Unpack/log to application support path

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -13,9 +13,8 @@ jre = ${bootstrap.resourcespath}/packages/jre
 java = ${launcher.jre}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.sha1}.jar
 main = com.defold.editor.Start
-log =
 debug = 1
-vmargs = -Ddefold.editor2.log=${launcher.log},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
+vmargs = -Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -19,8 +19,7 @@
                      [prismatic/plumbing                          "0.5.2"]
                      [at.bestsolution.eclipse/org.eclipse.fx.code.editor.fx "2.2.0"]
                      [com.google.protobuf/protobuf-java           "2.3.0"]
-                     [org.slf4j/slf4j-api                         "1.7.14"]
-                     [ch.qos.logback/logback-classic              "1.1.3"]
+                     [ch.qos.logback/logback-classic              "1.2.1"]
                      [joda-time/joda-time                         "2.9.2"]
                      [commons-io/commons-io                       "2.4"]
                      [commons-configuration/commons-configuration "1.10"

--- a/editor/resources/logback.xml
+++ b/editor/resources/logback.xml
@@ -5,16 +5,12 @@
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>${defold.editor2.log:-editor2.log}</file>
-    <append>true</append>
-    <encoder>
-	<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
-    </encoder>
-  </appender>
-
   <root level="TRACE">
     <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="FILE"/>
+    <!--
+        An additional file appender is added programatically in
+        com.defold.editor.Start as we need access to platform specific
+        support path for storing the logfiles.
+    -->
   </root>
 </configuration>

--- a/editor/src/java/com/defold/editor/Editor.java
+++ b/editor/src/java/com/defold/editor/Editor.java
@@ -1,9 +1,28 @@
 package com.defold.editor;
 
+import com.defold.util.SupportPath;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public class Editor {
 
     public static boolean isDev() {
         return System.getProperty("defold.version") == null;
+    }
+
+    public static Path getSupportPath() {
+        try {
+            Path supportPath = SupportPath.getPlatformSupportPath("Defold");
+            if (supportPath != null && (Files.exists(supportPath) || supportPath.toFile().mkdirs())) {
+                return supportPath;
+            }
+        } catch (Exception e) {
+            System.err.println("Unable to determine support path: " + e);
+        }
+
+        return null;
     }
 
 }

--- a/editor/src/java/com/defold/editor/Platform.java
+++ b/editor/src/java/com/defold/editor/Platform.java
@@ -27,6 +27,10 @@ public enum Platform {
         this.libPrefix = libPrefix;
     }
 
+    public String getOs() {
+        return os;
+    }
+
     public String getExeSuffix() {
         return exeSuffix;
     }

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -240,12 +240,11 @@ public class Start extends Application {
         appender.setName("FILE");
         appender.setAppend(true);
         appender.setPrudent(true);
-        appender.setFile(logDirectory.resolve("editor2.log").toString());
         appender.setContext(root.getLoggerContext());
 
         TimeBasedRollingPolicy rollingPolicy = new TimeBasedRollingPolicy();
         rollingPolicy.setMaxHistory(30);
-        rollingPolicy.setFileNamePattern("editor2.%d{yyyy-MM-dd}.log");
+        rollingPolicy.setFileNamePattern(logDirectory.resolve("editor2.%d{yyyy-MM-dd}.log").toString());
         rollingPolicy.setTotalSizeCap(FileSize.valueOf("1GB"));
         rollingPolicy.setContext(root.getLoggerContext());
         rollingPolicy.setParent(appender);

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -7,6 +7,9 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -20,8 +23,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.FileAppender;
+import ch.qos.logback.core.rolling.*;
+import ch.qos.logback.core.util.FileSize;
+
 import com.defold.editor.Updater.PendingUpdate;
 import com.defold.libs.ResourceUnpacker;
+import com.defold.util.SupportPath;
 
 import javafx.application.Application;
 import javafx.beans.value.ChangeListener;
@@ -215,6 +224,43 @@ public class Start extends Application {
 
     public static void main(String[] args) throws Exception {
         createdFromMain = true;
+        initializeLogging();
         Start.launch(args);
     }
+
+    private static void initializeLogging() {
+        Path logDirectory = Editor.isDev() ? Paths.get("") : Editor.getSupportPath();
+        if (logDirectory == null) {
+            logDirectory = Paths.get(System.getProperty("user.home"));
+        }
+
+        ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
+        RollingFileAppender appender = new RollingFileAppender();
+        appender.setName("FILE");
+        appender.setAppend(true);
+        appender.setPrudent(true);
+        appender.setFile(logDirectory.resolve("editor2.log").toString());
+        appender.setContext(root.getLoggerContext());
+
+        TimeBasedRollingPolicy rollingPolicy = new TimeBasedRollingPolicy();
+        rollingPolicy.setMaxHistory(30);
+        rollingPolicy.setFileNamePattern("editor2.%d{yyyy-MM-dd}.log");
+        rollingPolicy.setTotalSizeCap(FileSize.valueOf("1GB"));
+        rollingPolicy.setContext(root.getLoggerContext());
+        rollingPolicy.setParent(appender);
+        appender.setRollingPolicy(rollingPolicy);
+        rollingPolicy.start();
+
+        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+        encoder.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n");
+        encoder.setContext(root.getLoggerContext());
+        encoder.start();
+
+        appender.setEncoder(encoder);
+        appender.start();
+
+        root.addAppender(appender);
+    }
+
 }

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+import com.defold.editor.Editor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,7 @@ import com.defold.editor.Platform;
 public class ResourceUnpacker {
 
     public static final String DEFOLD_UNPACK_PATH_KEY = "defold.unpack.path";
+    public static final String DEFOLD_SHA1_KEY = "defold.sha1";
 
     private static boolean isInitialized = false;
     private static Logger logger = LoggerFactory.getLogger(ResourceUnpacker.class);
@@ -79,8 +81,12 @@ public class ResourceUnpacker {
                     if (dest.equals(target)) {
                         continue;
                     }
-                    logger.debug("unpacking '{}' to '{}'", source, dest);
-                    Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
+                    if (Files.exists(dest)) {
+                        logger.debug("skipping already unpacked '{}'", source);
+                    } else {
+                        logger.debug("unpacking '{}' to '{}'", source, dest);
+                        Files.copy(source, dest);
+                    }
                 }
             }
         }
@@ -97,16 +103,23 @@ public class ResourceUnpacker {
     private static Path getUnpackPath() throws IOException {
         String unpackPath = System.getProperty(DEFOLD_UNPACK_PATH_KEY);
         if (unpackPath != null) {
-            Path p = Paths.get(unpackPath);
-            File f = p.toFile();
-            if (f.exists()) {
-                FileUtils.cleanDirectory(f);
-            } else {
-                f.mkdirs();
-            }
-            return p;
-        } else {
-            return Files.createTempDirectory("defold-unpack");
+            return ensureDirectory(Paths.get(unpackPath));
         }
+
+        Path supportPath = Editor.getSupportPath();
+        String sha1 = System.getProperty(DEFOLD_SHA1_KEY);
+        if (supportPath != null && sha1 != null) {
+            return ensureDirectory(supportPath.resolve(Paths.get("unpack", sha1)));
+        }
+
+        return Files.createTempDirectory("defold-unpack");
+    }
+
+    private static Path ensureDirectory(Path path) throws IOException {
+        File f = path.toFile();
+        if (!f.exists()) {
+            f.mkdirs();
+        }
+        return path;
     }
 }

--- a/editor/src/java/com/defold/util/SupportPath.java
+++ b/editor/src/java/com/defold/util/SupportPath.java
@@ -1,0 +1,91 @@
+package com.defold.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.defold.editor.Platform;
+
+public class SupportPath {
+
+    public static Path getPlatformSupportPath(String applicationName) {
+        Platform platform = Platform.getHostPlatform();
+        switch(platform.getOs()) {
+            case "win32":
+                return getWindowsSupportPath(applicationName);
+            case "darwin":
+                return getMacSupportPath(applicationName);
+            case "linux":
+                return getLinuxSupportPath(applicationName);
+            default:
+                return null;
+        }
+    }
+
+    // macOS
+
+    public static Path getMacSupportPath(String applicationName) {
+        final String userHome = System.getProperty("user.home");
+        if (userHome == null) {
+            return null;
+        }
+        Path applicationSupport = Paths.get(userHome, "Library", "Application Support");
+        if (Files.isDirectory(applicationSupport)) {
+            return applicationSupport.resolve(applicationName);
+        }
+
+        return null;
+    }
+
+    // win
+
+    public static Path getWindowsSupportPath(String applicationName) {
+        // 1. LOCALAPPDATA environment variable
+        final String localAppDataEnv = System.getenv("LOCALAPPDATA");
+        if (localAppDataEnv != null) {
+            Path localAppData = Paths.get(localAppDataEnv);
+            if (Files.isDirectory(localAppData)) {
+                return localAppData.resolve(applicationName);
+            }
+        }
+
+        // Ensure we have a user.home set
+        final String userHome = System.getProperty("user.home");
+        if (userHome == null) {
+            return null;
+        }
+
+        // 2. "${user.home}/AppData/Local"
+        final Path appDataLocal = Paths.get(userHome, "AppData", "Local");
+        if (Files.isDirectory(appDataLocal)) {
+            return appDataLocal.resolve(applicationName);
+        }
+
+        // 3. "${user.home}/Local Settings/Application Data"
+        final Path localSettingsAppData = Paths.get(userHome, "Local Settings", "Application Data");
+        if (Files.isDirectory(localSettingsAppData)) {
+            return localSettingsAppData.resolve(applicationName);
+        }
+
+        return null;
+    }
+
+    // linux
+
+    private static Path getLinuxSupportPath(String applicationName) {
+        final String userHome = System.getProperty("user.home");
+        if (userHome == null) {
+            return null;
+        }
+        final Path home = Paths.get(userHome);
+        if (Files.isDirectory(home)) {
+            return home.resolve("." + applicationName);
+        }
+
+        return null;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("done: " + getPlatformSupportPath("Defold"));
+    }
+}

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -24,7 +24,6 @@
 
 // bootstrap.resourcespath must default to resourcespath of the installation
 #define RESOURCES_PATH_KEY ("bootstrap.resourcespath")
-#define LOG_PATH_KEY ("launcher.log")
 #define MAX_ARGS_SIZE (10 * DMPATH_MAX_PATH)
 
 struct ReplaceContext
@@ -32,8 +31,6 @@ struct ReplaceContext
     dmConfigFile::HConfig m_Config;
     // Will be set to either bootstrap.resourcespath (if set) or the default installation resources path
     const char* m_ResourcesPath;
-    // Will be set to launcher.log or default log path
-    const char* m_LogPath;
 };
 
 static const char* ReplaceCallback(void* user_data, const char* key)
@@ -43,10 +40,6 @@ static const char* ReplaceCallback(void* user_data, const char* key)
     if (dmStrCaseCmp(key, RESOURCES_PATH_KEY) == 0)
     {
         return context->m_ResourcesPath;
-    }
-    else if (dmStrCaseCmp(key, LOG_PATH_KEY) == 0)
-    {
-        return context->m_LogPath;
     }
 
     return dmConfigFile::GetString(context->m_Config, key, 0x0);
@@ -90,8 +83,6 @@ static bool ConfigGetString(ReplaceContext* context, const char* key, char* buf,
 int Launch(int argc, char **argv) {
     char default_resources_path[DMPATH_MAX_PATH];
     char config_path[DMPATH_MAX_PATH];
-    char application_support_path[DMPATH_MAX_PATH];
-    char default_logfile_path[DMPATH_MAX_PATH];
     char java_path[DMPATH_MAX_PATH];
     char jar_path[DMPATH_MAX_PATH];
     char os_args[MAX_ARGS_SIZE];
@@ -105,15 +96,6 @@ int Launch(int argc, char **argv) {
 
     dmStrlCpy(config_path, default_resources_path, sizeof(config_path));
     dmStrlCat(config_path, "/config", sizeof(config_path));
-
-    r = dmSys::GetApplicationSupportPath("Defold", application_support_path, sizeof(application_support_path));
-    if (r != dmSys::RESULT_OK) {
-        dmLogFatal("Failed to locate application support path (%d)", r);
-        return 5;
-    }
-
-    dmStrlCpy(default_logfile_path, application_support_path, sizeof(default_logfile_path));
-    dmStrlCat(default_logfile_path, "/editor2.log", sizeof(default_logfile_path));
 
     dmConfigFile::HConfig config;
     dmConfigFile::Result cr = dmConfigFile::Load(config_path, argc, (const char**) argv, &config);
@@ -133,12 +115,6 @@ int Launch(int argc, char **argv) {
     if (*context.m_ResourcesPath == '\0')
     {
         context.m_ResourcesPath = default_resources_path;
-    }
-
-    context.m_LogPath = dmConfigFile::GetString(config, LOG_PATH_KEY, default_logfile_path);
-    if (*context.m_LogPath == '\0')
-    {
-        context.m_LogPath = default_logfile_path;
     }
 
     const char* main = dmConfigFile::GetString(config, "launcher.main", "Main");


### PR DESCRIPTION
Supersedes #1370 which was broken.

New approach is to determine application support path in Java and do even less in launcher.

Fixes https://github.com/defold/editor2-issues/issues/466, https://github.com/defold/editor2-issues/issues/469, 