### PR TITLE
DEFEDIT-1166 Help sentry to not forget our error IDs

### DIFF
--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -11,7 +11,6 @@
    [editor.import :as import]
    [editor.prefs :as prefs]
    [editor.progress :as progress]
-   [editor.sentry :as sentry]
    [editor.ui :as ui]
    [editor.updater :as updater]
    [service.log :as log])

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -146,7 +146,7 @@
     (let [sentry-id (deref sentry-id-promise 100 nil)
           fields (cond-> {}
                    sentry-id
-                   (assoc "Error" (format "<a href='https://sentry.io/defold/editor2/?query=%s'>%s</a>"
+                   (assoc "Error" (format "<a href='https://sentry.io/defold/editor2/?query=id%%3A\"%s\"'>%s</a>"
                                           sentry-id sentry-id)))]
       (ui/open-url (github/new-issue-link fields)))))
 

--- a/editor/src/clj/editor/sentry.clj
+++ b/editor/src/clj/editor/sentry.clj
@@ -80,9 +80,10 @@
 
 (defn make-event
   [^Exception ex ^Thread thread]
-  (let [environment (if (system/defold-version) "release" "dev")
+  (let [id (string/replace (str (java.util.UUID/randomUUID)) "-" "")
+        environment (if (system/defold-version) "release" "dev")
         gl-info (gl/gl-info)
-        event {:event_id    (string/replace (str (java.util.UUID/randomUUID)) "-" "")
+        event {:event_id    id
                :message     (.getMessage ex)
                :timestamp   (LocalDateTime/now ZoneOffset/UTC)
                :level       "error"
@@ -92,7 +93,8 @@
                :device      {:name (system/os-name) :version (system/os-version)}
                :culprit     (module-name (.getStackTrace ex))
                :release     (or (system/defold-version) "dev")
-               :tags        {:defold-sha1 (system/defold-sha1)
+               :tags        {:id id
+                             :defold-sha1 (system/defold-sha1)
                              :defold-version (or (system/defold-version) "dev")
                              :os-name (system/os-name)
                              :os-arch (system/os-arch)


### PR DESCRIPTION
### Technical changes

- sentry forgets `event_id` after seven days. Send id as a tag too,
  ensures that we can query for it forever.