### PR TITLE
DEFEDIT-1109 File change * doesn't always hide when saving

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -265,48 +265,43 @@
   (console/clear-console!)
   (ui/default-render-progress-now! (progress/make "Building..."))
   (ui/->future 0.01
-    (fn []
-      (let [build-options (make-build-options build-errors-view)
-            build (project/build-and-save-project project prefs build-options)
-            render-error! (:render-error! build-options)]
-        (when (and (future? build) @build)
-          (or (when-let [target (targets/selected-target prefs)]
-                (let [local-url (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix)]
-                  (engine/reboot target local-url)))
-              (try
-                (engine/launch project prefs)
-                (catch Exception e
-                  (when-not (engine-build-errors/handle-build-error! render-error! project e)
-                    (throw e))))))))))
+               (fn []
+                 (let [build-options (make-build-options build-errors-view)
+                       build (project/build-and-write-project project prefs build-options)
+                       render-error! (:render-error! build-options)]
+                   (when build
+                     (or (when-let [target (targets/selected-target prefs)]
+                           (let [local-url (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix)]
+                             (engine/reboot target local-url)))
+                         (try
+                           (engine/launch project prefs)
+                           (catch Exception e
+                             (when-not (engine-build-errors/handle-build-error! render-error! project e)
+                               (throw e))))))))))
 
 (handler/defhandler :build :global
-  (enabled? [] (not (project/ongoing-build-save?)))
   (run [project prefs web-server build-errors-view]
     (build-handler project prefs web-server build-errors-view)))
 
 (handler/defhandler :rebuild :global
-  (enabled? [] (not (project/ongoing-build-save?)))
   (run [project prefs web-server build-errors-view]
     (project/reset-build-caches project)
     (build-handler project prefs web-server build-errors-view)))
 
 (handler/defhandler :build-html5 :global
-  (enabled? [] (not (project/ongoing-build-save?)))
   (run [project prefs web-server build-errors-view changes-view]
     (console/clear-console!)
     ;; We need to save because bob reads from FS
-    (project/save-all! project
-      (fn []
-        (changes-view/refresh! changes-view)
-        (ui/default-render-progress-now! (progress/make "Building..."))
-        (ui/->future 0.01
-          (fn []
-            (let [build-options (make-build-options build-errors-view)
-                  succeeded? (deref (bob/build-html5! project prefs build-options))]
-              (ui/default-render-progress-now! progress/done)
-              (when succeeded?
-                (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix))))))))))
-
+    (project/save-all! project)
+    (changes-view/refresh! changes-view)
+    (ui/default-render-progress-now! (progress/make "Building..."))
+    (ui/->future 0.01
+                 (fn []
+                   (let [build-options (make-build-options build-errors-view)
+                         succeeded? (deref (bob/build-html5! project prefs build-options))]
+                     (ui/default-render-progress-now! progress/done)
+                     (when succeeded?
+                       (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix))))))))
 
 (def ^:private unreloadable-resource-build-exts #{"collectionc" "goc"})
 
@@ -320,8 +315,8 @@
       (ui/->future 0.01
                    (fn []
                      (let [build-options (make-build-options build-errors-view)
-                           build (project/build-and-save-project project prefs build-options)]
-                       (when (and (future? build) @build)
+                           build (project/build-and-write-project project prefs build-options)]
+                       (when build
                          (engine/reload-resource (:url (targets/selected-target prefs)) resource))))))))
 
 (handler/defhandler :close :global
@@ -746,9 +741,9 @@
                     (:view-types resource-type))))))
 
 (handler/defhandler :save-all :global
-  (enabled? [] (not (project/ongoing-build-save?)))
   (run [project changes-view]
-       (project/save-all! project #(changes-view/refresh! changes-view))))
+    (project/save-all! project)
+    (changes-view/refresh! changes-view)))
 
 (handler/defhandler :show-in-desktop :global
   (active? [selection] (selection->single-resource selection))
@@ -826,21 +821,19 @@
     ;; We need to save because bob reads from FS.
     ;; Before saving, perform a resource sync to ensure we do not overwrite external changes.
     (workspace/resource-sync! (project/workspace project))
-    (project/save-all! project
-                       (fn []
-                         (changes-view/refresh! changes-view)
-                         (ui/default-render-progress-now! (progress/make "Bundling..."))
-                         (ui/->future 0.01
-                                      (fn []
-                                        (let [succeeded? (deref (bob/bundle! project prefs platform build-options))]
-                                          (ui/default-render-progress-now! progress/done)
-                                          (if (and succeeded? (some-> output-directory .isDirectory))
-                                            (ui/open-file output-directory)
-                                            (ui/run-later
-                                              (dialogs/make-alert-dialog "Failed to bundle project. Please fix build errors and try again."))))))))))
+    (project/save-all! project)
+    (changes-view/refresh! changes-view)
+    (ui/default-render-progress-now! (progress/make "Bundling..."))
+    (ui/->future 0.01
+                 (fn []
+                   (let [succeeded? (deref (bob/bundle! project prefs platform build-options))]
+                     (ui/default-render-progress-now! progress/done)
+                     (if (and succeeded? (some-> output-directory .isDirectory))
+                       (ui/open-file output-directory)
+                       (ui/run-later
+                         (dialogs/make-alert-dialog "Failed to bundle project. Please fix build errors and try again."))))))))
 
 (handler/defhandler :bundle :global
-  (enabled? [] (not (project/ongoing-build-save?)))
   (run [user-data workspace project prefs app-view changes-view build-errors-view]
        (let [owner-window (g/node-value app-view :stage)
              platform (:platform user-data)

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -77,23 +77,23 @@
   (enabled? [changes-view]
             (g/node-value changes-view :git))
   (run [changes-view workspace project]
-       (let [git   (g/node-value changes-view :git)
-             prefs (g/node-value changes-view :prefs)]
-         ; Save the project before we initiate the sync process. We need to do this because
-         ; the unsaved files may also have changed on the server, and we'll need to merge.
-         (project/save-all! project (fn []
-                                      (when (login/login prefs)
-                                        (let [creds (git/credentials prefs)
-                                              flow (sync/begin-flow! git creds)]
-                                          (sync/open-sync-dialog flow)
-                                          (let [diff (workspace/resource-sync! workspace)]
-                                            ; The call to resource-sync! will refresh the changes view if it detected any
-                                            ; changes since last time it was called. However, we also want to refresh the
-                                            ; changes view if our changes were pushed to the server. In this scenario the
-                                            ; files on disk will not have changed, so we explicitly refresh the changes
-                                            ; view here in case resource-sync! reported no changes.
-                                            (when (resource-watch/empty-diff? diff)
-                                              (refresh! changes-view))))))))))
+    (let [git   (g/node-value changes-view :git)
+          prefs (g/node-value changes-view :prefs)]
+      ;; Save the project before we initiate the sync process. We need to do this because
+      ;; the unsaved files may also have changed on the server, and we'll need to merge.
+      (project/save-all! project)
+      (when (login/login prefs)
+        (let [creds (git/credentials prefs)
+              flow (sync/begin-flow! git creds)]
+          (sync/open-sync-dialog flow)
+          (let [diff (workspace/resource-sync! workspace)]
+            ;; The call to resource-sync! will refresh the changes view if it detected any
+            ;; changes since last time it was called. However, we also want to refresh the
+            ;; changes view if our changes were pushed to the server. In this scenario the
+            ;; files on disk will not have changed, so we explicitly refresh the changes
+            ;; view here in case resource-sync! reported no changes.
+            (when (resource-watch/empty-diff? diff)
+              (refresh! changes-view))))))))
 
 (ui/extend-menu ::menubar :editor.app-view/open
                 [{:label "Synchronize..."

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -32,16 +32,10 @@
 
     ;; If we have a project, save it before restarting the editor.
     (when (some? project)
-      ;; If a build or save was in progress, wait for it to complete.
-      (while (project/ongoing-build-save?)
-        (Thread/sleep 300))
-
       ;; Save the project and block until complete. Before saving, perform a
       ;; resource sync to ensure we do not overwrite external changes.
       (workspace/resource-sync! (project/workspace project))
-      (let [save-future (project/save-all! project nil)]
-        (when (future? save-future)
-          (deref save-future))))
+      (project/save-all! project))
 
     ;; Install update and restart the editor.
     (try

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -252,13 +252,11 @@
     (let [[workspace project] (setup-scratch world)]
       (testing "Add internal file"
         (add-file workspace "/test.collection")
-        (let [node (project/get-resource-node project "/test.collection")
-              saved (promise)]
+        (let [node (project/get-resource-node project "/test.collection")]
           (g/transact
             (g/set-property node :name "new_name"))
           (is (has-undo? project))
-          (project/save-all! project #(deliver saved :done) #(%) progress/null-render-progress!)
-          (is (= :done (deref saved 100 :timeout)))
+          (project/save-all! project progress/null-render-progress!)
           (sync! workspace)
           (is (has-undo? project)))))))
 


### PR DESCRIPTION
Seems to be caused by bad/overly optimistic update of system cache
with results from save on separate thread. Fix runs both save and
build on main thread for now.