### PR TITLE
DEFEDIT-1180 Updated copyright start year in About box to match splash screen

### DIFF
--- a/editor/resources/about.fxml
+++ b/editor/resources/about.fxml
@@ -60,7 +60,7 @@
                   <Font size="11.0" />
                </font>
             </TextField>
-            <Label text="Copyright (c) 2011-2017" GridPane.rowIndex="7">
+            <Label text="Copyright (c) 2009-2017" GridPane.rowIndex="7">
                <font>
                   <Font size="11.0" />
                </font>


### PR DESCRIPTION
Fixes defold/editor2-issues#275

### User-facing changes
* Updated copyright start year in About box to match splash screen.