### PR TITLE
DEFEDIT-1124 Fix lagging console log

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -58,11 +58,30 @@
             trimmed-char-count (transduce (map count) + trimmed-line-count trimmed-lines)]
         (.deleteText text-area 0 (min trimmed-char-count (.getLength text-area)))))))
 
-(defn append-console-message! [message]
+(def ^:private ^:const message-buffer-initial-capacity 4096)
+(def ^:private ^StringBuilder message-buffer (StringBuilder. message-buffer-initial-capacity))
+(def ^:private message-buffer-lock (Object.))
+
+(defn- flip-message-buffer!
+  []
+  (locking message-buffer-lock
+    (when (pos? (.length message-buffer))
+      (let [messages (.toString message-buffer)
+            new-buf (StringBuilder. message-buffer-initial-capacity)]
+        (alter-var-root #'message-buffer (constantly new-buf))
+        messages))))
+
+(defn- update-console!
+  []
   (when-let [^TextArea node @node]
-    (ui/run-later
-      (.appendText node message)
+    (when-let [messages (flip-message-buffer!)]
+      (.appendText node messages)
       (trim-console-message! node 3000))))
+
+(defn append-console-message!
+  [^String message]
+  (locking message-buffer-lock
+    (.append message-buffer message)))
 
 (handler/defhandler :copy :console-view
   (enabled? []
@@ -87,6 +106,7 @@
   (ui/on-action! prev prev-console!)
   (ui/observe (.textProperty search) search-console)
   (ui/context! text :console-view {} (DummySelectionProvider.))
+  (ui/timer-start! (ui/->timer 10 "update-console" (fn [_ _] (update-console!))))
   (.addEventFilter search KeyEvent/KEY_PRESSED
                    (ui/event-handler event
                                      (let [code (.getCode ^KeyEvent event)]

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -64,7 +64,6 @@
           (when (> n -1)
             (let [msg (String. buf 0 n)]
               (console/append-console-message! msg)
-              (Thread/sleep 10)
               (recur)))))
       (catch IOException _
         ;; Losing the log connection is ok and even expected


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1156

### User facing changes

- Console log output should no longer lag behind regardless of how
  frequently the application logs.

### Technical changes

- Buffer messages appended to console and flush them to TextArea on a
  timer instead of appending text on a per-line basis. This means we
  can remove the `Thread/sleep` that was previously introduced to
  ensure we didn't stall the UI thread.