### PR TITLE
DEFEDIT-890 Collision Object build output validation

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -23,7 +23,7 @@
 
 (namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id produce-value node-by-id-at])
 
-(namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate worse-than])
+(namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate precluding-errors worse-than])
 
 (namespaces/import-vars [internal.node value-type-schema value-type? isa-node-type? value-type-dispatch-value has-input? has-output? has-property? type-compatible? merge-display-order NodeType supertypes transforms transform-types internal-properties declared-properties public-properties externs declared-inputs injectable-inputs declared-outputs cached-outputs input-dependencies input-cardinality cascade-deletes substitute-for input-type output-type input-labels output-labels property-labels property-display-order])
 

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -53,3 +53,11 @@
      (map->ErrorValue {:severity max-severity :causes es})))
   ([es & kvs]
    (apply assoc (error-aggregate es) kvs)))
+
+(defmacro precluding-errors [errors result]
+  `(or (when-let [some-errors# (->> ~errors
+                                    flatten
+                                    (remove nil?)
+                                    not-empty)]
+         (error-aggregate some-errors#))
+       ~result))


### PR DESCRIPTION
Fixes defold/editor2-issues#664

**User-facing changes**
* Collision objects can now assign either `.tilemap` or `.convexshape` resources as Collision Shape.
* A Collision Object with a non-positive Mass will now generate a build error.
* A Collision Object with no shapes will now generate a build error.
* A Collision Object with Capsule shapes in a project using 2D physics will now generate a build error.
* A Tile Map without a Tile Source will now generate a build error.
* A Tile Map that indexes outside the Tile Source range will now generate a build error.

**Technical changes**
* Added `g/precluding-errors` macro, useful when producing build targets.