### PR TITLE
DEF-2647 gui spine callback crash

### DIFF
--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2728,40 +2728,48 @@ namespace dmGui
             return RESULT_INVAL_ERROR;
         }
 
+        SpineAnimation animation;
+        uint32_t animation_index = 0xffffffff;
+
+        // Overwrite old animation for the same node
+        for (uint32_t i = 0; i < scene->m_SpineAnimations.Size(); ++i)
+        {
+            const SpineAnimation* anim = &scene->m_SpineAnimations[i];
+            if (node == anim->m_Node)
+            {
+                animation_index = i;
+                break;
+            }
+        }
+
+        if (animation_index == 0xffffffff)
+        {
+            if (scene->m_SpineAnimations.Full())
+            {
+                dmLogWarning("Out of animation resources (%d)", scene->m_SpineAnimations.Size());
+                return RESULT_INVAL_ERROR;
+            }
+            animation_index = scene->m_SpineAnimations.Size();
+            scene->m_SpineAnimations.SetSize(animation_index+1);
+        }
+
         if (animation_complete)
         {
-            SpineAnimation animation;
-            uint32_t animation_index = 0xffffffff;
-
-            // Remove old animation for the same property
-            for (uint32_t i = 0; i < scene->m_SpineAnimations.Size(); ++i)
-            {
-                const SpineAnimation* anim = &scene->m_SpineAnimations[i];
-                if (node == anim->m_Node)
-                {
-                    animation_index = i;
-                    break;
-                }
-            }
-
-            if (animation_index == 0xffffffff)
-            {
-                if (scene->m_SpineAnimations.Full())
-                {
-                    dmLogWarning("Out of animation resources (%d)", scene->m_SpineAnimations.Size());
-                    return RESULT_INVAL_ERROR;
-                }
-                animation_index = scene->m_SpineAnimations.Size();
-                scene->m_SpineAnimations.SetSize(animation_index+1);
-            }
-
             animation.m_Node = node;
             animation.m_AnimationComplete = animation_complete;
             animation.m_Userdata1 = userdata1;
             animation.m_Userdata2 = userdata2;
             scene->m_SpineAnimations[animation_index] = animation;
-
             SetEventCallback(rig_instance, RigEventCallback, scene, &scene->m_SpineAnimations[animation_index]);
+        }
+        else
+        {
+            animation.m_Node = node;
+            animation.m_AnimationComplete = 0;
+            animation.m_Userdata1 = 0;
+            animation.m_Userdata2 = 0;
+            scene->m_SpineAnimations[animation_index] = animation;
+            SetEventCallback(rig_instance, 0, 0, 0);
         }
 
         return RESULT_OK;

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -178,6 +178,7 @@ bool FetchRigSceneDataCallback(void* spine_scene, dmhash_t rig_scene_id, dmGui::
 
     dmGui::RigSceneDataDesc* spine_scene_ptr = (dmGui::RigSceneDataDesc*)spine_scene;
     out_data->m_BindPose = spine_scene_ptr->m_BindPose;
+    out_data->m_TrackIdxToPose = spine_scene_ptr->m_TrackIdxToPose;
     out_data->m_Skeleton = spine_scene_ptr->m_Skeleton;
     out_data->m_MeshSet = spine_scene_ptr->m_MeshSet;
     out_data->m_AnimationSet = spine_scene_ptr->m_AnimationSet;
@@ -200,6 +201,7 @@ public:
     dmRig::HRigContext      m_RigContext;
     dmRig::HRigInstance     m_RigInstance;
     dmArray<dmRig::RigBone> m_BindPose;
+    dmArray<uint32_t>       m_TrackIdxToPose;
     dmRigDDF::Skeleton*     m_Skeleton;
     dmRigDDF::MeshSet*      m_MeshSet;
     dmRigDDF::AnimationSet* m_AnimationSet;
@@ -401,6 +403,13 @@ private:
         m_BindPose.SetCapacity(bone_count);
         m_BindPose.SetSize(bone_count);
 
+        m_TrackIdxToPose.SetCapacity(bone_count);
+        m_TrackIdxToPose.SetSize(bone_count);
+        for (int i = 0; i < bone_count; ++i)
+        {
+            m_TrackIdxToPose[i] = i;
+        }
+
         // IK
         m_Skeleton->m_Iks.m_Data = new dmRigDDF::IK[1];
         m_Skeleton->m_Iks.m_Count = 1;
@@ -492,6 +501,7 @@ private:
 
         // Data
         create_params.m_BindPose     = &m_BindPose;
+        create_params.m_TrackIdxToPose = &m_TrackIdxToPose;
         create_params.m_Skeleton     = m_Skeleton;
         create_params.m_MeshSet      = m_MeshSet;
         create_params.m_AnimationSet = m_AnimationSet;
@@ -4725,6 +4735,58 @@ TEST_F(dmGuiTest, SpineNodeGetSkin)
 
     // get skin
     ASSERT_EQ(dmHashString64("skin1"), dmGui::GetNodeSpineSkin(m_Scene, node));
+}
+
+uint32_t SpineAnimationCompleteCount = 0;
+void SpineAnimationComplete(dmGui::HScene scene,
+                         dmGui::HNode node,
+                         bool finished,
+                         void* userdata1,
+                         void* userdata2)
+{
+    SpineAnimationCompleteCount++;
+}
+TEST_F(dmGuiTest, SpineNodeCompleteCallback)
+{
+    SpineAnimationCompleteCount = 0;
+    uint32_t width = 100;
+    uint32_t height = 50;
+    float dt = 1.500001;
+
+    dmGui::SetPhysicalResolution(m_Context, width, height);
+    dmGui::SetSceneResolution(m_Scene, width, height);
+
+    dmGui::RigSceneDataDesc rig_scene_desc;
+    rig_scene_desc.m_BindPose = &m_BindPose;
+    rig_scene_desc.m_Skeleton = m_Skeleton;
+    rig_scene_desc.m_MeshSet = m_MeshSet;
+    rig_scene_desc.m_AnimationSet = m_AnimationSet;
+    rig_scene_desc.m_TrackIdxToPose = &m_TrackIdxToPose;
+
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::AddSpineScene(m_Scene, "test_spine", (void*)&rig_scene_desc));
+
+    // create node
+    dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(0, 0, 0), Vector3(0, 0, 0), dmGui::NODE_TYPE_SPINE);
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::SetNodeSpineScene(m_Scene, node, dmHashString64("test_spine"), dmHashString64((const char*)"skin1"), dmHashString64((const char*)""), true));
+
+    // duration is 3.0 seconds
+    // play animation with cb
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeSpineAnim(m_Scene, node, dmHashString64("valid"), dmGui::PLAYBACK_ONCE_FORWARD, 0.0, 0.0, 1.0, &SpineAnimationComplete, (void*)m_Scene, 0));
+    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(SpineAnimationCompleteCount, 1);
+
+    // play animation without cb
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeSpineAnim(m_Scene, node, dmHashString64("valid"), dmGui::PLAYBACK_ONCE_FORWARD, 0.0, 0.0, 1.0, 0, 0, 0));
+    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(SpineAnimationCompleteCount, 1);
+
+    // play animation with cb once more
+    ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeSpineAnim(m_Scene, node, dmHashString64("valid"), dmGui::PLAYBACK_ONCE_FORWARD, 0.0, 0.0, 1.0, &SpineAnimationComplete, (void*)m_Scene, 0));
+    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(SpineAnimationCompleteCount, 2);
 }
 
 TEST_F(dmGuiTest, SpineNodeSetCursor)

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -431,7 +431,7 @@ private:
         dmRigDDF::RigAnimation& anim0 = m_AnimationSet->m_Animations.m_Data[0];
         dmRigDDF::RigAnimation& anim1 = m_AnimationSet->m_Animations.m_Data[1];
         anim0.m_Id = dmHashString64("valid");
-        anim0.m_Duration            = 3.0f;
+        anim0.m_Duration            = 2.0f;
         anim0.m_SampleRate          = 1.0f;
         anim0.m_EventTracks.m_Count = 0;
         anim0.m_MeshTracks.m_Count  = 0;

--- a/engine/rig/src/test/test_rig.cpp
+++ b/engine/rig/src/test/test_rig.cpp
@@ -485,13 +485,14 @@ void SetUpSimpleRig(dmArray<dmRig::RigBone>& bind_pose, dmRigDDF::Skeleton* skel
             anim_track1.m_Positions.m_Count = 0;
             anim_track1.m_Scale.m_Count     = 0;
 
-            uint32_t samples = 4;
+            uint32_t samples = 5;
             anim_track0.m_Rotations.m_Data = new float[samples*4];
             anim_track0.m_Rotations.m_Count = samples*4;
             ((Quat*)anim_track0.m_Rotations.m_Data)[0] = Quat::identity();
             ((Quat*)anim_track0.m_Rotations.m_Data)[1] = Quat::identity();
             ((Quat*)anim_track0.m_Rotations.m_Data)[2] = Quat::rotationZ((float)M_PI / 2.0f);
             ((Quat*)anim_track0.m_Rotations.m_Data)[3] = Quat::rotationZ((float)M_PI / 2.0f);
+            ((Quat*)anim_track0.m_Rotations.m_Data)[4] = Quat::rotationZ((float)M_PI / 2.0f);
 
             anim_track1.m_Rotations.m_Data = new float[samples*4];
             anim_track1.m_Rotations.m_Count = samples*4;
@@ -499,6 +500,7 @@ void SetUpSimpleRig(dmArray<dmRig::RigBone>& bind_pose, dmRigDDF::Skeleton* skel
             ((Quat*)anim_track1.m_Rotations.m_Data)[1] = Quat::rotationZ((float)M_PI / 2.0f);
             ((Quat*)anim_track1.m_Rotations.m_Data)[2] = Quat::identity();
             ((Quat*)anim_track1.m_Rotations.m_Data)[3] = Quat::identity();
+            ((Quat*)anim_track1.m_Rotations.m_Data)[4] = Quat::identity();
         }
 
         // Animation 1: "ik"
@@ -970,13 +972,12 @@ TEST_P(RigInstanceCursorPingpongTest, CursorSet)
     ASSERT_NEAR(1.0f / 3.0f, dmRig::GetCursor(m_Instance, true), RIG_EPSILON_FLOAT);
 
     // Setting cursor > 0.5f (normalized) should still put the cursor in the "ping" part of the animation
-    // DEF-2369 Special case for pingpong and cursor at duration
-    /*ASSERT_NEAR(dmRig::RESULT_OK, dmRig::SetCursor(m_Instance, 2.0f, false), RIG_EPSILON_FLOAT);
+    ASSERT_NEAR(dmRig::RESULT_OK, dmRig::SetCursor(m_Instance, 2.0f, false), RIG_EPSILON_FLOAT);
     ASSERT_NEAR(2.0f, dmRig::GetCursor(m_Instance, false), RIG_EPSILON_FLOAT);
     ASSERT_NEAR(2.0f / 3.0f, dmRig::GetCursor(m_Instance, true), RIG_EPSILON_FLOAT);
     ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_Context, 1.0f));
     ASSERT_NEAR(3.0f, dmRig::GetCursor(m_Instance, false), RIG_EPSILON_FLOAT);
-    ASSERT_NEAR(1.0f, dmRig::GetCursor(m_Instance, true), RIG_EPSILON_FLOAT);*/
+    ASSERT_NEAR(1.0f, dmRig::GetCursor(m_Instance, true), RIG_EPSILON_FLOAT);
 }
 
 TEST_P(RigInstanceCursorBackwardTest, CursorSet)


### PR DESCRIPTION
Reset callback ref explicitly when overwriting an existing spine gui animation with one that does not have a callback