### PR TITLE
DEF-3161 Status 204 No Content - take 2

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -909,6 +909,12 @@ bail:
             return r;
         }
 
+        if (response.m_Status == 204 /* No Content*/)
+        {
+            assert(response.m_ContentLength == -1);
+            response.m_ContentLength = 0;
+        }
+
         if (response.m_Chunked)
         {
             // Ok


### PR DESCRIPTION
DEF-3161 Explicitly set content length to zero for no content messages. No Content messages does not contain an explicit content length header (since that is redundant) so we check for 204 and set the length to zero explicitly, if we did not we would try to wait for data from the server.

When response.m_ContentLength is -1 it is interpreted to mean "content of one byte or more". 