### PR TITLE
DEF-2561 Handling reset keys for spine draw order offsets

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/SpineSceneTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/SpineSceneTest.java
@@ -509,6 +509,47 @@ public class SpineSceneTest {
     }
     
     @Test
+    public void testSampleDrawOrderResetKey() throws Exception {
+        SpineSceneUtil scene = load("draw_order_skeleton_sparse_duplicates.json");
+        Animation anim = scene.getAnimation("animation");
+        
+        assertEquals(3, anim.slotTracks.size());
+        
+        SlotAnimationTrack track_4 = anim.slotTracks.get(0);
+
+        double sampleRate = 30.0;
+        double spf = 1.0/sampleRate;
+        double duration = anim.duration;
+        boolean interpolate = false;
+        boolean shouldSlerp = false;
+        int expectedSampleCountPerMesh = 14;
+        int signal_done = 0xDEAD;
+        
+        MeshAnimationTrack.Builder trackBuilder = MeshAnimationTrack.newBuilder();
+        MockDrawOrderBuilder drawOrderBuilder = new MockDrawOrderBuilder(trackBuilder);
+        
+        // Mesh "_4" [0, 0, 0, 2, 2, 2, 1, 1, 1, 0xDEAD, 0xDEAD, 0xDEAD, 0, 0]
+        drawOrderBuilder = new MockDrawOrderBuilder(trackBuilder);
+        RigUtil.sampleTrack(track_4, drawOrderBuilder, new Integer(0), duration, sampleRate, spf, interpolate, shouldSlerp);
+        assertEquals(expectedSampleCountPerMesh, drawOrderBuilder.GetOrderOffsetCount());
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(0));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(1));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(2));
+        assertEquals(2, drawOrderBuilder.GetOrderOffset(3));
+        assertEquals(2, drawOrderBuilder.GetOrderOffset(4));
+        assertEquals(2, drawOrderBuilder.GetOrderOffset(5));
+        assertEquals(1, drawOrderBuilder.GetOrderOffset(6));
+        assertEquals(1, drawOrderBuilder.GetOrderOffset(7));
+        assertEquals(1, drawOrderBuilder.GetOrderOffset(8));
+        assertEquals(signal_done, drawOrderBuilder.GetOrderOffset(9));
+        assertEquals(signal_done, drawOrderBuilder.GetOrderOffset(10));
+        assertEquals(signal_done, drawOrderBuilder.GetOrderOffset(11));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(12));
+        assertEquals(0, drawOrderBuilder.GetOrderOffset(13));
+        trackBuilder.clear();
+    }
+    
+    @Test
     public void testSampleSparseDrawOrderAnim() throws Exception {
         SpineSceneUtil scene = load("draw_order_skeleton_sparse.json");
         Animation anim = scene.getAnimation("animation");

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/SpineSceneTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/SpineSceneTest.java
@@ -523,7 +523,7 @@ public class SpineSceneTest {
         boolean interpolate = false;
         boolean shouldSlerp = false;
         int expectedSampleCountPerMesh = 14;
-        int signal_done = 0xDEAD;
+        int signal_locked = 0x10CCED;
         
         MeshAnimationTrack.Builder trackBuilder = MeshAnimationTrack.newBuilder();
         MockDrawOrderBuilder drawOrderBuilder = new MockDrawOrderBuilder(trackBuilder);
@@ -541,9 +541,9 @@ public class SpineSceneTest {
         assertEquals(1, drawOrderBuilder.GetOrderOffset(6));
         assertEquals(1, drawOrderBuilder.GetOrderOffset(7));
         assertEquals(1, drawOrderBuilder.GetOrderOffset(8));
-        assertEquals(signal_done, drawOrderBuilder.GetOrderOffset(9));
-        assertEquals(signal_done, drawOrderBuilder.GetOrderOffset(10));
-        assertEquals(signal_done, drawOrderBuilder.GetOrderOffset(11));
+        assertEquals(signal_locked, drawOrderBuilder.GetOrderOffset(9));
+        assertEquals(signal_locked, drawOrderBuilder.GetOrderOffset(10));
+        assertEquals(signal_locked, drawOrderBuilder.GetOrderOffset(11));
         assertEquals(0, drawOrderBuilder.GetOrderOffset(12));
         assertEquals(0, drawOrderBuilder.GetOrderOffset(13));
         trackBuilder.clear();

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/test/draw_order_skeleton_sparse_duplicates.json
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/test/draw_order_skeleton_sparse_duplicates.json
@@ -1,0 +1,71 @@
+{
+"skeleton": { "hash": "eWrbFnVVrOIryxNwhtKSHaNgUx4", "spine": "3.5.51", "width": 589.89, "height": 573 },
+"bones": [
+	{ "name": "root" },
+	{ "name": "bone", "parent": "root" },
+	{ "name": "bone2", "parent": "root" }
+],
+"slots": [
+	{ "name": "_5", "bone": "bone2", "attachment": "5" },
+	{ "name": "_4", "bone": "bone", "attachment": "4" },
+	{ "name": "_3", "bone": "bone", "attachment": "3" },
+	{ "name": "_2", "bone": "bone", "attachment": "2" },
+	{ "name": "_1", "bone": "bone", "attachment": "1" }
+],
+"skins": {
+	"default": {
+		"_1": {
+			"1": { "x": -100.4, "y": 204.42, "width": 225, "height": 225 }
+		},
+		"_2": {
+			"2": { "x": -5.04, "y": 113.35, "width": 225, "height": 225 }
+		},
+		"_3": {
+			"3": { "x": 80.61, "y": 25.19, "width": 189, "height": 266 }
+		},
+		"_4": {
+			"4": { "x": 193.96, "y": -50.38, "width": 300, "height": 300 }
+		},
+		"_5": {
+			"5": { "x": 264.49, "y": -143.58, "width": 225, "height": 225 }
+		}
+	}
+},
+"animations": {
+	"animation": {
+		"bones": {
+			"root": {
+				"translate": [
+					{ "time": 0, "x": -8, "y": 0 },
+					{ "time": 0.4, "x": 597.77, "y": 0 }
+				]
+			}
+		},
+		"drawOrder": [
+			{
+				"time": 0.1,
+				"offsets": [
+					{ "slot": "_4", "offset": 2 },
+					{ "slot": "_3", "offset": 2 }
+				]
+			},
+			{
+				"time": 0.2,
+				"offsets": [
+					{ "slot": "_5", "offset": 4 },
+					{ "slot": "_4", "offset": 1 },
+					{ "slot": "_3", "offset": 1 }
+				]
+			},
+			{
+				"time": 0.3,
+				"offsets": [
+					{ "slot": "_5", "offset": 4 },
+					{ "slot": "_4", "offset": 0 }
+				]
+			},
+			{ "time": 0.4 }
+		]
+	}
+}
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/SpineSceneUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/SpineSceneUtil.java
@@ -470,6 +470,7 @@ public class SpineSceneUtil {
             }
         }
         float duration = 0.0f;
+        int signal_done = 0xDEAD;
         JsonNode drawOrderNode = animNode.get("drawOrder");
         if (drawOrderNode != null) {
             Iterator<JsonNode> animDrawOrderIt = drawOrderNode.getElements();
@@ -495,11 +496,17 @@ public class SpineSceneUtil {
                         }
                         SlotAnimationKey key = new SlotAnimationKey();
                         key.orderOffset = JsonUtil.get(offsetNode, "offset", 0);
+                        
+                        // Key with explicit offset 0 means that a previous draw order offset is finished at this key, but it should yet not be considered unchanged.
+                        if(key.orderOffset == 0) {
+                            key.orderOffset = signal_done;
+                        }
+                        
                         key.t = t;
                         track.keys.add(key);
                     }
                 }
-                // Add default keys for all slots who were not explicitly changed in offset this key
+                // Add default keys for all slots who were previously offset:ed but not explicitly changed in offset this key
                 for (Map.Entry<String, SlotAnimationTrack> entry : slotTracks.entrySet()) {
                     SlotAnimationTrack track = entry.getValue();
                     SlotAnimationKey key = track.keys.get(track.keys.size() - 1);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/SpineSceneUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/SpineSceneUtil.java
@@ -470,7 +470,7 @@ public class SpineSceneUtil {
             }
         }
         float duration = 0.0f;
-        int signal_done = 0xDEAD;
+        int signal_locked = 0x10CCED; // "LOCKED" indicates that draw order offset for this key should not be modified in runtime
         JsonNode drawOrderNode = animNode.get("drawOrder");
         if (drawOrderNode != null) {
             Iterator<JsonNode> animDrawOrderIt = drawOrderNode.getElements();
@@ -499,7 +499,7 @@ public class SpineSceneUtil {
                         
                         // Key with explicit offset 0 means that a previous draw order offset is finished at this key, but it should yet not be considered unchanged.
                         if(key.orderOffset == 0) {
-                            key.orderOffset = signal_done;
+                            key.orderOffset = signal_locked;
                         }
                         
                         key.t = t;

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -9,7 +9,7 @@ namespace dmRig
     static const dmhash_t NULL_ANIMATION = dmHashString64("");
     static const uint32_t INVALID_BONE_INDEX = 0xffff;
     static const float CURSOR_EPSILON = 0.0001f;
-    static const uint32_t SIGNAL_ORDER_DONE = 0xdead;
+    static const uint32_t SIGNAL_ORDER_LOCKED = 0x10cced; // "locked" indicates that draw order offset should not be modified
 
     /// Config key to use for tweaking the total maximum number of rig instances in a context.
     const char* RIG_MAX_INSTANCES_KEY = "rig.max_instance_count";
@@ -879,7 +879,7 @@ namespace dmRig
         // changed so that it is not shuffled when re-ordering.
 
         // Subtract with arbitrary "large" number, catch meshes that have up to -5000 in draw offset in initial pose (unlikely)
-        uint32_t signal_done_thresh = SIGNAL_ORDER_DONE - 5000;
+        uint32_t signal_locked_thresh = SIGNAL_ORDER_LOCKED - 5000;
         out_order_to_mesh.SetSize(mesh_count);
 
         // Intialize
@@ -893,7 +893,7 @@ namespace dmRig
         // Update changed
         for (uint32_t i = 0; i < mesh_count; ++i) {
             uint32_t order = instance->m_MeshProperties[i].m_Order;
-            if (order > signal_done_thresh) {
+            if (order > signal_locked_thresh) {
                 out_order_to_mesh[i] = order;
             }
             else if (order != i) {
@@ -916,7 +916,7 @@ namespace dmRig
 
         // Set all done entries
         for (uint32_t i = 0; i < mesh_count; ++i) {
-            if (out_order_to_mesh[i] > signal_done_thresh) {
+            if (out_order_to_mesh[i] > signal_locked_thresh) {
                 out_order_to_mesh[i] = i;
             }
         }

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -9,6 +9,7 @@ namespace dmRig
     static const dmhash_t NULL_ANIMATION = dmHashString64("");
     static const uint32_t INVALID_BONE_INDEX = 0xffff;
     static const float CURSOR_EPSILON = 0.0001f;
+    static const uint32_t SIGNAL_ORDER_DONE = 0xdead;
 
     /// Config key to use for tweaking the total maximum number of rig instances in a context.
     const char* RIG_MAX_INSTANCES_KEY = "rig.max_instance_count";
@@ -873,7 +874,14 @@ namespace dmRig
         // Init: [0, 1, 2]
         // Changed: 1 => 0, results in [1, 1, 2]
         // Unchanged: 0 => 0, 2 => 2, results in [1, 0, 2] (indices 1 and 2 were untouched and filled)
+        // An exception is made if there is an explicit entry with offset "0". This means that previous offset
+        // change is "done". In that case the order should be unchanged, but it should be considered as
+        // changed so that it is not shuffled when re-ordering.
+
+        // Subtract with arbitrary "large" number, catch meshes that have up to -5000 in draw offset in initial pose (unlikely)
+        uint32_t signal_done_thresh = SIGNAL_ORDER_DONE - 5000;
         out_order_to_mesh.SetSize(mesh_count);
+
         // Intialize
         for (uint32_t i = 0; i < mesh_count; ++i) {
             out_order_to_mesh[i] = i;
@@ -885,7 +893,10 @@ namespace dmRig
         // Update changed
         for (uint32_t i = 0; i < mesh_count; ++i) {
             uint32_t order = instance->m_MeshProperties[i].m_Order;
-            if (order != i) {
+            if (order > signal_done_thresh) {
+                out_order_to_mesh[i] = order;
+            }
+            else if (order != i) {
                 out_order_to_mesh[order] = i;
             }
         }
@@ -900,6 +911,13 @@ namespace dmRig
                 }
                 out_order_to_mesh[draw_order] = i;
                 ++draw_order;
+            }
+        }
+
+        // Set all done entries
+        for (uint32_t i = 0; i < mesh_count; ++i) {
+            if (out_order_to_mesh[i] > signal_done_thresh) {
+                out_order_to_mesh[i] = i;
             }
         }
     }


### PR DESCRIPTION
Entry in spine exported json with explicit offset "0" means that the ordering of that mesh is unchanged, but it should not be touched when reordering meshes in runtime.