### PR TITLE
DEFEDIT-1371 Filter out non-editable resources from Open Assets dialog

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1336,6 +1336,7 @@ If you do not specifically require different script states, consider changing th
 (defn- query-and-open! [workspace project app-view prefs term]
   (doseq [resource (dialogs/make-resource-dialog workspace project
                                                  (cond-> {:title "Open Assets"
+                                                          :accept-fn resource/editable-resource?
                                                           :selection :multiple
                                                           :ok-label "Open"
                                                           :tooltip-gen (partial gen-tooltip workspace project app-view)}

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -384,10 +384,12 @@
 (defn make-resource-dialog [workspace project options]
   (let [exts         (let [ext (:ext options)] (if (string? ext) (list ext) (seq ext)))
         accepted-ext (if (seq exts) (set exts) (constantly true))
+        accept-fn    (or (:accept-fn options) (constantly true))
         items        (into []
                            (filter #(and (= :file (resource/source-type %))
                                          (accepted-ext (resource/ext %))
-                                         (not (resource/internal? %))))
+                                         (not (resource/internal? %))
+                                         (accept-fn %)))
                            (g/node-value workspace :resource-list))
         options (-> {:title "Select Resource"
                      :prompt "Type to filter"

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -43,6 +43,12 @@
   (and (satisfies? Resource value)
        (openable? value)))
 
+(defn editable-resource? [value]
+  ;; A resource is considered editable if the Defold Editor can edit it. Before
+  ;; opening, you must also make sure the resource exists.
+  (and (openable-resource? value)
+       (true? (:editable? (resource-type value)))))
+
 (defn- ->unix-seps ^String [^String path]
   (FilenameUtils/separatorsToUnix path))
 

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -945,5 +945,5 @@
                                     :ddf-type Tile$TileSet
                                     :load-fn load-tile-source
                                     :icon tile-source-icon
-                                    :view-types [:scene :test]
+                                    :view-types [:scene :text]
                                     :view-opts {:scene {:tool-controller ToolController}}))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -85,8 +85,14 @@ ordinary paths."
 (defn get-view-type [workspace id]
   (get (g/node-value workspace :view-types) id))
 
+(defn- editable-view-type? [view-type]
+  (case view-type
+    (:default :text) false
+    true))
+
 (defn register-resource-type [workspace & {:keys [textual? ext build-ext node-type load-fn dependencies-fn read-fn write-fn icon view-types view-opts tags tag-opts template label stateless?]}]
   (let [resource-type {:textual? (true? textual?)
+                       :editable? (some? (some editable-view-type? view-types))
                        :ext ext
                        :build-ext (if (nil? build-ext) (str ext "c") build-ext)
                        :node-type node-type


### PR DESCRIPTION
Addresses the "Prioritize files that have an editor" part of defold/editor2-issues#1473.

### User-facing changes
* Non-editable resources are no longer listed in the **Open Assets** dialog. Type-to-filter is slightly more responsive inside large projects as a result.