### PR TITLE
DEFEDIT-1308 Debugging blossom hangs

### DIFF
--- a/editor/bundle-resources/_defold/debugger/debugger.lua
+++ b/editor/bundle-resources/_defold/debugger/debugger.lua
@@ -7,9 +7,18 @@ local function identity(v)
   return v
 end
 
+local function onexit(code, close)
+  msg.post("@system:", "exit", {code = code})
+end
+
 function M.start(port)
   mobdebug.line = identity
   mobdebug.dump = edn.encode
+  -- mobdebug.onexit does os.exit which does not
+  -- let the engine shut down properly. One step
+  -- skipped is SSDP Deannounce, which makes the
+  -- target linger longer than necessary.
+  mobdebug.onexit = onexit
   if jit then
     jit.flush()
   end

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -50,6 +50,9 @@
   ([] (clone-system @*the-system*))
   ([sys] (is/clone-system sys)))
 
+(defn system= [s1 s2]
+  (is/system= s1 s2))
+
 (defmacro with-system [sys & body]
   `(binding [*the-system* (atom ~sys)]
      ~@body))
@@ -759,6 +762,12 @@
   [evaluation-context]
   (is/update-cache-from-evaluation-context! @*the-system* evaluation-context)
   nil)
+
+(defmacro with-auto-evaluation-context [ec & body]
+  `(let [~ec (make-evaluation-context)
+         result# (do ~@body)]
+     (update-cache-from-evaluation-context! ~ec)
+     result#))
 
 (defn node-value
   "Pull a value from a node's output, identified by `label`.

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -281,16 +281,13 @@
   (let [tab-pane ^TabPane (g/node-value app-view :tab-pane)]
     (.getTabs tab-pane)))
 
-(defn- make-build-options
+(defn- make-render-build-error
   [build-errors-view]
-  {:clear-errors! (fn []
-                     (ui/run-later
-                       (build-errors-view/clear-build-errors build-errors-view)))
-   :render-error! (fn [errors]
-                    (ui/run-later
-                      (build-errors-view/update-build-errors
-                        build-errors-view
-                        errors)))})
+  (fn [errors] (build-errors-view/update-build-errors build-errors-view errors)))
+
+(defn- make-clear-build-errors
+  [build-errors-view]
+  (fn [] (build-errors-view/clear-build-errors build-errors-view)))
 
 (def ^:private remote-log-pump-thread (atom nil))
 (def ^:private console-stream (atom nil))
@@ -334,14 +331,14 @@
 
 (def ^:private render-task-progress-ui-inflight (ref false))
 
-(def ^:private progress-controls [(Label.)
-                                  (doto (ProgressBar.)
-                                    (ui/add-style! "really-small-progress-bar"))])
+(defonce ^:private progress-controls [(Label.)
+                                      (doto (ProgressBar.)
+                                        (ui/add-style! "really-small-progress-bar"))])
 
-(def progress-hbox (doto (HBox.)
-                     (ui/visible! false)
-                     (ui/children! progress-controls)
-                     (ui/add-style! "progress-hbox")))
+(defonce progress-hbox (doto (HBox.)
+                         (ui/visible! false)
+                         (ui/children! progress-controls)
+                         (ui/add-style! "progress-hbox")))
 
 (defn- task-progress-controls [key]
   (case key
@@ -388,20 +385,20 @@
 (defn render-main-task-progress! [progress]
   (render-task-progress! :main progress))
 
-(defn- report-build-launch-progress [message]
+(defn- report-build-launch-progress! [message]
   (render-main-task-progress! (progress/make message)))
 
-(defn- launch-engine [project prefs debug?]
+(defn- launch-engine! [project prefs debug?]
   (try
-    (report-build-launch-progress "Launching engine...")
+    (report-build-launch-progress! "Launching engine...")
     (let [launched-target (->> (engine/launch! project prefs debug?)
                                (targets/add-launched-target!)
                                (targets/select-target! prefs))]
-      (report-build-launch-progress "Launched engine.")
+      (report-build-launch-progress! (format "Launched %s" (targets/target-message-label launched-target)))
       launched-target)
     (catch Exception e
       (targets/kill-launched-targets!)
-      (report-build-launch-progress "Launch failed.")
+      (report-build-launch-progress! "Launch failed")
       (throw e))))
 
 (defn- reset-console-stream! [stream]
@@ -423,26 +420,25 @@
       (when (= @console-stream (:log-stream launched-target))
         (console/append-console-line! line)))))
 
-(defn- reboot-engine [target web-server debug?]
+(defn- reboot-engine! [target web-server debug?]
   (try
-    (report-build-launch-progress (format "Rebooting %s..." (targets/target-label target)))
-    (engine/reboot target (local-url target web-server) debug?)
-    (report-build-launch-progress (format "Rebooted %s" (targets/target-label target)))
+    (report-build-launch-progress! (format "Rebooting %s..." (targets/target-message-label target)))
+    (engine/reboot! target (local-url target web-server) debug?)
+    (report-build-launch-progress! (format "Rebooted %s" (targets/target-message-label target)))
     target
     (catch Exception e
-      (report-build-launch-progress "Reboot failed")
+      (report-build-launch-progress! "Reboot failed")
       (throw e))))
 
 (def ^:private build-in-progress? (atom false))
 
-(defn- launch-built-project [project prefs web-server console-view debug? render-error!]
-  (console/show! console-view)
-  (try
-    (let [selected-target (targets/selected-target prefs)]
+(defn- launch-built-project! [project prefs web-server debug? render-error!]
+  (let [selected-target (targets/selected-target prefs)]
+    (try
       (cond
         (not selected-target)
         (do (targets/kill-launched-targets!)
-            (let [launched-target (launch-engine project prefs debug?)
+            (let [launched-target (launch-engine! project prefs debug?)
                   log-stream      (:log-stream launched-target)]
               (reset-console-stream! log-stream)
               (reset-remote-log-pump-thread! nil)
@@ -453,7 +449,7 @@
         (do
           (assert (targets/launched-target? selected-target))
           (targets/kill-launched-targets!)
-          (let [launched-target (launch-engine project prefs debug?)
+          (let [launched-target (launch-engine! project prefs debug?)
                 log-stream      (:log-stream launched-target)]
             (reset-console-stream! log-stream)
             (reset-remote-log-pump-thread! nil)
@@ -465,7 +461,7 @@
           (let [log-stream (engine/get-log-service-stream selected-target)]
             (reset-console-stream! log-stream)
             (reset-remote-log-pump-thread! (start-log-pump! log-stream (make-remote-log-sink log-stream)))
-            (reboot-engine selected-target web-server debug?)))
+            (reboot-engine! selected-target web-server debug?)))
 
         :else
         (do
@@ -476,53 +472,60 @@
           ;; running to keep engine process
           ;; from halting because stdout/err is
           ;; not consumed.
-          (reboot-engine selected-target web-server debug?))))
-    (catch Exception e
-      (log/warn :exception e)
-      (when-not (engine-build-errors/handle-build-error! render-error! project e)
-        (ui/run-later (dialogs/make-alert-dialog (str "Build failed: " (.getMessage e))))))))
+          (reboot-engine! selected-target web-server debug?)))
+      (catch Exception e
+        (log/warn :exception e)
+        (when-not (engine-build-errors/handle-build-error! render-error! project e)
+          (dialogs/make-alert-dialog (format "Launching %s failed: \n%s"
+                                             (if (some? selected-target)
+                                               (targets/target-message-label selected-target)
+                                               "New Local Engine")
+                                             (.getMessage e))))))))
 
-(defn- build-handler
-  ([project prefs web-server build-errors-view console-view]
-   (build-handler project prefs web-server build-errors-view console-view nil))
-  ([project prefs web-server build-errors-view console-view {:keys [debug?]
-                                                             :or   {debug? false}
-                                                             :as   opts}]
-   (let [render-build-progress! (make-render-task-progress :build)
-         build-options (assoc (make-build-options build-errors-view) :render-progress! render-build-progress!)
-         local-system (g/clone-system)]
-     (reset! build-in-progress? true)
-     (future
-       (try
-         (g/with-system local-system
-           (let [evaluation-context  (g/make-evaluation-context)
-                 extra-build-targets (when debug?
-                                       (debug-view/build-targets project evaluation-context))
-                 build               (ui/with-progress [_ render-build-progress!]
-                                       (project/build-and-write-project project evaluation-context extra-build-targets build-options))
-                 render-error!       (:render-error! build-options)
-                 ;; pipeline/build! uses g/user-data for storing info on
-                 ;; built resources.
-                 ;; This will end up in the local *the-system*, so we will manually
-                 ;; transfer this afterwards.
-                 workspace           (project/workspace project)
-                 artifacts           (g/user-data workspace :editor.pipeline/artifacts)
-                 etags               (g/user-data workspace :editor.pipeline/etags)]
-             (ui/run-later
-               (g/update-cache-from-evaluation-context! evaluation-context)
-               (g/user-data! workspace :editor.pipeline/artifacts artifacts)
-               (g/user-data! workspace :editor.pipeline/etags etags)
-               (when build (launch-built-project project prefs web-server console-view debug? (:render-error! build-options))))))
-         (catch Throwable t
-           (error-reporting/report-exception! t))
-         (finally
-           (reset! build-in-progress? false)))))))
+(defn- async-build! [project {:keys [debug?] :or {debug? false} :as opts} old-artifact-map result-fn]
+  (let [render-build-progress! (make-render-task-progress :build)
+        local-system           (g/clone-system)]
+    (assert (not @build-in-progress?))
+    (reset! build-in-progress? true)
+    (future
+      (try
+        (g/with-system local-system
+          (let [evaluation-context  (g/make-evaluation-context)
+                extra-build-targets (when debug?
+                                      (debug-view/build-targets project evaluation-context))
+                build-results       (ui/with-progress [_ render-build-progress!]
+                                      (project/build-and-write-project project evaluation-context extra-build-targets old-artifact-map render-build-progress!))]
+            (ui/run-later
+              (g/update-cache-from-evaluation-context! evaluation-context)
+              (when result-fn (result-fn build-results)))
+            build-results))
+      (catch Throwable t
+        (error-reporting/report-exception! t))
+      (finally
+        (reset! build-in-progress? false))))))
+
+(defn- handle-build-results! [workspace build-errors-view build-results]
+  (let [{:keys [error artifacts artifact-map etags]} build-results]
+    (if (some? error)
+      (do
+        (build-errors-view/update-build-errors build-errors-view error)
+        nil)
+      (do
+        (workspace/artifact-map! workspace artifact-map)
+        (workspace/etags! workspace etags)
+        (build-errors-view/clear-build-errors build-errors-view)
+        build-results))))
+
 
 (handler/defhandler :build :global
   (enabled? [] (not @build-in-progress?))
-  (run [project prefs web-server build-errors-view console-view debug-view]
+  (run [project workspace prefs web-server build-errors-view console-view debug-view]
     (debug-view/detach! debug-view)
-    (build-handler project prefs web-server build-errors-view console-view)))
+    (async-build! project {:debug? false} (workspace/artifact-map workspace)
+                  (fn [build-results]
+                    (when (handle-build-results! workspace build-errors-view build-results)
+                      (console/show! console-view)
+                      (launch-built-project! project prefs web-server false (make-render-build-error build-errors-view)))))))
 
 (defn- debugging-supported?
   [project]
@@ -534,43 +537,67 @@ If you do not specifically require different script states, consider changing th
         false)))
 
 (handler/defhandler :start-debugger :global
-  (enabled? [debug-view] (nil? (debug-view/current-session debug-view)))
-  (run [project prefs web-server build-errors-view console-view debug-view]
+  (enabled? [debug-view]
+            (and (not @build-in-progress?)
+                 (nil? (debug-view/current-session debug-view))))
+  (run [project workspace prefs web-server build-errors-view console-view debug-view]
     (when (debugging-supported? project)
-      (when-some [target (build-handler project prefs web-server build-errors-view console-view {:debug? true})]
-        (debug-view/start-debugger! debug-view project (:address target "localhost"))))))
+      (async-build! project {:debug? true} (workspace/artifact-map workspace)
+                    (fn [build-results]
+                      (when (handle-build-results! workspace build-errors-view build-results)
+                        (when-let [target (launch-built-project! project prefs web-server true (make-render-build-error build-errors-view))]
+                          (when (nil? (debug-view/current-session debug-view))
+                            (debug-view/start-debugger! debug-view project (:address target "localhost"))))))))))
 
 (handler/defhandler :attach-debugger :global
   (enabled? [debug-view prefs]
             (and (nil? (debug-view/current-session debug-view))
                  (let [target (targets/selected-target prefs)]
                    (and target (targets/controllable-target? target)))))
-  (run [project build-errors-view debug-view prefs]
+  (run [project workspace build-errors-view debug-view prefs]
+    (debug-view/detach! debug-view)
     (when (debugging-supported? project)
-      (let [target (targets/selected-target prefs)
-            build-options (make-build-options build-errors-view)]
-        (debug-view/attach! debug-view project target build-options)))))
+      (async-build! project {:debug? true} (workspace/artifact-map workspace)
+                    (fn [build-results]
+                      (when (handle-build-results! workspace build-errors-view build-results)
+                        (let [target (targets/selected-target prefs)]
+                          (when (targets/controllable-target? target)
+                            (debug-view/attach! debug-view project target (:artifacts build-results))))))))))
 
 (handler/defhandler :rebuild :global
+  (enabled? [] (not @build-in-progress?))
   (run [workspace project prefs web-server build-errors-view console-view debug-view]
     (debug-view/detach! debug-view)
-    (pipeline/reset-cache! workspace)
-    (build-handler project prefs web-server build-errors-view console-view)))
+    (workspace/reset-cache! workspace)
+    (async-build! project {:debug? false} (workspace/artifact-map workspace)
+                  (fn [build-results]
+                    (when (handle-build-results! workspace build-errors-view build-results)
+                      (console/show! console-view)
+                      (launch-built-project! project prefs web-server false (make-render-build-error build-errors-view)))))))
+
+(defn- handle-bob-error! [render-error! project error]
+  (if (instance? Exception error)
+    (when-not (engine-build-errors/handle-build-error! render-error! project error)
+      (throw error))
+    (render-error! error)))
 
 (handler/defhandler :build-html5 :global
   (run [project prefs web-server build-errors-view changes-view]
-    (console/clear-console!)
-    ;; We need to save because bob reads from FS
-    (project/save-all! project)
-    (changes-view/refresh! changes-view)
-    (render-main-task-progress! (progress/make "Building..."))
-    (ui/->future 0.01
-                 (fn []
-                   (let [build-options (make-build-options build-errors-view)
-                         succeeded? (deref (bob/build-html5! project prefs build-options))]
-                     (render-main-task-progress! progress/done)
-                     (when succeeded?
-                       (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix))))))))
+    (let [clear-errors! (make-clear-build-errors build-errors-view)
+          render-error! (make-render-build-error build-errors-view)]
+      (console/clear-console!)
+      ;; We need to save because bob reads from FS
+      (project/save-all! project)
+      (changes-view/refresh! changes-view)
+      (clear-errors!)
+      (render-main-task-progress! (progress/make "Building..."))
+      (ui/->future 0.01
+                   (fn []
+                     (let [result (deref (bob/build-html5! project prefs))]
+                       (render-main-task-progress! progress/done)
+                       (if-let [error (:error result)]
+                         (handle-bob-error! render-error! project error)
+                         (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix)))))))))
 
 (def ^:private unreloadable-resource-build-exts #{"collectionc" "goc"})
 
@@ -586,15 +613,25 @@ If you do not specifically require different script states, consider changing th
     (when-let [resource (context-resource-file app-view selection)]
       (ui/->future 0.01
                    (fn []
-                     (let [build-options (make-build-options build-errors-view)
-                           evaluation-context (g/make-evaluation-context)
-                           build (project/build-and-write-project project evaluation-context build-options)]
+                     (let [evaluation-context (g/make-evaluation-context)
+                           workspace (project/workspace project)
+                           old-artifact-map (workspace/artifact-map workspace)
+                           {:keys [error artifacts artifact-map etags]} (project/build-and-write-project project
+                                                                                                         evaluation-context
+                                                                                                         nil
+                                                                                                         old-artifact-map
+                                                                                                         (make-render-task-progress :build))]
                        (g/update-cache-from-evaluation-context! evaluation-context)
-                       (when build
-                         (try
-                           (engine/reload-resource (targets/selected-target prefs) resource)
-                           (catch Exception e
-                             (dialogs/make-alert-dialog (format "Failed to reload resource on '%s'" (targets/target-label (targets/selected-target prefs)))))))))))))
+                       (if (some? error)
+                         (build-errors-view/update-build-errors build-errors-view error)
+                         (do
+                           (workspace/artifact-map! workspace artifact-map)
+                           (workspace/etags! workspace etags)
+                           (try
+                             (build-errors-view/clear-build-errors build-errors-view)
+                             (engine/reload-resource (targets/selected-target prefs) resource)
+                             (catch Exception e
+                               (dialogs/make-alert-dialog (format "Failed to reload resource on '%s'" (targets/target-message-label (targets/selected-target prefs))))))))))))))
 
 (handler/defhandler :close :global
   (enabled? [app-view] (not-empty (get-tabs app-view)))
@@ -1160,24 +1197,28 @@ If you do not specifically require different script states, consider changing th
       (search-results-view/set-search-term! term))
     (search-results-view/show-search-in-files-dialog! search-results-view project)))
 
-(defn- bundle! [changes-view build-errors-view project prefs platform build-options]
+(defn- bundle! [changes-view build-errors-view project prefs platform bundle-options]
   (console/clear-console!)
-  (let [output-directory ^File (:output-directory build-options)
-        build-options (merge build-options (make-build-options build-errors-view))]
+  (let [output-directory ^File (:output-directory bundle-options)
+        clear-errors! (make-clear-build-errors build-errors-view)
+        render-error! (make-render-build-error build-errors-view)]
     ;; We need to save because bob reads from FS.
     ;; Before saving, perform a resource sync to ensure we do not overwrite external changes.
     (workspace/resource-sync! (project/workspace project))
     (project/save-all! project)
     (changes-view/refresh! changes-view)
+    (clear-errors!)
     (render-main-task-progress! (progress/make "Bundling..."))
     (ui/->future 0.01
                  (fn []
-                   (let [succeeded? (deref (bob/bundle! project prefs platform build-options))]
+                   (let [result (deref (bob/bundle! project prefs platform bundle-options))]
                      (render-main-task-progress! progress/done)
-                     (if (and succeeded? (some-> output-directory .isDirectory))
-                       (ui/open-file output-directory)
-                       (ui/run-later
-                         (dialogs/make-alert-dialog "Failed to bundle project. Please fix build errors and try again."))))))))
+                     (if-let [error (:error result)]
+                       (handle-bob-error! render-error! project error)
+                       (if (some-> output-directory .isDirectory)
+                         (ui/open-file output-directory)
+                         (ui/run-later
+                           (dialogs/make-alert-dialog "Failed to bundle project. Please fix build errors and try again.")))))))))
 
 (handler/defhandler :bundle :global
   (run [user-data workspace project prefs app-view changes-view build-errors-view]
@@ -1223,5 +1264,11 @@ If you do not specifically require different script states, consider changing th
 (handler/defhandler :sign-ios-app :global
   (active? [] (util/is-mac-os?))
   (run [workspace project prefs build-errors-view]
-    (let [build-options (make-build-options build-errors-view)]
-      (bundle/make-sign-dialog workspace prefs project build-options))))
+    (build-errors-view/clear-build-errors build-errors-view)
+    (let [result (bundle/make-sign-dialog workspace prefs project)]
+      (when-let [error (:error result)]
+        (if (engine-build-errors/handle-build-error! (make-render-build-error build-errors-view) project error)
+          (dialogs/make-alert-dialog "Failed to build ipa with Native Extensions. Please fix build errors and try again.")
+          (do (error-reporting/report-exception! error)
+              (when-let [message (:message result)]
+                (dialogs/make-alert-dialog message))))))))

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -540,20 +540,20 @@
 (handler/defhandler ::query-output-directory :bundle-dialog
   (run [bundle! prefs presenter stage]
     (save-prefs! presenter prefs)
-    (let [build-options (get-options presenter)
+    (let [bundle-options (get-options presenter)
           initial-directory (get-file-pref prefs "bundle-output-directory")]
-      (assert (string? (not-empty (:platform build-options))))
+      (assert (string? (not-empty (:platform bundle-options))))
       (when-let [output-directory (query-directory! "Output Directory" initial-directory stage)]
         (set-file-pref! prefs "bundle-output-directory" output-directory)
-        (let [platform-bundle-output-directory (io/file output-directory (:platform build-options))
+        (let [platform-bundle-output-directory (io/file output-directory (:platform bundle-options))
               platform-bundle-output-directory-exists? (.exists platform-bundle-output-directory)]
           (when (or (not platform-bundle-output-directory-exists?)
                     (query-overwrite! platform-bundle-output-directory stage))
             (when (not platform-bundle-output-directory-exists?)
               (fs/create-directories! platform-bundle-output-directory))
-            (let [build-options (assoc build-options :output-directory platform-bundle-output-directory)]
+            (let [bundle-options (assoc bundle-options :output-directory platform-bundle-output-directory)]
               (ui/close! stage)
-              (bundle! build-options))))))))
+              (bundle! bundle-options))))))))
 
 (defn show-bundle-dialog! [workspace platform prefs owner-window bundle!]
   (let [stage (doto (ui/make-dialog-stage owner-window)

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -208,13 +208,18 @@
                                                                                [:resource :node-resources]]})
             []))))))
 
-(defn get-resource-node [project path-or-resource]
-  (when-let [resource (cond
-                        (string? path-or-resource) (workspace/find-resource (g/node-value project :workspace) path-or-resource)
-                        (satisfies? resource/Resource path-or-resource) path-or-resource
-                        :else (assert false (str (type path-or-resource) " is neither a path nor a resource: " (pr-str path-or-resource))))]
-    (let [nodes-by-resource-path (g/node-value project :nodes-by-resource-path)]
-      (get nodes-by-resource-path (resource/proj-path resource)))))
+(defn get-resource-node
+  ([project path-or-resource]
+   (g/with-auto-evaluation-context ec
+     (get-resource-node project path-or-resource ec)))
+  ([project path-or-resource evaluation-context]
+   (when-let [resource (cond
+                         ;; TODO: pass evaluation-context to workspace/find-resource functions
+                         (string? path-or-resource) (workspace/find-resource (g/node-value project :workspace evaluation-context) path-or-resource)
+                         (satisfies? resource/Resource path-or-resource) path-or-resource
+                         :else (assert false (str (type path-or-resource) " is neither a path nor a resource: " (pr-str path-or-resource))))]
+     (let [nodes-by-resource-path (g/node-value project :nodes-by-resource-path evaluation-context)]
+       (get nodes-by-resource-path (resource/proj-path resource))))))
 
 (defn load-project
   ([project]
@@ -302,29 +307,20 @@
         (render-progress! @progress)))))
 
 (defn build
-  ([project node evaluation-context opts]
-   (build project node evaluation-context nil opts))
-  ([project node evaluation-context extra-build-targets {:keys [render-progress! render-error!]
-                                                         :or   {render-progress! progress/null-render-progress!}
-                                                         :as   opts}]
-   (let [steps (atom [])
-         node-id->resource-path (clojure.set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context))
-         _ (g/node-value node :build-targets (assoc evaluation-context
-                                                    :dry-run true
-                                                    :tracer (make-collect-progress-steps-tracer steps)))
-         node-build-targets (g/node-value node :build-targets
-                                          (assoc evaluation-context
-                                                 :tracer (make-progress-tracer steps node-id->resource-path
-                                                                               (progress/nest-render-progress render-progress! (progress/make "" 10) 7))))
-         build-targets (cond-> node-build-targets
-                         (seq extra-build-targets)
-                         (into extra-build-targets))]
-     (if (g/error? build-targets)
-       (do
-         (when render-error!
-           (render-error! build-targets))
-         nil)
-       (pipeline/build! (workspace project) build-targets (progress/nest-render-progress render-progress! (progress/make "" 10 7) 3))))))
+  [project node evaluation-context extra-build-targets old-artifact-map render-progress!]
+  (let [steps                  (atom [])
+        collect-tracer         (make-collect-progress-steps-tracer steps)
+        _                      (g/node-value node :build-targets (assoc evaluation-context :dry-run true :tracer collect-tracer))
+        node-id->resource-path (clojure.set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context))
+        progress-tracer        (make-progress-tracer steps node-id->resource-path (progress/nest-render-progress render-progress! (progress/make "" 10) 7))
+        node-build-targets     (g/node-value node :build-targets (assoc evaluation-context :tracer progress-tracer))
+        build-targets          (cond-> node-build-targets
+                                 (seq extra-build-targets)
+                                 (into extra-build-targets))
+        build-dir              (workspace/build-path (workspace project))]
+    (if (g/error? build-targets)
+      {:error build-targets}
+      (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 7) 3)))))
 
 (handler/defhandler :undo :global
   (enabled? [project-graph] (g/has-undo? project-graph))
@@ -587,19 +583,15 @@
     (map (fn [r] [r (get resource-path-to-node (resource/proj-path r))]) resources)))
 
 (defn build-and-write-project
-  ([project evaluation-context build-options]
-   (build-and-write-project project evaluation-context nil build-options))
-  ([project evaluation-context extra-build-targets build-options]
-   (let [game-project  (get-resource-node project "/game.project")
-         clear-errors! (:clear-errors! build-options)
-         build-options (update build-options :render-progress! (fnil progress/throttle-render-progress progress/null-render-progress!))]
-     (try
-       (ui/with-progress [render-fn (:render-progress! build-options)]
-         (clear-errors!)
-         (seq (build project game-project evaluation-context extra-build-targets build-options)))
-       (catch Throwable error
-         (error-reporting/report-exception! error)
-         nil)))))
+  [project evaluation-context extra-build-targets old-artifact-map render-progress!]
+  (let [game-project  (get-resource-node project "/game.project" evaluation-context)
+        render-progress! (progress/throttle-render-progress render-progress!)]
+    (try
+      (ui/with-progress [render-progress! (progress/throttle-render-progress render-progress!)]
+        (build project game-project evaluation-context extra-build-targets old-artifact-map render-progress!))
+      (catch Throwable error
+        (error-reporting/report-exception! error)
+        nil))))
 
 (defn settings [project]
   (g/node-value project :settings))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -52,7 +52,7 @@
       (finally
         (.disconnect conn)))))
 
-(defn reboot [target local-url debug?]
+(defn reboot! [target local-url debug?]
   (let [uri  (URI. (format "%s/post/@system/reboot" (:url target)))
         conn ^HttpURLConnection (get-connection uri)
         args (cond-> [(str "--config=resource.uri=" local-url)]
@@ -72,7 +72,7 @@
       (finally
         (.disconnect conn)))))
 
-(defn run-script [target lua-module]
+(defn run-script! [target lua-module]
   (let [uri  (URI. (format "%s/post/@system/run_script" (:url target)))
         conn ^HttpURLConnection (get-connection uri)]
     (try

--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -22,12 +22,12 @@
   (-> content io/input-stream IOUtils/toByteArray))
 
 (defn- handler [workspace project {:keys [url method headers]}]
-  (let [build-path (FilenameUtils/normalize (workspace/build-path workspace))
+  (let [build-path (FilenameUtils/normalize (str (workspace/build-path workspace)))
         path (subs url (count url-prefix))
         full-path (format "%s%s" build-path path)]
    ;; Avoid going outside the build path with '..'
    (if (string/starts-with? full-path build-path)
-     (let [etag (pipeline/etag workspace path)
+     (let [etag (workspace/etag workspace path)
            remote-etag (first (get headers "If-none-match"))
            cached? (when remote-etag (= etag remote-etag))
            content (when (not cached?)
@@ -60,7 +60,7 @@
                                            (.normalize)
                                            (.getPath))
                                     local-path (subs path (count url-prefix))]
-                                (when (= etag (pipeline/etag workspace local-path))
+                                (when (= etag (workspace/etag workspace local-path))
                                   path))))))
           out-body (string/join "\n" entries)]
       {:code 200

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -149,10 +149,10 @@
     (prune-build-dir! build-dir build-targets-by-key)
     (let [results (into []
                         (map (fn [[key {:keys [resource] :as build-target}]]
-                               (swap! progress #(-> %
-                                                    (progress/advance)
-                                                    (progress/with-message (str "Writing " (resource/proj-path resource)))))
-                               (render-progress! @progress)
+                               (render-progress! (swap! progress
+                                                        #(-> %
+                                                             (progress/advance)
+                                                             (progress/with-message (str "Writing " (resource/proj-path resource))))))
                                (or (when-let [artifact (get artifacts resource)]
                                      (and (valid? artifact) artifact))
                                    (let [{:keys [resource deps build-fn user-data]} build-target

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -1,7 +1,6 @@
 (ns editor.pipeline
   (:require
    [clojure.java.io :as io]
-   [dynamo.graph :as g]
    [editor.fs :as fs]
    [editor.resource :as resource]
    [editor.progress :as progress]
@@ -113,9 +112,6 @@
         (filter (fn [[resource result]] (contains? build-targets-by-key (:key result))))
         artifacts))
 
-(defn- workspace->artifacts [workspace]
-  (or (g/user-data workspace ::artifacts) {}))
-
 (defn- valid? [artifact]
   (when-let [^File f (io/as-file (:resource artifact))]
     (let [{:keys [mtime size]} artifact]
@@ -138,49 +134,35 @@
           :size size
           :etag (digest/sha1->hex content))))))
 
-(defn- prune-build-dir! [workspace build-targets-by-key]
-  (let [targets (into #{} (map (fn [[_ target]] (io/as-file (:resource target)))) build-targets-by-key)
-        dir (io/as-file (workspace/build-path workspace))]
-    (fs/create-directories! dir)
-    (doseq [^File f (file-seq dir)]
+(defn- prune-build-dir! [build-dir build-targets-by-key]
+  (let [targets (into #{} (map (fn [[_ target]] (io/as-file (:resource target)))) build-targets-by-key)]
+    (fs/create-directories! build-dir)
+    (doseq [^File f (file-seq build-dir)]
       (when (and (not (.isDirectory f)) (not (contains? targets f)))
         (fs/delete! f)))))
 
 (defn build!
-  ([workspace build-targets]
-   (build! workspace build-targets progress/null-render-progress!))
-  ([workspace build-targets render-progress!]
-   (let [build-targets-by-key (make-build-targets-by-key build-targets)
-         artifacts (-> (workspace->artifacts workspace)
-                       (prune-artifacts build-targets-by-key))
-         progress  (atom (progress/make "" (count build-targets-by-key)))]
-     (prune-build-dir! workspace build-targets-by-key)
-     (let [results (into []
-                         (map (fn [[key {:keys [resource] :as build-target}]]
-                                (swap! progress #(-> %
-                                                     (progress/advance)
-                                                     (progress/with-message (str "Writing " (resource/proj-path resource)))))
-                                (or (when-let [artifact (get artifacts resource)]
-                                      (and (valid? artifact) artifact))
-                                    (render-progress! @progress)
-                                    (let [{:keys [resource deps build-fn user-data]} build-target
-                                          dep-resources (make-dep-resources deps build-targets-by-key)
-                                          result (-> (build-fn resource dep-resources user-data)
-                                                     (to-disk! key))]
-                                      result))))
-                         build-targets-by-key)
-           new-artifacts (into {} (map (fn [a] [(:resource a) a])) results)
-           etags (into {} (map (fn [a] [(resource/proj-path (:resource a)) (:etag a)])) results)]
-       (g/user-data! workspace ::artifacts new-artifacts)
-       (g/user-data! workspace ::etags etags)
-       results))))
-
-(defn reset-cache! [workspace]
-  (g/user-data! workspace ::artifacts nil)
-  (g/user-data! workspace ::etags nil))
-
-(defn etags [workspace]
-  (g/user-data workspace ::etags))
-
-(defn etag [workspace path]
-  (get (etags workspace) path))
+  [build-targets build-dir old-artifact-map render-progress!]
+  (let [build-targets-by-key (make-build-targets-by-key build-targets)
+        artifacts (prune-artifacts old-artifact-map build-targets-by-key)
+        progress  (atom (progress/make "" (count build-targets-by-key)))]
+    (prune-build-dir! build-dir build-targets-by-key)
+    (let [results (into []
+                        (map (fn [[key {:keys [resource] :as build-target}]]
+                               (swap! progress #(-> %
+                                                    (progress/advance)
+                                                    (progress/with-message (str "Writing " (resource/proj-path resource)))))
+                               (render-progress! @progress)
+                               (or (when-let [artifact (get artifacts resource)]
+                                     (and (valid? artifact) artifact))
+                                   (let [{:keys [resource deps build-fn user-data]} build-target
+                                         dep-resources (make-dep-resources deps build-targets-by-key)
+                                         result (-> (build-fn resource dep-resources user-data)
+                                                    (to-disk! key))]
+                                     result))))
+                        build-targets-by-key)
+          new-artifact-map (into {} (map (fn [a] [(:resource a) a])) results)
+          etags (into {} (map (fn [a] [(resource/proj-path (:resource a)) (:etag a)])) results)]
+      {:artifacts results
+       :artifact-map new-artifact-map
+       :etags etags})))

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -24,7 +24,7 @@
 (def html5-url-prefix "/html5")
 
 ;; TODO - this should be fixed with proper progress at some point
-(defn ->progress []
+(defn- ->progress []
   (reify IProgress
     (subProgress [this work]
       (->progress))
@@ -37,7 +37,7 @@
     (isCanceled [this]
       false)))
 
-(defn ->graph-resource-scanner [ws]
+(defn- ->graph-resource-scanner [ws]
   (let [res-map (->> (g/node-value ws :resource-map)
                   (map (fn [[key val]] [(subs key 1) val]))
                   (into {}))]
@@ -64,35 +64,28 @@
   (let [proj-settings (project/settings project)]
     (get proj-settings ["project" "title"] "Unnamed")))
 
-(defn- run-commands! [project ^Project bob-project {:keys [render-error!] :as _build-options} commands]
+(defn- run-commands! [project ^Project bob-project commands]
   (try
     (let [progress (->progress)
           result (.build bob-project progress (into-array String commands))
           failed-tasks (filter (fn [^TaskResult r] (not (.isOk r))) result)]
       (if (empty? failed-tasks)
-        true
-        (do (render-error! {:causes (engine-build-errors/failed-tasks-error-causes project failed-tasks)})
-            false)))
+        nil
+        {:error {:causes (engine-build-errors/failed-tasks-error-causes project failed-tasks)}}))
     (catch Exception e
-      (when-not (engine-build-errors/handle-build-error! render-error! project e)
-        (throw e))
-      false)))
+      {:error e})))
 
-(defn- bob-build! [project bob-commands bob-args {:keys [clear-errors! render-error!] :as build-options}]
+(defn- bob-build! [project bob-commands bob-args]
   (assert (vector? bob-commands))
   (assert (every? string? bob-commands))
   (assert (map? bob-args))
   (assert (every? (fn [[key val]] (and (string? key) (string? val))) bob-args))
-  (assert (fn? clear-errors!))
-  (assert (fn? render-error!))
   (future
     (error-reporting/catch-all!
-      (clear-errors!)
       (if (and (some #(= "build" %) bob-commands)
                (native-extensions/has-extensions? project)
                (not (native-extensions/supported-platform? (get bob-args "platform"))))
-        (do (render-error! {:causes (engine-build-errors/unsupported-platform-error-causes project)})
-            false)
+        {:error {:causes (engine-build-errors/unsupported-platform-error-causes project)}}
         (let [ws (project/workspace project)
               proj-path (str (workspace/project-path ws))
               bob-project (Project. (DefaultFileSystem.) proj-path "build/default")]
@@ -108,7 +101,7 @@
               (.resolveLibUrls bob-project (->progress))))
           (.mount bob-project (->graph-resource-scanner ws))
           (.findSources bob-project proj-path skip-dirs)
-          (run-commands! project bob-project build-options bob-commands))))))
+          (run-commands! project bob-project bob-commands))))))
 
 (defn- boolean? [value]
   (or (false? value) (true? value)))
@@ -118,7 +111,7 @@
 ;; -----------------------------------------------------------------------------
 
 
-(defn- generic-bundle-bob-args [prefs {:keys [release-mode? generate-build-report? publish-live-update-content? platform ^File output-directory] :as _build-options}]
+(defn- generic-bundle-bob-args [prefs {:keys [release-mode? generate-build-report? publish-live-update-content? platform ^File output-directory] :as _bundle-options}]
   (assert (some? output-directory))
   (assert (or (not (.exists output-directory))
               (.isDirectory output-directory)))
@@ -150,33 +143,33 @@
             generate-build-report? (assoc "build-report-html" build-report-path)
             publish-live-update-content? (assoc "liveupdate" "true"))))
 
-(defn- android-bundle-bob-args [{:keys [^File certificate ^File private-key] :as _build-options}]
+(defn- android-bundle-bob-args [{:keys [^File certificate ^File private-key] :as _bundle-options}]
   (assert (or (nil? certificate) (.isFile certificate)))
   (assert (or (nil? private-key) (.isFile private-key)))
   (cond-> {}
           certificate (assoc "certificate" (.getAbsolutePath certificate))
           private-key (assoc "private-key" (.getAbsolutePath private-key))))
 
-(defn- ios-bundle-bob-args [{:keys [code-signing-identity ^File provisioning-profile] :as _build-options}]
+(defn- ios-bundle-bob-args [{:keys [code-signing-identity ^File provisioning-profile] :as _bundle-options}]
   (assert (string? (not-empty code-signing-identity)))
   (assert (some-> provisioning-profile .isFile))
   (let [provisioning-profile-path (.getAbsolutePath provisioning-profile)]
     {"mobileprovisioning" provisioning-profile-path
      "identity" code-signing-identity}))
 
-(defmulti bundle-bob-args (fn [_prefs platform _build-options] platform))
-(defmethod bundle-bob-args :default [_prefs platform _build-options] (throw (IllegalArgumentException. (str "Unsupported platform: " platform))))
-(defmethod bundle-bob-args :android [prefs _platform build-options] (merge (generic-bundle-bob-args prefs build-options) (android-bundle-bob-args build-options)))
-(defmethod bundle-bob-args :html5   [prefs _platform build-options] (generic-bundle-bob-args prefs build-options))
-(defmethod bundle-bob-args :ios     [prefs _platform build-options] (merge (generic-bundle-bob-args prefs build-options) (ios-bundle-bob-args build-options)))
-(defmethod bundle-bob-args :linux   [prefs _platform build-options] (generic-bundle-bob-args prefs build-options))
-(defmethod bundle-bob-args :macos   [prefs _platform build-options] (generic-bundle-bob-args prefs build-options))
-(defmethod bundle-bob-args :windows [prefs _platform build-options] (generic-bundle-bob-args prefs build-options))
+(defmulti bundle-bob-args (fn [_prefs platform _bundle-options] platform))
+(defmethod bundle-bob-args :default [_prefs platform _bundle-options] (throw (IllegalArgumentException. (str "Unsupported platform: " platform))))
+(defmethod bundle-bob-args :android [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) (android-bundle-bob-args bundle-options)))
+(defmethod bundle-bob-args :html5   [prefs _platform bundle-options] (generic-bundle-bob-args prefs bundle-options))
+(defmethod bundle-bob-args :ios     [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) (ios-bundle-bob-args bundle-options)))
+(defmethod bundle-bob-args :linux   [prefs _platform bundle-options] (generic-bundle-bob-args prefs bundle-options))
+(defmethod bundle-bob-args :macos   [prefs _platform bundle-options] (generic-bundle-bob-args prefs bundle-options))
+(defmethod bundle-bob-args :windows [prefs _platform bundle-options] (generic-bundle-bob-args prefs bundle-options))
 
-(defn bundle! [project prefs platform build-options]
+(defn bundle! [project prefs platform bundle-options]
   (let [bob-commands ["distclean" "build" "bundle"]
-        bob-args (bundle-bob-args prefs platform build-options)]
-    (bob-build! project bob-commands bob-args build-options)))
+        bob-args (bundle-bob-args prefs platform bundle-options)]
+    (bob-build! project bob-commands bob-args)))
 
 ;; -----------------------------------------------------------------------------
 ;; Build HTML5
@@ -185,9 +178,9 @@
 (defn- build-html5-output-path [project]
   (let [ws (project/workspace project)
         build-path (workspace/build-path ws)]
-    (str build-path "__htmlLaunchDir")))
+    (io/file build-path  "__htmlLaunchDir")))
 
-(defn build-html5! [project prefs build-options]
+(defn build-html5! [project prefs]
   (let [output-path (build-html5-output-path project)
         proj-settings (project/settings project)
         build-server-url (native-extensions/get-build-server-url prefs)
@@ -197,22 +190,22 @@
         bob-commands ["distclean" "build" "bundle"]
         bob-args (cond-> {"platform" "js-web"
                           "archive" "true"
-                          "bundle-output" output-path
+                          "bundle-output" (str output-path)
                           "build-server" build-server-url
                           "defoldsdk" defold-sdk-sha1
                           "local-launch" "true"}
                          email (assoc "email" email)
                          auth (assoc "auth" auth)
                          compress-archive? (assoc "compress" "true"))]
-    (bob-build! project bob-commands bob-args build-options)))
+    (bob-build! project bob-commands bob-args)))
 
 (defn- handler [project {:keys [url method headers]}]
   (if (= method "GET")
     (let [path (-> url
-                 (subs (count html5-url-prefix))
-                 (URLDecoder/decode "UTF-8"))
-          path (format "%s/%s%s" (build-html5-output-path project) (project-title project) path)
-          f (io/file path)]
+                   (subs (count html5-url-prefix))
+                   (URLDecoder/decode "UTF-8"))
+;;          path (format "%s/%s%s" (build-html5-output-path project) (project-title project) path)
+          f (io/file (build-html5-output-path project) (project-title project) path)]
       (if (.exists f)
         (let [length (.length f)
               response {:code 200

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -178,7 +178,7 @@
 (defn- build-html5-output-path [project]
   (let [ws (project/workspace project)
         build-path (workspace/build-path ws)]
-    (io/file build-path  "__htmlLaunchDir")))
+    (io/file build-path "__htmlLaunchDir")))
 
 (defn build-html5! [project prefs]
   (let [output-path (build-html5-output-path project)
@@ -204,7 +204,6 @@
     (let [path (-> url
                    (subs (count html5-url-prefix))
                    (URLDecoder/decode "UTF-8"))
-;;          path (format "%s/%s%s" (build-html5-output-path project) (project-title project) path)
           f (io/file (build-html5-output-path project) (project-title project) path)]
       (if (.exists f)
         (let [length (.length f)

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -73,7 +73,7 @@
         nil
         {:error {:causes (engine-build-errors/failed-tasks-error-causes project failed-tasks)}}))
     (catch Exception e
-      {:error e})))
+      {:exception e})))
 
 (defn- bob-build! [project bob-commands bob-args]
   (assert (vector? bob-commands))

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -330,11 +330,16 @@
     (catch Exception _
       "invalid host")))
 
-(defn target-label [target]
+(defn target-menu-label [target]
   (format "%s - %s" (str (if (local-target? target) "Local " "") (:name target)) (url-string (:url target))))
 
+(defn target-message-label [target]
+  (let [url (:url target)]
+    (str (when (local-target? target) "Local ") (:name target)
+         (when (some? url) (str " - " (url-string url))))))
+
 (defn- target-option [target]
-  {:label     (target-label target)
+  {:label     (target-menu-label target)
    :command   :target
    :check     true
    :user-data target})

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -27,7 +27,7 @@ ordinary paths."
   (io/as-file (g/node-value workspace :root)))
 
 (defn build-path [workspace]
-  (str (project-path workspace) build-dir))
+  (io/file (project-path workspace) "build/default/"))
 
 (defrecord BuildResource [resource prefix]
   resource/Resource
@@ -41,7 +41,7 @@ ordinary paths."
                  (if-let [path (resource/path resource)]
                    (str (FilenameUtils/removeExtension path) "." ext)
                    (str prefix "_generated_" suffix "." ext))))
-  (abs-path [this] (.getAbsolutePath (File. (str (build-path (resource/workspace this)) (resource/path this)))))
+  (abs-path [this] (.getAbsolutePath (io/file (build-path (resource/workspace this)) (resource/path this))))
   (proj-path [this] (str "/" (resource/path this)))
   (resource-name [this] (resource/resource-name resource))
   (workspace [this] (resource/workspace resource))
@@ -326,6 +326,25 @@ ordinary paths."
 (defn update-build-settings!
   [workspace prefs]
   (g/set-property! workspace :build-settings (make-build-settings prefs)))
+
+(defn artifact-map [workspace]
+  (g/user-data workspace ::artifact-map))
+
+(defn artifact-map! [workspace artifact-map]
+  (g/user-data! workspace ::artifact-map artifact-map))
+
+(defn etags [workspace]
+  (g/user-data workspace ::etags))
+
+(defn etag [workspace path]
+  (get (etags workspace) path))
+
+(defn etags! [workspace etags]
+  (g/user-data! workspace ::etags etags))
+
+(defn reset-cache! [workspace]
+  (g/user-data! workspace ::artifact-map nil)
+  (g/user-data! workspace ::etags nil))
 
 (defn make-workspace [graph project-path build-settings]
   (g/make-node! graph Workspace

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -378,3 +378,18 @@
      :user-data (ref (deref (:user-data s)))
      :invalidate-counters (ref (deref (:invalidate-counters s)))
      :last-graph (:last-graph s)}))
+
+(defn system= [s1 s2]
+  (dosync
+    (and (= (map (fn [[gid gref]] [gid (deref gref)]) (:graphs s1))
+            (map (fn [[gid gref]] [gid (deref gref)]) (:graphs s2)))
+         (= (map (fn [[gid href]] [gid (deref href)]) (:history s1))
+            (map (fn [[gid href]] [gid (deref href)]) (:history s2)))
+         (= (map (fn [[gid ^AtomicLong gen]] [gid (.longValue gen)]) (:id-generators s1))
+            (map (fn [[gid ^AtomicLong gen]] [gid (.longValue gen)]) (:id-generators s2)))
+         (= (.longValue ^AtomicLong (:override-id-generator s1))
+            (.longValue ^AtomicLong (:override-id-generator s2)))
+         (= (deref (:cache s1)) (deref (:cache s2)))
+         (= (deref (:user-data s1)) (deref (:user-data s2)))
+         (= (deref (:invalidate-counters s1)) (deref (:invalidate-counters s2)))
+         (= (:last-graph s1) (:last-graph s2)))))

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -6,6 +6,7 @@
             [editor.fs :as fs]
             [editor.git :as git]
             [editor.defold-project :as project]
+            [editor.progress :as progress]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [support.test-support :refer [spit-until-new-mtime with-clean-system]])
@@ -141,13 +142,17 @@
           main-dir (workspace/find-resource workspace "/main")]
       (is main-dir)
       (let [evaluation-context (g/make-evaluation-context)
-            build-results (project/build project game-project evaluation-context {})]
+            old-artifact-map (workspace/artifact-map workspace)
+            build-results (project/build project game-project evaluation-context nil old-artifact-map progress/null-render-progress!)]
         (g/update-cache-from-evaluation-context! evaluation-context)
-        (is (seq build-results))
-        (is (not (g/error? build-results))))
+        (is (seq (:artifacts build-results)))
+        (is (not (g/error? (:error build-results))))
+        (workspace/artifact-map! workspace (:artifact-map build-results)))
       (asset-browser/rename main-dir "/blahonga")
       (is (nil? (workspace/find-resource workspace "/main")))
       (is (workspace/find-resource workspace "/blahonga"))
-      (let [build-results (project/build project game-project (g/make-evaluation-context) {})]
-        (is (seq build-results))
-        (is (not (g/error? build-results)))))))
+      (let [old-artifact-map (workspace/artifact-map workspace)
+            build-results (project/build project game-project (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)]
+        (is (seq (:artifacts build-results)))
+        (is (not (g/error? (:error build-results))))
+        (workspace/artifact-map! workspace (:artifact-map build-results))))))

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -4,7 +4,9 @@
             [editor.build-errors-view :as build-errors-view]
             [editor.collection :as collection]
             [editor.defold-project :as project]
+            [editor.workspace :as workspace]
             [editor.game-object :as game-object]
+            [editor.progress :as progress]
             [editor.resource :as resource]
             [integration.test-util :as test-util]
             [internal.util :as util]
@@ -69,20 +71,21 @@
 
       (testing "Build error links to source node"
         (are [component-resource-path error-resource-path error-outline-path]
-          (with-open [_ (make-restore-point!)]
-            (let [render-error! (test-util/make-call-logger)]
+            (with-open [_ (make-restore-point!)]
               (add-component-from-file! workspace game-object component-resource-path)
-              (project/build project main-collection (g/make-evaluation-context) {:render-error! render-error!})
-              (let [error-value (build-error render-error!)]
-                (when (is (some? error-value) component-resource-path)
+              (let [old-artifact-map (workspace/artifact-map workspace)
+                    build-results (project/build project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                    error-value (:error build-results)]
+                (if (is (some? error-value) component-resource-path)
                   (let [error-tree (build-errors-view/build-resource-tree error-value)]
                     (is (= (resource error-resource-path)
                            (error-resource error-tree)))
                     (is (= (resource-node error-resource-path)
                            (error-resource-node error-tree)))
                     (is (= (outline-node error-resource-path error-outline-path)
-                           (error-outline-node error-tree)))))))
-            true)
+                           (error-outline-node error-tree))))
+                  (workspace/artifact-map! workspace (:artifact-map build-results))))
+              true)
 
           "/errors/syntax_error.script"
           "/errors/syntax_error.script" []
@@ -107,20 +110,21 @@
 
       (testing "Build error does not link to missing files"
         (are [resource-path error-resource-path error-outline-path add-fn]
-          (with-open [_ (make-restore-point!)]
-            (let [render-error! (test-util/make-call-logger)]
+            (with-open [_ (make-restore-point!)]
               (add-fn resource-path)
-              (project/build project main-collection (g/make-evaluation-context) {:render-error! render-error!})
-              (let [error-value (build-error render-error!)]
-                (when (is (some? error-value) resource-path)
+              (let [old-artifact-map (workspace/artifact-map workspace)
+                    build-results (project/build project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                    error-value (:error build-results)]
+                (if (is (some? error-value) resource-path)
                   (let [error-tree (build-errors-view/build-resource-tree error-value)]
                     (is (= (resource error-resource-path)
                            (error-resource error-tree)))
                     (is (= (resource-node error-resource-path)
                            (error-resource-node error-tree)))
                     (is (= (outline-node error-resource-path error-outline-path)
-                          (error-outline-node error-tree)))))))
-            true)
+                           (error-outline-node error-tree))))
+                  (workspace/artifact-map! workspace (:artifact-map build-results))))
+              true)
 
           "/file_not_found.gui"
           "/main/main.collection" ["go", "file_not_found"]
@@ -132,19 +136,20 @@
 
       (testing "Errors from the same source are not duplicated"
         (with-open [_ (make-restore-point!)]
-          (let [render-error! (test-util/make-call-logger)]
-            (doseq [path ["/errors/button_break_self.gui"
-                          "/errors/panel_break_button.gui"
-                          "/errors/panel_using_button_break_self.gui"
-                          "/errors/panel_using_name_conflict_twice.gui"
-                          "/errors/window_using_panel_break_button.gui"]]
-              (add-component-from-file! workspace game-object path))
-            (project/build project main-collection (g/make-evaluation-context) {:render-error! render-error!})
-            (let [error-value (build-error render-error!)]
-              (when (is (some? error-value))
-                (let [error-tree (build-errors-view/build-resource-tree error-value)]
-                  (is (= ["/errors/button_break_self.gui" "/errors/name_conflict.gui" "/errors/panel_break_button.gui"]
-                         (sort (map #(resource/proj-path (get-in % [:value :resource])) (:children error-tree)))))
-                  (is (= 1 (count (get-in error-tree [:children 0 :children]))))
-                  (is (= 2 (count (get-in error-tree [:children 1 :children]))))
-                  (is (= 1 (count (get-in error-tree [:children 2 :children])))))))))))))
+          (doseq [path ["/errors/button_break_self.gui"
+                        "/errors/panel_break_button.gui"
+                        "/errors/panel_using_button_break_self.gui"
+                        "/errors/panel_using_name_conflict_twice.gui"
+                        "/errors/window_using_panel_break_button.gui"]]
+            (add-component-from-file! workspace game-object path))
+          (let [old-artifact-map (workspace/artifact-map workspace)
+                build-results (project/build project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                error-value (:error build-results)]
+            (if (is (some? error-value))
+              (let [error-tree (build-errors-view/build-resource-tree error-value)]
+                (is (= ["/errors/button_break_self.gui" "/errors/name_conflict.gui" "/errors/panel_break_button.gui"]
+                       (sort (map #(resource/proj-path (get-in % [:value :resource])) (:children error-tree)))))
+                (is (= 1 (count (get-in error-tree [:children 0 :children]))))
+                (is (= 2 (count (get-in error-tree [:children 1 :children]))))
+                (is (= 1 (count (get-in error-tree [:children 2 :children])))))
+              (workspace/artifact-map! workspace (:artifact-map build-results)))))))))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -370,7 +370,7 @@
                  (is (= 1 (count-exts (keys content-by-target) "spritec")))))
       (g/undo! (g/node-id->graph-id project))
       (testing "Verify equivalent sprites are not merged after being changed in memory"
-        (let [sprite (test-util/prop-node-id comp-node :blend-mode)]
+               (let [sprite (test-util/prop-node-id comp-node :blend-mode)]
                  (test-util/prop! sprite :blend-mode :blend-mode-add)
                  (let [build-artifacts   (project-build-artifacts project resource-node (g/make-evaluation-context))
                        content-by-target (into {} (map #(do [(resource/proj-path (:resource %)) (content-bytes %)])
@@ -405,7 +405,7 @@
 (defn- abs-project-path [workspace proj-path]
   (io/file (workspace/project-path workspace) proj-path))
 
-(defn mtime [f]
+(defn mtime [^File f]
   (.lastModified f))
 
 (deftest build-atlas


### PR DESCRIPTION
This is a cleanup PR in preparation for fixing several debugger
issues.

* Don't pass report/clear callbacks to build functions, instead let
  them return build results or errors and report errors as needed by
  caller.
* Stop sneakily storing etags/artifact cache with g/user-data!, return as
  part of build results and let caller decide what to do.
* Run with debugger etc also uses background thread build with a
  continuation function to be run on ui thread when done.