### PR TITLE
DEFEDIT-1258 NPE in new text editor (tab stops)

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -340,10 +340,9 @@
 
 (defn- next-tab-stop-x
   ^double [tab-stops ^double x]
-  (some (fn [^double tab-stop]
-          (when (< x tab-stop)
-            tab-stop))
-        tab-stops))
+  (let [^double tab-width (:tab-width (first tab-stops))]
+    (max ^double (* (Math/ceil (/ x tab-width)) tab-width)
+         ^double tab-width)))
 
 (defn- advance-text-impl [glyph-metrics tab-stops ^String text start-index end-index start-x]
   (loop [^long index start-index
@@ -454,7 +453,9 @@
 (defn tab-stops [glyph-metrics tab-spaces]
   (let [^double space-width (char-width glyph-metrics \space)
         tab-width (* space-width (double tab-spaces))]
-    (take 100 (iterate (partial + tab-width) tab-width)))) ; Limit so we won't try to print an infinite sequence.
+    ;; tab-stops is now a list of rules applicable for a range.
+    ;; For now, there is one range covering the whole x range.
+    [{:tab-width tab-width}]))
 
 (defn gutter-metrics [glyph-metrics ^double gutter-margin ^long source-line-count]
   (let [max-line-number-width (Math/ceil (* ^double (char-width glyph-metrics \0) (count (str source-line-count))))]

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -454,7 +454,7 @@
   (let [^double space-width (char-width glyph-metrics \space)
         tab-width (* space-width (double tab-spaces))]
     ;; tab-stops is now a list of rules applicable for a range.
-    ;; For now, there is one range covering the whole x range.
+    ;; For now, there is one rule covering the whole x range.
     [{:tab-width tab-width}]))
 
 (defn gutter-metrics [glyph-metrics ^double gutter-margin ^long source-line-count]


### PR DESCRIPTION
* User facing changes
  - Tabs in long lines no longer causes NPE
* Technical changes
  - Changed tab stop representation from list of 100 (intended to be infinite?) stops to list of 1 rule.