### PR TITLE
DEFEDIT-1340 Disable Git features when there is no HEAD commit

### DIFF
--- a/editor/src/clj/editor/bundle.clj
+++ b/editor/src/clj/editor/bundle.clj
@@ -36,7 +36,7 @@
       (throw (ex-info (format "Shell call failed:\n%s" args) {} e)))))
 
 (defn- cr-project-id [workspace]
-  (when-let [git (git/open (workspace/project-path workspace))]
+  (when-let [git (git/try-open (workspace/project-path workspace))]
     (try
       (when-let [remote-url (git/remote-origin-url git)]
         (let [url (URL. remote-url)

--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -37,16 +37,19 @@
                                                  ".cproject"
                                                  "builtins"])))
 
-(defn open ^Git [^File repo-path]
+(defn try-open
+  ^Git [^File repo-path]
   (try
     (Git/open repo-path)
-    (catch RepositoryNotFoundException e
+    (catch Exception _
       nil)))
 
-(defn get-commit [^Repository repository revision]
-  (let [walk (RevWalk. repository)]
-    (.setRetainBody walk true)
-    (.parseCommit walk (.resolve repository revision))))
+(defn get-commit
+  ^RevCommit [^Repository repository revision]
+  (when-some [object-id (.resolve repository revision)]
+    (let [walk (RevWalk. repository)]
+      (.setRetainBody walk true)
+      (.parseCommit walk object-id))))
 
 (defn- diff-entry->map [^DiffEntry de]
   ; NOTE: We convert /dev/null paths to nil, and convert copies into adds.


### PR DESCRIPTION
Fixes defold/editor2-issues#1613
Fixes defold/editor2-issues#1735
Fixes defold/editor2-issues#1740
Fixes defold/editor2-issues#1771

### User-facing changes
* A project without a `HEAD` commit will be treated as if not having a Git repo in the editor.