### PR TITLE
DEFEDIT-597 Texture Profiles

### DIFF
--- a/editor/src/clj/editor/display_profiles.clj
+++ b/editor/src/clj/editor/display_profiles.clj
@@ -51,16 +51,12 @@
      :fields [{:path [:profiles]
                :label "Profile"
                :type :2panel
-               :panel-key {:path [:name] :type :string}
+               :panel-key {:path [:name] :type :string :default "New Display Profile"}
                :on-add (partial add-profile! _node-id "New Display Profile" [])
-               :on-remove (fn [v] (g/delete-node! (:node-id v)))
+               :on-remove (fn [vals] (g/transact (map #(g/delete-node (:node-id %)) vals)))
                :set (fn [v path val] (g/set-property! (:node-id v) (first path) val))
                :panel-form {:sections
-                            [{:fields [{:path [:name]
-                                        :label "Name"
-                                        :type :string
-                                        :default "New Display Profile"}
-                                       {:path [:qualifiers]
+                            [{:fields [{:path [:qualifiers]
                                         :label "Qualifiers"
                                         :type :table
                                         :columns [{:path [:width]

--- a/editor/src/clj/editor/form.clj
+++ b/editor/src/clj/editor/form.clj
@@ -56,3 +56,9 @@
       (reduce merge
               {}
               sections-defaults))))
+
+(defn two-panel-defaults [panel-field-info]
+  (let [panel-key-defaults (field-defaults [(:panel-key panel-field-info)])
+        panel-form-defaults (form-defaults (:panel-form panel-field-info))]
+    (when (and panel-key-defaults panel-form-defaults)
+      (merge panel-key-defaults panel-form-defaults))))

--- a/editor/src/clj/editor/protobuf_forms.clj
+++ b/editor/src/clj/editor/protobuf_forms.clj
@@ -258,7 +258,7 @@
   (let [os-values (protobuf/enum-values Graphics$PlatformProfile$OS)
         format-values (protobuf/enum-values Graphics$TextureImage$TextureFormat)
         compression-values (protobuf/enum-values Graphics$TextureFormatAlternative$CompressionLevel)
-        ]
+        profile-options (mapv #(do [% %]) (map :name (:profiles pb)))]
         {
          :sections
          [
@@ -281,7 +281,9 @@
               {
                :path [:profile]
                :label "Profile"
-               :type :string
+               :type :choicebox
+               :from-string str :to-string str ; allow manual entry
+               :options profile-options
                :default "Default"
                }
               ]
@@ -290,7 +292,7 @@
              :path [:profiles]
              :label "Profiles"
              :type :2panel
-             :panel-key {:path [:name] :type :string}
+             :panel-key {:path [:name] :type :string :default "Default"}
              :panel-form
              {
               :sections
@@ -299,17 +301,11 @@
                 :fields
                 [
                  {
-                  :path [:name]
-                  :label "Name"
-                  :type :string
-                  :default "New Profile"
-                  }
-                 {
                   :path [:platforms]
                   :label "Platforms"
                   :type :2panel
                   :panel-key
-                  {:path [:os] :type :choicebox :options (make-options os-values)}
+                  {:path [:os] :type :choicebox :options (make-options os-values) :default (ffirst os-values)}
                   :panel-form
                   {
                    :sections
@@ -317,13 +313,6 @@
                     {
                      :fields
                      [
-                      {
-                       :path [:os]
-                       :label "OS"
-                       :type :choicebox
-                       :options (make-options os-values)
-                       :default (ffirst os-values)
-                       }
                       {
                        :path [:formats]
                        :label "Formats"
@@ -376,8 +365,7 @@
   ([node-id pb def]
     (produce-form-data node-id pb def (protobuf-form-data node-id pb def)))
   ([node-id pb def form-data]
-    (let [form-data (merge (default-form-ops node-id)
-                      form-data)]
+    (let [form-data (merge (default-form-ops node-id) form-data)]
       (if (contains? form-data :values)
         form-data
         (assoc form-data :values (form-values form-data pb))))))


### PR DESCRIPTION
Form for texture profiles somewhat slimmed down. Added feature to
remove multiple rows from lists/tables.
Move focus to table instead of editing-cell on click to avoid
startEdit/cancelEdit race.