### PR TITLE
DEFEDIT-1084 Fix issue with protobuf name mangling

### DIFF
--- a/editor/src/clj/camel_snake_kebab.clj
+++ b/editor/src/clj/camel_snake_kebab.clj
@@ -2,7 +2,10 @@
   "Original code (C) and thanks to  Christoffer Sawicki & ToBeReplaced.
 
   See https://github.com/qerub/camel-snake-kebab"
-  (:require [clojure.string :refer [split join capitalize lower-case upper-case]])
+  (:require [clojure.string :refer [split join]]
+            [editor.util :refer [lower-case* upper-case* capitalize*] :rename {lower-case* lower-case
+                                                                               upper-case* upper-case
+                                                                               capitalize* capitalize}])
   (:import  (clojure.lang Keyword Symbol)))
 
 (def ^:private upper-case-http-headers

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -105,7 +105,7 @@ Macros currently mean no foreseeable performance gain however."
           :else
           (recur (inc i) sb true)))
       (cond-> sb
-        (= (int \#) (.codePointAt s (dec (.length s))))
+        (and (pos? (.length s)) (= (int \#) (.codePointAt s (dec (.length s)))))
         (.appendCodePoint (int \_))
 
         true

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -1,11 +1,49 @@
 (ns editor.util
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string])
+  (:import [java.util Locale]))
+
+(set! *warn-on-reflection* true)
 
 (defmacro spy
   [& body]
   `(let [ret# (try ~@body (catch Throwable t# (prn t#) (throw t#)))]
      (prn ret#)
      ret#))
+
+
+;; See http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug
+
+(defmacro with-locale
+  [locale & body]
+  `(let [original# (Locale/getDefault)]
+     (try
+       (Locale/setDefault ~locale)
+       ~@body
+       (finally
+         (Locale/setDefault original#)))))
+
+(defmacro with-root-locale
+  [& body]
+  `(with-locale Locale/ROOT ~@body))
+
+(defn lower-case*
+  [^CharSequence s]
+  "Like clojure.string/lower-case but using root locale."
+  (.. s toString (toLowerCase Locale/ROOT)))
+
+(defn upper-case*
+  [^CharSequence s]
+  "Like clojure.string/upper-case but using root locale."
+  (.. s toString (toUpperCase Locale/ROOT)))
+
+(defn ^String capitalize*
+  "Like clojure.string/capitalize but using root locale."
+  [^CharSequence s]
+  (let [s (.toString s)]
+    (if (< (count s) 2)
+      (.toUpperCase s Locale/ROOT)
+      (str (.toUpperCase (subs s 0 1) Locale/ROOT)
+           (.toLowerCase (subs s 1) Locale/ROOT)))))
 
 
 ;; non-lazy implementation of variant of the Alphanum Algorithm:

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -13,19 +13,6 @@
 
 ;; See http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug
 
-(defmacro with-locale
-  [locale & body]
-  `(let [original# (Locale/getDefault)]
-     (try
-       (Locale/setDefault ~locale)
-       ~@body
-       (finally
-         (Locale/setDefault original#)))))
-
-(defmacro with-root-locale
-  [& body]
-  `(with-locale Locale/ROOT ~@body))
-
 (defn lower-case*
   [^CharSequence s]
   "Like clojure.string/lower-case but using root locale."

--- a/editor/src/clj/service/log.clj
+++ b/editor/src/clj/service/log.clj
@@ -16,8 +16,8 @@
   are key-value pairs, which will be printed as with 'pr'. The special
   key :exception should have a java.lang.Throwable as its value, and
   will be passed separately to the underlying logging API."
-  (:require clojure.string)
-  (:import (org.slf4j LoggerFactory)))
+  (:import (org.slf4j LoggerFactory))
+  (:require [editor.util :as util]))
 
 (set! *warn-on-reflection* true)
 
@@ -35,7 +35,7 @@
         logger' (gensym "logger")  ; for nested syntax-quote
         string' (gensym "string")
         enabled-method' (symbol (str ".is"
-                                     (clojure.string/capitalize (name level))
+                                     (util/capitalize* (name level))
                                      "Enabled"))
         log-method' (symbol (str "." (name level)))]
     `(when-not *logging-suppressed*

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -130,3 +130,8 @@
 
 (deftest field-order
   (is (= :uint-value ((protobuf/fields-by-indices TestDdf$Msg) 1))))
+
+(deftest underscores-to-camel-case-test
+  (is (= "Id" (protobuf/underscores-to-camel-case "id")))
+  (is (= "StoreFrontImageUrl" (protobuf/underscores-to-camel-case "store_front_image_url")))
+  (is (= "IOSExecutableUrl" (protobuf/underscores-to-camel-case "iOSExecutableUrl"))))

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -134,4 +134,5 @@
 (deftest underscores-to-camel-case-test
   (is (= "Id" (protobuf/underscores-to-camel-case "id")))
   (is (= "StoreFrontImageUrl" (protobuf/underscores-to-camel-case "store_front_image_url")))
-  (is (= "IOSExecutableUrl" (protobuf/underscores-to-camel-case "iOSExecutableUrl"))))
+  (is (= "IOSExecutableUrl" (protobuf/underscores-to-camel-case "iOSExecutableUrl")))
+  (is (= "SomeField_" (protobuf/underscores-to-camel-case "some_field#"))))


### PR DESCRIPTION
The clojure.string/{upper-case,lower-case,capitalize} functions
provide no means to pass a Locale, and without doing so we will
experience the "Infamous Turkish Locale" problem.

This commit introduces utility functions that use the root locale
instead, and fixes usages in camel-snake-kebab and the protobuf name
mangling.

Fixes https://github.com/defold/editor2-issues/issues/1099