### PR TITLE
DEFEDIT-1196 Fix exception when editing lists in form view

### DIFF
--- a/editor/src/clj/editor/form_view.clj
+++ b/editor/src/clj/editor/form_view.clj
@@ -501,8 +501,8 @@
           (proxy [ListCell] []
             (startEdit []
               (let [this ^ListCell this]
+                (proxy-super startEdit)
                 (when (not (.isEmpty this))
-                  (proxy-super startEdit)
                   (reset! ctrl-data (create-cell-field-control this element-info ctxt))
                   (reset! edited-cell-atom this)
                   ((:update (second @ctrl-data)) (.getItem this))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1611,14 +1611,12 @@
         focus-owner (.getFocusOwner scene)
         root        (.getRoot scene)]
     (.setDisable root true)
-    (.addEventFilter scene javafx.event.EventType/ROOT disabled-ui-event-filter)
     focus-owner))
 
 (defn enable-ui
   [^Node focus-owner]
   (let [scene       (.getScene (main-stage))
         root        (.getRoot scene)]
-    (.removeEventFilter scene javafx.event.EventType/ROOT disabled-ui-event-filter)
     (.setDisable root false)
     (when focus-owner
       (.requestFocus focus-owner))))


### PR DESCRIPTION
### User facing changes

- Fixes an issue where the form editor (game.project dependencies or
  material tags) would break, resulting in an error when trying to
  edit such properties.

### Technical changes

- The error was triggered by running "Fetch Libraries", which would
  lock the UI using `ui/with-disabled-ui`. For some unknown reason,
  the event filter added/removed by that function would permanently break event
  dispatching for `ListView`, causing the exception. We don't really
  need those filters as the UI is disabled which should drop input
  events anyway.