### PR TITLE
DEFEDIT-1256 Default to new text editor

### DIFF
--- a/editor/src/clj/editor/code/integration.clj
+++ b/editor/src/clj/editor/code/integration.clj
@@ -2,4 +2,4 @@
   (:require [clojure.java.io :as io]))
 
 (defonce use-new-code-editor?
-  (.exists (io/file (System/getProperty "user.home") ".defold" ".newcode")))
+  (not (.exists (io/file (System/getProperty "user.home") ".defold" ".oldcode"))))


### PR DESCRIPTION
### User facing changes

- A new, much improved text editor for code editing.

### Technical changes

- Invert the `use-new-code-editor?` condition: unless an ".oldcode" file
  exists in ~/.defold/.oldcode the new editor is used.