### PR TITLE
DEFEDIT-1181 When opening a existing project it doesnt default to where the projects are saved

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -248,7 +248,10 @@
         (.layout sp)))))
 
 (handler/defhandler :open-project :global
-  (run [] (when-let [file-name (ui/choose-file "Open Project" "Project Files" ["*.project"])]
+  (run [] (when-let [file-name (some-> (ui/choose-file {:title "Open Project"
+                                                        :filters [{:description "Project Files"
+                                                                   :exts ["*.project"]}]})
+                                       (.getAbsolutePath))]
             (EditorApplication/openEditor (into-array String [file-name])))))
 
 (handler/defhandler :logout :global

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -78,6 +78,8 @@
     (.setOnShown stage (ui/event-handler event (ui/timer-start! timer)))
     (.setOnHiding stage (ui/event-handler event (ui/timer-stop! timer)))))
 
+(def ^:const open-project-directory "open-project-directory")
+
 (defn open-welcome [prefs update-context cont]
   (let [^VBox root (ui/load-fxml "welcome.fxml")
         stage (ui/make-dialog-stage)
@@ -90,13 +92,19 @@
       (install-pending-update-check! stage update-context))
 
     (ui/set-main-stage stage)
-    (ui/on-action! open-project (fn [_] (when-let [file-name (ui/choose-file "Open Project" "Project Files" ["*.project"])]
+    (ui/on-action! open-project (fn [_] (when-let [file (ui/choose-file {:title "Open Project"
+                                                                                 :directory (prefs/get-prefs prefs open-project-directory nil)
+                                                                                 :filters [{:description "Project Files"
+                                                                                            :exts ["*.project"]}]})]
+                                          (when (.isFile file)
+                                            (prefs/set-prefs prefs open-project-directory (.getParent file)))
+
                                           (ui/close! stage)
-                                          ; NOTE (TODO): We load the project in the same class-loader as welcome is loaded from.
-                                          ; In other words, we can't reuse the welcome page and it has to be closed.
-                                          ; We should potentially changed this when we have uberjar support and hence
-                                          ; faster loading.
-                                          (cont file-name))))
+                                          ;; NOTE (TODO): We load the project in the same class-loader as welcome is loaded from.
+                                          ;; In other words, we can't reuse the welcome page and it has to be closed.
+                                          ;; We should potentially changed this when we have uberjar support and hence
+                                          ;; faster loading.
+                                          (cont (.getAbsolutePath file)))))
 
     (ui/on-action! import-project (fn [_] (when-let [file-name (import/open-import-dialog prefs)]
                                             (ui/close! stage)

--- a/editor/src/clj/editor/bundle.clj
+++ b/editor/src/clj/editor/bundle.clj
@@ -156,7 +156,10 @@
 (handler/defhandler ::select-provisioning-profile :dialog
   (enabled? [] true)
   (run [stage controls]
-    (let [f (ui/choose-file "Select Provisioning Profile" "Provisioning Profile (*.mobileprovision)" ["*.mobileprovision"])]
+    (let [f (some-> (ui/choose-file {:title "Select Provisioning Profile"
+                                     :filters [{:description "Provisioning Profile (*.mobileprovision)"
+                                                :exts ["*.mobileprovision"]}]})
+                    (.getAbsolutePath))]
       (ui/text! (:provisioning-profile controls) f))))
 
 (handler/defhandler ::select-build-dir :dialog

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -164,13 +164,16 @@
            (.initOwner stage owner)))
      stage)))
 
-(defn choose-file [title ^String ext-descr exts]
-  (let [chooser (FileChooser.)
-        ext-array (into-array exts)]
-    (.setTitle chooser title)
-    (.add (.getExtensionFilters chooser) (FileChooser$ExtensionFilter. ext-descr ^"[Ljava.lang.String;" ext-array))
-    (let [file (.showOpenDialog chooser nil)]
-      (if file (.getAbsolutePath file)))))
+(defn ^File choose-file [{:keys [^String title ^String directory filters] :or {title "Choose File"}}]
+  (let [chooser (doto (FileChooser.)
+                  (.setTitle title))]
+    (when-let [initial-directory (some-> directory (File.))]
+      (when (.isDirectory initial-directory)
+        (.setInitialDirectory chooser initial-directory)))
+    (doseq [{:keys [^String description exts]} filters]
+      (let [ext-array (into-array exts)]
+        (.add (.getExtensionFilters chooser) (FileChooser$ExtensionFilter. description ^"[Ljava.lang.String;" ext-array))))
+    (.showOpenDialog chooser nil)))
 
 (defn choose-directory
   ([title ^File initial-dir] (choose-directory title initial-dir @*main-stage*))


### PR DESCRIPTION
Fixes: defold/editor2-issues#155

* User facing changes
  - When opening a project with "From Disk" the directory will be used
  as initial directory the next time.

* Technical changes
  - ui/choose-file now takes an "options" parameter for specifying
  title, initial directory and file filters (description + extensions)
  - new preference for open project directory