### PR TITLE
 Fix random filenames for uploads

### DIFF
--- a/server/src/main/java/com/dynamo/cr/server/services/ProjectService.java
+++ b/server/src/main/java/com/dynamo/cr/server/services/ProjectService.java
@@ -248,7 +248,6 @@ public class ProjectService {
         addScreenshot(projectId, new Screenshot(resourcePath, Screenshot.MediaType.IMAGE));
     }
 
-
     private String uploadImage(long projectId, String user, String originalFilename, InputStream file) throws Exception {
         String contextPath = String.format("/projects/%d/images", projectId);
         return uploadFile(user, originalFilename, file, contextPath);
@@ -261,9 +260,28 @@ public class ProjectService {
 
     private String uploadFile(String user, String originalFilename, InputStream file, String contextPath) throws Exception {
         String writeToken = magazineClient.createWriteToken(user, contextPath);
-        String filename = UUID.randomUUID().toString() + "-" + originalFilename;
+        String filename = createFilename(originalFilename);
         magazineClient.put(writeToken, "", file, filename);
         return Paths.get(contextPath, filename).toString();
+    }
+
+    /**
+     * Creates a random filename but keeping the file extension. The reason for using this is to create unique filnames
+     * for uploaded files and also not have to care about special characters.
+     *
+     * @param originalFilename Original filename.
+     * @return Random filename with file extension preserved.
+     */
+    String createFilename(String originalFilename) {
+        String filename = UUID.randomUUID().toString();
+
+        if (originalFilename != null) {
+            int beginIndex = originalFilename.lastIndexOf(".");
+            if (beginIndex > -1) {
+                filename += originalFilename.substring(beginIndex);
+            }
+        }
+        return filename;
     }
 
     @Transactional

--- a/server/src/test/java/com/dynamo/cr/server/services/ProjectServiceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/services/ProjectServiceTest.java
@@ -1,0 +1,27 @@
+package com.dynamo.cr.server.services;
+
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+
+public class ProjectServiceTest {
+
+    @Test
+    public void uploadFilenameTest() {
+        ProjectService projectService = new ProjectService();
+
+        Pattern patternFilenameWithExtension = Pattern.compile("[0-9a-f-]+\\.[a-z]+");
+        Pattern patternFilenameWithoutExtension = Pattern.compile("[0-9a-f-]+");
+
+        assertTrue(patternFilenameWithExtension.matcher(projectService.createFilename("apa.jpg")).matches());
+        assertTrue(patternFilenameWithExtension.matcher(projectService.createFilename("apa.björn.jpg")).matches());
+
+        assertTrue(patternFilenameWithoutExtension.matcher(projectService.createFilename("apa")).matches());
+        assertTrue(patternFilenameWithoutExtension.matcher(projectService.createFilename("")).matches());
+        assertTrue(patternFilenameWithoutExtension.matcher(projectService.createFilename(null)).matches());
+    }
+
+}


### PR DESCRIPTION
This makes sure that random filenames generated for uploaded files
only keeps the file extension of the original file. By doing so you
do not have to care for serving files with special characters in the
filename.