### PR TITLE
DEF-2736 Editor support for texture profiles

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -403,12 +403,19 @@
               (when-not (engine-build-errors/handle-build-error! render-error! project e)
                 (ui/run-later (dialogs/make-alert-dialog (str "Build failed: " (.getMessage e))))))))))))
 
+(defn- update-build-settings!
+  [workspace prefs]
+  (g/set-property! workspace :build-settings
+                   {:compress-textures? (prefs/get-prefs prefs "general-enable-texture-compression" false)}))
+
 (handler/defhandler :build :global
-  (run [project prefs web-server build-errors-view]
+  (run [workspace project prefs web-server build-errors-view]
+    (update-build-settings! workspace prefs)
     (build-handler project prefs web-server build-errors-view)))
 
 (handler/defhandler :rebuild :global
   (run [workspace project prefs web-server build-errors-view]
+    (update-build-settings! workspace prefs)
     (pipeline/reset-cache! workspace)
     (build-handler project prefs web-server build-errors-view)))
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -254,7 +254,9 @@
   (run [prefs] (login/logout prefs)))
 
 (handler/defhandler :preferences :global
-  (run [prefs] (prefs-dialog/open-prefs prefs)))
+  (run [workspace prefs]
+    (prefs-dialog/open-prefs prefs)
+    (workspace/update-build-settings! workspace prefs)))
 
 (defn- collect-resources [{:keys [children] :as resource}]
   (if (empty? children)
@@ -403,19 +405,12 @@
               (when-not (engine-build-errors/handle-build-error! render-error! project e)
                 (ui/run-later (dialogs/make-alert-dialog (str "Build failed: " (.getMessage e))))))))))))
 
-(defn- update-build-settings!
-  [workspace prefs]
-  (g/set-property! workspace :build-settings
-                   {:compress-textures? (prefs/get-prefs prefs "general-enable-texture-compression" false)}))
-
 (handler/defhandler :build :global
-  (run [workspace project prefs web-server build-errors-view]
-    (update-build-settings! workspace prefs)
+  (run [project prefs web-server build-errors-view]
     (build-handler project prefs web-server build-errors-view)))
 
 (handler/defhandler :rebuild :global
   (run [workspace project prefs web-server build-errors-view]
-    (update-build-settings! workspace prefs)
     (pipeline/reset-cache! workspace)
     (build-handler project prefs web-server build-errors-view)))
 

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -434,7 +434,7 @@
                                                                                  (flatten image-resources))]
                                                            (texture-set-gen/layout-images (:layout texture-set-data) id->image))))
 
-  (output texture-image    g/Any               (g/fnk [_node-id packed-image texture-profile]
+  (output texture-image    g/Any               (g/fnk [packed-image texture-profile]
                                                  (tex-gen/make-preview-texture-image packed-image texture-profile)))
 
   (output aabb             AABB                (g/fnk [layout-size]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -62,8 +62,8 @@
     (alter-var-root #'*project-graph*   (fn [_] (g/make-graph! :history true  :volatility 1)))
     (alter-var-root #'*view-graph*      (fn [_] (g/make-graph! :history false :volatility 2)))))
 
-(defn setup-workspace [project-path]
-  (let [workspace (workspace/make-workspace *workspace-graph* project-path)]
+(defn setup-workspace [project-path build-settings]
+  (let [workspace (workspace/make-workspace *workspace-graph* project-path build-settings)]
     (g/transact
       (concat
         (text/register-view-types workspace)
@@ -293,7 +293,8 @@
 (defn open-project
   [^File game-project-file prefs render-progress! update-context]
   (let [project-path (.getPath (.getParentFile game-project-file))
-        workspace    (setup-workspace project-path)
+        build-settings (workspace/make-build-settings prefs)
+        workspace    (setup-workspace project-path build-settings)
         game-project-res (workspace/resolve-workspace-resource workspace "/game.project")
         project      (project/open-project! *project-graph* workspace game-project-res render-progress! (partial login/login prefs))]
     (ui/run-now

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -460,9 +460,6 @@
         resources        (resource/filter-resources (g/node-value project :resources) query)]
     (map (fn [r] [r (get resource-path-to-node (resource/proj-path r))]) resources)))
 
-(defn- make-build-settings
-  [prefs]
-  {:compress-textures? (prefs/get-prefs prefs "general-enable-texture-compression" false)})
 
 (defn build-and-write-project [project prefs build-options]
   (let [game-project  (get-resource-node project "/game.project")
@@ -470,7 +467,6 @@
     (try
       (ui/with-progress [render-fn ui/default-render-progress!]
         (clear-errors!)
-        (g/set-property! (workspace project) :build-settings (make-build-settings prefs))
         (not (empty? (build project game-project
                             (assoc build-options
                                    :render-progress! render-fn)))))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -95,7 +95,8 @@
                                    [:profile-data :display-profiles-data]]
    ["bootstrap" "main_collection"] [[:build-targets :dep-build-targets]]
    ["bootstrap" "render"] [[:build-targets :dep-build-targets]]
-   ["graphics" "texture_profiles"] [[:build-targets :dep-build-targets]]
+   ["graphics" "texture_profiles"] [[:build-targets :dep-build-targets]
+                                    [:pb :texture-profiles-data]]
    ["input" "gamepads"] [[:build-targets :dep-build-targets]]
    ["input" "game_binding"] [[:build-targets :dep-build-targets]]})
 
@@ -124,6 +125,9 @@
   (input display-profiles-data g/Any)
   (output display-profiles-data g/Any (gu/passthrough display-profiles-data))
 
+  (input texture-profiles-data g/Any)
+  (output texture-profiles-data g/Any (gu/passthrough texture-profiles-data))
+  
   (input settings-map g/Any)
   (output settings-map g/Any :cached (gu/passthrough settings-map))
 

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -190,7 +190,7 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
         bufs))))
 
 (defn- texture-image->texture-data
-  [^Graphics$TextureImage texture-image]
+  ^TextureData [^Graphics$TextureImage texture-image]
   (let [image            (select-texture-image-image texture-image)
         gl-profile       (GLProfile/getGL2GL3)
         gl-format        (int (format->gl-format (.getFormat image)))

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -6,7 +6,8 @@
             [editor.scene-cache :as scene-cache]
             [dynamo.graph :as g])
   (:import [java.awt.image BufferedImage DataBuffer DataBufferByte]
-           [java.nio IntBuffer ByteBuffer]
+           [java.nio Buffer IntBuffer ByteBuffer]
+           [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$Image Graphics$TextureImage$TextureFormat]
            [com.jogamp.opengl GL GL2 GL3 GLContext GLProfile]
            [com.jogamp.common.nio Buffers]
            [com.jogamp.opengl.util.texture Texture TextureIO TextureData]
@@ -159,13 +160,83 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
           unit (+ unit-index GL2/GL_TEXTURE0)]
       (->TextureLifecycle request-id ::texture unit params texture-data))))
 
+
+(def format->gl-format
+  {Graphics$TextureImage$TextureFormat/TEXTURE_FORMAT_LUMINANCE
+   GL2/GL_LUMINANCE
+
+   Graphics$TextureImage$TextureFormat/TEXTURE_FORMAT_RGB
+   GL2/GL_RGB
+
+   Graphics$TextureImage$TextureFormat/TEXTURE_FORMAT_RGBA
+   GL2/GL_RGBA})
+
+(defn- select-texture-image-image
+  ^Graphics$TextureImage$Image [^Graphics$TextureImage texture-image]
+  (first (filter #(format->gl-format (.getFormat ^Graphics$TextureImage$Image %))
+                 (.getAlternativesList texture-image))))
+
+(defn- image->mipmap-buffers
+  ^"[Ljava.nio.Buffer;" [^Graphics$TextureImage$Image image]
+  (assert (= (.getMipMapSizeCount image) (.getMipMapOffsetCount image)))
+  (let [mipmap-count (.getMipMapSizeCount image)
+        data (.toByteArray (.getData image))
+        ^"[Ljava.nio.Buffer;" bufs (make-array Buffer mipmap-count)]
+    (loop [i 0]
+      (if (< i mipmap-count)
+        (let [buf (ByteBuffer/wrap data (.getMipMapOffset image i) (.getMipMapSize image i))]
+          (aset bufs i buf)
+          (recur (inc i)))
+        bufs))))
+
+(defn- texture-image->texture-data
+  [^Graphics$TextureImage texture-image]
+  (let [image            (select-texture-image-image texture-image)
+        gl-profile       (GLProfile/getGL2GL3)
+        gl-format        (int (format->gl-format (.getFormat image)))
+        mipmap-buffers   (image->mipmap-buffers image)]
+    (TextureData. gl-profile
+                  gl-format
+                  (.getWidth image)
+                  (.getHeight image)
+                  0                       ; border
+                  gl-format
+                  GL/GL_UNSIGNED_BYTE     ; gl type
+                  false                   ; compressed?
+                  false                   ; flip vertically?
+                  mipmap-buffers
+                  nil)))
+
+(defn texture-image->gpu-texture
+  "Create an image texture from a generated `TextureImage`. The returned value
+  supports GlBind and GlEnable. You can use it in do-gl and with-gl-bindings.
+
+  If supplied, the params argument must be a map of parameter name to value.
+  Parameter names can be OpenGL constants (e.g., GL_TEXTURE_WRAP_S) or their
+  keyword equivalents from `texture-params` (e.g., :wrap-s).
+
+  If you supply parameters, then those parameters are used. If you do not supply
+  parameters, then defaults in `default-image-texture-params` are used.
+
+  If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The
+  default is 0."
+  ([request-id img]
+   (texture-image->gpu-texture request-id img default-image-texture-params 0))
+  ([request-id img params]
+   (texture-image->gpu-texture request-id img params 0))
+  ([request-id ^Graphics$TextureImage img params unit-index]
+    (assert (< unit-index GL2/GL_MAX_TEXTURE_IMAGE_UNITS) (format "the maximum number of texture units is %d" GL2/GL_MAX_TEXTURE_IMAGE_UNITS))
+   (let [texture-data (texture-image->texture-data img)
+         unit (+ unit-index GL2/GL_TEXTURE0)]
+      (->TextureLifecycle request-id ::texture unit params texture-data))))
+
 (defn empty-texture [request-id width height data-format params unit-index]
   (let [unit (+ unit-index GL2/GL_TEXTURE0)]
     (->TextureLifecycle request-id ::texture unit params (->texture-data width height data-format nil false))))
 
 (def white-pixel (image-texture ::white (-> (image/blank-image 1 1) (image/flood 1.0 1.0 1.0)) (assoc default-image-texture-params
-                                                                                             :min-filter GL2/GL_NEAREST
-                                                                                             :mag-filter GL2/GL_NEAREST)))
+                                                                                                      :min-filter GL2/GL_NEAREST
+                                                                                                      :mag-filter GL2/GL_NEAREST)))
 
 (defn tex-sub-image [^GL2 gl ^TextureLifecycle texture data x y w h data-format]
   (let [tex (->texture texture gl)

--- a/editor/src/clj/editor/pipeline/tex_gen.clj
+++ b/editor/src/clj/editor/pipeline/tex_gen.clj
@@ -1,15 +1,59 @@
 (ns editor.pipeline.tex-gen
   (:require [editor.protobuf :as protobuf])
-  (:import [com.defold.editor.pipeline TextureGenerator]
-           [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureProfile]
+  (:import [com.defold.editor.pipeline TextureGenerator TextureUtil]
+           [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$TextureFormat Graphics$TextureProfiles Graphics$TextureProfile]
            [java.awt.image BufferedImage]))
 
 (set! *warn-on-reflection* true)
 
-(defn ->bytes [^BufferedImage image texture-profile]
-  (let [texture-profile (protobuf/map->pb Graphics$TextureProfile texture-profile)
-  		; the trailing boolean in the call below should come from the "Enable Texture Profiles" checkbox
-  		; texture profiles does not seem to be applied at all when build+launch, and checkbox has no effect when bundling
-  		; (bundling always uses texture profiles)
-        texture-image (TextureGenerator/generate ^BufferedImage image ^Graphics$TextureProfile texture-profile true)]
-    (protobuf/pb->bytes texture-image)))
+(def ^:private texture-format->editor-format
+  {:texture-format-luminance         :texture-format-luminance
+   :texture-format-rgb               :texture-format-rgb
+   :texture-format-rgba              :texture-format-rgba
+   :texture-format-rgb-pvrtc-2bppv   :texture-format-rgb
+   :texture-format-rgb-pvrtc-4bppv1  :texture-format-rgb
+   :texture-format-rgba-pvrtc-2bppv1 :texture-format-rgba
+   :texture-format-rgba-pvrtc-4bppv1 :texture-format-rgba
+   :texture-format-rgb-etc1          :texture-format-rgb
+   :texture-format-rgb-16bpp         :texture-format-rgb
+   :texture-format-rgba-16bpp        :texture-format-rgba
+
+   ;; This is incorrect, but it seems like jogl does not define or
+   ;; support a pixelformat of L8A8. So we use RGBA instead to at
+   ;; least previewing with alpha.
+   :texture-format-luminance-alpha   :texture-format-rgba})
+
+(defn match-texture-profile
+  [texture-profiles ^String path]
+  (let [texture-profiles-data (some->> texture-profiles (protobuf/map->pb Graphics$TextureProfiles))
+        path (if (.startsWith path "/") (subs path 1) path)]
+    (when-some [texture-profile (TextureUtil/getTextureProfileByPath texture-profiles-data path)]
+      (protobuf/pb->map texture-profile))))
+
+(defn make-texture-image
+  (^Graphics$TextureImage [^BufferedImage image texture-profile]
+   (make-texture-image image texture-profile false))
+  (^Graphics$TextureImage [^BufferedImage image texture-profile compress?]
+   (let [^Graphics$TextureProfile texture-profile-data (some->> texture-profile (protobuf/map->pb Graphics$TextureProfile))]
+     (TextureGenerator/generate image texture-profile-data ^boolean compress?))))
+
+(defn- make-preview-profile
+  "Given a texture-profile, return a simplified texture-profile that can be used
+  for previewing purposes in editor. Will only produce data for one texture
+  format."
+  [{:keys [name platforms] :as texture-profile}]
+  (let [platform-profile (or (first (filter #(= :os-id-generic (:os %)) (:platforms texture-profile)))
+                             (first (:platforms texture-profile)))
+        texture-format   (first (:formats platform-profile))]
+    (when (and platform-profile texture-format)
+      {:name      "editor"
+       :platforms [{:os                :os-id-generic
+                    :formats           [(update texture-format :format texture-format->editor-format)]
+                    :mipmaps           (:mipmaps platform-profile)
+                    :max-texture-size  (:max-texture-size platform-profile)
+                    :premultiply-alpha (:premultiply-alpha platform-profile)}]})))
+
+(defn make-preview-texture-image
+  ^Graphics$TextureImage [^BufferedImage image texture-profile]
+  (let [preview-profile (make-preview-profile texture-profile)]
+    (make-texture-image image preview-profile false)))

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -111,4 +111,4 @@
                                          (when (= code KeyCode/ESCAPE)
                                            (.close stage)))))
 
-    (ui/show! stage)))
+    (ui/show-and-wait! stage)))

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -79,7 +79,7 @@
 (defn- pref-pages
   []
   [{:name  "General"
-    :prefs [{:label "Enable Texture Profiles" :type :boolean :key "general-enable-texture-profiles" :default true}
+    :prefs [{:label "Enable Texture Compression" :type :boolean :key "general-enable-texture-compression" :default false}
             {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}]}
    {:name  "Scene"
     :prefs [{:label "Selection Color" :type :color :key "scene-selection-color" :default (Color/web "#00ff00ff")}

--- a/editor/src/clj/editor/protobuf_forms.clj
+++ b/editor/src/clj/editor/protobuf_forms.clj
@@ -354,6 +354,13 @@
                        :default 0
                        :optional true
                        }
+                      {
+                       :path [:premultiply-alpha]
+                       :type :boolean
+                       :label "Premultiply alpha"
+                       :default true
+                       :optional true
+                       }
                       ]
                      }
                     ]

--- a/editor/src/clj/editor/resource_update.clj
+++ b/editor/src/clj/editor/resource_update.clj
@@ -41,8 +41,8 @@
       (println "REDIRECTING:" (resource-node-info node) "TO:" (resource-info new))))
   plan)
 
-(defn- loadable? [resource]
-  (not (nil? (:load-fn (resource/resource-type resource)))))
+(defn- stateful? [resource]
+  (not (:stateless? (resource/resource-type resource))))
 
 (defn- merge-resource-change-plans [& plans]
   (apply merge-with into plans))
@@ -69,7 +69,7 @@
   ;; But since the resource data is embedded some resources (ZipResource), those have to be explicitly
   ;; marked deleted as well.
   (let [non-moved-removed (remove (comp move-source-paths resource/proj-path) removed)
-        {loadable-removed true stateless-removed false} (group-by loadable? non-moved-removed)
+        {loadable-removed true stateless-removed false} (group-by stateful? non-moved-removed)
         {stateless-embedded true stateless-external false} (group-by resource-data-embedded? stateless-removed)]
     {:mark-deleted (mapv resource->old-node (concat loadable-removed stateless-embedded))
      :invalidate-outputs (mapv resource->old-node stateless-external)
@@ -87,7 +87,7 @@
   ;; ZipResource to another - and since the data is embedded in that value, we must
   ;; update the :resource field of the node. Just like a redirect.
   (let [non-moved-changed (remove (comp (some-fn move-source-paths move-target-paths) resource/proj-path) changed)
-        {loadable-changed true stateless-changed false} (group-by loadable? non-moved-changed)
+        {loadable-changed true stateless-changed false} (group-by stateful? non-moved-changed)
         {stateless-swapped true stateless-changed false} (group-by resource-swapped? stateless-changed)]
     (merge-resource-change-plans
       (replace-resources-plan plan-info loadable-changed)
@@ -115,7 +115,7 @@
 
 (defmethod resource-moved-case-plan [:removed :changed] [_ move-pairs {:keys [resource->old-node]}]
   ;; We don't have to do the resource->changed-resource translation because move target always comes from new snapshot.
-  (let [{loadable-targets-changed true stateless-targets-changed false} (group-by loadable? (map second move-pairs))
+  (let [{loadable-targets-changed true stateless-targets-changed false} (group-by stateful? (map second move-pairs))
         ;; Transfer overrides from old source nodes to the new target node, and from the old loadable target nodes.
         ;; We don't need to bother with stateless targets as those nodes are not replaced.
         transfer-overrides (into (mapv (fn [[source target]] [target (resource->old-node source)]) move-pairs)
@@ -134,7 +134,7 @@
 (defmethod resource-moved-case-plan [:changed :added] [_ move-pairs {:keys [resource->old-node resource-swapped? resource->changed-resource]}]
   ;; Just like in resource-changed-plan, we must handle the case of the actual resource value being updated
   ;; for stateless resources. I.e. redirect instead of invalidate-outputs.
-  (let [{loadable-sources-changed true stateless-sources-changed false} (group-by loadable? (map (comp resource->changed-resource first) move-pairs))
+  (let [{loadable-sources-changed true stateless-sources-changed false} (group-by stateful? (map (comp resource->changed-resource first) move-pairs))
         new (concat loadable-sources-changed (map second move-pairs))
         transfer-overrides (into (mapv (fn [source] [source (resource->old-node source)]) loadable-sources-changed)
                                  (keep (fn [[_ target]] (when-let [old-target-node (resource->old-node target)] [target old-target-node])))
@@ -154,8 +154,8 @@
 (defmethod resource-moved-case-plan [:changed :changed] [_ move-pairs {:keys [resource->old-node resource-swapped? resource->changed-resource]}]
   ;; Just like in resource-changed-plan, we must handle the case of the actual resource value being updated
   ;; for stateless resources. I.e. redirect instead of invalidate-outputs.
-  (let [{loadable-sources-changed true stateless-sources-changed false} (group-by loadable? (map (comp resource->changed-resource first) move-pairs))
-        {loadable-targets-changed true stateless-targets-changed false} (group-by loadable? (map (comp resource->changed-resource second) move-pairs))
+  (let [{loadable-sources-changed true stateless-sources-changed false} (group-by stateful? (map (comp resource->changed-resource first) move-pairs))
+        {loadable-targets-changed true stateless-targets-changed false} (group-by stateful? (map (comp resource->changed-resource second) move-pairs))
         new (concat loadable-sources-changed loadable-targets-changed)
         transfer-overrides (into (mapv (fn [source] [source (resource->old-node source)]) loadable-sources-changed)
                                  (mapv (fn [target] [target (resource->old-node target)]) loadable-targets-changed))

--- a/editor/src/clj/editor/texture/engine.clj
+++ b/editor/src/clj/editor/texture/engine.clj
@@ -6,7 +6,7 @@
   (:import [java.awt.image BufferedImage ColorModel]
            [java.nio ByteBuffer]
            [com.dynamo.graphics.proto Graphics$TextureImage$TextureFormat Graphics$TextureFormatAlternative$CompressionLevel]
-           [com.defold.libs TexcLibrary TexcLibrary$ColorSpace TexcLibrary$PixelFormat TexcLibrary$CompressionType]
+           [com.defold.libs TexcLibrary TexcLibrary$ColorSpace TexcLibrary$PixelFormat TexcLibrary$CompressionType TexcLibrary$DitherType]
            [com.sun.jna Pointer]))
 
 (set! *warn-on-reflection* true)
@@ -64,7 +64,7 @@
   (TexcLibrary/TEXC_GenMipMaps texture))
 
 (defn- transcode [texture pixel-format color-model compression-level]
-  (TexcLibrary/TEXC_Transcode texture pixel-format color-model compression-level TexcLibrary$CompressionType/CT_DEFAULT))
+  (TexcLibrary/TEXC_Transcode texture pixel-format color-model compression-level TexcLibrary$CompressionType/CT_DEFAULT TexcLibrary$DitherType/DT_DEFAULT))
 
 (defn double-down [[n m]] [(max (bit-shift-right n 1) 1)
                            (max (bit-shift-right m 1) 1)])

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -577,7 +577,7 @@
   (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
   (output packed-image     BufferedImage       (g/fnk [texture-set-data image-resource tile-source-attributes]
                                                  (texture-set-gen/layout-tile-source (:layout texture-set-data) (image/read-image image-resource) tile-source-attributes)))
-  (output texture-image    g/Any               (g/fnk [_node-id packed-image texture-profile]
+  (output texture-image    g/Any               (g/fnk [packed-image texture-profile]
                                                  (tex-gen/make-preview-texture-image packed-image texture-profile)))
 
   (output convex-hull-points g/Any :cached produce-convex-hull-points)

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -82,7 +82,7 @@ ordinary paths."
 (defn get-view-type [workspace id]
   (get (g/node-value workspace :view-types) id))
 
-(defn register-resource-type [workspace & {:keys [textual? ext build-ext node-type load-fn read-fn write-fn icon view-types view-opts tags tag-opts template label]}]
+(defn register-resource-type [workspace & {:keys [textual? ext build-ext node-type load-fn read-fn write-fn icon view-types view-opts tags tag-opts template label stateless?]}]
   (let [resource-type {:textual? (true? textual?)
                        :ext ext
                        :build-ext (if (nil? build-ext) (str ext "c") build-ext)
@@ -96,7 +96,8 @@ ordinary paths."
                        :tags tags
                        :tag-opts tag-opts
                        :template template
-                       :label label}
+                       :label label
+                       :stateless? (if (nil? stateless?) (nil? load-fn) stateless?)}
         resource-types (if (string? ext)
                          [(assoc resource-type :ext ext)]
                          (map (fn [ext] (assoc resource-type :ext ext)) ext))]
@@ -293,6 +294,7 @@ ordinary paths."
   (property view-types g/Any)
   (property resource-types g/Any)
   (property library-snapshot-cache g/Any (default {}))
+  (property build-settings g/Any)
 
   (output resource-tree FileResource :cached produce-resource-tree)
   (output resource-list g/Any :cached produce-resource-list)

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -6,6 +6,7 @@ ordinary paths."
             [clojure.set :as set]
             [dynamo.graph :as g]
             [editor.resource :as resource]
+            [editor.prefs :as prefs]
             [editor.progress :as progress]
             [editor.resource-watch :as resource-watch]
             [editor.library :as library]
@@ -300,12 +301,21 @@ ordinary paths."
   (output resource-list g/Any :cached produce-resource-list)
   (output resource-map g/Any :cached produce-resource-map))
 
-(defn make-workspace [graph project-path]
+(defn make-build-settings
+  [prefs]
+  {:compress-textures? (prefs/get-prefs prefs "general-enable-texture-compression" false)})
+
+(defn update-build-settings!
+  [workspace prefs]
+  (g/set-property! workspace :build-settings (make-build-settings prefs)))
+
+(defn make-workspace [graph project-path build-settings]
   (g/make-node! graph Workspace
                 :root project-path
                 :resource-snapshot (resource-watch/empty-snapshot)
                 :view-types {:default {:id :default}}
-                :resource-listeners (atom [])))
+                :resource-listeners (atom [])
+                :build-settings build-settings))
 
 (defn register-view-type [workspace & {:keys [id label make-view-fn make-preview-fn focus-fn]}]
   (let [view-type (merge {:id    id

--- a/editor/src/java/com/defold/editor/pipeline/TextureGenerator.java
+++ b/editor/src/java/com/defold/editor/pipeline/TextureGenerator.java
@@ -18,14 +18,16 @@ import javax.imageio.ImageIO;
 
 import com.defold.libs.TexcLibrary;
 import com.defold.libs.TexcLibrary.ColorSpace;
-import com.defold.libs.TexcLibrary.CompressionLevel;
-import com.defold.libs.TexcLibrary.FlipAxis;
+import com.dynamo.bob.TexcLibrary.DitherType;
 import com.defold.libs.TexcLibrary.PixelFormat;
+import com.defold.libs.TexcLibrary.CompressionLevel;
 import com.defold.libs.TexcLibrary.CompressionType;
+import com.defold.libs.TexcLibrary.FlipAxis;
+import com.dynamo.bob.util.TextureUtil;
 import com.dynamo.graphics.proto.Graphics.PlatformProfile;
-import com.dynamo.graphics.proto.Graphics.TextureFormatAlternative;
 import com.dynamo.graphics.proto.Graphics.TextureImage;
 import com.dynamo.graphics.proto.Graphics.TextureImage.TextureFormat;
+import com.dynamo.graphics.proto.Graphics.TextureFormatAlternative;
 import com.dynamo.graphics.proto.Graphics.TextureImage.Type;
 import com.dynamo.graphics.proto.Graphics.TextureProfile;
 import com.google.protobuf.ByteString;
@@ -59,9 +61,9 @@ public class TextureGenerator {
         pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGBA_PVRTC_2BPPV1, PixelFormat.RGBA_PVRTC_2BPPV1);
         pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1, PixelFormat.RGBA_PVRTC_4BPPV1);
         pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGB_ETC1, PixelFormat.RGB_ETC1);
-        // pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGB_16BPP, PixelFormat.R5G6B5);
-        // pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGBA_16BPP, PixelFormat.R4G4B4A4);
-        // pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_LUMINANCE_ALPHA, PixelFormat.L8A8);
+        pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGB_16BPP, PixelFormat.R5G6B5);
+        pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_RGBA_16BPP, PixelFormat.R4G4B4A4);
+        pixelFormatLUT.put(TextureFormat.TEXTURE_FORMAT_LUMINANCE_ALPHA, PixelFormat.L8A8);
 
         /*
         JIRA issue: DEF-994
@@ -105,12 +107,16 @@ public class TextureGenerator {
             case TEXTURE_FORMAT_RGB: {
                 if (componentCount == 1)
                     return TextureFormat.TEXTURE_FORMAT_LUMINANCE;
+                if (componentCount == 2)
+                    return TextureFormat.TEXTURE_FORMAT_LUMINANCE_ALPHA;
                 return TextureFormat.TEXTURE_FORMAT_RGB;
             }
 
             case TEXTURE_FORMAT_RGBA: {
                 if (componentCount == 1)
                     return TextureFormat.TEXTURE_FORMAT_LUMINANCE;
+                if (componentCount == 2)
+                    return TextureFormat.TEXTURE_FORMAT_LUMINANCE_ALPHA;
                 else if (componentCount == 3)
                     return TextureFormat.TEXTURE_FORMAT_RGB;
 
@@ -254,7 +260,7 @@ public class TextureGenerator {
                 throw new TextureGeneratorException("could not flip");
             }
 
-            if (!TexcLibrary.TEXC_Transcode(texture, pixelFormat, ColorSpace.SRGB, texcCompressionLevel, texcCompressionType)) {
+            if (!TexcLibrary.TEXC_Transcode(texture, pixelFormat, ColorSpace.SRGB, texcCompressionLevel, texcCompressionType, DitherType.DT_DEFAULT)) {
                 throw new TextureGeneratorException("could not transcode");
             }
 

--- a/editor/src/java/com/defold/libs/TexcLibrary.java
+++ b/editor/src/java/com/defold/libs/TexcLibrary.java
@@ -38,6 +38,10 @@ public class TexcLibrary {
         public static int RGBA_PVRTC_2BPPV1 = 5;
         public static int RGBA_PVRTC_4BPPV1 = 6;
         public static int RGB_ETC1          = 7;
+        public static int R5G6B5            = 8;
+        public static int R4G4B4A4          = 9;
+        public static int L8A8              = 10;
+
         /*
         JIRA issue: DEF-994
         public static int RGB_DXT1          = 8;
@@ -71,6 +75,11 @@ public class TexcLibrary {
         public static int FLIP_AXIS_Z = 2;
     }
 
+    public interface DitherType {
+        public static int DT_NONE = 0;
+        public static int DT_DEFAULT = 1;
+    }
+
     public static native Pointer TEXC_Create(int width, int height, int pixelFormat, int colorSpace, Buffer data);
     public static native void TEXC_Destroy(Pointer texture);
 
@@ -84,6 +93,6 @@ public class TexcLibrary {
     public static native boolean TEXC_PreMultiplyAlpha(Pointer texture);
     public static native boolean TEXC_GenMipMaps(Pointer texture);
     public static native boolean TEXC_Flip(Pointer texture, int flipAxis);
-    public static native boolean TEXC_Transcode(Pointer texture, int pixelFormat, int colorSpace, int compressionLevel, int compressionType);
+    public static native boolean TEXC_Transcode(Pointer texture, int pixelFormat, int colorSpace, int compressionLevel, int compressionType, int dither);
 
 }

--- a/editor/test/editor/defold_project_test.clj
+++ b/editor/test/editor/defold_project_test.clj
@@ -43,7 +43,9 @@
 (deftest loading
   (reset! load-counter 0)
   (with-clean-system
-    (let [workspace (workspace/make-workspace world (.getAbsolutePath (io/file "test/resources/load_project")))]
+    (let [workspace (workspace/make-workspace world
+                                              (.getAbsolutePath (io/file "test/resources/load_project"))
+                                              {})]
       (g/transact
        (register-resource-types workspace [{:ext "type_a"
                                             :node-type ANode

--- a/editor/test/editor/pipeline/tex_gen_test.clj
+++ b/editor/test/editor/pipeline/tex_gen_test.clj
@@ -1,20 +1,61 @@
 (ns editor.pipeline.tex-gen-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
+            [editor.protobuf :as protobuf]
             [editor.pipeline.tex-gen :as tex-gen])
   (:import [javax.imageio ImageIO]
            [com.dynamo.graphics.proto Graphics$TextureImage]))
 
-(def test-profile {:name "test-profile"
-                   :platforms [{:os :os-id-generic
-                                :formats [{:format :texture-format-rgba
-                                           :compression-level :fast}]
-                                :mipmaps false}]})
-
 (deftest gen-bytes
-  (let [img (ImageIO/read (io/resource "test_project/graphics/ball.png"))
-        b (tex-gen/->bytes img test-profile)
-        tex-img (Graphics$TextureImage/parseFrom b)
-        alt (.getAlternatives tex-img 0)]
+  (let [img     (ImageIO/read (io/resource "test_project/graphics/ball.png"))
+        bytes   (protobuf/pb->bytes (tex-gen/make-texture-image img {:name      "test-profile"
+                                                                     :platforms [{:os      :os-id-generic
+                                                                                  :formats [{:format            :texture-format-rgba
+                                                                                             :compression-level :fast}]
+                                                                                  :mipmaps false}]}))
+        tex-img (Graphics$TextureImage/parseFrom bytes)
+        alt     (.getAlternatives tex-img 0)]
     (is (= 64 (.getWidth alt)))
     (is (= 32 (.getHeight alt)))))
+
+(deftest make-texture-image-test
+  (let [img     (ImageIO/read (io/resource "test_project/graphics/ball.png"))
+        tex-img (tex-gen/make-texture-image img {:name      "test-profile"
+                                                 :platforms [{:os                :os-id-generic
+                                                              :formats           [{:format            :texture-format-rgb
+                                                                                   :compression-level :best}
+                                                                                  {:format            :texture-format-rgba
+                                                                                   :compression-level :best}
+                                                                                  {:format            :texture-format-luminance
+                                                                                   :compression-level :best}]
+                                                              :mipmaps           false
+                                                              :premultiply-alpha true}]}
+                                            false)]
+    (is (= 3 (.getAlternativesCount tex-img)))
+    (is (= (* 3 32 64) (.. tex-img (getAlternatives 0) (getData) (size))))
+    (is (= (* 4 32 64) (.. tex-img (getAlternatives 1) (getData) (size))))
+    (is (= (* 1 32 64) (.. tex-img (getAlternatives 2) (getData) (size))))))
+
+(deftest make-preview-texture-image-test
+  (let [img     (ImageIO/read (io/resource "test_project/graphics/ball.png"))
+        tex-img (tex-gen/make-preview-texture-image img {:name      "test-profile"
+                                                         :platforms [{:os                :os-id-generic
+                                                                      :formats           [{:format            :texture-format-rgb
+                                                                                           :compression-level :best}
+                                                                                          {:format            :texture-format-rgba
+                                                                                           :compression-level :best}
+                                                                                          {:format            :texture-format-luminance
+                                                                                           :compression-level :best}]
+                                                                      :mipmaps           false
+                                                                      :premultiply-alpha true}]})]
+    (is (= 1 (.getAlternativesCount tex-img)))
+    (is (= (* 3 32 64) (.. tex-img (getAlternatives 0) (getData) (size))))))
+
+(deftest match-texture-profile-test
+  (let [texture-profiles {:path-settings [{:path "/**/photos/*.png" :profile "Photo"}
+                                          {:path "**" :profile "Default"}]
+                          :profiles      [{:name "Default"}
+                                          {:name "Photo"}]}]
+    (is (= "Default" (:name (tex-gen/match-texture-profile texture-profiles "/foo/bar.atlas"))))
+    (is (= "Default" (:name (tex-gen/match-texture-profile texture-profiles "/foo/photos/not-a-png.atlas"))))
+    (is (= "Photo"   (:name (tex-gen/match-texture-profile texture-profiles "/foo/photos/a-png.png"))))))

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -143,7 +143,6 @@
             (let [error-value (build-error render-error!)]
               (when (is (some? error-value))
                 (let [error-tree (build-errors-view/build-resource-tree error-value)]
-                  (println (pr-str error-tree))
                   (is (= ["/errors/button_break_self.gui" "/errors/name_conflict.gui" "/errors/panel_break_button.gui"]
                          (sort (map #(resource/proj-path (get-in % [:value :resource])) (:children error-tree)))))
                   (is (= 1 (count (get-in error-tree [:children 0 :children]))))

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -758,7 +758,7 @@
             paths (map resource/proj-path all-files)]
         (bulk-change workspace
                      (touch-files workspace paths))
-        (let [internal-paths (map resource/proj-path (filter (fn [r] (:load-fn (resource/resource-type r))) all-files))
+        (let [internal-paths (map resource/proj-path (filter (fn [r] (not (:stateless? (resource/resource-type r)))) all-files))
               saved-paths (set (map (fn [s] (resource/proj-path (:resource s))) (g/node-value project :save-data)))
               missing (filter #(not (contains? saved-paths %)) internal-paths)]
           (is (empty? missing)))))))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -76,7 +76,9 @@
   ([graph]
    (setup-workspace! graph project-path))
   ([graph project-path]
-   (let [workspace (workspace/make-workspace graph (.getAbsolutePath (io/file project-path)))]
+   (let [workspace (workspace/make-workspace graph
+                                             (.getAbsolutePath (io/file project-path))
+                                             {})]
      (g/transact
        (concat
          (scene/register-view-types workspace)))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1292

### User facing changes

- Texture profiles are now respected both when viewing textures in editor, and when starting application using "Project -> Build".

### Technical changes

- support for texture profiles
  - used when generating texture in editor
  - used when building, optionally with compression
- new `build-settings` property on Workspace, set from prefs when building
- new `texture-profiles` property on Project
- updated `TexcLibrary` and `TextureGenerator` from bob
- new function go generate gpu-texture using `TextureImage` instead of `BufferedImage`, ie. an image that is generate from our pipeline