### PR TITLE
DEFEDIT-1325 Crash when filtering projects during Import from Dashboard

### DIFF
--- a/editor/src/clj/editor/ui/fuzzy_choices_popup.clj
+++ b/editor/src/clj/editor/ui/fuzzy_choices_popup.clj
@@ -58,9 +58,10 @@
           (let [text-comparison (compare a-text b-text)]
             (if-not (zero? text-comparison)
               text-comparison
-              (if (and (instance? Comparable a) (instance? Comparable b))
+              (try
                 (compare a b)
-                0))))))))
+                (catch ClassCastException _ ; since value part of option may contain non-Comparable values (f.i. PersistentHashMap)
+                  (compare (System/identityHashCode a) (System/identityHashCode b)))))))))))
 
 (defn fuzzy-option-filter-fn [option->matched-text option->label-text filter-text options]
   (if (empty? filter-text)


### PR DESCRIPTION
* Technical changes
  - Comparing fuzzy options may throw a ClassCastException because
  some part of the option value is not java.lang.Comparable. In this
  case we fall back to System/identityHashCode.