### PR TITLE
Liveupdate unused variables cleanup

### DIFF
--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -72,7 +72,6 @@ namespace dmResourceArchive
         uint32_t count = 0;
         uint32_t entry_count = JAVA_TO_C(lu_archive_container->m_ArchiveIndex->m_EntryDataCount);
         uint32_t entries_offset = JAVA_TO_C(lu_archive_container->m_ArchiveIndex->m_EntryDataOffset);
-        uint32_t hash_length = JAVA_TO_C(lu_archive_container->m_ArchiveIndex->m_HashLength);
         uint32_t hash_offset = JAVA_TO_C(lu_archive_container->m_ArchiveIndex->m_HashOffset);
         uint32_t bundled_hash_offset = JAVA_TO_C(bundled_archive_container->m_ArchiveIndex->m_HashOffset);
 
@@ -153,7 +152,6 @@ namespace dmResourceArchive
     Result ReloadBundledArchiveIndex(const char* bundled_index_path, const char* bundled_resource_path, const char* lu_index_path, const char* lu_resource_path, ArchiveIndexContainer*& lu_index_container, void*& index_mount_info)
     {
         LiveUpdateEntries* lu_entries = new LiveUpdateEntries;
-        uint32_t num_lu_entries = 0;
         void* bundled_index_mount_info = 0;
 
         // Mount bundled archive and make deep copy
@@ -181,7 +179,7 @@ namespace dmResourceArchive
             int insert_index = -1;
             const uint8_t* hash = (const uint8_t*)((uintptr_t)lu_entries->m_Hashes + hash_len * i);
             const EntryData* entry = (EntryData*)((uintptr_t)lu_entries->m_Entries + sizeof(EntryData) * i);
-            Result index_result = GetInsertionIndex(reloaded_index, hash, (const uint8_t*)reloaded_hashes, &insert_index);
+            GetInsertionIndex(reloaded_index, hash, (const uint8_t*)reloaded_hashes, &insert_index);
 
             // Insert each liveupdate entry WITHOUT writing any resource data!
             Result insert_result = ShiftAndInsert(bundled_archive_container, reloaded_index, hash, hash_len, insert_index, 0x0, entry);
@@ -585,7 +583,7 @@ namespace dmResourceArchive
             Result write_res = WriteResourceToArchive(archive_container, (uint8_t*)resource->m_Data, resource->m_Count, bytes_written, offs);
             if (write_res != RESULT_OK)
             {
-                dmLogError("All bytes not written for resource, bytes written: %u, resource size: %u", bytes_written, resource->m_Count);
+                dmLogError("All bytes not written for resource, bytes written: %u, resource size: %lu", bytes_written, resource->m_Count);
                 delete archive;
                 return RESULT_IO_ERROR;
             }
@@ -838,7 +836,6 @@ namespace dmResourceArchive
             void* r = 0x0;
             if (loaded_with_liveupdate)
             {
-                uint32_t bufsize = (compressed_size != 0xFFFFFFFF) ? compressed_size : size;
                 r = (void*) (((uintptr_t)archive->m_LiveUpdateResourceData + entry_data->m_ResourceDataOffset));
             }
             else

--- a/engine/resource/src/test/test_resource.cpp
+++ b/engine/resource/src/test/test_resource.cpp
@@ -740,7 +740,6 @@ TEST(dmResource, Builtins)
     dmResource::RegisterType(factory, "adc", 0, 0, AdResourceCreate, AdResourceDestroy, 0, 0);
 
     void* resource;
-    const uint64_t path_hash[]  = { 0x1db7f0530911b1ce, 0x731d3cc48697dfe4, 0x8417331f14a42e4b, 0xb4870d43513879ba, 0xe1f97b41134ff4a6 };
     const char* path_name[]     = { "/archive_data/file4.adc", "/archive_data/file1.adc", "/archive_data/file3.adc", "/archive_data/file2.adc" };
     const char* content[]       = {
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -105,7 +105,6 @@ void GetMutableBundledIndexData(void*& arci_data, uint32_t& arci_size, uint32_t 
     ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
 
     uint32_t entry_count = htonl(archive->m_ArchiveIndex->m_EntryDataCount);
-    uint32_t hash_length = JAVA_TO_C(archive->m_ArchiveIndex->m_HashLength);
     uint32_t hash_offset = JAVA_TO_C(archive->m_ArchiveIndex->m_HashOffset);
     uint32_t entries_offset = JAVA_TO_C(archive->m_ArchiveIndex->m_EntryDataOffset);
     dmResourceArchive::EntryData* entries = (dmResourceArchive::EntryData*)((uintptr_t)archive->m_ArchiveIndex + entries_offset);
@@ -212,7 +211,6 @@ TEST(dmResourceArchive, ShiftInsertResource)
 
     // Find inserted entry in archive after insertion
     dmResourceArchive::EntryData entry;
-    char buffer[1024] = { 0 };
     result = dmResourceArchive::FindEntry(archive, sorted_middle_hash, &entry);
     ASSERT_EQ(dmResourceArchive::RESULT_OK, result);
     ASSERT_EQ(entry.m_ResourceSize, resource->m_Count);
@@ -251,7 +249,6 @@ TEST(dmResourceArchive, CacheLiveUpdateEntries)
 {
     dmResourceArchive::HArchiveIndexContainer bundled_archive_container;
     dmResourceArchive::ArchiveIndex* bundled_archive_index;
-    uint32_t bundled_archive_size;
 
     dmResourceArchive::HArchiveIndexContainer archive_container = 0;
     dmResourceArchive::Result result = dmResourceArchive::WrapArchiveBuffer((void*) RESOURCES_ARCI, RESOURCES_ARCI_SIZE, RESOURCES_ARCD, 0x0, 0x0, 0x0, &archive_container);


### PR DESCRIPTION
When building engine/resource there are some warnings about unused variables