### PR TITLE
DEFEDIT-1206 Optionally track active item in asset browser

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -7,6 +7,7 @@
             [editor.handler :as handler]
             [editor.jfx :as jfx]
             [editor.ui :as ui]
+            [editor.prefs :as prefs]
             [editor.resource :as resource]
             [editor.resource-watch :as resource-watch]
             [editor.workspace :as workspace]
@@ -57,7 +58,7 @@
         (.addAll ^"[Ljavafx.scene.control.TreeItem;" items)))))
 
 ; NOTE: Without caching stack-overflow... WHY?
-(defn tree-item [parent]
+(defn tree-item ^TreeItem [parent]
   (let [cached (atom false)]
     (proxy [TreeItem] [parent]
       (isLeaf []
@@ -467,7 +468,7 @@
 (defn- item->path [^TreeItem item]
   (-> item (.getValue) (resource/proj-path)))
 
-(defn- sync-tree [old-root new-root]
+(defn- sync-tree! [old-root new-root]
   (let [item-seq (ui/tree-item-seq old-root)
         expanded (zipmap (map item->path item-seq)
                          (map #(.isExpanded ^TreeItem %) item-seq))]
@@ -476,6 +477,15 @@
         (.setExpanded item true))))
   new-root)
 
+(g/defnk produce-tree-root
+  [^TreeView raw-tree-view resource-tree]
+  (let [old-root (.getRoot raw-tree-view)
+        new-root (tree-item resource-tree)]
+    (when new-root
+      (sync-tree! old-root new-root)
+      (.setExpanded new-root true)
+      new-root)))
+
 (defn- auto-expand [items selected-paths]
   (reduce #(or %1 %2) false (map (fn [^TreeItem item] (let [path (item->path item)
                                                             selected (boolean (selected-paths path))
@@ -483,32 +493,60 @@
                                                         (when expanded (.setExpanded item expanded))
                                                         selected)) items)))
 
-(defn- sync-selection [^TreeView tree-view ^TreeItem root selected-paths]
-  (when (and root (seq selected-paths))
-    (let [selected-paths (set selected-paths)]
-      (auto-expand (.getChildren root) selected-paths)
-      (let [count (.getExpandedItemCount tree-view)
-            selected-indices (filter #(selected-paths (item->path (.getTreeItem tree-view %))) (range count))]
-        (when (not (empty? selected-indices))
-          (ui/select-indices! tree-view selected-indices))))))
-
-(defn update-tree-view [^TreeView tree-view resource-tree selected-paths]
+(defn- sync-selection!
+  [^TreeView tree-view selected-paths]
   (let [root (.getRoot tree-view)
-        ^TreeItem new-root (->>
-                             (tree-item resource-tree)
-                             (sync-tree root))]
-    (when new-root
-      (.setExpanded new-root true))
-    (.setRoot tree-view new-root)
-    (sync-selection tree-view new-root selected-paths)
-    tree-view))
+        selection-model (.getSelectionModel tree-view)]
+    (.clearSelection selection-model)
+    (when (and root (seq selected-paths))
+      (let [selected-paths (set selected-paths)]
+        (auto-expand (.getChildren root) selected-paths)
+        (let [count (.getExpandedItemCount tree-view)
+              selected-indices (filter #(selected-paths (item->path (.getTreeItem tree-view %))) (range count))]
+          (when (not (empty? selected-indices))
+            (ui/select-indices! tree-view selected-indices))
+          (when-some [first-item (first (.getSelectedItems selection-model))]
+            (ui/scroll-to-item! tree-view first-item)))))))
 
-(g/defnk produce-tree-view [_node-id raw-tree-view resource-tree]
-  (let [selected-paths (or (ui/user-data raw-tree-view ::pending-selection)
+(defn- update-tree-view-selection!
+  [^TreeView tree-view selected-paths]
+  (sync-selection! tree-view selected-paths)
+  tree-view)
+
+(defn- update-tree-view-root!
+  [^TreeView tree-view ^TreeItem root selected-paths]
+  (when root
+    (.setExpanded root true)
+    (.setRoot tree-view root))
+  (sync-selection! tree-view selected-paths)
+  tree-view)
+
+(defn track-active-item? [prefs]
+  (prefs/get-prefs prefs "asset-browser-track-active-item?" false))
+
+(defn set-track-active-item! [prefs enabled?]
+  (assert (or (true? enabled?) (false? enabled?)))
+  (prefs/set-prefs prefs "asset-browser-track-active-item?" enabled?))
+
+(g/defnk produce-tree-view
+  [^TreeView raw-tree-view ^TreeItem root active-resource prefs]
+  (let [track-active-item? (track-active-item? prefs)
+        selected-paths (or (ui/user-data raw-tree-view ::pending-selection)
+                           (when (and track-active-item? active-resource)
+                             [(resource/proj-path active-resource)])
                            (mapv resource/proj-path (ui/selection raw-tree-view)))]
-    (update-tree-view raw-tree-view resource-tree selected-paths)
     (ui/user-data! raw-tree-view ::pending-selection nil)
-    raw-tree-view))
+    (cond
+      ;; different roots?
+      (not (identical? (.getRoot raw-tree-view) root))
+      (update-tree-view-root! raw-tree-view root selected-paths)
+
+      ;; same root, different selection?
+      (not (= (set selected-paths) (set (map resource/proj-path (ui/selection raw-tree-view)))))
+      (update-tree-view-selection! raw-tree-view selected-paths)
+
+      :else
+      raw-tree-view)))
 
 (defn- drag-detected [^MouseEvent e selection]
   (let [resources (roots selection)
@@ -652,17 +690,20 @@
 
 (g/defnode AssetBrowser
   (property raw-tree-view TreeView)
+  (property prefs g/Any)
 
   (input resource-tree FileResource)
+  (input active-resource resource/Resource :substitute nil)
 
+  (output root TreeItem :cached produce-tree-root)
   (output tree-view TreeView :cached produce-tree-view))
 
-(defn make-asset-browser [graph workspace tree-view]
+(defn make-asset-browser [graph workspace tree-view prefs]
   (let [asset-browser (first
                         (g/tx-nodes-added
                           (g/transact
                             (g/make-nodes graph
-                                          [asset-browser [AssetBrowser :raw-tree-view tree-view]]
+                                          [asset-browser [AssetBrowser :raw-tree-view tree-view :prefs prefs]]
                                           (g/connect workspace :resource-tree asset-browser :resource-tree)))))]
     (setup-asset-browser asset-browser workspace tree-view)
     asset-browser))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -152,7 +152,7 @@
           app-view             (app-view/make-app-view *view-graph* workspace project stage menu-bar editor-tabs)
           outline-view         (outline-view/make-outline-view *view-graph* *project-graph* outline app-view)
           properties-view      (properties-view/make-properties-view workspace project app-view *view-graph* (.lookup root "#properties"))
-          asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets)
+          asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs)
           web-server           (-> (http-server/->server 0 {"/profiler" web-profiler/handler
                                                             hot-reload/url-prefix (partial hot-reload/build-handler workspace project)
                                                             hot-reload/verify-etags-url-prefix (partial hot-reload/verify-etags-handler workspace project)
@@ -229,6 +229,7 @@
             (g/connect project label app-view label))
           (g/connect project :_node-id app-view :project-id)
           (g/connect app-view :selected-node-ids outline-view :selection)
+          (g/connect app-view :active-resource asset-browser :active-resource)
           (for [label [:active-resource-node :active-outline :open-resource-nodes]]
             (g/connect app-view label outline-view label))
           (let [auto-pulls [[properties-view :pane]

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -80,7 +80,8 @@
   []
   [{:name  "General"
     :prefs [{:label "Enable Texture Profiles" :type :boolean :key "general-enable-texture-profiles" :default true}
-            {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}]}
+            {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}
+            {:label "Track Active Item in Asset Browser" :type :boolean :key "asset-browser-track-active-item?" :default false}]}
    {:name  "Scene"
     :prefs [{:label "Selection Color" :type :color :key "scene-selection-color" :default (Color/web "#00ff00ff")}
             {:label "Grid" :type :choicebox :key "scene-grid-type" :default :auto :options [[:auto "Auto"] [:manual "Manual"]]}

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -81,7 +81,7 @@
   [{:name  "General"
     :prefs [{:label "Enable Texture Profiles" :type :boolean :key "general-enable-texture-profiles" :default true}
             {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}
-            {:label "Track Active Item in Asset Browser" :type :boolean :key "asset-browser-track-active-item?" :default false}]}
+            {:label "Track Active Tab in Asset Browser" :type :boolean :key "asset-browser-track-active-tab?" :default false}]}
    {:name  "Scene"
     :prefs [{:label "Selection Color" :type :color :key "scene-selection-color" :default (Color/web "#00ff00ff")}
             {:label "Grid" :type :choicebox :key "scene-grid-type" :default :auto :options [[:auto "Auto"] [:manual "Manual"]]}


### PR DESCRIPTION
### User facing changes

Fixes https://github.com/defold/editor2-issues/issues/1357

- There's now a new setting "Track Active Item in Asset Browser". When
  enabled, the resource being edited will also be selected and focused
  in the asset browser.

### Technical changes

- Separate production of tree root and update of `TreeView` and make
  update smarter depending on what has actually changed.
- New preference "asset-browser-track-active-item?"
- Always scroll to selection in asset browser