### PR TITLE
DEF-1286 physics.ray_cast crashes engine when using vectors with z component and project uses 2D physics

### DIFF
--- a/engine/engine/src/test/ray_cast/ray_cast.script
+++ b/engine/engine/src/test/ray_cast/ray_cast.script
@@ -29,6 +29,18 @@ function init(self)
 	physics.ray_cast(from, go.get_position("trigger_b"), { A, B }, 10)		-- miss
 	physics.ray_cast(from, go.get_position("miss"), { A, B }, 11)			-- miss
 
+	-- ray cast with zero length
+	local from3d = go.get_position("dynamic_b")
+	local to3d = go.get_position("dynamic_b")
+	physics.ray_cast(from3d, to3d, { A, B }, 12)							-- zero length ray
+
+	-- ray cast with zero length (ignoring z-value variation)
+	local from2d = go.get_position("dynamic_b")
+	local to2d = go.get_position("dynamic_b")
+	from2d.z = -1
+	to2d.z = 1
+	physics.ray_cast(from2d, to2d, { A, B }, 13)							-- zero length ray
+
 	self.frame_count = 0
 	self.messages = {}
 end
@@ -51,6 +63,9 @@ function update(self, dt)
 
 		assert(m[10] and m[10].message_id == MISS)
 		assert(m[11] and m[11].message_id == MISS)
+
+		assert(not m[12])
+		assert(not m[13])
 
 		msg.post("main:/main#script", "done")
 	end

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -897,7 +897,10 @@ namespace dmPhysics
         if (!world->m_RayCastRequests.Full())
         {
             // Verify that the ray is not 0-length
-            if (Vectormath::Aos::lengthSqr(request.m_To - request.m_From) <= 0.0f)
+            // We need to remove the z-value before calculating length (DEF-1286)
+            const Vectormath::Aos::Point3 from2d = Vectormath::Aos::Point3(request.m_From.getX(), request.m_From.getY(), 0.0);
+            const Vectormath::Aos::Point3 to2d = Vectormath::Aos::Point3(request.m_To.getX(), request.m_To.getY(), 0.0);
+            if (Vectormath::Aos::lengthSqr(to2d - from2d) <= 0.0f)
             {
                 dmLogWarning("Ray had 0 length when ray casting, ignoring request.");
             }


### PR DESCRIPTION
Ignore the z-component when checking length of ray in physics 2D