### PR TITLE
DEFEDIT-1152 Handle deleted resource in dirty check

### DIFF
--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -30,10 +30,11 @@
                                       (cond-> {:resource resource :dirty? dirty? :value save-value :node-id _node-id}
                                         (and write-fn save-value) (assoc :content (write-fn save-value))))))
   (output source-value g/Any :cached (g/fnk [resource]
-                                       (when-let [read-fn (some-> resource
-                                                            (resource/resource-type)
-                                                            :read-fn)]
-                                         (read-fn resource))))
+                                       (when (and (some? resource) (resource/exists? resource))
+                                         (when-some [read-fn (some-> resource
+                                                                     (resource/resource-type)
+                                                                     :read-fn)]
+                                           (read-fn resource)))))
   (output save-value g/Any (g/constantly nil))
   (output cleaned-save-value g/Any :cached (g/fnk [resource save-value]
                                              (when resource


### PR DESCRIPTION
### User facing changes

Fixes https://github.com/defold/editor2-issues/issues/1244

- Fix a "File not found" error that would sometimes happen after a resource had been
  deleted externally.

### Technical changes

- We did not check that a resource existed before calling `read-fn` on
  it to obtain a source-value used for the dirty check. If a resource
  was deleted externally to the editor, and the `dirty?` output was
  pulled before the resource-sync happened (which would detect and
  remove the deleted resource), we the `read-fn` would throw a
  `FileNotFoundException` when opening a reader on the resource.