### PR TITLE
DEFEDIT-1064 Color icons in New Asset context menu

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -413,6 +413,7 @@
              (let [resource-types (filter (fn [rt] (workspace/template rt)) (workspace/get-resource-types workspace))]
                (sort-by (fn [rt] (string/lower-case (:label rt))) (map (fn [res-type] {:label (or (:label res-type) (:ext res-type))
                                                                                        :icon (:icon res-type)
+                                                                                       :style (resource/ext-style-classes (:ext res-type))
                                                                                        :command :new-file
                                                                                        :user-data {:resource-type res-type}}) resource-types))))))
 

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -281,8 +281,13 @@
            :folder "resource-folder"
            nil)]))
 
+(defn ext-style-classes [resource-ext]
+  (assert (or (nil? resource-ext) (string? resource-ext)))
+  (if-some [ext (not-empty resource-ext)]
+    #{"resource" (str "resource-ext-" ext)}
+    #{"resource"}))
+
 (defn filter-resources [resources query]
   (let [file-system ^FileSystem (FileSystems/getDefault)
         matcher (.getPathMatcher file-system (str "glob:" query))]
     (filter (fn [r] (let [path (.getPath file-system (path r) (into-array String []))] (.matches matcher path))) resources)))
-

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -90,8 +90,8 @@ $script-intellisense:   #00FFFF;
 /* File extension group colors */
 $folder:                #6b7b8b;
 $folder-active:         #a2b0be;
-$unknown-file:          #606367;
-$unknown-file-active:   #8f9296;
+$unknown-file:          #6b7b8b;
+$unknown-file-active:   #a2b0be;
 $design-file:           #325c7e;
 $design-file-active:    #4cb1ff;
 $script-file:           #7c7e37;

--- a/editor/styling/stylesheets/mixins/_file-extensions.scss
+++ b/editor/styling/stylesheets/mixins/_file-extensions.scss
@@ -2,20 +2,28 @@
     .image-view {
         @include colorize-image-view($color);  
     }
-    &:selected, &:hover {
-        @if($element == "tab") {
-            .tab-container {
-                .tab-label {
-                    .image-view {
-                        @include colorize-image-view($active-color);  
+    @if($element == "menu") {
+        &:focused {
+            .image-view {
+                @include colorize-image-view($active-color);
+            }
+        }
+    } @else {
+        &:selected, &:hover {
+            @if($element == "tab") {
+                .tab-container {
+                    .tab-label {
+                        .image-view {
+                            @include colorize-image-view($active-color);
+                        }
                     }
                 }
+            } @else {
+                .image-view {
+                    @include colorize-image-view($active-color);
+                }
             }
-        } @else {
-            .image-view {
-                @include colorize-image-view($active-color);  
-            }
-        } 
+        }
     }
 }
 
@@ -45,6 +53,7 @@
         }
 
         /* Property container files */
+        &animationset,
         &camera, &collectionfactory, &collectionproxy,
         &display_profiles, &factory,
         &gamepads, &input_binding, &material, &project,

--- a/editor/styling/stylesheets/mixins/_menu-elements.scss
+++ b/editor/styling/stylesheets/mixins/_menu-elements.scss
@@ -22,12 +22,6 @@
             }
         }
 
-        &:hover {
-            -fx-background-color: $menu-background-hover;
-            > .label {
-                -fx-text-fill: $menu-foreground-hover;
-            }
-        }
         &:focused {
             -fx-background-color: $menu-background-hover;
             > .label {
@@ -37,6 +31,9 @@
                 @include effect-lighten-blue();
             }
         }
+
+        // Generate css for file extensions
+        @include extensions(menu);
     }
 
     .separator {


### PR DESCRIPTION
Implements defold/editor2-issues#654

### User-facing changes
* Icons in New Asset context menu are now colored by resource type.

### Technical changes
* It is now possible to specify style classes for menu items by supplying a set of strings with the `:style` key.

![menu-icon-colors](https://user-images.githubusercontent.com/22448941/27697182-d19a6e3c-5cf3-11e7-847b-5e5ae0e7d8f4.png)