### PR TITLE
DEFEDIT-1033 Hit build and got FileNotFoundException

### DIFF
--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -6,7 +6,10 @@
    [editor.protobuf :as protobuf]
    [editor.workspace :as workspace])
   (:import
+   (java.io File)
    (java.util UUID)))
+
+(set! *warn-on-reflection* true)
 
 (defn- resolve-resource-paths
   [pb dep-resources resource-props]
@@ -109,16 +112,20 @@
         dep-resources (make-dep-resources deps build-targets-by-key)]
     (build-fn node-id basis resource dep-resources user-data)))
 
+(defn- empty-build-cache []
+  {:dir (fs/create-temp-directory! "defold-build-cache")
+   :entries {}})
+
+(defn build-cache-dir ^File [build-cache]
+  (:dir @build-cache))
+
 (defn- revalidate-build-cache-dir! [build-cache]
-  (swap! (:dir build-cache) #(if (and % (.exists %)) % (fs/create-temp-directory! "defold-build-cache"))))
+  (when-not (.exists (build-cache-dir build-cache))
+    (reset! build-cache (empty-build-cache)))
+  (build-cache-dir build-cache))
 
 (defn make-build-cache []
-  (doto {:dir     (atom nil)
-         :entries (atom {})}
-    (revalidate-build-cache-dir!)))
-
-(defn build-cache-dir [build-cache]
-  @(:dir build-cache))
+  (atom (empty-build-cache)))
 
 (defn cache!
   [build-cache resource key result]
@@ -129,12 +136,12 @@
                         (dissoc :content)
                         (assoc :id id :key key :cached true))]
     (io/copy content cache-file)
-    (swap! (:entries build-cache) assoc resource cache-value)
+    (swap! build-cache assoc-in [:entries resource] cache-value)
     (assoc result :key key)))
 
 (defn lookup
   [build-cache resource key]
-  (when-let [entry (get @(:entries build-cache) resource)]
+  (when-let [entry (get (:entries @build-cache) resource)]
     (when (= key (:key entry))
       (let [file (io/file (build-cache-dir build-cache) (:id entry))]
         (when (.exists file)
@@ -142,14 +149,13 @@
               (dissoc :id)
               (assoc :content file)))))))
 
-(defn- prune-build-cache!
-  [{:keys [dir entries] :as build-cache} build-targets-by-key]
-  (swap! entries #(reduce-kv (fn [ret resource {:keys [key] :as result}]
-                               (if (contains? build-targets-by-key key)
-                                 (assoc ret resource result)
-                                 ret))
-                             {}
-                             %))
+(defn- prune-build-cache! [build-cache build-targets-by-key]
+  (swap! build-cache update :entries #(reduce-kv (fn [ret resource {:keys [key] :as result}]
+                                                   (if (contains? build-targets-by-key key)
+                                                     (assoc ret resource result)
+                                                     ret))
+                                                 {}
+                                                 %))
   build-cache)
 
 (defn build-target-cached

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -109,17 +109,22 @@
         dep-resources (make-dep-resources deps build-targets-by-key)]
     (build-fn node-id basis resource dep-resources user-data)))
 
+(defn- revalidate-build-cache-dir! [build-cache]
+  (swap! (:dir build-cache) #(if (and % (.exists %)) % (fs/create-temp-directory! "defold-build-cache"))))
 
-(defn make-build-cache
-  []
-  {:dir     (fs/create-temp-directory! "defold-build-cache")
-   :entries (atom {})})
+(defn make-build-cache []
+  (doto {:dir     (atom nil)
+         :entries (atom {})}
+    (revalidate-build-cache-dir!)))
+
+(defn build-cache-dir [build-cache]
+  @(:dir build-cache))
 
 (defn cache!
   [build-cache resource key result]
   (let [id (str (UUID/randomUUID))
         content (:content result)
-        cache-file (io/file (:dir build-cache) id)
+        cache-file (io/file (revalidate-build-cache-dir! build-cache) id)
         cache-value (-> result
                         (dissoc :content)
                         (assoc :id id :key key :cached true))]
@@ -131,10 +136,11 @@
   [build-cache resource key]
   (when-let [entry (get @(:entries build-cache) resource)]
     (when (= key (:key entry))
-      (let [file (io/file (:dir build-cache) (:id entry))]
-        (-> entry
-            (dissoc :id)
-            (assoc :content file))))))
+      (let [file (io/file (build-cache-dir build-cache) (:id entry))]
+        (when (.exists file)
+          (-> entry
+              (dissoc :id)
+              (assoc :content file)))))))
 
 (defn- prune-build-cache!
   [{:keys [dir entries] :as build-cache} build-targets-by-key]

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -438,12 +438,12 @@
             path          "/main/main.collection"
             resource-node (test-util/resource-node project path)
             _             (project/build project resource-node {})
-            cache-count   (-> (g/node-value project :build-cache) :entries deref count)]
+            cache-count   (-> (g/node-value project :build-cache) deref :entries count)]
         (g/transact
          (for [[node-id label] (g/sources-of resource-node :dep-build-targets)]
            (g/delete-node node-id)))
         (project/build project resource-node {})
-        (is (< (-> (g/node-value project :build-cache) :entries deref count) cache-count))))))
+        (is (< (-> (g/node-value project :build-cache) deref :entries count) cache-count))))))
 
 (deftest prune-fs-build-cache
   (testing "Verify the fs build cache works as expected"


### PR DESCRIPTION
Create a new build cache temp dir in case the old is missing i.e. has
been purged by the OS. Check cached build result file still exists on
lookup.