### PR TITLE
DEFEDIT-1082 Context menu and edit command fixes

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -329,7 +329,7 @@
         (remove-tab tab-pane tab)))))
 
 (handler/defhandler :close-other :global
-  (enabled? [app-view] (not-empty (get-tabs app-view)))
+  (enabled? [app-view] (not-empty (next (get-tabs app-view))))
   (run [app-view]
     (let [tab-pane ^TabPane (g/node-value app-view :tab-pane)]
       (when-let [selected-tab (-> tab-pane (.getSelectionModel) (.getSelectedItem))]
@@ -400,6 +400,7 @@
                              {:label "Hot Reload"
                               :acc "Shortcut+R"
                               :command :hot-reload}
+                             {:label :separator}
                              {:label "Close"
                               :acc "Shortcut+W"
                               :command :close}
@@ -428,18 +429,18 @@
                               :icon "icons/redo.png"
                               :command :redo}
                              {:label :separator}
-                             {:label "Copy"
-                              :acc "Shortcut+C"
-                              :command :copy}
                              {:label "Cut"
                               :acc "Shortcut+X"
                               :command :cut}
+                             {:label "Copy"
+                              :acc "Shortcut+C"
+                              :command :copy}
                              {:label "Paste"
                               :acc "Shortcut+V"
                               :command :paste}
                              {:label "Delete"
                               :acc "Shortcut+BACKSPACE"
-                              :icon_ "icons/redo.png"
+                              :icon "icons/32/Icons_M_06_trash.png"
                               :command :delete}
                              {:label :separator}
                              {:label "Move Up"
@@ -473,9 +474,17 @@
                               :command :about}]}])
 
 (ui/extend-menu ::tab-menu nil
-                [{:label "Hot Reload"
+                [{:label "Show In Desktop"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :show-in-desktop}
+                 {:label "Referencing Files"
+                  :command :referencing-files}
+                 {:label "Dependencies"
+                  :command :dependencies}
+                 {:label "Hot Reload"
                   :acc "Shortcut+R"
                   :command :hot-reload}
+                 {:label :separator}
                  {:label "Close"
                   :acc "Shortcut+W"
                   :command :close}
@@ -559,6 +568,12 @@
     second
     :resource-node))
 
+(defrecord TabPaneSelectionProvider [^TabPane tab-pane]
+  handler/SelectionProvider
+  (selection [this] [(-> tab-pane .getSelectionModel .getSelectedItem tab->resource-node)])
+  (succeeding-selection [this] [])
+  (alt-selection [this] []))
+
 (defn make-app-view [view-graph workspace project ^Stage stage ^MenuBar menu-bar ^TabPane tab-pane]
   (let [app-scene (.getScene stage)]
     (.setUseSystemMenuBar menu-bar true)
@@ -579,6 +594,11 @@
             (reify ListChangeListener
               (onChanged [this change]
                 (ui/restyle-tabs! tab-pane)))))
+
+      (ui/register-tab-pane-context-menu tab-pane ::tab-menu)
+      (ui/context! tab-pane :editor-tabs {:app-view app-view} (->TabPaneSelectionProvider tab-pane) {}
+                   {resource/Resource (fn [resource-node-id]
+                                        (g/node-value resource-node-id :resource))})
 
       ;; Workaround for JavaFX bug: https://bugs.openjdk.java.net/browse/JDK-8167282
       ;; Consume key events that would select non-existing tabs in case we have none.
@@ -628,7 +648,6 @@
       (select app-view resource-node [resource-node]))
     (.setGraphic tab (jfx/get-image-view (:icon resource-type "icons/64/Icons_29-AT-Unknown.png") 16))
     (.addAll (.getStyleClass tab) ^Collection (resource/style-classes resource))
-    (ui/register-tab-context-menu tab ::tab-menu)
     (ui/register-tab-toolbar tab "#toolbar" :toolbar)
     (let [close-handler (.getOnClosed tab)]
       (.setOnClosed tab (ui/event-handler

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -439,7 +439,7 @@
                               :acc "Shortcut+V"
                               :command :paste}
                              {:label "Delete"
-                              :acc "Shortcut+BACKSPACE"
+                              :acc "DELETE"
                               :icon "icons/32/Icons_M_06_trash.png"
                               :command :delete}
                              {:label :separator}
@@ -570,7 +570,7 @@
 
 (defrecord TabPaneSelectionProvider [^TabPane tab-pane]
   handler/SelectionProvider
-  (selection [this] [(-> tab-pane .getSelectionModel .getSelectedItem tab->resource-node)])
+  (selection [this] (or (some-> tab-pane .getSelectionModel .getSelectedItem tab->resource-node (g/node-value :resource) vector) []))
   (succeeding-selection [this] [])
   (alt-selection [this] []))
 
@@ -596,9 +596,7 @@
                 (ui/restyle-tabs! tab-pane)))))
 
       (ui/register-tab-pane-context-menu tab-pane ::tab-menu)
-      (ui/context! tab-pane :editor-tabs {:app-view app-view} (->TabPaneSelectionProvider tab-pane) {}
-                   {resource/Resource (fn [resource-node-id]
-                                        (g/node-value resource-node-id :resource))})
+      (ui/context! tab-pane :editor-tabs {:app-view app-view} (->TabPaneSelectionProvider tab-pane))
 
       ;; Workaround for JavaFX bug: https://bugs.openjdk.java.net/browse/JDK-8167282
       ;; Consume key events that would select non-existing tabs in case we have none.

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -107,7 +107,7 @@
                  {:label "Delete"
                   :command :delete
                   :icon "icons/32/Icons_M_06_trash.png"
-                  :acc "Shortcut+BACKSPACE"}
+                  :acc "DELETE"}
                  {:label :separator}
                  {:label "Rename..."
                   :command :rename}])

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -95,21 +95,22 @@
                   :command :new-folder
                   :icon "icons/32/Icons_01-Folder-closed.png"}
                  {:label :separator}
-                 {:label "Copy"
-                  :command :copy
-                  :acc "Shortcut+C"}
                  {:label "Cut"
                   :command :cut
                   :acc "Shortcut+X"}
+                 {:label "Copy"
+                  :command :copy
+                  :acc "Shortcut+C"}
                  {:label "Paste"
                   :command :paste
                   :acc "Shortcut+V"}
-                 {:label "Rename..."
-                  :command :rename}
                  {:label "Delete"
                   :command :delete
                   :icon "icons/32/Icons_M_06_trash.png"
-                  :acc "Shortcut+BACKSPACE"}])
+                  :acc "Shortcut+BACKSPACE"}
+                 {:label :separator}
+                 {:label "Rename..."
+                  :command :rename}])
 
 (def fixed-resource-paths #{"/" "/game.project"})
 

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -32,14 +32,7 @@
     (refresh-list-view! git list-view)))
 
 (ui/extend-menu ::changes-menu nil
-                [{:label "View Diff"
-                  :icon "icons/32/Icons_S_06_arrowup.png"
-                  :command :diff}
-                 {:label "Revert"
-                  :icon "icons/32/Icons_S_02_Reset.png"
-                  :command :revert}
-                 {:label :separator}
-                 {:label "Open"
+                [{:label "Open"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
                   :command :open}
                  {:label "Open As"
@@ -47,7 +40,21 @@
                   :command :open-as}
                  {:label "Show in Desktop"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
-                  :command :show-in-desktop}])
+                  :command :show-in-desktop}
+                 {:label "Referencing Files"
+                  :command :referencing-files}
+                 {:label "Dependencies"
+                  :command :dependencies}
+                 {:label "Hot Reload"
+                  :acc "Shortcut+R"
+                  :command :hot-reload}
+                 {:label :separator}
+                 {:label "View Diff"
+                  :icon "icons/32/Icons_S_06_arrowup.png"
+                  :command :diff}
+                 {:label "Revert"
+                  :icon "icons/32/Icons_S_02_Reset.png"
+                  :command :revert}])
 
 (defn- path->file [workspace ^String path]
   (File. ^File (workspace/project-path workspace) path))

--- a/editor/src/clj/editor/code_view_ux.clj
+++ b/editor/src/clj/editor/code_view_ux.clj
@@ -139,8 +139,8 @@
   :Alt+Shortcut+E        {:command :replace-next                :label "Replace Next"                :group "Replace" :order 2}
 
   ;; Delete
-  :Backspace             {:command :delete}
-  :Delete                {:command :delete-forward}
+  :Backspace             {:command :delete-backward}
+  :Delete                {:command :delete}
   :Shortcut+D            {:command :delete-line                 :label "Delete Line"                 :group "Delete" :order 1}
   :Alt+Delete            {:command :delete-next-word}           ;; these two do not work when they are included in the menu
   :Alt+Backspace         {:command :delete-prev-word}           ;; the menu event does not get propagated back like the rest
@@ -816,14 +816,14 @@
            (replace-text-and-caret source-viewer pos 2 "" pos)
            (replace-text-and-caret source-viewer pos 1 "" pos)))))))
 
-(handler/defhandler :delete :code-view
+(handler/defhandler :delete-backward :code-view
   (enabled? [source-viewer] (editable? source-viewer))
   (run [source-viewer]
     (when (editable? source-viewer)
       (delete source-viewer false)
       (typing-changes! source-viewer true))))
 
-(handler/defhandler :delete-forward :code-view
+(handler/defhandler :delete :code-view
   (enabled? [source-viewer] (editable? source-viewer))
   (run [source-viewer]
     (when (editable? source-viewer)

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -171,7 +171,21 @@
                                                   (alt-selection tree-selection))))
 
 (ui/extend-menu ::outline-menu nil
-                [{:label "Add"
+                [{:label "Open"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :open}
+                 {:label "Open As"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :open-as}
+                 {:label "Show in Desktop"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :show-in-desktop}
+                 {:label "Referencing Files"
+                  :command :referencing-files}
+                 {:label "Dependencies"
+                  :command :dependencies}
+                 {:label :separator}
+                 {:label "Add"
                   :icon "icons/32/Icons_M_07_plus.png"
                   :command :add}
                  {:label "Add From File"
@@ -183,19 +197,19 @@
                  {:label "Add Secondary From File"
                   :icon "icons/32/Icons_M_07_plus.png"
                   :command :add-secondary-from-file}
+                 {:label :separator}
+                 {:label "Cut"
+                  :command :cut
+                  :acc "Shortcut+X"}
+                 {:label "Copy"
+                  :command :copy
+                  :acc "Shortcut+C"}
+                 {:label "Paste"
+                  :command :paste
+                  :acc "Shortcut+V"}
                  {:label "Delete"
                   :icon "icons/32/Icons_M_06_trash.png"
-                  :command :delete}
-                 {:label :separator}
-                 {:label "Open"
-                  :icon "icons/32/Icons_S_14_linkarrow.png"
-                  :command :open}
-                 {:label "Open As"
-                  :icon "icons/32/Icons_S_14_linkarrow.png"
-                  :command :open-as}
-                 {:label "Show in Desktop"
-                  :icon "icons/32/Icons_S_14_linkarrow.png"
-                  :command :show-in-desktop}])
+                  :command :delete}])
 
 (defn- selection->nodes [selection]
   (handler/adapt-every selection Long))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -209,7 +209,8 @@
                   :acc "Shortcut+V"}
                  {:label "Delete"
                   :icon "icons/32/Icons_M_06_trash.png"
-                  :command :delete}])
+                  :command :delete
+                  :acc "DELETE"}])
 
 (defn- selection->nodes [selection]
   (handler/adapt-every selection Long))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -818,17 +818,21 @@
   [^TextInputControl control]
   (not (string/blank? (.getSelectedText control))))
 
-(handler/defhandler :copy :text-input-control
-  (enabled? [^TextInputControl control] (has-selection? control))
-  (run [^TextInputControl control] (.copy control)))
-
 (handler/defhandler :cut :text-input-control
   (enabled? [^TextInputControl control] (and (editable control) (has-selection? control)))
   (run [^TextInputControl control] (.cut control)))
 
+(handler/defhandler :copy :text-input-control
+  (enabled? [^TextInputControl control] (has-selection? control))
+  (run [^TextInputControl control] (.copy control)))
+
 (handler/defhandler :paste :text-input-control
   (enabled? [^TextInputControl control] (and (editable control) (.. Clipboard getSystemClipboard hasString)))
   (run [^TextInputControl control] (.paste control)))
+
+(handler/defhandler :delete :text-input-control
+  (enabled? [^TextInputControl control] (editable control))
+  (run [^TextInputControl control] (.deleteNextChar control)))
 
 (handler/defhandler :undo :text-input-control
   (enabled? [^TextInputControl control] (.isUndoable control))

--- a/editor/test/editor/code_view_ux_test.clj
+++ b/editor/test/editor/code_view_ux_test.clj
@@ -123,11 +123,11 @@
 (defn- select-all! [source-viewer]
   (cvx/handler-run :select-all [(->context source-viewer nil)]{}))
 
+(defn- delete-backward! [source-viewer]
+  (cvx/handler-run :delete-backward [(->context source-viewer nil)]{}))
+
 (defn- delete! [source-viewer]
   (cvx/handler-run :delete [(->context source-viewer nil)]{}))
-
-(defn- delete-forward! [source-viewer]
-  (cvx/handler-run :delete-forward [(->context source-viewer nil)]{}))
 
 (defn- delete-prev-word! [source-viewer]
   (cvx/handler-run :delete-prev-word [(->context source-viewer nil)]{}))
@@ -554,50 +554,50 @@
       (is (= "hello there" (text-selection source-viewer)))
       (is (= (caret source-viewer) (count (text source-viewer)))))))
 
-(deftest delete-test
+(deftest delete-backward-test
   (with-code lua/lua "blue"
     (testing "deleting"
       (caret! source-viewer 3 false)
-      (delete! source-viewer)
+      (delete-backward! source-viewer)
       (is (= \e (get-char-at-caret source-viewer)))
       (is (= "ble" (text source-viewer))))
     (testing "deleting with highlighting selection"
       (caret! source-viewer 0 false)
       (text-selection! source-viewer 0 2)
-      (delete! source-viewer)
+      (delete-backward! source-viewer)
       (is (= "e" (text source-viewer))))
     (testing "delete works with automatch"
       (text! source-viewer "[]hello")
       (caret! source-viewer 1 false)
-      (delete! source-viewer)
+      (delete-backward! source-viewer)
       (is (= "hello" (text source-viewer))))
     (testing "automatch delete doesn't invoke when second char is deleted"
       (text! source-viewer "[]hello")
       (caret! source-viewer 2 false)
-      (delete! source-viewer)
+      (delete-backward! source-viewer)
       (is (= "[hello" (text source-viewer))))))
 
-(deftest delete-forward-test
+(deftest delete-test
   (with-code lua/lua "blue"
     (testing "deleting"
       (caret! source-viewer 2 false)
-      (delete-forward! source-viewer)
+      (delete! source-viewer)
       (is (= \e (get-char-at-caret source-viewer)))
       (is (= "ble" (text source-viewer))))
     (testing "deleting with highlighting selection"
       (caret! source-viewer 0 false)
       (text-selection! source-viewer 0 2)
-      (delete-forward! source-viewer)
+      (delete! source-viewer)
       (is (= "e" (text source-viewer))))
     (testing "delete works with automatch"
       (text! source-viewer "[]hello")
       (caret! source-viewer 0 false)
-      (delete-forward! source-viewer)
+      (delete! source-viewer)
       (is (= "hello" (text source-viewer))))
     (testing "automatch delete doesn't invoke when second char is deleted"
       (text! source-viewer "[]hello")
       (caret! source-viewer 1 false)
-      (delete-forward! source-viewer)
+      (delete! source-viewer)
       (is (= "[hello" (text source-viewer))))))
 
 (deftest cut-test


### PR DESCRIPTION
Fixes defold/editor2-issues#164
Fixes defold/editor2-issues#823

### User-facing changes
* The Show in Desktop, Referencing Files and Dependencies commands are now available from context menus on Editor Tabs, as well as on entries in the Changes and Outline panels.
* The Open, Open As, Cut, Copy, Paste, Delete commands are now available from the Outline panel context menu.
* Context menu sections now appear in a consistent order throughout the application.
* The Cut, Copy, Paste, Delete menu entries now appear in the correct order.
* The Close Others context menu entry cannot be selected if there is only one tab open.
* The Delete key is now context sensitive and will delete scene elements, selected text, or Assets depending on what has input focus.

### Technical changes
* The `TabPane` now has a ui context whose selection provides a `Resource`.
* `Tab` context menus were moved to the `TabPane` which supports the `CONTEXT_MENU_REQUESTED` event required to refresh the menu state dynamically.
* The `:delete` handler in the code view was renamed to `:delete-backward` as it was actually performing a backspace in case Delete was selected from the Edit menu. Conversely, the `:delete-forward` handler was renamed to `:delete`.
* The `:delete-forward` handler in the code view was ren
* The `ui/find-node-of-type` function has been renamed to `closest-node-of-type`, which mirrors the term used in the popular jQuery library. In addition `ui/closest-node-where` and `closest-node-with-style` were added. These take a predicate or a style class, respectively.
