### PR TITLE
DEFEDIT-1133 Can delete open markdown file

### DIFF
--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -23,17 +23,18 @@
 (g/defnode MarkdownNode
   (inherits resource-node/ResourceNode)
 
-  (property markdown g/Str)
+  (property markdown g/Str
+            (dynamic visible (g/constantly false)))
 
   (output html g/Str :cached (g/fnk [_node-id markdown]
                                (str "<!DOCTYPE html>"
                                     "<html><head></head><body>"
-                                    markdown
+                                    (markdown->html markdown)
                                     "</body></html>"))))
 
 (defn load-markdown
   [project self resource]
-  (g/set-property self :markdown (markdown->html (slurp resource :encoding "UTF-8"))))
+  (g/set-property self :markdown (slurp resource :encoding "UTF-8")))
 
 (defn register-resource-types
   [workspace]

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -23,11 +23,17 @@
 (g/defnode MarkdownNode
   (inherits resource-node/ResourceNode)
 
-  (output html g/Str (g/fnk [_node-id resource]
-                       (str "<!DOCTYPE html>"
-                            "<html><head></head><body>"
-                            (markdown->html (slurp resource :encoding "UTF-8"))
-                            "</body></html>"))))
+  (property markdown g/Str)
+
+  (output html g/Str :cached (g/fnk [_node-id markdown]
+                               (str "<!DOCTYPE html>"
+                                    "<html><head></head><body>"
+                                    markdown
+                                    "</body></html>"))))
+
+(defn load-markdown
+  [project self resource]
+  (g/set-property self :markdown (markdown->html (slurp resource :encoding "UTF-8"))))
 
 (defn register-resource-types
   [workspace]
@@ -35,5 +41,6 @@
                                     :ext "md"
                                     :label "Markdown"
                                     :node-type MarkdownNode
-                                    :view-types [:html]
+                                    :load-fn load-markdown
+                                    :view-types [:html :text]
                                     :view-opts nil))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1110

### User facing changes

- You can now delete an open markdown file without error, and tab will
  close as expected.

### Technical changes

- Provide a `load-fn` when registering resource type for markdown, and
  load file as we do with other resources.