### PR TITLE
DEFEDIT-1003 Collision Object protobuf error

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -15,6 +15,7 @@
             [editor.gl.vertex :as vtx]
             [editor.defold-project :as project]
             [editor.math :as math]
+            [editor.properties :as properties]
             [editor.types :as types]
             [editor.workspace :as workspace]
             [editor.resource :as resource]
@@ -248,11 +249,7 @@
   (property flip-horizontal g/Bool)
   (property flip-vertical   g/Bool)
   (property playback        types/AnimationPlayback
-            (dynamic edit-type (g/constantly
-                                 (let [options (protobuf/enum-values Tile$Playback)]
-                                   {:type :choicebox
-                                    :options (zipmap (map first options)
-                                                     (map (comp :display-name second) options))}))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Tile$Playback))))
 
   (output child->order g/Any :cached (g/fnk [nodes] (zipmap nodes (range))))
 

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -239,18 +239,10 @@
   (property leading g/Num)
   (property tracking g/Num)
   (property pivot g/Keyword (default :pivot-center)
-            (dynamic edit-type (g/constantly
-                                (let [options (protobuf/enum-values Label$LabelDesc$Pivot)]
-                                  {:type :choicebox
-                                   :options (zipmap (map first options)
-                                                    (map (comp :display-name second) options))}))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Label$LabelDesc$Pivot))))
   (property blend-mode g/Any (default :blend-mode-alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Label$LabelDesc$BlendMode))
-            (dynamic edit-type (g/constantly
-                                (let [options (protobuf/enum-values Label$LabelDesc$BlendMode)]
-                                  {:type :choicebox
-                                   :options (zipmap (map first options)
-                                                    (map (comp :display-name second) options))}))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Label$LabelDesc$BlendMode))))
   (property line-break g/Bool)
     
   (property font resource/Resource

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -45,12 +45,6 @@
 (def ^:private emitter-template "templates/template.emitter")
 (def ^:private modifier-icon "icons/32/Icons_19-ParicleFX-Modifier.png")
 
-(defn- ->choicebox [cls]
-  (let [options (protobuf/enum-values cls)]
-    {:type :choicebox
-     :options (zipmap (map first options)
-                      (map (comp :display-name second) options))}))
-
 (defn particle-fx-transform [pb]
   (let [xform (fn [v]
                 (let [p (doto (Point3d.) (math/clj->vecmath (:position v)))
@@ -459,11 +453,11 @@
 
   (property id g/Str)
   (property mode g/Keyword
-            (dynamic edit-type (g/constantly (->choicebox Particle$PlayMode)))
+            (dynamic edit-type (g/constantly (props/->pb-choicebox Particle$PlayMode)))
             (dynamic label (g/constantly "Play Mode")))
   (property duration g/Num)
   (property space g/Keyword
-            (dynamic edit-type (g/constantly (->choicebox Particle$EmissionSpace)))
+            (dynamic edit-type (g/constantly (props/->pb-choicebox Particle$EmissionSpace)))
             (dynamic label (g/constantly "Emission Space")))
 
   (property tile-source resource/Resource
@@ -484,16 +478,16 @@
 
   (property animation g/Str
             (value (g/fnk [animation anim-ids]
-                     (if (and (nil? animation) (seq anim-ids))
+                     (if (and (str/blank? animation) (seq anim-ids))
                        (first (sort-anim-ids anim-ids))
                        animation)))
             (dynamic error (g/fnk [_node-id animation anim-ids]
                              (when animation
                                (or (validation/prop-error :fatal _node-id :animation validation/prop-empty? animation "Animation")
                                    (validation/prop-error :fatal _node-id :animation validation/prop-anim-missing? animation anim-ids)))))
-            (dynamic edit-type
-                     (g/fnk [anim-ids] {:type :choicebox
-                                        :options (or (and anim-ids (not (g/error? anim-ids)) (zipmap anim-ids anim-ids)) {})})))
+            (dynamic edit-type (g/fnk [anim-ids]
+                                      (let [vals (or (and anim-ids (not (g/error? anim-ids)) anim-ids) [])]
+                                        (props/->choicebox vals)))))
 
   (property material resource/Resource
             (value (gu/passthrough material-resource))
@@ -509,17 +503,17 @@
 
   (property blend-mode g/Keyword
             (dynamic tip (validation/blend-mode-tip blend-mode Particle$BlendMode))
-            (dynamic edit-type (g/constantly (->choicebox Particle$BlendMode))))
+            (dynamic edit-type (g/constantly (props/->pb-choicebox Particle$BlendMode))))
 
-  (property particle-orientation g/Keyword (dynamic edit-type (g/constantly (->choicebox Particle$ParticleOrientation))))
+  (property particle-orientation g/Keyword (dynamic edit-type (g/constantly (props/->pb-choicebox Particle$ParticleOrientation))))
   (property inherit-velocity g/Num)
   (property max-particle-count g/Int)
   (property type g/Keyword
-            (dynamic edit-type (g/constantly (->choicebox Particle$EmitterType)))
+            (dynamic edit-type (g/constantly (props/->pb-choicebox Particle$EmitterType)))
             (dynamic label (g/constantly "Emitter Type")))
   (property start-delay g/Num)
   (property size-mode g/Keyword
-            (dynamic edit-type (g/constantly (->choicebox Particle$SizeMode)))
+            (dynamic edit-type (g/constantly (props/->pb-choicebox Particle$SizeMode)))
             (dynamic label (g/constantly "Size Mode")))
 
   (display-order [:id scene/SceneNode :mode :size-mode :space :duration :start-delay :tile-source :animation :material :blend-mode

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -471,13 +471,12 @@
 
 (defn ->choicebox [vals]
   {:type :choicebox
-   :options (zipmap vals vals)})
+   :options (map (juxt identity identity) vals)})
 
 (defn ->pb-choicebox [cls]
-  (let [options (protobuf/enum-values cls)]
+  (let [values (protobuf/enum-values cls)]
     {:type :choicebox
-     :options (zipmap (map first options)
-                      (map (comp :display-name second) options))}))
+     :options (map (juxt first (comp :display-name second)) values)}))
 
 (defn vec3->vec2 [default-z]
   {:type t/Vec2

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -278,31 +278,36 @@
                                           (properties/set-values! (property-fn) values))))
     [color-picker update-ui-fn]))
 
-(defmethod create-property-control! :choicebox [edit-type _ property-fn]
-  (let [options      (:options edit-type)
-        inv-options  (clojure.set/map-invert options)
+(defmethod create-property-control! :choicebox [{:keys [options]} _ property-fn]
+  (let [option-map   (into {} options)
+        inv-options  (clojure.set/map-invert option-map)
         converter    (proxy [StringConverter] []
                        (toString [value]
-                         (get options value (str value)))
+                         (get option-map value (str value)))
                        (fromString [s]
-                         (inv-options s)))
+                         (get inv-options s)))
         cb           (doto (ComboBox.)
                        (.setPrefWidth Double/MAX_VALUE)
                        (.setConverter converter)
-                       (ui/cell-factory! (fn [val]  {:text (options val)}))
+                       (ui/cell-factory! (fn [val]  {:text (option-map val)}))
                        (-> (.getItems) (.addAll (object-array (map first options)))))
         update-ui-fn (fn [values message read-only?]
                        (binding [*programmatic-setting* true]
                          (let [value (properties/unify-values values)]
-                           (if (contains? options value)
+                           (if (contains? option-map value)
                              (do
                                (.setValue cb value)
-                               (.setText (.getEditor cb) (options value)))
+                               (.setText (.getEditor cb) (option-map value)))
                              (do
                                (.setValue cb nil)
                                (.. cb (getSelectionModel) (clearSelection)))))
                          (update-field-message [cb] message)
-                         (ui/editable! cb (not read-only?))))]
+                         ;; .setEditable enables/disables text input
+                         (.setEditable cb false)
+                         ;; ui/editable! for ComboBox uses
+                         ;; .setEditable instead of .setDisabled as it
+                         ;; does for everything else
+                         (.setDisable cb (boolean read-only?))))]
     (ui/observe (.valueProperty cb) (fn [observable old-val new-val]
                                       (when-not *programmatic-setting*
                                         (properties/set-values! (property-fn) (repeat new-val)))))

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -8,6 +8,7 @@
             [editor.gl.shader :as shader]
             [editor.gl.vertex :as vtx]
             [editor.defold-project :as project]
+            [editor.properties :as properties]
             [editor.scene :as scene]
             [editor.workspace :as workspace]
             [editor.validation :as validation]
@@ -228,8 +229,8 @@
             (dynamic error (g/fnk [_node-id image anim-ids default-animation]
                              (when image
                                (validation/prop-error :fatal _node-id :default-animation validation/prop-anim-missing? default-animation anim-ids))))
-            (dynamic edit-type (g/fnk [anim-ids] {:type :choicebox
-                                                  :options (zipmap anim-ids anim-ids)})))
+            (dynamic edit-type (g/fnk [anim-ids] (properties/->choicebox anim-ids))))
+
   (property material resource/Resource
             (value (gu/passthrough material-resource))
             (set (fn [basis self old-value new-value]
@@ -244,11 +245,7 @@
 
   (property blend-mode g/Any (default :blend-mode-alpha)
             (dynamic tip (validation/blend-mode-tip blend-mode Sprite$SpriteDesc$BlendMode))
-            (dynamic edit-type (g/constantly
-                                (let [options (protobuf/enum-values Sprite$SpriteDesc$BlendMode)]
-                                  {:type :choicebox
-                                   :options (zipmap (map first options)
-                                                    (map (comp :display-name second) options))}))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Sprite$SpriteDesc$BlendMode))))
 
   (input image-resource resource/Resource)
   (input anim-data g/Any :substitute (fn [v] (assoc v :user-data "the Image has internal errors")))

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -247,11 +247,7 @@
                                   (validation/prop-error :fatal _node-id :end-tile (partial prop-tile-range? tile-count) end-tile "End Tile"))))
   (property playback types/AnimationPlayback
             (default :playback-once-forward)
-            (dynamic edit-type (g/constantly
-                                (let [options (protobuf/enum-values Tile$Playback)]
-                                  {:type :choicebox
-                                   :options (zipmap (map first options)
-                                                    (map (comp :display-name second) options))}))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Tile$Playback))))
   (property fps g/Int (default 30)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? fps)))
   (property flip-horizontal g/Bool (default false))


### PR DESCRIPTION
Replaced uses of :choicebox edit type with helper functions in
properties namespace and removed arbitrary text input.