### PR TITLE
Can't set scale 0 in factory.create (DEF-2862)

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -277,10 +277,6 @@ namespace dmGameSystem
             else
             {
                 float val = luaL_checknumber(L, 5);
-                if (val <= 0.0f)
-                {
-                    return luaL_error(L, "The scale supplied to factory.create must be greater than 0.");
-                }
                 scale = Vector3(val, val, val);
             }
         }


### PR DESCRIPTION
Description:
Can't set scale to 0 in factory create, but I can animate to 0 with go.animate.

Expected result:
I should be able to set it.

Actual result:
Get error saying 0 isn't supported, which is super strange.
2017-10-23 16:08:25 (Bjorn.Ritzl)
This issue is pretty weird and inconsistent. We currently allow a vector3(0, 0, 0) but not passing scale of 0. [~M.Westerdahl] had a suspicion that this was connected to issues with physics components and physics systems not really liking a scale of 0 (which makes sense). If I set a vector3(0,0,0) the physics will ignore this value and instead treat it as 1.0. My suggestion is that we remove the check for a scale of 0.0 and allow this (just like we allow a vector3 of 0.0) and instead focus on improving the physics so that it allows run-time scaling of collision components (like Mathias experimented with during an exploration day)
2017-10-23 16:19:45 (Bjorn.Ritzl)
PR: (LINK REMOVED)
2017-10-25 06:49:14 (Bjorn.Ritzl)
PR not accepted. Physics scaling must be addressed on a larger level.