### PR TITLE
DEFEDIT-1149 Save vector script properties in same format as editor1

### DIFF
--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -174,10 +174,10 @@
 
 (defn go-prop->str [value type]
   (case type
-    :property-type-vector3 (apply format "%s,%s,%s" (map str value))
-    :property-type-vector4 (apply format "%s,%s,%s,%s" (map str value))
+    :property-type-vector3 (apply format "%s, %s, %s" value)
+    :property-type-vector4 (apply format "%s, %s, %s, %s" value)
     :property-type-quat (let [q (math/euler->quat value)]
-                          (apply format "%s,%s,%s,%s" (map (comp str q-round) (math/vecmath->clj q))))
+                          (apply format "%s, %s, %s, %s" (map q-round (math/vecmath->clj q))))
     (str value)))
 
 (defn- parse-num [s]

--- a/editor/test/resources/test_project/game_object/props.go
+++ b/editor/test/resources/test_project/game_object/props.go
@@ -29,17 +29,17 @@ components {
   }
   properties {
     id: "vec3"
-    value: "1.0,2.0,3.0"
+    value: "1.0, 2.0, 3.0"
     type: PROPERTY_TYPE_VECTOR3
   }
   properties {
     id: "quat"
-    value: "1.0,0.0,0.0,0.0"
+    value: "1.0, 0.0, 0.0, 0.0"
     type: PROPERTY_TYPE_QUAT
   }
   properties {
     id: "vec4"
-    value: "1.0,2.0,3.0,4.0"
+    value: "1.0, 2.0, 3.0, 4.0"
     type: PROPERTY_TYPE_VECTOR4
   }
   properties {


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1240

### User facing changes

- Script properties are now saved in same format as editor1, ie. with
  spaces in between components.