### PR TITLE
DEFEDIT-1205 Focus selected object in outline

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -85,8 +85,9 @@
                                                         (or selected expanded))) items)))
 
 (defn- sync-selection [^TreeView tree-view selection]
-  (let [root (.getRoot tree-view)]
-    (.. tree-view getSelectionModel clearSelection)
+  (let [root (.getRoot tree-view)
+        selection-model (.getSelectionModel tree-view)]
+    (.clearSelection selection-model)
     (when (and root (not (empty? selection)))
       (let [selected-ids (set selection)]
         (when (auto-expand (.getChildren root) selected-ids)
@@ -94,7 +95,9 @@
         (let [count (.getExpandedItemCount tree-view)
               selected-indices (filter #(selected-ids (item->node-id (.getTreeItem tree-view %))) (range count))]
           (when (not (empty? selected-indices))
-            (ui/select-indices! tree-view selected-indices)))))))
+            (ui/select-indices! tree-view selected-indices))
+          (when-some [first-item (first (.getSelectedItems selection-model))]
+            (ui/scroll-to-item! tree-view first-item)))))))
 
 (defn- decorate
   ([root]
@@ -407,7 +410,7 @@
                        (proxy-super setText nil)
                        (proxy-super setGraphic nil)
                        (proxy-super setContextMenu nil)
-                       (proxy-super setStyle nil))                                                                    
+                       (proxy-super setStyle nil))
                      (let [{:keys [label icon link outline-error? outline-overridden? outline-reference? parent-reference? child-error? child-overridden?]} item
                            icon (if outline-error? "icons/32/Icons_E_02_error.png" icon)
                            label (if (and link outline-reference?) (format "%s - %s" label (resource/resource->proj-path link)) label)]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -827,7 +827,7 @@
   [^TreeView tree-view ^TreeItem tree-item]
   (let [row (.getRow tree-view tree-item)]
     (when-not (= -1 row)
-        (.scrollTo tree-view row))))
+      (.scrollTo tree-view row))))
 
 (defmacro observe-selection
   "Helper macro that lets you observe selection changes in a generic fashion.


### PR DESCRIPTION
### User facing changes

Fixes https://github.com/defold/editor2-issues/issues/710, https://github.com/defold/editor2-issues/issues/1324, https://github.com/defold/editor2-issues/issues/1233

- When an object is selected in the main view we now scroll to it in
  outline.