### PR TITLE
luajit-share.zip is now deleted during clean task for building Bob

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.xml
@@ -34,6 +34,7 @@
         <delete dir="generated"/>
         <delete dir="dist"/>
         <delete dir="tmp"/>
+        <delete file="lib/luajit-share.zip"/>
     </target>
 
     <target name="git.revision" description="Store git revision in ${repository.version}">


### PR DESCRIPTION
Solves a strange issue where sometimes luajit-share.zip is not recreated on CI.