### PR TITLE
DEFEDIT-1035 Better rendering of tile sources and tile maps

### DIFF
--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -16,6 +16,7 @@
    [editor.gl.vertex2 :as vtx]
    [editor.graph-util :as gu]
    [editor.handler :as handler]
+   [editor.material :as material]
    [editor.math :as math]
    [editor.outline :as outline]
    [editor.properties :as properties]
@@ -24,6 +25,7 @@
    [editor.scene :as scene]
    [editor.scene-tools :as scene-tools]
    [editor.tile-map-grid :as tile-map-grid]
+   [editor.tile-source :as tile-source]
    [editor.types :as types]
    [editor.ui :as ui]
    [editor.util :as util]
@@ -376,6 +378,7 @@
   (input gpu-texture g/Any)
   (input material-resource resource/Resource)
   (input material-shader ShaderLifecycle)
+  (input material-samplers g/Any)
 
   ;; tile source
   (property tile-source resource/Resource
@@ -399,7 +402,8 @@
                    (project/resource-setter basis self old-value new-value
                                             [:resource :material-resource]
                                             [:build-targets :dep-build-targets]
-                                            [:shader :material-shader])))
+                                            [:shader :material-shader]
+                                            [:samplers :material-samplers])))
             (dynamic error (g/fnk [_node-id material]
                                   (prop-resource-error :fatal _node-id :material material "Material")))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext "material"})))
@@ -423,7 +427,12 @@
                   [width height])))))
 
   (output texture-set-data g/Any (gu/passthrough texture-set-data))
-  (output gpu-texture g/Any (gu/passthrough gpu-texture))
+  (output diffuse-texture-sampler g/Any (g/fnk [material-samplers]
+                                          (first (filter #(= "DIFFUSE_TEXTURE" (:name %)) material-samplers))))
+  (output gpu-texture g/Any (g/fnk [gpu-texture diffuse-texture-sampler]
+                              (cond-> gpu-texture
+                                diffuse-texture-sampler
+                                (texture/set-params (material/sampler->tex-params diffuse-texture-sampler)))))
   (output material-shader ShaderLifecycle (gu/passthrough material-shader))
   (output scene g/Any :cached produce-scene)
   (output node-outline outline/OutlineData :cached produce-node-outline)
@@ -627,10 +636,7 @@
   [^GL2 gl render-args tile-source-attributes texture-set-data gpu-texture]
   (let [vbuf (gen-palette-tiles-vbuf tile-source-attributes texture-set-data)
         vb (vtx/use-with ::palette-tiles vbuf tex-shader)
-        gpu-texture (texture/set-params gpu-texture {:min-filter gl/linear
-                                                     :mag-filter gl/linear
-                                                     :wrap-s     gl/clamp
-                                                     :wrap-t     gl/clamp})]
+        gpu-texture (texture/set-params gpu-texture tile-source/texture-params)]
     (gl/with-gl-bindings gl render-args [gpu-texture tex-shader vb]
       (shader/set-uniform tex-shader gl "texture" 0)
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -53,6 +53,12 @@
 (def animation-icon "icons/32/Icons_24-AT-Animation.png")
 (def collision-icon "icons/32/Icons_43-Tilesource-Collgroup.png")
 
+(def texture-params
+  {:min-filter gl/nearest
+   :mag-filter gl/nearest
+   :wrap-s     gl/clamp
+   :wrap-t     gl/clamp})
+
 (vtx/defvertex pos-uv-vtx
   (vec4 position)
   (vec2 texcoord0))
@@ -334,7 +340,8 @@
 (defn- render-tiles
   [^GL2 gl render-args node-id gpu-texture tile-source-attributes uv-transforms scale-factor]
   (let [vbuf (gen-tiles-vbuf tile-source-attributes uv-transforms scale-factor)
-        vb (vtx/use-with node-id vbuf tile-shader)]
+        vb (vtx/use-with node-id vbuf tile-shader)
+        gpu-texture (texture/set-params gpu-texture texture-params)]
     (gl/with-gl-bindings gl render-args [gpu-texture tile-shader vb]
       (shader/set-uniform tile-shader gl "texture" 0)
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))


### PR DESCRIPTION
This commit improves how we sample data from texture when rendering
tile sources and tile maps.

- For tile sources where we have no material defining which sampler to
  use, we use nearest filtering, like editor1.
- For tile maps we have a material, use sampler from that material if
  one is defined for `DIFFUSE_TEXTURE`, otherwise default to same as engine.

Fixes https://github.com/defold/editor2-issues/issues/1012