### PR TITLE
DEFEDIT-1038 Use assigned materials everywhere

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -435,7 +435,8 @@
                                                      (types/->AABB (Point3d. 0 0 0) (Point3d. w h 0))))))
 
   (output gpu-texture      g/Any               :cached (g/fnk [_node-id packed-image]
-                                                         (texture/image-texture _node-id packed-image)))
+                                                         (texture/image-texture _node-id packed-image {:min-filter gl/nearest
+                                                                                                       :mag-filter gl/nearest})))
 
   (output anim-data        g/Any               :cached produce-anim-data)
   (output image-path->rect g/Any               :cached produce-image-path->rect)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -497,8 +497,8 @@
 (defn parse-filter-param
   [_node-id ^String s]
   (cond
-    (.equalsIgnoreCase s "nearest") gl/nearest
-    (.equalsIgnoreCase s "linear") gl/linear
+    (.equalsIgnoreCase "nearest" s) gl/nearest
+    (.equalsIgnoreCase "linear" s) gl/linear
     :else (g/error-fatal (format "Invalid value for filter param: '%s'" s))))
 
 (g/defnk produce-default-tex-params

--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -529,16 +529,10 @@ the `do-gl` macro from `editor.gl`."
       (unbind-vertex-buffer-with-shader! gl vertex-buffer shader))))
 
 (defn use-with
-  "Prepare a vertex buffer to be used in rendering by binding its attributes to
-  the given shader's attributes. Matching is done by attribute names. An
-  attribute that exists in the vertex buffer but is not used by the shader will
-  simply be ignored.
-
-  At the time when `use-with` is called, it binds the buffer to GL as a GL_ARRAY_BUFFER.
-  This is also when it binds attribs to the shader.
-
-  This function returns an object that satisfies editor.gl.protocols/GlEnable,
-  editor.gl.protocols/GlDisable."
+  "Return a GlBind implementation that can match vertex buffer attributes to the
+  given shader's attributes. Matching is done by attribute names. An attribute
+  that exists in the vertex buffer but is not used by the shader will simply be
+  ignored."
   [request-id ^PersistentVertexBuffer vertex-buffer shader]
   (->VertexBufferShaderLink request-id vertex-buffer shader))
 

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -309,9 +309,10 @@
   (output save-data g/Any :cached produce-save-data)
   (output scene g/Any :cached produce-scene)
   (output build-targets g/Any :cached produce-build-targets)
-  (output gpu-texture g/Any :cached (g/fnk [_node-id gpu-texture material-samplers]
-                                           (->> (material/sampler->tex-params (first material-samplers))
-                                             (texture/set-params gpu-texture)))))
+  (output tex-params g/Any :cached (g/fnk [material-samplers]
+                                     (some-> material-samplers first material/sampler->tex-params)))
+  (output gpu-texture g/Any :cached (g/fnk [_node-id gpu-texture tex-params]
+                                      (texture/set-params gpu-texture tex-params))))
 
 (defmethod scene-tools/manip-scalable? ::LabelNode [_node-id] true)
 

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -6,9 +6,11 @@
             [util.murmur :as murmur]
             [editor.graph-util :as gu]
             [editor.geom :as geom]
+            [editor.material :as material]
             [editor.math :as math]
             [editor.gl :as gl]
             [editor.gl.shader :as shader]
+            [editor.gl.texture :as texture]
             [editor.gl.vertex :as vtx]
             [editor.defold-project :as project]
             [editor.resource :as resource]
@@ -671,16 +673,16 @@
 
       (= pass pass/transparent)
       (do (when-let [vb (gen-vb renderables)]
-            (let [vertex-binding (vtx/use-with ::spine-trans vb render/shader-tex-tint)
-                  user-data (:user-data (first renderables))
+            (let [user-data (:user-data (first renderables))
+                  blend-mode (:blend-mode user-data)
                   gpu-texture (:gpu-texture user-data)
-                  blend-mode (:blend-mode user-data)]
-              (gl/with-gl-bindings gl render-args [gpu-texture render/shader-tex-tint vertex-binding]
+                  shader (get user-data :shader render/shader-tex-tint)
+                  vertex-binding (vtx/use-with ::spine-trans vb shader)]
+              (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
                 (case blend-mode
                   :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
                   (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
                   :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
-                (shader/set-uniform render/shader-tex-tint gl "texture" 0)
                 (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))
                 (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA))))
           (when-let [vb (gen-skeleton-vb renderables)]
@@ -694,7 +696,7 @@
           (gl/with-gl-bindings gl render-args [render/shader-tex-tint vertex-binding]
             (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))))))))
 
-(g/defnk produce-scene [_node-id aabb gpu-texture spine-scene-pb scene-structure]
+(g/defnk produce-scene [_node-id aabb gpu-texture default-tex-params spine-scene-pb scene-structure]
   (let [scene {:node-id _node-id
                :aabb aabb}]
     (if gpu-texture
@@ -705,6 +707,7 @@
                                   :user-data {:spine-scene-pb spine-scene-pb
                                               :scene-structure scene-structure
                                               :gpu-texture gpu-texture
+                                              :tex-params default-tex-params
                                               :blend-mode blend-mode}
                                   :passes [pass/transparent pass/selection pass/outline]}))
       scene)))
@@ -750,6 +753,7 @@
   (input atlas-resource resource/Resource)
 
   (input anim-data g/Any)
+  (input default-tex-params g/Any)
   (input gpu-texture g/Any)
   (input dep-build-targets g/Any :array)
   (input spine-scene g/Any)
@@ -769,10 +773,12 @@
   (let [spine          (protobuf/read-text Spine$SpineSceneDesc resource)
         spine-resource (workspace/resolve-resource resource (:spine-json spine))
         atlas          (workspace/resolve-resource resource (:atlas spine))]
-    (g/set-property self
-                    :spine-json spine-resource
-                    :atlas atlas
-                    :sample-rate (:sample-rate spine))))
+    (concat
+      (g/connect project :default-tex-params self :default-tex-params)
+      (g/set-property self
+                      :spine-json spine-resource
+                      :atlas atlas
+                      :sample-rate (:sample-rate spine)))))
 
 (g/defnk produce-model-pb [spine-scene-resource default-animation skin material-resource blend-mode]
   {:spine-scene (resource/resource->proj-path spine-scene-resource)
@@ -833,6 +839,7 @@
                    (project/resource-setter basis self old-value new-value
                                                 [:resource :material-resource]
                                                 [:shader :material-shader]
+                                                [:samplers :material-samplers]
                                                 [:build-targets :dep-build-targets])))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext "material"}))
             (dynamic error (g/fnk [_node-id material]
@@ -869,12 +876,21 @@
   (input aabb AABB)
   (input material-resource resource/Resource)
   (input material-shader ShaderLifecycle)
+  (input material-samplers g/Any)
+  (input default-tex-params g/Any)
   (input anim-data g/Any)
+
+  (output tex-params g/Any (g/fnk [material-samplers default-tex-params]
+                             (or (some-> material-samplers first material/sampler->tex-params)
+                                 default-tex-params)))
   (output anim-ids g/Any :cached (g/fnk [anim-data] (vec (sort (keys anim-data)))))
   (output material-shader ShaderLifecycle (gu/passthrough material-shader))
-  (output scene g/Any :cached (g/fnk [spine-scene-scene skin]
+  (output scene g/Any :cached (g/fnk [spine-scene-scene material-shader tex-params skin]
                                 (if (:renderable spine-scene-scene)
-                                  (assoc-in spine-scene-scene [:renderable :user-data :skin] skin)
+                                  (-> spine-scene-scene
+                                      (assoc-in [:renderable :user-data :shader] material-shader)
+                                      (update-in [:renderable :user-data :gpu-texture] texture/set-params tex-params)
+                                      (assoc-in [:renderable :user-data :skin] skin))
                                   spine-scene-scene)))
   (output model-pb g/Any :cached produce-model-pb)
   (output save-data g/Any :cached produce-model-save-data)
@@ -886,8 +902,10 @@
         spine (-> (protobuf/read-text Spine$SpineModelDesc resource)
                 (update :spine-scene resolve-fn)
                 (update :material resolve-fn))]
-    (for [[k v] spine]
-      (g/set-property self k v))))
+    (concat
+      (g/connect project :default-tex-params self :default-tex-params)
+      (for [[k v] spine]
+        (g/set-property self k v)))))
 
 (defn register-resource-types [workspace]
   (concat

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -6,8 +6,10 @@
             [editor.geom :as geom]
             [editor.gl :as gl]
             [editor.gl.shader :as shader]
+            [editor.gl.texture :as texture]
             [editor.gl.vertex :as vtx]
             [editor.defold-project :as project]
+            [editor.material :as material]
             [editor.properties :as properties]
             [editor.scene :as scene]
             [editor.workspace :as workspace]
@@ -145,7 +147,6 @@
             :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
             (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
             :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
-          (shader/set-uniform shader gl "texture" 0)
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* count 6))
           (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))
 
@@ -234,6 +235,7 @@
                    (project/resource-setter basis self old-value new-value
                                             [:resource :material-resource]
                                             [:shader :material-shader]
+                                            [:samplers :material-samplers]
                                             [:build-targets :dep-build-targets])))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext #{"material"}}))
             (dynamic error (g/fnk [_node-id material]
@@ -252,7 +254,13 @@
 
   (input material-resource resource/Resource)
   (input material-shader ShaderLifecycle)
+  (input material-samplers g/Any)
+  (input default-tex-params g/Any)
 
+  (output tex-params g/Any (g/fnk [material-samplers material-shader default-tex-params]
+                             (or (some-> material-samplers first material/sampler->tex-params)
+                                 default-tex-params)))
+  (output gpu-texture g/Any (g/fnk [gpu-texture tex-params] (texture/set-params gpu-texture tex-params)))
   (output animation g/Any (g/fnk [anim-data default-animation] (get anim-data default-animation))) ; TODO - use placeholder animation
   (output aabb AABB (g/fnk [animation] (if animation
                                          (let [hw (* 0.5 (:width animation))
@@ -270,6 +278,7 @@
         image    (workspace/resolve-resource resource (:tile-set sprite))
         material (workspace/resolve-resource resource (:material sprite))]
     (concat
+      (g/connect project :default-tex-params self :default-tex-params)
       (g/set-property self :image image)
       (g/set-property self :default-animation (:default-animation sprite))
       (g/set-property self :material material)

--- a/editor/test/integration/font_test.clj
+++ b/editor/test/integration/font_test.clj
@@ -124,3 +124,13 @@
       (is (= (g/node-value score-no-antialias :antialiased) false))
       (g/set-property! score-no-antialias :antialias nil)
       (is (= (g/node-value score-no-antialias :antialiased) nil)))))
+
+(deftest font-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/fonts/logo.font")]
+      (test-util/test-uses-assigned-material workspace project node-id
+                                             :material
+                                             [:renderable :user-data :shader]
+                                             [:renderable :user-data :texture]))))

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -44,6 +44,17 @@
          scene (g/node-value node-id :scene)]
      (is (= 0.25 (get-in scene [:children 2 :children 0 :renderable :user-data :color 3]))))))
 
+(deftest gui-scene-material
+   (with-clean-system
+     (let [workspace (test-util/setup-workspace! world)
+           project   (test-util/setup-project! workspace)
+           node-id   (test-util/resource-node project "/gui/simple.gui")
+           scene (g/node-value node-id :scene)]
+       (test-util/test-uses-assigned-material workspace project node-id
+                                              :material
+                                              [:children 0 :renderable :user-data :material-shader]
+                                              [:children 0 :renderable :user-data :gpu-texture]))))
+
 (deftest gui-scene-validation
  (with-clean-system
    (let [workspace (test-util/setup-workspace! world)

--- a/editor/test/integration/label_test.clj
+++ b/editor/test/integration/label_test.clj
@@ -141,3 +141,13 @@
           (is (= {pass/outline {label/render-lines 2}
                   pass/transparent {label/render-tris 2}}
                  (render-call-counts #{} :batch-key))))))))
+
+(deftest label-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/label/test.label")]
+      (test-util/test-uses-assigned-material workspace project node-id
+                                             :material
+                                             [:renderable :user-data :material-shader]
+                                             [:renderable :user-data :gpu-texture]))))

--- a/editor/test/integration/particlefx_test.clj
+++ b/editor/test/integration/particlefx_test.clj
@@ -5,6 +5,7 @@
             [editor.collection :as collection]
             [editor.handler :as handler]
             [editor.defold-project :as project]
+            [editor.material :as material]
             [editor.workspace :as workspace]
             [editor.types :as types]
             [editor.particle-lib :as plib]
@@ -84,3 +85,25 @@
       (doseq [v ["" "not_found"]]
         (test-util/with-prop [emitter :animation v]
           (is (g/error? (test-util/prop-error emitter :animation))))))))
+
+(deftest particle-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/particlefx/default.particlefx")
+          material-node (project/get-resource-node project "/materials/test_samplers.material")          
+          [emitter-a emitter-b] (g/node-value node-id :nodes)]
+      (testing "uses shader and texture params from assigned material"
+        (test-util/with-prop [emitter-a :material (workspace/resolve-workspace-resource workspace "/materials/test_samplers.material")]
+          (testing "emitter-a uses material"
+            (let [sim-data (g/node-value emitter-a :emitter-sim-data)]
+              (is (= (get-in sim-data [:shader])
+                     (g/node-value material-node :shader)))
+              (is (= (get-in sim-data [:gpu-texture :params])
+                     (material/sampler->tex-params  (first (g/node-value material-node :samplers)))))))
+          (testing "emitter-b does not use material"
+            (let [sim-data (g/node-value emitter-b :emitter-sim-data)]
+              (is (not= (get-in sim-data [:shader])
+                        (g/node-value material-node :shader)))
+              (is (not= (get-in sim-data [:gpu-texture :params])
+                        (material/sampler->tex-params  (first (g/node-value material-node :samplers))))))))))))

--- a/editor/test/integration/spine_test.clj
+++ b/editor/test/integration/spine_test.clj
@@ -100,3 +100,13 @@
       (doseq [v ["no_such_skin"]]
         (test-util/with-prop [node-id :skin v]
           (is (g/error? (test-util/prop-error node-id :skin))))))))
+
+(deftest spine-model-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/spine/reload.spinemodel")]
+      (test-util/test-uses-assigned-material workspace project node-id
+                                             :material
+                                             [:renderable :user-data :shader]
+                                             [:renderable :user-data :gpu-texture]))))

--- a/editor/test/integration/sprite_test.clj
+++ b/editor/test/integration/sprite_test.clj
@@ -34,3 +34,13 @@
       (testing "invalid atlas"
                (test-util/with-prop [node-id :image (workspace/resolve-workspace-resource workspace "/graphics/img_not_found.atlas")]
                  (is (g/error? (test-util/prop-error node-id :image))))))))
+
+(deftest sprite-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/sprite/atlas.sprite")]
+      (test-util/test-uses-assigned-material workspace project node-id
+                                             :material
+                                             [:renderable :user-data :shader]
+                                             [:renderable :user-data :gpu-texture]))))

--- a/editor/test/integration/tile_map_test.clj
+++ b/editor/test/integration/tile_map_test.clj
@@ -39,3 +39,14 @@
         (doseq [v [-1.1 1.1]]
           (test-util/with-prop [layer :z v]
             (is (g/error? (test-util/prop-error layer :z)))))))))
+
+(deftest tile-map-scene
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (project/get-resource-node project "/tilegrid/with_layers.tilemap")]
+      (doseq [n (range 3)]
+        (test-util/test-uses-assigned-material workspace project node-id
+                                               :material
+                                               [:children n :renderable :user-data :shader]
+                                               [:children n :renderable :user-data :gpu-texture])))))

--- a/editor/test/resources/test_project/materials/test_samplers.fp
+++ b/editor/test/resources/test_project/materials/test_samplers.fp
@@ -1,0 +1,17 @@
+varying mediump vec2 var_texcoord0;
+
+uniform lowp sampler2D a;
+uniform lowp sampler2D b;
+uniform lowp vec4 asdf;
+
+void main()
+{
+    // Pre-multiply alpha since all runtime textures already are
+    lowp vec4 tint_pm = vec4(asdf.xyz * asdf.w, asdf.w);
+    gl_FragColor = mix(
+	  texture2D(a, vec2(0.9, 0.9) - var_texcoord0.xy) * tint_pm,
+	  texture2D(b, vec2(1.0, 1.0) - var_texcoord0.xy) * tint_pm,
+	  0.5
+	);
+	gl_FragColor = texture2D(b, var_texcoord0.xy) * tint_pm;
+}

--- a/editor/test/resources/test_project/materials/test_samplers.material
+++ b/editor/test/resources/test_project/materials/test_samplers.material
@@ -1,0 +1,31 @@
+name: "sprite"
+tags: "tile"
+vertex_program: "/materials/test_samplers.vp"
+fragment_program: "/materials/test_samplers.fp"
+vertex_constants {
+  name: "test"
+  type: CONSTANT_TYPE_VIEWPROJ
+  value {
+    x: 1.0
+    y: 2.0
+    z: 3.0
+    w: 4.0
+  }
+}
+fragment_constants {
+  name: "test"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 2.0
+    z: 3.0
+    w: 4.0
+  }
+}
+samplers {
+  name: "test"
+  wrap_u: WRAP_MODE_REPEAT
+  wrap_v: WRAP_MODE_MIRRORED_REPEAT
+  filter_min: FILTER_MODE_MIN_LINEAR
+  filter_mag: FILTER_MODE_MAG_NEAREST
+}

--- a/editor/test/resources/test_project/materials/test_samplers.vp
+++ b/editor/test/resources/test_project/materials/test_samplers.vp
@@ -1,0 +1,13 @@
+uniform mediump mat4 view_proj;
+
+// positions are in world space
+attribute mediump vec4 position;
+attribute mediump vec2 texcoord0;
+
+varying mediump vec2 var_texcoord0;
+
+void main()
+{
+    gl_Position = view_proj * vec4(position.xyz, 1.0);
+    var_texcoord0 = texcoord0;
+}


### PR DESCRIPTION
Fixes the following outstanding rendering/material issues:

- respect default min/mag filtering settings from game.project
- render particlefxs using material shader/samplers
- render spine models using material shader/samplers
- render sprites using material samplers

https://github.com/defold/editor2-issues/issues/543

**Still TODO** (in separate issue):

- Set sampler uniforms to the correct texture. This currently works incidentally for everything but models (where we explicitly set the sampler uniforms) because GLSL sampler uniforms seem to default to texture unit 0 if not explicitly set. When multiple samplers are defined in material, we currently just pick the first one. We should do correct matching similar to the other uniforms.