### PR TITLE
DEFEDIT-1169 Include unregistered resource types when browsing for resources

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -398,7 +398,7 @@
 (defn make-resource-dialog [workspace project options]
   (let [exts         (let [ext (:ext options)] (if (string? ext) (list ext) (seq ext)))
         accepted-ext (if (seq exts) (set exts) (constantly true))
-        items        (filter #(and (= :file (resource/source-type %)) (accepted-ext (:ext (resource/resource-type %))))
+        items        (filter #(and (= :file (resource/source-type %)) (accepted-ext (resource/ext %)))
                              (g/node-value workspace :resource-list))
         options (-> {:title "Select Resource"
                      :prompt "Type to filter"


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1312

### User facing changes

- Previously, not all project resource could be found using the
  "Select Resource" dialog. For example, it was not possible to pick a
  "AndroidManifest.xml" file for the "android.manifest" game project
  attribute. This has now been resolved.

### Technical changes

- Look at extension of original resource, instead of registered
  resource type when filtering for resource dialog.