### PR TITLE
DEFEDIT-1316 Removed intermittently failing load time test from gui-template-outline-perf test

### DIFF
--- a/editor/test/integration/perf_test.clj
+++ b/editor/test/integration/perf_test.clj
@@ -3,8 +3,7 @@
             [dynamo.graph :as g]
             [integration.test-util :as test-util]
             [internal.node :as in]
-            [support.test-support :refer [with-clean-system]]
-            [criterium.core :as criterium]))
+            [support.test-support :refer [with-clean-system]]))
 
 (defn- gui-node [scene id]
   (let [id->node (->> (get-in (g/node-value scene :node-outline) [:children 0])
@@ -29,27 +28,12 @@
      (let [end# (clock)]
        (/ (- end# start#) ~(second binding)))))
 
-(defn- test-load []
-  ;; Don't use with-loaded-project here as we are in fact testing load speed
-  (with-clean-system
-    (let [workspace (test-util/setup-workspace! world)
-          project (test-util/setup-project! workspace)])))
-
 (deftest gui-template-outline-perf
   (binding [in/*check-schemas* false]
-    (testing "loading"
-      ;; WARM-UP
-      (dotimes [i 5]
-        (test-load))
-      (System/gc)
-      (dotimes [i 1]
-        (let [elapsed (measure [i 1] (test-load))]
-          (is (< elapsed 1300)))))
     (testing "drag-pull-outline"
       (test-util/with-loaded-project
         (let [node-id (test-util/resource-node project "/gui/scene.gui")
               box (gui-node node-id "sub_scene/sub_box")]
-          ;; (bench/bench (drag-pull-outline! node-id box))
           ;; WARM-UP
           (dotimes [i 50]
             (drag-pull-outline! node-id box i))


### PR DESCRIPTION
Part of the `gui-template-outline-perf` test measures the time it takes to load the test project. It fails intermittently because the time it takes can vary a bit depending on JIT warmup or system load. It is also a poor historic indicator of project load times, since we keep adding content to the test project.

This change removes the load time test as a passing requirement. I've added a separate task for setting up and graphing load times using a stable project in **DEFEDIT-1315**.