### PR TITLE
DEFEDIT-1017 Resetting override no longer requires clicking twice

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -497,6 +497,7 @@
                     (ui/add-styles! ["clear-button" "button-small"])
                     (ui/on-action! (fn [_]
                                      (properties/clear-override! (property-fn key))
+                                     (ui/suppress-auto-commit! control)
                                      (.requestFocus control))))
 
         label-box (let [box (GridPane.)]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -386,7 +386,13 @@
                                     (user-data! node ::auto-commit? false)
                                     (when (user-data node ::auto-commit?)
                                       (commit-fn nil)))))
-  (on-edit! node (fn [_old _new] (user-data! node ::auto-commit? true))))
+  (on-edit! node (fn [_old new]
+                   (if (user-data node ::suppress-auto-commit?)
+                     (user-data! node ::suppress-auto-commit? false)
+                     (user-data! node ::auto-commit? true)))))
+
+(defn suppress-auto-commit! [^Node node]
+  (user-data! node ::suppress-auto-commit? true))
 
 (defn- apply-default-css! [^Parent root]
   (.. root getStylesheets (add (str (io/resource "editor.css"))))


### PR DESCRIPTION
Supress auto-commit machinery when we programatically clear the
override property so that it does not get set again on next update.

Fixes https://github.com/defold/editor2-issues/issues/739
