### PR TITLE
DEFEDIT-1248 Supply source to shader compiler as a single string

### DIFF
--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -67,24 +67,23 @@
 (defn- build-shader [resource _dep-resources user-data]
   {:resource resource :content user-data})
 
-(g/defnk produce-build-targets [_node-id resource full-source]
-  (let [source (string/join "\n" full-source)
-        content (.getBytes source "UTF-8")]
+(g/defnk produce-build-targets [_node-id resource ^String full-source]
+  (let [content (.getBytes full-source "UTF-8")]
     [{:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-shader
       :user-data content}]))
 
 (g/defnk produce-full-source [resource lines]
-  (if-some [compat-directive-lines (get shader/compat-directives (resource/ext resource))]
-    (shader/insert-directives lines compat-directive-lines)
-    lines))
+  (string/join "\n" (if-some [compat-directive-lines (get shader/compat-directives (resource/ext resource))]
+                      (shader/insert-directives lines compat-directive-lines)
+                      lines)))
 
 (g/defnode ShaderNode
   (inherits r/CodeEditorResourceNode)
 
   (output build-targets g/Any :cached produce-build-targets)
-  (output full-source shader/ShaderSource :cached produce-full-source))
+  (output full-source g/Str :cached produce-full-source))
 
 (defn register-resource-types [workspace]
   (for [def shader-defs

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -94,15 +94,12 @@ There are some examples in the testcases in dynamo.shader.translate-test."
           [editor.workspace :as workspace]
           [editor.resource :as resource]
           [editor.resource-node :as resource-node]
-          [editor.scene-cache :as scene-cache]
-          [schema.core :as s])
+          [editor.scene-cache :as scene-cache])
 (:import [java.nio IntBuffer ByteBuffer]
          [com.jogamp.opengl GL GL2]
          [javax.vecmath Matrix4d Vector4f Vector4d Point3d]))
 
 (set! *warn-on-reflection* true)
-
-(g/deftype ShaderSource (s/cond-pre s/Str [s/Str]))
 
 ;; ======================================================================
 ;; shader translation comes from https://github.com/overtone/shadertone.
@@ -356,14 +353,18 @@ This must be submitted to the driver for compilation before you can use it. See
 
 (defn make-shader*
   [type ^GL2 gl source]
+  ;; Shader source can be either a string or a collection of strings.
+  ;; However, it is not intended to be a collection of lines. The
+  ;; shader compiler will simply read from each string in turn as if
+  ;; they were concatenated. Thus, you need to have newline characters
+  ;; at the end of each line.
   (assert (or (string? source) (coll? source)))
-  (let [shader-name (.glCreateShader gl type)]
-    (.glShaderSource gl shader-name 1
-      (into-array String
-                  (if (coll? source)
-                    source
-                    [source]))
-      nil)
+  (let [shader-name (.glCreateShader gl type)
+        source-strings (into-array String
+                                   (if (coll? source)
+                                     source
+                                     [source]))]
+    (.glShaderSource gl shader-name (count source-strings) source-strings nil)
     (.glCompileShader gl shader-name)
     (let [status (IntBuffer/allocate 1)]
       (.glGetShaderiv gl shader-name GL2/GL_COMPILE_STATUS status)
@@ -629,7 +630,7 @@ locate the .vp and .fp files. Returns an object that satisifies GlBind and GlEna
   (property selection-length g/Int (dynamic visible (g/constantly false)) (default 0))
 
   (output build-targets g/Any produce-build-targets)
-  (output full-source ShaderSource (g/fnk [resource code] (compat resource code))))
+  (output full-source g/Str (g/fnk [resource code] (compat resource code))))
 
 (defn register-resource-types [workspace]
   (for [def shader-defs

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -210,9 +210,9 @@
 
   (input dep-build-targets g/Any :array)
   (input vertex-resource resource/Resource)
-  (input vertex-source shader/ShaderSource)
+  (input vertex-source g/Str)
   (input fragment-resource resource/Resource)
-  (input fragment-source shader/ShaderSource)
+  (input fragment-source g/Str)
 
   (output pb-msg g/Any :cached produce-pb-msg)
 


### PR DESCRIPTION
### User-facing changes
* Sprites and GUI elements are again rendered in scene views when running with `.newcode`.

### Technical changes
* #1960 broke materials in scene views when using the new code editor due to a misunderstanding about what `glShaderSource` expects from its arguments. This reverts to submitting the shader source as a single concatenated string for both the old and the new shader nodes.