### PR TITLE
DEFEDIT-1123 Tweaked fuzzy text match scoring

### DIFF
--- a/editor/src/clj/editor/fuzzy_text.clj
+++ b/editor/src/clj/editor/fuzzy_text.clj
@@ -8,9 +8,10 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 (def ^:private adjacency-bonus "Bonus for adjacent matches." 15)
-(def ^:private separator-bonus "Bonus if match occurs after a separator." 30)
-(def ^:private camel-bonus "Bonus if match is uppercase and previous character is lowercase." 30)
+(def ^:private separator-bonus "Bonus if match occurs after a separator." 15)
+(def ^:private camel-bonus "Bonus if match is uppercase and previous character is lowercase." 15)
 (def ^:private first-letter-bonus "Bonus if the first letter is matched." 15)
+(def ^:private filename-bonus "Bonus for matches to the filename part when using match-path." 20)
 (def ^:private leading-letter-penalty "Penalty applied for every letter in str before the first match." -5)
 (def ^:private max-leading-letter-penalty "Maximum penalty for leading letters." -15)
 (def ^:private unmatched-letter-penalty "Penalty for every letter that doesn't matter." -1)
@@ -45,7 +46,7 @@
         score (volatile! 0)]
     (loop [str-idx (+ start-index offset)
            pattern-idx 0
-           prev-matched? false
+           prev-matched-idx nil
            prev-lower? false
            prev-separator? true]
       (if (= str-length str-idx)
@@ -58,7 +59,7 @@
           (if (and pattern-char (char-blank? pattern-char))
             (recur str-idx
                    (inc pattern-idx)
-                   prev-matched?
+                   prev-matched-idx
                    prev-lower?
                    prev-separator?)
             (let [pattern-lower (some-> pattern-char char->lower)
@@ -84,7 +85,7 @@
                     (let [camel-boundary? (and prev-lower? (= str-upper str-char) (not= str-upper str-lower))
                           first-letter? (= start-index str-idx)
                           new-score (cond-> 0
-                                            prev-matched? (add adjacency-bonus)
+                                            (= prev-matched-idx (dec str-idx)) (add adjacency-bonus)
                                             prev-separator? (add separator-bonus)
                                             camel-boundary? (add camel-bonus)
                                             first-letter? (add first-letter-bonus))]
@@ -97,12 +98,12 @@
                         (vreset! best-letter-score new-score)))
                     (recur (inc str-idx)
                            (if next-match? (inc pattern-idx) pattern-idx)
-                           true
+                           (when-not rematch? str-idx)
                            (and (= str-lower str-char) (not= str-upper str-lower))
                            (contains? separator-chars str-char)))
                 (recur (inc str-idx)
                        pattern-idx
-                       false
+                       prev-matched-idx
                        (and (= str-lower str-char) (not= str-upper str-lower))
                        (contains? separator-chars str-char))))))))))
 
@@ -121,6 +122,9 @@
               (inc (sub (first matching-indices) start-index)))
        best-match))))
 
+(defn- add-filename-bonus [[^long score matched-indices]]
+  [(+ score ^long filename-bonus) matched-indices])
+
 (defn match-path
   "Convenience function for matching against paths. The match function is
   called for the entire path as well as just the file name. We return the
@@ -129,7 +133,7 @@
   (when-some [path-match (match pattern path)]
     (if-some [last-slash-index (string/last-index-of path \/)]
       (let [name-index (inc ^long last-slash-index)]
-        (if-some [name-match (match pattern path name-index)]
+        (if-some [name-match (some-> (match pattern path name-index) add-filename-bonus)]
           (max-key first name-match path-match)
           path-match))
       path-match)))

--- a/editor/test/editor/fuzzy_text_test.clj
+++ b/editor/test/editor/fuzzy_text_test.clj
@@ -57,7 +57,9 @@
 
 (deftest score-test
   (is (> (score "game.script" "/game/game.script")
-         (score "game.script" "/game/score/score.gui_script"))))
+         (score "game.script" "/game/score/score.gui_script")))
+  (is (> (score "camera" "/utils/camera.lua")
+         (score "camera" "/juego/com/king/juego/starlevel/app_star_level_game_round_api.lua"))))
 
 (deftest runs-test
   (are [length matching-indices expected]


### PR DESCRIPTION
Fixes defold/editor2-issues#1159

### User-facing changes
* Improved ordering of results when performing fuzzy text filtering.