### PR TITLE
Replace deprecated URLs

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.editor/plugin.xml
+++ b/com.dynamo.cr/com.dynamo.cr.editor/plugin.xml
@@ -172,7 +172,7 @@
                style="push">
             <parameter
                   name="com.dynamo.crepo.commands.openWebLink.url"
-                  value="http://www.defold.com/doc">
+                  value="https://www.defold.com/manuals/introduction/">
             </parameter>
          </command>
          <command
@@ -181,7 +181,7 @@
                style="push">
             <parameter
                   name="com.dynamo.crepo.commands.openWebLink.url"
-                  value="http://forum.defold.com">
+                  value="https://forum.defold.com">
             </parameter>
          </command>
          <command

--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/welcome/welcome.html
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/welcome/welcome.html
@@ -96,14 +96,14 @@ a {
     </div>
     <h2>First Step</h2>
     <p>
-        The fastest way to get started is to run the introductory <a href="http://www.defold.com/tutorials/side-scroller">Side scroller</a>
+        The fastest way to get started is to run the introductory <a href="https://www.defold.com/tutorials/side-scroller/">Side scroller</a>
         tutorial.
     </p>
     <p>
         If you want to start by finding your way around on your own, follow these steps:
     </p>
     <ol>
-        <li>Create a project in the <a href="http://dashboard.defold.com">Dashboard</a>.</li>
+        <li>Create a project in the <a href="https://www.defold.com/dashboard/">Dashboard</a>.</li>
         <li>Open the project (Ctrl+O or Cmd + O).</li>
         <li>Open your files either from the Project Explorer to the left or by browsing using Ctrl+Shift+R or Cmd+Shift+R.</li>
     </ol>
@@ -114,9 +114,9 @@ a {
     </p>
     <h2>Next Step</h2>
     <p>
-        For questions, bug-reports, suggestions and other feedback please visit the <a href="http://forum.defold.com">user-forum</a>.
+        For questions, bug-reports, suggestions and other feedback please visit the <a href="https://forum.defold.com/">user-forum</a>.
         Reference documentation, guides, script samples and tutorials are located here <a
-            href="http://www.defold.com/documentation">www.defold.com/documentation</a>.
+            href="https://www.defold.com/learn/">www.defold.com/learn</a>.
     </p>
 </body>
 </html>

--- a/com.dynamo.cr/com.dynamo.cr.web2/templates/base.html
+++ b/com.dynamo.cr/com.dynamo.cr.web2/templates/base.html
@@ -106,7 +106,7 @@
                         <span class="slash slash-blue">//</span>About
                     </h3>
                     <ul class="unstyled">
-                        <li><a href="http://doc.defold.com/release_notes">Release notes</a></li>
+                        <li><a href="https://www.defold.com/release-notes/">Release notes</a></li>
                         <li><a href="/about/company">Company</a></li>
                         <li><a href="/about/story">Story</a></li>
                         <li><a href="/about/eula">Terms of Service</a></li>
@@ -127,7 +127,7 @@
                         <span class="slash slash-orange">//</span>Support
                     </h3>
                     <ul class="unstyled">
-                        <li><a href="http://doc.defold.com">Documentation</a></li>
+                        <li><a href="https://www.defold.com/learn/">Documentation</a></li>
                     </ul>
                 </div>
             </div>

--- a/com.dynamo.cr/com.dynamo.cr.web2/templates/doc_index.html
+++ b/com.dynamo.cr/com.dynamo.cr.web2/templates/doc_index.html
@@ -8,7 +8,7 @@
     </div>
 
     <div class="row">
-        <b>All documentation has moved to <a href="http://doc.defold.com">doc.defold.com</a></b>
+        <b>All documentation has moved to <a href="https://www.defold.com/learn/">www.defold.com/learn</a></b>
     </div>
 </div>
 {% endblock %}

--- a/com.dynamo.cr/com.dynamo.cr.web2/templates/landing.html
+++ b/com.dynamo.cr/com.dynamo.cr.web2/templates/landing.html
@@ -19,9 +19,9 @@
                     <img src="images/white_logo.png"></img>
                 </a>
                 <ul class="nav pull-right">
-                    <li><a href="http://doc.defold.com/release_notes">Release notes</a></li>
-                    <li><a href="http://doc.defold.com">Documentation</a></li>
-                    <li><a href="http://forum.defold.com">Forum</a></li>
+                    <li><a href="https://www.defold.com/release-notes/">Release notes</a></li>
+                    <li><a href="https://www.defold.com/learn/">Documentation</a></li>
+                    <li><a href="https://forum.defold.com">Forum</a></li>
                     <li><a href="/dashboard">Dashboard</a></li>
                 </ul>
             </div>

--- a/defold-robot/project.clj
+++ b/defold-robot/project.clj
@@ -1,6 +1,6 @@
 (defproject defold-robot "0.1.0"
   :description "FIXME: write description"
-  :url "http://www.defold.com"
+  :url "https://www.defold.com"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -1,6 +1,6 @@
 (defproject defold-editor "2.0.0-SNAPSHOT"
   :description      "Defold game editor"
-  :url              "http://doc.defold.com"
+  :url              "https://www.defold.com/learn/"
 
   :repositories     {"local" ~(str (.toURI (java.io.File. "localjars")))}
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -677,7 +677,7 @@ If you do not specifically require different script states, consider changing th
     (ui/show! stage)))
 
 (handler/defhandler :documentation :global
-  (run [] (ui/open-url "http://www.defold.com/learn/")))
+  (run [] (ui/open-url "https://www.defold.com/learn/")))
 
 (handler/defhandler :report-issue :global
   (run [] (ui/open-url (github/new-issue-link))))

--- a/editor/src/clj/editor/client.clj
+++ b/editor/src/clj/editor/client.clj
@@ -30,7 +30,7 @@
 
 ; NOTE: Version without exceptions. Haven't decided yet...
 #_(defn rget [client path entity-class]
-   (let [server-url (prefs/get-prefs (:prefs client) "server-url" "http://cr.defold.com")
+   (let [server-url (prefs/get-prefs (:prefs client) "server-url" "https://cr.defold.com")
          resource (.resource (:client client) (URI. server-url))]
      (let [^ClientResponse cr (-> resource
                                 (.path path)


### PR DESCRIPTION
- Replace deprecated URLs, e.g. doc.defold.com -> www.defold.com/learn
- Use secure URLs