### PR TITLE
DEFEDIT-999 Catch usage of unhandled resource types at build time

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -65,7 +65,10 @@
                                      (DigestUtils/sha256Hex ^String content))))))
 
 (g/defnode PlaceholderResourceNode
-  (inherits ResourceNode))
+  (inherits ResourceNode)
+
+  (output build-targets g/Any (g/fnk [_node-id resource]
+                                (g/error-fatal (format "Cannot build resource of type '%s'" (resource/ext resource))))))
 
 (defn graph [project]
   (g/node-id->graph-id project))

--- a/editor/test/integration/game_object_test.clj
+++ b/editor/test/integration/game_object_test.clj
@@ -27,7 +27,11 @@
                  (is (g/error? (test-util/prop-error comp-id :path))))
                (let [not-found (workspace/resolve-workspace-resource workspace "/not_found.script")]
                  (test-util/with-prop [comp-id :path {:resource not-found :overrides []}]
-                   (is (g/error? (test-util/prop-error comp-id :path))))))
+                   (is (g/error? (test-util/prop-error comp-id :path)))))
+               (let [unknown-resource (workspace/resolve-workspace-resource workspace "/unknown-resource.gurka")]
+                 (test-util/with-prop [comp-id :path {:resource unknown-resource :overrides []}]
+                   (is (g/error? (test-util/prop-error comp-id :path)))
+                   (is (build-error? go-id)))))
       (testing "component embedded instance"
                (let [r-type (workspace/get-resource-type workspace "factory")]
                  (game-object/add-embedded-component-handler {:_node-id go-id :resource-type r-type} nil)


### PR DESCRIPTION
When unhandled resource types are (incorrectly) referred to as
resources, we will attempt to establish connections to a PlaceholderResourceNode.
Make sure PlaceholderResourceNode has a build-target output that
produces an error, so that we catch the error at build time.