### PR TITLE
DEFEDIT-1037 Building when a build is already in progress produces error

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -301,8 +301,7 @@
   (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix))
 
 (defn- report-build-launch-progress [message]
-  (ui/default-render-progress-now! (progress/make message))
-  (console/append-console-message! (str message "\n")))
+  (ui/default-render-progress-now! (progress/make message)))
 
 (defn- launch-engine [project prefs]
   (try

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -39,7 +39,7 @@
   (:import [com.defold.control TabPaneBehavior]
            [com.defold.editor Editor EditorApplication]
            [com.defold.editor Start]
-           [java.net URI]
+           [java.net URI Socket]
            [java.util Collection]
            [javafx.application Platform]
            [javafx.beans.value ChangeListener]
@@ -56,7 +56,7 @@
            [javafx.scene.paint Color]
            [javafx.stage Screen Stage FileChooser WindowEvent]
            [javafx.util Callback]
-           [java.io File]
+           [java.io InputStream File IOException BufferedReader]
            [java.util.prefs Preferences]
            [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]))
 
@@ -270,6 +270,36 @@
                         build-errors-view
                         errors)))})
 
+(def ^:private engine-log-stream (atom nil))
+(def ^:private ssdp-pump-thread (atom nil))
+
+(defn- reset-ssdp-pump-thread! [^Thread new]
+  (when-let [old ^Thread @ssdp-pump-thread]
+    (.interrupt old))
+  (reset! ssdp-pump-thread new))
+
+(defn- start-log-pump! [log-stream]
+  (doto (Thread. (fn []
+                     (try
+                       (with-open [buffered-reader ^BufferedReader (io/reader log-stream :encoding "UTF-8")]
+                         (loop []
+                           (when-not (Thread/interrupted)
+                             (when-let [line (.readLine buffered-reader)]
+                               (when (= @engine-log-stream log-stream)
+                                 (console/append-console-message! (str line "\n")))
+                               (Thread/sleep 10)
+                               (recur)))))
+                       (catch IOException e
+                         ;; Losing the log connection is ok and even expected
+                         nil)
+                       (catch InterruptedException _
+                         ;; Losing the log connection is ok and even expected
+                         nil))))
+    (.start)))
+
+(defn- local-url [target web-server]
+  (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix))
+
 (defn- build-handler [project prefs web-server build-errors-view]
   (console/clear-console!)
   (ui/default-render-progress-now! (progress/make "Building..."))
@@ -279,15 +309,47 @@
                        build (project/build-and-write-project project prefs build-options)
                        render-error! (:render-error! build-options)]
                    (when build
+                     (reset! engine-log-stream nil)
                      (or (when-let [target (targets/selected-target prefs)]
-                           (let [local-url (format "http://%s:%s%s" (:local-address target) (http-server/port web-server) hot-reload/url-prefix)]
-                             (engine/reboot target local-url)))
+                           (console/append-console-message! (format "Rebooting %s\n" (targets/target-label target)))
+                           (if (targets/launched-target? target)
+                             (do (reset! engine-log-stream (:log-stream target))
+                                 (reset-ssdp-pump-thread! nil)
+                                 ;; Launched target log pump already
+                                 ;; running to keep engine process
+                                 ;; from halting because stdout/err is
+                                 ;; not consumed.
+                                 )
+                             (when-let [log-stream (engine/get-log-service-stream target)]
+                               (reset! engine-log-stream log-stream)
+                               (reset-ssdp-pump-thread! (start-log-pump! log-stream))))
+                           (if (engine/reboot target (local-url target web-server))
+                             :rebooted
+                             (do (console/append-console-message! "Reboot failed\n")
+                                 nil)))
                          (try
-                           (engine/launch project prefs)
-                           (console/show!)
-                           (catch Exception e
-                             (when-not (engine-build-errors/handle-build-error! render-error! project e)
-                               (throw e))))))))))
+                           (console/append-console-message! "Launching engine\n")
+                           (if (some-> (try
+                                         (engine/launch project prefs)
+                                         (catch Exception e
+                                           (when-not (engine-build-errors/handle-build-error! render-error! project e)
+                                             (throw e))))
+                                       (#(try
+                                           (targets/add-launched-target! %)
+                                           (catch Exception _
+                                             (ui/run-later (dialogs/make-alert-dialog "Can't add launched target"))
+                                             (targets/kill-launched-target! %))))
+                                       (#(targets/select-target! prefs %))
+                                       (#(try
+                                           (reset! engine-log-stream (:log-stream %))
+                                           (start-log-pump! (:log-stream %))
+                                           %
+                                           (catch Exception _
+                                             (ui/run-later (dialogs/make-alert-dialog "Can't connect to engine log"))
+                                             (targets/kill-launched-target! %)))))
+                             :launched
+                             (do (console/append-console-message! "Launch failed\n")
+                                 nil)))))))))
 
 (handler/defhandler :build :global
   (run [project prefs web-server build-errors-view]
@@ -316,9 +378,10 @@
 (def ^:private unreloadable-resource-build-exts #{"collectionc" "goc"})
 
 (handler/defhandler :hot-reload :global
-  (enabled? [app-view selection]
-            (when-some [resource (context-resource-file app-view selection)]
-              (not (contains? unreloadable-resource-build-exts (:build-ext (resource/resource-type resource))))))
+  (enabled? [app-view selection prefs]
+            (when-let [resource (context-resource-file app-view selection)]
+              (and (targets/selected-target prefs)
+                   (not (contains? unreloadable-resource-build-exts (:build-ext (resource/resource-type resource)))))))
   (run [project app-view prefs build-errors-view selection]
     (when-let [resource (context-resource-file app-view selection)]
       (ui/default-render-progress-now! (progress/make "Building..."))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -357,6 +357,7 @@
             selected-target (targets/selected-target prefs)]
         (ui/default-render-progress-now! (progress/make "Done Building."))
         (when build
+          (console/show!)
           (try
             (cond
               (not selected-target)
@@ -439,7 +440,7 @@
                      (let [build-options (make-build-options build-errors-view)
                            build (project/build-and-write-project project prefs build-options)]
                        (when build
-                         (try 
+                         (try
                            (engine/reload-resource (targets/selected-target prefs) resource)
                            (catch Exception e
                              (dialogs/make-alert-dialog (format "Failed to reload resource on '%s'" (targets/target-label (targets/selected-target prefs)))))))))))))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -24,12 +24,6 @@
               (str/lower-case @term)
               ^Long (inc (or (first @positions) -1)))))
 
-(defn clear-console! []
-  (when-let [^TextArea node @node]
-    (reset! term "")
-    (reset! positions '())
-    (ui/run-later (.clear node))))
-
 (defn- search-console [_ _ ^String new]
   (reset! term new)
   (reset! positions '())
@@ -49,7 +43,7 @@
     (swap! positions rest))
   (update-highlight (first @positions)))
 
-(defn- trim-console-message! [^TextArea text-area max-line-count]
+(defn- trim-console! [^TextArea text-area max-line-count]
   (let [lines (.getParagraphs text-area)
         line-count (count lines)
         trimmed-line-count (max 0 (- line-count max-line-count))]
@@ -58,30 +52,46 @@
             trimmed-char-count (transduce (map count) + trimmed-line-count trimmed-lines)]
         (.deleteText text-area 0 (min trimmed-char-count (.getLength text-area)))))))
 
-(def ^:private ^:const message-buffer-initial-capacity 4096)
-(def ^:private ^StringBuilder message-buffer (StringBuilder. message-buffer-initial-capacity))
-(def ^:private message-buffer-lock (Object.))
+(def ^:private buffer-state-lock (Object.))
+(def ^:private ^:const messages-initial-capacity 4096)
+(def ^:private ^StringBuilder message-buffer (StringBuilder. messages-initial-capacity))
+(def ^:private clear-console false)
 
-(defn- flip-message-buffer!
+(defn- flip-buffer-state!
   []
-  (locking message-buffer-lock
-    (when (pos? (.length message-buffer))
-      (let [messages (.toString message-buffer)
-            new-buf (StringBuilder. message-buffer-initial-capacity)]
-        (alter-var-root #'message-buffer (constantly new-buf))
-        messages))))
+  (locking buffer-state-lock
+    (let [result (cond-> nil
+                   clear-console
+                   (assoc :clear true)
+
+                   (pos? (.length message-buffer))
+                   (assoc :text (.toString message-buffer)))]
+      (when result
+        (.setLength message-buffer 0)
+        (alter-var-root #'clear-console (constantly false)))
+      result)))
 
 (defn- update-console!
   []
   (when-let [^TextArea node @node]
-    (when-let [messages (flip-message-buffer!)]
-      (.appendText node messages)
-      (trim-console-message! node 3000))))
+    (let [{:keys [clear text]} (flip-buffer-state!)]
+      (when clear
+        (.clear node))
+      (when text
+        (.appendText node text)
+        (trim-console! node 3000)))))
 
 (defn append-console-message!
   [^String message]
-  (locking message-buffer-lock
+  (locking buffer-state-lock
     (.append message-buffer message)))
+
+(defn clear-console! []
+  (locking buffer-state-lock
+    (reset! term "")
+    (reset! positions '())
+    (.setLength message-buffer 0)
+    (alter-var-root #'clear-console (constantly true))))
 
 (defn show!
   []

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -91,7 +91,7 @@
 (def ^:private loopback-address "127.0.0.1")
 
 (defn parse-launched-target-info [output]
-  (let [log-port (second (re-find #"DLIB: Log started on port (\d*)" output))
+  (let [log-port (second (re-find #"DLIB: Log server started on port (\d*)" output))
         service-port (second (re-find #"ENGINE: Engine service started on port (\d*)" output))]
     (merge (when service-port
              {:url (str "http://" loopback-address ":" service-port)

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -32,8 +32,7 @@
   ;; spamming engine. Same thing if using plain (.read).
   (let [buffer (byte-array 1024)]
     (try
-      (while (not= -1 (.read is buffer))
-        (Thread/sleep 10))
+      (while (not= -1 (.read is buffer)))
       (catch IOException e
         ;; For instance socket closed because engine was killed
         nil))))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -18,7 +18,6 @@
 (set! *warn-on-reflection* true)
 
 (def ^:const timeout 2000)
-(def ^:const engine-ports-output-timeout 3000)
 
 (defn- get-connection [^URL url]
   (doto ^HttpURLConnection (.openConnection url)

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -1,27 +1,25 @@
 (ns editor.engine
   (:require [clojure.java.io :as io]
-            [dynamo.graph :as g]
+            [editor.process :as process]
             [editor.prefs :as prefs]
             [editor.dialogs :as dialogs]
             [editor.error-reporting :as error-reporting]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
-            [editor.console :as console]
             [editor.ui :as ui]
-            [editor.targets :as targets]
             [editor.defold-project :as project]
             [editor.workspace :as workspace]
             [editor.engine.native-extensions :as native-extensions])
   (:import [com.defold.editor Platform]
            [java.net HttpURLConnection InetSocketAddress Socket URI URL]
-           [java.io BufferedReader File InputStream IOException]
+           [java.io SequenceInputStream BufferedReader File InputStream ByteArrayOutputStream IOException]
+           [java.nio.charset Charset StandardCharsets]
            [java.lang Process ProcessBuilder]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:const timeout 2000)
-(defonce engine-input-stream (atom nil))
-(defonce shutdown-hook (atom nil))
+(def ^:const engine-ports-output-timeout 3000)
 
 (defn- get-connection [^URL url]
   (doto ^HttpURLConnection (.openConnection url)
@@ -31,117 +29,139 @@
     (.setDoOutput true)
     (.setRequestMethod "POST")))
 
+(defn- ignore-all-output [^InputStream is]
+  ;; Using a too small byte array here may fill the buffer and halt a
+  ;; spamming engine. Same thing if using plain (.read).
+  (let [buffer (byte-array 1024)]
+    (try
+      (while (not= -1 (.read is buffer))
+        (Thread/sleep 10))
+      (catch IOException e
+        ;; For instance socket closed because engine was killed
+        nil))))
+
 (defn reload-resource [target resource]
   (let [url  (URL. (str target "/post/@resource/reload"))
         conn ^HttpURLConnection (get-connection url)]
     (try
-      (let [os (.getOutputStream conn)]
+      (with-open [os (.getOutputStream conn)]
         (.write os ^bytes (protobuf/map->bytes
-                           com.dynamo.resource.proto.Resource$Reload
-                           {:resource (str (resource/proj-path resource) "c")}))
-        (.close os))
-      (let [is (.getInputStream conn)]
-        (while (not= -1 (.read is))
-          (Thread/sleep 10))
-        (.close is))
+                            com.dynamo.resource.proto.Resource$Reload
+                            {:resource (str (resource/proj-path resource) "c")})))
+      (with-open [is (.getInputStream conn)]
+        (ignore-all-output is))
       (catch Exception e
         (ui/run-later (dialogs/make-alert-dialog (str "Error connecting to engine on " target))))
       (finally
         (.disconnect conn)))))
 
-(defn- swap-engine-input-stream! [new-input-stream]
-  (swap! engine-input-stream (fn [^InputStream is new-is]
-                               (when is (.close is))
-                               new-is)
-    new-input-stream))
-
-(defn- pump-output [^InputStream is]
-  (swap-engine-input-stream! is)
-  (let [buf (byte-array 1024)]
-    (try
-      (loop []
-        (let [n (.read is buf)]
-          (when (> n -1)
-            (let [msg (String. buf 0 n)]
-              (console/append-console-message! msg)
-              (recur)))))
-      (catch IOException _
-        ;; Losing the log connection is ok and even expected
-        nil))))
-
 (defn reboot [target local-url]
   (let [url  (URL. (format "%s/post/@system/reboot" (:url target)))
         conn ^HttpURLConnection (get-connection url)]
     (try
-      (swap-engine-input-stream! nil)
-      (let [os  (.getOutputStream conn)]
+      (with-open [os  (.getOutputStream conn)]
         (.write os ^bytes (protobuf/map->bytes
-                           com.dynamo.engine.proto.Engine$Reboot
-                           {:arg1 (str "--config=resource.uri=" local-url)
-                            :arg2 (str local-url "/game.projectc")}))
-        (.close os))
-      (let [is (.getInputStream conn)]
-        (while (not= -1 (.read is))
-          (Thread/sleep 10))
-        (.close is)
-        (.disconnect conn)
-        (.start (Thread. (fn []
-                           ;; We try our best to connect to logging, fail without retry if we couldn't
-                           (try
-                             (let [port (Integer/parseInt (:log-port target))
-                                   socket-addr (InetSocketAddress. ^String (:address target) port)]
-                               (with-open [socket (doto (Socket.)
-                                                    (.setSoTimeout timeout)
-                                                    (.connect socket-addr timeout))]
-                                 (let [is (.getInputStream socket)
-                                       status (-> ^BufferedReader (io/reader is)
-                                                (.readLine))]
-                                   ;; The '0 OK' string is part of the log service protocol
-                                   (if (= "0 OK" status)
-                                     (do
-                                       (console/append-console-message! (format "[Running on target '%s' (%s)]\n" (:name target) (:address target)))
-                                       ;; Setting to 0 means wait indefinitely for new data
-                                       (.setSoTimeout socket 0)
-                                       (pump-output is))))))
-                             (catch Exception e
-                               (error-reporting/report-exception! e))))))
-        :ok)
+                            com.dynamo.engine.proto.Engine$Reboot
+                            {:arg1 (str "--config=resource.uri=" local-url)
+                             :arg2 (str local-url "/game.projectc")})))
+      (with-open [is (.getInputStream conn)]
+        (ignore-all-output is))
+      (.disconnect conn)
+      :ok
       (catch Exception e
         (.disconnect conn)
         false))))
 
-(defn- parent-resource [r]
-  (let [workspace (resource/workspace r)
-        path (resource/proj-path r)
-        parent-path (subs path 0 (dec (- (count path) (count (resource/resource-name r)))))
-        parent (workspace/resolve-workspace-resource workspace parent-path)]
-    parent))
+(defn get-log-service-stream [target]
+  (let [port (Integer/parseInt (:log-port target))
+        socket-addr (InetSocketAddress. ^String (:address target) port)
+        socket (doto (Socket.) (.setSoTimeout timeout))]
+    (try
+      (.connect socket socket-addr timeout)
+      ;; closing is will also close the socket
+      ;; https://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#getInputStream()
+      (let [is (.getInputStream socket)
+            status (-> ^BufferedReader (io/reader is) (.readLine))]
+        ;; The '0 OK' string is part of the log service protocol
+        (if (= "0 OK" status)
+          (do
+            ;; Setting to 0 means wait indefinitely for new data
+            (.setSoTimeout socket 0)
+            is)
+          (do
+            (.close socket)
+            nil)))
+      (catch Exception e
+        (.close socket)
+        (throw e)))))
 
-(defn- do-launch [path launch-dir prefs]
+(defn- read-bytes-until [^InputStream stream pred]
+  (let [byte-stream (ByteArrayOutputStream.)
+        buffer (byte-array 1024)]
+    (loop []
+      (let [bytes (.toByteArray byte-stream)]
+        (if (pred bytes)
+          bytes
+          (let [byte-count (.read stream buffer)]
+            (when (> byte-count 0)
+              (.write byte-stream buffer 0 byte-count)
+              (recur))))))))
+
+(def ^:private loopback-address "127.0.0.1")
+
+(defn- parse-target-info [output]
+  (let [log-port (second (re-find #"LOG: Started on port (\d*)" output))
+        service-port (second (re-find #"SERVICE: Started on port (\d*)" output))]
+    (when (and log-port service-port)
+      {:url (str "http://" loopback-address ":" service-port)
+       :log-port log-port
+       :address loopback-address})))
+
+(defn- ->byte-parser [parser-fn]
+  (fn [^bytes bytes] (parser-fn (String. bytes StandardCharsets/UTF_8))))
+
+(defn ->enumeration [coll]
+  (let [coll (atom coll)]
+    (reify java.util.Enumeration
+      (hasMoreElements [this]
+        (boolean (seq @coll)))
+      (nextElement [this]
+        (let [val (first @coll)]
+          (swap! coll rest)
+          val)))))
+
+(defn- sequence-input-stream [& streams]
+  (SequenceInputStream. (->enumeration streams)))
+
+(defn- do-launch [^File path launch-dir prefs]
   (let [defold-log-dir (some-> (System/getProperty "defold.log.dir")
-                         (File.)
-                         (.getAbsolutePath))
-        ^java.util.List args (cond-> [path]
-                               defold-log-dir (conj "--config=project.write_log=1" (format "--config=project.log_dir=%s" defold-log-dir))
-                               true list*)
-        pb (doto (ProcessBuilder. args)
-             (.redirectErrorStream true)
-             (.directory launch-dir))]
-    (when (prefs/get-prefs prefs "general-quit-on-esc" false)
-      (doto (.environment pb)
-        (.put "DM_QUIT_ON_ESC" "1")))
-    (let [p  (.start pb)
-          is (.getInputStream p)]
-      (swap! shutdown-hook (fn [^Thread current-hook ^Process p]
-                             (let [rt (Runtime/getRuntime)]
-                               (when current-hook
-                                 (.removeShutdownHook rt current-hook))
-                               (let [new-hook (Thread. (fn [] (when (.isAlive p)
-                                                                (.destroy p))))]
-                                 (.addShutdownHook rt new-hook)
-                                 new-hook)))
-        p)
-      (.start (Thread. (fn [] (pump-output is)))))))
+                               (File.)
+                               (.getAbsolutePath))
+        command (.getAbsolutePath path)
+        args (when defold-log-dir
+               ["--config=project.write_log=1" (format "--config=project.log_dir=%s" defold-log-dir)])
+        env {"DM_SERVICE_PORT" "dynamic"
+             "DM_QUIT_ON_ESC" (if (prefs/get-prefs prefs "general-quit-on-esc" false)
+                                "1" "0")}
+        opts {:directory launch-dir
+              :redirect-error-stream? true
+              :env env}]
+    ;; Closing "is" seems to cause any dmengine output to stdout/err
+    ;; to generate SIGPIPE and close/crash. Also we need to read
+    ;; the output of dmengine because there is a risk of the stream
+    ;; buffer filling up, stopping the process.
+    ;; https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers
+    (let [p (process/start! command args opts)
+          is (.getInputStream p)
+          parse-target-info-from-bytes (->byte-parser parse-target-info)]
+      (if-let [initial-bytes-output (some-> (deref (future (read-bytes-until is parse-target-info-from-bytes)) engine-ports-output-timeout nil))]
+        (let [target-info (parse-target-info-from-bytes initial-bytes-output)]
+          (assoc target-info
+                 :process p
+                 :name (.getName path)
+                 :log-stream (sequence-input-stream (io/input-stream initial-bytes-output) is)))
+        (do (.destroy p)
+            nil)))))
 
 (defn- bundled-engine [platform]
   (let [suffix (.getExeSuffix (Platform/getHostPlatform))
@@ -157,4 +177,4 @@
 (defn launch [project prefs]
   (let [launch-dir   (io/file (workspace/project-path (project/workspace project)))
         ^File engine (get-engine project prefs (.getPair (Platform/getJavaPlatform)))]
-    (do-launch (.getAbsolutePath engine) launch-dir prefs)))
+    (do-launch engine launch-dir prefs)))

--- a/editor/src/clj/editor/process.clj
+++ b/editor/src/clj/editor/process.clj
@@ -1,0 +1,23 @@
+(ns editor.process
+  (:require [clojure.java.io :as io])
+  (:import [java.lang Process ProcessBuilder]))
+
+(set! *warn-on-reflection* true)
+
+(defn start! ^Process [^String command args opts]
+  (let [pb (ProcessBuilder. ^"[Ljava.lang.String;" (into-array String (list* command args)))]
+    (when (contains? opts :directory)
+      (.directory pb (:directory opts)))
+    (when (contains? opts :env)
+      (let [environment (.environment pb)]
+        (doseq [[k v] (:env opts)]
+          (.put environment k v))))
+    (when (contains? opts :redirect-error-stream?)
+      (.redirectErrorStream pb (:redirect-error-stream? opts)))
+    (.start pb)))
+
+(defn watchdog! ^Thread [^Process proc on-exit]
+  (doto (Thread. (fn []
+                   (.waitFor proc)
+                   (on-exit)))
+    (.start)))

--- a/editor/src/clj/editor/process.clj
+++ b/editor/src/clj/editor/process.clj
@@ -4,16 +4,18 @@
 
 (set! *warn-on-reflection* true)
 
-(defn start! ^Process [^String command args opts]
+(defn start! ^Process [^String command args {:keys [directory env redirect-error-stream?]
+                                             :or {redirect-error-stream? false}
+                                             :as opts}]
   (let [pb (ProcessBuilder. ^"[Ljava.lang.String;" (into-array String (list* command args)))]
-    (when (contains? opts :directory)
-      (.directory pb (:directory opts)))
-    (when (contains? opts :env)
+    (when directory
+      (.directory pb directory))
+    (when env
       (let [environment (.environment pb)]
-        (doseq [[k v] (:env opts)]
+        (doseq [[k v] env]
           (.put environment k v))))
-    (when (contains? opts :redirect-error-stream?)
-      (.redirectErrorStream pb (:redirect-error-stream? opts)))
+    (when (some? redirect-error-stream?)
+      (.redirectErrorStream pb (boolean redirect-error-stream?)))
     (.start pb)))
 
 (defn watchdog! ^Thread [^Process proc on-exit]

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.xml :as xml]
             [clojure.java.io :as io]
+            [editor.process :as process]
             [editor.dialogs :as dialogs]
             [editor.handler :as handler]
             [editor.prefs :as prefs]
@@ -18,16 +19,8 @@
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:const local-target
-  {:name "Local"
-   :url  "http://127.0.0.1:8001"
-   :address "127.0.0.1"
-   ;; :local-address must be an ipv4 address. dmengine
-   ;; will resolve "localhost" as an ipv6 address and not find
-   ;; the editor web server.
-   :local-address "127.0.0.1"})
-
-(defonce ^:private targets (atom [local-target]))
+(defonce ^:private launched-targets (atom []))
+(defonce ^:private ssdp-targets (atom []))
 (defonce ^:private manual-device (atom nil))
 (defonce ^:private last-search (atom 0))
 (defonce ^:private running (atom false))
@@ -41,6 +34,37 @@
 (def ^:const update-interval 1000)
 (def ^:const timeout 200)
 (def ^:const max-log-entries 512)
+
+(defn kill-launched-target! [target]
+  (let [^Process process (:process target)]
+    (when (.isAlive process)
+      (.destroy process))))
+
+(defn kill-launched-targets! []
+  (doseq [launched-target @launched-targets]
+    (kill-launched-target! launched-target))
+  (reset! launched-targets []))
+
+(def ^:private kill-lingering-launched-targets-hook
+  (Thread. (fn [] (kill-launched-targets!))))
+
+(defn- invalidate-target-menu! []
+  (ui/invalidate-menubar-item! ::target))
+
+(defn launched-target? [target]
+  (contains? target :process))
+
+(defn add-launched-target! [target]
+  (assert (launched-target? target))
+  (let [launched-target (assoc target :local-address "127.0.0.1")]
+    (kill-launched-targets!)
+    (swap! launched-targets conj launched-target)
+    (invalidate-target-menu!)
+    (process/watchdog! (:process launched-target)
+                       (fn []
+                         (swap! launched-targets (partial remove #(= (:url %) (:url launched-target))))
+                         (invalidate-target-menu!)))
+    launched-target))
 
 (defn- http-get [^URL url]
   (let [conn   ^URLConnection (doto (.openConnection url)
@@ -73,10 +97,10 @@
   nil)
 
 (def ^:private update-targets-context
-  {:targets-atom targets
+  {:targets-atom ssdp-targets
    :log-fn log
    :fetch-url-fn http-get
-   :on-targets-changed-fn #(ui/invalidate-menubar-item! ::target)})
+   :on-targets-changed-fn invalidate-target-menu!})
 
 (defn- device->target [{:keys [fetch-url-fn]} device]
   ;; The reason we try/throw/catch is so that this function can run through pmap,
@@ -102,9 +126,7 @@
         (let [tags (->> desc :content (filter #(= :device (:tag %))) first :content)
               address (:address device)
               local-address (:local-address device)
-              name (if (= address local-address)
-                     "Local"
-                     (tag->val :friendlyName tags))
+              name (tag->val :friendlyName tags)
               target {:name name
                       :url (tag->val :defold:url tags)
                       :log-port (tag->val :defold:logPort tags)
@@ -116,7 +138,8 @@
       (.getMessage e))))
 
 (defn- local-target? [target]
-  (= (:address target) (:local-address target)))
+  (or (= (:address target) (:local-address target))
+      (launched-target? target)))
 
 (defn update-targets! [{:keys [targets-atom log-fn on-targets-changed-fn] :as context} devices]
   (let [devices (if-let [manual-device @manual-device]
@@ -133,9 +156,9 @@
                     devices)
                   (filter some?))
         errors (filter string? targets-result)
-        local-target (or (first (filter local-target? targets)) local-target)
-        external-targets (remove local-target? targets)
-        targets (vec (distinct (cons local-target (sort-by :name util/natural-order external-targets))))]
+        {external-targets false local-targets true} (group-by local-target? targets)
+        targets (vec (distinct (into (vec (sort-by :name util/natural-order local-targets))
+                                     (sort-by :name util/natural-order external-targets))))]
     (doseq [error errors]
       (log-fn error))
     (reset! targets-atom targets)
@@ -191,7 +214,10 @@
 (defn start []
   (when (not @running)
     (reset! running true)
-    (reset! worker (future (targets-worker)))))
+    (reset! worker (future (targets-worker)))
+    (doto (Runtime/getRuntime)
+      (.removeShutdownHook kill-lingering-launched-targets-hook)
+      (.addShutdownHook kill-lingering-launched-targets-hook))))
 
 (defn stop []
   (reset! running false)
@@ -205,8 +231,8 @@
   (stop)
   (start))
 
-(defn get-targets []
-  @targets)
+(defn all-targets []
+  (concat @launched-targets @ssdp-targets))
 
 (defn make-target-log-dialog []
   (let [root        ^Parent (ui/load-fxml "target-log.fxml")
@@ -246,30 +272,50 @@
     (ui/show! stage)))
 
 (defn selected-target [prefs]
-  (let [target-address (prefs/get-prefs prefs "selected-target-address" nil)
-        targets (get-targets)]
-    (or (first (filter #(= target-address (:address %)) targets))
-      (first targets))))
+  (let [target-address (prefs/get-prefs prefs "selected-target-address" nil)]
+    (first (filter #(= target-address (:url %)) (all-targets)))))
 
-(defn- select-target! [prefs target]
-  (prefs/set-prefs prefs "selected-target-address" (:address target)))
+(defn select-target! [prefs target]
+  (prefs/set-prefs prefs "selected-target-address" (:url target))
+  target)
+
+(defn- url-host [url-string]
+  (try
+    (let [url (URL. url-string)]
+      (.getHost url))
+    (catch Exception _
+      "invalid host")))
+
+(defn target-label [target]
+  (format "%s - %s" (str (if (local-target? target) "Local " "") (:name target)) (url-host (:url target))))
+
+(defn- target-option [target]
+  {:label     (target-label target)
+   :command   :target
+   :check     true
+   :user-data target})
+
+(def ^:private separator {:label :separator})
 
 (handler/defhandler :target :global
   (run [user-data prefs]
     (when user-data
-      (select-target! prefs user-data)))
+      (select-target! prefs (if (= user-data :new-local-engine) nil user-data))))
   (state [user-data prefs]
          (let [selected-target (selected-target prefs)]
-           (= user-data selected-target)))
+           (or (= user-data selected-target)
+               (and (nil? selected-target)
+                    (= user-data :new-local-engine)))))
   (options [user-data prefs]
            (when-not user-data
-             (let [targets (get-targets)]
-               (mapv (fn [target]
-                       {:label     (format "%s (%s)" (:name target) (:address target))
-                        :command   :target
-                        :check     true
-                        :user-data target})
-                 targets)))))
+             (let [launched-options (mapv target-option @launched-targets)
+                   ssdp-options (mapv target-option @ssdp-targets)]
+               (cond
+                 (seq launched-options)
+                 (into launched-options (concat [separator] ssdp-options))
+
+                 :else
+                 (into [{:label "New Local Engine" :check true :command :target :user-data :new-local-engine} separator] ssdp-options))))))
 
 (defn- locate-device [ip]
   (when (not-empty ip)
@@ -298,7 +344,7 @@
               (do
                 (reset! manual-device device)
                 (prefs/set-prefs prefs "selected-target-address" (not-empty manual-ip))
-                (ui/invalidate-menubar-item! ::target)))))))))
+                (invalidate-target-menu!)))))))))
 
 (handler/defhandler :target-log :global
   (run []

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -68,7 +68,7 @@
     (invalidate-target-menu!)
     (process/watchdog! (:process launched-target)
                        (fn []
-                         (swap! launched-targets (partial remove #(= (:process %) (:process launched-target))))
+                         (swap! launched-targets (partial remove #(= (:id %) (:id launched-target))))
                          (invalidate-target-menu!)))
     launched-target))
 
@@ -179,8 +179,8 @@
                   (filter some?))
         errors (filter string? targets-result)
         {external-targets false local-targets true} (group-by local-target? targets)
-        targets (vec (distinct (into (vec (sort-by :name util/natural-order local-targets))
-                                     (sort-by :name util/natural-order external-targets))))]
+        targets (into [] (comp cat (distinct)) [(sort-by :name util/natural-order local-targets)
+                                                (sort-by :name util/natural-order external-targets)])]
     (doseq [error errors]
       (log-fn error))
     (reset! targets-atom targets)

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -76,7 +76,7 @@
   (let [old @launched-targets]
     (reset! launched-targets
             (map (fn [launched-target]
-                   (if (= (:process launched-target) (:process target))
+                   (if (= (:id launched-target) (:id target))
                      (merge launched-target target-info)
                      launched-target))
                  old))

--- a/editor/test/editor/targets_test.clj
+++ b/editor/test/editor/targets_test.clj
@@ -29,6 +29,12 @@
    "defold:url"
    "friendlyName"])
 
+(def ^:private local-target
+  {:name "Local"
+   :url  "http://127.0.0.1:8001"
+   :address "127.0.0.1"
+   :local-address "127.0.0.1"})
+
 (defn- ^:private device-desc-template-without
   "Returns the device desc template with the specified device tag removed."
   [device-tag]
@@ -37,7 +43,7 @@
        (remove (fn [line] (string/includes? line (str "<" device-tag ">"))))
        (string/join "\n")))
 
-(def ^:private defold-port (.getPort (URL. (:url targets/local-target))))
+(def ^:private defold-port (.getPort (URL. (:url local-target))))
 (def ^:private defold-log-port 12345)
 
 (defn- make-udn
@@ -57,7 +63,7 @@
       (string/replace "${DEFOLD_PORT}" (str defold-port))
       (string/replace "${DEFOLD_LOG_PORT}" (str defold-log-port))))
 
-(def ^:private local-hostname (:address targets/local-target))
+(def ^:private local-hostname (:address local-target))
 (def ^:private local-id "local-id")
 (def ^:private local-url (make-device-url local-hostname local-id))
 (def ^:private iphone-hostname "iphone-hostname")
@@ -68,13 +74,13 @@
 (def ^:private tablet-url (make-device-url tablet-hostname tablet-id))
 
 (def ^:private fetch-url
-  {local-url (make-device-desc device-desc-template (:name targets/local-target) "osx" local-hostname)
+  {local-url (make-device-desc device-desc-template (:name local-target) "osx" local-hostname)
    iphone-url (make-device-desc device-desc-template "iPhone" "ios" iphone-hostname)
    tablet-url (make-device-desc device-desc-template "Tablet" "android" tablet-hostname)})
 
 (defn- make-context
   []
-  {:targets-atom (atom #{targets/local-target})
+  {:targets-atom (atom #{local-target})
    :log-fn (test-util/make-call-logger)
    :fetch-url-fn fetch-url
    :on-targets-changed-fn (test-util/make-call-logger)})

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -180,9 +180,7 @@ static void dmLogUpdateNetwork()
             {
                 if (self->m_Connections.Full())
                 {
-                    dmLogInfo("Too many log connections opened");
-                    const char* msg = "ERROR:DLIB: Too many log connections opened";
-                    fprintf(stderr, "%s\n", msg);
+                    dmLogError("Too many log connections opened");
                     const char* resp = "1 Too many log connections opened\n";
                     SendAll(client_socket, resp, strlen(resp));
                     dmSocket::Shutdown(client_socket, dmSocket::SHUTDOWNTYPE_READWRITE);
@@ -310,6 +308,10 @@ void dmLogInitialize(const dmLogParams* params)
     thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
     g_dmLogServer->m_Thread = thread;
 
+    /*
+     * This message is parsed by editor 2 - don't remove or change without
+     * corresponding changes in engine.clj
+     */
     dmLogInfo("Log server started on port %u", (unsigned int) port);
 }
 

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -180,6 +180,7 @@ static void dmLogUpdateNetwork()
             {
                 if (self->m_Connections.Full())
                 {
+                    dmLogInfo("Too many log connections opened");
                     const char* msg = "ERROR:DLIB: Too many log connections opened";
                     fprintf(stderr, "%s\n", msg);
                     const char* resp = "1 Too many log connections opened\n";
@@ -309,6 +310,7 @@ void dmLogInitialize(const dmLogParams* params)
     thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
     g_dmLogServer->m_Thread = thread;
 
+    fprintf(stderr, "LOG: Started on port %u\n", (unsigned int) port);
 }
 
 void dmLogFinalize()

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -310,7 +310,7 @@ void dmLogInitialize(const dmLogParams* params)
     thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
     g_dmLogServer->m_Thread = thread;
 
-    fprintf(stderr, "LOG: Started on port %u\n", (unsigned int) port);
+    dmLogInfo("Log server started on port %u", (unsigned int) port);
 }
 
 void dmLogFinalize()

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1328,7 +1328,6 @@ bail:
             }
 
             engine_service = dmEngineService::New(engine_port);
-            fprintf(stderr, "SERVICE: Started on port %u\n", (unsigned int) dmEngineService::GetPort(engine_service));
         }
 
         dmEngine::RunResult run_result = InitRun(engine_service, argc, argv, pre_run, post_run, context);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1317,6 +1317,7 @@ bail:
 
             char* service_port_env = getenv("DM_SERVICE_PORT");
 
+            // editor 2 specifies DM_SERVICE_PORT=dynamic when launching dmengine
             if (service_port_env) {
                 unsigned int env_port = 0;
                 if (sscanf(service_port_env, "%u", &env_port) == 1) {

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -5,6 +5,7 @@
 #include <vectormath/cpp/vectormath_aos.h>
 #include <sys/stat.h>
 
+#include <stdio.h>
 #include <algorithm>
 
 #include <dlib/dlib.h>
@@ -1312,7 +1313,22 @@ bail:
 
         if (dLib::IsDebugMode() && dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP | DM_FEATURE_BIT_SOCKET_SERVER_UDP))
         {
-            engine_service = dmEngineService::New(8001);
+            uint16_t engine_port = 8001;
+
+            char* service_port_env = getenv("DM_SERVICE_PORT");
+
+            if (service_port_env) {
+                unsigned int env_port = 0;
+                if (sscanf(service_port_env, "%u", &env_port) == 1) {
+                    engine_port = (uint16_t) env_port;
+                }
+                else if (strcmp(service_port_env, "dynamic") == 0) {
+                    engine_port = 0;
+                }
+            }
+
+            engine_service = dmEngineService::New(engine_port);
+            fprintf(stderr, "SERVICE: Started on port %u\n", (unsigned int) dmEngineService::GetPort(engine_service));
         }
 
         dmEngine::RunResult run_result = InitRun(engine_service, argc, argv, pre_run, post_run, context);

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -320,6 +320,17 @@ namespace dmEngineService
             // UDN must be unique and this scheme is probably unique enough
             dmStrlCpy(m_DeviceDesc.m_UDN, "defold-", sizeof(m_DeviceDesc.m_UDN));
             dmStrlCat(m_DeviceDesc.m_UDN, local_address_str, sizeof(m_DeviceDesc.m_UDN));
+            dmStrlCat(m_DeviceDesc.m_UDN, ":", sizeof(m_DeviceDesc.m_UDN));
+            /*
+             * Note that we use the engine service port for
+             * distinguishing the dmengine instances rather than the
+             * ssdp http server port. Several dmengine's all running
+             * on the standard port (8001) will thus be
+             * indistinguishable. Having them show up as separate
+             * devices is pointless since we can't determine which one
+             * we're connecting to anyhow (port reuse).
+             */
+            dmStrlCat(m_DeviceDesc.m_UDN, m_PortText, sizeof(m_DeviceDesc.m_UDN));
             dmStrlCat(m_DeviceDesc.m_UDN, "-", sizeof(m_DeviceDesc.m_UDN));
             dmStrlCat(m_DeviceDesc.m_UDN, info.m_DeviceModel, sizeof(m_DeviceDesc.m_UDN));
 
@@ -336,20 +347,20 @@ namespace dmEngineService
             ssdp_params.m_AnnounceInterval = 30;
             dmSSDP::HSSDP ssdp;
             dmSSDP::Result sr = dmSSDP::New(&ssdp_params, &ssdp);
-            if (sr != dmSSDP::RESULT_OK)
+            if (sr == dmSSDP::RESULT_OK)
             {
-                dmLogError("Unable to create ssdp service (%d)", sr);
-                dmWebServer::Delete(web_server);
-                return false;
+                sr = dmSSDP::RegisterDevice(ssdp, &m_DeviceDesc);
+                if (sr != dmSSDP::RESULT_OK)
+                {
+                    dmSSDP::Delete(ssdp);
+                    ssdp = 0;
+                    dmLogWarning("Unable to register ssdp device (%d)", sr);
+                }
             }
-
-            sr = dmSSDP::RegisterDevice(ssdp, &m_DeviceDesc);
-            if (sr != dmSSDP::RESULT_OK)
+            else
             {
-                dmWebServer::Delete(web_server);
-                dmSSDP::Delete(ssdp);
-                dmLogError("Unable to register ssdp device (%d)", sr);
-                return false;
+                ssdp = 0;
+                dmLogWarning("Unable to create ssdp service (%d)", sr);
             }
 
             dmWebServer::HandlerParams post_params;
@@ -368,9 +379,8 @@ namespace dmEngineService
             dmWebServer::AddHandler(web_server, "/info", &info_params);
 
             // The purpose of this handler is both for debugging but also for Editor2,
-            // where the user can manually specify an IP to connect to.
-            // We therefore need this handler because this is the only server where the port is known.
-            // SSDP has its own http server which binds to a dynamic port.
+            // where the user can manually specify an IP (and optionally port) to connect to.
+            // The port is known (8001) or set via environment variable DM_SERVICE_PORT and logged on startup.
             dmWebServer::HandlerParams upnp_params;
             upnp_params.m_Handler = UpnpHandler;
             upnp_params.m_Userdata = this;
@@ -384,8 +394,12 @@ namespace dmEngineService
         void Final()
         {
             dmWebServer::Delete(m_WebServer);
-            dmSSDP::DeregisterDevice(m_SSDP, "defold");
-            dmSSDP::Delete(m_SSDP);
+
+            if (m_SSDP)
+            {
+                dmSSDP::DeregisterDevice(m_SSDP, "defold");
+                dmSSDP::Delete(m_SSDP);
+            }
         }
 
 
@@ -408,6 +422,7 @@ namespace dmEngineService
         HEngineService service = new EngineService();
         if (service->Init(port))
         {
+            dmLogInfo("Engine service started on port %u", (unsigned int) GetPort(service));
             return service;
         }
         else
@@ -427,7 +442,11 @@ namespace dmEngineService
     {
         DM_PROFILE(Engine, "Service");
         dmWebServer::Update(engine_service->m_WebServer);
-        dmSSDP::Update(engine_service->m_SSDP, false);
+
+        if (engine_service->m_SSDP)
+        {
+            dmSSDP::Update(engine_service->m_SSDP, false);
+        }
     }
 
     uint16_t GetPort(HEngineService engine_service)

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -422,6 +422,10 @@ namespace dmEngineService
         HEngineService service = new EngineService();
         if (service->Init(port))
         {
+            /*
+             * This message is parsed by editor 2 - don't remove or change without
+             * corresponding changes in engine.clj
+             */
             dmLogInfo("Engine service started on port %u", (unsigned int) GetPort(service));
             return service;
         }


### PR DESCRIPTION
### User facing changes
* Target menu contains pseudo-target for launching new local dmengine. When launched, details on the instance appears instead. Only one editor-launched instance allowed.
* User can start several dmengine instances from command line and assign them different service ports (DM_SERVICE_PORT) and use them as targets from the editor when they are found via SSDP.
* Can provide a port when manually specifying a target
* More apparent when the editor is actually building vs launching a dmengine

### Technical changes
* dmengine engine port controllable through env var DM_SERVICE_PORT
* dmengine outputs engine port (and log port) using dmLogInfo
* Starting SSDP is no longer a prerequisite for dmengine to launch engine service
* SSDP UDN contains engine port to make it more unique
* editor 2 parses output for engine port