### PR TITLE
DEFEDIT-1058 Name added components after source files

### DIFF
--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -28,11 +28,8 @@
 (defn- prefix-animation-id [prefix animation]
   (update animation :id (fn [id] (string/join "/" (filter not-empty [prefix id])))))
 
-(defn- base-name [resource]
-  (-> resource resource/proj-path FilenameUtils/getBaseName))
-
 (defn- merge-animations [merged-animations animations resource]
-  (let [prefix-animation-id (partial prefix-animation-id (base-name resource))]
+  (let [prefix-animation-id (partial prefix-animation-id (resource/base-name resource))]
     (into merged-animations (map prefix-animation-id) animations)))
 
 (defn- merge-bone-list [merged-bone-list bone-list]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -599,7 +599,7 @@
 
 (defn add-game-object-file [coll-node parent resource select-fn]
   (let [project (project/get-project coll-node)
-        base (FilenameUtils/getBaseName (resource/resource-name resource))
+        base (resource/base-name resource)
         id (gen-instance-id coll-node base)
         op-seq (gensym)
         [go-node] (g/tx-nodes-added
@@ -700,7 +700,7 @@
          (let [ext           "collection"
                resource-type (workspace/get-resource-type workspace ext)]
            (when-let [resource (first (dialogs/make-resource-dialog workspace project {:ext ext :title "Select Collection File"}))]
-             (let [base (FilenameUtils/getBaseName (resource/resource-name resource))
+             (let [base (resource/base-name resource)
                    id (gen-instance-id coll-node base)
                    op-seq (gensym)
                    [coll-inst-node] (g/tx-nodes-added

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -427,7 +427,7 @@
                     (select-fn [comp-node])))))
 
 (defn add-component-file [go-id resource select-fn]
-  (let [id (gen-component-id go-id (:ext (resource/resource-type resource)))]
+  (let [id (gen-component-id go-id (resource/base-name resource))]
     (g/transact
       (concat
         (g/operation-label "Add Component")

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1939,7 +1939,7 @@
   (seq (dialogs/make-resource-dialog (project/workspace project) project {:ext exts :title title :selection :multiple})))
 
 (defn- resource->id [resource]
-  (FilenameUtils/getBaseName ^String (resource/resource-name resource)))
+  (resource/base-name resource))
 
 (defn add-gui-node! [project scene parent node-type select-fn]
   (let [id (outline/resolve-id (subs (name node-type) 5) (keys (g/node-value scene :node-ids)))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -240,6 +240,9 @@
 (g/defnode ResourceNode
   (extern resource Resource (dynamic visible (g/constantly false))))
 
+(defn base-name ^String [resource]
+  (FilenameUtils/getBaseName (resource-name resource)))
+
 (defn- seq-children [resource]
   (seq (children resource)))
 


### PR DESCRIPTION
Implements defold/editor2-issues#249

### User-facing changes
* Components added from files are now named after the source file by default, just like Game Objects and Collections already are.

### Technical changes
* Added `resource/base-name` utility function and updated usages.