### PR TITLE
No authentication of public endpoints.

### DIFF
--- a/server/src/test/java/com/dynamo/cr/server/resources/UsersResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/UsersResourceTest.java
@@ -481,7 +481,7 @@ public class UsersResourceTest extends AbstractResourceTest {
 
             assertNull(userInfo);
         } catch (UniformInterfaceException e) {
-            assertEquals(Status.UNAUTHORIZED, e.getResponse().getClientResponseStatus());
+            assertEquals(Status.FORBIDDEN, e.getResponse().getClientResponseStatus());
         }
     }
 

--- a/server/src/test/java/com/dynamo/cr/server/resources/v2/ProjectSitesResourceTest.java
+++ b/server/src/test/java/com/dynamo/cr/server/resources/v2/ProjectSitesResourceTest.java
@@ -56,6 +56,10 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
         return createBaseResource(user.email, user.password).path("v2/projects").path(projectId.toString()).path("site");
     }
 
+    private WebResource projectSiteResourceWithFaultyPassword(Long projectId) {
+        return createBaseResource("FAULTY", "FAULTY").path("v2/projects").path(projectId.toString()).path("site");
+    }
+
     private WebResource projectSitesResource(TestUser user) {
         return createBaseResource(user.email, user.password).path("v2/projects").path("sites");
     }
@@ -78,6 +82,10 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
 
     private Protocol.ProjectSite getProjectSite(Long projectId) {
         return projectSiteResource(projectId).get(Protocol.ProjectSite.class);
+    }
+
+    private Protocol.ProjectSite getProjectSiteWithFaultyPassword(Long projectId) {
+        return projectSiteResourceWithFaultyPassword(projectId).get(Protocol.ProjectSite.class);
     }
 
     private void addAppStoreReference(TestUser testUser, Long projectId, Protocol.NewAppStoreReference newAppStoreReference) {
@@ -120,6 +128,21 @@ public class ProjectSitesResourceTest extends AbstractResourceTest {
         Protocol.ProjectSiteList result = getProjectSites(TestUser.JAMES);
 
         assertEquals(originalSitesCount + 1, result.getSitesCount());
+    }
+
+    @Test
+    public void accessPublicSiteWithExpiredSession() {
+        Protocol.ProjectInfo project = createProject(TestUser.JAMES);
+
+        Protocol.ProjectSite projectSiteUpdate = Protocol.ProjectSite.newBuilder()
+                .setIsPublicSite(true)
+                .build();
+
+        updateProjectSite(TestUser.JAMES, project.getId(), projectSiteUpdate);
+
+
+        Protocol.ProjectSite projectSite = getProjectSiteWithFaultyPassword(project.getId());
+        assertNotNull(projectSite);
     }
 
     @Test


### PR DESCRIPTION
This changes the security filter so that it doesn't respond with
"Unauthorized" when trying to access public endpoints. Instead the
user will be authenticated as an anonymous user.

NOTE: A side effect of this is that instead of returning "Unauthorized"
when accessing an non-public endpoint with wrong credentials, it will respond with
"Forbidden" (meaning anonymous user is forbidden to access endpoint).