### PR TITLE
DEFEDIT-1114 Speed up loading images from disk

### DIFF
--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -18,6 +18,7 @@
    [com.defold.control ListCell]
    [java.io File]
    [java.util Arrays]
+   [javax.imageio ImageIO]
    [javafx.scene Scene]
    [javafx.scene.control Button Control Label ListView]
    [javafx.scene.input MouseEvent]
@@ -142,6 +143,11 @@
     (ui/run-now
       (dialogs/make-error-dialog ex-map sentry-id-promise))))
 
+(defn disable-imageio-cache!
+  []
+  ;; Disabling ImageIO cache speeds up reading images from disk significantly
+  (ImageIO/setUseCache false))
+
 (def cli-options
   ;; Path to preference file, mainly used for testing
   [["-prefs" "--preferences PATH" "Path to preferences file"]])
@@ -151,6 +157,7 @@
                                            :sentry   {:project-id "97739"
                                                       :key        "9e25fea9bc334227b588829dd60265c1"
                                                       :secret     "f694ef98d47d42cf8bb67ef18a4e9cdb"}})
+  (disable-imageio-cache!)
   (let [args (Arrays/asList args)
         opts (cli/parse-opts args cli-options)
         namespace-loader (load-namespaces-in-background)


### PR DESCRIPTION
### User facing changes

- Opening atlases with many or large images should be quicker in some cases

### Technical changes
- Disable `javax.imageio` file system caching on by default. Tests show caching has a
significant, negative impact for our use cases.