### PR TITLE
DEFEDIT-859 gui texture rendering issues

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -133,6 +133,7 @@
                                 :source-paths      ["dev/clj"]
                                 :resource-paths    ["test/resources"]
                                 :jvm-opts          ["-Ddefold.unpack.path=tmp/unpack"
+                                                    "-Djogl.texture.notexrect=true"
                                                     "-XX:+UnlockCommercialFeatures"
                                                     "-XX:+FlightRecorder"
                                                     "-XX:-OmitStackTraceInFastThrow"]}})

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -158,13 +158,15 @@
   (let [user-data (get-in renderables [0 :user-data])]
     (cond
       (contains? user-data :geom-data)
-      (let [[vs uvs colors] (reduce (fn [[vs uvs colors] renderable]
+      (let [[vs uvs colors] (reduce (fn [[vs uvs colors :as vb] renderable]
                                       (let [user-data (:user-data renderable)
                                             world-transform (:world-transform renderable)
                                             vcount (count (:geom-data user-data))]
-                                        [(into vs (geom/transf-p world-transform (:geom-data user-data)))
-                                         (into uvs (:uv-data user-data))
-                                         (into colors (repeat vcount (premul (:color user-data))))]))
+                                        (if (pos? vcount)
+                                          [(into vs (geom/transf-p world-transform (:geom-data user-data)))
+                                           (into uvs (:uv-data user-data))
+                                           (into colors (repeat vcount (premul (:color user-data))))]
+                                          vb)))
                                     [[] [] []] renderables)]
         (when (not-empty vs)
           (->uv-color-vtx-vb vs uvs colors (count vs))))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -120,16 +120,12 @@
 (defn- ->color-vtx-vb [vs colors vcount]
   (let [vb (->color-vtx vcount)
         vs (mapv (comp vec concat) vs colors)]
-    (doseq [v vs]
-      (conj! vb v))
-    (persistent! vb)))
+    (persistent! (reduce conj! vb vs))))
 
 (defn- ->uv-color-vtx-vb [vs uvs colors vcount]
   (let [vb (->uv-color-vtx vcount)
         vs (mapv (comp vec concat) vs uvs colors)]
-    (doseq [v vs]
-      (conj! vb v))
-    (persistent! vb)))
+    (persistent! (reduce conj! vb vs))))
 
 (def outline-color (scene/select-color pass/outline false [1.0 1.0 1.0 1.0]))
 (def selected-outline-color (scene/select-color pass/outline true [1.0 1.0 1.0 1.0]))


### PR DESCRIPTION
- Under some [circumstances](https://jogamp.org/deployment/v2.3.2/javadoc/jogl/javadoc/com/jogamp/opengl/util/texture/Texture.html#nonpow2) JOGL will attempt to use non-power-of-two textures. This is not supported by us (builtin shaders uses texture2D for example) and is disabled in bundled builds. Disable locally too to avoid further grief.
- Make sure vertex and UV data line up. For zero-sized GUI nodes (width and/or height) we did not generate any vertex data, but did generate UV data. When generating data for a batch with multiple nodes, this would cause us to, depending on order, use the wrong UVs for some nodes.
- Fix case of in-place bashing of transients

Fixes https://github.com/defold/editor2-issues/issues/621