### PR TITLE
DEFEDIT-1352 Create discrete undo step for auto-complete in the code editor

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1169,7 +1169,7 @@
               new-cursor-ranges (if (seq tab-trigger-word-regions)
                                   (mapv (comp data/sanitize-cursor-range first) tab-trigger-word-region-colls)
                                   (mapv data/cursor-range-end-range cursor-ranges))]
-          (set-properties! view-node :typing
+          (set-properties! view-node nil
                            (cond-> (assoc props :cursor-ranges new-cursor-ranges)
 
                                    (seq tab-trigger-word-regions)


### PR DESCRIPTION
Fixes defold/editor2-issues#1641

### User-facing changes
* Auto-completing in the Code Editor now generates a discrete undo step.