### PR TITLE
DEFEDIT-1314 Fixed Gui nodes parented to Text nodes not visible in Scene View

### DIFF
--- a/editor/src/clj/editor/gl.clj
+++ b/editor/src/clj/editor/gl.clj
@@ -62,7 +62,6 @@
 
 (defmacro gl-polygon-mode [gl face mode] `(.glPolygonMode ~gl ~face ~mode))
 
-(defmacro gl-active-texture [gl texunit]                                 `(.glActiveTexture ~gl ~texunit))
 (defmacro gl-get-attrib-location [gl shader name]                        `(.glGetAttribLocation ~gl ~shader ~name))
 (defmacro gl-bind-buffer [gl type name]                                  `(.glBindBuffer ~gl ~type ~name))
 (defmacro gl-buffer-data [gl type size data usage]                       `(.glBufferData ~gl ~type ~size ~data ~usage))

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -38,13 +38,13 @@
    :wrap-t       GL2/GL_TEXTURE_WRAP_T
    :wrap-r       GL2/GL_TEXTURE_WRAP_R})
 
-(defn- apply-params
-  [gl ^Texture texture params]
+(defn- apply-params!
+  [^GL gl ^long texture-target params]
   (doseq [[p v] params]
     (if-let [pname (texture-params p)]
-      (.setTexParameteri texture gl pname v)
+      (.glTexParameteri gl texture-target pname v)
       (if (integer? p)
-        (.setTexParameteri texture gl p v)
+        (.glTexParameteri gl texture-target p v)
         (println "WARNING: ignoring unknown texture parameter " p)))))
 
 (defprotocol TextureProxy
@@ -57,16 +57,20 @@
 
   GlBind
   (bind [this gl _render-args]
-    (let [tex (->texture this gl)]
-      (.glActiveTexture ^GL2 gl unit)
-      (.enable tex gl)
-      (.bind tex gl)
-      (apply-params gl tex params)))
+    (let [tex (->texture this gl)
+          tgt (.getTarget tex)]
+      (.enable tex gl)                ; Enable the type of texturing e.g. GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
+      (.glActiveTexture ^GL2 gl unit) ; Set the active texture unit. Implicit parameter to (.bind ...)
+      (.bind tex gl)                  ; Bind our texture to the active texture unit. Used for subsequent render calls. Also implicit parameter to (apply-params! ...)
+      (apply-params! gl tgt params))) ; Apply filtering settings to the bound texture
 
   (unbind [this gl _render-args]
-    (let [tex (->texture this gl)]
-      (.disable tex gl))
-    (gl/gl-active-texture ^GL gl GL/GL_TEXTURE0)))
+    (let [tex (->texture this gl)
+          tgt (.getTarget tex)]
+      (.glActiveTexture ^GL2 gl unit)           ; Set the active texture unit. Implicit parameter to (.glBindTexture ...)
+      (.glBindTexture ^GL2 gl tgt 0)            ; Re-bind default "no-texture" to the active texture unit
+      (.glActiveTexture ^GL2 gl GL/GL_TEXTURE0) ; Set TEXTURE0 as the active texture unit in case anything outside of the bind / unbind cycle forgets to call (.glActiveTexture ...)
+      (.disable tex gl))))                      ; Disable the type of texturing e.g. GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
 
 (defn set-params [^TextureLifecycle tlc params]
   (update tlc :params merge params))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -687,7 +687,9 @@
   (output scene-renderable-user-data g/Any (g/constantly nil))
   (output scene-renderable g/Any :cached
           (g/fnk [_node-id layer-index blend-mode inherit-alpha gpu-texture material-shader scene-renderable-user-data aabb]
-            (let [gpu-texture (or gpu-texture (:gpu-texture scene-renderable-user-data))]
+            (let [clipping-state (:clipping-state scene-renderable-user-data)
+                  gpu-texture (or gpu-texture (:gpu-texture scene-renderable-user-data))
+                  material-shader (get scene-renderable-user-data :override-material-shader material-shader)]
               {:render-fn render-nodes
                :aabb aabb
                :passes [pass/transparent pass/selection pass/outline]
@@ -696,7 +698,7 @@
                                  :inherit-alpha inherit-alpha
                                  :material-shader material-shader
                                  :blend-mode blend-mode)
-               :batch-key {:texture gpu-texture :blend-mode blend-mode}
+               :batch-key [clipping-state blend-mode gpu-texture material-shader]
                :select-batch-key _node-id
                :layer-index layer-index
                :topmost? true
@@ -925,17 +927,20 @@
                                         (font-datas ""))))
 
   ;; Overloaded outputs
-  (output material-shader ShaderLifecycle (g/fnk [font-shaders font]
-                                            (or (font-shaders font)
-                                                (font-shaders ""))))
   (output gpu-texture TextureLifecycle (g/fnk [font-data] (:texture font-data)))
   (output scene-renderable-user-data g/Any :cached
-          (g/fnk [aabb-size pivot text-data]
+          (g/fnk [aabb-size font font-shaders pivot text-data]
                  (let [[w h] aabb-size
                        offset (pivot-offset pivot aabb-size)
-                       lines (mapv conj (apply concat (take 4 (partition 2 1 (cycle (geom/transl offset [[0 0] [w 0] [w h] [0 h]]))))) (repeat 0))]
+                       lines (mapv conj (apply concat (take 4 (partition 2 1 (cycle (geom/transl offset [[0 0] [w 0] [w h] [0 h]]))))) (repeat 0))
+                       font-shader (or (font-shaders font) (font-shaders ""))]
+                   ;; The material-shader output is used to propagate the shader
+                   ;; from the GuiSceneNode to our child nodes. Thus we cannot
+                   ;; simply overload the material-shader output on this node.
+                   ;; Instead, the base VisualNode will pick it up from here.
                    {:line-data lines
-                    :text-data text-data})))
+                    :text-data text-data
+                    :override-material-shader font-shader})))
   (output text-layout g/Any :cached (g/fnk [size font-data text line-break text-leading text-tracking]
                                            (font/layout-text (:font-map font-data) text line-break (first size) text-tracking text-leading)))
   (output aabb-size g/Any :cached (g/fnk [text-layout]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -694,11 +694,14 @@
                :aabb aabb
                :passes [pass/transparent pass/selection pass/outline]
                :user-data (assoc scene-renderable-user-data
+                                 :blend-mode blend-mode
                                  :gpu-texture gpu-texture
                                  :inherit-alpha inherit-alpha
-                                 :material-shader material-shader
-                                 :blend-mode blend-mode)
-               :batch-key [clipping-state blend-mode gpu-texture material-shader]
+                                 :material-shader material-shader)
+               :batch-key {:clipping-state clipping-state
+                           :blend-mode blend-mode
+                           :gpu-texture gpu-texture
+                           :material-shader material-shader}
                :select-batch-key _node-id
                :layer-index layer-index
                :topmost? true
@@ -1808,7 +1811,7 @@
                :aabb aabb
                :renderable {:render-fn render-lines
                             :passes [pass/transparent]
-                            :batch-key []
+                            :batch-key nil
                             :user-data {:line-data [[0 0 0] [w 0 0] [w 0 0] [w h 0] [w h 0] [0 h 0] [0 h 0] [0 0 0]]
                                         :line-color colors/defold-white}}
                :children (mapv (partial apply-alpha 1.0) child-scenes)}]


### PR DESCRIPTION
Fixes defold/editor2-issues#1669

### Technical changes
* Bind the default "no texture" to the used texture unit in `TextureLifeCycle/unbind`.
* Avoid excessive calls to `glBindTexture` in `texture/apply-params!`.
* Added missing `clipping-state` and `material-shader` to `gui/VisualNode` `:batch-key`.
* Removed overloaded `material-shader`output from `gui/TextNode`, since it was causing all children to use the font shader and fail to render. Supply the font shader as an `:override-material-shader` in the `scene-renderable-user-data` output instead, and pick it up when generating the `scene-renderable` in `gui/VisualNode`.
* Removed unused `gl/gl-active-texture` macro.