### PR TITLE
DEFEDIT-1232 Find-in-file options are not remembered across sessions

### DIFF
--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -5,6 +5,7 @@
    [clojure.stacktrace :as stack]
    [clojure.tools.cli :as cli]
    [dynamo.graph :as g]
+   [editor.code.view :as code-view]
    [editor.dialogs :as dialogs]
    [editor.system :as system]
    [editor.error-reporting :as error-reporting]
@@ -151,6 +152,7 @@
        (render-progress! (swap! progress progress/message "Initializing project..."))
        ;; ensure that namespace loading has completed
        @namespace-loader
+       (code-view/initialize! prefs)
        (apply (var-get (ns-resolve 'editor.boot-open-project 'initialize-project)) [])
        (add-to-recent-projects prefs project)
        (apply (var-get (ns-resolve 'editor.boot-open-project 'open-project)) [project-file prefs render-progress! update-context])

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -4,6 +4,7 @@
             [editor.code.data :as data]
             [editor.code.resource :as r]
             [editor.code.util :refer [pair split-lines]]
+            [editor.prefs :as prefs]
             [editor.resource :as resource]
             [editor.ui :as ui]
             [editor.ui.fuzzy-choices-popup :as popup]
@@ -24,7 +25,7 @@
            (java.util Collection)
            (java.util.regex Pattern)
            (javafx.beans.binding Bindings)
-           (javafx.beans.property SimpleBooleanProperty SimpleStringProperty)
+           (javafx.beans.property Property SimpleBooleanProperty SimpleStringProperty)
            (javafx.geometry HPos Point2D VPos)
            (javafx.scene Node Parent)
            (javafx.scene.canvas Canvas GraphicsContext)
@@ -1528,7 +1529,18 @@
 (defonce ^SimpleStringProperty find-replacement-property (doto (SimpleStringProperty.) (.setValue "")))
 (defonce ^SimpleBooleanProperty find-whole-word-property (doto (SimpleBooleanProperty.) (.setValue false)))
 (defonce ^SimpleBooleanProperty find-case-sensitive-property (doto (SimpleBooleanProperty.) (.setValue false)))
-(defonce ^SimpleBooleanProperty find-wrap-property (doto (SimpleBooleanProperty.) (.setValue false)))
+(defonce ^SimpleBooleanProperty find-wrap-property (doto (SimpleBooleanProperty.) (.setValue true)))
+
+(defn- init-property-and-bind-preference! [^Property property prefs preference default]
+  (.setValue property (prefs/get-prefs prefs preference default))
+  (ui/observe property (fn [_ _ new] (prefs/set-prefs prefs preference new))))
+
+(defn initialize! [prefs]
+  (init-property-and-bind-preference! find-term-property prefs "code-editor-find-term" "")
+  (init-property-and-bind-preference! find-replacement-property prefs "code-editor-find-replacement" "")
+  (init-property-and-bind-preference! find-whole-word-property prefs "code-editor-find-whole-word" false)
+  (init-property-and-bind-preference! find-case-sensitive-property prefs "code-editor-find-case-sensitive" false)
+  (init-property-and-bind-preference! find-wrap-property prefs "code-editor-find-wrap" true))
 
 (defonce ^SimpleStringProperty highlighted-find-term-property
   (-> (Bindings/when (Bindings/or (Bindings/equal (name :find) bar-ui-type-property)


### PR DESCRIPTION
* User facing changes
 - In the new code editor: find term, replacement, case sensitivity, whole word, wrap are remembered across sessions

* Technical changes
 - editor.code.view gets an initalize! function called from boot after loading namespaces