### PR TITLE
DEFEDIT-1326 Opening a README.me throws null pointer

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -954,9 +954,7 @@ If you do not specifically require different script states, consider changing th
     (assert (g/node-instance? view/WorkbenchView view))
     (g/transact
       (concat
-        (g/connect resource-node :_node-id view :resource-node)
-        (g/connect resource-node :node-id+resource view :node-id+resource)
-        (g/connect resource-node :dirty? view :dirty?)
+        (view/connect-resource-node view resource-node)
         (g/connect view :view-data app-view :open-views)
         (g/connect view :view-dirty? app-view :open-dirty-views)))
     (ui/user-data! tab ::view view)

--- a/editor/src/clj/editor/html.clj
+++ b/editor/src/clj/editor/html.clj
@@ -17,4 +17,3 @@
                                     :node-type HtmlNode
                                     :view-types [:html]
                                     :view-opts nil))
-

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1866,11 +1866,15 @@ command."
 
 (defonce ^Desktop desktop (when (Desktop/isDesktopSupported) (Desktop/getDesktop)))
 
+(defn as-url
+  [url]
+  (if (instance? URI url) url (URI. url)))
+
 (defn open-url
   [url]
   (if (some-> desktop (.isSupported Desktop$Action/BROWSE))
     (do
-      (.start (Thread. #(.browse desktop (URI. url))))
+      (.start (Thread. #(.browse desktop (as-url url))))
       true)
     false))
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1867,7 +1867,7 @@ command."
 (defonce ^Desktop desktop (when (Desktop/isDesktopSupported) (Desktop/getDesktop)))
 
 (defn as-url
-  [url]
+  ^URI [url]
   (if (instance? URI url) url (URI. url)))
 
 (defn open-url

--- a/editor/src/clj/editor/view.clj
+++ b/editor/src/clj/editor/view.clj
@@ -11,3 +11,9 @@
                                         {:resource-node node-id
                                          :resource resource})]))
   (output view-dirty? g/Any (g/fnk [_node-id dirty?] [_node-id dirty?])))
+
+(defn connect-resource-node [view resource-node]
+  (concat
+    (g/connect resource-node :_node-id view :resource-node)
+    (g/connect resource-node :node-id+resource view :node-id+resource)
+    (g/connect resource-node :dirty? view :dirty?)))

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -3,7 +3,7 @@
             [editor.error-reporting :as error-reporting]
             [service.log :as log])
   (:import [java.io InputStream IOException OutputStream ByteArrayInputStream ByteArrayOutputStream BufferedOutputStream]
-           [java.net InetSocketAddress URLDecoder]
+           [java.net InetSocketAddress InetAddress URLDecoder]
            [org.apache.commons.io IOUtils]
            [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]))
 
@@ -40,18 +40,33 @@
         (IOUtils/copy in out)))
     (.close e)))
 
-(defn ->server [port handlers]
-  (let [server (HttpServer/create (InetSocketAddress. port) 0)]
-    (doseq [[path handler] (merge default-handlers handlers)]
-      (.createContext server path (reify HttpHandler
-                                    (handle [this t]
-                                      (try
-                                        (-> (handler (exchange->request! t))
+(defn- setup-server!
+  [^HttpServer server handlers]
+  (doseq [[path handler] (merge default-handlers handlers)]
+    (.createContext server path (reify HttpHandler
+                                  (handle [this t]
+                                    (try
+                                      (-> (handler (exchange->request! t))
                                           (response->exchange! t))
-                                        (catch Throwable t
-                                          (error-reporting/report-exception! t)))))))
-    (.setExecutor server nil)
-    server))
+                                      (catch Throwable t
+                                        (error-reporting/report-exception! t)))))))
+  (.setExecutor server nil)
+  server)
+
+(defn ->server
+  ([port handlers]
+   (-> (HttpServer/create (InetSocketAddress. port) 0)
+       (setup-server! handlers)))
+  ([address port handlers]
+   (let [inet-socket-address
+         (cond
+           (instance? String address)
+           (InetSocketAddress. ^String address ^int port)
+
+           (instance? InetAddress address)
+           (InetSocketAddress. ^InetAddress address ^int port))]
+     (-> (HttpServer/create inet-socket-address 0)
+         (setup-server! handlers)))))
 
 (defn start! [^HttpServer server]
   (.start server)
@@ -63,6 +78,10 @@
 
 (defn local-url [^HttpServer server]
   (format "http://localhost:%d" (.getPort (.getAddress server))))
+
+(defn url [^HttpServer server]
+  (let [address (.getAddress server)]
+    (format "http://%s:%d" (.getHostString address) (.getPort address))))
 
 (defn port [^HttpServer server]
   (.getPort (.getAddress server)))


### PR DESCRIPTION
* User facing changes
  - Can open README.md from library dependency

* Technical changes
  - We no longer rewrite the `:html` output to set a base path =
  `file://<project directory>`. Instead we launch an http server that
  serves project paths
  - Links to external pages (host supplied in url) are opened in
  external browser
  - Links to resource files are opened in same tab, and new resource
  node is connected to view node