### PR TITLE
DEFEDIT-1050 Font fixes

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -55,7 +55,7 @@ public class FontBuilder extends Builder<Void>  {
                 @Override
                 public InputStream getResource(String resourceName)
                         throws FileNotFoundException {
-                    IResource res = curRes.getResource(resourceName);
+                    IResource res = inputFontFile.getResource(resourceName);
                     if (!res.exists()) {
                         throw new FileNotFoundException("Could not find resource: " + res.getPath());
                     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FontBuilder.java
@@ -41,9 +41,8 @@ public class FontBuilder extends Builder<Void>  {
         FontDesc.Builder fontDescbuilder = FontDesc.newBuilder();
         ProtoUtil.merge(task.input(0), fontDescbuilder);
         FontDesc fontDesc = fontDescbuilder.build();
-        final IResource curRes = task.input(0);
 
-        IResource inputFontFile = BuilderUtil.checkResource(this.project, task.input(0), "font", fontDesc.getFont());
+        final IResource inputFontFile = BuilderUtil.checkResource(this.project, task.input(0), "font", fontDesc.getFont());
         BuilderUtil.checkResource(this.project, task.input(0), "material", fontDesc.getMaterial());
 
         Fontc fontc = new Fontc();

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -377,6 +377,20 @@
 (defn- int->bool [val]
   (when (some? val) (if (= val 0) false true)))
 
+(defn- glyph-channels->data-format [^long channels]
+  (case channels
+    1 :gray
+    3 :rgb
+    4 :rgba))
+
+(g/defnk output-format-defold? [font output-format]
+  (let [type (font-type font output-format)]
+    (= type :defold)))
+
+(g/defnk output-format-defold-or-distance-field? [font output-format]
+  (let [type (font-type font output-format)]
+    (or (= type :defold) (= type :distance-field))))
+
 (g/defnode FontNode
   (inherits project/ResourceNode)
 
@@ -408,52 +422,46 @@
                           :ext ["material"]})))
 
   (property size g/Int
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (or (= type :defold) (= type :distance-field)))))
+            (dynamic visible output-format-defold-or-distance-field?)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-zero-or-below? size)))
 
   (property antialias g/Int (dynamic visible (g/constantly false)))
   (property antialiased g/Bool
+            (dynamic visible output-format-defold?)
             (dynamic label (g/constantly "Antialias"))
             (value (g/fnk [antialias] (int->bool antialias)))
             (set (fn [basis self old-value new-value]
                    (g/set-property self :antialias (bool->int new-value)))))
   
   (property alpha g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (= type :defold))))
+            (dynamic visible output-format-defold?)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? alpha))
             (dynamic edit-type (g/constantly alpha-slider-edit-type)))
   (property outline-alpha g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (= type :defold))))
+            (dynamic visible output-format-defold?)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? outline-alpha))
             (dynamic edit-type (g/constantly alpha-slider-edit-type)))
   (property outline-width g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (or (= type :defold) (= type :distance-field)))))
+            (dynamic visible output-format-defold-or-distance-field?)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? outline-width)))
   (property shadow-alpha g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (= type :defold))))
+            (dynamic visible output-format-defold?)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? shadow-alpha))
             (dynamic edit-type (g/constantly alpha-slider-edit-type)))
   (property shadow-blur g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (= type :defold))))
+            (dynamic visible output-format-defold?)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? shadow-blur)))
   (property shadow-x g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (= type :defold)))))
+            (dynamic visible output-format-defold?))
   (property shadow-y g/Num
-            (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                           (= type :defold)))))
-  (property extra-characters g/Str (dynamic visible (g/fnk [font output-format] (let [type (font-type font output-format)]
-                                                                                  (or (= type :defold) (= type :distance-field))))))
+            (dynamic visible output-format-defold?))
+  (property extra-characters g/Str
+            (dynamic visible output-format-defold-or-distance-field?))
   (property output-format g/Keyword
-    (dynamic edit-type (g/constantly (properties/->pb-choicebox Font$FontTextureFormat))))
+            (dynamic edit-type (g/constantly (properties/->pb-choicebox Font$FontTextureFormat))))
 
-  (property all-chars g/Bool)
+  (property all-chars g/Bool
+            (dynamic visible output-format-defold?))
   (property cache-width g/Int
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? cache-width)))
   (property cache-height g/Int
@@ -485,8 +493,9 @@
                                            (when font-map
                                              (let [w (:cache-width font-map)
                                                    h (:cache-height font-map)
-                                                   channels (:glyph-channels font-map)]
-                                               (texture/empty-texture _node-id w h channels
+                                                   channels (:glyph-channels font-map)
+                                                   data-format (glyph-channels->data-format channels)]
+                                               (texture/empty-texture _node-id w h data-format
                                                                       (material/sampler->tex-params (first material-samplers)) 0)))))
   (output material-shader ShaderLifecycle (gu/passthrough material-shader))
   (output type g/Keyword produce-font-type)
@@ -562,7 +571,7 @@
                          (.put src-data)
                          (.flip))]
           (when (> (:glyph-data-size glyph) 0)
-            (texture/tex-sub-image gl texture tgt-data x y w h (:glyph-channels font-map)))))
+            (texture/tex-sub-image gl texture tgt-data x y w h (glyph-channels->data-format (:glyph-channels font-map))))))
       (swap! cache update :free rest)
       cell)))
 

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -320,13 +320,11 @@
                              (remove nil?)
                              (not-empty))]
         (g/error-aggregate errors))
-      (let [project (project/get-project _node-id)
-            workspace (project/workspace project)
-            resolver (partial workspace/resolve-workspace-resource workspace)]
+      (let [resolver (partial workspace/resolve-resource font)]
         (try
           (font-gen/generate pb-msg font resolver)
-          (catch Exception _
-            (g/->error _node-id :font :fatal font "Failed to generate bitmap from Font. Unsupported format?"))))))
+          (catch Exception error
+            (g/->error _node-id :font :fatal font (str "Failed to generate bitmap from Font. " (.getMessage error))))))))
 
 (defn- build-font [_self _basis resource dep-resources user-data]
   (let [font-map (assoc (:font-map user-data) :textures [(resource/proj-path (second (first dep-resources)))])]

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -77,29 +77,44 @@
    :wrap-s     gl/clamp
    :wrap-t     gl/clamp})
 
-(defn- channels->internal-format [^long channels]
-  (case channels
-    1 GL2/GL_LUMINANCE
-    3 GL2/GL_RGB
-    4 GL2/GL_RGBA))
+(defn- data-format->internal-format [data-format]
+  ;; Internal format signifies only color content, not channel order.
+  (case data-format
+    :gray GL2/GL_LUMINANCE
+    :bgr  GL2/GL_RGB
+    :abgr GL2/GL_RGBA
+    :rgb  GL2/GL_RGB
+    :rgba GL2/GL_RGBA))
 
-(defn- channels->pixel-format [^long channels]
-  (case channels
-    1 GL2/GL_LUMINANCE
-    3 GL2/GL_BGR
-    4 GL2/GL_RGBA))
+(defn- data-format->pixel-format [data-format]
+  ;; Pixel format signifies channel order.
+  (case data-format
+    :gray GL2/GL_LUMINANCE
+    :bgr  GL2/GL_BGR
+    :abgr GL2/GL_RGBA ;; There is no GL_ABGR, so this is swizzled into ABGR by the GL_UNSIGNED_INT_8_8_8_8 type returned by data-format->type.
+    :rgb  GL2/GL_RGB
+    :rgba GL2/GL_RGBA))
 
-(defn- channels->type [^long channels]
-  (case channels
-    1 GL2/GL_UNSIGNED_BYTE
-    3 GL2/GL_UNSIGNED_BYTE
-    4 GL2/GL_UNSIGNED_INT_8_8_8_8))
+(defn- data-format->type [data-format]
+  ;; Type signifies packing / endian order.
+  (case data-format
+    :gray GL2/GL_UNSIGNED_BYTE
+    :bgr  GL2/GL_UNSIGNED_BYTE
+    :abgr GL2/GL_UNSIGNED_INT_8_8_8_8
+    :rgb  GL2/GL_UNSIGNED_BYTE
+    :rgba GL2/GL_UNSIGNED_BYTE))
 
-(defn- ->texture-data [width height channels data mipmap]
-  (let [internal-format (channels->internal-format channels)
-        pixel-format (channels->pixel-format channels)
-        _ (assert internal-format (format "Invalid channel count %d" channels))
-        type (channels->type channels)
+(defn- image-type->data-format [^long image-type]
+  (condp = image-type
+    BufferedImage/TYPE_BYTE_GRAY :gray
+    BufferedImage/TYPE_3BYTE_BGR :bgr
+    BufferedImage/TYPE_4BYTE_ABGR :abgr
+    BufferedImage/TYPE_4BYTE_ABGR_PRE :abgr))
+
+(defn- ->texture-data [width height data-format data mipmap]
+  (let [internal-format (data-format->internal-format data-format)
+        pixel-format (data-format->pixel-format data-format)
+        type (data-format->type data-format)
         border 0]
     (TextureData. (GLProfile/getGL2GL3) internal-format width height border pixel-format type mipmap false false data nil)))
 
@@ -110,8 +125,9 @@
                3 BufferedImage/TYPE_3BYTE_BGR
                1 BufferedImage/TYPE_BYTE_GRAY)
         img (image/image-convert-type img type)
+        data-type (image-type->data-format type)
         data (ByteBuffer/wrap (.getData ^DataBufferByte (.getDataBuffer (.getRaster img))))]
-    (->texture-data (.getWidth img) (.getHeight img) channels data mipmap)))
+    (->texture-data (.getWidth img) (.getHeight img) data-type data mipmap)))
 
 (defn- flip-y [^BufferedImage img]
   ;; Flip the image before we create a OGL texture, to mimic how UVs are handled in engine.
@@ -143,17 +159,17 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
           unit (+ unit-index GL2/GL_TEXTURE0)]
       (->TextureLifecycle request-id ::texture unit params texture-data))))
 
-(defn empty-texture [request-id width height channels params unit-index]
+(defn empty-texture [request-id width height data-format params unit-index]
   (let [unit (+ unit-index GL2/GL_TEXTURE0)]
-    (->TextureLifecycle request-id ::texture unit params (->texture-data width height channels nil false))))
+    (->TextureLifecycle request-id ::texture unit params (->texture-data width height data-format nil false))))
 
 (def white-pixel (image-texture ::white (-> (image/blank-image 1 1) (image/flood 1.0 1.0 1.0)) (assoc default-image-texture-params
                                                                                              :min-filter GL2/GL_NEAREST
                                                                                              :mag-filter GL2/GL_NEAREST)))
 
-(defn tex-sub-image [^GL2 gl ^TextureLifecycle texture data x y w h channels]
+(defn tex-sub-image [^GL2 gl ^TextureLifecycle texture data x y w h data-format]
   (let [tex (->texture texture gl)
-        data (->texture-data w h channels data false)]
+        data (->texture-data w h data-format data false)]
     (.updateSubImage tex gl data 0 x y)))
 
 (def default-cubemap-texture-params

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -13,7 +13,7 @@
   (:import [editor.types Rect Image]
            [java.awt Color]
            [java.awt.image BufferedImage]
-           [javax.imageio ImageIO ImageReader ImageTypeSpecifier]))
+           [javax.imageio ImageIO]))
 
 (set! *warn-on-reflection* true)
 
@@ -26,20 +26,21 @@
                                            :compression-level :fast}]
                                 :mipmaps true}]})
 
+(defn- convert-to-abgr
+  [^BufferedImage image]
+  (let [type (.getType image)]
+    (if (= type BufferedImage/TYPE_4BYTE_ABGR)
+      image
+      (let [abgr-image (BufferedImage. (.getWidth image) (.getHeight image) BufferedImage/TYPE_4BYTE_ABGR)]
+        (doto (.createGraphics abgr-image)
+          (.drawImage image 0 0 nil)
+          (.dispose))
+        abgr-image))))
+
 (defn read-image
-  ^BufferedImage [source]
-  (with-open [source-stream (io/input-stream source)
-              image-stream (ImageIO/createImageInputStream source-stream)]
-    (let [readers (ImageIO/getImageReaders image-stream)]
-      (when (.hasNext readers)
-        (let [^ImageReader reader (.next readers)]
-          (try
-            (.setInput reader image-stream true true)
-            (.read reader 0
-                   (doto (.getDefaultReadParam reader)
-                     (.setDestinationType (ImageTypeSpecifier/createFromBufferedImageType BufferedImage/TYPE_4BYTE_ABGR))))
-            (finally
-              (.dispose reader))))))))
+  [source]
+  (with-open [source-stream (io/input-stream source)]
+    (convert-to-abgr (ImageIO/read source-stream))))
 
 (defn- read-size
   [source]
@@ -54,6 +55,7 @@
              :height (.getHeight reader 0)}
             (finally
               (.dispose reader))))))))
+
 
 (defn- build-texture [self basis resource dep-resources user-data]
   {:resource resource :content (tex-gen/->bytes (:image user-data) test-profile)})

--- a/editor/src/clj/editor/pipeline/font_gen.clj
+++ b/editor/src/clj/editor/pipeline/font_gen.clj
@@ -13,7 +13,7 @@
           font-map-builder (Font$FontMap/newBuilder)
           font-res-resolver (reify Fontc$FontResourceResolver
                               (getResource [this resource-name]
-                                (io/input-stream (resolver (str "/" resource-name)))))]
+                                (io/input-stream (resolver resource-name))))]
       (with-open [font-stream (io/input-stream font-path)]
         (let [^Font$FontMap font-map (-> (doto (Fontc.)
                                            (.compile font-stream font-desc false font-res-resolver))


### PR DESCRIPTION
Fixes defold/editor2-issues#371
Fixes defold/editor2-issues#867
Possibly fixes defold/editor2-issues#830

### User-facing changes
* Relative references to files from BMFonts are now supported in both the new and the old editor.
* You can now use BMFonts in the new editor.
* Some properties are now hidden when they do not make sense for the current Font type.
* Outlined Fonts now render correctly in the Scene View.
* Improved error messages when trying to use unsupported font formats.

### Technical changes
* The `read-image` function now performs ABGR conversion at read-time.
* Texture-related functions that used to take a `channels` numeric argument now take a `data-format` argument instead. This is expected to be a keyword in the format `:rgb`, `:rgba`, `:bgr`, `:abgr`, etc.