### PR TITLE
DEFEDIT-891 Limit console log size

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -49,10 +49,20 @@
     (swap! positions rest))
   (update-highlight (first @positions)))
 
+(defn- trim-console-message! [^TextArea text-area max-line-count]
+  (let [lines (.getParagraphs text-area)
+        line-count (count lines)
+        trimmed-line-count (max 0 (- line-count max-line-count))]
+    (when (pos? trimmed-line-count)
+      (let [trimmed-lines (take trimmed-line-count lines)
+            trimmed-char-count (transduce (map count) + trimmed-line-count trimmed-lines)]
+        (.deleteText text-area 0 (min trimmed-char-count (.getLength text-area)))))))
+
 (defn append-console-message! [message]
   (when-let [^TextArea node @node]
     (ui/run-later
-     (.appendText node message))))
+      (.appendText node message)
+      (trim-console-message! node 3000))))
 
 (handler/defhandler :copy :console-view
   (enabled? []


### PR DESCRIPTION
Fixes defold/editor2-issues#322

This is a stopgap measure to prevent severe slowdown. We might want to revisit with a proper solution that does not throw away old log entries.