### PR TITLE
DEFEDIT-894 Return boolean success when building project

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -582,9 +582,11 @@
                                                       :render-progress! render-fn
                                                       :basis (g/now)
                                                       :cache cache)))
-              (update-system-cache! old-cache-val cache)))
+              (update-system-cache! old-cache-val cache)
+              true))
           (catch Throwable error
-            (error-reporting/report-exception! error))
+            (error-reporting/report-exception! error)
+            false)
           (finally (reset! ongoing-build-save-atom false)))))))
 
 (defn settings [project]

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -35,7 +35,8 @@
       ([]
        (.interrupt thread))
       ([exception sentry-id-promise]
-       (.offer queue [exception sentry-id-promise])))))
+       (.offer queue [exception sentry-id-promise])
+       nil))))
 
 (defn init-exception-notifier!
   [notify-fn]
@@ -96,7 +97,8 @@
            (println "Suppressed unhandled" (ExceptionUtils/getFullStackTrace exception)))
          (do (log/error :exception exception)
              (let [sentry-id-promise (sentry-reporter exception thread)]
-               (exception-notifier ex-map sentry-id-promise)))))
+               (exception-notifier ex-map sentry-id-promise)
+               nil))))
      (catch Throwable t
        (println (format "Fatal error reporting unhandled exception: '%s'\n%s" (.getMessage t) (pr-str (Throwable->map t))))))))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#629

* `build-and-save-project` returns a promise that reports success using either `true` or `false`.
* Stopped return values from leaking out of exception notifiers.