### PR TITLE
DEFEDIT-1261 Fix tab indentation in new text editor

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -341,8 +341,7 @@
 (defn- next-tab-stop-x
   ^double [tab-stops ^double x]
   (let [^double tab-width (:tab-width (first tab-stops))]
-    (max ^double (* (Math/ceil (/ x tab-width)) tab-width)
-         ^double tab-width)))
+    (* (+ (quot x tab-width) 1) tab-width)))
 
 (defn- advance-text-impl [glyph-metrics tab-stops ^String text start-index end-index start-x]
   (loop [^long index start-index


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/1496

Sloppy rewrite of tab stops replaced by hopefully correct one.