### PR TITLE
DEFEDIT-1271 Missing game.project setting for gui particles

### DIFF
--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -158,17 +158,17 @@
    "contacts with an impulse below this limit will not be reported to scripts, 0 (disabled) by default",
    :default 0.0,
    :path ["physics" "contact_impulse_limit"]}
-  {:type :number,
+  {:type :integer,
    :help
    "maximum number of ray casts per frame when using 2D physics",
    :default 64,
    :path ["physics" "ray_cast_limit_2d"]},
-  {:type :number,
+  {:type :integer,
    :help
    "maximum number of ray casts per frame when using 3D physics",
    :default 128,
    :path ["physics" "ray_cast_limit_3d"]},
-  {:type :number,
+  {:type :integer,
    :help
    "maximum number of overlapping triggers that can be detected, 16 by default",
    :default 16,
@@ -299,7 +299,7 @@
    :path ["gui" "max_particlefx_count"]}
   {:type :integer,
    :help
-   "max total number of living particles in gui, 1024 by default",
+   "max total number of living particles in gui per collection, 1024 by default",
    :default 1024,
    :path ["gui" "max_particle_count"]}
   {:type :integer,

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -158,6 +158,21 @@
    "contacts with an impulse below this limit will not be reported to scripts, 0 (disabled) by default",
    :default 0.0,
    :path ["physics" "contact_impulse_limit"]}
+  {:type :number,
+   :help
+   "maximum number of ray casts per frame when using 2D physics",
+   :default 64,
+   :path ["physics" "ray_cast_limit_2d"]},
+  {:type :number,
+   :help
+   "maximum number of ray casts per frame when using 3D physics",
+   :default 128,
+   :path ["physics" "ray_cast_limit_3d"]},
+  {:type :number,
+   :help
+   "maximum number of overlapping triggers that can be detected, 16 by default",
+   :default 16,
+   :path ["physics" "trigger_overlap_capacity"]},
   {:type :string,
    :help
    "which filtering to use for min filtering, linear (default) or nearest",
@@ -276,7 +291,17 @@
   {:type :integer,
    :help "max number of gui components per collection, 64 by default",
    :default 64,
-   :path ["gui" "max_count"]}
+   :path ["gui" "max_count"]},
+  {:type :integer,
+   :help
+   "max number of particlefx nodes per collection",
+   :default 64,
+   :path ["gui" "max_particlefx_count"]}
+  {:type :integer,
+   :help
+   "max total number of living particles in gui, 1024 by default",
+   :default 1024,
+   :path ["gui" "max_particle_count"]}
   {:type :integer,
    :help "max number of labels, 64 by default",
    :default 64,

--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -28,7 +28,7 @@
   {:current-category nil :settings nil})
 
 (defn- parse-category-line [{:keys [current-category settings] :as parse-state} line]
-  (when-let [[_ new-category] (re-find #"\[([^\]]*)\]" line)]
+  (when-let [[_ new-category] (re-find #"^\s*\[([^\]]*)\]" line)]
     (assoc parse-state :current-category new-category)))
 
 (defn- parse-setting-line [{:keys [current-category settings] :as parse-state} line]


### PR DESCRIPTION
* User facing changes
  - Added fields in game.project editor: physics/ray_cast_limit_2d,
  physics/ray_cast_limit_3d, physics/trigger_overlap_capacity,
  gui/max_particlefx_count, gui/max_particle_count

* Technical changes
  - Changed parsing of settings files slightly. Now a category line
  `[category]` is only recognised if it appears in the beginning of
  the line + whitespace.