### PR TITLE
DEFEDIT-1128 Include inherited connections when copying override nodes

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -967,28 +967,13 @@
 
 (defn- deep-arcs-by-head
   "Like arcs-by-head, but also includes connections from nodes earlier in the
-  override chain."
+  override chain. Note that arcs-by-tail already does this."
   ([source-node-id]
    (deep-arcs-by-head (now) source-node-id))
   ([basis source-node-id]
    (into []
          (mapcat (partial gt/arcs-by-head basis))
          (override-chain basis source-node-id))))
-
-(defn- deep-arcs-by-tail
-  "Like arcs-by-tail, but also includes non-covered connections to nodes earlier
-  in the override chain."
-  ([target-node-id]
-   (deep-arcs-by-tail (now) target-node-id))
-  ([basis target-node-id]
-   (into []
-         (mapcat val)
-         (reduce (fn [arcs-by-target-label node-id]
-                   (merge arcs-by-target-label
-                          (group-by :targetLabel
-                                    (gt/arcs-by-tail basis node-id))))
-                 {}
-                 (override-chain basis target-node-id)))))
 
 (defn copy
   "Given a vector of root ids, and an options map that can contain an
@@ -1030,7 +1015,7 @@
   ([basis root-ids {:keys [traverse? serializer flatten-overrides?] :or {traverse? (clojure.core/constantly false) serializer default-node-serializer flatten-overrides? false} :as opts}]
     (s/validate opts-schema opts)
    (let [arcs-by-head   (partial (if flatten-overrides? deep-arcs-by-head gt/arcs-by-head) basis)
-         arcs-by-tail   (partial (if flatten-overrides? deep-arcs-by-tail gt/arcs-by-tail) basis)
+         arcs-by-tail   (partial gt/arcs-by-tail basis)
          node-ids-xform (if flatten-overrides?
                           (mapcat (fn [[original-id {serial-id :serial-id}]]
                                     (map #(vector % serial-id)

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -930,14 +930,6 @@
         [tgt-id tgt-label]  (gt/tail arc)]
     [(id-dictionary src-id) src-label (id-dictionary tgt-id) tgt-label]))
 
-(defn- connecting-arcs
-  [basis nodes]
-  (reduce (fn [merged arcs]
-            (into merged (filter (partial ig/arc-endpoints-p (into #{} nodes)) arcs)))
-          #{}
-          [(mapcat #(gt/arcs-by-tail basis %) nodes)
-           (mapcat #(gt/arcs-by-head basis %) nodes)]))
-
 (defn- in-same-graph? [_ arc]
   (apply = (map node-id->graph-id (take-nth 2 arc))))
 
@@ -959,7 +951,44 @@
      :properties properties-without-fns}))
 
 (def opts-schema {(s/optional-key :traverse?) Runnable
-                  (s/optional-key :serializer) Runnable})
+                  (s/optional-key :serializer) Runnable
+                  (s/optional-key :flatten-overrides?) Boolean})
+
+(declare override-original)
+
+(defn override-chain
+  "Given a node id, returns a sequence of node ids starting with the
+  non-override node and proceeding with every override node leading
+  up to and including the supplied node id."
+  ([node-id]
+   (override-chain (now) node-id))
+  ([basis node-id]
+   (into '() (take-while some? (iterate (partial override-original basis) node-id)))))
+
+(defn- deep-arcs-by-head
+  "Like arcs-by-head, but also includes connections from nodes earlier in the
+  override chain."
+  ([source-node-id]
+   (deep-arcs-by-head (now) source-node-id))
+  ([basis source-node-id]
+   (into []
+         (mapcat (partial gt/arcs-by-head basis))
+         (override-chain basis source-node-id))))
+
+(defn- deep-arcs-by-tail
+  "Like arcs-by-tail, but also includes non-covered connections to nodes earlier
+  in the override chain."
+  ([target-node-id]
+   (deep-arcs-by-tail (now) target-node-id))
+  ([basis target-node-id]
+   (into []
+         (mapcat val)
+         (reduce (fn [arcs-by-target-label node-id]
+                   (merge arcs-by-target-label
+                          (group-by :targetLabel
+                                    (gt/arcs-by-tail basis node-id))))
+                 {}
+                 (override-chain basis target-node-id)))))
 
 (defn copy
   "Given a vector of root ids, and an options map that can contain an
@@ -987,22 +1016,42 @@
   `:serializer` will be called with the node value. It must return an
    associative data structure (e.g., a map or a record).
 
+   If the `:flatten-overrides?` flag is true, connections to or from
+  any nodes along the override chain will be flattened to source or
+  target the serialized node instead of the nodes that it overrides.
+
   Example:
 
   `(g/copy root-ids {:traverse? (comp not resource? #(nth % 3))
-                     :serializer (some-fn custom-serializer default-node-serializer %)})"
+                     :serializer (some-fn custom-serializer default-node-serializer %)
+                     :flatten-overrides? true})"
   ([root-ids opts]
    (copy (now) root-ids opts))
-  ([basis root-ids {:keys [traverse? serializer] :or {traverse? (clojure.core/constantly false) serializer default-node-serializer} :as opts}]
+  ([basis root-ids {:keys [traverse? serializer flatten-overrides?] :or {traverse? (clojure.core/constantly false) serializer default-node-serializer flatten-overrides? false} :as opts}]
     (s/validate opts-schema opts)
-   (let [serializer     #(assoc (serializer basis (gt/node-by-id-at basis %2)) :serial-id %1)
+   (let [arcs-by-head   (partial (if flatten-overrides? deep-arcs-by-head gt/arcs-by-head) basis)
+         arcs-by-tail   (partial (if flatten-overrides? deep-arcs-by-tail gt/arcs-by-tail) basis)
+         node-ids-xform (if flatten-overrides?
+                          (mapcat (fn [[original-id {serial-id :serial-id}]]
+                                    (map #(vector % serial-id)
+                                         (override-chain basis original-id))))
+                          (map (juxt key (comp :serial-id val))))
+         serializer     #(assoc (serializer basis (gt/node-by-id-at basis %2)) :serial-id %1)
          original-ids   (input-traverse basis traverse? root-ids)
          replacements   (zipmap original-ids (map-indexed serializer original-ids))
-         serial-ids     (util/map-vals :serial-id replacements)
-         fragment-arcs  (connecting-arcs basis original-ids)]
-     {:roots              (map serial-ids root-ids)
+         serial-ids     (into {} node-ids-xform replacements)
+         include-arc?   (partial ig/arc-endpoints-p (partial contains? serial-ids))
+         serialize-arc  (partial serialize-arc serial-ids)
+         incoming-arcs  (mapcat arcs-by-tail original-ids)
+         outgoing-arcs  (mapcat arcs-by-head original-ids)
+         fragment-arcs  (into []
+                              (comp (filter include-arc?)
+                                    (map serialize-arc)
+                                    (distinct))
+                              (concat incoming-arcs outgoing-arcs))]
+     {:roots              (mapv serial-ids root-ids)
       :nodes              (vec (vals replacements))
-      :arcs               (mapv (partial serialize-arc serial-ids) fragment-arcs)
+      :arcs               fragment-arcs
       :node-id->serial-id serial-ids})))
 
 (defn- deserialize-arc

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -103,7 +103,7 @@
     (copy src-item-iterators default-copy-traverse))
   ([src-item-iterators traverse?]
     (let [root-ids (mapv #(:node-id (value %)) src-item-iterators)
-          fragment (-> (g/copy root-ids {:traverse? traverse?})
+          fragment (-> (g/copy root-ids {:traverse? traverse? :flatten-overrides? true})
                        (add-attachments root-ids))]
       (serialize fragment))))
 

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -711,9 +711,9 @@
           tool-user-data (g/node-value view-id :tool-user-data)
           action-queue (g/node-value view-id :input-action-queue)
           active-updatables (g/node-value view-id :active-updatables)
-          updatable-states (g/node-value view-id :updatable-states)
           {:keys [frame-version] :as render-args} (g/node-value view-id :render-args)]
-      (g/set-property! view-id :input-action-queue [])
+      (when (seq action-queue)
+        (g/set-property! view-id :input-action-queue []))
       (when (seq active-updatables)
         (g/invalidate-outputs! [[view-id :render-args]]))
       (when main-frame?
@@ -723,7 +723,8 @@
           (doseq [action action-queue]
             (dispatch-input input-handlers action @tool-user-data))))
       (profiler/profile "updatables" -1
-        (g/update-property! view-id :updatable-states update-updatables play-mode active-updatables))
+        (when (seq active-updatables)
+          (g/update-property! view-id :updatable-states update-updatables play-mode active-updatables)))
       (profiler/profile "render" -1
         (let [current-frame-version (ui/user-data image-view ::current-frame-version)]
           (with-drawable-as-current drawable

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -652,7 +652,10 @@
       (-> (reduce (fn [ctx [f node-id property old-value new-value :as deferred]]
                     (try
                       (if (gt/node-by-id-at (:basis ctx) node-id)
-                        (apply-tx ctx (f (:basis ctx) node-id old-value new-value))
+                        (let [setter-actions (f (:basis ctx) node-id old-value new-value)]
+                          (when *tx-debug*
+                            (println (txerrstr ctx "deferred setter actions" (seq setter-actions))))
+                          (apply-tx ctx setter-actions))
                         ctx)
                       (catch clojure.lang.ArityException ae
                         (println "ArityException while inside " f " on node " node-id " with " old-value new-value (meta deferred)


### PR DESCRIPTION
### Technical changes
* A `:flatten-overrides?` flag was added to the `opts` map of `g/copy`. This should be `true` if the provided node `serializer` outputs node data that effectively flattens the override hierarchy. The `:flatten-overrides?` flag will cause connections inherited from earlier in the override chain to be included in the copy. This also means that the resulting `node-id->serial-id` map might contain several entries mapping different original node ids to a single serial node id.
* Output deferred setter actions when `*tx-debug*` is `true`.
* Stopped the `SceneNode` from needlessly setting properties every frame, as it was interfering with `*tx-debug*`.