### PR TITLE
DEFEDIT-970 Fix intermittent ci error related to resource sync

### DIFF
--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -200,7 +200,8 @@
                      entries
                      (conj entries {:name (FilenameUtils/getName (.getName e))
                                     :path (path-relative-base base-path e)
-                                    :buffer (read-zip-entry zip e)})))))))))
+                                    :buffer (read-zip-entry zip e)
+                                    :crc (.getCrc e)})))))))))
 
 (defn- ->zip-resources [workspace zip-url path [key val]]
   (let [path' (if (string/blank? path) key (str path "/" key))]
@@ -208,13 +209,14 @@
       (ZipResource. workspace zip-url (:name val) (:path val) (:buffer val) nil)
       (ZipResource. workspace zip-url key path' nil (mapv (fn [x] (->zip-resources workspace zip-url path' x)) val)))))
 
-(defn make-zip-tree
+(defn load-zip-resources
   ([workspace file-or-url]
-   (make-zip-tree workspace file-or-url nil))
+   (load-zip-resources workspace file-or-url nil))
   ([workspace file-or-url base-path]
    (let [entries (load-zip file-or-url base-path)]
-     (->> (reduce (fn [acc node] (assoc-in acc (string/split (:path node) #"/") node)) {} entries)
-          (mapv (fn [x] (->zip-resources workspace (io/as-url file-or-url) "" x)))))))
+     {:tree (->> (reduce (fn [acc node] (assoc-in acc (string/split (:path node) #"/") node)) {} entries)
+                 (mapv (fn [x] (->zip-resources workspace (io/as-url file-or-url) "" x))))
+      :crc (into {} (map (juxt (fn [e] (str "/" (:path e))) :crc) entries))})))
 
 (g/defnode ResourceNode
   (extern resource Resource (dynamic visible (g/constantly false))))

--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -25,29 +25,33 @@
     (let [settings (settings-core/parse-settings reader)]
       (parse-include-dirs (str (settings-core/get-setting settings ["library" "include_dirs"]))))))
 
-(defn- make-library-zip-tree [workspace file]
+(defn- load-library-zip [workspace file]
   (let [base-path (library/library-base-path file)
-        zip-resources (resource/make-zip-tree workspace file base-path)
-        game-project-resource (first (filter (fn [resource] (= "game.project" (resource/resource-name resource))) zip-resources))]
+        zip-resources (resource/load-zip-resources workspace file base-path)
+        game-project-resource (first (filter (fn [resource] (= "game.project" (resource/resource-name resource))) (:tree zip-resources)))]
     (when game-project-resource
       (let [include-dirs (set (extract-game-project-include-dirs game-project-resource))]
-        (filter #(include-dirs (resource-root-dir %)) zip-resources)))))
+        (update zip-resources :tree (fn [tree] (filter #(include-dirs (resource-root-dir %)) tree)))))))
 
 (defn- make-library-snapshot [workspace lib-state]
   (let [file ^File (:file lib-state)
         tag (:tag lib-state)
-        version (if-not (str/blank? tag) tag (str (.lastModified file)))
-        resources (make-library-zip-tree workspace file)
+        zip-file-version (if-not (str/blank? tag) tag (str (.lastModified file)))
+        {resources :tree crc :crc} (load-library-zip workspace file)
         flat-resources (resource/resource-list-seq resources)]
     {:resources resources
-     :status-map (into {} (map (juxt resource/proj-path (constantly {:version version :source :library :library (:url lib-state)})) flat-resources))}))
+     :status-map (into {} (map (fn [resource]
+                                 (let [path (resource/proj-path resource)
+                                       version (str zip-file-version ":" (crc path))]
+                                   [path {:version version :source :library :library (:url lib-state)}]))
+                               flat-resources))}))
 
 (defn- make-library-snapshots [workspace project-directory library-urls]
   (let [lib-states (filter :file (library/current-library-state project-directory library-urls))]
     (map (partial make-library-snapshot workspace) lib-states)))
 
 (defn- make-builtins-snapshot [workspace]
-  (let [resources (resource/make-zip-tree workspace (io/resource "builtins.zip"))
+  (let [resources (:tree (resource/load-zip-resources workspace (io/resource "builtins.zip")))
         flat-resources (resource/resource-list-seq resources)]
     {:resources resources
      :status-map (into {} (map (juxt resource/proj-path (constantly {:version :constant :source :builtins})) flat-resources))}))
@@ -102,8 +106,8 @@
 (defn make-resource-map [snapshot]
   (into {} (map (juxt resource/proj-path identity) (resource/resource-list-seq (:resources snapshot)))))
 
-(defn- resource-version [snapshot path]
-  (get-in snapshot [:status-map path :version]))
+(defn- resource-status [snapshot path]
+  (get-in snapshot [:status-map path]))
 
 (defn diff [old-snapshot new-snapshot]
   (let [old-map (make-resource-map old-snapshot)
@@ -113,7 +117,7 @@
         common-paths (clojure.set/intersection new-paths old-paths)
         added-paths (clojure.set/difference new-paths old-paths)
         removed-paths (clojure.set/difference old-paths new-paths)
-        changed-paths (filter #(not= (resource-version old-snapshot %) (resource-version new-snapshot %)) common-paths)
+        changed-paths (filter #(not= (resource-status old-snapshot %) (resource-status new-snapshot %)) common-paths)
         added (map new-map added-paths)
         removed (map old-map removed-paths)
         changed (map new-map changed-paths)]


### PR DESCRIPTION
Problem was that the test library dependency we used had the exact
same mtime as a resource we intended to replace.

* Use complete resource status instead of only version when checking
  for differences. This includes :source and :library. Furthermore the
  :version for resources from zip's now include the crc from the ZipEntry.