### PR TITLE
DEFEDIT-955 Delete nested game objects correctly

### DIFF
--- a/editor/src/clj/editor/core.clj
+++ b/editor/src/clj/editor/core.clj
@@ -58,10 +58,10 @@ When a Scope is deleted, all nodes within that scope will also be deleted."
                            (g/outputs node-id)))]
      scope))
   ([node-id node-type]
-   (when node-id
-     (if (g/node-instance? node-type node-id)
-       node-id
-       (recur (scope node-id) node-type)))))
+   (when-let [scope-id (some-> node-id scope)]
+     (if (g/node-instance? node-type scope-id)
+       scope-id
+       (recur scope-id node-type)))))
 
 
 (g/defnode Saveable

--- a/editor/src/clj/editor/core.clj
+++ b/editor/src/clj/editor/core.clj
@@ -48,14 +48,21 @@ connected to the Scope's :nodes input.
 When a Scope is deleted, all nodes within that scope will also be deleted."
   (input nodes g/Any :array :cascade-delete))
 
-(defn scope [node-id]
-  (let [[_ _ scope _] (first
-                        (filter
-                          (fn [[src src-lbl tgt tgt-lbl]]
-                            (and (= src-lbl :_node-id)
-                                 (= tgt-lbl :nodes)))
-                          (g/outputs node-id)))]
-    scope))
+(defn scope
+  ([node-id]
+   (let [[_ _ scope _] (first
+                         (filter
+                           (fn [[src src-lbl tgt tgt-lbl]]
+                             (and (= src-lbl :_node-id)
+                                  (= tgt-lbl :nodes)))
+                           (g/outputs node-id)))]
+     scope))
+  ([node-id node-type]
+   (when node-id
+     (if (g/node-instance? node-type node-id)
+       node-id
+       (recur (scope node-id) node-type)))))
+
 
 (g/defnode Saveable
   "Mixin. Content root nodes (i.e., top level nodes for an editor tab) can inherit

--- a/editor/test/integration/collection_test.clj
+++ b/editor/test/integration/collection_test.clj
@@ -19,15 +19,25 @@
 
 (deftest hierarchical-outline
   (testing "Hierarchical outline"
-           (with-clean-system
-             (let [workspace (test-util/setup-workspace! world)
-                   project   (test-util/setup-project! workspace)
-                   node-id   (test-util/resource-node project "/logic/hierarchy.collection")
-                   outline   (g/node-value node-id :node-outline)]
-               ; Two game objects under the collection
-               (is (= 2 (count (:children outline))))
-               ; One component and game object under the game object
-               (is (= 2 (count (:children (second (:children outline))))))))))
+    (with-clean-system
+      (let [workspace (test-util/setup-workspace! world)
+            project   (test-util/setup-project! workspace)
+            node-id   (test-util/resource-node project "/logic/hierarchy.collection")
+            outline   (g/node-value node-id :node-outline)]
+        ;; Two game objects under the collection
+        (is (= 2 (count (:children outline))))
+        ;; One component and game object under the game object
+        (is (= 2 (count (:children (second (:children outline)))))))))
+  (testing "Deleting hierarchy deletes children"
+    (with-clean-system
+      (let [workspace (test-util/setup-workspace! world)
+            project   (test-util/setup-project! workspace)
+            node-id   (test-util/resource-node project "/logic/hierarchy.collection")
+            outline   (g/node-value node-id :node-outline)
+            parent    (first (filter #(= "parent_id" (:label %)) (tree-seq :children :children outline)))]
+        (is (= #{"parent_id" "child_id" "embedded_id"} (set (g/node-value node-id :ids))))
+        (g/delete-node! (:node-id parent))
+        (is (= #{"embedded_id"} (set (g/node-value node-id :ids))))))))
 
 (deftest hierarchical-scene
   (testing "Hierarchical scene"


### PR DESCRIPTION
- GOs are now scoped to their parent, not the root collection

Fixes https://github.com/defold/editor2-issues/issues/573