### PR TITLE
DEF-3132 Propagate the component transform to bone GOs from rig

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1756,7 +1756,7 @@ namespace dmGameObject
     uint32_t SetBoneTransforms(HInstance instance, dmTransform::Transform& component_transform, dmTransform::Transform* transforms, uint32_t transform_count)
     {
         HCollection collection = instance->m_Collection;
-        return DoSetBoneTransforms(collection, component_transform, instance->m_Index, transforms, transform_count);
+        return DoSetBoneTransforms(collection, &component_transform, instance->m_Index, transforms, transform_count);
     }
 
     static void DoDeleteBones(HCollection collection, uint16_t first_index) {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1724,7 +1724,7 @@ namespace dmGameObject
         return instance->m_Bone;
     }
 
-    static uint32_t DoSetBoneTransforms(HCollection collection, uint16_t first_index, dmTransform::Transform* transforms, uint32_t transform_count)
+    static uint32_t DoSetBoneTransforms(HCollection collection, dmTransform::Transform* component_transform, uint16_t first_index, dmTransform::Transform* transforms, uint32_t transform_count)
     {
         if (transform_count == 0)
             return 0;
@@ -1736,9 +1736,12 @@ namespace dmGameObject
             if (instance->m_Bone)
             {
                 instance->m_Transform = transforms[count++];
+                if (component_transform && count == 1) {
+                    instance->m_Transform = dmTransform::Mul(*component_transform, instance->m_Transform);
+                }
                 if (count < transform_count)
                 {
-                    count += DoSetBoneTransforms(collection, instance->m_FirstChildIndex, &transforms[count], transform_count - count);
+                    count += DoSetBoneTransforms(collection, 0x0, instance->m_FirstChildIndex, &transforms[count], transform_count - count);
                 }
                 if (transform_count == count)
                 {
@@ -1750,10 +1753,10 @@ namespace dmGameObject
         return count;
     }
 
-    uint32_t SetBoneTransforms(HInstance instance, dmTransform::Transform* transforms, uint32_t transform_count)
+    uint32_t SetBoneTransforms(HInstance instance, dmTransform::Transform& component_transform, dmTransform::Transform* transforms, uint32_t transform_count)
     {
         HCollection collection = instance->m_Collection;
-        return DoSetBoneTransforms(collection, instance->m_Index, transforms, transform_count);
+        return DoSetBoneTransforms(collection, component_transform, instance->m_Index, transforms, transform_count);
     }
 
     static void DoDeleteBones(HCollection collection, uint16_t first_index) {

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -997,11 +997,12 @@ namespace dmGameObject
      * Set the local transforms recursively of all instances flagged as bones, starting with component with id.
      * The order of the transforms is depth-first.
      * @param instance First Instance of the hierarchy to set
+     * @param component_transform the transform for component root
      * @param transforms Array of transforms to set depth-first for the bone instances
      * @param transform_count Size of the transforms array
      * @return Number of instances found
      */
-    uint32_t SetBoneTransforms(HInstance instance, dmTransform::Transform* transforms, uint32_t transform_count);
+    uint32_t SetBoneTransforms(HInstance instance, dmTransform::Transform& component_transform, dmTransform::Transform* transforms, uint32_t transform_count);
 
     /**
      * Recursively delete all instances flagged as bones under the given parent instance.

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -675,7 +675,9 @@ TEST_F(HierarchyTest, TestHierarchyBonesOrder)
         dmGameObject::SetParent(instances[index], parent);
     }
 
-    ASSERT_EQ(instance_count, SetBoneTransforms(instances[0], transforms, instance_count));
+    dmTransform::Transform component_transform;
+    component_transform.SetIdentity();
+    ASSERT_EQ(instance_count, SetBoneTransforms(instances[0], component_transform, transforms, instance_count));
 
     for (uint32_t i = 0; i < instance_count; ++i)
     {
@@ -723,7 +725,9 @@ TEST_F(HierarchyTest, TestHierarchyBonesMulti)
 
     ASSERT_NEAR(1.0f, world.GetTranslation().getX(), EPSILON);
 
-    ASSERT_EQ(2, SetBoneTransforms(p1, t, 2));
+    dmTransform::Transform component_transform;
+    component_transform.SetIdentity();
+    ASSERT_EQ(2, SetBoneTransforms(p1, component_transform, t, 2));
 
     ret = dmGameObject::Update(m_Collection, &m_UpdateContext);
     ASSERT_TRUE(ret);

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -664,7 +664,7 @@ TEST_F(HierarchyTest, TestHierarchyBonesOrder)
         instances[i] = dmGameObject::New(m_Collection, 0x0);
         dmGameObject::SetBone(instances[i], true);
         transforms[i].SetIdentity();
-        transforms[i].SetTranslation(Vector3((float)i, 0.0f, 0.0f));
+        transforms[i].SetTranslation(Vector3((float)i + 1, (float)i + 2, (float)i + 3));
     }
     for (uint32_t i = 0; i < instance_count; ++i)
     {
@@ -681,7 +681,23 @@ TEST_F(HierarchyTest, TestHierarchyBonesOrder)
 
     for (uint32_t i = 0; i < instance_count; ++i)
     {
-        ASSERT_NEAR((float)i, dmGameObject::GetPosition(instances[i]).getX(), EPSILON);
+        ASSERT_NEAR((float)i + 1.f, dmGameObject::GetPosition(instances[i]).getX(), EPSILON);
+        ASSERT_NEAR((float)i + 2.f, dmGameObject::GetPosition(instances[i]).getY(), EPSILON);
+        ASSERT_NEAR((float)i + 3.f, dmGameObject::GetPosition(instances[i]).getZ(), EPSILON);
+    }
+
+    component_transform.SetTranslation(Vector3(100.0f, 100.0f, 100.0f));
+    ASSERT_EQ(instance_count, SetBoneTransforms(instances[0], component_transform, transforms, instance_count));
+
+    ASSERT_NEAR((float)101.f, dmGameObject::GetPosition(instances[0]).getX(), EPSILON);
+    ASSERT_NEAR((float)102.f, dmGameObject::GetPosition(instances[0]).getY(), EPSILON);
+    ASSERT_NEAR((float)103.f, dmGameObject::GetPosition(instances[0]).getZ(), EPSILON);
+
+    for (uint32_t i = 1; i < instance_count; ++i)
+    {
+        ASSERT_NEAR((float)i + 1, dmGameObject::GetPosition(instances[i]).getX(), EPSILON);
+        ASSERT_NEAR((float)i + 2, dmGameObject::GetPosition(instances[i]).getY(), EPSILON);
+        ASSERT_NEAR((float)i + 3, dmGameObject::GetPosition(instances[i]).getZ(), EPSILON);
     }
 
     for (uint32_t i = 0; i < instance_count; ++i)

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -154,7 +154,7 @@ namespace dmGameSystem
         // Include instance transform in the GO instance reflecting the root bone
         dmArray<dmTransform::Transform>& pose = *dmRig::GetPose(component->m_RigInstance);
         if (!pose.Empty()) {
-            dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], pose.Begin(), pose.Size());
+            dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], component->m_Transform, pose.Begin(), pose.Size());
         }
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -211,8 +211,7 @@ namespace dmGameSystem
         // Include instance transform in the GO instance reflecting the root bone
         dmArray<dmTransform::Transform>& pose = *dmRig::GetPose(component->m_RigInstance);
         if (!pose.Empty()) {
-            pose[0] = dmTransform::Mul(component->m_Transform, pose[0]);
-            dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], pose.Begin(), pose.Size());
+            dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], component->m_Transform, pose.Begin(), pose.Size(), &component->m_Transform);
         }
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -211,7 +211,7 @@ namespace dmGameSystem
         // Include instance transform in the GO instance reflecting the root bone
         dmArray<dmTransform::Transform>& pose = *dmRig::GetPose(component->m_RigInstance);
         if (!pose.Empty()) {
-            dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], component->m_Transform, pose.Begin(), pose.Size(), &component->m_Transform);
+            dmGameObject::SetBoneTransforms(component->m_NodeInstances[0], component->m_Transform, pose.Begin(), pose.Size());
         }
     }
 


### PR DESCRIPTION
DEF-3132,DEF-3195 Added component_transform to dmGameObject::SetBoneTransforms() to properly calculate the GO transform after rig animations