### PR TITLE
DEFEDIT-1278 Part 2: Long resource sync when returning to the editor.

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -477,7 +477,7 @@
             (g/mark-defective node flaw))))
 
       (let [all-outputs (mapcat (fn [node]
-                                    (map (fn [[output _]] [node output]) (gu/outputs node)))
+                                  (map (fn [[output _]] [node output]) (gu/outputs node)))
                                 (:invalidate-outputs plan))]
         (g/invalidate-outputs! all-outputs))
 


### PR DESCRIPTION
* User facing changes
  - Shorter hickup when returning to editor

* Technical changes
  - Run make-snapshot (scan fs) on background thread before performing
  resource sync! after regaining focus