### PR TITLE
DEFEDIT-1011 Folders with extensions get registered icons & cant change/remove extension by rename

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -358,8 +358,9 @@
           parent-path (resource/parent-proj-path (resource/proj-path resource))
           options {:title (if dir? "Rename Folder" "Rename File")
                    :label (if dir? "New Folder Name" "New File Name")
+                   :sanitize (if dir? dialogs/sanitize-folder-name (partial dialogs/sanitize-file-name extension))
                    :validate (partial validate-new-resource-name parent-path)}
-          new-name (dialogs/make-rename-dialog name extension options)]
+          new-name (dialogs/make-rename-dialog name options)]
       (when-let [sane-new-name (some-> new-name not-empty)]
         (rename resource sane-new-name)))))
 

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -269,10 +269,14 @@
         (io/copy in f))
       (.getAbsolutePath f))))
 
+(defn- file? [resource]
+  (when (= (source-type resource) :file)
+    resource))
+
 (defn style-classes [resource]
   (into #{}
         (keep not-empty)
-        [(some->> resource ext not-empty (str "resource-ext-"))
+        [(some->> resource file? ext not-empty (str "resource-ext-"))
          (when (read-only? resource) "resource-read-only")]))
 
 (defn filter-resources [resources query]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -128,15 +128,16 @@ ordinary paths."
       (with-open [f (io/reader resource)]
         (slurp f)))))
 
-(def default-icons {:file "icons/32/Icons_29-AT-Unknown.png" :folder "icons/32/Icons_01-Folder-closed.png"})
-
 (defn resource-icon [resource]
   (when resource
     (if (and (resource/read-only? resource)
              (= (resource/path resource) (resource/resource-name resource)))
       "icons/32/Icons_03-Builtins.png"
-      (or (:icon (resource/resource-type resource))
-          (get default-icons (resource/source-type resource))))))
+      (condp = (resource/source-type resource)
+        :file
+        (or (:icon (resource/resource-type resource)) "icons/32/Icons_29-AT-Unknown.png")
+        :folder
+        "icons/32/Icons_01-Folder-closed.png"))))
 
 (defn file-resource [workspace path-or-file]
   (let [root (g/node-value workspace :root)


### PR DESCRIPTION
* Don't give resource type icons & styles to folders
* Only respect extension when renaming files
* Also, don't allow empty names