### PR TITLE
DEFEDIT-1138 Speed up resource sync

### DIFF
--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -292,6 +292,7 @@ ordinary paths."
   (property resource-listeners g/Any (default (atom [])))
   (property view-types g/Any)
   (property resource-types g/Any)
+  (property library-snapshot-cache g/Any (default {}))
 
   (output resource-tree FileResource :cached produce-resource-tree)
   (output resource-list g/Any :cached produce-resource-list)


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1225

### User facing changes

- When you leave and return to editor, we check if the state on disk
  has changed to make sure we are up to date. This is when the
  "Reloading modified resources" message is shown. This operation has
  now been speed up significantly, meaning switching in/out of editor
  should be less intrusive.

### Technical changes

- In `editor.resource-watch/make-file-tree` we (inadvertently?) called
  the wrong overload in the recursive case, meaning we made an
  unneccessary `g/node-value` call for each file traversed.
- Introduce a cache from library file to snapshot, with mtime as an
  additional cache condition. Libraries rarely change, and if their zip
  file mtime has not changed, we know the snapshot is the same and can
  be safely re-used.