### PR TITLE
Changed confusing tostring for ScriptInstance.

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -229,7 +229,7 @@ namespace dmGameObject
 
     static int ScriptInstance_tostring (lua_State *L)
     {
-        lua_pushfstring(L, "GameObject: %p", lua_touserdata(L, 1));
+        lua_pushfstring(L, "Script: %p", lua_touserdata(L, 1));
         return 1;
     }
 


### PR DESCRIPTION
Was "GameObject", is now "Script" (in lieu of "GuiScript" and "RenderScript").