### PR TITLE
DEFEDIT-1202 Search searches in all text files in project

### DIFF
--- a/editor/resources/search-in-files-dialog.fxml
+++ b/editor/resources/search-in-files-dialog.fxml
@@ -14,25 +14,26 @@
       <Label text="Search pattern (* to match any string)" />
       <TextField id="search" />
       <Label text="File types to search in (comma separated)" />
-      <TextField id="types"/>
+      <TextField id="types" />
       <TreeView id="resources-tree" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS" />
-    <HBox maxHeight="-Infinity" maxWidth="+Infinity" minHeight="-Infinity" minWidth="-Infinity">
+    <HBox alignment="CENTER" maxHeight="-Infinity" maxWidth="+Infinity">
       <children>
-        <HBox fx:id="actionParent" alignment="CENTER">
-          <HBox.margin>
-            <Insets />
-          </HBox.margin>
-        </HBox>
+            <HBox id="search-in-progress" alignment="CENTER">
+               <children>
+                  <ProgressIndicator minHeight="-Infinity" minWidth="-Infinity" prefHeight="24.0" prefWidth="24.0" />
+                  <Label text="Searching">
+                     <padding>
+                        <Insets left="8.0" />
+                     </padding>
+                  </Label>
+               </children>
+            </HBox>
         <Pane maxWidth="+Infinity" HBox.hgrow="ALWAYS" />
-        <HBox fx:id="okParent" alignment="CENTER">
-          <children>
-            <Button id="ok" minWidth="80.0" focusTraversable="false" mnemonicParsing="false" text="OK" HBox.hgrow="NEVER">
-              <HBox.margin>
-                <Insets left="14.0" />
-              </HBox.margin>
-            </Button>
-          </children>
-        </HBox>
+      <Button id="ok" focusTraversable="false" minWidth="80.0" mnemonicParsing="false" text="OK" HBox.hgrow="NEVER">
+        <HBox.margin>
+          <Insets left="14.0" />
+        </HBox.margin>
+      </Button>
       </children>
     </HBox>
    </children>

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -527,23 +527,14 @@
         (settings-core/get-setting ["project" "dependencies"])
         (library/parse-library-urls))))
 
-(defn- cache-node-value! [node-id label]
-  (g/node-value node-id label)
-  nil)
-
-(defn- cache-save-data! [project render-progress!]
-  ;; Save data is required for the Search in Files feature. Sadly we cannot
-  ;; warm the caches in the background, as the graph cache cannot be updated
-  ;; from another thread.
-  (let [save-data-sources (g/sources-of project :save-data)
-        progress (atom (progress/make "Indexing..." (inc (count save-data-sources))))]
-    (doseq [[node-id label] save-data-sources]
-      (when render-progress!
-        (render-progress! (swap! progress progress/advance)))
-      (cache-node-value! node-id label))
-    (when render-progress!
-      (render-progress! (swap! progress progress/advance)))
-    (cache-node-value! project :save-data)))
+(defn- cache-save-data! [project]
+  ;; Save data is required for the Search in Files feature so we pull
+  ;; it in the background here to cache it.
+  (let [evaluation-context (g/make-evaluation-context)]
+    (future
+      ;; TODO progress reporting
+      (g/node-value project :save-data evaluation-context)
+      (ui/run-later (g/update-cache-from-evaluation-context! evaluation-context)))))
 
 (defn open-project! [graph workspace-id game-project-resource render-progress! login-fn]
   (let [progress (atom (progress/make "Updating dependencies..." 3))]
@@ -555,7 +546,7 @@
     (render-progress! (swap! progress progress/advance 1 "Loading project"))
     (let [project (make-project graph workspace-id)
           populated-project (load-project project (g/node-value project :resources) (progress/nest-render-progress render-progress! @progress))]
-      (cache-save-data! populated-project (progress/nest-render-progress render-progress! @progress))
+      (cache-save-data! populated-project)
       populated-project)))
 
 (defn resource-setter [self old-value new-value & connections]

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -1,13 +1,41 @@
 (ns editor.defold-project-search
-  (:require [clojure.string :as string]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.ui :as ui]
             [editor.resource :as resource]
-            [util.thread-util :as thread-util])
+            [util.thread-util :as thread-util]
+            [util.text-util :as text-util])
   (:import (java.util.concurrent LinkedBlockingQueue)
-           (java.util.regex Pattern)))
+           (java.util.regex Pattern)
+           (java.io BufferedReader StringReader)
+           (clojure.lang IReduceInit)))
 
 (set! *warn-on-reflection* true)
+
+(defn- make-line-coll
+  [make-buffered-reader]
+  (reify IReduceInit
+    (reduce [_ rf init]
+      (with-open [^BufferedReader rdr (make-buffered-reader)]
+        (loop [ret init
+               row 0
+               pos 0]
+          (if-some [line (.readLine rdr)]
+            (let [ret (rf ret {:line line
+                               :row row
+                               :pos pos})]
+              (if (reduced? ret)
+                @ret
+                (recur ret (inc row) (+ pos (count line)))))
+            ret))))))
+
+(defn- line-coll
+  [{:keys [content resource] :as save-data}]
+  (or (when (some? content)
+        (make-line-coll #(BufferedReader. (StringReader. content))))
+      (when (and (resource/exists? resource) (not (text-util/binary? resource)))
+        (make-line-coll #(BufferedReader. (io/reader resource))))))
 
 (defn compile-find-in-files-regex
   "Convert a search-string to a case-insensitive java regex."
@@ -17,9 +45,19 @@
                        (string/join ".*"))]
     (re-pattern (str "(?i)^(.*)(" clean-str ")(.*)$"))))
 
-(defn- line->caret-pos [content line]
-  (let [line-counts (map (comp inc count) (string/split-lines content))]
-    (reduce + (take line line-counts))))
+(defn- find-matches [pattern save-data]
+  (when-some [lines (line-coll save-data)]
+    (into []
+          (comp (keep (fn [{:keys [line row pos]}]
+                        (let [matcher (re-matcher pattern line)]
+                          (when (.matches matcher)
+                            {:line row
+                             :caret-position pos
+                             :match (str (apply str (take-last 24 (string/triml (.group matcher 1))))
+                                         (.group matcher 2)
+                                         (apply str (take 24 (string/trimr (.group matcher 3)))))}))))
+                (take 10))
+          lines)))
 
 (defn- save-data-sort-key [entry]
   (some-> entry :resource resource/proj-path))
@@ -28,25 +66,19 @@
   (let [evaluation-context (g/make-evaluation-context)]
     (future
       (try
-        (let [result (->> (g/node-value project :save-data evaluation-context)
-                          (filter #(some-> % :resource resource/source-type (= :file)))
-                          (sort-by save-data-sort-key))]
+        (let [search-data (->> (into []
+                                     (keep (fn [node-id]
+                                             (let [save-data (g/node-value node-id :save-data evaluation-context)
+                                                   resource (:resource save-data)]
+                                               (when (and (some? resource) (= :file (resource/source-type resource)))
+                                                 save-data))))
+                                     (g/node-value project :nodes evaluation-context))
+                               (sort-by save-data-sort-key))]
           (ui/run-later (g/update-cache-from-evaluation-context! evaluation-context))
-          result)
+          search-data)
         (catch Throwable error
           (report-error! error)
           nil)))))
-
-(defn- find-matches [pattern content]
-  (->> (string/split-lines content)
-       (keep-indexed (fn [idx l]
-                       (let [[_ pre m post] (re-matches pattern l)]
-                         (when m
-                           {:line           idx
-                            :caret-position (line->caret-pos content idx)
-                            :match          (str (apply str (take-last 24 (string/triml pre)))
-                                                 m
-                                                 (apply str (take 24 (string/trimr post))))}))))))
 
 (defn- start-search-thread [report-error! file-resource-save-data-future term exts produce-fn]
   (future
@@ -60,17 +92,18 @@
                                         (string/replace #" " "")
                                         (string/split #",")))
             xform (comp (map thread-util/abortable-identity!)
-                        (filter :content)
-                        (filter (fn [save-data]
+                        (filter (fn [{:keys [resource]}]
                                   (or (empty? file-ext-pats)
-                                      (let [ext (-> save-data :resource resource/ext)]
+                                      (let [ext (resource/ext resource)]
                                         (some #(re-matches % ext) file-ext-pats)))))
-                        (map #(assoc % :matches (take 10 (find-matches pattern (:content %)))))
+                        (map (fn [{:keys [resource] :as save-data}]
+                               {:resource resource
+                                :matches (find-matches pattern save-data)}))
                         (filter #(seq (:matches %))))]
-        (run! produce-fn (sequence xform (deref file-resource-save-data-future)))
+        (run! #(produce-fn %) (eduction xform (deref file-resource-save-data-future)))
         (produce-fn ::done))
       (catch InterruptedException _
-        ; future-cancel was invoked from another thread.
+        ;; future-cancel was invoked from another thread.
         nil)
       (catch Throwable error
         (report-error! error)
@@ -107,11 +140,16 @@
                         (abort-search! pending-search)
                         (if (seq term)
                           (let [queue (LinkedBlockingQueue. 1024)
-                                thread (start-search-thread report-error! file-resource-save-data-future term exts #(.put queue %))
-                                consumer (start-consumer! #(.poll queue))]
+                                produce-fn #(do
+                                              (.put queue %))
+                                consume-fn #(let [results (java.util.ArrayList.)]
+                                              (.drainTo queue results)
+                                              (seq results))
+                                thread (start-search-thread report-error! file-resource-save-data-future term exts produce-fn)
+                                consumer (start-consumer! consume-fn)]
                             {:thread thread
                              :consumer consumer})
-                          (do (start-consumer! (constantly ::done))
+                          (do (start-consumer! (constantly [::done]))
                               nil)))]
     {:start-search! (fn [term exts]
                       (try

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -48,22 +48,29 @@
       (when first-match?
         (-> tree-view .getSelectionModel (.clearAndSelect 1))))))
 
-(defn- seconds->nanoseconds [seconds]
-  (long (* 1000000000 seconds)))
-
-(defn- start-tree-update-timer! [tree-views poll-fn]
-  (let [timer (ui/->timer "tree-update-timer"
-                          (fn [^AnimationTimer timer _dt]
-                            (let [start-time (System/nanoTime)
-                                  end-time (+ start-time (seconds->nanoseconds (/ 1 90)))]
-                              (loop [poll-time 0]
-                                (when (> end-time poll-time)
-                                  (when-let [entry (poll-fn)]
-                                    (if (= ::project-search/done entry)
+(defn- start-tree-update-timer! [tree-views search-in-progress results-fn]
+  (let [t (atom 0)
+        timer (ui/->timer 5 "tree-update-timer"
+                          (fn [^AnimationTimer timer dt]
+                            ;; TODO This can go away when we replace dt with t for all timers.
+                            (let [t' (swap! t + dt)]
+                              ;; Delay showing the progress indicator a bit to avoid flashing for
+                              ;; searches that complete quickly.
+                              (when (< 0.2 t')
+                                (ui/visible! search-in-progress true)))
+                            (when-some [results (results-fn)]
+                              (loop [[result & more] results]
+                                (when result
+                                  (cond
+                                    (= ::project-search/done result)
+                                    (do
                                       (.stop timer)
-                                      (do (doseq [^TreeView tree-view tree-views]
-                                            (insert-search-result tree-view entry))
-                                          (recur (System/nanoTime))))))))))]
+                                      (ui/visible! search-in-progress false))
+
+                                    :else
+                                    (do (doseq [^TreeView tree-view tree-views]
+                                          (insert-search-result tree-view result))
+                                        (recur more))))))))]
     (doseq [^TreeView tree-view tree-views]
       (.clear (.getChildren (.getRoot tree-view))))
     (ui/timer-start! timer)
@@ -110,8 +117,9 @@
                     (.initStyle StageStyle/DECORATED)
                     (.initOwner (ui/main-stage))
                     (.setResizable false))]
-    (ui/with-controls root [^TextField search ^TextField types ^TreeView resources-tree ok]
-      (let [start-consumer! (partial start-tree-update-timer! [resources-tree results-tab-tree-view])
+    (ui/with-controls root [^TextField search ^TextField types ^TreeView resources-tree ok search-in-progress]
+      (ui/visible! search-in-progress false)
+      (let [start-consumer! (partial start-tree-update-timer! [resources-tree results-tab-tree-view] search-in-progress)
             stop-consumer! ui/timer-stop!
             report-error! (fn [error] (ui/run-later (throw error)))
             file-resource-save-data-future (project-search/make-file-resource-save-data-future report-error! project)

--- a/editor/src/clj/util/text_util.clj
+++ b/editor/src/clj/util/text_util.clj
@@ -112,7 +112,7 @@
   ([readable {:keys [chars-to-check binary-chars-threshold]
               :or   {chars-to-check 1000
                      binary-chars-threshold 0.01}}]
-   (with-open [rdr (BufferedReader. (io/reader readable))]
+   (with-open [rdr (io/reader readable)]
      (let [cbuf (char-array chars-to-check)
            nread (.read rdr cbuf 0 chars-to-check)
            limit (* binary-chars-threshold nread)]

--- a/editor/src/clj/util/text_util.clj
+++ b/editor/src/clj/util/text_util.clj
@@ -1,7 +1,7 @@
 (ns util.text-util
   (:require [clojure.java.io :as io]
             [clojure.string :as string])
-  (:import (java.io Reader)))
+  (:import (java.io BufferedReader Reader)))
 
 (defn text-char?
   "Returns true if the supplied character is textual. This can
@@ -101,3 +101,26 @@
   Returns nil if the input is nil."
   [^String text]
   (some-> text (string/replace #"\r" "") (string/replace #"\n" "\r\n")))
+
+(defn binary?
+  "Tries to guess whether some readable thing has binary content. Looks at the
+  first `chars-to-check` number of chars from readable and if more than
+  `binary-chars-threshold` of them are not `text-char?` then consider the
+  content binary."
+  ([readable]
+   (binary? readable nil))
+  ([readable {:keys [chars-to-check binary-chars-threshold]
+              :or   {chars-to-check 1000
+                     binary-chars-threshold 0.01}}]
+   (with-open [rdr (BufferedReader. (io/reader readable))]
+     (let [cbuf (char-array chars-to-check)
+           nread (.read rdr cbuf 0 chars-to-check)
+           limit (* binary-chars-threshold nread)]
+       (loop [i 0
+              binary-chars 0]
+         (if (< i nread)
+           (if (< limit binary-chars)
+             true
+             (recur (inc i) (if (text-char? (aget cbuf i)) binary-chars (inc binary-chars))))
+           false))))))
+

--- a/editor/styling/stylesheets/components/_progress-indicator.scss
+++ b/editor/styling/stylesheets/components/_progress-indicator.scss
@@ -1,0 +1,3 @@
+.progress-indicator {
+    -fx-progress-color: $grey;
+}

--- a/editor/styling/stylesheets/main.sass
+++ b/editor/styling/stylesheets/main.sass
@@ -29,6 +29,7 @@
 @import 'components/_menu-bar';
 @import 'components/_menu-button';
 @import 'components/_progress-bar';
+@import 'components/_progress-indicator';
 @import 'components/_property';
 @import 'components/_radio-button';
 @import 'components/_scroll-bar';

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -1,13 +1,15 @@
 (ns editor.defold-project-search-test
-  (:require [clojure.test :refer :all]
-            [clojure.set :as set]
-            [dynamo.graph :as g]
-            [editor.defold-project-search :as project-search]
-            [editor.resource :as resource]
-            [integration.test-util :as test-util]
-            [support.test-support :refer [with-clean-system]]
-            [util.thread-util :as thread-util])
-  (:import (java.util.concurrent LinkedBlockingQueue)))
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [dynamo.graph :as g]
+   [editor.defold-project-search :as project-search]
+   [editor.resource :as resource]
+   [integration.test-util :as test-util]
+   [support.test-support :refer [with-clean-system]]
+   [util.thread-util :as thread-util])
+  (:import
+   (java.util.concurrent LinkedBlockingQueue)))
 
 (def ^:const search-project-path "test/resources/search_project")
 (def ^:const timeout-ms 5000)
@@ -36,6 +38,7 @@
                                                   ::not-done))]
                                       (when (= ret ::not-done)
                                         (when (< (- poll-time last-response-time) (* 1000000 timeout-ms))
+                                          (Thread/sleep 10)
                                           (recur last-response-time)))))
                                   (catch InterruptedException _
                                     nil)

--- a/editor/test/editor/defold_project_search_test.clj
+++ b/editor/test/editor/defold_project_search_test.clj
@@ -1,5 +1,7 @@
 (ns editor.defold-project-search-test
   (:require [clojure.test :refer :all]
+            [clojure.set :as set]
+            [dynamo.graph :as g]
             [editor.defold-project-search :as project-search]
             [editor.resource :as resource]
             [integration.test-util :as test-util]
@@ -13,7 +15,7 @@
 (defn- make-consumer [report-error!]
   (atom {:consumed [] :future nil :report-error! report-error!}))
 
-(defn- consumer-start! [consumer-atom poll-fn!]
+(defn- consumer-start! [consumer-atom results-fn!]
   (swap! consumer-atom
          (fn [consumer]
            (when (:future consumer)
@@ -25,12 +27,15 @@
                                   (loop [last-response-time (System/nanoTime)]
                                     (thread-util/throw-if-interrupted!)
                                     (let [poll-time (System/nanoTime)
-                                          entry (poll-fn!)]
-                                      (if (some? entry)
-                                        (if (not= ::project-search/done entry)
-                                          (do (swap! consumer-atom update :consumed conj entry)
-                                              (recur poll-time)))
-                                        (if (< (- poll-time last-response-time) (* 1000000 timeout-ms))
+                                          ret (loop [[result & more] (results-fn!)]
+                                                (if result
+                                                  (if (= ::project-search/done result)
+                                                    ::done
+                                                    (do (swap! consumer-atom update :consumed conj result)
+                                                        (recur more)))
+                                                  ::not-done))]
+                                      (when (= ret ::not-done)
+                                        (when (< (- poll-time last-response-time) (* 1000000 timeout-ms))
                                           (recur last-response-time)))))
                                   (catch InterruptedException _
                                     nil)
@@ -109,13 +114,10 @@
     (test-util/with-ui-run-later-rebound
       (let [report-error! (test-util/make-call-logger)
             save-data-future (project-search/make-file-resource-save-data-future report-error! project)
-            proj-paths (->> save-data-future deref (map :resource) (map resource/proj-path))
-            contents (->> save-data-future deref (map :content))]
-        (is (= ["/game.project"
-                "/modules/colors.lua"
-                "/scripts/actors.script"
-                "/scripts/apples.script"] proj-paths))
-        (is (every? string? contents))
+            search-paths (->> save-data-future deref (map :resource) (map resource/proj-path))]
+        (is (= (set search-paths)
+               (set (keep #(some-> (g/node-value % :save-data) :resource resource/proj-path)
+                          (g/node-value project :nodes)))))
         (is (= [] (test-util/call-logger-calls report-error!)))))))
 
 (deftest file-searcher-results-test
@@ -134,16 +136,23 @@
         (is (= [] (perform-search! nil nil)))
         (is (= [] (perform-search! "" nil)))
         (is (= [] (perform-search! nil "")))
-        (is (= [["/modules/colors.lua" ["red = {255, 0, 0},"]]
-                ["/scripts/apples.script" ["\"Red Delicious\","]]] (perform-search! "red" nil)))
-        (is (= [["/modules/colors.lua" ["red = {255, 0, 0},"
-                                        "green = {0, 255, 0},"
-                                        "blue = {0, 0, 255}"]]] (perform-search! "255" nil)))
-        (is (= [["/scripts/actors.script" ["\"Will Smith\""]]
-                ["/scripts/apples.script" ["\"Granny Smith\""]]] (perform-search! "smith" "script")))
-        (is (= [["/modules/colors.lua" ["return {"]]
-                ["/scripts/actors.script" ["return {"]]
-                ["/scripts/apples.script" ["return {"]]] (perform-search! "return" "lua, script")))
+        (is (set/subset? #{["/modules/colors.lua" ["red = {255, 0, 0},"]]
+                           ["/scripts/apples.script" ["\"Red Delicious\","]]}
+                         (set (perform-search! "red" nil))))
+        (is (set/subset? #{["/modules/colors.lua" ["red = {255, 0, 0},"
+                                                    "green = {0, 255, 0},"
+                                                   "blue = {0, 0, 255}"]]}
+                         (set (perform-search! "255" nil))))
+        (is (set/subset? #{["/scripts/actors.script" ["\"Will Smith\""]]
+                           ["/scripts/apples.script" ["\"Granny Smith\""]]}
+                         (set (perform-search! "smith" "script"))))
+        (is (set/subset? #{["/modules/colors.lua" ["return {"]]
+                           ["/scripts/actors.script" ["return {"]]
+                           ["/scripts/apples.script" ["return {"]]}
+                         (set (perform-search! "return" "lua, script"))))
+        (is (some #(.startsWith % "/builtins")
+                  (map first (perform-search! "return" "lua, script"))))
+        (is (= [["/foo.bar" ["Buckle my shoe;"]]] (perform-search! "buckle" nil)))
         (abort-search!)
         (is (true? (test-util/block-until true? timeout-ms consumer-stopped? consumer)))
         (is (= [] (test-util/call-logger-calls report-error!)))))))

--- a/editor/test/resources/search_project/foo.bar
+++ b/editor/test/resources/search_project/foo.bar
@@ -1,0 +1,4 @@
+One, two,
+Buckle my shoe;
+Three, four,
+Knock at the door;


### PR DESCRIPTION
### User facing changes

Fixes https://github.com/defold/editor2-issues/issues/1370, https://github.com/defold/editor2-issues/issues/607

- "Search in Files" will now search all text files in project,
  including dependencies, builtins and files that are not editied
  within editor.

### Technical changes

- we now cache save data on a background thread so the "Indexing..."
  step when loading a project is gone
- consider all resource-nodes connected to Project/nodes when
  searching
  - if they have save-data with content, search that
  - otherwise search the disk contents
  - ignore files that look like they don't have textual content