### PR TITLE
DEFEDIT-1164 Fix for incorrectly restored panel sizes at startup

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -243,7 +243,8 @@
       (doseq [[k pos] div-pos
               :let [^SplitPane sp (get controls k)]
               :when sp]
-        (.setDividerPositions sp (into-array Double/TYPE pos))))))
+        (.setDividerPositions sp (into-array Double/TYPE pos))
+        (.layout sp)))))
 
 (handler/defhandler :open-project :global
   (run [] (when-let [file-name (ui/choose-file "Open Project" "Project Files" ["*.project"])]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -186,7 +186,8 @@
                                                     (handle-changes [_ changes _]
                                                       (handle-resource-changes! changes changes-view editor-tabs))))
 
-      (app-view/restore-split-positions! stage prefs)
+      (ui/run-later
+        (app-view/restore-split-positions! stage prefs))
 
       (ui/on-closing! stage (fn [_]
                               (let [result (or (empty? (project/dirty-save-data project))


### PR DESCRIPTION
Fixes defold/editor2-issues#1287

### User-facing changes
* Panel sizes are restored correctly when restarting the editor.