### PR TITLE
DEF-3182 - Spine mesh/attachment color not used when bundling

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/SpineSceneUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/SpineSceneUtil.java
@@ -203,6 +203,9 @@ public class SpineSceneUtil {
     }
 
     private void loadMesh(JsonNode attNode, Mesh mesh, Bone bone, boolean skinned) throws LoadException {
+        String hex = JsonUtil.get(attNode, "color", "ffffffff");
+        JsonUtil.hexToRGBA(hex, mesh.color);
+
         Iterator<JsonNode> vertexIt = attNode.get("vertices").getElements();
         Iterator<JsonNode> uvIt = attNode.get("uvs").getElements();
         int vertexCount = 0;

--- a/editor/src/clj/editor/render.clj
+++ b/editor/src/clj/editor/render.clj
@@ -33,9 +33,7 @@
   (varying vec4 var_color)
   (uniform sampler2D texture)
   (defn void main []
-    (setq gl_FragColor (* var_color (texture2D texture var_texcoord0.xy)))
-    (setq gl_FragColor (vec4 var_texcoord0.x var_texcoord0.y 0 1.0))
-    (setq gl_FragColor (texture2D texture var_texcoord0.xy))))
+    (setq gl_FragColor (* var_color (texture2D texture var_texcoord0.xy)))))
 
 (def shader-tex-tint (shader/make-shader ::shader shader-ver-tex-col shader-frag-tex-tint))
 

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -653,8 +653,11 @@
          (sort-by :draw-order)
          (map (partial transform-positions (:world-transform renderable)))
          (map (fn [mesh]
-                (let [color (get-in renderable [:user-data :color] [1.0 1.0 1.0 1.0])]
-                  (update mesh :color (fn [src tint] (mapv * src tint)) color)))))))
+                (let [tint-color (get-in renderable [:user-data :color] [1.0 1.0 1.0 1.0])
+                      slot-color (:color mesh)
+                      skin-color (:skin-color mesh)
+                      final-color (mapv * slot-color tint-color skin-color)]
+                  (assoc mesh :color final-color)))))))
 
 (defn- mesh->verts [mesh]
   (let [verts (mapv concat (partition 3 (:positions mesh)) (partition 2 (:texcoord0 mesh)) (repeat (:color mesh)))]


### PR DESCRIPTION
- Fixed issue in Bob/Ed1 where mesh color was not set if slot attachment was mesh (not region).
- Fixed preview in Ed2.