### PR TITLE
DEFEDIT-394 Support for tracing node-value calls

### DIFF
--- a/editor/resources/editor.fxml
+++ b/editor/resources/editor.fxml
@@ -230,8 +230,13 @@
       </SplitPane>
       <HBox>
         <children>
-          <Label id="progress-status-label" text="Ready" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308"/>
-          <Label id="update-available-label" text="Update Available" visible="false"/>
+          <Label id="status-label" text="Ready" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308"/>
+	  <AnchorPane id="status-pane"/>
+	  <!--
+	      status-pane will contain either:
+	      - update available label
+	      - progress controls
+	  -->
         </children>
       </HBox>
    </children>

--- a/editor/resources/progress.fxml
+++ b/editor/resources/progress.fxml
@@ -33,7 +33,7 @@
                         <ProgressBar id="progress" progress="0.74" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                      </children>
                   </AnchorPane>
-                  <Label id="message" text="Message..." />
+                  <Label id="message" text="" />
                   <Pane VBox.vgrow="ALWAYS" />
                   <HBox>
                      <children>

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -83,6 +83,11 @@
   []
   (is/system-cache @*the-system*))
 
+(defn clear-system-cache!
+  "Clears *the-system* cache, useful when debugging"
+  []
+  (swap! *the-system* assoc :cache (ref (is/make-cache {}))))
+
 (defn graph "Given a graph id, returns the particular graph in the system at the current point in time"
   [graph-id]
   (is/graph @*the-system* graph-id))
@@ -690,6 +695,55 @@
   [node-id defective-value]
   (assert node-id)
   (transact (mark-defective node-id defective-value)))
+
+;; ---------------------------------------------------------------------------
+;; Tracing
+;; ---------------------------------------------------------------------------
+;;
+;; Run several tracers using (juxt (g/make-print-tracer) (g/make-tree-tracer result))
+;;
+
+(defn make-print-tracer
+  "Prints an indented tree of all eval steps taken."
+  []
+  (let [depth (atom 0)]
+    (fn [state node output-type label]
+      (when (or (= :end state) (= :fail state))
+        (swap! depth dec))
+      (println (str (apply str (take @depth (repeat "  "))) state " " node " " output-type " " label))
+      (when (= :begin state)
+        (swap! depth inc)))))
+
+(defn make-tree-tracer
+  "Creates a tree trace of the evaluation of the form
+  {:node-id ... :output-type ... :label ... :state ... :dependencies [{...} ...]}
+
+  You can also pass in a function to decorate the steps. For timing for instance:
+
+    (defn timing-decorator [step state]
+      (case state
+        :begin (assoc step :start-time (System/currentTimeMillis))
+        (:end :fail) (-> step
+                         (assoc :elapsed (- (System/currentTimeMillis) (:start-time step)))
+                         (dissoc :start-time))))
+
+    (g/node-value node :output (g/make-evaluation-context {:tracer (g/make-tree-tracer result-atom timing-decorator)}))"
+  ([result-atom]
+   (make-tree-tracer result-atom (fn [step _] step)))
+  ([result-atom step-decorator]
+   (let [stack (atom '())]
+     (fn [state node output-type label]
+       (case state
+         :begin
+         (swap! stack conj (step-decorator {:node-id node :output-type output-type :label label :dependencies []} state))
+
+         (:end :fail)
+         (let [step (step-decorator (assoc (first @stack) :state state) state)]
+           (swap! stack rest)
+           (let [parent (first @stack)]
+             (if parent
+               (swap! stack #(conj (rest %) (update parent :dependencies conj step)))
+               (reset! result-atom step)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Values

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -513,6 +513,8 @@
                (g/user-data! workspace :editor.pipeline/artifacts artifacts)
                (g/user-data! workspace :editor.pipeline/etags etags)
                (when build (launch-built-project project prefs web-server console-view debug? (:render-error! build-options))))))
+         (catch Throwable t
+           (error-reporting/report-exception! t))
          (finally
            (reset! build-in-progress? false)))))))
 

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -42,7 +42,7 @@
   (:import [java.io File]
            [javafx.scene Node Scene]
            [javafx.stage Stage]
-           [javafx.scene.layout Region VBox]
+           [javafx.scene.layout Region VBox AnchorPane]
            [javafx.scene.control Label MenuBar Tab TabPane TreeView]))
 
 (set! *warn-on-reflection* true)
@@ -80,13 +80,11 @@
 
 (defn- handle-application-focused! [workspace changes-view]
   (when-not (sync/sync-dialog-open?)
-    (ui/default-render-progress-now! (progress/make "Reloading modified resources..."))
-    (ui/->future 0.01
-                 #(try
-                    (ui/with-progress [render-fn ui/default-render-progress!]
-                      (changes-view/resource-sync-after-git-change! changes-view workspace [] render-fn))
-                    (finally
-                      (ui/default-render-progress-now! progress/done))))))
+    (let [render-fn (progress/throttle-render-progress (app-view/make-render-task-progress :resource-sync))]
+      (ui/->future 0.01
+                   (fn []
+                     (ui/with-progress [render-fn render-fn]
+                       (changes-view/resource-sync-after-git-change! changes-view workspace [] render-fn)))))))
 
 (defn- find-tab [^TabPane tabs id]
   (some #(and (= id (.getId ^Tab %)) %) (.getTabs tabs)))
@@ -96,26 +94,39 @@
     (changes-view/refresh! changes-view)))
 
 (defn- install-pending-update-check-timer! [^Stage stage ^Label label update-context]
-  (let [update-visibility! (fn [] (.setVisible label (let [update (updater/pending-update update-context)]
+  (let [update-visibility! (fn [] (ui/visible! label (let [update (updater/pending-update update-context)]
                                                        (and (some? update) (not= update (system/defold-editor-sha1))))))
         tick-fn (fn [_ _] (update-visibility!))
         timer (ui/->timer 0.1 "pending-update-check" tick-fn)]
     (update-visibility!)
-    (.setOnShown stage (ui/event-handler event (ui/timer-start! timer)))
-    (.setOnHiding stage (ui/event-handler event (ui/timer-stop! timer)))))
+    (ui/add-on-shown! stage #(ui/timer-start! timer))
+    (ui/add-on-hiding! stage #(ui/timer-stop! timer))))
 
-(defn- init-pending-update-indicator! [^Stage stage ^VBox root project update-context]
-  (let [label (.lookup root "#update-available-label")]
-    (.setOnMouseClicked label
-                        (ui/event-handler event
-                                          (when (dialogs/make-pending-update-dialog stage)
-                                            (when (updater/install-pending-update! update-context (io/file (system/defold-resourcespath)))
-                                              ;; Save the project and block until complete. Before saving, perform a
-                                              ;; resource sync to ensure we do not overwrite external changes.
-                                              (workspace/resource-sync! (project/workspace project))
-                                              (project/save-all! project)
-                                              (updater/restart!)))))
-    (install-pending-update-check-timer! stage label update-context)))
+(defn- init-pending-update-indicator! [^Stage stage ^Label label project update-context]
+  (.setOnMouseClicked label
+                      (ui/event-handler event
+                                        (when (dialogs/make-pending-update-dialog stage)
+                                          (when (updater/install-pending-update! update-context (io/file (system/defold-resourcespath)))
+                                            ;; Save the project and block until complete. Before saving, perform a
+                                            ;; resource sync to ensure we do not overwrite external changes.
+                                            (workspace/resource-sync! (project/workspace project))
+                                            (project/save-all! project)
+                                            (updater/restart!)))))
+  (install-pending-update-check-timer! stage label update-context))
+
+(defn- update-status-pane-contents! [^AnchorPane status-pane content-prospects]
+  (let [content (first (.getChildren status-pane))
+        new-content (first (filter ui/visible? content-prospects))]
+    (when (not= content new-content)
+      (ui/children! status-pane (when new-content [new-content]))
+      (when new-content
+        (ui/fill-control new-content)))))
+
+(defn- init-status-pane-timer! [^Stage stage ^AnchorPane status-pane content-prospects]
+  (let [timer (ui/->timer 5 "update-status-pane" (fn [_ _] (update-status-pane-contents! status-pane content-prospects)))]
+    (update-status-pane-contents! status-pane content-prospects)
+    (ui/add-on-shown! stage #(ui/timer-start! timer))
+    (ui/add-on-hiding! stage #(ui/timer-stop! timer))))
 
 (defn- show-tracked-internal-files-warning! []
   (dialogs/make-alert-dialog (str "It looks like internal files such as downloaded dependencies or build output were placed under source control.\n"
@@ -126,17 +137,26 @@
 (defn load-stage [workspace project prefs update-context]
   (let [^VBox root (ui/load-fxml "editor.fxml")
         stage      (ui/make-stage)
-        scene      (Scene. root)]
+        scene      (Scene. root)
+        status-pane (.lookup root "#status-pane")
+        update-available-label (doto (Label. "Update Available")
+                                 (ui/visible! false)
+                                 (ui/add-style! "link-label"))]
+
+    (ui/init-stage-shown-hiding-hooks! stage)
 
     (when update-context
-      (init-pending-update-indicator! stage root project update-context))
+      (init-pending-update-indicator! stage update-available-label project update-context))
+
+    (init-status-pane-timer! stage status-pane
+                             [app-view/progress-hbox
+                              update-available-label])
 
     (ui/set-main-stage stage)
     (.setScene stage scene)
 
     (app-view/restore-window-dimensions stage prefs)
-
-    (ui/init-progress!)
+    
     (ui/show! stage)
     (targets/start)
 

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -273,12 +273,31 @@
 
 (defn save-all!
   ([project]
-   (save-all! project ui/default-render-progress!))
+   ;; TODO: should generally pass in task specific render-progress! to save-all!
+   (save-all! project (progress/throttle-render-progress progress/null-render-progress!)))
   ([project render-progress-fn]
    (let [workspace     (workspace project)]
      (ui/with-progress [render-fn render-progress-fn]
        (write-save-data-to-disk! project {:render-progress! render-fn}))
      (workspace/resource-sync! workspace false [] progress/null-render-progress!))))
+
+(defn make-collect-progress-steps-tracer [steps-atom]
+  (fn [state node output-type label]
+    (when (= [state output-type label] [:begin :output :build-targets])
+      (swap! steps-atom conj [node output-type label]))))
+
+(defn make-progress-tracer [steps-atom node-id->resource-path render-progress!]
+  (let [steps-left (atom @steps-atom)
+        progress (atom (progress/make "" (count @steps-atom)))]
+    (fn [state node output-type label]
+      (when (and (= [state output-type label] [:begin :output :build-targets])
+                 (= (first @steps-left) [node output-type label]))
+        (swap! steps-left rest)
+        (let [new-message (if-let [path (node-id->resource-path node)]
+                            (str "Building " path)
+                            (or (progress/message @progress) ""))]
+          (swap! progress progress/advance 1 new-message))
+        (render-progress! @progress)))))
 
 (defn build
   ([project node evaluation-context opts]
@@ -286,7 +305,15 @@
   ([project node evaluation-context extra-build-targets {:keys [render-progress! render-error!]
                                                          :or   {render-progress! progress/null-render-progress!}
                                                          :as   opts}]
-   (let [node-build-targets (g/node-value node :build-targets evaluation-context)
+   (let [steps (atom [])
+         node-id->resource-path (clojure.set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context))
+         _ (g/node-value node :build-targets (assoc evaluation-context
+                                                    :dry-run true
+                                                    :tracer (make-collect-progress-steps-tracer steps)))
+         node-build-targets (g/node-value node :build-targets
+                                          (assoc evaluation-context
+                                                 :tracer (make-progress-tracer steps node-id->resource-path
+                                                                               (progress/nest-render-progress render-progress! (progress/make "" 10) 7))))
          build-targets (cond-> node-build-targets
                          (seq extra-build-targets)
                          (into extra-build-targets))]
@@ -295,7 +322,7 @@
          (when render-error!
            (render-error! build-targets))
          nil)
-       (pipeline/build! (workspace project) build-targets)))))
+       (pipeline/build! (workspace project) build-targets (progress/nest-render-progress render-progress! (progress/make "" 10 7) 3))))))
 
 (handler/defhandler :undo :global
   (enabled? [project-graph] (g/has-undo? project-graph))
@@ -562,11 +589,12 @@
    (build-and-write-project project evaluation-context nil build-options))
   ([project evaluation-context extra-build-targets build-options]
    (let [game-project  (get-resource-node project "/game.project")
-         clear-errors! (:clear-errors! build-options)]
+         clear-errors! (:clear-errors! build-options)
+         build-options (update build-options :render-progress! (fnil progress/throttle-render-progress progress/null-render-progress!))]
      (try
-       (ui/with-progress [render-fn ui/default-render-progress!]
+       (ui/with-progress [render-fn (:render-progress! build-options)]
          (clear-errors!)
-         (seq (build project game-project evaluation-context extra-build-targets (assoc build-options :render-progress! render-fn))))
+         (seq (build project game-project evaluation-context extra-build-targets build-options)))
        (catch Throwable error
          (error-reporting/report-exception! error)
          nil)))))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -273,12 +273,14 @@
 
 (defn save-all!
   ([project]
-   ;; TODO: should generally pass in task specific render-progress! to save-all!
+   ;; TODO: We call save-all! from build-html5, when bundling, when updating and when actually saving all.
+   ;; In all those cases we probably want to pass in a properly nested render-progress!, but for now we default
+   ;; to no progress reporting.
    (save-all! project (progress/throttle-render-progress progress/null-render-progress!)))
-  ([project render-progress-fn]
+  ([project render-progress!]
    (let [workspace     (workspace project)]
-     (ui/with-progress [render-fn render-progress-fn]
-       (write-save-data-to-disk! project {:render-progress! render-fn}))
+     (ui/with-progress [render-progress! render-progress!]
+       (write-save-data-to-disk! project {:render-progress! render-progress!}))
      (workspace/resource-sync! workspace false [] progress/null-render-progress!))))
 
 (defn make-collect-progress-steps-tracer [steps-atom]

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -76,7 +76,7 @@
     (.show stage)
     {:stage              stage
      :render-progress-fn (fn [progress]
-                           (ui/update-progress-controls! progress (:progress controls) (:message controls)))}))
+                           (ui/render-progress-controls! progress (:progress controls) (:message controls)))}))
 
 (defn ^:dynamic make-alert-dialog [text]
   (let [root ^Parent (ui/load-fxml "alert.fxml")

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -159,7 +159,7 @@
                          (map (fn [[key {:keys [resource] :as build-target}]]
                                 (swap! progress #(-> %
                                                      (progress/advance)
-                                                     (progress/with-message (str "Writing " (or (resource/proj-path (:resource resource)) "embedded resource")))))
+                                                     (progress/with-message (str "Writing " (resource/proj-path resource)))))
                                 (or (when-let [artifact (get artifacts resource)]
                                       (and (valid? artifact) artifact))
                                     (render-progress! @progress)

--- a/editor/src/clj/editor/sync.clj
+++ b/editor/src/clj/editor/sync.clj
@@ -484,7 +484,7 @@
         push-controls   (ui/collect-controls push-root ["changed" "staged" "message" "content-box" "main-label" "diff" "stage" "unstage"])
         render-progress (fn [progress]
                           (ui/run-later
-                            (ui/update-progress-controls! progress (:progress-bar dialog-controls) nil)))
+                            (ui/render-progress-controls! progress (:progress-bar dialog-controls) nil)))
         update-push-buttons! (fn []
                                ;; The stage, unstage and diff buttons are enabled
                                ;; if the changed or staged views have input focus

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -24,6 +24,49 @@
 
 (def ^:dynamic *node-value-debug* nil)
 
+(defn- tracer-begin [tracer node output-type label]
+  (when tracer
+    (try 
+      (tracer :begin (gt/node-id node) output-type label)
+      (catch Exception e
+        (assert (not e) (str "tracer failed: " e))))))
+
+(defn- tracer-end [tracer node output-type label]
+  (when tracer
+    (try
+      (tracer :end (gt/node-id node) output-type label)
+      (catch Exception e
+        (.printStackTrace e)
+        (assert (not e) (str "tracer failed: " e))))))
+
+(defn- tracer-fail [tracer node output-type label]
+  (when tracer
+    (try 
+      (tracer :fail (gt/node-id node) output-type label)
+      (catch Exception e
+        (assert (not e) (str "tracer failed: " e))))))
+
+(defn trace-expr [self ctx output output-type deferred-expr]
+  (let [tracer (:tracer ctx)]
+    (try
+      (tracer-begin tracer self output-type output)
+      (let [result (deferred-expr)]
+        (tracer-end tracer self output-type output)
+        result)
+      (catch Exception e
+        (tracer-fail tracer self output-type output)
+        (throw e)))))
+
+(defn- with-tracer-calls-form [self-name ctx-name output-name output-type expr]
+  `(trace-expr ~self-name ~ctx-name ~output-name ~output-type
+               (fn [] ~expr)))
+
+(defn- check-dry-run-form
+  ([ctx-name expr]
+   `(when-not (:dry-run ~ctx-name) ~expr))
+  ([ctx-name expr dry-expr]
+   `(if-not (:dry-run ~ctx-name) ~expr ~dry-expr)))
+
 (defn nodevalstr [this node-type label & t]
   (apply str "\t" (:_node-id this) "\t"  (:name @node-type) label "\t" t))
 
@@ -261,9 +304,9 @@
   (produce-value [this label evaluation-context]
     (let [beh (behavior node-type label)]
       (assert beh (str "No such output, input, or property " label
-                            " exists for node " (gt/node-id this)
-                            " of type " (:name @node-type)
-                            "\nIn production: " (get evaluation-context :in-production)))
+                       " exists for node " (gt/node-id this)
+                       " of type " (:name @node-type)
+                       "\nIn production: " (get evaluation-context :in-production)))
       (when *node-value-debug*
         (println (nodevalstr this node-type label)))
       ((:fn beh) this evaluation-context)))
@@ -333,7 +376,7 @@
   (and node (gt/produce-value node label evaluation-context)))
 
 (defn- validate-evaluation-context-options [options]
-  (assert (every? #{:basis :cache :initial-invalidate-counters} (keys options)) (str (keys options)))
+  (assert (every? #{:basis :cache :initial-invalidate-counters :tracer :dry-run} (keys options)) (str (keys options)))
   (assert (not (and (some? (:cache options)) (nil? (:basis options))))))
 
 (defn make-evaluation-context
@@ -350,6 +393,12 @@
   (assert (some? (:local evaluation-context)))
   (assert (some? (:hits evaluation-context))))
 
+(defn- apply-dry-run-cache [evaluation-context]
+  (cond-> evaluation-context
+    (:dry-run evaluation-context)
+    (assoc :local (atom @(:local evaluation-context))
+           :hits (atom @(:hits evaluation-context)))))
+
 (defn node-value
   "Get a value, possibly cached, from a node. This is the entry point
   to the \"plumbing\". If the value is cacheable and exists in the
@@ -361,7 +410,7 @@
   (validate-evaluation-context evaluation-context)
   (let [basis (:basis evaluation-context)
         node (if (gt/node-id? node-or-node-id) (gt/node-by-id-at basis node-or-node-id) node-or-node-id)]
-    (node-value* node label evaluation-context)))
+    (node-value* node label (apply-dry-run-cache evaluation-context))))
 
 (defn- node-property-value* [node label evaluation-context]
   (let [basis              (:basis evaluation-context)
@@ -1133,23 +1182,30 @@
   (let [property-definition (get-in description [:property prop-name])
         default?            (not (:value property-definition))]
     (if default?
-      `(gt/get-property ~self-name (:basis ~ctx-name) ~prop-name)
-      (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym prop-name description
-                                              (:arguments (:value property-definition))
-                                              `(var ~(symbol (dollar-name (:name description) [:property prop-name :value])))))))
-
+      (with-tracer-calls-form self-name ctx-name prop-name :raw-property
+        (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~prop-name)))
+      (with-tracer-calls-form self-name ctx-name prop-name :property
+        (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym prop-name description
+                                                     (get-in property-definition [:value :arguments])
+                                                     (check-dry-run-form ctx-name
+                                                                         `(var ~(symbol (dollar-name (:name description) [:property prop-name :value])))
+                                                                         `(constantly nil)))))))
 (defn- collect-property-value-form
   [self-name ctx-name nodeid-sym description prop]
   (let [property-definition (get-in description [:property prop])
         default?            (not (:value property-definition))
         get-expr            (if default?
-                              `(gt/get-property ~self-name (:basis ~ctx-name) ~prop)
-                              (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym prop description
-                                                                           (get-in property-definition [:value :arguments])
-                                                                           `(var ~(dollar-name (:name description) [:property prop :value]))))]
+                              (with-tracer-calls-form self-name ctx-name prop :raw-property
+                                (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~prop)))
+                              (with-tracer-calls-form self-name ctx-name prop :property
+                                (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym prop description
+                                                                             (get-in property-definition [:value :arguments])
+                                                                             (check-dry-run-form ctx-name
+                                                                                                 `(var ~(dollar-name (:name description) [:property prop :value]))
+                                                                                                 `(constantly nil)))))]
     get-expr))
 
-(defn- fnk-argument-form
+(defn fnk-argument-form
   [self-name ctx-name nodeid-sym output description argument]
   (cond
     (= :this argument)
@@ -1162,11 +1218,12 @@
     (collect-property-value-form self-name ctx-name nodeid-sym description argument)
 
     (unoverloaded-output? description argument output)
-    `(gt/produce-value  ~self-name ~argument ~ctx-name)
+    `(gt/produce-value ~self-name ~argument ~ctx-name)
 
     (desc-has-property? description argument)
     (if (= output argument)
-      `(gt/get-property  ~self-name (:basis ~ctx-name) ~argument)
+      (with-tracer-calls-form self-name ctx-name argument :raw-property
+        (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~argument)))
       (collect-property-value-form self-name ctx-name nodeid-sym description argument))
 
     (has-multivalued-input? description argument)
@@ -1201,11 +1258,11 @@
                        (gt/node-by-id-at basis# (original-root basis# ~nodeid-sym))
                        ~self-name)]
        (if-let [jammer# (get (:_output-jammers original#) ~transform)]
-        (let [jam-value# (jammer#)]
-          (if (ie/error? jam-value#)
-            (assoc jam-value# :_label ~transform :_node-id ~nodeid-sym)
-            jam-value#))
-        ~forms))
+         (let [jam-value# (jammer#)]
+           (if (ie/error? jam-value#)
+             (assoc jam-value# :_label ~transform :_node-id ~nodeid-sym)
+             jam-value#))
+         ~forms))
     forms))
 
 (defn- property-has-default-getter?       [description label] (not (get-in description [:property label :value])))
@@ -1216,7 +1273,8 @@
         default?  (and (property-has-default-getter? description property-name)
                        (property-has-no-overriding-output? description property-name))]
     (if default?
-      `(gt/get-property ~self-name (:basis ~ctx-name) ~property-name)
+      (with-tracer-calls-form self-name ctx-name property-name :raw-property
+        (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~property-name)))
       forms)))
 
 (defn mark-in-production [ctx node-type-name node-id label]
@@ -1228,18 +1286,26 @@
   `(let [~ctx-name (mark-in-production ~ctx-name ~(:name description) ~nodeid-sym ~transform)]
      ~forms))
 
-(defn- check-caches-form [ctx-name nodeid-sym description transform local-cache-sym forms]
-  (if (get-in description [:output transform :flags :cached])
-    `(let [~local-cache-sym (:local ~ctx-name)
-           local#  (deref ~local-cache-sym)
-           global# (:cache ~ctx-name)
-           key# [~nodeid-sym ~transform]]
-       (cond
-         (contains? local# key#) (get local# key#)
-         (contains? global# key#) (if-some [cached# (get global# key#)]
-                                           (do (swap! (:hits ~ctx-name) conj key#) cached#))
-         true ~forms))
-    forms))
+(defn check-caches-form [self-name ctx-name nodeid-sym description transform local-cache-sym forms]
+  (gensyms [local global key]
+           (if (get-in description [:output transform :flags :cached])
+             `(let [~local-cache-sym (:local ~ctx-name)
+                    ~local  (deref ~local-cache-sym)
+                    ~global (:cache ~ctx-name)
+                    ~key [~nodeid-sym ~transform]]
+                (cond
+                  (contains? ~local ~key)
+                  ~(with-tracer-calls-form self-name ctx-name transform :cache
+                     `(get ~local ~key))
+
+                  (contains? ~global ~key)
+                  ~(with-tracer-calls-form self-name ctx-name transform :cache
+                     `(if-some [cached# (get ~global ~key)]
+                        (do (swap! (:hits ~ctx-name) conj ~key)
+                            cached#)))
+
+                  true ~forms))
+             forms)))
 
 (defn- gather-inputs-form [input-sym schema-sym self-name ctx-name nodeid-sym description transform production-function forms]
   (let [arg-names       (get-in description [:output transform :arguments])
@@ -1259,7 +1325,7 @@
 
 (defn- call-production-function-form [self-name ctx-name description transform input-sym nodeid-sym output-sym forms]
   `(let [~output-sym ~(input-error-check-form self-name ctx-name description transform nodeid-sym input-sym
-                                              `((var ~(symbol (dollar-name (:name description) [:output transform]))) ~input-sym))]
+                                              (check-dry-run-form ctx-name `((var ~(symbol (dollar-name (:name description) [:output transform]))) ~input-sym)))]
      ~forms))
 
 (defn- cache-output-form [ctx-name description transform nodeid-sym output-sym local-cache-sym forms]
@@ -1292,7 +1358,7 @@
   (if *check-schemas*
     `(let [output-schema# ~(deduce-output-type-form self-name description transform)]
        (try
-         (if-let [validation-error# (s/check output-schema# ~output-sym)]
+         (if-let [validation-error# (when-not (:dry-run ~ctx-name) (s/check output-schema# ~output-sym))]
            (report-schema-error ~(:name description) ~transform ~nodeid-sym ~output-sym output-schema# validation-error#)
            ~forms)
          (catch IllegalArgumentException iae#
@@ -1309,7 +1375,8 @@
 
 (defn- node-output-value-function-form
   [description transform]
-  (let [production-function (get-in description [:output transform :fn])]
+  (let [production-function (get-in description [:output transform :fn])
+        tracer-output-type (if (desc-has-explicit-output? description transform) :output :property)]
     (gensyms [self-name ctx-name nodeid-sym input-sym schema-sym output-sym local-cache-sym]
       `(fn [~self-name ~ctx-name]
          (let [~nodeid-sym (gt/node-id ~self-name)]
@@ -1318,12 +1385,13 @@
               (check-jammed-form self-name ctx-name nodeid-sym transform
                 (apply-default-property-shortcut-form self-name ctx-name transform description
                   (mark-in-production-form ctx-name nodeid-sym transform description
-                    (check-caches-form ctx-name nodeid-sym description transform local-cache-sym
-                      (gather-inputs-form input-sym schema-sym self-name ctx-name nodeid-sym description transform production-function
-                        (call-production-function-form self-name ctx-name description transform input-sym nodeid-sym output-sym
-                          (schema-check-output-form self-name ctx-name description transform nodeid-sym output-sym
-                            (cache-output-form ctx-name description transform nodeid-sym output-sym local-cache-sym
-                              output-sym))))))))))))))
+                    (check-caches-form self-name ctx-name nodeid-sym description transform local-cache-sym
+                      (with-tracer-calls-form self-name ctx-name transform tracer-output-type
+                        (gather-inputs-form input-sym schema-sym self-name ctx-name nodeid-sym description transform production-function
+                          (call-production-function-form self-name ctx-name description transform input-sym nodeid-sym output-sym
+                            (schema-check-output-form self-name ctx-name description transform nodeid-sym output-sym
+                              (cache-output-form ctx-name description transform nodeid-sym output-sym local-cache-sym
+                                output-sym)))))))))))))))
 
 (defn- assemble-properties-map-form
   [nodeid-sym value-sym display-order]
@@ -1335,7 +1403,12 @@
   [self-name ctx-name nodeid-sym description property-name property-type value-form]
   (apply merge
          (for [[dynamic-label {:keys [arguments] :as dynamic}] (get property-type :dynamics)]
-           {dynamic-label (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym dynamic-label description arguments `(var ~(dollar-name (:name description) [:property property-name :dynamics dynamic-label])))})))
+           {dynamic-label
+            (with-tracer-calls-form self-name ctx-name [property-name dynamic-label] :dynamic
+              (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym dynamic-label description arguments
+                                                           (check-dry-run-form ctx-name
+                                                                               `(var ~(dollar-name (:name description) [:property property-name :dynamics dynamic-label]))
+                                                                               `(constantly nil))))})))
 
 (defn- property-value-exprs
   [self-name ctx-name nodeid-sym description prop-name prop-type]
@@ -1358,7 +1431,7 @@
                ~value-map     ~(apply merge {}
                                       (for [[p _] (filter (comp external-property? val) props)]
                                         {p (property-value-exprs self-name ctx-name nodeid-sym description p (get props p))}))]
-           ~(assemble-properties-map-form nodeid-sym value-map display-order))))))
+           ~(check-dry-run-form ctx-name (assemble-properties-map-form nodeid-sym value-map display-order)))))))
 
 (defn- node-input-value-function-form
   [description input]
@@ -1408,27 +1481,28 @@
         (let [beh           (behavior type output)
               props         ((:fn beh) this evaluation-context)
               original      (gt/node-by-id-at basis original-id)
-              orig-props    (:properties (gt/produce-value original output evaluation-context))
-              static-props  (all-properties type)
-              props         (reduce-kv (fn [p k v]
-                                         (if (and (not (contains? static-props k))
-                                                  (= original-id (:node-id v)))
-                                           (assoc-in p [:properties k :value] (:value v))
-                                           p))
-                                       props orig-props)]
-          (reduce (fn [props [k v]]
-                    (let [prop-type (get-in props [:properties k :type])]
-                      (if (nil? (s/check (prop-type->schema prop-type) v))
-                        (cond-> props
-                          (and (= :_properties output)
-                               (not (contains? static-props k)))
-                          (assoc-in [:properties k :value] v)
+              orig-props    (:properties (gt/produce-value original output evaluation-context))]
+          (when-not (:dry-run evaluation-context)
+            (let [static-props  (all-properties type)
+                  props         (reduce-kv (fn [p k v]
+                                             (if (and (not (contains? static-props k))
+                                                      (= original-id (:node-id v)))
+                                               (assoc-in p [:properties k :value] (:value v))
+                                               p))
+                                           props orig-props)]
+              (reduce (fn [props [k v]]
+                        (let [prop-type (get-in props [:properties k :type])]
+                          (if (nil? (s/check (prop-type->schema prop-type) v))
+                            (cond-> props
+                              (and (= :_properties output)
+                                   (not (contains? static-props k)))
+                              (assoc-in [:properties k :value] v)
 
-                          (contains? orig-props k)
-                          (assoc-in [:properties k :original-value]
-                                    (get-in orig-props [k :value])))
-                        props)))
-                  props properties))
+                              (contains? orig-props k)
+                              (assoc-in [:properties k :original-value]
+                                        (get-in orig-props [k :value])))
+                            props)))
+                      props properties))))
 
         (or (has-output? type output)
             (has-input? type output))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -164,7 +164,7 @@
   [{graph :initial-graph :or {graph (assoc (ig/empty-graph) :_gid 0)}}]
   graph)
 
-(defn- make-cache
+(defn make-cache
   [{cache-size :cache-size :or {cache-size maximum-cached-items}}]
   (c/make-cache cache-size))
 

--- a/editor/styling/stylesheets/components/_progress-bar.scss
+++ b/editor/styling/stylesheets/components/_progress-bar.scss
@@ -16,15 +16,34 @@
 }
 
 .small-progress-bar {
-    .bar {
-        -fx-background-color: $defold-light-blue;
-        -fx-background-insets: 0;
-        -fx-background-radius: 0;
-        -fx-padding: 1em;
-    }
+  .bar {
+    -fx-background-color: $defold-light-blue;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-padding: 1em;
+  }
 
-    .track {
-        -fx-background-color: $dark-grey;
-        -fx-background-insets: 0;
-        -fx-background-radius: 0; }
+  .track {
+    -fx-background-color: $dark-grey;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0; }
+}
+
+.really-small-progress-bar {
+  -fx-background-radius: 0;
+  -fx-min-width: 140px;
+  .bar {
+    -fx-background-color: $defold-light-blue;
+    -fx-background-insets: 0;
+    -fx-background-radius: 4;
+    -fx-min-height: 5px;
+    -fx-padding: 0em;
+  }
+
+  .track {
+    -fx-background-color: $mid-grey;
+    -fx-background-insets: 0;
+    -fx-border-width: 0;
+    -fx-background-radius: 4;
+  }
 }

--- a/editor/styling/stylesheets/editor.scss
+++ b/editor/styling/stylesheets/editor.scss
@@ -97,16 +97,27 @@ Links:
   -fx-text-fill: $bright-grey;
 }
 
+.progress-hbox {
+  .label {
+    -fx-text-fill: $grey;
+  }
+  -fx-alignment: center-left;
+  -fx-spacing: 10px;
+}
+
+.link-label {
+  -fx-text-fill: $defold-light-blue;
+  &:hover {
+    -fx-underline: true;
+  }
+}
+
 /* Status bar */
-#progress-status-label {
+#status-label {
   -fx-text-fill: $grey;
   -fx-padding: 7 0 7 15;
 }
 
-#update-available-label {
-    -fx-text-fill: $defold-light-blue;
-    -fx-padding: 7 15 7 0;
-    &:hover {
-	-fx-underline: true;
-    }
+#status-pane {
+  -fx-padding: 7 15 7 0;
 }

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -383,7 +383,7 @@
             _ (g/update-cache-from-evaluation-context! evaluation-context)
             evaluation-context (g/make-evaluation-context)
             second-time   (measure (project/build project resource-node evaluation-context {}))]
-        (is (< (* 50 second-time) first-time))
+        (is (< (* 20 second-time) first-time))
         (let [atlas (test-util/resource-node project "/player/spineboy.atlas")]
           (g/transact (g/set-property atlas :margin 10))
           (let [third-time (measure (project/build project resource-node (g/make-evaluation-context) {}))]

--- a/editor/test/internal/graph/graph_test.clj
+++ b/editor/test/internal/graph/graph_test.clj
@@ -98,9 +98,15 @@
 
 (g/defnode TestNode
   (property val g/Str)
+  (property custom-val g/Str
+            (value (g/fnk [val] val)))
+  (output custom-val g/Str :cached (g/fnk [custom-val] custom-val))
   (output val-val g/Str :cached (g/fnk [val] (str val val))))
 
 (g/defnode PassthroughNode
+  (property str-prop g/Str
+            (value (g/fnk [str-in] str-in))
+            (dynamic str-prop-dynamic (g/fnk [] 123)))
   (input str-in g/Str)
   (output str-out g/Str :cached (g/fnk [str-in] str-in)))
 
@@ -206,3 +212,93 @@
         (g/update-cache-from-evaluation-context! init-ec)
 
         (is (= ::miss (cc/lookup (g/cache) [n2 :str-out] ::miss)))))))
+
+(deftest tracer
+  (with-clean-system
+    (let [[tn n1] (tx-nodes (g/make-nodes world [tn (TestNode :val "initial")
+                                                 n1 PassthroughNode]
+                                           (g/connect tn :custom-val n1 :str-in)))]
+      (let [result (atom nil)]
+        (g/node-value n1 :str-out (g/make-evaluation-context {:tracer (g/make-tree-tracer result)}))
+        (is (= @result
+               {:node-id n1,
+                :output-type :output,
+                :label :str-out,
+                :dependencies
+                [{:node-id tn,
+                  :output-type :output,
+                  :label :custom-val,
+                  :dependencies
+                  [{:node-id tn,
+                    :output-type :property,
+                    :label :custom-val,
+                    :dependencies
+                    [{:node-id tn,
+                      :output-type :raw-property,
+                      :label :val,
+                      :dependencies [],
+                      :state :end}],
+                    :state :end}],
+                  :state :end}],
+                :state :end}))
+
+        (let [ec (g/make-evaluation-context {:tracer (g/make-tree-tracer result)})]
+          (g/node-value n1 :_properties ec)
+          (is (= @result
+                 {:node-id n1,
+                  :output-type :output,
+                  :label :_properties,
+                  :dependencies
+                  [{:node-id n1,
+                    :output-type :dynamic,
+                    :label [:str-prop :str-prop-dynamic],
+                    :dependencies [],
+                    :state :end}
+                   {:node-id n1,
+                    :output-type :property,
+                    :label :str-prop,
+                    :dependencies
+                    [{:node-id tn,
+                      :output-type :output,
+                      :label :custom-val,
+                      :dependencies
+                      [{:node-id tn,
+                        :output-type :property,
+                        :label :custom-val,
+                        :dependencies
+                        [{:node-id tn,
+                          :output-type :raw-property,
+                          :label :val,
+                          :dependencies [],
+                          :state :end}],
+                        :state :end}],
+                      :state :end}],
+                    :state :end}],
+                  :state :end}))
+
+          ;; Now, ec :local contains n :custom-val, so trace is slightly shorter.
+          ;; Note that the tree tracer in the ec can be reused.
+
+          (g/node-value n1 :_properties ec)
+          (is (= @result
+                 {:node-id n1,
+                  :output-type :output,
+                  :label :_properties,
+                  :dependencies
+                  [{:node-id n1,
+                    :output-type :dynamic,
+                    :label [:str-prop :str-prop-dynamic],
+                    :dependencies [],
+                    :state :end}
+                   {:node-id n1,
+                    :output-type :property,
+                    :label :str-prop,
+                    :dependencies
+                    [{:node-id tn,
+                      :output-type :cache,
+                      :label :custom-val
+                      :dependencies []
+                      :state :end}]
+                    :state :end}]
+                  :state :end})))))))
+


### PR DESCRIPTION
    * User facing changes
      - background build with progress bar

    * Technical changes
      - build happens in (future ...)
      - support for :tracer and :dry-run options to evaluation-context
        respected during value production in internal.node
      - progress namespace revamp
      - saner progress on application load