### PR TITLE
DEF-3077 Optimised game object dispatch messages

### DIFF
--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -286,6 +286,8 @@ namespace dmMessage
 
     bool HasMessages(HSocket socket)
     {
+        if (!socket)
+            return false;
         DM_MUTEX_SCOPED_LOCK(g_MessageContext->m_Mutex);
         MessageSocket* s = g_MessageContext->m_Sockets.Get(socket);
         if (s != 0)

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2047,20 +2047,20 @@ namespace dmGameObject
             iterate = false;
             for (uint32_t i = 0; i < socket_count; ++i)
             {
-                if (dmMessage::IsSocketValid(sockets[i]))
+                if (!dmMessage::HasMessages(sockets[i]))
                 {
-                    // Make sure the transforms are updated if we are about to dispatch messages
-                    if (dmMessage::HasMessages(sockets[i]) && collection->m_DirtyTransforms)
-                    {
-                        UpdateTransforms(collection);
-                    }
-                    uint32_t message_count = dmMessage::Dispatch(sockets[i], &DispatchMessagesFunction, (void*) &ctx);
-                    if (message_count > 0)
-                    {
-                        collection->m_DirtyTransforms = true;
-                        iterate = true;
-                    }
-
+                    continue; // no need to try to update or send anything
+                }
+                // Make sure the transforms are updated if we are about to dispatch messages
+                if (collection->m_DirtyTransforms)
+                {
+                    UpdateTransforms(collection);
+                }
+                uint32_t message_count = dmMessage::Dispatch(sockets[i], &DispatchMessagesFunction, (void*) &ctx);
+                if (message_count > 0)
+                {
+                    collection->m_DirtyTransforms = true;
+                    iterate = true;
                 }
             }
             ++iteration_count;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2057,7 +2057,7 @@ namespace dmGameObject
                     UpdateTransforms(collection);
                 }
                 uint32_t message_count = dmMessage::Dispatch(sockets[i], &DispatchMessagesFunction, (void*) &ctx);
-                if (message_count > 0)
+                if (message_count)
                 {
                     collection->m_DirtyTransforms = true;
                     iterate = true;


### PR DESCRIPTION
Presto lvl.1 (iPhone 4S)
	From ~2-3.5 ms in 162 calls
	to   ~0.8-1.2ms in 162 calls

(Starting to see some green profile frames for this game now!)