### PR TITLE
DEFEDIT-1037 Building when a build is already in progress

### DIFF
--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -1,27 +1,24 @@
 (ns editor.engine
   (:require [clojure.java.io :as io]
-            [dynamo.graph :as g]
             [editor.prefs :as prefs]
             [editor.dialogs :as dialogs]
             [editor.error-reporting :as error-reporting]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
-            [editor.console :as console]
             [editor.ui :as ui]
-            [editor.targets :as targets]
             [editor.defold-project :as project]
             [editor.workspace :as workspace]
             [editor.engine.native-extensions :as native-extensions])
   (:import [com.defold.editor Platform]
            [java.net HttpURLConnection InetSocketAddress Socket URI URL]
-           [java.io BufferedReader File InputStream IOException]
+           [java.io BufferedReader File InputStream ByteArrayOutputStream IOException]
+           [java.nio.charset Charset StandardCharsets]
            [java.lang Process ProcessBuilder]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:const timeout 2000)
-(defonce engine-input-stream (atom nil))
-(defonce shutdown-hook (atom nil))
+(def ^:const engine-ports-output-timeout 3000)
 
 (defn- get-connection [^URL url]
   (doto ^HttpURLConnection (.openConnection url)
@@ -31,98 +28,92 @@
     (.setDoOutput true)
     (.setRequestMethod "POST")))
 
+(defn- ignore-all-output [^InputStream is]
+  (try
+    (while (not= -1 (.read is))
+      (Thread/sleep 10))
+    (catch IOException _
+      ;; For instance socket closed because engine was killed
+      nil)))
+
 (defn reload-resource [target resource]
   (let [url  (URL. (str target "/post/@resource/reload"))
         conn ^HttpURLConnection (get-connection url)]
     (try
-      (let [os (.getOutputStream conn)]
+      (with-open [os (.getOutputStream conn)]
         (.write os ^bytes (protobuf/map->bytes
-                           com.dynamo.resource.proto.Resource$Reload
-                           {:resource (str (resource/proj-path resource) "c")}))
-        (.close os))
-      (let [is (.getInputStream conn)]
-        (while (not= -1 (.read is))
-          (Thread/sleep 10))
-        (.close is))
+                            com.dynamo.resource.proto.Resource$Reload
+                            {:resource (str (resource/proj-path resource) "c")})))
+      (with-open [is (.getInputStream conn)]
+        (ignore-all-output is))
       (catch Exception e
         (ui/run-later (dialogs/make-alert-dialog (str "Error connecting to engine on " target))))
       (finally
         (.disconnect conn)))))
 
-(defn- swap-engine-input-stream! [new-input-stream]
-  (swap! engine-input-stream (fn [^InputStream is new-is]
-                               (when is (.close is))
-                               new-is)
-    new-input-stream))
-
-(defn- pump-output [^InputStream is]
-  (swap-engine-input-stream! is)
-  (let [buf (byte-array 1024)]
-    (try
-      (loop []
-        (let [n (.read is buf)]
-          (when (> n -1)
-            (let [msg (String. buf 0 n)]
-              (console/append-console-message! msg)
-              (Thread/sleep 10)
-              (recur)))))
-      (catch IOException _
-        ;; Losing the log connection is ok and even expected
-        nil))))
-
 (defn reboot [target local-url]
   (let [url  (URL. (format "%s/post/@system/reboot" (:url target)))
         conn ^HttpURLConnection (get-connection url)]
     (try
-      (swap-engine-input-stream! nil)
-      (let [os  (.getOutputStream conn)]
+      (with-open [os  (.getOutputStream conn)]
         (.write os ^bytes (protobuf/map->bytes
-                           com.dynamo.engine.proto.Engine$Reboot
-                           {:arg1 (str "--config=resource.uri=" local-url)
-                            :arg2 (str local-url "/game.projectc")}))
-        (.close os))
-      (let [is (.getInputStream conn)]
-        (while (not= -1 (.read is))
-          (Thread/sleep 10))
-        (.close is)
-        (.disconnect conn)
-        (.start (Thread. (fn []
-                           ;; We try our best to connect to logging, fail without retry if we couldn't
-                           (try
-                             (let [port (Integer/parseInt (:log-port target))
-                                   socket-addr (InetSocketAddress. ^String (:address target) port)]
-                               (with-open [socket (doto (Socket.)
-                                                    (.setSoTimeout timeout)
-                                                    (.connect socket-addr timeout))]
-                                 (let [is (.getInputStream socket)
-                                       status (-> ^BufferedReader (io/reader is)
-                                                (.readLine))]
-                                   ;; The '0 OK' string is part of the log service protocol
-                                   (if (= "0 OK" status)
-                                     (do
-                                       (console/append-console-message! (format "[Running on target '%s' (%s)]\n" (:name target) (:address target)))
-                                       ;; Setting to 0 means wait indefinitely for new data
-                                       (.setSoTimeout socket 0)
-                                       (pump-output is))))))
-                             (catch Exception e
-                               (error-reporting/report-exception! e))))))
-        :ok)
+                            com.dynamo.engine.proto.Engine$Reboot
+                            {:arg1 (str "--config=resource.uri=" local-url)
+                             :arg2 (str local-url "/game.projectc")})))
+      (with-open [is (.getInputStream conn)]
+        (ignore-all-output is))
+      (.disconnect conn)
+      :ok
       (catch Exception e
         (.disconnect conn)
         false))))
 
-(defn- parent-resource [r]
-  (let [workspace (resource/workspace r)
-        path (resource/proj-path r)
-        parent-path (subs path 0 (dec (- (count path) (count (resource/resource-name r)))))
-        parent (workspace/resolve-workspace-resource workspace parent-path)]
-    parent))
+(defn get-log-connection [target]
+  (let [port (Integer/parseInt (:log-port target))
+        socket-addr (InetSocketAddress. ^String (:address target) port)
+        socket (doto (Socket.) (.setSoTimeout timeout))]
+    (try
+      (.connect socket socket-addr timeout)
+      (let [is (.getInputStream socket)
+            status (-> ^BufferedReader (io/reader is) (.readLine))]
+        ;; The '0 OK' string is part of the log service protocol
+        (if (= "0 OK" status)
+          (do
+            ;; Setting to 0 means wait indefinitely for new data
+            (.setSoTimeout socket 0)
+            {:socket socket :stream is})
+          (do
+            (.close socket)
+            nil)))
+      (catch Exception e
+        (.close socket)
+        (error-reporting/report-exception! e)))))
 
-(defn- do-launch [path launch-dir prefs]
+(defn- read-output-until [^InputStream stream substr]
+  (let [byte-stream (ByteArrayOutputStream.)
+        buffer (byte-array 1000)]
+    (loop []
+      (let [str (String. (.toByteArray byte-stream) StandardCharsets/UTF_8)]
+        (if (clojure.string/includes? str substr)
+          str
+          (let [byte-count (.read stream buffer)]
+            (when (> byte-count 0)
+              (.write byte-stream buffer)
+              (recur))))))))
+
+(defn- parse-target-info [output]
+  (let [[log-addr log-port] (rest (re-find #"LOG: Started on ([^:]*):(\d*)" output))
+        [service-addr service-port] (rest (re-find #"SERVICE: Started on http://([^:]*):(\d*)" output))]
+    (when (and log-addr log-port service-addr service-port)
+      {:url (str "http://" service-addr ":" service-port)
+       :log-port log-port
+       :address log-addr})))
+
+(defn- do-launch [^File path launch-dir prefs]
   (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")
-                         (File.)
-                         (.getAbsolutePath))
-        ^java.util.List args (cond-> [path]
+                               (File.)
+                               (.getAbsolutePath))
+        ^java.util.List args (cond-> [(.getAbsolutePath path)]
                                defold-log-dir (conj "--config=project.write_log=1" (format "--config=project.log_dir=%s" defold-log-dir))
                                true list*)
         pb (doto (ProcessBuilder. args)
@@ -131,18 +122,21 @@
     (when (prefs/get-prefs prefs "general-quit-on-esc" false)
       (doto (.environment pb)
         (.put "DM_QUIT_ON_ESC" "1")))
-    (let [p  (.start pb)
+    (doto (.environment pb)
+      (.put "DM_SERVICE_PORT" "dynamic")) ; let the engine service choose an available port
+    ;; Closing "is" seems to cause any dmengine output to stdout/err
+    ;; to generate SIGPIPE and close/crash. Also we need to read
+    ;; the output of dmengine because there is a risk of the stream
+    ;; buffer filling up, stopping the process.
+    ;; https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers
+    (let [p (.start pb)
           is (.getInputStream p)]
-      (swap! shutdown-hook (fn [^Thread current-hook ^Process p]
-                             (let [rt (Runtime/getRuntime)]
-                               (when current-hook
-                                 (.removeShutdownHook rt current-hook))
-                               (let [new-hook (Thread. (fn [] (when (.isAlive p)
-                                                                (.destroy p))))]
-                                 (.addShutdownHook rt new-hook)
-                                 new-hook)))
-        p)
-      (.start (Thread. (fn [] (pump-output is)))))))
+      (if-let [initial-output (deref (future (read-output-until is "INFO:ENGINE: Defold Engine")) engine-ports-output-timeout nil)]
+        (if-let [local-target (parse-target-info initial-output)]
+          (do (.start (Thread. (fn [] (ignore-all-output is))))
+              (assoc local-target :process p :name (.getName path)))
+          (.destroy p))
+        (.destroy p)))))
 
 (defn- bundled-engine [platform]
   (let [suffix (.getExeSuffix (Platform/getHostPlatform))
@@ -158,4 +152,4 @@
 (defn launch [project prefs]
   (let [launch-dir   (io/file (workspace/project-path (project/workspace project)))
         ^File engine (get-engine project prefs (.getPair (Platform/getJavaPlatform)))]
-    (do-launch (.getAbsolutePath engine) launch-dir prefs)))
+    (do-launch engine launch-dir prefs)))

--- a/editor/test/editor/targets_test.clj
+++ b/editor/test/editor/targets_test.clj
@@ -29,6 +29,12 @@
    "defold:url"
    "friendlyName"])
 
+(def ^:private local-target
+  {:name "Local"
+   :url  "http://127.0.0.1:8001"
+   :address "127.0.0.1"
+   :local-address "127.0.0.1"})
+
 (defn- ^:private device-desc-template-without
   "Returns the device desc template with the specified device tag removed."
   [device-tag]
@@ -37,7 +43,7 @@
        (remove (fn [line] (string/includes? line (str "<" device-tag ">"))))
        (string/join "\n")))
 
-(def ^:private defold-port (.getPort (URL. (:url targets/local-target))))
+(def ^:private defold-port (.getPort (URL. (:url local-target))))
 (def ^:private defold-log-port 12345)
 
 (defn- make-udn
@@ -57,7 +63,7 @@
       (string/replace "${DEFOLD_PORT}" (str defold-port))
       (string/replace "${DEFOLD_LOG_PORT}" (str defold-log-port))))
 
-(def ^:private local-hostname (:address targets/local-target))
+(def ^:private local-hostname (:address local-target))
 (def ^:private local-id "local-id")
 (def ^:private local-url (make-device-url local-hostname local-id))
 (def ^:private iphone-hostname "iphone-hostname")
@@ -68,13 +74,13 @@
 (def ^:private tablet-url (make-device-url tablet-hostname tablet-id))
 
 (def ^:private fetch-url
-  {local-url (make-device-desc device-desc-template (:name targets/local-target) "osx" local-hostname)
+  {local-url (make-device-desc device-desc-template (:name local-target) "osx" local-hostname)
    iphone-url (make-device-desc device-desc-template "iPhone" "ios" iphone-hostname)
    tablet-url (make-device-desc device-desc-template "Tablet" "android" tablet-hostname)})
 
 (defn- make-context
   []
-  {:targets-atom (atom #{targets/local-target})
+  {:targets-atom (atom #{local-target})
    :log-fn (test-util/make-call-logger)
    :fetch-url-fn fetch-url
    :on-targets-changed-fn (test-util/make-call-logger)})

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -180,6 +180,7 @@ static void dmLogUpdateNetwork()
             {
                 if (self->m_Connections.Full())
                 {
+                    dmLogInfo("Too many log connections opened");
                     const char* msg = "ERROR:DLIB: Too many log connections opened";
                     fprintf(stderr, "%s\n", msg);
                     const char* resp = "1 Too many log connections opened\n";
@@ -309,6 +310,9 @@ void dmLogInitialize(const dmLogParams* params)
     thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
     g_dmLogServer->m_Thread = thread;
 
+    const char* straddr = dmSocket::AddressToIPString(address);
+    fprintf(stderr, "LOG: Started on %s:%d\n", straddr, (int) port);
+    free((void*) straddr);
 }
 
 void dmLogFinalize()

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -5,6 +5,7 @@
 #include <vectormath/cpp/vectormath_aos.h>
 #include <sys/stat.h>
 
+#include <stdio.h>
 #include <algorithm>
 
 #include <dlib/dlib.h>
@@ -1286,7 +1287,22 @@ bail:
 
         if (dLib::IsDebugMode() && dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP | DM_FEATURE_BIT_SOCKET_SERVER_UDP))
         {
-            engine_service = dmEngineService::New(8001);
+            uint16_t engine_port = 8001;
+
+            char* service_port_env = getenv("DM_SERVICE_PORT");
+
+            if (service_port_env) {
+                unsigned int env_port = 0;
+                if (sscanf(service_port_env, "%u", &env_port) == 1) {
+                    engine_port = (uint16_t) env_port;
+                }
+                else if (strcmp(service_port_env, "dynamic") == 0) {
+                    engine_port = 0;
+                }
+            }
+
+            engine_service = dmEngineService::New(engine_port);
+            fprintf(stderr, "SERVICE: Started on http://%s:%d\n", dmEngineService::GetAddressString(engine_service), dmEngineService::GetPort(engine_service));
         }
 
         dmEngine::RunResult run_result = InitRun(engine_service, argc, argv, pre_run, post_run, context);

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -314,6 +314,10 @@ namespace dmEngineService
             DM_SNPRINTF(m_PortText, sizeof(m_PortText), "%d", (int) m_Port);
             DM_SNPRINTF(m_LogPortText, sizeof(m_LogPortText), "%d", (int) dmLogGetPort());
 
+            char* address_str = dmSocket::AddressToIPString(address);
+            dmStrlCpy(m_Address, address_str, sizeof(m_Address));
+            free(address_str);
+
             char* local_address_str =  dmSocket::AddressToIPString(local_address);
             dmStrlCpy(m_LocalAddress, local_address_str, sizeof(m_LocalAddress));
 
@@ -391,6 +395,7 @@ namespace dmEngineService
 
         dmWebServer::HServer m_WebServer;
         uint16_t             m_Port;
+        char                 m_Address[128];
         char                 m_PortText[16];
         char                 m_LogPortText[16];
         char                 m_Name[128];
@@ -435,5 +440,9 @@ namespace dmEngineService
         return engine_service->m_Port;
     }
 
+    const char* GetAddressString(HEngineService engine_service)
+    {
+        return engine_service->m_Address;
+    }
 }
 

--- a/engine/engine/src/engine_service.h
+++ b/engine/engine/src/engine_service.h
@@ -9,7 +9,7 @@ namespace dmEngineService
     void Delete(HEngineService engine_service);
     void Update(HEngineService engine_service);
     uint16_t GetPort(HEngineService engine_service);
-
+    const char* GetAddressString(HEngineService engine_service);
 }
 
 #endif // DM_ENGINE_SERVICE


### PR DESCRIPTION
* Treat launched dmengine's mostly like other ssdp targets
* Engine prints service & log ports on startup
* Service port is configurable via env var DM_SERVICE_PORT (dynamic is
  an option). This makes it possible to run several dmengine's on the
  same system without them fighting over port 8001.
* When launching new engine, connect to log port instead of polling
  stdout/err