### PR TITLE
DEF-1217 spine keyable draworder

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/MockDrawOrderBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/MockDrawOrderBuilder.java
@@ -1,0 +1,21 @@
+package com.dynamo.bob.test.util;
+
+import com.dynamo.bob.util.RigUtil.DrawOrderBuilder;
+import com.dynamo.rig.proto.Rig.MeshAnimationTrack.Builder;
+
+public class MockDrawOrderBuilder extends DrawOrderBuilder {
+
+    public MockDrawOrderBuilder(Builder builder) {
+        super(builder);
+        // TODO Auto-generated constructor stub
+    }
+
+    int GetOrderOffset(int index) {
+        return builder.getOrderOffset(index);
+    }
+    
+    int GetOrderOffsetCount()
+    {
+        return builder.getOrderOffsetCount();
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/SpineSceneTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/SpineSceneTest.java
@@ -453,6 +453,60 @@ public class SpineSceneTest {
             }
         }
     }
+    
+    @Test
+    public void testSampleDrawOrderAnim() throws Exception {
+        SpineSceneUtil scene = load("draw_order_skeleton.json");
+        Animation anim = scene.getAnimation("animation");
+        
+        assertEquals(3, anim.slotTracks.size()); // should only contain 3 draw_order slot tracks
+        
+        SlotAnimationTrack track_4 = anim.slotTracks.get(0);
+        SlotAnimationTrack track_3 = anim.slotTracks.get(1);
+        SlotAnimationTrack track_5 = anim.slotTracks.get(2);
+
+        double sampleRate = 30.0;
+        double spf = 1.0/sampleRate;
+        double duration = anim.duration;
+        boolean interpolate = false;
+        boolean shouldSlerp = false;
+
+        int expectedSampleCountPerMesh = 5;
+        
+        MeshAnimationTrack.Builder trackBuilder = MeshAnimationTrack.newBuilder();
+        
+        // Mesh "_3" [0, 2, 1, 0, 0]
+        MockDrawOrderBuilder drawOrderBuilder = new MockDrawOrderBuilder(trackBuilder);
+        RigUtil.sampleTrack(track_3, drawOrderBuilder, new Integer(0), duration, sampleRate, spf, interpolate, shouldSlerp);
+        assertEquals(expectedSampleCountPerMesh, drawOrderBuilder.GetOrderOffsetCount());
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(0));
+        assertEquals(2, drawOrderBuilder.GetOrderOffset(1));
+        assertEquals(1, drawOrderBuilder.GetOrderOffset(2));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(3));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(4));
+        trackBuilder.clear();
+
+        // Mesh "_4" [0, 2, 1, 0, 0]
+        drawOrderBuilder = new MockDrawOrderBuilder(trackBuilder);
+        RigUtil.sampleTrack(track_4, drawOrderBuilder, new Integer(0), duration, sampleRate, spf, interpolate, shouldSlerp);
+        assertEquals(expectedSampleCountPerMesh, drawOrderBuilder.GetOrderOffsetCount());
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(0));
+        assertEquals(2, drawOrderBuilder.GetOrderOffset(1));
+        assertEquals(1, drawOrderBuilder.GetOrderOffset(2));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(3));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(4));
+        trackBuilder.clear();
+        
+        // Mesh "_5" [0, 0, 4, 4, 0]
+        drawOrderBuilder = new MockDrawOrderBuilder(trackBuilder);
+        RigUtil.sampleTrack(track_5, drawOrderBuilder, new Integer(0), duration, sampleRate, spf, interpolate, shouldSlerp);
+        assertEquals(expectedSampleCountPerMesh, drawOrderBuilder.GetOrderOffsetCount());
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(0));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(1));
+        assertEquals(4, drawOrderBuilder.GetOrderOffset(2));
+        assertEquals(4, drawOrderBuilder.GetOrderOffset(3));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(4));
+    }
 
     @Test
     public void testEmptyScene() throws Exception {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/test/draw_order_skeleton.json
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/test/draw_order_skeleton.json
@@ -1,0 +1,70 @@
+{
+"skeleton": { "hash": "ifECh0ShlsPaEtA765jMN2eq//E", "spine": "3.5.49", "width": 589.89, "height": 573.01 },
+"bones": [
+	{ "name": "root" },
+	{ "name": "bone", "parent": "root" },
+	{ "name": "bone2", "parent": "root" }
+],
+"slots": [
+	{ "name": "_5", "bone": "bone2", "attachment": "5" },
+	{ "name": "_4", "bone": "bone", "attachment": "4" },
+	{ "name": "_3", "bone": "bone", "attachment": "3" },
+	{ "name": "_2", "bone": "bone", "attachment": "2" },
+	{ "name": "_1", "bone": "bone", "attachment": "1" }
+],
+"skins": {
+	"default": {
+		"_1": {
+			"1": { "x": -100.4, "y": 204.42, "width": 225, "height": 225 }
+		},
+		"_2": {
+			"2": { "x": -5.04, "y": 113.35, "width": 225, "height": 225 }
+		},
+		"_3": {
+			"3": { "x": 80.61, "y": 25.19, "width": 189, "height": 266 }
+		},
+		"_4": {
+			"4": { "x": 193.96, "y": -50.38, "width": 300, "height": 300 }
+		},
+		"_5": {
+			"5": { "x": 264.49, "y": -143.58, "width": 225, "height": 225 }
+		}
+	}
+},
+"animations": {
+	"animation": {
+		"bones": {
+			"root": {
+				"translate": [
+					{ "time": 0, "x": -8, "y": 0 },
+					{ "time": 0.1333, "x": 597.77, "y": 0 }
+				]
+			}
+		},
+		"drawOrder": [
+			{
+				"time": 0.0333,
+				"offsets": [
+					{ "slot": "_4", "offset": 2 },
+					{ "slot": "_3", "offset": 2 }
+				]
+			},
+			{
+				"time": 0.0667,
+				"offsets": [
+					{ "slot": "_5", "offset": 4 },
+					{ "slot": "_4", "offset": 1 },
+					{ "slot": "_3", "offset": 1 }
+				]
+			},
+			{
+				"time": 0.1,
+				"offsets": [
+					{ "slot": "_5", "offset": 4 }
+				]
+			},
+			{ "time": 0.1333 }
+		]
+	}
+}
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/RigUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/RigUtil.java
@@ -19,6 +19,8 @@ import com.dynamo.rig.proto.Rig.MeshAnimationTrack;
  * Should preferably have been an extension to Bob rather than located inside it.
  */
 public class RigUtil {
+    static double EPSILON = 0.0001;
+    
     @SuppressWarnings("serial")
     public static class LoadException extends Exception {
         public LoadException(String msg) {
@@ -534,8 +536,8 @@ public class RigUtil {
         T endValue = propertyBuilder.toComposite(track.keys.get(keyCount-1));
         for (int i = 0; i < sampleCount; ++i) {
             double cursor = i * spf;
-            // Skip passed keys
-            while ((next != null && next.t <= cursor) || (key == null && Math.abs(next.t - cursor) < 0.0001)) {
+            // Skip passed keys. Also handles corner case where the cursor is sufficiently close to the very first key frame.
+            while ((next != null && next.t <= cursor) || (key == null && Math.abs(next.t - cursor) < EPSILON)) {
                 key = next;
                 ++keyIndex;
                 if (keyIndex < keyCount) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/RigUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/RigUtil.java
@@ -535,7 +535,7 @@ public class RigUtil {
         for (int i = 0; i < sampleCount; ++i) {
             double cursor = i * spf;
             // Skip passed keys
-            while (next != null && next.t <= cursor) {
+            while ((next != null && next.t <= cursor) || (key == null && Math.abs(next.t - cursor) < 0.0001)) {
                 key = next;
                 ++keyIndex;
                 if (keyIndex < keyCount) {


### PR DESCRIPTION
One issue with keyable draw order was resolved by DEF-2430.

The issue here was caused by a if a track is to be sampled without interpolation and the first keyframe is not at t = 0, we did a float compare that would sometimes (and sometimes not) sample correctly.