### PR TITLE
DEFEDIT-919 Gui id validation

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -23,7 +23,7 @@
 
 (namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id produce-value node-by-id-at])
 
-(namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate flatten-errors precluding-errors worse-than])
+(namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate flatten-errors package-errors precluding-errors unpack-errors worse-than])
 
 (namespaces/import-vars [internal.node value-type-schema value-type? isa-node-type? value-type-dispatch-value has-input? has-output? has-property? type-compatible? merge-display-order NodeType supertypes transforms transform-types internal-property-labels declared-properties declared-property-labels externs declared-inputs injectable-inputs declared-outputs cached-outputs input-dependencies input-cardinality cascade-deletes substitute-for input-type output-type input-labels output-labels property-display-order])
 

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -52,7 +52,7 @@
         (when (or (nil? origin-override-id)
                   (not= origin-override-id (g/override-id node-id)))
           (when-let [resource (existing-resource node-id)]
-            {:node-id node-id
+            {:node-id (or (g/override-original node-id) node-id)
              :resource resource})))
       (when-some [remaining-errors (next errors)]
         (recur remaining-errors origin-override-depth origin-override-id))))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -75,10 +75,6 @@
      :icon ""
      :label ""}))
 
-(defn- prop-id-duplicate? [id-counts id]
-  (when (> (id-counts id) 1)
-    (format "'%s' is in use by another instance" id)))
-
 (def ^:private identity-transform-properties
   {:position [0.0 0.0 0.0]
    :rotation [0.0 0.0 0.0 1.0]
@@ -138,7 +134,7 @@
   (property id g/Str
             (dynamic error (g/fnk [_node-id id id-counts]
                                   (or (validation/prop-error :fatal _node-id :id validation/prop-empty? id "Id")
-                                      (validation/prop-error :fatal _node-id :id (partial prop-id-duplicate? id-counts) id))))
+                                      (validation/prop-error :fatal _node-id :id (partial validation/prop-id-duplicate? id-counts) id))))
             (dynamic read-only? (g/fnk [_node-id]
                                   (g/override? _node-id))))
   (property url g/Str

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -572,7 +572,7 @@
   (output node-outline-reqs g/Any :cached (g/fnk []
                                             (mapv (fn [[nt kw]] {:node-type nt :tx-attach-fn (gen-gui-node-attach-fn kw)}) node-type->kw)))
   (output node-outline outline/OutlineData :cached
-          (g/fnk [_node-id id node-outline-children node-outline-reqs type outline-overridden?]
+          (g/fnk [_node-id id node-outline-children node-outline-reqs type outline-error? outline-overridden?]
                  {:node-id _node-id
                   :label id
                   :icon (node-icons type)
@@ -582,6 +582,7 @@
                                        (and (g/node-instance? GuiNode node-id)
                                             (not= node-id (g/node-value node-id :parent)))))
                   :children node-outline-children
+                  :outline-error? outline-error?
                   :outline-overridden? outline-overridden?}))
 
   (output transform-properties g/Any scene/produce-scalable-transform-properties)
@@ -618,6 +619,7 @@
                                                 (g/flatten-errors [child-build-errors
                                                                    (prop-unique-id-error _node-id :id id id-counts "Id")
                                                                    (validate-layer false _node-id layer-names layer)])))
+  (output outline-error? g/Bool :accept-errors (g/fnk [build-errors] (some? build-errors)))
   (output build-errors g/Any (gu/passthrough build-errors-gui-node))
   (input template-build-targets g/Any :array)
   (output template-build-targets g/Any (gu/passthrough template-build-targets)))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -625,7 +625,7 @@
   (output build-errors g/Any :cached (g/fnk [_node-id own-build-errors child-build-errors]
                                        (g/package-errors _node-id
                                                          child-build-errors
-                                                         (:causes (g/unpack-errors own-build-errors)))))
+                                                         own-build-errors)))
   (input template-build-targets g/Any :array)
   (output template-build-targets g/Any (gu/passthrough template-build-targets)))
 
@@ -1868,7 +1868,7 @@
 (g/defnk produce-build-errors [_node-id build-errors own-build-errors]
   (g/package-errors _node-id
                     build-errors
-                    (:causes (g/unpack-errors own-build-errors))))
+                    own-build-errors))
 
 (defn- get-ids [outline]
   (map :label (tree-seq (constantly true) :children outline)))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2307,44 +2307,6 @@
 (defn- convert-node-desc [node-desc]
   (into {} (map (fn [[key val]] (let [[new-key f] (get node-property-fns key [key key])]
                                   [new-key (f node-desc)])) node-desc)))
-
-(defn- uniquify-ids [node-descs]
-  (loop [input node-descs
-         output (transient [])
-         taken-ids #{}
-         renamed-ids {}]
-    (if-some [node-desc (first input)]
-      (let [old-id (:id node-desc)
-            new-id (outline/resolve-id old-id taken-ids)
-            renamed? (not= old-id new-id)]
-        (recur (next input)
-               (conj! output (if renamed?
-                               (assoc node-desc :id new-id)
-                               node-desc))
-               (conj taken-ids new-id)
-               (if renamed?
-                 (assoc renamed-ids old-id new-id)
-                 renamed-ids)))
-      [(persistent! output) taken-ids renamed-ids])))
-
-(defn- repair-broken-id-links [node-descs taken-ids renamed-ids]
-  (mapv (fn [node-desc]
-          (or (when-some [old-parent-id (not-empty (:parent node-desc))]
-                (when-not (contains? taken-ids old-parent-id)
-                  (assoc node-desc :parent (get renamed-ids old-parent-id ""))))
-              node-desc))
-        node-descs))
-
-(defn- sanitize-node-descs
-  "Ensures all nodes have unique ids, and tries to repair parent-child links
-  for any renamed nodes. Since we cannot distinguish between which of two nodes
-  with conflicting ids you meant to use as a parent, we cannot guarantee correct
-  parent-child relationships after a rename. We do however guarantee that all
-  nodes will still be in the scene somewhere. Note that this function retains
-  the original node-desc order."
-  [node-descs]
-  (apply repair-broken-id-links (uniquify-ids node-descs)))
-
 (defn- sort-node-descs
   [node-descs]
   (let [parent-id->children (group-by :parent (remove #(str/blank? (:id %)) node-descs))
@@ -2357,7 +2319,7 @@
         resource           (g/node-value self :resource)
         resolve-fn         (partial workspace/resolve-resource resource)
         graph-id           (g/node-id->graph-id self)
-        node-descs         (sanitize-node-descs (map convert-node-desc (:nodes scene)))
+        node-descs         (map convert-node-desc (:nodes scene))
         tmpl-node-descs    (into {} (map (fn [n] [(:id n) {:template (:parent n) :data (extract-overrides n)}])
                                          (filter :template-node-child node-descs)))
         tmpl-node-descs    (into {} (map (fn [[id data]]
@@ -2541,11 +2503,9 @@
                      (for [layout-desc (:layouts scene)
                            :let [layout-desc (-> layout-desc
                                                (select-keys prop-keys)
-                                               (update :nodes (fn [nodes]
-                                                                (into {}
-                                                                      (map (juxt :id identity))
-                                                                      (sanitize-node-descs (map (comp extract-overrides convert-node-desc)
-                                                                                                nodes))))))]]
+                                               (update :nodes (fn [nodes] (->> nodes
+                                                                            (map (fn [v] [(:id v) (-> v extract-overrides convert-node-desc)]))
+                                                                            (into {})))))]]
                        (g/make-nodes graph-id [layout [LayoutNode layout-desc]]
                                      (attach-layout self layouts-node layout))))))))
 

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -51,6 +51,7 @@
                         :icon                                 s/Str
                         (s/optional-key :children)            [s/Any]
                         (s/optional-key :child-reqs)          [s/Any]
+                        (s/optional-key :outline-error?)      s/Bool
                         (s/optional-key :outline-overridden?) s/Bool
                         s/Keyword                             s/Any})
 
@@ -62,7 +63,7 @@
   (output outline-overridden? g/Bool :cached (g/fnk [_overridden-properties child-outlines]
                                                     (boolean
                                                       (or (not (empty? _overridden-properties))
-                                                          (some :outline-overridden child-outlines))))))
+                                                          (some :outline-overridden? child-outlines))))))
 
 (defn- outline-attachments
   [node-id]

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -58,12 +58,7 @@
 (g/defnode OutlineNode
   (input source-outline OutlineData)
   (input child-outlines OutlineData :array)
-
-  (output node-outline OutlineData :abstract)
-  (output outline-overridden? g/Bool :cached (g/fnk [_overridden-properties child-outlines]
-                                                    (boolean
-                                                      (or (not (empty? _overridden-properties))
-                                                          (some :outline-overridden? child-outlines))))))
+  (output node-outline OutlineData :abstract))
 
 (defn- outline-attachments
   [node-id]

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -401,12 +401,15 @@
                        (proxy-super setGraphic nil)
                        (proxy-super setContextMenu nil)
                        (proxy-super setStyle nil))                                                                    
-                     (let [{:keys [label icon color outline-overridden? link]} item]
+                     (let [{:keys [label icon color outline-error? outline-overridden? link]} item]
                        (let [label (if link
                                      (format "%s - %s" label (resource/resource->proj-path link))
                                      label)]
                          (proxy-super setText label))
                        (proxy-super setGraphic (jfx/get-image-view icon 16))
+                       (if outline-error?
+                         (ui/add-style! this "error")
+                         (ui/remove-style! this "error"))
                        (if outline-overridden?
                          (ui/add-style! this "overridden")
                          (ui/remove-style! this "overridden"))

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -15,6 +15,10 @@
          (format "\"%s\" has been replaced by \"%s\"",
                  (options# :blend-mode-add-alpha) (options# :blend-mode-add))))))
 
+(defn prop-id-duplicate? [id-counts id]
+  (when (> (id-counts id) 1)
+    (format "'%s' is in use by another instance" id)))
+
 (defn prop-negative? [v name]
   (when (< v 0)
     (format "'%s' must be positive" name)))

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -14,7 +14,7 @@
 
 (defn error-value
   ([severity message]
-    (error-value severity message {}))
+    (error-value severity message nil))
   ([severity message user-data]
     (map->ErrorValue {:severity severity :message message :user-data user-data})))
 
@@ -24,7 +24,7 @@
 
 (defn ->error
   ([node-id label severity value message]
-    (->error node-id label severity value message {}))
+    (->error node-id label severity value message nil))
   ([node-id label severity value message user-data]
     (->ErrorValue node-id label severity value message nil user-data)))
 

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -53,7 +53,7 @@
                                                       result
                                                       severity))
                               :info (keep :severity es))]
-     (map->ErrorValue {:severity max-severity :causes es})))
+     (map->ErrorValue {:severity max-severity :causes (vec es)})))
   ([es & kvs]
    (apply assoc (error-aggregate es) kvs)))
 

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -9,9 +9,6 @@
 
 (defrecord ErrorValue [_node-id _label severity value message causes user-data])
 
-(defmethod print-method ErrorValue [error-value ^java.io.Writer w]
-  (.write w (format "{:ErrorValue %s}" (pr-str (into {} (filter (comp some? val)) error-value)))))
-
 (defn error-value
   ([severity message]
     (error-value severity message nil))
@@ -58,9 +55,6 @@
    (apply assoc (error-aggregate es) kvs)))
 
 (defrecord ErrorPackage [packaged-errors])
-
-(defmethod print-method ErrorPackage [error-package ^java.io.Writer w]
-  (.write w (format "{:ErrorPackage %s}" (pr-str (:packaged-errors error-package)))))
 
 (defn- unpack-if-package [error-or-package]
   (if (instance? ErrorPackage error-or-package)

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -819,7 +819,7 @@
                  :output              {klabel outdef}}]
     desc))
 
-(def ^:private output-flags   #{:cached :abstract :accept-errors})
+(def ^:private output-flags   #{:cached :abstract})
 (def ^:private output-options #{})
 
 (defmethod process-as 'output [[_ label & forms]]
@@ -1343,8 +1343,7 @@
           forms)))
 
 (defn input-error-check [self-name ctx-name description label nodeid-sym input-sym tail]
-  (if (or (contains? internal-keys label)
-          (contains? (get-in description [:output label :flags]) :accept-errors))
+  (if (contains? internal-keys label)
     tail
     `(let [serious-input-errors# (filter-error-vals (:ignore-errors ~ctx-name) ~input-sym)]
        (if (empty? serious-input-errors#)

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -819,7 +819,7 @@
                  :output              {klabel outdef}}]
     desc))
 
-(def ^:private output-flags   #{:cached :abstract})
+(def ^:private output-flags   #{:cached :abstract :accept-errors})
 (def ^:private output-options #{})
 
 (defmethod process-as 'output [[_ label & forms]]
@@ -1343,7 +1343,8 @@
           forms)))
 
 (defn input-error-check [self-name ctx-name description label nodeid-sym input-sym tail]
-  (if (contains? internal-keys label)
+  (if (or (contains? internal-keys label)
+          (contains? (get-in description [:output label :flags]) :accept-errors))
     tail
     `(let [serious-input-errors# (filter-error-vals (:ignore-errors ~ctx-name) ~input-sym)]
        (if (empty? serious-input-errors#)

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -74,6 +74,12 @@ $scene-toolbar-button-selected-background: $input-background;
 $scene-toolbar-button-selected-foreground: $defold-white;
 $scene-toolbar-button-hovered-foreground: $defold-white;
 
+/* Status colors */
+$error-severity-fatal: $defold-red;
+$error-severity-fatal-dim: #ad4051;
+$error-severity-warning: $defold-yellow;
+$error-severity-warning-dim: rgba($error-severity-warning, 0.5);
+
 /* Lua script colors */
 $script-helper:         #33cccc;
 $script-self:           #E066FF;

--- a/editor/styling/stylesheets/main.sass
+++ b/editor/styling/stylesheets/main.sass
@@ -54,6 +54,7 @@
 @import 'modules/_console';
 @import 'modules/_curve-view';
 @import 'modules/_diff-view';
+@import 'modules/_outline';
 @import 'modules/_preferences';
 @import 'modules/_progress-bar';
 @import 'modules/_properties';

--- a/editor/styling/stylesheets/modules/_outline.scss
+++ b/editor/styling/stylesheets/modules/_outline.scss
@@ -1,23 +1,44 @@
 /* Outline panel */
 
-@mixin colorize-tree-item($color, $active-color) {
+@mixin colorize-icon($color, $active-color) {
   &:filled {
-    -fx-text-fill: $color;
     .image-view {
       -fx-effect: innershadow(gaussian, $color, 20, 1.0, 0, 0);
     }
 
     &:hover {
-      -fx-text-fill: $active-color;
       .image-view {
         -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);
       }
     }
 
     &:selected {
-      -fx-text-fill: $active-color;
       .image-view {
         -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);;
+      }
+    }
+  }
+}
+
+@mixin colorize-label($color, $active-color) {
+  &:filled {
+    -fx-text-fill: $color;
+
+    &:hover {
+      -fx-text-fill: $active-color;
+    }
+
+    &:selected {
+      -fx-text-fill: $active-color;
+    }
+  }
+}
+
+@mixin colorize-disclosure-arrow($color) {
+  &:filled {
+    .tree-disclosure-node {
+      .arrow {
+        -fx-effect: innershadow(gaussian, $color, 20, 1.0, 0, 0);
       }
     }
   }
@@ -26,11 +47,21 @@
 #outline {
   .tree-cell {
     &.overridden {
-      @include colorize-tree-item($defold-light-blue, lighten($defold-light-blue, 15%));
+      @include colorize-icon(#52a5d9, $defold-light-blue);
+      @include colorize-label(#52a5d9, $defold-light-blue);
+    }
+
+    &.child-overridden {
+      @include colorize-disclosure-arrow(#52a5d9);
     }
 
     &.error {
-      @include colorize-tree-item($defold-red, lighten($defold-red, 15%));
+      // NOTE: Icon image also changes to the error icon.
+      @include colorize-icon($error-severity-fatal-dim, $error-severity-fatal);
+    }
+
+    &.child-error {
+      @include colorize-disclosure-arrow($error-severity-fatal-dim);
     }
   }
 }

--- a/editor/styling/stylesheets/modules/_outline.scss
+++ b/editor/styling/stylesheets/modules/_outline.scss
@@ -1,0 +1,36 @@
+/* Outline panel */
+
+@mixin colorize-tree-item($color, $active-color) {
+  &:filled {
+    -fx-text-fill: $color;
+    .image-view {
+      -fx-effect: innershadow(gaussian, $color, 20, 1.0, 0, 0);
+    }
+
+    &:hover {
+      -fx-text-fill: $active-color;
+      .image-view {
+        -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);
+      }
+    }
+
+    &:selected {
+      -fx-text-fill: $active-color;
+      .image-view {
+        -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);;
+      }
+    }
+  }
+}
+
+#outline {
+  .tree-cell {
+    &.overridden {
+      @include colorize-tree-item($defold-light-blue, lighten($defold-light-blue, 15%));
+    }
+
+    &.error {
+      @include colorize-tree-item($defold-red, lighten($defold-red, 15%));
+    }
+  }
+}

--- a/editor/styling/stylesheets/modules/_tool-tabs.scss
+++ b/editor/styling/stylesheets/modules/_tool-tabs.scss
@@ -152,18 +152,16 @@
             }
         }
 
-        $error-severity-fatal: $defold-red;
-        $error-severity-warning: $defold-yellow;
         $graphic-text-gap: 9px;
 
         &.severity-error {
             -fx-graphic-text-gap: $graphic-text-gap;
-            @include colorize-severity(#ad4051, $error-severity-fatal);
+            @include colorize-severity($error-severity-fatal-dim, $error-severity-fatal);
         }
 
         &.severity-warning {
             -fx-graphic-text-gap: $graphic-text-gap;
-            @include colorize-severity(rgba($error-severity-warning, 0.5), $error-severity-warning);
+            @include colorize-severity($error-severity-warning-dim, $error-severity-warning);
         }
 
         &.severity-info {

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -138,13 +138,16 @@
             (doseq [path ["/errors/button_break_self.gui"
                           "/errors/panel_break_button.gui"
                           "/errors/panel_using_button_break_self.gui"
+                          "/errors/panel_using_name_conflict_twice.gui"
                           "/errors/window_using_panel_break_button.gui"]]
               (add-component-from-file! workspace game-object path))
             (project/build project main-collection {:render-error! render-error!})
             (let [error-value (build-error render-error!)]
               (when (is (some? error-value))
                 (let [error-tree (build-errors-view/build-resource-tree error-value)]
-                  (is (= ["/errors/button_break_self.gui" "/errors/panel_break_button.gui"]
+                  (println (pr-str error-tree))
+                  (is (= ["/errors/button_break_self.gui" "/errors/name_conflict.gui" "/errors/panel_break_button.gui"]
                          (sort (map #(resource/proj-path (get-in % [:value :resource])) (:children error-tree)))))
                   (is (= 1 (count (get-in error-tree [:children 0 :children]))))
-                  (is (= 1 (count (get-in error-tree [:children 1 :children])))))))))))))
+                  (is (= 2 (count (get-in error-tree [:children 1 :children]))))
+                  (is (= 1 (count (get-in error-tree [:children 2 :children])))))))))))))

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -367,12 +367,15 @@
   (with-clean-system
     (let [[workspace project] (test-util/setup! world)
           root (test-util/resource-node project "/gui/scene.gui")
-          paths [[0 1] [0 1 0]]
           new-pos [-100.0 0.0 0.0]
           sub-box (:node-id (outline root [0 1 0]))]
       (g/transact (g/set-property sub-box :position new-pos))
-      (doseq [path paths]
-        (is (true? (:outline-overridden? (outline root path))))))))
+      ;; NOTE: Only the affected node is marked as overridden.
+      ;; Parent nodes obtain the :child-overridden? attribute
+      ;; when decorated in the outline view.
+      (is (not (:outline-overridden? (outline root [0]))))
+      (is (not (:outline-overridden? (outline root [0 1]))))
+      (is (:outline-overridden? (outline root [0 1 0]))))))
 
 (deftest read-only-gui-template-sub-items
   (with-clean-system

--- a/editor/test/internal/graph/error_values_test.clj
+++ b/editor/test/internal/graph/error_values_test.clj
@@ -58,6 +58,25 @@
                                                    [(error-fatal "2a") [(error-fatal "2ba")
                                                                         (error-fatal "2bb")]]))))))
 
+  (testing "Packaging returns nil if no errors"
+    (is (nil? (package-errors 12345 nil)))
+    (is (nil? (package-errors 12345
+                              nil
+                              [nil nil]
+                              [nil [nil
+                                    nil]]))))
+
+  (testing "The flatten-errors function returns nil if no errors"
+    (is (nil? (flatten-errors nil)))
+    (is (nil? (flatten-errors nil
+                              [nil nil]
+                              [nil [nil
+                                    nil]]))))
+
+  (testing "The flatten-errors function filters out nil values"
+    (is (= (map->ErrorValue {:severity :fatal
+                             :causes [(error-fatal "wrapped")]})
+           (flatten-errors nil [nil (error-fatal "wrapped")]))))
 
   (testing "The flatten-errors function unpacks packaged errors"
     (is (= (map->ErrorValue {:severity :fatal

--- a/editor/test/internal/graph/error_values_test.clj
+++ b/editor/test/internal/graph/error_values_test.clj
@@ -66,6 +66,23 @@
                               [nil [nil
                                     nil]]))))
 
+  (testing "Packaging lifts packaged errors with matching node id"
+    (is (= (map->ErrorValue {:_node-id 12345
+                             :severity :fatal
+                             :causes [(error-fatal "0")
+                                      (error-fatal "1a")
+                                      (error-fatal "1b")
+                                      (error-fatal "2a")
+                                      (error-fatal "2ba")
+                                      (error-fatal "2bb")]})
+           (unpack-errors (package-errors 12345
+                                          (error-fatal "0")
+                                          (package-errors 12345
+                                                          [(error-fatal "1a") (error-fatal "1b")])
+                                          (package-errors 12345
+                                                          [(error-fatal "2a") (package-errors 12345 [(error-fatal "2ba")
+                                                                                                     (error-fatal "2bb")])]))))))
+
   (testing "The flatten-errors function returns nil if no errors"
     (is (nil? (flatten-errors nil)))
     (is (nil? (flatten-errors nil

--- a/editor/test/resources/errors_project/errors/name_conflict.gui
+++ b/editor/test/resources/errors_project/errors/name_conflict.gui
@@ -1,0 +1,16 @@
+script: ""
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+layers {
+  name: "duplicate_layer"
+}
+layers {
+  name: "duplicate_layer"
+}
+material: "/builtins/materials/gui.material"
+adjust_reference: ADJUST_REFERENCE_LEGACY
+max_nodes: 512

--- a/editor/test/resources/errors_project/errors/panel_using_name_conflict_twice.gui
+++ b/editor/test/resources/errors_project/errors/panel_using_name_conflict_twice.gui
@@ -1,0 +1,88 @@
+script: ""
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "name_conflict"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/errors/name_conflict.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/errors/name_conflict.gui"
+  template_node_child: false
+}
+material: "/builtins/materials/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512


### PR DESCRIPTION
Fixes defold/editor2-issues#738
Fixes defold/editor2-issues#977

### User-facing changes
* Duplicate ids or resource names inside gui scenes now result in a Build Error.
* Gui nodes with errors are now highlighted in the Outline Panel.
* Nodes with overrides are now highlighted in the Outline Panel.
* You can now double-click on a template node to open the template scene in the editor.

### Technical changes
* Introduced `:outline-error?` key to `OutlineData`.
* If you set `:outline-overridden?` or `:outline-error?` in your `OutlineData`, the outline view will decorate parent nodes with `:child-overridden?` and `:child-error?`, respectively. We use these to highlight the path up to the error or override using CSS classes defined in `_outline.scss`.
* Removed the `outline-overridden?` output from `OutlineNode`, since it was only used in the `node-outline` production function of `GuiNode`.
* Added `ErrorPackage` functionality. This allows us to aggregate and wrap `ErrorValues` to they can travel in the graph. We use this in `gui.clj` to send build errors around so we can produce `node-outline` data with the `:outline-error?` flag set.

![errors-in-outline](https://user-images.githubusercontent.com/22448941/29261750-7bb35c48-80d1-11e7-84e7-bc4bd3da0c5b.png)