### PR TITLE
DEF-1520 Trigger overlap capacity

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -112,6 +112,10 @@ ray_cast_limit_3d.type = number
 ray_cast_limit_3d.help = maximum number of ray casts per frame when using 3D physics
 ray_cast_limit_3d.default = 128
 
+trigger_overlap_capacity.type = number
+trigger_overlap_capacity.help = maximum number of overlapping triggers that can be detected, 16 by default
+trigger_overlap_capacity.default = 16
+
 [bootstrap]
 help = Initial settings for the engine
 main_collection.type = resource

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -687,6 +687,7 @@ namespace dmEngine
         physics_params.m_Scale = dmConfigFile::GetFloat(engine->m_Config, "physics.scale", 1.0f);
         physics_params.m_RayCastLimit2D = dmConfigFile::GetInt(engine->m_Config, "physics.ray_cast_limit_2d", 64);
         physics_params.m_RayCastLimit3D = dmConfigFile::GetInt(engine->m_Config, "physics.ray_cast_limit_3d", 128);
+        physics_params.m_TriggerOverlapCapacity = dmConfigFile::GetInt(engine->m_Config, "physics.trigger_overlap_capacity", 16);
         if (physics_params.m_Scale < dmPhysics::MIN_SCALE || physics_params.m_Scale > dmPhysics::MAX_SCALE)
         {
             dmLogWarning("Physics scale must be in the range %.2f - %.2f and has been clamped.", dmPhysics::MIN_SCALE, dmPhysics::MAX_SCALE);

--- a/engine/physics/src/physics/physics.cpp
+++ b/engine/physics/src/physics/physics.cpp
@@ -22,6 +22,7 @@ namespace dmPhysics
     , m_TriggerEnterLimit(0.0f)
     , m_RayCastLimit2D(0)
     , m_RayCastLimit3D(0)
+    , m_TriggerOverlapCapacity(0)
     {
 
     }
@@ -91,11 +92,18 @@ namespace dmPhysics
 
     }
 
+    OverlapCache::OverlapCache(uint32_t triggerOverlapCapacity)
+    : m_TriggerOverlapCapacity(triggerOverlapCapacity)
+    , m_OverlapCache()
+    {
+
+    }
+
     /**
      * Adds the overlap of an object to a specific entry.
      * Returns whether the overlap was added (might be out of space).
      */
-    static bool AddOverlap(OverlapEntry* entry, void* object, bool* out_found)
+    static bool AddOverlap(OverlapEntry* entry, void* object, bool* out_found, const uint32_t triggerOverlapCapacity)
     {
         bool found = false;
         for (uint32_t i = 0; i < entry->m_OverlapCount; ++i)
@@ -112,7 +120,7 @@ namespace dmPhysics
             *out_found = found;
         if (!found)
         {
-            if (entry->m_OverlapCount == MAX_OVERLAP_COUNT)
+            if (entry->m_OverlapCount == triggerOverlapCapacity)
             {
                 dmLogError("Trigger overlap capacity reached, overlap will not be stored for enter/exit callbacks.");
                 return false;
@@ -152,27 +160,28 @@ namespace dmPhysics
     static void AddEntry(OverlapCache* cache, void* object_a, void* user_data_a, void* object_b, uint16_t group_a)
     {
         // Check if the cache needs to be expanded
-        uint32_t size = cache->Size();
-        uint32_t capacity = cache->Capacity();
+        uint32_t size = cache->m_OverlapCache.Size();
+        uint32_t capacity = cache->m_OverlapCache.Capacity();
         // Expand when 80% full
         if (size > 3 * capacity / 4)
         {
             capacity += CACHE_EXPANSION;
-            cache->SetCapacity(3 * capacity / 4, capacity);
+            cache->m_OverlapCache.SetCapacity(3 * capacity / 4, capacity);
         }
         OverlapEntry entry;
         memset(&entry, 0, sizeof(entry));
+        entry.m_Overlaps = (Overlap*)malloc(cache->m_TriggerOverlapCapacity * sizeof(Overlap));
         entry.m_UserData = user_data_a;
         entry.m_Group = group_a;
         // Add overlap to the entry
-        AddOverlap(&entry, object_b, 0x0);
+        AddOverlap(&entry, object_b, 0x0, cache->m_TriggerOverlapCapacity);
         // Add the entry
-        cache->Put((uintptr_t)object_a, entry);
+        cache->m_OverlapCache.Put((uintptr_t)object_a, entry);
     }
 
     void OverlapCacheInit(OverlapCache* cache)
     {
-        cache->SetCapacity(3 * CACHE_INITIAL_CAPACITY / 4, CACHE_INITIAL_CAPACITY);
+    	cache->m_OverlapCache.SetCapacity(3 * CACHE_INITIAL_CAPACITY / 4, CACHE_INITIAL_CAPACITY);
     }
 
     /**
@@ -189,7 +198,7 @@ namespace dmPhysics
 
     void OverlapCacheReset(OverlapCache* cache)
     {
-        cache->Iterate(ResetOverlap, (void*)0x0);
+    	cache->m_OverlapCache.Iterate(ResetOverlap, (void*)0x0);
     }
 
     OverlapCacheAddData::OverlapCacheAddData()
@@ -200,19 +209,19 @@ namespace dmPhysics
     void OverlapCacheAdd(OverlapCache* cache, const OverlapCacheAddData& data)
     {
         bool found = false;
-        OverlapEntry* entry_a = cache->Get((uintptr_t)data.m_ObjectA);
+        OverlapEntry* entry_a = cache->m_OverlapCache.Get((uintptr_t)data.m_ObjectA);
         if (entry_a != 0x0)
         {
-            if (!AddOverlap(entry_a, data.m_ObjectB, &found))
+            if (!AddOverlap(entry_a, data.m_ObjectB, &found, cache->m_TriggerOverlapCapacity))
             {
                 // The overlap could not be added to entry_a, bail out
                 return;
             }
         }
-        OverlapEntry* entry_b = cache->Get((uintptr_t)data.m_ObjectB);
+        OverlapEntry* entry_b = cache->m_OverlapCache.Get((uintptr_t)data.m_ObjectB);
         if (entry_b != 0x0)
         {
-            if (!AddOverlap(entry_b, data.m_ObjectA, &found))
+            if (!AddOverlap(entry_b, data.m_ObjectA, &found, cache->m_TriggerOverlapCapacity))
             {
                 // No space in entry_b, clean up entry_a
                 if (entry_a != 0x0)
@@ -240,21 +249,22 @@ namespace dmPhysics
 
     void OverlapCacheRemove(OverlapCache* cache, void* object)
     {
-        OverlapEntry* entry = cache->Get((uintptr_t)object);
+        OverlapEntry* entry = cache->m_OverlapCache.Get((uintptr_t)object);
         if (entry != 0x0)
         {
             // Remove back-references to the object from others
             for (uint32_t i = 0; i < entry->m_OverlapCount; ++i)
             {
                 Overlap& overlap = entry->m_Overlaps[i];
-                OverlapEntry* entry2 = cache->Get((uintptr_t)overlap.m_Object);
+                OverlapEntry* entry2 = cache->m_OverlapCache.Get((uintptr_t)overlap.m_Object);
                 if (entry2 != 0x0)
                 {
                     RemoveOverlap(entry2, object);
                 }
             }
             // Remove the object from the cache
-            cache->Erase((uintptr_t)object);
+            cache->m_OverlapCache.Erase((uintptr_t)object);
+            free(entry->m_Overlaps);
         }
     }
 
@@ -285,7 +295,7 @@ namespace dmPhysics
             // Condition to prune: no registered contacts
             if (overlap.m_Count == 0)
             {
-                OverlapEntry* entry = cache->Get((uintptr_t)overlap.m_Object);
+                OverlapEntry* entry = cache->m_OverlapCache.Get((uintptr_t)overlap.m_Object);
                 // Trigger exit callback
                 if (callback != 0x0)
                 {
@@ -319,6 +329,6 @@ namespace dmPhysics
         context.m_Callback = data.m_TriggerExitedCallback;
         context.m_UserData = data.m_TriggerExitedUserData;
         context.m_Cache = cache;
-        cache->Iterate(PruneOverlap, &context);
+        cache->m_OverlapCache.Iterate(PruneOverlap, &context);
     }
 }

--- a/engine/physics/src/physics/physics.cpp
+++ b/engine/physics/src/physics/physics.cpp
@@ -92,8 +92,8 @@ namespace dmPhysics
 
     }
 
-    OverlapCache::OverlapCache(uint32_t triggerOverlapCapacity)
-    : m_TriggerOverlapCapacity(triggerOverlapCapacity)
+    OverlapCache::OverlapCache(uint32_t trigger_overlap_capacity)
+    : m_TriggerOverlapCapacity(trigger_overlap_capacity)
     , m_OverlapCache()
     {
 
@@ -103,7 +103,7 @@ namespace dmPhysics
      * Adds the overlap of an object to a specific entry.
      * Returns whether the overlap was added (might be out of space).
      */
-    static bool AddOverlap(OverlapEntry* entry, void* object, bool* out_found, const uint32_t triggerOverlapCapacity)
+    static bool AddOverlap(OverlapEntry* entry, void* object, bool* out_found, const uint32_t trigger_overlap_capacity)
     {
         bool found = false;
         for (uint32_t i = 0; i < entry->m_OverlapCount; ++i)
@@ -120,7 +120,7 @@ namespace dmPhysics
             *out_found = found;
         if (!found)
         {
-            if (entry->m_OverlapCount == triggerOverlapCapacity)
+            if (entry->m_OverlapCount == trigger_overlap_capacity)
             {
                 dmLogError("Trigger overlap capacity reached, overlap will not be stored for enter/exit callbacks.");
                 return false;

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -200,6 +200,8 @@ namespace dmPhysics
         uint32_t m_RayCastLimit2D;
         /// Maximum number of ray casts per frame when using 3D physics
         uint32_t m_RayCastLimit3D;
+        /// Maximum number of overlapping triggers
+        uint32_t m_TriggerOverlapCapacity;
     };
 
     /**

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -20,12 +20,14 @@ namespace dmPhysics
     , m_InvScale(1.0f)
     , m_ContactImpulseLimit(0.0f)
     , m_TriggerEnterLimit(0.0f)
+    , m_RayCastLimit(0)
+    , m_TriggerOverlapCapacity(0)
     {
 
     }
 
     World2D::World2D(HContext2D context, const NewWorldParams& params)
-    : m_TriggerOverlaps()
+    : m_TriggerOverlaps(context->m_TriggerOverlapCapacity)
     , m_Context(context)
     , m_World(context->m_Gravity)
     , m_RayCastRequests()
@@ -159,6 +161,7 @@ namespace dmPhysics
         context->m_ContactImpulseLimit = params.m_ContactImpulseLimit * params.m_Scale;
         context->m_TriggerEnterLimit = params.m_TriggerEnterLimit * params.m_Scale;
         context->m_RayCastLimit = params.m_RayCastLimit2D;
+        context->m_TriggerOverlapCapacity = params.m_TriggerOverlapCapacity;
         dmMessage::Result result = dmMessage::NewSocket(PHYSICS_SOCKET_NAME, &context->m_Socket);
         if (result != dmMessage::RESULT_OK)
         {

--- a/engine/physics/src/physics/physics_2d.h
+++ b/engine/physics/src/physics/physics_2d.h
@@ -52,6 +52,7 @@ namespace dmPhysics
         float                       m_ContactImpulseLimit;
         float                       m_TriggerEnterLimit;
         int                         m_RayCastLimit;
+        int                         m_TriggerOverlapCapacity;
     };
 
     class ProcessRayCastResultCallback2D : public b2RayCastCallback

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -103,6 +103,8 @@ namespace dmPhysics
     , m_InvScale(1.0f)
     , m_ContactImpulseLimit(0.0f)
     , m_TriggerEnterLimit(0.0f)
+    , m_RayCastLimit(0)
+    , m_TriggerOverlapCapacity(0)
     {
 
     }
@@ -110,6 +112,7 @@ namespace dmPhysics
     World3D::World3D(HContext3D context, const NewWorldParams& params)
     : m_DebugDraw(&context->m_DebugCallbacks)
     , m_Context(context)
+    , m_TriggerOverlaps(context->m_TriggerOverlapCapacity)
     {
         m_CollisionConfiguration = new btDefaultCollisionConfiguration();
         m_Dispatcher = new btCollisionDispatcher(m_CollisionConfiguration);
@@ -184,6 +187,7 @@ namespace dmPhysics
         context->m_ContactImpulseLimit = params.m_ContactImpulseLimit * params.m_Scale;
         context->m_TriggerEnterLimit = params.m_TriggerEnterLimit * params.m_Scale;
         context->m_RayCastLimit = params.m_RayCastLimit3D;
+        context->m_TriggerOverlapCapacity = params.m_TriggerOverlapCapacity;
         dmMessage::Result result = dmMessage::NewSocket(PHYSICS_SOCKET_NAME, &context->m_Socket);
         if (result != dmMessage::RESULT_OK)
         {

--- a/engine/physics/src/physics/physics_3d.h
+++ b/engine/physics/src/physics/physics_3d.h
@@ -40,6 +40,7 @@ namespace dmPhysics
         float                       m_ContactImpulseLimit;
         float                       m_TriggerEnterLimit;
         int                         m_RayCastLimit;
+        int                         m_TriggerOverlapCapacity;
     };
 
     inline void ToBt(const Vectormath::Aos::Point3& p0, btVector3& p1, float scale)

--- a/engine/physics/src/physics/physics_private.h
+++ b/engine/physics/src/physics/physics_private.h
@@ -16,12 +16,6 @@ namespace dmPhysics
     };
 
     /**
-     * Max count of tracked overlaps per object.
-     * Exceeding this limit is safe and results in warnings.
-     */
-    const uint32_t MAX_OVERLAP_COUNT = 16;
-
-    /**
      * Initial capacity of the cache.
      * The cache is a hash table with 75% as many buckets as capacity.
      */
@@ -38,7 +32,7 @@ namespace dmPhysics
     struct OverlapEntry
     {
         void* m_UserData;
-        Overlap m_Overlaps[MAX_OVERLAP_COUNT];
+        Overlap* m_Overlaps;
         uint32_t m_OverlapCount;
         uint16_t m_Group;
     };
@@ -46,7 +40,17 @@ namespace dmPhysics
     /**
      * Stores every set of overlaps for each object.
      */
-    typedef dmHashTable<uintptr_t, OverlapEntry> OverlapCache;
+    struct OverlapCache {
+    	OverlapCache(uint32_t triggerOverlapCapacity);
+
+    	dmHashTable<uintptr_t, OverlapEntry> m_OverlapCache;
+
+        /**
+         * Max count of tracked overlaps per object.
+         * Exceeding this limit is safe and results in warnings.
+         */
+    	uint32_t m_TriggerOverlapCapacity;
+    };
 
     /**
      * Initialize the cache with CACHE_INITIAL_CAPACITY and 75% as many buckets.

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -37,6 +37,7 @@ protected:
         context_params.m_Scale = PHYSICS_SCALE;
         context_params.m_RayCastLimit2D = 64;
         context_params.m_RayCastLimit3D = 128;
+        context_params.m_TriggerOverlapCapacity = 16;
         m_Context = (*m_Test.m_NewContextFunc)(context_params);
         dmPhysics::NewWorldParams world_params;
         world_params.m_GetWorldTransformCallback = GetWorldTransform;


### PR DESCRIPTION
Made trigger overlap capacity configurable from game.project and changed from a MAX_OVERLAP_COUNT constant to a per world value.