### PR TITLE
DEFEDIT-1171 Adapt build process for new editor-alpha channel

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -7,16 +7,17 @@ launcherpath =
 [build]
 # These fields are filled in by bundle.py
 version = 2.0.0
-sha1 = 2.0.0
+editor_sha1 =
+engine_sha1 =
 time =
 [launcher]
 jre = ${bootstrap.resourcespath}/packages/jre
 java = ${launcher.jre}/bin/java
-jar = ${bootstrap.resourcespath}/packages/defold-${build.sha1}.jar
+jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Start
 debug = 1
 updateurl = https://d.defold.com/editor2
-vmargs = -Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.sha1=${build.sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Ddefold.update.url=${launcher.updateurl},-Dglass.accessible.force=false
+vmargs = -Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Ddefold.update.url=${launcher.updateurl},-Dglass.accessible.force=false
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -101,8 +101,7 @@
                       :output-directory "resources/editor.css"
                       :source-maps false}
 
-  :aliases           {"benchmark"     ["with-profile" "+test" "trampoline" "run" "-m" "benchmark.graph-benchmark"]
-                      "do-init"       ["do" "clean," "local-jars," "builtins," "protobuf," "sass" "once," "pack"]}
+  :aliases           {"benchmark"     ["with-profile" "+test" "trampoline" "run" "-m" "benchmark.graph-benchmark"]}
 
   ;; used by `pack` task
   :packing           {:pack-path "resources/_unpack"}

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -101,9 +101,8 @@
                       :output-directory "resources/editor.css"
                       :source-maps false}
 
-  :aliases           {"ci"        ["do" "test," "uberjar"]
-                      "benchmark" ["with-profile" "+test" "trampoline" "run" "-m" "benchmark.graph-benchmark"]
-                      "init"      ["do" "local-jars," "clean," "builtins," "protobuf," "sass" "once," "pack"]}
+  :aliases           {"benchmark"     ["with-profile" "+test" "trampoline" "run" "-m" "benchmark.graph-benchmark"]
+                      "do-init"       ["do" "clean," "local-jars," "builtins," "protobuf," "sass" "once," "pack"]}
 
   ;; used by `pack` task
   :packing           {:pack-path "resources/_unpack"}

--- a/editor/resources/about.fxml
+++ b/editor/resources/about.fxml
@@ -44,22 +44,27 @@
                   <Font size="11.0" />
                </font>
             </Label>
-            <TextField id="sha1" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="2" editable="false" focusTraversable="false" alignment="center" styleClass="copyable-label">
+            <TextField id="editor-sha1" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="2" editable="false" focusTraversable="false" alignment="center" styleClass="copyable-label">
                <font>
                   <Font size="11.0" />
                </font>
             </TextField>
-            <Label id="time" text="Built: n/a" GridPane.rowIndex="3">
+            <TextField id="engine-sha1" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="3" editable="false" focusTraversable="false" alignment="center" styleClass="copyable-label">
+               <font>
+                  <Font size="11.0" />
+               </font>
+            </TextField>
+            <Label id="time" text="Built: n/a" GridPane.rowIndex="5">
                <font>
                   <Font size="11.0" />
                </font>
             </Label>
-            <Label text="Copyright (c) 2011-2017" GridPane.rowIndex="5">
+            <Label text="Copyright (c) 2011-2017" GridPane.rowIndex="6">
                <font>
                   <Font size="11.0" />
                </font>
             </Label>
-            <Label text="Midasplayer Technology AB" GridPane.rowIndex="6">
+            <Label text="Midasplayer Technology AB" GridPane.rowIndex="7">
                <font>
                   <Font size="11.0" />
                </font>

--- a/editor/resources/about.fxml
+++ b/editor/resources/about.fxml
@@ -7,7 +7,6 @@
 <?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 
-
 <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="484.0" stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <top>
       <ImageView fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" BorderPane.alignment="CENTER">
@@ -28,10 +27,12 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
+          <RowConstraints minHeight="10.0" prefHeight="20.0" vgrow="NEVER" />
+          <RowConstraints minHeight="10.0" prefHeight="40.0" vgrow="NEVER" />
+          <RowConstraints minHeight="10.0" prefHeight="40.0" vgrow="NEVER" />
+          <RowConstraints minHeight="10.0" prefHeight="60.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
-            <RowConstraints minHeight="10.0" prefHeight="60.0" vgrow="NEVER" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
         </rowConstraints>
          <children>
             <Label text="Defold Editor">
@@ -44,27 +45,27 @@
                   <Font size="11.0" />
                </font>
             </Label>
-            <TextField id="editor-sha1" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="2" editable="false" focusTraversable="false" alignment="center" styleClass="copyable-label">
-               <font>
-                  <Font size="11.0" />
-               </font>
-            </TextField>
-            <TextField id="engine-sha1" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="3" editable="false" focusTraversable="false" alignment="center" styleClass="copyable-label">
-               <font>
-                  <Font size="11.0" />
-               </font>
-            </TextField>
-            <Label id="time" text="Built: n/a" GridPane.rowIndex="5">
+            <Label id="time" text="Built: n/a" GridPane.rowIndex="2">
                <font>
                   <Font size="11.0" />
                </font>
             </Label>
-            <Label text="Copyright (c) 2011-2017" GridPane.rowIndex="6">
+            <TextField id="editor-sha1" alignment="center" editable="false" focusTraversable="false" styleClass="copyable-label" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="4">
+               <font>
+                  <Font size="11.0" />
+               </font>
+            </TextField>
+            <TextField id="engine-sha1" alignment="center" editable="false" focusTraversable="false" styleClass="copyable-label" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="5">
+               <font>
+                  <Font size="11.0" />
+               </font>
+            </TextField>
+            <Label text="Copyright (c) 2011-2017" GridPane.rowIndex="7">
                <font>
                   <Font size="11.0" />
                </font>
             </Label>
-            <Label text="Midasplayer Technology AB" GridPane.rowIndex="7">
+            <Label text="Midasplayer Technology AB" GridPane.rowIndex="8">
                <font>
                   <Font size="11.0" />
                </font>

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -96,15 +96,14 @@ def git_sha1_from_version_file():
     process = subprocess.Popen(['git', 'rev-list', '-n', '1', version], stdout = subprocess.PIPE)
     out, err = process.communicate()
     if process.returncode != 0:
-        return None
-    else:
-        return out.strip()
+        sys.exit("Unable to find git sha from VERSION file: %s" % (version))
+    return out.strip()
 
 def git_sha1(ref = 'HEAD'):
     process = subprocess.Popen(['git', 'rev-parse', ref], stdout = subprocess.PIPE)
     out, err = process.communicate()
     if process.returncode != 0:
-        sys.exit(process.returncode)
+        sys.exit("Unable to find git sha from ref: %s" % (version))
     return out.strip()
 
 def remove_readonly_retry(function, path, excinfo):
@@ -151,7 +150,6 @@ def launcher_path(options, platform, exe_suffix):
         return launcher
     else:
         return path.join(os.environ['DYNAMO_HOME'], "bin", platform_to_legacy[platform], "launcher%s" % exe_suffix)
-
 
 def bundle(platform, jar_file, options):
     rmtree('tmp')

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -34,6 +34,7 @@
             [editor.hot-reload :as hot-reload]
             [editor.url :as url]
             [editor.view :as view]
+            [editor.system :as system]
             [service.log :as log]
             [internal.util :refer [first-where]]
             [util.profiler :as profiler]
@@ -476,10 +477,11 @@
   (let [root ^Parent (ui/load-fxml "about.fxml")
         stage (ui/make-dialog-stage)
         scene (Scene. root)
-        controls (ui/collect-controls root ["version" "sha1" "time"])]
+        controls (ui/collect-controls root ["version" "editor-sha1" "engine-sha1" "time"])]
     (ui/text! (:version controls) (str "Version: " (System/getProperty "defold.version" "NO VERSION")))
-    (ui/text! (:sha1 controls) (System/getProperty "defold.sha1" "NO SHA1"))
-    (ui/text! (:time controls) (System/getProperty "defold.buildtime" "NO BUILD TIME"))
+    (ui/text! (:editor-sha1 controls) (or (system/defold-editor-sha1) "No editor sha1"))
+    (ui/text! (:engine-sha1 controls) (or (system/defold-engine-sha1) "No engine sha1"))
+    (ui/text! (:time controls) (or (system/defold-build-time) "No build time"))
     (ui/title! stage "About")
     (.setScene stage scene)
     (ui/show! stage)))

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -69,7 +69,7 @@
 (defn- install-pending-update-check! [^Stage stage update-context]
   (let [tick-fn (fn [^AnimationTimer timer _dt]
                   (when-let [pending (updater/pending-update update-context)]
-                    (when (not= pending (system/defold-sha1))
+                    (when (not= pending (system/defold-editor-sha1))
                       (.stop timer) ; we only ask once on the start screen
                       (ui/run-later
                         (when (dialogs/make-pending-update-dialog stage)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -94,7 +94,7 @@
 
 (defn- install-pending-update-check-timer! [^Stage stage ^Label label update-context]
   (let [update-visibility! (fn [] (.setVisible label (let [update (updater/pending-update update-context)]
-                                                       (and (some? update) (not= update (system/defold-sha1))))))
+                                                       (and (some? update) (not= update (system/defold-editor-sha1))))))
         tick-fn (fn [^AnimationTimer timer _dt] (update-visibility!))
         timer (ui/->timer 0.1 "pending-update-check" tick-fn)]
     (update-visibility!)

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -272,7 +272,7 @@
     (unpack-dmengine (find-or-build-engine-archive (cache-dir (workspace/project-path (project/workspace project)))
                                                    build-server
                                                    (get-in extender-platforms [platform :platform])
-                                                   (system/defold-sha1)
+                                                   (system/defold-engine-sha1)
                                                    (merge (global-resource-nodes-by-upload-path project)
                                                           (extension-resource-nodes-by-upload-path project roots platform)))
                      project platform)))

--- a/editor/src/clj/editor/github.clj
+++ b/editor/src/clj/editor/github.clj
@@ -12,13 +12,14 @@
 
 (defn- default-fields
   []
-  {"Defold version" (or (system/defold-version) "dev")
-   "Defold sha"     (or (system/defold-sha1) "")
-   "Build time"     (or (system/defold-build-time) "")
-   "OS name"        (system/os-name)
-   "OS version"     (system/os-version)
-   "OS arch"        (system/os-arch)
-   "Java version"   (system/java-runtime-version)})
+  {"Defold version"    (or (system/defold-version) "dev")
+   "Defold editor sha" (or (system/defold-editor-sha1) "")
+   "Defold engine sha" (or (system/defold-engine-sha1) "")
+   "Build time"        (or (system/defold-build-time) "")
+   "OS name"           (system/os-name)
+   "OS version"        (system/os-version)
+   "OS arch"           (system/os-arch)
+   "Java version"      (system/java-runtime-version)})
 
 (defn- issue-body
   ([fields]

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -129,7 +129,7 @@
         build-server-url (native-extensions/get-build-server-url prefs)
         build-report-path (.getAbsolutePath (io/file output-directory "report.html"))
         bundle-output-path (.getAbsolutePath output-directory)
-        defold-sdk-sha1 (or (system/defold-sha1) "")]
+        defold-sdk-sha1 (or (system/defold-engine-sha1) "")]
     (cond-> {"platform" platform
 
              ;; From AbstractBundleHandler
@@ -193,7 +193,7 @@
   (let [output-path (build-html5-output-path project)
         proj-settings (project/settings project)
         build-server-url (native-extensions/get-build-server-url prefs)
-        defold-sdk-sha1 (or (system/defold-sha1) "")
+        defold-sdk-sha1 (or (system/defold-engine-sha1) "")
         compress-archive? (get proj-settings ["project" "compress_archive"])
         [email auth] (login/credentials prefs)
         bob-commands ["distclean" "build" "bundle"]

--- a/editor/src/clj/editor/sentry.clj
+++ b/editor/src/clj/editor/sentry.clj
@@ -92,7 +92,8 @@
                :device      {:name (system/os-name) :version (system/os-version)}
                :culprit     (module-name (.getStackTrace ex))
                :release     (or (system/defold-version) "dev")
-               :tags        {:defold-sha1 (system/defold-sha1)
+               :tags        {:defold-editor-sha1 (system/defold-editor-sha1)
+                             :defold-engine-sha1 (system/defold-engine-sha1)
                              :defold-version (or (system/defold-version) "dev")
                              :os-name (system/os-name)
                              :os-arch (system/os-arch)

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -27,9 +27,13 @@
   ^String []
   (System/getProperty "defold.resourcespath"))
 
-(defn defold-sha1
+(defn defold-editor-sha1
   ^String []
-  (System/getProperty "defold.sha1"))
+  (System/getProperty "defold.editor.sha1"))
+
+(defn defold-engine-sha1
+  ^String []
+  (System/getProperty "defold.engine.sha1"))
 
 (defn defold-build-time
   ^String []

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -74,7 +74,7 @@
     (.purge)))
 
 (defn start!
-  ([] (start! (system/defold-update-url) (system/defold-sha1) initial-update-delay update-delay))
+  ([] (start! (system/defold-update-url) (system/defold-editor-sha1) initial-update-delay update-delay))
   ([update-url sha1 initial-update-delay update-delay]
    (if (and (not (string/blank? update-url)) (not (string/blank? sha1)))
      (let [update-context (make-update-context update-url sha1)
@@ -82,5 +82,5 @@
        (log/info :message "automatic updates enabled")
        {:timer timer :update-context update-context})
      (do
-       (log/info :message (format "automatic updates disabled (defold.update.url='%s', defold.sha1='%s')" update-url sha1))
+       (log/info :message (format "automatic updates disabled (url='%s', sha1='%s')" update-url sha1))
        nil))))

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -164,7 +164,7 @@ public class Start extends Application {
     }
 
     private void prunePackages() {
-        String sha1 = System.getProperty("defold.sha1");
+        String sha1 = System.getProperty("defold.editor.sha1");
         String resourcesPath = System.getProperty("defold.resourcespath");
         if (sha1 != null && resourcesPath != null) {
             try {

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -27,7 +27,7 @@ public class ResourceUnpacker {
 
     public static final String DEFOLD_UNPACK_PATH_KEY = "defold.unpack.path";
     public static final String DEFOLD_UNPACK_PATH_ENV_VAR = "DEFOLD_UNPACK_PATH";
-    public static final String DEFOLD_SHA1_KEY = "defold.sha1";
+    public static final String DEFOLD_EDITOR_SHA1_KEY = "defold.editor.sha1";
 
     private static boolean isInitialized = false;
     private static Logger logger = LoggerFactory.getLogger(ResourceUnpacker.class);
@@ -122,7 +122,7 @@ public class ResourceUnpacker {
         }
 
         Path supportPath = Editor.getSupportPath();
-        String sha1 = System.getProperty(DEFOLD_SHA1_KEY);
+        String sha1 = System.getProperty(DEFOLD_EDITOR_SHA1_KEY);
         if (supportPath != null && sha1 != null) {
             return ensureDirectory(supportPath.resolve(Paths.get("unpack", sha1)), false);
         }

--- a/editor/tasks/leiningen/builtins.clj
+++ b/editor/tasks/leiningen/builtins.clj
@@ -2,8 +2,13 @@
   (:require [clojure.java.io :as io]
             [leiningen.util.http-cache :as http-cache]))
 
+(defn- builtins-zip
+  [sha]
+  (if sha
+    (http-cache/download (format "https://d.defold.com/archive/%s/engine/share/builtins.zip" sha))
+    (io/file (format "%s/share/builtins.zip" (get (System/getenv) "DYNAMO_HOME")))))
+
 (defn builtins [project & [git-sha]]
-  (let [f (when git-sha
-            (http-cache/download (format "https://d.defold.com/archive/%s/engine/share/builtins.zip" git-sha)))]
-    (io/copy (or f (io/file (format "%s/share/builtins.zip" (get (System/getenv) "DYNAMO_HOME"))))
-      (io/file "generated-resources/builtins.zip"))))
+  (let [sha (or git-sha (:engine project))]
+    (io/copy (builtins-zip sha)
+             (io/file "generated-resources/builtins.zip"))))

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -1,0 +1,65 @@
+(ns leiningen.init
+  (:require
+   [clojure.java.shell :as sh]
+   [clojure.string :as string]
+   [leiningen.core.main :as main]))
+
+(defn- sha-from-version-file
+  []
+  (let [stable-version (slurp "../VERSION")
+        {:keys [exit out err]} (sh/sh "git" "rev-list" "-n" "1" stable-version)]
+    (if (zero? exit)
+      (string/trim out)
+      (throw (ex-info (format "Unable to determine engine version sha from version file, was '%s'" stable-version)
+                      {:exit exit
+                       :out out
+                       :err err})))))
+
+(defn- sha-from-ref
+  [ref]
+  (let [{:keys [exit out err]} (sh/sh "git" "rev-parse" ref)]
+    (if (zero? exit)
+      (string/trim out)
+      (throw (ex-info (format "Unable to determine engine version sha for HEAD")
+                      {:exit exit
+                       :out out
+                       :err err})))))
+
+(defn- head-is-descended-from-branch?
+  [branch]
+  (let [{:keys [exit out err]} (sh/sh "git" "merge-base" "--is-ancestor" branch "HEAD")]
+    (zero? exit)))
+
+(defn- autodetect-sha
+  []
+  (println "Autodetecting which engine artifacts to use")
+  (cond
+    (head-is-descended-from-branch? "origin/dev")
+    (do
+      (println "origin/dev branch: Using artifacts from dynamo-home")
+      nil)
+
+    (head-is-descended-from-branch? "origin/editor-dev")
+    (do
+      (println "origin/editor-dev branch: Using artifacts from VERSION")
+      (sha-from-version-file))
+
+    :else
+    (throw (Exception. "Don't know which artifacts to use for HEAD" ))))
+
+(defn resolve-version
+  [version]
+  (when version
+    (case version
+      "dynamo-home"     nil ; for symmetry
+      "archived-stable" (sha-from-version-file)
+      "archived"        (sha-from-ref "HEAD")
+      "auto"            (autodetect-sha)
+      version)))
+
+(defn init
+  [project & [version]]
+  (let [git-sha (resolve-version version)
+        project (assoc project :engine git-sha)]
+    (println (format "Initializing editor with version '%s', resolved to '%s'" version git-sha))
+    (main/resolve-and-apply project ["do-init"])))

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -58,6 +58,14 @@
       "auto"            (autodetect-sha)
       version)))
 
+(def init-tasks
+  [["clean"]
+   ["local-jars"]
+   ["builtins"]
+   ["protobuf"]
+   ["sass" "once"]
+   ["pack"]])
+
 (defn init
   "Initialise project with required engine artifacts based on `version`, or
   $DYNAMO_HOME if none given.
@@ -68,4 +76,5 @@
   (let [git-sha (resolve-version version)
         project (assoc project :engine git-sha)]
     (println (format "Initializing editor with version '%s', resolved to '%s'" version git-sha))
-    (main/resolve-and-apply project ["do-init"])))
+    (doseq [task+args init-tasks]
+      (main/resolve-and-apply project task+args))))

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -26,10 +26,18 @@
                        :out out
                        :err err})))))
 
+(defn- autodetect-sha
+  []
+  (try
+    (sha-from-version-file)
+    (catch clojure.lang.ExceptionInfo e
+      (sha-from-ref "HEAD"))))
+
 (defn- resolve-version
   [version]
   (when version
     (case version
+      "auto"            (autodetect-sha)
       "dynamo-home"     nil ; for symmetry
       "archived-stable" (sha-from-version-file)
       "archived"        (sha-from-ref "HEAD")

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -26,28 +26,6 @@
                        :out out
                        :err err})))))
 
-(defn- head-is-descended-from-branch?
-  [branch]
-  (let [{:keys [exit out err]} (sh/sh "git" "merge-base" "--is-ancestor" branch "HEAD")]
-    (zero? exit)))
-
-(defn- autodetect-sha
-  []
-  (println "Autodetecting which engine artifacts to use")
-  (cond
-    (head-is-descended-from-branch? "dev")
-    (do
-      (println "dev branch: Using artifacts from dynamo-home")
-      nil)
-
-    (head-is-descended-from-branch? "editor-dev")
-    (do
-      (println "editor-dev branch: Using artifacts from VERSION")
-      (sha-from-version-file))
-
-    :else
-    (throw (Exception. "Don't know which artifacts to use for HEAD"))))
-
 (defn- resolve-version
   [version]
   (when version
@@ -55,7 +33,6 @@
       "dynamo-home"     nil ; for symmetry
       "archived-stable" (sha-from-version-file)
       "archived"        (sha-from-ref "HEAD")
-      "auto"            (autodetect-sha)
       version)))
 
 (def init-tasks
@@ -71,7 +48,7 @@
   $DYNAMO_HOME if none given.
 
   Arguments:
-    - version: dynamo-home, archived, archived-stable, auto or a sha."
+    - version: dynamo-home, archived, archived-stable or a sha."
   [project & [version]]
   (let [git-sha (resolve-version version)
         project (assoc project :engine git-sha)]

--- a/editor/tasks/leiningen/local_jars.clj
+++ b/editor/tasks/leiningen/local_jars.clj
@@ -29,11 +29,12 @@
 
 (defn local-jars
   "Install local jar dependencies into the ~/.m2 Maven repository."
-  [_project & [git-sha]]
-  (let [jar-decls (conj jar-decls {:artifact-id "bob"
-                                      :group-id "com.defold.lib"
-                                      :jar-file (.getAbsolutePath (bob-artifact-file git-sha))
-                                      :version "1.0"})]
+  [project & [git-sha]]
+  (let [sha (or git-sha (:engine project))
+        jar-decls (conj jar-decls {:artifact-id "bob"
+                                   :group-id "com.defold.lib"
+                                   :jar-file (.getAbsolutePath (bob-artifact-file sha))
+                                   :version "1.0"})]
     (doseq [{:keys [group-id artifact-id version jar-file]} (sort-by :jar-file jar-decls)]
       (main/info (format "Installing %s" jar-file))
       (aether/install-artifacts

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -138,13 +138,7 @@
             (FileUtils/copyFile src dest)))))))
 
 (defn pack
-  "Pack all files that need to be unpacked at runtime into `pack-path`.
-
-  Arguments:
-
-    - git-sha [optional]: If supplied, download and use archived engine artifacts
-                          for the given sha. Otherwise use local engine artifacts
-                          when they exist."
+  "Pack all files that need to be unpacked at runtime into `pack-path`."
   [{:keys [dependencies packing] :as project} & [git-sha]]
   (let [sha (or git-sha (:engine project))
         {:keys [pack-path]} packing]

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -146,7 +146,8 @@
                           for the given sha. Otherwise use local engine artifacts
                           when they exist."
   [{:keys [dependencies packing] :as project} & [git-sha]]
-  (let [{:keys [pack-path]} packing]
+  (let [sha (or git-sha (:engine project))
+        {:keys [pack-path]} packing]
     (FileUtils/deleteQuietly (io/file pack-path))
-    (copy-artifacts pack-path git-sha)
+    (copy-artifacts pack-path sha)
     (pack-jogl-natives pack-path dependencies)))

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1004,12 +1004,8 @@ instructions.configure=\
                '--platform=x86_64-linux',
                '--platform=x86-win32',
                '--platform=x86_64-win32',
-               '--version=%s' % self.version]
-
-        if self.channel == 'editor-alpha':
-            cmd += ['--engine-artifacts=archived-stable']
-        else:
-            cmd += ['--engine-artifacts=archived']
+               '--version=%s' % self.version,
+               '--engine-artifacts=auto']
 
         cwd = join(self.defold_root, 'editor')
 


### PR DESCRIPTION
### Technical changes

- Only release_editor2 when channel is 'editor-alpha'. This channel
  does not exist yet, so until it does this means we won't be making
  any releases of editor2 on branches where this change has been
  merged.

- Introduce the notion of engine artifact version, can be either:
    - `dynamo-home` take everything from DYNAMO_HOME
    - `archived` download archived artifacts for HEAD
    - `archived-stable` download archived artifacts for VERSION-file
    - a sha - download archived artifacts for given sha

- bundle.py: Replace bundle arguments `--git-rev` and `--pack-local`
  with a single `--engine-artifacts` argument as above.

- Extend leiningen init task to support engine artifact version as an
  argument.
  - Additionally support an `auto` argument which will initialize
    editor project with artifacts depending on whether HEAD is
    descended from origin/dev (or origin/edutor-dev).