### PR TITLE
DEFEDIT-1252 Initialize size of Console canvas to match parent

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -351,11 +351,13 @@
      ["editor.selection.occurrence.outline" (if code-integration/use-new-code-editor? (Color/valueOf "#A2B0BE") Color/TRANSPARENT)]]))
 
 (defn make-console! [graph ^Tab console-tab ^GridPane console-grid-pane]
-  (let [canvas (Canvas.)
-        ^Pane canvas-pane (.lookup console-grid-pane "#console-canvas-pane")
+  (let [^Pane canvas-pane (.lookup console-grid-pane "#console-canvas-pane")
+        canvas (Canvas. (.getWidth canvas-pane) (.getHeight canvas-pane))
         view-node (setup-view! (g/make-node! graph ConsoleNode)
                                (g/make-node! graph view/CodeEditorView
                                              :canvas canvas
+                                             :canvas-width (.getWidth canvas)
+                                             :canvas-height (.getHeight canvas)
                                              :color-scheme console-color-scheme
                                              :grammar console-grammar
                                              :gutter-view (ConsoleGutterView.)


### PR DESCRIPTION
Fixes forum issue:
https://forum.defold.com/t/text-not-visible-in-editor-2-0-console/14557/7

### User-facing changes
* Users no longer need to adjust the size of the editor window or the Console panel for text to appear in the Console.