### PR TITLE
DEFEDIT-1323 Constant rebuilds in large projects (Blossom)

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -749,6 +749,9 @@
                (swap! stack #(conj (rest %) (update parent :dependencies conj step)))
                (reset! result-atom step)))))))))
 
+(defn tree-trace-seq [result]
+  (tree-seq :dependencies :dependencies result))
+
 ;; ---------------------------------------------------------------------------
 ;; Values
 ;; ---------------------------------------------------------------------------

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -166,7 +166,7 @@
                                                                    :order order
                                                                    :icon image-icon}
                                                                   (resource/openable-resource? image-resource) (assoc :link image-resource :outline-reference? false))))
-  (output ddf-message g/Any :cached (g/fnk [path order] {:image path :order order}))
+  (output ddf-message g/Any (g/fnk [path order] {:image path :order order}))
   (output scene g/Any :cached produce-image-scene))
 
 (defn- sort-by-and-strip-order [images]

--- a/editor/src/clj/editor/code/resource.clj
+++ b/editor/src/clj/editor/code/resource.clj
@@ -67,7 +67,12 @@
 
   (output completions g/Any :cached (g/constantly {}))
   (output breakpoint-rows BreakpointRows :cached produce-breakpoint-rows)
-  (output breakpoints project/Breakpoints :cached produce-breakpoints)
+
+  ;; Breakpoints output only consumed by project (array input of all code files)
+  ;; and already cached there. Changing breakpoints and pulling project breakpoints
+  ;; does imply a pass over all C.E.R.N's of the project to produce new breakpoints,
+  ;; but does not seem to be much of a perf issue.
+  (output breakpoints project/Breakpoints produce-breakpoints)
   (output save-value Lines (gu/passthrough lines)))
 
 (defn register-code-resource-type [workspace & {:keys [ext node-type icon view-types view-opts tags tag-opts label] :as args}]

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -173,16 +173,9 @@
 (g/defnk produce-completions [completion-info module-completion-infos]
   (code-completion/combine-completions completion-info module-completion-infos))
 
-;; TODO: Remove and replace with property once DEFEDIT-1226 is addressed.
-;; See comment in lines property setter below.
-(g/defnk produce-completion-info [lines resource]
-  (let [completion-info (lua-parser/lua-info (data/lines-reader lines))
-        module (lua/path->lua-module (resource/proj-path resource))]
-    (assoc completion-info :module module)))
-
-(g/defnk produce-user-properties [_node-id completion-info]
-  (let [script-props (filter #(= :ok (:status %)) (:script-properties completion-info))
-        display-order (mapv prop->key script-props)
+(g/defnk produce-user-properties [_node-id script-properties]
+  (let [display-order (mapv prop->key script-properties)
+        read-only? (nil? (g/override-original _node-id))
         props (into {}
                     (map (fn [key prop]
                            (let [type (:type prop)
@@ -192,10 +185,10 @@
                                                  :error (status-errors (:status prop))
                                                  :edit-type {:type (go-prop-type->property-types type)}
                                                  :go-prop-type type
-                                                 :read-only? (nil? (g/override-original _node-id))))]
+                                                 :read-only? read-only?))]
                              [key prop]))
                          display-order
-                         script-props))]
+                         script-properties))]
     {:properties props
      :display-order display-order}))
 
@@ -205,8 +198,7 @@
   (input dep-build-targets g/Any :array)
   (input module-completion-infos g/Any :array :substitute gu/array-subst-remove-errors)
 
-  ;; TODO: Must be an output until DEFEDIT-1226 is addressed. See below.
-  ;; (property completion-info g/Any (default {}) (dynamic visible (g/constantly false)))
+  (property completion-info g/Any (default {}) (dynamic visible (g/constantly false)))
 
   ;; Overrides lines property in CodeEditorResourceNode.
   (property lines r/Lines
@@ -217,16 +209,12 @@
                          resource (g/node-value self :resource evaluation-context)
                          own-module (lua/path->lua-module (resource/proj-path resource))
                          completion-info (assoc lua-info :module own-module)
-                         modules (into [] (comp (map second) (remove lua/preinstalled-modules)) (:requires lua-info))]
+                         modules (into [] (comp (map second) (remove lua/preinstalled-modules)) (:requires lua-info))
+                         script-properties (filterv #(= :ok (:status %)) (:script-properties completion-info))]
                      (concat
-                       ;; TODO:
-                       ;; Once DEFEDIT-1226 is addressed, we can store completion-info in a property here.
-                       ;; Currently it must be an output since this deferred setter is run *after*
-                       ;; referencing Game Objects and Collections filter out property overrides for
-                       ;; mismatched types. This results in all overrides being removed, since the
-                       ;; ScriptNode reports no properties.
-                       ;; (g/set-property self :completion-info completion-info)
-                       (g/set-property self :modules modules))))))
+                       (g/set-property self :completion-info completion-info)
+                       (g/set-property self :modules modules)
+                       (g/set-property self :script-properties script-properties))))))
 
   (property modules Modules
             (default [])
@@ -243,12 +231,15 @@
                                                           [[:build-targets :dep-build-targets]
                                                            [:completion-info :module-completion-infos]]))))))))
 
+  (property script-properties g/Any
+            (default [])
+            (dynamic visible (g/constantly false)))
+
   (output _properties g/Properties :cached produce-properties)
   (output bytecode g/Any :cached produce-bytecode)
   (output build-targets g/Any :cached produce-build-targets)
   (output completions g/Any :cached produce-completions)
-  (output completion-info g/Any :cached produce-completion-info) ;; TODO: Replace with property once DEFEDIT-1226 is addressed.
-  (output user-properties g/Properties :cached produce-user-properties))
+  (output user-properties g/Properties produce-user-properties))
 
 (defn register-resource-types [workspace]
   (for [def script-defs

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -305,10 +305,12 @@
   [project debug-view]
   (let [state   (volatile! {})
         tick-fn (fn [timer _]
-                  (let [breakpoints (set (g/node-value project :breakpoints))]
-                    (when-some [debug-session (g/node-value debug-view :debug-session)]
-                      (update-breakpoints! debug-session (:breakpoints @state) breakpoints))
-                    (vreset! state {:breakpoints breakpoints})))]
+                  ;; if we don't have a debug session going on, there is no point in pulling
+                  ;; project/breakpoints or updating the "last breakpoints" state.
+                  (when-some [debug-session (g/node-value debug-view :debug-session)]
+                    (let [breakpoints (set (g/node-value project :breakpoints))]
+                      (update-breakpoints! debug-session (:breakpoints @state) breakpoints)
+                      (vreset! state {:breakpoints breakpoints}))))]
     (ui/->timer 4 "debugger-update-timer" tick-fn)))
 
 (defn- setup-view! [debug-view app-view]

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -138,7 +138,8 @@
   (output texture-profiles-data g/Any (gu/passthrough texture-profiles-data))
   
   (input settings-map g/Any)
-  (output settings-map g/Any :cached (gu/passthrough settings-map))
+  ;; settings-map already cached in SettingsNode
+  (output settings-map g/Any (gu/passthrough settings-map))
 
   (input form-data g/Any)
   (output form-data g/Any :cached (gu/passthrough form-data))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -611,7 +611,7 @@
                     (resource/openable-resource? node-outline-link) (assoc :link node-outline-link :outline-reference? true))))
 
   (output transform-properties g/Any scene/produce-scalable-transform-properties)
-  (output node-msg g/Any :cached produce-node-msg)
+  (output node-msg g/Any produce-node-msg)
   (input node-msgs g/Any :array)
   (output node-msgs g/Any :cached (g/fnk [node-msgs node-msg] (into [node-msg] node-msgs)))
   (input node-rt-msgs g/Any :array)
@@ -741,9 +741,9 @@
   (output gpu-texture TextureLifecycle (g/fnk [texture-gpu-textures texture]
                                          (or (texture-gpu-textures texture)
                                              (texture-gpu-textures ""))))
-  (output texture-size g/Any :cached (g/fnk [anim-data]
-                                       (when (some? anim-data)
-                                         [(double (:width anim-data)) (double (:height anim-data)) 0.0])))
+  (output texture-size g/Any (g/fnk [anim-data]
+                                    (when (some? anim-data)
+                                      [(double (:width anim-data)) (double (:height anim-data)) 0.0])))
   (output build-errors-shape-node g/Any :cached (g/fnk [build-errors-visual-node _node-id texture texture-names]
                                                   (g/package-errors _node-id
                                                                     build-errors-visual-node

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -58,6 +58,10 @@
   (input build-settings g/Any)
   (input texture-profiles g/Any)
   
+  ;; we never modify ImageNode, save-data and source-value can be trivial and not cached
+  (output save-data g/Any (g/constantly nil))
+  (output source-value g/Any (g/constantly nil))
+
   (output texture-profile g/Any (g/fnk [texture-profiles resource]
                                   (tex-gen/match-texture-profile texture-profiles (resource/proj-path resource))))
 

--- a/editor/src/clj/editor/json.clj
+++ b/editor/src/clj/editor/json.clj
@@ -30,6 +30,11 @@
   (inherits resource-node/ResourceNode)
   (property content g/Any)
   (input structure g/Any)
+
+  ;; we never modify JsonNode, save-data and source-value can be trivial and not cached
+  (output save-data g/Any (g/constantly nil))
+  (output source-value g/Any (g/constantly nil))
+
   (output structure g/Any (g/fnk [structure] structure)))
 
 (defn load-json [project self resource]

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -214,7 +214,7 @@
   (input fragment-resource resource/Resource)
   (input fragment-source g/Str)
 
-  (output pb-msg g/Any :cached produce-pb-msg)
+  (output pb-msg g/Any produce-pb-msg)
 
   (output save-value g/Any (gu/passthrough pb-msg))
   (output build-targets g/Any :cached produce-build-targets)
@@ -225,7 +225,7 @@
                                                     (let [uniforms (into {} (map (fn [constant] [(:name constant) (constant->val constant)])
                                                                                  (concat vertex-constants fragment-constants)))]
                                                       (shader/make-shader _node-id vertex-source fragment-source uniforms)))))
-  (output samplers [g/KeywordMap] :cached (g/fnk [samplers] (vec samplers))))
+  (output samplers [g/KeywordMap] (g/fnk [samplers] (vec samplers))))
 
 (defn- make-sampler [name]
   (assoc default-sampler :name name))

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -299,7 +299,7 @@
   (property max-distance Curve (dynamic visible (g/fnk [type] (contains? #{:modifier-type-radial :modifier-type-vortex} type))))
 
   (output transform-properties g/Any scene/produce-unscalable-transform-properties)
-  (output pb-msg g/Any :cached produce-modifier-pb)
+  (output pb-msg g/Any produce-modifier-pb)
   (output node-outline outline/OutlineData :cached
     (g/fnk [_node-id type]
       (let [mod-type (mod-types type)]
@@ -568,7 +568,7 @@
   (output gpu-texture g/Any (g/fnk [gpu-texture tex-params] (texture/set-params gpu-texture tex-params)))
   (output transform-properties g/Any scene/produce-unscalable-transform-properties)
   (output scene g/Any :cached produce-emitter-scene)
-  (output pb-msg g/Any :cached produce-emitter-pb)
+  (output pb-msg g/Any produce-emitter-pb)
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id id child-outlines]
                                                      {:node-id _node-id
                                                       :label id
@@ -711,8 +711,8 @@
 
   (output default-tex-params g/Any (gu/passthrough default-tex-params))
   (output save-value g/Any (gu/passthrough pb-data))
-  (output pb-data g/Any :cached (g/fnk [emitter-msgs modifier-msgs]
-                                       {:emitters emitter-msgs :modifiers modifier-msgs}))
+  (output pb-data g/Any (g/fnk [emitter-msgs modifier-msgs]
+                               {:emitters emitter-msgs :modifiers modifier-msgs}))
   (output rt-pb-data g/Any :cached (g/fnk [pb-data] (particle-fx-transform pb-data)))
   (output emitter-sim-data g/Any :cached (gu/passthrough emitter-sim-data))
   (output build-targets g/Any :cached produce-build-targets)

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -47,16 +47,17 @@
                                               (resource-dependencies resource save-value)))
   
   (output save-value g/Any (g/constantly nil))
-  (output cleaned-save-value g/Any :cached (g/fnk [resource save-value]
-                                             (when resource
-                                               (let [resource-type (resource/resource-type resource)
-                                                     read-fn (:read-fn resource-type)
-                                                     write-fn (:write-fn resource-type)]
-                                                 (if (and read-fn write-fn)
-                                                   (with-open [reader (StringReader. (write-fn save-value))]
-                                                     (read-fn reader))
-                                                   save-value)))))
-  (output dirty? g/Bool :cached (g/fnk [cleaned-save-value source-value]
+
+  (output cleaned-save-value g/Any (g/fnk [resource save-value]
+                                          (when resource
+                                            (let [resource-type (resource/resource-type resource)
+                                                  read-fn (:read-fn resource-type)
+                                                  write-fn (:write-fn resource-type)]
+                                              (if (and read-fn write-fn)
+                                                (with-open [reader (StringReader. (write-fn save-value))]
+                                                  (read-fn reader))
+                                                save-value)))))
+  (output dirty? g/Bool (g/fnk [cleaned-save-value source-value]
                                   (and cleaned-save-value (not= cleaned-save-value source-value))))
   (output node-id+resource g/Any (g/fnk [_node-id resource] [_node-id resource]))
   (output own-build-errors g/Any (g/constantly nil))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -28,7 +28,8 @@
                          (apply project/resource-setter target-node old-value new-value
                            connections)))))))
   (input resource resource/Resource)
-  (output resource-setting-reference g/Any :cached (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))
+  ;; resource-setting-reference only consumed by SettingsNode and already cached there.
+  (output resource-setting-reference g/Any (g/fnk [_node-id path value] {:path path :node-id _node-id :value value})))
 
 (g/defnk produce-settings-map [meta-info raw-settings resource-settings]
   (let [meta-settings (:settings meta-info)

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -150,7 +150,7 @@
 
   (output form-data g/Any :cached produce-form-data)
   (output node-outline outline/OutlineData :cached produce-outline-data)
-  (output pb-msg g/Any :cached produce-pb-msg)
+  (output pb-msg g/Any produce-pb-msg)
   (output save-value g/Any (gu/passthrough pb-msg))
   (output build-targets g/Any :cached produce-build-targets))
 

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -783,7 +783,7 @@
   (input spine-scene g/Any)
   (input scene-structure g/Any)
 
-  (output save-value g/Any :cached produce-save-value)
+  (output save-value g/Any produce-save-value)
   (output own-build-errors g/Any :cached produce-scene-own-build-errors)
   (output build-targets g/Any :cached produce-scene-build-targets)
   (output spine-scene-pb g/Any :cached produce-spine-scene-pb)
@@ -933,7 +933,7 @@
                                         (update-in [:renderable :user-data :gpu-texture] texture/set-params tex-params)
                                         (assoc-in [:renderable :user-data :skin] skin))
                                     spine-scene-scene))))
-  (output model-pb g/Any :cached produce-model-pb)
+  (output model-pb g/Any produce-model-pb)
   (output save-value g/Any (gu/passthrough model-pb))
   (output own-build-errors g/Any :cached produce-model-own-build-errors)
   (output build-targets g/Any :cached produce-model-build-targets)

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -268,7 +268,7 @@
                                              (geom/aabb-incorporate (Point3d. (- hw) (- hh) 0))
                                              (geom/aabb-incorporate (Point3d. hw hh 0))))
                                          (geom/null-aabb))))
-  (output save-value g/Any :cached produce-save-value)
+  (output save-value g/Any produce-save-value)
   (output scene g/Any :cached produce-scene)
   (output build-targets g/Any :cached produce-build-targets))
 

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -3,6 +3,24 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private MB 1048576)
+
+(defn rt-mem []
+  (let [rt    (Runtime/getRuntime)
+        total (.totalMemory rt)
+        max   (.maxMemory rt)
+        free  (.freeMemory rt)]
+    {:total (int (/ total MB))
+     :max   (int (/ max MB))
+     :free  (int (/ free MB))
+     :used  (int (/ (- total free) MB))}))
+
+(defn mem-diff [before after]
+  {:total (- (:total after) (:total before))
+   :max   (- (:max after) (:max before))
+   :free  (- (:free after) (:free before))
+   :used  (- (:used after) (:used before))})
+
 (defn os-name
   ^String []
   (System/getProperty "os.name"))

--- a/editor/src/clj/editor/view.clj
+++ b/editor/src/clj/editor/view.clj
@@ -10,7 +10,9 @@
                             [_node-id (when-let [[node-id resource] node-id+resource]
                                         {:resource-node node-id
                                          :resource resource})]))
-  (output view-dirty? g/Any (g/fnk [_node-id dirty?] [_node-id dirty?])))
+  ;; we cache view-dirty? to avoid recomputing dirty? on the resource
+  ;; node for every open tab whenever one resource changes
+  (output view-dirty? g/Any :cached (g/fnk [_node-id dirty?] [_node-id dirty?])))
 
 (defn connect-resource-node [view resource-node]
   (concat


### PR DESCRIPTION
This PR addresses another reason for constant rebuilds: saving after a
build encaches so many entries that the cached stuff from build is
effectively evicted.

* User facing changes
  - Build->adjust->save->build cycle is less painful in large projects

* Technical changes
  - Removed lots of cases where outputs were :cached
  "unnecessarily". Either they were relatively cheap, or only used by
  a handful of other :cached outputs.
  - Applied diff from the multiple textures branch to change script
  outputs to properties
  - Only touch the breakpoint outputs if we have a debug session
  - Dont cache save-data/source-value for stateless/external
  nodes (ImageNode, JsonNode)