### PR TITLE
DEFEDIT-495 Draw selection outlines on top of other outlines

### DIFF
--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -303,7 +303,10 @@
     (append-flattened-scene-renderables! scene selection-set view-proj node-path parent-world-transform out-renderables tmp-v4d)
     (into {}
           (map (fn [[pass renderables]]
-                 [pass (persistent! renderables)]))
+                 ;; Draw selection outlines on top of other outlines.
+                 [pass (if (= pass/outline pass)
+                         (sort-by :selected (persistent! renderables))
+                         (persistent! renderables))]))
           out-renderables)))
 
 (defn- get-selection-pass-renderables-by-node-id


### PR DESCRIPTION
**User-facing changes**
* Selected objects will appear selected even if overlapped by outlines from unselected objects.

**Technical changes**
* Reorder renderables in the `outline` pass so selected outlines will be drawn last.