### PR TITLE
DEFEDIT-1115 Stale successors in graph after undo

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -774,7 +774,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Interrogating the Graph
 ;; ---------------------------------------------------------------------------
-(defn- arcs->tuples
+(defn arcs->tuples
   [arcs]
   (util/project arcs [:source :sourceLabel :target :targetLabel]))
 


### PR DESCRIPTION
New hydrated arcs were not considered when updating the successors
map according to modified outputs. Every source node + label of
hydrated arcs is now added to the list.