### PR TITLE
DEFEDIT-1275 Spine default skin handled differently in bob/ed2

### DIFF
--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -114,7 +114,7 @@
                  :resource-fields [:texture-set :skeleton :animation-set :mesh-set]
                  :test-fn (fn [pb targets]
                             (is (some? (-> pb :texture-set (target targets) :texture)))
-                            (is (not= 0 (-> pb :mesh-set (target targets) :mesh-entries first :id)))
+                            (is (= 0 (-> pb :mesh-set (target targets) :mesh-entries first :id)))
                             (is (< 0 (-> pb :mesh-set (target targets) :mesh-entries count)))
                             (is (< 0 (-> pb :animation-set (target targets) :animations count)))
                             (is (< 0 (-> pb :skeleton (target targets) :bones count))))}
@@ -134,7 +134,7 @@
                  :resource-fields [:texture-set :skeleton :animation-set :mesh-set]
                  :test-fn (fn [pb targets]
                             (is (some? (-> pb :texture-set (target targets) :texture)))
-                            (is (not= 0 (-> pb :mesh-set (target targets) :mesh-entries first :id)))
+                            (is (= 0 (-> pb :mesh-set (target targets) :mesh-entries first :id)))
                             (is (< 0 (-> pb :mesh-set (target targets) :mesh-entries count)))
                             (is (< 0 (-> pb :animation-set (target targets) :animations count)))
                             (is (< 0 (-> pb :skeleton (target targets) :bones count)))


### PR DESCRIPTION
* Technical changes
  - "default" skin from spine scene is now built as a mesh entry with
  id hash("") instead of hash("default"), like editor 1 + bob does it.