### PR TITLE
DEFEDIT-1087 Fix NPE when bundling for HTML5

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -153,6 +154,7 @@ public class HTML5Bundler implements IBundler {
         Map<String, IResource> bundleResources = ExtenderUtil.collectResources(project, Platform.JsWeb);
 
         BobProjectProperties projectProperties = project.getProjectProperties();
+        BobProjectProperties metaProperties = getPropertiesMeta();
 
         Platform targetPlatform = Platform.JsWeb;
         Boolean localLaunch = project.option("local-launch", "false").equals("true");
@@ -192,8 +194,8 @@ public class HTML5Bundler implements IBundler {
 
         Map<String, Object> infoData = new HashMap<String, Object>();
         infoData.put("DEFOLD_ENGINE", engine);
-        infoData.put("DEFOLD_DISPLAY_WIDTH", projectProperties.getIntValue("display", "width"));
-        infoData.put("DEFOLD_DISPLAY_HEIGHT", projectProperties.getIntValue("display", "height"));
+        infoData.put("DEFOLD_DISPLAY_WIDTH", projectProperties.getIntValue("display", "width", metaProperties.getIntValue("display", "width.default")));
+        infoData.put("DEFOLD_DISPLAY_HEIGHT", projectProperties.getIntValue("display", "height", metaProperties.getIntValue("display", "height.default")));
         infoData.put("DEFOLD_SPLASH_IMAGE", getName(splashImage));
         infoData.put("DEFOLD_SPLIT", String.format("%s/%s", SplitFileDir, SplitFileJson));
         infoData.put("DEFOLD_HEAP_SIZE", customHeapSize);
@@ -290,4 +292,16 @@ public class HTML5Bundler implements IBundler {
         }
     }
 
+    private static BobProjectProperties getPropertiesMeta() throws IOException {
+        BobProjectProperties meta = new BobProjectProperties();
+        InputStream is = Bob.class.getResourceAsStream("meta.properties");
+        try {
+            meta.load(is);
+            return meta;
+        } catch (ParseException e) {
+            throw new RuntimeException("Failed to parse meta.properties", e);
+        } finally {
+            IOUtils.closeQuietly(is);
+        }
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -74,6 +74,28 @@ public class BobProjectProperties {
     }
 
     /**
+     * Get property as integer with default value
+     * @param category property category
+     * @param key category key
+     * @param defaultValue
+     * @return property value as integer. defaultValue if not set or on number format errors
+     */
+    public Integer getIntValue(String category, String key, Integer defaultValue) {
+        Map<String, String> group = this.properties.get(category);
+        if (group != null) {
+            String val = group.get(key);
+            if (val != null) {
+                try {
+                    return new Integer(val);
+                } catch (NumberFormatException e) {
+                    return defaultValue;
+                }
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
      * Get property as boolean
      * @param category property category
      * @param key category key

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -76,7 +76,7 @@
         error (assoc (first (drop-while (comp (fn [node-id] (or (nil? node-id) (missing-resource-node node-id))) :_node-id) root-cause))
                 :message message)
         [origin-node-id origin-override-depth] (find-override-value-origin (:_node-id error) (:_label error) 0)
-        origin-override-id (g/override-id origin-node-id)
+        origin-override-id (when (some? origin-node-id) (g/override-id origin-node-id))
         parent (parent-resource root-cause origin-override-depth origin-override-id)
         line (error-line error)]
     (cond-> {:parent parent


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1136, https://github.com/defold/editor2-issues/issues/1122, https://github.com/defold/editor2-issues/issues/1103

### User facing changes

- Can now bundle for HTML5 with default (or absent) values for display/width and display/height


### Technical changes

- Use default values for display/width and display/height when no explicit values have been set in game.project.
- Handle absence of node-id when presenting build errors. Happens for some errors coming from bob where we are unable to determine source file.