### PR TITLE
DEFEDIT-1067 View for html/markdown documents

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -47,6 +47,8 @@
                      [com.defold.lib/bob                          "1.0"]
                      [com.defold.lib/openmali                     "1.0"]
 
+                     [com.atlassian.commonmark/commonmark         "0.9.0"]
+
                      [amazonica                                   "0.3.79"
                       :exclusions [com.amazonaws/aws-java-sdk com.amazonaws/amazon-kinesis-client]]
                      [com.amazonaws/aws-java-sdk-core             "1.11.63"]

--- a/editor/resources/markdown.css
+++ b/editor/resources/markdown.css
@@ -1,0 +1,19 @@
+body {
+    color: #dddddd;
+    background-color: #292c30;
+    font-family: "Source Sans Pro", Arial, Helvetica, san-serif;
+}
+
+h1 {
+
+}
+
+a {
+    color: #0084ff;
+}
+
+code, pre {
+    font-family: "Dejavu Sans Mono";
+    padding: 1em;
+    background-color: #232529;
+}

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -15,6 +15,7 @@
             [editor.graph-view :as graph-view]
             [editor.hot-reload :as hot-reload]
             [editor.login :as login]
+            [editor.html-view :as html-view]
             [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.progress :as progress]
@@ -66,7 +67,8 @@
         (text/register-view-types workspace)
         (code-view/register-view-types workspace)
         (scene/register-view-types workspace)
-        (form-view/register-view-types workspace)))
+        (form-view/register-view-types workspace)
+        (html-view/register-view-types workspace)))
     (resource-types/register-resource-types! workspace)
     (workspace/resource-sync! workspace)
     workspace))

--- a/editor/src/clj/editor/html.clj
+++ b/editor/src/clj/editor/html.clj
@@ -7,7 +7,7 @@
 (g/defnode HtmlNode
   (inherits project/ResourceNode)
 
-  (output html g/Str (g/fnk [resource] (slurp resource))))
+  (output html g/Str (g/fnk [resource] (slurp resource :encoding "UTF-8"))))
 
 (defn register-resource-types
   [workspace]

--- a/editor/src/clj/editor/html.clj
+++ b/editor/src/clj/editor/html.clj
@@ -1,0 +1,20 @@
+(ns editor.html
+  (:require
+   [dynamo.graph :as g]
+   [editor.defold-project :as project]
+   [editor.workspace :as workspace]))
+
+(g/defnode HtmlNode
+  (inherits project/ResourceNode)
+
+  (output html g/Str (g/fnk [resource] (slurp resource))))
+
+(defn register-resource-types
+  [workspace]
+  (workspace/register-resource-type workspace
+                                    :ext "html"
+                                    :label "HTML"
+                                    :node-type HtmlNode
+                                    :view-types [:html]
+                                    :view-opts nil))
+

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -1,0 +1,204 @@
+(ns editor.html-view
+  (:require
+   [clojure.core.protocols :as p]
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [dynamo.graph :as g]
+   [editor.defold-project :as project]
+   [editor.dialogs :as dialogs]
+   [editor.handler :as handler]
+   [editor.resource :as resource]
+   [editor.ui :as ui]
+   [editor.view :as view]
+   [editor.workspace :as workspace])
+  (:import
+   (java.net URI URLDecoder)
+   (javafx.scene Node Parent)
+   (javafx.scene.layout GridPane Priority ColumnConstraints)
+   (javafx.scene.web WebEngine WebView)
+   (javafx.concurrent Worker Worker$State)
+   (org.w3c.dom Document Element NodeList)
+   (org.w3c.dom.events Event EventListener EventTarget)))
+
+(set! *warn-on-reflection* true)
+
+
+;; make NodeList reducible
+
+(extend-protocol p/CollReduce
+  NodeList
+  (coll-reduce
+    ([coll f]
+     (let [n (.getLength coll)]
+       (if (zero? n)
+         (f)
+         (loop [ret nil
+                i 0]
+           (if (< i n)
+             (let [ret (f ret (.item coll i))]
+             (if (reduced? ret)
+               @ret
+               (recur ret (inc i)))))))))
+    ([coll f val]
+     (let [n (.getLength coll)]
+       (loop [ret val
+              i 0]
+         (if (< i n)
+           (let [ret (f ret (.item coll i))]
+             (if (reduced? ret)
+               @ret
+               (recur ret (inc i))))))))))
+
+(defn- update-attribute!
+  [^Element elem attr f & args]
+  (when-some [v (.getAttribute elem attr)]
+    (.setAttribute elem attr (apply f v args))))
+
+
+;;--------------------------------------------------------------------
+;; view
+
+(defn- query-params->map
+  [params]
+  (when (not (string/blank? params))
+    (into {}
+          (map (fn [param]
+                 (let [[k v] (string/split param #"=")]
+                   [(keyword k) (URLDecoder/decode v "UTF-8")])))
+          (string/split params #"&"))))
+
+(defmulti url->command (fn [^URI uri dispatch-args] (.getHost uri)))
+
+(defmethod url->command "open"
+  [^URI uri {:keys [project]}]
+  (let [params (query-params->map (.getQuery uri))
+        proj-path (:path params)
+        resource-id (project/get-resource-node project proj-path)
+        resource (g/node-value resource-id :resource)]
+    {:command   :open
+     :user-data {:resources [resource]}}))
+
+(defmethod url->command :default
+  [^URI uri _]
+  {:command (keyword (.getHost uri))})
+
+(defn dispatch-url
+  [project ^URI uri]
+  (when-some [{:keys [command user-data]} (url->command uri {:project project})]
+    (when-let [handler-ctx (handler/active command (ui/contexts (.getScene (ui/main-stage))) user-data)]
+      (when (handler/enabled? handler-ctx)
+        (handler/run handler-ctx)))))
+
+(defn- handle-click
+  [project ^Event ev]
+  (let [^Element target (.getTarget ev)
+        uri (URI. (.getAttribute target "href"))]
+    (dispatch-url project uri)))
+
+(defn- hijack-defold-links
+  [^Document doc project]
+  (let [links (.getElementsByTagName doc "a")
+        handler (reify EventListener
+                  (handleEvent [this ev]
+                    (handle-click project ev)
+                    (.preventDefault ev)))]
+    (run! (fn [^Element item]
+            (try
+              (let [href (URI. (.getAttribute item "href"))]
+                (when (= "defold" (.getScheme href))
+                  (.addEventListener ^EventTarget item "click" handler true)))
+              (catch java.net.URISyntaxException e)))
+          links)))
+
+(defn- on-load-succeeded
+  [^WebEngine web-engine project]
+  (when-some [doc (.getDocument web-engine)]
+    (doto doc
+      (hijack-defold-links project))))
+
+(defn- on-load-failed
+  [^WebEngine web-engine]
+  (let [load-worker (.getLoadWorker web-engine)]
+    (when-some [ex (.getException load-worker)]
+      (dialogs/make-alert-dialog (str (.getMessage load-worker)
+                                      ": "
+                                      (.getMessage ex))))))
+
+(defn- inject-base-url
+  [html html-resource]
+  ;; NOTE: This is a slight hack to enable project-directory relative
+  ;; URLs in the html. By adding a <base> tag to head, with a href of
+  ;; the directory of the resource being displayed, any relative link
+  ;; in document (img src, link href etc) will be resolved using this
+  ;; base href. This allows us to easily reference resource in project
+  ;; from html.
+  (let [base-url (str "file://" (resource/parent-proj-path (resource/abs-path html-resource)) "/")]
+    (string/replace-first html #"\<head\>"
+                          (format "<head><base href=\"%s\"/>" base-url))))
+
+(g/defnk produce-html
+  [html html-resource]
+  (if (and html html-resource)
+    (inject-base-url html html-resource)
+    html))
+
+(g/defnk update-web-view
+  [html ^WebView web-view]
+  (doto (.getEngine web-view)
+    (.setUserStyleSheetLocation (str (io/resource "markdown.css")))
+    (.loadContent html)))
+
+(g/defnode WebViewNode
+  (inherits view/WorkbenchView)
+
+  (input html g/Any)
+  (input html-resource g/Any)
+
+  (property web-view WebView)
+
+  (output html g/Any :cached produce-html)
+  (output refresh g/Any :cached update-web-view))
+
+(defn- make-web-view
+  [project]
+  (let [web-view (WebView.)
+        web-engine (.getEngine web-view)
+        load-worker (.getLoadWorker web-engine)]
+    (ui/observe (.stateProperty load-worker)
+                (fn [_ old new]
+                  (condp = new
+                    Worker$State/SUCCEEDED (on-load-succeeded web-engine project)
+                    Worker$State/FAILED (on-load-failed web-engine)
+                    nil)))
+    web-view))
+
+(defn make-view
+  [graph ^Parent parent html-node opts]
+  (let [project (or (:project opts)
+                    (project/get-project html-node))
+        web-view (make-web-view project)
+        view-id (g/make-node! graph WebViewNode :web-view web-view)
+        repainter (ui/->timer 1 "update-web-view" (fn [_ dt] (g/node-value view-id :refresh)))]
+    (ui/children! parent [web-view])
+    (ui/fill-control web-view)
+    (g/transact
+      (concat
+        (g/connect html-node :html view-id :html)
+        (g/connect html-node :resource view-id :html-resource)))
+    (g/node-value view-id :refresh)
+    (ui/timer-start! repainter)
+    (when-some [^Tab tab (:tab opts)]
+      (ui/timer-stop-on-closed! tab repainter))
+    view-id))
+
+(defn register-view-types [workspace]
+  (workspace/register-view-type workspace
+                                :id :html
+                                :label "Web"
+                                :make-view-fn make-view))
+
+(comment
+
+  (ui/run-later (g/transact (register-view-types 0)))
+
+  )

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -36,9 +36,10 @@
                 i 0]
            (if (< i n)
              (let [ret (f ret (.item coll i))]
-             (if (reduced? ret)
-               @ret
-               (recur ret (inc i)))))))))
+               (if (reduced? ret)
+                 @ret
+                 (recur ret (inc i))))
+             ret)))))
     ([coll f val]
      (let [n (.getLength coll)]
        (loop [ret val
@@ -47,7 +48,8 @@
            (let [ret (f ret (.item coll i))]
              (if (reduced? ret)
                @ret
-               (recur ret (inc i))))))))))
+               (recur ret (inc i))))
+           ret))))))
 
 (defn- update-attribute!
   [^Element elem attr f & args]

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -73,7 +73,7 @@
   (output html g/Str (g/fnk [_node-id resource]
                        (str "<!DOCTYPE html>"
                             "<html><head></head><body>"
-                            (markdown->html (slurp resource)
+                            (markdown->html (slurp resource :encoding "UTF-8")
                                             #_(make-visitor (project/get-project _node-id)))
                             "</body></html>"))))
 

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -1,0 +1,87 @@
+(ns editor.markdown
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [dynamo.graph :as g]
+   [editor.defold-project :as project]
+   [editor.handler :as handler]
+   [editor.resource :as resource]
+   [editor.ui :as ui]
+   [editor.view :as view]
+   [editor.workspace :as workspace])
+  (:import
+   (org.commonmark Extension)
+   (org.commonmark.node CustomBlock FencedCodeBlock Link Visitor)
+   (org.commonmark.parser Parser Parser$Builder Parser$ParserExtension)
+   (org.commonmark.renderer.html HtmlRenderer)))
+
+(defn- process-defold-code-block
+  [^FencedCodeBlock node project]
+  (let [info (.getInfo node)]
+    (when (.startsWith info "defold")
+      (let [proj-path (string/trim (.getLiteral node))
+            resource (workspace/find-resource (project/workspace project) proj-path)]
+        (.setLiteral node (slurp resource))))))
+
+(defn- make-visitor
+  [project]
+  (letfn [(visit-children [^Visitor visitor ^org.commonmark.node.Node parent]
+            (loop [node (.getFirstChild parent)]
+              (when node
+                (let [next (.getNext node)]
+                  (.accept node visitor)
+                  (recur next)))))]
+    (reify Visitor
+      (^void visit [this ^org.commonmark.node.BlockQuote node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.BulletList node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Code node] (visit-children node))
+      (^void visit [this ^org.commonmark.node.CustomBlock node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.CustomNode node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Document node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Emphasis node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.FencedCodeBlock node]
+       (process-defold-code-block node project)
+       (visit-children this node))
+      (^void visit [this ^org.commonmark.node.HardLineBreak node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Heading node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.HtmlBlock node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.HtmlInline node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Image node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.IndentedCodeBlock node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Link node] (visit-children this node))      
+      (^void visit [this ^org.commonmark.node.ListItem node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.OrderedList node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Paragraph node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.SoftLineBreak node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.StrongEmphasis node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.Text node] (visit-children this node))
+      (^void visit [this ^org.commonmark.node.ThematicBreak node] (visit-children this node)))))
+
+(defn markdown->html
+  ([markdown]
+   (markdown->html markdown nil))
+  ([markdown visitor]
+   (let [parser (.build (Parser/builder))
+         doc (.parse parser markdown)
+         renderer (.build (HtmlRenderer/builder))]
+     (when visitor (.accept doc visitor))
+     (.render renderer doc))))
+
+(g/defnode MarkdownNode
+  (inherits project/ResourceNode)
+
+  (output html g/Str (g/fnk [_node-id resource]
+                       (str "<!DOCTYPE html>"
+                            "<html><head></head><body>"
+                            (markdown->html (slurp resource)
+                                            #_(make-visitor (project/get-project _node-id)))
+                            "</body></html>"))))
+
+(defn register-resource-types
+  [workspace]
+  (workspace/register-resource-type workspace
+                                    :ext "md"
+                                    :label "Markdown"
+                                    :node-type MarkdownNode
+                                    :view-types [:html]
+                                    :view-opts nil))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -10,62 +10,15 @@
    [editor.view :as view]
    [editor.workspace :as workspace])
   (:import
-   (org.commonmark Extension)
-   (org.commonmark.node CustomBlock FencedCodeBlock Link Visitor)
    (org.commonmark.parser Parser Parser$Builder Parser$ParserExtension)
    (org.commonmark.renderer.html HtmlRenderer)))
 
-(defn- process-defold-code-block
-  [^FencedCodeBlock node project]
-  (let [info (.getInfo node)]
-    (when (.startsWith info "defold")
-      (let [proj-path (string/trim (.getLiteral node))
-            resource (workspace/find-resource (project/workspace project) proj-path)]
-        (.setLiteral node (slurp resource))))))
-
-(defn- make-visitor
-  [project]
-  (letfn [(visit-children [^Visitor visitor ^org.commonmark.node.Node parent]
-            (loop [node (.getFirstChild parent)]
-              (when node
-                (let [next (.getNext node)]
-                  (.accept node visitor)
-                  (recur next)))))]
-    (reify Visitor
-      (^void visit [this ^org.commonmark.node.BlockQuote node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.BulletList node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Code node] (visit-children node))
-      (^void visit [this ^org.commonmark.node.CustomBlock node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.CustomNode node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Document node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Emphasis node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.FencedCodeBlock node]
-       (process-defold-code-block node project)
-       (visit-children this node))
-      (^void visit [this ^org.commonmark.node.HardLineBreak node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Heading node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.HtmlBlock node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.HtmlInline node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Image node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.IndentedCodeBlock node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Link node] (visit-children this node))      
-      (^void visit [this ^org.commonmark.node.ListItem node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.OrderedList node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Paragraph node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.SoftLineBreak node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.StrongEmphasis node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.Text node] (visit-children this node))
-      (^void visit [this ^org.commonmark.node.ThematicBreak node] (visit-children this node)))))
-
 (defn markdown->html
-  ([markdown]
-   (markdown->html markdown nil))
-  ([markdown visitor]
-   (let [parser (.build (Parser/builder))
-         doc (.parse parser markdown)
-         renderer (.build (HtmlRenderer/builder))]
-     (when visitor (.accept doc visitor))
-     (.render renderer doc))))
+  [markdown]
+  (let [parser (.build (Parser/builder))
+        doc (.parse parser markdown)
+        renderer (.build (HtmlRenderer/builder))]
+    (.render renderer doc)))
 
 (g/defnode MarkdownNode
   (inherits project/ResourceNode)
@@ -73,8 +26,7 @@
   (output html g/Str (g/fnk [_node-id resource]
                        (str "<!DOCTYPE html>"
                             "<html><head></head><body>"
-                            (markdown->html (slurp resource :encoding "UTF-8")
-                                            #_(make-visitor (project/get-project _node-id)))
+                            (markdown->html (slurp resource :encoding "UTF-8"))
                             "</body></html>"))))
 
 (defn register-resource-types

--- a/editor/src/clj/editor/resource_types.clj
+++ b/editor/src/clj/editor/resource_types.clj
@@ -15,10 +15,12 @@
             [editor.game-project :as game-project]
             [editor.gl.shader :as shader]
             [editor.gui :as gui]
+            [editor.html :as html]
             [editor.image :as image]
             [editor.json :as json]
             [editor.label :as label]
             [editor.live-update-settings :as live-update-settings]
+            [editor.markdown :as markdown]
             [editor.material :as material]
             [editor.model :as model]
             [editor.particlefx :as particlefx]
@@ -50,10 +52,12 @@
       (game-object/register-resource-types workspace)
       (game-project/register-resource-types workspace)
       (gui/register-resource-types workspace)
+      (html/register-resource-types workspace)
       (image/register-resource-types workspace)
       (json/register-resource-types workspace)
       (label/register-resource-types workspace)
       (live-update-settings/register-resource-types workspace)
+      (markdown/register-resource-types workspace)
       (material/register-resource-types workspace)
       (model/register-resource-types workspace)
       (particlefx/register-resource-types workspace)


### PR DESCRIPTION
We can now display HTML/Markdown documents directly in editor.

- support project-relative URLs to images, stylesheets etc. ie. if you have an HTML-document in `/docs/index.html` you can reference images in `/assets/images` like so: `<img src="../assets/images/gurka.png" />`.
- initial, limited support for "editor" URLs, ie. URLs with scheme `defold://`. For example:
  - `defold://open?path=/main/main.collection` will open main.collection
  - `defold://build` will build and run project.

