### PR TITLE
DEF-3162 - Changed what part of the script filepath is reported on Lua errors.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -71,7 +71,19 @@ public abstract class LuaBuilder extends Builder<Void> {
             //       correct chunk name (the original original source file) already here.
             //
             // See implementation of luaO_chunkid and why a prefix '=' is used; it is to pass through the filename without modifications.
-            ProcessBuilder pb = new ProcessBuilder(new String[] { Bob.getExe(Platform.getHostPlatform(), "luajit"), "-bgf", ("=" + task.input(0).getPath()), inputFile.getAbsolutePath(), outputFile.getAbsolutePath() }).redirectErrorStream(true);
+            //
+            // We will also limit the chunkname (the identifying part of a script/source chunk) to 59 chars.
+            // Lua has a maximum length of chunknames, by default defined to 60 chars.
+            //
+            // If a script error occurs in runtime we want Lua to report the end of the filepath
+            // associated with the chunk, since this is where the filename is visible.
+            //
+            String chunkName = task.input(0).getPath();
+            if (chunkName.length() >= 59) {
+                chunkName = chunkName.substring(chunkName.length() - 59);
+            }
+            chunkName = "=" + chunkName;
+            ProcessBuilder pb = new ProcessBuilder(new String[] { Bob.getExe(Platform.getHostPlatform(), "luajit"), "-bgf", chunkName, inputFile.getAbsolutePath(), outputFile.getAbsolutePath() }).redirectErrorStream(true);
 
             java.util.Map<String, String> env = pb.environment();
             env.put("LUA_PATH", Bob.getPath("share/luajit/") + "/?.lua");

--- a/editor/src/clj/editor/luajit.clj
+++ b/editor/src/clj/editor/luajit.clj
@@ -29,7 +29,11 @@
   [proj-path ^File input ^File output]
   (let [{:keys [exit out err]} (shell/sh (luajit-exec-path)
                                          "-bgf"
-                                         (str "=" proj-path)
+                                         ; Take the last 59 chars from the path as Lua chunkname.
+                                         ; Prefix "=" which tells Lua this is a literal file path,
+                                         ; the total length is now at maximum 60 chars (which is the
+                                         ; maximum length of chunknames in Lua).
+                                         (str "=" (subs proj-path (max 0 (- (count proj-path) 59) )))
                                          (.getAbsolutePath input)
                                          (.getAbsolutePath output)
                                          :env {"LUA_PATH" (str (luajit-lua-path) "/?.lua")})]

--- a/engine/script/src/script_module.cpp
+++ b/engine/script/src/script_module.cpp
@@ -52,7 +52,7 @@ namespace dmScript
     // This function will return a pointer to where the chunkname part can be found in the
     // input filepath. We limit the remaining character count in the string to 59 since
     // we want to prefix the final string with '=', see PrefixFilename() below.
-    static const char* FindSuitableChunkname(const char* input)
+    const char* FindSuitableChunkname(const char* input)
     {
         if (!input)
             return 0;
@@ -71,7 +71,7 @@ namespace dmScript
     // chunk name strings unmangled. '=' prefix means user data and will not be automagically modified.
     //
     // For this reason a null value for input is also just returned as null as it indicates unused argument.
-    static const char* PrefixFilename(const char *input, char prefix, char *buf, uint32_t size)
+    const char* PrefixFilename(const char *input, char prefix, char *buf, uint32_t size)
     {
         if (!input)
             return 0;

--- a/engine/script/src/script_private.h
+++ b/engine/script/src/script_private.h
@@ -43,6 +43,10 @@ namespace dmScript
      * @param context script context
      */
     void ClearModules(HContext context);
+
+    // Exposed here for tests in test_script_module.cpp
+    const char* FindSuitableChunkname(const char* input);
+    const char* PrefixFilename(const char *input, char prefix, char *buf, uint32_t size);
 }
 
 #endif // SCRIPT_PRIVATE_H


### PR DESCRIPTION
* Last 59 chars of script filepaths are used instead of first 59.
* Fix for Ed1/Bob, Ed2 and runtime.
* Runtime fix applies for vanilla Lua chunk loading.
* Buildtime fixes applies for LuaJit chunks since the chunkname is included in the compiled Lua sources.