### PR TITLE
DEFEDIT-1329 showAndWait errors in Sentry.io

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -637,7 +637,7 @@ If you do not specifically require different script states, consider changing th
                              (build-errors-view/clear-build-errors build-errors-view)
                              (engine/reload-resource (targets/selected-target prefs) resource)
                              (catch Exception e
-                               (dialogs/make-alert-dialog (format "Failed to reload resource on '%s'" (targets/target-message-label (targets/selected-target prefs))))))))))))))
+                               (dialogs/make-alert-dialog (format "Failed to reload resource on '%s':\n%s" (targets/target-message-label (targets/selected-target prefs)) (.getMessage e)))))))))))))
 
 (handler/defhandler :close :global
   (enabled? [app-view] (not-empty (get-tabs app-view)))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1719,14 +1719,15 @@ command."
                                    (let [elapsed (- now start)
                                          delta (- now @last)]
                                      (when (or (nil? interval) (> delta interval))
-                                       (try
-                                         (run-later (tick-fn this (* elapsed 1e-9)))
-                                         (reset! last (- now (if interval
-                                                               (- delta interval)
-                                                               0)))
-                                         (catch Throwable t
-                                           (.stop ^AnimationTimer this)
-                                           (error-reporting/report-exception! t))))))))})))
+                                       (run-later
+                                         (try
+                                           (tick-fn this (* elapsed 1e-9))
+                                           (reset! last (- now (if interval
+                                                                 (- delta interval)
+                                                                 0)))
+                                           (catch Throwable t
+                                             (.stop ^AnimationTimer this)
+                                             (error-reporting/report-exception! t)))))))))})))
 
 (defn timer-start! [timer]
   (.start ^AnimationTimer (:timer timer)))


### PR DESCRIPTION
* Lots of "showAndWait is not allowed during animation or layout processing" in Sentry.io
* We use Stage#showAndWait for many dialogs (e.g. resource browsing, error messages, etc.)
* It's illegal to call Stage#showAndWait when a nested event-loop can't be created.
  This is the case when inside the JavaFX "pulse", e.g. while running JFX animations.
* We implement both ui/->future and ui/->timer with javafx.animation.* classes
* Consequently, whenever we try to show a dialog as a result, the above error happens
* It also occurs sometimes when trying to show the error dialog, thus hiding an underlying error
* The problem seems worse on Linux, where event dispatching in many cases seems to be in
  the same callstack as e.g. app-view/refresh-ui!, which in turn is governed by a ui/->timer
* The fix is to implement ui/->future and ui/->timer using ui/run-later instead