### PR TITLE
DEFEDIT-732 Pasting in search dialog also pastes in text editor

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -759,11 +759,12 @@
 
 (defn contexts
   ([^Scene scene]
-    (contexts scene true))
+   (contexts scene true))
   ([^Scene scene all-selections?]
-    (if scene
-      (node-contexts (or (.getFocusOwner scene) (.getRoot scene)) all-selections?)
-      [])))
+   (let [window (.getWindow scene)]
+     (if (and window (.isFocused window) scene)
+       (node-contexts (or (.getFocusOwner scene) (.getRoot scene)) all-selections?)
+       []))))
 
 (defn extend-menu [id location menu]
   (menu/extend-menu id location menu))


### PR DESCRIPTION
Only produce command contexts when scene window has focus.

Fixes defold/editor2-issues#8