### PR TITLE
DEFEDIT-1293 Close Search in Files dialog after opening a file

### DIFF
--- a/editor/resources/search-in-files-dialog.fxml
+++ b/editor/resources/search-in-files-dialog.fxml
@@ -29,7 +29,7 @@
                </children>
             </HBox>
         <Pane maxWidth="+Infinity" HBox.hgrow="ALWAYS" />
-      <Button id="ok" focusTraversable="false" minWidth="80.0" mnemonicParsing="false" text="OK" HBox.hgrow="NEVER">
+      <Button id="ok" focusTraversable="false" minWidth="80.0" mnemonicParsing="false" text="Keep Results" HBox.hgrow="NEVER">
         <HBox.margin>
           <Insets left="14.0" />
         </HBox.margin>

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -138,7 +138,8 @@
                                              (ui/close! stage))
             open-selected! (fn []
                              (doseq [[resource opts] (resolve-search-in-files-tree-view-selection (ui/selection resources-tree))]
-                               (open-fn resource opts)))]
+                               (open-fn resource opts))
+                             (dismiss-and-abort-search!))]
         (ui/title! stage "Search in Files")
         (init-search-in-files-tree-view! resources-tree)
 


### PR DESCRIPTION
### User-facing changes
* Double-clicking a match in the Search in Files dialog closes the dialog after opening the file.
* Also does this if enter is pressed while one or more matches are selected.
* The OK button now says Keep Results to reflect what it does.