### PR TITLE
DEFEDIT-1336 Smoke test fails intermittently on the build step

### DIFF
--- a/share/smoke_test.json
+++ b/share/smoke_test.json
@@ -26,7 +26,7 @@
 		["wait" 2000],
 		["screen-capture" "script"],
 		["press" "Shortcut+B"],
-		["await-log" "engine-log" 4000 "intro started"],
+		["await-log" "engine-log" 10000 "intro started"],
 		["await-log" "engine-log" 60000 " seconds"],
 		["screen-capture" "game_intro"],
 		["await-log" "engine-log" 60000 "level started"],


### PR DESCRIPTION
* Technical changes
  - Bump timeout 4s -> 10 s. Possibly caused by changes to what we
  mark as :cached. No apparent difference "on my machine" though.