### PR TITLE
DEFEDIT-1187 Run fuzzy filtering in parallel

### DIFF
--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -308,9 +308,9 @@
     resources
     (sort-by (comp :score meta)
              descending-order
-             (r/foldcat (r/filter some?
-                                  (r/map (partial resource->fuzzy-matched-resource filter-value)
-                                         resources))))))
+             (into [] (r/foldcat (r/filter some?
+                                           (r/map (partial resource->fuzzy-matched-resource filter-value)
+                                                  resources)))))))
 
 (defn- override-seq [node-id]
   (tree-seq g/overrides g/overrides node-id))
@@ -398,8 +398,9 @@
 (defn make-resource-dialog [workspace project options]
   (let [exts         (let [ext (:ext options)] (if (string? ext) (list ext) (seq ext)))
         accepted-ext (if (seq exts) (set exts) (constantly true))
-        items        (filter #(and (= :file (resource/source-type %)) (accepted-ext (resource/ext %)))
-                             (g/node-value workspace :resource-list))
+        items        (into []
+                           (filter #(and (= :file (resource/source-type %)) (accepted-ext (resource/ext %))))
+                           (g/node-value workspace :resource-list))
         options (-> {:title "Select Resource"
                      :prompt "Type to filter"
                      :filter ""

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -308,9 +308,9 @@
     resources
     (sort-by (comp :score meta)
              descending-order
-             (into [] (r/foldcat (r/filter some?
-                                           (r/map (partial resource->fuzzy-matched-resource filter-value)
-                                                  resources)))))))
+             (seq (r/foldcat (r/filter some?
+                                       (r/map (partial resource->fuzzy-matched-resource filter-value)
+                                              resources)))))))
 
 (defn- override-seq [node-id]
   (tree-seq g/overrides g/overrides node-id))


### PR DESCRIPTION
### User facing changes

- Entering a filter in the "Select Resource" dialog should now produce
  results a bit quicker on large projects.

### Technical changes

- We were already using reducers when filtering the list of resources,
  but the list was a lazy-sequence, which is not foldable, meaning
  we'd get no parallelism. Instead, eagerly produce a vector of
  resources and fold that. Speedup on seems to be roughly 2-4x.