### PR TITLE
DEF-2566 Hash not supported for gui.new_texture

### DIFF
--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -502,9 +502,8 @@ namespace dmGui
         return true;
     }
 
-    Result NewDynamicTexture(HScene scene, const char* texture_name, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
+    Result NewDynamicTexture(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
     {
-        dmhash_t texture_hash = dmHashString64(texture_name);
         uint32_t expected_buffer_size = width * height * dmImage::BytesPerPixel(type);
         if (buffer_size != expected_buffer_size) {
             dmLogError("Invalid image buffer size. Expected %d, got %d", expected_buffer_size, buffer_size);
@@ -544,9 +543,8 @@ namespace dmGui
         return RESULT_OK;
     }
 
-    Result DeleteDynamicTexture(HScene scene, const char* texture_name)
+Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     {
-        dmhash_t texture_hash = dmHashString64(texture_name);
         DynamicTexture* t = scene->m_DynamicTextures.Get(texture_hash);
 
         if (!t) {
@@ -562,9 +560,8 @@ namespace dmGui
         return RESULT_OK;
     }
 
-    Result SetDynamicTextureData(HScene scene, const char* texture_name, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
+    Result SetDynamicTextureData(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
     {
-        dmhash_t texture_hash = dmHashString64(texture_name);
         DynamicTexture*t = scene->m_DynamicTextures.Get(texture_hash);
 
         if (!t) {
@@ -598,9 +595,8 @@ namespace dmGui
         return RESULT_OK;
     }
 
-    Result GetDynamicTextureData(HScene scene, const char* texture_name, uint32_t* out_width, uint32_t* out_height, dmImage::Type* out_type, const void** out_buffer)
+    Result GetDynamicTextureData(HScene scene, const dmhash_t texture_hash, uint32_t* out_width, uint32_t* out_height, dmImage::Type* out_type, const void** out_buffer)
     {
-        dmhash_t texture_hash = dmHashString64(texture_name);
         DynamicTexture*t = scene->m_DynamicTextures.Get(texture_hash);
 
         if (!t) {

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -541,7 +541,7 @@ namespace dmGui
     /**
      * Create a new dynamic texture
      * @param scene
-     * @param texture_name
+     * @param texture_hash
      * @param width
      * @param height
      * @param type
@@ -550,20 +550,20 @@ namespace dmGui
      * @param buffer_size
      * @return
      */
-    Result NewDynamicTexture(HScene scene, const char* texture_name, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size);
+    Result NewDynamicTexture(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size);
 
     /**
      * Delete dynamic texture
      * @param scene
-     * @param texture_name
+     * @param texture_hash
      * @return
      */
-    Result DeleteDynamicTexture(HScene scene, const char* texture_name);
+    Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash);
 
     /**
      * Update dynamic texture
      * @param scene
-     * @param texture_name
+     * @param texture_hash
      * @param width
      * @param height
      * @param type
@@ -572,19 +572,19 @@ namespace dmGui
      * @param buffer_size
      * @return
      */
-    Result SetDynamicTextureData(HScene scene, const char* texture_name, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size);
+    Result SetDynamicTextureData(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size);
 
     /**
      * Get texture data for a dynamic texture
      * @param scene
-     * @param texture_name
+     * @param texture_hash
      * @param out_width
      * @param out_height
      * @param out_type
      * @param out_buffer
      * @return
      */
-    Result GetDynamicTextureData(HScene scene, const char* texture_name, uint32_t* out_width, uint32_t* out_height, dmImage::Type* out_type, const void** out_buffer);
+    Result GetDynamicTextureData(HScene scene, const dmhash_t texture_hash, uint32_t* out_width, uint32_t* out_height, dmImage::Type* out_type, const void** out_buffer);
 
     /**
      * Adds a font with the specified name to the scene.

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -1656,7 +1656,8 @@ namespace dmGui
         int top = lua_gettop(L);
         (void) top;
 
-        const char* name = luaL_checkstring(L, 1);
+        const dmhash_t name = dmScript::CheckHashOrString(L, 1);
+
         int width = luaL_checkinteger(L, 2);
         int height = luaL_checkinteger(L, 3);
         const char* type_str = luaL_checkstring(L, 4);
@@ -1714,7 +1715,7 @@ namespace dmGui
         int top = lua_gettop(L);
         (void) top;
 
-        const char* name = luaL_checkstring(L, 1);
+        const dmhash_t name = dmScript::CheckHashOrString(L, 1);
 
         Scene* scene = GuiScriptInstance_Check(L);
 
@@ -1776,7 +1777,7 @@ namespace dmGui
         int top = lua_gettop(L);
         (void) top;
 
-        const char* name = luaL_checkstring(L, 1);
+        const dmhash_t name = dmScript::CheckHashOrString(L, 1);
         int width = luaL_checkinteger(L, 2);
         int height = luaL_checkinteger(L, 3);
         const char* type_str = luaL_checkstring(L, 4);

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -966,16 +966,16 @@ TEST_F(dmGuiTest, DynamicTexture)
 
     // Test creation/deletion in the same frame (case 2355)
     dmGui::Result r;
-    r = dmGui::NewDynamicTexture(m_Scene, "t1", width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
+    r = dmGui::NewDynamicTexture(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
     ASSERT_EQ(r, dmGui::RESULT_OK);
-    r = dmGui::DeleteDynamicTexture(m_Scene, "t1");
+    r = dmGui::DeleteDynamicTexture(m_Scene, dmHashString64("t1"));
     ASSERT_EQ(r, dmGui::RESULT_OK);
     dmGui::RenderScene(m_Scene, rp, &count);
 
-    r = dmGui::NewDynamicTexture(m_Scene, "t1", width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
+    r = dmGui::NewDynamicTexture(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
-    r = dmGui::SetDynamicTextureData(m_Scene, "t1", width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
+    r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX);
@@ -990,18 +990,18 @@ TEST_F(dmGuiTest, DynamicTexture)
     dmGui::RenderScene(m_Scene, rp, &count);
     ASSERT_EQ(1U, count);
 
-    r = dmGui::DeleteDynamicTexture(m_Scene, "t1");
+    r = dmGui::DeleteDynamicTexture(m_Scene, dmHashString64("t1"));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Recreate the texture again (without RenderScene)
-    r = dmGui::NewDynamicTexture(m_Scene, "t1", width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
+    r = dmGui::NewDynamicTexture(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
-    r = dmGui::DeleteDynamicTexture(m_Scene, "t1");
+    r = dmGui::DeleteDynamicTexture(m_Scene, dmHashString64("t1"));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Set data on deleted texture
-    r = dmGui::SetDynamicTextureData(m_Scene, "t1", width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
+    r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, false, data, sizeof(data));
     ASSERT_EQ(r, dmGui::RESULT_INVAL_ERROR);
 
     dmGui::DeleteNode(m_Scene, node);
@@ -1054,11 +1054,11 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
 
     // Create and upload RGB image + flip
     dmGui::Result r;
-    r = dmGui::NewDynamicTexture(m_Scene, "t1", width, height, dmImage::TYPE_RGB, true, data_rgb, sizeof(data_rgb));
+    r = dmGui::NewDynamicTexture(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, true, data_rgb, sizeof(data_rgb));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Get buffer, verify same as input but flipped
-    r = dmGui::GetDynamicTextureData(m_Scene, "t1", &out_width, &out_height, &out_type, (const void**)&out_buffer);
+    r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
     ASSERT_EQ(r, dmGui::RESULT_OK);
     ASSERT_EQ(width, out_width);
     ASSERT_EQ(height, out_height);
@@ -1066,11 +1066,11 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
     ASSERT_BUFFER(data_rgb_flip, out_buffer, width*height*3);
 
     // Upload RGBA data and flip
-    r = dmGui::SetDynamicTextureData(m_Scene, "t1", width, height, dmImage::TYPE_RGBA, true, data_rgba, sizeof(data_rgba));
+    r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGBA, true, data_rgba, sizeof(data_rgba));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Verify flipped result
-    r = dmGui::GetDynamicTextureData(m_Scene, "t1", &out_width, &out_height, &out_type, (const void**)&out_buffer);
+    r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
     ASSERT_EQ(r, dmGui::RESULT_OK);
     ASSERT_EQ(width, out_width);
     ASSERT_EQ(height, out_height);
@@ -1078,18 +1078,18 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
     ASSERT_BUFFER(data_rgba_flip, out_buffer, width*height*4);
 
     // Upload luminance data and flip
-    r = dmGui::SetDynamicTextureData(m_Scene, "t1", width, height, dmImage::TYPE_LUMINANCE, true, data_lum, sizeof(data_lum));
+    r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_LUMINANCE, true, data_lum, sizeof(data_lum));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Verify flipped result
-    r = dmGui::GetDynamicTextureData(m_Scene, "t1", &out_width, &out_height, &out_type, (const void**)&out_buffer);
+    r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
     ASSERT_EQ(r, dmGui::RESULT_OK);
     ASSERT_EQ(width, out_width);
     ASSERT_EQ(height, out_height);
     ASSERT_EQ(dmImage::TYPE_LUMINANCE, out_type);
     ASSERT_BUFFER(data_lum_flip, out_buffer, width*height);
 
-    r = dmGui::DeleteDynamicTexture(m_Scene, "t1");
+    r = dmGui::DeleteDynamicTexture(m_Scene, dmHashString64("t1"));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 }
 
@@ -1191,6 +1191,14 @@ TEST_F(dmGuiTest, ScriptDynamicTexture)
                     "    local n = gui.get_node('n')\n"
                     "    gui.set_texture(n, 't')\n"
                     "    gui.delete_texture('t')\n"
+
+                    "    local r = gui.new_texture(hash('t'), 2, 2, 'rgb', string.rep('\\0', 2 * 2 * 3))\n"
+                    "    assert(r == true)\n"
+                    "    local r = gui.set_texture_data(hash('t'), 2, 2, 'rgb', string.rep('\\0', 2 * 2 * 3))\n"
+                    "    assert(r == true)\n"
+                    "    local n = gui.get_node('n')\n"
+                    "    gui.set_texture(n, hash('t'))\n"
+                    "    gui.delete_texture(hash('t'))\n"
                     "end\n";
 
     ASSERT_TRUE(SetScript(m_Script, s));


### PR DESCRIPTION
Changed new_texture, delete_texture and set_texture_data to also accept hash.