### PR TITLE
DEFEDIT-1301 Fix editor freeze or memory issues on complex build error

### DIFF
--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -5,43 +5,23 @@
             [editor.resource :as resource]
             [editor.ui :as ui]
             [editor.workspace :as workspace])
-  (:import [editor.resource Resource MemoryResource]
+  (:import [clojure.lang MapEntry PersistentQueue]
            [java.util Collection]
            [javafx.collections ObservableList]
            [javafx.scene.control TabPane TreeItem TreeView]))
 
 (set! *warn-on-reflection* true)
 
-(defn- persistent-queue
-  [coll]
-  (into clojure.lang.PersistentQueue/EMPTY coll))
+(defn- pair [a b]
+  (MapEntry. a b))
 
-(defn- root-causes
-  "Returns a set of ErrorValue paths. Each path starts with the root cause and
-  continues with every parent up to and including the supplied error-value.
-  The causes are stripped from ErrorValues in the returned path."
-  [error-value]
-  (letfn [(push-causes [queue error path]
-            (let [new-path (conj path (dissoc error :causes))]
-              (reduce (fn [queue error]
-                        (conj queue [error new-path])) queue (:causes error))))]
-    (loop [queue (persistent-queue [[error-value (list)]])
-           ret []]
-      (if-let [[error path] (peek queue)]
-        (cond
-          (seq (:causes error))
-          (recur (push-causes (pop queue) error path) ret)
+(defn- queue [item]
+  (conj PersistentQueue/EMPTY item))
 
-          :else
-          (recur (pop queue) (conj ret (conj path (dissoc error :causes)))))
-        (distinct ret)))))
-
-(defn- existing-resource [node-id]
-  (when (g/node-instance? resource/ResourceNode node-id)
-    (when-let [resource (g/node-value node-id :resource)]
-      (when (and (instance? Resource resource)
-                 (not (instance? MemoryResource resource))
-                 (resource/exists? resource))
+(defn- openable-resource [evaluation-context node-id]
+  (when (g/node-instance? (:basis evaluation-context) resource/ResourceNode node-id)
+    (when-some [resource (g/node-value node-id :resource evaluation-context)]
+      (when (resource/openable-resource? resource)
         resource))))
 
 (defn- node-id-at-override-depth [override-depth node-id]
@@ -49,37 +29,44 @@
     (recur (dec override-depth) (g/override-original node-id))
     node-id))
 
-(defn- parent-resource [errors origin-override-depth origin-override-id]
-  (or (when-let [node-id (node-id-at-override-depth origin-override-depth (:_node-id (first errors)))]
-        (when (or (nil? origin-override-id)
-                  (not= origin-override-id (g/override-id node-id)))
-          (when-let [resource (existing-resource node-id)]
-            {:node-id (or (g/override-original node-id) node-id)
-             :resource resource})))
+(defn- parent-resource [evaluation-context errors origin-override-depth origin-override-id]
+  (or (when-some [node-id (node-id-at-override-depth origin-override-depth (:_node-id (first errors)))]
+        (let [basis (:basis evaluation-context)]
+          (when (or (nil? origin-override-id)
+                    (not= origin-override-id (g/override-id basis node-id)))
+            (when-some [resource (openable-resource evaluation-context node-id)]
+              {:node-id (or (g/override-original basis node-id) node-id)
+               :resource resource}))))
       (when-some [remaining-errors (next errors)]
-        (recur remaining-errors origin-override-depth origin-override-id))))
+        (recur evaluation-context remaining-errors origin-override-depth origin-override-id))))
 
-(defn find-override-value-origin [node-id label depth]
-  (if (and node-id (g/override? node-id))
-    (if-not (g/property-overridden? node-id label)
-      (recur (g/override-original node-id) label (inc depth))
-      [node-id depth])
-    [node-id depth]))
+(defn- find-override-value-origin [basis node-id label depth]
+  (if (and node-id (g/override? basis node-id))
+    (if-not (g/property-overridden? basis node-id label)
+      (recur basis (g/override-original basis node-id) label (inc depth))
+      (pair node-id depth))
+    (pair node-id depth)))
 
 (defn- error-line [error]
   (-> error :value ex-data :line))
 
-(defn- missing-resource-node [node-id]
-  (when (g/node-instance? resource/ResourceNode node-id)
-    (not (existing-resource node-id))))
+(defn- missing-resource-node? [evaluation-context node-id]
+  (and (g/node-instance? (:basis evaluation-context) resource/ResourceNode node-id)
+       (some? (g/node-value node-id :resource evaluation-context))
+       (some? (g/node-value node-id :_output-jammers evaluation-context))))
 
-(defn- error-item [root-cause]
+(defn- error-item [evaluation-context root-cause]
   (let [message (:message (first root-cause))
-        error (assoc (first (drop-while (comp (fn [node-id] (or (nil? node-id) (missing-resource-node node-id))) :_node-id) root-cause))
-                :message message)
-        [origin-node-id origin-override-depth] (find-override-value-origin (:_node-id error) (:_label error) 0)
-        origin-override-id (when (some? origin-node-id) (g/override-id origin-node-id))
-        parent (parent-resource root-cause origin-override-depth origin-override-id)
+        errors (drop-while (comp (fn [node-id]
+                                   (or (nil? node-id)
+                                       (missing-resource-node? evaluation-context node-id)))
+                                 :_node-id)
+                           root-cause)
+        error (assoc (first errors) :message message)
+        basis (:basis evaluation-context)
+        [origin-node-id origin-override-depth] (find-override-value-origin basis (:_node-id error) (:_label error) 0)
+        origin-override-id (when (some? origin-node-id) (g/override-id basis origin-node-id))
+        parent (parent-resource evaluation-context errors origin-override-depth origin-override-id)
         line (error-line error)]
     (cond-> {:parent parent
              :node-id origin-node-id
@@ -87,20 +74,47 @@
              :severity (:severity error)}
             line (assoc :line line))))
 
+(defn- push-causes [queue error path]
+  (let [new-path (conj path error)]
+    (reduce (fn [queue error]
+              (conj queue (pair error new-path)))
+            queue
+            (:causes error))))
+
+(defn- root-causes-helper [queue]
+  (lazy-seq
+    (when-some [[error path] (peek queue)]
+      (if (seq (:causes error))
+        (root-causes-helper (push-causes (pop queue) error path))
+        (cons (conj path error)
+              (root-causes-helper (pop queue)))))))
+
+(defn- root-causes
+  "Returns a lazy sequence of distinct error items from the causes in the supplied ErrorValue."
+  [error-value]
+  ;; Use a throwaway evaluation context to avoid context creation overhead.
+  ;; We don't evaluate any outputs, so there is no need to update the cache.
+  (let [evaluation-context (g/make-evaluation-context)]
+    (sequence (comp (take 10000)
+                    (map (partial error-item evaluation-context))
+                    (distinct))
+              (root-causes-helper (queue (pair error-value (list)))))))
+
+(defn- error-items [root-error]
+  (->> (root-causes root-error)
+       (group-by :parent)
+       (sort-by (comp resource/resource->proj-path :resource key))
+       (mapv (fn [[resource errors]]
+               (if resource
+                 {:type :resource
+                  :value resource
+                  :children errors}
+                 {:type :default
+                  :children errors})))))
+
 (defn build-resource-tree [root-error]
-  (let [items (->> (root-causes root-error)
-                   (map error-item)
-                   (group-by :parent)
-                   (sort-by (comp resource/resource->proj-path :resource key))
-                   (mapv (fn [[resource errors]]
-                           (if resource
-                             {:type :resource
-                              :value resource
-                              :children (vec (distinct errors))}
-                             {:type :default
-                              :children (vec (distinct errors))}))))]
-    {:label "root"
-     :children items}))
+  {:label "root"
+   :children (error-items root-error)})
 
 (defmulti make-tree-cell
   (fn [tree-item] (:type tree-item)))

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -28,17 +28,17 @@
 
 (defn refresh! [changes-view]
   (let [list-view (g/node-value changes-view :list-view)
-        git (g/node-value changes-view :git)
+        unconfigured-git (g/node-value changes-view :unconfigured-git)
         refresh-pending (ui/user-data list-view :refresh-pending)
         schedule-refresh (ref nil)]
-    (when git
+    (when unconfigured-git
       (dosync
         (ref-set schedule-refresh (not @refresh-pending))
         (ref-set refresh-pending true))
       (when @schedule-refresh
         (future
           (dosync (ref-set refresh-pending false))
-          (let [unified-status (git/unified-status git)]
+          (let [unified-status (git/unified-status unconfigured-git)]
             (ui/run-later (refresh-list-view! list-view unified-status))))))))
 
 (defn refresh-after-resource-sync! [changes-view diff]
@@ -109,7 +109,7 @@
 
 (handler/defhandler :synchronize :global
   (enabled? [changes-view]
-            (g/node-value changes-view :git))
+            (g/node-value changes-view :unconfigured-git))
   (run [changes-view workspace project]
     (let [git   (g/node-value changes-view :git)
           prefs (g/node-value changes-view :prefs)]

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -325,8 +325,8 @@
                                                      (get invalidate-counters node-id+output 0))))
             safe-cache-hits (remove invalidated-during-node-value? @(:hits evaluation-context))
             safe-cache-misses (remove (comp invalidated-during-node-value? first) @(:local evaluation-context))]
-        (alter cache c/cache-hit safe-cache-hits)
-        (alter cache c/cache-encache safe-cache-misses)))))
+        (when (seq safe-cache-hits) (alter cache c/cache-hit safe-cache-hits))
+        (when (seq safe-cache-misses) (alter cache c/cache-encache safe-cache-misses))))))
 
 (defn node-value
   "Get a value, possibly cached, from a node. This is the entry point


### PR DESCRIPTION
Fixes defold/editor2-issues#1638
Fixes defold/editor2-issues#1643

### User-facing changes
* Editor no longer stalls for a long time if a complex build error occurs.

### Technical changes
* `ErrorValue` paths were collected into a huge vector before being collated into unique root causes. If there was a large number of errors, this could cause out of memory errors or hit the GC limit. With this change we lazily consume only the first 10000 `ErrorValue` paths when presenting build errors. This means successive builds might yield new errors after fixes, but at least you'll know about the error quickly.
* Avoid disk access when collating errors from `ResourceNodes`.
* Use `unconfigured-git` to avoid garbage when possible.
* Skip unnecessary `alter` calls when updating cache from evaluation context.