### PR TITLE
DEFEDIT-971 Fix "Close Others" in tab-pane

### DIFF
--- a/editor/styling/stylesheets/components/_tab.scss
+++ b/editor/styling/stylesheets/components/_tab.scss
@@ -6,8 +6,9 @@
         -fx-border-color: $mid-grey;
         -fx-padding: 0.0em;
         -fx-background-insets: 0;
-        -fx-open-tab-animation: NONE;
-        -fx-close-tab-animation: NONE; }
+        -fx-open-tab-animation: none;
+        -fx-close-tab-animation: grow; // This is critical as it avoids an issue with tab-header cleanup
+    }
         
         .tab {
             -fx-background-radius: 0;


### PR DESCRIPTION
The JavaFX implementation does things differently depending on whether
a close animation has been set or not for the tab pane. Setting the
animation to "grow" avoids the issue we are seeing.

Fixes https://github.com/defold/editor2-issues/issues/364