### PR TITLE
DEFEDIT-888 Improvements to Build Errors view

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -710,14 +710,16 @@
                            (let [image-view ^ImageView (.getGraphic tooltip)]
                              (when-not (.getImage image-view)
                                (let [resource-node (project/get-resource-node project resource)
-                                         view-graph (g/make-graph! :history false :volatility 2)
-                                         opts (assoc ((:id view-type) (:view-opts resource-type))
-                                                     :app-view app-view
-                                                     :project project
-                                                     :workspace workspace)
-                                         preview (make-preview-fn view-graph resource-node opts 256 256)]
-                                     (.setImage image-view ^Image (g/node-value preview :image))
-                                     (ui/user-data! image-view :graph view-graph))))))
+                                     view-graph (g/make-graph! :history false :volatility 2)
+                                     select-fn (partial select app-view)
+                                     opts (assoc ((:id view-type) (:view-opts resource-type))
+                                            :app-view app-view
+                                            :select-fn select-fn
+                                            :project project
+                                            :workspace workspace)
+                                     preview (make-preview-fn view-graph resource-node opts 256 256)]
+                                 (.setImage image-view ^Image (g/node-value preview :image))
+                                 (ui/user-data! image-view :graph view-graph))))))
           (.setOnHiding (ui/event-handler
                           e
                           (let [image-view ^ImageView (.getGraphic tooltip)]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -553,9 +553,11 @@
                      (.setContent parent)
                      (ui/user-data! ::view-type view-type))
         view-graph (g/make-graph! :history false :volatility 2)
+        select-fn  (partial select app-view)
         opts       (merge opts
                           (get (:view-opts resource-type) (:id view-type))
                           {:app-view  app-view
+                           :select-fn select-fn
                            :project   project
                            :workspace workspace
                            :tab       tab})

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -589,7 +589,7 @@
             (string/replace tmpl (format "{%s}" (name key)) (str val)))
     tmpl args))
 
-(defn- invalid-resource-node? [resource-node]
+(defn- defective-resource-node? [resource-node]
   (g/error-fatal? (g/node-value resource-node :node-id+resource)))
 
 (defn open-resource
@@ -603,7 +603,7 @@
          view-type     (or (:selected-view-type opts)
                            (first (:view-types resource-type))
                            (workspace/get-view-type workspace :text))]
-     (if (invalid-resource-node? resource-node)
+     (if (defective-resource-node? resource-node)
        (do (dialogs/make-alert-dialog (format "Unable to open '%s', since it appears damaged." (resource/proj-path resource)))
            false)
        (if-let [custom-editor (and (or (= (:id view-type) :code) (= (:id view-type) :text))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -139,8 +139,8 @@
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          (fn [resource node-id opts]
-                                                                           (open-resource resource opts)
-                                                                           (app-view/select! app-view node-id)))
+                                                                           (when (open-resource resource opts)
+                                                                             (app-view/select! app-view node-id))))
           search-results-view  (search-results-view/make-search-results-view! *view-graph*
                                                                               (.lookup root "#search-results-container")
                                                                               open-resource)

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -178,12 +178,13 @@
   (output ddf-message g/Any :abstract)
   (output node-outline-extras g/Any (g/constantly {}))
   (output build-resource resource/Resource (g/fnk [source-build-targets] (:resource (first source-build-targets))))
-  (output build-targets g/Any (g/fnk [build-resource source-build-targets ddf-message transform]
+  (output build-targets g/Any (g/fnk [build-resource source-build-targets build-error ddf-message transform]
                                      (let [target (assoc (first source-build-targets)
                                                          :resource build-resource)]
                                        [(assoc target :instance-data {:resource (:resource target)
                                                                       :instance-msg ddf-message
                                                                       :transform transform})])))
+  (output build-error g/Err (g/constantly nil))
 
   (output scene g/Any :cached (g/fnk [_node-id transform scene child-scenes]
                                      (let [aabb (reduce #(geom/aabb-union %1 (:aabb %2)) (or (:aabb scene) (geom/null-aabb)) child-scenes)
@@ -301,7 +302,9 @@
   (display-order [:id :url :path scene/ScalableSceneNode])
 
   (output ddf-message g/Any :cached (g/fnk [id child-ids source-resource position rotation scale ddf-component-properties]
-                                           (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties))))
+                                           (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties)))
+  (output build-error g/Err (g/fnk [_node-id source-resource]
+                                   (path-error _node-id source-resource))))
 
 (g/defnk produce-proto-msg [name scale-along-z ref-inst-ddf embed-inst-ddf ref-coll-ddf]
   {:name name

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -178,13 +178,12 @@
   (output ddf-message g/Any :abstract)
   (output node-outline-extras g/Any (g/constantly {}))
   (output build-resource resource/Resource (g/fnk [source-build-targets] (:resource (first source-build-targets))))
-  (output build-targets g/Any (g/fnk [build-resource source-build-targets build-error ddf-message transform]
+  (output build-targets g/Any (g/fnk [build-resource source-build-targets ddf-message transform]
                                      (let [target (assoc (first source-build-targets)
                                                          :resource build-resource)]
                                        [(assoc target :instance-data {:resource (:resource target)
                                                                       :instance-msg ddf-message
                                                                       :transform transform})])))
-  (output build-error g/Err (g/constantly nil))
 
   (output scene g/Any :cached (g/fnk [_node-id transform scene child-scenes]
                                      (let [aabb (reduce #(geom/aabb-union %1 (:aabb %2)) (or (:aabb scene) (geom/null-aabb)) child-scenes)
@@ -302,9 +301,7 @@
   (display-order [:id :url :path scene/ScalableSceneNode])
 
   (output ddf-message g/Any :cached (g/fnk [id child-ids source-resource position rotation scale ddf-component-properties]
-                                           (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties)))
-  (output build-error g/Err (g/fnk [_node-id source-resource]
-                                   (path-error _node-id source-resource))))
+                                           (gen-ref-ddf id child-ids position rotation scale source-resource ddf-component-properties))))
 
 (g/defnk produce-proto-msg [name scale-along-z ref-inst-ddf embed-inst-ddf ref-coll-ddf]
   {:name name

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -134,7 +134,7 @@
   (let [coll-id (core/scope _node-id)]
     (-> {:node-id _node-id
          :label id
-         :icon (:icon source-outline game-object/game-object-icon)
+         :icon (or (not-empty (:icon source-outline)) game-object/game-object-icon)
          :children (into (outline/natural-sort child-outlines) (:children source-outline))
          :child-reqs [{:node-type ReferencedGOInstanceNode
                        :tx-attach-fn (fn [self-id child-id]
@@ -461,7 +461,7 @@
 (g/defnk produce-coll-inst-outline [_node-id id source-resource source-outline source-id source-resource]
   (-> {:node-id _node-id
        :label id
-       :icon (:icon source-outline collection-icon)
+       :icon (or (not-empty (:icon source-outline)) collection-icon)
        :children (:children source-outline)}
     (cond->
       (and source-resource (resource/path source-resource)) (assoc :link source-resource))))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -118,7 +118,7 @@
             overridden? (boolean (some (fn [[_ p]] (contains? p :original-value)) (:properties source-properties)))]
         (-> {:node-id _node-id
              :label id
-             :icon (:icon source-outline)
+             :icon (or (not-empty (:icon source-outline)) unknown-icon)
              :outline-overridden? overridden?
              :children (:children source-outline)}
           (cond->

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -446,10 +446,6 @@
   (or (validation/prop-error nil-severity _node-id prop-kw validation/prop-nil? prop-value prop-name)
       (validation/prop-error :fatal _node-id prop-kw validation/prop-resource-not-exists? prop-value prop-name)))
 
-(defn- prop-anim-missing? [animation anim-ids]
-  (when (and anim-ids (not-any? #(= animation %) anim-ids))
-    (format "'%s' could not be found in the specified image" animation)))
-
 (defn- sort-anim-ids
   [anim-ids]
   (sort-by str/lower-case anim-ids))
@@ -493,7 +489,7 @@
             (dynamic error (g/fnk [_node-id animation anim-ids]
                              (when animation
                                (or (validation/prop-error :fatal _node-id :animation validation/prop-empty? animation "Animation")
-                                   (validation/prop-error :fatal _node-id :animation prop-anim-missing? animation anim-ids)))))
+                                   (validation/prop-error :fatal _node-id :animation validation/prop-anim-missing? animation anim-ids)))))
             (dynamic edit-type
                      (g/fnk [anim-ids] {:type :choicebox
                                         :options (or (and anim-ids (not (g/error? anim-ids)) (zipmap anim-ids anim-ids)) {})})))
@@ -536,7 +532,7 @@
                                 (or (when-let [errors (->> [(validation/prop-error :fatal _node-id :tile-source validation/prop-nil? tile-source "Image")
                                                             (validation/prop-error :fatal _node-id :material validation/prop-nil? material "Material")
                                                             (validation/prop-error :fatal _node-id :animation validation/prop-nil? animation "Animation")
-                                                            (validation/prop-error :fatal _node-id :animation prop-anim-missing? animation anim-ids)]
+                                                            (validation/prop-error :fatal _node-id :animation validation/prop-anim-missing? animation anim-ids)]
                                                            (remove nil?)
                                                            (seq))]
                                       (g/error-aggregate errors))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1,7 +1,6 @@
 (ns editor.scene
   (:require [clojure.set :as set]
             [dynamo.graph :as g]
-            [editor.app-view :as app-view]
             [editor.background :as background]
             [editor.camera :as c]
             [editor.scene-selection :as selection]
@@ -857,6 +856,7 @@
 (defn setup-view [view-id resource-node opts]
   (let [view-graph  (g/node-id->graph-id view-id)
         app-view-id (:app-view opts)
+        select-fn   (:select-fn opts)
         project     (:project opts)
         grid-type   (cond
                       (true? (:grid opts)) grid/Grid
@@ -866,7 +866,12 @@
     (concat
       (g/make-nodes view-graph
                     [background      background/Background
-                     selection       [selection/SelectionController :select-fn (fn [selection op-seq] (app-view/select! app-view-id selection op-seq))]
+                     selection       [selection/SelectionController :select-fn (fn [selection op-seq]
+                                                                                 (g/transact
+                                                                                   (concat
+                                                                                     (g/operation-sequence op-seq)
+                                                                                     (g/operation-label "Select")
+                                                                                     (select-fn selection))))]
                      camera          [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000}))]
                      grid            grid-type
                      tool-controller tool-controller-type
@@ -909,7 +914,7 @@
                     (g/connect view-id :viewport rulers :viewport)
                     (g/connect view-id :cursor-pos rulers :cursor-pos))
       (when-let [node-id (:select-node opts)]
-        (app-view/select app-view-id [node-id])))))
+        (select-fn [node-id])))))
 
 (defn make-view [graph ^Parent parent resource-node opts]
   (let [view-id (make-scene-view graph parent opts)]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1130,9 +1130,11 @@
 
 (defn- refresh-toolbar [td command-contexts]
  (let [menu (menu/realize-menu (:menu-id td))
-       ^Pane control (:control td)]
-   (when-not (and (= menu (user-data control ::menu))
-                  (= command-contexts (user-data control ::command-contexts)))
+       ^Pane control (:control td)
+       scene (.getScene control)]
+   (when (and (some? scene)
+              (or (not= menu (user-data control ::menu))
+                  (not= command-contexts (user-data control ::command-contexts))))
      (.clear (.getChildren control))
      (user-data! control ::menu menu)
      (user-data! control ::command-contexts command-contexts)
@@ -1156,8 +1158,7 @@
                                                    (.setAll (.getItems cb) ^java.util.Collection opts)
                                                    (observe (.valueProperty cb) (fn [this old new]
                                                                                   (when new
-                                                                                    (let [scene (.getScene control)
-                                                                                          command-contexts (contexts scene)]
+                                                                                    (let [command-contexts (contexts scene)]
                                                                                       (when-let [handler-ctx (handler/active (:command new) command-contexts (:user-data new))]
                                                                                         (when (handler/enabled? handler-ctx)
                                                                                           (handler/run handler-ctx)
@@ -1166,14 +1167,12 @@
                                                    (.add (.getChildren hbox) cb)
                                                    hbox)
                                                  (let [button (ToggleButton. (or (handler/label handler-ctx) (:label menu-item)))
-                                                       icon (:icon menu-item)
-                                                       selection-provider (:selection-provider td)]
+                                                       icon (:icon menu-item)]
                                                    (when icon
                                                      (.setGraphic button (jfx/get-image-view icon 16)))
                                                    (when command
                                                      (on-action! button (fn [event]
-                                                                          (let [scene (.getScene control)
-                                                                                command-contexts (contexts scene)]
+                                                                          (let [command-contexts (contexts scene)]
                                                                             (when-let [handler-ctx (handler/active command command-contexts user-data)]
                                                                               (when (handler/enabled? handler-ctx)
                                                                                 (handler/run handler-ctx)

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -34,6 +34,10 @@
 (defn prop-resource-not-exists? [v name]
   (and v (not (resource/exists? v)) (format "%s '%s' could not be found" name (resource/resource-name v))))
 
+(defn prop-anim-missing? [animation anim-ids]
+  (when (and anim-ids (not-any? #(= animation %) anim-ids))
+    (format "'%s' could not be found in the specified image" animation)))
+
 (defn prop-outside-range? [[min max] v name]
   (let [tmpl (if (integer? min)
                "'%s' must be between %d and %d"

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -66,9 +66,9 @@
             -fx-effect: innershadow(gaussian, $defold-white, 20, 0.3, 0, 0) !important;
         }
         >.choice-box {
+            -fx-border-width: 0;
             -fx-pref-width: 90px;
             >.label {
-                -fx-border-width: 0;
                 -fx-background-color: $scene-toolbar-background;
                 -fx-text-fill: $defold-white;
             }

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -203,7 +203,7 @@
 
 (defn open-scene-view! [project app-view path width height]
   (make-tab! project app-view path (fn [view-graph resource-node]
-                                     (scene/make-preview view-graph resource-node {:app-view app-view :project project} width height))))
+                                     (scene/make-preview view-graph resource-node {:app-view app-view :project project :select-fn (partial app-view/select app-view)} width height))))
 
 (defn close-tab! [project app-view path]
   (let [node-id (project/get-resource-node project path)


### PR DESCRIPTION
Fixes defold/editor2-issues#653

**User-facing changes**
* Missing resource errors are now reported from all referencing nodes instead of on the missing resource node itself.
* Double-clicking an error in the Build Errors view now selects the offending `SceneNode` so erroneous settings can be corrected using the Property Editor.
* Attempting to open a defective resource now shows an alert informing the user of the problem.
* A Sprite with a bad Default Animation is now considered a build error.
* Fixes some minor bugs that were discovered during testing.

**Technical changes**
* `scene.clj` is no longer dependent on `app-view.clj`. A `:select-fn` must be supplied when creating scene views.