### PR TITLE
DEF-3152 render dispatches exhausted

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1716,6 +1716,7 @@ namespace dmGameSystem
             while (lastEnd < gui_world->m_GuiRenderObjects.Size())
             {
                 const GuiRenderObject& gro = gui_world->m_GuiRenderObjects[lastEnd];
+                write_ptr->m_MinorOrder = 0;
                 write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_AFTER_WORLD;
                 write_ptr->m_Order = MakeFinalRenderOrder(render_order, gro.m_SortOrder);
                 write_ptr->m_UserData = (uintptr_t) &gro.m_RenderObject;

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -29,6 +29,8 @@ namespace dmGameSystem
     using namespace Vectormath::Aos;
     using namespace dmGameSystemDDF;
 
+    static const uint32_t VERTEX_BUFFER_MAX_BATCHES = 16;     // Max dmRender::RenderListEntry.m_MinorOrder (4 bits)
+
     static const dmhash_t PROP_SKIN = dmHashString64("skin");
     static const dmhash_t PROP_ANIMATION = dmHashString64("animation");
     static const dmhash_t PROP_CURSOR = dmHashString64("cursor");
@@ -65,9 +67,16 @@ namespace dmGameSystem
                 {"texcoord0", 1, 2, dmGraphics::TYPE_FLOAT, false},
                 {"normal", 2, 3, dmGraphics::TYPE_FLOAT, false},
         };
+        dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
+        world->m_VertexDeclaration = dmGraphics::NewVertexDeclaration(graphics_context, ve, sizeof(ve) / sizeof(dmGraphics::VertexElement));
+        world->m_MaxElementsVertices = dmGraphics::GetMaxElementsVertices(graphics_context);
+        world->m_VertexBuffers = new dmGraphics::HVertexBuffer[VERTEX_BUFFER_MAX_BATCHES];
+        world->m_VertexBufferData = new dmArray<dmRig::RigModelVertex>[VERTEX_BUFFER_MAX_BATCHES];
+        for(uint32_t i = 0; i < VERTEX_BUFFER_MAX_BATCHES; ++i)
+        {
+            world->m_VertexBuffers[i] = dmGraphics::NewVertexBuffer(graphics_context, 0, 0x0, dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
+        }
 
-        world->m_VertexDeclaration = dmGraphics::NewVertexDeclaration(dmRender::GetGraphicsContext(render_context), ve, sizeof(ve) / sizeof(dmGraphics::VertexElement));
-        world->m_VertexBuffer = dmGraphics::NewVertexBuffer(dmRender::GetGraphicsContext(render_context), 0, 0x0, dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
         *params.m_World = world;
 
         dmResource::RegisterResourceReloadedCallback(context->m_Factory, ResourceReloadedCallback, world);
@@ -79,11 +88,17 @@ namespace dmGameSystem
     {
         ModelWorld* world = (ModelWorld*)params.m_World;
         dmGraphics::DeleteVertexDeclaration(world->m_VertexDeclaration);
-        dmGraphics::DeleteVertexBuffer(world->m_VertexBuffer);
+        for(uint32_t i = 0; i < VERTEX_BUFFER_MAX_BATCHES; ++i)
+        {
+            dmGraphics::DeleteVertexBuffer(world->m_VertexBuffers[i]);
+        }
 
         dmResource::UnregisterResourceReloadedCallback(((ModelContext*)params.m_Context)->m_Factory, ResourceReloadedCallback, world);
 
         dmRig::DeleteContext(world->m_RigContext);
+
+        delete [] world->m_VertexBufferData;
+        delete [] world->m_VertexBuffers;
 
         delete world;
 
@@ -364,6 +379,8 @@ namespace dmGameSystem
     {
         DM_PROFILE(Model, "RenderBatch");
 
+        uint32_t batchIndex = buf[*begin].m_MinorOrder;
+
         const ModelComponent* first = (ModelComponent*) buf[*begin].m_UserData;
         uint32_t vertex_count = 0;
         uint32_t max_component_vertices = 0;
@@ -380,9 +397,11 @@ namespace dmGameSystem
             return;
         }
 
-        dmArray<dmRig::RigModelVertex> &vertex_buffer = world->m_VertexBufferData;
+        dmArray<dmRig::RigModelVertex>& vertex_buffer = world->m_VertexBufferData[batchIndex];
         if (vertex_buffer.Remaining() < vertex_count)
             vertex_buffer.OffsetCapacity(vertex_count - vertex_buffer.Remaining());
+
+        dmGraphics::HVertexBuffer& gfx_vertex_buffer = world->m_VertexBuffers[batchIndex];
 
         // Fill in vertex buffer
         dmRig::RigModelVertex *vb_begin = vertex_buffer.End();
@@ -403,7 +422,7 @@ namespace dmGameSystem
 
         ro.Init();
         ro.m_VertexDeclaration = world->m_VertexDeclaration;
-        ro.m_VertexBuffer = world->m_VertexBuffer;
+        ro.m_VertexBuffer = gfx_vertex_buffer;
         ro.m_PrimitiveType = dmGraphics::PRIMITIVE_TRIANGLES;
         ro.m_VertexStart = vb_begin - vertex_buffer.Begin();
         ro.m_VertexCount = vb_end - vb_begin;
@@ -503,10 +522,11 @@ namespace dmGameSystem
         {
             case dmRender::RENDER_LIST_OPERATION_BEGIN:
             {
-                dmGraphics::SetVertexBufferData(world->m_VertexBuffer, 0, 0, dmGraphics::BUFFER_USAGE_STATIC_DRAW);
                 world->m_RenderObjects.SetSize(0);
-                dmArray<dmRig::RigModelVertex>& vertex_buffer = world->m_VertexBufferData;
-                vertex_buffer.SetSize(0);
+                for (uint32_t batch_index = 0; batch_index < VERTEX_BUFFER_MAX_BATCHES; ++batch_index)
+                {
+                    world->m_VertexBufferData[batch_index].SetSize(0);
+                }
                 break;
             }
             case dmRender::RENDER_LIST_OPERATION_BATCH:
@@ -516,9 +536,20 @@ namespace dmGameSystem
             }
             case dmRender::RENDER_LIST_OPERATION_END:
             {
-                dmGraphics::SetVertexBufferData(world->m_VertexBuffer, sizeof(dmRig::RigModelVertex) * world->m_VertexBufferData.Size(),
-                                                world->m_VertexBufferData.Begin(), dmGraphics::BUFFER_USAGE_STATIC_DRAW);
-                DM_COUNTER("ModelVertexBuffer", world->m_VertexBufferData.Size() * sizeof(dmRig::RigModelVertex));
+                uint32_t total_size = 0;
+                for (uint32_t batch_index = 0; batch_index < VERTEX_BUFFER_MAX_BATCHES; ++batch_index)
+                {
+                    dmArray<dmRig::RigModelVertex>& vertex_buffer_data = world->m_VertexBufferData[batch_index];
+                    if (vertex_buffer_data.Empty())
+                    {
+                        continue;
+                    }
+                    uint32_t vb_size = sizeof(dmRig::RigModelVertex) * vertex_buffer_data.Size();
+                    dmGraphics::HVertexBuffer& gfx_vertex_buffer = world->m_VertexBuffers[batch_index];
+                    dmGraphics::SetVertexBufferData(gfx_vertex_buffer, vb_size, vertex_buffer_data.Begin(), dmGraphics::BUFFER_USAGE_DYNAMIC_DRAW);
+                    total_size += vb_size;
+                }
+                DM_COUNTER("ModelVertexBuffer", total_size);
                 break;
             }
             default:
@@ -543,11 +574,22 @@ namespace dmGameSystem
         dmRender::HRenderListDispatch dispatch = dmRender::RenderListMakeDispatch(render_context, &RenderListDispatch, world);
         dmRender::RenderListEntry* write_ptr = render_list;
 
+        const uint32_t max_elements_vertices = world->m_MaxElementsVertices;
+        uint32_t minor_order = 0; // Will translate to vb index.
+        uint32_t vertex_count_total = 0;
         for (uint32_t i = 0; i < count; ++i)
         {
             ModelComponent& component = *components[i];
             if (!component.m_DoRender)
                 continue;
+
+            uint32_t vertex_count = dmRig::GetVertexCount(component.m_RigInstance);
+            if(vertex_count_total + vertex_count >= max_elements_vertices)
+            {
+                vertex_count_total = 0;
+                minor_order = dmMath::Min(minor_order + 1, VERTEX_BUFFER_MAX_BATCHES-1);
+            }
+            vertex_count_total += vertex_count;
 
             const Vector4 trans = component.m_World.getCol(3);
             write_ptr->m_WorldPosition = Point3(trans.getX(), trans.getY(), trans.getZ());
@@ -555,6 +597,7 @@ namespace dmGameSystem
             write_ptr->m_BatchKey = component.m_MixedHash;
             write_ptr->m_TagMask = dmRender::GetMaterialTagMask(component.m_Resource->m_Material);
             write_ptr->m_Dispatch = dispatch;
+            write_ptr->m_MinorOrder = minor_order;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;
         }

--- a/engine/gamesys/src/gamesys/components/comp_model.h
+++ b/engine/gamesys/src/gamesys/components/comp_model.h
@@ -39,11 +39,14 @@ namespace dmGameSystem
         dmObjectPool<ModelComponent*>   m_Components;
         dmArray<dmRender::RenderObject> m_RenderObjects;
         dmGraphics::HVertexDeclaration  m_VertexDeclaration;
-        dmGraphics::HVertexBuffer       m_VertexBuffer;
-        dmArray<dmRig::RigModelVertex>  m_VertexBufferData;
+        dmGraphics::HVertexBuffer*      m_VertexBuffers;
+        dmArray<dmRig::RigModelVertex>* m_VertexBufferData;
         // Temporary scratch array for instances, only used during the creation phase of components
         dmArray<dmGameObject::HInstance> m_ScratchInstances;
         dmRig::HRigContext              m_RigContext;
+        uint32_t                        m_MaxElementsVertices;
+        uint32_t                        m_VertexBufferSwapChainIndex;
+        uint32_t                        m_VertexBufferSwapChainSize;
     };
 
     dmGameObject::CreateResult CompModelNewWorld(const dmGameObject::ComponentNewWorldParams& params);

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -310,6 +310,7 @@ namespace dmGameSystem
                     write_ptr->m_BatchKey = render_data->m_MixedHash;
                     write_ptr->m_TagMask = dmRender::GetMaterialTagMask((dmRender::HMaterial)render_data->m_Material);
                     write_ptr->m_Dispatch = dispatch;
+                    write_ptr->m_MinorOrder = 0;
                     write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
                     ++write_ptr;
                 }

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -616,6 +616,7 @@ namespace dmGameSystem
             write_ptr->m_BatchKey = component.m_MixedHash;
             write_ptr->m_TagMask = dmRender::GetMaterialTagMask(component.m_Resource->m_Material);
             write_ptr->m_Dispatch = dispatch;
+            write_ptr->m_MinorOrder = 0;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;
         }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -656,6 +656,7 @@ namespace dmGameSystem
             write_ptr->m_BatchKey = component.m_MixedHash;
             write_ptr->m_TagMask = dmRender::GetMaterialTagMask(component.m_Resource->m_Material);
             write_ptr->m_Dispatch = sprite_dispatch;
+            write_ptr->m_MinorOrder = 0;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;
         }

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -476,6 +476,7 @@ namespace dmGameSystem
             write_ptr->m_TagMask = dmRender::GetMaterialTagMask(tile_grid->m_TileGridResource->m_Material);
             write_ptr->m_BatchKey = i;
             write_ptr->m_Dispatch = dispatch;
+            write_ptr->m_MinorOrder = 0;
             write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;
             ++write_ptr;
         }

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -521,6 +521,8 @@ namespace dmGraphics
     void SetVertexBufferSubData(HVertexBuffer buffer, uint32_t offset, uint32_t size, const void* data);
     void* MapVertexBuffer(HVertexBuffer buffer, BufferAccess access);
     bool UnmapVertexBuffer(HVertexBuffer buffer);
+    uint32_t GetMaxElementsVertices(HContext context);
+
 
     HIndexBuffer NewIndexBuffer(HContext context, uint32_t size, const void* data, BufferUsage buffer_usage);
     void DeleteIndexBuffer(HIndexBuffer buffer);
@@ -528,6 +530,7 @@ namespace dmGraphics
     void SetIndexBufferSubData(HIndexBuffer buffer, uint32_t offset, uint32_t size, const void* data);
     void* MapIndexBuffer(HIndexBuffer buffer, BufferAccess access);
     bool UnmapIndexBuffer(HIndexBuffer buffer);
+    uint32_t GetMaxElementsIndices(HContext context);
 
     HVertexDeclaration NewVertexDeclaration(HContext context, VertexElement* element, uint32_t count);
     HVertexDeclaration NewVertexDeclaration(HContext context, VertexElement* element, uint32_t count, uint32_t stride);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -332,6 +332,11 @@ namespace dmGraphics
         return true;
     }
 
+    uint32_t GetMaxElementsVertices(HContext context)
+    {
+        return 65536;
+    }
+
     HIndexBuffer NewIndexBuffer(HContext context, uint32_t size, const void* data, BufferUsage buffer_usage)
     {
         IndexBuffer* ib = new IndexBuffer();
@@ -383,6 +388,11 @@ namespace dmGraphics
         delete [] ib->m_Copy;
         ib->m_Copy = 0x0;
         return true;
+    }
+
+    uint32_t GetMaxElementsIndices(HContext context)
+    {
+        return 65536;
     }
 
     HVertexDeclaration NewVertexDeclaration(HContext context, VertexElement* element, uint32_t count, uint32_t stride)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -615,9 +615,25 @@ static void LogFrameBufferError(GLenum status)
         context->m_DepthBufferBits = (uint32_t) depth_buffer_bits;
 #endif
 
-        GLint max_texture_size;
-        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
-        context->m_MaxTextureSize = max_texture_size;
+        GLint gl_int_result;
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &gl_int_result);
+        context->m_MaxTextureSize = gl_int_result;
+        CLEAR_GL_ERROR
+
+#if (defined(__arm__) || defined(__arm64__)) || (defined(ANDROID))
+        // Hardcoded values for iOS and Android for now. The value is a hint, max number of vertices will still work with performance penalty
+        // The below seems to be the reported sweet spot for modern or semi-modern hardware
+        context->m_MaxElementVertices = 1024*1024;
+        context->m_MaxElementIndices = 1024*1024;
+#else
+        // We don't accept values lower than 65k. It's a trade-off on drawcalls vs bufferdata upload
+        glGetIntegerv(GL_MAX_ELEMENTS_VERTICES, &gl_int_result);
+        context->m_MaxElementVertices = dmMath::Max(65536, gl_int_result);
+        CLEAR_GL_ERROR
+        glGetIntegerv(GL_MAX_ELEMENTS_INDICES, &gl_int_result);
+        context->m_MaxElementIndices = dmMath::Max(65536, gl_int_result);
+        CLEAR_GL_ERROR
+#endif
 
         JobQueueInitialize();
         if(JobQueueIsAsync())
@@ -834,6 +850,11 @@ static void LogFrameBufferError(GLenum status)
         CHECK_GL_ERROR
     }
 
+    uint32_t GetMaxElementsVertices(HContext context)
+    {
+        return context->m_MaxElementVertices;
+    }
+
     HIndexBuffer NewIndexBuffer(HContext context, uint32_t size, const void* data, BufferUsage buffer_usage)
     {
         uint32_t buffer = 0;
@@ -870,6 +891,11 @@ static void LogFrameBufferError(GLenum status)
         CHECK_GL_ERROR
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, 0);
         CHECK_GL_ERROR
+    }
+
+    uint32_t GetMaxElementIndices(HContext context)
+    {
+        return context->m_MaxElementIndices;
     }
 
     static uint32_t GetTypeSize(Type type)

--- a/engine/graphics/src/opengl/graphics_opengl.h
+++ b/engine/graphics/src/opengl/graphics_opengl.h
@@ -25,6 +25,8 @@ namespace dmGraphics
         uint32_t                m_MaxTextureSize;
         TextureFilter           m_DefaultTextureMinFilter;
         TextureFilter           m_DefaultTextureMagFilter;
+        uint32_t                m_MaxElementVertices;
+        uint32_t                m_MaxElementIndices;
         // Counter to keep track of various modifications. Used for cache flush etc
         // Version zero is never used
         uint32_t                m_ModificationVersion;

--- a/engine/render/src/render/debug_renderer.cpp
+++ b/engine/render/src/render/debug_renderer.cpp
@@ -283,6 +283,7 @@ namespace dmRender
             if (vertex_count > 0)
             {
                 dmGraphics::SetVertexBufferSubData(debug_renderer.m_VertexBuffer, ro.m_VertexStart * sizeof(DebugVertex), vertex_count * sizeof(DebugVertex), type_data.m_ClientBuffer);
+                write_ptr->m_MinorOrder = 0;
                 write_ptr->m_MajorOrder = RENDER_ORDER_AFTER_WORLD;
                 write_ptr->m_Order = render_order;
                 write_ptr->m_UserData = (uintptr_t) &ro;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -753,6 +753,7 @@ namespace dmRender
                 {
                     TextEntry& te = text_context.m_TextEntries[text_context.m_TextEntriesFlushed + i];
                     write_ptr->m_WorldPosition = Point3(te.m_Transform.getTranslation());
+                    write_ptr->m_MinorOrder = 0;
                     write_ptr->m_MajorOrder = major_order;
                     write_ptr->m_Order = render_order;
                     write_ptr->m_UserData = (uintptr_t) &te; // The text entry must live until the dispatch is done

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -582,16 +582,11 @@ namespace dmRender
         {
             uint32_t *idx = context->m_RenderListSortBuffer.Begin() + i;
             const RenderListEntry *last_entry = &base[*last];
+            const RenderListEntry *current_entry = &base[*idx];
 
             // continue batch on match, or dispatch
-            if (i < count && (last_entry->m_Dispatch == base[*idx].m_Dispatch && last_entry->m_BatchKey == base[*idx].m_BatchKey && last_entry->m_MinorOrder == base[*idx].m_MinorOrder))
+            if (i < count && (last_entry->m_Dispatch == current_entry->m_Dispatch && last_entry->m_BatchKey == current_entry->m_BatchKey && last_entry->m_MinorOrder == current_entry->m_MinorOrder))
                 continue;
-
-            if(i == context->m_RenderListDispatch.Capacity())
-            {
-                dmLogError("Exhausted number of render dispatches (%d, max is %d)", count, context->m_RenderListDispatch.Capacity());
-                return RESULT_BUFFER_IS_FULL;
-            }
 
             if (last_entry->m_Dispatch != RENDERLIST_INVALID_DISPATCH)
             {

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -458,6 +458,7 @@ namespace dmRender
                     // use the integer value provided.
                     sort_values[idx].m_Order = entry->m_Order;
                 }
+                sort_values[idx].m_MinorOrder = entry->m_MinorOrder;
                 sort_values[idx].m_BatchKey = entry->m_BatchKey & 0xffffff;
                 sort_values[idx].m_Dispatch = entry->m_Dispatch;
                 context->m_RenderListSortBuffer.Push(idx);
@@ -572,7 +573,7 @@ namespace dmRender
         params.m_Operation = RENDER_LIST_OPERATION_BATCH;
         params.m_Buf = context->m_RenderList.Begin();
 
-        // Make batches for matching dispatch & batch key
+        // Make batches for matching dispatch, batch key & minor order
         RenderListEntry *base = context->m_RenderList.Begin();
         uint32_t *last = context->m_RenderListSortBuffer.Begin();
         uint32_t count = context->m_RenderListSortBuffer.Size();
@@ -583,8 +584,14 @@ namespace dmRender
             const RenderListEntry *last_entry = &base[*last];
 
             // continue batch on match, or dispatch
-            if (i < count && (last_entry->m_Dispatch == base[*idx].m_Dispatch && last_entry->m_BatchKey == base[*idx].m_BatchKey))
+            if (i < count && (last_entry->m_Dispatch == base[*idx].m_Dispatch && last_entry->m_BatchKey == base[*idx].m_BatchKey && last_entry->m_MinorOrder == base[*idx].m_MinorOrder))
                 continue;
+
+            if(i == context->m_RenderListDispatch.Capacity())
+            {
+                dmLogError("Exhausted number of render dispatches (%d, max is %d)", count, context->m_RenderListDispatch.Capacity());
+                return RESULT_BUFFER_IS_FULL;
+            }
 
             if (last_entry->m_Dispatch != RENDERLIST_INVALID_DISPATCH)
             {

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -174,6 +174,7 @@ namespace dmRender
         uint32_t m_BatchKey;
         uint32_t m_TagMask;
         uintptr_t m_UserData;
+        uint32_t m_MinorOrder:4;
         uint32_t m_MajorOrder:2;
         uint32_t m_Dispatch:8;
     };

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -176,7 +176,8 @@ namespace dmRender
                 uint32_t m_BatchKey:24;
                 uint32_t m_Dispatch:8;
                 uint32_t m_Order:24;
-                uint32_t m_MajorOrder:8;
+                uint32_t m_MajorOrder:4;        // currently only 2 bits used (dmRender::RenderOrder)
+                uint32_t m_MinorOrder:4;
             };
             // only temporarily used
             float m_ZW;


### PR DESCRIPTION
Removed bad check in DrawRenderList() causing drawing and log errors.
Added a current_entry variable to increase readability of batch matching test.

Reverted revert of DEF-3152