### PR TITLE
DEF-3099 - Childed GOs to dmRig bones are delayed one frame

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -696,13 +696,6 @@ namespace dmEngine
             return false;
         }
 
-        go_result = dmGameObject::SetCollectionDefaultRigCapacity(engine->m_Register, dmConfigFile::GetInt(engine->m_Config, dmRig::RIG_MAX_INSTANCES_KEY, dmRig::DEFAULT_MAX_RIG_CAPACITY));
-        if(go_result != dmGameObject::RESULT_OK)
-        {
-            dmLogFatal("Failed to set max rig instance count for collections (%d)", go_result);
-            return false;
-        }
-
         dmRender::RenderContextParams render_params;
         render_params.m_MaxRenderTypes = 16;
         render_params.m_MaxInstances = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_draw_calls", 1024);
@@ -738,6 +731,13 @@ namespace dmEngine
             return false;
         }
 
+        // rig.max_instance_count is deprecated in favour of component specific max count values.
+        // For backwards combatibility we get the rig generic value and take the max of it and each
+        // specific component max value.
+        int32_t max_rig_instance = dmConfigFile::GetInt(engine->m_Config, "rig.max_instance_count", 128);
+        int32_t max_model_count = dmMath::Max(dmConfigFile::GetInt(engine->m_Config, "model.max_count", 128), max_rig_instance);
+        int32_t max_spine_count = dmMath::Max(dmConfigFile::GetInt(engine->m_Config, "spine.max_count", 128), max_rig_instance);
+
         dmGui::NewContextParams gui_params;
         gui_params.m_ScriptContext = engine->m_GuiScriptContext;
         gui_params.m_GetURLCallback = dmGameSystem::GuiGetURLCallback;
@@ -756,6 +756,7 @@ namespace dmEngine
         engine->m_GuiContext.m_MaxGuiComponents = dmConfigFile::GetInt(engine->m_Config, "gui.max_count", 64);
         engine->m_GuiContext.m_MaxParticleFXCount = dmConfigFile::GetInt(engine->m_Config, "gui.max_particlefx_count", 64);
         engine->m_GuiContext.m_MaxParticleCount = dmConfigFile::GetInt(engine->m_Config, "gui.max_particle_count", 1024);
+        engine->m_GuiContext.m_MaxSpineCount = dmConfigFile::GetInt(engine->m_Config, "gui.max_spine_count", max_spine_count);
 
         dmPhysics::NewContextParams physics_params;
         physics_params.m_WorldCount = dmConfigFile::GetInt(engine->m_Config, "physics.world_count", 4);
@@ -817,11 +818,11 @@ namespace dmEngine
 
         engine->m_ModelContext.m_RenderContext = engine->m_RenderContext;
         engine->m_ModelContext.m_Factory = engine->m_Factory;
-        engine->m_ModelContext.m_MaxModelCount = dmConfigFile::GetInt(engine->m_Config, "model.max_count", 128);
+        engine->m_ModelContext.m_MaxModelCount = max_model_count;
 
         engine->m_SpineModelContext.m_RenderContext = engine->m_RenderContext;
         engine->m_SpineModelContext.m_Factory = engine->m_Factory;
-        engine->m_SpineModelContext.m_MaxSpineModelCount = dmConfigFile::GetInt(engine->m_Config, "spine.max_count", 128);
+        engine->m_SpineModelContext.m_MaxSpineModelCount = max_spine_count;
 
         engine->m_LabelContext.m_RenderContext      = engine->m_RenderContext;
         engine->m_LabelContext.m_MaxLabelCount      = dmConfigFile::GetInt(engine->m_Config, "label.max_count", 64);

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -9,7 +9,6 @@
 #include <dlib/hashtable.h>
 #include <dlib/message.h>
 #include <dlib/transform.h>
-#include <rig/rig.h>
 
 #include <ddf/ddf.h>
 
@@ -941,7 +940,7 @@ namespace dmGameObject
      */
     void SetInheritScale(HInstance instance, bool inherit_scale);
 
-    /**
+    /** 
      * Tells the collection that a transform was updated
      */
     void SetDirtyTransforms(HCollection collection);
@@ -1066,13 +1065,6 @@ namespace dmGameObject
      * @return The frame message socket of the specified collection
      */
     dmMessage::HSocket GetFrameMessageSocket(HCollection collection);
-
-    /**
-     * Retrieve the rig context for the specified collection.
-     * @param collection Collection handle
-     * @return The rig context of the specified collection
-     */
-    dmRig::HRigContext GetRigContext(HCollection collection);
 
     /**
      * Returns whether the scale of the instances in a collection should be applied along Z or not.

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -677,26 +677,11 @@ namespace dmGameObject
     Result SetCollectionDefaultCapacity(HRegister regist, uint32_t capacity);
 
     /**
-     * Set default rig instance capacity of collections in this register. This does not affect existing collections.
-     * @param regist Register
-     * @param capacity Default capacity of rig instances for collections in this register (0-32766).
-     * @return RESULT_OK on success or RESULT_INVALID_OPERATION if max_count is not within range
-     */
-    Result SetCollectionDefaultRigCapacity(HRegister regist, uint32_t capacity);
-
-    /**
      * Get default capacity of collections in this register.
      * @param regist Register
      * @return Default capacity
      */
     uint32_t GetCollectionDefaultCapacity(HRegister regist);
-
-    /**
-     * Get default rig instance capacity of collections in this register.
-     * @param regist Register
-     * @return Default rig instance capacity
-     */
-    uint32_t GetCollectionDefaultRigCapacity(HRegister regist);
 
     /**
      * Delete a component type register
@@ -712,7 +697,7 @@ namespace dmGameObject
      * @param max_instances Max instances in this collection
      * @return HCollection
      */
-    HCollection NewCollection(const char* name, dmResource::HFactory factory, HRegister regist, uint32_t max_instances, uint32_t max_riginstances);
+    HCollection NewCollection(const char* name, dmResource::HFactory factory, HRegister regist, uint32_t max_instances);
 
     /**
      * Deletes a gameobject collection
@@ -956,7 +941,7 @@ namespace dmGameObject
      */
     void SetInheritScale(HInstance instance, bool inherit_scale);
 
-    /** 
+    /**
      * Tells the collection that a transform was updated
      */
     void SetDirtyTransforms(HCollection collection);
@@ -1088,7 +1073,7 @@ namespace dmGameObject
      * @return The rig context of the specified collection
      */
     dmRig::HRigContext GetRigContext(HCollection collection);
- 
+
     /**
      * Returns whether the scale of the instances in a collection should be applied along Z or not.
      * @param collection Collection

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -188,7 +188,6 @@ namespace dmGameObject
         dmArray<HCollection>        m_Collections;
         // Default capacity of collections
         uint32_t                    m_DefaultCollectionCapacity;
-        uint32_t                    m_DefaultCollectionRigCapacity;
 
         Register();
         ~Register();
@@ -260,8 +259,6 @@ namespace dmGameObject
 
         // Index pool for mapping Instance::m_Index to m_Instances
         dmIndexPool16            m_InstanceIndices;
-
-        dmRig::HRigContext       m_RigContext;
 
         // Array of dynamically allocated index arrays, one for each level
         // Used for calculating transforms in scene-graph

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -45,8 +45,7 @@ namespace dmGameObject
         dmMutex::Lock(regist->m_Mutex);
 
         uint32_t collection_capacity = dmGameObject::GetCollectionDefaultCapacity(regist);
-        uint32_t collection_rig_capacity = dmGameObject::GetCollectionDefaultRigCapacity(regist);
-        HCollection collection = NewCollection(collection_desc->m_Name, params.m_Factory, regist, collection_capacity, collection_rig_capacity);
+        HCollection collection = NewCollection(collection_desc->m_Name, params.m_Factory, regist, collection_capacity);
         if (collection == 0)
         {
             dmMutex::Unlock(regist->m_Mutex);

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -28,7 +28,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, dmGameObject::GetCollectionDefaultCapacity(m_Register), dmGameObject::GetCollectionDefaultRigCapacity(m_Register));
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, dmGameObject::GetCollectionDefaultCapacity(m_Register));
         m_FinishCount = 0;
         m_CancelCount = 0;
     }

--- a/engine/gameobject/src/gameobject/test/bones/test_gameobject_bones.cpp
+++ b/engine/gameobject/src/gameobject/test/bones/test_gameobject_bones.cpp
@@ -121,7 +121,7 @@ dmGameObject::ComponentDestroy BonesTest::AComponentDestroy = TestComponentDestr
  */
 TEST_F(BonesTest, DeleteBones)
 {
-    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
     ASSERT_EQ(0, m_Collection->m_InstanceIndices.Size());
 
     // Create the game object, the component above will create a child bone to that game object, which in turn will get a lower index because of the gap above
@@ -144,7 +144,7 @@ TEST_F(BonesTest, DeleteBones)
  */
 TEST_F(BonesTest, ComponentCreatingInstances)
 {
-    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 
     // First create three game objects to create gaps in the instance array
     dmGameObject::HInstance tmp_inst[3];

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
@@ -28,7 +28,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("testcollection", m_Factory, m_Register, dmGameObject::GetCollectionDefaultCapacity(m_Register), dmGameObject::GetCollectionDefaultRigCapacity(m_Register));
+        m_Collection = dmGameObject::NewCollection("testcollection", m_Factory, m_Register, dmGameObject::GetCollectionDefaultCapacity(m_Register));
 
         dmResource::Result e;
         e = dmResource::RegisterType(m_Factory, "a", this, 0, ACreate, 0, ADestroy, 0, 0);
@@ -238,7 +238,7 @@ TEST_F(CollectionTest, CollectionSpawningToFail)
     const uint32_t max = 100;
 
     dmGameObject::HCollection coll;
-    coll = dmGameObject::NewCollection("TestCollection", m_Factory, m_Register, max, 0);
+    coll = dmGameObject::NewCollection("TestCollection", m_Factory, m_Register, max);
     dmGameObject::Init(coll);
 
     Vectormath::Aos::Point3 pos(0,0,0);

--- a/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
+++ b/engine/gameobject/src/gameobject/test/component/test_gameobject_component.cpp
@@ -30,7 +30,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 
         // Register dummy physical resource type
         dmResource::Result e;
@@ -486,7 +486,7 @@ TEST_F(ComponentTest, TestComponentType)
 // The test is to verify that the final callback is called for a cascading deletion of objects.
 TEST_F(ComponentTest, FinalCallsFinal)
 {
-    dmGameObject::HCollection collection = dmGameObject::NewCollection("test_final_collection", m_Factory, m_Register, 11, 0);
+    dmGameObject::HCollection collection = dmGameObject::NewCollection("test_final_collection", m_Factory, m_Register, 11);
 
     dmGameObject::HInstance go_a = dmGameObject::New(collection, "/test_final_final.goc");
     dmGameObject::SetIdentifier(collection, go_a, "first");

--- a/engine/gameobject/src/gameobject/test/delete/test_gameobject_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/delete/test_gameobject_delete.cpp
@@ -27,7 +27,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 
         dmResource::Result e;
         e = dmResource::RegisterType(m_Factory, "deleteself", this, 0, ResDeleteSelfCreate, 0, ResDeleteSelfDestroy, 0, 0);

--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -27,7 +27,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 
         dmResource::Result e;
         e = dmResource::RegisterType(m_Factory, "a", this, 0, ACreate, 0, ADestroy, 0, 0);

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -33,7 +33,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
     }
 
     virtual void TearDown()

--- a/engine/gameobject/src/gameobject/test/id/test_gameobject_id.cpp
+++ b/engine/gameobject/src/gameobject/test/id/test_gameobject_id.cpp
@@ -21,7 +21,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
     }
 
     virtual void TearDown()

--- a/engine/gameobject/src/gameobject/test/input/test_gameobject_input.cpp
+++ b/engine/gameobject/src/gameobject/test/input/test_gameobject_input.cpp
@@ -32,7 +32,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 
         dmResource::Result e = dmResource::RegisterType(m_Factory, "it", this, 0, ResInputTargetCreate, 0, ResInputTargetDestroy, 0, 0);
         ASSERT_EQ(dmResource::RESULT_OK, e);

--- a/engine/gameobject/src/gameobject/test/message/test_gameobject_message.cpp
+++ b/engine/gameobject/src/gameobject/test/message/test_gameobject_message.cpp
@@ -58,7 +58,7 @@ protected:
         dmGameObject::Result result = dmGameObject::RegisterComponentType(m_Register, mt_type);
         ASSERT_EQ(dmGameObject::RESULT_OK, result);
 
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
     }
 
 

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -58,7 +58,7 @@ protected:
         m_Register = dmGameObject::NewRegister();
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 
         // Register dummy physical resource type
         dmResource::Result e = dmResource::RegisterType(m_Factory, "no_user_datac", this, 0, ResCreate, 0, ResDestroy, 0, 0);

--- a/engine/gameobject/src/gameobject/test/reload/test_gameobject_reload.cpp
+++ b/engine/gameobject/src/gameobject/test/reload/test_gameobject_reload.cpp
@@ -63,7 +63,7 @@ protected:
 
         m_World = 0x0;
 
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
     }
 
     virtual void TearDown()

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -36,7 +36,7 @@ protected:
         m_ModuleContext.m_ScriptContexts.Push(m_ScriptContext);
         dmGameObject::RegisterResourceTypes(m_Factory, m_Register, m_ScriptContext, &m_ModuleContext);
         dmGameObject::RegisterComponentTypes(m_Factory, m_Register, m_ScriptContext);
-        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 0);
+        m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
         dmMessage::Result result = dmMessage::NewSocket("@system", &m_Socket);
         assert(result == dmMessage::RESULT_OK);
     }

--- a/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
+++ b/engine/gameobject/src/gameobject/test/spawn_delete/test_gameobject_spawn_delete.cpp
@@ -98,7 +98,7 @@ protected:
 
         ASSERT_EQ(dmGameObject::RESULT_OK, go_result);
 
-        m_Collection = NewCollection("collection", m_Factory, m_Register, 10u, 0u);
+        m_Collection = NewCollection("collection", m_Factory, m_Register, 10u);
     }
 
     virtual void TearDown()
@@ -361,7 +361,7 @@ TEST_F(SpawnDeleteTest, CollectionDelete_ScriptFinal_Spawn)
 {
     // Temp swap collections to delete at end
     dmGameObject::HCollection old_collection = m_Collection;
-    m_Collection = dmGameObject::NewCollection("collection2", m_Factory, m_Register, 10u, 0u);
+    m_Collection = dmGameObject::NewCollection("collection2", m_Factory, m_Register, 10u);
 
     New("/final_spawn.goc");
 
@@ -436,7 +436,7 @@ TEST_F(SpawnDeleteTest, CollectionDelete_ScriptFinal_Delete)
 {
     // Temp swap collections to delete at end
     dmGameObject::HCollection old_collection = m_Collection;
-    m_Collection = dmGameObject::NewCollection("collection2", m_Factory, m_Register, 10u, 0u);
+    m_Collection = dmGameObject::NewCollection("collection2", m_Factory, m_Register, 10u);
 
     New("/final_delete.goc");
     dmGameObject::HInstance go2 = New("/a.goc");
@@ -534,7 +534,7 @@ TEST_F(SpawnDeleteTest, CollectionDelete_ScriptFinal_SpawnDelete)
 {
     // Temp swap collections to delete at end
     dmGameObject::HCollection old_collection = m_Collection;
-    m_Collection = dmGameObject::NewCollection("collection2", m_Factory, m_Register, 10u, 0u);
+    m_Collection = dmGameObject::NewCollection("collection2", m_Factory, m_Register, 10u);
 
     New("/final_spawndelete.goc");
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -76,6 +76,16 @@ namespace dmGameSystem
             dmLogWarning("The gui world could not be stored since the buffer is full (%d). Reload will not work for the scenes in this world.", gui_context->m_Worlds.Size());
         }
 
+        dmRig::NewContextParams rig_params = {0};
+        rig_params.m_Context = &gui_world->m_RigContext;
+        rig_params.m_MaxRigInstanceCount = gui_context->m_MaxSpineCount;
+        dmRig::Result rr = dmRig::NewContext(rig_params);
+        if (rr != dmRig::RESULT_OK)
+        {
+            dmLogFatal("Unable to create model rig context: %d", rr);
+            return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
+        }
+
         gui_world->m_Components.SetCapacity(gui_context->m_MaxGuiComponents);
 
         dmGraphics::VertexElement ve[] =
@@ -149,6 +159,8 @@ namespace dmGameSystem
         dmGraphics::DeleteVertexDeclaration(gui_world->m_VertexDeclaration);
         dmGraphics::DeleteVertexBuffer(gui_world->m_VertexBuffer);
         dmGraphics::DeleteTexture(gui_world->m_WhiteTexture);
+
+        dmRig::DeleteContext(gui_world->m_RigContext);
 
         delete gui_world;
         return dmGameObject::CREATE_RESULT_OK;
@@ -534,7 +546,7 @@ namespace dmGameSystem
         scene_params.m_MaxTextures = 128;
         scene_params.m_MaxParticlefx = gui_world->m_MaxParticleFXCount;
         scene_params.m_MaxSpineScenes = 128;
-        scene_params.m_RigContext = dmGameObject::GetRigContext(dmGameObject::GetCollection(params.m_Instance));
+        scene_params.m_RigContext = gui_world->m_RigContext;
         scene_params.m_ParticlefxContext = gui_world->m_ParticleContext;
         scene_params.m_FetchTextureSetAnimCallback = &FetchTextureSetAnimCallback;
         scene_params.m_FetchRigSceneDataCallback = &FetchRigSceneDataCallback;
@@ -946,7 +958,7 @@ namespace dmGameSystem
             if (dmGui::GetNodeIsBone(scene, node)) {
                 continue;
             }
-            const dmRig::HRigContext rig_context = dmGui::GetRigContext(scene);
+            const dmRig::HRigContext rig_context = gui_world->m_RigContext;
             const dmRig::HRigInstance rig_instance = dmGui::GetNodeRigInstance(scene, node);
             float opacity = node_opacities[i];
             Vector4 color = dmGui::GetNodeProperty(scene, node, dmGui::PROPERTY_COLOR);
@@ -1621,6 +1633,9 @@ namespace dmGameSystem
     dmGameObject::UpdateResult CompGuiUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result)
     {
         GuiWorld* gui_world = (GuiWorld*)params.m_World;
+
+        dmRig::Update(gui_world->m_RigContext, params.m_UpdateContext->m_DT);
+
         gui_world->m_DT = params.m_UpdateContext->m_DT;
         dmParticle::Update(gui_world->m_ParticleContext, params.m_UpdateContext->m_DT, &FetchAnimationCallback);
         for (uint32_t i = 0; i < gui_world->m_Components.Size(); ++i)

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -82,7 +82,7 @@ namespace dmGameSystem
         dmRig::Result rr = dmRig::NewContext(rig_params);
         if (rr != dmRig::RESULT_OK)
         {
-            dmLogFatal("Unable to create model rig context: %d", rr);
+            dmLogFatal("Unable to create gui rig context: %d", rr);
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui.h
@@ -6,6 +6,7 @@
 #include <gui/gui.h>
 #include <gameobject/gameobject.h>
 #include <render/render.h>
+#include <rig/rig.h>
 
 namespace dmGameSystem
 {
@@ -72,6 +73,7 @@ namespace dmGameSystem
         uint32_t                         m_MaxParticleCount;
         uint32_t                         m_RenderedParticlesSize;
         float                            m_DT;
+        dmRig::HRigContext               m_RigContext;
     };
 
     typedef BoxVertex ParticleGuiVertex;

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -459,7 +459,7 @@ namespace dmGameSystem
     {
         ModelWorld* world = (ModelWorld*)params.m_World;
 
-        dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
+        dmRig::Result rig_res = dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
 
         dmArray<ModelComponent*>& components = world->m_Components.m_Objects;
         const uint32_t count = components.Size();
@@ -485,7 +485,7 @@ namespace dmGameSystem
             component.m_DoRender = 1;
         }
 
-        update_result.m_TransformsUpdated = count != 0;
+        update_result.m_TransformsUpdated = rig_res == dmRig::RESULT_UPDATED_POSE;
         return dmGameObject::UPDATE_RESULT_OK;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_model.h
+++ b/engine/gamesys/src/gamesys/components/comp_model.h
@@ -43,6 +43,7 @@ namespace dmGameSystem
         dmArray<dmRig::RigModelVertex>  m_VertexBufferData;
         // Temporary scratch array for instances, only used during the creation phase of components
         dmArray<dmGameObject::HInstance> m_ScratchInstances;
+        dmRig::HRigContext              m_RigContext;
     };
 
     dmGameObject::CreateResult CompModelNewWorld(const dmGameObject::ComponentNewWorldParams& params);

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -525,7 +525,7 @@ namespace dmGameSystem
     {
         SpineModelWorld* world = (SpineModelWorld*)params.m_World;
 
-        dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
+        dmRig::Result rig_res = dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
 
         dmArray<SpineModelComponent*>& components = world->m_Components.m_Objects;
         const uint32_t count = components.Size();
@@ -551,7 +551,7 @@ namespace dmGameSystem
             component.m_DoRender = 1;
         }
 
-        update_result.m_TransformsUpdated = count != 0;
+        update_result.m_TransformsUpdated = rig_res == dmRig::RESULT_UPDATED_POSE;
         return dmGameObject::UPDATE_RESULT_OK;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -61,8 +61,17 @@ namespace dmGameSystem
         dmRender::HRenderContext render_context = context->m_RenderContext;
         SpineModelWorld* world = new SpineModelWorld();
 
+        dmRig::NewContextParams rig_params = {0};
+        rig_params.m_Context = &world->m_RigContext;
+        rig_params.m_MaxRigInstanceCount = context->m_MaxSpineModelCount;
+        dmRig::Result rr = dmRig::NewContext(rig_params);
+        if (rr != dmRig::RESULT_OK)
+        {
+            dmLogFatal("Unable to create spine rig context: %d", rr);
+            return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
+        }
+
         world->m_Components.SetCapacity(context->m_MaxSpineModelCount);
-        // world->m_RigContext = context->m_RigContext;
         world->m_RenderObjects.SetCapacity(context->m_MaxSpineModelCount);
 
         dmGraphics::VertexElement ve[] =
@@ -92,6 +101,8 @@ namespace dmGameSystem
         dmGraphics::DeleteVertexBuffer(world->m_VertexBuffer);
 
         dmResource::UnregisterResourceReloadedCallback(((SpineModelContext*)params.m_Context)->m_Factory, ResourceReloadedCallback, world);
+
+        dmRig::DeleteContext(world->m_RigContext);
 
         delete world;
 
@@ -323,7 +334,7 @@ namespace dmGameSystem
 
         // Create rig instance
         dmRig::InstanceCreateParams create_params = {0};
-        create_params.m_Context = dmGameObject::GetRigContext(dmGameObject::GetCollection(component->m_Instance));
+        create_params.m_Context = world->m_RigContext;
         create_params.m_Instance = &component->m_RigInstance;
 
         create_params.m_PoseCallback = CompSpineModelPoseCallback;
@@ -345,7 +356,11 @@ namespace dmGameSystem
 
         dmRig::Result res = dmRig::InstanceCreate(create_params);
         if (res != dmRig::RESULT_OK) {
-            dmLogError("Failed to create a rig instance needed by spine model: %d.", res);
+            if (res == dmRig::RESULT_ERROR_BUFFER_FULL) {
+                dmLogError("Try increasing the spine.max_count value in game.project");
+            } else {
+                dmLogError("Failed to create a rig instance needed by spine model: %d.", res);
+            }
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
 
@@ -371,8 +386,7 @@ namespace dmGameSystem
         component->m_NodeInstances.SetCapacity(0);
 
         dmRig::InstanceDestroyParams params = {0};
-        // params.m_Context = world->m_RigContext;
-        params.m_Context = dmGameObject::GetRigContext(dmGameObject::GetCollection(component->m_Instance));
+        params.m_Context = world->m_RigContext;
         params.m_Instance = component->m_RigInstance;
         dmRig::InstanceDestroy(params);
 
@@ -410,10 +424,10 @@ namespace dmGameSystem
         // Fill in vertex buffer
         dmRig::RigSpineModelVertex *vb_begin = vertex_buffer.End();
         dmRig::RigSpineModelVertex *vb_end = vb_begin;
+        dmRig::HRigContext rig_context = world->m_RigContext;
         for (uint32_t *i=begin;i!=end;i++)
         {
             const SpineModelComponent* c = (SpineModelComponent*) buf[*i].m_UserData;
-            dmRig::HRigContext rig_context = dmGameObject::GetRigContext(dmGameObject::GetCollection(c->m_Instance));
             vb_end = (dmRig::RigSpineModelVertex*)dmRig::GenerateVertexData(rig_context, c->m_RigInstance, c->m_World, Matrix4::identity(), Vector4(1.0), dmRig::RIG_VERTEX_FORMAT_SPINE, (void*)vb_end);
         }
         vertex_buffer.SetSize(vb_end - vertex_buffer.Begin());
@@ -510,6 +524,8 @@ namespace dmGameSystem
     dmGameObject::UpdateResult CompSpineModelUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result)
     {
         SpineModelWorld* world = (SpineModelWorld*)params.m_World;
+
+        dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
 
         dmArray<SpineModelComponent*>& components = world->m_Components.m_Objects;
         const uint32_t count = components.Size();
@@ -726,7 +742,7 @@ namespace dmGameSystem
 
     static bool OnResourceReloaded(SpineModelWorld* world, SpineModelComponent* component, int index)
     {
-        dmRig::HRigContext rig_context = dmGameObject::GetRigContext(dmGameObject::GetCollection(component->m_Instance));
+        dmRig::HRigContext rig_context = world->m_RigContext;
 
         // Destroy old rig
         dmRig::InstanceDestroyParams destroy_params = {0};

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.h
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.h
@@ -43,6 +43,7 @@ namespace dmGameSystem
         dmArray<dmRig::RigSpineModelVertex> m_VertexBufferData;
         // Temporary scratch array for instances, only used during the creation phase of components
         dmArray<dmGameObject::HInstance>    m_ScratchInstances;
+        dmRig::HRigContext                  m_RigContext;
     };
 
     dmGameObject::CreateResult CompSpineModelNewWorld(const dmGameObject::ComponentNewWorldParams& params);

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -273,7 +273,7 @@ namespace dmGameSystem
                 CompSpineModelNewWorld, CompSpineModelDeleteWorld,
                 CompSpineModelCreate, CompSpineModelDestroy, 0, 0, CompSpineModelAddToUpdate,
                 CompSpineModelUpdate, CompSpineModelRender, 0, CompSpineModelOnMessage, 0, CompSpineModelOnReload, CompSpineModelGetProperty, CompSpineModelSetProperty,
-                1);
+                0);
 
         REGISTER_COMPONENT_TYPE("labelc", 1400, label_context,
                 CompLabelNewWorld, CompLabelDeleteWorld,

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -85,6 +85,7 @@ namespace dmGameSystem
         uint32_t                    m_MaxGuiComponents;
         uint32_t                    m_MaxParticleFXCount;
         uint32_t                    m_MaxParticleCount;
+        uint32_t                    m_MaxSpineCount;
     };
 
     struct SpriteContext

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -203,6 +203,7 @@ void GamesysTest<T>::SetUp()
     m_GuiContext.m_GuiContext = dmGui::NewContext(&gui_params);
     m_GuiContext.m_MaxParticleFXCount = 64;
     m_GuiContext.m_MaxParticleCount = 1024;
+    m_GuiContext.m_MaxSpineCount = 8;
 
     m_HidContext = dmHID::NewContext(dmHID::NewContextParams());
     dmHID::Init(m_HidContext);
@@ -253,7 +254,7 @@ void GamesysTest<T>::SetUp()
 
     assert(dmGameObject::RESULT_OK == dmGameSystem::RegisterComponentTypes(m_Factory, m_Register, m_RenderContext, &m_PhysicsContext, &m_ParticleFXContext, &m_GuiContext, &m_SpriteContext, &m_CollectionProxyContext, &m_FactoryContext, &m_CollectionFactoryContext, &m_SpineModelContext, &m_ModelContext, &m_LabelContext));
 
-    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024, 4);
+    m_Collection = dmGameObject::NewCollection("collection", m_Factory, m_Register, 1024);
 }
 
 template<typename T>

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2621,7 +2621,11 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
         dmRig::Result res = dmRig::InstanceCreate(create_params);
         if (res != dmRig::RESULT_OK) {
-            dmLogError("Could not create the node, failed to create rig instance: %d.", res);
+            if (res == dmRig::RESULT_ERROR_BUFFER_FULL) {
+                dmLogError("Try increasing the gui.max_spine_count value in game.project");
+            } else {
+                dmLogError("Could not create the node, failed to create rig instance: %d.", res);
+            }
             return RESULT_DATA_ERROR;
         }
 

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -4808,20 +4808,20 @@ TEST_F(dmGuiTest, SpineNodeCompleteCallback)
     // duration is 3.0 seconds
     // play animation with cb
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeSpineAnim(m_Scene, node, dmHashString64("valid"), dmGui::PLAYBACK_ONCE_FORWARD, 0.0, 0.0, 1.0, &SpineAnimationComplete, (void*)m_Scene, 0));
-    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
-    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_UPDATED_POSE, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_UPDATED_POSE, dmRig::Update(m_RigContext, dt));
     ASSERT_EQ(SpineAnimationCompleteCount, 1);
 
     // play animation without cb
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeSpineAnim(m_Scene, node, dmHashString64("valid"), dmGui::PLAYBACK_ONCE_FORWARD, 0.0, 0.0, 1.0, 0, 0, 0));
-    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
-    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_UPDATED_POSE, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_UPDATED_POSE, dmRig::Update(m_RigContext, dt));
     ASSERT_EQ(SpineAnimationCompleteCount, 1);
 
     // play animation with cb once more
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeSpineAnim(m_Scene, node, dmHashString64("valid"), dmGui::PLAYBACK_ONCE_FORWARD, 0.0, 0.0, 1.0, &SpineAnimationComplete, (void*)m_Scene, 0));
-    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
-    ASSERT_EQ(dmRig::RESULT_OK, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_UPDATED_POSE, dmRig::Update(m_RigContext, dt));
+    ASSERT_EQ(dmRig::RESULT_UPDATED_POSE, dmRig::Update(m_RigContext, dt));
     ASSERT_EQ(SpineAnimationCompleteCount, 2);
 }
 

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -729,6 +729,7 @@ namespace dmRig
     {
         const dmArray<RigInstance*>& instances = context->m_Instances.m_Objects;
         uint32_t count = instances.Size();
+        uint32_t updated_pose = false;
         for (uint32_t i = 0; i < count; ++i)
         {
             RigInstance* instance = instances[i];
@@ -739,12 +740,13 @@ namespace dmRig
             // Notify any listener that the pose has been recalculated
             if (instance->m_PoseCallback) {
                 instance->m_PoseCallback(instance->m_PoseCBUserData1, instance->m_PoseCBUserData2);
+                updated_pose = true;
             }
 
 
         }
 
-        return dmRig::RESULT_OK;
+        return updated_pose ? dmRig::RESULT_UPDATED_POSE : dmRig::RESULT_OK;
     }
 
     Result Update(HRigContext context, float dt)

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -12,9 +12,6 @@ namespace dmRig
     static const uint32_t SIGNAL_ORDER_LOCKED = 0x10cced; // "locked" indicates that draw order offset should not be modified
     static const int SIGNAL_SLOT_UNUSED = -1; // Used to indicate if a draw order slot is unused
 
-    /// Config key to use for tweaking the total maximum number of rig instances in a context.
-    const char* RIG_MAX_INSTANCES_KEY = "rig.max_instance_count";
-
     Result NewContext(const NewContextParams& params)
     {
         *params.m_Context = new RigContext();
@@ -1559,8 +1556,8 @@ namespace dmRig
 
         if (context->m_Instances.Full())
         {
-            dmLogError("Rig Instance could not be created since the buffer is full (%d), consider increasing %s.", context->m_Instances.Capacity(), RIG_MAX_INSTANCES_KEY);
-            return dmRig::RESULT_ERROR;
+            dmLogError("Rig instance could not be created since the buffer is full (%d).", context->m_Instances.Capacity());
+            return dmRig::RESULT_ERROR_BUFFER_FULL;
         }
 
         *params.m_Instance = new RigInstance;

--- a/engine/rig/src/rig.h
+++ b/engine/rig/src/rig.h
@@ -28,7 +28,8 @@ namespace dmRig
         RESULT_OK             = 0,
         RESULT_ERROR          = 1,
         RESULT_ERROR_BUFFER_FULL = 2,
-        RESULT_ANIM_NOT_FOUND = 3
+        RESULT_ANIM_NOT_FOUND = 3,
+        RESULT_UPDATED_POSE   = 4
     };
 
     enum RigMeshType

--- a/engine/rig/src/rig.h
+++ b/engine/rig/src/rig.h
@@ -18,12 +18,6 @@ using namespace Vectormath::Aos;
 
 namespace dmRig
 {
-    /// Config key to use for tweaking the total maximum number of rig instances in a context.
-    extern const char* RIG_MAX_INSTANCES_KEY;
-
-    /// Default max rig instances in each context
-    const uint32_t DEFAULT_MAX_RIG_CAPACITY = 128;
-
     using namespace dmRigDDF;
 
     typedef struct RigContext*  HRigContext;
@@ -33,7 +27,8 @@ namespace dmRig
     {
         RESULT_OK             = 0,
         RESULT_ERROR          = 1,
-        RESULT_ANIM_NOT_FOUND = 2
+        RESULT_ERROR_BUFFER_FULL = 2,
+        RESULT_ANIM_NOT_FOUND = 3
     };
 
     enum RigMeshType

--- a/engine/rig/src/test/test_rig.cpp
+++ b/engine/rig/src/test/test_rig.cpp
@@ -1316,7 +1316,7 @@ TEST_F(RigContextTest, InvalidInstanceCreation)
     ASSERT_NE((dmRig::HRigInstance)0x0, instance1);
 
     create_params.m_Instance = &instance2;
-    ASSERT_EQ(dmRig::RESULT_ERROR, dmRig::InstanceCreate(create_params));
+    ASSERT_EQ(dmRig::RESULT_ERROR_BUFFER_FULL, dmRig::InstanceCreate(create_params));
     ASSERT_EQ((dmRig::HRigInstance)0x0, instance2);
 
     delete create_params.m_Skeleton;


### PR DESCRIPTION
Changed so that spine/model/gui components store a RigContext in their world
instead of having one global per collection. The size of the context use
the component specific max values (ex spine.max_count) instead of the old
rig.max_instance_count. The old option should be considered deprecated.

The dmRig::Update call has been moved into each components update function
instead, making it behave more like all other components.