### PR TITLE
DEFEDIT-1132 Focus console when building and running

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -284,7 +284,7 @@
                              (engine/reboot target local-url)))
                          (try
                            (engine/launch project prefs)
-                           (console/focus!)
+                           (console/show!)
                            (catch Exception e
                              (when-not (engine-build-errors/handle-build-error! render-error! project e)
                                (throw e))))))))))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -284,6 +284,7 @@
                              (engine/reboot target local-url)))
                          (try
                            (engine/launch project prefs)
+                           (console/focus!)
                            (catch Exception e
                              (when-not (engine-build-errors/handle-build-error! render-error! project e)
                                (throw e))))))))))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -2,7 +2,7 @@
   (:require [editor.ui :as ui]
             [editor.handler :as handler]
             [clojure.string :as str])
-  (:import [javafx.scene.control Button TextArea TextField]
+  (:import [javafx.scene.control Button TextArea TabPane TextField]
            [javafx.scene.input KeyCode KeyEvent Clipboard ClipboardContent]))
 
 (set! *warn-on-reflection* true)
@@ -82,6 +82,11 @@
   [^String message]
   (locking message-buffer-lock
     (.append message-buffer message)))
+
+(defn focus!
+  []
+  (let [^TabPane tab-pane (ui/closest-node-of-type TabPane @node)]
+    (.select (.getSelectionModel tab-pane) 0)))
 
 (handler/defhandler :copy :console-view
   (enabled? []

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -83,7 +83,7 @@
   (locking message-buffer-lock
     (.append message-buffer message)))
 
-(defn focus!
+(defn show!
   []
   (let [^TabPane tab-pane (ui/closest-node-of-type TabPane @node)]
     (.select (.getSelectionModel tab-pane) 0)))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/549

### User facing changes

- When building and running a game, focus the console if the game is
  started successfully.