### PR TITLE
DEFEDIT-912 Remove output noise during tests

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -217,8 +217,8 @@
 
 (defn save-all!
   ([project on-complete-fn]
-   (save-all! project on-complete-fn #(ui/run-later (%))))
-  ([project on-complete-fn exec-fn]
+   (save-all! project on-complete-fn #(ui/run-later (%)) ui/default-render-progress!))
+  ([project on-complete-fn exec-fn render-progress-fn]
    (when (compare-and-set! ongoing-build-save-atom false true)
      (let [workspace     (workspace project)
            old-cache-val @(g/cache)
@@ -226,7 +226,7 @@
            basis         (g/now)]
        (future
          (try
-           (ui/with-progress [render-fn ui/default-render-progress!]
+           (ui/with-progress [render-fn render-progress-fn]
              (write-save-data-to-disk! project {:render-progress! render-fn
                                                 :basis            basis
                                                 :cache            cache})

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -94,7 +94,7 @@
      (let [{:keys [ex-map suppressed?]} (record-exception! exception)]
        (if suppressed?
          (when (system/defold-dev?)
-           (println "Suppressed unhandled" (ExceptionUtils/getFullStackTrace exception)))
+           (log/debug :msg "Suppressed unhandled" :exception exception))
          (do (log/error :exception exception)
              (let [sentry-id-promise (sentry-reporter exception thread)]
                (exception-notifier ex-map sentry-id-promise)

--- a/editor/test/editor/progress_test.clj
+++ b/editor/test/editor/progress_test.clj
@@ -1,4 +1,5 @@
 (ns editor.progress-test
+  (:refer-clojure :exclude [mapv])
   (:require [clojure.test :refer :all]
             [editor.progress :refer :all]))
 

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -12,6 +12,7 @@
             [editor.game-object :as game-object]
             [editor.script :as script]
             [editor.asset-browser :as asset-browser]
+            [editor.progress :as progress]
             [editor.protobuf :as protobuf]
             [editor.atlas :as atlas]
             [editor.resource :as resource]
@@ -225,7 +226,7 @@
           (g/transact
             (g/set-property node :name "new_name"))
           (is (has-undo? project))
-          (project/save-all! project #(deliver saved :done) #(%))
+          (project/save-all! project #(deliver saved :done) #(%) progress/null-render-progress!)
           (is (= :done (deref saved 100 :timeout)))
           (sync! workspace)
           (is (has-undo? project)))))))


### PR DESCRIPTION
- replace a use of `println` with `log/debug`
- allow passing a `progress-render-fn` to `project/save-all!` so we can use a `null-render-progress!` fn in tests
- remove refer warning