### PR TITLE
DEFEDIT-1297 Random crash happening a lot!

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -281,7 +281,7 @@
          save-data (dirty-save-data project)]
      (ui/with-progress [render-progress! render-progress!]
        (write-save-data-to-disk! save-data {:render-progress! render-progress!}))
-     (workspace/update-resource-snapshot! workspace (map :resource save-data)))))
+     (workspace/update-snapshot-status! workspace (map :resource save-data)))))
 
 (defn make-collect-progress-steps-tracer [steps-atom]
   (fn [state node output-type label]


### PR DESCRIPTION
* Technical changes
  - DEFEDIT-1278 accidentally performed library snapshot cache update, a
  graph transaction, in a background thread causing "Concurrent
  modification" exceptions. Moved cache update to ui thread.