### PR TITLE
DEFEDIT-1324 Fix for game not starting after HTML5 build

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -202,7 +202,7 @@
 (defn- handler [project {:keys [url method headers]}]
   (if (= method "GET")
     (let [path (-> url
-                   (subs (count html5-url-prefix))
+                   (subs (inc (count html5-url-prefix))) ; Strip prefix and slash character.
                    (URLDecoder/decode "UTF-8"))
           f (io/file (build-html5-output-path project) (project-title project) path)]
       (if (.exists f)

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -1,5 +1,6 @@
 (ns util.http-server
   (:require [clojure.java.io :as io]
+            [editor.error-reporting :as error-reporting]
             [service.log :as log])
   (:import [java.io InputStream IOException OutputStream ByteArrayInputStream ByteArrayOutputStream BufferedOutputStream]
            [java.net InetSocketAddress URLDecoder]
@@ -48,7 +49,7 @@
                                         (-> (handler (exchange->request! t))
                                           (response->exchange! t))
                                         (catch Throwable t
-                                          (prn (Throwable->map t))))))))
+                                          (error-reporting/report-exception! t)))))))
     (.setExecutor server nil)
     server))
 


### PR DESCRIPTION
Looks like #2119 broke this because `io/file` throws an exception when a path fragment starts with a leading slash.

### User-facing changes
* HTML5 builds no longer result in an empty browser window after the build completes.

### Technical changes
* Report unhandled exceptions from `http-server` handlers.