### PR TITLE
DEFEDIT-1024 Divide by zero when pie node perimiter vertices is 0

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -665,7 +665,9 @@
   (property outer-bounds g/Keyword (default :piebounds-ellipse)
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Gui$NodeDesc$PieBounds))))
   (property inner-radius g/Num (default 0.0))
-  (property perimeter-vertices g/Num (default 10.0))
+  (property perimeter-vertices g/Int (default 10)
+            (dynamic error (validation/prop-error-fnk :fatal (partial validation/prop-outside-range? [4 1000]) perimeter-vertices)))
+
   (property pie-fill-angle g/Num (default 360.0))
 
   (display-order (into base-display-order
@@ -673,9 +675,11 @@
                         :color :alpha :inherit-alpha :layer :blend-mode :pivot :x-anchor :y-anchor
                         :adjust-mode :clipping :visible-clipper :inverted-clipper]))
 
-  (output pie-data g/KeywordMap (g/fnk [outer-bounds inner-radius perimeter-vertices pie-fill-angle]
-                                            {:outer-bounds outer-bounds :inner-radius inner-radius
-                                             :perimeter-vertices perimeter-vertices :pie-fill-angle pie-fill-angle}))
+  (output pie-data g/KeywordMap (g/fnk [_node-id outer-bounds inner-radius perimeter-vertices pie-fill-angle]
+                                       (g/precluding-errors
+                                         [(validation/prop-error :fatal _node-id :perimeter-vertices validation/prop-outside-range? [4 1000] perimeter-vertices "Perimeter Vertices")]
+                                         {:outer-bounds outer-bounds :inner-radius inner-radius
+                                          :perimeter-vertices perimeter-vertices :pie-fill-angle pie-fill-angle})))
 
   ;; Overloaded outputs
   (output scene-renderable-user-data g/Any :cached

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -91,8 +91,17 @@
     (let [workspace (test-util/setup-workspace! world)
           project   (test-util/setup-project! workspace)
           node-id   (test-util/resource-node project "/logic/main.gui")
+          pie (gui-node node-id "hexagon")
           scene (g/node-value node-id :scene)]
-      (is (> (count (get-in scene [:children 3 :renderable :user-data :line-data])) 0)))))
+      (is (> (count (get-in scene [:children 3 :renderable :user-data :line-data])) 0))
+      (test-util/with-prop [pie :perimeter-vertices 3]
+        (is (g/error-fatal? (test-util/prop-error pie :perimeter-vertices))))
+      (test-util/with-prop [pie :perimeter-vertices 4]
+        (is (not (g/error-fatal? (test-util/prop-error pie :perimeter-vertices)))))
+      (test-util/with-prop [pie :perimeter-vertices 1000]
+        (is (not (g/error-fatal? (test-util/prop-error pie :perimeter-vertices)))))
+      (test-util/with-prop [pie :perimeter-vertices 1001]
+        (is (g/error-fatal? (test-util/prop-error pie :perimeter-vertices)))))))
 
 (deftest gui-textures
   (with-clean-system


### PR DESCRIPTION
Changed type to g/Int. Fractional perimeter vertices did look pretty cool though!
Added validation [4 1000] as in editor 1. Not a build error yet.