### PR TITLE
DEFEDIT-836 Support for custom text editor, experimental/dev packaging

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -627,15 +627,14 @@
          view-type     (or (:selected-view-type opts)
                            (first (:view-types resource-type))
                            (workspace/get-view-type workspace :text))]
-     (if-let [custom-editor (and (= (:id view-type) :code)
+     (if-let [custom-editor (and (or (= (:id view-type) :code) (= (:id view-type) :text))
                               (let [ed-pref (string/trim (prefs/get-prefs prefs "code-custom-editor" ""))]
                                 (and (not (string/blank? ed-pref)) ed-pref)))]
        (let [arg-tmpl (string/trim (if (:line opts) (prefs/get-prefs prefs "code-open-file-at-line" "{file}:{line}") (prefs/get-prefs prefs "code-open-file" "{file}")))
              arg-sub (cond-> {:file (resource/abs-path resource)}
                        (:line opts) (assoc :line (:line opts)))
-             args (-> arg-tmpl
-                    (substitute-args arg-sub)
-                    (string/split #" "))]
+             args (->> (string/split arg-tmpl #" ")
+                    (map #(substitute-args % arg-sub)))]
          (doto (ProcessBuilder. ^java.util.List (cons custom-editor args))
            (.directory (workspace/project-path workspace))
            (.start)))

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -347,7 +347,7 @@
                                                                                 (= (count selection) 1)
                                                                                 (not= nil (some-> (handler/adapt-single selection resource/Resource)
                                                                                             resource/abs-path)))))
-  (run [selection user-data asset-browser app-view workspace project]
+  (run [selection user-data asset-browser app-view prefs workspace project]
        (let [project-path (workspace/project-path workspace)
              base-folder (-> (or (some-> (handler/adapt-every selection resource/Resource)
                                    first
@@ -363,7 +363,7 @@
              (let [resource-map (g/node-value workspace :resource-map)
                    new-resource-path (resource/file->proj-path project-path new-file)
                    resource (resource-map new-resource-path)]
-               (app-view/open-resource app-view workspace project resource)
+               (app-view/open-resource app-view prefs workspace project resource)
                (select-resource! asset-browser resource))))))
   (options [workspace selection user-data]
            (when (not user-data)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -130,7 +130,7 @@
           clear-console        (.lookup root "#clear-console")
           search-console       (.lookup root "#search-console")
           workbench            (.lookup root "#workbench")
-          app-view             (app-view/make-app-view *view-graph* workspace project stage menu-bar editor-tabs prefs)
+          app-view             (app-view/make-app-view *view-graph* workspace project stage menu-bar editor-tabs)
           outline-view         (outline-view/make-outline-view *view-graph* *project-graph* outline app-view)
           properties-view      (properties-view/make-properties-view workspace project app-view *view-graph* (.lookup root "#properties"))
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets)
@@ -141,6 +141,7 @@
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          (fn [resource node-id opts]
                                                                            (app-view/open-resource app-view
+                                                                                                   prefs
                                                                                                    (g/node-value project :workspace)
                                                                                                    project
                                                                                                    resource

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -89,7 +89,7 @@
    {:name  "Code"
     :prefs [{:label "Custom Editor" :type :string :key "code-custom-editor"}
             {:label "Open File" :type :string :key "code-open-file" :default "{file}"}
-            {:label "Open File At Line" :type :string :key "code-open-file-at-line" :default "{file}:{line}"}]}
+            {:label "Open File at Line" :type :string :key "code-open-file-at-line" :default "{file}:{line}"}]}
    {:name  "Extensions"
     :prefs [{:label "Enable Extensions" :type :boolean :key "enable-extensions" :default false}
             {:label "Build Server" :type :string :key "extensions-server" :default native-extensions/defold-build-server-url}]}])

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -1,5 +1,6 @@
 (ns editor.prefs-dialog
-  (:require [service.log :as log]
+  (:require [clojure.java.io :as io]
+            [service.log :as log]
             [editor.ui :as ui]
             [editor.prefs :as prefs]
             [editor.system :as system]
@@ -7,10 +8,10 @@
   (:import [com.defold.control LongField]
            [javafx.scene Parent Scene]
            [javafx.scene.paint Color]
-           [javafx.scene.control ColorPicker Control CheckBox ChoiceBox Label TextField Tab TabPane]
-           [javafx.scene.layout GridPane]
+           [javafx.scene.control Button ColorPicker Control CheckBox ChoiceBox Label TextField Tab TabPane]
+           [javafx.scene.layout AnchorPane GridPane]
            [javafx.scene.input KeyCode KeyEvent]
-           [javafx.stage Stage Modality DirectoryChooser]
+           [javafx.stage Stage Modality DirectoryChooser FileChooser]
            [javafx.util StringConverter]))
 
 (set! *warn-on-reflection* true)
@@ -58,7 +59,6 @@
 (defn- create-prefs-row! [prefs ^GridPane grid row desc]
   (let [label (Label. (str (:label desc) ":"))
         ^Parent control (create-control! prefs grid desc)]
-
     (GridPane/setConstraints label 1 row)
     (GridPane/setConstraints control 2 row)
 
@@ -86,6 +86,10 @@
             {:label "Grid" :type :choicebox :key "scene-grid-type" :default :auto :options [[:auto "Auto"] [:manual "Manual"]]}
             {:label "Grid Size" :type :long :key "scene-grid-size" :default 100}
             {:label "Grid Color" :type :color :key "scene-grid-color" :default (Color/web "#999999ff")}]}
+   {:name  "Code"
+    :prefs [{:label "Custom Editor" :type :string :key "code-custom-editor"}
+            {:label "Open File" :type :string :key "code-open-file" :default "{file}"}
+            {:label "Open File At Line" :type :string :key "code-open-file-at-line" :default "{file}:{line}"}]}
    {:name  "Extensions"
     :prefs [{:label "Enable Extensions" :type :boolean :key "enable-extensions" :default false}
             {:label "Build Server" :type :string :key "extensions-server" :default native-extensions/defold-build-server-url}]}])
@@ -108,6 +112,3 @@
                                            (.close stage)))))
 
     (ui/show! stage)))
-
-#_(let [prefs (prefs/make-prefs "defold")]
-  (ui/run-now (open-prefs prefs)))

--- a/editor/test/editor/menu_test.clj
+++ b/editor/test/editor/menu_test.clj
@@ -8,7 +8,7 @@
                                       :id ::new
                                       :acc "Shortcut+N"
                                   :command :new}
-                                     {:label "Open..."
+                                     {:label "Open"
                                       :id ::open
                                       :acc "Shortcut+O"
                                       :command :open}]}


### PR DESCRIPTION
* The reasoning is; if a custom text editor is set, that will be used instead of the built-in
* You can still do Open As > External Editor on a code file, which will let the OS decide how to open it
* The preferences are very barebone
** A tight text field to set the app path
** A primitive way of configuring how to execute it for lines etc
* Could use a lot of polishing but since it's an interim solution for text editor savvy coders, we could do it later