### PR TITLE
DEF-2845 Font cache texture artefacts

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -6,7 +6,6 @@
 #include <dlib/log.h>
 
 #include <render/font_renderer.h>
-#include <render/font_ddf.h>
 #include <render/render_ddf.h>
 
 namespace dmGameSystem
@@ -62,6 +61,8 @@ namespace dmGameSystem
         params.m_CacheCellWidth = ddf->m_CacheCellWidth;
         params.m_CacheCellHeight = ddf->m_CacheCellHeight;
         params.m_CacheCellPadding = ddf->m_GlyphPadding;
+
+        params.m_ImageFormat = ddf->m_ImageFormat;
 
         // Copy and unpack glyphdata
         params.m_GlyphData = malloc(ddf->m_GlyphData.m_Count);

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -41,6 +41,7 @@ namespace dmRender
     , m_CacheCellWidth(0)
     , m_CacheCellHeight(0)
     , m_CacheCellPadding(0)
+    , m_ImageFormat(dmRenderDDF::TYPE_BITMAP)
     {
 
     }

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -112,6 +112,21 @@ namespace dmRender
 
     static float GetLineTextMetrics(HFontMap font_map, float tracking, const char* text, int n);
 
+    void InitDistanceFieldFontmap(FontMapParams& params, dmGraphics::TextureParams& tex_params)
+    {
+        uint8_t bpp = params.m_GlyphChannels;
+        uint32_t data_size = tex_params.m_Width * tex_params.m_Height * bpp;
+        tex_params.m_Data = malloc(data_size);
+        tex_params.m_DataSize = data_size;
+        memset((void*)tex_params.m_Data, 0xff, tex_params.m_DataSize);
+    }
+
+    void CleanupDistanceFieldFontmap(dmGraphics::TextureParams& tex_params)
+    {
+        free((void*)tex_params.m_Data);
+        tex_params.m_DataSize = 0;
+    }
+
     HFontMap NewFontMap(dmGraphics::HContext graphics_context, FontMapParams& params)
     {
         FontMap* font_map = new FontMap();
@@ -183,7 +198,16 @@ namespace dmRender
         tex_params.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
         tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
         font_map->m_Texture = dmGraphics::NewTexture(graphics_context, tex_create_params);
+
+        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
+        {
+            InitDistanceFieldFontmap(params, tex_params);
+        }
         dmGraphics::SetTexture(font_map->m_Texture, tex_params);
+        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
+        {
+            CleanupDistanceFieldFontmap(tex_params);
+        }
 
         return font_map;
     }
@@ -258,8 +282,16 @@ namespace dmRender
         tex_params.m_DataSize = 0x0;
         tex_params.m_Width = params.m_CacheWidth;
         tex_params.m_Height = params.m_CacheHeight;
-        dmGraphics::SetTexture(font_map->m_Texture, tex_params);
 
+        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
+        {
+            InitDistanceFieldFontmap(params, tex_params);
+        }
+        dmGraphics::SetTexture(font_map->m_Texture, tex_params);
+        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
+        {
+            CleanupDistanceFieldFontmap(tex_params);
+        }
     }
 
     dmGraphics::HTexture GetFontMapTexture(HFontMap font_map)
@@ -494,7 +526,7 @@ namespace dmRender
                 tex_params.m_Width = g->m_Width + font_map->m_CacheCellPadding*2;
                 tex_params.m_Height = g->m_Ascent + g->m_Descent + font_map->m_CacheCellPadding*2;
                 tex_params.m_Data = (uint8_t*)font_map->m_GlyphData + g->m_GlyphDataOffset;
-                SetTexture(font_map->m_Texture, tex_params);
+                dmGraphics::SetTexture(font_map->m_Texture, tex_params);
                 break;
             }
 

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -113,16 +113,16 @@ namespace dmRender
 
     static float GetLineTextMetrics(HFontMap font_map, float tracking, const char* text, int n);
 
-    void InitDistanceFieldFontmap(FontMapParams& params, dmGraphics::TextureParams& tex_params)
+    static void InitFontmap(FontMapParams& params, dmGraphics::TextureParams& tex_params, uint8_t init_val)
     {
         uint8_t bpp = params.m_GlyphChannels;
         uint32_t data_size = tex_params.m_Width * tex_params.m_Height * bpp;
         tex_params.m_Data = malloc(data_size);
         tex_params.m_DataSize = data_size;
-        memset((void*)tex_params.m_Data, 0xff, tex_params.m_DataSize);
+        memset((void*)tex_params.m_Data, init_val, tex_params.m_DataSize);
     }
 
-    void CleanupDistanceFieldFontmap(dmGraphics::TextureParams& tex_params)
+    static void CleanupFontmap(dmGraphics::TextureParams& tex_params)
     {
         free((void*)tex_params.m_Data);
         tex_params.m_DataSize = 0;
@@ -200,15 +200,10 @@ namespace dmRender
         tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
         font_map->m_Texture = dmGraphics::NewTexture(graphics_context, tex_create_params);
 
-        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
-        {
-            InitDistanceFieldFontmap(params, tex_params);
-        }
+        uint8_t clear_val = (params.m_ImageFormat == dmRenderDDF::TYPE_BITMAP) ? 0 : 0xFF;
+        InitFontmap(params, tex_params, clear_val);
         dmGraphics::SetTexture(font_map->m_Texture, tex_params);
-        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
-        {
-            CleanupDistanceFieldFontmap(tex_params);
-        }
+        CleanupFontmap(tex_params);
 
         return font_map;
     }
@@ -284,15 +279,10 @@ namespace dmRender
         tex_params.m_Width = params.m_CacheWidth;
         tex_params.m_Height = params.m_CacheHeight;
 
-        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
-        {
-            InitDistanceFieldFontmap(params, tex_params);
-        }
+        uint8_t clear_val = (params.m_ImageFormat == dmRenderDDF::TYPE_BITMAP) ? 0 : 0xFF;
+        InitFontmap(params, tex_params, clear_val);
         dmGraphics::SetTexture(font_map->m_Texture, tex_params);
-        if (params.m_ImageFormat == dmRenderDDF::TYPE_DISTANCE_FIELD)
-        {
-            CleanupDistanceFieldFontmap(tex_params);
-        }
+        CleanupFontmap(tex_params);
     }
 
     dmGraphics::HTexture GetFontMapTexture(HFontMap font_map)

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -7,6 +7,8 @@
 
 #include <graphics/graphics.h>
 
+#include <render/font_ddf.h>
+
 #include "render.h"
 
 namespace dmRender
@@ -88,6 +90,8 @@ namespace dmRender
         uint32_t m_CacheCellWidth;
         uint32_t m_CacheCellHeight;
         uint8_t m_CacheCellPadding;
+
+        dmRenderDDF::FontTextureFormat m_ImageFormat;
     };
 
     /**


### PR DESCRIPTION
Init font cache to 0xFF for distance field fonts.