### PR TITLE
DEFEDIT-847 Added missing arguments to build-project call for hot reload

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -294,7 +294,7 @@
       (ui/default-render-progress-now! (progress/make "Building..."))
       (ui/->future 0.01
                    (fn []
-                     (let [build (build-project project build-errors-view)]
+                     (let [build (build-project project prefs project/build-and-save-project build-errors-view)]
                        (when (and (future? build) @build)
                          (engine/reload-resource (:url (prefs/get-prefs prefs "last-target" targets/local-target)) resource))))))))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#582