### PR TITLE
DEFEDIT-1220 Fix lost script property overrides in new code editor

### DIFF
--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1077,7 +1077,7 @@
 (defn pull-input-values-with-substitute
   [input sub node evaluation-context]
   ;; todo - invoke substitute
-  (pull-input-values input evaluation-context node))
+  (pull-input-values input node evaluation-context))
 
 (defn- input-value-form
   [self-name ctx-name input]

--- a/editor/test/integration/collection_test.clj
+++ b/editor/test/integration/collection_test.clj
@@ -127,7 +127,7 @@
   (let [key (properties/user-name->key name)]
     (test-util/prop-clear! (test-util/prop-node-id node-id key) key)))
 
-(deftest add-script-properties
+(defn- perform-add-script-properties-test! []
   (test-util/with-loaded-project
     (let [parent-id (test-util/resource-node project "/collection/parent.collection")
           coll-id   (test-util/resource-node project "/collection/test.collection")
@@ -168,8 +168,14 @@
           (is (= 1.0 (script-prop go-comp "number")))
           (is (= 4.0 (script-prop coll-comp "number")))
           (is (= 4.0 (script-prop parent-comp "number")))
-          (g/set-property! script-id :code "go.property(\"new_value\", 2.0)\n")
+          (test-util/code-editor-source! script-id "go.property(\"new_value\", 2.0)\n")
           (is (= 2.0 (script-prop coll-comp "new_value"))))))))
+
+(deftest add-script-properties
+  (with-bindings {#'test-util/use-new-code-editor? false}
+    (perform-add-script-properties-test!))
+  (with-bindings {#'test-util/use-new-code-editor? true}
+    (perform-add-script-properties-test!)))
 
 (deftest read-only-id-property
   (test-util/with-loaded-project

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -4,7 +4,7 @@
             [clojure.set :as set]
             [clojure.java.io :as io]
             [dynamo.graph :as g]
-            [support.test-support :refer [with-clean-system undo-stack write-until-new-mtime spit-until-new-mtime touch-until-new-mtime]]
+            [support.test-support :as test-support :refer [undo-stack write-until-new-mtime spit-until-new-mtime touch-until-new-mtime]]
             [editor.math :as math]
             [editor.defold-project :as project]
             [editor.fs :as fs]
@@ -79,6 +79,16 @@
 
 (def ^:private scriptlib-url (first lib-urls)) ; /scripts/main.script
 (def ^:private imagelib1-url (second lib-urls)) ; /images/{pow,paddle}.png
+
+;; Temporary hack to run tests in both implementations of the code editor resource nodes.
+(defmacro with-clean-system [& forms]
+  `(do
+     (with-bindings {#'test-util/use-new-code-editor? false}
+       (test-support/with-clean-system
+         ~@forms))
+     (with-bindings {#'test-util/use-new-code-editor? true}
+       (test-support/with-clean-system
+         ~@forms))))
 
 (defn- setup-scratch
   ([ws-graph] (setup-scratch ws-graph reload-project-path))

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -12,7 +12,6 @@
             [editor.dialogs :as dialogs]
             [editor.game-project :as game-project]
             [editor.game-object :as game-object]
-            [editor.script :as script]
             [editor.asset-browser :as asset-browser]
             [editor.progress :as progress]
             [editor.protobuf :as protobuf]
@@ -433,11 +432,12 @@
       (is (= (atlas-image-resources atlas>pow) [(resource graphics>ball)]))
       (is (= (atlas-image-resources atlas>ball) atlas>ball-image-resources)))))
 
-(defn game-object-script-nodes [node-id]
-  (let [components (->> (g/node-value node-id :nodes)
-                        (filter (fn [node] (= (g/node-type* node) game-object/ReferencedComponent)))
-                        (map #(g/node-value % :source-id)))]
-    (filter (fn [node] (= (g/node-type* node) script/ScriptNode)) components)))
+(defn game-object-script-nodes [game-object-node-id]
+  (keep (fn [node-id]
+          (when (and (= game-object/ReferencedComponent (g/node-type* node-id))
+                     (= "script" (:ext (resource/resource-type (g/node-value node-id :source-resource)))))
+            (g/node-value node-id :source-id)))
+        (g/node-value game-object-node-id :nodes)))
 
 (deftest move-internal-removed-changed
   ;; /game_object/props.go has a script component /script/props.script

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -39,7 +39,7 @@
                            "spinemodel" Spine$SpineModelDesc
                            "tilesource" Tile$TileSet})
 
-(deftest save-all
+(defn- perform-save-all-test! []
   (let [queries ["**/env.cubemap"
                  "**/switcher.atlas"
                  "**/atlas_sprite.collection"
@@ -106,7 +106,13 @@
                         (is (nil? save)))
                       (is (= file (:content save)))))))))))
 
-(deftest save-all-literal-equality
+(deftest save-all
+  (with-bindings {#'test-util/use-new-code-editor? false}
+    (perform-save-all-test!))
+  (with-bindings {#'test-util/use-new-code-editor? true}
+    (perform-save-all-test!)))
+
+(defn- perform-save-all-literal-equality-test! []
   (let [paths ["/collection/embedded_instances.collection"
                "/editor1/test.collection"
                "/game_object/embedded_components.go"
@@ -143,6 +149,12 @@
                       (prn "s" s))))))
             (is (= file (:content save)))))))))
 
+(deftest save-all-literal-equality
+  (with-bindings {#'test-util/use-new-code-editor? false}
+    (perform-save-all-literal-equality-test!))
+  (with-bindings {#'test-util/use-new-code-editor? true}
+    (perform-save-all-literal-equality-test!)))
+
 (defn- save-all! [project]
   (project/write-save-data-to-disk! project nil))
 
@@ -162,7 +174,7 @@
   (g/update-property! node-id :code (partial format "%s\n%s" line)))
 
 (defn- append-lua-code-line! [node-id]
-  (append-code-line! node-id "-- added line"))
+  (test-util/code-editor-source! node-id (str (test-util/code-editor-source node-id) "\n-- added line")))
 
 (defn- append-c-code-line! [node-id]
   (append-code-line! node-id "// added line"))
@@ -174,7 +186,7 @@
       (let [{:keys [user-data set]} (:form-ops form-data)]
         (set user-data path value)))))
 
-(deftest save-dirty
+(defn- perform-save-dirty-tests! []
   (let [black-list #{"/game_object/type_faulty_props.go"
                      "/collection/type_faulty_props.collection"}
         paths [["/sprite/atlas.sprite" (set-prop-fn :default-animation "no-anim")]
@@ -241,6 +253,12 @@
           (save-all! project)
           (is (clean?)))))))
 
+(deftest save-dirty
+  (with-bindings {#'test-util/use-new-code-editor? false}
+    (perform-save-dirty-tests!))
+  (with-bindings {#'test-util/use-new-code-editor? true}
+    (perform-save-dirty-tests!)))
+
 (defn- setup-scratch
   [ws-graph]
   (let [workspace (test-util/setup-scratch-workspace! ws-graph test-util/project-path)
@@ -295,7 +313,7 @@
   (-> git .reset (.setRef "HEAD") (.setMode ResetCommand$ResetType/HARD) .call)
   nil)
 
-(deftest save-respects-line-endings
+(defn- perform-save-respects-line-endings-test! []
   (with-git [project-path (test-util/make-temp-project-copy! test-util/project-path)
              git (git/init project-path)]
     (set-autocrlf! git false)
@@ -327,3 +345,9 @@
           (is (< 100 crlf))
           (project/write-save-data-to-disk! project nil)
           (is (= line-endings-before (line-endings-by-resource project))))))))
+
+(deftest save-respects-line-endings
+  (with-bindings {#'test-util/use-new-code-editor? false}
+    (perform-save-respects-line-endings-test!))
+  (with-bindings {#'test-util/use-new-code-editor? true}
+    (perform-save-respects-line-endings-test!)))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -74,6 +74,19 @@
 (defn make-test-prefs []
   (prefs/load-prefs "test/resources/test_prefs.json"))
 
+(def ^:dynamic use-new-code-editor? false)
+(declare prop prop!)
+
+(defn code-editor-source [script-id]
+  (if use-new-code-editor?
+    (string/join "\n" (prop script-id :lines))
+    (prop script-id :code)))
+
+(defn code-editor-source! [script-id source]
+  (if use-new-code-editor?
+    (prop! script-id :lines (string/split source #"\r?\n" -1))
+    (prop! script-id :code source)))
+
 (defn setup-workspace!
   ([graph]
    (setup-workspace! graph project-path))
@@ -84,7 +97,7 @@
      (g/transact
        (concat
          (scene/register-view-types workspace)))
-     (resource-types/register-resource-types! workspace false)
+     (resource-types/register-resource-types! workspace use-new-code-editor?)
      (workspace/resource-sync! workspace)
      workspace)))
 
@@ -230,7 +243,7 @@
           app-view  (setup-app-view! project)]
       [workspace project app-view])))
 
-(defn- load-system-and-project-raw [path]
+(defn- load-system-and-project-raw [path _use-new-code-editor?]
   (test-support/with-clean-system
     (let [workspace (setup-workspace! world path)
           project (setup-project! workspace)]
@@ -243,7 +256,7 @@
   (let [custom-path?  (or (string? (first forms)) (symbol? (first forms)))
         project-path  (if custom-path? (first forms) project-path)
         forms         (if custom-path? (next forms) forms)]
-    `(let [[system# ~'workspace ~'project] (load-system-and-project ~project-path)
+    `(let [[system# ~'workspace ~'project] (load-system-and-project ~project-path use-new-code-editor?)
            ~'system (is/clone-system system#)
            ~'cache  (:cache ~'system)
            ~'world  (g/node-id->graph-id ~'workspace)]


### PR DESCRIPTION
### User-facing changes
* Script property overrides are no longer lost in some cases when using the hidden `.newcode` mode.

### Technical changes
* We now run relevant tests on both the old an new code editor resource nodes to ensure we've not broken something in the new resource node implementations.
* Fixed bad argument order in call to `pull-input-values` from `pull-input-values-with-substitute` in `internal/node` found during testing.