### PR TITLE
DEFEDIT-1154 Better dependency editing in game.project

### DIFF
--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -15,10 +15,9 @@
    :help "compress archive (not for Android)",
    :default true,
    :path ["project" "compress_archive"]}
-  {:type :string,
+  {:type :library-list,
    :help
    "a comma separated list of URL:s to projects required by this project",
-   :default "",
    :path ["project" "dependencies"]}
   {:type :string,
    :help

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -952,8 +952,7 @@
          (bundle-dialog/show-bundle-dialog! workspace platform prefs owner-window bundle!))))
 
 (defn- fetch-libraries [workspace project prefs]
-  (let [library-url-string (project/project-dependencies project)
-        library-urls (library/parse-library-urls library-url-string)
+  (let [library-urls (project/project-dependencies project)
         hosts (into #{} (map url/strip-path) library-urls)]
     (if-let [first-unreachable-host (first-where (complement url/reachable?) hosts)]
       (dialogs/make-alert-dialog (string/join "\n" ["Fetch was aborted because the following host could not be reached:"
@@ -963,7 +962,7 @@
       (future
         (ui/with-disabled-ui
           (ui/with-progress [render-fn ui/default-render-progress!]
-            (workspace/fetch-libraries! workspace library-url-string render-fn (partial login/login prefs))))))))
+            (workspace/fetch-libraries! workspace library-urls render-fn (partial login/login prefs))))))))
 
 (handler/defhandler :fetch-libraries :global
   (run [workspace project prefs] (fetch-libraries workspace project prefs)))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -10,6 +10,7 @@
             [editor.gl :as gl]
             [editor.handler :as handler]
             [editor.ui :as ui]
+            [editor.library :as library]
             [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
@@ -531,9 +532,9 @@
 
 (defn- read-dependencies [game-project-resource]
   (with-open [game-project-reader (io/reader game-project-resource)]
-    (-> game-project-reader
-        settings-core/parse-settings
-        (settings-core/get-setting ["project" "dependencies"]))))
+    (-> (settings-core/parse-settings game-project-reader)
+        (settings-core/get-setting ["project" "dependencies"])
+        (library/parse-library-urls))))
 
 (defn- cache-node-value! [node-id label]
   (g/node-value node-id label)

--- a/editor/src/clj/editor/form_view.clj
+++ b/editor/src/clj/editor/form_view.clj
@@ -4,6 +4,7 @@
             [editor.form :as form]
             [editor.field-expression :as field-expression]
             [editor.ui :as ui]
+            [editor.url :as url]
             [editor.jfx :as jfx]            
             [editor.dialogs :as dialogs]
             [editor.workspace :as workspace]
@@ -107,6 +108,9 @@
 
 (defmethod create-field-control :number [field-info field-ops ctxt]
   (create-text-field-control field-expression/to-double str field-info field-ops))
+
+(defmethod create-field-control :url [field-info field-ops ctxt]
+  (create-text-field-control url/try-parse str field-info field-ops))
 
 (defmethod create-field-control :boolean [{:keys [path help]} {:keys [set cancel]} ctxt]
   (let [check (CheckBox.)

--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -1,7 +1,9 @@
 (ns editor.library
   (:require [editor.prefs :as prefs]
             [editor.progress :as progress]
+            [editor.settings-core :as settings-core]
             [editor.fs :as fs]
+            [editor.url :as url]
             [clojure.java.io :as io]
             [clojure.string :as str])
   (:import [java.io File InputStream]
@@ -12,15 +14,14 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- parse-url [url-string]
-  (when (not (str/blank? (str/trim url-string)))
-    (try
-      (URL. url-string)
-      (catch Exception e
-        nil))))
-
 (defn parse-library-urls [url-string]
-  (keep parse-url (str/split url-string #"[,\s]")))
+  (into [] (keep url/try-parse) (str/split url-string #"[,\s]")))
+
+(defmethod settings-core/parse-setting-value :library-list [_ raw]
+  (when raw (parse-library-urls raw)))
+
+(defmethod settings-core/render-raw-setting-value :library-list [_ value]
+  (when (seq value) (str/join "," value)))
 
 (defn- mangle-library-url [^URL url]
   (DigestUtils/sha1Hex (str url)))

--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -15,10 +15,11 @@
 (set! *warn-on-reflection* true)
 
 (defn parse-library-urls [url-string]
-  (into [] (keep url/try-parse) (str/split url-string #"[,\s]")))
+  (when url-string
+    (into [] (keep url/try-parse) (str/split url-string #"[,\s]"))))
 
 (defmethod settings-core/parse-setting-value :library-list [_ raw]
-  (when raw (parse-library-urls raw)))
+  (parse-library-urls raw))
 
 (defmethod settings-core/render-raw-setting-value :library-list [_ value]
   (when (seq value) (str/join "," value)))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -68,16 +68,16 @@
       camel/->Camel_Snake_Case_String
       (string/replace "_" " ")))
 
-(defn- convert-options-carrying-to-choicebox [setting]
-  (if (contains? setting :options)
-    (assoc setting :type :choicebox)
-    setting))
-
 (defn- make-form-field [setting]
-  (-> (assoc setting
-             :label (or (:label setting) (label (second (:path setting))))
-             :optional true)
-      (convert-options-carrying-to-choicebox)))
+  (cond-> (assoc setting
+                 :label (or (:label setting) (label (second (:path setting))))
+                 :optional true)
+
+    (contains? setting :options)
+    (assoc :type :choicebox)
+
+    (= :library-list (:type setting))
+    (assoc :type :list :element {:type :url :default "http://url.to/library"})))
 
 (defn- make-form-section [category-name category-info settings]
   {:title (or (:title category-info) category-name)
@@ -173,5 +173,3 @@
                         (when resource
                           (g/set-property resource-setting-node :value resource))
                         (g/connect resource-setting-node :resource-setting-reference self :resource-setting-references)))))))
-  
-  

--- a/editor/src/clj/editor/url.clj
+++ b/editor/src/clj/editor/url.clj
@@ -1,5 +1,5 @@
 (ns editor.url
-  (:import [java.net HttpURLConnection URL]
+  (:import [java.net HttpURLConnection MalformedURLException URL]
            [java.io IOException]))
 
 (defn defold-hosted?
@@ -26,3 +26,7 @@
 (defn strip-path
   ^URL [^URL url]
   (URL. (.getProtocol url) (.getHost url) (.getPort url) ""))
+
+(defn try-parse
+  ^URL [^String s]
+  (try (URL. s) (catch MalformedURLException _ nil)))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -13,6 +13,7 @@ ordinary paths."
             [editor.url :as url]
             [service.log :as log])
   (:import [java.io ByteArrayOutputStream File FilterOutputStream]
+           [java.net URL]
            [java.util.zip ZipEntry ZipInputStream]
            [org.apache.commons.io FilenameUtils]
            [editor.resource FileResource]))
@@ -170,10 +171,9 @@ ordinary paths."
       (when-let [workspace (:workspace base-resource)]
         (resolve-workspace-resource workspace path)))))
 
-(defn set-project-dependencies! [workspace library-url-string]
-  (let [library-urls (library/parse-library-urls (str library-url-string))]
-    (g/set-property! workspace :dependencies library-urls)
-    library-urls))
+(defn set-project-dependencies! [workspace library-urls]
+  (g/set-property! workspace :dependencies library-urls)
+  library-urls)
 
 (defn dependencies [workspace]
   (g/node-value workspace :dependencies))
@@ -284,9 +284,12 @@ ordinary paths."
 (defn add-resource-listener! [workspace listener]
   (swap! (g/node-value workspace :resource-listeners) conj listener))
 
+
+(g/deftype UrlVec [URL])
+
 (g/defnode Workspace
   (property root g/Str)
-  (property dependencies g/Any) ; actually vector of URLs
+  (property dependencies UrlVec)
   (property opened-files g/Any (default (atom #{})))
   (property resource-snapshot g/Any)
   (property resource-listeners g/Any (default (atom [])))

--- a/editor/test/integration/library_test.clj
+++ b/editor/test/integration/library_test.clj
@@ -10,6 +10,7 @@
             [editor.settings-core :as settings-core]
             [editor.game-project :as game-project]
             [editor.gui :as gui]
+            [editor.url :as url]
             [integration.test-util :as test-util]
             [service.log :as log])
   (:import [java.net URL]
@@ -31,9 +32,9 @@
 
 (deftest url-parsing
   (testing "sane urls"
-    (is (= urls (list (URL. "file:/scriptlib") (URL. "file:/imagelib1") (URL. "file:/imagelib2") (URL. "file:/bogus"))))
+    (is (= urls [(URL. "file:/scriptlib") (URL. "file:/imagelib1") (URL. "file:/imagelib2") (URL. "file:/bogus")]))
     (is (= (library/parse-library-urls "file:/scriptlib,file:/imagelib1,file:/imagelib2,file:/bogus")
-           (list (URL. "file:/scriptlib") (URL. "file:/imagelib1") (URL. "file:/imagelib2") (URL. "file:/bogus")))))
+           [(URL. "file:/scriptlib") (URL. "file:/imagelib1") (URL. "file:/imagelib2") (URL. "file:/bogus")])))
   (testing "various spacing and commas allowed"
     (is (= urls (library/parse-library-urls "   file:/scriptlib   file:/imagelib1\tfile:/imagelib2  file:/bogus\t")))
     (is (= urls (library/parse-library-urls " ,, file:/scriptlib ,  ,,  file:/imagelib1\tfile:/imagelib2 ,,,,  file:/bogus\t,")))
@@ -136,7 +137,7 @@
       ;; make sure we don't have library file to begin with
       (is (= 0 (count (project/find-resources project "lib_resource_project/simple.gui"))))
       ;; add dependency, fetch libraries, we should now have library file
-      (game-project/set-setting! game-project ["project" "dependencies"] url)
+      (game-project/set-setting! game-project ["project" "dependencies"] [url])
       (workspace/fetch-libraries! workspace (project/project-dependencies project) identity (constantly true))
       (is (= 1 (count (project/find-resources project "lib_resource_project/simple.gui")))))))
 
@@ -150,6 +151,6 @@
       (is (= 0 (count (project/find-resources project "lib_resource_project/simple.gui"))))
 
       ;; add dependency, fetch libraries, we should now have library file
-      (game-project/set-setting! game-project ["project" "dependencies"] url)
+      (game-project/set-setting! game-project ["project" "dependencies"] [url])
       (workspace/fetch-libraries! workspace (project/project-dependencies project) identity (constantly true))
       (is (= 1 (count (project/find-resources project "lib_resource_project/simple.gui")))))))

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -358,11 +358,11 @@
     (let [[workspace project] (setup-scratch world)
           pow (project/get-resource-node project "/graphics/pow.png")
           initial-graph-nodes (graph-nodes project)]
-      
+
       (move-file workspace "/graphics/pow.png" "/graphics/pow2.png")
 
       (is (nil? (project/get-resource-node project "/graphics/pow.png")))
-      
+
       (let [pow2 (project/get-resource-node project "/graphics/pow2.png")]
         ;; resource node simply repointed
         (is (= pow pow2))
@@ -374,11 +374,11 @@
     (let [[workspace project] (setup-scratch world)
           main (project/get-resource-node project "/main/main.script")
           initial-graph-nodes (graph-nodes project)]
-      
+
       (move-file workspace "/main/main.script" "/main/main2.script")
 
       (is (nil? (project/get-resource-node project "/main/main.script")))
-      
+
       (let [main2 (project/get-resource-node project "/main/main2.script")]
         ;; resource node simply repointed
         (is (= main main2))
@@ -408,7 +408,7 @@
       (is (= atlas>powball-image-resources [(resource graphics>pow) (resource graphics>ball)]))
       (is (= atlas>pow-image-resources [(resource graphics>pow)]))
       (is (= atlas>ball-image-resources [(resource graphics>ball)]))
-      
+
       (move-file workspace "/graphics/pow.png" "/graphics/ball.png")
 
       ;; resource /graphics/pow.png removed
@@ -443,9 +443,9 @@
           initial-graph-nodes (graph-nodes project)]
       (is (= (map g/override-original game_object>props-scripts) [script>props]))
       (is (= (map g/override-original main>main-go-scripts) [main>main-script]))
-      
+
       (move-file workspace "/script/props.script" "/main/main.script")
-      
+
       ;; resource /script/props.script removed
       (is (nil? (project/get-resource-node project "/script/props.script")))
       ;; old resource node for /main/main.script is removed (but has been replaced/reloaded as below)
@@ -476,19 +476,19 @@
           initial-graph-nodes (graph-nodes project)]
       (is (= (map resource/proj-path (atlas-image-resources atlas>powball))
              ["/graphics/pow.png" "/graphics/ball.png"]))
-      
+
       (let [graphics-dir-resource (workspace/find-resource workspace "/graphics")]
         (asset-browser/rename graphics-dir-resource "images"))
 
       (let [images>pow (project/get-resource-node project "/images/pow.png")
             images>pow-resource (resource images>pow)]
-        
+
         (is (= (map resource/proj-path (atlas-image-resources atlas>powball))
                ["/images/pow.png" "/images/ball.png"]))
         (is (= initial-graph-nodes (graph-nodes project)))
 
         ;; actual test
-        (workspace/set-project-dependencies! workspace (str imagelib1-url)) 
+        (workspace/set-project-dependencies! workspace [imagelib1-url])
         (let [images-dir-resource (workspace/find-resource workspace "/images")]
           (asset-browser/rename images-dir-resource "graphics"))
 
@@ -530,7 +530,7 @@
         (is (= (map g/override-original game_object>main-go-scripts)
                [scripts>main]))
 
-        (workspace/set-project-dependencies! workspace (str scriptlib-url))
+        (workspace/set-project-dependencies! workspace [scriptlib-url])
         (let [scripts-dir-resource (workspace/find-resource workspace "/scripts")]
           (asset-browser/rename scripts-dir-resource "project_scripts"))
 
@@ -565,7 +565,7 @@
             images>pow-resource (resource images>pow)
             image>ball (project/get-resource-node project "/images/ball.png")
             initial-graph-nodes (graph-nodes project)]
-        (workspace/set-project-dependencies! workspace (str imagelib1-url))
+        (workspace/set-project-dependencies! workspace [imagelib1-url])
         (binding [dialogs/make-resolve-file-conflicts-dialog (fn [src-dest-pairs] :overwrite)]
           (let [images-dir-resource (workspace/find-resource workspace "/images")]
             (asset-browser/rename images-dir-resource "graphics")))
@@ -603,8 +603,8 @@
             game_object>main-scripts (game-object-script-nodes game_object>main)
             initial-graph-nodes (graph-nodes project)]
         (is (= (map g/override-original game_object>main-scripts) [scripts>main]))
-        
-        (workspace/set-project-dependencies! workspace (str scriptlib-url)) ; /scripts/main.script
+
+        (workspace/set-project-dependencies! workspace [scriptlib-url]) ; /scripts/main.script
         (binding [dialogs/make-resolve-file-conflicts-dialog (fn [src-dest-pairs] :overwrite)]
           (let [scripts-dir-resource (workspace/find-resource workspace "/scripts")]
             (asset-browser/rename scripts-dir-resource "main")))

--- a/editor/test/integration/resource_watch_test.clj
+++ b/editor/test/integration/resource_watch_test.clj
@@ -69,23 +69,23 @@
 (deftest only-load-specified-libraries
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup world))]
-      (workspace/set-project-dependencies! workspace (str imagelib1-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url])
       (workspace/resource-sync! workspace)
       (is (= (workspace-resource-paths workspace) (set/union directory-resources imagelib1-resources)))
-      (workspace/set-project-dependencies! workspace (str imagelib2-url))
+      (workspace/set-project-dependencies! workspace [imagelib2-url])
       (workspace/resource-sync! workspace)
       (is (= (workspace-resource-paths workspace) (set/union directory-resources imagelib2-resources)))
-      (workspace/set-project-dependencies! workspace (str scriptlib-url))
+      (workspace/set-project-dependencies! workspace [scriptlib-url])
       (workspace/resource-sync! workspace)
       (is (= (workspace-resource-paths workspace) (set/union directory-resources scriptlib-resources)))
-      (workspace/set-project-dependencies! workspace (str imagelib1-url " " scriptlib-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url scriptlib-url])
       (workspace/resource-sync! workspace)
       (is (= (workspace-resource-paths workspace) (set/union directory-resources imagelib1-resources scriptlib-resources))))))
 
 (deftest skip-colliding-libraries
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup world))]
-      (workspace/set-project-dependencies! workspace (str imagelib1-url " " imagelib2-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url imagelib2-url])
       (workspace/resource-sync! workspace)
       (is (= (workspace-resource-paths workspace)
              (clojure.set/union directory-resources imagelib1-resources))))))
@@ -93,7 +93,7 @@
 (deftest skip-bad-lib-urls []
   (with-clean-system
     (let [[workspace projec†] (log/without-logging (setup world))]
-      (workspace/set-project-dependencies! workspace (str imagelib1-url " " bogus-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url bogus-url])
       (workspace/resource-sync! workspace)
       (is (= (workspace-resource-paths workspace)
              (clojure.set/union directory-resources imagelib1-resources))))))
@@ -101,17 +101,17 @@
 (deftest resource-sync!-diff
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup-scratch world))]
-      (workspace/set-project-dependencies! workspace (str imagelib1-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url])
       (let [il1-diff (workspace/resource-sync! workspace)]
         (is (= (resource-paths (:added il1-diff)) imagelib1-resources))
         (is (empty? (:removed il1-diff)))
         (is (empty? (:changed il1-diff))))
-      (workspace/set-project-dependencies! workspace "")
+      (workspace/set-project-dependencies! workspace [])
       (let [remove-il1-diff (workspace/resource-sync! workspace)]
         (is (empty? (:added remove-il1-diff)))
         (is (= (resource-paths (:removed remove-il1-diff)) imagelib1-resources))
         (is (empty? (:changed remove-il1-diff))))
-      (workspace/set-project-dependencies! workspace (str imagelib1-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url])
       (workspace/resource-sync! workspace)
       (let [project-directory (workspace/project-path workspace)]
         ;; this fakes having downloaded a different version of the library
@@ -129,12 +129,12 @@
 (deftest exchange-of-zipresource-updates-corresponding-resource-node
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup world))]
-      (workspace/set-project-dependencies! workspace (str imagelib1-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url])
       (workspace/resource-sync! workspace)
       (let [lib1-pow (project/get-resource-node project "/images/pow.png")
             lib1-pow-resource (g/node-value lib1-pow :resource)]
         (is (not (g/error? lib1-pow-resource)))
-        (workspace/set-project-dependencies! workspace (str imagelib2-url))
+        (workspace/set-project-dependencies! workspace [imagelib2-url])
         (workspace/resource-sync! workspace)
         (let [lib2-pow (project/get-resource-node project "/images/pow.png")
               lib2-pow-resource (g/node-value lib2-pow :resource)]
@@ -145,11 +145,11 @@
 (deftest delete-of-zipresource-marks-corresponding-resource-node-defective
   (with-clean-system
     (let [[workspace project] (log/without-logging (setup world))]
-      (workspace/set-project-dependencies! workspace (str imagelib1-url))
+      (workspace/set-project-dependencies! workspace [imagelib1-url])
       (workspace/resource-sync! workspace)
       (let [lib1-paddle (project/get-resource-node project "/images/paddle.png")]
         (is (not (g/error? (g/node-value lib1-paddle :content))))
-        (workspace/set-project-dependencies! workspace (str imagelib2-url))
+        (workspace/set-project-dependencies! workspace [imagelib2-url])
         (workspace/resource-sync! workspace)
         (is (g/error? (g/node-value lib1-paddle :content))))))) ; removed, should emit errors
 


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/217

### User facing changes

- Project dependencies is now a multi line field rather than a single
  text field which should make working with dependencies more pleasant

### Technical changes

- Use vector of URLs as canonical representation of dependencies and
  use it everywhere
- Introduce a new type for settings data: `library-list`, edited using
  a list control.
- Teach form view about URL text fields so we can edit urls in list control.