### PR TITLE
DEFEDIT-1179 Support basic auth for dependencies

### DIFF
--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -650,3 +650,17 @@
             (project/build project game-project {})
             (is (not (= initial-some-mtime (mtime (build-path workspace "/assets/some.stuff")))))
             (is (= initial-some2-mtime (mtime (build-path workspace "/assets/some2.stuff"))))))))))
+
+(deftest dependencies-are-removed-from-game-project
+  (test-util/with-loaded-project project-path
+    (let [path           "/game.project"
+          game-project   (test-util/resource-node project path)
+          dependency-url "http://localhost:1234/dependency.zip"]
+      (game-project/set-setting! game-project ["project" "dependencies"] dependency-url)
+      (let [build-results        (project/build project game-project {})
+            content-by-source    (into {} (keep #(when-let [r (:resource (:resource %))]
+                                                   [(resource/proj-path r) (content-bytes %)]))
+                                       build-results)
+            content              (get content-by-source "/game.project")
+            game-project-content (String. content)]
+        (is (not (.contains game-project-content dependency-url)))))))


### PR DESCRIPTION
### User facing changes

- You can now use dependencies hosted in locations protected by HTTP
  basic auth by supplying credentials in the dependency URL. For
  example:

     http://username:password@some.location.com/my-dependency.zip

  To prevent credentials from being exposed in a bundled application,
  the "project.depdendencies" setting is removed from game.project
  when building, and can not be retrieved at runtime.

### Technical changes

- support basic auth form dependency URLs
- filter "project.dependencies" when building `game.project`