### PR TITLE
DEF-3132 world_position of spine model bone now includes component pos

### DIFF
--- a/engine/engine/src/test/spine_anim/banana.script
+++ b/engine/engine/src/test/spine_anim/banana.script
@@ -14,7 +14,14 @@ function update(self, dt)
     -- Remove this function if not needed
     self.ticks = self.ticks + 1
     if 10 == self.ticks then
-    	msg.post("@system:", "exit", { code = 0 })
+        -- Validate that spine component position is applied to the bone position DEF-3132 
+        local pos = go.get_world_position(spine.get_go("go#spinemodel", "root"))
+        if pos.x ~= 200.0 then
+            print("Invalid bone x pos: ", pos.x, " expected it to be 200")
+        	msg.post("@system:", "exit", { code = 1 })
+        else      
+        	msg.post("@system:", "exit", { code = 0 })
+        end
     end
 end
 

--- a/engine/engine/src/test/spine_anim/spine.collection
+++ b/engine/engine/src/test/spine_anim/spine.collection
@@ -2,9 +2,9 @@ name: "default"
 scale_along_z: 0
 embedded_instances {
   id: "go"
-  data: "components {\n  id: \"script\"\n  component: \"/spine_anim/banana.script\"\n  position {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n  }\n  rotation {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n    w: 1.0\n  }\n}\nembedded_components {\n  id: \"spinemodel\"\n  type: \"spinemodel\"\n  data: \"spine_scene: \\\"/spine_anim/banana.spinescene\\\"\\ndefault_animation: \\\"animation\\\"\\nskin: \\\"\\\"\\nblend_mode: BLEND_MODE_ALPHA\\nmaterial: \\\"/builtins/materials/sprite.material\\\"\\n\"\n  position {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n  }\n  rotation {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n    w: 1.0\n  }\n}\n"
+  data: "components {\n  id: \"script\"\n  component: \"/spine_anim/banana.script\"\n  position {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n  }\n  rotation {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n    w: 1.0\n  }\n}\nembedded_components {\n  id: \"spinemodel\"\n  type: \"spinemodel\"\n  data: \"spine_scene: \\\"/spine_anim/banana.spinescene\\\"\\ndefault_animation: \\\"animation\\\"\\nskin: \\\"\\\"\\nblend_mode: BLEND_MODE_ALPHA\\nmaterial: \\\"/builtins/materials/sprite.material\\\"\\n\"\n  position {\n    x: 100.0\n    y: 0.0\n    z: 0.0\n  }\n  rotation {\n    x: 0.0\n    y: 0.0\n    z: 0.0\n    w: 1.0\n  }\n}\n"
   position {
-    x: 179.98445
+    x: 100.0
     y: 0.0
     z: 0.0
   }

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -211,6 +211,7 @@ namespace dmGameSystem
         // Include instance transform in the GO instance reflecting the root bone
         dmArray<dmTransform::Transform>& pose = *dmRig::GetPose(component->m_RigInstance);
         if (!pose.Empty()) {
+            pose[0] = dmTransform::Mul(component->m_Transform, pose[0]);
             dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], pose.Begin(), pose.Size());
         }
     }


### PR DESCRIPTION
Make sure to take spine Component position into account when writing back the transforms from the animated state