### PR TITLE
DEFEDIT-1076 Deleted nodes have their connected nodes invalidated fro…

### DIFF
--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -281,6 +281,14 @@
     (->> (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id tgt-label)
       (mapv gt/head))))
 
+(defn explicit-targets
+  ([basis src-id]
+    (->> (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id)
+      (mapv gt/tail)))
+  ([basis src-id tgt-label]
+    (->> (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id tgt-label)
+      (mapv gt/tail))))
+
 (defn- implicit-overrides [basis node-id label arc-fn override-filter-fn]
   (let [graph (get (:graphs basis) (gt/node-id->graph-id node-id))]
     (loop [overrides (overrides graph node-id)

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -34,6 +34,10 @@
 (defn- delete? [node path]
   (outline/delete? [(->iterator node path)]))
 
+(defn- delete! [node path]
+  (when (delete? node path)
+    (g/delete-node! (:node-id (outline node path)))))
+
 (defn- copy! [node path]
   (let [data (outline/copy [(->iterator node path)])]
     (alter-var-root #'*clipboard* (constantly data))))
@@ -138,6 +142,15 @@
       (cut! root [0])
       ; 1 comp instances
       (is (= 1 (child-count root))))))
+
+(deftest delete-component
+  (with-clean-system
+    (let [[workspace project app-view] (test-util/setup! world)
+          root (test-util/resource-node project "/logic/atlas_sprite.go")]
+      ; 1 comp instance
+      (is (= 1 (child-count root)))
+      (delete! root [0])
+      (is (= 0 (child-count root))))))
 
 (deftest copy-paste-collection
   (with-clean-system


### PR DESCRIPTION
…m cache

* Regression from earlier perf work; deleted nodes were removed from successors map
* It meant successors were not properly invalidated when a node was deleted
* Fix was to trace connections when performing the tx-step and add the successors explicitly