### PR TITLE
DEFEDIT-1162 Login using system browser instead of embedded

### DIFF
--- a/editor/resources/login.fxml
+++ b/editor/resources/login.fxml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.text.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import java.lang.*?>
 <?import javafx.scene.web.*?>
 
-
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox prefHeight="184.0" prefWidth="524.0" spacing="12.0" styleClass="login-dialog" stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <WebView id="web" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS" />
+      <Text id="message" fontSmoothingType="LCD" strokeType="OUTSIDE" strokeWidth="0.0" text="We've now opened a browser window that should take you through the login process. If a browser window did not open, you can manually login by opening the link below in a browser." wrappingWidth="500.0" VBox.vgrow="ALWAYS" />
+      <TextArea id="link" editable="false" prefWidth="500.0" text="link" wrapText="true" VBox.vgrow="ALWAYS" />
+      <Button id="cancel" minWidth="80.0" mnemonicParsing="false" text="Cancel" AnchorPane.bottomAnchor="0.0" AnchorPane.rightAnchor="0.0" VBox.vgrow="NEVER" />
    </children>
+   <padding>
+      <Insets bottom="12.0" left="12.0" right="12.0" top="12.0" />
+   </padding>
 </VBox>

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -250,6 +250,7 @@
             (EditorApplication/openEditor (into-array String [file-name])))))
 
 (handler/defhandler :logout :global
+  (enabled? [prefs] (login/has-token? prefs))
   (run [prefs] (login/logout prefs)))
 
 (handler/defhandler :preferences :global

--- a/editor/src/clj/editor/login.clj
+++ b/editor/src/clj/editor/login.clj
@@ -56,12 +56,13 @@
 
 (defn- open-login-dialog [prefs client]
   (let [root ^Parent (ui/load-fxml "login.fxml")
-        stage (ui/make-dialog-stage nil)
+        stage (ui/make-dialog-stage)
         scene (Scene. root)
         return (atom false)
-        ;; delay the closing here to give the server some time to
-        ;; flush the response to the client before it is stopped.
-        close-stage! (fn [] (ui/run-later (ui/->future 0.5 #(ui/close! stage))))
+        close-stage! (fn [] (ui/run-later
+                              ;; delay the closing here to give the server some time to
+                              ;; flush the response to the client before it is stopped.
+                              (ui/->future 0.5 #(ui/close! stage))))
         server (make-server client {:on-success (fn [exchange-info]
                                                   (prefs/set-prefs prefs "email" (:email exchange-info))
                                                   (prefs/set-prefs prefs "first-name" (:first-name exchange-info))

--- a/editor/src/clj/editor/login.clj
+++ b/editor/src/clj/editor/login.clj
@@ -5,10 +5,10 @@
             [editor.ui :as ui]
             [service.log :as log])
   (:import [com.dynamo.cr.protocol.proto Protocol$TokenExchangeInfo Protocol$TokenExchangeInfo$Type Protocol$UserInfo]
-           [fi.iki.elonen NanoHTTPD NanoHTTPD$Response NanoHTTPD$IHTTPSession]
+           [java.net URLEncoder]
+           [fi.iki.elonen NanoHTTPD NanoHTTPD$Response NanoHTTPD$Response$Status NanoHTTPD$IHTTPSession]
            [javafx.fxml FXMLLoader]
            [javafx.scene Parent Scene]
-           [javafx.scene.web WebView]
            [javafx.stage Stage Modality]))
 
 (set! *warn-on-reflection* true)
@@ -23,46 +23,63 @@
         false))
     false))
 
+(defn- make-redirect-to-url
+  [^NanoHTTPD server]
+  (format "http://localhost:%d/{token}/{action}" (.getListeningPort server)))
+
 (defn- parse-url [url]
-  (if-let [[_ token action] (re-find #"/(.+?)/(.+?)" url)]
-    [token action]
-    (throw (Exception. (format "invalid url %s" url)))))
+  (when-let [[_ token action] (re-find #"/(.+?)/(.+?)" url)]
+    [token action]))
 
-(defn- exchange-info [client token]
-  (client/rget client (format "/login/oauth/exchange/%s" token) Protocol$TokenExchangeInfo))
-
-(defn- handle-request [prefs client ^NanoHTTPD$IHTTPSession session]
-  (let [[token action] (parse-url (.getUri session))
-         exchange-info (exchange-info client token)]
+(defn- get-exchange-info [client token]
+  (let [exchange-info (client/rget client (format "/login/oauth/exchange/%s" token) Protocol$TokenExchangeInfo)]
     (if (= (:type exchange-info) :SIGNUP)
       (throw (Exception. "This account is not associated with defold.com yet. Please go to defold.com to signup"))
       exchange-info)))
+
+(defn- make-server
+  ^NanoHTTPD [client {:keys [on-success on-error]}]
+  (doto (proxy [NanoHTTPD] [0]
+          (serve [^NanoHTTPD$IHTTPSession session]
+            (if-let [[token action] (parse-url (.getUri session))]
+              (try
+                (let [exchange-info (get-exchange-info client token)]
+                  (on-success exchange-info)
+                  (NanoHTTPD$Response. "<p>Login successful. You can now close this browser tab and return to the defold editor.</p>"))
+                (catch Exception e
+                  (log/error :exception e)
+                  (on-error e)
+                  (NanoHTTPD$Response. (format "<h1>Login failed: %s</h1>" (.getMessage e)))))
+              ;; Handle other requests, for example /favicon.ico with a 404.
+              (NanoHTTPD$Response. (NanoHTTPD$Response$Status/NOT_FOUND) NanoHTTPD/MIME_PLAINTEXT "Not found"))))
+    (.start)))
 
 (defn- open-login-dialog [prefs client]
   (let [root ^Parent (ui/load-fxml "login.fxml")
         stage (ui/make-dialog-stage nil)
         scene (Scene. root)
-        web-view ^WebView (.lookup root "#web")
-        engine (.getEngine web-view)
         return (atom false)
-        server (proxy [NanoHTTPD] [0]
-                 (serve [^NanoHTTPD$IHTTPSession session]
-                   (try
-                     (let [exchange-info (handle-request prefs client session)]
-                       (prefs/set-prefs prefs "email" (:email exchange-info))
-                       (prefs/set-prefs prefs "first-name" (:first-name exchange-info))
-                       (prefs/set-prefs prefs "last-name" (:last-name exchange-info))
-                       (prefs/set-prefs prefs "token" (:auth-token exchange-info)))
-                     (reset! return true)
-                     (catch Exception e
-                       (reset! return e)
-                       (log/error :exception e)))
-                   (ui/run-later (ui/close! stage))
-                   (NanoHTTPD$Response. "")))]
+        ;; delay the closing here to give the server some time to
+        ;; flush the response to the client before it is stopped.
+        close-stage! (fn [] (ui/run-later (ui/->future 0.5 #(ui/close! stage))))
+        server (make-server client {:on-success (fn [exchange-info]
+                                                  (prefs/set-prefs prefs "email" (:email exchange-info))
+                                                  (prefs/set-prefs prefs "first-name" (:first-name exchange-info))
+                                                  (prefs/set-prefs prefs "last-name" (:last-name exchange-info))
+                                                  (prefs/set-prefs prefs "token" (:auth-token exchange-info))
+                                                  (reset! return true)
+                                                  (close-stage!))
+                                    :on-error   (fn [exception]
+                                                  (reset! return exception)
+                                                  (close-stage!))})
+        redirect-to-url (make-redirect-to-url server)
+        url (format "https://cr.defold.com/login/oauth/google?redirect_to=%s" (URLEncoder/encode redirect-to-url))]
+    (ui/with-controls root [^Button cancel ^TextArea link]
+      (ui/text! link url)
+      (ui/on-action! cancel (fn [_] (.close stage))))
     (.setTitle stage "Login")
-    (.start server)
     (.setOnHidden stage (ui/event-handler event (.stop server)))
-    (.load engine (format "https://cr.defold.com/login/oauth/google?redirect_to=http://localhost:%d/{token}/{action}" (.getListeningPort server)))
+    (ui/open-url url)
     (.setScene stage scene)
     (.showAndWait stage)
     (if (instance? Throwable @return)
@@ -80,6 +97,9 @@
   (prefs/set-prefs prefs "first-name" nil)
   (prefs/set-prefs prefs "last-name" nil)
   (prefs/set-prefs prefs "token" nil))
+
+(defn has-token? [prefs]
+  (some? (prefs/get-prefs prefs "token" nil)))
 
 (defn credentials [prefs]
   (let [email (prefs/get-prefs prefs "email" nil)

--- a/editor/styling/stylesheets/components/_login-dialog.scss
+++ b/editor/styling/stylesheets/components/_login-dialog.scss
@@ -1,0 +1,16 @@
+/* Login Dialog */
+.login-dialog {
+
+    #link {
+        -fx-background-color: transparent;
+        -fx-border-width: 0;
+        -fx-padding: 0;
+
+        &:focused {
+            -fx-border-width: 0;
+        }
+    }
+    #message {
+        -fx-fill: $bright-grey-light;
+    }
+}

--- a/editor/styling/stylesheets/main.sass
+++ b/editor/styling/stylesheets/main.sass
@@ -25,6 +25,7 @@
 @import 'components/_form';
 @import 'components/_fuzzy-combo-box';
 @import 'components/_list-view';
+@import 'components/_login-dialog';
 @import 'components/_menu-bar';
 @import 'components/_menu-button';
 @import 'components/_progress-bar';


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1288, https://github.com/defold/editor2-issues/issues/1098

### User facing changes

- We now use the system browser for login. This means that when you
  need to login, an external browser window will open and take you
  through the login process. You will have access to your saved
  passwords, remembered logins etc. and the experience will be more
  like when you login to the defold dashboard on the web.

### Technical changes

- Open oauth URL using ui/open-url instead of WebView
- Show dialog with message about what is happening, and the URL that
  can be used if opening a browser window fails.
- Makes us not reliant on the javafx webview being compatible with the latest google login changes