### PR TITLE
DEFEDIT-1097 Checkbox in atlas to disable rotation when packing sprites

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -167,6 +167,6 @@ public class AtlasUtil {
         return TextureSetGenerator.generate(images, iterator,
                 Math.max(0, atlas.getMargin()),
                 Math.max(0,  atlas.getInnerPadding()),
-                Math.max(0, atlas.getExtrudeBorders()), false, false, true, false, null);
+                Math.max(0, atlas.getExtrudeBorders()), false, false, atlas.getAllowRotation() != 0, false, null);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasLoader.java
+++ b/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasLoader.java
@@ -29,6 +29,7 @@ public class AtlasLoader implements INodeLoader<AtlasNode> {
         node.setMargin(atlas.getMargin());
         node.setInnerPadding(atlas.getInnerPadding());
         node.setExtrudeBorders(atlas.getExtrudeBorders());
+        node.setAllowRotation(atlas.getAllowRotation() != 0);
         for (AtlasImage image : atlas.getImagesList()) {
             node.addChild(new AtlasImageNode(image.getImage()));
         }
@@ -58,6 +59,7 @@ public class AtlasLoader implements INodeLoader<AtlasNode> {
         atlasBuilder.setMargin(node.getMargin());
         atlasBuilder.setInnerPadding(node.getInnerPadding());
         atlasBuilder.setExtrudeBorders(node.getExtrudeBorders());
+        atlasBuilder.setAllowRotation(node.isAllowRotation() ? 1 : 0);
 
         for (Node n : node.getChildren()) {
             if (n instanceof AtlasImageNode) {

--- a/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasNode.java
+++ b/com.dynamo.cr/com.dynamo.cr.tileeditor/src/com/dynamo/cr/tileeditor/scene/AtlasNode.java
@@ -37,6 +37,9 @@ public class AtlasNode extends TextureSetNode {
     @Property
     @GreaterEqualThanZero
     private int innerPadding;
+    
+    @Property
+    private boolean allowRotation;
 
     private transient AtlasAnimationNode playBackNode;
     private transient TextureHandle textureHandle = new TextureHandle();
@@ -80,6 +83,15 @@ public class AtlasNode extends TextureSetNode {
 
     public void setInnerPadding(int innerPadding) {
         this.innerPadding = innerPadding;
+        increaseVersion();
+    }
+
+    public boolean isAllowRotation() {
+        return allowRotation;
+    }
+
+    public void setAllowRotation(boolean allowRotation) {
+        this.allowRotation = allowRotation;
         increaseVersion();
     }
 
@@ -169,7 +181,7 @@ public class AtlasNode extends TextureSetNode {
                 TextureSetResult result = TextureSetGenerator.generate(images, iterator,
                         Math.max(0, margin),
                         Math.max(0, innerPadding),
-                        Math.max(0, extrudeBorders), true, true, true, false, null);
+                        Math.max(0, extrudeBorders), true, true, allowRotation, false, null);
                 TextureSet textureSet = result.builder.setTexture("").build();
                 runtimeTextureSet.update(textureSet, result.uvTransforms);
 

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -282,10 +282,11 @@
   (output updatable g/Any :cached produce-animation-updatable)
   (output scene g/Any :cached produce-animation-scene))
 
-(g/defnk produce-save-value [margin inner-padding extrude-borders img-ddf anim-ddf]
+(g/defnk produce-save-value [margin inner-padding extrude-borders allow-rotation img-ddf anim-ddf]
   {:margin margin
    :inner-padding inner-padding
    :extrude-borders extrude-borders
+   :allow-rotation allow-rotation
    :images (sort-by-and-strip-order img-ddf)
    :animations anim-ddf})
 
@@ -352,7 +353,7 @@
      :children child-scenes}))
 
 (g/defnk produce-texture-set-data
-  [_node-id animations all-atlas-images margin inner-padding extrude-borders]
+  [_node-id animations all-atlas-images margin inner-padding extrude-borders allow-rotation]
   (or (when-let [errors (->> [[margin "Margin"]
                               [inner-padding "Inner Padding"]
                               [extrude-borders "Extrude Borders"]]
@@ -360,7 +361,7 @@
                                      (validation/prop-error :fatal _node-id :layout-result validation/prop-negative? v name)))
                              not-empty)]
         (g/error-aggregate errors))
-      (texture-set-gen/atlas->texture-set-data animations all-atlas-images margin inner-padding extrude-borders)))
+      (texture-set-gen/atlas->texture-set-data animations all-atlas-images margin inner-padding extrude-borders allow-rotation)))
 
 (g/defnk produce-anim-data
   [texture-set uv-transforms]
@@ -398,6 +399,8 @@
   (property extrude-borders g/Int
             (default 0)
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? extrude-borders)))
+  (property allow-rotation g/Bool
+            (default true))
 
   (output child->order g/Any :cached (g/fnk [nodes] (zipmap nodes (range))))
 
@@ -498,6 +501,7 @@
       (g/set-property self :margin (:margin atlas))
       (g/set-property self :inner-padding (:inner-padding atlas))
       (g/set-property self :extrude-borders (:extrude-borders atlas))
+      (g/set-property self :allow-rotation (not (zero? (:allow-rotation atlas))))
       (attach-image-nodes self
                           [[:animation :animations]
                            [:id :animation-ids]]

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -62,7 +62,7 @@
 
 
 (defn atlas->texture-set-data
-  [animations images margin inner-padding extrude-borders]
+  [animations images margin inner-padding extrude-borders allow-rotation?]
   (let [img-to-index (into {} (map-indexed #(vector %2 (Integer. ^int %1)) images))
         anims-atom (atom animations)
         anim-imgs-atom (atom [])
@@ -81,7 +81,7 @@
                           (reset! anim-imgs-atom [])))
         result (TextureSetGenerator/calculateLayout
                  (map map->Rect images) anim-iterator margin inner-padding extrude-borders
-                 false false true false nil)]
+                 false false allow-rotation? false nil)]
     (doto (.builder result)
       (.setTexture "unknown"))
     (TextureSetResult->result result)))

--- a/editor/test/resources/test_project/switcher/switcher.atlas
+++ b/editor/test/resources/test_project/switcher/switcher.atlas
@@ -131,3 +131,4 @@ animations {
 margin: 4
 extrude_borders: 2
 inner_padding: 0
+allow_rotation: 1

--- a/engine/gamesys/proto/atlas_ddf.proto
+++ b/engine/gamesys/proto/atlas_ddf.proto
@@ -30,4 +30,5 @@ message Atlas
     optional uint32 margin              = 3 [default = 0];
     optional uint32 extrude_borders     = 4 [default = 0];
     optional uint32 inner_padding       = 5 [default = 0];
+    optional uint32 allow_rotation      = 6 [default = 1];
 }


### PR DESCRIPTION
Implements defold/editor2-issues#1134

### User-facing changes
* Altas resources now have an "Allow Rotation" checkbox which is enabled by default.
* Unchecking "Allow Rotation" packs all the sprites with their original image rotation.
* A new field for this property has been introduced in the file Atlas file format.