### PR TITLE
DEFEDIT-1185 Fix NPE when browsing for resources with leading space

### DIFF
--- a/editor/src/clj/editor/fuzzy_text.clj
+++ b/editor/src/clj/editor/fuzzy_text.clj
@@ -53,8 +53,9 @@
         (do (when (some? @best-letter)
               (vswap! score add @best-letter-score)
               (vswap! matched-indices conj @best-letter-idx))
-            (when (= pattern-length pattern-idx)
-              [@score @matched-indices]))
+            (let [final-matched-indices @matched-indices]
+              (when (and (= pattern-length pattern-idx) (seq final-matched-indices))
+                [@score final-matched-indices])))
         (let [pattern-char (when (not= pattern-length pattern-idx) (.charAt pattern pattern-idx))]
           (if (and pattern-char (char-blank? pattern-char))
             (recur str-idx

--- a/editor/test/editor/fuzzy_text_test.clj
+++ b/editor/test/editor/fuzzy_text_test.clj
@@ -4,12 +4,12 @@
 
 (deftest match-test
   (are [pattern str str-matches]
-      (let [expected-matching-indices (when str-matches
-                                        (into []
-                                              (comp (map-indexed vector)
-                                                    (filter #(= \= (second %)))
-                                                    (map first))
-                                              str-matches))
+    (let [expected-matching-indices (when str-matches
+                                      (into []
+                                            (comp (map-indexed vector)
+                                                  (filter #(= \= (second %)))
+                                                  (map first))
+                                            str-matches))
           [_score matching-indices] (fuzzy-text/match pattern str)]
       (is (= expected-matching-indices matching-indices)))
     ;; Empty string matches nothing.

--- a/editor/test/editor/fuzzy_text_test.clj
+++ b/editor/test/editor/fuzzy_text_test.clj
@@ -4,13 +4,23 @@
 
 (deftest match-test
   (are [pattern str str-matches]
-    (let [expected-matching-indices (into []
-                                          (comp (map-indexed vector)
-                                                (filter #(= \= (second %)))
-                                                (map first))
-                                          str-matches)
+      (let [expected-matching-indices (when str-matches
+                                        (into []
+                                              (comp (map-indexed vector)
+                                                    (filter #(= \= (second %)))
+                                                    (map first))
+                                              str-matches))
           [_score matching-indices] (fuzzy-text/match pattern str)]
       (is (= expected-matching-indices matching-indices)))
+    ;; Empty string matches nothing.
+    ""
+    "text"
+    nil
+
+    ;; Whitespace-only matches nothing.
+    " "
+    "text"
+    nil
 
     ;; Matches against filename.
     "image"


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1327

### User facing changes

- Entering a leading space when browsing for resources no longer
  causes an error.