### PR TITLE
DEFEDIT-1077 Build errors of missing files can be "opened"

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -1113,7 +1113,7 @@
    (property-overridden? (now) node-id property))
   ([basis node-id property]
    (if-let [node (node-by-id basis node-id)]
-     (gt/property-overridden? node property)
+     (and (has-property? (node-type node) property) (gt/property-overridden? node property))
      false)))
 
 (defn property-value-origin?

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -38,7 +38,7 @@
 
 (def ^:dynamic *load-cache* nil)
 
-(def ^:private unknown-icon "icons/32/Icons_29-AT-Unknown.png")
+(def unknown-icon "icons/32/Icons_29-AT-Unknown.png")
 
 (g/defnode ResourceNode
   (inherits core/Scope)
@@ -88,8 +88,8 @@
                 (g/connect node-id :save-data project :save-data)))
             (catch Exception e
               (log/warn :msg (format "Unable to load resource '%s'" (resource/proj-path resource)) :exception e)
-              (g/mark-defective node-id node-type (g/error-fatal (format "The file '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content}))))
-          (g/mark-defective node-id node-type (g/error-fatal (format "The file '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found})))
+              (g/mark-defective node-id node-type (validation/invalid-content-error node-id nil :fatal resource))))
+          (g/mark-defective node-id node-type (validation/file-not-found-error node-id nil :fatal resource)))
         []))
     (catch Throwable t
       (throw (ex-info (format "Error when loading resource '%s'" (resource/resource->proj-path resource))
@@ -461,9 +461,7 @@
 
       (g/transact
         (for [node (:mark-deleted plan)]
-          (let [flaw (g/error-fatal (format "The resource '%s' has been deleted"
-                                            (resource/proj-path (g/node-value node :resource)))
-                                    {:type :file-not-found})]
+          (let [flaw (validation/file-not-found-error node nil :fatal (g/node-value node :resource))]
             (g/mark-defective node flaw))))
 
       (let [all-outputs (mapcat (fn [node]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -65,10 +65,14 @@
       target)))
 
 (defn- source-outline-subst [err]
-  ;; TODO: embed error
-  {:node-id -1
-   :icon ""
-   :label ""})
+  (if-let [resource (get-in err [:user-data :resource])]
+    (let [rt (resource/resource-type resource)]
+      {:node-id (:node-id err)
+       :label (or (:label rt) (:ext rt) "unknown")
+       :icon (or (:icon rt) project/unknown-icon)})
+    {:node-id -1
+     :icon ""
+     :label ""}))
 
 (defn- prop-id-duplicate? [id-counts id]
   (when (> (id-counts id) 1)

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -7,6 +7,7 @@
             [editor.defold-project :as project]
             [editor.types :as types]
             [editor.resource :as resource]
+            [editor.validation :as validation]
             [editor.workspace :as workspace]
             [editor.pipeline.tex-gen :as tex-gen]
             [service.log :as log])
@@ -69,23 +70,23 @@
 (g/defnode ImageNode
   (inherits project/ResourceNode)
 
-  (output size g/Any :cached (g/fnk [resource]
+  (output size g/Any :cached (g/fnk [_node-id resource]
                                (try
                                  (or (read-size resource)
-                                     (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content}))
+                                   (validation/invalid-content-error _node-id :size :fatal resource))
                                  (catch java.io.FileNotFoundException e
-                                   (g/error-fatal (format "The image '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found}))
+                                   (validation/file-not-found-error _node-id :size :fatal resource))
                                  (catch Exception _
-                                   (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content})))))
+                                   (validation/invalid-content-error _node-id :size :fatal resource)))))
   
-  (output content BufferedImage (g/fnk [resource]
+  (output content BufferedImage (g/fnk [_node-id resource]
                                   (try
                                     (or (read-image resource)
-                                        (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content}))
+                                        (validation/invalid-content-error _node-id :content :fatal resource))
                                     (catch java.io.FileNotFoundException e
-                                      (g/error-fatal (format "The image '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found}))
+                                      (validation/file-not-found-error _node-id :content :fatal resource))
                                     (catch Exception _
-                                      (g/error-fatal (format "The image '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content})))))
+                                      (validation/invalid-content-error _node-id :content :fatal resource)))))
   
   (output build-targets g/Any :cached produce-build-targets))
 

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -68,3 +68,9 @@
         name# (properties/keyword->name name-kw#)]
     `(g/fnk [~'_node-id ~property]
             (prop-error ~severity ~'_node-id ~name-kw# ~f ~property ~name#))))
+
+(defn file-not-found-error [node-id label severity resource]
+  (g/->error node-id label severity nil (format "The file '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found :resource resource}))
+
+(defn invalid-content-error [node-id label severity resource]
+  (g/->error node-id label severity nil (format "The file '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content :resource resource}))


### PR DESCRIPTION
* Takes user to referencing entities
* Game objects show components with missing files in outline