### PR TITLE
DEF-1580 distance field font rendering improvements

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -209,7 +209,7 @@ public class Fontc {
         Graphics2D g;
         image = new BufferedImage(1024, 1024, BufferedImage.TYPE_3BYTE_BGR);
         g = image.createGraphics();
-        g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
+        g.setBackground(Color.BLACK);
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         setHighQuality(g);
 
@@ -324,7 +324,7 @@ public class Fontc {
             fontMapBuilder.setAlpha(this.fontDesc.getAlpha());
             fontMapBuilder.setOutlineAlpha(this.fontDesc.getOutlineAlpha());
             fontMapBuilder.setShadowAlpha(this.fontDesc.getShadowAlpha());
-            fontMapBuilder.setEdgeValue(edge);
+            fontMapBuilder.setSdfEdgeValue(edge);
         }
 
         // Load external image resource for BMFont files
@@ -599,7 +599,6 @@ public class Fontc {
         double kx = 1 / (double)width;
         double ky = 1 / (double)height;
 
-        double max_outside_dist = -10000.0f;
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         for (int v=0;v<height;v++) {
             int ofs = v * width;
@@ -608,8 +607,6 @@ public class Fontc {
                 double gy = v0 + ky * v * (v1 - v0);
                 double value = res[ofs + u];
                 if (!sh.contains(gx, gy)) {
-                    if (value > max_outside_dist)
-                        max_outside_dist = value;
                     value = -value;
                 }
                 float df_norm = (float) ((value / sdf_spread));
@@ -739,7 +736,7 @@ public class Fontc {
         Graphics2D g;
         BufferedImage previewImage = new BufferedImage(fontMapBuilder.getCacheWidth(), fontMapBuilder.getCacheHeight(), BufferedImage.TYPE_3BYTE_BGR);
         g = previewImage.createGraphics();
-        g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
+        g.setBackground(Color.BLACK);
         g.clearRect(0, 0, previewImage.getWidth(), previewImage.getHeight());
         setHighQuality(g);
 

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/content/label_df.fp
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/content/label_df.fp
@@ -2,34 +2,21 @@ varying vec2 var_texcoord0;
 
 uniform sampler2D texture;
 
-uniform vec4 uni_sdf_params;
 uniform vec4 uni_face_color;
 uniform vec4 uni_outline_color;
-
-float sdf_edge = uni_sdf_params.x;
-float sdf_outline = uni_sdf_params.y;
-float sdf_smoothing = uni_sdf_params.z;
-
-float sample_df(vec2 where)
-{
-    return texture2D(texture, where.xy).x;
-}
-
-vec2 get_alphas(float distance)
-{
-    float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    return vec2(alpha, outline_alpha);
-}
-
-void main_default()
-{
-    vec2 alphas = get_alphas(sample_df(var_texcoord0));
-    vec4 color = mix(uni_outline_color, uni_face_color, alphas.x);
-    gl_FragColor = color * alphas.y;
-}
+uniform vec4 uni_sdf_params;
 
 void main()
 {
-    main_default();
+    float distance = texture2D(texture, var_texcoord0).x;
+
+    float sdf_edge = uni_sdf_params.x;
+    float sdf_outline = uni_sdf_params.y;
+    float sdf_smoothing = uni_sdf_params.z;
+    
+    float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    vec4 color = mix(uni_outline_color, uni_face_color, alpha);
+
+    gl_FragColor = color * outline_alpha;
 }

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/content/label_df.fp
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/content/label_df.fp
@@ -6,26 +6,30 @@ uniform vec4 uni_sdf_params;
 uniform vec4 uni_face_color;
 uniform vec4 uni_outline_color;
 
+float sdf_edge = uni_sdf_params.x;
+float sdf_outline = uni_sdf_params.y;
+float sdf_smoothing = uni_sdf_params.z;
+
 float sample_df(vec2 where)
 {
     return texture2D(texture, where.xy).x;
 }
 
-float scale_sample(float v)
+vec2 get_alphas(float distance)
 {
-    return v * uni_sdf_params.x + uni_sdf_params.y;
+    float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    return vec2(alpha, outline_alpha);
 }
 
-
-vec2 eval_borders(vec2 where)
+void main_default()
 {
-    float df = scale_sample(sample_df(where));
-    vec2 borders = vec2(clamp((df - uni_sdf_params.z), 0.0, uni_sdf_params.w), clamp(df, 0.0, uni_sdf_params.w));
-    return borders * borders * (3.0 - 2.0 * borders);
+    vec2 alphas = get_alphas(sample_df(var_texcoord0));
+    vec4 color = mix(uni_outline_color, uni_face_color, alphas.x);
+    gl_FragColor = color * alphas.y;
 }
 
 void main()
 {
-    vec2 borders = eval_borders(var_texcoord0);
-    gl_FragColor = mix(mix(uni_face_color, uni_outline_color, borders.y), vec4(0.0), borders.x);
+    main_default();
 }

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/LabelRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/LabelRenderer.java
@@ -279,9 +279,10 @@ public class LabelRenderer implements INodeRenderer<LabelNode> {
                 shader = this.shaderDF;
                 shader.enable(gl);
 
+                float sdf_edge_value = 0.75f;
                 float sdf_world_scale = (float) Math.sqrt(node.getScale().getX() * node.getScale().getX() + node.getScale().getY() * node.getScale().getY());
-                float smoothing = 0.25f / (sdf_world_scale * fontMap.getSdfScale());
-                float [] sdfParams = new float[] { fontMap.getSdfEdgeValue(), fontMap.getSdfOutline(), smoothing, fontMap.getSdfScale() };
+                float smoothing = 0.25f / (sdf_world_scale * fontMap.getSdfSpread());
+                float [] sdfParams = new float[] { sdf_edge_value, fontMap.getSdfOutline(), smoothing, fontMap.getSdfSpread() };
                 shader.setUniforms(gl, "uni_sdf_params", sdfParams);
                 shader.setUniforms(gl, "uni_outline_color", calcNormRGBA(node.getOutline(), (float)fontMap.getOutlineAlpha() * (float)node.getOutlineAlpha() * color[3]));
                 color[3] *= (float) fontMap.getAlpha();

--- a/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/LabelRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.ddfeditor/src/com/dynamo/cr/ddfeditor/scene/LabelRenderer.java
@@ -280,7 +280,8 @@ public class LabelRenderer implements INodeRenderer<LabelNode> {
                 shader.enable(gl);
 
                 float sdf_world_scale = (float) Math.sqrt(node.getScale().getX() * node.getScale().getX() + node.getScale().getY() * node.getScale().getY());
-                float [] sdfParams = new float[] { sdf_world_scale * fontMap.getSdfScale(), sdf_world_scale * fontMap.getSdfOffset(), sdf_world_scale * fontMap.getSdfOutline(), 1.0f  };
+                float smoothing = 0.25f / (sdf_world_scale * fontMap.getSdfScale());
+                float [] sdfParams = new float[] { fontMap.getSdfEdgeValue(), fontMap.getSdfOutline(), smoothing, fontMap.getSdfScale() };
                 shader.setUniforms(gl, "uni_sdf_params", sdfParams);
                 shader.setUniforms(gl, "uni_outline_color", calcNormRGBA(node.getOutline(), (float)fontMap.getOutlineAlpha() * (float)node.getOutlineAlpha() * color[3]));
                 color[3] *= (float) fontMap.getAlpha();

--- a/com.dynamo.cr/com.dynamo.cr.guied/content/font_df.fp
+++ b/com.dynamo.cr/com.dynamo.cr.guied/content/font_df.fp
@@ -2,34 +2,21 @@ varying vec2 var_texcoord0;
 
 uniform sampler2D texture;
 
-uniform vec4 uni_sdf_params;
 uniform vec4 uni_face_color;
 uniform vec4 uni_outline_color;
-
-float sdf_edge = uni_sdf_params.x;
-float sdf_outline = uni_sdf_params.y;
-float sdf_smoothing = uni_sdf_params.z;
-
-float sample_df(vec2 where)
-{
-    return texture2D(texture, where.xy).x;
-}
-
-vec2 get_alphas(float distance)
-{
-    float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    return vec2(alpha, outline_alpha);
-}
-
-void main_default()
-{
-    vec2 alphas = get_alphas(sample_df(var_texcoord0));
-    vec4 color = mix(uni_outline_color, uni_face_color, alphas.x);
-    gl_FragColor = color * alphas.y;
-}
+uniform vec4 uni_sdf_params;
 
 void main()
 {
-    main_default();
+    float distance = texture2D(texture, var_texcoord0).x;
+
+    float sdf_edge = uni_sdf_params.x;
+    float sdf_outline = uni_sdf_params.y;
+    float sdf_smoothing = uni_sdf_params.z;
+    
+    float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    vec4 color = mix(uni_outline_color, uni_face_color, alpha);
+
+    gl_FragColor = color * outline_alpha;
 }

--- a/com.dynamo.cr/com.dynamo.cr.guied/content/font_df.fp
+++ b/com.dynamo.cr/com.dynamo.cr.guied/content/font_df.fp
@@ -6,26 +6,30 @@ uniform vec4 uni_sdf_params;
 uniform vec4 uni_face_color;
 uniform vec4 uni_outline_color;
 
+float sdf_edge = uni_sdf_params.x;
+float sdf_outline = uni_sdf_params.y;
+float sdf_smoothing = uni_sdf_params.z;
+
 float sample_df(vec2 where)
 {
     return texture2D(texture, where.xy).x;
 }
 
-float scale_sample(float v)
+vec2 get_alphas(float distance)
 {
-    return v * uni_sdf_params.x + uni_sdf_params.y;
+    float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    return vec2(alpha, outline_alpha);
 }
 
-
-vec2 eval_borders(vec2 where)
+void main_default()
 {
-    float df = scale_sample(sample_df(where));
-    vec2 borders = vec2(clamp((df - uni_sdf_params.z), 0.0, uni_sdf_params.w), clamp(df, 0.0, uni_sdf_params.w));
-    return borders * borders * (3.0 - 2.0 * borders);
+    vec2 alphas = get_alphas(sample_df(var_texcoord0));
+    vec4 color = mix(uni_outline_color, uni_face_color, alphas.x);
+    gl_FragColor = color * alphas.y;
 }
 
 void main()
 {
-    vec2 borders = eval_borders(var_texcoord0);
-    gl_FragColor = mix(mix(uni_face_color, uni_outline_color, borders.y), vec4(0.0), borders.x);
+    main_default();
 }

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -298,7 +298,8 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
                 shader.enable(gl);
 
                 float sdf_world_scale = (float) Math.sqrt(node.getScale().getX() * node.getScale().getX() + node.getScale().getY() * node.getScale().getY());
-                float [] sdfParams = new float[] { sdf_world_scale * fontMap.getSdfScale(), sdf_world_scale * fontMap.getSdfOffset(), sdf_world_scale * fontMap.getSdfOutline(), 1.0f  };
+                float smoothing = 0.25f / (sdf_world_scale * fontMap.getSdfScale());
+                float [] sdfParams = new float[] { fontMap.getSdfEdgeValue(), fontMap.getSdfOutline(), smoothing, fontMap.getSdfScale() };
                 shader.setUniforms(gl, "uni_sdf_params", sdfParams);
                 shader.setUniforms(gl, "uni_outline_color", calcNormRGBA(node.getOutline(), (float)fontMap.getOutlineAlpha() * (float)node.getOutlineAlpha() * color[3]));
                 color[3] *= (float) fontMap.getAlpha();

--- a/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
+++ b/com.dynamo.cr/com.dynamo.cr.guied/src/com/dynamo/cr/guied/ui/TextNodeRenderer.java
@@ -297,9 +297,10 @@ public class TextNodeRenderer implements INodeRenderer<TextNode> {
                 shader = this.shaderDF;
                 shader.enable(gl);
 
+                float sdf_edge_value = 0.75f;
                 float sdf_world_scale = (float) Math.sqrt(node.getScale().getX() * node.getScale().getX() + node.getScale().getY() * node.getScale().getY());
-                float smoothing = 0.25f / (sdf_world_scale * fontMap.getSdfScale());
-                float [] sdfParams = new float[] { fontMap.getSdfEdgeValue(), fontMap.getSdfOutline(), smoothing, fontMap.getSdfScale() };
+                float smoothing = 0.25f / (sdf_world_scale * fontMap.getSdfSpread());
+                float [] sdfParams = new float[] { sdf_edge_value, fontMap.getSdfOutline(), smoothing, fontMap.getSdfSpread() };
                 shader.setUniforms(gl, "uni_sdf_params", sdfParams);
                 shader.setUniforms(gl, "uni_outline_color", calcNormRGBA(node.getOutline(), (float)fontMap.getOutlineAlpha() * (float)node.getOutlineAlpha() * color[3]));
                 color[3] *= (float) fontMap.getAlpha();

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -192,7 +192,8 @@
         glyphs (font-map->glyphs font-map)
         char->glyph (comp glyphs int)
         line-height (+ (:max-ascent font-map) (:max-descent font-map))
-        sdf-params [(:sdf-scale font-map) (:sdf-offset font-map) (:sdf-outline font-map) 1.0]
+        smoothing (/ 0.25 (:sdf-scale font-map))
+        sdf-params [(:sdf-edge-value font-map) (:sdf-outline font-map) smoothing (:sdf-scale font-map)]
         vs (loop [vs (transient [])
                   text-entries text-entries]
              (if-let [entry (first text-entries)]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -185,7 +185,6 @@
                :line-widths line-widths)))))
 
 (defn gen-vertex-buffer [^GL2 gl {:keys [type font-map texture]} text-entries]
-  (def sdf-edge-value 0.75)
   (let [cache (scene-cache/request-object! ::glyph-caches texture gl [font-map])
         w (:cache-width font-map)
         h (:cache-height font-map)
@@ -194,6 +193,7 @@
         char->glyph (comp glyphs int)
         line-height (+ (:max-ascent font-map) (:max-descent font-map))
         smoothing (/ 0.25 (:sdf-spread font-map))
+        sdf-edge-value 0.75
         sdf-params [sdf-edge-value (:sdf-outline font-map) smoothing (:sdf-spread font-map)]
         vs (loop [vs (transient [])
                   text-entries text-entries]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -185,6 +185,7 @@
                :line-widths line-widths)))))
 
 (defn gen-vertex-buffer [^GL2 gl {:keys [type font-map texture]} text-entries]
+  (def sdf-edge-value 0.75)
   (let [cache (scene-cache/request-object! ::glyph-caches texture gl [font-map])
         w (:cache-width font-map)
         h (:cache-height font-map)
@@ -192,8 +193,8 @@
         glyphs (font-map->glyphs font-map)
         char->glyph (comp glyphs int)
         line-height (+ (:max-ascent font-map) (:max-descent font-map))
-        smoothing (/ 0.25 (:sdf-scale font-map))
-        sdf-params [(:sdf-edge-value font-map) (:sdf-outline font-map) smoothing (:sdf-scale font-map)]
+        smoothing (/ 0.25 (:sdf-spread font-map))
+        sdf-params [sdf-edge-value (:sdf-outline font-map) smoothing (:sdf-spread font-map)]
         vs (loop [vs (transient [])
                   text-entries text-entries]
              (if-let [entry (first text-entries)]

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -209,7 +209,7 @@ public class Fontc {
         Graphics2D g;
         image = new BufferedImage(1024, 1024, BufferedImage.TYPE_3BYTE_BGR);
         g = image.createGraphics();
-        g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
+        g.setBackground(Color.BLACK);
         g.clearRect(0, 0, image.getWidth(), image.getHeight());
         setHighQuality(g);
 
@@ -282,18 +282,17 @@ public class Fontc {
         // is the extra padding added to the bitmap data to avoid filtering glitches when rendered.
         int padding = 0;
         int cell_padding = 1;
-        float sdf_scale = 0;
-        float sdf_offset = 0;
+        float sdf_spread = 0.0f;
+        float edge = 0.75f;
         int shadowBlur = fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? 0 : fontDesc.getShadowBlur();
         if (fontDesc.getAntialias() != 0)
             padding = Math.min(4, shadowBlur) + (int)Math.ceil(fontDesc.getOutlineWidth() * 0.5f);
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
             // need sqrt(2) on either side of the range [0, outlineWidth + 1] to prevent clamped values being used
-            // for interpolation across texels in the output. The extra is for smoothstep room.
+            // for interpolation across texels in the output.
             float sqrt2 = 1.4142f;
-            sdf_scale = 1.0f / (1 + 2.0f * sqrt2 + fontDesc.getOutlineWidth());
-            sdf_offset = sdf_scale * sqrt2; // where glyph ends
+            sdf_spread = sqrt2 + fontDesc.getOutlineWidth();
         }
         ConvolveOp shadowConvolve = null;
         Composite blendComposite = new BlendComposite();
@@ -310,11 +309,16 @@ public class Fontc {
             shadowConvolve = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, hints);
         }
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
-            // sdf_scale has up until now been the value to scale with.
-            // Now recompute their inverses to be used for unpacking it.
-            fontMapBuilder.setSdfScale(1.0f / sdf_scale);
-            fontMapBuilder.setSdfOffset(-sdf_offset / sdf_scale);
-            fontMapBuilder.setSdfOutline(this.fontDesc.getOutlineWidth());
+            fontMapBuilder.setSdfScale(sdf_spread);
+
+            float outline_edge = -(fontDesc.getOutlineWidth() / (sdf_spread)); // Map to [-1, 1]
+            outline_edge = outline_edge * (1.0f - edge) + edge; // Map to edge distribution
+            fontMapBuilder.setSdfOutline(outline_edge);
+
+            fontMapBuilder.setAlpha(this.fontDesc.getAlpha());
+            fontMapBuilder.setOutlineAlpha(this.fontDesc.getOutlineAlpha());
+            fontMapBuilder.setShadowAlpha(this.fontDesc.getShadowAlpha());
+            fontMapBuilder.setSdfEdgeValue(edge);
         }
 
         // Load external image resource for BMFont files
@@ -418,8 +422,8 @@ public class Fontc {
                 glyphImage = drawBMFontGlyph(glyph, imageBMFont);
             } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
                        inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
-                glyphImage = makeDistanceField(glyph, padding, sdf_scale, sdf_offset, font);
-                clearData = 255;
+                glyphImage = makeDistanceField(glyph, padding, sdf_spread, font, edge);
+                clearData = 0;
             } else {
                 throw new FontFormatException("Invalid font format combination!");
             }
@@ -535,7 +539,7 @@ public class Fontc {
         return imageBMFontInput.getSubimage(glyph.x, glyph.y, glyph.width, glyph.ascent + glyph.descent);
     }
 
-    private BufferedImage makeDistanceField(Glyph glyph, int padding, float sdf_scale, float sdf_offset, Font font) {
+    private BufferedImage makeDistanceField(Glyph glyph, int padding, float sdf_spread, Font font, float edge) {
         int width = glyph.width + padding * 2;
         int height = glyph.ascent + glyph.descent + padding * 2;
 
@@ -594,9 +598,11 @@ public class Fontc {
                 double gx = u0 + kx * u * (u1 - u0);
                 double gy = v0 + ky * v * (v1 - v0);
                 double value = res[ofs + u];
-                if (sh.contains(gx, gy))
+                if (!sh.contains(gx, gy))
                     value = -value;
-                int oval = (int)(255 * (value * sdf_scale + sdf_offset));
+                float df_norm = (float) ((value / sdf_spread)); // Map to [-1, 1]
+                df_norm = df_norm * (1.0f - edge) + edge; // Map to edge distribution [0, 1]
+                int oval = (int)(255.0f * df_norm); // Map to [0, 255]
 
                 if (oval < 0) {
                     oval = 0;
@@ -721,7 +727,7 @@ public class Fontc {
         Graphics2D g;
         BufferedImage previewImage = new BufferedImage(fontMapBuilder.getCacheWidth(), fontMapBuilder.getCacheHeight(), BufferedImage.TYPE_3BYTE_BGR);
         g = previewImage.createGraphics();
-        g.setBackground(fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? Color.WHITE : Color.BLACK);
+        g.setBackground(Color.BLACK);
         g.clearRect(0, 0, previewImage.getWidth(), previewImage.getHeight());
         setHighQuality(g);
 

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -289,8 +289,9 @@ public class Fontc {
             padding = Math.min(4, shadowBlur) + (int)Math.ceil(fontDesc.getOutlineWidth() * 0.5f);
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
-            // need sqrt(2) on either side of the range [0, outlineWidth + 1] to prevent clamped values being used
-            // for interpolation across texels in the output.
+
+            // Make sure the outline edge is not zero which would cause everything outside the edge becoming outline.
+            // We use sqrt(2) since it is the diagonal length of a pixel, but any small positive value would do.
             float sqrt2 = 1.4142f;
             sdf_spread = sqrt2 + fontDesc.getOutlineWidth();
         }
@@ -309,8 +310,9 @@ public class Fontc {
             shadowConvolve = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, hints);
         }
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
-            fontMapBuilder.setSdfScale(sdf_spread);
+            fontMapBuilder.setSdfSpread(sdf_spread);
 
+            // Transform outline edge from pixel unit to edge offset in distance field unit
             float outline_edge = -(fontDesc.getOutlineWidth() / (sdf_spread)); // Map to [-1, 1]
             outline_edge = outline_edge * (1.0f - edge) + edge; // Map to edge distribution
             fontMapBuilder.setSdfOutline(outline_edge);
@@ -318,7 +320,6 @@ public class Fontc {
             fontMapBuilder.setAlpha(this.fontDesc.getAlpha());
             fontMapBuilder.setOutlineAlpha(this.fontDesc.getOutlineAlpha());
             fontMapBuilder.setShadowAlpha(this.fontDesc.getShadowAlpha());
-            fontMapBuilder.setSdfEdgeValue(edge);
         }
 
         // Load external image resource for BMFont files
@@ -598,8 +599,10 @@ public class Fontc {
                 double gx = u0 + kx * u * (u1 - u0);
                 double gy = v0 + ky * v * (v1 - v0);
                 double value = res[ofs + u];
-                if (!sh.contains(gx, gy))
+                if (!sh.contains(gx, gy)) {
                     value = -value;
+                }
+                // Transform distance from pixel unit to edge-relative distance field unit
                 float df_norm = (float) ((value / sdf_spread)); // Map to [-1, 1]
                 df_norm = df_norm * (1.0f - edge) + edge; // Map to edge distribution [0, 1]
                 int oval = (int)(255.0f * df_norm); // Map to [0, 255]

--- a/engine/engine/content/builtins/fonts/font-df-ms.fp
+++ b/engine/engine/content/builtins/fonts/font-df-ms.fp
@@ -7,34 +7,29 @@ uniform mediump sampler2D texture;
 uniform lowp vec4 texture_size_recip;
 
 float sample_df(vec2 where)
-{   
+{
     return texture2D(texture, where).x;
 }
 
-vec2 get_alphas(float distance)
+void main()
 {
     lowp float sdf_edge = var_sdf_params.x;
     lowp float sdf_outline = var_sdf_params.y;
     lowp float sdf_smoothing = var_sdf_params.z;
 
-    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-
-    return vec2(alpha, outline_alpha);
-}
-
-void main()
-{
-    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
     // sample 4 points around var_texcoord0
+    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
     lowp vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
-    lowp float dist = 2.0 * (sample_df(var_texcoord0))
+    lowp float distance = 2.0 * (sample_df(var_texcoord0))
                    + sample_df(dt.xy) // upper left
                    + sample_df(dt.xw) // bottom left
                    + sample_df(dt.zy) // upper right
                    + sample_df(dt.zw); // bottom right
-    dist = (1.0 / 6.0) * dist;
-    lowp vec2 alphas = get_alphas(dist);
-    lowp vec4 color = mix(var_outline_color, var_face_color, alphas.x);
-    gl_FragColor = color * alphas.y;
+    distance = (1.0 / 6.0) * distance;
+
+    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    lowp vec4 color = mix(var_outline_color, var_face_color, alpha);
+
+    gl_FragColor = color * outline_alpha;
 }

--- a/engine/engine/content/builtins/fonts/font-df-ms.fp
+++ b/engine/engine/content/builtins/fonts/font-df-ms.fp
@@ -1,0 +1,40 @@
+varying lowp vec2 var_texcoord0;
+varying lowp vec4 var_face_color;
+varying lowp vec4 var_outline_color;
+varying lowp vec4 var_sdf_params;
+
+uniform mediump sampler2D texture;
+uniform lowp vec4 texture_size_recip;
+
+float sample_df(vec2 where)
+{   
+    return texture2D(texture, where).x;
+}
+
+vec2 get_alphas(float distance)
+{
+    lowp float sdf_edge = var_sdf_params.x;
+    lowp float sdf_outline = var_sdf_params.y;
+    lowp float sdf_smoothing = var_sdf_params.z;
+
+    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+
+    return vec2(alpha, outline_alpha);
+}
+
+void main()
+{
+    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
+    // sample 4 points around var_texcoord0
+    lowp vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
+    lowp float dist = 2.0 * (sample_df(var_texcoord0))
+                   + sample_df(dt.xy) // upper left
+                   + sample_df(dt.xw) // bottom left
+                   + sample_df(dt.zy) // upper right
+                   + sample_df(dt.zw); // bottom right
+    dist = (1.0 / 6.0) * dist;
+    lowp vec2 alphas = get_alphas(dist);
+    lowp vec4 color = mix(var_outline_color, var_face_color, alphas.x);
+    gl_FragColor = color * alphas.y;
+}

--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -12,28 +12,28 @@ float sample_df(vec2 where)
 
 vec2 get_alphas(float distance)
 {
-    mediump float sdf_edge = var_sdf_params.x;
-    mediump float sdf_outline = var_sdf_params.y;
-    mediump float sdf_smoothing = var_sdf_params.z;
+    lowp float sdf_edge = var_sdf_params.x;
+    lowp float sdf_outline = var_sdf_params.y;
+    lowp float sdf_smoothing = var_sdf_params.z;
 
-    mediump float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    mediump float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
     
     return vec2(alpha, outline_alpha);
 }
 
 void main_supersample()
 {
-    mediump vec2 dtex = vec2(0.5 * texture_size_recip.xy);
+    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
     // sample 4 points around var_texcoord0
-    mediump vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
+    lowp vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
     lowp vec2 alphas = 2.0 * get_alphas(sample_df(var_texcoord0))
                    + get_alphas(sample_df(dt.xy)) // upper left
                    + get_alphas(sample_df(dt.xw)) // bottom left
                    + get_alphas(sample_df(dt.zy)) // upper right
                    + get_alphas(sample_df(dt.zw)); // bottom right
     alphas = (1.0 / 6.0) * alphas;
-    vec4 color = mix(var_outline_color, var_face_color, alphas.x);
+    lowp vec4 color = mix(var_outline_color, var_face_color, alphas.x);
     gl_FragColor = color * alphas.y;
 }
 

--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -5,10 +5,6 @@ varying mediump vec4 var_sdf_params;
 uniform lowp sampler2D texture;
 uniform lowp vec4 texture_size_recip;
 
-mediump float sdf_edge = var_sdf_params.x;
-mediump float sdf_outline = var_sdf_params.y;
-mediump float sdf_smoothing = var_sdf_params.z;
-
 float sample_df(vec2 where)
 {   
     return texture2D(texture, where).x;
@@ -16,8 +12,13 @@ float sample_df(vec2 where)
 
 vec2 get_alphas(float distance)
 {
+    mediump float sdf_edge = var_sdf_params.x;
+    mediump float sdf_outline = var_sdf_params.y;
+    mediump float sdf_smoothing = var_sdf_params.z;
+
     mediump float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
     mediump float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    
     return vec2(alpha, outline_alpha);
 }
 

--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -5,46 +5,45 @@ varying mediump vec4 var_sdf_params;
 uniform lowp sampler2D texture;
 uniform lowp vec4 texture_size_recip;
 
-mediump float sample_df(mediump vec2 where)
-{
-    return texture2D(texture, where.xy).x;
+mediump float sdf_edge = var_sdf_params.x;
+mediump float sdf_outline = var_sdf_params.y;
+mediump float sdf_smoothing = var_sdf_params.z;
+
+float sample_df(vec2 where)
+{   
+    return texture2D(texture, where).x;
 }
 
-mediump float scale_sample(mediump float v)
+vec2 get_alphas(float distance)
 {
-    return v * var_sdf_params.x + var_sdf_params.y;
-}
-
-mediump vec2 eval_borders(mediump vec2 where)
-{
-    mediump float df = scale_sample(sample_df(where));
-    mediump vec2 borders = vec2(clamp((df - var_sdf_params.z), 0.0, var_sdf_params.w), clamp(df, 0.0, var_sdf_params.w));
-    return borders * borders * (3.0 - 2.0 * borders);
+    mediump float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    mediump float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    return vec2(alpha, outline_alpha);
 }
 
 void main_supersample()
 {
-    mediump vec2 dtex = vec2(0.5 * texture_size_recip.xy / var_sdf_params.x);
-    // sample 4 points around var_texcoord. the sample pattern will not be fixed in texture coordinate space,
-    // and it is assumed the text is uniformly scaled.
+    mediump vec2 dtex = vec2(0.5 * texture_size_recip.xy);
+    // sample 4 points around var_texcoord0
     mediump vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
-    mediump vec2 borders = 2.0 * eval_borders(var_texcoord0)
-                   + eval_borders(dt.xy) // upper left
-                   + eval_borders(dt.xw) // bottom left
-                   + eval_borders(dt.zy) // upper right
-                   + eval_borders(dt.zw); // bottom right
-
-    borders = (1.0/6.0) * borders;
-    gl_FragColor = mix(mix(var_face_color, var_outline_color, borders.y), vec4(0), borders.x);
+    lowp vec2 alphas = 2.0 * get_alphas(sample_df(var_texcoord0))
+                   + get_alphas(sample_df(dt.xy)) // upper left
+                   + get_alphas(sample_df(dt.xw)) // bottom left
+                   + get_alphas(sample_df(dt.zy)) // upper right
+                   + get_alphas(sample_df(dt.zw)); // bottom right
+    alphas = (1.0 / 6.0) * alphas;
+    vec4 color = mix(var_outline_color, var_face_color, alphas.x);
+    gl_FragColor = color * alphas.y;
 }
 
 void main_default()
 {
-    lowp vec2 borders = eval_borders(var_texcoord0);
-    gl_FragColor = mix(mix(var_face_color, var_outline_color, borders.y), vec4(0), borders.x);
+    lowp vec2 alphas = get_alphas(sample_df(var_texcoord0));
+    lowp vec4 color = mix(var_outline_color, var_face_color, alphas.x);
+    gl_FragColor = color * alphas.y;
 }
 
 void main()
 {
-      main_default();
+    main_default();
 }

--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -13,7 +13,7 @@ void main()
     lowp float sdf_edge = var_sdf_params.x;
     lowp float sdf_outline = var_sdf_params.y;
     lowp float sdf_smoothing = var_sdf_params.z;
-    
+
     lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
     lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
     lowp vec4 color = mix(var_outline_color, var_face_color, alpha);

--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -1,50 +1,22 @@
-varying mediump vec2 var_texcoord0;
+varying lowp vec2 var_texcoord0;
 varying lowp vec4 var_face_color;
 varying lowp vec4 var_outline_color;
-varying mediump vec4 var_sdf_params;
-uniform lowp sampler2D texture;
+varying lowp vec4 var_sdf_params;
+
+uniform mediump sampler2D texture;
 uniform lowp vec4 texture_size_recip;
-
-float sample_df(vec2 where)
-{   
-    return texture2D(texture, where).x;
-}
-
-vec2 get_alphas(float distance)
-{
-    lowp float sdf_edge = var_sdf_params.x;
-    lowp float sdf_outline = var_sdf_params.y;
-    lowp float sdf_smoothing = var_sdf_params.z;
-
-    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
-    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
-    
-    return vec2(alpha, outline_alpha);
-}
-
-void main_supersample()
-{
-    lowp vec2 dtex = vec2(0.5 * texture_size_recip.xy);
-    // sample 4 points around var_texcoord0
-    lowp vec4 dt = vec4(vec2(var_texcoord0 - dtex), vec2(var_texcoord0 + dtex));
-    lowp vec2 alphas = 2.0 * get_alphas(sample_df(var_texcoord0))
-                   + get_alphas(sample_df(dt.xy)) // upper left
-                   + get_alphas(sample_df(dt.xw)) // bottom left
-                   + get_alphas(sample_df(dt.zy)) // upper right
-                   + get_alphas(sample_df(dt.zw)); // bottom right
-    alphas = (1.0 / 6.0) * alphas;
-    lowp vec4 color = mix(var_outline_color, var_face_color, alphas.x);
-    gl_FragColor = color * alphas.y;
-}
-
-void main_default()
-{
-    lowp vec2 alphas = get_alphas(sample_df(var_texcoord0));
-    lowp vec4 color = mix(var_outline_color, var_face_color, alphas.x);
-    gl_FragColor = color * alphas.y;
-}
 
 void main()
 {
-    main_default();
+    lowp float distance = texture2D(texture, var_texcoord0).x;
+
+    lowp float sdf_edge = var_sdf_params.x;
+    lowp float sdf_outline = var_sdf_params.y;
+    lowp float sdf_smoothing = var_sdf_params.z;
+    
+    lowp float alpha = smoothstep(sdf_edge - sdf_smoothing, sdf_edge + sdf_smoothing, distance);
+    lowp float outline_alpha = smoothstep(sdf_outline - sdf_smoothing, sdf_outline + sdf_smoothing, distance);
+    lowp vec4 color = mix(var_outline_color, var_face_color, alpha);
+
+    gl_FragColor = color * outline_alpha;
 }

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -63,6 +63,7 @@ namespace dmGameSystem
         params.m_CacheCellPadding = ddf->m_GlyphPadding;
 
         params.m_ImageFormat = ddf->m_ImageFormat;
+        params.m_EdgeValue = ddf->m_EdgeValue;
 
         // Copy and unpack glyphdata
         params.m_GlyphData = malloc(ddf->m_GlyphData.m_Count);

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -63,7 +63,7 @@ namespace dmGameSystem
         params.m_CacheCellPadding = ddf->m_GlyphPadding;
 
         params.m_ImageFormat = ddf->m_ImageFormat;
-        params.m_EdgeValue = ddf->m_EdgeValue;
+        params.m_SdfEdgeValue = ddf->m_SdfEdgeValue;
 
         // Copy and unpack glyphdata
         params.m_GlyphData = malloc(ddf->m_GlyphData.m_Count);

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -47,7 +47,7 @@ namespace dmGameSystem
         params.m_MaxAscent = ddf->m_MaxAscent;
         params.m_MaxDescent = ddf->m_MaxDescent;
         params.m_SdfOffset = ddf->m_SdfOffset;
-        params.m_SdfScale = ddf->m_SdfScale;
+        params.m_SdfSpread = ddf->m_SdfSpread;
         params.m_SdfOutline = ddf->m_SdfOutline;
         params.m_OutlineAlpha = ddf->m_OutlineAlpha;
         params.m_ShadowAlpha = ddf->m_ShadowAlpha;
@@ -63,7 +63,6 @@ namespace dmGameSystem
         params.m_CacheCellPadding = ddf->m_GlyphPadding;
 
         params.m_ImageFormat = ddf->m_ImageFormat;
-        params.m_SdfEdgeValue = ddf->m_SdfEdgeValue;
 
         // Copy and unpack glyphdata
         params.m_GlyphData = malloc(ddf->m_GlyphData.m_Count);

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -58,7 +58,7 @@ message FontMap
     required float max_ascent = 8;
     required float max_descent = 9;
     optional FontTextureFormat image_format = 10 [default = TYPE_BITMAP];
-    optional float sdf_scale = 11 [default = 1];
+    optional float sdf_spread = 11 [default = 1];
     optional float sdf_offset = 12 [default = 0];
     optional float sdf_outline = 13 [default = 0];
 
@@ -76,6 +76,4 @@ message FontMap
     optional float alpha = 21 [default = 1.0];
     optional float outline_alpha = 22 [default = 1.0];
     optional float shadow_alpha = 23 [default = 1.0];
-    
-    optional float sdf_edge_value = 24 [default = 0.0];
 }

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -76,5 +76,6 @@ message FontMap
     optional float alpha = 21 [default = 1.0];
     optional float outline_alpha = 22 [default = 1.0];
     optional float shadow_alpha = 23 [default = 1.0];
-    optional float edge_value = 24 [default = 0.0];
+    
+    optional float sdf_edge_value = 24 [default = 0.0];
 }

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -76,4 +76,5 @@ message FontMap
     optional float alpha = 21 [default = 1.0];
     optional float outline_alpha = 22 [default = 1.0];
     optional float shadow_alpha = 23 [default = 1.0];
+    optional float edge_value = 24 [default = 0.0];
 }

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -34,6 +34,7 @@ namespace dmRender
     , m_SdfScale(1.0f)
     , m_SdfOffset(0)
     , m_SdfOutline(0)
+    , m_SdfEdgeValue(0)
     , m_CacheWidth(0)
     , m_CacheHeight(0)
     , m_GlyphChannels(1)
@@ -42,7 +43,6 @@ namespace dmRender
     , m_CacheCellHeight(0)
     , m_CacheCellPadding(0)
     , m_ImageFormat(dmRenderDDF::TYPE_BITMAP)
-    //, m_EdgeValue(0)
     {
 
     }
@@ -95,7 +95,7 @@ namespace dmRender
         float                   m_Alpha;
         float                   m_OutlineAlpha;
         float                   m_ShadowAlpha;
-        float                   m_EdgeValue;
+        float                   m_SdfEdgeValue;
 
         uint32_t                m_CacheWidth;
         uint32_t                m_CacheHeight;
@@ -152,7 +152,7 @@ namespace dmRender
         font_map->m_Alpha = params.m_Alpha;
         font_map->m_OutlineAlpha = params.m_OutlineAlpha;
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
-        font_map->m_EdgeValue = params.m_EdgeValue;
+        font_map->m_SdfEdgeValue = params.m_SdfEdgeValue;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -206,7 +206,6 @@ namespace dmRender
         tex_params.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
         font_map->m_Texture = dmGraphics::NewTexture(graphics_context, tex_create_params);
 
-        uint8_t clear_val = (params.m_ImageFormat == dmRenderDDF::TYPE_BITMAP) ? 0 : 0xFF;
         InitFontmap(params, tex_params, 0);
         dmGraphics::SetTexture(font_map->m_Texture, tex_params);
         CleanupFontmap(tex_params);
@@ -245,7 +244,7 @@ namespace dmRender
         font_map->m_Alpha = params.m_Alpha;
         font_map->m_OutlineAlpha = params.m_OutlineAlpha;
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
-        font_map->m_EdgeValue = params.m_EdgeValue;
+        font_map->m_SdfEdgeValue = params.m_SdfEdgeValue;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -286,7 +285,6 @@ namespace dmRender
         tex_params.m_Width = params.m_CacheWidth;
         tex_params.m_Height = params.m_CacheHeight;
 
-        uint8_t clear_val = (params.m_ImageFormat == dmRenderDDF::TYPE_BITMAP) ? 0 : 0xFF;
         InitFontmap(params, tex_params, 0);
         dmGraphics::SetTexture(font_map->m_Texture, tex_params);
         CleanupFontmap(tex_params);
@@ -582,7 +580,7 @@ namespace dmRender
         // }
 
         float sdf_scale   = font_map->m_SdfScale;
-        float sdf_edge_value = font_map->m_EdgeValue;
+        float sdf_edge_value = font_map->m_SdfEdgeValue;
         float sdf_outline = font_map->m_SdfOutline;
 
         sdf_smoothing = 0.25f / (font_map->m_SdfScale * sdf_world_scale);
@@ -657,10 +655,10 @@ namespace dmRender
                             v.m_FaceColor = face_color; \
                             v.m_OutlineColor = outline_color; \
                             v.m_ShadowColor = shadow_color; \
-                            v.m_SdfParams[0] = sdf_scale; \
-                            v.m_SdfParams[1] = sdf_edge_value; \
-                            v.m_SdfParams[2] = sdf_outline; \
-                            v.m_SdfParams[3] = sdf_smoothing; \
+                            v.m_SdfParams[0] = sdf_edge_value; \
+                            v.m_SdfParams[1] = sdf_outline; \
+                            v.m_SdfParams[2] = sdf_smoothing; \
+                            v.m_SdfParams[3] = sdf_scale; \
 
                         SET_VERTEX_PARAMS(v1)
                         SET_VERTEX_PARAMS(v2)

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -31,10 +31,9 @@ namespace dmRender
     , m_ShadowY(0.0f)
     , m_MaxAscent(0.0f)
     , m_MaxDescent(0.0f)
-    , m_SdfScale(1.0f)
+    , m_SdfSpread(1.0f)
     , m_SdfOffset(0)
     , m_SdfOutline(0)
-    , m_SdfEdgeValue(0)
     , m_CacheWidth(0)
     , m_CacheHeight(0)
     , m_GlyphChannels(1)
@@ -89,13 +88,12 @@ namespace dmRender
         float                   m_ShadowY;
         float                   m_MaxAscent;
         float                   m_MaxDescent;
-        float                   m_SdfScale;
+        float                   m_SdfSpread;
         float                   m_SdfOffset;
         float                   m_SdfOutline;
         float                   m_Alpha;
         float                   m_OutlineAlpha;
         float                   m_ShadowAlpha;
-        float                   m_SdfEdgeValue;
 
         uint32_t                m_CacheWidth;
         uint32_t                m_CacheHeight;
@@ -146,13 +144,12 @@ namespace dmRender
         font_map->m_ShadowY = params.m_ShadowY;
         font_map->m_MaxAscent = params.m_MaxAscent;
         font_map->m_MaxDescent = params.m_MaxDescent;
-        font_map->m_SdfScale = params.m_SdfScale;
+        font_map->m_SdfSpread = params.m_SdfSpread;
         font_map->m_SdfOffset = params.m_SdfOffset;
         font_map->m_SdfOutline = params.m_SdfOutline;
         font_map->m_Alpha = params.m_Alpha;
         font_map->m_OutlineAlpha = params.m_OutlineAlpha;
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
-        font_map->m_SdfEdgeValue = params.m_SdfEdgeValue;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -235,13 +232,12 @@ namespace dmRender
         font_map->m_ShadowY = params.m_ShadowY;
         font_map->m_MaxAscent = params.m_MaxAscent;
         font_map->m_MaxDescent = params.m_MaxDescent;
-        font_map->m_SdfScale = params.m_SdfScale;
+        font_map->m_SdfSpread = params.m_SdfSpread;
         font_map->m_SdfOffset = params.m_SdfOffset;
         font_map->m_SdfOutline = params.m_SdfOutline;
         font_map->m_Alpha = params.m_Alpha;
         font_map->m_OutlineAlpha = params.m_OutlineAlpha;
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
-        font_map->m_SdfEdgeValue = params.m_SdfEdgeValue;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -556,14 +552,14 @@ namespace dmRender
         // No support for non-uniform scale with SDF so just peek at the first
         // row to extract scale factor. The purpose of this scaling is to have
         // world space distances in the computation, for good 'anti aliasing' no matter
-        // what scale is being rendered in. Scaling down does, however, not work well.
+        // what scale is being rendered in.
         const Vectormath::Aos::Vector4 r0 = te.m_Transform.getRow(0);
+        const float sdf_edge_value = 0.75f;
         float sdf_world_scale = sqrtf(r0.getX() * r0.getX() + r0.getY() * r0.getY());
-
-        float sdf_scale   = font_map->m_SdfScale;
-        float sdf_edge_value = font_map->m_SdfEdgeValue;
+        float sdf_scale   = font_map->m_SdfSpread;
         float sdf_outline = font_map->m_SdfOutline;
-        float sdf_smoothing = 0.25f / (font_map->m_SdfScale * sdf_world_scale);
+        // For anti-aliasing, 0.25 represents the single-axis radius of half a pixel.
+        float sdf_smoothing = 0.25f / (font_map->m_SdfSpread * sdf_world_scale);
 
         uint32_t vertexindex = 0;
         for (int line = 0; line < line_count; ++line) {

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -169,15 +169,12 @@ namespace dmRender
         switch (params.m_GlyphChannels)
         {
             case 1:
-                dmLogInfo("LUM8");
                 font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
             break;
             case 3:
-                dmLogInfo("R8G8B8");
                 font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGB;
             break;
             case 4:
-                dmLogInfo("R8G8B8A8");
                 font_map->m_CacheFormat = dmGraphics::TEXTURE_FORMAT_RGBA;
             break;
             default:
@@ -533,7 +530,6 @@ namespace dmRender
         }
     }
 
-    float g_world_scale = -1337.0f;
     static int CreateFontVertexDataInternal(TextContext& text_context, HFontMap font_map, const char* text, const TextEntry& te, float recip_w, float recip_h, GlyphVertex* vertices, uint32_t num_vertices)
     {
         float width = te.m_Width;
@@ -563,33 +559,11 @@ namespace dmRender
         // what scale is being rendered in. Scaling down does, however, not work well.
         const Vectormath::Aos::Vector4 r0 = te.m_Transform.getRow(0);
         float sdf_world_scale = sqrtf(r0.getX() * r0.getX() + r0.getY() * r0.getY());
-        float sdf_smoothing = 1.0f;
-
-        // There will be no hope for an outline smaller than a quarter than a pixel
-        // so effectively disable it.
-        // if ((font_map->m_SdfOutline > 0) && (font_map->m_SdfOutline * sdf_world_scale < 0.25f))
-        // {
-        //     outline_color = face_color;
-        // }
-
-        // Trade scale for smoothing when scaling down
-        // if (sdf_world_scale < 1.0f)
-        // {
-        //     sdf_world_scale = 1.0f;
-        //     sdf_smoothing = sdf_world_scale;
-        // }
 
         float sdf_scale   = font_map->m_SdfScale;
         float sdf_edge_value = font_map->m_SdfEdgeValue;
         float sdf_outline = font_map->m_SdfOutline;
-
-        sdf_smoothing = 0.25f / (font_map->m_SdfScale * sdf_world_scale);
-
-        if (fabs(sdf_world_scale - g_world_scale) > 0.0001f)
-        {
-            g_world_scale = sdf_world_scale;
-            //dmLogInfo("sdf_smoothing: %f, sdf_scale: %f, sdf_edge_value: %f, sdf_outline: %f sdf_world_scale: %f", sdf_smoothing, sdf_scale, sdf_edge_value, sdf_outline, sdf_world_scale);
-        }
+        float sdf_smoothing = 0.25f / (font_map->m_SdfScale * sdf_world_scale);
 
         uint32_t vertexindex = 0;
         for (int line = 0; line < line_count; ++line) {

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -70,13 +70,11 @@ namespace dmRender
         /// Max descent of font, positive value
         float m_MaxDescent;
         /// Value to scale SDF texture values with
-        float m_SdfScale;
+        float m_SdfSpread;
         /// Value to offset SDF texture values with
         float m_SdfOffset;
         /// Distance value where outline should end
         float m_SdfOutline;
-        /// Distance field edge value
-        float m_SdfEdgeValue;
         /// Font alpha
         float m_Alpha;
         /// Font outline alpha

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -75,14 +75,14 @@ namespace dmRender
         float m_SdfOffset;
         /// Distance value where outline should end
         float m_SdfOutline;
+        /// Distance field edge value
+        float m_SdfEdgeValue;
         /// Font alpha
         float m_Alpha;
         /// Font outline alpha
         float m_OutlineAlpha;
         /// Font shadow alpha
         float m_ShadowAlpha;
-        /// Distance field edge value
-        float m_EdgeValue;
 
         uint32_t m_CacheWidth;
         uint32_t m_CacheHeight;

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -81,6 +81,8 @@ namespace dmRender
         float m_OutlineAlpha;
         /// Font shadow alpha
         float m_ShadowAlpha;
+        /// Distance field edge value
+        float m_EdgeValue;
 
         uint32_t m_CacheWidth;
         uint32_t m_CacheHeight;


### PR DESCRIPTION
* Better anti-aliasing/smoothing in font rendering
* Glyph shape follows the actual font more closely
* Distance field font fragment shader more readable and follows convention better
* Will break custom shaders that have been copied from previous builtins font-df.fp