### PR TITLE
DEFEDIT-1040 Color code dir and filename in resource browser

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -376,17 +376,30 @@
       distinct)
     []))
 
-(defn- make-matched-text-run [matched? text]
+(defn- make-text-run [text style-class]
   (let [text-view (Text. text)]
-    (when matched?
-      (.add (.getStyleClass text-view) "matched"))
+    (when (some? style-class)
+      (.add (.getStyleClass text-view) style-class))
     text-view))
 
 (defn- matched-text-runs [text matching-indices]
-  (into []
-        (map (fn [[matched? start end]]
-               (make-matched-text-run matched? (subs text start end))))
-        (fuzzy-text/runs (count text) matching-indices)))
+  (let [/ (or (some-> text (str/last-index-of \/) inc) 0)]
+    (into []
+          (mapcat (fn [[matched? start end]]
+                    (cond
+                      matched?
+                      [(make-text-run (subs text start end) "matched")]
+
+                      (< start / end)
+                      [(make-text-run (subs text start /) "diminished")
+                       (make-text-run (subs text / end) nil)]
+
+                      (<= start end /)
+                      [(make-text-run (subs text start end) "diminished")]
+
+                      :else
+                      [(make-text-run (subs text start end) nil)])))
+          (fuzzy-text/runs (count text) matching-indices))))
 
 (defn- make-matched-list-item-graphic [icon text matching-indices]
   (let [icon-view (jfx/get-image-view icon 16)
@@ -401,7 +414,7 @@
         items        (filter #(and (= :file (resource/source-type %)) (accepted-ext (:ext (resource/resource-type %))))
                              (g/node-value workspace :resource-list))
         options (-> {:title "Select Resource"
-                     :prompt "filter resources - '*' to match any string, '.' to filter file extensions"
+                     :prompt "Type to filter"
                      :filter ""
                      :cell-fn (fn [r]
                                 (let [text (resource/proj-path r)

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -274,7 +274,7 @@
     resource))
 
 (defn style-classes [resource]
-  (into #{}
+  (into #{"resource"}
         (keep not-empty)
         [(some->> resource file? ext not-empty (str "resource-ext-"))
          (when (read-only? resource) "resource-read-only")]))

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -88,6 +88,8 @@ $script-number:         #aaaaff;
 $script-intellisense:   #00FFFF;
 
 /* File extension group colors */
+$unknown-file:          #606367;
+$unknown-file-active:   #8f9296;
 $design-file:           #325c7e;
 $design-file-active:    #4cb1ff;
 $script-file:           #7c7e37;

--- a/editor/styling/stylesheets/components/_flat-list-view.scss
+++ b/editor/styling/stylesheets/components/_flat-list-view.scss
@@ -9,6 +9,9 @@
         Text {
             -fx-font-smoothing-type: lcd;
             -fx-fill: $bright-grey-light;
+            &.diminished {
+                -fx-opacity: 0.5;
+            }
             &.matched {
                 -fx-fill: $defold-light-blue;
             }

--- a/editor/styling/stylesheets/mixins/_file-extensions.scss
+++ b/editor/styling/stylesheets/mixins/_file-extensions.scss
@@ -20,6 +20,10 @@
 }
 
 @mixin extensions ($element) {
+    &.resource {
+        @include extension-template($element, $unknown-file, $unknown-file-active)
+    }
+
     &.resource-ext- {
         /* Script files */
         &fp, &gui_script, &lua,


### PR DESCRIPTION
Implements defold/editor2-issues#1006

### User-facing changes
* The path leading up to the file name in the Open Assets... dialog is de-emphasized compared to the file name part.
* Icons for unknown resource types such as `png` or `ttf` no longer appear brighter than icons for known resource types.
* Updated filter field prompt in Open Assets... dialog to reflect the fuzzy matching behavior.

![open-assets-colorize-paths](https://user-images.githubusercontent.com/22448941/27338530-c1e10a16-55d5-11e7-92b9-3db977cea898.png)