### PR TITLE
DEFEDIT-1229 Add ability to use custom engine in dev mode

### DIFF
--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -4,6 +4,7 @@
             [editor.ui :as ui]
             [editor.prefs :as prefs]
             [editor.system :as system]
+            [editor.engine :as engine]
             [editor.engine.native-extensions :as native-extensions])
   (:import [com.defold.control LongField]
            [javafx.scene Parent Scene]
@@ -78,21 +79,25 @@
 
 (defn- pref-pages
   []
-  [{:name  "General"
-    :prefs [{:label "Enable Texture Compression" :type :boolean :key "general-enable-texture-compression" :default false}
-            {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}
-            {:label "Track Active Tab in Asset Browser" :type :boolean :key "asset-browser-track-active-tab?" :default false}]}
-   {:name  "Scene"
-    :prefs [{:label "Selection Color" :type :color :key "scene-selection-color" :default (Color/web "#00ff00ff")}
-            {:label "Grid" :type :choicebox :key "scene-grid-type" :default :auto :options [[:auto "Auto"] [:manual "Manual"]]}
-            {:label "Grid Size" :type :long :key "scene-grid-size" :default 100}
-            {:label "Grid Color" :type :color :key "scene-grid-color" :default (Color/web "#999999ff")}]}
-   {:name  "Code"
-    :prefs [{:label "Custom Editor" :type :string :key "code-custom-editor" :default ""}
-            {:label "Open File" :type :string :key "code-open-file" :default "{file}"}
-            {:label "Open File at Line" :type :string :key "code-open-file-at-line" :default "{file}:{line}"}]}
-   {:name  "Extensions"
-    :prefs [{:label "Build Server" :type :string :key "extensions-server" :default native-extensions/defold-build-server-url}]}])
+  (cond-> [{:name  "General"
+            :prefs [{:label "Enable Texture Compression" :type :boolean :key "general-enable-texture-compression" :default false}
+                    {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}
+                    {:label "Track Active Tab in Asset Browser" :type :boolean :key "asset-browser-track-active-tab?" :default false}]}
+           {:name  "Scene"
+            :prefs [{:label "Selection Color" :type :color :key "scene-selection-color" :default (Color/web "#00ff00ff")}
+                    {:label "Grid" :type :choicebox :key "scene-grid-type" :default :auto :options [[:auto "Auto"] [:manual "Manual"]]}
+                    {:label "Grid Size" :type :long :key "scene-grid-size" :default 100}
+                    {:label "Grid Color" :type :color :key "scene-grid-color" :default (Color/web "#999999ff")}]}
+           {:name  "Code"
+            :prefs [{:label "Custom Editor" :type :string :key "code-custom-editor" :default ""}
+                    {:label "Open File" :type :string :key "code-open-file" :default "{file}"}
+                    {:label "Open File at Line" :type :string :key "code-open-file-at-line" :default "{file}:{line}"}]}
+           {:name  "Extensions"
+            :prefs [{:label "Build Server" :type :string :key "extensions-server" :default native-extensions/defold-build-server-url}]}]
+    
+    (system/defold-dev?)
+    (conj {:name "Dev"
+           :prefs [{:label "Custom Engine" :type :string :key engine/custom-engine-pref-key :default ""}]})))
 
 (defn open-prefs [preferences]
   (let [root ^Parent (ui/load-fxml "prefs.fxml")

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -40,7 +40,8 @@
   (System/getProperty "defold.buildtime"))
 
 (defn defold-dev? []
-  (not (defold-version)))
+  (or (some? (System/getProperty "defold.dev"))
+      (not (defold-version))))
 
 (defn java-home
   ^String []


### PR DESCRIPTION
### Technical changes

- Add new system property "defold.dev" to force dev mode
- When in dev mode, expose preference to set a custom engine and if
  one is set use it.