### PR TITLE
Unchanged files are saved because data stored in strings is not sanitized (DEFEDIT-1197)

### DIFF
--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -789,6 +789,7 @@
 
 (defn- sanitize-instance [instance]
   (-> instance
+      (update :children (comp vec sort))
       (sanitize-instance-data [:component-properties :properties])))
 
 (defn- sanitize-embedded-instance [workspace embedded-instance]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -33,7 +33,7 @@
            [com.jogamp.opengl.util.awt TextRenderer]
            [editor.types Region Animation Camera Image TexturePacking Rect EngineFormatTexture AABB TextureSetAnimationFrame TextureSetAnimation TextureSet]
            [java.awt.image BufferedImage]
-           [java.io PushbackReader]
+           [java.io PushbackReader StringReader]
            [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
            [com.jogamp.opengl.glu GLU]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d Vector4d]
@@ -772,16 +772,39 @@
     [scale scale scale]
     scale3))
 
-(defn- uniform->non-uniform-scale [v]
-  (-> v
-    (assoc :scale3 (read-scale3-or-scale v))
-    (dissoc :scale)))
+(defn- uniform->non-uniform-scale [instance]
+  (-> instance
+      (assoc :scale3 (read-scale3-or-scale instance))
+      (dissoc :scale)))
 
-(defn- sanitize-instances [is]
-  (mapv uniform->non-uniform-scale is))
+(defn- sanitize-instance-data [instance go-prop-entries-path]
+  (->> instance
+       uniform->non-uniform-scale
+       (game-object/sanitize-go-prop-entries go-prop-entries-path)))
 
-(defn- sanitize-collection [c]
-  (reduce (fn [c f] (update c f sanitize-instances)) c [:instances :embedded-instances :collection-instances]))
+(defn- sanitize-embedded-go-data [embedded key workspace]
+  (let [{:keys [read-fn write-fn]} (workspace/get-resource-type workspace "go")]
+    (assoc embedded key (with-open [reader (StringReader. (get embedded key))]
+                          (write-fn (read-fn reader))))))
+
+(defn- sanitize-instance [instance]
+  (-> instance
+      (sanitize-instance-data [:component-properties :properties])))
+
+(defn- sanitize-embedded-instance [workspace embedded-instance]
+  (-> embedded-instance
+      (sanitize-instance-data [:component-properties :properties])
+      (sanitize-embedded-go-data :data workspace)))
+
+(defn- sanitize-collection-instance [collection-instance]
+  (-> collection-instance
+      (sanitize-instance-data [:instance-properties :properties :properties])))
+
+(defn- sanitize-collection [workspace collection]
+  (-> collection
+      (update :instances (partial mapv sanitize-instance))
+      (update :embedded-instances (partial mapv (partial sanitize-embedded-instance workspace)))
+      (update :collection-instances (partial mapv sanitize-collection-instance))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
@@ -790,7 +813,7 @@
                                     :node-type CollectionNode
                                     :ddf-type GameObject$CollectionDesc
                                     :load-fn load-collection
-                                    :sanitize-fn sanitize-collection
+                                    :sanitize-fn (partial sanitize-collection workspace)
                                     :icon collection-icon
                                     :view-types [:scene :text]
                                     :view-opts {:scene {:grid true}}))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -21,6 +21,7 @@
             [editor.outline :as outline])
   (:import [com.dynamo.gameobject.proto GameObject$PrototypeDesc]
            [com.dynamo.sound.proto Sound$SoundDesc]
+           [java.io StringReader]
            [javax.vecmath Matrix4d Vector3d]))
 
 (set! *warn-on-reflection* true)
@@ -526,13 +527,35 @@
                 transform-properties (select-transform-properties resource-type embedded)]]
       (add-embedded-component self project (:type embedded) (:data embedded) (:id embedded) transform-properties false))))
 
-(defn- sanitize-component [c]
-  (cond-> c
-    (every? (fn [[key vs]] (empty? vs)) (:property-decls c))
-    (dissoc c :property-decls)))
+(defn- sanitize-go-prop-entry [go-prop-entry]
+  (let [value (:value go-prop-entry)
+        type (:type go-prop-entry)]
+    (assert (string? value))
+    (assert (keyword? type))
+    (assoc go-prop-entry :value (-> value
+                                    (properties/str->go-prop type)
+                                    (properties/go-prop->str type)))))
 
-(defn- sanitize-game-object [go]
-  (update go :components (partial mapv sanitize-component)))
+(defn sanitize-go-prop-entries [go-prop-entries-path instance]
+  (if-some [path-token (first go-prop-entries-path)]
+    (if-some [unsanitized-entries (not-empty (get instance path-token))]
+      (assoc instance path-token (mapv (partial sanitize-go-prop-entries (next go-prop-entries-path)) unsanitized-entries))
+      instance)
+    (sanitize-go-prop-entry instance)))
+
+(defn- sanitize-component [component]
+  (cond-> (sanitize-go-prop-entries [:properties] component)
+          (every? (fn [[_key vs]] (empty? vs)) (:property-decls component)) (dissoc :property-decls)))
+
+(defn- sanitize-embedded-component [workspace embedded]
+  (let [{:keys [read-fn write-fn]} (workspace/get-resource-type workspace (:type embedded))]
+    (assoc embedded :data (with-open [reader (StringReader. (:data embedded))]
+                            (write-fn (read-fn reader))))))
+
+(defn sanitize-game-object [workspace go]
+  (-> go
+      (update :components (partial mapv sanitize-component))
+      (update :embedded-components (partial mapv (partial sanitize-embedded-component workspace)))))
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
@@ -541,7 +564,7 @@
     :node-type GameObjectNode
     :ddf-type GameObject$PrototypeDesc
     :load-fn load-game-object
-    :sanitize-fn sanitize-game-object
+    :sanitize-fn (partial sanitize-game-object workspace)
     :icon game-object-icon
     :view-types [:scene :text]
     :view-opts {:scene {:grid true}}))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -338,7 +338,7 @@
                                               :size-mode :size-mode-auto)))
               (into (map (fn [[k v]] [v (get-in props [k :value])]) pb-renames)))
         msg (-> (reduce (fn [msg [k default]] (update msg k v3->v4 default)) msg v3-fields)
-              (update :rotation (fn [r] (conj (math/quat->euler (doto (Quat4d.) (math/clj->vecmath (or r [0.0 0.0 0.0 1.0])))) 1))))]
+              (update :rotation (fn [r] (conj (math/quat->euler (doto (Quat4d.) (math/clj->vecmath (or r [0.0 0.0 0.0 1.0])))) 1.0))))]
     msg))
 
 (def gui-node-parent-attachments
@@ -2597,8 +2597,12 @@
               [:outline :outline-alpha]])
     (cond->
       (= :type-text (:type node))
-      ;; Size mode is not applicable for text nodes, but might still be stored in the files from editor1
-      (dissoc node :size-mode))))
+      ;; These properties are not applicable to text nodes, but might still be stored in files from editor1.
+      (dissoc node :clipping-inverted :clipping-mode :clipping-visible :size-mode)
+
+      (= :type-template (:type node))
+      ;; These properties are not applicable to template nodes, but might still be stored in files from editor1.
+      (dissoc node :adjust-mode :blend-mode :clipping-inverted :clipping-mode :clipping-visible :pivot :size-mode :xanchor :yanchor))))
 
 (defn- sanitize-scene [scene]
   (update scene :nodes (partial mapv sanitize-node)))

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -155,7 +155,9 @@
     (mapv * size [xs ys 1])))
 
 (defn- v3->v4 [v]
-  (conj v 0.0))
+  ;; We use 1.0 as the W component for both the size
+  ;; and scale properties in the Label file format.
+  (conj v 1.0))
 
 (defn- v4->v3 [v4]
   (subvec v4 0 3))
@@ -335,12 +337,20 @@
                       :font font
                       :material material))))
 
+(def ^:private sanitize-v4 (comp v3->v4 v4->v3))
+
+(defn- sanitize-label [label]
+  (-> label
+      (update :size sanitize-v4)
+      (update :scale sanitize-v4)))
+
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
     :ext "label"
     :node-type LabelNode
     :ddf-type Label$LabelDesc
     :load-fn load-label
+    :sanitize-fn sanitize-label
     :icon label-icon
     :view-types [:scene :text]
     :tags #{:component}


### PR DESCRIPTION
Includes but probably not limited to:
* The "load_dynamically" property on Factories.
* Vector properties since we now write spaces after comma separators.
2017-10-26 19:30:53 (Mats.Gisselson)
(LINK REMOVED)