### PR TITLE
DEFEDIT-980 fs/create-file! returns Path instead of File

### DIFF
--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -130,9 +130,10 @@
   (.toFile (Files/createDirectories (.toPath directory) empty-file-attrs)))
 
 (defn create-parent-directories!
-  "Creates the directory path up to the parent directory of file. Returns the parent directory."
+  "Creates the directory path (if any) up to the parent directory of file. Returns the parent directory."
   ^File [^File file]
-  (create-directories! (.getParentFile file)))
+  (when-let [parent (.getParentFile file)]
+    (create-directories! parent)))
 
 (defn create-directory!
   "Creates a directory assuming all parent directories are in place. Returns the directory."
@@ -147,7 +148,7 @@
   (^File [^File target]
    (if (not (Files/exists (.toPath target) no-follow-link-options))
      (do (create-parent-directories! target)
-         (Files/createFile (.toPath target) empty-file-attrs))
+         (.toFile (Files/createFile (.toPath target) empty-file-attrs)))
      target))
   (^File [^File target content]
    (create-file! target)

--- a/editor/test/integration/game_project_test.clj
+++ b/editor/test/integration/game_project_test.clj
@@ -31,7 +31,6 @@
 
 (defn- write-file [^String name content]
   (let [f (file-in-project name)]
-    (fs/create-parent-directories! f)
     (fs/create-file! f)
     (spit-until-new-mtime f content)))
 


### PR DESCRIPTION
* .toFile
* handle no-parents case in create-parent-directories!
* remove superfluous use of create-parent-directories!