### PR TITLE
DEFEDIT-946 Having a dae model open, and then deleting it produces an error

### DIFF
--- a/editor/src/clj/editor/collada_scene.clj
+++ b/editor/src/clj/editor/collada_scene.clj
@@ -192,7 +192,11 @@
     (with-open [stream (io/input-stream resource)]
       (collada/load-scene stream))
     (catch NumberFormatException _
-      (error-values/error-fatal "The scene contains invalid numbers, likely produced by a buggy exporter."))))
+      (error-values/error-fatal "The scene contains invalid numbers, likely produced by a buggy exporter." {:type :invalid-content}))
+    (catch java.io.FileNotFoundException _
+      (error-values/error-fatal (format "The scene '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found}))
+    (catch Exception _
+      (error-values/error-fatal (format "The scene '%s' could not be loaded." (resource/proj-path resource) {:type :invalid-content})))))
 
 (defn- vbuf-size [meshes]
   (reduce (fn [sz m] (max sz (alength ^ints (:indices m)))) 0 meshes))

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -73,14 +73,19 @@
                                  (or (read-size resource)
                                      (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content}))
                                  (catch java.io.FileNotFoundException e
-                                   (g/error-fatal (format "The image '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found})))))
+                                   (g/error-fatal (format "The image '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found}))
+                                 (catch Exception _
+                                   (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content})))))
   
   (output content BufferedImage (g/fnk [resource]
                                   (try
                                     (or (read-image resource)
                                         (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content}))
                                     (catch java.io.FileNotFoundException e
-                                      (g/error-fatal (format "The image '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found})))))
+                                      (g/error-fatal (format "The image '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found}))
+                                    (catch Exception _
+                                      (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content})))))
+  
   (output build-targets g/Any :cached produce-build-targets))
 
 (defmacro with-graphics


### PR DESCRIPTION
Catch FileNotFoundException when producing content, just as we do for ImageNode.