### PR TITLE
DEFEDIT-1175 Smarter auto-increment when generating unique object names and ids

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -225,7 +225,7 @@
   (let [suffix (string/replace basename original-basename "")]
     (if (.isEmpty suffix)
       (str original-basename "1")
-      (str original-basename (str (inc (Integer/parseInt suffix)))))))
+      (str original-basename (inc (bigint suffix))))))
 
 (defmulti resolve-conflicts (fn [strategy src-dest-pairs] strategy))
 

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -201,7 +201,8 @@
             parent-outline (g/node-value parent-id :node-outline)
             child-id (serial-id->node-id child-serial-id)
             child-node (id->node child-id)
-            [item reqs] (match-reqs [child-node] parent-outline)]
+            [item reqs] (or (match-reqs [child-node] parent-outline)
+                            (match-reqs [child-node] (:alt-outline parent-outline)))]
         (attach-pasted-nodes! op-label op-seq item reqs [child-id])))
     (when select-fn
       (g/transact

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -277,10 +277,19 @@
                               {:id id
                                :lookup lookup}))))
 
+(defn- trim-digits
+  ^String [^String id]
+  (loop [index (.length id)]
+    (if (zero? index)
+      ""
+      (if (Character/isDigit (.charAt id (unchecked-dec index)))
+        (recur (unchecked-dec index))
+        (.. id (subSequence 0 index) toString)))))
+
 (defn resolve-id [id ids]
   (let [ids (ids->lookup ids)]
     (if (ids id)
-      (let [prefix id]
+      (let [prefix (trim-digits id)]
         (loop [suffix ""
                index 1]
           (let [id (str prefix suffix)]

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -300,7 +300,7 @@
       ""
       (if (Character/isDigit (.charAt id (unchecked-dec index)))
         (recur (unchecked-dec index))
-        (.. id (subSequence 0 index) toString)))))
+        (subs id 0 index)))))
 
 (defn resolve-id [id ids]
   (let [ids (ids->lookup ids)]

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -459,6 +459,8 @@
   [anim-ids]
   (sort-by str/lower-case anim-ids))
 
+(declare ParticleFXNode)
+
 (g/defnode EmitterNode
   (inherits scene/SceneNode)
   (inherits outline/OutlineNode)
@@ -561,16 +563,15 @@
   (output transform-properties g/Any scene/produce-unscalable-transform-properties)
   (output scene g/Any :cached produce-emitter-scene)
   (output pb-msg g/Any :cached produce-emitter-pb)
-  (output node-outline outline/OutlineData :cached
-    (g/fnk [_node-id id child-outlines]
-      (let [pfx-id (core/scope _node-id)]
-        {:node-id _node-id
-         :label id
-         :icon emitter-icon
-         :children (outline/natural-sort child-outlines)
-         :child-reqs [{:node-type ModifierNode
-                       :tx-attach-fn (fn [self-id child-id]
-                                       (attach-modifier pfx-id self-id child-id))}]})))
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id id child-outlines]
+                                                     {:node-id _node-id
+                                                      :label id
+                                                      :icon emitter-icon
+                                                      :children (outline/natural-sort child-outlines)
+                                                      :child-reqs [{:node-type ModifierNode
+                                                                    :tx-attach-fn (fn [self-id child-id]
+                                                                                    (let [pfx-id (core/scope-of-type self-id ParticleFXNode)]
+                                                                                      (attach-modifier pfx-id self-id child-id)))}]}))
   (output aabb AABB (g/fnk [type emitter-key-size-x emitter-key-size-y emitter-key-size-z]
                            (let [[x y z] (mapv props/sample [emitter-key-size-x emitter-key-size-y emitter-key-size-z])
                                  [w h d] (case type

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -46,7 +46,7 @@
             (when c (Character/isDigit c)))
           (complete-chunk [state ^StringBuilder sb]
             (case state
-              :digit (Integer/parseInt (.toString sb))
+              :digit (bigint (.toString sb))
               :other (string/lower-case (.toString sb))))]
     (loop [[c & cs]          (seq s)
            state             (if (digit? c) :digit :other)

--- a/editor/test/editor/util_test.clj
+++ b/editor/test/editor/util_test.clj
@@ -18,4 +18,6 @@
        ;; numbers
        ["a1" "a"] ["a" "a1"]
        ["a1" "a10" "a2"] ["a1" "a2" "a10"]
-       ["a2" "b" "a1"] ["a1" "a2" "b"]))
+       ["a2" "b" "a1"] ["a1" "a2" "b"]
+       ;; really large numbers (these have one more digit than Long/MAX_VALUE)
+       ["a10000000000000000001" "a10000000000000000000"] ["a10000000000000000000" "a10000000000000000001"]))

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -4,7 +4,9 @@
             [dynamo.graph :as g]
             [support.test-support :refer [with-clean-system]]
             [editor.app-view :as app-view]
+            [editor.collection :as collection]
             [editor.defold-project :as project]
+            [editor.game-object :as game-object]
             [editor.outline :as outline]
             [integration.test-util :as test-util]))
 
@@ -435,6 +437,47 @@
       (paste! project app-view root)
       (is (= 5 (child-count root)))
       (is (some? (g/node-value (:node-id (outline root [3])) :scene))))))
+
+(deftest copied-contents
+  (test-util/with-loaded-project
+    (let [root (test-util/resource-node project "/collection/sub_sub_props.collection")]
+      ;; Original tree
+      ;; Collection (collection "/collection/sub_sub_props.collection")
+      ;; + sub_props (collection "/collection/sub_props.collection")
+      ;;   + props (collection "/collection/props.collection")
+      ;;     + props (game_object "/game_object/props.go")
+      ;;       + script (script "/script/props.script")
+      ;;     + props_embedded (game-object)
+      ;;       + script (script "/script/props.script")
+
+      ;; Copy "props_embedded" game_object.
+      (is (= "props_embedded" (:label (outline root [0 0 1]))))
+      (let [{:keys [arcs attachments nodes]} (#'outline/deserialize (copy! root [0 0 1]))
+            serial-id->node-type (into {} (map (juxt :serial-id :node-type)) nodes)]
+
+        (is (= {0 collection/EmbeddedGOInstanceNode
+                1 game-object/GameObjectNode
+                2 game-object/ReferencedComponent}
+               serial-id->node-type))
+
+        ;; When pasting, we will invoke the tx-attach-fn from the matching req.
+        ;; In this case, EmbeddedGOInstanceNode will select the GameObjectNode
+        ;; as the parent for the pasted ReferencedComponent.
+        (is (= [[0 2]]
+               (sort attachments)))
+
+        ;; Copied arcs should not include connections made by the tx-attach-fn
+        ;; selected to attach the ReferencedComponent to the GameObjectNode.
+        (is (= [[0 :url 1 :base-url]
+                [1 :_node-id 0 :source-id]
+                [1 :build-targets 0 :source-build-targets]
+                [1 :ddf-component-properties 0 :ddf-component-properties]
+                [1 :node-outline 0 :source-outline]
+                [1 :proto-msg 0 :proto-msg]
+                [1 :resource 0 :source-resource]
+                [1 :save-data 0 :source-save-data]
+                [1 :scene 0 :scene]]
+               (sort arcs)))))))
 
 (deftest drag-drop-between-referenced-collections
   (test-util/with-loaded-project

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -835,3 +835,27 @@
       (add-child-game-object! root [0 0 1])
       (is (= 2 (child-count root [0 0 1])))
       (is (= 4 (count (keys (g/node-value props-collection :go-inst-ids))))))))
+
+(deftest resolve-id-test
+  (testing "Single ids"
+    (are [expected-id candidate-id taken-ids]
+      (do (is (= expected-id (outline/resolve-id candidate-id taken-ids)))
+          (is (= [expected-id] (outline/resolve-ids [candidate-id] taken-ids))))
+
+      "sprite" "sprite" #{""}
+      "sprite2" "sprite2" #{"sprite"}
+      "sprite1" "sprite" #{"sprite"}
+      "sprite2" "sprite" #{"sprite" "sprite1"}
+      "sprite2" "sprite1" #{"sprite" "sprite1"}
+      "sprite1" "sprite" #{"sprite" "sprite2"}
+      "sprite" "sprite1" #{"sprite1" "sprite2"}))
+
+  (testing "Multiple ids"
+    (is (= ["sprite" "sprite1" "sprite2"]
+           (outline/resolve-ids ["sprite" "sprite" "sprite"] #{})))
+
+    (is (= ["sprite3" "sprite4" "sprite5"]
+           (outline/resolve-ids ["sprite" "sprite" "sprite"] #{"sprite" "sprite1" "sprite2"})))
+
+    (is (= ["sprite3" "sprite4" "sprite5"]
+           (outline/resolve-ids ["sprite1" "sprite2" "sprite3"] #{"sprite" "sprite1" "sprite2"})))))


### PR DESCRIPTION
Fixes defold/editor2-issues#328
Fixes defold/editor2-issues#683
Fixes defold/editor2-issues#1220

### User-facing changes
* Smarter auto-increment when generating unique object names and ids.
* Having really large numbers in object names no longer causes arithmetic overflow.

### Technical changes
* When copying, any arcs produced by a `:tx-attach-fn` will be excluded, since these will be established by the `:tx-attach-fn` when pasting.
* When pasting multiple items, we perform individual transactions for each pasted item so each `:tx-attach-fn` will be able to see the names of nodes that were pasted alongside them.
* We now look up matching reqs under `:alt-outline` is a few places we'd missed to do so.