### PR TITLE
ed2-1721: Autocomplete asserts because of bad formatting

### DIFF
--- a/editor/src/clj/editor/lua_parser.clj
+++ b/editor/src/clj/editor/lua_parser.clj
@@ -226,9 +226,11 @@
           result)))
     ;; 'local' namelist ('=' explist)?
     (let [[_ _ namelist _ _explist] node]
-      (if-let [parsed-names (parse-namelist namelist)]
-        (conj result {:local-vars parsed-names})
-        result))))
+      (if (error-node? namelist)
+        result
+        (if-let [parsed-names (parse-namelist namelist)]
+          (conj result {:local-vars parsed-names})
+          result)))))
 
 (defmethod collect-stat-node-info :default [_ result _node] result)
 

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -241,7 +241,7 @@
 
 (deftest test-broken-table-def
   ;; "=" missing after MY_LIST creates an antlr error node wrapping the namelist
-  (let [code "local MY_LIST { 1] = \"hello\", [2] = \"world\" }"
+  (let [code "local MY_LIST { [1] = \"hello\", [2] = \"world\" }"
         result (lua-info code)]
     (is (= #{} (:local-vars result)))))
 

--- a/editor/test/editor/lua_parser_test.clj
+++ b/editor/test/editor/lua_parser_test.clj
@@ -239,6 +239,12 @@
     "local function\nfunction foo(a,b"
     "local function\nfunction foo(a,b)"))
 
+(deftest test-broken-table-def
+  ;; "=" missing after MY_LIST creates an antlr error node wrapping the namelist
+  (let [code "local MY_LIST { 1] = \"hello\", [2] = \"world\" }"
+        result (lua-info code)]
+    (is (= #{} (:local-vars result)))))
+
 (defn- src->properties [src]
   (:script-properties (lua-info src)))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#1721

* Technical changes
  - lua parser handles antlr error in namelist