### PR TITLE
DEFEDIT-1177 Render 3d AABBs as boxes, not rectangles

### DIFF
--- a/editor/src/clj/editor/collada_scene.clj
+++ b/editor/src/clj/editor/collada_scene.clj
@@ -163,10 +163,8 @@
 
       (= pass pass/outline)
       (let [renderable (first renderables)
-            node-id (:node-id renderable)
-            outline-vertex-binding (vtx1/use-with [node-id ::outline] (render/gen-outline-vb renderables rcount) render/shader-outline)]
-        (gl/with-gl-bindings gl render-args [render/shader-outline outline-vertex-binding]
-          (gl/gl-draw-arrays gl GL/GL_LINES 0 (* rcount 8)))))))
+            node-id (:node-id renderable)]
+        (render/render-aabb-outline gl render-args [node-id ::outline] renderables rcount)))))
 
 (g/defnk produce-animation-set [resource content]
   (let [animation-set (:animation-set content)

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -671,9 +671,7 @@
   (let [pass (:pass render-args)]
     (cond
       (= pass pass/outline)
-      (let [outline-vertex-binding (vtx/use-with ::spine-outline (render/gen-outline-vb renderables rcount) render/shader-outline)]
-        (gl/with-gl-bindings gl render-args [render/shader-outline outline-vertex-binding]
-          (gl/gl-draw-arrays gl GL/GL_LINES 0 (* rcount 8))))
+      (render/render-aabb-outline gl render-args ::spine-outline renderables rcount)
 
       (= pass pass/transparent)
       (do (when-let [vb (gen-vb renderables)]


### PR DESCRIPTION
### User facing changes

- Bounding boxes for 3d objects are now rendered as boxes, not flat rectangles.

### Technical changes

- Introduce render/render-aabb-outline that knows how to draw a line
  box given an AABB.