### PR TITLE
Added additional increment of offset when reading counters

### DIFF
--- a/engine/dlib/data/profiler.html
+++ b/engine/dlib/data/profiler.html
@@ -223,6 +223,11 @@
                     var name_id = readPtr(d, offset, ptrSize);
                     var value = readUInt32(d, offset + ptrSize);
                     offset += (4 + ptrSize);
+                    // if the pointer size is 8 bytes (eg on iOS 64 bit) the
+                    // counters data struct gets padded with 4 additional bytes
+                    if (ptrSize == 8) {
+                      offset += 4;
+                    }
                     var name = table[name_id];
                     counters_data[name] = {
                         value: value


### PR DESCRIPTION
When the pointer size is 8 bytes the counters data struct will be padded with an additional 4 bytes to an even 16 bytes.