### PR TITLE
DEFEDIT-1083 Fix for invisible curve labels

### DIFF
--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -677,7 +677,7 @@
                         (proxy-super updateItem item empty)
                         (when (and item (not empty))
                           (let [[r g b] (colors/hsl->rgb (:hue item) 1.0 0.75)]
-                            (proxy-super setStyle (format "-fx-text-fill: rgb(%f, %f, %f);" (* 255 r) (* 255 g) (* 255 b))))))))))))))
+                            (proxy-super setStyle (format "-fx-text-fill: rgb(%d, %d, %d);" (int (* 255 r)) (int (* 255 g)) (int (* 255 b)))))))))))))))
       node-id)))
 
 (defn- reload-curve-view []


### PR DESCRIPTION
Fixes defold/editor2-issues#1089

* `format` outputs `,` decimal separators on swedish-locale Windows, producing invalid CSS.