### PR TITLE
DEFEDIT-1163 Scene rendering performance improvements

### DIFF
--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -5,7 +5,7 @@
             [editor.graph-util :as gu]
             [editor.geom :as geom]
             [editor.gl :as gl]
-            [editor.gl.vertex :as vtx]
+            [editor.gl.vertex2 :as vtx]
             [editor.gl.texture :as texture]
             [editor.defold-project :as project]
             [editor.scene-cache :as scene-cache]
@@ -21,6 +21,7 @@
   (:import [com.dynamo.render.proto Font$FontDesc Font$FontMap Font$FontTextureFormat]
            [editor.types AABB]
            [editor.gl.shader ShaderLifecycle]
+           [editor.gl.vertex2 VertexBuffer]
            [java.nio ByteBuffer]
            [com.jogamp.opengl GL GL2]
            [javax.vecmath Matrix4d Point3d Vector3d]
@@ -37,14 +38,14 @@
                                        :max 1.0
                                        :precision 0.01})
 
-(vtx/defvertex DefoldVertex
+(vtx/defvertex ^:no-put DefoldVertex
   (vec3 position)
   (vec2 texcoord0)
   (vec4 face_color)
   (vec4 outline_color)
   (vec4 shadow_color))
 
-(vtx/defvertex DFVertex
+(vtx/defvertex ^:no-put DFVertex
   (vec3 position)
   (vec2 texcoord0)
   (vec4 sdf_params)
@@ -54,24 +55,62 @@
 
 (def ^:private vertex-order [0 1 2 1 3 2])
 
-(defn- glyph->quad [font-map su sv ^Matrix4d transform glyph]
-  (let [padding (:glyph-padding font-map)
-        u0 (* su (+ (:x glyph) padding))
-        v0 (* sv (+ (:y glyph) padding))
-        u1 (+ u0 (* su (:width glyph)))
-        v1 (+ v0 (* sv (+ (:ascent glyph) (:descent glyph))))
-        x0 (:left-bearing glyph)
-        x1 (+ x0 (:width glyph))
-        y1 (:ascent glyph)
-        y0 (- y1 (:ascent glyph) (:descent glyph))
-        p (Point3d.)
-        vs (vec (for [[y v] [[y0 v1] [y1 v0]]
-                      [x u] [[x0 u0] [x1 u1]]]
-                  (do
-                    (.set p x y 0.0)
-                    (.transform transform p)
-                    [(.x p) (.y p) (.z p) u v])))]
-    (mapv #(get vs %) vertex-order)))
+(defn- put-pos-uv!
+  [^ByteBuffer bb x y z u v]
+  (.putFloat bb x)
+  (.putFloat bb y)
+  (.putFloat bb z)
+  (.putFloat bb u)
+  (.putFloat bb v))
+
+(defn- wrap-with-sdf-params
+  [put-pos-uv-fn font-map]
+  (let [{:keys [sdf-spread sdf-outline]} font-map
+        sdf-smoothing (/ 0.25 sdf-spread)
+        sdf-edge 0.75]
+    (fn [^ByteBuffer bb x y z u v]
+      (put-pos-uv-fn bb x y z u v)
+      (.putFloat bb sdf-edge) (.putFloat bb sdf-outline) (.putFloat bb sdf-smoothing) (.putFloat bb sdf-spread))))
+
+(defn- wrap-with-colors
+  [put-pos-uv-fn color outline shadow]
+  (let [[color-r color-g color-b color-a] color
+        [outline-r outline-g outline-b outline-a] outline
+        [shadow-r shadow-g shadow-b shadow-a] shadow]
+    (fn [^ByteBuffer bb x y z u v]
+      (put-pos-uv-fn bb x y z u v)
+      (.putFloat bb color-r) (.putFloat bb color-g) (.putFloat bb color-b) (.putFloat bb color-a)
+      (.putFloat bb outline-r) (.putFloat bb outline-g) (.putFloat bb outline-b) (.putFloat bb outline-a)
+      (.putFloat bb shadow-r) (.putFloat bb shadow-g) (.putFloat bb shadow-b) (.putFloat bb shadow-a))))
+
+(defn- make-put-glyph-quad-fn
+  [font-map]
+  (let [^int w (:cache-width font-map)
+        ^int h (:cache-height font-map)
+        ^long padding (:glyph-padding font-map)
+        su (/ 1.0 w)
+        sv (/ 1.0 h)]
+    (fn [^VertexBuffer vbuf glyph ^Matrix4d transform put-pos-uv-fn]
+      (let [u0 (* su (+ ^long (:x glyph) padding))
+            v0 (* sv (+ ^long (:y glyph) padding))
+            u1 (+ u0 (* su ^long (:width glyph)))
+            v1 (+ v0 (* sv (+ ^long (:ascent glyph) ^long (:descent glyph))))
+            ^double x0 (:left-bearing glyph)
+            x1 (+ ^double x0 ^long (:width glyph))
+            ^double y1 (:ascent glyph)
+            y0 (- y1 ^long (:ascent glyph) ^long (:descent glyph))]
+        (let [^ByteBuffer bb (.buf vbuf)
+              p (Point3d.)
+              vs (vec (for [[y v] [[y0 v1] [y1 v0]]
+                            [x u] [[x0 u0] [x1 u1]]]
+                        (do
+                          (.set p x y 0.0)
+                          (.transform transform p)
+                          [(.x p) (.y p) (.z p) u v])))]
+          (run! (fn [idx]
+                  (let [[x y z u v] (nth vs idx)]
+                    (put-pos-uv-fn bb x y z u v))) vertex-order)
+          vbuf)))))
 
 (defn- font-type [font output-format]
   (if (= output-format :type-bitmap)
@@ -79,15 +118,6 @@
       :bitmap
       :defold)
     :distance-field))
-
-(defn- vertex-buffer [vs type font-map]
-  (let [vcount (count vs)]
-    (when (> vcount 0)
-      (let [vb (case type
-                 (:defold :bitmap) (->DefoldVertex vcount)
-                 :distance-field (->DFVertex vcount))]
-        (reduce conj! vb vs)
-        (persistent! vb)))))
 
 (defn- measure-line [glyphs text-tracking line]
   (let [w (reduce + (- text-tracking) (map (fn [c] (+ text-tracking (get-in glyphs [(int c) :advance] 0))) line))]
@@ -129,7 +159,7 @@
     line-break? (break-lines glyphs max-width text-tracking)))
 
 (defn- font-map->glyphs [font-map]
-  (into {} (map (fn [g] [(:character g) g]) (:glyphs font-map))))
+  (into {} (map (fn [g] [(:character g) g])) (:glyphs font-map)))
 
 (defn measure
   ([font-map text]
@@ -149,12 +179,12 @@
                      :font-map schema/Any
                      :texture  schema/Any})
 
-(defn- cell->coords [cell font-map]
-  (let [cw (:cache-cell-width font-map)
-        ch (:cache-cell-height font-map)
-        w (int (/ (:cache-width font-map) cw))
-        h (int (/ (:cache-height font-map) ch))]
-    [(* (mod cell w) cw)
+(defn- cell->coords [^long cell font-map]
+  (let [^long cw (:cache-cell-width font-map)
+        ^long ch (:cache-cell-height font-map)
+        w (long (/ ^long (:cache-width font-map) cw))
+        h (long (/ ^long (:cache-height font-map) ch))]
+    [(* (Math/floorMod cell w) cw)
      (* (int (/ cell w)) ch)]))
 
 (defn- place-glyph [^GL2 gl cache font-map texture glyph]
@@ -184,59 +214,81 @@
                :lines lines
                :line-widths line-widths)))))
 
-(defn gen-vertex-buffer [^GL2 gl {:keys [type font-map texture]} text-entries]
-  (let [cache (scene-cache/request-object! ::glyph-caches texture gl [font-map])
-        w (:cache-width font-map)
-        h (:cache-height font-map)
-        glyph-fn (partial glyph->quad font-map (/ 1 w) (/ 1 h))
-        glyphs (font-map->glyphs font-map)
-        char->glyph (comp glyphs int)
-        line-height (+ (:max-ascent font-map) (:max-descent font-map))
-        smoothing (/ 0.25 (:sdf-spread font-map))
-        sdf-edge-value 0.75
-        sdf-params [sdf-edge-value (:sdf-outline font-map) smoothing (:sdf-spread font-map)]
-        vs (loop [vs (transient [])
-                  text-entries text-entries]
-             (if-let [entry (first text-entries)]
-               (let [colors (repeat (cond->> (into (:color entry) (concat (:outline entry) (:shadow entry)))
-                                      (= type :distance-field) (into sdf-params)))
-                     text-layout (:text-layout entry)
-                     text-tracking (* line-height (:text-tracking text-layout 0))
-                     text-leading (:text-leading text-layout 1)
-                     offset (:offset entry)
-                     xform (doto (Matrix4d.)
-                             (.set (let [[x y] offset]
-                                     (Vector3d. x y 0.0))))
-                     _ (.mul xform ^Matrix4d (:world-transform entry) xform)
-                     lines (:lines text-layout)
-                     line-widths (:line-widths text-layout)
-                     max-width (:width text-layout)
-                     align (:align entry :center)
-                     vs (loop [vs vs
-                               lines lines
-                               line-widths line-widths
-                               line-no 0]
-                          (if-let [line (first lines)]
-                            (let [line-width (first line-widths)
-                                  y (* line-no (- (* line-height text-leading)))
-                                  vs (loop [vs vs
-                                            glyphs (map char->glyph line)
-                                            x (case align
-                                                :left 0.0
-                                                :center (* 0.5 (- max-width line-width))
-                                                :right (- max-width line-width))]
-                                       (if-let [glyph (first glyphs)]
-                                         (let [glyph (place-glyph gl cache font-map texture glyph)
-                                               cursor (doto (Matrix4d.) (.set (Vector3d. x y 0.0)))
-                                               cursor (doto cursor (.mul xform cursor))
-                                               vs (reduce conj! vs (map into (glyph-fn cursor glyph) colors))]
-                                           (recur vs (rest glyphs) (+ x (:advance glyph) text-tracking)))
-                                         vs))]
-                              (recur vs (rest lines) (rest line-widths) (inc line-no)))
-                            vs))]
-                 (recur vs (rest text-entries)))
-               (persistent! vs)))]
-    (vertex-buffer vs type font-map)))
+(defn glyph-count
+  [text-entries]
+  (transduce (comp
+               (mapcat (comp :lines :text-layout))
+               (map count))
+             +
+             text-entries))
+
+(defn- vertex-count
+  [text-entries]
+  (* 6 (glyph-count text-entries)))
+
+(defn- make-vbuf
+  [type text-entries]
+  (let [vcount (vertex-count text-entries)]
+    (case type
+      (:defold :bitmap) (->DefoldVertex vcount)
+      :distance-field   (->DFVertex vcount))))
+
+(defn- fill-vertex-buffer
+  [^GL2 gl vbuf {:keys [type font-map texture] :as font-data} text-entries]
+  (let [put-glyph-quad-fn (make-put-glyph-quad-fn font-map)
+        put-pos-uv-fn (cond-> put-pos-uv!
+                        (= type :distance-field)
+                        (wrap-with-sdf-params font-map))
+        cache (scene-cache/request-object! ::glyph-caches texture gl [font-map])
+        char->glyph (comp (font-map->glyphs font-map) int) 
+        line-height (+ ^long (:max-ascent font-map) ^long (:max-descent font-map))]
+    (reduce (fn [vbuf entry]
+              (let [put-pos-uv-fn (wrap-with-colors put-pos-uv-fn (:color entry) (:outline entry) (:shadow entry))
+                    text-layout (:text-layout entry)
+                    text-tracking (* line-height ^long (:text-tracking text-layout 0))
+                    ^double text-leading (:text-leading text-layout 1)
+                    offset (:offset entry)
+                    xform (doto (Matrix4d.)
+                            (.set (let [[x y] offset]
+                                    (Vector3d. x y 0.0))))
+                    _ (.mul xform ^Matrix4d (:world-transform entry) xform)
+                    ^double max-width (:width text-layout)
+                    align (:align entry :center)]
+                (loop [vbuf vbuf
+                       [line & lines] (:lines text-layout)
+                       [^double line-width & line-widths] (:line-widths text-layout)
+                       line-no 0]
+                  (if line
+                    (let [y (* line-no (- (* line-height text-leading)))]
+                      (loop [vbuf vbuf
+                             [glyph & glyphs] (map char->glyph line)
+                             x (case align
+                                 :left 0.0
+                                 :center (* 0.5 (- max-width line-width))
+                                 :right (- max-width line-width))]
+                        (if glyph
+                          (let [glyph (place-glyph gl cache font-map texture glyph)
+                                cursor (doto (Matrix4d.) (.set (Vector3d. x y 0.0)))
+                                cursor (doto cursor (.mul xform cursor))]
+                            (recur (put-glyph-quad-fn vbuf glyph cursor put-pos-uv-fn)
+                                   glyphs
+                                   (+ x ^double (:advance glyph) text-tracking)))
+                          vbuf))
+                      (recur vbuf lines line-widths (inc line-no)))
+                    vbuf))))
+            vbuf
+            text-entries)))
+
+(defn gen-vertex-buffer
+  [^GL2 gl {:keys [type] :as font-data} text-entries]
+  (let [vbuf (make-vbuf type text-entries)]
+    (vtx/flip! (fill-vertex-buffer gl vbuf font-data text-entries))))
+
+(defn request-vertex-buffer
+  [^GL2 gl request-id font-data text-entries]
+  (scene-cache/request-object! ::vb [request-id (:type font-data) (vertex-count text-entries)] gl
+                               {:font-data font-data
+                                :text-entries text-entries}))
 
 (defn render-font [^GL2 gl render-args renderables rcount]
   (let [user-data (get (first renderables) :user-data)
@@ -581,3 +633,18 @@
     (swap! (:cache cache) update :free conj glyph)))
 
 (scene-cache/register-object-cache! ::glyph-cells make-glyph-cell update-glyph-cell destroy-glyph-cells)
+
+(defn- update-vb
+  [^GL2 gl ^VertexBuffer vb {:keys [font-data text-entries]}]
+  (vtx/clear! vb)
+  (vtx/flip! (fill-vertex-buffer gl vb font-data text-entries)))
+
+(defn- make-vb
+  [^GL2 gl {:keys [font-data text-entries] :as data}]
+  (let [vb (make-vbuf (:type font-data) text-entries)]
+    (vtx/flip! (fill-vertex-buffer gl vb font-data text-entries))))
+
+(defn- destroy-vbs
+  [^GL2 gl vbs _])
+
+(scene-cache/register-object-cache! ::vb make-vb update-vb destroy-vbs)

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -299,17 +299,30 @@
     (aabb-incorporate  1  1  1)
     (aabb-incorporate -1 -1 -1)))
 
+;; From Graphics Gems:
+;; https://github.com/erich666/GraphicsGems/blob/master/gems/TransBox.c
 (defn aabb-transform [^AABB aabb ^Matrix4d transform]
   (if (= aabb (null-aabb))
     aabb
-    (let [extents [(types/min-p aabb) (types/max-p aabb)]
-          points (for [x (map #(let [^Point3d p %] (.x p)) extents)
-                       y (map #(let [^Point3d p %] (.y p)) extents)
-                       z (map #(let [^Point3d p %] (.z p)) extents)
-                       ] (Point3d. x y z))]
-      (doseq [^Point3d p points]
-        (.transform transform p))
-      (reduce #(aabb-incorporate %1 %2) (null-aabb) points))))
+    (let [min-p  (as-array (.min aabb))
+          max-p  (as-array (.max aabb))
+          min-p' (double-array [(.m03 transform) (.m13 transform) (.m23 transform)])
+          max-p' (double-array [(.m03 transform) (.m13 transform) (.m23 transform)])]
+      (loop [i 0, j 0]
+        (if (< i 3)
+          (if (< j 3)
+            (let [av (* (.getElement transform i j) (aget min-p j))
+                  bv (* (.getElement transform i j) (aget max-p j))]
+              (if (< av bv)
+                (do
+                  (aset ^doubles min-p' i (+ (aget min-p' i) av))
+                  (aset ^doubles max-p' i (+ (aget max-p' i) bv)))
+                (do
+                  (aset ^doubles min-p' i (+ (aget min-p' i) bv))
+                  (aset ^doubles max-p' i (+ (aget max-p' i) av))))
+              (recur i (inc j)))
+            (recur (inc i) 0))))
+      (types/->AABB (Point3d. min-p') (Point3d. max-p')))))
 
 ; -------------------------------------
 ; Primitive shapes as vertex arrays

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -309,7 +309,7 @@
           min-p' (double-array [(.m03 transform) (.m13 transform) (.m23 transform)])
           max-p' (double-array [(.m03 transform) (.m13 transform) (.m23 transform)])]
       (loop [i 0, j 0]
-        (if (< i 3)
+        (when (< i 3)
           (if (< j 3)
             (let [av (* (.getElement transform i j) (aget min-p j))
                   bv (* (.getElement transform i j) (aget max-p j))]

--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -178,7 +178,7 @@ the `do-gl` macro from `editor.gl`."
         arglist         (into [] (concat ['slices 'idx] names))
         multiplications (indexers "idx" vsteps)
         references      (map (comp first multiplications) vsteps)]
-    `(fn [~'slices ~'idx [~@names]]
+    `(fn [~'slices ~(with-meta 'idx {:tag 'long}) [~@names]]
        (let ~(into [] (apply concat (vals multiplications)))
          ~@(map (fn [i nm setter refer]
                  (list setter (with-meta (list `nth 'slices i) {:tag `ByteBuffer}) refer nm))
@@ -190,7 +190,7 @@ the `do-gl` macro from `editor.gl`."
         vsteps          (attribute-vsteps  vertex-format)
         multiplications (indexers "idx" vsteps)
         references      (map (comp first multiplications) vsteps)]
-    `(fn [~'slices ~'idx]
+    `(fn [~'slices ~(with-meta 'idx {:tag 'long})]
        (let ~(into [] (apply concat (vals multiplications)))
          [~@(map (fn [i getter refer]
                    (list getter (with-meta (list `nth 'slices i) {:tag `ByteBuffer}) (list `int refer)))

--- a/editor/src/clj/editor/gl/vertex2.clj
+++ b/editor/src/clj/editor/gl/vertex2.clj
@@ -146,7 +146,8 @@
   (let [attributes         (mapv parse-attribute-definition attribute-definitions)
         vertex-description (make-vertex-description name attributes)
         ctor-name          (symbol (str "->" name))
-        put-name           (symbol (str name "-put!"))]
+        put-name           (symbol (str name "-put!"))
+        gen-put?           (not (:no-put (meta name)))]
     `(do
        (def ~name '~vertex-description)
        (defn ~ctor-name
@@ -155,7 +156,8 @@
          ([capacity# usage#]
            (assert (contains? usage-types usage#) (format "usage must be %s" (str/join " or " (map str (keys usage-types)))))
            (make-vertex-buffer '~vertex-description usage# capacity#)))
-       (def ~put-name ~(make-put-fn (:attributes vertex-description))))))
+       ~(when gen-put?
+          `(def ~put-name ~(make-put-fn (:attributes vertex-description)))))))
 
 
 ;; GL stuff

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -10,11 +10,13 @@
             [editor.gl :as gl]
             [editor.gl.shader :as shader]
             [editor.gl.vertex :as vtx]
+            [editor.gl.vertex2 :as vtx2]
             [editor.gl.texture :as texture]
             [editor.gui-clipping :as clipping]
             [editor.defold-project :as project]
             [editor.progress :as progress]
             [editor.scene :as scene]
+            [editor.scene-cache :as scene-cache]
             [editor.workspace :as workspace]
             [editor.math :as math]
             [editor.colors :as colors]
@@ -36,6 +38,7 @@
             Gui$NodeDesc$Pivot Gui$NodeDesc$AdjustMode Gui$NodeDesc$BlendMode Gui$NodeDesc$ClippingMode Gui$NodeDesc$PieBounds Gui$NodeDesc$SizeMode]
            [editor.gl.shader ShaderLifecycle]
            [editor.gl.texture TextureLifecycle]
+           [editor.gl.vertex2 VertexBuffer]
            [editor.types AABB]
            [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d]
@@ -74,11 +77,11 @@
 
 ; Fallback shader
 
-(vtx/defvertex color-vtx
+(vtx2/defvertex color-vtx
   (vec3 position)
   (vec4 color))
 
-(vtx/defvertex uv-color-vtx
+(vtx2/defvertex uv-color-vtx
   (vec3 position)
   (vec2 texcoord0)
   (vec4 color))
@@ -135,52 +138,69 @@
 (def outline-color (scene/select-color pass/outline false [1.0 1.0 1.0 1.0]))
 (def selected-outline-color (scene/select-color pass/outline true [1.0 1.0 1.0 1.0]))
 
+(defn- gen-lines-vb
+  [renderables]
+  (let [vcount (transduce (map (comp count :line-data :user-data)) + renderables)]
+    (when (pos? vcount)
+      (vtx2/flip! (reduce (fn [vb {:keys [world-transform user-data selected] :as renderable}]
+                            (let [line-data (:line-data user-data)
+                                  [r g b a] (get user-data :line-color (if (:selected renderable) selected-outline-color outline-color))]
+                              (reduce (fn [vb [x y z]]
+                                        (color-vtx-put! vb x y z r g b a))
+                                      vb
+                                      (geom/transf-p world-transform line-data))))
+                          (->color-vtx vcount)
+                          renderables)))))
+
 (defn render-lines [^GL2 gl render-args renderables rcount]
-  (let [[vs colors] (reduce (fn [[vs colors] renderable]
-                              (let [world-transform (:world-transform renderable)
-                                    user-data (:user-data renderable)
-                                    line-data (:line-data user-data)
-                                    vcount (count line-data)
-                                    color (get user-data :line-color (if (:selected renderable) selected-outline-color outline-color))]
-                                [(into vs (geom/transf-p world-transform (:line-data user-data)))
-                                 (into colors (repeat vcount color))]))
-                      [[] []] renderables)
-        vcount (count vs)]
-    (when (> vcount 0)
-      (let [vertex-binding (vtx/use-with ::lines (->color-vtx-vb vs colors vcount) line-shader)]
-        (gl/with-gl-bindings gl render-args [line-shader vertex-binding]
-          (gl/gl-draw-arrays gl GL/GL_LINES 0 vcount))))))
+  (when-let [vb (gen-lines-vb renderables)]
+    (let [vertex-binding (vtx2/use-with ::lines vb line-shader)]
+      (gl/with-gl-bindings gl render-args [line-shader vertex-binding]
+        (gl/gl-draw-arrays gl GL/GL_LINES 0 (count vb))))))
 
 (defn- premul [color]
   (let [[r g b a] color]
     [(* r a) (* g a) (* b a) a]))
 
+(defn- gen-geom-vb
+  [renderables]
+  (let [vcount (transduce (map (comp count :geom-data :user-data)) + renderables)]
+    (when (pos? vcount)
+      (vtx2/flip! (reduce (fn [vb {:keys [world-transform user-data] :as renderable}]
+                            (if-let [geom-data (seq (:geom-data user-data))]
+                              (let [[r g b a] (premul (:color user-data))]
+                                (loop [vb vb
+                                       [[x y z :as v] & vs] (geom/transf-p world-transform geom-data)
+                                       [[u v :as uv] & uvs] (:uv-data user-data)]
+                                  (if v
+                                    (recur (uv-color-vtx-put! vb x y z u v r g b a) vs uvs)
+                                    vb)))
+                              vb))
+                          (->uv-color-vtx vcount)
+                          renderables)))))
+
+(defn- gen-font-vb
+  [gl user-data renderables]
+  (let [font-data (get-in user-data [:text-data :font-data])
+        text-entries (mapv (fn [r] (let [text-data (get-in r [:user-data :text-data])
+                                         alpha (get-in text-data [:color 3])]
+                                     (-> text-data
+                                         (assoc :world-transform (:world-transform r))
+                                         (update-in [:outline 3] * alpha)
+                                         (update-in [:shadow 3] * alpha))))
+                           renderables)
+        node-ids (into #{} (map :node-id) renderables)]
+    (font/request-vertex-buffer gl node-ids font-data text-entries)))
+
 (defn- gen-vb [^GL2 gl renderables]
   (let [user-data (get-in renderables [0 :user-data])]
     (cond
       (contains? user-data :geom-data)
-      (let [[vs uvs colors] (reduce (fn [[vs uvs colors :as vb] renderable]
-                                      (let [user-data (:user-data renderable)
-                                            world-transform (:world-transform renderable)
-                                            vcount (count (:geom-data user-data))]
-                                        (if (pos? vcount)
-                                          [(into vs (geom/transf-p world-transform (:geom-data user-data)))
-                                           (into uvs (:uv-data user-data))
-                                           (into colors (repeat vcount (premul (:color user-data))))]
-                                          vb)))
-                                    [[] [] []] renderables)]
-        (when (not-empty vs)
-          (->uv-color-vtx-vb vs uvs colors (count vs))))
+      (gen-geom-vb renderables)
 
       (get-in user-data [:text-data :font-data])
-      (font/gen-vertex-buffer gl (get-in user-data [:text-data :font-data])
-                              (map (fn [r] (let [text-data (get-in r [:user-data :text-data])
-                                                 alpha (get-in text-data [:color 3])]
-                                             (-> text-data
-                                                 (assoc :world-transform (:world-transform r))
-                                                 (update-in [:outline 3] * alpha)
-                                                 (update-in [:shadow 3] * alpha))))
-                                   renderables))
+      (gen-font-vb gl user-data renderables)
+
       (contains? user-data :spine-scene-pb)
       (spine/gen-vb renderables))))
 
@@ -194,7 +214,9 @@
         vcount (count vb)]
     (when (> vcount 0)
       (let [shader (or material-shader shader)
-            vertex-binding (vtx/use-with ::tris vb shader)]
+            vertex-binding (if (instance? editor.gl.vertex2.VertexBuffer vb)
+                             (vtx2/use-with ::tris vb shader)
+                             (vtx/use-with ::tris vb shader))]
         (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
           (clipping/setup-gl gl clipping-state)
           (case blend-mode
@@ -676,7 +698,8 @@
                :batch-key {:texture gpu-texture :blend-mode blend-mode}
                :select-batch-key _node-id
                :layer-index layer-index
-               :topmost? true})))
+               :topmost? true
+               :pass-overrides {pass/outline {:batch-key ::outline}}})))
   (output build-errors-visual-node g/Any (gu/passthrough build-errors-gui-node))
   (output own-build-errors g/Any (gu/passthrough build-errors-visual-node)))
 

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -143,8 +143,10 @@
   (let [vcount (transduce (map (comp count :line-data :user-data)) + renderables)]
     (when (pos? vcount)
       (vtx2/flip! (reduce (fn [vb {:keys [world-transform user-data selected] :as renderable}]
-                            (let [line-data (:line-data user-data)
-                                  [r g b a] (get user-data :line-color (if (:selected renderable) selected-outline-color outline-color))]
+                            (let [{:keys [line-data line-color]} user-data
+                                  [r g b a] (or line-color
+                                                (and selected selected-outline-color)
+                                                outline-color)]
                               (reduce (fn [vb [x y z]]
                                         (color-vtx-put! vb x y z r g b a))
                                       vb

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -7,7 +7,7 @@
             [editor.gl.pass :as pass]
             [editor.gl.shader :as shader]
             [editor.gl.texture :as texture]
-            [editor.gl.vertex :as vtx]
+            [editor.gl.vertex2 :as vtx]
             [editor.graph-util :as gu]
             [editor.material :as material]
             [editor.math :as math]
@@ -70,41 +70,38 @@
 (def outline-color (scene/select-color pass/outline false [1.0 1.0 1.0]))
 (def selected-outline-color (scene/select-color pass/outline true [1.0 1.0 1.0]))
 
-(defn- ->color-vtx-vb [vs colors vcount]
-  (let [vb (->color-vtx vcount)
-        vs (mapv (comp vec concat) vs colors)]
-    (doseq [v vs]
-      (conj! vb v))
-    (persistent! vb)))
-
-; Rendering
+(defn- gen-lines-vb
+  [renderables]
+  (let [vcount (transduce (map (comp count :line-data :user-data)) + renderables)]
+    (when (pos? vcount)
+      (vtx/flip! (reduce (fn [vb {:keys [world-transform user-data selected] :as renderable}]
+                           (let [line-data (:line-data user-data)
+                                 [r g b a] (get user-data :line-color (if (:selected renderable) selected-outline-color outline-color))]
+                             (reduce (fn [vb [x y z]]
+                                       (color-vtx-put! vb x y z r g b a))
+                                     vb
+                                     (geom/transf-p world-transform line-data))))
+                         (->color-vtx vcount)
+                         renderables)))))
 
 (defn render-lines [^GL2 gl render-args renderables rcount]
-  (let [[vs colors] (reduce (fn [[vs colors] renderable]
-                              (let [world-transform (:world-transform renderable)
-                                    user-data (:user-data renderable)
-                                    line-data (:line-data user-data)
-                                    vcount (count line-data)
-                                    color (get user-data :line-color (if (:selected renderable) selected-outline-color outline-color))]
-                                [(into vs (geom/transf-p world-transform (:line-data user-data)))
-                                 (into colors (repeat vcount color))]))
-                      [[] []] renderables)
-        vcount (count vs)]
-    (when (> vcount 0)
-      (let [vertex-binding (vtx/use-with ::lines (->color-vtx-vb vs colors vcount) line-shader)]
-        (gl/with-gl-bindings gl render-args [line-shader vertex-binding]
-          (gl/gl-draw-arrays gl GL/GL_LINES 0 vcount))))))
+  (when-let [vb (gen-lines-vb renderables)]
+    (let [vertex-binding (vtx/use-with ::lines vb line-shader)]
+      (gl/with-gl-bindings gl render-args [line-shader vertex-binding]
+        (gl/gl-draw-arrays gl GL/GL_LINES 0 (count vb))))))
 
 (defn- gen-vb [^GL2 gl renderables]
-  (let [user-data (get-in renderables [0 :user-data])]
-    (font/gen-vertex-buffer gl (get-in user-data [:text-data :font-data])
-                            (map (fn [r] (let [text-data (get-in r [:user-data :text-data])
-                                               alpha (get-in text-data [:color 3])]
-                                           (-> text-data
-                                             (assoc :world-transform (:world-transform r))
-                                             (update-in [:outline 3] * alpha)
-                                             (update-in [:shadow 3] * alpha))))
-                                 renderables))))
+  (let [user-data (get-in renderables [0 :user-data])
+        font-data (get-in user-data [:text-data :font-data])
+        text-entries (mapv (fn [r] (let [text-data (get-in r [:user-data :text-data])
+                                         alpha (get-in text-data [:color 3])]
+                                     (-> text-data
+                                         (assoc :world-transform (:world-transform r))
+                                         (update-in [:outline 3] * alpha)
+                                         (update-in [:shadow 3] * alpha))))
+                           renderables)
+        node-ids (into #{} (map :node-id) renderables)]
+    (font/request-vertex-buffer gl node-ids font-data text-entries)))
 
 (defn render-tris [^GL2 gl render-args renderables rcount]
   (let [user-data (get-in renderables [0 :user-data])

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -132,17 +132,18 @@
 (defn vp-not-empty? [^Region viewport]
   (not (types/empty-space? viewport)))
 
-(defn z-distance [^Matrix4d view-proj ^Matrix4d world-transform ^Vector4d tmp-v4d]
-  (let [^Matrix4d t (or world-transform geom/Identity4d)]
+(defn z-distance [^Matrix4d view-proj ^Matrix4d world-transform]
+  (let [^Matrix4d t (or world-transform geom/Identity4d)
+        tmp-v4d (Vector4d.)]
     (.getColumn t 3 tmp-v4d)
     (.transform view-proj tmp-v4d)
     (let [ndc-z (/ (.z tmp-v4d) (.w tmp-v4d))
           wz (min 1.0 (max 0.0 (* (+ ndc-z 1.0) 0.5)))]
       (long (* Integer/MAX_VALUE (max 0.0 wz))))))
 
-(defn- render-key [^Matrix4d view-proj ^Matrix4d world-transform index topmost? tmp-v4d]
+(defn- render-key [^Matrix4d view-proj ^Matrix4d world-transform index topmost?]
   [(boolean topmost?)
-   (- Long/MAX_VALUE (z-distance view-proj world-transform tmp-v4d))
+   (- Long/MAX_VALUE (z-distance view-proj world-transform))
    (or index 0)])
 
 (defn gl-viewport [^GL2 gl viewport]
@@ -300,7 +301,21 @@
       (setup-pass context gl pass camera viewport)
       (batch-render gl render-args pass-renderables false :batch-key))))
 
-(defn- append-flattened-scene-renderables! [scene selection-set view-proj node-path parent-world-transform out-renderables tmp-v4d]
+(defn- apply-pass-overrides
+  [pass renderable]
+  (let [overrides (get-in renderable [:pass-overrides pass])]
+    (cond-> (dissoc renderable :pass-overrides)
+      overrides
+      (merge overrides))))
+
+(defn- update-pass-renderables
+  [pass-renderables scene flattened-renderable]
+  (reduce (fn [pass-renderables pass]
+            (update pass-renderables pass conj! (apply-pass-overrides pass flattened-renderable)))
+          pass-renderables
+          (-> scene :renderable :passes)))
+
+(defn- flatten-scene-renderables! [pass-renderables scene selection-set view-proj node-path parent-world-transform]
   (let [renderable (:renderable scene)
         local-transform ^Matrix4d (:transform scene geom/Identity4d)
         world-transform (doto (Matrix4d. ^Matrix4d parent-world-transform) (.mul local-transform))
@@ -316,25 +331,24 @@
                                   :user-data (:user-data renderable)
                                   :batch-key (:batch-key renderable)
                                   :aabb (geom/aabb-transform ^AABB (:aabb scene (geom/null-aabb)) parent-world-transform)
-                                  :render-key (render-key view-proj world-transform (:index renderable) (:topmost? renderable) tmp-v4d)))]
-    (doseq [pass (:passes renderable)]
-      (conj! (get out-renderables pass) new-renderable))
-    (doseq [child-scene (:children scene)]
-      (append-flattened-scene-renderables! child-scene selection-set view-proj (conj node-path (:node-id child-scene)) world-transform out-renderables tmp-v4d))))
+                                  :render-key (render-key view-proj world-transform (:index renderable) (:topmost? renderable))))
+        pass-renderables (update-pass-renderables pass-renderables scene new-renderable)]
+    (reduce (fn [pass-renderables child-scene]
+              (flatten-scene-renderables! pass-renderables child-scene selection-set view-proj (conj node-path (:node-id child-scene)) world-transform))
+            pass-renderables
+            (:children scene))))
 
 (defn- flatten-scene [scene selection-set view-proj]
   (let [node-path []
         parent-world-transform (doto (Matrix4d.) (.setIdentity))
-        out-renderables (into {} (map #(vector % (transient [])) pass/all-passes))
-        tmp-v4d (Vector4d.)]
-    (append-flattened-scene-renderables! scene selection-set view-proj node-path parent-world-transform out-renderables tmp-v4d)
-    (into {}
-          (map (fn [[pass renderables]]
-                 ;; Draw selection outlines on top of other outlines.
-                 [pass (if (= pass/outline pass)
-                         (sort-by :selected (persistent! renderables))
-                         (persistent! renderables))]))
-          out-renderables)))
+        pass-renderables (into {} (map #(vector % (transient [])) pass/all-passes))]
+    (->> (flatten-scene-renderables! pass-renderables scene selection-set view-proj node-path parent-world-transform)
+         (into {}
+               (map (fn [[pass renderables]]
+                      ;; Draw selection outlines on top of other outlines.
+                      [pass (if (= pass/outline pass)
+                              (sort-by :selected (persistent! renderables))
+                              (persistent! renderables))]))))))
 
 (defn- get-selection-pass-renderables-by-node-id
   "Returns a map of renderables that were in a selection pass by their node id.

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -209,28 +209,28 @@
   (satisfies? types/Pass pass))
 
 (defn- output-renderable? [renderable]
-  (and (map? renderable)
-       (= #{:aabb
-            :batch-key
-            :node-id
-            :node-path
-            :picking-id
-            :parent-world-transform
-            :render-fn
-            :render-key
-            :selected
-            :user-data
-            :world-transform} (set (keys renderable)))
-       (instance? AABB (:aabb renderable))
-       (some? (:node-id renderable))
-       (vector? (:node-path renderable))
-       (every? some? (:node-path renderable))
-       (or (nil? (:picking-id renderable)) (= (type (:node-id renderable)) (type (:picking-id renderable))))
-       (instance? Matrix4d (:parent-world-transform renderable))
-       (some? (:render-fn renderable))
-       (instance? Comparable (:render-key renderable))
-       (or (true? (:selected renderable)) (false? (:selected renderable)))
-       (instance? Matrix4d (:world-transform renderable))))
+  (is (map? renderable))
+  (is (= #{:aabb
+           :batch-key
+           :node-id
+           :node-path
+           :picking-id
+           :parent-world-transform
+           :render-fn
+           :render-key
+           :selected
+           :user-data
+           :world-transform} (set (keys renderable))))
+  (is (instance? AABB (:aabb renderable)))
+  (is (some? (:node-id renderable)))
+  (is (vector? (:node-path renderable)))
+  (is (every? some? (:node-path renderable)))
+  (is (or (nil? (:picking-id renderable)) (= (type (:node-id renderable)) (type (:picking-id renderable)))))
+  (is (instance? Matrix4d (:parent-world-transform renderable)))
+  (is (some? (:render-fn renderable)))
+  (is (instance? Comparable (:render-key renderable)))
+  (is (or (true? (:selected renderable)) (false? (:selected renderable))))
+  (is (instance? Matrix4d (:world-transform renderable))))
 
 (defn- output-renderable-vector? [coll]
   (and (vector? coll)


### PR DESCRIPTION
### User facing changes

- Big scenes, especially with a large number of GUIs should now render
  much more quickly and be more pleasant to work with in editor.

### Technical changes

- scene rendering:
  - introduce a `:pass-overrides` renderable key that allows for
    overriding renderable attributes on a per-pass basis
  - change flatten-scene to not bash transients in place (unsafe)
  - better implementation of geom/aabb-transform which was a hot-spot
    in scene flattening
- gui rendering:
  - switch to vertex2 vbufs
  - improve render-lines and render-geom
  - use `:pass-overrides` to batch outline pass more effectively
- font rendering:
  - switch to vertex2 vbufs
  - remove unboxed math in hot code
  - cache and re-use vbufs if possible to reduce ByteBuffer allocation
    pressure
- label rendering:
  - adapt to font/gui changes