### PR TITLE
DEFEDIT-1269 Fix NPE when declaring go.property with empty name

### DIFF
--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -341,10 +341,10 @@
   (let [name-info (parse-script-property-name-info (first arg-exps))
         value-info (parse-script-property-value-info (second arg-exps))
         status-info (cond
-                      (or (< (count arg-exps) 2))
+                      (< (count arg-exps) 2)
                       {:status :invalid-args}
 
-                      (or (nil? name-info) (zero? (some-> name-info :name count)))
+                      (string/blank? (:name name-info))
                       {:status :invalid-name}
 
                       (nil? value-info)

--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -341,8 +341,11 @@
   (let [name-info (parse-script-property-name-info (first arg-exps))
         value-info (parse-script-property-value-info (second arg-exps))
         status-info (cond
-                      (or (nil? name-info) (< (count arg-exps) 2))
+                      (or (< (count arg-exps) 2))
                       {:status :invalid-args}
+
+                      (or (nil? name-info) (zero? (some-> name-info :name count)))
+                      {:status :invalid-name}
 
                       (nil? value-info)
                       {:status :invalid-value}

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -304,7 +304,15 @@
                                    "go.property(\"test\", vmath.quat())"
                                    "go.property(\"test\", vmath.quat(1, 2, 3, 4))"])))))
 
-  (is (= [] (src->properties "foo.property(\"test\", true)")))
-  (is (= [] (src->properties "go.property")))
-  (is (= [{:status :invalid-args}] (src->properties "go.property()")))
-  (is (= [{:status :invalid-args :name "test"}] (src->properties "go.property(\"test\")"))))
+  (is (= []
+         (src->properties "foo.property(\"test\", true)")))
+  (is (= []
+         (src->properties "go.property")))
+  (is (= [{:status :invalid-args}]
+         (src->properties "go.property()")))
+  (is (= [{:status :invalid-args :name "test"}]
+         (src->properties "go.property(\"test\")")))
+  (is (= [{:status :invalid-name :name "" :type :property-type-number :value 0.0}]
+         (src->properties "go.property(\"\", 0.0)")))
+  (is (= [{:status :invalid-value :name "test"}]
+         (src->properties "go.property(\"test\", \"foo\")"))))


### PR DESCRIPTION
### User-facing changes

Fixes https://github.com/defold/editor2-issues/issues/1521

- Fix error when declaring `go.property` with empty name: `go.property("", 0)`.

### Technical changes

- Treat empty strings as property names as invalid when parsing.