### PR TITLE
DEFEDIT-1376 Fixed GLException when closing a Scene view with visible error overlay

### DIFF
--- a/editor/src/clj/editor/curve_view.clj
+++ b/editor/src/clj/editor/curve_view.clj
@@ -499,10 +499,6 @@
 
   (output all-renderables g/Any :cached (g/fnk [renderables curve-renderables cp-renderables tool-renderables]
                                           (reduce (partial merge-with into) renderables (into [curve-renderables cp-renderables] tool-renderables))))
-  (output refresh-fn g/Any :cached (g/fnk [image-view drawable async-copier]
-                                          (fn []
-                                            (when-not (ui/inside-hidden-tab? image-view)
-                                              (scene/update-image-view! image-view drawable async-copier)))))
   (output curves g/Any :cached produce-curves)
   (output visible-curves g/Any :cached (g/fnk [curves hidden-curves] (remove #(contains? hidden-curves (:property %)) curves)))
   (output curve-renderables g/Any :cached produce-curve-renderables)
@@ -565,19 +561,6 @@
             local-cam (g/node-value camera :local-camera)
             end-camera (c/camera-orthographic-frame-aabb-y local-cam viewport aabb)]
         (scene/set-camera! camera local-cam end-camera animate?)))))
-
-(defn destroy-view! [parent ^AnchorPane view view-id ^ListView list]
-  (when view-id
-    (when-let [scene (g/node-by-id view-id)]
-      (when-let [^GLAutoDrawable drawable (g/node-value view-id :drawable)]
-        (let [gl (.getGL drawable)]
-          (when-let [^AsyncCopier copier (g/node-value view-id :async-copier)]
-            (.dispose copier gl))
-          (scene-cache/drop-context! gl)
-          (.destroy drawable))))
-    (g/transact (g/delete-node view-id))
-    (ui/children! view [])
-    (ui/remove-list-observers list (ui/selection list))))
 
 (defn- camera-filter-fn [camera]
   (let [^Point3d p (:position camera)
@@ -656,7 +639,7 @@
                                                 (g/connect rulers :renderables view-id :aux-renderables)
                                                 (g/connect view-id :viewport rulers :viewport)
                                                 (g/connect view-id :cursor-pos rulers :cursor-pos)
-                                                (g/connect view-id :refresh-fn app-view :scene-view-refresh-fns))))]
+                                                (g/connect view-id :_node-id app-view :scene-view-ids))))]
       (when parent
         (let [^Node pane (scene/make-gl-pane! node-id opts)]
           (ui/context! parent :curve-view {:view-id node-id} (SubSelectionProvider. app-view))
@@ -691,13 +674,6 @@
                           (let [[r g b] (colors/hsl->rgb (:hue item) 1.0 0.75)]
                             (proxy-super setStyle (format "-fx-text-fill: rgb(%d, %d, %d);" (int (* 255 r)) (int (* 255 g)) (int (* 255 b)))))))))))))))
       node-id)))
-
-(defn- reload-curve-view []
-  (when @view-state
-    (let [{:keys [app-view graph ^Parent parent ^ListView list ^AnchorPane view opts view-id]} @view-state]
-      (ui/run-now
-        (destroy-view! parent view view-id list)
-        (make-view! app-view graph parent list view opts true)))))
 
 (defn- delete-cps [sub-selection]
   (let [m (sub-selection->map sub-selection)]

--- a/editor/src/clj/editor/scene_text.clj
+++ b/editor/src/clj/editor/scene_text.clj
@@ -3,7 +3,6 @@
             [editor.scene-cache :as scene-cache])
   (:import [com.jogamp.opengl.util.awt TextRenderer]
            [java.awt Font]
-           [java.awt.geom Rectangle2D]
            [com.jogamp.opengl GL2]))
 
 (set! *warn-on-reflection* true)
@@ -34,7 +33,7 @@
     (.dispose text-renderer)))
 
 (defn- update-text-renderer [^GL2 gl text-renderer data]
-  (destroy-text-renderers gl [text-renderer])
+  (destroy-text-renderers gl [text-renderer] nil)
   (make-text-renderer gl data))
 
 (scene-cache/register-object-cache! ::text-renderer make-text-renderer update-text-renderer destroy-text-renderers)

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -360,13 +360,15 @@ ordinary paths."
                 :resource-listeners (atom [])
                 :build-settings build-settings))
 
-(defn register-view-type [workspace & {:keys [id label make-view-fn make-preview-fn focus-fn text-selection-fn]}]
+(defn register-view-type [workspace & {:keys [id label make-view-fn make-preview-fn dispose-preview-fn focus-fn text-selection-fn]}]
   (let [view-type (merge {:id    id
                           :label label}
                          (when make-view-fn
                            {:make-view-fn make-view-fn})
                          (when make-preview-fn
                            {:make-preview-fn make-preview-fn})
+                         (when dispose-preview-fn
+                           {:dispose-preview-fn dispose-preview-fn})
                          (when focus-fn
                            {:focus-fn focus-fn})
                          (when text-selection-fn


### PR DESCRIPTION
Fixes defold/editor2-issues#1841

`TextRenderer.dispose()` needs the OpenGL context to be current. We needed to call `make-context-current` on the `drawable` of a `SceneView` before dropping its scene-cache context.

### Technical changes
* Removed `scene-cache/drop-all!` function. Instead, The `AppView` is responsible for disposing all open scene views and the curve view when it closes.
* `make-context-current` is called inside `dispose-scene-view!` before before dropping its scene-cache context.
* We also needed to do this for previews. To simplify things, we now immediately clean up after generating preview thumbnail image.
* Along with a `:make-preview-fn`, you can now supply a `:dispose-preview-fn` when registering resource types.