### PR TITLE
DEFEDIT-1275 Spine default skin handled differently in bob/ed2

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1195,7 +1195,7 @@
   (output node-rt-msgs g/Any :cached
     (g/fnk [node-msgs node-rt-msgs bone-node-msgs spine-skin-ids]
       (let [pb-msg (first node-msgs)
-            rt-pb-msgs (into node-rt-msgs [(update pb-msg :spine-skin (fn [skin] (if (str/blank? skin) (first spine-skin-ids) skin)))])]
+            rt-pb-msgs (into node-rt-msgs [(update pb-msg :spine-skin (fn [skin] (or skin "")))])]
         (into rt-pb-msgs bone-node-msgs))))
   (output own-build-errors g/Any :cached (g/fnk [_node-id build-errors-visual-node spine-anim-ids spine-default-animation spine-skin-ids spine-skin spine-scene spine-scene-names]
                                            (g/package-errors _node-id

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -215,7 +215,7 @@
                  :test-fn (fn [pb targets]
                             (let [main-node (first (filter #(= "spine" (:id %)) (:nodes pb)))
                                   nodes (into #{} (map :id (:nodes pb)))]
-                              (is (= "default" (:spine-skin main-node)))
+                              (is (= "" (:spine-skin main-node)))
                               (is (every? nodes ["spine" "spine/root" "box"]))))}]
                "/model/book_of_defold_no_tex.model"
                [{:label "Model with empty texture"


### PR DESCRIPTION
Corresponding fix for building spines in gui.