### PR TITLE
DEFEDIT-913 Fixed disappearing app window

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -51,7 +51,7 @@
            [javafx.scene.input KeyEvent]
            [javafx.scene.layout AnchorPane GridPane StackPane HBox Priority]
            [javafx.scene.paint Color]
-           [javafx.stage Stage FileChooser WindowEvent]
+           [javafx.stage Screen Stage FileChooser WindowEvent]
            [javafx.util Callback]
            [java.io File ByteArrayOutputStream]
            [java.nio.file Paths]
@@ -160,12 +160,21 @@
 
 (defn restore-window-dimensions [^Stage stage prefs]
   (when-let [dims (prefs/get-prefs prefs prefs-window-dimensions nil)]
-    (.setX stage (:x dims))
-    (.setY stage (:y dims))
-    (.setWidth stage (:width dims))
-    (.setHeight stage (:height dims))
-    (.setMaximized stage (:maximized dims false))
-    (.setFullScreen stage (:full-screen dims false))))
+    (let [{:keys [x y width height maximized full-screen]} dims]
+      (when (and (number? x) (number? y) (number? width) (number? height))
+        (when-let [screens (seq (Screen/getScreensForRectangle x y width height))]
+          (doto stage
+            (.setX x)
+            (.setY y))
+          ;; Maximized and setWidth/setHeight in combination triggers a bug on macOS where the window becomes invisible
+          (when (and (not maximized) (not full-screen))
+            (doto stage
+              (.setWidth width)
+              (.setHeight height)))))
+      (when maximized
+        (.setMaximized stage true))
+      (when full-screen
+        (.setFullScreen stage true)))))
 
 (def ^:private legacy-split-ids ["main-split"
                                  "center-split"


### PR DESCRIPTION
* The root problem was setting maximized AND width/height on OSX