### PR TITLE
DEFEDIT-1195 Openable resources

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -850,9 +850,9 @@
 
 (handler/defhandler :open :global
   (active? [selection user-data] (:resources user-data (not-empty (selection->openable-resources selection))))
-  (enabled? [selection user-data] (every? resource/exists? (:resources user-data (selection->openable-resources selection))))
+  (enabled? [selection user-data] (some resource/exists? (:resources user-data (selection->openable-resources selection))))
   (run [selection app-view prefs workspace project user-data]
-       (doseq [resource (:resources user-data (selection->openable-resources selection))]
+       (doseq [resource (filter resource/exists? (:resources user-data (selection->openable-resources selection)))]
          (open-resource app-view prefs workspace project resource))))
 
 (handler/defhandler :open-as :global

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -452,7 +452,8 @@
 (handler/defhandler :hot-reload :global
   (enabled? [app-view selection prefs]
             (when-let [resource (context-resource-file app-view selection)]
-              (and (some-> (targets/selected-target prefs)
+              (and (resource/exists? resource)
+                   (some-> (targets/selected-target prefs)
                            (targets/controllable-target?))
                    (not (contains? unreloadable-resource-build-exts (:build-ext (resource/resource-type resource)))))))
   (run [project app-view prefs build-errors-view selection]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -116,20 +116,20 @@
   (output keymap g/Any :cached (g/fnk []
                                  (keymap/make-keymap keymap/default-key-bindings {:valid-command? (set (handler/available-commands))}))))
 
-(defn- selection->resource-files [selection]
+(defn- selection->openable-resources [selection]
   (when-let [resources (handler/adapt-every selection resource/Resource)]
-    (vec (keep (fn [r] (when (and (= :file (resource/source-type r)) (resource/exists? r)) r)) resources))))
+    (filterv resource/openable-resource? resources)))
 
-(defn- selection->single-resource-file [selection]
+(defn- selection->single-openable-resource [selection]
   (when-let [r (handler/adapt-single selection resource/Resource)]
-    (when (= :file (resource/source-type r))
+    (when (resource/openable-resource? r)
       r)))
 
 (defn- selection->single-resource [selection]
   (handler/adapt-single selection resource/Resource))
 
 (defn- context-resource-file [app-view selection]
-  (or (selection->single-resource-file selection)
+  (or (selection->single-openable-resource selection)
       (g/node-value app-view :active-resource)))
 
 (defn- context-resource [app-view selection]
@@ -848,22 +848,22 @@
              false)))))))
 
 (handler/defhandler :open :global
-  (active? [selection user-data] (:resources user-data (not-empty (selection->resource-files selection))))
-  (enabled? [selection user-data] (every? resource/exists? (:resources user-data (selection->resource-files selection))))
+  (active? [selection user-data] (:resources user-data (not-empty (selection->openable-resources selection))))
+  (enabled? [selection user-data] (every? resource/exists? (:resources user-data (selection->openable-resources selection))))
   (run [selection app-view prefs workspace project user-data]
-       (doseq [resource (:resources user-data (selection->resource-files selection))]
+       (doseq [resource (:resources user-data (selection->openable-resources selection))]
          (open-resource app-view prefs workspace project resource))))
 
 (handler/defhandler :open-as :global
-  (active? [selection] (selection->single-resource-file selection))
-  (enabled? [selection user-data] (resource/exists? (selection->single-resource-file selection)))
+  (active? [selection] (selection->single-openable-resource selection))
+  (enabled? [selection user-data] (resource/exists? (selection->single-openable-resource selection)))
   (run [selection app-view prefs workspace project user-data]
-       (let [resource (selection->single-resource-file selection)]
+       (let [resource (selection->single-openable-resource selection)]
          (open-resource app-view prefs workspace project resource (when-let [view-type (:selected-view-type user-data)]
                                                                     {:selected-view-type view-type}))))
   (options [workspace selection user-data]
            (when-not user-data
-             (let [resource (selection->single-resource-file selection)
+             (let [resource (selection->single-openable-resource selection)
                    resource-type (resource/resource-type resource)]
                (map (fn [vt]
                       {:label     (or (:label vt) "External Editor")

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -163,7 +163,7 @@
                                                                    :label id
                                                                    :order order
                                                                    :icon image-icon}
-                                                            image-resource (assoc :link image-resource :outline-reference? false))))
+                                                                  (resource/openable-resource? image-resource) (assoc :link image-resource :outline-reference? false))))
   (output ddf-message g/Any :cached (g/fnk [path order] {:image path :order order}))
   (output scene g/Any :cached produce-image-scene))
 

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -147,7 +147,7 @@
                                          (child-go-go self-id child-id))))}]}
       (merge node-outline-extras)
       (cond->
-        (and source-resource (resource/path source-resource)) (assoc :link source-resource :outline-reference? true))))
+        (resource/openable-resource? source-resource) (assoc :link source-resource :outline-reference? true))))
 
 (defn- source-outline-subst [err]
   ;; TODO: embed error so can warn in outline
@@ -469,7 +469,7 @@
        :icon (or (not-empty (:icon source-outline)) collection-icon)
        :children (:children source-outline)}
     (cond->
-      (and source-resource (resource/path source-resource))
+      (resource/openable-resource? source-resource)
       (assoc :link source-resource
              :outline-reference? true
              :alt-outline source-outline))))

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -96,7 +96,7 @@
                                                               :label "Collection Proxy"
                                                               :icon collection-proxy-icon}
 
-                                                             (and collection (resource/path collection))
+                                                             (resource/openable-resource? collection)
                                                              (assoc :link collection :outline-reference? false))))
 
   (output pb-msg g/Any :cached produce-pb-msg)

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -117,7 +117,7 @@
                                                               :label (get-in factory-types [factory-type :title])
                                                               :icon (get-in factory-types [factory-type :icon])}
 
-                                                             (and prototype (resource/path prototype))
+                                                             (resource/openable-resource? prototype)
                                                              (assoc :link prototype :outline-reference? false))))
 
   (output pb-msg g/Any :cached produce-pb-msg)

--- a/editor/src/clj/editor/form_view.clj
+++ b/editor/src/clj/editor/form_view.clj
@@ -174,7 +174,7 @@
         content (atom nil)
         update-fn (fn [value]
                     (reset! content value)
-                    (ui/editable! open-button (boolean (and value (resource/proj-path value) (resource/exists? value))))
+                    (ui/editable! open-button (and (resource/openable-resource? value) (resource/exists? value)))
                     (ui/text! text (resource/resource->proj-path value)))
         commit-fn (fn [_] (let [resource-path (ui/text text)
                                 resource (some->> (when-not (string/blank? resource-path) resource-path)

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -166,7 +166,7 @@
              :outline-overridden? overridden?
              :children (:children source-outline)}
           (cond->
-            (and source-resource (resource/path source-resource)) (assoc :link source-resource :outline-reference? true)
+            (resource/openable-resource? source-resource) (assoc :link source-resource :outline-reference? true)
             source-id (assoc :alt-outline source-outline))))))
   (output ddf-message g/Any :cached (g/fnk [rt-ddf-message] (dissoc rt-ddf-message :property-decls)))
   (output rt-ddf-message g/Any :abstract)

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -65,6 +65,7 @@
   (resource-name [this] (resource/resource-name resource))
   (workspace [this] (resource/workspace resource))
   (resource-hash [this] (resource/resource-hash resource))
+  (openable? [this] (resource/openable? resource))
 
   io/IOFactory
   (io/make-input-stream  [this opts] (io/input-stream resource))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -608,7 +608,7 @@
                      :children node-outline-children
                      :outline-error? (g/error-fatal? own-build-errors)
                      :outline-overridden? (not (empty? _overridden-properties))}
-                    (some-> node-outline-link resource/path) (assoc :link node-outline-link :outline-reference? true))))
+                    (resource/openable-resource? node-outline-link) (assoc :link node-outline-link :outline-reference? true))))
 
   (output transform-properties g/Any scene/produce-scalable-transform-properties)
   (output node-msg g/Any :cached produce-node-msg)
@@ -1371,7 +1371,7 @@
                                                       :label name
                                                       :icon texture-icon
                                                       :outline-error? (g/error-fatal? build-errors)}
-                                               texture-resource (assoc :link texture-resource :outline-reference? false))))
+                                                     (resource/openable-resource? texture-resource) (assoc :link texture-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name texture-resource]
                          {:name name
                           :texture (proj-path texture-resource)}))
@@ -1416,7 +1416,7 @@
                                                               :label name
                                                               :icon font-icon
                                                               :outline-error? (g/error-fatal? build-errors)}
-                                                       font-resource (assoc :link font-resource :outline-reference? false))))
+                                                             (resource/openable-resource? font-resource) (assoc :link font-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name font-resource]
                               {:name name
                                :font (proj-path font-resource)}))
@@ -1510,7 +1510,7 @@
                                                                    :label name
                                                                    :icon spine/spine-scene-icon
                                                                    :outline-error? (g/error-fatal? build-errors)}
-                                                            spine-scene-resource (assoc :link spine-scene-resource :outline-reference? false))))
+                                                                  (resource/openable-resource? spine-scene-resource) (assoc :link spine-scene-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name spine-scene]
                               {:name name
                                :spine-scene (proj-path spine-scene)}))
@@ -1552,7 +1552,7 @@
                                                               :label name
                                                               :icon particlefx/particle-fx-icon
                                                               :outline-error? (g/error-fatal? build-errors)}
-                                                       particlefx-resource (assoc :link particlefx-resource :outline-reference? false))))
+                                                             (resource/openable-resource? particlefx-resource) (assoc :link particlefx-resource :outline-reference? false))))
   (output pb-msg g/Any (g/fnk [name particlefx]
                               {:name name
                                :particlefx (proj-path particlefx)}))

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -49,6 +49,7 @@
 (g/deftype OutlineData {:node-id                              s/Int
                         :label                                s/Str
                         :icon                                 s/Str
+                        (s/optional-key :link)                (s/maybe (s/pred resource/openable-resource?))
                         (s/optional-key :children)            [s/Any]
                         (s/optional-key :child-reqs)          [s/Any]
                         (s/optional-key :outline-error?)      s/Bool

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -458,12 +458,10 @@
   ;; Collection it instantiates, or a SpineModel can link to its SpineScene.
   (let [node-id (:node-id outline-data)]
     (or (when (g/node-instance? resource/ResourceNode node-id)
-          (when-some [resource (g/node-value node-id :resource)]
-            (when (some? (resource/path resource))
+          (let [resource (g/node-value node-id :resource)]
+            (when (resource/openable-resource? resource)
               resource)))
-        (when-some [link (:link outline-data)]
-          (when (some? (resource/path link))
-            link)))))
+        (:link outline-data))))
 
 (defn- setup-tree-view [proj-graph ^TreeView tree-view outline-view app-view]
   (let [drag-entered-handler (ui/event-handler e (drag-entered proj-graph outline-view e))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -322,7 +322,7 @@
                         (update-text-fn text (fn [v] (when v (resource/proj-path v))) values message read-only?)
                         (let [val (properties/unify-values values)]
                           (ui/editable! browse-button (not read-only?))
-                          (ui/editable! open-button (boolean (and val (resource/proj-path val) (resource/exists? val))))))
+                          (ui/editable! open-button (and (resource/openable-resource? val) (resource/exists? val)))))
         commit-fn     (fn [_]
                         (let [path     (ui/text text)
                               resource (workspace/resolve-workspace-resource workspace path)]

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -30,7 +30,14 @@
   (proj-path ^String [this])
   (resource-name ^String [this])
   (workspace [this])
-  (resource-hash [this]))
+  (resource-hash [this])
+  (openable? [this]))
+
+(defn openable-resource? [value]
+  ;; A resource is considered openable if its kind can be opened in the editor.
+  ;; You should also make sure the resource exists before attempting to open it.
+  (and (satisfies? Resource value)
+       (openable? value)))
 
 (defn- ->unix-seps ^String [^String path]
   (FilenameUtils/separatorsToUnix path))
@@ -70,6 +77,7 @@
   (resource-name [this] name)
   (workspace [this] workspace)
   (resource-hash [this] (hash (proj-path this)))
+  (openable? [this] (= :file source-type))
 
   io/IOFactory
   (io/make-input-stream  [this opts] (io/make-input-stream (io/file this) opts))
@@ -128,6 +136,7 @@
   (resource-name [this] nil)
   (workspace [this] workspace)
   (resource-hash [this] (hash data))
+  (openable? [this] false)
 
   io/IOFactory
   (io/make-input-stream  [this opts] (io/make-input-stream (IOUtils/toInputStream ^String (:data this)) opts))
@@ -157,6 +166,7 @@
   (resource-name [this] name)
   (workspace [this] workspace)
   (resource-hash [this] (hash (proj-path this)))
+  (openable? [this] (= :file (source-type this)))
 
   io/IOFactory
   (io/make-input-stream  [this opts] (io/make-input-stream (:data this) opts))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -34,8 +34,11 @@
   (openable? [this]))
 
 (defn openable-resource? [value]
-  ;; A resource is considered openable if its kind can be opened in the editor.
-  ;; You should also make sure the resource exists before attempting to open it.
+  ;; A resource is considered openable if its kind can be opened. Typically this
+  ;; is a resource that is part of the project and is not a directory. Note
+  ;; that the resource does not have to be openable in the Defold Editor - an
+  ;; external application could be assigned to handle it. Before opening, you
+  ;; must also make sure the resource exists.
   (and (satisfies? Resource value)
        (openable? value)))
 

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -30,7 +30,8 @@
   (abs-path [_this]      (resource/abs-path parent-resource))
   (proj-path [_this]     (resource/proj-path parent-resource))
   (workspace [_this]     (resource/workspace parent-resource))
-  (resource-hash [_this] (resource/resource-hash parent-resource)))
+  (resource-hash [_this] (resource/resource-hash parent-resource))
+  (openable? [_this]     (resource/openable? parent-resource)))
 
 (defn- make-match-tree-item [resource {:keys [line caret-position match]}]
   (TreeItem. (->MatchContextResource resource line caret-position match)))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -45,6 +45,7 @@ ordinary paths."
   (resource-name [this] (resource/resource-name resource))
   (workspace [this] (resource/workspace resource))
   (resource-hash [this] (resource/resource-hash resource))
+  (openable? [this] false)
 
   io/IOFactory
   (io/make-input-stream  [this opts] (io/make-input-stream (File. (resource/abs-path this)) opts))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -128,6 +128,7 @@
   (resource-name [this] (.getName file))
   (workspace [this] workspace)
   (resource-hash [this] (hash (resource/proj-path this)))
+  (openable? [this] (= :file source-type))
 
   io/IOFactory
   (io/make-input-stream  [this opts] (io/make-input-stream content opts))


### PR DESCRIPTION
### Technical changes
* Adds a `openable?` function to the `Resource` protocol. This should return `true` if the resource is **of a kind** that can be opened. It should not be conflated with whether it points to a valid resource, or that the resource is editable using the Defold Editor. A `Resource` is considered openable if it is acceptable for use with the `:open` command. Typically this is a resource that is in the project, and is not a directory.
* Updated all the places where we link between resources in this manner.