### PR TITLE
DEFEDIT-1372 Move work from build-targets to build-fn's

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -164,11 +164,24 @@
                                        :resources  (mapv lua/lua-module->build-path modules)
                                        :properties (properties/properties->decls properties true)})})))
 
+(defn strip-user-property-node-ids [user-properties]
+  (-> user-properties
+      (update :properties
+              (fn [properties]
+                (into {}
+                      (map (fn [[prop-kw v]]
+                             [prop-kw (into {}
+                                            (remove (fn [[k _]] (= k :node-id)))
+                                            v)]))
+                      properties)))))
+
 (g/defnk produce-build-targets [_node-id resource lines user-properties modules dep-build-targets]
   [{:node-id _node-id
     :resource (workspace/make-build-resource resource)
     :build-fn build-script
-    :user-data {:lines lines :user-properties user-properties :modules modules :proj-path (resource/proj-path resource)}
+    ;; strip away node-id's, otherwise we unnecessarily create one
+    ;; build-target per use (override) of the script...
+    :user-data {:lines lines :user-properties (strip-user-property-node-ids user-properties) :modules modules :proj-path (resource/proj-path resource)}
     :deps dep-build-targets}])
 
 (g/defnk produce-completions [completion-info module-completion-infos]

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -99,11 +99,12 @@
                                  (render-cubemap gl render-args camera gpu-texture vertex-binding)))
                   :passes [pass/transparent]}}))
 
-(defn- cubemap-side-setter [resource-label image-label size-label]
+(defn- cubemap-side-setter [resource-label image-label image-generator-label size-label]
   (fn [evaluation-context self old-value new-value]
     (project/resource-setter self old-value new-value
                              [:resource resource-label]
                              [:content image-label]
+                             [:content-generator image-generator-label]
                              [:size size-label])))
 
 (defn- generate-gpu-texture [{:keys [cubemap-images texture-profile]} request-id params unit]
@@ -113,12 +114,21 @@
     params
     unit))
 
+(defn- generate-images [image-generators]
+  (into {}
+        (map (fn [[dir generator]]
+               [dir ((:f generator) (:args generator))]))
+        image-generators))
+
 (defn- build-cubemap [resource dep-resources user-data]
-  (let [{:keys [images texture-profile compress?]} user-data
-        texture-images (tex-gen/make-cubemap-texture-images images texture-profile compress?)
-        cubemap-texture-image (tex-gen/assemble-cubemap-texture-images texture-images)]
-    {:resource resource
-     :content (protobuf/pb->bytes cubemap-texture-image)}))
+  (let [{:keys [image-generators texture-profile compress?]} user-data
+        images (generate-images image-generators)]
+    (g/precluding-errors
+      (filter g/error? (vals images))
+      (let [texture-images (tex-gen/make-cubemap-texture-images images texture-profile compress?)
+            cubemap-texture-image (tex-gen/assemble-cubemap-texture-images texture-images)]
+        {:resource resource
+         :content (protobuf/pb->bytes cubemap-texture-image)}))))
 
 (def ^:private cubemap-dir->property
   {:px :right
@@ -149,14 +159,14 @@
                                    [:px :nx :py :ny :pz :nz]))]
         (g/->error node-id nil :fatal nil message)))))
 
-(g/defnk produce-build-targets [_node-id resource cubemap-images cubemap-image-resources cubemap-image-sizes texture-profile build-settings]
+(g/defnk produce-build-targets [_node-id resource cubemap-image-generators cubemap-image-resources cubemap-image-sizes texture-profile build-settings]
   (g/precluding-errors
     [(cubemap-images-missing-error _node-id cubemap-image-resources)
      (cubemap-image-sizes-error _node-id cubemap-image-sizes)]
     [{:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-cubemap
-      :user-data {:images cubemap-images
+      :user-data {:image-generators cubemap-image-generators
                   :texture-profile texture-profile
                   :compress? (:compress? build-settings false)}}]))
 
@@ -179,32 +189,32 @@
 
   (property right resource/Resource
             (value (gu/passthrough right-resource))
-            (set (cubemap-side-setter :right-resource :right-image :right-size))
+            (set (cubemap-side-setter :right-resource :right-image :right-image-generator :right-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error right)))
   (property left resource/Resource
             (value (gu/passthrough left-resource))
-            (set (cubemap-side-setter :left-resource :left-image :left-size))
+            (set (cubemap-side-setter :left-resource :left-image :left-image-generator :left-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error left)))
   (property top resource/Resource
             (value (gu/passthrough top-resource))
-            (set (cubemap-side-setter :top-resource :top-image :top-size))
+            (set (cubemap-side-setter :top-resource :top-image :top-image-generator :top-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error top)))
   (property bottom resource/Resource
             (value (gu/passthrough bottom-resource))
-            (set (cubemap-side-setter :bottom-resource :bottom-image :bottom-size))
+            (set (cubemap-side-setter :bottom-resource :bottom-image :bottom-image-generator :bottom-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error bottom)))
   (property front resource/Resource
             (value (gu/passthrough front-resource))
-            (set (cubemap-side-setter :front-resource :front-image :front-size))
+            (set (cubemap-side-setter :front-resource :front-image :front-image-generator :front-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error front)))
   (property back resource/Resource
             (value (gu/passthrough back-resource))
-            (set (cubemap-side-setter :back-resource :back-image :back-size))
+            (set (cubemap-side-setter :back-resource :back-image :back-image-generator :back-size))
             (dynamic edit-type (g/constantly {:type resource/Resource :ext image/exts}))
             (dynamic error (cubemap-side-error back)))
 
@@ -222,6 +232,13 @@
   (input front-image  BufferedImage)
   (input back-image   BufferedImage)
 
+  (input right-image-generator  g/Any)
+  (input left-image-generator   g/Any)
+  (input top-image-generator    g/Any)
+  (input bottom-image-generator g/Any)
+  (input front-image-generator  g/Any)
+  (input back-image-generator   g/Any)
+
   (input right-size  g/Any)
   (input left-size   g/Any)
   (input top-size    g/Any)
@@ -235,6 +252,10 @@
 
   (output cubemap-images g/Any :cached (g/fnk [right-image left-image top-image bottom-image front-image back-image]
                                               {:px right-image :nx left-image :py top-image :ny bottom-image :pz front-image :nz back-image}))
+
+  (output cubemap-image-generators g/Any (g/fnk [right-image-generator left-image-generator top-image-generator bottom-image-generator front-image-generator back-image-generator]
+                                                        {:px right-image-generator :nx left-image-generator :py top-image-generator :ny bottom-image-generator :pz front-image-generator :nz back-image-generator}))
+
 
   (output cubemap-image-sizes g/Any :cached (g/fnk [right-size left-size top-size bottom-size front-size back-size]
                                                    {:px right-size :nx left-size :py top-size :ny bottom-size :pz front-size :nz back-size}))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -577,7 +577,7 @@
   (let [game-project  (get-resource-node project "/game.project" evaluation-context)
         render-progress! (progress/throttle-render-progress render-progress!)]
     (try
-      (ui/with-progress [render-progress! (progress/throttle-render-progress render-progress!)]
+      (ui/with-progress [render-progress! render-progress!]
         (build! project game-project evaluation-context extra-build-targets old-artifact-map render-progress!))
       (catch Throwable error
         (error-reporting/report-exception! error)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -1,5 +1,6 @@
 (ns editor.font
   (:require [clojure.string :as s]
+            [clojure.java.io :as io]
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [editor.graph-util :as gu]
@@ -19,13 +20,16 @@
             [editor.gl.pass :as pass]
             [schema.core :as schema])
   (:import [com.dynamo.render.proto Font$FontDesc Font$FontMap Font$FontTextureFormat]
+           [com.defold.editor.pipeline BMFont]
            [editor.types AABB]
            [editor.gl.shader ShaderLifecycle]
            [editor.gl.vertex2 VertexBuffer]
            [java.nio ByteBuffer]
+           [java.nio.file Paths]
            [com.jogamp.opengl GL GL2]
            [javax.vecmath Matrix4d Point3d Vector3d]
-           [com.google.protobuf ByteString]))
+           [com.google.protobuf ByteString]
+           [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 
@@ -373,24 +377,25 @@
           (g/->error _node-id :font :fatal font (str "Failed to generate bitmap from Font. " (.getMessage error)))))))
 
 
-(defn- make-font-resource-resolver [resource-map]
-  ;; Note: We only resolve absolute paths, and only to existing resources.
-  resource-map)
+(defn- make-font-resource-resolver [font resource-map]
+  (let [base-path (resource/parent-proj-path (resource/proj-path font))]
+    (fn [path]
+      (let [proj-path (str base-path "/" path)]
+        (resource-map proj-path)))))
 
-(g/defnk produce-font-map [_node-id font type pb-msg]
-  (let [resource-map (g/node-value (:workspace font) :resource-map)]
-    (make-font-map _node-id font type pb-msg (make-font-resource-resolver resource-map))))
+(g/defnk produce-font-map [_node-id font type font-resource-map pb-msg]
+  (make-font-map _node-id font type pb-msg (make-font-resource-resolver font font-resource-map)))
 
 (defn- build-font [resource dep-resources user-data]
-  (let [{:keys [font type resource-map pb-msg]} user-data
-        font-resource-resolver (make-font-resource-resolver resource-map)
+  (let [{:keys [font type font-resource-map pb-msg]} user-data
+        font-resource-resolver (make-font-resource-resolver font font-resource-map)
         font-map (make-font-map nil font type pb-msg font-resource-resolver)]
     (g/precluding-errors
       [font-map]
       (let [font-map (assoc font-map :textures [(resource/proj-path (second (first dep-resources)))])]
         {:resource resource :content (protobuf/map->bytes Font$FontMap font-map)}))))
 
-(g/defnk produce-build-targets [_node-id resource font type pb-msg #_font-map material dep-build-targets]
+(g/defnk produce-build-targets [_node-id resource font type font-resource-map font-resource-hashes pb-msg material dep-build-targets]
   (or (when-let [errors (->> [(validation/prop-error :fatal _node-id :material validation/prop-nil? material "Material")
                               (validation/prop-error :fatal _node-id :material validation/prop-resource-not-exists? material "Material")]
                              (remove nil?)
@@ -402,11 +407,34 @@
         :user-data {:font font
                     :type type
                     :pb-msg pb-msg
-                    :resource-map (g/node-value (:workspace font) :resource-map)}
+                    :font-resource-map font-resource-map
+                    :font-resource-hashes font-resource-hashes}
         :deps (flatten dep-build-targets)}]))
 
 (g/defnode FontSourceNode
-  (inherits resource-node/ResourceNode))
+  (inherits resource-node/ResourceNode)
+  (input texture-resource resource/Resource)
+  (input texture-size g/Any) ; we pipe in size to provoke errors, for instance if the texture node is defective / non-existant
+  (output font-resource-map g/Any (g/fnk [texture-resource texture-size]
+                                         (if texture-resource
+                                           {(resource/proj-path texture-resource) texture-resource}
+                                           {}))))
+
+(defn load-font-source [project self resource]
+  (when (= (resource/ext resource) "fnt")
+    (let [bm-font (BMFont.)]
+      (with-open [bm-stream (io/input-stream resource)]
+        (.parse bm-font bm-stream))
+      (let [;; this weird dance stolen from Fontc.java
+            texture-file-name (.. (-> (.. bm-font page (get 0))
+                                      FilenameUtils/normalize
+                                      (Paths/get (into-array String [])))
+                                  getFileName
+                                  toString)
+            texture-resource (workspace/resolve-resource resource texture-file-name)]
+        (when texture-resource
+          (project/connect-resource-node project texture-resource self [[:resource :texture-resource]
+                                                                        [:size :texture-size]]))))))
 
 (g/defnk produce-font-type [font output-format]
   (font-type font output-format))
@@ -461,7 +489,8 @@
     (value (gu/passthrough font-resource))
     (set (fn [_evaluation-context self old-value new-value]
            (project/resource-setter self old-value new-value
-                                    [:resource :font-resource])))
+                                    [:resource :font-resource]
+                                    [:font-resource-map :font-resource-map])))
     (dynamic error (g/fnk [_node-id font-resource]
                           (or (validation/prop-error :fatal _node-id :font validation/prop-nil? font-resource "Font")
                               (validation/prop-error :fatal _node-id :font validation/prop-resource-not-exists? font-resource "Font"))))
@@ -535,10 +564,12 @@
   (input material-resource resource/Resource)
   (input material-samplers [g/KeywordMap])
   (input material-shader ShaderLifecycle)
+  (input font-resource-map g/Any)
 
   (output outline g/Any :cached (g/fnk [_node-id] {:node-id _node-id :label "Font" :icon font-icon}))
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-value g/Any (gu/passthrough pb-msg))
+  (output font-resource-hashes g/Any (g/fnk [font-resource-map] (map resource/resource->sha1-hex (vals font-resource-map))))
   (output build-targets g/Any :cached produce-build-targets)
   (output font-map g/Any :cached produce-font-map)
   (output scene g/Any :cached produce-scene)
@@ -590,6 +621,8 @@
       :ext font-file-extensions
       :label "Font"
       :node-type FontSourceNode
+      :load-fn load-font-source
+      :stateless? true
       :icon font-icon
       :view-types [:default])))
 

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -622,7 +622,6 @@
       :label "Font"
       :node-type FontSourceNode
       :load-fn load-font-source
-      :stateless? true
       :icon font-icon
       :view-types [:default])))
 

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -145,29 +145,42 @@
       (when (and (not (.isDirectory f)) (not (contains? targets f)))
         (fs/delete! f)))))
 
+(defn- expensive? [build-target]
+  (contains? #{"fontc"} (resource/ext (:resource build-target))))
+
+(defn- batched-pmap [f batches]
+  (->> batches
+       (pmap (fn [batch] (doall (map f batch))))
+       (apply concat)))
+
+(def ^:private cheap-batch-size 500)
+(def ^:private expensive-batch-size 5)
+
 (defn build!
   [build-targets build-dir old-artifact-map render-progress!]
   (let [build-targets-by-key (make-build-targets-by-key build-targets)
         pruned-old-artifacts (prune-artifacts old-artifact-map build-targets-by-key)
         progress (atom (progress/make "" (count build-targets-by-key)))]
     (prune-build-dir! build-dir build-targets-by-key)
-    (let [results (into []
-                        (map (fn [[key {:keys [node-id resource] :as build-target}]]
-                               (let [cached-artifact (when-let [artifact (get pruned-old-artifacts resource)]
-                                                       (and (valid? artifact) artifact))
-                                     message (str "Building " (resource/proj-path resource))]
-                                 (render-progress! (swap! progress
-                                                          #(-> %
-                                                               (progress/advance)
-                                                               (progress/with-message message))))
-                                 (or cached-artifact
-                                     (let [{:keys [resource deps build-fn user-data]} build-target
-                                           dep-resources (make-dep-resources deps build-targets-by-key)
-                                           result (build-fn resource dep-resources user-data)]
-                                       (if (g/error? result)
-                                         (assoc result :_node-id node-id)
-                                         (to-disk! result key)))))))
-                        build-targets-by-key)
+    (let [{cheap-build-targets false expensive-build-targets true} (group-by expensive? (vals build-targets-by-key))
+          build-target-batches (into (partition-all cheap-batch-size cheap-build-targets)
+                                     (partition-all expensive-batch-size expensive-build-targets))
+          results (doall (batched-pmap
+                           (fn [build-target]
+                             (let [{:keys [key node-id resource deps build-fn user-data]} build-target
+                                   cached-artifact (when-let [artifact (get pruned-old-artifacts resource)]
+                                                     (and (valid? artifact) artifact))
+                                   message (str "Building " (resource/proj-path resource))]
+                               (render-progress! (swap! progress progress/with-message message))
+                               (let [result (or cached-artifact
+                                                (let [dep-resources (make-dep-resources deps build-targets-by-key)
+                                                      build-result (build-fn resource dep-resources user-data)]
+                                                  (if (g/error? build-result)
+                                                    (assoc build-result :_node-id node-id)
+                                                    (to-disk! build-result key))))]
+                                 (render-progress! (swap! progress progress/advance))
+                                 result)))
+                           build-target-batches))
           {successful-results false error-results true} (group-by #(boolean (g/error? %)) results)
           new-artifact-map (into {} (map (fn [a] [(:resource a) a])) successful-results)
           etags (into {} (map (fn [a] [(resource/proj-path (:resource a)) (:etag a)])) successful-results)]

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -41,7 +41,7 @@
     [{:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-sound-source
-      :user-data {:content-hash (vec (digest/sha1 (resource->bytes resource)))}}]
+      :user-data {:content-hash (resource/resource->sha1-hex resource)}}]
     (catch IOException e
       (g/->error _node-id :resource :fatal resource (format "Couldn't read audio file %s" (resource/resource->proj-path resource))))))
 


### PR DESCRIPTION
* User facing changes
  - Faster builds, possibly higher memory consumption during build
* Technical changes
  - do less in ShaderNode build-targets
  - use image generators for cubemap images
  - move font build stuff to build-fn
  - sound build target uses stream sha1 instead of roundtrip to bytes
  - chunked pmap approach to calling build-fns
  - don't rebuild scripts for every use :)