### PR TITLE
Facilitate caching of Magazine resources.

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/clients/magazine/MagazineClient.java
+++ b/server/src/main/java/com/dynamo/cr/server/clients/magazine/MagazineClient.java
@@ -68,7 +68,11 @@ public class MagazineClient {
     public String createReadUrl(String resource) {
         String fileName = Paths.get(resource).getFileName().toString();
         String path = Paths.get(resource).getParent().toString();
-        String jwt = jwtFactory.create("", Instant.now().plus(READ_EXPIRATION), path, false);
+
+        // Truncated to facilitate caching (preventing ever changing URL).
+        Instant expires = Instant.now().truncatedTo(ChronoUnit.DAYS).plus(READ_EXPIRATION);
+
+        String jwt = jwtFactory.create("", expires, path, false);
         return getMagazineServiceUrl() + "/" + jwt + "/" + fileName;
     }
 


### PR DESCRIPTION
This facilitates browser caching of resources served by the
Magazine service. It's done by truncating the expire date
of the JWT so that the URL doesn't change between every request
as time goes by...