### PR TITLE
 DEFEDIT Fixed “local function” parse error in new code editor

### DIFF
--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -215,7 +215,7 @@
            (= "function" (nth node 2)))
     ;; 'local' 'function' NAME funcbody
     (let [[_ _ _ fname funcbody] node]
-      (if-not (error-node? fname)
+      (if-not (some error-node? node)
         (let [[parlist block] (parse-funcbody funcbody)]
           (collect-node-info (conj result {:local-functions {fname {:params (parse-parlist parlist)}}}) block))
         result))

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -219,6 +219,15 @@
             :script-properties []
             :requires []} result))))
 
+(deftest function-following-local-function
+  (is (= {:vars #{}
+          :local-vars #{}
+          :functions {}
+          :local-functions {}
+          :script-properties []
+          :requires []}
+         (lua-info "local function\nfunction foo("))))
+
 (defn- src->properties [src]
   (:script-properties (lua-info src)))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#1416