### PR TITLE
DEFEDIT-1273 Updating a library dependency has no effect

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1122,7 +1122,11 @@ If you do not specifically require different script states, consider changing th
       (future
         (ui/with-disabled-ui
           (ui/with-progress [render-fn ui/default-render-progress!]
-            (workspace/fetch-libraries! workspace library-urls render-fn (partial login/login prefs))))))))
+            (when (workspace/dependencies-reachable? library-urls (partial login/login prefs))
+              (let [lib-states (workspace/fetch-and-validate-libraries workspace library-urls render-fn)]
+                (ui/run-later
+                  (workspace/install-validated-libraries! workspace library-urls lib-states)
+                  (workspace/resource-sync! workspace))))))))))
 
 (handler/defhandler :fetch-libraries :global
   (run [workspace project prefs] (fetch-libraries workspace project prefs)))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -17,6 +17,7 @@
             [editor.defold-project :as project]
             [editor.github :as github]
             [editor.engine.build-errors :as engine-build-errors]
+            [editor.error-reporting :as error-reporting]
             [editor.pipeline :as pipeline]
             [editor.pipeline.bob :as bob]
             [editor.prefs :as prefs]
@@ -1122,11 +1123,12 @@ If you do not specifically require different script states, consider changing th
       (future
         (ui/with-disabled-ui
           (ui/with-progress [render-fn ui/default-render-progress!]
-            (when (workspace/dependencies-reachable? library-urls (partial login/login prefs))
-              (let [lib-states (workspace/fetch-and-validate-libraries workspace library-urls render-fn)]
-                (ui/run-later
-                  (workspace/install-validated-libraries! workspace library-urls lib-states)
-                  (workspace/resource-sync! workspace))))))))))
+            (error-reporting/catch-all!
+              (when (workspace/dependencies-reachable? library-urls (partial login/login prefs))
+                (let [lib-states (workspace/fetch-and-validate-libraries workspace library-urls render-fn)]
+                  (ui/run-later
+                    (workspace/install-validated-libraries! workspace library-urls lib-states)
+                    (workspace/resource-sync! workspace)))))))))))
 
 (handler/defhandler :fetch-libraries :global
   (run [workspace project prefs] (fetch-libraries workspace project prefs)))


### PR DESCRIPTION
Fixes defold/editor2-issues#1546

* User visible changes
  - Changing library dependencies and fetching libraries no longer (!)
    silently fails due to concurrent transaction, leaving the resource
    tree in a bad state.

* Technical changes
  - Fetching and validating the library zips are still run in a future.
    The state updating part of fetch libraries (installing the library
    zips in the .internal/lib directory, and resource-sync!) are now
    run on the ui thread as it should.
  