### PR TITLE
DEFEDIT-203 Animation previewing

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -13,12 +13,14 @@
             [editor.gl.texture :as texture]
             [editor.gl.vertex :as vtx]
             [editor.defold-project :as project]
+            [editor.math :as math]
             [editor.types :as types]
             [editor.workspace :as workspace]
             [editor.resource :as resource]
             [editor.pipeline :as pipeline]
             [editor.pipeline.texture-set-gen :as texture-set-gen]
             [editor.scene :as scene]
+            [editor.texture-set :as texture-set]
             [editor.outline :as outline]
             [editor.validation :as validation]
             [editor.gl.pass :as pass]
@@ -27,17 +29,12 @@
            [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$Image Graphics$TextureImage$Type]
            [com.dynamo.textureset.proto TextureSetProto$Constants TextureSetProto$TextureSet TextureSetProto$TextureSetAnimation]
            [com.dynamo.tile.proto Tile$Playback]
-           [com.google.protobuf ByteString]
-           [editor.types Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
+           [editor.types Animation Image Rect AABB]
            [java.awt.image BufferedImage]
-           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.vecmath Point3d Matrix4d]
-           [java.nio ByteBuffer ByteOrder FloatBuffer]))
+           [com.jogamp.opengl GL GL2]
+           [javax.vecmath Point3d Vector3d Matrix4d]))
 
 (set! *warn-on-reflection* true)
-
-(defn mind ^double [^double a ^double b] (Math/min a b))
-(defn maxd ^double [^double a ^double b] (Math/max a b))
 
 (def ^:const atlas-icon "icons/32/Icons_13-Atlas.png")
 (def ^:const animation-icon "icons/32/Icons_24-AT-Animation.png")
@@ -64,20 +61,13 @@
 ; TODO - macro of this
 (def atlas-shader (shader/make-shader ::atlas-shader pos-uv-vert pos-uv-frag))
 
-(defn render-texture-set
-  [gl render-args vertex-binding gpu-texture]
-  (gl/with-gl-bindings gl render-args [gpu-texture atlas-shader vertex-binding]
-    (shader/set-uniform atlas-shader gl "texture" 0)
-    (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 6)))
-
-(defn render-image-outline
-  [^GL2 gl render-args renderable image-data]
-  (let [rect (:rect image-data)
-        x0 (:x rect)
+(defn- render-rect
+  [^GL2 gl rect color]
+  (let [x0 (:x rect)
         y0 (:y rect)
         x1 (+ x0 (:width rect))
         y1 (+ y0 (:height rect))
-        [cr cg cb ca] scene/selected-outline-color]
+        [cr cg cb ca] color]
     (.glColor4d gl cr cg cb ca)
     (.glBegin gl GL2/GL_QUADS)
     (.glVertex3d gl x0 y0 0)
@@ -85,6 +75,34 @@
     (.glVertex3d gl x1 y1 0)
     (.glVertex3d gl x1 y0 0)
     (.glEnd gl)))
+
+(defn render-image-outline
+  [^GL2 gl render-args renderable]
+  (let [animating? (-> renderable :updatable :state)]
+    (when (if animating?
+            (= (-> renderable :updatable :state :frame) (-> renderable :user-data :order))
+            (:selected renderable))
+      (render-rect gl (-> renderable :user-data :rect) scene/selected-outline-color))))
+
+(defn render-images
+  [^GL2 gl render-args renderables n]
+  (condp = (:pass render-args)
+    pass/outline
+    (run! #(render-image-outline gl render-args %) renderables)
+
+    pass/selection
+    (run! #(render-rect gl (-> % :user-data :rect) [1.0 1.0 1.0 1.0]) renderables)))
+
+(g/defnk produce-image-scene
+  [_node-id id order image-id->rect animation-updatable]
+  (let [rect (get image-id->rect id)]
+    {:node-id _node-id
+     :aabb (geom/rect->aabb rect)
+     :renderable {:render-fn render-images
+                  :user-data {:rect rect
+                              :order order}
+                  :passes [pass/outline pass/selection]}
+     :updatable animation-updatable}))
 
 (defn- path->id [path]
   (-> path
@@ -101,21 +119,6 @@
                          :flip-vertical   false
                          :playback        :playback-once-forward}))
 
-(g/defnk produce-image-scene
-  [_node-id id image-data]
-  (let [image-data (get image-data id)]
-    {:node-id _node-id
-     :aabb (geom/rect->aabb (:rect image-data))
-     :renderable {:render-fn (fn [gl render-args [renderable] n]
-                               (condp = (:pass render-args)
-                                 pass/outline
-                                 (when (:selected renderable)
-                                   (render-image-outline gl render-args renderable image-data))
-
-                                 pass/selection
-                                 (render-image-outline gl render-args renderable image-data)))
-                  :passes [pass/outline pass/selection]}}))
-
 (g/defnode AtlasImage
   (inherits outline/OutlineNode)
 
@@ -123,7 +126,6 @@
     (value (g/fnk [image-size] [(:width image-size 0) (:height image-size 0)]))
     (dynamic edit-type (g/constantly {:type types/Vec2 :labels ["W" "H"]}))
     (dynamic read-only? (g/constantly true)))
-  (property order g/Int (dynamic visible (g/constantly false)) (default 0))
 
   (property image resource/Resource
             (value (gu/passthrough image-resource))
@@ -137,16 +139,20 @@
   (output image-resource resource/Resource (gu/passthrough image-resource))
 
   (input image-size g/Any)
+  (input image-id->rect g/Any)
 
-  (input image-data g/Any)
+  (input child->order g/Any)
+  (output order g/Any (g/fnk [_node-id child->order]
+                        (child->order _node-id)))
 
-  (output image-order g/Any (g/fnk [_node-id order] [_node-id order]))
+  (input animation-updatable g/Any)
+
   (output path g/Str (g/fnk [image-resource] (resource/proj-path image-resource)))
   (output id g/Str (g/fnk [path] (path->id path)))
-  (output frame Image (g/fnk [path image-size]
-                        (Image. path nil (:width image-size) (:height image-size))))
-
-  (output animation Animation (g/fnk [frame id] (image->animation frame id)))
+  (output atlas-image Image (g/fnk [path image-size]
+                              (Image. path nil (:width image-size) (:height image-size))))
+  (output animation Animation (g/fnk [atlas-image id]
+                                      (image->animation atlas-image id)))
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id id image-resource order]
                                                           (cond-> {:node-id _node-id
                                                                    :label id
@@ -169,18 +175,19 @@
    :playback playback
    :images (sort-by-and-strip-order img-ddf)})
 
-(defn- attach-image [parent labels image-node scope-node image-order]
+(defn- attach-image [parent labels image-node]
   (concat
-    (g/set-property image-node :order image-order)
-    (g/connect image-node :image-order          parent     :image-order)
-    (g/connect image-node :_node-id             scope-node :nodes)
     (for [[from to] labels]
       (g/connect image-node from parent to))
+    (g/connect image-node :_node-id             parent     :nodes)
     (g/connect image-node :node-outline         parent     :child-outlines)
     (g/connect image-node :ddf-message          parent     :img-ddf)
     (g/connect image-node :scene                parent     :child-scenes)
     (g/connect image-node :image-resource       parent     :image-resources)
-    (g/connect parent     :image-data           image-node :image-data)))
+    (g/connect image-node :atlas-image          parent     :atlas-images)
+    (g/connect parent     :image-id->rect       image-node :image-id->rect)
+    (g/connect parent     :updatable            image-node :animation-updatable)
+    (g/connect parent     :child->order         image-node :child->order)))
 
 (defn- attach-animation [atlas-node animation-node]
   (concat
@@ -191,25 +198,43 @@
    (g/connect animation-node :ddf-message          atlas-node :anim-ddf)
    (g/connect animation-node :scene                atlas-node :child-scenes)
    (g/connect animation-node :image-resources      atlas-node :image-resources)
-   (g/connect atlas-node     :image-data           animation-node :image-data)))
-
-(defn- next-image-order [parent]
-  (inc (apply max -1 (map second (g/node-value parent :image-order)))))
+   (g/connect atlas-node     :image-id->rect       animation-node :image-id->rect)
+   (g/connect atlas-node     :anim-data            animation-node :anim-data)
+   (g/connect atlas-node     :gpu-texture          animation-node :gpu-texture)))
 
 (defn- tx-attach-image-to-animation [animation-node image-node]
   (attach-image animation-node
-                [[:frame :frames]]
-                image-node
-                (core/scope animation-node)
-                (next-image-order animation-node)))
+                []
+                image-node))
+
+(defn render-animation
+  [^GL2 gl render-args renderables n]
+  (condp = (:pass render-args)
+    pass/selection
+    nil
+
+    pass/overlay
+    (texture-set/render-animation-overlay gl render-args renderables n ->texture-vtx atlas-shader)))
+
+(g/defnk produce-animation-updatable
+  [_node-id id anim-data]
+  (texture-set/make-animation-updatable _node-id "Atlas Animation" (get anim-data id)))
 
 (g/defnk produce-animation-scene
-  [_node-id child-scenes]
-  {:node-id _node-id
-   :aabb (reduce geom/aabb-union (geom/null-aabb) (keep :aabb child-scenes))
-   :children child-scenes})
+  [_node-id id child-scenes gpu-texture updatable anim-data]
+  {:node-id    _node-id
+   :aabb       (reduce geom/aabb-union (geom/null-aabb) (keep :aabb child-scenes))
+   :renderable {:render-fn render-animation
+                :batch-key nil
+                :user-data {:gpu-texture gpu-texture
+                            :anim-id     id
+                            :anim-data   (get anim-data id)}
+                :passes    [pass/overlay pass/selection]}
+   :updatable  updatable
+   :children   child-scenes})
 
 (g/defnode AtlasAnimation
+  (inherits core/Scope)
   (inherits outline/OutlineNode)
 
   (property id g/Str
@@ -226,17 +251,25 @@
                                     :options (zipmap (map first options)
                                                      (map (comp :display-name second) options))}))))
 
-  (input frames Image :array)
+  (output child->order g/Any :cached (g/fnk [nodes] (zipmap nodes (range))))
+
+  (input atlas-images Image :array)
   (input img-ddf g/Any :array)
   (input child-scenes g/Any :array)
-  (input image-order g/Any :array)
-  (input image-data g/Any)
+
+  (input anim-data g/Any)
+
   (input image-resources g/Any :array)
   (output image-resources g/Any (gu/passthrough image-resources))
 
-  (output animation Animation (g/fnk [this id frames fps flip-horizontal flip-vertical playback]
-                                (types/->Animation id frames fps flip-horizontal flip-vertical playback)))
-  (output image-data g/Any (gu/passthrough image-data))
+  (input image-id->rect g/Any)
+  (output image-id->rect g/Any (gu/passthrough image-id->rect))
+
+  (input gpu-texture g/Any)
+
+  (output animation Animation (g/fnk [this id atlas-images fps flip-horizontal flip-vertical playback]
+                                      (types/->Animation id atlas-images fps flip-horizontal flip-vertical playback)))
+
   (output node-outline outline/OutlineData :cached
     (g/fnk [_node-id id child-outlines] {:node-id _node-id
                                          :label id
@@ -245,6 +278,7 @@
                                          :child-reqs [{:node-type AtlasImage
                                                        :tx-attach-fn tx-attach-image-to-animation}]}))
   (output ddf-message g/Any :cached produce-anim-ddf)
+  (output updatable g/Any :cached produce-animation-updatable)
   (output scene g/Any :cached produce-animation-scene))
 
 (g/defnk produce-save-data [resource margin inner-padding extrude-borders img-ddf anim-ddf]
@@ -283,19 +317,43 @@
            (conj! [x1 y0 0 1 1 0])
            (conj! [x0 y0 0 1 0 0])))))
 
+(defn- render-atlas
+  [^GL2 gl render-args [renderable] n]
+  (let [{:keys [pass]} render-args]
+    (condp = pass
+      pass/transparent
+      (let [{:keys [user-data]} renderable
+            {:keys [vbuf gpu-texture]} user-data
+            vertex-binding (vtx/use-with ::atlas-binding vbuf atlas-shader)]
+        (gl/with-gl-bindings gl render-args [gpu-texture atlas-shader vertex-binding]
+          (shader/set-uniform atlas-shader gl "texture" 0)
+          (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 6)))      
+      
+      pass/outline
+      (let [{:keys [aabb]} renderable
+            [x0 y0] (math/vecmath->clj (types/min-p aabb))
+            [x1 y1] (math/vecmath->clj (types/max-p aabb))
+            [cr cg cb ca] scene/outline-color]
+        (.glColor4d gl cr cg cb ca)
+        (.glBegin gl GL2/GL_QUADS)
+        (.glVertex3d gl x0 y0 0)
+        (.glVertex3d gl x0 y1 0)
+        (.glVertex3d gl x1 y1 0)
+        (.glVertex3d gl x1 y0 0)
+        (.glEnd gl)))))
+
 (g/defnk produce-scene
-  [_node-id layout-size aabb gpu-texture child-scenes]
-  (let [[width height] layout-size
-        vertex-buffer (gen-renderable-vertex-buffer width height)
-        vertex-binding (vtx/use-with _node-id vertex-buffer atlas-shader)]
+  [_node-id aabb layout-size gpu-texture child-scenes]
+  (let [[width height] layout-size]
     {:aabb aabb
-     :renderable {:render-fn (fn [gl render-args renderables count]
-                               (render-texture-set gl render-args vertex-binding gpu-texture))
-                  :passes [pass/transparent]}
+     :renderable {:render-fn render-atlas
+                  :user-data {:gpu-texture gpu-texture
+                              :vbuf        (gen-renderable-vertex-buffer width height)}
+                  :passes [pass/transparent pass/outline]}
      :children child-scenes}))
 
 (g/defnk produce-texture-set-data
-  [_node-id animations images margin inner-padding extrude-borders]
+  [_node-id animations all-atlas-images margin inner-padding extrude-borders]
   (or (when-let [errors (->> [[margin "Margin"]
                               [inner-padding "Inner Padding"]
                               [extrude-borders "Extrude Borders"]]
@@ -303,72 +361,27 @@
                                      (validation/prop-error :fatal _node-id :layout-result validation/prop-negative? v name)))
                              not-empty)]
         (g/error-aggregate errors))
-      (texture-set-gen/atlas->texture-set-data animations images margin inner-padding extrude-borders)))
+      (texture-set-gen/atlas->texture-set-data animations all-atlas-images margin inner-padding extrude-borders)))
 
-(defn- ->uv-vertex [vert-index ^FloatBuffer tex-coords]
-  (let [index (* vert-index 2)]
-    [(.get tex-coords ^int index) (.get tex-coords ^int (inc index))]))
+(g/defnk produce-anim-data
+  [texture-set uv-transforms]
+  (texture-set/make-anim-data texture-set uv-transforms))
 
-(defn- ->uv-quad [quad-index tex-coords]
-  (let [offset (* quad-index 4)]
-    (mapv #(->uv-vertex (+ offset %) tex-coords) (range 4))))
-
-(defn- ->anim-frame [frame-index tex-coords]
-  {:tex-coords (->uv-quad frame-index tex-coords)})
-
-(defn- ->anim-data [anim tex-coords uv-transforms]
-  {:width (:width anim)
-   :height (:height anim)
-   :frames (mapv #(->anim-frame % tex-coords) (range (:start anim) (:end anim)))
-   :uv-transforms (subvec uv-transforms (:start anim) (:end anim))})
-
-(g/defnk produce-anim-data [texture-set uv-transforms]
-  (let [tex-coords (-> ^ByteString (:tex-coords texture-set)
-                     (.asReadOnlyByteBuffer)
-                     (.order ByteOrder/LITTLE_ENDIAN)
-                     (.asFloatBuffer))
-        animations (:animations texture-set)]
-    (into {} (map #(do [(:id %) (->anim-data % tex-coords uv-transforms)]) animations))))
-
-(defn- tex-coords->rect
-  [^FloatBuffer tex-coords index atlas-width atlas-height]
-  (let [quad (->uv-quad index tex-coords)
-        x0 (reduce mind (map first quad))
-        y0 (reduce mind (map second quad))
-        x1 (reduce maxd (map first quad))
-        y1 (reduce maxd (map second quad))
-        w (- x1 x0)
-        h (- y1 y0)]
-    (types/rect (* x0 atlas-width)
-                (* y0 atlas-height)
-                (* w atlas-width)
-                (* h atlas-height))))
-
-(defn- ->image-data
-  [index tex-coords atlas-width atlas-height]
-  {:rect (tex-coords->rect tex-coords index atlas-width atlas-height)})
-
-(g/defnk produce-image-data [images layout-size texture-set]
-  (let [[width height] layout-size
-        tex-coords (-> ^ByteString (:tex-coords texture-set)
-                       (.asReadOnlyByteBuffer)
-                       (.order ByteOrder/LITTLE_ENDIAN)
-                       (.asFloatBuffer))
-        xform (map-indexed (fn [idx image]
-                             [(path->id (:path image)) (->image-data idx tex-coords width height)]))]
-    (into {} xform images)))
+(g/defnk produce-image-id->rect
+  [layout-size layout-rects]
+  (let [[w h] layout-size]
+    (into {} (map (fn [{:keys [path x y width height]}]
+                    [(path->id path) (types/->Rect path x (- h height y) width height)]))
+          layout-rects)))
 
 (defn- tx-attach-image-to-atlas [atlas-node image-node]
   (attach-image atlas-node
                 [[:animation :animations]
                  [:id :animation-ids]]
-                image-node
-                atlas-node
-                (next-image-order atlas-node)))
+                image-node))
 
 (defn- atlas-outline-sort-by-fn [v]
   [(:name (g/node-type* (:node-id v)))])
-
 
 (g/defnode AtlasNode
   (inherits project/ResourceNode)
@@ -387,21 +400,24 @@
             (default 0)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? extrude-borders)))
 
+  (output child->order g/Any :cached (g/fnk [nodes] (zipmap nodes (range))))
+
+  (input atlas-images g/Any :array)
   (input animations Animation :array)
   (input animation-ids g/Str :array)
   (input img-ddf g/Any :array)
   (input anim-ddf g/Any :array)
-  (input image-order g/Any :array)
   (input child-scenes g/Any :array)
   (input image-resources g/Any :array)
 
-  (output images           [Image]             :cached (g/fnk [animations]
-                                                         (vals (into {} (map (fn [img] [(:path img) img]) (mapcat :images animations))))))
+  (output all-atlas-images           [Image]             :cached (g/fnk [animations]
+                                                                   (vals (into {} (map (fn [img] [(:path img) img]) (mapcat :images animations))))))
 
   (output texture-set-data g/Any               :cached produce-texture-set-data)
   (output layout-size      g/Any               (g/fnk [texture-set-data] (:size texture-set-data)))
   (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
   (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
+  (output layout-rects     g/Any               (g/fnk [texture-set-data] (:rects texture-set-data)))
 
   (output packed-image     BufferedImage       :cached (g/fnk [_node-id texture-set-data image-resources]
                                                          (let [id->image (reduce (fn [ret image-resource]
@@ -422,7 +438,7 @@
                                                          (texture/image-texture _node-id packed-image)))
 
   (output anim-data        g/Any               :cached produce-anim-data)
-  (output image-data       g/Any               :cached produce-image-data)
+  (output image-id->rect   g/Any               :cached produce-image-id->rect)
   (output anim-ids         g/Any               :cached (gu/passthrough animation-ids))
   (output node-outline     outline/OutlineData :cached (g/fnk [_node-id child-outlines]
                                                          {:node-id    _node-id
@@ -435,22 +451,17 @@
                                                                         :tx-attach-fn attach-animation}]}))
   (output save-data        g/Any          :cached produce-save-data)
   (output build-targets    g/Any          :cached produce-build-targets)
+  (output updatable        g/Any          (g/fnk [] nil))
   (output scene            g/Any          :cached produce-scene))
 
-(def ^:private atlas-animation-keys [:flip-horizontal :flip-vertical :fps :playback :id])
-
 (defn- attach-image-nodes
-  [parent labels image-resources scope-node]
+  [parent labels image-resources]
   (let [graph-id (g/node-id->graph-id parent)]
-    (let [next-order (next-image-order parent)]
-      (map-indexed
-       (fn [index image-resource]
-         (let [image-order (+ next-order index)]
-           (g/make-nodes
-            graph-id
-            [atlas-image [AtlasImage {:image image-resource}]]
-            (attach-image parent labels atlas-image scope-node image-order))))
-       image-resources))))
+    (for [image-resource image-resources]
+      (g/make-nodes
+        graph-id
+        [atlas-image [AtlasImage {:image image-resource}]]
+        (attach-image parent labels atlas-image)))))
 
 
 (defn add-images [atlas-node img-resources]
@@ -458,7 +469,7 @@
   (attach-image-nodes atlas-node
                       [[:animation :animations]
                        [:id :animation-ids]]
-                      img-resources atlas-node))
+                      img-resources))
 
 (defn- attach-atlas-animation [atlas-node anim]
   (let [graph-id (g/node-id->graph-id atlas-node)
@@ -470,7 +481,7 @@
      [atlas-anim [AtlasAnimation :flip-horizontal (:flip-horizontal anim) :flip-vertical (:flip-vertical anim)
                   :fps (:fps anim) :playback (:playback anim) :id (:id anim)]]
      (attach-animation atlas-node atlas-anim)
-     (attach-image-nodes atlas-anim [[:frame :frames]] image-resources atlas-node))))
+     (attach-image-nodes atlas-anim [] image-resources))))
 
 (defn- update-int->bool [keys m]
   (reduce (fn [m key]
@@ -491,8 +502,7 @@
       (attach-image-nodes self
                           [[:animation :animations]
                            [:id :animation-ids]]
-                          image-resources
-                          self)
+                          image-resources)
       (map (comp (partial attach-atlas-animation self)
                  (partial update-int->bool [:flip-horizontal :flip-vertical]))
            (:animations atlas)))))
@@ -507,7 +517,7 @@
                                     :load-fn load-atlas
                                     :icon atlas-icon
                                     :view-types [:scene :text]
-                                    :view-opts {:scene {:grid true}}))
+                                    :view-opts {:scene {:grid false}}))
 
 (defn- selection->atlas [selection] (handler/adapt-single selection AtlasNode))
 (defn- selection->animation [selection] (handler/adapt-single selection AtlasAnimation))
@@ -531,12 +541,12 @@
   (active? [selection] (selection->atlas selection))
   (run [selection] (add-animation-group-handler (selection->atlas selection))))
 
-(defn- add-images-handler [workspace project labels parent scope-node] ; parent = new parent of images
+(defn- add-images-handler [workspace project labels parent] ; parent = new parent of images
   (when-let [image-resources (seq (dialogs/make-resource-dialog workspace project {:ext image/exts :title "Select Images" :selection :multiple}))]
     (g/transact
      (concat
       (g/operation-label "Add Images")
-      (attach-image-nodes parent labels image-resources scope-node)))))
+      (attach-image-nodes parent labels image-resources)))))
 
 (handler/defhandler :add-from-file :workbench
   (label [] "Add Images...")
@@ -546,44 +556,46 @@
                                (add-images-handler workspace project
                                                    [[:animation :animations]
                                                     [:id :animation-ids]]
-                                                   atlas-node atlas-node)
+                                                   atlas-node)
                                (when-let [animation-node (selection->animation selection)]
-                                 (add-images-handler workspace project [[:frame :frames]] animation-node (core/scope animation-node)))))))
+                                 (add-images-handler workspace project [] animation-node))))))
 
-(defn- targets-of [node label]
-  (keep
-   (fn [[src src-lbl trg trg-lbl]]
-     (when (= src-lbl label)
-       [trg trg-lbl]))
-   (g/outputs node)))
+(defn- vec-move
+  [v x offset]
+  (let [current-index (.indexOf ^java.util.List v x)
+        new-index (max 0 (+ current-index offset))
+        [before after] (split-at new-index (remove #(= x %) v))]
+    (vec (concat before [x] after))))
 
-(defn- image-parent [node]
-  (first (first (targets-of node :image-order))))
+(defn- move-node!
+  [node-id offset]
+  (let [parent (core/scope node-id)
+        children (vec (g/node-value parent :nodes))
+        new-children (vec-move children node-id offset)
+        connections (keep (fn [[source source-label target target-label]]
+                            (when (and (= source node-id)
+                                       (= target parent))
+                              [source-label target-label]))
+                          (g/outputs node-id))]
+    (g/transact
+      (concat
+        (for [child children
+              [source target] connections]
+          (g/disconnect child source parent target))
+        (for [child new-children
+              [source target] connections]
+          (g/connect child source parent target))))))
 
 (defn- move-active? [selection]
   (some->> selection
     selection->image
-    image-parent
+    core/scope
     (g/node-instance? AtlasAnimation)))
-
-(defn- run-move [selection direction]
-  (let [image (selection->image selection)
-        parent (image-parent image)
-        order-delta (if (= direction :move-up) -1 1)
-        new-image-order (->> (g/node-value parent :image-order) ; original image order
-                          (sort-by second) ; sort by order
-                          (map-indexed (fn [ix [node _]] [node (* 2 ix)])) ; compact order + make space
-                          (map (fn [[node ix]] [node (if (= image node) (+ ix (* 3 order-delta)) ix)])) ; move image to space before previous or after successor
-                          (sort-by second))]
-    (g/transact
-      (map (fn [[image order]]
-             (g/set-property image :order order))
-           new-image-order))))
 
 (handler/defhandler :move-up :workbench
   (active? [selection] (move-active? selection))
-  (run [selection] (run-move selection :move-up)))
+  (run [selection] (move-node! (selection->image selection) -1)))
 
 (handler/defhandler :move-down :workbench
   (active? [selection] (move-active? selection))
-  (run [selection] (run-move selection :move-down)))
+  (run [selection] (move-node! (selection->image selection) 1)))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -94,8 +94,8 @@
     (run! #(render-rect gl (-> % :user-data :rect) [1.0 1.0 1.0 1.0]) renderables)))
 
 (g/defnk produce-image-scene
-  [_node-id id order image-id->rect animation-updatable]
-  (let [rect (get image-id->rect id)]
+  [_node-id path order image-path->rect animation-updatable]
+  (let [rect (get image-path->rect path)]
     {:node-id _node-id
      :aabb (geom/rect->aabb rect)
      :renderable {:render-fn render-images
@@ -139,7 +139,7 @@
   (output image-resource resource/Resource (gu/passthrough image-resource))
 
   (input image-size g/Any)
-  (input image-id->rect g/Any)
+  (input image-path->rect g/Any)
 
   (input child->order g/Any)
   (output order g/Any (g/fnk [_node-id child->order]
@@ -185,7 +185,7 @@
     (g/connect image-node :scene                parent     :child-scenes)
     (g/connect image-node :image-resource       parent     :image-resources)
     (g/connect image-node :atlas-image          parent     :atlas-images)
-    (g/connect parent     :image-id->rect       image-node :image-id->rect)
+    (g/connect parent     :image-path->rect     image-node :image-path->rect)
     (g/connect parent     :updatable            image-node :animation-updatable)
     (g/connect parent     :child->order         image-node :child->order)))
 
@@ -198,7 +198,7 @@
    (g/connect animation-node :ddf-message          atlas-node :anim-ddf)
    (g/connect animation-node :scene                atlas-node :child-scenes)
    (g/connect animation-node :image-resources      atlas-node :image-resources)
-   (g/connect atlas-node     :image-id->rect       animation-node :image-id->rect)
+   (g/connect atlas-node     :image-path->rect     animation-node :image-path->rect)
    (g/connect atlas-node     :anim-data            animation-node :anim-data)
    (g/connect atlas-node     :gpu-texture          animation-node :gpu-texture)))
 
@@ -262,8 +262,8 @@
   (input image-resources g/Any :array)
   (output image-resources g/Any (gu/passthrough image-resources))
 
-  (input image-id->rect g/Any)
-  (output image-id->rect g/Any (gu/passthrough image-id->rect))
+  (input image-path->rect g/Any)
+  (output image-path->rect g/Any (gu/passthrough image-path->rect))
 
   (input gpu-texture g/Any)
 
@@ -367,11 +367,11 @@
   [texture-set uv-transforms]
   (texture-set/make-anim-data texture-set uv-transforms))
 
-(g/defnk produce-image-id->rect
+(g/defnk produce-image-path->rect
   [layout-size layout-rects]
   (let [[w h] layout-size]
     (into {} (map (fn [{:keys [path x y width height]}]
-                    [(path->id path) (types/->Rect path x (- h height y) width height)]))
+                    [path (types/->Rect path x (- h height y) width height)]))
           layout-rects)))
 
 (defn- tx-attach-image-to-atlas [atlas-node image-node]
@@ -438,7 +438,7 @@
                                                          (texture/image-texture _node-id packed-image)))
 
   (output anim-data        g/Any               :cached produce-anim-data)
-  (output image-id->rect   g/Any               :cached produce-image-id->rect)
+  (output image-path->rect g/Any               :cached produce-image-path->rect)
   (output anim-ids         g/Any               :cached (gu/passthrough animation-ids))
   (output node-outline     outline/OutlineData :cached (g/fnk [_node-id child-outlines]
                                                          {:node-id    _node-id

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -411,7 +411,7 @@
   (input image-resources g/Any :array)
 
   (output all-atlas-images           [Image]             :cached (g/fnk [animations]
-                                                                   (vals (into {} (map (fn [img] [(:path img) img]) (mapcat :images animations))))))
+                                                                   (into [] (comp (mapcat :images) (distinct)) animations)))
 
   (output texture-set-data g/Any               :cached produce-texture-set-data)
   (output layout-size      g/Any               (g/fnk [texture-set-data] (:size texture-set-data)))

--- a/editor/src/clj/editor/colors.clj
+++ b/editor/src/clj/editor/colors.clj
@@ -16,6 +16,7 @@
 (def defold-red (hex-color->color "#ff0000"))
 (def defold-yellow (hex-color->color "#fbce2f"))
 (def defold-turquoise (hex-color->color "#00e6e1"))
+(def defold-pink (hex-color->color "#E200E6"))
 (def defold-green (hex-color->color "#3cff00"))
 (def defold-orange (hex-color->color "#fd6623"))
 (def selected-blue (hex-color->color "#264a8b"))

--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -453,6 +453,7 @@
   (property hidden-curves g/Any)
   (property tool-user-data g/Any (default (atom [])))
   (property input-action-queue g/Any (default []))
+  (property updatable-states g/Any (default (atom {})))
 
   (input camera-id g/NodeID :cascade-delete)
   (input grid-id g/NodeID :cascade-delete)

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -658,10 +658,11 @@
 (g/defnk produce-scene-updatable [_node-id rt-pb-data fetch-anim-fn]
   {:node-id _node-id
    :name "ParticleFX"
-   :update-fn (g/fnk [dt world-transform]
+   :update-fn (fn [state {:keys [dt world-transform]}]
                 (let [data [max-emitter-count max-particle-count rt-pb-data world-transform]
                       pfx-sim-ref (:pfx-sim (scene-cache/request-object! ::pfx-sim _node-id nil data))]
-                  (swap! pfx-sim-ref plib/simulate dt fetch-anim-fn [world-transform])))})
+                  (swap! pfx-sim-ref plib/simulate dt fetch-anim-fn [world-transform])
+                  state))})
 
 (defn- attach-emitter [self-id emitter-id resolve-id?]
   (concat

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -29,6 +29,15 @@
   [{:keys [path width height]}]
   (TextureSetLayout$Rect. path (int width) (int height)))
 
+(defn- Rect->map
+  [^TextureSetLayout$Rect rect]
+  {:path (.id rect)
+   :x (.x rect)
+   :y (.y rect)
+   :width (.width rect)
+   :height (.height rect)
+   :rotated (.rotated rect)})
+
 (defn- Metrics->map
   [^TileSetUtil$Metrics metrics]
   (when metrics
@@ -44,7 +53,8 @@
   {:texture-set (protobuf/pb->map (.build (.builder tex-set-result)))
    :uv-transforms (vec (.uvTransforms tex-set-result))
    :layout (.layoutResult tex-set-result)
-   :size [(.. tex-set-result layoutResult layout getWidth) (.. tex-set-result layoutResult layout getHeight)]})
+   :size [(.. tex-set-result layoutResult layout getWidth) (.. tex-set-result layoutResult layout getHeight)]
+   :rects (into [] (map Rect->map) (.. tex-set-result layoutResult layout getRectangles))})
 
 (defn layout-images
   [layout-result id->image]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -261,11 +261,10 @@
 
 (defn- assoc-updatable-states
   [renderables updatable-states]
-  (into []
-        (map (fn [renderable]
-               (if-let [updatable-node-id (get-in renderable [:updatable :node-id])]
-                 (assoc-in renderable [:updatable :state] (get-in updatable-states [updatable-node-id]))
-                 renderable)))
+  (mapv (fn [renderable]
+          (if-let [updatable-node-id (get-in renderable [:updatable :node-id])]
+            (assoc-in renderable [:updatable :state] (get-in updatable-states [updatable-node-id]))
+            renderable))
         renderables))
 
 (defn render! [render-args ^GLContext context updatable-states]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -53,12 +53,9 @@
            [com.jogamp.opengl.glu GLU]
            [javax.vecmath Point2i Point3d Quat4d Matrix4d Vector4d Matrix3d Vector3d]
            [sun.awt.image IntegerComponentRaster]
-           [java.util.concurrent Executors]
            [com.defold.editor AsyncCopier]))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private executor (Executors/newFixedThreadPool 1))
 
 (defn overlay-text [^GL2 gl ^String text x y]
   (scene-text/overlay gl text x y))
@@ -262,16 +259,27 @@
     {:camera camera :viewport viewport :view view :projection proj :view-proj view-proj :world world
      :world-view world-view :texture texture :normal normal}))
 
-(defn render! [render-args ^GLContext context]
+(defn- assoc-updatable-states
+  [renderables updatable-states]
+  (into []
+        (map (fn [renderable]
+               (if-let [updatable-node-id (get-in renderable [:updatable :node-id])]
+                 (assoc-in renderable [:updatable :state] (get-in updatable-states [updatable-node-id]))
+                 renderable)))
+        renderables))
+
+(defn render! [render-args ^GLContext context updatable-states]
   (let [^GL2 gl (.getGL context)
         {:keys [viewport camera renderables]} render-args]
     (gl/gl-clear gl 0.0 0.0 0.0 1)
     (.glColor4f gl 1.0 1.0 1.0 1.0)
     (gl-viewport gl viewport)
     (doseq [pass pass/render-passes
-            :let [render-args (assoc render-args :pass pass)]]
+            :let [render-args (assoc render-args :pass pass)
+                  pass-renderables (-> (get renderables pass)
+                                       (assoc-updatable-states updatable-states))]]
       (setup-pass context gl pass camera viewport)
-      (batch-render gl render-args (get renderables pass) false :batch-key))))
+      (batch-render gl render-args pass-renderables false :batch-key))))
 
 (defn- append-flattened-scene-renderables! [scene selection-set view-proj node-path parent-world-transform out-renderables tmp-v4d]
   (let [renderable (:renderable scene)
@@ -359,9 +367,10 @@
                                                                            (:aabb scene)
                                                                            (reduce geom/aabb-union (geom/null-aabb) (map :aabb selected-renderables)))))
   (output selected-updatables g/Any :cached (g/fnk [selected-renderables]
-                                              (some (fn [r]
-                                                      (when-let [u (:updatable r)]
-                                                        {(:node-id u) u})) selected-renderables)))
+                                              (into {}
+                                                    (comp (keep :updatable)
+                                                          (map (juxt :node-id identity)))
+                                                    selected-renderables)))
   (output updatables g/Any :cached (g/fnk [renderables]
                                      ;; Currently updatables are implemented as extra info on the renderables.
                                      ;; The renderable associates an updatable with itself, which contains info
@@ -503,6 +512,7 @@
   (property tool-picking-rect Rect)
   (property tool-user-data g/Any (default (atom [])))
   (property input-action-queue g/Any (default []))
+  (property updatable-states g/Any)
 
   (input input-handlers Runnable :array)
   (input picking-rect Rect)
@@ -579,7 +589,8 @@
   (g/transact
     (concat
       (g/set-property view-id :play-mode :idle)
-      (g/set-property view-id :active-updatable-ids []))))
+      (g/set-property view-id :active-updatable-ids [])
+      (g/set-property view-id :updatable-states (atom {})))))
 
 (handler/defhandler :scene-stop :global
   (enabled? [app-view] (when-let [view (active-scene-view app-view)]
@@ -659,11 +670,11 @@
   (when main-frame?
     (profiler/begin-frame))
   (when-let [view-id (ui/user-data image-view ::view-id)]
-    (let [view-graph (g/node-id->graph-id view-id)
-          play-mode (g/node-value view-id :play-mode)
+    (let [play-mode (g/node-value view-id :play-mode)
           tool-user-data (g/node-value view-id :tool-user-data)
           action-queue (g/node-value view-id :input-action-queue)
           active-updatables (g/node-value view-id :active-updatables)
+          updatable-states (g/node-value view-id :updatable-states)
           {:keys [frame-version] :as render-args} (g/node-value view-id :render-args)]
       (g/set-property! view-id :input-action-queue [])
       (when (seq active-updatables)
@@ -678,14 +689,17 @@
         ; Fixed dt for deterministic playback
         (let [dt 1/60
               context {:dt (if (= play-mode :playing) dt 0)}]
-          (doseq [updatable active-updatables
-                  :let [context (assoc context :world-transform (:world-transform updatable))]]
-            ((get updatable :update-fn) context))))
+          (doseq [{:keys [update-fn node-id world-transform initial-state]} active-updatables]
+            (let [context (assoc context
+                                 :world-transform world-transform)
+                  state (get-in @updatable-states [node-id] initial-state)
+                  state' (update-fn state context)]
+              (swap! updatable-states assoc-in [node-id] state')))))
       (profiler/profile "render" -1
         (let [current-frame-version (ui/user-data image-view ::current-frame-version)]
           (with-drawable-as-current drawable
             (when (not= current-frame-version frame-version)
-              (render! render-args gl-context)
+              (render! render-args gl-context @updatable-states)
               (ui/user-data! image-view ::current-frame-version frame-version)
               (scene-cache/prune-object-caches! gl))
             (when-let [^WritableImage image (.flip async-copier gl frame-version)]
@@ -793,14 +807,14 @@
     scene-view-pane))
 
 (defn- make-scene-view [scene-graph ^Parent parent opts]
-  (let [view-id (g/make-node! scene-graph SceneView :select-buffer (make-select-buffer) :frame-version (atom 0))
+  (let [view-id (g/make-node! scene-graph SceneView :select-buffer (make-select-buffer) :frame-version (atom 0) :updatable-states (atom {}))
         scene-view-pane (make-scene-view-pane view-id opts)]
     (ui/children! parent [scene-view-pane])
     view-id))
 
 (g/defnk produce-frame [render-args ^GLAutoDrawable drawable]
   (with-drawable-as-current drawable
-    (render! render-args gl-context)
+    (render! render-args gl-context nil)
     (let [[w h] (vp-dims (:viewport render-args))
           buf-image (read-to-buffered-image w h)]
       (scene-cache/prune-object-caches! gl)

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -13,12 +13,14 @@
             [editor.validation :as validation]
             [editor.pipeline :as pipeline]
             [editor.resource :as resource]
+            [editor.texture-set :as texture-set]
             [editor.gl.pass :as pass]
             [editor.types :as types])
   (:import [com.dynamo.graphics.proto Graphics$Cubemap Graphics$TextureImage Graphics$TextureImage$Image Graphics$TextureImage$Type]
            [com.dynamo.sprite.proto Sprite$SpriteDesc Sprite$SpriteDesc$BlendMode]
            [com.jogamp.opengl.util.awt TextRenderer]
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
+           [editor.gl.shader ShaderLifecycle]
            [java.awt.image BufferedImage]
            [java.io PushbackReader]
            [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
@@ -32,7 +34,7 @@
 ; Render assets
 
 (vtx/defvertex texture-vtx
-  (vec3 position)
+  (vec4 position)
   (vec2 texcoord0 true))
 
 (shader/defshader vertex-shader
@@ -72,40 +74,18 @@
 ; TODO - macro of this
 (def outline-shader (shader/make-shader ::outline-shader outline-vertex-shader outline-fragment-shader))
 
-; Vertex generation
-
-(defn- gen-vertex [^Matrix4d wt ^Point3d pt x y u v]
-  (.set pt x y 0)
-  (.transform wt pt)
-  [(.x pt) (.y pt) (.z pt) u v])
-
-(defn- conj-quad! [vbuf ^Matrix4d wt ^Point3d pt width height anim-uvs]
-  (let [x1 (* 0.5 width)
-        y1 (* 0.5 height)
-        x0 (- x1)
-        y0 (- y1)
-        [[u0 v0] [u1 v1] [u2 v2] [u3 v3]] anim-uvs]
-    (-> vbuf
-      (conj! (gen-vertex wt pt x0 y0 u0 v0))
-      (conj! (gen-vertex wt pt x1 y0 u3 v3))
-      (conj! (gen-vertex wt pt x0 y1 u1 v1))
-      (conj! (gen-vertex wt pt x1 y0 u3 v3))
-      (conj! (gen-vertex wt pt x1 y1 u2 v2))
-      (conj! (gen-vertex wt pt x0 y1 u1 v1)))))
+(defn- conj-animation-data!
+  [vbuf animation frame-index world-transform]
+  (reduce conj! vbuf (texture-set/vertex-data (get-in animation [:frames frame-index]) world-transform)))
 
 (defn- gen-vertex-buffer
   [renderables count]
-  (let [tmp-point (Point3d.)]
-    (loop [renderables renderables
-          vbuf (->texture-vtx (* count 6))]
-      (if-let [renderable (first renderables)]
-        (let [world-transform (:world-transform renderable)
-              user-data (:user-data renderable)
-              anim-uvs (:anim-uvs user-data)
-              anim-width (:anim-width user-data)
-              anim-height (:anim-height user-data)]
-          (recur (rest renderables) (conj-quad! vbuf world-transform tmp-point anim-width anim-height anim-uvs)))
-        (persistent! vbuf)))))
+  (persistent! (reduce (fn [vbuf {:keys [world-transform updatable user-data]}]
+                         (let [{:keys [animation]} user-data
+                               frame (get-in updatable [:state :frame] 0)]
+                           (conj-animation-data! vbuf animation frame world-transform)))
+                       (->texture-vtx (* count 6))
+                       renderables)))
 
 (defn- gen-outline-vertex [^Matrix4d wt ^Point3d pt x y cr cg cb]
   (.set pt x y 0)
@@ -138,8 +118,8 @@
               cb (get color 2)
               world-transform (:world-transform renderable)
               user-data (:user-data renderable)
-              anim-width (:anim-width user-data)
-              anim-height (:anim-height user-data)]
+              anim-width (-> user-data :animation :width)
+              anim-height (-> user-data :animation :height)]
           (recur (rest renderables) (conj-outline-quad! vbuf world-transform tmp-point anim-width anim-height cr cg cb)))
         (persistent! vbuf)))))
 
@@ -154,8 +134,9 @@
           (gl/gl-draw-arrays gl GL/GL_LINES 0 (* count 8))))
 
       (= pass pass/transparent)
-      (let [vertex-binding (vtx/use-with ::sprite-trans (gen-vertex-buffer renderables count) shader)
-            user-data (:user-data (first renderables))
+      (let [user-data (:user-data (first renderables))
+            shader (:shader user-data)
+            vertex-binding (vtx/use-with ::sprite-trans (gen-vertex-buffer renderables count) shader)
             gpu-texture (:gpu-texture user-data)
             blend-mode (:blend-mode user-data)]
         (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
@@ -182,26 +163,23 @@
                :material (resource/resource->proj-path material)
                :blend-mode blend-mode})})
 
-(defn anim-uvs [anim]
-  (let [frame (first (:frames anim))]
-    (:tex-coords frame)))
-
 (g/defnk produce-scene
-  [_node-id aabb gpu-texture animation blend-mode]
-  (let [scene {:node-id _node-id
-               :aabb aabb}]
-    (if animation
-      (let []
-        (assoc scene :renderable {:render-fn render-sprites
-                                  :batch-key gpu-texture
-                                  :select-batch-key _node-id
-                                  :user-data {:gpu-texture gpu-texture
-                                              :anim-uvs (anim-uvs animation)
-                                              :anim-width (:width animation 0)
-                                              :anim-height (:height animation 0)
-                                              :blend-mode blend-mode}
-                                  :passes [pass/transparent pass/selection pass/outline]}))
-     scene)))
+  [_node-id aabb gpu-texture material-shader animation blend-mode]
+  (cond-> {:node-id _node-id
+           :aabb aabb}
+
+    (seq (:frames animation))
+    (assoc :renderable {:render-fn render-sprites
+                        :batch-key [gpu-texture blend-mode material-shader]
+                        :select-batch-key _node-id
+                        :user-data {:gpu-texture gpu-texture
+                                    :shader material-shader
+                                    :animation animation
+                                    :blend-mode blend-mode}
+                        :passes [pass/transparent pass/selection pass/outline]})
+
+    (< 1 (count (:frames animation)))
+    (assoc :updatable (texture-set/make-animation-updatable _node-id "Sprite" animation))))
 
 (g/defnk produce-build-targets [_node-id resource image anim-ids default-animation material blend-mode dep-build-targets]
   (or (when-let [errors (->> [(validation/prop-error :fatal _node-id :image validation/prop-nil? image "Image")
@@ -257,7 +235,9 @@
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
                                             [:resource :material-resource]
+                                            [:shader :material-shader]
                                             [:build-targets :dep-build-targets])))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext #{"material"}}))
             (dynamic error (g/fnk [_node-id material]
                                   (or (validation/prop-error :fatal _node-id :material validation/prop-nil? material "Material")
                                       (validation/prop-error :fatal _node-id :material validation/prop-resource-not-exists? material "Material")))))
@@ -277,6 +257,7 @@
   (input dep-build-targets g/Any :array)
 
   (input material-resource resource/Resource)
+  (input material-shader ShaderLifecycle)
 
   (output animation g/Any (g/fnk [anim-data default-animation] (get anim-data default-animation))) ; TODO - use placeholder animation
   (output aabb AABB (g/fnk [animation] (if animation

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -18,10 +18,10 @@
 (set! *warn-on-reflection* true)
 
 (def ^:const tex-coord-orders
-  [[0 1 2 3]   ; -
-   [1 0 3 2]   ; v
-   [3 2 1 0]   ; h
-   [2 3 0 1]]) ; vh
+  [[0 1 2 3]   ; no flip
+   [1 0 3 2]   ; flip v
+   [3 2 1 0]   ; flip h
+   [2 3 0 1]]) ; flip vh
 
 (defn- tex-coord-lookup
   [flip-horizontal flip-vertical]
@@ -87,12 +87,12 @@
 
 (defn- dimension
   [vertices]
-  (let [x0 (reduce mind (map first vertices))
-        y0 (reduce mind (map second vertices))
-        x1 (reduce maxd (map first vertices))
-        y1 (reduce maxd (map second vertices))]
-    {:width (long (- x1 x0))
-     :height (long (- y1 y0))}))
+  (loop [[[x y :as v] & more] vertices
+         x0 0.0, y0 0.0, x1 0.0, y1 0.0]
+    (if v
+      (recur more (mind x x0) (mind y y0) (maxd x x1) (maxd y y1))
+      {:width (long (- x1 x0))
+       :height (long (- y1 y0))})))
 
 (defn- frame-dimensions
   [texture-set]

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -1,0 +1,234 @@
+(ns editor.texture-set
+  (:require
+   [dynamo.graph :as g]
+   [editor.camera :as camera]
+   [editor.colors :as colors]
+   [editor.gl :as gl]
+   [editor.gl.pass :as pass]
+   [editor.gl.shader :as shader]
+   [editor.gl.vertex :as vtx]
+   [editor.scene :as scene]
+   [editor.types :as types])
+  (:import
+   (java.nio ByteBuffer ByteOrder FloatBuffer)
+   (javax.vecmath Point3d Vector3d Matrix4d)
+   (com.google.protobuf ByteString)
+   (com.jogamp.opengl GL2)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:const tex-coord-orders
+  [[0 1 2 3]   ; -
+   [1 0 3 2]   ; v
+   [3 2 1 0]   ; h
+   [2 3 0 1]]) ; vh
+
+(defn- tex-coord-lookup
+  [flip-horizontal flip-vertical]
+  (nth tex-coord-orders (bit-xor flip-vertical
+                                 (bit-shift-left flip-horizontal 1))))
+
+(defn- ->uv-vertex
+  [vert-index ^FloatBuffer tex-coords]
+  (let [index (* vert-index 2)]
+    [(.get tex-coords ^int index) (.get tex-coords ^int (inc index))]))
+
+(defn- ->uv-quad
+  [quad-index tex-coords tex-coord-order]
+  (let [offset (* quad-index 4)]
+    (mapv #(->uv-vertex (+ offset %) tex-coords) tex-coord-order)))
+
+
+;; anim data
+
+(defn- ->anim-frame
+  [frame-index tex-coords tex-coord-order dimensions]
+  (let [tex-coords-data (->uv-quad frame-index tex-coords tex-coord-order)
+        {:keys [width height]} (nth dimensions frame-index)]
+    {:tex-coords tex-coords-data
+     :width width
+     :height height}))
+
+(defn- ->anim-data
+  [{:keys [start end fps flip-horizontal flip-vertical playback]} tex-coords uv-transforms dimensions]
+  (let [tex-coord-order (tex-coord-lookup flip-horizontal flip-vertical)
+        frames (mapv #(->anim-frame % tex-coords tex-coord-order dimensions) (range start end))]
+    {:width (transduce (map :width) max 0 frames)
+     :height (transduce (map :height) max 0 frames)
+     :playback playback
+     :fps fps
+     :frames frames
+     :uv-transforms (subvec uv-transforms start end)}))
+
+(defn- decode-vertices
+  [texture-set]
+  (let [vs-buf (-> ^ByteString (:vertices texture-set)
+                   (.asReadOnlyByteBuffer)
+                   (.order ByteOrder/LITTLE_ENDIAN))]
+    (loop [vs (transient [])]
+      (if (.hasRemaining vs-buf)
+        (recur (conj! vs [(.getFloat vs-buf)
+                          (.getFloat vs-buf)
+                          (.getFloat vs-buf)
+                          (.getShort vs-buf)
+                          (.getShort vs-buf)]))
+        (persistent! vs)))))
+
+(defn- frame-vertices
+  [texture-set]
+  (let [vs (decode-vertices texture-set)]
+    (mapv (fn [start n]
+            (mapv (fn [i] (nth vs i)) (range start (+ start n))))
+          (:vertex-start texture-set)
+          (:vertex-count texture-set))))
+
+(defn- mind ^double [^double a ^double b] (Math/min a b))
+(defn- maxd ^double [^double a ^double b] (Math/max a b))
+
+(defn- dimension
+  [vertices]
+  (let [x0 (reduce mind (map first vertices))
+        y0 (reduce mind (map second vertices))
+        x1 (reduce maxd (map first vertices))
+        y1 (reduce maxd (map second vertices))]
+    {:width (long (- x1 x0))
+     :height (long (- y1 y0))}))
+
+(defn- frame-dimensions
+  [texture-set]
+  (mapv dimension (frame-vertices texture-set)))
+
+(defn make-anim-data
+  [texture-set uv-transforms]
+  (let [tex-coords (-> ^ByteString (:tex-coords texture-set)
+                       (.asReadOnlyByteBuffer)
+                       (.order ByteOrder/LITTLE_ENDIAN)
+                       (.asFloatBuffer))
+        animations (:animations texture-set)
+        frame-dimensions (frame-dimensions texture-set)]
+    (into {}
+          (map #(vector (:id %) (->anim-data % tex-coords uv-transforms frame-dimensions)))
+          animations)))
+
+
+;; vertex data
+
+(defn- gen-vertex
+  [^Matrix4d world-transform x y u v]
+  (let [p (Point3d. x y 0)]
+    (.transform world-transform p)
+    (vector-of :double (.x p) (.y p) (.z p) 1 u v)))
+
+(defn vertex-data
+  [{:keys [width height tex-coords] :as frame} world-transform]
+  (let [x1 (* 0.5 width)
+        y1 (* 0.5 height)
+        x0 (- x1)
+        y0 (- y1)
+        [[u0 v0] [u1 v1] [u2 v2] [u3 v3]] tex-coords]
+    [(gen-vertex world-transform x0 y0 u0 v0)
+     (gen-vertex world-transform x1 y0 u3 v3)
+     (gen-vertex world-transform x0 y1 u1 v1)
+     (gen-vertex world-transform x1 y0 u3 v3)
+     (gen-vertex world-transform x1 y1 u2 v2)
+     (gen-vertex world-transform x0 y1 u1 v1)]))
+
+
+;; animation
+
+(defn- next-frame
+  [frame playback frame-time frame-count]
+  (case playback
+    :playback-none frame
+
+    (:playback-once-forward :playback-loop-forward)
+    (mod frame-time frame-count)
+
+    (:playback-once-backward :playback-loop-backward)
+    (- (dec frame-count) (mod frame-time frame-count))
+
+    (:playback-once-pingpong :playback-loop-pingpong)
+    ;; Unwrap to frame-count + (frame-count - 2)
+    (let [pingpong-frame-count (max (- (* frame-count 2) 2) 1)
+          next-frame (mod frame-time pingpong-frame-count)]
+      (if (< next-frame frame-count)
+        next-frame
+        (- (dec frame-count) (- next-frame frame-count) 1)))))
+
+(defn step-animation
+  [{:keys [t frame] :as state} dt anim-data]
+  (let [t' (+ t dt)
+        time-per-frame (/ 1.0 (:fps anim-data))
+        frame-time (long (+ 0.5 (/ t' time-per-frame)))
+        frame' (next-frame frame (:playback anim-data) frame-time (count (:frames anim-data)))]
+    (assoc state :t t' :frame frame')))
+
+(defn make-animation-updatable
+  [node-id name anim-data]
+  (when (seq anim-data)
+    {:node-id       node-id
+     :name          name
+     :update-fn     (fn [state {:keys [dt]}]
+                      (step-animation state dt anim-data))
+     :initial-state {:t         0
+                     :frame     0}}))
+
+
+;; rendering
+
+(def ^:const animation-preview-offset 40)
+
+(defn- anim-data->vbuf
+  [anim-data frame-index world-transform make-vbuf-fn]
+  (let [vd (vertex-data (get-in anim-data [:frames frame-index]) world-transform)]
+    (persistent! (reduce conj! (make-vbuf-fn (count vd)) vd))))
+
+(defn render-animation-overlay
+  [^GL2 gl render-args renderables n make-vbuf-fn shader]
+  (let [{:keys [pass camera viewport]} render-args
+        [sx sy sz] (camera/scale-factor camera viewport)
+        scale-m (doto (Matrix4d.)
+                  (.setIdentity)
+                  (.setM00 (/ 1 sx))
+                  (.setM11 (- (/ 1 sy))) ; flip
+                  (.setM22 (/ 1 sz))
+                  (.setM33 1))
+        world-pos (Vector3d. animation-preview-offset (- (:bottom viewport) animation-preview-offset) 0)]
+    (doseq [renderable renderables]
+      (let [state (-> renderable :updatable :state)]
+        (when-let [frame (:frame state)]
+          (let [user-data (:user-data renderable)
+                anim-data (:anim-data user-data)
+                world-transform (doto (Matrix4d.)
+                                  (.setIdentity)
+                                  (.setTranslation (Vector3d. (+ (.x world-pos)  (* 0.5 (/ 1 sx) (:width anim-data)))
+                                                              (- (.y world-pos) (* 0.5 (/ 1 sy) (:height anim-data)))
+                                                              0))
+                                  (.mul scale-m))
+                vbuf (anim-data->vbuf anim-data frame world-transform make-vbuf-fn)]
+            (when vbuf
+              (let [vertex-binding (vtx/use-with ::animation vbuf shader)
+                    gpu-texture (:gpu-texture user-data)
+                    x0 (.x world-pos)
+                    y0 (.y world-pos)
+                    x1 (+ x0 (* (/ 1 sx) (:width anim-data)))
+                    y1 (- y0 (* (/ 1 sy) (:height anim-data)) )
+                    [cr cg cb ca] scene/outline-color
+                    [xr xg xb xa] colors/scene-background]
+                (.glColor4d gl xr xg xb xa)
+                (.glBegin gl GL2/GL_QUADS)
+                (.glVertex3d gl x0 y0 0)
+                (.glVertex3d gl x0 y1 0)
+                (.glVertex3d gl x1 y1 0)
+                (.glVertex3d gl x1 y0 0)
+                (.glEnd gl)
+                (.glColor4d gl cr cg cb ca)
+                (.glBegin gl GL2/GL_LINE_LOOP)
+                (.glVertex3d gl x0 y0 0)
+                (.glVertex3d gl x0 y1 0)
+                (.glVertex3d gl x1 y1 0)
+                (.glVertex3d gl x1 y0 0)
+                (.glEnd gl)
+                (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
+                  (shader/set-uniform shader gl "texture" 0)
+                  (gl/gl-draw-arrays gl GL2/GL_TRIANGLES 0 (* n 6)))))))))))

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -204,8 +204,8 @@
         (let [state (-> renderable :updatable :state)]
           (when-let [frame (:frame state)]
             (let [user-data (:user-data renderable)
-                  tile-source-attributes (:tile-source-attributes user-data)
-                  [[x0 y0] [x1 y1]] (tile-coords frame tile-source-attributes [sx sy])
+                  {:keys [start-tile tile-source-attributes]} user-data
+                  [[x0 y0] [x1 y1]] (tile-coords (+ (dec start-tile) frame) tile-source-attributes [sx sy])
                   [cr cg cb ca] scene/selected-outline-color]
               (.glColor4d gl cr cg cb ca)
               (.glBegin gl GL2/GL_LINE_LOOP)
@@ -223,15 +223,16 @@
   (texture-set/make-animation-updatable _node-id "Tile Source Animation" (get anim-data id)))
 
 (g/defnk produce-animation-scene
-  [_node-id gpu-texture updatable id anim-data tile-source-attributes]
+  [_node-id gpu-texture updatable id anim-data tile-source-attributes start-tile]
   {:node-id    _node-id
    :aabb       (geom/null-aabb)
    :renderable {:render-fn render-animation
                 :batch-key nil
                 :user-data {:gpu-texture gpu-texture
                             :tile-source-attributes tile-source-attributes
-                            :anim-data   (get anim-data id)}
-                :passes    [pass/outline pass/overlay]}
+                            :anim-data   (get anim-data id)
+                            :start-tile  start-tile}
+                :passes    [pass/outline pass/overlay pass/selection]}
    :updatable  updatable})
 
 (g/defnode TileAnimationNode

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -4,7 +4,6 @@
    [dynamo.graph :as g]
    [editor.app-view :as app-view]
    [editor.camera :as camera]
-   [editor.colors :as colors]
    [editor.collision-groups :as collision-groups]
    [editor.graph-util :as gu]
    [editor.image :as image]
@@ -23,6 +22,7 @@
    [editor.pipeline.texture-set-gen :as texture-set-gen]
    [editor.properties :as properties]
    [editor.scene :as scene]
+   [editor.texture-set :as texture-set]
    [editor.outline :as outline]
    [editor.protobuf :as protobuf]
    [editor.util :as util]
@@ -32,7 +32,7 @@
    [com.dynamo.textureset.proto TextureSetProto$TextureSet]
    [com.google.protobuf ByteString]
    [editor.types AABB]
-   [javax.vecmath Point3d Matrix4d]
+   [javax.vecmath Point3d Matrix4d Vector3d]
    [com.jogamp.opengl GL GL2]
    [java.awt.image BufferedImage]
    [java.nio ByteBuffer ByteOrder FloatBuffer]))
@@ -53,6 +53,62 @@
 (def animation-icon "icons/32/Icons_24-AT-Animation.png")
 (def collision-icon "icons/32/Icons_43-Tilesource-Collgroup.png")
 
+(vtx/defvertex pos-uv-vtx
+  (vec4 position)
+  (vec2 texcoord0))
+
+(shader/defshader pos-uv-vert
+  (attribute vec4 position)
+  (attribute vec2 texcoord0)
+  (varying vec2 var_texcoord0)
+  (defn void main []
+    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
+    (setq var_texcoord0 texcoord0)))
+
+(shader/defshader pos-uv-frag
+  (varying vec2 var_texcoord0)
+  (uniform sampler2D texture)
+  (defn void main []
+    (setq gl_FragColor (texture2D texture var_texcoord0.xy))))
+
+(def tile-shader (shader/make-shader ::tile-shader pos-uv-vert pos-uv-frag))
+
+(vtx/defvertex pos-color-vtx
+  (vec3 position)
+  (vec4 color))
+
+(shader/defshader pos-color-vert
+  (attribute vec4 position)
+  (attribute vec4 color)
+  (varying vec4 var_color)
+  (defn void main []
+    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
+    (setq var_color color)))
+
+(shader/defshader pos-color-frag
+  (varying vec4 var_color)
+  (defn void main []
+    (setq gl_FragColor var_color)))
+
+(def color-shader (shader/make-shader ::color-shader pos-color-vert pos-color-frag))
+
+(def tile-border-size 3.0)
+
+(defn- tile-coords
+  [tile-index tile-source-attributes [scale-x scale-y]]
+  (let [w (:width tile-source-attributes)
+        h (:height tile-source-attributes)
+        rows (:tiles-per-column tile-source-attributes)
+        cols (:tiles-per-row tile-source-attributes)
+        row (mod tile-index cols)
+        col (long (/ tile-index cols))
+        x-border (* scale-x tile-border-size)
+        y-border (* scale-y tile-border-size)        
+        x0 (+ (* row (+ x-border w)) x-border)
+        x1 (+ x0 w)
+        y0 (+ (* (- rows col 1) (+ y-border h)) y-border)
+        y1 (+ y0 h)]
+    [[x0 y0] [x1 y1]]))
 
 (defn assign-collision-group
   [tile->collision-group tile group-node-id]
@@ -98,33 +154,8 @@
       :deps [texture-target]}]))
 
 
-
-;; TODO - copied from atlas, generalize into separate file - texture-set-util?
-
-(defn- ->uv-vertex [vert-index ^FloatBuffer tex-coords]
-  (let [index (* vert-index 2)]
-    [(.get tex-coords ^int index) (.get tex-coords ^int (inc index))]))
-
-(defn- ->uv-quad [quad-index tex-coords]
-  (let [offset (* quad-index 4)]
-    (mapv #(->uv-vertex (+ offset %) tex-coords) (range 4))))
-
-(defn- ->anim-frame [frame-index tex-coords]
-  {:tex-coords (->uv-quad frame-index tex-coords)})
-
-(defn- ->anim-data [anim tex-coords uv-transforms]
-  {:width (:width anim)
-   :height (:height anim)
-   :frames (mapv #(->anim-frame % tex-coords) (range (:start anim) (:end anim)))
-   :uv-transforms (subvec uv-transforms (:start anim) (:end anim))})
-
-(g/defnk produce-anim-data [uv-transforms texture-set]
-  (let [tex-coords (-> ^ByteString (:tex-coords texture-set)
-                       (.asReadOnlyByteBuffer)
-                       (.order ByteOrder/LITTLE_ENDIAN)
-                       (.asFloatBuffer))
-        animations (:animations texture-set)]
-    (into {} (map #(do [(:id %) (->anim-data % tex-coords uv-transforms)]) animations))))
+(g/defnk produce-anim-data [texture-set uv-transforms]
+  (texture-set/make-anim-data texture-set uv-transforms))
 
 (g/defnode CollisionGroupNode
   (inherits outline/OutlineNode)
@@ -163,6 +194,46 @@
   (when (or (< v 1) (< max v))
     (format "%s is outside the tile range (1-%d)" name max)))
 
+(defn render-animation
+  [^GL2 gl render-args renderables n]
+  (let [{:keys [camera viewport pass]} render-args
+        [sx sy sz] (camera/scale-factor camera viewport)]
+    (condp = pass
+      pass/outline
+      (doseq [renderable renderables]
+        (let [state (-> renderable :updatable :state)]
+          (when-let [frame (:frame state)]
+            (let [user-data (:user-data renderable)
+                  tile-source-attributes (:tile-source-attributes user-data)
+                  [[x0 y0] [x1 y1]] (tile-coords frame tile-source-attributes [sx sy])
+                  [cr cg cb ca] scene/selected-outline-color]
+              (.glColor4d gl cr cg cb ca)
+              (.glBegin gl GL2/GL_LINE_LOOP)
+              (.glVertex3d gl x0 y0 0)
+              (.glVertex3d gl x0 y1 0)
+              (.glVertex3d gl x1 y1 0)
+              (.glVertex3d gl x1 y0 0)
+              (.glEnd gl)))))
+      
+      pass/overlay
+      (texture-set/render-animation-overlay gl render-args renderables n ->pos-uv-vtx tile-shader))))
+
+(g/defnk produce-animation-updatable
+  [_node-id id anim-data]
+  (texture-set/make-animation-updatable _node-id "Tile Source Animation" (get anim-data id)))
+
+(g/defnk produce-animation-scene
+  [_node-id gpu-texture updatable id anim-data tile-source-attributes]
+  {:node-id    _node-id
+   :aabb       (geom/null-aabb)
+   :renderable {:render-fn render-animation
+                :batch-key nil
+                :user-data {:gpu-texture gpu-texture
+                            :tile-source-attributes tile-source-attributes
+                            :anim-data   (get anim-data id)}
+                :passes    [pass/outline pass/overlay pass/selection]}
+   :updatable  updatable})
+
 (g/defnode TileAnimationNode
   (inherits outline/OutlineNode)
   (property id g/Str
@@ -187,9 +258,15 @@
   (property cues g/Any (dynamic visible (g/constantly false)))
 
   (input tile-count g/Int)
+  (input tile-source-attributes g/Any)
+  (input anim-data g/Any)
+  (input gpu-texture g/Any)
+
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id id] {:node-id _node-id :label id :icon animation-icon}))
   (output ddf-message g/Any produce-animation-ddf)
-  (output animation-data g/Any (g/fnk [_node-id ddf-message] {:node-id _node-id :ddf-message ddf-message})))
+  (output animation-data g/Any (g/fnk [_node-id ddf-message] {:node-id _node-id :ddf-message ddf-message}))
+  (output updatable g/Any produce-animation-updatable)
+  (output scene g/Any produce-animation-scene))
 
 (defn- attach-animation-node [self animation-node]
   (concat
@@ -197,9 +274,13 @@
                      [:node-outline :child-outlines]
                      [:ddf-message :animation-ddfs]
                      [:animation-data :animation-data]
-                     [:id :animation-ids]]]
+                     [:id :animation-ids]
+                     [:scene :child-scenes]]]
       (g/connect animation-node from self to))
-    (for [[from to] [[:tile-count :tile-count]]]
+    (for [[from to] [[:tile-count :tile-count]
+                     [:tile-source-attributes :tile-source-attributes]
+                     [:anim-data :anim-data]
+                     [:gpu-texture :gpu-texture]]]
       (g/connect self from animation-node to))))
 
 (defn- attach-collision-group-node
@@ -235,64 +316,15 @@
       (types/->AABB (Point3d. 0 0 0) (Point3d. visual-width visual-height 0)))
     (geom/null-aabb)))
 
-(vtx/defvertex pos-uv-vtx
-  (vec4 position)
-  (vec2 texcoord0))
-
-(shader/defshader pos-uv-vert
-  (attribute vec4 position)
-  (attribute vec2 texcoord0)
-  (varying vec2 var_texcoord0)
-  (defn void main []
-    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
-    (setq var_texcoord0 texcoord0)))
-
-(shader/defshader pos-uv-frag
-  (varying vec2 var_texcoord0)
-  (uniform sampler2D texture)
-  (defn void main []
-    (setq gl_FragColor (texture2D texture var_texcoord0.xy))))
-
-(def tile-shader (shader/make-shader ::tile-shader pos-uv-vert pos-uv-frag))
-
-(vtx/defvertex pos-color-vtx
-  (vec3 position)
-  (vec4 color))
-
-(shader/defshader pos-color-vert
-  (attribute vec4 position)
-  (attribute vec4 color)
-  (varying vec4 var_color)
-  (defn void main []
-    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
-    (setq var_color color)))
-
-(shader/defshader pos-color-frag
-  (varying vec4 var_color)
-  (defn void main []
-    (setq gl_FragColor var_color)))
-
-(def color-shader (shader/make-shader ::color-shader pos-color-vert pos-color-frag))
-
-
-(def tile-border-size 3.0)
-
 (defn gen-tiles-vbuf
-  [tile-source-attributes uv-transforms [scale-x scale-y]]
+  [tile-source-attributes uv-transforms scale]
   (let [uvs uv-transforms
-        w (:width tile-source-attributes)
-        h (:height tile-source-attributes)
         rows (:tiles-per-column tile-source-attributes)
-        cols (:tiles-per-row tile-source-attributes)
-        x-border (* scale-x tile-border-size)
-        y-border (* scale-y tile-border-size)]
+        cols (:tiles-per-row tile-source-attributes)]
     (persistent!
-     (reduce (fn [vbuf [x y]]
-               (let [uv (nth uvs (+ x (* y cols)))
-                     x0 (+ (* x (+ x-border w)) x-border)
-                     x1 (+ x0 w)
-                     y0 (+ (* (- rows y 1) (+ y-border h)) y-border)
-                     y1 (+ y0 h)
+     (reduce (fn [vbuf tile-index]
+               (let [uv (nth uvs tile-index)
+                     [[x0 y0] [x1 y1]] (tile-coords tile-index tile-source-attributes scale)
                      [[u0 v0] [u1 v1]] (geom/uv-trans uv [[0 0] [1 1]])]
                  (-> vbuf
                      (conj! [x0 y0 0 1 u0 v1])
@@ -300,7 +332,7 @@
                      (conj! [x1 y1 0 1 u1 v0])
                      (conj! [x1 y0 0 1 u1 v1]))))
              (->pos-uv-vtx (* 4 rows cols))
-             (for [y (range rows) x (range cols)] [x y])))))
+             (range (* rows cols))))))
 
 (defn- render-tiles
   [^GL2 gl render-args node-id gpu-texture tile-source-attributes uv-transforms scale-factor]
@@ -311,20 +343,13 @@
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))
 
 (defn gen-tile-outlines-vbuf
-  [tile-set-attributes convex-hulls [scale-x scale-y] collision-groups-data]
-  (let [w (:width tile-set-attributes)
-        h (:height tile-set-attributes)
-        rows (:tiles-per-column tile-set-attributes)
-        cols (:tiles-per-row tile-set-attributes)
-        x-border (* scale-x tile-border-size)
-        y-border (* scale-y tile-border-size)]
+  [tile-source-attributes convex-hulls scale collision-groups-data]
+  (let [rows (:tiles-per-column tile-source-attributes)
+        cols (:tiles-per-row tile-source-attributes)]
     (persistent!
-     (reduce (fn [vbuf [x y]]
-               (let [x0 (+ (* x (+ x-border w)) x-border)
-                     x1 (+ x0 w)
-                     y0 (+ (* (- rows y 1) (+ y-border h)) y-border)
-                     y1 (+ y0 h)
-                     {:keys [points collision-group]} (nth convex-hulls (+ x (* y cols)) nil)
+     (reduce (fn [vbuf tile-index]
+               (let [[[x0 y0] [x1 y1]] (tile-coords tile-index tile-source-attributes scale)
+                     {:keys [points collision-group]} (nth convex-hulls tile-index nil)
                      [cr cg cb ca] (if (seq points)
                                      (if collision-group
                                        (collision-groups/color collision-groups-data collision-group)
@@ -336,11 +361,11 @@
                      (conj! [x1 y1 0 cr cg cb ca])
                      (conj! [x1 y0 0 cr cg cb ca]))))
              (->pos-color-vtx (* 4 rows cols))
-             (for [y (range rows) x (range cols)] [x y])))))
+             (range (* rows cols))))))
 
 (defn- render-tile-outlines
-  [^GL2 gl render-args node-id tile-set-attributes convex-hulls scale-factor collision-groups-data]
-  (let [vbuf (gen-tile-outlines-vbuf tile-set-attributes convex-hulls scale-factor collision-groups-data)
+  [^GL2 gl render-args node-id tile-source-attributes convex-hulls scale-factor collision-groups-data]
+  (let [vbuf (gen-tile-outlines-vbuf tile-source-attributes convex-hulls scale-factor collision-groups-data)
         vb (vtx/use-with node-id vbuf color-shader)]
     (gl/with-gl-bindings gl render-args [color-shader vb]
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))
@@ -404,7 +429,7 @@
         (render-hulls gl render-args node-id tile-source-attributes convex-hulls scale-factor collision-groups-data)))))
 
 (g/defnk produce-scene
-  [_node-id tile-source-attributes aabb uv-transforms texture-set gpu-texture convex-hulls collision-groups-data]
+  [_node-id tile-source-attributes aabb uv-transforms texture-set gpu-texture convex-hulls collision-groups-data child-scenes]
   (when tile-source-attributes
     {:aabb aabb
      :renderable {:render-fn render-tile-source
@@ -414,7 +439,8 @@
                               :gpu-texture gpu-texture
                               :convex-hulls convex-hulls
                               :collision-groups-data collision-groups-data}
-                  :passes [pass/transparent pass/outline]}}))
+                  :passes [pass/transparent pass/outline]}
+     :children child-scenes}))
 
 (g/defnk produce-convex-hull-points
   [collision-resource original-convex-hulls tile-source-attributes]
@@ -534,6 +560,7 @@
   (input collision-size g/Any)
   (input collision-groups-data g/Any)
   (input cleaned-convex-hulls g/Any :substitute [])
+  (input child-scenes g/Any :array)
 
   (output tile-source-attributes g/Any :cached produce-tile-source-attributes)
   (output tile->collision-group-node g/Any :cached produce-tile->collision-group-node)
@@ -544,7 +571,7 @@
   (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
   (output packed-image     BufferedImage       (g/fnk [texture-set-data image-resource tile-source-attributes]
                                                  (texture-set-gen/layout-tile-source (:layout texture-set-data) (image/read-image image-resource) tile-source-attributes)))
-  
+
   (output convex-hull-points g/Any :cached produce-convex-hull-points)
   (output convex-hulls g/Any :cached produce-convex-hulls)
 

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -231,7 +231,7 @@
                 :user-data {:gpu-texture gpu-texture
                             :tile-source-attributes tile-source-attributes
                             :anim-data   (get anim-data id)}
-                :passes    [pass/outline pass/overlay pass/selection]}
+                :passes    [pass/outline pass/overlay]}
    :updatable  updatable})
 
 (g/defnode TileAnimationNode


### PR DESCRIPTION
Supported in atlas editor, tile source editor and scene editor. In
scene editor, only sprites currently support animation previewing.

**Major changes**:

Updatables:

- Change updatable `update-fn` signature and semantics:
  - should be a function `(state, context) -> state`
  - will be passed data in `:inital-state` on first invocation, then
    the return value of the previous invocation.
- Updatable state will be merged into a matching renderable when it is
  playing, available through `(get-in renderable [:updatable :state])`
  so that it can be queried and used to affect rendering in
  `render-fn`.

New namespace `editor.texture-set`:

- contains functionality shared between producers/consumers of
  texture-set animation data (atlas/tile source/sprite):
  - creating "anim-data" from texture set data
  - creating vertex data from "anim-data"
  - creating updatables for "anim-data"
  - rendering animation overlay

**Fixes**:

- animations now respect flipping
- sprites render using the selected material: https://github.com/defold/editor2-issues/issues/535
- sprite AABBs/rendering take the entire animation into consideration
  and will incorporate the dimensions of all frames

**Known issues**:

- GUI nodes do not support animation previewing
- Have not adressed issue animation and multiple instances of same referenced game object 