### PR TITLE
DEFEDIT-1302 Fix exception when selecting next occurrence on empty line

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -2190,7 +2190,9 @@
                                (if (cursor-range-midpoint-follows? reference-cursor-range unadjusted-mouse-cursor)
                                  (assoc reference-cursor-range
                                    :from (cursor-range-end reference-cursor-range)
-                                   :to (min-cursor (cursor-range-start word-cursor-range) (cursor-range-start reference-cursor-range)))
+                                   :to (if (= (.col mouse-cursor) (count (lines (.row mouse-cursor))))
+                                         mouse-cursor
+                                         (min-cursor (cursor-range-start word-cursor-range) (cursor-range-start reference-cursor-range))))
                                  (assoc reference-cursor-range
                                    :from (cursor-range-start reference-cursor-range)
                                    :to (max-cursor (cursor-range-end word-cursor-range) (cursor-range-end reference-cursor-range)))))

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -792,29 +792,32 @@
 
 (defn- word-cursor-range-at-cursor
   ^CursorRange [lines ^Cursor cursor]
-  (let [line (lines (.row cursor))
-        line-length (count line)
-        on-whitespace? (and (whitespace-character-at-index? line (.col cursor))
-                            (or (zero? (.col cursor))
-                                (whitespace-character-at-index? line (dec (.col cursor)))))
-        same-word? (if on-whitespace?
-                     (partial whitespace-character-at-index? line)
-                     (partial identifier-character-at-index? line))
-        col (if (or (= line-length (.col cursor))
-                    (not (same-word? (.col cursor))))
-              (max 0 (dec (.col cursor)))
-              (.col cursor))
-        start-col (inc (or (long (first (drop-while same-word? (iterate dec col)))) -1))
-        end-col (or (first (drop-while same-word? (iterate inc col))) line-length)]
-    (->CursorRange (->Cursor (.row cursor) start-col)
-                   (->Cursor (.row cursor) end-col))))
+  (let [row (.row cursor)
+        line (lines row)
+        line-length (count line)]
+    (if (zero? line-length)
+      (Cursor->CursorRange (->Cursor row 0))
+      (let [on-whitespace? (and (whitespace-character-at-index? line (.col cursor))
+                                (or (zero? (.col cursor))
+                                    (whitespace-character-at-index? line (dec (.col cursor)))))
+            same-word? (if on-whitespace?
+                         (partial whitespace-character-at-index? line)
+                         (partial identifier-character-at-index? line))
+            col (if (or (= line-length (.col cursor))
+                        (not (same-word? (.col cursor))))
+                  (max 0 (dec (.col cursor)))
+                  (.col cursor))
+            start-col (inc (or (long (first (drop-while same-word? (iterate dec col)))) -1))
+            end-col (or (first (drop-while same-word? (iterate inc col))) line-length)]
+        (->CursorRange (->Cursor row start-col)
+                       (->Cursor row end-col))))))
 
 (defn word-cursor-range? [lines ^CursorRange adjusted-cursor-range]
   (let [cursor (cursor-range-start adjusted-cursor-range)
         word-cursor-range (word-cursor-range-at-cursor lines cursor)]
-    (when (and (cursor-range-equals? word-cursor-range adjusted-cursor-range)
-               (not (Character/isWhitespace (.charAt ^String (lines (.row cursor)) (.col cursor)))))
-      adjusted-cursor-range)))
+    (and (not (cursor-range-empty? word-cursor-range))
+         (cursor-range-equals? word-cursor-range adjusted-cursor-range)
+         (not (Character/isWhitespace (.charAt ^String (lines (.row cursor)) (.col cursor)))))))
 
 (defn selected-word-cursor-range
   ^CursorRange [lines cursor-ranges]

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -1104,6 +1104,10 @@
       (is (= (cr [0 start-col] [0 end-col])
              (word-cursor-range-at-cursor [line] (->Cursor 0 col)))))
 
+    (testing "Empty line"
+      (is (= (cr [1 0] [1 0])
+             (word-cursor-range-at-cursor ["" ""] (->Cursor 1 0)))))
+
     (testing "Whitespace"
       (let [lines ["\t  \t  word  \t  \t"]]
         (doseq [col (range 6)]
@@ -1115,6 +1119,16 @@
         (doseq [col (range 11 16)] ;; 11 because the end of "word" has priority.
           (is (= (cr [0 10] [0 16])
                  (word-cursor-range-at-cursor lines (->Cursor 0 col)))))))))
+
+(deftest word-cursor-range-test
+  (is (true? (data/word-cursor-range? ["one" "two" "three"] (cr [0 0] [0 3]))))
+  (is (true? (data/word-cursor-range? ["one" "two" "three"] (cr [1 0] [1 3]))))
+  (is (true? (data/word-cursor-range? ["one" "two" "three"] (cr [2 0] [2 5]))))
+  (is (false? (data/word-cursor-range? [""] (cr [0 0] [0 0]))))
+  (is (false? (data/word-cursor-range? ["one" "" "three"] (cr [1 0] [1 0]))))
+  (is (false? (data/word-cursor-range? ["one" "two" "three"] (cr [0 0] [1 3]))))
+  (is (false? (data/word-cursor-range? ["one"] (cr [0 1] [0 3]))))
+  (is (false? (data/word-cursor-range? ["one"] (cr [0 0] [0 2])))))
 
 (defn- find-prev-occurrence [haystack-lines needle-lines from-cursor]
   (data/find-prev-occurrence haystack-lines needle-lines from-cursor false false))


### PR DESCRIPTION
Fixes defold/editor2-issues#1588

### User-facing changes
* Choosing **Select Next Occurrence** on an empty line no longer throws an exception.
* Double-click drag selections now snap to line ends when dragging upwards.
