### PR TITLE
DEF-3161 Handle https status 204 No Content

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -503,13 +503,8 @@ namespace dmHttpClient
             // NOTE: We have an extra byte for null-termination so no buffer overrun here.
             client->m_Buffer[response->m_TotalReceived] = '\0';
 
-            // According to the HTTP spec, all responses should end with double line feed to indicate end of headers
-            // Unfortunately some server implementations only end with one linefeed if the response is '204 No Content' so we take special measures
-            // to force parsing of headers if we have received no more data and the last time we tried we ended up with a 204 status
-            bool force_parsing_of_headers = response->m_Status == 204 && recv_bytes == 0;
-
             dmHttpClientPrivate::ParseResult parse_res;
-            parse_res = dmHttpClientPrivate::ParseHeader(client->m_Buffer, response, force_parsing_of_headers, &HandleVersion, &HandleHeader, &HandleContent);
+            parse_res = dmHttpClientPrivate::ParseHeader(client->m_Buffer, response, recv_bytes == 0, &HandleVersion, &HandleHeader, &HandleContent);
             if (parse_res == dmHttpClientPrivate::PARSE_RESULT_NEED_MORE_DATA)
             {
                 if (recv_bytes == 0)

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -503,8 +503,13 @@ namespace dmHttpClient
             // NOTE: We have an extra byte for null-termination so no buffer overrun here.
             client->m_Buffer[response->m_TotalReceived] = '\0';
 
+            // According to the HTTP spec, all responses should end with double line feed to indicate end of headers
+            // Unfortunately some server implementations only end with one linefeed if the response is '204 No Content' so we take special measures
+            // to force parsing of headers if we have received no more data and the last time we tried we ended up with a 204 status
+            bool force_parsing_of_headers = response->m_Status == 204 && recv_bytes == 0;
+
             dmHttpClientPrivate::ParseResult parse_res;
-            parse_res = dmHttpClientPrivate::ParseHeader(client->m_Buffer, response, &HandleVersion, &HandleHeader, &HandleContent);
+            parse_res = dmHttpClientPrivate::ParseHeader(client->m_Buffer, response, force_parsing_of_headers, &HandleVersion, &HandleHeader, &HandleContent);
             if (parse_res == dmHttpClientPrivate::PARSE_RESULT_NEED_MORE_DATA)
             {
                 if (recv_bytes == 0)

--- a/engine/dlib/src/dlib/http_client_private.cpp
+++ b/engine/dlib/src/dlib/http_client_private.cpp
@@ -11,6 +11,9 @@ namespace dmHttpClientPrivate
                             void (*header)(void* user_data, const char* key, const char* value),
                             void (*body)(void* user_data, int offset))
     {
+        // Check for end of header and beginning of body before null-terminating the version portion of the header
+        char* end = strstr(header_str, "\r\n\r\n");
+
         char* version_str = header_str;
         char* end_version = strstr(header_str, "\r\n");
         if (end_version == 0)
@@ -35,12 +38,12 @@ namespace dmHttpClientPrivate
 
         version(user_data, major, minor, status, tok);
 
-        char* end = strstr(header_str, "\r\n\r\n");
         if (end == 0)
         {
-            // The response contains no headers and a zero-length body
+            // The response contains no body as the "\r\n\r\n" was not found
+            // which is in between the headers and the body.
             // Status '204 No Content' is an example of such a response
-            body(user_data, 0);
+            body(user_data, (int) (end_version - header_str));
             return PARSE_RESULT_OK;
         }
 

--- a/engine/dlib/src/dlib/http_client_private.cpp
+++ b/engine/dlib/src/dlib/http_client_private.cpp
@@ -41,7 +41,7 @@ namespace dmHttpClientPrivate
             // According to the HTTP spec, all responses should end with double line feed to indicate end of headers
             // Unfortunately some server implementations only end with one linefeed if the response is '204 No Content' so we take special measures
             // to force parsing of headers if we have received no more data and the we get a 204 status
-             if(end_of_receive && status == 204)
+            if(end_of_receive && status == 204)
             {
                 // Treat entire input as just headers
                 body_start = (end_version + 1) + strlen(end_version + 1);

--- a/engine/dlib/src/dlib/http_client_private.h
+++ b/engine/dlib/src/dlib/http_client_private.h
@@ -12,7 +12,7 @@ namespace dmHttpClientPrivate
 
     ParseResult ParseHeader(char* header_str,
                             void* user_data,
-                            bool force_parsing_of_headers,
+                            bool end_of_receive,
                             void (*version)(void* user_data, int major, int minor, int status, const char* status_str),
                             void (*header)(void* user_data, const char* key, const char* value),
                             void (*body)(void* user_data, int offset));

--- a/engine/dlib/src/dlib/http_client_private.h
+++ b/engine/dlib/src/dlib/http_client_private.h
@@ -12,6 +12,7 @@ namespace dmHttpClientPrivate
 
     ParseResult ParseHeader(char* header_str,
                             void* user_data,
+                            bool force_parsing_of_headers,
                             void (*version)(void* user_data, int major, int minor, int status, const char* status_str),
                             void (*header)(void* user_data, const char* key, const char* value),
                             void (*body)(void* user_data, int offset));

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -775,7 +775,7 @@ bail:
 
         if (response)
         {
-            dmHttpClientPrivate::ParseResult pr = dmHttpClientPrivate::ParseHeader((char*) ssdp->m_Buffer, &state, false, VersionCallback, HeaderCallback, ResponseCallback);
+            dmHttpClientPrivate::ParseResult pr = dmHttpClientPrivate::ParseHeader((char*) ssdp->m_Buffer, &state, true, VersionCallback, HeaderCallback, ResponseCallback);
             ok = pr == dmHttpClientPrivate::PARSE_RESULT_OK;
         }
         else

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -775,7 +775,7 @@ bail:
 
         if (response)
         {
-            dmHttpClientPrivate::ParseResult pr = dmHttpClientPrivate::ParseHeader((char*) ssdp->m_Buffer, &state, VersionCallback, HeaderCallback, ResponseCallback);
+            dmHttpClientPrivate::ParseResult pr = dmHttpClientPrivate::ParseHeader((char*) ssdp->m_Buffer, &state, false, VersionCallback, HeaderCallback, ResponseCallback);
             ok = pr == dmHttpClientPrivate::PARSE_RESULT_OK;
         }
         else

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -159,11 +159,11 @@ public:
         self->m_ContentOffset = offset;
     }
 
-    dmHttpClientPrivate::ParseResult Parse(const char* headers, bool force_parse_of_headers)
+    dmHttpClientPrivate::ParseResult Parse(const char* headers, bool end_of_receive)
     {
         char* h = strdup(headers);
         dmHttpClientPrivate::ParseResult r;
-        r = dmHttpClientPrivate::ParseHeader(h, this, force_parse_of_headers,
+        r = dmHttpClientPrivate::ParseHeader(h, this, end_of_receive,
                                              &dmHttpClientParserTest::Version,
                                              &dmHttpClientParserTest::Header,
                                              &dmHttpClientParserTest::Content);
@@ -189,9 +189,7 @@ TEST_F(dmHttpClientParserTest, TestMoreData)
     dmHttpClientPrivate::ParseResult r;
     r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_NEED_MORE_DATA, r);
-    ASSERT_EQ(1, m_Major);
-    ASSERT_EQ(1, m_Minor);
-    ASSERT_EQ(200, m_Status);
+    ASSERT_EQ(-1, m_Status);
 }
 
 TEST_F(dmHttpClientParserTest, TestSyntaxError)
@@ -295,7 +293,7 @@ TEST_F(dmHttpClientParserTest, TestContentAndHeaders)
 TEST_F(dmHttpClientParserTest, TestNoContent)
 {
     // Most servers seem to not add the empty line at the end of a 204 response even though the spec says we should. Test this specific case.
-    const char* headers = "HTTP/1.1 204 OK\r\n"
+    const char* headers = "HTTP/1.1 204 No Content\r\n"
 "Server: Jetty(7.0.2.v20100331)\r\n"
 ;
     dmHttpClientPrivate::ParseResult r;
@@ -304,8 +302,9 @@ TEST_F(dmHttpClientParserTest, TestNoContent)
     ASSERT_EQ(1, m_Major);
     ASSERT_EQ(1, m_Minor);
     ASSERT_EQ(204, m_Status);
-    ASSERT_EQ("OK", m_StatusString);
+    ASSERT_EQ("No Content", m_StatusString);
     ASSERT_EQ((size_t) 1, m_Headers.size());
+    ASSERT_EQ("Jetty(7.0.2.v20100331)", m_Headers["Server"]);
 }
 
 #ifndef _WIN32

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -159,11 +159,11 @@ public:
         self->m_ContentOffset = offset;
     }
 
-    dmHttpClientPrivate::ParseResult Parse(const char* headers)
+    dmHttpClientPrivate::ParseResult Parse(const char* headers, bool force_parse_of_headers)
     {
         char* h = strdup(headers);
         dmHttpClientPrivate::ParseResult r;
-        r = dmHttpClientPrivate::ParseHeader(h, this,
+        r = dmHttpClientPrivate::ParseHeader(h, this, force_parse_of_headers,
                                              &dmHttpClientParserTest::Version,
                                              &dmHttpClientParserTest::Header,
                                              &dmHttpClientParserTest::Content);
@@ -187,11 +187,11 @@ TEST_F(dmHttpClientParserTest, TestMoreData)
     const char* headers = "HTTP/1.1 200 OK\r\n";
 
     dmHttpClientPrivate::ParseResult r;
-    r = Parse(headers);
+    r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_NEED_MORE_DATA, r);
-    ASSERT_EQ(-1, m_Major);
-    ASSERT_EQ(-1, m_Minor);
-    ASSERT_EQ(-1, m_Status);
+    ASSERT_EQ(1, m_Major);
+    ASSERT_EQ(1, m_Minor);
+    ASSERT_EQ(200, m_Status);
 }
 
 TEST_F(dmHttpClientParserTest, TestSyntaxError)
@@ -199,7 +199,7 @@ TEST_F(dmHttpClientParserTest, TestSyntaxError)
     const char* headers = "HTTP/x.y 200 OK\r\n\r\n";
 
     dmHttpClientPrivate::ParseResult r;
-    r = Parse(headers);
+    r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_SYNTAX_ERROR, r);
 }
 
@@ -208,7 +208,7 @@ TEST_F(dmHttpClientParserTest, TestMissingStatusString)
     const char* headers = "HTTP/1.0 200\r\n\r\n";
 
     dmHttpClientPrivate::ParseResult r;
-    r = Parse(headers);
+    r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_SYNTAX_ERROR, r);
 }
 
@@ -221,7 +221,7 @@ TEST_F(dmHttpClientParserTest, TestHeaders)
 "\r\n";
 
     dmHttpClientPrivate::ParseResult r;
-    r = Parse(headers);
+    r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_OK, r);
 
     ASSERT_EQ(1, m_Major);
@@ -244,7 +244,7 @@ TEST_F(dmHttpClientParserTest, TestWhitespaceHeaders)
 "\r\n";
 
     dmHttpClientPrivate::ParseResult r;
-    r = Parse(headers);
+    r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_OK, r);
 
     ASSERT_EQ(1, m_Major);
@@ -266,10 +266,46 @@ TEST_F(dmHttpClientParserTest, TestContent)
 ;
 
     dmHttpClientPrivate::ParseResult r;
-    r = Parse(headers);
+    r = Parse(headers, false);
     ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_OK, r);
 
     ASSERT_STREQ("foo\r\n\r\nbar", headers + m_ContentOffset);
+}
+
+TEST_F(dmHttpClientParserTest, TestContentAndHeaders)
+{
+    const char* headers = "HTTP/1.1 200 OK\r\n"
+"Content-Type: text/html;charset=UTF-8\r\n"
+"Content-Length: 2\r\n"
+"Server: Jetty(7.0.2.v20100331)\r\n"
+"\r\n"
+"30"
+;
+
+    dmHttpClientPrivate::ParseResult r;
+    r = Parse(headers, false);
+    ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_OK, r);
+    ASSERT_EQ("text/html;charset=UTF-8", m_Headers["Content-Type"]);
+    ASSERT_EQ("2", m_Headers["Content-Length"]);
+    ASSERT_EQ("Jetty(7.0.2.v20100331)", m_Headers["Server"]);
+
+    ASSERT_STREQ("30", headers + m_ContentOffset);
+}
+
+TEST_F(dmHttpClientParserTest, TestNoContent)
+{
+    // Most servers seem to not add the empty line at the end of a 204 response even though the spec says we should. Test this specific case.
+    const char* headers = "HTTP/1.1 204 OK\r\n"
+"Server: Jetty(7.0.2.v20100331)\r\n"
+;
+    dmHttpClientPrivate::ParseResult r;
+    r = Parse(headers, true);
+    ASSERT_EQ(dmHttpClientPrivate::PARSE_RESULT_OK, r);
+    ASSERT_EQ(1, m_Major);
+    ASSERT_EQ(1, m_Minor);
+    ASSERT_EQ(204, m_Status);
+    ASSERT_EQ("OK", m_StatusString);
+    ASSERT_EQ((size_t) 1, m_Headers.size());
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
Properly parse 204 No Content responses that contain no body and missing empty line after headers