### PR TITLE
DEFEDIT-1191 Double-click Collection Proxies or Factories to open instantiated scene

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -163,7 +163,7 @@
                                                                    :label id
                                                                    :order order
                                                                    :icon image-icon}
-                                                            image-resource (assoc :link image-resource))))
+                                                            image-resource (assoc :link image-resource :outline-reference? false))))
   (output ddf-message g/Any :cached (g/fnk [path order] {:image path :order order}))
   (output scene g/Any :cached produce-image-scene))
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -147,7 +147,7 @@
                                          (child-go-go self-id child-id))))}]}
       (merge node-outline-extras)
       (cond->
-        (and source-resource (resource/path source-resource)) (assoc :link source-resource))))
+        (and source-resource (resource/path source-resource)) (assoc :link source-resource :outline-reference? true))))
 
 (defn- source-outline-subst [err]
   ;; TODO: embed error so can warn in outline
@@ -471,6 +471,7 @@
     (cond->
       (and source-resource (resource/path source-resource))
       (assoc :link source-resource
+             :outline-reference? true
              :alt-outline source-outline))))
 
 (defn- or-coll-traverse? [basis [src-id src-label tgt-id tgt-label]]

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -91,10 +91,13 @@
   
   (output form-data g/Any produce-form-data)
 
-  (output node-outline outline/OutlineData :cached (g/fnk [_node-id]
-                                                     {:node-id _node-id
-                                                      :label "Collection Proxy"
-                                                      :icon collection-proxy-icon}))
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id collection]
+                                                     (cond-> {:node-id _node-id
+                                                              :label "Collection Proxy"
+                                                              :icon collection-proxy-icon}
+
+                                                             (and collection (resource/path collection))
+                                                             (assoc :link collection :outline-reference? false))))
 
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-value g/Any (gu/passthrough pb-msg))

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -112,10 +112,13 @@
 
   (output form-data g/Any produce-form-data)
 
-  (output node-outline outline/OutlineData :cached (g/fnk [_node-id factory-type]
-                                                     {:node-id _node-id
-                                                      :label (get-in factory-types [factory-type :title])
-                                                      :icon (get-in factory-types [factory-type :icon])}))
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id factory-type prototype]
+                                                     (cond-> {:node-id _node-id
+                                                              :label (get-in factory-types [factory-type :title])
+                                                              :icon (get-in factory-types [factory-type :icon])}
+
+                                                             (and prototype (resource/path prototype))
+                                                             (assoc :link prototype :outline-reference? false))))
 
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-value g/Any (gu/passthrough pb-msg))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -166,7 +166,7 @@
              :outline-overridden? overridden?
              :children (:children source-outline)}
           (cond->
-            (and source-resource (resource/path source-resource)) (assoc :link source-resource)
+            (and source-resource (resource/path source-resource)) (assoc :link source-resource :outline-reference? true)
             source-id (assoc :alt-outline source-outline))))))
   (output ddf-message g/Any :cached (g/fnk [rt-ddf-message] (dissoc rt-ddf-message :property-decls)))
   (output rt-ddf-message g/Any :abstract)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -608,7 +608,7 @@
                      :children node-outline-children
                      :outline-error? (g/error-fatal? own-build-errors)
                      :outline-overridden? (not (empty? _overridden-properties))}
-                    (some-> node-outline-link resource/path) (assoc :link node-outline-link))))
+                    (some-> node-outline-link resource/path) (assoc :link node-outline-link :outline-reference? true))))
 
   (output transform-properties g/Any scene/produce-scalable-transform-properties)
   (output node-msg g/Any :cached produce-node-msg)
@@ -1371,7 +1371,7 @@
                                                       :label name
                                                       :icon texture-icon
                                                       :outline-error? (g/error-fatal? build-errors)}
-                                               texture-resource (assoc :link texture-resource))))
+                                               texture-resource (assoc :link texture-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name texture-resource]
                          {:name name
                           :texture (proj-path texture-resource)}))
@@ -1416,7 +1416,7 @@
                                                               :label name
                                                               :icon font-icon
                                                               :outline-error? (g/error-fatal? build-errors)}
-                                                       font-resource (assoc :link font-resource))))
+                                                       font-resource (assoc :link font-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name font-resource]
                               {:name name
                                :font (proj-path font-resource)}))
@@ -1510,7 +1510,7 @@
                                                                    :label name
                                                                    :icon spine/spine-scene-icon
                                                                    :outline-error? (g/error-fatal? build-errors)}
-                                                            spine-scene-resource (assoc :link spine-scene-resource))))
+                                                            spine-scene-resource (assoc :link spine-scene-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name spine-scene]
                               {:name name
                                :spine-scene (proj-path spine-scene)}))
@@ -1552,7 +1552,7 @@
                                                               :label name
                                                               :icon particlefx/particle-fx-icon
                                                               :outline-error? (g/error-fatal? build-errors)}
-                                                       particlefx-resource (assoc :link particlefx-resource))))
+                                                       particlefx-resource (assoc :link particlefx-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name particlefx]
                               {:name name
                                :particlefx (proj-path particlefx)}))

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -53,6 +53,7 @@
                         (s/optional-key :child-reqs)          [s/Any]
                         (s/optional-key :outline-error?)      s/Bool
                         (s/optional-key :outline-overridden?) s/Bool
+                        (s/optional-key :outline-reference?)  s/Bool
                         s/Keyword                             s/Any})
 
 (g/defnode OutlineNode

--- a/editor/styling/stylesheets/modules/_outline.scss
+++ b/editor/styling/stylesheets/modules/_outline.scss
@@ -46,13 +46,13 @@
 
 #outline {
   .tree-cell {
-    &.linked {
+    &.reference {
       .text {
         -fx-font-family: $default-font-italic;
       }
     }
 
-    &.parent-linked {
+    &.parent-reference {
       .text {
         -fx-font-family: $default-font-italic;
       }


### PR DESCRIPTION
Fixes defold/editor2-issues#948

### User-facing changes
* Double-clicking an embedded Collection Proxy in the Outline opens the referenced Collection.
* Double-clicking an embedded Factory in the Outline opens the referenced Game Object or Collection.

### Technical changes
* Introduced `:outline-reference?` flag to `OutlineData`. If true when a `:link` is specified, the node and its children will appear in italics in the Outline panel, and the `proj-path` of the linked resource will appear next to the label. This allows us to use the `:link` attribute on `OutlineData` without the node showing up as a reference in the Outline.
* Updated the `Resource` adapter in the Outline view to prioritize the `resource` property on `ResourceNodes` over the `:link` attribute if it resolves to an openable resource. This allows `ResourceNodes` to specify a `:link` to a primary resource associated with them. When embedded, the `resource` does not have a path, so double-clicking will follow the `:link` instead.