### PR TITLE
DEFEDIT-996 Simplify anonymous fn class names when reporting to sentry

### DIFF
--- a/editor/src/clj/editor/sentry.clj
+++ b/editor/src/clj/editor/sentry.clj
@@ -15,13 +15,19 @@
 
 (def user-agent "sentry-defold/1.0")
 
+(defn- cleanup-anonymous-fn-class-name
+  [s]
+  (-> s
+      (string/replace #"fn__\d+" "fn")
+      (string/replace #"reify__\d+" "reify")))
+
 (defn- stacktrace-data
   [^Exception ex]
   {:frames (vec (for [^StackTraceElement frame (reverse (.getStackTrace ex))]
                   {:filename (.getFileName frame)
                    :lineno (.getLineNumber frame)
                    :function (.getMethodName frame)
-                   :module (.getClassName frame)}))})
+                   :module (some-> (.getClassName frame) cleanup-anonymous-fn-class-name)}))})
 
 (defn module-name
   [frames]


### PR DESCRIPTION
This will turn generated classes for anonymous fns like:

`editor.scene$make_gl_pane_BANG_$fn__32451$fn__32452$fn__32457`

into

`editor.scene$make_gl_pane_BANG_$fn$fn$fn` 

when we report them to sentry. The hope is that sentry will be able to de-dupe better across different builds.