### PR TITLE
DEFEDIT-942 Use default unit length for .dae files if not specified

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
@@ -49,6 +49,7 @@ import org.jagatoo.loaders.models.collada.stax.XMLSampler;
 import org.jagatoo.loaders.models.collada.stax.XMLNode;
 import org.jagatoo.loaders.models.collada.stax.XMLSkin;
 import org.jagatoo.loaders.models.collada.stax.XMLSource;
+import org.jagatoo.loaders.models.collada.stax.XMLUnit;
 import org.jagatoo.loaders.models.collada.stax.XMLVisualScene;
 import org.jagatoo.loaders.models.collada.stax.XMLAsset.UpAxis;
 import org.openmali.FastMath;
@@ -574,7 +575,8 @@ public class ColladaUtil {
         Matrix4f axisMatrix = createUpAxisMatrix(collada.asset.upAxis);
         bindShapeMatrix.mul(axisMatrix, bindShapeMatrix);
 
-        float meter = collada.asset.unit.meter;
+        XMLUnit unit = collada.asset.unit;
+        float meter = unit == null ? 1.0f : unit.meter;
         List<Float> position_list = new ArrayList<Float>(positions.floatArray.count);
         for (int i = 0; i < positions.floatArray.count / 3; ++i) {
             Point3f p = new Point3f(positions.floatArray.floats[i*3], positions.floatArray.floats[i*3+1], positions.floatArray.floats[i*3+2]);

--- a/editor/src/clj/editor/engine/build_errors.clj
+++ b/editor/src/clj/editor/engine/build_errors.clj
@@ -54,7 +54,10 @@
 
 (extend-type TaskResult
   ErrorInfoProvider
-  (error-message [this] (.getMessage this))
+  (error-message [this] (if-let [message (.getMessage this)]
+                          message
+                          (throw (or (.getException this)
+                                     (ex-info "TaskResult failed without message or exception." {})))))
   (error-path [this] (some-> this .getTask root-task .getInputs ^IResource first .getPath (str "/")))
   (error-line [this] (.getLineNumber this))
   (error-severity [_this] :fatal))

--- a/editor/src/java/com/defold/editor/pipeline/ColladaUtil.java
+++ b/editor/src/java/com/defold/editor/pipeline/ColladaUtil.java
@@ -49,6 +49,7 @@ import org.jagatoo.loaders.models.collada.stax.XMLSampler;
 import org.jagatoo.loaders.models.collada.stax.XMLNode;
 import org.jagatoo.loaders.models.collada.stax.XMLSkin;
 import org.jagatoo.loaders.models.collada.stax.XMLSource;
+import org.jagatoo.loaders.models.collada.stax.XMLUnit;
 import org.jagatoo.loaders.models.collada.stax.XMLVisualScene;
 import org.jagatoo.loaders.models.collada.stax.XMLAsset.UpAxis;
 import org.openmali.FastMath;
@@ -574,7 +575,8 @@ public class ColladaUtil {
         Matrix4f axisMatrix = createUpAxisMatrix(collada.asset.upAxis);
         bindShapeMatrix.mul(axisMatrix, bindShapeMatrix);
 
-        float meter = collada.asset.unit.meter;
+        XMLUnit unit = collada.asset.unit;
+        float meter = unit == null ? 1.0f : unit.meter;
         List<Float> position_list = new ArrayList<Float>(positions.floatArray.count);
         for (int i = 0; i < positions.floatArray.count / 3; ++i) {
             Point3f p = new Point3f(positions.floatArray.floats[i*3], positions.floatArray.floats[i*3+1], positions.floatArray.floats[i*3+2]);


### PR DESCRIPTION
Fixes defold/editor2-issues#812

### User-facing changes
* Use default unit length for `.dae` files if not specified.

### Technical changes
* Throw exception in Editor 2 if a Bob `TaskResult` fails without a message. We want to know about this in Sentry if it happens, since the user cannot do anything to address the issue.