### PR TITLE
DEFEDIT-1039 Fixed fuzzy match scoring of project paths

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -297,18 +297,8 @@
 
     (ui/user-data stage ::selected-items)))
 
-(defn- resource->fuzzy-match [pattern resource]
-  (let [proj-path (resource/proj-path resource)
-        path-match (fuzzy-text/match pattern proj-path)]
-    (when (some? path-match)
-      (let [name-index (inc (str/last-index-of proj-path \/))
-            name-match (fuzzy-text/match pattern proj-path name-index)]
-        (if (some? name-match)
-          (max-key first path-match name-match)
-          path-match)))))
-
 (defn- resource->fuzzy-matched-resource [pattern resource]
-  (when-some [[score matching-indices] (resource->fuzzy-match pattern resource)]
+  (when-some [[score matching-indices] (fuzzy-text/match-proj-path pattern (resource/proj-path resource))]
     (with-meta resource
                {:score score
                 :matching-indices matching-indices})))

--- a/editor/test/editor/fuzzy_text_test.clj
+++ b/editor/test/editor/fuzzy_text_test.clj
@@ -52,6 +52,13 @@
     "two_words"
     "=== ====="))
 
+(defn- score [pattern proj-path]
+  (first (fuzzy-text/match-proj-path pattern proj-path)))
+
+(deftest score-test
+  (is (> (score "game.script" "/game/game.script")
+         (score "game.script" "/game/score/score.gui_script"))))
+
 (deftest runs-test
   (are [length matching-indices expected]
     (is (= expected (fuzzy-text/runs length matching-indices)))


### PR DESCRIPTION
Fixes defold/editor2-issues#990

Fixed invalid `leading-letter-penalty` being applied to `file-name` scoring.