### PR TITLE
DEFEDIT-1296 Round 32-bit floats to double equivalent before presenting

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -124,7 +124,7 @@
 
 (defmethod create-property-control! g/Num [_ _ property-fn]
   (let [text         (TextField.)
-        update-ui-fn (partial update-text-fn text field-expression/format-double)
+        update-ui-fn (partial update-text-fn text field-expression/format-number)
         update-fn    (fn [_] (if-let [v (field-expression/to-double (.getText text))]
                                (properties/set-values! (property-fn) (repeat v))
                                (update-ui-fn (properties/values (property-fn))
@@ -161,7 +161,7 @@
         box          (doto (GridPane.)
                        (.setHgap grid-hgap))
         get-fns (map-indexed (fn [i _] #(nth % i)) text-fields)
-        update-ui-fn (partial update-multi-text-fn text-fields field-expression/format-double get-fns)]
+        update-ui-fn (partial update-multi-text-fn text-fields field-expression/format-number get-fns)]
     (doseq [[t f] (map-indexed (fn [i t]
                                  [t (fn [_]
                                       (let [v            (field-expression/to-double (.getText ^TextField t))
@@ -202,7 +202,7 @@
         box          (doto (GridPane.)
                        (.setPrefWidth Double/MAX_VALUE))
         get-fns (map (fn [f] (or (:get-fn f) #(get-in % (:path f)))) fields)
-        update-ui-fn (partial update-multi-text-fn text-fields field-expression/format-double get-fns)]
+        update-ui-fn (partial update-multi-text-fn text-fields field-expression/format-number get-fns)]
     (doseq [[t f] (map (fn [f t]
                          (let [set-fn (or (:set-fn f)
                                           (fn [e v] (assoc-in e (:path f) v)))]

--- a/editor/test/editor/field_expression_test.clj
+++ b/editor/test/editor/field_expression_test.clj
@@ -1,12 +1,15 @@
 (ns editor.field-expression-test
   (:require [clojure.test :refer :all]
-            [editor.field-expression :refer [format-double format-int to-double to-int]]))
+            [editor.field-expression :refer [format-int format-number to-double to-int]]))
 
 (deftest format-double-test
   (are [n s]
-    (= s (format-double n))
+    (= s (#'editor.field-expression/format-double n))
 
     nil ""
+    Double/NaN "NaN"
+    Double/POSITIVE_INFINITY "Infinity"
+    Double/NEGATIVE_INFINITY "-Infinity"
     0 "0"
     -1 "-1"
     0.1 "0.1"
@@ -32,6 +35,32 @@
     31415926535897.93 "31415926535897.93"
     314159265358979.3 "314159265358979.3"))
 
+(deftest format-float-test
+  (are [n s]
+    (= s (#'editor.field-expression/format-float (some-> n float)))
+
+    nil ""
+    Float/NaN "NaN"
+    Float/POSITIVE_INFINITY "Infinity"
+    Float/NEGATIVE_INFINITY "-Infinity"
+    0 "0"
+    -1 "-1"
+    0.1 "0.1"
+    0.00001 "0.00001"
+    1.000001 "1.000001"
+    1100.11 "1100.11"
+    32767 "32767"
+    -32768 "-32768"
+    8388607 "8388607"
+    -8388608 "-8388608"
+
+    3.141593 "3.141593"
+    31.41593 "31.41593"
+    314.1593 "314.1593"
+    3141.593 "3141.593"
+    31415.93 "31415.93"
+    314159.3 "314159.3"))
+
 (deftest format-int-test
   (are [n s]
     (= s (format-int n))
@@ -41,6 +70,29 @@
     -1 "-1"
     2147483647 "2147483647"
     -2147483648 "-2147483648"))
+
+(deftest format-number-test
+  (are [n s]
+    (= s (format-number n))
+
+    nil ""
+    Double/NaN "NaN"
+    Double/POSITIVE_INFINITY "Infinity"
+    Double/NEGATIVE_INFINITY "-Infinity"
+    Float/NaN "NaN"
+    Float/POSITIVE_INFINITY "Infinity"
+    Float/NEGATIVE_INFINITY "-Infinity"
+    0 "0"
+    -1 "-1"
+    2147483647 "2147483647"
+    -2147483648 "-2147483648"
+    9223372036854775807 "9223372036854775807"
+    -9223372036854775808 "-9223372036854775808"
+    (float 0.1) "0.1"
+    (float 0.00001) "0.00001"
+    (float 1.000001) "1.000001"
+    (float 1100.11) "1100.11"
+    3.141592653589793 "3.141592653589793"))
 
 (deftest to-double-test
   (testing "String conversion"
@@ -89,9 +141,9 @@
       (is (= 30 (to-int "60 / 2"))))))
 
 (deftest double-loopback-test
-  (is (true? (Double/isNaN (to-double (format-double Double/NaN)))))
+  (is (true? (Double/isNaN (to-double (#'editor.field-expression/format-double Double/NaN)))))
   (are [n]
-    (= n (to-double (format-double n)))
+    (= n (to-double (#'editor.field-expression/format-double n)))
 
     Double/MAX_VALUE
     Double/MIN_VALUE
@@ -105,3 +157,63 @@
 
     Integer/MAX_VALUE
     Integer/MIN_VALUE))
+
+(deftest number-loopback-test
+  (is (true? (Double/isNaN (to-double (format-number Double/NaN)))))
+  (are [n]
+    (= n (to-double (format-number n)))
+
+    Double/MAX_VALUE
+    Double/MIN_VALUE
+    Double/MIN_NORMAL
+    Double/POSITIVE_INFINITY
+    Double/NEGATIVE_INFINITY
+
+    0.0
+    -1.0
+    0.1
+    0.00001
+    1.000001
+    1100.11
+    9223372036854775807.0
+    -9223372036854775808.0
+
+    3.141592653589793
+    31.41592653589793
+    314.1592653589793
+    3141.592653589793
+    31415.92653589793
+    314159.2653589793
+    3141592.653589793
+    31415926.53589793
+    314159265.3589793
+    3141592653.589793
+    31415926535.89793
+    314159265358.9793
+    3141592653589.793
+    31415926535897.93
+    314159265358979.3)
+
+  (is (true? (Double/isNaN (to-double (format-number Float/NaN)))))
+  (is (= Double/POSITIVE_INFINITY (to-double (format-number Float/POSITIVE_INFINITY))))
+  (is (= Double/NEGATIVE_INFINITY (to-double (format-number Float/NEGATIVE_INFINITY))))
+  (are [n]
+    (= n (to-double (format-number (float n))))
+
+    0.0
+    -1.0
+    0.1
+    0.00001
+    1.000001
+    1100.11
+    32767.0
+    -32768.0
+    8388607.0
+    -8388608.0
+
+    3.141593
+    31.41593
+    314.1593
+    3141.593
+    31415.93
+    314159.3))


### PR DESCRIPTION
Fixes defold/editor2-issues#1565
Fixes defold/editor2-issues#1604

### User-facing changes
* Floating-point numbers no longer show up with excessive decimal places in the Property Editor.