### PR TITLE
DEFEDIT-1126 Insert our shader directives after directives in the shader

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FragmentProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FragmentProgramBuilder.java
@@ -1,24 +1,15 @@
 package com.dynamo.bob.pipeline;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintWriter;
 
 import com.dynamo.bob.BuilderParams;
-import com.dynamo.bob.CopyBuilder;
-import com.dynamo.bob.Task;
-import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.pipeline.ShaderProgramBuilder;
 
 @BuilderParams(name = "FragmentProgram", inExts = ".fp", outExt = ".fpc")
-public class FragmentProgramBuilder extends CopyBuilder {
+public class FragmentProgramBuilder extends ShaderProgramBuilder {
 
     @Override
-    public void build(Task<Void> task) throws IOException {
-        IResource in = task.getInputs().get(0);
-        IResource out = task.getOutputs().get(0);
-
-        ByteArrayOutputStream os = new ByteArrayOutputStream(16 * 1024);
-        PrintWriter writer = new PrintWriter(os);
+    public void writeExtraDirectives(PrintWriter writer) {
         writer.println("#ifdef GL_ES");
         writer.println("precision mediump float;");
         writer.println("#endif");
@@ -27,20 +18,6 @@ public class FragmentProgramBuilder extends CopyBuilder {
         writer.println("#define mediump");
         writer.println("#define highp");
         writer.println("#endif");
-
-        // We want "correct" line numbers from the GLSL compiler.
-        //
-        // Some Android devices don't like setting #line to something below 1,
-        // see JIRA issue: DEF-1786.
-        // We still want to have correct line reporting on most devices so
-        // only output "#line 0" in debug builds.
-        if (project.hasOption("debug")) {
-            writer.println("#line 0");
-        }
-
-        writer.close();
-        os.write(in.getContent());
-        os.close();
-        out.setContent(os.toByteArray());
     }
+
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -15,7 +15,7 @@ import com.dynamo.bob.fs.IResource;
 
 public abstract class ShaderProgramBuilder extends CopyBuilder {
 
-    private static Pattern directiveLinePattern = Pattern.compile("\\s*(#|//).*");
+    private static Pattern directiveLinePattern = Pattern.compile("^\\s*(#|//).*");
 
     private static boolean isDirectiveLine(String line) {
         return line.isEmpty() || directiveLinePattern.matcher(line).find();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -1,0 +1,86 @@
+package com.dynamo.bob.pipeline;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import com.dynamo.bob.CopyBuilder;
+import com.dynamo.bob.Task;
+import com.dynamo.bob.fs.IResource;
+
+public abstract class ShaderProgramBuilder extends CopyBuilder {
+
+    private static Pattern directiveLinePattern = Pattern.compile("\\s*#.*");
+
+    private static boolean isDirectiveLine(String line) {
+        return line.isEmpty() || directiveLinePattern.matcher(line).find();
+    }
+
+    public abstract void writeExtraDirectives(PrintWriter writer);
+
+    @Override
+    public void build(Task<Void> task) throws IOException {
+        IResource in = task.getInputs().get(0);
+        IResource out = task.getOutputs().get(0);
+
+        try (ByteArrayInputStream is = new ByteArrayInputStream(in.getContent());
+             InputStreamReader isr = new InputStreamReader(is);
+             BufferedReader reader = new BufferedReader(isr);
+             ByteArrayOutputStream os = new ByteArrayOutputStream(is.available() + 128 * 16);
+             PrintWriter writer = new PrintWriter(os)) {
+
+            // Write directives from shader.
+            String line = null;
+            String firstNonDirectiveLine = null;
+            int directiveLineCount = 0;
+
+            while ((line = reader.readLine()) != null) {
+                if (isDirectiveLine(line)) {
+                    writer.println(line);
+                    ++directiveLineCount;
+                } else {
+                    firstNonDirectiveLine = line;
+                    break;
+                }
+            }
+
+            // Write our directives.
+            if (directiveLineCount != 0) {
+                writer.println();
+            }
+
+            writeExtraDirectives(writer);
+            writer.println();
+
+            // We want "correct" line numbers from the GLSL compiler.
+            //
+            // Some Android devices don't like setting #line to something below 1,
+            // see JIRA issue: DEF-1786.
+            // We still want to have correct line reporting on most devices so
+            // only output the "#line N" directive in debug builds.
+            if (project.hasOption("debug")) {
+                writer.printf(Locale.ROOT, "#line %d", directiveLineCount);
+                writer.println();
+            }
+
+            // Write the first non-directive line from above.
+            if (firstNonDirectiveLine != null) {
+                writer.println(firstNonDirectiveLine);
+            }
+
+            // Write the remaining lines from the shader.
+            while ((line = reader.readLine()) != null) {
+                writer.println(line);
+            }
+
+            writer.flush();
+            out.setContent(os.toByteArray());
+        }
+    }
+
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -15,7 +15,7 @@ import com.dynamo.bob.fs.IResource;
 
 public abstract class ShaderProgramBuilder extends CopyBuilder {
 
-    private static Pattern directiveLinePattern = Pattern.compile("\\s*#.*");
+    private static Pattern directiveLinePattern = Pattern.compile("\\s*(#|//).*");
 
     private static boolean isDirectiveLine(String line) {
         return line.isEmpty() || directiveLinePattern.matcher(line).find();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/VertexProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/VertexProgramBuilder.java
@@ -1,44 +1,20 @@
 package com.dynamo.bob.pipeline;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintWriter;
 
 import com.dynamo.bob.BuilderParams;
-import com.dynamo.bob.CopyBuilder;
-import com.dynamo.bob.Task;
-import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.pipeline.ShaderProgramBuilder;
 
 @BuilderParams(name = "VertexProgram", inExts = ".vp", outExt = ".vpc")
-public class VertexProgramBuilder extends CopyBuilder {
+public class VertexProgramBuilder extends ShaderProgramBuilder {
 
     @Override
-    public void build(Task<Void> task) throws IOException {
-        IResource in = task.getInputs().get(0);
-        IResource out = task.getOutputs().get(0);
-
-        ByteArrayOutputStream os = new ByteArrayOutputStream(16 * 1024);
-        PrintWriter writer = new PrintWriter(os);
+    public void writeExtraDirectives(PrintWriter writer) {
         writer.println("#ifndef GL_ES");
         writer.println("#define lowp");
         writer.println("#define mediump");
         writer.println("#define highp");
         writer.println("#endif");
-
-        // We want "correct" line numbers from the GLSL compiler.
-        //
-        // Some Android devices don't like setting #line to something below 1,
-        // see JIRA issue: DEF-1786.
-        // We still want to have correct line reporting on most devices so
-        // only output "#line 0" in debug builds.
-        if (project.hasOption("debug")) {
-            writer.println("#line 0");
-        }
-
-        writer.close();
-        os.write(in.getContent());
-        os.close();
-        out.setContent(os.toByteArray());
     }
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/handlers/LaunchHandler.java
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/handlers/LaunchHandler.java
@@ -146,7 +146,7 @@ public class LaunchHandler extends AbstractHandler {
                     sdkVersion = "";
                 }
                 bobArgs.put("defoldsdk", sdkVersion);
-
+                bobArgs.put("debug", "true");
                 BobUtil.putBobArgs(bobArgs, args);
 
                 try {

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -590,7 +590,7 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
   (or (string/blank? line)
       (some? (re-matches directive-line-re line))))
 
-(defn- insert-directives
+(defn insert-directives
   [code-lines inserted-directive-lines]
   ;; Our directives should be inserted after any directives in the shader.
   ;; This makes it possible to use directives such as #extension in the shader.

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -584,7 +584,7 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
                                         "#endif"
                                         ""]})
 
-(def ^:private directive-line-re #"\s*(#|//).*")
+(def ^:private directive-line-re #"^\s*(#|//).*")
 
 (defn- directive-line? [line]
   (or (string/blank? line)

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -584,7 +584,7 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
                                         "#endif"
                                         ""]})
 
-(def ^:private directive-line-re #"\s*#.*")
+(def ^:private directive-line-re #"\s*(#|//).*")
 
 (defn- directive-line? [line]
   (or (string/blank? line)

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -566,25 +566,44 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
                    :view-types [:code :default]
                    :view-opts glsl-opts}])
 
-(def ^:private prefix {"vp" (string/join "\n" ["#ifndef GL_ES"
-                                               "#define lowp"
-                                               "#define mediump"
-                                               "#define highp"
-                                               "#endif"
-                                               ""])
-                       "fp" (string/join "\n" ["#ifdef GL_ES"
-                                               "precision mediump float;"
-                                               "#endif"
-                                               "#ifndef GL_ES"
-                                               "#define lowp"
-                                               "#define mediump"
-                                               "#define highp"
-                                               "#endif"
-                                               ""])})
+(def ^:private compat-directives {"vp" [""
+                                        "#ifndef GL_ES"
+                                        "#define lowp"
+                                        "#define mediump"
+                                        "#define highp"
+                                        "#endif"
+                                        ""]
+                                  "fp" [""
+                                        "#ifdef GL_ES"
+                                        "precision mediump float;"
+                                        "#endif"
+                                        "#ifndef GL_ES"
+                                        "#define lowp"
+                                        "#define mediump"
+                                        "#define highp"
+                                        "#endif"
+                                        ""]})
+
+(def ^:private directive-line-re #"\s*#.*")
+
+(defn- directive-line? [line]
+  (or (string/blank? line)
+      (some? (re-matches directive-line-re line))))
+
+(defn- insert-directives
+  [code-lines inserted-directive-lines]
+  ;; Our directives should be inserted after any directives in the shader.
+  ;; This makes it possible to use directives such as #extension in the shader.
+  (let [[code-directive-lines code-non-directive-lines] (split-with directive-line? code-lines)]
+    (into []
+          (concat code-directive-lines
+                  inserted-directive-lines
+                  [(str "#line " (count code-directive-lines))]
+                  code-non-directive-lines))))
 
 (defn- compat [resource code]
-  (if-let [prefix (-> resource (resource/ext) prefix)]
-    (str prefix code)
+  (if-let [directives (-> resource (resource/ext) compat-directives)]
+    (string/join "\n" (insert-directives (string/split-lines code) directives))
     code))
 
 (defn- build-shader [self basis resource dep-resources user-data]

--- a/editor/test/editor/gl/shader_test.clj
+++ b/editor/test/editor/gl/shader_test.clj
@@ -1,0 +1,134 @@
+(ns editor.gl.shader-test
+  (:require [clojure.test :refer :all]
+            [editor.gl.shader :as shader]))
+
+(deftest insert-directives-test
+  (testing "Insertion rules"
+    (is (= ["#ours"
+            "#line 0"]
+           (shader/insert-directives []
+                                     ["#ours"])))
+    (is (= [""
+            "#ours"
+            "#line 1"]
+           (shader/insert-directives [""]
+                                     ["#ours"])))
+    (is (= ["#theirs"
+            "#ours"
+            "#line 1"]
+           (shader/insert-directives ["#theirs"]
+                                     ["#ours"])))
+    (is (= ["#theirs"
+            "#ours"
+            "#line 1"
+            "theirs"]
+           (shader/insert-directives ["#theirs"
+                                      "theirs"]
+                                     ["#ours"])))
+    (is (= [""
+            "#ours"
+            "#line 1"
+            "theirs"]
+           (shader/insert-directives [""
+                                      "theirs"]
+                                     ["#ours"])))
+    (are [prefix]
+      (let [their-first-line (str prefix "theirs")]
+        (= [their-first-line
+            "#ours"
+            "#line 1"
+            "theirs"]
+           (shader/insert-directives [their-first-line
+                                      "theirs"]
+                                     ["#ours"])))
+      "#"
+      "\t#"
+      "    #"
+      "  \t  #"
+      "//"
+      "\t//"
+      "    //"
+      "  \t  //"
+      "//#"
+      "\t//#"
+      "    //#"
+      "  \t  //#")
+
+    (are [suffix]
+      (let [their-first-line (str "#theirs" suffix)]
+        (= [their-first-line
+            "#ours"
+            "#line 1"
+            "theirs"]
+           (shader/insert-directives [their-first-line
+                                      "theirs"]
+                                     ["#ours"])))
+      "//"
+      "\t//"
+      "    //"
+      "  \t  //"))
+
+  (testing "Real-world use"
+    (is (= ["#version 300"
+            "#extension GL_EXT_shader_texture_lod : enable"
+            "#extension GL_OES_standard_derivatives : enable"
+            "#defold-one"
+            "#defold-two"
+            "#line 3"]
+           (shader/insert-directives ["#version 300"
+                                      "#extension GL_EXT_shader_texture_lod : enable"
+                                      "#extension GL_OES_standard_derivatives : enable"]
+                                     ["#defold-one"
+                                      "#defold-two"])))
+    (is (= ["#version 300"
+            "#extension GL_EXT_shader_texture_lod : enable"
+            "#extension GL_OES_standard_derivatives : enable"
+            ""
+            "#defold-one"
+            "#defold-two"
+            "#line 4"
+            "uniform sampler2D myTexture;"
+            "varying vec2 texcoord;"
+            ""
+            "void main() {"
+            "    gl_FragColor = texture2DGradEXT(myTexture, mod(texcoord, vec2(0.1, 0.5)), dFdx(texcoord), dFdy(texcoord));"
+            "}"]
+           (shader/insert-directives ["#version 300"
+                                      "#extension GL_EXT_shader_texture_lod : enable"
+                                      "#extension GL_OES_standard_derivatives : enable"
+                                      ""
+                                      "uniform sampler2D myTexture;"
+                                      "varying vec2 texcoord;"
+                                      ""
+                                      "void main() {"
+                                      "    gl_FragColor = texture2DGradEXT(myTexture, mod(texcoord, vec2(0.1, 0.5)), dFdx(texcoord), dFdy(texcoord));"
+                                      "}"]
+                                     ["#defold-one"
+                                      "#defold-two"])))
+    (is (= ["#version 300"
+            "// #extension GL_EXT_shader_texture_lod : enable"
+            "// #extension GL_OES_standard_derivatives : enable"
+            ""
+            "#defold-one"
+            "#defold-two"
+            "#line 4"
+            "uniform sampler2D myTexture;"
+            "varying vec2 texcoord;"
+            ""
+            "void main() {"
+            "    // gl_FragColor = texture2DGradEXT(myTexture, mod(texcoord, vec2(0.1, 0.5)), dFdx(texcoord), dFdy(texcoord));"
+            "    gl_FragColor = texture2D(myTexture, texcoord.x, texcoord.y);"
+            "}"]
+           (shader/insert-directives ["#version 300"
+                                      "// #extension GL_EXT_shader_texture_lod : enable"
+                                      "// #extension GL_OES_standard_derivatives : enable"
+                                      ""
+                                      "uniform sampler2D myTexture;"
+                                      "varying vec2 texcoord;"
+                                      ""
+                                      "void main() {"
+                                      "    // gl_FragColor = texture2DGradEXT(myTexture, mod(texcoord, vec2(0.1, 0.5)), dFdx(texcoord), dFdy(texcoord));"
+                                      "    gl_FragColor = texture2D(myTexture, texcoord.x, texcoord.y);"
+                                      "}"]
+                                     ["#defold-one"
+                                      "#defold-two"])))))


### PR DESCRIPTION
Fixes defold/editor2-issues#1155.
Also reported as DEF-2793.

### User-facing changes
* We inject our precision shader directives after any directives in the shader. This makes it possible to use the `#extension` directive in shaders.

### Technical changes
* Added `ShaderProgramBuilder` abstract base class.
* Supply `debug=true` flag to Bob in `LaunchHandler.java` so that the `#line N` directive is included in shaders when choosing **Build and Run** from the Editor 1 menu bar.