### PR TITLE
DEFEDIT-1323 Constant rebuilds in large projects (Blossom)

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -89,7 +89,8 @@
 (defn clear-system-cache!
   "Clears *the-system* cache, useful when debugging"
   []
-  (swap! *the-system* assoc :cache (ref (is/make-cache {}))))
+  (swap! *the-system* assoc :cache (ref (is/make-cache {})))
+  nil)
 
 (defn graph "Given a graph id, returns the particular graph in the system at the current point in time"
   [graph-id]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -496,13 +496,15 @@
                 build-results       (ui/with-progress [_ render-build-progress!]
                                       (project/build-and-write-project project evaluation-context extra-build-targets old-artifact-map render-build-progress!))]
             (ui/run-later
-              (g/update-cache-from-evaluation-context! evaluation-context)
-              (when result-fn (result-fn build-results)))
+              (try
+                (g/update-cache-from-evaluation-context! evaluation-context)
+                (when result-fn (result-fn build-results))
+                (finally
+                  (reset! build-in-progress? false))))
             build-results))
-      (catch Throwable t
-        (error-reporting/report-exception! t))
-      (finally
-        (reset! build-in-progress? false))))))
+        (catch Throwable t
+          (reset! build-in-progress? false)
+          (error-reporting/report-exception! t))))))
 
 (defn- handle-build-results! [workspace build-errors-view build-results]
   (let [{:keys [error artifacts artifact-map etags]} build-results]

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -87,7 +87,7 @@
     * new node-id if the path is being reloaded
     * old node-id if the path is not being reloaded
 
-  `resource-node-dependencies` is a map from node id to the project
+  `resource-node-dependencies` is a function from node id to the project
   paths which are the in-memory/current dependencies for nodes not
   being reloaded."
 
@@ -127,22 +127,6 @@
                   (conj dep-queued node-id)
                   batch
                   load-deps)))))))
-
-(defn resource-node-dependencies
-  "Returns a map from node id to its current project path dependencies.
-
-  Does not work in the intermediate stages of the resource sync. Must
-  be called when the project is in a stable state, i.e. before
-  creating new versions of resource nodes to be reloaded."
-  [node-ids]
-  (let [evaluation-context (g/make-evaluation-context)
-        dependencies (into {}
-                           (map (fn [node-id]
-                                  (let [dependency-paths (g/node-value node-id :reload-dependencies evaluation-context)]
-                                    [node-id dependency-paths])))
-                           node-ids)]
-    (g/update-cache-from-evaluation-context! evaluation-context)
-    dependencies))
 
 (defn load-resource-nodes [project node-ids render-progress! resource-node-dependencies]
   (let [evaluation-context (g/make-evaluation-context)
@@ -418,7 +402,10 @@
 (defn- perform-resource-change-plan [plan project render-progress!]
   (binding [*load-cache* (atom (into #{} (g/node-value project :nodes)))]
     (let [old-nodes-by-path (g/node-value project :nodes-by-resource-path)
-          old-resource-node-dependencies (resource-node-dependencies (g/node-value project :nodes))
+          rn-dependencies-evaluation-context (g/make-evaluation-context)
+          old-resource-node-dependencies (memoize
+                                           (fn [node-id]
+                                             (g/node-value node-id :reload-dependencies rn-dependencies-evaluation-context)))
           resource->old-node (comp old-nodes-by-path resource/proj-path)
           new-nodes (make-nodes! project (:new plan))
           resource-path->new-node (into {} (map (fn [resource-node]
@@ -448,6 +435,8 @@
           (g/delete-node node)))
 
       (load-nodes! project new-nodes render-progress! old-resource-node-dependencies)
+
+      (g/update-cache-from-evaluation-context! rn-dependencies-evaluation-context)
 
       (g/transact
         (for [[source-resource output-arcs] (:transfer-outgoing-arcs plan)]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -170,7 +170,7 @@
           (cond->
             (resource/openable-resource? source-resource) (assoc :link source-resource :outline-reference? true)
             source-id (assoc :alt-outline source-outline))))))
-  (output ddf-message g/Any :cached (g/fnk [rt-ddf-message] (dissoc rt-ddf-message :property-decls)))
+  (output ddf-message g/Any (g/fnk [rt-ddf-message] (dissoc rt-ddf-message :property-decls)))
   (output rt-ddf-message g/Any :abstract)
   (output scene g/Any :cached (g/fnk [_node-id transform scene]
                                 (let [transform (if-let [local-transform (:transform scene)]

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1092,8 +1092,11 @@
                                 :make-preview-fn make-preview
                                 :focus-fn focus-view))
 
-(g/defnk produce-transform [^Vector3d position-v3 ^Quat4d rotation-q4 ^Vector3d scale-v3]
-  (math/->mat4-non-uniform position-v3 rotation-q4 scale-v3))
+(g/defnk produce-transform [position rotation scale]
+  (let [position-v3 (doto (Vector3d.) (math/clj->vecmath position))
+        rotation-q4 (doto (Quat4d.) (math/clj->vecmath rotation))
+        scale-v3 (Vector3d. (double-array scale))]
+    (math/->mat4-non-uniform position-v3 rotation-q4 scale-v3)))
 
 (def produce-no-transform-properties (g/constantly #{}))
 (def produce-scalable-transform-properties (g/constantly #{:position :rotation :scale}))
@@ -1109,9 +1112,6 @@
             (dynamic visible (g/fnk [transform-properties] (contains? transform-properties :scale))))
 
   (output transform-properties g/Any :abstract)
-  (output position-v3 Vector3d :cached (g/fnk [^types/Vec3 position] (doto (Vector3d.) (math/clj->vecmath position))))
-  (output rotation-q4 Quat4d :cached (g/fnk [^types/Vec4 rotation] (doto (Quat4d.) (math/clj->vecmath rotation))))
-  (output scale-v3 Vector3d :cached (g/fnk [^types/Vec3 scale] (Vector3d. (double-array scale))))
   (output transform Matrix4d :cached produce-transform)
   (output scene g/Any :cached (g/fnk [^g/NodeID _node-id ^Matrix4d transform] {:node-id _node-id :transform transform}))
   (output aabb AABB :cached (g/constantly (geom/null-aabb))))

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -8,9 +8,10 @@
             [editor.scene :as scene]
             [editor.system :as system]
             [editor.types :as types]
+            [editor.math :as math]
             [integration.test-util :as test-util])
   (:import [editor.types AABB]
-           [javax.vecmath Point3d Matrix4d]))
+           [javax.vecmath Point3d Matrix4d Quat4d Vector3d]))
 
 (defn- make-aabb [min max]
   (reduce geom/aabb-incorporate (geom/null-aabb) (map #(Point3d. (double-array (conj % 0))) [min max])))
@@ -96,11 +97,13 @@
                (is (every? #(test-util/selected? app-view %) go-nodes))))))
 
 (defn- pos [node]
-  (g/node-value node :position-v3))
+  (doto (Vector3d.) (math/clj->vecmath (g/node-value node :position))))
+
 (defn- rot [node]
-  (g/node-value node :rotation-q4))
+  (doto (Quat4d.) (math/clj->vecmath (g/node-value node :rotation))))
+
 (defn- scale [node]
-  (g/node-value node :scale-v3))
+  (doto (Vector3d.) (math/clj->vecmath (g/node-value node :scale))))
 
 (deftest transform-tools
   (testing "Transform tools and manipulator interactions"

--- a/editor/test/internal/graph/graph_test.clj
+++ b/editor/test/internal/graph/graph_test.clj
@@ -214,6 +214,21 @@
 
         (g/update-cache-from-evaluation-context! init-ec)
 
+        (is (= ::miss (cc/lookup (g/cache) [n2 :str-out] ::miss))))))
+
+  (testing "Update cache does not add entries for deleted nodes"
+    (with-clean-system
+      (let [[n n2] (tx-nodes (g/make-nodes world [n (TestNode :val "initial")
+                                                  n2 PassthroughNode]
+                                           (g/connect n :val n2 :str-in)))
+            init-ec (g/make-evaluation-context)]
+        (g/node-value n2 :str-out init-ec)
+        (is (= ::miss (cc/lookup (g/cache) [n2 :str-out] ::miss)))
+
+        (g/transact (g/delete-node n2))
+
+        (g/update-cache-from-evaluation-context! init-ec)
+
         (is (= ::miss (cc/lookup (g/cache) [n2 :str-out] ::miss)))))))
 
 (deftest tracer


### PR DESCRIPTION
* Technical changes
  - Reduce congestion in cache by removing some :cached outputs or
  removing :cached from cheap outputs
  - Don't calculate resource node dependencies for all resource nodes
  upfront as this creates a huge number of cache misses, evicting
  cached build results. Instead, compute lazily on an evaluation
  context grabbed before resource sync hustling begins.
  - Unrelated: change when build action becomes enabled.