### PR TITLE
DEFEDIT-936 Avoid exception for substring in text editor

### DIFF
--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -332,7 +332,7 @@
 (defn remember-caret-col [source-viewer np]
   (let [line-offset (line-offset source-viewer)
         line-text (line source-viewer)
-        text-before (subs line-text 0 (- np line-offset))]
+        text-before (subs line-text 0 (min (count line-text) (- np line-offset)))]
     (preferred-offset! source-viewer (tab-expanded-count text-before))))
 
 (defn handle-mouse-clicked [^MouseEvent e source-viewer]


### PR DESCRIPTION
* When remembering the horizontal offset of the cursor for moving up/down