### PR TITLE
DEF-1311 - Compound script properties couldn't be decomposed or animated.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -10,8 +10,22 @@ import com.dynamo.bob.test.util.PropertiesTestUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.lua.proto.Lua.LuaModule;
 import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarations;
+import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarationEntry;
 
 public class LuaBuilderTest extends AbstractProtoBuilderTest {
+
+    private static void assertSubElementsV3(PropertyDeclarationEntry entry) {
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".x"), entry.getElementIds(0));
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".y"), entry.getElementIds(1));
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".z"), entry.getElementIds(2));
+    }
+
+    private static void assertSubElementsV4(PropertyDeclarationEntry entry) {
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".x"), entry.getElementIds(0));
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".y"), entry.getElementIds(1));
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".z"), entry.getElementIds(2));
+        assertEquals(MurmurHash.hash64(entry.getKey() + ".w"), entry.getElementIds(3));
+    }
 
     @Test
     public void testProps() throws Exception {
@@ -39,6 +53,11 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         PropertiesTestUtil.assertVector4(properties, 4, 5, 6, 7, 0);
         PropertiesTestUtil.assertQuat(properties, 8, 9, 10, 11, 0);
         PropertiesTestUtil.assertBoolean(properties, true, 0);
+
+        // Verify that .x, .y, .z and .w exists as sub element ids for Vec3, Vec4 and Quat.
+        assertSubElementsV3(properties.getVector3Entries(0));
+        assertSubElementsV4(properties.getVector4Entries(0));
+        assertSubElementsV4(properties.getQuatEntries(0));
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -198,6 +198,9 @@ public abstract class LuaBuilder extends Builder<Void> {
                         break;
                     case PROPERTY_TYPE_VECTOR3:
                         entryBuilder.setIndex(builder.getFloatValuesCount());
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".x"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".y"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".z"));
                         Vector3d v3 = (Vector3d)property.value;
                         builder.addFloatValues((float)v3.getX());
                         builder.addFloatValues((float)v3.getY());
@@ -206,6 +209,10 @@ public abstract class LuaBuilder extends Builder<Void> {
                         break;
                     case PROPERTY_TYPE_VECTOR4:
                         entryBuilder.setIndex(builder.getFloatValuesCount());
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".x"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".y"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".z"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".w"));
                         Vector4d v4 = (Vector4d)property.value;
                         builder.addFloatValues((float)v4.getX());
                         builder.addFloatValues((float)v4.getY());
@@ -215,6 +222,10 @@ public abstract class LuaBuilder extends Builder<Void> {
                         break;
                     case PROPERTY_TYPE_QUAT:
                         entryBuilder.setIndex(builder.getFloatValuesCount());
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".x"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".y"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".z"));
+                        entryBuilder.addElementIds(MurmurHash.hash64(property.name + ".w"));
                         Quat4d q = (Quat4d)property.value;
                         builder.addFloatValues((float)q.getX());
                         builder.addFloatValues((float)q.getY());

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -161,7 +161,7 @@
                                                                             (ByteString/copyFrom ^bytes bytecode))}
                                                        :modules modules
                                                        :resources (mapv lua/lua-module->build-path modules)
-                                                       :properties (properties/properties->decls properties)})}))
+                                                       :properties (properties/properties->decls properties true)})}))
 
 (g/defnk produce-build-targets [_node-id resource lines bytecode user-properties modules dep-build-targets]
   [{:node-id _node-id

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -304,7 +304,7 @@
                              {:id (properties/key->user-name key)
                               :type (:go-prop-type p)
                               :value (properties/go-prop->str (:value p) (:go-prop-type p))}))))))
-  (output ddf-property-decls g/Any :cached (g/fnk [ddf-properties] (properties/properties->decls ddf-properties)))
+  (output ddf-property-decls g/Any :cached (g/fnk [ddf-properties] (properties/properties->decls ddf-properties false)))
   (output rt-ddf-message g/Any :cached (g/fnk [id position rotation source-resource ddf-properties ddf-property-decls]
                                               (gen-ref-ddf id position rotation source-resource ddf-properties ddf-property-decls))))
 
@@ -404,7 +404,7 @@
                              props
                              (conj props (-> m
                                            (select-keys [:id :properties])
-                                           (assoc :property-decls (properties/properties->decls (:properties m)))))))
+                                           (assoc :property-decls (properties/properties->decls (:properties m) false))))))
                          [] ref-ddf)))
   (output id-counts g/Any :cached (g/fnk [component-id-pairs]
                                          (reduce (fn [res id]

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -239,9 +239,20 @@
                     :property-type-quat (-> value (math/euler->quat) (math/vecmath->clj))
                     value)
             [entry-key values-key] (type->entry-keys type)
-            entry {:key (:id prop)
-                   :id (murmur/hash64 (:id prop))
-                   :index (count (get decl values-key))}]
+            entry (cond-> {:key (:id prop)
+                           :id (murmur/hash64 (:id prop))
+                           :index (count (get decl values-key))}
+
+                          (case type
+                            (:property-type-vector3 :property-type-vector4 :property-type-quat) true
+                            false)
+                          (assoc :element-ids (mapv #(murmur/hash64 (str (:id prop) %))
+                                                    [".x" ".y" ".z"]))
+
+                          (case type
+                            (:property-type-vector4 :property-type-quat) true
+                            false)
+                          (update :element-ids conj (murmur/hash64 (str (:id prop) ".w"))))]
         (recur (rest properties)
                (-> decl
                  (update entry-key conj! entry)

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -253,7 +253,8 @@
                     (or (= type :property-type-vector4)
                         (= type :property-type-quat))
                     (assoc entry :element-ids (mapv #(murmur/hash64 (str (:id prop) %))
-                                                    [".x" ".y" ".z" ".w"])))]
+                                                    [".x" ".y" ".z" ".w"]))
+                    :else entry)]
         (recur (rest properties)
                (-> decl
                  (update entry-key conj! entry)


### PR DESCRIPTION
We had functionality for this in the runtime, and tests for this. However, those tests used data that was built with our python build pipeline which had code for adding [.x, .y, .z, .w] components... The Java build pipeline did not add these components.

I have added so that the subelement hashes are added in Bob/Ed1 and Ed2 with this PR.