### PR TITLE
DEFEDIT-1022 Workararound tree view hangs on Windows 10

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -15,7 +15,7 @@ jar = ${bootstrap.resourcespath}/packages/defold-${build.sha1}.jar
 main = com.defold.editor.Start
 debug = 1
 updateurl = https://d.defold.com/editor2
-vmargs = -Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Ddefold.update.url=${launcher.updateurl}
+vmargs = -Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Ddefold.update.url=${launcher.updateurl},-Dglass.accessible.force=false
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =


### PR DESCRIPTION
The root cause for this issue seems to be similar to an old JavaFX
bug JDK-8132897 which was caused by a combination of having a touch
screen or a tablet attached and clicking an out-of-focus control. That
bug has been fixed but it seems like a similar bug could still be
present for the tree view control we are using.

Workaround is to disable the accessability support in JavaFX by
setting the property "glass.accessible.force" to false.

Fixes https://github.com/defold/editor2-issues/issues/943