### PR TITLE
DEFEDIT-1337 Reduce memory usage during build

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -87,10 +87,11 @@
   (is/system-cache @*the-system*))
 
 (defn clear-system-cache!
-  "Clears *the-system* cache, useful when debugging"
-  []
-  (swap! *the-system* assoc :cache (ref (is/make-cache {})))
-  nil)
+  "Clears a cache (default *the-system* cache), useful when debugging"
+  ([] (clear-system-cache! *the-system*))
+  ([sys-atom]
+   (swap! sys-atom assoc :cache (ref (is/make-cache {})))
+   nil))
 
 (defn graph "Given a graph id, returns the particular graph in the system at the current point in time"
   [graph-id]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -494,7 +494,7 @@
                 extra-build-targets (when debug?
                                       (debug-view/build-targets project evaluation-context))
                 build-results       (ui/with-progress [_ render-build-progress!]
-                                      (project/build-and-write-project project evaluation-context extra-build-targets old-artifact-map render-build-progress!))]
+                                      (project/build-project! project evaluation-context extra-build-targets old-artifact-map render-build-progress!))]
             (ui/run-later
               (try
                 (g/update-cache-from-evaluation-context! evaluation-context)
@@ -622,11 +622,11 @@ If you do not specifically require different script states, consider changing th
                      (let [evaluation-context (g/make-evaluation-context)
                            workspace (project/workspace project)
                            old-artifact-map (workspace/artifact-map workspace)
-                           {:keys [error artifacts artifact-map etags]} (project/build-and-write-project project
-                                                                                                         evaluation-context
-                                                                                                         nil
-                                                                                                         old-artifact-map
-                                                                                                         (make-render-task-progress :build))]
+                           {:keys [error artifacts artifact-map etags]} (project/build-project! project
+                                                                                                evaluation-context
+                                                                                                nil
+                                                                                                old-artifact-map
+                                                                                                (make-render-task-progress :build))]
                        (g/update-cache-from-evaluation-context! evaluation-context)
                        (if (some? error)
                          (build-errors-view/update-build-errors build-errors-view error)

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -442,13 +442,13 @@
 
   (output packed-image-generator g/Any (g/fnk [_node-id texture-set-data-generator image-resources]
                                               (let [flat-image-resources (flatten image-resources)
-                                                    shas                 (str/join (map #(validation/resource-io-with-errors resource/resource->sha1-hex % _node-id nil)
-                                                                                        flat-image-resources))
+                                                    shas                 (map #(validation/resource-io-with-errors resource/resource->sha1-hex % _node-id nil)
+                                                                              flat-image-resources)
                                                     errors               (filter g/error? shas)]
                                                 (if (seq errors)
                                                   (g/error-aggregate errors)
                                                   {:f    generate-packed-image
-                                                   :sha1 shas
+                                                   :sha1 (str/join shas)
                                                    :args {:_node-id                   _node-id
                                                           :image-resources            flat-image-resources
                                                           :texture-set-data-generator texture-set-data-generator}}))))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -291,11 +291,11 @@
    :images (sort-by-and-strip-order img-ddf)
    :animations anim-ddf})
 
-(g/defnk produce-build-targets [_node-id resource texture-set packed-image texture-profile build-settings]
+(g/defnk produce-build-targets [_node-id resource texture-set packed-image-generator texture-profile build-settings]
   (let [project           (project/get-project _node-id)
         workspace         (project/workspace project)
         compress?         (:compress-textures? build-settings false)
-        texture-target    (image/make-texture-build-target workspace _node-id packed-image texture-profile compress?)
+        texture-target    (image/make-texture-build-target workspace _node-id packed-image-generator texture-profile compress?)
         pb-msg            texture-set
         dep-build-targets [texture-target]]
     [(pipeline/make-protobuf-build-target resource dep-build-targets
@@ -354,16 +354,19 @@
                   :passes [pass/transparent pass/outline]}
      :children child-scenes}))
 
-(g/defnk produce-texture-set-data
-  [_node-id animations all-atlas-images margin inner-padding extrude-borders]
-  (or (when-let [errors (->> [[margin "Margin"]
-                              [inner-padding "Inner Padding"]
-                              [extrude-borders "Extrude Borders"]]
-                             (keep (fn [[v name]]
-                                     (validation/prop-error :fatal _node-id :layout-result validation/prop-negative? v name)))
-                             not-empty)]
-        (g/error-aggregate errors))
-      (texture-set-gen/atlas->texture-set-data animations all-atlas-images margin inner-padding extrude-borders)))
+(defn- generate-texture-set-data [{:keys [animations all-atlas-images margin inner-padding extrude-borders]}]
+  (texture-set-gen/atlas->texture-set-data animations all-atlas-images margin inner-padding extrude-borders))
+
+(defn- call-generator [generator]
+  ((:f generator) (:args generator)))
+
+(defn- generate-packed-image [{:keys [_node-id image-resources texture-set-data-generator]}]
+  (let [buffered-images (mapv #(validation/resource-io-with-errors image-util/read-image % _node-id nil) image-resources)
+        errors (filter g/error? buffered-images)]
+    (if (seq errors)
+      (g/error-aggregate errors)
+      (let [id->image (zipmap (map resource/proj-path image-resources) buffered-images)]
+        (texture-set-gen/layout-images (:layout (call-generator texture-set-data-generator)) id->image)))))
 
 (g/defnk produce-anim-data
   [texture-set uv-transforms]
@@ -420,20 +423,37 @@
   (output all-atlas-images           [Image]             :cached (g/fnk [animations]
                                                                    (into [] (comp (mapcat :images) (distinct)) animations)))
 
-  (output texture-set-data g/Any               :cached produce-texture-set-data)
+  (output texture-set-data-generator g/Any (g/fnk [_node-id animations all-atlas-images margin inner-padding extrude-borders :as args]
+                                                  (or (when-let [errors (->> [[margin "Margin"]
+                                                                              [inner-padding "Inner Padding"]
+                                                                              [extrude-borders "Extrude Borders"]]
+                                                                             (keep (fn [[v name]]
+                                                                                     (validation/prop-error :fatal _node-id :layout-result validation/prop-negative? v name)))
+                                                                             not-empty)]
+                                                        (g/error-aggregate errors))
+                                                      {:f    generate-texture-set-data
+                                                       :args args})))
+
+  (output texture-set-data g/Any               :cached (g/fnk [texture-set-data-generator] (call-generator texture-set-data-generator)))
   (output layout-size      g/Any               (g/fnk [texture-set-data] (:size texture-set-data)))
   (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
   (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
   (output layout-rects     g/Any               (g/fnk [texture-set-data] (:rects texture-set-data)))
 
-  (output packed-image     BufferedImage       :cached (g/fnk [_node-id texture-set-data image-resources]
-                                                         (let [id->image (reduce (fn [ret image-resource]
-                                                                                   (let [id (resource/proj-path image-resource)
-                                                                                         image (image-util/read-image image-resource)]
-                                                                                     (assoc ret id image)))
-                                                                                 {}
-                                                                                 (flatten image-resources))]
-                                                           (texture-set-gen/layout-images (:layout texture-set-data) id->image))))
+  (output packed-image-generator g/Any (g/fnk [_node-id texture-set-data-generator image-resources]
+                                              (let [flat-image-resources (flatten image-resources)
+                                                    shas                 (str/join (map #(validation/resource-io-with-errors resource/resource->sha1-hex % _node-id nil)
+                                                                                        flat-image-resources))
+                                                    errors               (filter g/error? shas)]
+                                                (if (seq errors)
+                                                  (g/error-aggregate errors)
+                                                  {:f    generate-packed-image
+                                                   :sha1 shas
+                                                   :args {:_node-id                   _node-id
+                                                          :image-resources            flat-image-resources
+                                                          :texture-set-data-generator texture-set-data-generator}}))))
+
+  (output packed-image     BufferedImage       :cached (g/fnk [packed-image-generator] (call-generator packed-image-generator)))
 
   (output texture-image    g/Any               (g/fnk [packed-image texture-profile]
                                                  (tex-gen/make-preview-texture-image packed-image texture-profile)))

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -134,40 +134,41 @@
               (update :properties into (:properties user-properties))
               (update :display-order into (:display-order user-properties)))))
 
-(g/defnk produce-bytecode
-  [_node-id lines resource]
+(defn- script->bytecode [lines proj-path]
   (try
-    (luajit/bytecode (data/lines-reader lines) (resource/proj-path resource))
+    (luajit/bytecode (data/lines-reader lines) proj-path)
     (catch Exception e
       (let [{:keys [filename line message]} (ex-data e)]
-        (g/->error _node-id :lines :fatal e (.getMessage e)
+        (g/->error nil :lines :fatal e (.getMessage e)
                    {:filename filename
                     :line     line
                     :message  message})))))
 
 (defn- build-script [resource _dep-resources user-data]
   (let [user-properties (:user-properties user-data)
-        properties (mapv (fn [[k v]] (let [type (:go-prop-type v)]
-                                       {:id (properties/key->user-name k)
-                                        :value (properties/go-prop->str (:value v) type)
-                                        :type type}))
-                         (:properties user-properties))
-        modules (:modules user-data)
-        bytecode (:bytecode user-data)]
-    {:resource resource :content (protobuf/map->bytes Lua$LuaModule
-                                                      {:source {:script (ByteString/copyFromUtf8 (slurp (data/lines-reader (:lines user-data))))
-                                                                :filename (resource/proj-path (:resource resource))
-                                                                :bytecode (when-not (g/error? bytecode)
-                                                                            (ByteString/copyFrom ^bytes bytecode))}
-                                                       :modules modules
-                                                       :resources (mapv lua/lua-module->build-path modules)
-                                                       :properties (properties/properties->decls properties true)})}))
+        properties      (mapv (fn [[k v]] (let [type (:go-prop-type v)]
+                                            {:id    (properties/key->user-name k)
+                                             :value (properties/go-prop->str (:value v) type)
+                                             :type  type}))
+                              (:properties user-properties))
+        modules         (:modules user-data)
+        bytecode        (script->bytecode (:lines user-data) (resource/proj-path resource))]
+    (g/precluding-errors
+      [bytecode]
+      {:resource resource
+       :content  (protobuf/map->bytes Lua$LuaModule
+                                      {:source     {:script   (ByteString/copyFromUtf8 (slurp (data/lines-reader (:lines user-data))))
+                                                    :filename (resource/proj-path (:resource resource))
+                                                    :bytecode (ByteString/copyFrom ^bytes bytecode)}
+                                       :modules    modules
+                                       :resources  (mapv lua/lua-module->build-path modules)
+                                       :properties (properties/properties->decls properties true)})})))
 
-(g/defnk produce-build-targets [_node-id resource lines bytecode user-properties modules dep-build-targets]
+(g/defnk produce-build-targets [_node-id resource lines user-properties modules dep-build-targets]
   [{:node-id _node-id
     :resource (workspace/make-build-resource resource)
     :build-fn build-script
-    :user-data {:lines lines :user-properties user-properties :modules modules :bytecode bytecode}
+    :user-data {:lines lines :user-properties user-properties :modules modules}
     :deps dep-build-targets}])
 
 (g/defnk produce-completions [completion-info module-completion-infos]
@@ -236,7 +237,6 @@
             (dynamic visible (g/constantly false)))
 
   (output _properties g/Properties :cached produce-properties)
-  (output bytecode g/Any :cached produce-bytecode)
   (output build-targets g/Any :cached produce-build-targets)
   (output completions g/Any :cached produce-completions)
   (output user-properties g/Properties produce-user-properties))

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -64,15 +64,15 @@
                    :view-types [:code :default]
                    :view-opts glsl-opts}])
 
-(defn- build-shader [resource _dep-resources user-data]
-  {:resource resource :content user-data})
+(defn- build-shader [resource _dep-resources ^String user-data]
+  ;; user-data is full-source
+  {:resource resource :content (.getBytes user-data "UTF-8")})
 
 (g/defnk produce-build-targets [_node-id resource ^String full-source]
-  (let [content (.getBytes full-source "UTF-8")]
-    [{:node-id _node-id
-      :resource (workspace/make-build-resource resource)
-      :build-fn build-shader
-      :user-data content}]))
+  [{:node-id _node-id
+    :resource (workspace/make-build-resource resource)
+    :build-fn build-shader
+    :user-data full-source}])
 
 (g/defnk produce-full-source [resource lines]
   (string/join "\n" (if-some [compat-directive-lines (get shader/compat-directives (resource/ext resource))]

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -79,8 +79,7 @@
 
 (g/defnk produce-gpu-texture
   [_node-id gpu-texture-generator]
-  (let [{:keys [generate-fn user-data]} gpu-texture-generator]
-    (generate-fn user-data _node-id texture/default-cubemap-texture-params 0)))
+  ((:f gpu-texture-generator) (:args gpu-texture-generator) _node-id texture/default-cubemap-texture-params 0))
 
 (g/defnk produce-save-value [right left top bottom front back]
   {:right (resource/resource->proj-path right)
@@ -244,9 +243,9 @@
                                                      (g/precluding-errors
                                                        [(cubemap-images-missing-error _node-id cubemap-image-resources)
                                                         (cubemap-image-sizes-error _node-id cubemap-image-sizes)]
-                                                       {:generate-fn generate-gpu-texture
-                                                        :user-data {:cubemap-images cubemap-images
-                                                                    :texture-profile texture-profile}})))
+                                                       {:f    generate-gpu-texture
+                                                        :args {:cubemap-images  cubemap-images
+                                                               :texture-profile texture-profile}})))
 
   (output build-targets g/Any :cached produce-build-targets)
 

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -284,7 +284,7 @@
                  (= (first @steps-left) [node output-type label]))
         (swap! steps-left rest)
         (let [new-message (if-let [path (node-id->resource-path node)]
-                            (str "Planning " path)
+                            (str "Compiling " path)
                             (or (progress/message @progress) ""))]
           (swap! progress progress/advance 1 new-message))
         (render-progress! @progress)))))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -26,7 +26,6 @@
             [editor.util :as util]
             [service.log :as log]
             [editor.graph-util :as gu]
-            [util.digest :as digest]
             [util.http-server :as http-server]
             [util.text-util :as text-util]
             [clojure.string :as str]
@@ -285,12 +284,12 @@
                  (= (first @steps-left) [node output-type label]))
         (swap! steps-left rest)
         (let [new-message (if-let [path (node-id->resource-path node)]
-                            (str "Building " path)
+                            (str "Planning " path)
                             (or (progress/message @progress) ""))]
           (swap! progress progress/advance 1 new-message))
         (render-progress! @progress)))))
 
-(defn build
+(defn build!
   [project node evaluation-context extra-build-targets old-artifact-map render-progress!]
   (let [steps                  (atom [])
         collect-tracer         (make-collect-progress-steps-tracer steps)
@@ -573,13 +572,13 @@
         resources        (resource/filter-resources (g/node-value project :resources) query)]
     (map (fn [r] [r (get resource-path-to-node (resource/proj-path r))]) resources)))
 
-(defn build-and-write-project
+(defn build-project!
   [project evaluation-context extra-build-targets old-artifact-map render-progress!]
   (let [game-project  (get-resource-node project "/game.project" evaluation-context)
         render-progress! (progress/throttle-render-progress render-progress!)]
     (try
       (ui/with-progress [render-progress! (progress/throttle-render-progress render-progress!)]
-        (build project game-project evaluation-context extra-build-targets old-artifact-map render-progress!))
+        (build! project game-project evaluation-context extra-build-targets old-artifact-map render-progress!))
       (catch Throwable error
         (error-reporting/report-exception! error)
         nil))))

--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -4,8 +4,7 @@
             [dynamo.graph :as g]
             [editor.pipeline :as pipeline]
             [editor.workspace :as workspace]
-            [editor.resource :as resource]
-            [util.digest :as digest])
+            [editor.resource :as resource])
   (:import [java.io FileNotFoundException]
            [java.net URI]
            [org.apache.commons.io FilenameUtils IOUtils]))

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -58,10 +58,7 @@
   (texture/texture-image->gpu-texture request-id texture-image params unit))
 
 (defn- generate-content [{:keys [_node-id resource]}]
-  (validation/resource-io-with-errors
-    #(or (image-util/read-image %)
-         (validation/invalid-content-error _node-id :resource :fatal %))
-    resource _node-id :resource))
+  (validation/resource-io-with-errors image-util/read-image resource _node-id :resource))
 
 (g/defnode ImageNode
   (inherits resource-node/ResourceNode)
@@ -77,10 +74,7 @@
                                   (tex-gen/match-texture-profile texture-profiles (resource/proj-path resource))))
 
   (output size g/Any :cached (g/fnk [_node-id resource]
-                                    (validation/resource-io-with-errors
-                                      #(or (image-util/read-size %)
-                                           (validation/invalid-content-error _node-id :size :fatal %))
-                                      resource _node-id :size)))
+                               (validation/resource-io-with-errors image-util/read-size resource _node-id :size)))
 
   (output content BufferedImage (g/fnk [content-generator]
                                   ((:f content-generator) (:args content-generator))))

--- a/editor/src/clj/editor/image_util.clj
+++ b/editor/src/clj/editor/image_util.clj
@@ -34,14 +34,15 @@
   (with-open [source-stream (io/input-stream source)
               image-stream (ImageIO/createImageInputStream source-stream)]
     (let [readers (ImageIO/getImageReaders image-stream)]
-      (when (.hasNext readers)
+      (if (.hasNext readers)
         (let [^javax.imageio.ImageReader reader (.next readers)]
           (try
             (.setInput reader image-stream true true)
             {:width (.getWidth reader 0)
              :height (.getHeight reader 0)}
             (finally
-              (.dispose reader))))))))
+              (.dispose reader))))
+        (throw (ex-info "No matching ImageReader"))))))
 
 (defmacro with-graphics
   [binding & body]

--- a/editor/src/clj/editor/json.clj
+++ b/editor/src/clj/editor/json.clj
@@ -28,8 +28,14 @@
 
 (g/defnode JsonNode
   (inherits resource-node/ResourceNode)
-  (property content g/Any)
+  (property content-transform g/Any
+            (dynamic visible (g/constantly false)))
   (input structure g/Any)
+
+  (output content g/Any (g/fnk [resource content-transform]
+                               (-> (slurp resource)
+                                   json/read-str
+                                   content-transform)))
 
   ;; we never modify JsonNode, save-data and source-value can be trivial and not cached
   (output save-data g/Any (g/constantly nil))
@@ -40,15 +46,15 @@
 (defn load-json [project self resource]
   (let [content (-> (slurp resource)
                   json/read-str)
-        [load-fn new-content] (some (fn [[loader-id {:keys [accept-fn load-fn]}]]
+        [load-fn accept-fn new-content] (some (fn [[loader-id {:keys [accept-fn load-fn]}]]
                                       (when-let [new-content (accept-fn content)]
-                                        [load-fn new-content]))
+                                        [load-fn accept-fn new-content]))
                                     @json-loaders)]
     (if load-fn
       (concat
-        (g/set-property self :content new-content)
+        (g/set-property self :content-transform accept-fn)
         (load-fn self new-content))
-      (g/set-property self :content content))))
+      (g/set-property self :content-transform identity))))
 
 (defn register-resource-types [workspace]
   (workspace/register-resource-type workspace

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -155,10 +155,7 @@
                         (map (fn [[key {:keys [node-id resource] :as build-target}]]
                                (let [cached-artifact (when-let [artifact (get pruned-old-artifacts resource)]
                                                        (and (valid? artifact) artifact))
-                                     message (str (if cached-artifact
-                                                    "Reusing cached "
-                                                    "Building ")
-                                                  (resource/proj-path resource))]
+                                     message (str "Building " (resource/proj-path resource))]
                                  (render-progress! (swap! progress
                                                           #(-> %
                                                                (progress/advance)

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -150,7 +150,7 @@
             (run! #(.addConvexHullPoints builder %) points))
           convex-hulls)))
 
-(defn tile-source->texture-set-data [image tile-source-attributes convex-hulls collision-groups animations]
+(defn tile-source->texture-set-data [tile-source-attributes convex-hulls collision-groups animations]
   (let [image-rects (split-rects tile-source-attributes)
         anims-atom (atom animations)
         anim-indices-atom (atom [])

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -18,6 +18,7 @@ Macros currently mean no foreseeable performance gain however."
            [com.dynamo.proto DdfExtensions DdfMath$Point3 DdfMath$Vector3 DdfMath$Vector4 DdfMath$Quat DdfMath$Matrix4]
            [java.lang.reflect Method]
            [java.io Reader ByteArrayOutputStream]
+           [java.security MessageDigest]
            [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
@@ -588,9 +589,9 @@ Macros currently mean no foreseeable performance gain however."
 
 (defn pb->hash
   ^bytes [^String algorithm ^Message pb]
-  (.digest (with-open [digest-output-stream (digest/make-digest-output-stream algorithm)]
-             (.writeTo pb digest-output-stream)
-             (.getMessageDigest digest-output-stream))))
+  (with-open [digest-output-stream (digest/make-digest-output-stream algorithm)]
+    (.writeTo pb digest-output-stream)
+    (.digest (.getMessageDigest digest-output-stream))))
 
 (defn map->sha1-hex
   ^String [^Class cls m]

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -6,7 +6,8 @@
             [schema.core :as s]
             [editor.core :as core]
             [editor.fs :as fs]
-            [editor.handler :as handler])
+            [editor.handler :as handler]
+            [util.digest :as digest])
   (:import [java.io ByteArrayOutputStream File FilterOutputStream]
            [java.nio.file FileSystem FileSystems PathMatcher]
            [java.net URI URL]
@@ -125,6 +126,9 @@
 (defmethod print-method FileResource [file-resource ^java.io.Writer w]
   (.write w (format "{:FileResource %s}" (pr-str (proj-path file-resource)))))
 
+;; Note that `data` is used for resource-hash, used to name
+;; the output of build-resources. So better be unique for the
+;; data the MemoryResource represents!
 (defrecord MemoryResource [workspace ext data]
   Resource
   (children [this] nil)
@@ -274,6 +278,10 @@
   (if resource
     (proj-path resource)
     ""))
+
+(defn resource->sha1-hex [resource]
+  (with-open [rs (io/input-stream resource)]
+    (digest/stream->sha1-hex rs)))
 
 (g/deftype ResourceVec [(s/maybe (s/protocol Resource))])
 

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -9,8 +9,7 @@
             [editor.settings-core :as settings-core]
             [util.text-util :as text-util]
             [editor.workspace :as workspace]
-            [editor.outline :as outline]
-            [util.digest :as digest])
+            [editor.outline :as outline])
   (:import [org.apache.commons.codec.digest DigestUtils]
            [java.io StringReader]))
 

--- a/editor/src/clj/editor/rig.clj
+++ b/editor/src/clj/editor/rig.clj
@@ -4,7 +4,8 @@
    [editor.pipeline :as pipeline]
    [editor.protobuf :as protobuf]
    [editor.resource :as resource]
-   [editor.workspace :as workspace])
+   [editor.workspace :as workspace]
+   [util.digest :as digest])
   (:import
    [com.dynamo.rig.proto Rig$RigScene Rig$MeshSet Rig$AnimationSet Rig$Skeleton]))
 
@@ -15,7 +16,10 @@
 (defn make-skeleton-build-target
   [workspace node-id skeleton]
   (let [skeleton-type     (workspace/get-resource-type workspace "skeleton")
-        skeleton-resource (resource/make-memory-resource workspace skeleton-type (str (gensym)))]
+        ;; data of memory-resource below only used for
+        ;; resource/resource-hash used to name the
+        ;; corresponding "generated" build resource.
+        skeleton-resource (resource/make-memory-resource workspace skeleton-type (digest/string->sha1-hex (protobuf/map->str Rig$Skeleton skeleton)))]
     {:node-id   node-id
      :resource  (workspace/make-build-resource skeleton-resource)
      :build-fn  build-skeleton
@@ -29,7 +33,10 @@
 (defn make-animation-set-build-target
   [workspace node-id animation-set]
   (let [animation-set-type     (workspace/get-resource-type workspace "animationset")
-        animation-set-resource (resource/make-memory-resource workspace animation-set-type (str (gensym)))]
+        ;; data of memory-resource below only used for
+        ;; resource/resource-hash used to name the
+        ;; corresponding "generated" build resource.
+        animation-set-resource (resource/make-memory-resource workspace animation-set-type (digest/string->sha1-hex (protobuf/map->str Rig$AnimationSet animation-set)))]
     {:node-id   node-id
      :resource  (workspace/make-build-resource animation-set-resource)
      :build-fn  build-animation-set
@@ -43,7 +50,10 @@
 (defn make-mesh-set-build-target
   [workspace node-id mesh-set]
   (let [mesh-set-type     (workspace/get-resource-type workspace "meshset")
-        mesh-set-resource (resource/make-memory-resource workspace mesh-set-type (str (gensym)))]
+        ;; data of memory-resource below only used for
+        ;; resource/resource-hash used to name the
+        ;; corresponding "generated" build resource.
+        mesh-set-resource (resource/make-memory-resource workspace mesh-set-type (digest/string->sha1-hex (protobuf/map->str Rig$MeshSet mesh-set)))]
     {:node-id   node-id
      :resource  (workspace/make-build-resource mesh-set-resource)
      :build-fn  build-mesh-set

--- a/editor/src/clj/editor/rig.clj
+++ b/editor/src/clj/editor/rig.clj
@@ -19,7 +19,7 @@
         ;; data of memory-resource below only used for
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
-        skeleton-resource (resource/make-memory-resource workspace skeleton-type (digest/string->sha1-hex (protobuf/map->str Rig$Skeleton skeleton)))]
+        skeleton-resource (resource/make-memory-resource workspace skeleton-type (protobuf/map->sha1-hex Rig$Skeleton skeleton))]
     {:node-id   node-id
      :resource  (workspace/make-build-resource skeleton-resource)
      :build-fn  build-skeleton
@@ -36,7 +36,7 @@
         ;; data of memory-resource below only used for
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
-        animation-set-resource (resource/make-memory-resource workspace animation-set-type (digest/string->sha1-hex (protobuf/map->str Rig$AnimationSet animation-set)))]
+        animation-set-resource (resource/make-memory-resource workspace animation-set-type (protobuf/map->sha1-hex Rig$AnimationSet animation-set))]
     {:node-id   node-id
      :resource  (workspace/make-build-resource animation-set-resource)
      :build-fn  build-animation-set
@@ -53,7 +53,7 @@
         ;; data of memory-resource below only used for
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
-        mesh-set-resource (resource/make-memory-resource workspace mesh-set-type (digest/string->sha1-hex (protobuf/map->str Rig$MeshSet mesh-set)))]
+        mesh-set-resource (resource/make-memory-resource workspace mesh-set-type (protobuf/map->sha1-hex Rig$MeshSet mesh-set))]
     {:node-id   node-id
      :resource  (workspace/make-build-resource mesh-set-resource)
      :build-fn  build-mesh-set

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -792,7 +792,7 @@
                                                       (reduce mesh->aabb (geom/null-aabb) meshes))))
   (output anim-data g/Any (gu/passthrough anim-data))
   (output scene-structure g/Any (gu/passthrough scene-structure))
-  (output spine-anim-ids g/Any (g/fnk [spine-scene] (keys (get spine-scene "animations")))))
+  (output spine-anim-ids g/Any (g/fnk [scene-structure] (:animations scene-structure))))
 
 (defn load-spine-scene [project self resource spine]
   (let [spine-resource (workspace/resolve-resource resource (:spine-json spine))
@@ -854,7 +854,7 @@
         pb (reduce #(assoc %1 (first %2) (second %2)) pb (map (fn [[label res]] [label (resource/proj-path (get dep-resources res))]) (:dep-resources user-data)))]
     {:resource resource :content (protobuf/map->bytes Spine$SpineModelDesc pb)}))
 
-(g/defnk produce-model-build-targets [_node-id own-build-errors resource model-pb spine-scene-resource material-resource dep-build-targets scene-structure]
+(g/defnk produce-model-build-targets [_node-id own-build-errors resource model-pb spine-scene-resource material-resource dep-build-targets]
   (g/precluding-errors own-build-errors
     (let [dep-build-targets (flatten dep-build-targets)
           deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
@@ -1022,7 +1022,8 @@
   (input content g/Any)
   (output structure g/Any :cached (g/fnk [skeleton content]
                                          {:skeleton (update-transforms (math/->mat4) skeleton)
-                                          :skins (vec (sort (keys (get content "skins"))))})))
+                                          :skins (vec (sort (keys (get content "skins"))))
+                                          :animations (keys (get content "animations"))})))
 
 (defn accept-spine-scene-json [content]
   (when (or (get-in content ["skeleton" "spine"])

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -147,9 +147,9 @@
     {:resource resource :content (protobuf/map->bytes TextureSetProto$TextureSet tex-set)}))
 
 (g/defnk produce-build-targets [_node-id resource packed-image-generator texture-set texture-profile build-settings]
-  (let [workspace        (project/workspace (project/get-project _node-id))
-        compress?         (:compress-textures? build-settings false)
-        texture-target   (image/make-texture-build-target workspace _node-id packed-image-generator texture-profile compress?)]
+  (let [workspace (project/workspace (project/get-project _node-id))
+        compress? (:compress-textures? build-settings false)
+        texture-target (image/make-texture-build-target workspace _node-id packed-image-generator texture-profile compress?)]
     [{:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-texture-set
@@ -578,29 +578,29 @@
   (output tile-source-attributes g/Any :cached produce-tile-source-attributes)
   (output tile->collision-group-node g/Any :cached produce-tile->collision-group-node)
 
-  (output texture-set-data-generator g/Any     (g/fnk [image-resource tile-source-attributes animation-data collision-groups convex-hulls collision tile-count :as args]
-                                                      (or (when-let [errors (not-empty (mapcat #(check-anim-error tile-count %) animation-data))]
-                                                            (g/error-aggregate errors))
-                                                          {:f    generate-texture-set-data
-                                                           :args args})))
+  (output texture-set-data-generator g/Any (g/fnk [image-resource tile-source-attributes animation-data collision-groups convex-hulls collision tile-count :as args]
+                                             (or (when-let [errors (not-empty (mapcat #(check-anim-error tile-count %) animation-data))]
+                                                   (g/error-aggregate errors))
+                                                 {:f generate-texture-set-data
+                                                  :args args})))
 
-  (output texture-set-data g/Any :cached       (g/fnk [texture-set-data-generator] (call-generator texture-set-data-generator)))
-  (output layout-size      g/Any               (g/fnk [texture-set-data] (:size texture-set-data)))
-  (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
-  (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
+  (output texture-set-data g/Any :cached (g/fnk [texture-set-data-generator] (call-generator texture-set-data-generator)))
+  (output layout-size g/Any (g/fnk [texture-set-data] (:size texture-set-data)))
+  (output texture-set g/Any (g/fnk [texture-set-data] (:texture-set texture-set-data)))
+  (output uv-transforms g/Any (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
 
-  (output packed-image-generator g/Any         (g/fnk [_node-id texture-set-data-generator image-resource tile-source-attributes]
-                                                      {:f    generate-packed-image
-                                                       :sha1 (resource/resource->sha1-hex image-resource)
-                                                       :args {:_node-id                   _node-id
-                                                              :texture-set-data-generator texture-set-data-generator
-                                                              :image-resource             image-resource
-                                                              :tile-source-attributes     tile-source-attributes}}))
+  (output packed-image-generator g/Any (g/fnk [_node-id texture-set-data-generator image-resource tile-source-attributes]
+                                          {:f generate-packed-image
+                                           :sha1 (resource/resource->sha1-hex image-resource)
+                                           :args {:_node-id _node-id
+                                                  :texture-set-data-generator texture-set-data-generator
+                                                  :image-resource image-resource
+                                                  :tile-source-attributes tile-source-attributes}}))
 
-  (output packed-image     BufferedImage       (g/fnk [packed-image-generator] (call-generator packed-image-generator)))
+  (output packed-image BufferedImage (g/fnk [packed-image-generator] (call-generator packed-image-generator)))
 
-  (output texture-image    g/Any               (g/fnk [packed-image texture-profile]
-                                                 (tex-gen/make-preview-texture-image packed-image texture-profile)))
+  (output texture-image g/Any (g/fnk [packed-image texture-profile]
+                                (tex-gen/make-preview-texture-image packed-image texture-profile)))
 
   (output convex-hull-points g/Any :cached produce-convex-hull-points)
   (output convex-hulls g/Any :cached produce-convex-hulls)
@@ -626,7 +626,7 @@
                                        (* (:tiles-per-row tile-source-attributes) (:tiles-per-column tile-source-attributes))))
   (output image-dim-error g/Err (g/fnk [image-size collision-size]
                                        (when (and image-size collision-size)
-                                         (let [{img-w :width img-h :height}   image-size
+                                         (let [{img-w :width img-h :height} image-size
                                                {coll-w :width coll-h :height} collision-size]
                                            (when (or (not= img-w coll-w)
                                                      (not= img-h coll-h))
@@ -637,7 +637,7 @@
                                         (let [dims (or image-size collision-size)]
                                           (when dims
                                             (let [{w :width} dims
-                                                  total-w    (+ tile-width tile-margin)]
+                                                  total-w (+ tile-width tile-margin)]
                                               (when (< w total-w)
                                                 (g/error-fatal (format "the total width ('Tile Width' + 'Tile Margin') is greater than the 'Image' width (%d vs %d)"
                                                                        total-w w))))))))
@@ -645,7 +645,7 @@
                                          (let [dims (or image-size collision-size)]
                                            (when dims
                                              (let [{h :height} dims
-                                                   total-h     (+ tile-height tile-margin)]
+                                                   total-h (+ tile-height tile-margin)]
                                                (when (< h total-h)
                                                  (g/error-fatal (format "the total height ('Tile Height' + 'Tile Margin') is greater than the 'Image' height (%d vs %d)"
                                                                         total-h h)))))))))

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -83,3 +83,13 @@
 
 (defn invalid-content-error [node-id label severity resource]
   (g/->error node-id label severity nil (format "The file '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content :resource resource}))
+
+(defn resource-io-with-errors
+  "Helper function that performs resource io and translates exceptions to g/errors"
+  [io-fn resource node-id label]
+  (try
+    (io-fn resource)
+    (catch java.io.FileNotFoundException e
+      (file-not-found-error node-id label :fatal resource))
+    (catch Exception _
+      (invalid-content-error node-id label :fatal resource))))

--- a/editor/src/clj/util/digest.clj
+++ b/editor/src/clj/util/digest.clj
@@ -1,6 +1,8 @@
 (ns util.digest
-  (:import [java.io InputStream]
-           [org.apache.commons.codec.digest DigestUtils]))
+  (:import [java.io InputStream OutputStream]
+           [java.security DigestOutputStream MessageDigest]
+           [org.apache.commons.codec.digest DigestUtils]
+           [org.apache.commons.codec.binary Hex]))
 
 (set! *warn-on-reflection* true)
 
@@ -22,3 +24,15 @@
 (defn stream->sha1-hex [^InputStream stream]
   (DigestUtils/sha1Hex stream))
 
+(def ^:private ^OutputStream sink-output-stream
+  (proxy [OutputStream] []
+    (write
+      ([byte-or-bytes])
+      ([^bytes b, ^long off, ^long len]))))
+
+(defn make-digest-output-stream
+  ^DigestOutputStream [^String algorithm]
+  (DigestOutputStream. sink-output-stream (MessageDigest/getInstance algorithm)))
+
+(defn bytes->hex [^bytes data]
+  (Hex/encodeHexString data))

--- a/editor/src/clj/util/digest.clj
+++ b/editor/src/clj/util/digest.clj
@@ -1,10 +1,24 @@
 (ns util.digest
-  (:import [org.apache.commons.codec.digest DigestUtils]))
+  (:import [java.io InputStream]
+           [org.apache.commons.codec.digest DigestUtils]))
 
 (set! *warn-on-reflection* true)
 
 (defn sha1 [^bytes data]
   (DigestUtils/sha1 data))
 
-(defn sha1->hex [^bytes data]
+(defn sha1-hex [^bytes data]
   (DigestUtils/sha1Hex data))
+
+(defn string->sha1 [^String s]
+  (DigestUtils/sha1 s))
+
+(defn string->sha1-hex [^String s]
+  (DigestUtils/sha1Hex s))
+
+(defn stream->sha1 [^InputStream stream]
+  (DigestUtils/sha1 stream))
+
+(defn stream->sha1-hex [^InputStream stream]
+  (DigestUtils/sha1Hex stream))
+

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -143,7 +143,7 @@
       (is main-dir)
       (let [evaluation-context (g/make-evaluation-context)
             old-artifact-map (workspace/artifact-map workspace)
-            build-results (project/build project game-project evaluation-context nil old-artifact-map progress/null-render-progress!)]
+            build-results (project/build! project game-project evaluation-context nil old-artifact-map progress/null-render-progress!)]
         (g/update-cache-from-evaluation-context! evaluation-context)
         (is (seq (:artifacts build-results)))
         (is (not (g/error? (:error build-results))))
@@ -152,7 +152,7 @@
       (is (nil? (workspace/find-resource workspace "/main")))
       (is (workspace/find-resource workspace "/blahonga"))
       (let [old-artifact-map (workspace/artifact-map workspace)
-            build-results (project/build project game-project (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)]
+            build-results (project/build! project game-project (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)]
         (is (seq (:artifacts build-results)))
         (is (not (g/error? (:error build-results))))
         (workspace/artifact-map! workspace (:artifact-map build-results))))))

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -74,7 +74,7 @@
             (with-open [_ (make-restore-point!)]
               (add-component-from-file! workspace game-object component-resource-path)
               (let [old-artifact-map (workspace/artifact-map workspace)
-                    build-results (project/build project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                    build-results (project/build! project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
                     error-value (:error build-results)]
                 (if (is (some? error-value) component-resource-path)
                   (let [error-tree (build-errors-view/build-resource-tree error-value)]
@@ -113,7 +113,7 @@
             (with-open [_ (make-restore-point!)]
               (add-fn resource-path)
               (let [old-artifact-map (workspace/artifact-map workspace)
-                    build-results (project/build project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                    build-results (project/build! project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
                     error-value (:error build-results)]
                 (if (is (some? error-value) resource-path)
                   (let [error-tree (build-errors-view/build-resource-tree error-value)]
@@ -143,7 +143,7 @@
                         "/errors/window_using_panel_break_button.gui"]]
             (add-component-from-file! workspace game-object path))
           (let [old-artifact-map (workspace/artifact-map workspace)
-                build-results (project/build project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
+                build-results (project/build! project main-collection (g/make-evaluation-context) nil old-artifact-map progress/null-render-progress!)
                 error-value (:error build-results)]
             (if (is (some? error-value))
               (let [error-tree (build-errors-view/build-resource-tree error-value)]

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -259,7 +259,7 @@
            ~'resource-node     (test-util/resource-node ~'project ~path)
            evaluation-context# (g/make-evaluation-context)
            old-artifact-map#   (workspace/artifact-map ~'workspace)
-           ~'build-results     (project/build ~'project ~'resource-node evaluation-context# nil old-artifact-map# progress/null-render-progress!)
+           ~'build-results     (project/build! ~'project ~'resource-node evaluation-context# nil old-artifact-map# progress/null-render-progress!)
            ~'build-artifacts   (:artifacts ~'build-results)
            ~'_                 (when-not (contains? ~'build-results :error)
                                  (workspace/artifact-map! ~'workspace (:artifact-map ~'build-results))
@@ -307,7 +307,7 @@
 (defn- project-build [project resource-node evaluation-context]
   (let [workspace (project/workspace project)
         old-artifact-map (workspace/artifact-map workspace)
-        build-results (project/build project resource-node evaluation-context nil old-artifact-map progress/null-render-progress!)]
+        build-results (project/build! project resource-node evaluation-context nil old-artifact-map progress/null-render-progress!)]
     (when-not (contains? build-results :error)
       (workspace/artifact-map! workspace (:artifact-map build-results))
       (workspace/etags! workspace (:etags build-results)))

--- a/editor/test/integration/hot_reload_test.clj
+++ b/editor/test/integration/hot_reload_test.clj
@@ -39,7 +39,7 @@
 (defn- project-build [project resource-node evaluation-context]
   (let [workspace (project/workspace project)
         old-artifact-map (workspace/artifact-map workspace)
-        build-results (project/build project resource-node evaluation-context nil old-artifact-map progress/null-render-progress!)]
+        build-results (project/build! project resource-node evaluation-context nil old-artifact-map progress/null-render-progress!)]
     (when-not (contains? build-results :error)
       (workspace/artifact-map! workspace (:artifact-map build-results))
       (workspace/etags! workspace (:etags build-results)))


### PR DESCRIPTION
* User facing changes
  - Less memory used for json (spine) resources
  - Less memory used/cached during build
  - Disk cache more often used when building

* Technical changes
  - JsonNodes no longer store clojurified json data in property,
  instead parsed on demand as part of output transform
  - build-target outputs for several types no longer produce data up
  front and put it in user-data (and thus also graph cache) for
  build-fn's to use. Instead they pass along "generators" - functions
  + arguments for producing the needed data. This also avoids
  non-value types in user-data, as those break the disk artifact cache
  lookup.
  - generate-xxx functions produce a value or g/error
  - produce-xxx-generator attempts to validate arguments as far as reasonable
  - build-targets outputs should mostly collect arguments/data from
  graph and perform cheap validation. Meaty work/validation (like
  reading external resources) should be performed in build-xxx
  - build-xxx should now produce a build artifact as before or a
  node-id-less g/error
  - pipeline/build! now needs to be prepared for g/errors from build
  functions and will decorate these with the corresponding _node-id
  for later error reporting
  - Renamed several functions, project/build! project/build-project!