### PR TITLE
DEF-2024 - Multi touch gave inconsistent input messages.

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -895,6 +895,7 @@ bail:
             dmHID::Touch& a = action->m_Touch[i];
             dmHID::Touch& ia = input_action.m_Touch[i];
             ia = action->m_Touch[i];
+            ia.m_Id = a.m_Id;
             ia.m_X = (a.m_X + 0.5f) * width_ratio;
             ia.m_Y = engine->m_Height - (a.m_Y + 0.5f) * height_ratio;
             ia.m_DX = a.m_DX * width_ratio;

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -398,6 +398,10 @@ namespace dmGameObject
                     lua_pushinteger(L, (lua_Integer) (i+1));
                     lua_createtable(L, 0, 6);
 
+                    lua_pushliteral(L, "id");
+                    lua_pushinteger(L, (lua_Integer) t.m_Id);
+                    lua_settable(L, -3);
+
                     lua_pushliteral(L, "tap_count");
                     lua_pushinteger(L, (lua_Integer) t.m_TapCount);
                     lua_settable(L, -3);

--- a/engine/glfw/include/GL/glfw.h
+++ b/engine/glfw/include/GL/glfw.h
@@ -400,6 +400,7 @@ typedef unsigned char   GLubyte;
 #define GLFW_PHASE_STATIONARY (2)
 #define GLFW_PHASE_ENDED (3)
 #define GLFW_PHASE_CANCELLED (4)
+#define GLFW_PHASE_TAPPED (5)
 
 /*************************************************************************
  * Typedefs
@@ -427,6 +428,7 @@ typedef struct {
     int DX;
     int DY;
     void* Reference;
+    int Id;
 } GLFWTouch;
 
 /* Thread ID */
@@ -449,7 +451,6 @@ typedef void (GLFWCALL * GLFWkeyfun)(int,int);
 typedef void (GLFWCALL * GLFWcharfun)(int,int);
 typedef void (GLFWCALL * GLFWmarkedtextfun)(char *);
 typedef void (GLFWCALL * GLFWthreadfun)(void *);
-typedef void (GLFWCALL * GLFWtouchfun)(GLFWTouch*,int);
 
 
 /*************************************************************************
@@ -500,7 +501,6 @@ GLFWAPI void GLFWAPIENTRY glfwResetKeyboard( void );
 GLFWAPI int  GLFWAPIENTRY glfwSetMouseButtonCallback( GLFWmousebuttonfun cbfun );
 GLFWAPI int  GLFWAPIENTRY glfwSetMousePosCallback( GLFWmouseposfun cbfun );
 GLFWAPI int  GLFWAPIENTRY glfwSetMouseWheelCallback( GLFWmousewheelfun cbfun );
-GLFWAPI int  GLFWAPIENTRY glfwSetTouchCallback( GLFWtouchfun cbfun );
 GLFWAPI int  GLFWAPIENTRY glfwGetTouch(GLFWTouch* touch, int count, int* out_count);
 
 GLFWAPI int GLFWAPIENTRY glfwGetAcceleration(float* x, float* y, float* z);

--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -55,6 +55,7 @@ static int g_appLaunchInterrupted = 0;
 
 static ASensorEventQueue* g_sensorEventQueue = 0;
 static ASensorRef g_accelerometer = 0;
+static GLFWTouch* g_MouseEmulationTouch = 0;
 
 static void initThreads( void )
 {
@@ -259,56 +260,94 @@ static void handleCommand(struct android_app* app, int32_t cmd) {
 static GLFWTouch* touchById(void *ref)
 {
     int32_t i;
-    for (i=0;i!=_glfwInput.TouchCount;i++)
+
+    GLFWTouch* freeTouch = 0x0;
+    for (i=0;i!=GLFW_MAX_TOUCH;i++)
     {
+        _glfwInput.Touch[i].Id = i;
         if (_glfwInput.Touch[i].Reference == ref)
             return &_glfwInput.Touch[i];
+
+        // Save touch entry for later if we need to "alloc" one in case we don't find the current reference.
+        if (freeTouch == 0x0 && _glfwInput.Touch[i].Reference == 0x0) {
+            freeTouch = &_glfwInput.Touch[i];
+        }
     }
-    return 0;
+
+    if (freeTouch != 0x0) {
+        freeTouch->Reference = ref;
+    }
+
+    return freeTouch;
 }
 
-static GLFWTouch* touchGetOrAlloc(void *ref)
+
+static GLFWTouch* findNextMouseTouch() {
+    int i=0;
+
+    for (i=0;i!=GLFW_MAX_TOUCH;i++)
+    {
+        if (_glfwInput.Touch[i].Reference && _glfwInput.Touch[i].Phase != GLFW_PHASE_ENDED && _glfwInput.Touch[i].Phase != GLFW_PHASE_TAPPED)
+            return &_glfwInput.Touch[i];
+    }
+
+    return 0x0;
+}
+
+static GLFWTouch* touchStart(void *ref, int32_t x, int32_t y)
 {
-    // Return existing touch or a memset:ed new.
     GLFWTouch *touch = touchById(ref);
-    if (touch) {
-        return touch;
-    }
-
-    if (_glfwInput.TouchCount < GLFW_MAX_TOUCH) {
-        touch = &_glfwInput.Touch[_glfwInput.TouchCount++];
-        memset(touch, 0x00, sizeof(GLFWTouch));
-        touch->Reference = ref;
-        return touch;
-    }
-
-    return 0;
-}
-
-static void touchStart(void *ref, int32_t x, int32_t y)
-{
-    GLFWTouch *touch = touchGetOrAlloc(ref);
     if (touch)
     {
+        if (g_MouseEmulationTouch == 0x0) {
+            g_MouseEmulationTouch = touch;
+        }
+
         touch->Phase = GLFW_PHASE_BEGAN;
         touch->X = x;
         touch->Y = y;
         touch->DX = 0;
         touch->DY = 0;
+
+        return touch;
     }
+
+    return 0;
 }
 
-static void* touchUpdate(void *ref, int32_t x, int32_t y, int phase)
+static GLFWTouch* touchUpdate(void *ref, int32_t x, int32_t y, int phase)
 {
-    GLFWTouch *touch = touchGetOrAlloc(ref);
+    GLFWTouch *touch = touchById(ref);
     if (touch)
     {
-        touch->Phase = phase;
+        int prevPhase = touch->Phase;
+        int newPhase = phase;
+
+        if (prevPhase == GLFW_PHASE_ENDED && newPhase == GLFW_PHASE_MOVED) {
+            return touch;
+        }
+
         touch->DX = x - touch->X;
         touch->DY = y - touch->Y;
         touch->X = x;
         touch->Y = y;
-        return ref;
+
+        if (prevPhase == GLFW_PHASE_BEGAN && newPhase == GLFW_PHASE_MOVED) {
+            return touch;
+        }
+
+        if (prevPhase == GLFW_PHASE_BEGAN && newPhase == GLFW_PHASE_ENDED) {
+            touch->Phase = GLFW_PHASE_TAPPED;
+            return touch;
+        }
+
+        touch->Phase = phase;
+
+        if (newPhase == GLFW_PHASE_ENDED) {
+            g_MouseEmulationTouch = findNextMouseTouch();
+        }
+
+        return touch;
     }
     return 0;
 }
@@ -351,31 +390,37 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
         switch (action_action)
         {
             case AMOTION_EVENT_ACTION_DOWN:
-                updateGlfwMousePos(x,y);
-                _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_PRESS );
-                touchStart(pointer_ref, x, y);
+                if (touchStart(pointer_ref, x, y) == g_MouseEmulationTouch) {
+                    updateGlfwMousePos(x,y);
+                    _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_PRESS );
+                }
                 break;
             case AMOTION_EVENT_ACTION_UP:
-                updateGlfwMousePos(x,y);
-                _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE );
-                touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
+                if (touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED) == g_MouseEmulationTouch || !g_MouseEmulationTouch) {
+                    updateGlfwMousePos(x,y);
+                    _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE );
+                }
                 break;;
             case AMOTION_EVENT_ACTION_POINTER_DOWN:
-                updateGlfwMousePos(x,y);
-                touchStart(pointer_ref, x, y);
+                if (touchStart(pointer_ref, x, y) == g_MouseEmulationTouch) {
+                    updateGlfwMousePos(x,y);
+                    _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_PRESS );
+                }
                 break;
             case AMOTION_EVENT_ACTION_POINTER_UP:
-                updateGlfwMousePos(x,y);
-                touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED);
+                if (touchUpdate(pointer_ref, x, y, GLFW_PHASE_ENDED) == g_MouseEmulationTouch || !g_MouseEmulationTouch) {
+                    updateGlfwMousePos(x,y);
+                    _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE );
+                }
                 break;
             case AMOTION_EVENT_ACTION_CANCEL:
-                updateGlfwMousePos(x,y);
-                touchUpdate(pointer_ref, x, y, GLFW_PHASE_CANCELLED);
+                if (touchUpdate(pointer_ref, x, y, GLFW_PHASE_CANCELLED) == g_MouseEmulationTouch || !g_MouseEmulationTouch) {
+                    updateGlfwMousePos(x,y);
+                    _glfwInputMouseClick( GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE );
+                }
                 break;
             case AMOTION_EVENT_ACTION_MOVE:
                 {
-                    updateGlfwMousePos(x,y);
-
                     // these events contain updates for all pointers.
                     int i, max = AMotionEvent_getPointerCount(event);
                     for (i=0;i<max;i++)
@@ -383,19 +428,17 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
                         x = AMotionEvent_getX(event, i);
                         y = AMotionEvent_getY(event, i);
                         pointer_ref = pointerIdToRef(AMotionEvent_getPointerId(event, i));
-                        touchUpdate(pointer_ref, x, y, GLFW_PHASE_MOVED);
-                        if (i == 0 && _glfwWin.mousePosCallback)
+
+                        if (touchUpdate(pointer_ref, x, y, GLFW_PHASE_MOVED) == g_MouseEmulationTouch)
                         {
-                            _glfwWin.mousePosCallback(x, y);
+                            updateGlfwMousePos(x,y);
+                            if (_glfwWin.mousePosCallback) {
+                                _glfwWin.mousePosCallback(x, y);
+                            }
                         }
                     }
                 }
                 break;
-        }
-
-        if (_glfwWin.touchCallback && _glfwInput.TouchCount > 0)
-        {
-            _glfwWin.touchCallback(_glfwInput.Touch, _glfwInput.TouchCount);
         }
 
         return 1;

--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -323,6 +323,10 @@ static GLFWTouch* touchUpdate(void *ref, int32_t x, int32_t y, int phase)
         int prevPhase = touch->Phase;
         int newPhase = phase;
 
+        if (newPhase == GLFW_PHASE_ENDED && g_MouseEmulationTouch == touch) {
+            g_MouseEmulationTouch = 0x0;
+        }
+
         if (prevPhase == GLFW_PHASE_ENDED && newPhase == GLFW_PHASE_MOVED) {
             return touch;
         }
@@ -342,10 +346,6 @@ static GLFWTouch* touchUpdate(void *ref, int32_t x, int32_t y, int phase)
         }
 
         touch->Phase = phase;
-
-        if (newPhase == GLFW_PHASE_ENDED) {
-            g_MouseEmulationTouch = findNextMouseTouch();
-        }
 
         return touch;
     }

--- a/engine/glfw/lib/android/platform.h
+++ b/engine/glfw/lib/android/platform.h
@@ -80,7 +80,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -163,7 +162,6 @@ GLFWGLOBAL struct {
     int  KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 
 // ========= PLATFORM SPECIFIC PART ======================================
 

--- a/engine/glfw/lib/carbon/platform.h
+++ b/engine/glfw/lib/carbon/platform.h
@@ -147,7 +147,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -232,7 +231,6 @@ GLFWGLOBAL struct {
     int      KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 // ========= PLATFORM SPECIFIC PART ======================================
 
     UInt32 Modifiers;

--- a/engine/glfw/lib/cocoa/platform.h
+++ b/engine/glfw/lib/cocoa/platform.h
@@ -77,7 +77,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -188,7 +187,6 @@ GLFWGLOBAL struct {
     int  KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 
 // ========= PLATFORM SPECIFIC PART ======================================
 

--- a/engine/glfw/lib/flash/platform.h
+++ b/engine/glfw/lib/flash/platform.h
@@ -78,7 +78,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -150,7 +149,6 @@ GLFWGLOBAL struct {
     int  KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 
 // ========= PLATFORM SPECIFIC PART ======================================
 

--- a/engine/glfw/lib/input.c
+++ b/engine/glfw/lib/input.c
@@ -305,29 +305,6 @@ GLFWAPI int GLFWAPIENTRY glfwSetMouseWheelCallback( GLFWmousewheelfun cbfun )
     return 1;
 }
 
-//========================================================================
-// Set callback function for touch
-// Returns 1 on success, 0 if GLFW is not initialised or not window open.
-//========================================================================
-
-GLFWAPI int GLFWAPIENTRY glfwSetTouchCallback( GLFWtouchfun cbfun )
-{
-    if( !_glfwInitialized || !_glfwWin.opened )
-    {
-        return 0;
-    }
-
-    // Set callback function
-    _glfwWin.touchCallback = cbfun;
-
-    if( cbfun )
-    {
-        cbfun( _glfwInput.Touch, _glfwInput.TouchCount );
-    }
-
-    return 1;
-}
-
 GLFWAPI int GLFWAPIENTRY glfwGetAcceleration(float* x, float* y, float* z)
 {
     return _glfwPlatformGetAcceleration(x, y, z);
@@ -335,39 +312,39 @@ GLFWAPI int GLFWAPIENTRY glfwGetAcceleration(float* x, float* y, float* z)
 
 GLFWAPI int GLFWAPIENTRY glfwGetTouch(GLFWTouch* touch, int count, int* out_count)
 {
-    int i, j;
-    int n = _glfwInput.TouchCount;
-    if (count < n)
-        n = count;
+    int i, touchCount;
 
-    *out_count = n;
+    touchCount = 0;
+    for (i = 0; i < GLFW_MAX_TOUCH; ++i) {
+        GLFWTouch* t = &_glfwInput.Touch[i];
+        if (t->Reference) {
+            touch[touchCount++] = *t;
 
-    for (i = 0; i < n; ++i) {
-        touch[i] = _glfwInput.Touch[i];
-    }
+            int phase = t->Phase;
+            if (phase == GLFW_PHASE_ENDED || phase == GLFW_PHASE_CANCELLED) {
+                // Clear reference since this touch has ended.
+                t->Reference = 0x0;
+            } else if (phase == GLFW_PHASE_BEGAN) {
+                // Touches that has begun will change to stationary until moved or released.
+                t->Phase = GLFW_PHASE_STATIONARY;
+            }
 
-    // Now to give a view where BEGAN and CANCELLED/ENDED are only
-    // seen once for every touch and call to glfwGetTouch, we do an update pass here.
-    //
-    // This should perhaps be done logically per frame, but since there is auto event polling
-    // causing event polling to be 2 times per frame, that is no good location to do it.
-    for (i=0;i<_glfwInput.TouchCount;i++) {
-        switch (_glfwInput.Touch[i].Phase) {
-            case GLFW_PHASE_CANCELLED:
-            case GLFW_PHASE_ENDED:
-                // These are erased so they do not appear a second time
-                _glfwInput.TouchCount--;
-                for (j=i;j<_glfwInput.TouchCount;j++)
-                    _glfwInput.Touch[j] = _glfwInput.Touch[j+1];
-                i--;
-                break;
-            case GLFW_PHASE_BEGAN:
-                _glfwInput.Touch[i].Phase = GLFW_PHASE_STATIONARY;
-                break;
-            default:
-                break;
+            // If this was a tap (began and ended on same frame), we need to
+            // make sure this touch results in an ended action next frame.
+            if (t->Phase == GLFW_PHASE_TAPPED) {
+                touch[touchCount].Phase = GLFW_PHASE_BEGAN;
+                t->Phase = GLFW_PHASE_ENDED;
+            }
+
         }
     }
+
+    if (count < touchCount)
+        touchCount = count;
+
+    *out_count = touchCount;
+
+    touchCount = 0;
 
     return 1;
 }

--- a/engine/glfw/lib/ios/ios_window.m
+++ b/engine/glfw/lib/ios/ios_window.m
@@ -634,6 +634,10 @@ Note that setting the view non-opaque will only work if the EAGL surface has an 
     int prevPhase = glfwt->Phase;
     int newPhase = t.phase;
 
+    if (newPhase == GLFW_PHASE_ENDED && _glfwInput.MouseEmulationTouch == glfwt) {
+        _glfwInput.MouseEmulationTouch = 0x0;
+    }
+
     if (prevPhase == GLFW_PHASE_ENDED && newPhase == GLFW_PHASE_MOVED) {
         return;
     }
@@ -655,9 +659,6 @@ Note that setting the view non-opaque will only work if the EAGL surface has an 
 
     glfwt->Phase = t.phase;
 
-    if (newPhase == GLFW_PHASE_ENDED) {
-        _glfwInput.MouseEmulationTouch = [self findNextMouseTouch];
-    }
 }
 
 - (int) fillTouchStart: (UIEvent*) event

--- a/engine/glfw/lib/ios/platform.h
+++ b/engine/glfw/lib/ios/platform.h
@@ -79,7 +79,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -193,7 +192,6 @@ GLFWGLOBAL struct {
     int  KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 
 // ========= PLATFORM SPECIFIC PART ======================================
 

--- a/engine/glfw/lib/win32/platform.h
+++ b/engine/glfw/lib/win32/platform.h
@@ -312,7 +312,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -414,7 +413,6 @@ GLFWGLOBAL struct {
     int  KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 
 // ========= PLATFORM SPECIFIC PART ======================================
 

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -127,8 +127,8 @@ void _glfwClearInput( void )
 
     for (i = 0; i < GLFW_MAX_TOUCH; ++i) {
         memset(&_glfwInput.Touch[i], 0, sizeof(_glfwInput.Touch[i]));
+        _glfwInput.Touch[i].Id = i;
     }
-    _glfwInput.TouchCount = 0;
 
     // The default is to disable key repeat
     _glfwInput.KeyRepeat = GL_FALSE;
@@ -539,7 +539,6 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
     _glfwWin.mousePosCallback      = NULL;
     _glfwWin.mouseButtonCallback   = NULL;
     _glfwWin.mouseWheelCallback    = NULL;
-    _glfwWin.touchCallback         = NULL;
 
     // Check width & height
     if( width > 0 && height <= 0 )

--- a/engine/glfw/lib/x11/platform.h
+++ b/engine/glfw/lib/x11/platform.h
@@ -222,7 +222,6 @@ struct _GLFWwin_struct {
     GLFWmousebuttonfun   mouseButtonCallback;
     GLFWmouseposfun      mousePosCallback;
     GLFWmousewheelfun    mouseWheelCallback;
-    GLFWtouchfun         touchCallback;
     GLFWkeyfun           keyCallback;
     GLFWcharfun          charCallback;
     GLFWmarkedtextfun    markedTextCallback;
@@ -353,7 +352,6 @@ GLFWGLOBAL struct {
     int  KeyRepeat;
 
     GLFWTouch Touch[GLFW_MAX_TOUCH];
-    int  TouchCount;
 
 // ========= PLATFORM SPECIFIC PART ======================================
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1560,6 +1560,10 @@ namespace dmGui
                             lua_pushinteger(L, (lua_Integer) (i+1));
                             lua_createtable(L, 0, 6);
 
+                            lua_pushliteral(L, "id");
+                            lua_pushinteger(L, (lua_Integer) t.m_Id);
+                            lua_settable(L, -3);
+
                             lua_pushliteral(L, "tap_count");
                             lua_pushinteger(L, (lua_Integer) t.m_TapCount);
                             lua_settable(L, -3);

--- a/engine/hid/src/hid.cpp
+++ b/engine/hid/src/hid.cpp
@@ -282,17 +282,26 @@ namespace dmHID
     }
 
     // NOTE: A bit contrived function only used for unit-tests. See AddTouchPosition
-    bool GetTouchPosition(TouchDevicePacket* packet, uint32_t touch_index, int32_t* x, int32_t* y)
+    bool GetTouch(TouchDevicePacket* packet, uint32_t touch_index, int32_t* x, int32_t* y, uint32_t* id, bool* pressed, bool* released)
     {
         if (packet != 0x0
                 && x != 0x0
-                && y != 0x0)
+                && y != 0x0
+                && id != 0x0)
         {
             if (touch_index < packet->m_TouchCount)
             {
                 const Touch& t = packet->m_Touches[touch_index];
                 *x = t.m_X;
                 *y = t.m_Y;
+                *id = t.m_Id;
+
+                if (pressed != 0x0) {
+                    *pressed = t.m_Phase == dmHID::PHASE_BEGAN;
+                }
+                if (released != 0x0) {
+                    *released = t.m_Phase == dmHID::PHASE_ENDED || t.m_Phase == dmHID::PHASE_CANCELLED;
+                }
                 return true;
             }
         }
@@ -301,7 +310,7 @@ namespace dmHID
 
     // NOTE: A bit contrived function only used for unit-tests
     // We should perhaps include additional relevant touch-arguments
-    void AddTouchPosition(HContext context, int32_t x, int32_t y)
+    void AddTouch(HContext context, int32_t x, int32_t y, uint32_t id, Phase phase)
     {
         if (context->m_TouchDeviceConnected)
         {
@@ -311,11 +320,13 @@ namespace dmHID
                 Touch& t = packet.m_Touches[packet.m_TouchCount++];
                 t.m_X = x;
                 t.m_Y = y;
+                t.m_Id = id;
+                t.m_Phase = phase;
             }
         }
     }
 
-    void ClearTouchPositions(HContext context)
+    void ClearTouches(HContext context)
     {
         if (context->m_TouchDeviceConnected)
         {

--- a/engine/hid/src/hid.h
+++ b/engine/hid/src/hid.h
@@ -581,29 +581,37 @@ namespace dmHID
 
     /**
      * Convenience function to retrieve the position of a specific touch.
+     * Used in unit tests (test_input.cpp)
      *
      * @param touch_index which touch to get the position from
      * @param x x-coordinate as out-parameter
      * @param y y-coordinate as out-parameter
+     * @param id identifier of touch as out-parameter
+     * @param pressed boolean indicating if touch is pressed as out-parameter
+     * @param released boolean indicating if touch is released as out-parameter
      * @return if the position could be retrieved
      */
-    bool GetTouchPosition(TouchDevicePacket* packet, uint32_t touch_index, int32_t* x, int32_t* y);
+    bool GetTouch(TouchDevicePacket* packet, uint32_t touch_index, int32_t* x, int32_t* y, uint32_t* id, bool* pressed = 0x0, bool* released = 0x0);
 
     /**
-     * Adds the position of a touch.
+     * Adds of a touch.
+     * Used in unit tests (test_input.cpp)
      *
      * @param context context handle
      * @param x x-coordinate of the position
      * @param y y-coordinate of the position
+     * @param phase phase of touch
+     * @param id identifier of touch
      */
-    void AddTouchPosition(HContext context, int32_t x, int32_t y);
+    void AddTouch(HContext context, int32_t x, int32_t y, uint32_t id, Phase phase);
 
     /**
      * Clears all touches.
+     * Used in unit tests (test_input.cpp)
      *
      * @param context context handle
      */
-    void ClearTouchPositions(HContext context);
+    void ClearTouches(HContext context);
 
     /**
      * Get the name of a keyboard key.

--- a/engine/hid/src/hid.h
+++ b/engine/hid/src/hid.h
@@ -257,6 +257,8 @@ namespace dmHID
         int32_t m_DX;
         /// dy
         int32_t m_DY;
+        // Touch id
+        int32_t m_Id;
     };
 
     /**

--- a/engine/hid/src/hid_glfw.cpp
+++ b/engine/hid/src/hid_glfw.cpp
@@ -173,6 +173,7 @@ namespace dmHID
                 for (int i = 0; i < n_touch; ++i)
                 {
                     packet->m_Touches[i].m_TapCount = glfw_touch[i].TapCount;
+                    packet->m_Touches[i].m_Id = glfw_touch[i].Id;
                     packet->m_Touches[i].m_Phase = (dmHID::Phase) glfw_touch[i].Phase;
                     packet->m_Touches[i].m_X = glfw_touch[i].X;
                     packet->m_Touches[i].m_Y = glfw_touch[i].Y;

--- a/engine/hid/src/test/test_hid.cpp
+++ b/engine/hid/src/test/test_hid.cpp
@@ -161,22 +161,28 @@ TEST_F(HIDTest, TouchDevice)
     // Touch all inputs
     for (uint32_t i = 0; i < dmHID::MAX_TOUCH_COUNT; ++i)
     {
-        dmHID::AddTouchPosition(m_Context, i*2, i*2+1);
+        dmHID::AddTouch(m_Context, i*2, i*2+1, 0, dmHID::PHASE_BEGAN);
     }
 
     ASSERT_TRUE(dmHID::GetTouchDevicePacket(m_Context, &packet));
 
     // Assert inputs
     int32_t x, y;
+    uint32_t id;
+    bool pressed;
+    bool released;
     for (uint32_t i = 0; i < dmHID::MAX_TOUCH_COUNT; ++i)
     {
-        ASSERT_TRUE(dmHID::GetTouchPosition(&packet, i, &x, &y));
+        ASSERT_TRUE(dmHID::GetTouch(&packet, i, &x, &y, &id, &pressed, &released));
         ASSERT_EQ((int32_t)i*2, x);
         ASSERT_EQ((int32_t)i*2+1, y);
+        ASSERT_EQ(0, id);
+        ASSERT_EQ(true, pressed);
+        ASSERT_EQ(false, released);
     }
 
     // Clear touches
-    dmHID::ClearTouchPositions(m_Context);
+    dmHID::ClearTouches(m_Context);
 
     ASSERT_TRUE(dmHID::GetTouchDevicePacket(m_Context, &packet));
 

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -623,6 +623,7 @@ namespace dmInput
                         int32_t tn = packet->m_TouchCount;
                         // NOTE: We assume dmHID::MAX_TOUCH_COUNT for both source and destination here
                         assert(tn <= (int32_t) (sizeof(action->m_Touch) / sizeof(action->m_Touch[0])));
+                        action->m_Value = 0;
                         for (int j = 0; j < tn; ++j) {
                             action->m_Touch[j] = packet->m_Touches[j];
                             dmHID::Phase p = packet->m_Touches[j].m_Phase;
@@ -633,6 +634,10 @@ namespace dmInput
                                 action->m_DX = action->m_Touch[j].m_DX;
                                 action->m_DY = action->m_Touch[j].m_DY;
                                 action->m_PositionSet = 1;
+                            }
+                            if (p == dmHID::PHASE_BEGAN || p == dmHID::PHASE_MOVED || p == dmHID::PHASE_STATIONARY)
+                            {
+                                action->m_Value = 1.0;
                             }
                         }
                         action->m_TouchCount = packet->m_TouchCount;

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -623,7 +623,6 @@ namespace dmInput
                         int32_t tn = packet->m_TouchCount;
                         // NOTE: We assume dmHID::MAX_TOUCH_COUNT for both source and destination here
                         assert(tn <= (int32_t) (sizeof(action->m_Touch) / sizeof(action->m_Touch[0])));
-                        action->m_Value = 0;
                         for (int j = 0; j < tn; ++j) {
                             action->m_Touch[j] = packet->m_Touches[j];
                             dmHID::Phase p = packet->m_Touches[j].m_Phase;
@@ -634,10 +633,6 @@ namespace dmInput
                                 action->m_DX = action->m_Touch[j].m_DX;
                                 action->m_DY = action->m_Touch[j].m_DY;
                                 action->m_PositionSet = 1;
-                            }
-                            if (p == dmHID::PHASE_BEGAN || p == dmHID::PHASE_MOVED || p == dmHID::PHASE_STATIONARY)
-                            {
-                                action->m_Value = 1.0;
                             }
                         }
                         action->m_TouchCount = packet->m_TouchCount;
@@ -763,7 +758,7 @@ namespace dmInput
 
     void ForEachActiveCallback(CallbackData* data, const dmhash_t* key, Action* action)
     {
-        bool active = action->m_Value != 0.0f || action->m_Pressed || action->m_Released || action->m_TextCount > 0 || action->m_HasText;
+        bool active = action->m_Value != 0.0f || action->m_Pressed || action->m_Released || action->m_TextCount > 0 || action->m_TouchCount > 0 || action->m_HasText;
         // Mouse move action
         active = active || (*key == 0 && (action->m_DX != 0 || action->m_DY != 0 || action->m_AccelerationSet));
         if (active)

--- a/engine/resource/test_resource_liveupdate.arcd
+++ b/engine/resource/test_resource_liveupdate.arcd
@@ -1,1 +1,0 @@
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/engine/resource/test_resource_liveupdate.arcd
+++ b/engine/resource/test_resource_liveupdate.arcd
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
* Redid most of the implementation of Android touch input handling in `android_init.c`. A touch is now allocated a specific entry in the `_glfwInput.Touch` array, and will keep that entry for the duration of a touch sequence. The `GLFWTouch.Reference` is used to keep track of a touch sequence validity (will be reset to `0x0` after the touch has ended).
* Reimplemented touch input handling in iOS to mimic the Android implementation.
* Added a new GLFW touch "phase" that represent touches that began and ended on the same frame; `GLFW_PHASE_TAPPED`.
* Added a new field to the GLFWTouch struct, `Id`, that should be used all the way to the Lua/scripting side to keep track of touch sequences.
* Removed code related to GLFW touch callback functionality. This was never used, and would not work in our current implementation/flow. I also doubt it ever worked before, but not sure since we didn't use it, it was just dead code.
* Changed how we distinguish if a touch event was triggered from looking at `m_Value` and `m_PrevValue` diff to checking size of `m_TouchCount`.