### PR TITLE
Add Sticky Iron fields.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.common/proto/cr_protocol_ddf.proto
+++ b/com.dynamo.cr/com.dynamo.cr.common/proto/cr_protocol_ddf.proto
@@ -133,6 +133,8 @@ message ProjectSite {
     optional string library_url = 16;
     optional string attachment_url = 17;
     optional bool is_public_site = 18;
+    optional bool show_name = 19;
+    optional bool allow_comments = 20;
 
     message AppStoreReference {
         required int64 id = 1;

--- a/server/src/main/java/com/dynamo/cr/server/model/ProjectSite.java
+++ b/server/src/main/java/com/dynamo/cr/server/model/ProjectSite.java
@@ -51,6 +51,12 @@ public class ProjectSite {
     @Column
     private boolean publicSite;
 
+    @Column
+    private boolean showName = true;
+
+    @Column
+    private boolean allowComments = true;
+
     @OneToMany(cascade = CascadeType.ALL)
     private Set<AppStoreReference> appStoreReferences = new HashSet<>();
 
@@ -175,5 +181,21 @@ public class ProjectSite {
 
     public void setPublicSite(boolean publicSite) {
         this.publicSite = publicSite;
+    }
+
+    public boolean isShowName() {
+        return showName;
+    }
+
+    public void setShowName(boolean showName) {
+        this.showName = showName;
+    }
+
+    public boolean isAllowComments() {
+        return allowComments;
+    }
+
+    public void setAllowComments(boolean allowComments) {
+        this.allowComments = allowComments;
     }
 }

--- a/server/src/main/java/com/dynamo/cr/server/resources/mappers/ProjectSiteMapper.java
+++ b/server/src/main/java/com/dynamo/cr/server/resources/mappers/ProjectSiteMapper.java
@@ -92,6 +92,8 @@ public class ProjectSiteMapper {
             }
 
             builder.setIsPublicSite(projectSite.isPublicSite());
+            builder.setShowName(projectSite.isShowName());
+            builder.setAllowComments(projectSite.isAllowComments());
 
             Set<AppStoreReference> appStoreReferences = projectSite.getAppStoreReferences();
             if (appStoreReferences != null) {

--- a/server/src/main/java/com/dynamo/cr/server/services/ProjectService.java
+++ b/server/src/main/java/com/dynamo/cr/server/services/ProjectService.java
@@ -153,6 +153,14 @@ public class ProjectService {
         if (projectSite.hasIsPublicSite()) {
             existingProjectSite.setPublicSite(projectSite.getIsPublicSite());
         }
+
+        if (projectSite.hasShowName()) {
+            existingProjectSite.setShowName(projectSite.getShowName());
+        }
+
+        if (projectSite.hasAllowComments()) {
+            existingProjectSite.setAllowComments(projectSite.getAllowComments());
+        }
     }
 
     @Transactional

--- a/server/src/test/java/com/dynamo/cr/server/resources/v2/ProjectSitesResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/v2/ProjectSitesResourceTest.java
@@ -135,6 +135,8 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
                 .setDevLogUrl("devLogUrl")
                 .setReviewUrl("reviewUrl")
                 .setLibraryUrl("libraryUrl")
+                .setShowName(false)
+                .setAllowComments(false)
                 .build();
 
         updateProjectSite(TestUser.JAMES, project.getId(), projectSite);
@@ -149,6 +151,8 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
         assertEquals("reviewUrl", result.getReviewUrl());
         assertEquals("libraryUrl", result.getLibraryUrl());
         assertEquals(false, result.getIsPublicSite()); // Project site should be private by default.
+        assertEquals(false, result.getShowName());
+        assertEquals(false, result.getAllowComments());
         assertEquals(project.getId(), result.getProjectId());
     }
 


### PR DESCRIPTION
This adds fields needed for Sticky Iron, such as "Show project name" and
"Allow comments" to project site.