### PR TITLE
DEFEDIT Select all in code editor

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -577,6 +577,8 @@
                               :command :copy}
                              {:label "Paste"
                               :command :paste}
+                             {:label "Select All"
+                              :command :select-all}
                              {:label "Delete"
                               :icon "icons/32/Icons_M_06_trash.png"
                               :command :delete}

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -2013,6 +2013,16 @@
         scroll-properties (scroll-to-cursor-range scroll-shortest scroll-center layout lines adjusted-cursor-range)]
     (assoc scroll-properties :cursor-ranges [adjusted-cursor-range])))
 
+(defn select-all [lines cursor-ranges]
+  (let [row (max 0 (dec (count lines)))
+        col (count (get lines row))
+        from (->Cursor 0 0)
+        to (->Cursor row col)
+        cursor-range (->CursorRange from to)]
+    (when (or (not= 1 (count cursor-ranges))
+              (not (cursor-range-equals? cursor-range (first cursor-ranges))))
+      {:cursor-ranges [cursor-range]})))
+
 (defn find-next [lines cursor-ranges ^LayoutInfo layout needle-lines case-sensitive? whole-word? wrap?]
   (let [from-cursor (next-occurrence-search-cursor cursor-ranges)]
     (if-some [matching-cursor-range (find-next-occurrence lines needle-lines from-cursor case-sensitive? whole-word?)]

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1366,6 +1366,13 @@
                                     (get-property view-node :layout)
                                     clipboard))))
 
+(handler/defhandler :select-all :new-code-view
+  (run [view-node]
+       (hide-suggestions! view-node)
+       (set-properties! view-node :selection
+                        (data/select-all (get-property view-node :lines)
+                                         (get-property view-node :cursor-ranges)))))
+
 (handler/defhandler :delete :new-code-view
   (run [view-node] (delete! view-node :delete-after)))
 

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -850,6 +850,20 @@
                    [(cr [0 0] [0 0])
                     (cr [0 3] [0 3])])))))
 
+(deftest select-all-test
+  (testing "Selects all text"
+    (is (= {:cursor-ranges [(cr [0 0] [0 1])]}
+           (data/select-all ["a"] [(c 0 0)])))
+    (is (= {:cursor-ranges [(cr [0 0] [2 5])]}
+           (data/select-all ["one"
+                             "two"
+                             "three"]
+                            [(c 0 0)]))))
+
+  (testing "Returns nil when everything is already selected"
+    (is (nil? (data/select-all ["a"] [(cr [0 0] [0 1])])))
+    (is (nil? (data/select-all ["a"] [(cr [0 1] [0 0])])))))
+
 (deftest word-cursor-range-at-cursor-test
   (let [word-cursor-range-at-cursor #'data/word-cursor-range-at-cursor
         cases [["one two"


### PR DESCRIPTION
### User-facing changes
* Adds **Select All** command under the Edit menu when using the new code editor.