### PR TITLE
DEFEDIT-860 Bob can build even when there is a space in the path to t…

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ClassLoaderScanner.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ClassLoaderScanner.java
@@ -3,6 +3,7 @@ package com.dynamo.bob;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,7 +29,7 @@ public class ClassLoaderScanner implements IClassScanner {
         String relPath = pkgname.replace('.', '/');
         String resPath = resource.getPath();
         String jarPath = resPath.replaceFirst("[.]jar[!].*", ".jar").replaceFirst("file:", "");
-        JarFile jarFile = new JarFile(jarPath);
+        JarFile jarFile = new JarFile(URLDecoder.decode(jarPath, "UTF-8"));
         try {
             Enumeration<JarEntry> entries = jarFile.entries();
             while(entries.hasMoreElements()) {


### PR DESCRIPTION
…he app

* Would fail when trying to scan the defold ed2 jar for compilers
* Problem was the space was converted to %20 in the URLs, added decoding to solve it
* Verified for Geometry Wars with space both in app path and project path