### PR TITLE
DEFEDIT-122 Only allow picking visible curves in curve view

### DIFF
--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -411,8 +411,8 @@
                            (* selection/min-pick-size selection/min-pick-size)))
       curve)))
 
-(g/defnk produce-picking-selection [curves picking-rect camera viewport]
-  (pick-control-points curves picking-rect camera viewport))
+(g/defnk produce-picking-selection [visible-curves picking-rect camera viewport]
+  (pick-control-points visible-curves picking-rect camera viewport))
 
 (defn- sub-selection->map [sub-selection]
   (reduce (fn [sel [nid prop idx]] (update sel [nid prop] (fn [v] (conj (or v #{}) idx))))


### PR DESCRIPTION
### User facing changes

Fixes https://github.com/defold/editor2-issues/issues/1440

- Only allow selecting visible curves in curve editor.