### PR TITLE
DEFEDIT-1155 Bind to "localhost" instead of "::"

### DIFF
--- a/editor/src/clj/editor/debug.clj
+++ b/editor/src/clj/editor/debug.clj
@@ -60,7 +60,7 @@
 
 (defn start-server
   [port]
-  (let [repl-config (cond-> {}
+  (let [repl-config (cond-> {:bind "localhost"}
                       true (maybe-load-cider)
                       true (maybe-load-refactor-nrepl)
                       port (assoc :port port))]


### PR DESCRIPTION
Fixes ipv6 issue with tools.nrepl 0.2.13.