### PR TITLE
DEFEDIT-1351 Find previous with Shift+Enter in the code editor

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1800,7 +1800,8 @@
     (.bindBidirectional (.selectedProperty whole-word) find-whole-word-property)
     (.bindBidirectional (.selectedProperty case-sensitive) find-case-sensitive-property)
     (.bindBidirectional (.selectedProperty wrap) find-wrap-property)
-    (ui/bind-keys! find-bar {KeyCode/ENTER :find-next})
+    (ui/bind-key-commands! find-bar {"Enter" :find-next
+                                     "Shift+Enter" :find-prev})
     (ui/bind-action! next :find-next)
     (ui/bind-action! prev :find-prev))
   find-bar)


### PR DESCRIPTION
Fixes defold/editor2-issues#1619

### User-facing changes
* `Shift+Enter` finds previous match in the code editor Find Bar.

### Technical changes
* Added `ui/bind-key-commands!`, a more flexible version of `bind-keys!` that supports modifier keys.