### PR TITLE
DEFEDIT-1048 Prevent Alt key from activating menu bar

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -115,6 +115,7 @@
         scene      (Scene. root)]
     (dialogs/observe-focus stage)
     (updater/install-pending-update-check! stage project)
+    (ui/disable-menu-alt-key-mnemonic! scene)
     (ui/set-main-stage stage)
     (.setScene stage scene)
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -980,6 +980,16 @@
 (defn remove-handle-shortcut-workaround! [^Scene scene handler]
   (.removeEventFilter scene KeyEvent/KEY_PRESSED handler))
 
+(defn disable-menu-alt-key-mnemonic!
+  "On Windows, the bare Alt KEY_PRESSED event causes the input focus to move to the menu bar.
+  This function disables this behavior by consuming any KEY_PRESSED events with the Alt key
+  pressed before they reach the MenuBarSkin event handler."
+  [^Scene scene]
+  (.addEventHandler scene KeyEvent/KEY_PRESSED
+                    (event-handler event
+                                   (when (.isAltDown ^KeyEvent event)
+                                     (.consume ^KeyEvent event)))))
+
 (defn register-menubar [^Scene scene menubar menu-id]
   ;; TODO: See comment below about top-level items. Should be enforced here
  (let [root (.getRoot scene)]


### PR DESCRIPTION
Fixes defold/editor2-issues#1028

### User-facing changes
* The Alt key no longer activates the menu bar on Windows.