### PR TITLE
DEFEDIT-1130 Remove dynamic functions from :form-ops

### DIFF
--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -18,13 +18,17 @@
 
 (def camera-icon "icons/32/Icons_20-Camera.png")
 
+(defn- set-form-op [{:keys [node-id]} [property] value]
+  (g/set-property! node-id property value))
+
+(defn- clear-form-op [{:keys [node-id]} [property]]
+  (g/clear-property! node-id property))
+
 (g/defnk produce-form-data
   [_node-id aspect-ratio fov near-z far-z auto-aspect-ratio]
-  {:form-ops {:user-data {}
-              :set (fn [v [property] val]
-                     (g/set-property! _node-id property val))
-              :clear (fn [property]
-                       (g/clear-property! _node-id property))}
+  {:form-ops {:user-data {:node-id _node-id}
+              :set set-form-op
+              :clear clear-form-op}
    :sections [{:title "Camera"
                :fields [{:path [:aspect-ratio]
                          :label "Aspect Ratio"

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -20,13 +20,17 @@
 
 (def collection-proxy-icon "icons/32/Icons_09-Collection.png")
 
+(defn- set-form-op [{:keys [node-id]} [property] value]
+  (g/set-property! node-id property value))
+
+(defn- clear-form-op [{:keys [node-id]} [property]]
+  (g/clear-property! node-id property))
+
 (g/defnk produce-form-data
   [_node-id collection-resource]
-  {:form-ops {:user-data {}
-              :set (fn [v [property] val]
-                     (g/set-property! _node-id property val))
-              :clear (fn [property]
-                       (g/clear-property! _node-id property))}
+  {:form-ops {:user-data {:node-id _node-id}
+              :set set-form-op
+              :clear clear-form-op}
    :sections [{:title "Collection Proxy"
                :fields [{:path [:collection]
                          :label "Collection"

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -30,13 +30,17 @@
                  :ext "collection"
                  :pb-type GameSystem$CollectionFactoryDesc}})
 
+(defn- set-form-op [{:keys [node-id]} [property] value]
+  (g/set-property! node-id property value))
+
+(defn- clear-form-op [{:keys [node-id]} [property]]
+  (g/clear-property! node-id property))
+
 (g/defnk produce-form-data
   [_node-id factory-type prototype-resource]
-  {:form-ops {:user-data {}
-              :set (fn [v path val]
-                     (g/set-property! _node-id :prototype val))
-              :clear (fn [path]
-                       (g/clear-property! _node-id :prototype))}
+  {:form-ops {:user-data {:node-id _node-id}
+              :set set-form-op
+              :clear clear-form-op}
    :sections [{:title (get-in factory-types [factory-type :title])
                :fields [{:path [:prototype]
                          :label "Prototype"

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -58,13 +58,17 @@
    :label "Sound"
    :icon sound-icon})
 
+(defn- set-form-op [{:keys [node-id]} [property] value]
+  (g/set-property! node-id property value))
+
+(defn- clear-form-op [{:keys [node-id]} [property]]
+  (g/clear-property! node-id property))
+
 (g/defnk produce-form-data
   [_node-id sound looping group gain]
-  {:form-ops {:user-data {}
-              :set (fn [v [property] val]
-                     (g/set-property! _node-id property val))
-              :clear (fn [property]
-                       (g/clear-property! _node-id property))}
+  {:form-ops {:user-data {:node-id _node-id}
+              :set set-form-op
+              :clear clear-form-op}
    :sections [{:title "Sound"
                :fields [{:path [:sound]
                          :label "Sound"


### PR DESCRIPTION
### Technical changes
* Remove dynamic functions from :form-ops everywhere, since they were interfering with equality checks.