### PR TITLE
DEFEDIT-1234 Automatically enter highlighted words into Search in Files and Open Assets

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1882,4 +1882,5 @@
                                 :id :new-code
                                 :label "Code"
                                 :make-view-fn (fn [graph parent resource-node opts] (make-view! graph parent resource-node opts))
-                                :focus-fn (fn [view-node opts] (focus-view! view-node opts))))
+                                :focus-fn (fn [view-node opts] (focus-view! view-node opts))
+                                :text-selection-fn non-empty-single-selection-text))

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -108,6 +108,9 @@
 
 (def ^:private search-in-files-dialog-state (atom nil))
 
+(defn set-search-term! [term]
+  (swap! search-in-files-dialog-state assoc :term term))
+
 (defn- start-search-in-files! [project results-tab-tree-view open-fn show-find-results-fn]
   (let [root      ^Parent (ui/load-fxml "search-in-files-dialog.fxml")
         scene     (Scene. root)

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -321,7 +321,7 @@ ordinary paths."
                 :resource-listeners (atom [])
                 :build-settings build-settings))
 
-(defn register-view-type [workspace & {:keys [id label make-view-fn make-preview-fn focus-fn]}]
+(defn register-view-type [workspace & {:keys [id label make-view-fn make-preview-fn focus-fn text-selection-fn]}]
   (let [view-type (merge {:id    id
                           :label label}
                          (when make-view-fn
@@ -329,5 +329,7 @@ ordinary paths."
                          (when make-preview-fn
                            {:make-preview-fn make-preview-fn})
                          (when focus-fn
-                           {:focus-fn focus-fn}))]
+                           {:focus-fn focus-fn})
+                         (when text-selection-fn
+                           {:text-selection-fn text-selection-fn}))]
      (g/update-property workspace :view-types assoc (:id view-type) view-type)))


### PR DESCRIPTION
* User facing features
 - when using the new code editor, text selection will be used as search term/filter for open assets and search in files

* Technical changes
 - the new code editor view-type contains a text-selection-fn that provides the text to be used as term/filter