### PR TITLE
DEFEDIT-1112 Sliders generate single undo step for track drags

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -377,8 +377,7 @@
                          (update-field-message [slider] message)
                          (ui/editable! slider (not read-only?))))]
     (.setPrefColumnCount textfield (if precision (count (str precision)) 5))
-    (ui/observe (.valueChangingProperty slider) (fn [observable old-val new-val]
-                                                  (ui/user-data! slider ::op-seq (gensym))))
+    (.addEventFilter slider MouseEvent/MOUSE_PRESSED (ui/event-handler event (ui/user-data! slider ::op-seq (gensym))))
     (ui/observe (.valueProperty slider) (fn [observable old-val new-val]
                                           (when-not *programmatic-setting*
                                             (let [val (if precision


### PR DESCRIPTION
Fixes defold/editor2-issues#1140

### User-facing changes
* Property editor slider controls now generate a single undo step when dragging along the track without grabbing the slider thumb.