### PR TITLE
DEFEDIT-1282 Indent with spaces

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -1598,6 +1598,43 @@
                 :else
                 :four-spaces))))))))
 
+(declare ^:private transform-indentation)
+
+(defn indent-type->indent-string
+  ^String [indent-type]
+  (case indent-type
+    :tabs "\t"
+    :two-spaces "  "
+    :four-spaces "    "))
+
+(defn indent-type->tab-spaces
+  ^long [indent-type]
+  (case indent-type
+    :two-spaces 2
+    (:tabs :four-spaces) 4))
+
+(defn convert-indentation [from-indent-type to-indent-type lines cursor-ranges regions]
+  (let [rows (range (count lines))
+        from-tab-spaces (indent-type->tab-spaces from-indent-type)
+        to-indent-string (indent-type->indent-string to-indent-type)]
+    (assoc (transform-indentation rows lines cursor-ranges regions
+                                  (fn [^String line]
+                                    (let [line-length (count line)
+                                          [indent-width text] (loop [index 0
+                                                                     visual-width 0]
+                                                                (if (<= line-length index)
+                                                                  [visual-width nil]
+                                                                  (case (.charAt line index)
+                                                                    \space (recur (inc index) (inc visual-width))
+                                                                    \tab (recur (inc index) (+ visual-width (- from-tab-spaces ^long (mod visual-width from-tab-spaces))))
+                                                                    [visual-width (subs line index)])))
+                                          indent-level (unchecked-divide-int indent-width from-tab-spaces)
+                                          indent-rest (- ^long indent-width (* indent-level from-tab-spaces))]
+                                      (str (string/join (repeat indent-level to-indent-string))
+                                           (string/join (repeat indent-rest \space))
+                                           text))))
+      :indent-type to-indent-type)))
+
 (defn indent-level-pattern
   ^Pattern [^long tab-spaces]
   (re-pattern (str "(?:^|\\G)(?:\\t|" (string/join (repeat tab-spaces \space)) ")")))

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -221,9 +221,9 @@
       (.close reader)
       (is (thrown? IOException (.read reader))))))
 
-(deftest guess-indent-string-test
+(deftest guess-indent-type-test
   (are [expected lines]
-    (= expected (data/guess-indent-string lines 4))
+    (= expected (first (data/guess-indent-type lines 4)))
 
     ;; Indeterminate. Used for nil or binary-looking input.
     nil nil
@@ -241,65 +241,65 @@
     nil ["    "]
 
     ;; Uniformly tabs.
-    "\t" ["\t{"]
-    "\t" ["{"
-          "\t{"]
-    "\t" ["{"
-          "\t{"
-          "\t\t{"]
+    :tabs ["\t{"]
+    :tabs ["{"
+           "\t{"]
+    :tabs ["{"
+           "\t{"
+           "\t\t{"]
 
-    ;; Uniformly 2 spaces.
-    "  " ["  {"]
-    "  " ["{"
-          "  {"]
-    "  " ["{"
-          "  {"
-          "    {"]
-    "  " ["  {"
-          "    {"
-          "    {"]
+    ;; Uniformly two spaces.
+    :two-spaces ["  {"]
+    :two-spaces ["{"
+                 "  {"]
+    :two-spaces ["{"
+                 "  {"
+                 "    {"]
+    :two-spaces ["  {"
+                 "    {"
+                 "    {"]
 
-    ;; Uniformly 4 spaces.
-    "    " ["    {"]
-    "    " ["{"
-            "    {"]
-    "    " ["{"
-            "    {"
-            "        {"]
-    "    " ["    {"
-            "    {"
-            "        {"]
+    ;; Uniformly four spaces.
+    :four-spaces ["    {"]
+    :four-spaces ["{"
+                  "    {"]
+    :four-spaces ["{"
+                  "    {"
+                  "        {"]
+    :four-spaces ["    {"
+                  "    {"
+                  "        {"]
 
     ;; Spaces mixed with tabs.
-    "\t" ["\t{"
-          "  {"
-          "\t{"]
-    "  " ["  {"
-          "\t{"
-          "    {"]
-    "    " ["    {"
-            "\t{"
-            "        {"]
+    :tabs ["\t{"
+           "  {"
+           "\t{"]
+    :two-spaces ["  {"
+                 "\t{"
+                 "    {"]
+    :four-spaces ["    {"
+                  "\t{"
+                  "        {"]
 
-    ;; 2 spaces mixed with 4 spaces.
-    "  " ["{"
-          "  {"
-          "    {"
-          "        {" ; <- rogue indent
-          "    {"
-          "    {"]
-    "  " ["{"
-          "  {"
-          "    {"
-          "      {"
-          "    {"
-          "    {"]
-    "    " ["{"
-            "    {"
-            "    {"
-            "      {" ; <- rogue indent
-            "    {"
-            "        {"]))
+    ;; Two spaces mixed with four spaces.
+    :two-spaces ["{"
+                 "  {"
+                 "    {"
+                 "        {" ; <- rogue indent
+                 "    {"
+                 "    {"]
+    :two-spaces ["{"
+                 "  {"
+                 "    {"
+                 "      {"
+                 "    {"
+                 "    {"]
+    :four-spaces ["{"
+                  "    {"
+                  "    {"
+                  "      {" ; <- rogue indent
+                  "    {"
+                  "        {"]))
 
 (deftest move-cursors-test
   (testing "Basic movement"


### PR DESCRIPTION
Implements defold/editor2-issues#971

### User-facing changes
* Upon opening a file in the code editor, we guess the indentation type from the contents of the buffer.
* Inserted text and adjustments to the indentation will now respect the indentation type.
* Mismatched indentation characters will be highlighted in the code editor.
* You can convert the file to a different indentation type from the Edit > Convert Indentation submenu.
