### PR TITLE
DEFEDIT-1217 Tweaked code editor auto-indentation rules

### DIFF
--- a/editor/test/editor/code/script_test.clj
+++ b/editor/test/editor/code/script_test.clj
@@ -37,6 +37,14 @@
        (insert-lines (into [] xform-test-lines->lines before)
                      (into [] xform-test-lines->cursor-ranges before)
                      inserted-lines))
+    [" "]
+    ["|"]
+    [" |"]
+
+    [" "]
+    [" |"]
+    ["  |"]
+
     [""
      ""]
     ["function foo()|"]
@@ -168,4 +176,10 @@
     ["    first| second| third"]
     ["    first"
      "    | second"
-     "    | third"]))
+     "    | third"]
+
+    ["e"]
+    ["function foo()"
+     "|    -- comment"]
+    ["function foo()"
+     "e|    -- comment"]))


### PR DESCRIPTION
### User-facing changes
* Fixed an issue where you could not edit whitespace at the start of a line in the new code editor.