### PR TITLE
DEFEDIT-1085 Prevent Hot Reload for unsupported resource types

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -308,9 +308,12 @@
                 (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix))))))))))
 
 
+(def ^:private unreloadable-resource-build-exts #{"animc" "collectionc" "goc" "materialc"})
+
 (handler/defhandler :hot-reload :global
   (enabled? [app-view selection]
-            (or (selection->single-resource-file selection) (g/node-value app-view :active-resource)))
+            (when-some [resource (or (selection->single-resource-file selection) (g/node-value app-view :active-resource))]
+              (not (contains? unreloadable-resource-build-exts (:build-ext (resource/resource-type resource))))))
   (run [project app-view prefs build-errors-view selection]
     (when-let [resource (or (selection->single-resource-file selection) (g/node-value app-view :active-resource))]
       (ui/default-render-progress-now! (progress/make "Building..."))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -308,7 +308,7 @@
                 (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix))))))))))
 
 
-(def ^:private unreloadable-resource-build-exts #{"animc" "collectionc" "goc" "materialc"})
+(def ^:private unreloadable-resource-build-exts #{"collectionc" "goc"})
 
 (handler/defhandler :hot-reload :global
   (enabled? [app-view selection]


### PR DESCRIPTION
Fixes defold/editor2-issues#1101

### User-facing changes
* The Hot Reload menu item is disabled for unsupported resource types.