### PR TITLE
DEFEDIT-1069 Improve handling of model animations

### DIFF
--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -25,11 +25,18 @@
   {:resource resource
    :content (protobuf/map->str Rig$AnimationSetDesc desc-pb-msg)})
 
-(defn- prefix-animation-id [prefix animation]
-  (update animation :id (fn [id] (string/join "/" (filter not-empty [prefix id])))))
+(defn- prefix-animation-id [animation-resource animation]
+  (update animation :id (fn [^String id]
+                          (cond
+                            (and (= "animationset" (resource/ext animation-resource))
+                                 (neg? (.indexOf id "/")))
+                            (str (resource/base-name animation-resource) "/" id)
+
+                            :else
+                            id))))
 
 (defn- merge-animations [merged-animations animations resource]
-  (let [prefix-animation-id (partial prefix-animation-id (resource/base-name resource))]
+  (let [prefix-animation-id (partial prefix-animation-id resource)]
     (into merged-animations (map prefix-animation-id) animations)))
 
 (defn- merge-bone-list [merged-bone-list bone-list]

--- a/editor/src/clj/editor/collada_scene.clj
+++ b/editor/src/clj/editor/collada_scene.clj
@@ -166,8 +166,12 @@
         (gl/with-gl-bindings gl render-args [render/shader-outline outline-vertex-binding]
           (gl/gl-draw-arrays gl GL/GL_LINES 0 (* rcount 8)))))))
 
-(g/defnk produce-animation-set [content]
-  (:animation-set content))
+(g/defnk produce-animation-set [resource content]
+  (let [animation-set (:animation-set content)
+        id (resource/base-name resource)]
+    (update animation-set :animations
+            (fn [animations]
+              (into [] (map #(assoc % :id id)) animations)))))
 
 (g/defnk produce-animation-set-build-target [_node-id resource animation-set]
   (let [animation-set-with-hash-ids (animation-set/hash-animation-set-ids animation-set)]

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -6,6 +6,7 @@
             [editor.graph-util :as gu]
             [editor.image :as image]
             [editor.material :as material]
+            [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.rig :as rig]
@@ -53,11 +54,17 @@
   (->> (mapcat (fn [field] (if (vector? field) (mapv (fn [i] (into [(first field) i] (rest field))) (range (count (get pb-msg (first field))))) [field])) fields)
     (map (fn [label] [label (get deps-by-source (if (vector? label) (get-in pb-msg label) (get pb-msg label)))]))))
 
-(g/defnk produce-build-targets [_node-id resource pb-msg dep-build-targets animation-set-build-target mesh-set-build-target skeleton-build-target animations material mesh skeleton]
+(defn- validate-default-animation [_node-id default-animation animation-ids]
+  (when (and (not (str/blank? default-animation)) (seq animation-ids))
+    (validation/prop-error :fatal _node-id :default-animation validation/prop-member-of? default-animation (set animation-ids)
+                           (format "Animation '%s' does not exist" default-animation))))
+
+(g/defnk produce-build-targets [_node-id resource pb-msg dep-build-targets default-animation animation-ids animation-set-build-target mesh-set-build-target skeleton-build-target animations material mesh skeleton]
   (or (some->> [(prop-resource-error :fatal _node-id :mesh mesh "Mesh")
                 (prop-resource-error :fatal _node-id :material material "Material")
                 (validation/prop-error :fatal _node-id :skeleton validation/prop-resource-not-exists? skeleton "Skeleton")
-                (validation/prop-error :fatal _node-id :animations validation/prop-resource-not-exists? animations "Animations")]
+                (validation/prop-error :fatal _node-id :animations validation/prop-resource-not-exists? animations "Animations")
+                (validate-default-animation _node-id default-animation animation-ids)]
                (filterv some?)
                not-empty
                g/error-aggregate)
@@ -163,12 +170,17 @@
             (set (fn [basis self old-value new-value]
                    (project/resource-setter basis self old-value new-value
                                             [:resource :animations-resource]
+                                            [:animation-set :animation-set]
                                             [:animation-set-build-target :animation-set-build-target])))
             (dynamic error (g/fnk [_node-id animations]
                                   (validation/prop-error :fatal _node-id :animations validation/prop-resource-not-exists? animations "Animations")))
             (dynamic edit-type (g/constantly {:type resource/Resource
                                               :ext ["dae" "animationset"]})))
-  (property default-animation g/Str)
+  (property default-animation g/Str
+            (dynamic error (g/fnk [_node-id default-animation animation-ids]
+                             (validate-default-animation _node-id default-animation animation-ids)))
+            (dynamic edit-type (g/fnk [animation-ids]
+                                 (properties/->choicebox (into [""] animation-ids)))))
 
   (input mesh-resource resource/Resource)
   (input mesh-set-build-target g/Any)
@@ -177,6 +189,7 @@
   (input skeleton-resource resource/Resource)
   (input skeleton-build-target g/Any)
   (input animations-resource resource/Resource)
+  (input animation-set g/Any)
   (input animation-set-build-target g/Any)
   (input texture-resources resource/Resource :array)
   (input images BufferedImage :array)
@@ -184,6 +197,7 @@
   (input scene g/Any)
   (input shader ShaderLifecycle)
 
+  (output animation-ids g/Any :cached (g/fnk [animation-set] (mapv :id (:animations animation-set))))
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-data g/Any :cached produce-save-data)
   (output build-targets g/Any :cached produce-build-targets)

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -38,6 +38,10 @@
   (or (prop-nil? v name)
       (prop-resource-not-exists? v name)))
 
+(defn prop-member-of? [v val-set message]
+  (when (and val-set (not (val-set v)))
+    message))
+
 (defn prop-anim-missing? [animation anim-ids]
   (when (and anim-ids (not-any? #(= animation %) anim-ids))
     (format "'%s' could not be found in the specified image" animation)))

--- a/editor/test/integration/animation_set_test.clj
+++ b/editor/test/integration/animation_set_test.clj
@@ -11,5 +11,8 @@
           node-id (test-util/resource-node project "/model/treasure_chest.animationset")
           {:keys [animations bone-list]} (g/node-value node-id :animation-set)]
       (is (= 3 (count bone-list)))
-      (is (= 2 (count animations)))
-      (is (= #{"treasure_chest" "treasure_chest_sub_animation/treasure_chest_anim_out"} (set (map :id animations)))))))
+      (is (= 3 (count animations)))
+      (is (= #{"treasure_chest"
+               "treasure_chest_sub_animation/treasure_chest_anim_out"
+               "treasure_chest_sub_sub_animation/treasure_chest_anim_out"}
+             (set (map :id animations)))))))

--- a/editor/test/integration/model_test.clj
+++ b/editor/test/integration/model_test.clj
@@ -36,16 +36,48 @@
                   :texture2)]
           (properties/set-values! p [original-texture]))))))
 
+(deftest animations
+  (with-clean-system
+    (let [workspace (test-util/setup-workspace! world)
+          project (test-util/setup-project! workspace)
+          node-id (test-util/resource-node project "/model/test.model")]
+      (testing "can assign single dae file as animations"
+        (let [dae-resource (workspace/resolve-workspace-resource workspace "/mesh/treasure_chest.dae")]
+          (test-util/with-prop [node-id :animations dae-resource]
+            (is (= #{"treasure_chest"} (set (map :id (:animations (g/node-value node-id :animation-set)))))))))
+      (testing "can assign animation set as animations"
+        (let [animation-set-resource (workspace/resolve-workspace-resource workspace "/model/treasure_chest.animationset")]
+          (test-util/with-prop [node-id :animations animation-set-resource]
+            (is (= #{"treasure_chest"
+                     "treasure_chest_sub_animation/treasure_chest_anim_out"
+                     "treasure_chest_sub_sub_animation/treasure_chest_anim_out"}
+                   (set (map :id (:animations (g/node-value node-id :animation-set))))))))))))
+
 (deftest model-validation
   (with-clean-system
     (let [workspace (test-util/setup-workspace! world)
           project (test-util/setup-project! workspace)
           node-id (test-util/resource-node project "/model/test.model")]
-      (is (nil? (test-util/prop-error node-id :mesh)))
-      (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.dae")]]
-        (test-util/with-prop [node-id :mesh v]
-          (is (g/error? (test-util/prop-error node-id :mesh)))))
-      (is (nil? (test-util/prop-error node-id :material)))
-      (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.material")]]
-        (test-util/with-prop [node-id :material v]
-          (is (g/error? (test-util/prop-error node-id :material))))))))
+
+      (testing "mesh is required"
+        (is (nil? (test-util/prop-error node-id :mesh)))
+        (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.dae")]]
+          (test-util/with-prop [node-id :mesh v]
+            (is (g/error? (test-util/prop-error node-id :mesh))))))
+
+      (testing "material is required"
+        (is (nil? (test-util/prop-error node-id :material)))
+        (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.material")]]
+          (test-util/with-prop [node-id :material v]
+            (is (g/error? (test-util/prop-error node-id :material))))))
+
+      (testing "default-animation should be empty string or a valid animation"
+        (is (nil? (test-util/prop-error node-id :animations)))
+        (is (nil? (test-util/prop-error node-id :default-animation)))
+        (test-util/with-prop [node-id :animations (workspace/resolve-workspace-resource workspace "/model/treasure_chest.animationset")]
+          (test-util/with-prop [node-id :default-animation ""]
+            (is (not (g/error? (test-util/prop-error node-id :default-animation)))))
+          (test-util/with-prop [node-id :default-animation "treasure_chest"]
+            (is (not (g/error? (test-util/prop-error node-id :default-animation)))))
+          (test-util/with-prop [node-id :default-animation "gurka"]
+            (is (g/error? (test-util/prop-error node-id :default-animation)))))))))

--- a/editor/test/resources/test_project/model/treasure_chest_sub_animation.animationset
+++ b/editor/test/resources/test_project/model/treasure_chest_sub_animation.animationset
@@ -1,3 +1,6 @@
 animations {
   animation: "/mesh/treasure_chest_anim_out.dae"
 }
+animations {
+  animation: "/model/treasure_chest_sub_sub_animation.animationset"
+}

--- a/editor/test/resources/test_project/model/treasure_chest_sub_sub_animation.animationset
+++ b/editor/test/resources/test_project/model/treasure_chest_sub_sub_animation.animationset
@@ -1,0 +1,3 @@
+animations {
+  animation: "/mesh/treasure_chest_anim_out.dae"
+}


### PR DESCRIPTION
- give animations in nested animation-sets same IDs as editor1.
- give animations directly from collada-resource correct ID
- make default-animation property a drop-down showing available
  animations
- validate default-animation against available animations

Fixes https://github.com/defold/editor2-issues/issues/1029