### PR TITLE
DEFEDIT-1165 Bundling project with dependencies works when not logged in

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -139,16 +139,18 @@
 
              ;; From BundleGenericHandler
              "build-server" build-server-url
-             "defoldsdk" defold-sdk-sha1}
+             "defoldsdk" defold-sdk-sha1
+
+             ;; Bob uses these to set X-Email/X-Auth HTTP headers,
+             ;; which fails if they are nil, so use empty string
+             ;; instead.
+             "email" (or email "")
+             "auth"  (or auth "")}
 
             ;; From BundleGenericHandler
             (not release-mode?) (assoc "debug" "true")
             generate-build-report? (assoc "build-report-html" build-report-path)
-            publish-live-update-content? (assoc "liveupdate" "true")
-
-            ;; Our additions
-            email (assoc "email" email)
-            auth (assoc "auth" auth))))
+            publish-live-update-content? (assoc "liveupdate" "true"))))
 
 (defn- android-bundle-bob-args [{:keys [^File certificate ^File private-key] :as _build-options}]
   (assert (or (nil? certificate) (.isFile certificate)))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1223

### User facing changes

- You can now successfully bundle a project with dependencies even
  when not logged in to a defold account.

### Technical changes

- When bundling, bob fetches libraries using HttpURLConnection,
  setting the X-Email/E-auth headers from the provided credentials.
  However, if user is not logged in, we would pass nil as email/auth
  to bob, which would then make the HTTP request fail with a 400 Bad
  Request. Fixed by passing email/auth as empty strings when not set.