### PR TITLE
DEFEDIT-1199 Support multiple release channels

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -10,14 +10,14 @@ version = 2.0.0
 editor_sha1 =
 engine_sha1 =
 time =
+channel =
 [launcher]
 jre = ${bootstrap.resourcespath}/packages/jre
 java = ${launcher.jre}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Start
 debug = 1
-updateurl = https://d.defold.com/editor2
-vmargs = -Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Ddefold.update.url=${launcher.updateurl},-Dglass.accessible.force=false
+vmargs = -Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Djava.ext.dirs=${launcher.jre}/lib/ext,-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/resources/about.fxml
+++ b/editor/resources/about.fxml
@@ -27,6 +27,7 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="20.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="40.0" vgrow="NEVER" />
           <RowConstraints minHeight="10.0" prefHeight="40.0" vgrow="NEVER" />
@@ -45,27 +46,32 @@
                   <Font size="11.0" />
                </font>
             </Label>
-            <Label id="time" text="Built: n/a" GridPane.rowIndex="2">
+            <Label id="channel" text="Channel: n/a" GridPane.rowIndex="2">
                <font>
                   <Font size="11.0" />
                </font>
             </Label>
-            <TextField id="editor-sha1" alignment="center" editable="false" focusTraversable="false" styleClass="copyable-label" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="4">
-               <font>
-                  <Font size="11.0" />
-               </font>
-            </TextField>
-            <TextField id="engine-sha1" alignment="center" editable="false" focusTraversable="false" styleClass="copyable-label" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="5">
-               <font>
-                  <Font size="11.0" />
-               </font>
-            </TextField>
-            <Label text="Copyright (c) 2009-2017" GridPane.rowIndex="7">
+            <Label id="time" text="Built: n/a" GridPane.rowIndex="3">
                <font>
                   <Font size="11.0" />
                </font>
             </Label>
-            <Label text="Midasplayer Technology AB" GridPane.rowIndex="8">
+            <TextField id="editor-sha1" alignment="center" editable="false" focusTraversable="false" styleClass="copyable-label" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="5">
+               <font>
+                  <Font size="11.0" />
+               </font>
+            </TextField>
+            <TextField id="engine-sha1" alignment="center" editable="false" focusTraversable="false" styleClass="copyable-label" text="2b680b3ec7af8a84401ad584d8bc47a246f82947" GridPane.rowIndex="6">
+               <font>
+                  <Font size="11.0" />
+               </font>
+            </TextField>
+            <Label text="Copyright (c) 2009-2017" GridPane.rowIndex="8">
+               <font>
+                  <Font size="11.0" />
+               </font>
+            </Label>
+            <Label text="Midasplayer Technology AB" GridPane.rowIndex="9">
                <font>
                   <Font size="11.0" />
                </font>

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -206,6 +206,9 @@ def bundle(platform, jar_file, options):
     config.set('build', 'version', options.version)
     config.set('build', 'time', datetime.datetime.now().isoformat())
 
+    if options.channel:
+        config.set('build', 'channel', options.channel)
+
     with open('%s/config' % resources_dir, 'wb') as f:
         config.write(f)
 
@@ -272,6 +275,10 @@ if __name__ == '__main__':
                       default = None,
                       help = 'Version')
 
+    parser.add_option('--channel', dest='channel',
+                      default = None,
+                      help = 'Channel')
+
     parser.add_option('--engine-artifacts', dest='engine_artifacts',
                       default = 'auto',
                       help = "Which engine artifacts to use, can be 'auto', 'dynamo-home', 'archived', 'archived-stable' or a sha1.")
@@ -324,7 +331,7 @@ if __name__ == '__main__':
 
     exec_command(init_command)
     check_reflections()
-    
+
     if options.skip_tests:
         print 'Skipping tests'
     else:

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -498,8 +498,9 @@
   (let [root ^Parent (ui/load-fxml "about.fxml")
         stage (ui/make-dialog-stage)
         scene (Scene. root)
-        controls (ui/collect-controls root ["version" "editor-sha1" "engine-sha1" "time"])]
+        controls (ui/collect-controls root ["version" "channel" "editor-sha1" "engine-sha1" "time"])]
     (ui/text! (:version controls) (str "Version: " (System/getProperty "defold.version" "NO VERSION")))
+    (ui/text! (:channel controls) (str "Channel: " (or (system/defold-channel) "No channel")))
     (ui/text! (:editor-sha1 controls) (or (system/defold-editor-sha1) "No editor sha1"))
     (ui/text! (:engine-sha1 controls) (or (system/defold-engine-sha1) "No engine sha1"))
     (ui/text! (:time controls) (or (system/defold-build-time) "No build time"))

--- a/editor/src/clj/editor/github.clj
+++ b/editor/src/clj/editor/github.clj
@@ -13,6 +13,7 @@
 (defn- default-fields
   []
   {"Defold version"    (or (system/defold-version) "dev")
+   "Defold channel"    (or (system/defold-channel) "")
    "Defold editor sha" (or (system/defold-editor-sha1) "")
    "Defold engine sha" (or (system/defold-engine-sha1) "")
    "Build time"        (or (system/defold-build-time) "")
@@ -34,7 +35,7 @@
          ""
          (when (seq fields)
            ["<table>"
-            (for [[name value] fields]
+            (for [[name value] (sort-by first fields)]
               (format "<tr><td>%s</td><td>%s</td></tr>" name value))
             "<table>"])]
         flatten

--- a/editor/src/clj/editor/sentry.clj
+++ b/editor/src/clj/editor/sentry.clj
@@ -97,6 +97,7 @@
                              :defold-editor-sha1 (system/defold-editor-sha1)
                              :defold-engine-sha1 (system/defold-engine-sha1)
                              :defold-version (or (system/defold-version) "dev")
+                             :defold-channel (system/defold-channel)
                              :os-name (system/os-name)
                              :os-arch (system/os-arch)
                              :os-version (system/os-version)

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -19,9 +19,9 @@
   ^String []
   (System/getProperty "defold.version"))
 
-(defn defold-update-url
+(defn defold-channel
   ^String []
-  (System/getProperty "defold.update.url"))
+  (System/getProperty "defold.channel"))
 
 (defn defold-resourcespath
   ^String []

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -73,14 +73,19 @@
     (.cancel)
     (.purge)))
 
+(defn- update-url
+  [channel]
+  (format "https://d.defold.com/editor2/channels/%s" channel))
+
 (defn start!
-  ([] (start! (system/defold-update-url) (system/defold-editor-sha1) initial-update-delay update-delay))
-  ([update-url sha1 initial-update-delay update-delay]
-   (if (and (not (string/blank? update-url)) (not (string/blank? sha1)))
-     (let [update-context (make-update-context update-url sha1)
+  ([] (start! (system/defold-channel) (system/defold-editor-sha1) initial-update-delay update-delay))
+  ([channel sha1 initial-update-delay update-delay]
+   (if (and (not (string/blank? channel)) (not (string/blank? sha1)))
+     (let [update-url (update-url channel)
+           update-context (make-update-context update-url sha1)
            timer (start-update-timer! update-context initial-update-delay update-delay)]
-       (log/info :message "automatic updates enabled")
+       (log/info :message (format "automatic updates enabled (channel='%s')" channel))
        {:timer timer :update-context update-context})
      (do
-       (log/info :message (format "automatic updates disabled (url='%s', sha1='%s')" update-url sha1))
+       (log/info :message (format "automatic updates disabled (channel='%s', sha1='%s')" channel sha1))
        nil))))

--- a/editor/src/java/com/defold/editor/Updater.java
+++ b/editor/src/java/com/defold/editor/Updater.java
@@ -75,12 +75,12 @@ public class Updater {
             }
         }
 
-	public void deleteFiles() {
-	    for (Entry<String, File> entry : files.entrySet()) {
-		FileUtils.deleteQuietly(entry.getValue());
-	    }
-	    FileUtils.deleteQuietly(config);
-	}
+        public void deleteFiles() {
+            for (Entry<String, File> entry : files.entrySet()) {
+                FileUtils.deleteQuietly(entry.getValue());
+            }
+            FileUtils.deleteQuietly(config);
+        }
 
         /**
          * Installs the update
@@ -159,7 +159,10 @@ public class Updater {
      * @throws IOException
      */
     public PendingUpdate check(String currentSha1) throws IOException {
-        JsonNode update = fetchJson(makeURI(updateUrl, "update.json"));
+        URI updateURI = makeURI(updateUrl, "update.json");
+        logger.debug(String.format("checking for update url='%s'", updateURI));
+
+        JsonNode update = fetchJson(updateURI);
         String packagesUrl = update.get("url").asText();
         URI packagesUri = makeURI(packagesUrl, "manifest.json");
         if (!"https".equals(packagesUri.getScheme())) {


### PR DESCRIPTION
**Note**: After this PR is merged, we should:

- copy "https://d.defold.com/editor2/update.json" to "https://d.defold.com/editor2/channels/editor-alpha/update.json"
- update "https://d.defold.com/editor2/update.json" to redirect to "https://d.defold.com/editor2/channels/editor-alpha/update.json"

This will ensure older editors that only check "/editor2/update.json" will see new updates.

### Technical changes

- always release editor2 if a channel has been specified
- upload editor2 update.json to a URL that incorporates channel:
    - https://d.defold.com/editor2/channels/${channel}/update.json
- remove "update url" as a config concept, replace with channel
  - editor knows how to construct a update-url given a channel
- bundle now accepts a --channel argument which will decide the
  default channel for the bundled editor