### PR TITLE
DEFEDIT-1105 Horizontal scroll bar in console and code editor

### DIFF
--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -36,7 +36,7 @@
   ([] (layout-info nil))
   ([lines] (layout-info lines (->GlyphMetrics 14.0 9.0 6.0)))
   ([lines glyph-metrics]
-   (data/layout-info 800.0 600.0 0.0 0.0 lines 30.0 5.0 glyph-metrics 4)))
+   (data/layout-info 800.0 600.0 0.0 0.0 lines 30.0 5.0 glyph-metrics 4 false)))
 
 (defn- word-boundary-before-index? [line index]
   (#'data/word-boundary-before-index? line index))
@@ -148,7 +148,7 @@
 
 (defn- visible-cursor-ranges [height lines ascending-cursor-ranges scroll-y]
   (let [glyph-metrics (->GlyphMetrics 14.0 9.0 6.0)
-        layout (data/layout-info 800.0 height 0.0 scroll-y lines 30.0 5.0 glyph-metrics 4)]
+        layout (data/layout-info 800.0 height 0.0 scroll-y lines 30.0 5.0 glyph-metrics 4 false)]
     (data/visible-cursor-ranges lines layout ascending-cursor-ranges)))
 
 (deftest visible-cursor-ranges-test

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -36,7 +36,7 @@
   ([] (layout-info nil))
   ([lines] (layout-info lines (->GlyphMetrics 14.0 9.0 6.0)))
   ([lines glyph-metrics]
-   (data/layout-info 800.0 600.0 0.0 0.0 lines 30.0 5.0 glyph-metrics 4 false)))
+   (data/layout-info 800.0 600.0 800.0 0.0 0.0 lines 30.0 5.0 glyph-metrics 4 false)))
 
 (defn- word-boundary-before-index? [line index]
   (#'data/word-boundary-before-index? line index))
@@ -148,7 +148,7 @@
 
 (defn- visible-cursor-ranges [height lines ascending-cursor-ranges scroll-y]
   (let [glyph-metrics (->GlyphMetrics 14.0 9.0 6.0)
-        layout (data/layout-info 800.0 height 0.0 scroll-y lines 30.0 5.0 glyph-metrics 4 false)]
+        layout (data/layout-info 800.0 height 800.0 0.0 scroll-y lines 30.0 5.0 glyph-metrics 4 false)]
     (data/visible-cursor-ranges lines layout ascending-cursor-ranges)))
 
 (deftest visible-cursor-ranges-test

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -30,13 +30,13 @@
   data/GlyphMetrics
   (ascent [_this] ascent)
   (line-height [_this] line-height)
-  (char-width [_this character] char-width))
+  (char-width [_this _character] char-width))
 
 (defn layout-info
   ([] (layout-info nil))
   ([lines] (layout-info lines (->GlyphMetrics 14.0 9.0 6.0)))
   ([lines glyph-metrics]
-   (data/layout-info 800.0 600.0 0.0 0.0 (count lines) 30.0 5.0 glyph-metrics 4)))
+   (data/layout-info 800.0 600.0 0.0 0.0 lines 30.0 5.0 glyph-metrics 4)))
 
 (defn- word-boundary-before-index? [line index]
   (#'data/word-boundary-before-index? line index))
@@ -148,7 +148,7 @@
 
 (defn- visible-cursor-ranges [height lines ascending-cursor-ranges scroll-y]
   (let [glyph-metrics (->GlyphMetrics 14.0 9.0 6.0)
-        layout (data/layout-info 800.0 height 0.0 scroll-y (count lines) 30.0 5.0 glyph-metrics 4)]
+        layout (data/layout-info 800.0 height 0.0 scroll-y lines 30.0 5.0 glyph-metrics 4)]
     (data/visible-cursor-ranges lines layout ascending-cursor-ranges)))
 
 (deftest visible-cursor-ranges-test


### PR DESCRIPTION
Fixes defold/editor2-issues#1464

### User-facing changes
* Adds a horizontal scroll bar to the Console and the new code editor.
* It is no longer possible to move the cursor behind the minimap.
* The minimap casts a shadow if it covers part of the document.