### PR TITLE
DEFEDIT-1207 Prevent UI from staying locked after build has completed

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -199,11 +199,7 @@
         (when render-error!
           (render-error! build-targets))
         nil)
-      (let [mapv-fn (progress/make-mapv render-progress!
-                                        (fn [[key build-target]]
-                                          (let [proj-path (some-> build-target :resource :resource resource/resource->proj-path)]
-                                            (str "Building " (or proj-path "inline resource")))))]
-        (pipeline/build! (workspace project) build-targets mapv-fn)))))
+      (pipeline/build! (workspace project) build-targets))))
 
 (handler/defhandler :undo :global
   (enabled? [project-graph] (g/has-undo? project-graph))


### PR DESCRIPTION
### User facing changes

Fixes https://github.com/defold/editor2-issues/issues/1369, https://github.com/defold/editor2-issues/issues/924

- When building large projects, the editor would sometimes remain
  unresponsive even after the build completed and the game was
  launched. The console output would be delayed too. This has now been
  fixed.

### Technical changes

- We swamped the UI thread by using `ui/run-later` to update the build
  progress for each build target being built. On large projects, this
  would be a substantial amount. Until we have a better story for
  progress, remove the reporting of progress during build.
- Use reducers when churning through all build-targets. This took
  rebuild time from ~8s to ~2s for one internal project.