### PR TITLE
DEFEDIT-1037 Building when a build is already in progress

### DIFF
--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -1,27 +1,24 @@
 (ns editor.engine
   (:require [clojure.java.io :as io]
-            [dynamo.graph :as g]
             [editor.prefs :as prefs]
             [editor.dialogs :as dialogs]
             [editor.error-reporting :as error-reporting]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
-            [editor.console :as console]
             [editor.ui :as ui]
-            [editor.targets :as targets]
             [editor.defold-project :as project]
             [editor.workspace :as workspace]
             [editor.engine.native-extensions :as native-extensions])
   (:import [com.defold.editor Platform]
            [java.net HttpURLConnection InetSocketAddress Socket URI URL]
-           [java.io BufferedReader File InputStream IOException]
+           [java.io BufferedReader File InputStream ByteArrayOutputStream IOException]
+           [java.nio.charset Charset StandardCharsets]
            [java.lang Process ProcessBuilder]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:const timeout 2000)
-(defonce engine-input-stream (atom nil))
-(defonce shutdown-hook (atom nil))
+(def ^:const engine-ports-output-timeout 3000)
 
 (defn- get-connection [^URL url]
   (doto ^HttpURLConnection (.openConnection url)
@@ -31,98 +28,99 @@
     (.setDoOutput true)
     (.setRequestMethod "POST")))
 
+(defn- ignore-all-output [^InputStream is]
+  ;; Using a too small byte array here may fill the buffer and halt a
+  ;; spamming engine. Same thing if using plain (.read).
+  (let [buffer (byte-array 1024)]
+    (try
+      (while (not= -1 (.read is buffer))
+        (Thread/sleep 10))
+      (catch IOException e
+        ;; For instance socket closed because engine was killed
+        nil))))
+
 (defn reload-resource [target resource]
   (let [url  (URL. (str target "/post/@resource/reload"))
         conn ^HttpURLConnection (get-connection url)]
     (try
-      (let [os (.getOutputStream conn)]
+      (with-open [os (.getOutputStream conn)]
         (.write os ^bytes (protobuf/map->bytes
-                           com.dynamo.resource.proto.Resource$Reload
-                           {:resource (str (resource/proj-path resource) "c")}))
-        (.close os))
-      (let [is (.getInputStream conn)]
-        (while (not= -1 (.read is))
-          (Thread/sleep 10))
-        (.close is))
+                            com.dynamo.resource.proto.Resource$Reload
+                            {:resource (str (resource/proj-path resource) "c")})))
+      (with-open [is (.getInputStream conn)]
+        (ignore-all-output is))
       (catch Exception e
         (ui/run-later (dialogs/make-alert-dialog (str "Error connecting to engine on " target))))
       (finally
         (.disconnect conn)))))
 
-(defn- swap-engine-input-stream! [new-input-stream]
-  (swap! engine-input-stream (fn [^InputStream is new-is]
-                               (when is (.close is))
-                               new-is)
-    new-input-stream))
-
-(defn- pump-output [^InputStream is]
-  (swap-engine-input-stream! is)
-  (let [buf (byte-array 1024)]
-    (try
-      (loop []
-        (let [n (.read is buf)]
-          (when (> n -1)
-            (let [msg (String. buf 0 n)]
-              (console/append-console-message! msg)
-              (Thread/sleep 10)
-              (recur)))))
-      (catch IOException _
-        ;; Losing the log connection is ok and even expected
-        nil))))
-
 (defn reboot [target local-url]
   (let [url  (URL. (format "%s/post/@system/reboot" (:url target)))
         conn ^HttpURLConnection (get-connection url)]
     (try
-      (swap-engine-input-stream! nil)
-      (let [os  (.getOutputStream conn)]
+      (with-open [os  (.getOutputStream conn)]
         (.write os ^bytes (protobuf/map->bytes
-                           com.dynamo.engine.proto.Engine$Reboot
-                           {:arg1 (str "--config=resource.uri=" local-url)
-                            :arg2 (str local-url "/game.projectc")}))
-        (.close os))
-      (let [is (.getInputStream conn)]
-        (while (not= -1 (.read is))
-          (Thread/sleep 10))
-        (.close is)
-        (.disconnect conn)
-        (.start (Thread. (fn []
-                           ;; We try our best to connect to logging, fail without retry if we couldn't
-                           (try
-                             (let [port (Integer/parseInt (:log-port target))
-                                   socket-addr (InetSocketAddress. ^String (:address target) port)]
-                               (with-open [socket (doto (Socket.)
-                                                    (.setSoTimeout timeout)
-                                                    (.connect socket-addr timeout))]
-                                 (let [is (.getInputStream socket)
-                                       status (-> ^BufferedReader (io/reader is)
-                                                (.readLine))]
-                                   ;; The '0 OK' string is part of the log service protocol
-                                   (if (= "0 OK" status)
-                                     (do
-                                       (console/append-console-message! (format "[Running on target '%s' (%s)]\n" (:name target) (:address target)))
-                                       ;; Setting to 0 means wait indefinitely for new data
-                                       (.setSoTimeout socket 0)
-                                       (pump-output is))))))
-                             (catch Exception e
-                               (error-reporting/report-exception! e))))))
-        :ok)
+                            com.dynamo.engine.proto.Engine$Reboot
+                            {:arg1 (str "--config=resource.uri=" local-url)
+                             :arg2 (str local-url "/game.projectc")})))
+      (with-open [is (.getInputStream conn)]
+        (ignore-all-output is))
+      (.disconnect conn)
+      :ok
       (catch Exception e
         (.disconnect conn)
         false))))
 
-(defn- parent-resource [r]
-  (let [workspace (resource/workspace r)
-        path (resource/proj-path r)
-        parent-path (subs path 0 (dec (- (count path) (count (resource/resource-name r)))))
-        parent (workspace/resolve-workspace-resource workspace parent-path)]
-    parent))
+(defn get-log-connection [target]
+  (let [port (Integer/parseInt (:log-port target))
+        socket-addr (InetSocketAddress. ^String (:address target) port)
+        socket (doto (Socket.) (.setSoTimeout timeout))]
+    (try
+      (.connect socket socket-addr timeout)
+      (let [is (.getInputStream socket)
+            status (-> ^BufferedReader (io/reader is) (.readLine))]
+        ;; The '0 OK' string is part of the log service protocol
+        (if (= "0 OK" status)
+          (do
+            ;; Setting to 0 means wait indefinitely for new data
+            (.setSoTimeout socket 0)
+            {:socket socket :stream is})
+          (do
+            (.close socket)
+            nil)))
+      (catch Exception e
+        (.close socket)
+        (throw e)))))
 
-(defn- do-launch [path launch-dir prefs]
+(defn- read-output-until [^InputStream stream pred]
+  ;; Can't use io/reader like in app_view log pump since closing the
+  ;; reader also closes the stream, closing/crashing dmengine.
+  (let [byte-stream (ByteArrayOutputStream.)
+        buffer (byte-array 1024)]
+    (loop []
+      (let [output (String. (.toByteArray byte-stream) StandardCharsets/UTF_8)]
+        (if (pred output)
+          output
+          (let [byte-count (.read stream buffer)]
+            (when (> byte-count 0)
+              (.write byte-stream buffer 0 byte-count)
+              (recur))))))))
+
+(def ^:private loopback-address "127.0.0.1")
+
+(defn- parse-target-info [output]
+  (let [log-port (second (re-find #"LOG: Started on port (\d*)" output))
+        service-port (second (re-find #"SERVICE: Started on port (\d*)" output))]
+    (when (and log-port service-port)
+      {:url (str "http://" loopback-address ":" service-port)
+       :log-port log-port
+       :address loopback-address})))
+
+(defn- do-launch [^File path launch-dir prefs]
   (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")
-                         (File.)
-                         (.getAbsolutePath))
-        ^java.util.List args (cond-> [path]
+                               (File.)
+                               (.getAbsolutePath))
+        ^java.util.List args (cond-> [(.getAbsolutePath path)]
                                defold-log-dir (conj "--config=project.write_log=1" (format "--config=project.log_dir=%s" defold-log-dir))
                                true list*)
         pb (doto (ProcessBuilder. args)
@@ -131,18 +129,21 @@
     (when (prefs/get-prefs prefs "general-quit-on-esc" false)
       (doto (.environment pb)
         (.put "DM_QUIT_ON_ESC" "1")))
-    (let [p  (.start pb)
+    (doto (.environment pb)
+      (.put "DM_SERVICE_PORT" "dynamic")) ; let the engine service choose an available port
+    ;; Closing "is" seems to cause any dmengine output to stdout/err
+    ;; to generate SIGPIPE and close/crash. Also we need to read
+    ;; the output of dmengine because there is a risk of the stream
+    ;; buffer filling up, stopping the process.
+    ;; https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers
+    (let [p (.start pb)
           is (.getInputStream p)]
-      (swap! shutdown-hook (fn [^Thread current-hook ^Process p]
-                             (let [rt (Runtime/getRuntime)]
-                               (when current-hook
-                                 (.removeShutdownHook rt current-hook))
-                               (let [new-hook (Thread. (fn [] (when (.isAlive p)
-                                                                (.destroy p))))]
-                                 (.addShutdownHook rt new-hook)
-                                 new-hook)))
-        p)
-      (.start (Thread. (fn [] (pump-output is)))))))
+      (if-let [local-target (some-> (deref (future (read-output-until is parse-target-info)) engine-ports-output-timeout nil)
+                                    (parse-target-info))]
+        (do (.start (Thread. (fn [] (ignore-all-output is))))
+            (assoc local-target :process p :name (.getName path)))
+        (do (.destroy p)
+            nil)))))
 
 (defn- bundled-engine [platform]
   (let [suffix (.getExeSuffix (Platform/getHostPlatform))
@@ -158,4 +159,4 @@
 (defn launch [project prefs]
   (let [launch-dir   (io/file (workspace/project-path (project/workspace project)))
         ^File engine (get-engine project prefs (.getPair (Platform/getJavaPlatform)))]
-    (do-launch (.getAbsolutePath engine) launch-dir prefs)))
+    (do-launch engine launch-dir prefs)))

--- a/editor/src/clj/editor/process.clj
+++ b/editor/src/clj/editor/process.clj
@@ -1,0 +1,23 @@
+(ns editor.process
+  (:require [clojure.java.io :as io])
+  (:import [java.lang Process ProcessBuilder]))
+
+(set! *warn-on-reflection* true)
+
+(defn start! ^Process [^String command args opts]
+  (let [pb (ProcessBuilder. ^"[Ljava.lang.String;" (into-array String (list* command args)))]
+    (when (contains? opts :directory)
+      (.directory pb (:directory opts)))
+    (when (contains? opts :env)
+      (let [environment (.environment pb)]
+        (doseq [[k v] (:env opts)]
+          (.put environment k v))))
+    (when (contains? opts :redirect-error-stream?)
+      (.redirectErrorStream pb (:redirect-error-stream? opts)))
+    (.start pb)))
+
+(defn watchdog! ^Thread [^Process proc on-exit]
+  (doto (Thread. (fn []
+                   (.waitFor proc)
+                   (on-exit)))
+    (.start)))

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -18,16 +18,8 @@
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:const local-target
-  {:name "Local"
-   :url  "http://127.0.0.1:8001"
-   :address "127.0.0.1"
-   ;; :local-address must be an ipv4 address. dmengine
-   ;; will resolve "localhost" as an ipv6 address and not find
-   ;; the editor web server.
-   :local-address "127.0.0.1"})
-
-(defonce ^:private targets (atom [local-target]))
+(defonce ^:private launched-targets (atom []))
+(defonce ^:private ssdp-targets (atom []))
 (defonce ^:private manual-device (atom nil))
 (defonce ^:private last-search (atom 0))
 (defonce ^:private running (atom false))
@@ -41,6 +33,34 @@
 (def ^:const update-interval 1000)
 (def ^:const timeout 200)
 (def ^:const max-log-entries 512)
+
+(defn kill-launched-target! [target]
+  (let [^Process process (:process target)]
+    (when (.isAlive process)
+      (.destroy process))))
+
+(defn kill-launched-targets! []
+  (doseq [launched-target @launched-targets]
+    (kill-launched-target! launched-target))
+  (reset! launched-targets []))
+
+(def ^:private kill-lingering-launched-targets-hook
+  (Thread. (fn [] (kill-launched-targets!))))
+
+(defn- launched-target? [target]
+  (contains? target :process))
+
+(defn add-launched-target! [target]
+  (assert (launched-target? target))
+  (let [launched-target (assoc target :local-address "127.0.0.1")]
+    (kill-launched-targets!)
+    (swap! launched-targets conj launched-target)
+    (ui/invalidate-menus!)
+    (.start (Thread. (fn []
+                       (.waitFor ^Process (:process launched-target))
+                       (swap! launched-targets (partial remove #(= (:url %) (:url launched-target))))
+                       (ui/invalidate-menus!))))
+    launched-target))
 
 (defn- http-get [^URL url]
   (let [conn   ^URLConnection (doto (.openConnection url)
@@ -73,7 +93,7 @@
   nil)
 
 (def ^:private update-targets-context
-  {:targets-atom targets
+  {:targets-atom ssdp-targets
    :log-fn log
    :fetch-url-fn http-get
    :on-targets-changed-fn #(ui/invalidate-menubar-item! ::target)})
@@ -102,9 +122,7 @@
         (let [tags (->> desc :content (filter #(= :device (:tag %))) first :content)
               address (:address device)
               local-address (:local-address device)
-              name (if (= address local-address)
-                     "Local"
-                     (tag->val :friendlyName tags))
+              name (tag->val :friendlyName tags)
               target {:name name
                       :url (tag->val :defold:url tags)
                       :log-port (tag->val :defold:logPort tags)
@@ -116,7 +134,8 @@
       (.getMessage e))))
 
 (defn- local-target? [target]
-  (= (:address target) (:local-address target)))
+  (or (= (:address target) (:local-address target))
+      (launched-target? target)))
 
 (defn update-targets! [{:keys [targets-atom log-fn on-targets-changed-fn] :as context} devices]
   (let [devices (if-let [manual-device @manual-device]
@@ -133,9 +152,9 @@
                     devices)
                   (filter some?))
         errors (filter string? targets-result)
-        local-target (or (first (filter local-target? targets)) local-target)
-        external-targets (remove local-target? targets)
-        targets (vec (distinct (cons local-target (sort-by :name util/natural-order external-targets))))]
+        {external-targets false local-targets true} (group-by local-target? targets)
+        targets (vec (distinct (into (vec (sort-by :name util/natural-order local-targets))
+                                     (sort-by :name util/natural-order external-targets))))]
     (doseq [error errors]
       (log-fn error))
     (reset! targets-atom targets)
@@ -191,7 +210,10 @@
 (defn start []
   (when (not @running)
     (reset! running true)
-    (reset! worker (future (targets-worker)))))
+    (reset! worker (future (targets-worker)))
+    (doto (Runtime/getRuntime)
+      (.removeShutdownHook kill-lingering-launched-targets-hook)
+      (.addShutdownHook kill-lingering-launched-targets-hook))))
 
 (defn stop []
   (reset! running false)
@@ -205,8 +227,8 @@
   (stop)
   (start))
 
-(defn get-targets []
-  @targets)
+(defn all-targets []
+  (concat @launched-targets @ssdp-targets))
 
 (defn make-target-log-dialog []
   (let [root        ^Parent (ui/load-fxml "target-log.fxml")
@@ -246,30 +268,50 @@
     (ui/show! stage)))
 
 (defn selected-target [prefs]
-  (let [target-address (prefs/get-prefs prefs "selected-target-address" nil)
-        targets (get-targets)]
-    (or (first (filter #(= target-address (:address %)) targets))
-      (first targets))))
+  (let [target-address (prefs/get-prefs prefs "selected-target-address" nil)]
+    (first (filter #(= target-address (:url %)) (all-targets)))))
 
-(defn- select-target! [prefs target]
-  (prefs/set-prefs prefs "selected-target-address" (:address target)))
+(defn select-target! [prefs target]
+  (prefs/set-prefs prefs "selected-target-address" (:url target))
+  target)
+
+(defn- url-host [url-string]
+  (try
+    (let [url (URL. url-string)]
+      (.getHost url))
+    (catch Exception _
+      "invalid host")))
+
+(defn target-label [target]
+  (format "%s - %s" (str (if (local-target? target) "Local " "") (:name target)) (url-host (:url target))))
+
+(defn- target-option [target]
+  {:label     (target-label target)
+   :command   :target
+   :check     true
+   :user-data target})
+
+(def ^:private separator {:label :separator})
 
 (handler/defhandler :target :global
   (run [user-data prefs]
     (when user-data
-      (select-target! prefs user-data)))
+      (select-target! prefs (if (= user-data :new-local-engine) nil user-data))))
   (state [user-data prefs]
          (let [selected-target (selected-target prefs)]
-           (= user-data selected-target)))
+           (or (= user-data selected-target)
+               (and (nil? selected-target)
+                    (= user-data :new-local-engine)))))
   (options [user-data prefs]
            (when-not user-data
-             (let [targets (get-targets)]
-               (mapv (fn [target]
-                       {:label     (format "%s (%s)" (:name target) (:address target))
-                        :command   :target
-                        :check     true
-                        :user-data target})
-                 targets)))))
+             (let [launched-options (mapv target-option @launched-targets)
+                   ssdp-options (mapv target-option @ssdp-targets)]
+               (cond
+                 (seq launched-options)
+                 (into launched-options (concat [separator] ssdp-options))
+
+                 :else
+                 (into [{:label "New Local Engine" :check true :command :target :user-data :new-local-engine} separator] ssdp-options))))))
 
 (defn- locate-device [ip]
   (when (not-empty ip)

--- a/editor/test/editor/targets_test.clj
+++ b/editor/test/editor/targets_test.clj
@@ -29,6 +29,12 @@
    "defold:url"
    "friendlyName"])
 
+(def ^:private local-target
+  {:name "Local"
+   :url  "http://127.0.0.1:8001"
+   :address "127.0.0.1"
+   :local-address "127.0.0.1"})
+
 (defn- ^:private device-desc-template-without
   "Returns the device desc template with the specified device tag removed."
   [device-tag]
@@ -37,7 +43,7 @@
        (remove (fn [line] (string/includes? line (str "<" device-tag ">"))))
        (string/join "\n")))
 
-(def ^:private defold-port (.getPort (URL. (:url targets/local-target))))
+(def ^:private defold-port (.getPort (URL. (:url local-target))))
 (def ^:private defold-log-port 12345)
 
 (defn- make-udn
@@ -57,7 +63,7 @@
       (string/replace "${DEFOLD_PORT}" (str defold-port))
       (string/replace "${DEFOLD_LOG_PORT}" (str defold-log-port))))
 
-(def ^:private local-hostname (:address targets/local-target))
+(def ^:private local-hostname (:address local-target))
 (def ^:private local-id "local-id")
 (def ^:private local-url (make-device-url local-hostname local-id))
 (def ^:private iphone-hostname "iphone-hostname")
@@ -68,13 +74,13 @@
 (def ^:private tablet-url (make-device-url tablet-hostname tablet-id))
 
 (def ^:private fetch-url
-  {local-url (make-device-desc device-desc-template (:name targets/local-target) "osx" local-hostname)
+  {local-url (make-device-desc device-desc-template (:name local-target) "osx" local-hostname)
    iphone-url (make-device-desc device-desc-template "iPhone" "ios" iphone-hostname)
    tablet-url (make-device-desc device-desc-template "Tablet" "android" tablet-hostname)})
 
 (defn- make-context
   []
-  {:targets-atom (atom #{targets/local-target})
+  {:targets-atom (atom #{local-target})
    :log-fn (test-util/make-call-logger)
    :fetch-url-fn fetch-url
    :on-targets-changed-fn (test-util/make-call-logger)})

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -180,6 +180,7 @@ static void dmLogUpdateNetwork()
             {
                 if (self->m_Connections.Full())
                 {
+                    dmLogInfo("Too many log connections opened");
                     const char* msg = "ERROR:DLIB: Too many log connections opened";
                     fprintf(stderr, "%s\n", msg);
                     const char* resp = "1 Too many log connections opened\n";
@@ -309,6 +310,7 @@ void dmLogInitialize(const dmLogParams* params)
     thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
     g_dmLogServer->m_Thread = thread;
 
+    fprintf(stderr, "LOG: Started on port %u\n", (unsigned int) port);
 }
 
 void dmLogFinalize()

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -5,6 +5,7 @@
 #include <vectormath/cpp/vectormath_aos.h>
 #include <sys/stat.h>
 
+#include <stdio.h>
 #include <algorithm>
 
 #include <dlib/dlib.h>
@@ -1312,7 +1313,22 @@ bail:
 
         if (dLib::IsDebugMode() && dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP | DM_FEATURE_BIT_SOCKET_SERVER_UDP))
         {
-            engine_service = dmEngineService::New(8001);
+            uint16_t engine_port = 8001;
+
+            char* service_port_env = getenv("DM_SERVICE_PORT");
+
+            if (service_port_env) {
+                unsigned int env_port = 0;
+                if (sscanf(service_port_env, "%u", &env_port) == 1) {
+                    engine_port = (uint16_t) env_port;
+                }
+                else if (strcmp(service_port_env, "dynamic") == 0) {
+                    engine_port = 0;
+                }
+            }
+
+            engine_service = dmEngineService::New(engine_port);
+            fprintf(stderr, "SERVICE: Started on port %u\n", (unsigned int) dmEngineService::GetPort(engine_service));
         }
 
         dmEngine::RunResult run_result = InitRun(engine_service, argc, argv, pre_run, post_run, context);


### PR DESCRIPTION
* Treat launched dmengine's mostly like other ssdp targets
* Engine prints service & log ports on startup
* Service port is configurable via env var DM_SERVICE_PORT (dynamic is
  an option). This makes it possible to run several dmengine's on the
  same system without them fighting over port 8001.
* When launching new engine, connect to log port instead of polling
  stdout/err
* Read log in lines and decode using utf-8