### PR TITLE
DEFEDIT-1201 Search window results needs two double clicks to open a file sometimes

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -848,7 +848,12 @@
                                                   resource-type view-type make-view-fn tabs opts))]
              (.select (.getSelectionModel tab-pane) tab)
              (when-let [focus (:focus-fn view-type)]
-               (focus (ui/user-data tab ::view) opts))
+               (ui/run-later
+                 ;; We run-later so javafx has time to squeeze in a
+                 ;; layout pass. The focus function of some views
+                 ;; needs proper width + height (f.i. code view for
+                 ;; scrolling to selected line).
+                 (focus (ui/user-data tab ::view) opts)))
              true)
            (let [^String path (or (resource/abs-path resource)
                                   (resource/temp-path resource))


### PR DESCRIPTION
* User facing changes
  - double clicking on a search result in search in files scrolls to the correct line in the new code editor.