### PR TITLE
DEFEDIT-1194 Validation for materials

### DIFF
--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -36,13 +36,13 @@
     (format "'%s' must be specified" name)))
 
 (defn prop-resource-not-exists? [v name]
-  (and v (not (resource/exists? v)) (format "%s '%s' could not be found" name (resource/resource-name v))))
+  (and v (not (resource/exists? v)) (format "%s '%s' could not be found" name (resource/resource->proj-path v))))
 
 (defn prop-resource-missing? [v name]
   (or (prop-nil? v name)
       (prop-resource-not-exists? v name)))
 
-(defn prop-resource-ext? [ext v name]
+(defn prop-resource-ext? [v ext name]
   (or (prop-resource-missing? v name)
       (when-not (= (resource/ext v) ext)
         (format "%s '%s' is not of type .%s" name (resource/resource->proj-path v) ext))))
@@ -68,8 +68,8 @@
 
 (defn prop-error
   ([severity _node-id prop-kw f prop-value & args]
-  (when-let [msg (apply f prop-value args)]
-    (g/->error _node-id prop-kw severity prop-value msg {}))))
+   (when-let [msg (apply f prop-value args)]
+     (g/->error _node-id prop-kw severity prop-value msg {}))))
 
 (defmacro prop-error-fnk
   [severity f property]

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -42,6 +42,11 @@
   (or (prop-nil? v name)
       (prop-resource-not-exists? v name)))
 
+(defn prop-resource-ext? [ext v name]
+  (or (prop-resource-missing? v name)
+      (when-not (= (resource/ext v) ext)
+        (format "%s '%s' is not of type .%s" name (resource/resource->proj-path v) ext))))
+
 (defn prop-member-of? [v val-set message]
   (when (and val-set (not (val-set v)))
     message))

--- a/editor/test/integration/material_test.clj
+++ b/editor/test/integration/material_test.clj
@@ -21,11 +21,11 @@
 (deftest material-validation
   (test-util/with-loaded-project
     (let [node-id   (test-util/resource-node project "/materials/test.material")]
-      (is (nil? (test-util/prop-error node-id :vertex-program)))
+      (is (not (g/error? (g/node-value node-id :validated-vertex-program))))
       (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.vp")]]
         (test-util/with-prop [node-id :vertex-program v]
-          (is (g/error? (test-util/prop-error node-id :vertex-program)))))
-      (is (nil? (test-util/prop-error node-id :fragment-program)))
+          (is (g/error? (g/node-value node-id :validated-vertex-program)))))
+      (is (not (g/error? (g/node-value node-id :validated-fragment-program))))
       (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.fp")]]
         (test-util/with-prop [node-id :fragment-program v]
-          (is (g/error? (test-util/prop-error node-id :fragment-program))))))))
+          (is (g/error? (g/node-value node-id :validated-fragment-program))))))))

--- a/editor/test/integration/material_test.clj
+++ b/editor/test/integration/material_test.clj
@@ -21,11 +21,15 @@
 (deftest material-validation
   (test-util/with-loaded-project
     (let [node-id   (test-util/resource-node project "/materials/test.material")]
-      (is (not (g/error? (g/node-value node-id :validated-vertex-program))))
+      (is (not (g/error? (g/node-value node-id :shader))))
+      (is (not (g/error? (g/node-value node-id :build-targets))))
       (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.vp")]]
         (test-util/with-prop [node-id :vertex-program v]
-          (is (g/error? (g/node-value node-id :validated-vertex-program)))))
-      (is (not (g/error? (g/node-value node-id :validated-fragment-program))))
+          (is (g/error? (g/node-value node-id :shader)))
+          (is (g/error? (g/node-value node-id :build-targets)))))
+      (is (not (g/error? (g/node-value node-id :shader))))
+      (is (not (g/error? (g/node-value node-id :build-targets))))
       (doseq [v [nil (workspace/resolve-workspace-resource workspace "/not_found.fp")]]
         (test-util/with-prop [node-id :fragment-program v]
-          (is (g/error? (g/node-value node-id :validated-fragment-program))))))))
+          (is (g/error? (g/node-value node-id :shader)))
+          (is (g/error? (g/node-value node-id :build-targets))))))))


### PR DESCRIPTION
* User facing changes
  - Invalid Vertex/Fragment program settings in material cause
  build- and render errors.

* Technical changes
  - produce-build-targets & shader output use validate programs
  - validate dynamic's removed from corresponding properties since not used