### PR TITLE
DEF-2468 http.request() does not support "HEAD" and "PUT" requests properly

### DIFF
--- a/engine/script/server.py
+++ b/engine/script/server.py
@@ -57,6 +57,22 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write('PONG')
         self.wfile.write(s)
 
+    def do_PUT(self):
+        len = self.headers.get('Content-Length')
+        s = self.rfile.read(int(len))
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write('PONG_PUT')
+        self.wfile.write(s)
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.send_header("Content-Length", 1234)
+        self.end_headers()
+
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     """ """

--- a/engine/script/src/test/test_http.lua
+++ b/engine/script/src/test/test_http.lua
@@ -1,7 +1,7 @@
 function callback(response)
 end
 
-requests_left = 5
+requests_left = 7
 
 function test_http()
     local headers = {}
@@ -16,16 +16,15 @@ function test_http()
         end,
     headers)
 
-    local post_data = "Some data..."
+    local post_data = "Some data to post..."
     http.request("http://127.0.0.1:" .. PORT, "POST",
         function(response)
             assert(response.status == 200)
-            assert(response.response == "PONGSome data...")
+            assert(response.response == "PONGSome data to post...")
             assert(response.headers.server == "Dynamo 1.0")
             requests_left = requests_left - 1
         end,
     headers, post_data)
-
 
     local binary_data = '\01\02\03'
     http.request("http://127.0.0.1:" .. PORT, "POST",
@@ -36,6 +35,26 @@ function test_http()
             requests_left = requests_left - 1
         end,
     headers, binary_data)
+
+    local put_data = "Some data to put..."
+    http.request("http://127.0.0.1:" .. PORT, "PUT",
+        function(response)
+            assert(response.status == 200)
+            assert(response.response == "PONG_PUTSome data to put...")
+            assert(response.headers.server == "Dynamo 1.0")
+            requests_left = requests_left - 1
+        end,
+    headers, put_data)
+
+    http.request("http://127.0.0.1:" .. PORT, "HEAD",
+        function(response)
+            assert(response.status == 200)
+            assert(response.response == "")
+            assert(response.headers.server == "Dynamo 1.0")
+            assert(response.headers["content-length"] == "1234")
+            requests_left = requests_left - 1
+        end,
+    headers)
 
     http.request("http://127.0.0.1:" .. PORT .. "/not_found", "GET",
         function(response)


### PR DESCRIPTION
Implemented support for PUT and HEAD.
Added additional tests in the Lua layer.
Also tested Cohesion to double check that things still behave as expected for GET and POST.