### PR TITLE
DEFEDIT-1204 Cmd+P for Open Assets

### DIFF
--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -93,6 +93,7 @@
    ["Shortcut+Left"         :beginning-of-line-text]
    ["Shortcut+N"            :new-file]
    ["Shortcut+O"            :open]
+   ["Shortcut+P"            :open-asset]
    ["Shortcut+Q"            :quit]
    ["Shortcut+R"            :hot-reload]
    ["Shortcut+Right"        :end-of-line]


### PR DESCRIPTION
Fixes defold/editor2-issues#1366
* User facing changes
  - Cmd+P as alias for Open Assets. By popular demand.