### PR TITLE
DEFEDIT-886 Fix tile source build error

### DIFF
--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -93,7 +93,8 @@
     [{:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-texture-set
-      :user-data {:texture-set texture-set}
+      :user-data {:texture-set texture-set
+                  :dep-resources [[:texture (:resource texture-target)]]}
       :deps [texture-target]}]))
 
 

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -442,6 +442,7 @@
 (g/defnk produce-tile-source-attributes
   [_node-id image-resource image-size tile-width tile-height tile-margin tile-spacing extrude-borders inner-padding collision-size]
   (or (validation/prop-error :fatal _node-id :image validation/prop-nil? image-resource "Image")
+      (validation/prop-error :fatal _node-id :image validation/prop-resource-not-exists? image-resource "Image")
       (let [properties {:width tile-width
                         :height tile-height
                         :margin tile-margin


### PR DESCRIPTION
`:dep-resources` was not included in build-target `:user-data` which meant build
target was not invalidated when it should've been.

Fixes https://github.com/defold/editor2-issues/issues/650