### PR TITLE
DEFEDIT-1303 Produce less garbage in node-value calls

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -749,8 +749,8 @@
 ;; Values
 ;; ---------------------------------------------------------------------------
 (defn make-evaluation-context
-  ([] (make-evaluation-context {}))
-  ([options] (is/make-evaluation-context @*the-system* options)))
+  ([] (is/default-evaluation-context @*the-system*))
+  ([options] (is/custom-evaluation-context @*the-system* options)))
 
 (defn- do-node-value [node-id label evaluation-context]
   (is/node-value @*the-system* node-id label evaluation-context))

--- a/editor/src/clj/internal/cache.clj
+++ b/editor/src/clj/internal/cache.clj
@@ -46,6 +46,9 @@
 ;; ----------------------------------------
 (def default-cache-limit 1000)
 
+(defn cache? [value]
+  (satisfies? cc/CacheProtocol value))
+
 (defn make-cache
   ([]
     (make-cache default-cache-limit))

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -54,6 +54,9 @@
      Takes and returns a map of the form {node-id #{label ...} ...}")
   (original-node    [this node-id]))
 
+(defn basis? [value]
+  (satisfies? IBasis value))
+
 ;; ---------------------------------------------------------------------------
 ;; ID helpers
 ;; ---------------------------------------------------------------------------

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -273,12 +273,9 @@
 
 (defn default-evaluation-context [sys]
   (dosync
-    {:basis (basis sys)
-     :cache (system-cache sys)
-     :initial-invalidate-counters @(:invalidate-counters sys)
-     :local (atom {})
-     :hits (atom [])
-     :in-production #{}}))
+    (in/default-evaluation-context (basis sys)
+                                   (system-cache sys)
+                                   @(:invalidate-counters sys))))
 
 (defn custom-evaluation-context
   ;; Basis & cache options:
@@ -307,7 +304,7 @@
                          (some? (:basis options))
                          (basis-graphs-identical? (:basis options) (:basis sys-options)))
                     sys-options))]
-    (in/make-evaluation-context options)))
+    (in/custom-evaluation-context options)))
 
 (defn update-cache-from-evaluation-context!
   [sys evaluation-context]

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -396,7 +396,7 @@
 
 (defn- call-setter-fn [ctx property setter-fn basis node-id old-value new-value]
   (try
-    (let [setter-actions (setter-fn (in/make-evaluation-context {:basis basis}) node-id old-value new-value)]
+    (let [setter-actions (setter-fn (in/custom-evaluation-context {:basis basis}) node-id old-value new-value)]
       (when *tx-debug*
         (println (txerrstr ctx "setter actions" (seq setter-actions))))
       setter-actions)
@@ -467,7 +467,7 @@
     (if-let [node (gt/node-by-id-at basis node-id)] ; nil if node was deleted in this transaction
       (let [;; Fetch the node value by either evaluating (value ...) for the property or looking in the node map
             ;; The context is intentionally bare, i.e. only :basis, for this reason
-            old-value (is/node-property-value node property (in/make-evaluation-context {:basis basis}))
+            old-value (is/node-property-value node property (in/custom-evaluation-context {:basis basis}))
             new-value (apply fn old-value args)
             override-node? (some? (gt/original node))
             dynamic? (not (contains? (some-> (gt/node-type node basis) in/all-properties) property))]


### PR DESCRIPTION
### Technical changes
* Avoid creating a little bit of garbage from option maps in the common case of invoking `g/make-evaluation-context` without specifying any `options`.
* Avoid filtering `cache-hits` and `cache-misses` in the common case where `invalidate-counters` are identical inside `g/update-cache-from-evaluation-context!`.