### PR TITLE
DEFEDIT-1068 Native Extension fixes for Win32

### DIFF
--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -191,7 +191,9 @@
         _ (.add (.getClasses cc) MultiPartWriter)
         _ (.add (.getClasses cc) InputStreamProvider)
         _ (.add (.getClasses cc) StringProvider)
-        client (Client/create cc)
+        client (doto (Client/create cc)
+                 (.setConnectTimeout (int (* 30 1000)))
+                 (.setReadTimeout (int (* 5 60 1000))))
         api-root (.resource client (URI. server-url))
         build-resource (.path api-root (build-url platform sdk-version))
         builder (.accept build-resource #^"[Ljavax.ws.rs.core.MediaType;" (into-array MediaType []))]

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -29,6 +29,8 @@
 (set! *warn-on-reflection* true)
 
 (def ^:const defold-build-server-url "https://build.defold.com")
+(def ^:const connect-timeout-ms (* 30 1000))
+(def ^:const read-timeout-ms (* 5 60 1000))
 
 ;;; Caching
 
@@ -192,8 +194,8 @@
         _ (.add (.getClasses cc) InputStreamProvider)
         _ (.add (.getClasses cc) StringProvider)
         client (doto (Client/create cc)
-                 (.setConnectTimeout (int (* 30 1000)))
-                 (.setReadTimeout (int (* 5 60 1000))))
+                 (.setConnectTimeout (int connect-timeout-ms))
+                 (.setReadTimeout (int read-timeout-ms)))
         api-root (.resource client (URI. server-url))
         build-resource (.path api-root (build-url platform sdk-version))
         builder (.accept build-resource #^"[Ljavax.ws.rs.core.MediaType;" (into-array MediaType []))]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -29,7 +29,7 @@ ordinary paths."
 
 (def build-dir "/build/default/")
 
-(defn project-path [workspace]
+(defn project-path ^File [workspace]
   (io/as-file (g/node-value workspace :root)))
 
 (defn build-path [workspace]


### PR DESCRIPTION
- Increase read timeout to 5mins when requesting an engine build.
- Unpack engine to $project/build/$platform instead of temp dir. This
  is consistent with editor1 and makes it simpler to debug native
  extensions.
- Copy bundled engine dependencies when unpacking NE dmengine. For
  win32, OpenAL32.dll and wrap_oal.dll are required.