### PR TITLE
DEFEDIT-1268 Fix "Stop Debugger" menu item appearance

### DIFF
--- a/editor/resources/console-view.fxml
+++ b/editor/resources/console-view.fxml
@@ -22,13 +22,13 @@
     <Button id="clear-console" text="Clear" />
     <HBox id="debugger-tool-bar" visible="false">
       <Separator id="debugger-separator" />
-      <Button id="pause-debugger" />
-      <Button id="play-debugger" visible="false" />
-      <Button id="stop-debugger" />
+      <Button id="pause-debugger-button" />
+      <Button id="play-debugger-button" visible="false" />
+      <Button id="stop-debugger-button" />
       <Separator id="step-over-separator" />
-      <Button id="step-over-debugger" />
-      <Button id="step-in-debugger" />
-      <Button id="step-out-debugger" />
+      <Button id="step-over-debugger-button" />
+      <Button id="step-in-debugger-button" />
+      <Button id="step-out-debugger-button" />
     </HBox>
   </HBox>
   <Pane id="console-canvas-pane" GridPane.rowIndex="1" />

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -64,14 +64,14 @@
       (ui/visible! debugger-prompt (and debug-session? suspended?))
       (ui/visible! debugger-tool-bar debug-session?))
     (when debug-session?
-      (ui/with-controls root [debugger-prompt-field pause-debugger play-debugger step-in-debugger step-out-debugger step-over-debugger]
-        (ui/visible! pause-debugger (not suspended?))
-        (ui/visible! play-debugger suspended?)
-        (ui/enable! pause-debugger (not suspended?))
-        (ui/enable! play-debugger suspended?)
-        (ui/enable! step-in-debugger suspended?)
-        (ui/enable! step-out-debugger suspended?)
-        (ui/enable! step-over-debugger suspended?)
+      (ui/with-controls root [debugger-prompt-field pause-debugger-button play-debugger-button step-in-debugger-button step-out-debugger-button step-over-debugger-button]
+        (ui/visible! pause-debugger-button (not suspended?))
+        (ui/visible! play-debugger-button suspended?)
+        (ui/enable! pause-debugger-button (not suspended?))
+        (ui/enable! play-debugger-button suspended?)
+        (ui/enable! step-in-debugger-button suspended?)
+        (ui/enable! step-out-debugger-button suspended?)
+        (ui/enable! step-over-debugger-button suspended?)
         (ui/enable! debugger-prompt-field suspended?)))))
 
 (g/defnk update-call-stack!
@@ -140,22 +140,22 @@
 
 (defn- setup-tool-bar!
   [^Parent console-tool-bar]
-  (ui/with-controls console-tool-bar [^Parent debugger-tool-bar ^Button pause-debugger ^Button play-debugger step-in-debugger step-out-debugger step-over-debugger stop-debugger]
+  (ui/with-controls console-tool-bar [^Parent debugger-tool-bar ^Button pause-debugger-button ^Button play-debugger-button step-in-debugger-button step-out-debugger-button step-over-debugger-button stop-debugger-button]
     (.bind (.managedProperty debugger-tool-bar) (.visibleProperty debugger-tool-bar))
-    (.bind (.managedProperty pause-debugger) (.visibleProperty pause-debugger))
-    (.bind (.managedProperty play-debugger) (.visibleProperty play-debugger))
-    (ui/tooltip! pause-debugger break-label)
-    (ui/tooltip! play-debugger continue-label)
-    (ui/tooltip! step-in-debugger step-into-label)
-    (ui/tooltip! step-out-debugger step-out-label)
-    (ui/tooltip! step-over-debugger step-over-label)
-    (ui/tooltip! stop-debugger stop-debugger-label)
-    (ui/bind-action! pause-debugger :break)
-    (ui/bind-action! play-debugger :continue)
-    (ui/bind-action! step-in-debugger :step-into)
-    (ui/bind-action! step-out-debugger :step-out)
-    (ui/bind-action! step-over-debugger :step-over)
-    (ui/bind-action! stop-debugger :stop-debugger)))
+    (.bind (.managedProperty pause-debugger-button) (.visibleProperty pause-debugger-button))
+    (.bind (.managedProperty play-debugger-button) (.visibleProperty play-debugger-button))
+    (ui/tooltip! pause-debugger-button break-label)
+    (ui/tooltip! play-debugger-button continue-label)
+    (ui/tooltip! step-in-debugger-button step-into-label)
+    (ui/tooltip! step-out-debugger-button step-out-label)
+    (ui/tooltip! step-over-debugger-button step-over-label)
+    (ui/tooltip! stop-debugger-button stop-debugger-label)
+    (ui/bind-action! pause-debugger-button :break)
+    (ui/bind-action! play-debugger-button :continue)
+    (ui/bind-action! step-in-debugger-button :step-into)
+    (ui/bind-action! step-out-debugger-button :step-out)
+    (ui/bind-action! step-over-debugger-button :step-over)
+    (ui/bind-action! stop-debugger-button :stop-debugger)))
 
 (defn- setup-call-stack-view!
   [^ListView debugger-call-stack]

--- a/editor/styling/stylesheets/modules/_console.scss
+++ b/editor/styling/stylesheets/modules/_console.scss
@@ -104,32 +104,32 @@ $console-background: #27292D;
   -fx-min-width: 49px;
 }
 
-#pause-debugger {
+#pause-debugger-button {
   @extend .console-image-button-base;
   -fx-background-image: url("icons/32/Icons_56-Pause.png");
 }
 
-#play-debugger {
+#play-debugger-button {
   @extend .console-image-button-base;
   -fx-background-image: url("icons/32/Icons_57-Play.png");
 }
 
-#stop-debugger {
+#stop-debugger-button {
   @extend .console-image-button-base;
   -fx-background-image: url("icons/32/Icons_58-Stop.png");
 }
 
-#step-over-debugger {
+#step-over-debugger-button {
   @extend .console-image-button-base;
   -fx-background-image: url("icons/32/Icons_53-Step-Over.png");
 }
 
-#step-in-debugger {
+#step-in-debugger-button {
   @extend .console-image-button-base;
   -fx-background-image: url("icons/32/Icons_55-Step-In.png");
 }
 
-#step-out-debugger {
+#step-out-debugger-button {
   @extend .console-image-button-base;
   -fx-background-image: url("icons/32/Icons_54-Step-Out.png");
 }


### PR DESCRIPTION
### User-facing changes

Fixes https://github.com/defold/editor2-issues/issues/1520

- Fix weird looking "Stop Debugger" menu item on Windows/Linux.

### Technical changes

- Menu items get their id from the command assigned. For "stop-debugger" we had conflicting CSS ids, from the debugger buttons.