### PR TITLE
DEFEDIT-1361 Ignore indent triggers inside strings

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -26,7 +26,7 @@
    :scope-name "source.lua"
    ;; indent patterns shamelessly stolen from textmate:
    ;; https://github.com/textmate/lua.tmbundle/blob/master/Preferences/Indent.tmPreferences
-   :indent {:begin #"^([^-]|-(?!-))*((\b(else|function|then|do|repeat)\b((?!\b(end|until)\b).)*)|(\{\s*))$"
+   :indent {:begin #"^([^-]|-(?!-))*((\b(else|function|then|do|repeat)\b((?!\b(end|until)\b)[^\"'])*)|(\{\s*))$"
             :end #"^\s*((\b(elseif|else|end|until)\b)|(\})|(\)))"}
    :patterns [{:captures {1 {:name "keyword.control.lua"}
                           2 {:name "entity.name.function.scope.lua"}

--- a/editor/test/editor/code/script_test.clj
+++ b/editor/test/editor/code/script_test.clj
@@ -182,4 +182,40 @@
     ["function foo()"
      "|    -- comment"]
     ["function foo()"
-     "e|    -- comment"]))
+     "e|    -- comment"]
+
+    [""
+     ""]
+    ["    -- will do something|"]
+    ["    -- will do something"
+     "    |"]
+
+    [""
+     ""]
+    ["    s = \"will do something\"|"]
+    ["    s = \"will do something\""
+     "    |"]
+
+    [""
+     ""]
+    ["    s = 'will do something'|"]
+    ["    s = 'will do something'"
+     "    |"]
+
+    [""
+     ""]
+    ["    -- will end something|"]
+    ["    -- will end something"
+     "    |"]
+
+    [""
+     ""]
+    ["    s = \"will end something\"|"]
+    ["    s = \"will end something\""
+     "    |"]
+
+    [""
+     ""]
+    ["    s = 'will end something'|"]
+    ["    s = 'will end something'"
+     "    |"]))


### PR DESCRIPTION
Fixes defold/editor2-issues#1710

### User-facing changes
* Lua keywords inside strings will no longer trigger indentation changes.