### PR TITLE
DEFEDIT-1335 Simplify syntax highlighting for C++ string literals

### DIFF
--- a/editor/src/clj/editor/code/lang/cish.clj
+++ b/editor/src/clj/editor/code/lang/cish.clj
@@ -402,7 +402,7 @@ U[a-fA-F0-9]{0,8} )"
                        }
                       ;; strings
                       {
-                       :begin #"(u|u8|U|L)?\""
+                       :begin #"(u|u8|U|L)?R?\""
                        :begin-captures {0 {:name "punctuation.definition.string.begin.cpp"}}
                        :end #"\""
                        :end-captures {0 {:name "punctuation.definition.string.end.cpp"}}

--- a/editor/src/clj/editor/code/lang/cish.clj
+++ b/editor/src/clj/editor/code/lang/cish.clj
@@ -403,8 +403,7 @@ U[a-fA-F0-9]{0,8} )"
                       ;; strings
                       {
                        :begin #"(u|u8|U|L)?\""
-                       :begin-captures {0 {:name "punctuation.definition.string.begin.cpp"}
-                                        1 {:name "meta.encoding.cpp"}}
+                       :begin-captures {0 {:name "punctuation.definition.string.begin.cpp"}}
                        :end #"\""
                        :end-captures {0 {:name "punctuation.definition.string.end.cpp"}}
                        :name "string.quoted.double.cpp"
@@ -425,13 +424,4 @@ U[a-fA-F0-9]{0,8} )"
                                            }
                                           ]
                                          c-string-placeholder-patterns)
-                       }
-                      {
-                       :begin #"(U|u8|U|L)?R\"(?:([^ ()\\\t]{0,16})|([^ ()\\\t]*))\("
-                       :begin-captures {0 {:name "punctuation.definition.string.begin.cpp"}
-                                        1 {:name "meta.encoding.cpp"}
-                                        3 {:name "invalid.illegal.delimiter-too-long.cpp"}}
-                       :end #"\)\2(\3)\""
-                       :end-captures {0 {:name "punctuation.definition.string.end.cpp"}
-                                      1 {:name "invalid.illegal.delimiter-too-long.cpp"}}
-                       :name "string.quoted.double.raw.cpp"}])})
+                       }])})

--- a/editor/test/editor/code/lang/cish_test.clj
+++ b/editor/test/editor/code/lang/cish_test.clj
@@ -14,9 +14,45 @@
             [4 "punctuation.definition.string.end.c"]
             [5 "source.cish"]]
            (analyze-runs "\"str\""))))
-  (testing "Wide string literal"
+
+  (testing "Prefixed string literals"
+    (are [line]
+      (= [[0 "punctuation.definition.string.begin.cpp"]
+          [2 "string.quoted.double.cpp"]
+          [5 "punctuation.definition.string.end.cpp"]
+          [6 "source.cish"]]
+         (analyze-runs line))
+
+      "L\"str\""
+      "u\"str\""
+      "U\"str\"")
+
+    (is (= [[0 "punctuation.definition.string.begin.cpp"]
+            [3 "string.quoted.double.cpp"]
+            [6 "punctuation.definition.string.end.cpp"]
+            [7 "source.cish"]]
+           (analyze-runs "u8\"str\""))))
+
+  (testing "Raw string literals"
+    (are [line]
+      (= [[0 "punctuation.definition.string.begin.cpp"]
+          [3 "string.quoted.double.cpp"]
+          [8 "punctuation.definition.string.end.cpp"]
+          [9 "source.cish"]]
+         (analyze-runs line))
+
+      "LR\"(str)\""
+      "uR\"(str)\""
+      "UR\"(str)\"")
+
+    (is (= [[0 "punctuation.definition.string.begin.cpp"]
+            [4 "string.quoted.double.cpp"]
+            [9 "punctuation.definition.string.end.cpp"]
+            [10 "source.cish"]]
+           (analyze-runs "u8R\"(str)\"")))
+
     (is (= [[0 "punctuation.definition.string.begin.cpp"]
             [2 "string.quoted.double.cpp"]
-            [5 "punctuation.definition.string.end.cpp"]
-            [6 "source.cish"]]
-           (analyze-runs "L\"str\"")))))
+            [7 "punctuation.definition.string.end.cpp"]
+            [8 "source.cish"]]
+           (analyze-runs "R\"(str)\"")))))

--- a/editor/test/editor/code/lang/cish_test.clj
+++ b/editor/test/editor/code/lang/cish_test.clj
@@ -1,0 +1,22 @@
+(ns editor.code.lang.cish-test
+  (:require [clojure.test :refer :all]
+            [editor.code.lang.cish :refer [grammar]]
+            [editor.code.syntax :as syntax]))
+
+(defn- analyze-runs [line]
+  (let [contexts (list (syntax/make-context (:scope-name grammar) (:patterns grammar)))]
+    (second (syntax/analyze contexts line))))
+
+(deftest string-literals-test
+  (testing "String literal"
+    (is (= [[0 "punctuation.definition.string.begin.c"]
+            [1 "string.quoted.double.c"]
+            [4 "punctuation.definition.string.end.c"]
+            [5 "source.cish"]]
+           (analyze-runs "\"str\""))))
+  (testing "Wide string literal"
+    (is (= [[0 "punctuation.definition.string.begin.cpp"]
+            [2 "string.quoted.double.cpp"]
+            [5 "punctuation.definition.string.end.cpp"]
+            [6 "source.cish"]]
+           (analyze-runs "L\"str\"")))))


### PR DESCRIPTION
Fixes defold/editor2-issues#1746

The issue is that `:begin-captures` and `:end-captures` appear to be broken if captures overlap among themselves or the whole pattern. Attempted to fix this properly in work-in-progress branch here: https://github.com/defold/defold/tree/DEFEDIT-1335-code-editor-syntax-capture

This turned out to be too much of a time-sink, so did this as a workaround for now.