### PR TITLE
DEFEDIT-988 Cubemap support

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -3,6 +3,7 @@
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [editor.image :as image]
+            [editor.image-util :as image-util]
             [editor.geom :as geom]
             [editor.core :as core]
             [editor.colors :as colors]
@@ -428,7 +429,7 @@
   (output packed-image     BufferedImage       :cached (g/fnk [_node-id texture-set-data image-resources]
                                                          (let [id->image (reduce (fn [ret image-resource]
                                                                                    (let [id (resource/proj-path image-resource)
-                                                                                         image (image/read-image image-resource)]
+                                                                                         image (image-util/read-image image-resource)]
                                                                                      (assoc ret id image)))
                                                                                  {}
                                                                                  (flatten image-resources))]

--- a/editor/src/clj/editor/collada_scene.clj
+++ b/editor/src/clj/editor/collada_scene.clj
@@ -133,7 +133,6 @@
       (let [renderable (first renderables)
             node-id (:node-id renderable)
             user-data (:user-data renderable)
-            scratch (:scratch-arrays user-data)
             meshes (:meshes user-data)
             shader (:shader user-data)
             textures (:textures user-data)]
@@ -148,6 +147,7 @@
           (doseq [renderable renderables]
             (let [node-id (:node-id renderable)
                   user-data (:user-data renderable)
+                  scratch (:scratch-arrays user-data)
                   meshes (:meshes user-data)
                   world-transform (:world-transform renderable)]
               (doseq [mesh meshes]

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -130,10 +130,10 @@
    :nz :back})
 
 (defn- cubemap-images-missing-error [node-id cubemap-image-resources]
-  (when-let [error (first (keep (fn [[dir image-resource]]
-                                  (when-let [message (validation/prop-resource-missing? image-resource (properties/keyword->name (cubemap-dir->property dir)))]
-                                    [dir message]))
-                                cubemap-image-resources))]
+  (when-let [error (some (fn [[dir image-resource]]
+                           (when-let [message (validation/prop-resource-missing? image-resource (properties/keyword->name (cubemap-dir->property dir)))]
+                             [dir message]))
+                         cubemap-image-resources)]
     (let [[dir message] error]
       (g/->error node-id (cubemap-dir->property dir) :fatal nil message))))
 

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -156,7 +156,6 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
   ([request-id img params]
    (image-texture request-id img params 0))
   ([request-id ^BufferedImage img params unit-index]
-    (assert (< unit-index GL2/GL_MAX_TEXTURE_IMAGE_UNITS) (format "the maximum number of texture units is %d" GL2/GL_MAX_TEXTURE_IMAGE_UNITS))
     (let [texture-data (image->texture-data (flip-y (or img (:contents image-util/placeholder-image))) true)
           unit (+ unit-index GL2/GL_TEXTURE0)]
       (->TextureLifecycle request-id ::texture unit params texture-data))))
@@ -226,7 +225,6 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
   ([request-id img params]
    (texture-image->gpu-texture request-id img params 0))
   ([request-id ^Graphics$TextureImage img params unit-index]
-    (assert (< unit-index GL2/GL_MAX_TEXTURE_IMAGE_UNITS) (format "the maximum number of texture units is %d" GL2/GL_MAX_TEXTURE_IMAGE_UNITS))
    (let [texture-data (texture-image->texture-data img)
          unit (+ unit-index GL2/GL_TEXTURE0)]
       (->TextureLifecycle request-id ::texture unit params texture-data))))
@@ -257,7 +255,6 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
   ([request-id texture-images params]
    (cubemap-texture-images->gpu-texture request-id texture-images params 0))
   ([request-id texture-images params unit-index]
-   (assert (< unit-index GL2/GL_MAX_TEXTURE_IMAGE_UNITS) (format "the maximum number of texture units is %d" GL2/GL_MAX_TEXTURE_IMAGE_UNITS))   
    (let [texture-datas (util/map-vals texture-image->texture-data texture-images)
          unit (+ unit-index GL2/GL_TEXTURE0)]
      (->TextureLifecycle request-id ::cubemap-texture unit params texture-datas))))

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -2,6 +2,8 @@
   (:require [clojure.java.io :as io]
             [dynamo.graph :as g]
             [schema.core :as s]
+            [editor.image-util :as image-util]
+            [editor.gl.texture :as texture]
             [editor.core :as core]
             [editor.geom :refer [clamper]]
             [editor.defold-project :as project]
@@ -21,36 +23,6 @@
 (set! *warn-on-reflection* true)
 
 (def exts ["jpg" "png"])
-
-(defn- convert-to-abgr
-  [^BufferedImage image]
-  (let [type (.getType image)]
-    (if (= type BufferedImage/TYPE_4BYTE_ABGR)
-      image
-      (let [abgr-image (BufferedImage. (.getWidth image) (.getHeight image) BufferedImage/TYPE_4BYTE_ABGR)]
-        (doto (.createGraphics abgr-image)
-          (.drawImage image 0 0 nil)
-          (.dispose))
-        abgr-image))))
-
-(defn read-image
-  [source]
-  (with-open [source-stream (io/input-stream source)]
-    (convert-to-abgr (ImageIO/read source-stream))))
-
-(defn- read-size
-  [source]
-  (with-open [source-stream (io/input-stream source)
-              image-stream (ImageIO/createImageInputStream source-stream)]
-    (let [readers (ImageIO/getImageReaders image-stream)]
-      (when (.hasNext readers)
-        (let [^javax.imageio.ImageReader reader (.next readers)]
-          (try
-            (.setInput reader image-stream true true)
-            {:width (.getWidth reader 0)
-             :height (.getHeight reader 0)}
-            (finally
-              (.dispose reader))))))))
 
 (defn- build-texture [resource dep-resources user-data]
   (let [{:keys [image texture-profile compress?]} user-data
@@ -77,6 +49,9 @@
                 :texture-profile texture-profile
                 :compress? (:compress? build-settings false)}}])
 
+(defn- generate-gpu-texture [{:keys [texture-image]} request-id params unit]
+  (texture/texture-image->gpu-texture request-id texture-image params unit))
+
 (g/defnode ImageNode
   (inherits resource-node/ResourceNode)
 
@@ -88,7 +63,7 @@
 
   (output size g/Any :cached (g/fnk [_node-id resource]
                                (try
-                                 (or (read-size resource)
+                                 (or (image-util/read-size resource)
                                    (validation/invalid-content-error _node-id :size :fatal resource))
                                  (catch java.io.FileNotFoundException e
                                    (validation/file-not-found-error _node-id :size :fatal resource))
@@ -97,141 +72,20 @@
   
   (output content BufferedImage (g/fnk [_node-id resource]
                                   (try
-                                    (or (read-image resource)
+                                    (or (image-util/read-image resource)
                                         (validation/invalid-content-error _node-id :content :fatal resource))
                                     (catch java.io.FileNotFoundException e
                                       (validation/file-not-found-error _node-id :content :fatal resource))
                                     (catch Exception _
                                       (validation/invalid-content-error _node-id :content :fatal resource)))))
+
+  (output texture-image g/Any (g/fnk [content texture-profile] (tex-gen/make-preview-texture-image content texture-profile)))
+
+  (output gpu-texture-generator g/Any :cached (g/fnk [texture-image :as user-data]
+                                                {:generate-fn generate-gpu-texture
+                                                 :user-data user-data}))
   
   (output build-targets g/Any :cached produce-build-targets))
-
-(defmacro with-graphics
-  [binding & body]
-  (let [rsym (gensym)]
-    `(let ~(into [] (concat binding [rsym `(do ~@body)]))
-       (.dispose ~(first binding))
-       ~rsym)))
-
-(s/defn make-color :- java.awt.Color
-  "creates a color using rgb values (optional a). Color values between 0 and 1.0"
-  ([r :- Float g :- Float b :- Float]
-    (java.awt.Color. r g b))
-  ([r :- Float g :- Float b :- Float a :- Float]
-    (java.awt.Color. r g b a)))
-
-(s/defn make-image :- Image
-  [nm :- s/Any contents :- BufferedImage]
-  (Image. nm contents (.getWidth contents) (.getHeight contents)))
-
-(s/defn blank-image :- BufferedImage
-  ([space :- Rect]
-    (blank-image (.width space) (.height space)))
-  ([width :- s/Int height :- s/Int]
-    (blank-image width height BufferedImage/TYPE_4BYTE_ABGR))
-  ([width :- s/Int height :- s/Int t :- s/Int]
-    (BufferedImage. width height t)))
-
-(s/defn flood :- BufferedImage
-  "Floods the image with the specified color (r g b <a>). Color values between 0 and 1.0."
-  [^BufferedImage img :- BufferedImage r :- Float g :- Float b :- Float]
-  (let [gfx (.createGraphics img)
-        color (make-color r g b)]
-    (.setColor gfx color)
-    (.fillRect gfx 0 0 (.getWidth img) (.getHeight img))
-    (.dispose gfx)
-    img))
-
-;; Use "Hollywood Cerise" for the placeholder image color.
-(def placeholder-image (make-image "placeholder" (flood (blank-image 64 64) 0.9568 0.0 0.6313)))
-
-(s/defn image-color-components :- long
-  [src :- BufferedImage]
-  (.. src (getColorModel) (getNumComponents)))
-
-(s/defn image-infer-type :- long
-  [src :- BufferedImage]
-  (if (not= 0 (.getType src))
-    (.getType src)
-    (case (image-color-components src)
-      4 BufferedImage/TYPE_4BYTE_ABGR
-      3 BufferedImage/TYPE_3BYTE_BGR
-      1 BufferedImage/TYPE_BYTE_GRAY)))
-
-(s/defn image-type :- g/Int
-  [src :- BufferedImage]
-  (let [t (.getType src)]
-    (if (not= 0 t) t (image-infer-type src))))
-
-(s/defn image-convert-type :- BufferedImage
-  [original :- BufferedImage new-type :- g/Int]
-  (if (= new-type (image-type original))
-    original
-    (let [new (blank-image (.getWidth original) (.getHeight original) new-type)]
-      (with-graphics [g2d (.createGraphics new)]
-        (.drawImage g2d original 0 0 nil))
-      new)))
-
-(s/defn image-bounds :- Rect
-  [source :- Image]
-  (types/rect (.path source) 0 0 (.width source) (.height source)))
-
-(s/defn image-pixels :- ints
-  [src :- BufferedImage]
-  (let [w      (.getWidth src)
-        h      (.getHeight src)
-        pixels (int-array (* w h (image-color-components src)))]
-    (.. src (getRaster) (getPixels 0 0 w h pixels))
-    pixels))
-
-(s/defn image-from-pixels :- BufferedImage
-  [^long width :- g/Int ^long height :- g/Int t :- g/Int pixels :- ints]
-  (doto (blank-image width height t)
-    (.. (getRaster) (setPixels 0 0 width height pixels))))
-
-(defmacro pixel-index [x y step stride]
-  `(* ~step (+ ~x (* ~y ~stride))))
-
-(s/defn extrude-borders :- Image
-  "Return a new pixel array, larger than the original by `extrusion`
-with the orig-pixels centered in it. The source pixels on the edges
-will bleed into the surrounding empty space. The pixels in the border
-region will be identical to the nearest pixel of the source image."
-  [extrusion :- g/Int src :- Image]
-  (if-not (< 0 extrusion)
-    src
-    (let [src-img        (types/contents src)
-          src-img        (image-convert-type src-img BufferedImage/TYPE_4BYTE_ABGR)
-          orig-width     (.width src)
-          orig-height    (.height src)
-          new-width      (+ orig-width (* 2 extrusion))
-          new-height     (+ orig-height (* 2 extrusion))
-          src-pixels     (image-pixels src-img)
-          num-components (image-color-components src-img)
-          clampx         (clamper 0 (dec orig-width))
-          clampy         (clamper 0 (dec orig-height))
-          new-pixels     (int-array (* new-width new-height num-components))]
-      (doseq [y (range new-height)
-              x (range new-width)]
-        (let [sx (clampx (- x extrusion))
-              sy (clampy (- y extrusion))
-              src-idx (pixel-index sx sy num-components orig-width)
-              tgt-idx (pixel-index x   y num-components new-width)]
-          (doseq [i (range num-components)]
-            (aset-int new-pixels (+ i tgt-idx) (aget src-pixels (+ i src-idx))))))
-      (make-image (.path src) (image-from-pixels new-width new-height (.getType src-img) new-pixels)))))
-
-(defn- map-by [p coll]
-  (zipmap (map p coll) coll))
-
-(s/defn composite :- BufferedImage
-  [onto :- BufferedImage placements :- [Rect] sources :- [Image]]
-  (let [src-by-path (map-by :path sources)]
-    (with-graphics [graphics (.getGraphics onto)]
-      (doseq [^Rect rect placements]
-        (.drawImage graphics (:contents (get src-by-path (.path rect))) (int (.x rect)) (int (.y rect)) nil)))
-    onto))
-
 
 (defn- load-image
   [project self resource]

--- a/editor/src/clj/editor/image_util.clj
+++ b/editor/src/clj/editor/image_util.clj
@@ -1,0 +1,173 @@
+(ns editor.image-util
+  (:require [clojure.java.io :as io]
+            [dynamo.graph :as g]
+            [schema.core :as s]
+            [editor.geom :refer [clamper]]
+            [editor.types :as types]
+            [editor.pipeline.tex-gen :as tex-gen]
+            [service.log :as log])
+  (:import [editor.types Rect Image]
+           [java.awt Color]
+           [java.awt.image BufferedImage]
+           [javax.imageio ImageIO]))
+
+(set! *warn-on-reflection* true)
+
+(defn- convert-to-abgr
+  [^BufferedImage image]
+  (let [type (.getType image)]
+    (if (= type BufferedImage/TYPE_4BYTE_ABGR)
+      image
+      (let [abgr-image (BufferedImage. (.getWidth image) (.getHeight image) BufferedImage/TYPE_4BYTE_ABGR)]
+        (doto (.createGraphics abgr-image)
+          (.drawImage image 0 0 nil)
+          (.dispose))
+        abgr-image))))
+
+(defn read-image
+  [source]
+  (with-open [source-stream (io/input-stream source)]
+    (convert-to-abgr (ImageIO/read source-stream))))
+
+(defn read-size
+  [source]
+  (with-open [source-stream (io/input-stream source)
+              image-stream (ImageIO/createImageInputStream source-stream)]
+    (let [readers (ImageIO/getImageReaders image-stream)]
+      (when (.hasNext readers)
+        (let [^javax.imageio.ImageReader reader (.next readers)]
+          (try
+            (.setInput reader image-stream true true)
+            {:width (.getWidth reader 0)
+             :height (.getHeight reader 0)}
+            (finally
+              (.dispose reader))))))))
+
+(defmacro with-graphics
+  [binding & body]
+  (let [rsym (gensym)]
+    `(let ~(into [] (concat binding [rsym `(do ~@body)]))
+       (.dispose ~(first binding))
+       ~rsym)))
+
+(s/defn make-color :- java.awt.Color
+  "creates a color using rgb values (optional a). Color values between 0 and 1.0"
+  ([r :- Float g :- Float b :- Float]
+    (java.awt.Color. r g b))
+  ([r :- Float g :- Float b :- Float a :- Float]
+    (java.awt.Color. r g b a)))
+
+(s/defn make-image :- Image
+  [nm :- s/Any contents :- BufferedImage]
+  (Image. nm contents (.getWidth contents) (.getHeight contents)))
+
+(s/defn blank-image :- BufferedImage
+  ([space :- Rect]
+    (blank-image (.width space) (.height space)))
+  ([width :- s/Int height :- s/Int]
+    (blank-image width height BufferedImage/TYPE_4BYTE_ABGR))
+  ([width :- s/Int height :- s/Int t :- s/Int]
+    (BufferedImage. width height t)))
+
+(s/defn flood :- BufferedImage
+  "Floods the image with the specified color (r g b <a>). Color values between 0 and 1.0."
+  [^BufferedImage img :- BufferedImage r :- Float g :- Float b :- Float]
+  (let [gfx (.createGraphics img)
+        color (make-color r g b)]
+    (.setColor gfx color)
+    (.fillRect gfx 0 0 (.getWidth img) (.getHeight img))
+    (.dispose gfx)
+    img))
+
+(defn load-image [src reference]
+  (make-image reference (read-image src)))
+
+;; Use "Hollywood Cerise" for the placeholder image color.
+(def placeholder-image (make-image "placeholder" (flood (blank-image 64 64) 0.9568 0.0 0.6313)))
+
+(s/defn image-color-components :- long
+  [src :- BufferedImage]
+  (.. src (getColorModel) (getNumComponents)))
+
+(s/defn image-infer-type :- long
+  [src :- BufferedImage]
+  (if (not= 0 (.getType src))
+    (.getType src)
+    (case (image-color-components src)
+      4 BufferedImage/TYPE_4BYTE_ABGR
+      3 BufferedImage/TYPE_3BYTE_BGR
+      1 BufferedImage/TYPE_BYTE_GRAY)))
+
+(s/defn image-type :- g/Int
+  [src :- BufferedImage]
+  (let [t (.getType src)]
+    (if (not= 0 t) t (image-infer-type src))))
+
+(s/defn image-convert-type :- BufferedImage
+  [original :- BufferedImage new-type :- g/Int]
+  (if (= new-type (image-type original))
+    original
+    (let [new (blank-image (.getWidth original) (.getHeight original) new-type)]
+      (with-graphics [g2d (.createGraphics new)]
+        (.drawImage g2d original 0 0 nil))
+      new)))
+
+(s/defn image-bounds :- Rect
+  [source :- Image]
+  (types/rect (.path source) 0 0 (.width source) (.height source)))
+
+(s/defn image-pixels :- ints
+  [src :- BufferedImage]
+  (let [w      (.getWidth src)
+        h      (.getHeight src)
+        pixels (int-array (* w h (image-color-components src)))]
+    (.. src (getRaster) (getPixels 0 0 w h pixels))
+    pixels))
+
+(s/defn image-from-pixels :- BufferedImage
+  [^long width :- g/Int ^long height :- g/Int t :- g/Int pixels :- ints]
+  (doto (blank-image width height t)
+    (.. (getRaster) (setPixels 0 0 width height pixels))))
+
+(defmacro pixel-index [x y step stride]
+  `(* ~step (+ ~x (* ~y ~stride))))
+
+(s/defn extrude-borders :- Image
+  "Return a new pixel array, larger than the original by `extrusion`
+with the orig-pixels centered in it. The source pixels on the edges
+will bleed into the surrounding empty space. The pixels in the border
+region will be identical to the nearest pixel of the source image."
+  [extrusion :- g/Int src :- Image]
+  (if-not (< 0 extrusion)
+    src
+    (let [src-img        (types/contents src)
+          src-img        (image-convert-type src-img BufferedImage/TYPE_4BYTE_ABGR)
+          orig-width     (.width src)
+          orig-height    (.height src)
+          new-width      (+ orig-width (* 2 extrusion))
+          new-height     (+ orig-height (* 2 extrusion))
+          src-pixels     (image-pixels src-img)
+          num-components (image-color-components src-img)
+          clampx         (clamper 0 (dec orig-width))
+          clampy         (clamper 0 (dec orig-height))
+          new-pixels     (int-array (* new-width new-height num-components))]
+      (doseq [y (range new-height)
+              x (range new-width)]
+        (let [sx (clampx (- x extrusion))
+              sy (clampy (- y extrusion))
+              src-idx (pixel-index sx sy num-components orig-width)
+              tgt-idx (pixel-index x   y num-components new-width)]
+          (doseq [i (range num-components)]
+            (aset-int new-pixels (+ i tgt-idx) (aget src-pixels (+ i src-idx))))))
+      (make-image (.path src) (image-from-pixels new-width new-height (.getType src-img) new-pixels)))))
+
+(defn- map-by [p coll]
+  (zipmap (map p coll) coll))
+
+(s/defn composite :- BufferedImage
+  [onto :- BufferedImage placements :- [Rect] sources :- [Image]]
+  (let [src-by-path (map-by :path sources)]
+    (with-graphics [graphics (.getGraphics onto)]
+      (doseq [^Rect rect placements]
+        (.drawImage graphics (:contents (get src-by-path (.path rect))) (int (.x rect)) (int (.y rect)) nil)))
+    onto))

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -88,15 +88,14 @@
           :deps dep-build-targets}])))
 
 (g/defnk produce-gpu-textures [_node-id samplers gpu-texture-generators]
-  (->> (map (fn [s [i {:keys [generate-fn user-data]}]]
-              (let [request-id [_node-id i]
-                    params (material/sampler->tex-params s)
-                    unit-index i
-                    t (generate-fn user-data request-id params unit-index)]
-                [(:name s) t]))
-            samplers
-            (map-indexed vector gpu-texture-generators))
-       (into {})))
+  (into {} (map (fn [unit-index sampler {:keys [generate-fn user-data]}]
+                  (let [request-id [_node-id unit-index]
+                        params (material/sampler->tex-params sampler)
+                        texture (generate-fn user-data request-id params unit-index)]
+                    [(:name sampler) texture]))
+                (range)
+                samplers
+                gpu-texture-generators)))
 
 (g/defnk produce-scene [scene shader gpu-textures]
   (update scene :renderable (fn [r]

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -38,9 +38,10 @@
                       (if (vector? label)
                         (assoc-in pb label resource)
                         (assoc pb label resource)))
-                    pb (map (fn [[label res]]
-                              [label (resource/proj-path (get dep-resources res))])
-                            (:dep-resources user-data)))]
+                    pb
+                    (map (fn [[label res]]
+                           [label (resource/proj-path (get dep-resources res))])
+                         (:dep-resources user-data)))]
     {:resource resource :content (protobuf/map->bytes ModelProto$Model pb)}))
 
 (defn- prop-resource-error [nil-severity _node-id prop-kw prop-value prop-name]
@@ -86,21 +87,23 @@
                       :dep-resources dep-resources}
           :deps dep-build-targets}])))
 
-(g/defnk produce-gpu-textures [_node-id samplers images]
-  (->> (map (fn [s [i img]]
+(g/defnk produce-gpu-textures [_node-id samplers gpu-texture-generators]
+  (->> (map (fn [s [i {:keys [generate-fn user-data]}]]
               (let [request-id [_node-id i]
                     params (material/sampler->tex-params s)
-                    unit i
-                    t (texture/image-texture request-id img params unit)]
-                [(:name s) t])) samplers (map-indexed vector images))
-   (into {})))
+                    unit-index i
+                    t (generate-fn user-data request-id params unit-index)]
+                [(:name s) t]))
+            samplers
+            (map-indexed vector gpu-texture-generators))
+       (into {})))
 
 (g/defnk produce-scene [scene shader gpu-textures]
   (update scene :renderable (fn [r]
                               (cond-> r
                                 shader (assoc-in [:user-data :shader] shader)
                                 true (assoc-in [:user-data :textures] gpu-textures)
-                                true (assoc :batch-key [shader gpu-textures])))))
+                                true (update :batch-key (fn [old-key] [old-key shader gpu-textures]))))))
 
 (defn- vset [v i value]
   (let [c (count v)
@@ -141,7 +144,7 @@
                    (let [project (project/get-project self)
                          connections [[:resource :texture-resources]
                                       [:build-targets :dep-build-targets]
-                                      [:content :images]]]
+                                      [:gpu-texture-generator :gpu-texture-generators]]]
                      (concat
                        (for [r old-value]
                          (if r
@@ -189,7 +192,7 @@
   (input animation-set g/Any)
   (input animation-set-build-target g/Any)
   (input texture-resources resource/Resource :array)
-  (input images BufferedImage :array)
+  (input gpu-texture-generators g/Any :array)
   (input dep-build-targets g/Any :array)
   (input scene g/Any)
   (input shader ShaderLifecycle)
@@ -210,16 +213,17 @@
                                                                                 :ext (conj image/exts "cubemap")}}
                                                         keys (map :name samplers)
                                                         p (->> keys
-                                                            (map-indexed (fn [i s] [(keyword (format "texture%d" i))
-                                                                                    (-> prop-entry
-                                                                                      (assoc :value (get textures i)
-                                                                                             :label s)
-                                                                                      (assoc-in [:edit-type :set-fn]
-                                                                                                (fn [_evaluation-context self old-value new-value]
-                                                                                                  (g/update-property self :textures vset i new-value))))])))]
+                                                               (map-indexed (fn [i s]
+                                                                              [(keyword (format "texture%d" i))
+                                                                               (-> prop-entry
+                                                                                   (assoc :value (get textures i)
+                                                                                          :label s)
+                                                                                   (assoc-in [:edit-type :set-fn]
+                                                                                             (fn [_evaluation-context self old-value new-value]
+                                                                                               (g/update-property self :textures vset i new-value))))])))]
                                                     (-> _declared-properties
-                                                      (update :properties into p)
-                                                      (update :display-order into (map first p)))))))
+                                                        (update :properties into p)
+                                                        (update :display-order into (map first p)))))))
 
 (defn load-model [project self resource pb]
   (concat

--- a/editor/src/clj/editor/pipeline/tex_gen.clj
+++ b/editor/src/clj/editor/pipeline/tex_gen.clj
@@ -85,7 +85,7 @@
                     mip-buf (byte-array mip-size)]
               texture (range 0 (count textures))
               :let [^ByteString alt-data (-> textures (nth texture) :alternatives (nth alt) :data)]]
-        (.copyTo alt-data mip-buf mip-offset 0 mip-size) ; (.copyTo source-byte-string target source-offset target-offset number-to-copy)
+        (.copyTo alt-data mip-buf mip-offset 0 mip-size)
         (.write data mip-buf))
       (-> template-alternative
           (assoc :data (ByteString/copyFrom (.toByteArray data)))

--- a/editor/src/clj/editor/pipeline/tex_gen.clj
+++ b/editor/src/clj/editor/pipeline/tex_gen.clj
@@ -1,7 +1,12 @@
 (ns editor.pipeline.tex-gen
-  (:require [editor.protobuf :as protobuf])
+  (:require [editor.protobuf :as protobuf]
+            [internal.util :as util])
   (:import [com.defold.editor.pipeline TextureGenerator TextureUtil]
+           [com.defold.libs TexcLibrary$FlipAxis]
+           [com.google.protobuf ByteString]
            [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$TextureFormat Graphics$TextureProfiles Graphics$TextureProfile]
+           [java.util EnumSet]
+           [java.io ByteArrayOutputStream]
            [java.awt.image BufferedImage]))
 
 (set! *warn-on-reflection* true)
@@ -34,8 +39,10 @@
   (^Graphics$TextureImage [^BufferedImage image texture-profile]
    (make-texture-image image texture-profile false))
   (^Graphics$TextureImage [^BufferedImage image texture-profile compress?]
+   (make-texture-image image texture-profile compress? true))
+  (^Graphics$TextureImage [^BufferedImage image texture-profile compress? flip-y?]
    (let [^Graphics$TextureProfile texture-profile-data (some->> texture-profile (protobuf/map->pb Graphics$TextureProfile))]
-     (TextureGenerator/generate image texture-profile-data ^boolean compress?))))
+     (TextureGenerator/generate image texture-profile-data ^boolean compress? (if ^boolean flip-y? (EnumSet/of TexcLibrary$FlipAxis/FLIP_AXIS_Y) (EnumSet/noneOf TexcLibrary$FlipAxis))))))
 
 (defn- make-preview-profile
   "Given a texture-profile, return a simplified texture-profile that can be used
@@ -57,3 +64,51 @@
   ^Graphics$TextureImage [^BufferedImage image texture-profile]
   (let [preview-profile (make-preview-profile texture-profile)]
     (make-texture-image image preview-profile false)))
+
+(defn make-cubemap-texture-images
+  ^Graphics$TextureImage [images texture-profile compress?]
+  (let [^Graphics$TextureProfile texture-profile-data (some->> texture-profile (protobuf/map->pb Graphics$TextureProfile))]
+    (util/map-vals #(make-texture-image % texture-profile compress? false) images)))
+
+(defn- make-cubemap-texture-image-alternatives [textures]
+  ;; Cube map textures are in the order px nx py ny nz pz.
+  ;; Size of texture[i].alternative[k] == texture[j].alternative[k]
+  ;; So mip map sizes & offsets also equal
+  ;; Format of alternative data n is:
+  ;; [<cube map textures' alternative n at mip level 0> <cube map textures' alternative n at mip level 1> ... <... at final mip level>]
+  (for [alt (range 0 (count (:alternatives (first textures))))]
+    (let [template-alternative (-> textures first :alternatives (nth alt))
+          data (ByteArrayOutputStream.)]
+      (doseq [mipmap (range 0 (count (:mip-map-size template-alternative))) ; mip-map-size always uncompressed
+              :let [mip-size (-> template-alternative :mip-map-size (nth mipmap))
+                    mip-offset (-> template-alternative :mip-map-offset (nth mipmap))
+                    mip-buf (byte-array mip-size)]
+              texture (range 0 (count textures))
+              :let [^ByteString alt-data (-> textures (nth texture) :alternatives (nth alt) :data)]]
+        (.copyTo alt-data mip-buf mip-offset 0 mip-size) ; (.copyTo source-byte-string target source-offset target-offset number-to-copy)
+        (.write data mip-buf))
+      (-> template-alternative
+          (assoc :data (ByteString/copyFrom (.toByteArray data)))
+          ;; thought we would have to update mip-map-size also, but CubemapBuilder doesn't so...
+          (update :mip-map-offset (fn [offsets] (map #(* 6 %) offsets)))))))
+
+(defn assemble-cubemap-texture-images
+  ^Graphics$TextureImage
+  [texture-images]
+  ;; FIXME: in graphics_opengl.cpp(1870ish) in the engine, we set the cubemap textures
+  ;; using glTexSubImage2D in the order +x, -x, +y, -y, and then ***-z***, ***+z***
+  ;; until this is fixed, if ever, we flip the order as below
+  (let [textures (mapv protobuf/pb->map ((juxt :px :nx :py :ny :nz :pz) texture-images))
+        alternatives (make-cubemap-texture-image-alternatives textures)
+        template-texture (first textures)]
+    (-> template-texture
+        (assoc :count 6)
+        (assoc :type :type-cubemap)
+        (assoc :alternatives alternatives)
+        (#(protobuf/map->pb Graphics$TextureImage %)))))
+
+(defn make-preview-cubemap-texture-images
+  ^Graphics$TextureImage [images texture-profile]
+  (let [preview-profile (make-preview-profile texture-profile)]
+    (make-cubemap-texture-images images preview-profile false)))
+

--- a/editor/src/clj/editor/rulers.clj
+++ b/editor/src/clj/editor/rulers.clj
@@ -8,7 +8,7 @@
             [editor.gl.texture :as texture]
             [editor.gl.vertex2 :as vtx]
             [editor.gl.pass :as pass]
-            [editor.image :as image]
+            [editor.image-util :as image-util]
             [editor.math :as math]
             [editor.types :as types])
   (:import  [com.jogamp.opengl GL GL2]
@@ -30,7 +30,7 @@
 (def ^:private marker-color colors/scene-ruler-marker)
 
 (defonce ^:private numbers-path "numbers.png")
-(defonce ^:private ^BufferedImage numbers-image (image/read-image (io/resource numbers-path)))
+(defonce ^:private ^BufferedImage numbers-image (image-util/read-image (io/resource numbers-path)))
 (defonce ^:private img-dims [(.getWidth numbers-image) (.getHeight numbers-image)])
 (defonce ^:private img-dims-recip (mapv #(/ 1 %) img-dims))
 (defonce ^:private numbers-texture-params (merge texture/default-image-texture-params {:min-filter gl/nearest :mag-filter gl/nearest}))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -260,7 +260,10 @@
                     (let [renderable (first renderables)
                           key (key-fn renderable)
                           render-fn (:render-fn renderable)
-                          break? (or (not= first-render-fn render-fn) (nil? first-key) (nil? key) (not= first-key key))]
+                          break? (or (not= first-render-fn render-fn)
+                                     (nil? first-key)
+                                     (nil? key)
+                                     (not= first-key key))]
                       (if break?
                         count
                         (recur (rest renderables) (inc count)))))]

--- a/editor/src/clj/editor/texture.clj
+++ b/editor/src/clj/editor/texture.clj
@@ -3,7 +3,7 @@
   (:require [clojure.string :as str]
             [dynamo.graph :as g]
             [schema.core :as s]
-            [editor.image :refer [flood blank-image extrude-borders image-bounds composite]]
+            [editor.image-util :refer [flood blank-image extrude-borders image-bounds composite]]
             [editor.types :as types]
             [editor.texture.engine :refer [texture-engine-format-generate]]
             [editor.texture.pack-max-rects :refer [max-rects-packing]])

--- a/editor/src/clj/editor/texture/engine.clj
+++ b/editor/src/clj/editor/texture/engine.clj
@@ -1,5 +1,5 @@
 (ns editor.texture.engine
-  (:require [editor.image :refer [image-pixels image-convert-type image-color-components]]
+  (:require [editor.image-util :refer [image-pixels image-convert-type image-color-components]]
             [editor.types :refer [map->EngineFormatTexture]]
             [editor.buffers :refer [little-endian new-byte-buffer]]
             [editor.texture.math :refer [closest-power-of-two]])

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -7,6 +7,7 @@
    [editor.collision-groups :as collision-groups]
    [editor.graph-util :as gu]
    [editor.image :as image]
+   [editor.image-util :as image-util]
    [editor.workspace :as workspace]
    [editor.resource :as resource]
    [editor.resource-node :as resource-node]
@@ -446,7 +447,7 @@
 (g/defnk produce-convex-hull-points
   [collision-resource original-convex-hulls tile-source-attributes]
   (if collision-resource
-    (texture-set-gen/calculate-convex-hulls (image/read-image collision-resource) tile-source-attributes)
+    (texture-set-gen/calculate-convex-hulls (image-util/read-image collision-resource) tile-source-attributes)
     original-convex-hulls))
 
 (g/defnk produce-convex-hulls
@@ -576,7 +577,7 @@
   (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
   (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
   (output packed-image     BufferedImage       (g/fnk [texture-set-data image-resource tile-source-attributes]
-                                                 (texture-set-gen/layout-tile-source (:layout texture-set-data) (image/read-image image-resource) tile-source-attributes)))
+                                                 (texture-set-gen/layout-tile-source (:layout texture-set-data) (image-util/read-image image-resource) tile-source-attributes)))
   (output texture-image    g/Any               (g/fnk [packed-image texture-profile]
                                                  (tex-gen/make-preview-texture-image packed-image texture-profile)))
 

--- a/editor/test/editor/image_test.clj
+++ b/editor/test/editor/image_test.clj
@@ -5,6 +5,7 @@
             [clojure.test.check.properties :as prop]
             [clojure.test :refer :all]
             [editor.image :refer :all]
+            [editor.image-util :refer :all]
             [editor.geom :refer :all]
             [schema.test])
   (:import [java.awt.image BufferedImage]))

--- a/editor/test/editor/texture/packing_test.clj
+++ b/editor/test/editor/texture/packing_test.clj
@@ -5,7 +5,7 @@
             [clojure.test :refer :all]
             [editor.types :as t :refer [rect]]
             [editor.geom :refer :all]
-            [editor.image :refer :all]
+            [editor.image-util :refer :all]
             [editor.texture :refer :all]
             [editor.texture.pack-max-rects :as itp :refer [max-rects-packing]]
             [schema.test :refer [validate-schemas]])


### PR DESCRIPTION
* User facing changes
  - Can build and preview cubemaps separately or as part of model
  - Texture profiles kicks in for images and cubemaps

* Technical changes
  - Split off image-util from image namespace because of circular
  dependency when introducing texture profiles
  - Support for generating cubemap gpu textures using texture profile