### PR TITLE
DEFEDIT-1241 Editor debugger UX polish

### DIFF
--- a/editor/resources/console-view.fxml
+++ b/editor/resources/console-view.fxml
@@ -13,15 +13,15 @@
     <RowConstraints vgrow="NEVER" />
   </rowConstraints>
   <HBox id="console-tool-bar" GridPane.rowIndex="0">
-    <TextField id="search-console" promptText="Search" HBox.hgrow="ALWAYS"/>
+    <TextField id="search-console" promptText="Search" HBox.hgrow="ALWAYS" />
     <Separator id="prev-console-separator" />
     <Button id="prev-console" />
     <Separator id="next-console-separator" />
     <Button id="next-console" />
     <Separator id="clear-console-separator" />
     <Button id="clear-console" text="Clear" />
-    <Separator id="debugger-separator" />
     <HBox id="debugger-tool-bar" visible="false">
+      <Separator id="debugger-separator" />
       <Button id="pause-debugger" />
       <Button id="play-debugger" visible="false" />
       <Button id="stop-debugger" />
@@ -29,13 +29,11 @@
       <Button id="step-over-debugger" />
       <Button id="step-in-debugger" />
       <Button id="step-out-debugger" />
-      <Separator id="toggle-debugger-separator" />
     </HBox>
-    <Button id="toggle-debugger" text="Debugger" />
   </HBox>
-  <Pane id="console-canvas-pane" GridPane.rowIndex="1"/>
+  <Pane id="console-canvas-pane" GridPane.rowIndex="1" />
   <HBox id="debugger-prompt" GridPane.rowIndex="2" visible="false">
-    <Label id="debugger-prompt-label" text="&gt;"/>
-    <TextField id="debugger-prompt-field" promptText="Evaluate Lua" HBox.hgrow="ALWAYS"/>
+    <Label id="debugger-prompt-label" text="&gt;" />
+    <TextField id="debugger-prompt-field" promptText="Evaluate Lua" HBox.hgrow="ALWAYS" />
   </HBox>
 </GridPane>

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -723,12 +723,12 @@
                    (let [^double old-value (or old-value 0.0)
                          ^double new-value new-value
                          scroll-y (g/node-value self :scroll-y evaluation-context)
-                         lines (g/node-value self :lines evaluation-context)
                          layout (g/node-value self :layout evaluation-context)
+                         line-count (count (g/node-value self :lines evaluation-context))
                          resize-reference (g/node-value self :resize-reference evaluation-context)
-                         new-scroll-y (data/limit-scroll-y layout lines (case resize-reference
-                                                                          :bottom (- ^double scroll-y (- old-value new-value))
-                                                                          :top scroll-y))]
+                         new-scroll-y (data/limit-scroll-y layout line-count (case resize-reference
+                                                                               :bottom (- ^double scroll-y (- old-value new-value))
+                                                                               :top scroll-y))]
                      (when (not= scroll-y new-scroll-y)
                        (g/set-property self :scroll-y new-scroll-y))))))
   (property document-width g/Num (default 0.0) (dynamic visible (g/constantly false)))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -60,6 +60,7 @@
 (g/deftype GutterMetrics [(s/one s/Num "gutter-width") (s/one s/Num "gutter-margin")])
 (g/deftype MatchingBraces [[(s/one r/TCursorRange "brace") (s/one r/TCursorRange "counterpart")]])
 (g/deftype UndoGroupingInfo [(s/one (s/->EnumSchema undo-groupings) "undo-grouping") (s/one s/Symbol "opseq")])
+(g/deftype ResizeReference (s/enum :bottom :top))
 (g/deftype SyntaxInfo IPersistentVector)
 (g/deftype SideEffect (s/eq nil))
 
@@ -715,11 +716,19 @@
                      (when (not= scroll-x new-scroll-x)
                        (g/set-property self :scroll-x new-scroll-x))))))
   (property canvas-height g/Num (default 0.0) (dynamic visible (g/constantly false))
-            (set (fn [evaluation-context self _old-value _new-value]
-                   (let [lines (g/node-value self :lines evaluation-context)
-                         layout (g/node-value self :layout evaluation-context)
+            (set (fn [evaluation-context self old-value new-value]
+                   ;; NOTE: old-value will be nil when the setter is invoked for the default.
+                   ;; However, our calls to g/node-value will see default values for all
+                   ;; properties even though their setter fns have not yet been called.
+                   (let [^double old-value (or old-value 0.0)
+                         ^double new-value new-value
                          scroll-y (g/node-value self :scroll-y evaluation-context)
-                         new-scroll-y (data/limit-scroll-y layout lines scroll-y)]
+                         lines (g/node-value self :lines evaluation-context)
+                         layout (g/node-value self :layout evaluation-context)
+                         resize-reference (g/node-value self :resize-reference evaluation-context)
+                         new-scroll-y (data/limit-scroll-y layout lines (case resize-reference
+                                                                          :bottom (- ^double scroll-y (- old-value new-value))
+                                                                          :top scroll-y))]
                      (when (not= scroll-y new-scroll-y)
                        (g/set-property self :scroll-y new-scroll-y))))))
   (property document-width g/Num (default 0.0) (dynamic visible (g/constantly false)))
@@ -729,6 +738,7 @@
   (property grammar g/Any (dynamic visible (g/constantly false)))
   (property gutter-view GutterView (dynamic visible (g/constantly false)))
   (property cursor-opacity g/Num (default 1.0) (dynamic visible (g/constantly false)))
+  (property resize-reference ResizeReference (default :top) (dynamic visible (g/constantly false)))
   (property scroll-x g/Num (default 0.0) (dynamic visible (g/constantly false)))
   (property scroll-y g/Num (default 0.0) (dynamic visible (g/constantly false)))
   (property suggested-completions g/Any (dynamic visible (g/constantly false)))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -333,7 +333,8 @@
                                              :grammar console-grammar
                                              :gutter-view (ConsoleGutterView.)
                                              :highlighted-find-term (.getValue find-term-property)
-                                             :line-height-factor 1.2))
+                                             :line-height-factor 1.2
+                                             :resize-reference :bottom))
         tool-bar (setup-tool-bar! (.lookup console-grid-pane "#console-tool-bar") view-node)
         repainter (ui/->timer "repaint-console-view" (fn [_ elapsed-time]
                                                        (when (.isSelected console-tab)

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -130,10 +130,10 @@
           frame (current-stack-frame debug-view)]
       (.clear input)
       (assert (= :suspended (mobdebug/state debug-session)))
-      (console/append-console-line! (str "❯ " code))
+      (console/append-console-entry! :eval-expression code)
       (let [ret (mobdebug/eval debug-session code frame)
             s (some->> ret :result vals (str/join ", "))]
-        (console/append-console-line! (str "❮ " s))))))
+        (console/append-console-entry! :eval-result (or s "nil"))))))
 
 (defn- setup-tool-bar!
   [^Parent console-tool-bar]

--- a/editor/styling/stylesheets/modules/_console.scss
+++ b/editor/styling/stylesheets/modules/_console.scss
@@ -77,7 +77,6 @@ $console-background: #27292D;
 
   .line {
     -fx-border-color: #3e4147;
-    -fx-max-height: 3px;
   }
 }
 
@@ -145,7 +144,7 @@ $console-background: #27292D;
   -fx-min-width: 42px;
   -fx-max-width: 42px;
   -fx-max-height: 100px;
-  -fx-padding: 0px 8px 0px 0px;
+  -fx-padding: 0px 9px 0px 0px;
 }
 
 #debugger-prompt-field {
@@ -154,6 +153,7 @@ $console-background: #27292D;
   -fx-border-width: 1px 0px 0px 0px;
   -fx-font-family: "Dejavu Sans Mono";
   -fx-font-size: 12px;
+  -fx-font-smoothing-type: lcd;
   -fx-min-height: 44px;
   -fx-padding: 0px;
   -fx-text-fill: $defold-white;

--- a/editor/styling/stylesheets/modules/_console.scss
+++ b/editor/styling/stylesheets/modules/_console.scss
@@ -38,15 +38,6 @@ $console-background: #27292D;
   }
 }
 
-.console-line-separator {
-  -fx-background-color: transparent;
-  -fx-padding: 0px 20px;
-
-  .line {
-    -fx-border-color: #3e4147;
-  }
-}
-
 #console-tool-bar {
   -fx-background-color: $panel-background;
   -fx-padding: 16px;
@@ -59,6 +50,10 @@ $console-background: #27292D;
 #console-canvas-pane {
   -fx-background-color: $console-background;
   -fx-min-height: 20px;
+}
+
+#search-console {
+  -fx-max-height: 26px;
 }
 
 #prev-console-separator {
@@ -77,7 +72,13 @@ $console-background: #27292D;
 }
 
 #debugger-separator {
-  @extend .console-line-separator;
+  -fx-background-color: transparent;
+  -fx-padding: 0px 12px 0px 20px;
+
+  .line {
+    -fx-border-color: #3e4147;
+    -fx-max-height: 3px;
+  }
 }
 
 #debugger-tool-bar {
@@ -87,11 +88,6 @@ $console-background: #27292D;
 #step-over-separator {
   @extend .console-space-separator;
   -fx-min-width: 8px;
-}
-
-#toggle-debugger-separator {
-  @extend .console-space-separator;
-  -fx-min-width: 24px;
 }
 
 #prev-console {
@@ -139,19 +135,14 @@ $console-background: #27292D;
   -fx-background-image: url("icons/32/Icons_54-Step-Out.png");
 }
 
-#toggle-debugger {
-  @extend .console-button-base;
-  -fx-min-width: 73px;
-}
-
 #debugger-prompt-label {
   -fx-alignment: center-right;
-  -fx-background-color: $panel-background;
-  -fx-border-color: transparent;
+  -fx-background-color: $console-background;
+  -fx-border-color: $input-border;
   -fx-border-width: 1px 0px 0px 0px;
   -fx-font-family: "Dejavu Sans Mono";
   -fx-font-size: 12px;
-  -fx-min-width: 52px;
+  -fx-min-width: 42px;
   -fx-max-width: 42px;
   -fx-max-height: 100px;
   -fx-padding: 0px 8px 0px 0px;
@@ -164,14 +155,15 @@ $console-background: #27292D;
   -fx-font-family: "Dejavu Sans Mono";
   -fx-font-size: 12px;
   -fx-min-height: 44px;
-  -fx-padding: 0px 12px;
+  -fx-padding: 0px;
   -fx-text-fill: $defold-white;
 
   &:focused {
     -fx-background-color: $console-background;
     -fx-border-color: $input-border;
     -fx-border-width: 1px 0px 0px 0px;
-    -fx-padding: 0px 12px;
+    -fx-padding: 0px;
     -fx-text-fill: $defold-white;
+    -fx-prompt-text-fill: transparent;
   }
 }

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -526,7 +526,7 @@
                         "\n")))))
 
 (defn- append-distinct-lines [lines regions new-lines]
-  (data/append-distinct-lines lines regions (layout-info lines) new-lines))
+  (data/append-distinct-lines lines regions new-lines))
 
 (defn- repeat-region [row line repeat-count]
   (assoc (cr [row 0] [row (count line)])


### PR DESCRIPTION
### User-facing changes
* The Console output is pinned to the bottom when the panel is resized.
* The Evaluate Lua prompt now only appears when suspended in the debugger.
* Adds Console gutter indicators for Lua evaluations.
* Removed Debugger button from Console tool bar.
* Some visual tweaks to the Console.