### PR TITLE
DEFEDIT-1294 Save all performs partial, broken, resource sync

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -345,7 +345,7 @@
         (when dest-file
           (let [src-files (doall (file-seq src-file))]
             (fs/move! src-file dest-file)
-            (workspace/resource-sync! workspace true (moved-files src-file dest-file src-files))))))))
+            (workspace/resource-sync! workspace (moved-files src-file dest-file src-files))))))))
 
 (defn rename? [resources]
   (and (= 1 (count resources))
@@ -654,7 +654,7 @@
         (when (seq pairs)
           (let [moved (drop-files! workspace pairs move?)]
             (select-files! workspace tree-view (mapv second pairs))
-            (workspace/resource-sync! workspace true moved))))))
+            (workspace/resource-sync! workspace moved))))))
   (.setDropCompleted e true)
   (.consume e))
 

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -47,7 +47,7 @@
   ([changes-view workspace moved-files]
    (resource-sync-after-git-change! changes-view workspace moved-files progress/null-render-progress!))
   ([changes-view workspace moved-files render-progress!]
-   (let [diff (workspace/resource-sync! workspace true moved-files render-progress!)]
+   (let [diff (workspace/resource-sync! workspace moved-files render-progress!)]
      ;; The call to resource-sync! will refresh the changes view if it detected changes,
      ;; but committing a file from the command line will not actually change the file
      ;; as far as resource-sync! is concerned. To ensure the changed files view reflects

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -245,28 +245,27 @@
   [project]
   (g/node-value project :dirty-save-data))
 
-(defn write-save-data-to-disk! [project {:keys [render-progress!]
-                                         :or {render-progress! progress/null-render-progress!}
-                                         :as opts}]
+(defn write-save-data-to-disk! [save-data {:keys [render-progress!]
+                                           :or {render-progress! progress/null-render-progress!}
+                                           :as opts}]
   (render-progress! (progress/make "Saving..."))
-  (let [save-data (dirty-save-data project)]
-    (if (g/error? save-data)
-      (throw (Exception. ^String (properties/error-message save-data)))
-      (do
-        (progress/progress-mapv
-          (fn [{:keys [resource content value node-id]} _]
-            (when-not (resource/read-only? resource)
-              ;; If the file is non-binary, convert line endings to the
-              ;; type used by the existing file.
-              (if (and (:textual? (resource/resource-type resource))
-                    (resource/exists? resource)
-                    (= :crlf (text-util/guess-line-endings (io/make-reader resource nil))))
-                (spit resource (text-util/lf->crlf content))
-                (spit resource content))))
-          save-data
-          render-progress!
-          (fn [{:keys [resource]}] (and resource (str "Saving " (resource/resource->proj-path resource)))))
-        (g/invalidate-outputs! (mapv (fn [sd] [(:node-id sd) :source-value]) save-data))))))
+  (if (g/error? save-data)
+    (throw (Exception. ^String (properties/error-message save-data)))
+    (do
+      (progress/progress-mapv
+        (fn [{:keys [resource content value node-id]} _]
+          (when-not (resource/read-only? resource)
+            ;; If the file is non-binary, convert line endings to the
+            ;; type used by the existing file.
+            (if (and (:textual? (resource/resource-type resource))
+                     (resource/exists? resource)
+                     (= :crlf (text-util/guess-line-endings (io/make-reader resource nil))))
+              (spit resource (text-util/lf->crlf content))
+              (spit resource content))))
+        save-data
+        render-progress!
+        (fn [{:keys [resource]}] (and resource (str "Saving " (resource/resource->proj-path resource)))))
+      (g/invalidate-outputs! (mapv (fn [sd] [(:node-id sd) :source-value]) save-data)))))
 
 (defn workspace [project]
   (g/node-value project :workspace))
@@ -278,10 +277,11 @@
    ;; to no progress reporting.
    (save-all! project (progress/throttle-render-progress progress/null-render-progress!)))
   ([project render-progress!]
-   (let [workspace     (workspace project)]
+   (let [workspace (workspace project)
+         save-data (dirty-save-data project)]
      (ui/with-progress [render-progress! render-progress!]
-       (write-save-data-to-disk! project {:render-progress! render-progress!}))
-     (workspace/resource-sync! workspace false [] progress/null-render-progress!))))
+       (write-save-data-to-disk! save-data {:render-progress! render-progress!}))
+     (workspace/update-resource-snapshot! workspace (map :resource save-data)))))
 
 (defn make-collect-progress-steps-tracer [steps-atom]
   (fn [state node output-type label]
@@ -692,7 +692,7 @@
            (workspace/install-validated-libraries! workspace-id dependencies)))
     
     (render-progress! (swap! progress progress/advance 1 "Syncing resources"))
-    (workspace/resource-sync! workspace-id false [] (progress/nest-render-progress render-progress! @progress))
+    (workspace/resource-sync! workspace-id [] (progress/nest-render-progress render-progress! @progress))
     (render-progress! (swap! progress progress/advance 1 "Loading project"))
     (let [project (make-project graph workspace-id)
           populated-project (load-project project (g/node-value project :resources) (progress/nest-render-progress render-progress! @progress))]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -200,14 +200,16 @@ ordinary paths."
                 (map :url))
           (library/current-library-state project-directory dependencies))))
 
+(defn update-resource-snapshot!
+  [workspace resources]
+  (g/update-property! workspace :resource-snapshot resource-watch/update-snapshot-status resources))
+
 (defn resource-sync!
   ([workspace]
-   (resource-sync! workspace true []))
-  ([workspace notify-listeners?]
-   (resource-sync! workspace notify-listeners? []))
-  ([workspace notify-listeners? moved-files]
-   (resource-sync! workspace notify-listeners? moved-files progress/null-render-progress!))
-  ([workspace notify-listeners? moved-files render-progress!]
+   (resource-sync! workspace []))
+  ([workspace moved-files]
+   (resource-sync! workspace moved-files progress/null-render-progress!))
+  ([workspace moved-files render-progress!]
    (let [project-path (project-path workspace)
          moved-proj-paths (keep (fn [[src tgt]]
                                   (let [src-path (resource/file->proj-path project-path src)
@@ -226,55 +228,54 @@ ordinary paths."
          changes      (resource-watch/diff old-snapshot new-snapshot)]
      (when (or (not (resource-watch/empty-diff? changes)) (seq moved-proj-paths))
        (g/set-property! workspace :resource-snapshot new-snapshot)
-       (when notify-listeners?
-         (let [changes (into {} (map (fn [[type resources]] [type (filter #(= :file (resource/source-type %)) resources)]) changes))
-               move-source-paths (map first moved-proj-paths)
-               move-target-paths (map second moved-proj-paths)
-               chain-moved-paths (set/intersection (set move-source-paths) (set move-target-paths))
-               merged-target-paths (set (map first (filter (fn [[k v]] (> v 1)) (frequencies move-target-paths))))
-               moved (keep (fn [[source-path target-path]]
-                             (when-not (or
-                                         ;; resource sync currently can't handle chained moves, so refactoring is
-                                         ;; temporarily disabled for those cases (no move pair)
-                                         (chain-moved-paths source-path) (chain-moved-paths target-path)
-                                         ;; also can't handle merged targets, multiple files with same name moved to same dir
-                                         (merged-target-paths target-path))
-                               (let [src-resource (old-map source-path)
-                                     tgt-resource (new-map target-path)]
-                                 ;; We used to (assert (some? src-resource)), but this could fail for instance if
-                                 ;; * source-path refers to a .dotfile (like .DS_Store) that we ignore in resource/make-snapshot
-                                 ;; * Some external process has created a file in a to-be-moved directory and we haven't run a resource-sync! before the move
-                                 ;; We handle these cases by ignoring the move. Any .dotfiles will stay ignored, and any new files will pop up as :added
-                                 ;;
-                                 ;; We also used to (assert (some? tgt-resource)) but an arguably very unlikely case is that the target of the move is
-                                 ;; deleted from disk after the move but before the snapshot.
-                                 ;; We handle that by ignoring the move and effectively treating target as just :removed.
-                                 ;; The source will be :removed or :changed (if a library snuck in).
-                                 (cond
-                                   (nil? src-resource)
-                                   (do (log/warn :msg (str "can't find source of move " source-path)) nil)
+       (let [changes (into {} (map (fn [[type resources]] [type (filter #(= :file (resource/source-type %)) resources)]) changes))
+             move-source-paths (map first moved-proj-paths)
+             move-target-paths (map second moved-proj-paths)
+             chain-moved-paths (set/intersection (set move-source-paths) (set move-target-paths))
+             merged-target-paths (set (map first (filter (fn [[k v]] (> v 1)) (frequencies move-target-paths))))
+             moved (keep (fn [[source-path target-path]]
+                           (when-not (or
+                                       ;; resource sync currently can't handle chained moves, so refactoring is
+                                       ;; temporarily disabled for those cases (no move pair)
+                                       (chain-moved-paths source-path) (chain-moved-paths target-path)
+                                       ;; also can't handle merged targets, multiple files with same name moved to same dir
+                                       (merged-target-paths target-path))
+                             (let [src-resource (old-map source-path)
+                                   tgt-resource (new-map target-path)]
+                               ;; We used to (assert (some? src-resource)), but this could fail for instance if
+                               ;; * source-path refers to a .dotfile (like .DS_Store) that we ignore in resource/make-snapshot
+                               ;; * Some external process has created a file in a to-be-moved directory and we haven't run a resource-sync! before the move
+                               ;; We handle these cases by ignoring the move. Any .dotfiles will stay ignored, and any new files will pop up as :added
+                               ;;
+                               ;; We also used to (assert (some? tgt-resource)) but an arguably very unlikely case is that the target of the move is
+                               ;; deleted from disk after the move but before the snapshot.
+                               ;; We handle that by ignoring the move and effectively treating target as just :removed.
+                               ;; The source will be :removed or :changed (if a library snuck in).
+                               (cond
+                                 (nil? src-resource)
+                                 (do (log/warn :msg (str "can't find source of move " source-path)) nil)
 
-                                   (nil? tgt-resource)
-                                   (do (log/warn :msg (str "can't find target of move " target-path)) nil)
+                                 (nil? tgt-resource)
+                                 (do (log/warn :msg (str "can't find target of move " target-path)) nil)
 
-                                   (and (= :file (resource/source-type src-resource))
-                                        (= :file (resource/source-type tgt-resource))) ; paranoia
-                                   [src-resource tgt-resource]))))
-                           moved-proj-paths)
-               changes-with-moved (assoc changes :moved moved)]
-           (assert (= (count (distinct (map (comp resource/proj-path first) moved)))
-                      (count (distinct (map (comp resource/proj-path second) moved)))
-                      (count moved))) ; no overlapping sources, dito targets
-           (assert (= (count (distinct (concat (map (comp resource/proj-path first) moved)
-                                               (map (comp resource/proj-path second) moved))))
-                      (* 2 (count moved)))) ; no chained moves src->tgt->tgt2...
-           (assert (empty? (set/intersection (set (map (comp resource/proj-path first) moved))
-                                             (set (map resource/proj-path (:added changes)))))) ; no move-source is in :added
-           (let [listeners @(g/node-value workspace :resource-listeners)
-                 parent-progress (atom (progress/make "" (count listeners)))]
+                                 (and (= :file (resource/source-type src-resource))
+                                      (= :file (resource/source-type tgt-resource))) ; paranoia
+                                 [src-resource tgt-resource]))))
+                         moved-proj-paths)
+             changes-with-moved (assoc changes :moved moved)]
+         (assert (= (count (distinct (map (comp resource/proj-path first) moved)))
+                    (count (distinct (map (comp resource/proj-path second) moved)))
+                    (count moved))) ; no overlapping sources, dito targets
+         (assert (= (count (distinct (concat (map (comp resource/proj-path first) moved)
+                                             (map (comp resource/proj-path second) moved))))
+                    (* 2 (count moved)))) ; no chained moves src->tgt->tgt2...
+         (assert (empty? (set/intersection (set (map (comp resource/proj-path first) moved))
+                                           (set (map resource/proj-path (:added changes)))))) ; no move-source is in :added
+         (let [listeners @(g/node-value workspace :resource-listeners)
+               parent-progress (atom (progress/make "" (count listeners)))]
            (doseq [listener @(g/node-value workspace :resource-listeners)]
              (resource/handle-changes listener changes-with-moved
-                                      (progress/nest-render-progress render-progress! @parent-progress)))))))
+                                      (progress/nest-render-progress render-progress! @parent-progress))))))
      changes)))
 
 (defn fetch-and-validate-libraries [workspace library-urls render-fn]

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -89,13 +89,13 @@
   (let [from-file (path->file workspace from)
         to-file (path->file workspace to)]
     (fs/move-file! from-file to-file)
-    (workspace/resource-sync! workspace true [[from-file to-file]])))
+    (workspace/resource-sync! workspace [[from-file to-file]])))
 
 (defn- edit-and-save! [workspace atlas margin]
   (g/set-property! atlas :margin margin)
   (let [save-data (g/node-value atlas :save-data)]
     (spit-until-new-mtime (:resource save-data) (:content save-data))
-    (workspace/resource-sync! workspace true [])))
+    (workspace/resource-sync! workspace [])))
 
 (defn- revert-all! [workspace git]
   (let [status (git/unified-status git)
@@ -103,7 +103,7 @@
                       (filter #(= (:change-type %) :rename))
                       (mapv #(vector (path->file workspace (:new-path %)) (path->file workspace (:old-path %)))))]
     (git/revert git (mapv (fn [status] (or (:new-path status) (:old-path status))) status))
-    (workspace/resource-sync! workspace true moved-files)))
+    (workspace/resource-sync! workspace moved-files)))
 
 (deftest revert-rename-of-opened-file
   (with-clean-system

--- a/editor/test/integration/asset_browser_test.clj
+++ b/editor/test/integration/asset_browser_test.clj
@@ -97,7 +97,7 @@
           read-only-dir-2 (make-dir-resource "read-only-dir-2" {:read-only? true})]
       (doseq [reserved-dir-name resource-watch/reserved-proj-paths]
         (fs/create-directories! (make-file (str "subdir" reserved-dir-name))))
-      (workspace/resource-sync! workspace false [])
+      (workspace/resource-sync! workspace [])
       (testing "paste?"
         (are [files-on-clipboard? target-resources expected] (= expected (asset-browser/paste? files-on-clipboard? target-resources))
           false nil false
@@ -230,7 +230,7 @@
         (let [moved (asset-browser/drop-files! workspace [[(io/as-file (resource-map "/game.project")) (make-file "collection/game.project")]
                                                           [(io/as-file (resource-map "/car/car.script")) (make-file "collection/car.script")]]
                                                :move)]
-          (workspace/resource-sync! workspace false moved)
+          (workspace/resource-sync! workspace moved)
           (let [resource-map (g/node-value workspace :resource-map)]
             (is (some? (resource-map "/game.project")))
             (is (some? (resource-map "/collection/game.project")))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -387,7 +387,7 @@
         (let [atlas (test-util/resource-node project "/player/spineboy.atlas")]
           (g/transact (g/set-property atlas :margin 10))
           (let [third-time (measure (project/build project resource-node (g/make-evaluation-context) {}))]
-            (is (< (* 5 second-time) third-time))))))))
+            (is (< (* 2 second-time) third-time))))))))
 
 (defn- build-path [workspace proj-path]
   (str (workspace/build-path workspace) proj-path))

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -362,13 +362,13 @@
   (let [f (File. (workspace/project-path workspace) name)]
     (fs/delete-file! f)))
 
-(deftest save-rs-snafu
+(deftest save-all-does-not-perform-resource-sync
   ;; During save-all! we used to perform a partial resource-sync! that
   ;; would detect file additions/removes on the workspace level - new
   ;; files would be added to the resource-snapshot and appear in the
   ;; asset browser - but not create new resource nodes for them.
   ;; This could cause havoc during later, complete, resource-sync!'s.
-  ;; The file deletion below would trigger an assert that an unknown
+  ;; The file deletion below would cause an assert that an unknown
   ;; resource was deleted.
   (with-clean-system
     (let [[workspace project] (setup-scratch world)
@@ -376,8 +376,8 @@
       (append-lua-code-line! script)
       (touch-file workspace "boom.md")
       (project/save-all! project)
-      (is (nil? (workspace/find-resource workspace "/boom.md"))) ; this test used to fail - the resource was found
-      (is (nil? (project/get-resource-node project "boom.md"))) ; this would succeed - no corresponding resource
+      (is (nil? (workspace/find-resource workspace "/boom.md"))) ; this test used to fail - the resource was found during partial resource sync
+      (is (nil? (project/get-resource-node project "boom.md"))) ; this would succeed - no corresponding resource node
       (delete-file workspace "boom.md")
-      (workspace/resource-sync! workspace) ; here, the assert would say a resource was removed but no corresponding resource node found
+      (workspace/resource-sync! workspace) ; here, the assert would say a resource was removed but no corresponding resource node was found
       (is (not (seq (g/node-value project :dirty-save-data)))))))

--- a/editor/test/integration/save_test.clj
+++ b/editor/test/integration/save_test.clj
@@ -4,7 +4,7 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [dynamo.graph :as g]
-            [support.test-support :refer [with-clean-system]]
+            [support.test-support :refer [with-clean-system touch-until-new-mtime]]
             [editor.defold-project :as project]
             [editor.fs :as fs]
             [editor.git :as git]
@@ -156,7 +156,7 @@
     (perform-save-all-literal-equality-test!)))
 
 (defn- save-all! [project]
-  (project/write-save-data-to-disk! project nil))
+  (project/write-save-data-to-disk! (project/dirty-save-data project) nil))
 
 (defn- dirty? [node-id]
   (some-> (g/node-value node-id :save-data)
@@ -330,7 +330,7 @@
               {:keys [lf crlf] :or {lf 0 crlf 0}} (frequencies (map second line-endings-before))]
           (is (< 100 lf))
           (is (> 100 crlf))
-          (project/write-save-data-to-disk! project nil)
+          (project/write-save-data-to-disk! (project/dirty-save-data project) nil)
           (is (= line-endings-before (line-endings-by-resource project))))))
 
     (testing "autocrlf true"
@@ -343,7 +343,7 @@
               {:keys [lf crlf] :or {lf 0 crlf 0}} (frequencies (map second line-endings-before))]
           (is (> 100 lf))
           (is (< 100 crlf))
-          (project/write-save-data-to-disk! project nil)
+          (project/write-save-data-to-disk! (project/dirty-save-data project) nil)
           (is (= line-endings-before (line-endings-by-resource project))))))))
 
 (deftest save-respects-line-endings
@@ -351,3 +351,33 @@
     (perform-save-respects-line-endings-test!))
   (with-bindings {#'test-util/use-new-code-editor? true}
     (perform-save-respects-line-endings-test!)))
+
+(defn- touch-file
+  [workspace name]
+  (let [f (File. (workspace/project-path workspace) name)]
+    (fs/create-parent-directories! f)
+    (touch-until-new-mtime f)))
+
+(defn- delete-file [workspace name]
+  (let [f (File. (workspace/project-path workspace) name)]
+    (fs/delete-file! f)))
+
+(deftest save-rs-snafu
+  ;; During save-all! we used to perform a partial resource-sync! that
+  ;; would detect file additions/removes on the workspace level - new
+  ;; files would be added to the resource-snapshot and appear in the
+  ;; asset browser - but not create new resource nodes for them.
+  ;; This could cause havoc during later, complete, resource-sync!'s.
+  ;; The file deletion below would trigger an assert that an unknown
+  ;; resource was deleted.
+  (with-clean-system
+    (let [[workspace project] (setup-scratch world)
+          script (test-util/resource-node project "/script/props.script")]
+      (append-lua-code-line! script)
+      (touch-file workspace "boom.md")
+      (project/save-all! project)
+      (is (nil? (workspace/find-resource workspace "/boom.md"))) ; this test used to fail - the resource was found
+      (is (nil? (project/get-resource-node project "boom.md"))) ; this would succeed - no corresponding resource
+      (delete-file workspace "boom.md")
+      (workspace/resource-sync! workspace) ; here, the assert would say a resource was removed but no corresponding resource node found
+      (is (not (seq (g/node-value project :dirty-save-data)))))))


### PR DESCRIPTION
* Technical changes
  - save-all no longer performs a resource-sync! with notify =
  false. The notify flag of resource-sync! has been completely removed
  as this was an invitation to failure. Instead, after saving the
  project file, we update the corresponding status map entries in
  our resource-snapshot to the latest mtime.
  - adjusted all call sites of resource-sync!