### PR TITLE
DEFEDIT-892 Font validation fixes

### DIFF
--- a/editor/resources/templates/template.font
+++ b/editor/resources/templates/template.font
@@ -1,3 +1,3 @@
-font: ""
+font: "/builtins/fonts/vera_mo_bd.ttf"
 material: "/builtins/fonts/font.material"
 size: 15

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -284,8 +284,9 @@ public class Fontc {
         int cell_padding = 1;
         float sdf_scale = 0;
         float sdf_offset = 0;
+        int shadowBlur = fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? 0 : fontDesc.getShadowBlur();
         if (fontDesc.getAntialias() != 0)
-            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)Math.ceil(fontDesc.getOutlineWidth() * 0.5f);
+            padding = Math.min(4, shadowBlur) + (int)Math.ceil(fontDesc.getOutlineWidth() * 0.5f);
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
             // need sqrt(2) on either side of the range [0, outlineWidth + 1] to prevent clamped values being used
@@ -294,8 +295,6 @@ public class Fontc {
             sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + fontDesc.getOutlineWidth());
             sdf_offset = sdf_scale * sqrt2; // where glyph ends
         }
-        Color faceColor = new Color(fontDesc.getAlpha(), 0.0f, 0.0f);
-        Color outlineColor = new Color(0.0f, fontDesc.getOutlineAlpha(), 0.0f);
         ConvolveOp shadowConvolve = null;
         Composite blendComposite = new BlendComposite();
         if (fontDesc.getShadowAlpha() > 0.0f) {
@@ -411,6 +410,8 @@ public class Fontc {
             int clearData = 0;
             if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
                 inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
+                Color faceColor = new Color(fontDesc.getAlpha(), 0.0f, 0.0f);
+                Color outlineColor = new Color(0.0f, fontDesc.getOutlineAlpha(), 0.0f);
                 glyphImage = drawGlyph(glyph, padding, font, blendComposite, faceColor, outlineColor, shadowConvolve);
             } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_BITMAP &&
                        inputFormat == InputFontFormat.FORMAT_BMFONT) {

--- a/editor/test/integration/font_test.clj
+++ b/editor/test/integration/font_test.clj
@@ -67,7 +67,7 @@
       (is (nil? (test-util/prop-error node-id :font)))
       (is (nil? (test-util/prop-error node-id :material)))
       (test-util/with-prop [node-id :font nil]
-        (is (g/error-info? (test-util/prop-error node-id :font))))
+        (is (g/error-fatal? (test-util/prop-error node-id :font))))
       (test-util/with-prop [node-id :font (workspace/resolve-workspace-resource workspace "/not_found.ttf")]
         (is (g/error-fatal? (test-util/prop-error node-id :font))))
       (test-util/with-prop [node-id :material nil]


### PR DESCRIPTION
Fixes defold/editor2-issues#675

**User-facing changes**
* A font must now have a `.ttf` file or equivalent glyph source assigned.
* New fonts are created with the builtin `.ttf` file assigned.
* Bad font properties now generate friendly errors in the scene view and when building.
* A font without a material no longer throws an exception in the scene view.
* Font size must now be greater than zero.
