### PR TITLE
DEFEDIT-1183 Use variable precision for numeric properties

### DIFF
--- a/editor/src/clj/editor/field_expression.clj
+++ b/editor/src/clj/editor/field_expression.clj
@@ -1,13 +1,17 @@
 (ns editor.field-expression
   (:require [clojure.string :as string]
-            [editor.math :as math]))
+            [editor.math :as math])
+  (:import (java.text DecimalFormat DecimalFormatSymbols)
+           (java.util Locale)))
+
+(set! *warn-on-reflection* true)
 
 (defn- parsable-number-format [text]
   (-> text
       (string/replace \, \.)))
 
 (defn- evaluate-expression [parse-fn precision text]
-  (if-let [matches (re-find #"(.+?)\s*([\+\-*/])\s*(.+)" text)]
+  (if-let [matches (re-find #"(.+?)\s*((?<![Ee])[\+\-*/])\s*(.+)" text)]
     (let [a (parse-fn (parsable-number-format (matches 1)))
           b (parse-fn (parsable-number-format (matches 3)))
           op (resolve (symbol (matches 2)))]
@@ -20,8 +24,25 @@
     (catch Throwable _
       nil)))
 
+(defn format-int
+  ^String [n]
+  (str n))
+
 (defn to-double [s]
  (try
    (evaluate-expression #(Double/parseDouble %) 0.01 s)
    (catch Throwable _
      nil)))
+
+(def ^:private ^DecimalFormat double-decimal-format
+  (doto (DecimalFormat. "0"
+                        (doto (DecimalFormatSymbols. Locale/ROOT)
+                          (.setInfinity (Double/toString Double/POSITIVE_INFINITY))
+                          (.setNaN (Double/toString Double/NaN))))
+    ;; Upper limit on fraction digits for a Java double.
+    ;; Taken from private constant DecimalFormat/DOUBLE_FRACTION_DIGITS.
+    (.setMaximumFractionDigits 340)))
+
+(defn format-double
+  ^String [n]
+  (.format double-decimal-format n))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -48,21 +48,21 @@
 
 (declare update-field-message)
 
-(defn- update-multi-text-fn [texts get-fns values message read-only?]
+(defn- update-multi-text-fn [texts format-fn get-fns values message read-only?]
   (update-field-message texts message)
   (doseq [[^TextInputControl text get-fn] (map vector texts get-fns)]
     (doto text
-      (ui/text! (str (properties/unify-values (map get-fn values))))
+      (ui/text! (format-fn (properties/unify-values (map get-fn values))))
       (ui/editable! (not read-only?)))
     (if (ui/focus? text)
       (.selectAll text)
       (.home text))))
 
 (defn- update-text-fn
-  ([^TextInputControl text values message read-only?]
-    (update-text-fn text identity values message read-only?))
-  ([^TextInputControl text get-fn values message read-only?]
-    (update-multi-text-fn [text] [get-fn] values message read-only?)))
+  ([^TextInputControl text format-fn values message read-only?]
+    (update-text-fn text format-fn identity values message read-only?))
+  ([^TextInputControl text format-fn get-fn values message read-only?]
+    (update-multi-text-fn [text] format-fn [get-fn] values message read-only?)))
 
 (defn edit-type->type [edit-type]
   (or (some-> edit-type :type g/value-type-dispatch-value)
@@ -103,7 +103,7 @@
 
 (defmethod create-property-control! g/Str [_ _ property-fn]
   (let [text         (TextField.)
-        update-ui-fn (partial update-text-fn text)
+        update-ui-fn (partial update-text-fn text str)
         update-fn    (fn [_]
                        (properties/set-values! (property-fn) (repeat (.getText text))))]
     (customize! text update-fn)
@@ -111,7 +111,7 @@
 
 (defmethod create-property-control! g/Int [_ _ property-fn]
   (let [text         (TextField.)
-        update-ui-fn (partial update-text-fn text)
+        update-ui-fn (partial update-text-fn text field-expression/format-int)
         update-fn    (fn [_]
                        (if-let [v (field-expression/to-int (.getText text))]
                          (let [property (property-fn)]
@@ -124,7 +124,7 @@
 
 (defmethod create-property-control! g/Num [_ _ property-fn]
   (let [text         (TextField.)
-        update-ui-fn (partial update-text-fn text)
+        update-ui-fn (partial update-text-fn text field-expression/format-double)
         update-fn    (fn [_] (if-let [v (field-expression/to-double (.getText text))]
                                (properties/set-values! (property-fn) (repeat v))
                                (update-ui-fn (properties/values (property-fn))
@@ -161,7 +161,7 @@
         box          (doto (GridPane.)
                        (.setHgap grid-hgap))
         get-fns (map-indexed (fn [i _] #(nth % i)) text-fields)
-        update-ui-fn (partial update-multi-text-fn text-fields get-fns)]
+        update-ui-fn (partial update-multi-text-fn text-fields field-expression/format-double get-fns)]
     (doseq [[t f] (map-indexed (fn [i t]
                                  [t (fn [_]
                                       (let [v            (field-expression/to-double (.getText ^TextField t))
@@ -202,7 +202,7 @@
         box          (doto (GridPane.)
                        (.setPrefWidth Double/MAX_VALUE))
         get-fns (map (fn [f] (or (:get-fn f) #(get-in % (:path f)))) fields)
-        update-ui-fn (partial update-multi-text-fn text-fields get-fns)]
+        update-ui-fn (partial update-multi-text-fn text-fields field-expression/format-double get-fns)]
     (doseq [[t f] (map (fn [f t]
                          (let [set-fn (or (:set-fn f)
                                           (fn [e v] (assoc-in e (:path f) v)))]
@@ -319,7 +319,7 @@
         text          (TextField.)
         dialog-opts   (if (:ext edit-type) {:ext (:ext edit-type)} {})
         update-ui-fn  (fn [values message read-only?]
-                        (update-text-fn text (fn [v] (when v (resource/proj-path v))) values message read-only?)
+                        (update-text-fn text str (fn [v] (when v (resource/proj-path v))) values message read-only?)
                         (let [val (properties/unify-values values)]
                           (ui/editable! browse-button (not read-only?))
                           (ui/editable! open-button (boolean (and val (resource/proj-path val) (resource/exists? val))))))
@@ -397,7 +397,7 @@
   (let [text         (doto (TextArea.)
                        (ui/add-style! "property")
                        (.setMinHeight 68))
-        update-ui-fn (partial update-text-fn text)
+        update-ui-fn (partial update-text-fn text str)
         update-fn    #(properties/set-values! (property-fn) (repeat (.getText text)))]
     (ui/bind-key! text "Shortcut+Enter" update-fn)
     (customize! text (fn [_] (update-fn)))
@@ -407,7 +407,7 @@
   (let [text         (TextField.)
         wrapper      (doto (HBox.)
                        (.setPrefWidth Double/MAX_VALUE))
-        update-ui-fn (partial update-text-fn text)]
+        update-ui-fn (partial update-text-fn text str)]
     (HBox/setHgrow text Priority/ALWAYS)
     (ui/children! wrapper [text])
     (.setDisable text true)

--- a/editor/test/editor/field_expression_test.clj
+++ b/editor/test/editor/field_expression_test.clj
@@ -1,0 +1,72 @@
+(ns editor.field-expression-test
+  (:require [clojure.test :refer :all]
+            [editor.field-expression :refer [format-double to-double]]))
+
+(deftest format-double-test
+  (are [n s]
+    (= s (format-double n))
+
+    0 "0"
+    -1 "-1"
+    0.1 "0.1"
+    0.00001 "0.00001"
+    1.000001 "1.000001"
+    1100.11 "1100.11"
+    9223372036854775807 "9223372036854775807"
+    -9223372036854775808 "-9223372036854775808"
+
+    3.141592653589793 "3.141592653589793"
+    31.41592653589793 "31.41592653589793"
+    314.1592653589793 "314.1592653589793"
+    3141.592653589793 "3141.592653589793"
+    31415.92653589793 "31415.92653589793"
+    314159.2653589793 "314159.2653589793"
+    3141592.653589793 "3141592.653589793"
+    31415926.53589793 "31415926.53589793"
+    314159265.3589793 "314159265.3589793"
+    3141592653.589793 "3141592653.589793"
+    31415926535.89793 "31415926535.89793"
+    314159265358.9793 "314159265358.9793"
+    3141592653589.793 "3141592653589.793"
+    31415926535897.93 "31415926535897.93"
+    314159265358979.3 "314159265358979.3"))
+
+
+(deftest to-double-test
+  (testing "String conversion"
+    (is (= 0.0 (to-double "0")))
+    (is (= 1.1 (to-double "1.1")))
+    (is (= -2.0 (to-double "-2")))
+    (is (= -2.5 (to-double "-2.5")))
+    (is (= -1.5 (to-double "-1,5")))
+    (is (= 3.1 (to-double "+3.1")))
+    (is (= 0.0001 (to-double "1.0e-4")))
+    (is (= 0.00001 (to-double "1.0E-5")))
+    (is (= 100000000000000000000.0 (to-double "1.0E20")))
+    (is (= 1000000000000000000000.0 (to-double "1.0E+21"))))
+
+  (testing "Arithmetic"
+    (testing "Whitespace not significant"
+      (is (= 3.0 (to-double "1+2")))
+      (is (= 4.0 (to-double "2 + 2"))))
+
+    (testing "Basic operations"
+      (is (= 20.0 (to-double "10 + 10")))
+      (is (= 10.0 (to-double "20 - 10")))
+      (is (= 25.0 (to-double "5 * 5")))
+      (is (= 30.0 (to-double "60 / 2"))))
+
+    (testing "Scientific notation terms"
+      (is (= 1.0 (to-double "1.0e-4 / 1.0e-4")))
+      (is (= 1.0 (to-double "1.0E-4 / 1.0E-4"))))))
+
+(deftest double-loopback-test
+  (is (true? (Double/isNaN (to-double (format-double Double/NaN)))))
+  (are [n]
+    (= n (to-double (format-double n)))
+
+    Double/MAX_VALUE
+    Double/MIN_VALUE
+    Double/MIN_NORMAL
+    Double/POSITIVE_INFINITY
+    Double/NEGATIVE_INFINITY))


### PR DESCRIPTION
Fixes defold/editor2-issues#1333
Fixes defold/editor2-issues#1338

### User-facing changes
* Numeric properties are now formatted using variable precision. Integers will present as integers, whereas real numbers will use the necessary number of decimal places to represent the value.
* Really small and really large numbers no longer use scientific notation in the property editor.
* Numeric property fields now accept numbers and expressions using scientific notation.