### PR TITLE
DEFEDIT-1145 Fix alt key selects first menu item workaround

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -674,6 +674,7 @@
 
 (defn make-app-view [view-graph workspace project ^Stage stage ^MenuBar menu-bar ^TabPane tab-pane]
   (let [app-scene (.getScene stage)]
+    (ui/disable-menu-alt-key-mnemonic! menu-bar)
     (.setUseSystemMenuBar menu-bar true)
     (.setTitle stage (make-title))
     (let [app-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph AppView :stage stage :tab-pane tab-pane :active-tool :move))))]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -145,7 +145,6 @@
     (when update-context
       (init-pending-update-indicator! stage root project update-context))
 
-    (ui/disable-menu-alt-key-mnemonic! scene)
     (ui/set-main-stage stage)
     (.setScene stage scene)
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1058,13 +1058,13 @@
 
 (defn disable-menu-alt-key-mnemonic!
   "On Windows, the bare Alt KEY_PRESSED event causes the input focus to move to the menu bar.
-  This function disables this behavior by consuming any KEY_PRESSED events with the Alt key
-  pressed before they reach the MenuBarSkin event handler."
-  [^Scene scene]
-  (.addEventHandler scene KeyEvent/KEY_PRESSED
-                    (event-handler event
-                                   (when (.isAltDown ^KeyEvent event)
-                                     (.consume ^KeyEvent event)))))
+  This function disables this behavior by replacing the Runnable that normally
+  selects the first menu item with a noop."
+  [^MenuBar menu-bar]
+  (let [menu-bar-skin (.getSkin menu-bar)
+        firstMenuRunnableField (doto (.. menu-bar-skin getClass (getDeclaredField "firstMenuRunnable"))
+                                 (.setAccessible true))]
+    (.set firstMenuRunnableField menu-bar-skin (fn []))))
 
 (defn register-menubar [^Scene scene menubar menu-id]
   ;; TODO: See comment below about top-level items. Should be enforced here

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1062,9 +1062,9 @@
   selects the first menu item with a noop."
   [^MenuBar menu-bar]
   (let [menu-bar-skin (.getSkin menu-bar)
-        firstMenuRunnableField (doto (.. menu-bar-skin getClass (getDeclaredField "firstMenuRunnable"))
+        first-menu-runnable-field (doto (.. menu-bar-skin getClass (getDeclaredField "firstMenuRunnable"))
                                  (.setAccessible true))]
-    (.set firstMenuRunnableField menu-bar-skin (fn []))))
+    (.set first-menu-runnable-field menu-bar-skin (fn []))))
 
 (defn register-menubar [^Scene scene menubar menu-id]
   ;; TODO: See comment below about top-level items. Should be enforced here


### PR DESCRIPTION
### User facing changes

- We can now use the alt key for shortcuts

### Technical changes

- Reflectively replace the Runnable used by MenuBarSkin to select
  first menu item on Alt key press with one that does nothing.