### PR TITLE
DEFEDIT-1028 Run project with custom dmengine

### DIFF
--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -26,6 +26,7 @@ import com.defold.editor.Platform;
 public class ResourceUnpacker {
 
     public static final String DEFOLD_UNPACK_PATH_KEY = "defold.unpack.path";
+    public static final String DEFOLD_UNPACK_PATH_ENV_VAR = "DEFOLD_UNPACK_PATH";
     public static final String DEFOLD_SHA1_KEY = "defold.sha1";
 
     private static boolean isInitialized = false;
@@ -106,6 +107,10 @@ public class ResourceUnpacker {
 
     private static Path getUnpackPath() throws IOException {
         String unpackPath = System.getProperty(DEFOLD_UNPACK_PATH_KEY);
+        if (unpackPath == null) {
+            unpackPath = System.getenv(DEFOLD_UNPACK_PATH_ENV_VAR);
+        }
+
         if (unpackPath != null) {
             return ensureDirectory(Paths.get(unpackPath), true);
         }


### PR DESCRIPTION
Use env var DEFOLD_UNPACK_PATH as target for unpacking native binaries
and libraries. These can then be exchanged in place with custom
versions.