### PR TITLE
DEFEDIT-1026 The font editor is missing the antialias checkbox

### DIFF
--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -374,10 +374,10 @@
     text))
 
 (defn- bool->int [val]
-  (when val (if val 1 0)))
+  (when (some? val) (if val 1 0)))
 
 (defn- int->bool [val]
-  (when val (if (= val 0) false true)))
+  (when (some? val) (if (= val 0) false true)))
 
 (g/defnode FontNode
   (inherits project/ResourceNode)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -373,6 +373,12 @@
         text (s/join " " (map (fn [l] (s/join (map char->string l))) lines))]
     text))
 
+(defn- bool->int [val]
+  (when val (if val 1 0)))
+
+(defn- int->bool [val]
+  (when val (if (= val 0) false true)))
+
 (g/defnode FontNode
   (inherits project/ResourceNode)
 
@@ -407,7 +413,14 @@
             (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
                                                            (or (= type :defold) (= type :distance-field)))))
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-zero-or-below? size)))
+
   (property antialias g/Int (dynamic visible (g/constantly false)))
+  (property antialiased g/Bool
+            (dynamic label (g/constantly "Antialias"))
+            (value (g/fnk [antialias] (int->bool antialias)))
+            (set (fn [basis self old-value new-value]
+                   (g/set-property self :antialias (bool->int new-value)))))
+  
   (property alpha g/Num
             (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
                                                            (= type :defold))))

--- a/editor/test/integration/font_test.clj
+++ b/editor/test/integration/font_test.clj
@@ -74,3 +74,53 @@
       (doseq [p [:size :alpha :outline-alpha :outline-width :shadow-alpha :shadow-blur :cache-width :cache-height]]
         (test-util/with-prop [node-id p -1]
           (is (g/error-fatal? (test-util/prop-error node-id p))))))))
+
+(defn pb-property [node-id property]
+  (get-in (g/node-value node-id :pb-msg) [property]))
+
+(deftest antialias
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project   (test-util/setup-project! workspace)
+          score    (test-util/resource-node project "/fonts/score.font")
+          score-not-antialias (test-util/resource-node project "/fonts/score_not_antialias.font")
+          score-no-antialias  (test-util/resource-node project "/fonts/score_no_antialias.font")]
+
+      (is (= (g/node-value score :antialiased) true))
+      (is (= (g/node-value score :antialias) 1))
+      (is (= (pb-property score :antialias) 1))
+
+      (g/set-property! score :antialiased false)
+      (is (= (g/node-value score :antialias) 0))
+      (is (= (pb-property score :antialias) 0))
+
+      (is (= (g/node-value score-not-antialias :antialiased) false))
+      (is (= (g/node-value score-not-antialias :antialias) 0))
+      (is (= (pb-property score-not-antialias :antialias) 0))
+
+      (g/set-property! score-not-antialias :antialiased true)
+      (is (= (g/node-value score-not-antialias :antialias) 1))
+      (is (= (pb-property score-not-antialias :antialias) 1))
+
+      (is (= (g/node-value score-no-antialias :antialiased) true)) ; font_ddf defaults antialias to 1 = true
+      (is (= (g/node-value score-no-antialias :antialias) 1))
+      (is (= (pb-property score-no-antialias :antialias) 1))
+
+      (g/set-property! score-no-antialias :antialiased false)
+      (is (= (g/node-value score-no-antialias :antialias) 0))
+      (is (= (pb-property score-no-antialias :antialias) 0))
+
+      (g/set-property! score-no-antialias :antialiased true)
+      (is (= (g/node-value score-no-antialias :antialias) 1))
+      (is (= (pb-property score-no-antialias :antialias) 1))
+
+      (g/set-property! score-no-antialias :antialias nil)
+      (is (= (g/node-value score-no-antialias :antialias) nil))
+      (is (= (pb-property score-no-antialias :antialias) nil))
+
+      (g/set-property! score-no-antialias :antialias 1)
+      (is (= (g/node-value score-no-antialias :antialiased) true))
+      (g/set-property! score-no-antialias :antialias 0)
+      (is (= (g/node-value score-no-antialias :antialiased) false))
+      (g/set-property! score-no-antialias :antialias nil)
+      (is (= (g/node-value score-no-antialias :antialiased) nil)))))

--- a/editor/test/resources/test_project/fonts/score_no_antialias.font
+++ b/editor/test/resources/test_project/fonts/score_no_antialias.font
@@ -1,0 +1,10 @@
+font: "/fonts/vera_mo_bd.ttf"
+material: "/fonts/font.material"
+size: 20
+alpha: 1.0
+outline_alpha: 0.5
+outline_width: 4.0
+shadow_alpha: 0.5
+shadow_blur: 4
+shadow_x: 5.0
+shadow_y: 5.0

--- a/editor/test/resources/test_project/fonts/score_not_antialias.font
+++ b/editor/test/resources/test_project/fonts/score_not_antialias.font
@@ -1,0 +1,11 @@
+font: "/fonts/vera_mo_bd.ttf"
+material: "/fonts/font.material"
+size: 20
+antialias: 0
+alpha: 1.0
+outline_alpha: 0.5
+outline_width: 4.0
+shadow_alpha: 0.5
+shadow_blur: 4
+shadow_x: 5.0
+shadow_y: 5.0


### PR DESCRIPTION
* Introduced corresponding visible antialias*ed* boolean property with
  custom value/set that uses underlying antialias int property
* Added tests for antialias/antialiased mapping and generating pb-msg