### PR TITLE
DEFEDIT-1151 Add "Show In Asset Browser" command

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -579,7 +579,10 @@
                               :command :about}]}])
 
 (ui/extend-menu ::tab-menu nil
-                [{:label "Show In Desktop"
+                [{:label "Show In Asset Browser"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :show-in-asset-browser}
+                 {:label "Show In Desktop"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
                   :command :show-in-desktop}
                  {:label "Referencing Files"

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -166,18 +166,25 @@
   (run [selection]
        (copy (-> selection roots fileify-resources!))))
 
-(defn- select-resource! [asset-browser resource]
-  ;; This is a hack!
-  ;; The reason is that the FileResource 'next' fetched prior to the deletion
-  ;; may have changed after the deletion, due to the 'children' field in the record.
-  ;; This is why we can't use ui/select! directly, but do our own implementation based on path.
-  (let [^TreeView tree-view (g/node-value asset-browser :tree-view)
-        tree-items (ui/tree-item-seq (.getRoot tree-view))
-        path (resource/resource->proj-path resource)]
-    (when-let [tree-item (some (fn [^TreeItem tree-item] (and (= path (resource/resource->proj-path (.getValue tree-item))) tree-item)) tree-items)]
-      (doto (.getSelectionModel tree-view)
-        (.clearSelection)
-        (.select tree-item)))))
+(defn- select-resource!
+  ([asset-browser resource]
+   (select-resource! asset-browser resource nil))
+  ([asset-browser resource {:keys [scroll?]
+                            :or   {scroll? false}
+                            :as opts}]
+   ;; This is a hack!
+   ;; The reason is that the FileResource 'next' fetched prior to the deletion
+   ;; may have changed after the deletion, due to the 'children' field in the record.
+   ;; This is why we can't use ui/select! directly, but do our own implementation based on path.
+   (let [^TreeView tree-view (g/node-value asset-browser :tree-view)
+         tree-items (ui/tree-item-seq (.getRoot tree-view))
+         path (resource/resource->proj-path resource)]
+     (when-let [tree-item (some (fn [^TreeItem tree-item] (and (= path (resource/resource->proj-path (.getValue tree-item))) tree-item)) tree-items)]
+       (doto (.getSelectionModel tree-view)
+         (.clearSelection)
+         (.select tree-item))
+       (when scroll?
+         (ui/scroll-to-item! tree-view tree-item))))))
 
 (handler/defhandler :cut :asset-browser
   (enabled? [selection] (and (seq selection) (every? deletable-resource? selection)))
@@ -442,6 +449,20 @@
           (do (fs/create-directories! folder)
               (workspace/resource-sync! workspace)
               (select-resource! asset-browser (workspace/file-resource workspace folder))))))))
+
+(defn- selected-or-active-resource
+  [selection active-resource]
+  (or (handler/adapt-single selection resource/Resource)
+      active-resource))
+
+(handler/defhandler :show-in-asset-browser :global
+  (active? [active-resource selection] (selected-or-active-resource selection active-resource))
+  (enabled? [active-resource selection]
+            (when-let [r (selected-or-active-resource selection active-resource)]
+              (resource/exists? r)))
+  (run [active-resource asset-browser selection]
+    (when-let [r (selected-or-active-resource selection active-resource)]
+      (select-resource! asset-browser r {:scroll? true}))))
 
 (defn- item->path [^TreeItem item]
   (-> item (.getValue) (resource/proj-path)))

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -38,6 +38,9 @@
                  {:label "Open As"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
                   :command :open-as}
+                 {:label "Show in Asset Browser"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :show-in-asset-browser}
                  {:label "Show in Desktop"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
                   :command :show-in-desktop}

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -184,6 +184,9 @@
                  {:label "Open As"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
                   :command :open-as}
+                 {:label "Show in Asset Browser"
+                  :icon "icons/32/Icons_S_14_linkarrow.png"
+                  :command :show-in-asset-browser}
                  {:label "Show in Desktop"
                   :icon "icons/32/Icons_S_14_linkarrow.png"
                   :command :show-in-desktop}

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -784,6 +784,12 @@
                               (.getRoot tree-view))]
     [(.getValue next-item)]))
 
+(defn scroll-to-item!
+  [^TreeView tree-view ^TreeItem tree-item]
+  (let [row (.getRow tree-view tree-item)]
+    (when-not (= -1 row)
+        (.scrollTo tree-view row))))
+
 (defmacro observe-selection
   "Helper macro that lets you observe selection changes in a generic fashion.
   Takes a Node that has a getSelectionModel method and a function that takes


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/923

### User facing changes

- You can now show and focus the a resource in the asset
  browser using the "Show In Asset Browser" command found in resource
  context menus.