### PR TITLE
DEFEDIT-867 Can add GUI nodes when in non-default layout

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1683,7 +1683,7 @@
       g/tx-nodes-added
       first)))
 
-(defn- add-gui-node-handler [project {:keys [scene parent node-type]} select-fn]
+(defn add-gui-node-handler [project {:keys [scene parent node-type]} select-fn]
   (add-gui-node! project scene parent node-type select-fn))
 
 (defn- add-texture-handler [project {:keys [scene parent node-type]} select-fn]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1748,6 +1748,7 @@
 
 (defn- add-handler-options [node]
   (let [types (protobuf/enum-values Gui$NodeDesc$Type)
+        node (if (g/override? node) (g/override-original node) node)
         scene (node->gui-scene node)
         node-options (if (some #(g/node-instance? % node) [GuiSceneNode GuiNode NodeTree])
                        (let [parent (if (= node scene)

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -440,6 +440,10 @@
         user-data {:scene scene :parent parent :display-profile name :handler-fn gui/add-layout-handler}]
     (test-util/handler-run :add [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
 
+(defn- add-gui-node! [project scene app-view parent node-type]
+  (let [user-data {:scene scene :parent parent :node-type node-type :handler-fn gui/add-gui-node-handler}]
+    (test-util/handler-run :add [{:name :workbench :env {:selection [parent] :project project :user-data user-data :app-view app-view}}] user-data)))
+
 (defn- set-visible-layout! [scene layout]
   (g/transact (g/set-property scene :visible-layout layout)))
 
@@ -467,6 +471,17 @@
       (add-layout! project app-view node-id "Portrait")
       (set-visible-layout! node-id "Portrait")
       (is (not= box (gui-node node-id "box"))))))
+
+(deftest gui-layout-add-node
+  (with-clean-system
+    (let [[workspace project app-view] (test-util/setup! world)
+          scene (test-util/resource-node project "/gui/layouts.gui")]
+      (add-layout! project app-view scene "Portrait")
+      (set-visible-layout! scene "Portrait")
+      (let [node-tree (g/node-value scene :node-tree)]
+        (is (= #{"box"} (set (map :label (:children (test-util/outline scene [0]))))))
+        (add-gui-node! project scene app-view node-tree :type-box)
+        (is (= #{"box" "box1"} (set (map :label (:children (test-util/outline scene [0]))))))))))
 
 (defn- gui-text [scene id]
   (-> (gui-node scene id)


### PR DESCRIPTION
When current layout is not the "Default" layout, `NodeTree` and children are overridden nodes. Always add nodes to the original (non-overridden) node. 

There remain issues with selection, see https://jira.int.midasplayer.com/browse/DEFEDIT-868

Fixes https://github.com/defold/editor2-issues/issues/620