### PR TITLE
DEF-3255 Support for reloading game object prototypes .goc

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -626,7 +626,7 @@ If you do not specifically require different script states, consider changing th
                        (when-not (handle-bob-error! render-error! project result)
                          (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix)))))))))
 
-(def ^:private unreloadable-resource-build-exts #{"collectionc" "goc"})
+(def ^:private unreloadable-resource-build-exts #{"collectionc" "tilemapc"})
 
 (handler/defhandler :hot-reload :global
   (enabled? [app-view debug-view selection prefs]

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -403,7 +403,7 @@ namespace dmGameObject
     dmResource::Result RegisterResourceTypes(dmResource::HFactory factory, HRegister regist, dmScript::HContext script_context, ModuleContext* module_context)
     {
         dmResource::Result ret = dmResource::RESULT_OK;
-        ret = dmResource::RegisterType(factory, "goc", (void*)regist, &ResPrototypePreload, &ResPrototypeCreate, 0, &ResPrototypeDestroy, 0, 0);
+        ret = dmResource::RegisterType(factory, "goc", (void*)regist, &ResPrototypePreload, &ResPrototypeCreate, 0, &ResPrototypeDestroy, &ResPrototypeRecreate, 0);
         if (ret != dmResource::RESULT_OK)
             return ret;
 
@@ -473,13 +473,7 @@ namespace dmGameObject
         instance->m_LevelIndex = level_index;
     }
 
-    HInstance NewInstance(HCollection collection, Prototype* proto, const char* prototype_name) {
-        if (collection->m_InstanceIndices.Remaining() == 0)
-        {
-            dmLogError("The game object instance could not be created since the buffer is full (%d).", collection->m_InstanceIndices.Capacity());
-            return 0;
-        }
-
+    static HInstance AllocInstance(Prototype* proto, const char* prototype_name) {
         // Count number of component userdata fields required
         uint32_t component_instance_userdata_count = 0;
         for (uint32_t i = 0; i < proto->m_Components.Size(); ++i)
@@ -500,6 +494,27 @@ namespace dmGameObject
         void* instance_memory = ::operator new (sizeof(Instance) + component_instance_userdata_count * component_userdata_size);
         Instance* instance = new(instance_memory) Instance(proto);
         instance->m_ComponentInstanceUserDataCount = component_instance_userdata_count;
+        return instance;
+    }
+
+    static void DeallocInstance(HInstance instance) {
+        instance->~Instance();
+        void* instance_memory = (void*) instance;
+
+        // This is required for failing test
+        // TODO: #ifdef on something...?
+        // Clear all memory excluding ComponentInstanceUserData
+        memset(instance_memory, 0xcc, sizeof(Instance));
+        operator delete (instance_memory);
+    }
+
+    HInstance NewInstance(HCollection collection, Prototype* proto, const char* prototype_name) {
+        if (collection->m_InstanceIndices.Remaining() == 0)
+        {
+            dmLogError("The game object instance could not be created since the buffer is full (%d).", collection->m_InstanceIndices.Capacity());
+            return 0;
+        }
+        HInstance instance = AllocInstance(proto, prototype_name);
         instance->m_Collection = collection;
         instance->m_ScaleAlongZ = collection->m_ScaleAlongZ;
         uint16_t instance_index = collection->m_InstanceIndices.Pop();
@@ -604,6 +619,32 @@ namespace dmGameObject
         }
 
         return ok;
+    }
+
+    void DestroyComponents(HCollection collection, HInstance instance) {
+        HPrototype prototype = instance->m_Prototype;
+        uint32_t next_component_instance_data = 0;
+        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        {
+            Prototype::Component* component = &prototype->m_Components[i];
+            ComponentType* component_type = component->m_Type;
+
+            uintptr_t* component_instance_data = 0;
+            if (component_type->m_InstanceHasUserData)
+            {
+                component_instance_data = &instance->m_ComponentInstanceUserData[next_component_instance_data++];
+            }
+            assert(next_component_instance_data <= instance->m_ComponentInstanceUserDataCount);
+
+            collection->m_ComponentInstanceCount[component->m_TypeIndex]--;
+            ComponentDestroyParams params;
+            params.m_Collection = collection;
+            params.m_Instance = instance;
+            params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
+            params.m_Context = component_type->m_Context;
+            params.m_UserData = component_instance_data;
+            component_type->m_DestroyFunction(params);
+        }
     }
 
     HInstance New(HCollection collection, const char* prototype_name) {
@@ -1265,6 +1306,39 @@ namespace dmGameObject
         }
     }
 
+    static bool InitComponents(HCollection collection, HInstance instance) {
+        uint32_t next_component_instance_data = 0;
+        Prototype* prototype = instance->m_Prototype;
+        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        {
+            Prototype::Component* component = &prototype->m_Components[i];
+            ComponentType* component_type = component->m_Type;
+
+            uintptr_t* component_instance_data = 0;
+            if (component_type->m_InstanceHasUserData)
+            {
+                component_instance_data = &instance->m_ComponentInstanceUserData[next_component_instance_data++];
+            }
+            assert(next_component_instance_data <= instance->m_ComponentInstanceUserDataCount);
+
+            if (component_type->m_InitFunction)
+            {
+                ComponentInitParams params;
+                params.m_Collection = collection;
+                params.m_Instance = instance;
+                params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
+                params.m_Context = component_type->m_Context;
+                params.m_UserData = component_instance_data;
+                CreateResult result = component_type->m_InitFunction(params);
+                if (result != CREATE_RESULT_OK)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     bool Init(HCollection collection, HInstance instance)
     {
         if (instance)
@@ -1298,36 +1372,7 @@ namespace dmGameObject
                     *trans = dmTransform::MulNoScaleZ(*parent_trans, dmTransform::ToMatrix4(instance->m_Transform));
                 }
             }
-
-            uint32_t next_component_instance_data = 0;
-            Prototype* prototype = instance->m_Prototype;
-            for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
-            {
-                Prototype::Component* component = &prototype->m_Components[i];
-                ComponentType* component_type = component->m_Type;
-
-                uintptr_t* component_instance_data = 0;
-                if (component_type->m_InstanceHasUserData)
-                {
-                    component_instance_data = &instance->m_ComponentInstanceUserData[next_component_instance_data++];
-                }
-                assert(next_component_instance_data <= instance->m_ComponentInstanceUserDataCount);
-
-                if (component_type->m_InitFunction)
-                {
-                    ComponentInitParams params;
-                    params.m_Collection = collection;
-                    params.m_Instance = instance;
-                    params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
-                    params.m_Context = component_type->m_Context;
-                    params.m_UserData = component_instance_data;
-                    CreateResult result = component_type->m_InitFunction(params);
-                    if (result != CREATE_RESULT_OK)
-                    {
-                        return false;
-                    }
-                }
-            }
+            return InitComponents(collection, instance);
         }
 
         return true;
@@ -1366,6 +1411,40 @@ namespace dmGameObject
         return result;
     }
 
+    static bool FinalComponents(HCollection collection, HInstance instance) {
+        uint32_t next_component_instance_data = 0;
+        Prototype* prototype = instance->m_Prototype;
+        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        {
+            Prototype::Component* component = &prototype->m_Components[i];
+            ComponentType* component_type = component->m_Type;
+            assert(component_type);
+
+            uintptr_t* component_instance_data = 0;
+            if (component_type->m_InstanceHasUserData)
+            {
+                component_instance_data = &instance->m_ComponentInstanceUserData[next_component_instance_data++];
+            }
+            assert(next_component_instance_data <= instance->m_ComponentInstanceUserDataCount);
+
+            if (component_type->m_FinalFunction)
+            {
+                ComponentFinalParams params;
+                params.m_Collection = collection;
+                params.m_Instance = instance;
+                params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
+                params.m_Context = component_type->m_Context;
+                params.m_UserData = component_instance_data;
+                CreateResult result = component_type->m_FinalFunction(params);
+                if (result != CREATE_RESULT_OK)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     bool Final(HCollection collection, HInstance instance)
     {
         if (instance)
@@ -1376,37 +1455,7 @@ namespace dmGameObject
                 dmLogWarning("%s", "Instance is finalized without being initialized, this may lead to undefined behaviour.");
 
             assert(collection->m_Instances[instance->m_Index] == instance);
-
-            uint32_t next_component_instance_data = 0;
-            Prototype* prototype = instance->m_Prototype;
-            for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
-            {
-                Prototype::Component* component = &prototype->m_Components[i];
-                ComponentType* component_type = component->m_Type;
-                assert(component_type);
-
-                uintptr_t* component_instance_data = 0;
-                if (component_type->m_InstanceHasUserData)
-                {
-                    component_instance_data = &instance->m_ComponentInstanceUserData[next_component_instance_data++];
-                }
-                assert(next_component_instance_data <= instance->m_ComponentInstanceUserDataCount);
-
-                if (component_type->m_FinalFunction)
-                {
-                    ComponentFinalParams params;
-                    params.m_Collection = collection;
-                    params.m_Instance = instance;
-                    params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
-                    params.m_Context = component_type->m_Context;
-                    params.m_UserData = component_instance_data;
-                    CreateResult result = component_type->m_FinalFunction(params);
-                    if (result != CREATE_RESULT_OK)
-                    {
-                        return false;
-                    }
-                }
-            }
+            return FinalComponents(collection, instance);
         }
 
         return true;
@@ -1428,7 +1477,6 @@ namespace dmGameObject
                 result = false;
             }
         }
-
         return result;
     }
 
@@ -1500,29 +1548,8 @@ namespace dmGameObject
             RemoveFromAddToUpdate(collection, instance);
         }
         dmResource::HFactory factory = collection->m_Factory;
-        uint32_t next_component_instance_data = 0;
         Prototype* prototype = instance->m_Prototype;
-        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
-        {
-            Prototype::Component* component = &prototype->m_Components[i];
-            ComponentType* component_type = component->m_Type;
-
-            uintptr_t* component_instance_data = 0;
-            if (component_type->m_InstanceHasUserData)
-            {
-                component_instance_data = &instance->m_ComponentInstanceUserData[next_component_instance_data++];
-            }
-            assert(next_component_instance_data <= instance->m_ComponentInstanceUserDataCount);
-
-            collection->m_ComponentInstanceCount[component->m_TypeIndex]--;
-            ComponentDestroyParams params;
-            params.m_Collection = collection;
-            params.m_Instance = instance;
-            params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
-            params.m_Context = component_type->m_Context;
-            params.m_UserData = component_instance_data;
-            component_type->m_DestroyFunction(params);
-        }
+        DestroyComponents(collection, instance);
 
         dmHashRelease64(&instance->m_CollectionPathHashState);
         if(instance->m_Generated)
@@ -1580,8 +1607,8 @@ namespace dmGameObject
         EraseSwapLevelIndex(collection, instance);
         MoveAllUp(collection, instance);
 
-        if (instance->m_Prototype != &EMPTY_PROTOTYPE)
-            dmResource::Release(factory, instance->m_Prototype);
+        if (prototype != &EMPTY_PROTOTYPE)
+            dmResource::Release(factory, prototype);
         collection->m_InstanceIndices.Push(instance->m_Index);
         collection->m_Instances[instance->m_Index] = 0;
 
@@ -1606,14 +1633,7 @@ namespace dmGameObject
             collection->m_InputFocusStack.Pop();
         }
 
-        instance->~Instance();
-        void* instance_memory = (void*) instance;
-
-        // This is required for failing test
-        // TODO: #ifdef on something...?
-        // Clear all memory excluding ComponentInstanceUserData
-        memset(instance_memory, 0xcc, sizeof(Instance));
-        operator delete (instance_memory);
+        DeallocInstance(instance);
 
         assert(collection->m_IDToInstance.Size() <= collection->m_InstanceIndices.Size());
     }
@@ -2412,7 +2432,6 @@ namespace dmGameObject
             if (collection->m_InputFocusStack[i] == instance)
             {
                 found = true;
-                dmLogWarning("Input focus already acquired for instance with id: '%s'.", dmHashReverseSafe64(instance->m_Identifier));
             }
             if (found && i < collection->m_InputFocusStack.Size() - 1)
             {
@@ -3099,6 +3118,68 @@ namespace dmGameObject
         return PROPERTY_RESULT_OK;
     }
 
+    // Recreate the instance at the given index with a new prototype.
+    // The old instance is destroyed.
+    static void RecreateInstance(Collection* collection, uint16_t index, Prototype* old_proto, Prototype* new_proto, const char* new_proto_name) {
+        HInstance instance = collection->m_Instances[index];
+        // We don't support recreating instances that are 'transitioning'
+        assert(instance->m_ToBeAdded == 0);
+        assert(instance->m_ToBeDeleted == 0);
+        HInstance new_instance = AllocInstance(new_proto, new_proto_name);
+        if (!new_instance) {
+            return;
+        }
+        new_instance->m_Collection = collection;
+        // hierarchy-related
+        new_instance->m_Index = instance->m_Index;
+        new_instance->m_LevelIndex = instance->m_LevelIndex;
+        new_instance->m_Depth = instance->m_Depth;
+        new_instance->m_Bone = instance->m_Bone;
+        new_instance->m_Parent = instance->m_Parent;
+        new_instance->m_FirstChildIndex = instance->m_FirstChildIndex;
+        new_instance->m_SiblingIndex = instance->m_SiblingIndex;
+        // transform-related
+        new_instance->m_Transform = instance->m_Transform;
+        new_instance->m_EulerRotation = instance->m_EulerRotation;
+        new_instance->m_PrevEulerRotation = instance->m_PrevEulerRotation;
+        new_instance->m_ScaleAlongZ = instance->m_ScaleAlongZ;
+        // id-related
+        new_instance->m_Identifier = instance->m_Identifier;
+        new_instance->m_IdentifierIndex = instance->m_IdentifierIndex;
+        dmHashClone64(&new_instance->m_CollectionPathHashState, &instance->m_CollectionPathHashState, true);
+        new_instance->m_Generated = instance->m_Generated;
+        bool res = CreateComponents(collection, new_instance);
+        if (!res) {
+            dmHashRelease64(&new_instance->m_CollectionPathHashState);
+            DeallocInstance(new_instance);
+            return;
+        }
+        if (instance->m_Initialized) {
+            InitComponents(collection, new_instance);
+            new_instance->m_Initialized = 1;
+        }
+        // Because of how hot-reloading reloads resources in-place, the old instance would already point to the 'new' resource, so re-point it to the old
+        instance->m_Prototype = old_proto;
+        if (instance->m_Initialized) {
+            FinalComponents(collection, instance);
+        }
+        DestroyComponents(collection, instance);
+        dmHashRelease64(&instance->m_CollectionPathHashState);
+        collection->m_Instances[index] = new_instance;
+        collection->m_IDToInstance.Put(new_instance->m_Identifier, new_instance);
+        dmArray<Instance*>& stack = collection->m_InputFocusStack;
+        uint32_t n_stack = stack.Size();
+        for (uint32_t i = 0; i < n_stack; ++i) {
+            if (stack[i] == instance) {
+                stack[i] = new_instance;
+                // instances are only permitted one slot in the stack
+                break;
+            }
+        }
+        DeallocInstance(instance);
+        DoAddToUpdate(collection, new_instance);
+    }
+
     void ResourceReloadedCallback(const dmResource::ResourceReloadedParams& params)
     {
         Collection* collection = (Collection*) params.m_UserData;
@@ -3110,32 +3191,36 @@ namespace dmGameObject
             {
                 uint16_t index = level[i];
                 Instance* instance = collection->m_Instances[index];
-                uint32_t next_component_instance_data = 0;
-                for (uint32_t j = 0; j < instance->m_Prototype->m_Components.Size(); ++j)
-                {
-                    Prototype::Component& component = instance->m_Prototype->m_Components[j];
-                    ComponentType* type = component.m_Type;
-                    if (component.m_ResourceId == params.m_Resource->m_NameHash)
+                if (instance->m_Prototype == params.m_Resource->m_Resource) {
+                    RecreateInstance(collection, index, (Prototype*)params.m_Resource->m_PrevResource, (Prototype*)params.m_Resource->m_Resource, params.m_Name);
+                } else {
+                    uint32_t next_component_instance_data = 0;
+                    for (uint32_t j = 0; j < instance->m_Prototype->m_Components.Size(); ++j)
                     {
-                        if (type->m_OnReloadFunction)
+                        Prototype::Component& component = instance->m_Prototype->m_Components[j];
+                        ComponentType* type = component.m_Type;
+                        if (component.m_ResourceId == params.m_Resource->m_NameHash)
                         {
-                            uintptr_t* user_data = 0;
-                            if (type->m_InstanceHasUserData)
+                            if (type->m_OnReloadFunction)
                             {
-                                user_data = &instance->m_ComponentInstanceUserData[next_component_instance_data];
+                                uintptr_t* user_data = 0;
+                                if (type->m_InstanceHasUserData)
+                                {
+                                    user_data = &instance->m_ComponentInstanceUserData[next_component_instance_data];
+                                }
+                                ComponentOnReloadParams on_reload_params;
+                                on_reload_params.m_Instance = instance;
+                                on_reload_params.m_Resource = params.m_Resource->m_Resource;
+                                on_reload_params.m_World = collection->m_ComponentWorlds[component.m_TypeIndex];
+                                on_reload_params.m_Context = type->m_Context;
+                                on_reload_params.m_UserData = user_data;
+                                type->m_OnReloadFunction(on_reload_params);
                             }
-                            ComponentOnReloadParams on_reload_params;
-                            on_reload_params.m_Instance = instance;
-                            on_reload_params.m_Resource = params.m_Resource->m_Resource;
-                            on_reload_params.m_World = collection->m_ComponentWorlds[component.m_TypeIndex];
-                            on_reload_params.m_Context = type->m_Context;
-                            on_reload_params.m_UserData = user_data;
-                            type->m_OnReloadFunction(on_reload_params);
                         }
-                    }
-                    if (type->m_InstanceHasUserData)
-                    {
-                        next_component_instance_data++;
+                        if (type->m_InstanceHasUserData)
+                        {
+                            next_component_instance_data++;
+                        }
                     }
                 }
             }

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -3119,6 +3119,10 @@ namespace dmGameObject
     }
 
     // Recreate the instance at the given index with a new prototype.
+    // Specifically:
+    //  - recreate components and call init/final functions
+    //  - patch data structures for identification and input stack
+    //  - copy the rest of the fields
     // The old instance is destroyed.
     static void RecreateInstance(Collection* collection, uint16_t index, Prototype* old_proto, Prototype* new_proto, const char* new_proto_name) {
         HInstance instance = collection->m_Instances[index];

--- a/engine/gameobject/src/gameobject/res_prototype.cpp
+++ b/engine/gameobject/src/gameobject/res_prototype.cpp
@@ -10,7 +10,7 @@
 
 namespace dmGameObject
 {
-    static void DestroyPrototype(Prototype* prototype, dmResource::HFactory factory)
+    static void ReleaseResources(dmResource::HFactory factory, Prototype* prototype)
     {
         for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
         {
@@ -18,8 +18,73 @@ namespace dmGameObject
             dmResource::Release(factory, c.m_Resource);
             DestroyPropertySetUserData(c.m_PropertySet.m_UserData);
         }
+    }
 
-        delete prototype;
+    dmResource::Result AcquireResources(dmResource::HFactory factory, dmGameObject::HRegister regist, dmGameObjectDDF::PrototypeDesc* proto_desc, Prototype* proto, const char* filename) {
+        proto->m_Components.SetCapacity(proto_desc->m_Components.m_Count);
+
+        for (uint32_t i = 0; i < proto_desc->m_Components.m_Count; ++i)
+        {
+            dmGameObjectDDF::ComponentDesc& component_desc = proto_desc->m_Components[i];
+            const char* component_resource = component_desc.m_Component;
+            void* component;
+            dmResource::Result fact_e = dmResource::Get(factory, component_resource, (void**) &component);
+
+            bool id_used = false;
+            dmhash_t id = 0;
+            if (fact_e == dmResource::RESULT_OK)
+            {
+                id = dmHashString64(component_desc.m_Id);
+                for (uint32_t j = 0; j < proto->m_Components.Size(); ++j)
+                {
+                    if (proto->m_Components[j].m_Id == id)
+                    {
+                        dmLogError("The id '%s' has already been used in the prototype %s.", component_desc.m_Id, filename);
+                        id_used = true;
+                    }
+                }
+            }
+
+            if (id_used || fact_e != dmResource::RESULT_OK)
+            {
+                // Error, release created
+                if (id_used)
+                    dmResource::Release(factory, component);
+                if (id_used)
+                    return dmResource::RESULT_FORMAT_ERROR;
+                else
+                    return fact_e;
+            }
+            else
+            {
+                dmResource::ResourceType resource_type;
+                fact_e = dmResource::GetType(factory, component, &resource_type);
+                assert(fact_e == dmResource::RESULT_OK);
+                uint32_t type_index;
+                ComponentType* type = FindComponentType(regist, resource_type, &type_index);
+                assert(type != 0x0);
+                dmResource::SResourceDescriptor descriptor;
+                fact_e = dmResource::GetDescriptor(factory, component_resource, &descriptor);
+                assert(fact_e == dmResource::RESULT_OK);
+
+                Prototype::Component c(component,
+                                                                              resource_type,
+                                                                              id,
+                                                                              descriptor.m_NameHash,
+                                                                              type,
+                                                                              type_index,
+                                                                              component_desc.m_Position,
+                                                                              component_desc.m_Rotation);
+                c.m_PropertySet.m_GetPropertyCallback = GetPropertyCallbackDDF;
+                bool r = CreatePropertySetUserData(&component_desc.m_PropertyDecls, &c.m_PropertySet.m_UserData);
+                proto->m_Components.Push(c);
+                if (!r)
+                {
+                    return dmResource::RESULT_FORMAT_ERROR;
+                }
+            }
+        }
+        return dmResource::RESULT_OK;
     }
 
     dmResource::Result ResPrototypePreload(const dmResource::ResourcePreloadParams& params)
@@ -48,84 +113,46 @@ namespace dmGameObject
         dmGameObjectDDF::PrototypeDesc* proto_desc = (dmGameObjectDDF::PrototypeDesc*) params.m_PreloadData;
 
         Prototype* proto = new Prototype();
-        proto->m_Components.SetCapacity(proto_desc->m_Components.m_Count);
-
-        for (uint32_t i = 0; i < proto_desc->m_Components.m_Count; ++i)
-        {
-            dmGameObjectDDF::ComponentDesc& component_desc = proto_desc->m_Components[i];
-            const char* component_resource = component_desc.m_Component;
-            void* component;
-            dmResource::Result fact_e = dmResource::Get(params.m_Factory, component_resource, (void**) &component);
-
-            bool id_used = false;
-            dmhash_t id = 0;
-            if (fact_e == dmResource::RESULT_OK)
-            {
-                id = dmHashString64(component_desc.m_Id);
-                for (uint32_t j = 0; j < proto->m_Components.Size(); ++j)
-                {
-                    if (proto->m_Components[j].m_Id == id)
-                    {
-                        dmLogError("The id '%s' has already been used in the prototype %s.", component_desc.m_Id, params.m_Filename);
-                        id_used = true;
-                    }
-                }
-            }
-
-            if (id_used || fact_e != dmResource::RESULT_OK)
-            {
-                // Error, release created
-                if (id_used)
-                    dmResource::Release(params.m_Factory, component);
-                DestroyPrototype(proto, params.m_Factory);
-                dmDDF::FreeMessage(proto_desc);
-                if (id_used)
-                    return dmResource::RESULT_FORMAT_ERROR;
-                else
-                    return fact_e;
-            }
-            else
-            {
-                dmResource::ResourceType resource_type;
-                fact_e = dmResource::GetType(params.m_Factory, component, &resource_type);
-                assert(fact_e == dmResource::RESULT_OK);
-                uint32_t type_index;
-                ComponentType* type = FindComponentType(regist, resource_type, &type_index);
-                assert(type != 0x0);
-                dmResource::SResourceDescriptor descriptor;
-                fact_e = dmResource::GetDescriptor(params.m_Factory, component_resource, &descriptor);
-                assert(fact_e == dmResource::RESULT_OK);
-
-                Prototype::Component c(component,
-                                                                              resource_type,
-                                                                              id,
-                                                                              descriptor.m_NameHash,
-                                                                              type,
-                                                                              type_index,
-                                                                              component_desc.m_Position,
-                                                                              component_desc.m_Rotation);
-                c.m_PropertySet.m_GetPropertyCallback = GetPropertyCallbackDDF;
-                bool r = CreatePropertySetUserData(&component_desc.m_PropertyDecls, &c.m_PropertySet.m_UserData);
-                proto->m_Components.Push(c);
-                if (!r)
-                {
-                    DestroyPrototype(proto, params.m_Factory);
-                    dmDDF::FreeMessage(proto_desc);
-                    return dmResource::RESULT_FORMAT_ERROR;
-                }
-            }
+        dmResource::Result r = AcquireResources(params.m_Factory, regist, proto_desc, proto, params.m_Filename);
+        if (r == dmResource::RESULT_OK) {
+            params.m_Resource->m_Resource = (void*) proto;
+        } else {
+            ReleaseResources(params.m_Factory, proto);
+            delete proto;
         }
 
-        params.m_Resource->m_Resource = (void*) proto;
-
         dmDDF::FreeMessage(proto_desc);
-        return dmResource::RESULT_OK;
+        return r;
     }
 
     dmResource::Result ResPrototypeDestroy(const dmResource::ResourceDestroyParams& params)
     {
         Prototype* proto = (Prototype*) params.m_Resource->m_Resource;
-        DestroyPrototype(proto, params.m_Factory);
+        ReleaseResources(params.m_Factory, proto);
+        delete proto;
         return dmResource::RESULT_OK;
+    }
+
+    dmResource::Result ResPrototypeRecreate(const dmResource::ResourceRecreateParams& params)
+    {
+        Register* regist = (Register*) params.m_Context;
+        dmGameObjectDDF::PrototypeDesc* proto_desc;
+        dmDDF::Result e = dmDDF::LoadMessage(params.m_Buffer, params.m_BufferSize, &proto_desc);
+        if (e != dmDDF::RESULT_OK)
+        {
+            return dmResource::RESULT_FORMAT_ERROR;
+        }
+        Prototype* temp = new Prototype();
+        dmResource::Result r = AcquireResources(params.m_Factory, regist, proto_desc, temp, params.m_Filename);
+        if (dmResource::RESULT_OK == r) {
+            Prototype* proto = (Prototype*) params.m_Resource->m_Resource;
+            proto->m_Components.Swap(temp->m_Components);
+            params.m_Resource->m_PrevResource = temp;
+        } else {
+            ReleaseResources(params.m_Factory, temp);
+            delete temp;
+        }
+        dmDDF::FreeMessage(proto_desc);
+        return r;
     }
 }

--- a/engine/gameobject/src/gameobject/res_prototype.h
+++ b/engine/gameobject/src/gameobject/res_prototype.h
@@ -12,6 +12,8 @@ namespace dmGameObject
     dmResource::Result ResPrototypeCreate(const dmResource::ResourceCreateParams& params);
 
     dmResource::Result ResPrototypeDestroy(const dmResource::ResourceDestroyParams& params);
+
+    dmResource::Result ResPrototypeRecreate(const dmResource::ResourceRecreateParams& params);
 }
 
 #endif // DM_GAMEOBJECT_RES_PROTOTYPE_H

--- a/engine/gameobject/src/gameobject/test/reload/rt.go_pb
+++ b/engine/gameobject/src/gameobject/test/reload/rt.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "rt"
+  component: "/reload_target.rt"
+}

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -1237,6 +1237,7 @@ static Result DoReloadResource(HFactory factory, const char* name, SResourceDesc
     params.m_BufferSize = file_size;
     params.m_Resource = rd;
     params.m_Filename = name;
+    rd->m_PrevResource = 0;
     Result create_result = resource_type->m_RecreateFunction(params);
     if (create_result == RESULT_OK)
     {
@@ -1245,12 +1246,23 @@ static Result DoReloadResource(HFactory factory, const char* name, SResourceDesc
             for (uint32_t i = 0; i < factory->m_ResourceReloadedCallbacks->Size(); ++i)
             {
                 ResourceReloadedCallbackPair& pair = (*factory->m_ResourceReloadedCallbacks)[i];
-                ResourceReloadedParams params;
-                params.m_UserData = pair.m_UserData;
-                params.m_Resource = rd;
-                params.m_Name = name;
-                pair.m_Callback(params);
+                ResourceReloadedParams reload_params;
+                reload_params.m_UserData = pair.m_UserData;
+                reload_params.m_Resource = rd;
+                reload_params.m_Name = name;
+                pair.m_Callback(reload_params);
             }
+        }
+        if (rd->m_PrevResource) {
+            SResourceDescriptor tmp_resource = *rd;
+            tmp_resource.m_Resource = rd->m_PrevResource;
+            ResourceDestroyParams params;
+            params.m_Factory = factory;
+            params.m_Context = resource_type->m_Context;
+            params.m_Resource = &tmp_resource;
+            dmResource::Result res = resource_type->m_DestroyFunction(params);
+            rd->m_PrevResource = 0x0;
+            return res;
         }
         return RESULT_OK;
     }

--- a/engine/resource/src/resource.h
+++ b/engine/resource/src/resource.h
@@ -115,6 +115,8 @@ namespace dmResource
 
         /// Resource pointer. Must be unique and not NULL.
         void*    m_Resource;
+        /// Resource pointer to a previous version of the resource, iff it exists. Only used when recreating resources.
+        void*    m_PrevResource;
 
         /// For internal use only
         void*    m_ResourceType;        // For internal use.


### PR DESCRIPTION
* Recreates instances when prototypes are reloaded
* Slight modification to resource system, where a recreate-callback can opt to keep the old version of the resource
* Enabled goc reload in editor2