### PR TITLE
DEFEDIT-1253 Fixed another "local function" parse error in new code editor

### DIFF
--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -220,13 +220,24 @@
             :requires []} result))))
 
 (deftest function-following-local-function
-  (is (= {:vars #{}
-          :local-vars #{}
-          :functions {}
-          :local-functions {}
-          :script-properties []
-          :requires []}
-         (lua-info "local function\nfunction foo("))))
+  (are [code]
+    (= {:vars #{}
+        :local-vars #{}
+        :functions {}
+        :local-functions {}
+        :script-properties []
+        :requires []}
+       (lua-info code))
+
+    "local function\nfunction"
+    "local function\nfunction foo"
+    "local function\nfunction foo("
+    "local function\nfunction foo()"
+    "local function\nfunction foo(a"
+    "local function\nfunction foo(a)"
+    "local function\nfunction foo(a,"
+    "local function\nfunction foo(a,b"
+    "local function\nfunction foo(a,b)"))
 
 (defn- src->properties [src]
   (:script-properties (lua-info src)))


### PR DESCRIPTION
Previously a similar issue was addressed in #1928, but it appears more situations can cause similar errors.

### User-facing changes
* Typing `local function` just before a `function` definition in the new code editor no longer causes an error.

### Technical changes
* Rewrote `lua-parser/parse-funcbody` to be more strict.
* Added more tests for this situation.