### PR TITLE
DEFEDIT-1167 Fix for "default" spine model skin setting

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -769,7 +769,9 @@
     tmpl args))
 
 (defn- defective-resource-node? [resource-node]
-  (g/error-fatal? (g/node-value resource-node :node-id+resource)))
+  (let [value (g/node-value resource-node :node-id+resource)]
+    (and (g/error? value)
+         (g/error-fatal? value))))
 
 (defn open-resource
   ([app-view prefs workspace project resource]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -583,7 +583,7 @@
                                           (and (g/node-instance? GuiNode node-id)
                                                (not= node-id (g/node-value node-id :parent)))))
                      :children node-outline-children
-                     :outline-error? (some? own-build-errors)
+                     :outline-error? (g/error-fatal? own-build-errors)
                      :outline-overridden? (not (empty? _overridden-properties))}
                     (some-> node-outline-link resource/path) (assoc :link node-outline-link))))
 
@@ -1090,7 +1090,7 @@
 
 (defn- validate-spine-skin [node-id spine-scene-names spine-skin-ids spine-skin spine-scene]
   (when-not (g/error? (validate-spine-scene node-id spine-scene-names spine-scene))
-    (validate-optional-gui-resource "skin '%s' could not be found in the specified spine scene" :spine-skin node-id spine-skin-ids spine-skin)))
+    (spine/validate-skin node-id :spine-skin spine-skin-ids spine-skin)))
 
 (g/defnode SpineNode
   (inherits VisualNode)
@@ -1345,7 +1345,7 @@
                                              (cond-> {:node-id _node-id
                                                       :label name
                                                       :icon texture-icon
-                                                      :outline-error? (some? build-errors)}
+                                                      :outline-error? (g/error-fatal? build-errors)}
                                                texture-resource (assoc :link texture-resource))))
   (output pb-msg g/Any (g/fnk [name texture-resource]
                          {:name name
@@ -1390,7 +1390,7 @@
                                                      (cond-> {:node-id _node-id
                                                               :label name
                                                               :icon font-icon
-                                                              :outline-error? (some? build-errors)}
+                                                              :outline-error? (g/error-fatal? build-errors)}
                                                        font-resource (assoc :link font-resource))))
   (output pb-msg g/Any (g/fnk [name font-resource]
                               {:name name
@@ -1421,7 +1421,7 @@
                                                           {:node-id _node-id
                                                            :label name
                                                            :icon layer-icon
-                                                           :outline-error? (some? build-errors)}))
+                                                           :outline-error? (g/error-fatal? build-errors)}))
   (output pb-msg g/Any (g/fnk [name]
                               {:name name}))
   (output build-errors g/Any :cached (g/fnk [_node-id name name-counts]
@@ -1484,7 +1484,7 @@
                                                           (cond-> {:node-id _node-id
                                                                    :label name
                                                                    :icon spine/spine-scene-icon
-                                                                   :outline-error? (some? build-errors)}
+                                                                   :outline-error? (g/error-fatal? build-errors)}
                                                             spine-scene-resource (assoc :link spine-scene-resource))))
   (output pb-msg g/Any (g/fnk [name spine-scene]
                               {:name name
@@ -1526,7 +1526,7 @@
                                                      (cond-> {:node-id _node-id
                                                               :label name
                                                               :icon particlefx/particle-fx-icon
-                                                              :outline-error? (some? build-errors)}
+                                                              :outline-error? (g/error-fatal? build-errors)}
                                                        particlefx-resource (assoc :link particlefx-resource))))
   (output pb-msg g/Any (g/fnk [name particlefx]
                               {:name name
@@ -1593,7 +1593,7 @@
                                                           {:node-id _node-id
                                                            :label name
                                                            :icon layout-icon
-                                                           :outline-error? (some? build-errors)}))
+                                                           :outline-error? (g/error-fatal? build-errors)}))
   (output pb-msg g/Any :cached (g/fnk [name node-msgs] (layout-pb-msg name node-msgs)))
   (output pb-rt-msg g/Any :cached (g/fnk [name node-rt-msgs] (layout-pb-msg name node-rt-msgs)))
   (input node-tree-node-outline g/Any)
@@ -2022,7 +2022,7 @@
                     :label (:label pb-def)
                     :icon (:icon pb-def)
                     :children (vec (sort-by :order (conj child-outlines node-outline)))
-                    :outline-error? (some? own-build-errors)})))
+                    :outline-error? (g/error-fatal? own-build-errors)})))
   (input default-scene g/Any)
   (input layout-scenes g/Any :array)
   (output layout-scenes g/Any :cached (g/fnk [layout-scenes] (into {} layout-scenes)))
@@ -2574,19 +2574,8 @@
       ;; Size mode is not applicable for text nodes, but might still be stored in the files from editor1
       (dissoc node :size-mode))))
 
-(defn- sanitize-gui-scene [scene]
+(defn- sanitize-scene [scene]
   (update scene :nodes (partial mapv sanitize-node)))
-
-(defn- migrate-node [node]
-  ;; For a period of time, it was possible to select "default" as the spine skin.
-  ;; This value ended up in the file format, but it should have been an
-  ;; empty string in order to be compatible with the old editor and Bob.
-  (cond-> node
-          (= "default" (:spine-skin node))
-          (assoc :spine-skin "")))
-
-(defn- migrate-gui-scene [scene]
-  (update scene :nodes (partial mapv migrate-node)))
 
 (defn- register [workspace def]
   (let [ext (:ext def)
@@ -2599,8 +2588,7 @@
         :node-type GuiSceneNode
         :ddf-type (:pb-class def)
         :load-fn load-gui-scene
-        :sanitize-fn sanitize-gui-scene
-        :migrate-fn migrate-gui-scene
+        :sanitize-fn sanitize-scene
         :icon (:icon def)
         :tags (:tags def)
         :tag-opts (:tag-opts def)

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -75,13 +75,20 @@
                                 (g/error-fatal (format "Cannot build resource of type '%s'" (resource/ext resource)))))
   (output save-value g/Any (g/constantly nil)))
 
-(defn register-ddf-resource-type [workspace & {:keys [ext node-type ddf-type load-fn sanitize-fn icon view-types tags tag-opts label] :as args}]
+(defn register-ddf-resource-type [workspace & {:keys [ext node-type ddf-type load-fn sanitize-fn migrate-fn icon view-types tags tag-opts label] :as args}]
+  ;; Supply a sanitize-fn when you want to "clean" the data but only write the sanitized data to disk after the user edits the file.
+  ;; Conversely, you can supply a migrate-fn if you want the migrated data to be written to disk on the next save.
+  ;; If both are supplied, the result of sanitize-fn will be fed into migrate-fn before being passed off to load-fn.
+  ;; Thus, sanitize-fn must be able to handle un-migrated data.
   (let [read-fn (comp (or sanitize-fn identity) (partial protobuf/read-text ddf-type))
         args (assoc args
                :textual? true
                :load-fn (fn [project self resource]
-                          (let [source-value (read-fn resource)]
-                            (load-fn project self resource source-value)))
+                          (let [source-value (read-fn resource)
+                                migrated-value (if (nil? migrate-fn)
+                                                 source-value
+                                                 (migrate-fn source-value))]
+                            (load-fn project self resource migrated-value)))
                :read-fn read-fn
                :write-fn (partial protobuf/map->str ddf-type))]
     (apply workspace/register-resource-type workspace (mapcat identity args))))

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -814,15 +814,13 @@
                            (disj (set spine-skins) "default"))))
 
 (defn- validate-model-default-animation [node-id spine-scene spine-anim-ids default-animation]
-  (when spine-scene
-    (or
-      (validation/prop-error :fatal node-id :default-animation validation/prop-empty? default-animation "Default Animation")
-      (validation/prop-error :fatal node-id :default-animation
-                             (fn [anim ids]
-                               (when-not (contains? ids anim)
-                                 (format "animation '%s' could not be found in the specified spine scene" anim)))
-                             default-animation
-                             (set spine-anim-ids)))))
+  (when (and spine-scene (not-empty default-animation))
+    (validation/prop-error :fatal node-id :default-animation
+                           (fn [anim ids]
+                             (when-not (contains? ids anim)
+                               (format "animation '%s' could not be found in the specified spine scene" anim)))
+                           default-animation
+                           (set spine-anim-ids))))
 
 (defn- validate-model-material [node-id material]
   (prop-resource-error :info node-id :material material "Material"))

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -106,8 +106,10 @@
            error-aggregate))
 
 (defmacro precluding-errors [errors result]
-  `(or (flatten-errors ~errors)
-       ~result))
+  `(let [error-value# (flatten-errors ~errors)]
+     (if (worse-than :info error-value#)
+       error-value#
+       ~result)))
 
 (defn package-errors [node-id & errors]
   (assert (gt/node-id? node-id))

--- a/editor/test/internal/graph/error_values_test.clj
+++ b/editor/test/internal/graph/error_values_test.clj
@@ -37,7 +37,6 @@
     (is (not (error? (package-errors 12345 (error-fatal ""))))))
 
   (testing "Packaged errors support severity testing"
-    (is (error-info? (package-errors 12345)))
     (is (error-info? (package-errors 12345 (error-info ""))))
     (is (error-warning? (package-errors 12345 (error-info "") (error-warning ""))))
     (is (error-fatal? (package-errors 12345 (error-info "") (error-warning "") (error-fatal "")))))
@@ -65,6 +64,7 @@
                                                                         (error-fatal "2bb")]]))))))
 
   (testing "Packaging returns nil if no errors"
+    (is (nil? (package-errors 12345)))
     (is (nil? (package-errors 12345 nil)))
     (is (nil? (package-errors 12345
                               nil
@@ -107,3 +107,13 @@
                                                         :severity :fatal
                                                         :causes [(error-fatal "wrapped")]})]})
            (flatten-errors (package-errors 12345 (error-fatal "wrapped")))))))
+
+(deftest precluding-errors-test
+  (testing "The precluding-errors macro returns fatal errors before the result"
+    (is (error-fatal? (precluding-errors [(error-info "") (error-warning "") (error-fatal "")] :the-result))))
+
+  (testing "The precluding-errors macro returns warnings before the result"
+    (is (error-warning? (precluding-errors [(error-info "") (error-warning "")] :the-result))))
+
+  (testing "The precluding-errors macro returns the result before infos"
+    (is (= :the-result (precluding-errors [(error-info "")] :the-result)))))

--- a/editor/test/internal/graph/error_values_test.clj
+++ b/editor/test/internal/graph/error_values_test.clj
@@ -36,6 +36,12 @@
   (testing "Packaged errors are not errors"
     (is (not (error? (package-errors 12345 (error-fatal ""))))))
 
+  (testing "Packaged errors support severity testing"
+    (is (error-info? (package-errors 12345)))
+    (is (error-info? (package-errors 12345 (error-info ""))))
+    (is (error-warning? (package-errors 12345 (error-info "") (error-warning ""))))
+    (is (error-fatal? (package-errors 12345 (error-info "") (error-warning "") (error-fatal "")))))
+
   (testing "Unpacking an error"
     (let [node-id 12345
           error (error-fatal "wrapped")


### PR DESCRIPTION
Fixes defold/editor2-issues#1049
Fixes defold/editor2-issues#1296

### Background
In the new editor, selecting the default skin from the dropdown would write the string `"default"` to the file. The old editor and the Bob build pipeline expects an empty string for the skin property when the default skin should be used. Effectively, the project will build and run just fine, but when bundling, these spine models will not render. You don't get an error - the models are just gone.

We're now in a situation where projects edited with the new editor can contain invalid references to the default skin inside `.spinemodel` resources. Instead of auto-migrating the project files, we thought it better if the user got a build error so they can fix it themselves.

### User-facing changes
* We now treat these invalid references as errors. The user will have to go in and manually fix instances where the `"default"` skin reference has been written to the `.spinemodel` resource.
* Bad property settings on Spine Scenes and Spine Models now produce errors during build.
* Spine Scenes and Spine Models with bad property settings are highlighted in the Outline panel.

### Technical changes
* The `g/precluding-errors` macro no longer treat `:info` `ErrorValues` as errors.
* The `ErrorValue` severity testing functions such as `g/error-fatal?` and `g/worse-than` now work on `ErrorPackages` as well as `ErrorValues`.
* Introduced `own-build-errors` output on base `ResourceNode`. If producing errors, the `ResourceNode` will be marked as faulty in the Outline panel.
* Default `node-outline` implementation on `ResourceNode` will highlight the node as overridden in case it has overridden properties.
