### PR TITLE
DEF-2768 String index out of bounds when bundling with bob

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/ZipMountPoint.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/ZipMountPoint.java
@@ -127,12 +127,14 @@ public class ZipMountPoint implements IMountPoint {
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
                 String entryPath = entry.getName();
-                entryPath = entryPath.substring(this.includeBaseDir.length());
-                if (includes(entryPath) && entryPath.startsWith(path)) {
-                    if (entry.isDirectory()) {
-                        walker.handleDirectory(entryPath, results);
-                    } else {
-                        walker.handleFile(entryPath, results);
+                if (entryPath.startsWith(this.includeBaseDir)) {
+                    entryPath = entryPath.substring(this.includeBaseDir.length());
+                    if (includes(entryPath) && entryPath.startsWith(path)) {
+                        if (entry.isDirectory()) {
+                            walker.handleDirectory(entryPath, results);
+                        } else {
+                            walker.handleFile(entryPath, results);
+                        }
                     }
                 }
             }

--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -31,7 +31,7 @@
   (String. (.decode (java.util.Base64/getUrlDecoder) b64str) "UTF-8"))
 
 (defn- library-url-to-file-name ^String [url tag]
-  (str (mangle-library-url url) "-" (str->b64 tag) ".zip"))
+  (str (mangle-library-url url) "-" (str->b64 (or tag "")) ".zip"))
 
 (defn library-directory ^File [project-directory]
   (io/file (io/as-file project-directory) ".internal/lib"))


### PR DESCRIPTION
ZipMountPoint: Check entryPath actually starts with includeBaseDir
before calculating relative entryPath.

Also, in editor 2 handle case where http server doesn't send an etag.