### PR TITLE
DEFEDIT-995 Ignore invalid require paths

### DIFF
--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -36,7 +36,12 @@
   (FilenameUtils/separatorsToUnix path))
 
 (defn relative-path [^File f1 ^File f2]
-  (->unix-seps (.toString (.relativize (.toPath f1) (.toPath f2)))))
+  (let [p1 (->unix-seps (str (.getAbsolutePath f1)))
+        p2 (->unix-seps (str (.getAbsolutePath f2)))
+        path (string/replace p2 p1 "")]
+    (if (.startsWith path "/")
+      (subs path 1)
+      path)))
 
 (defn file->proj-path [^File project-path ^File f]
   (try

--- a/editor/test/integration/script_test.clj
+++ b/editor/test/integration/script_test.clj
@@ -59,7 +59,11 @@
         (g/set-property! script-node :code "local x = 4711")
         (is (not (g/error? (g/node-value script-node :build-targets))))
         (is (empty? (g/node-value script-node :dep-build-targets)))
-        (is (empty? (g/node-value script-node :module-completion-infos)))))))
+        (is (empty? (g/node-value script-node :module-completion-infos))))
+      (testing "ignores invalid requires"
+        (g/set-property! script-node :code "require \"\"")
+        (g/set-property! script-node :code "require \"\"\"\"")
+        (g/set-property! script-node :code "require \"a.b.c\"\"")))))
 
 (defn- lines [& args] (str (str/join "\n" args) "\n"))
 


### PR DESCRIPTION
Change `resource/relative-path` to not use `Path` API when determining relative paths as that performs some unwanted validation. Since `relative-path` returns a relative path in Unix-format, we can convert to unix paths immediately and determine the relative paths textually based on those instead.

Fixes https://github.com/defold/editor2-issues/issues/925, https://github.com/defold/editor2-issues/issues/879