### PR TITLE
DEFEDIT-1246 Can't edit atlases with missing files

### DIFF
--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1264,7 +1264,8 @@
          (ie/error-aggregate input-errors# :_node-id ~nodeid-sym :_label ~label)))))
 
 (defn- call-production-function-form [self-name ctx-name description transform input-sym nodeid-sym output-sym forms]
-  `(let [~output-sym ((var ~(symbol (dollar-name (:name description) [:output transform]))) ~input-sym)]
+  `(let [~output-sym ~(input-error-check-form self-name ctx-name description transform nodeid-sym input-sym
+                                              `((var ~(symbol (dollar-name (:name description) [:output transform]))) ~input-sym))]
      ~forms))
 
 (defn- cache-output-form [ctx-name description transform nodeid-sym output-sym local-cache-sym forms]
@@ -1325,11 +1326,10 @@
                   (mark-in-production-form ctx-name nodeid-sym transform description
                     (check-caches-form ctx-name nodeid-sym description transform local-cache-sym
                       (gather-inputs-form input-sym schema-sym self-name ctx-name nodeid-sym description transform production-function
-                        (input-error-check-form self-name ctx-name description transform nodeid-sym input-sym
-                          (call-production-function-form self-name ctx-name description transform input-sym nodeid-sym output-sym
-                            (schema-check-output-form self-name ctx-name description transform nodeid-sym output-sym
-                              (cache-output-form ctx-name description transform nodeid-sym output-sym local-cache-sym
-                                output-sym)))))))))))))))
+                        (call-production-function-form self-name ctx-name description transform input-sym nodeid-sym output-sym
+                          (schema-check-output-form self-name ctx-name description transform nodeid-sym output-sym
+                            (cache-output-form ctx-name description transform nodeid-sym output-sym local-cache-sym
+                              output-sym))))))))))))))
 
 (defn- assemble-properties-map-form
   [nodeid-sym value-sym display-order]


### PR DESCRIPTION
### User facing changes

The atlas editor no longer becomes unusable when images are missing.

### Technical changes

Cached output's cache not just the returned value or error, but also
the aggregated argument error preventing the function from being
run. In this particular case the error produced by ImageNode:size on
the broken AtlasImage trickled up to AtlasNode:texture-set-data, then
out via AtlasNode:image-path->rect to all AtlasImage's in the atlas,
out via AtlasImage:scene used as input to AtlasNode:scene which was
being pulled by an animation timer. Since not much was being cached,
this whole error-circus was pretty expensive.