### PR TITLE
DEFEDIT-1377 Crashing when trying to use life stretch curves

### DIFF
--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -164,10 +164,6 @@
     {:points (curve-vals c)
      :spread (:spread c)})))
 
-(def default-curve (map->Curve {:points [{:x 0 :y 0 :t-x 1 :t-y 0}]}))
-
-(def default-curve-spread (map->CurveSpread {:points [{:x 0 :y 0 :t-x 1 :t-y 0}] :spread 0}))
-
 (defn- q-round [v]
   (let [f 10e6]
     (/ (Math/round (* v f)) f)))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -258,6 +258,7 @@
                        (update-ui-fn values message read-only?)
                        (let [curved? (boolean (< 1 (count (properties/curve-vals (first values)))))]
                          (.setSelected toggle-button curved?)
+                         (ui/editable! toggle-button (some? (first values)))
                          (ui/disable! text-field curved?)))]
     [box update-ui-fn]))
 
@@ -272,6 +273,7 @@
                          (update-ui-fn values message read-only?)
                          (let [curved? (boolean (< 1 (count (properties/curve-vals (first values)))))]
                            (.setSelected toggle-button curved?)
+                           (ui/editable! toggle-button (some? (first values)))
                            (ui/disable! text-field curved?)))]
     [box update-ui-fn]))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#1592

* Technical changes
  - Don't allow changing curves unless we have an initial value
  - (Unrelated) Remove weird faulty double definition of
  default-curve, default-curve-spread