### PR TITLE
DEFEDIT-1377 Crashing when trying to use life stretch curves

### DIFF
--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -900,6 +900,12 @@
       (for [modifier (:modifiers pb)]
         (make-modifier self self modifier)))))
 
+(defn- add-default-properties-to-modifier [mod-pb]
+  (update mod-pb :properties #(or (and (seq %) %) (get-in mod-types [(:type mod-pb) :template :properties]))))
+
+(defn- add-default-properties-to-modifiers [pb]
+  (update pb :modifiers (partial mapv add-default-properties-to-modifier)))
+
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
     :ext particlefx-ext
@@ -907,6 +913,7 @@
     :node-type ParticleFXNode
     :ddf-type Particle$ParticleFX
     :load-fn load-particle-fx
+    :sanitize-fn add-default-properties-to-modifiers
     :icon particle-fx-icon
     :tags #{:component :non-embeddable}
     :tag-opts {:component {:transform-properties #{:position :rotation}}}

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -901,7 +901,7 @@
         (make-modifier self self modifier)))))
 
 (defn- add-default-properties-to-modifier [mod-pb]
-  (update mod-pb :properties #(or (and (seq %) %) (get-in mod-types [(:type mod-pb) :template :properties]))))
+  (update mod-pb :properties #(or (not-empty %) (get-in mod-types [(:type mod-pb) :template :properties]))))
 
 (defn- add-default-properties-to-modifiers [pb]
   (update pb :modifiers (partial mapv add-default-properties-to-modifier)))

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -127,12 +127,12 @@
 (defn ->curve [control-points]
   (Curve. (iv/iv-vec control-points)))
 
-(def default-curve (->curve [[0 0 1 0]]))
+(def default-curve (->curve [[0.0 0.0 1.0 0.0]]))
 
 (defn ->curve-spread [control-points spread]
   (CurveSpread. (iv/iv-vec control-points) spread))
 
-(def default-curve-spread (->curve-spread [[0 0 1 0]] 0))
+(def default-curve-spread (->curve-spread [[0.0 0.0 1.0 0.0]] 0.0))
 
 (defn curve-vals [curve]
   (iv/iv-vals (:points curve)))
@@ -163,10 +163,6 @@
   (fn [^CurveSpread c]
     {:points (curve-vals c)
      :spread (:spread c)})))
-
-(def default-curve (map->Curve {:points [{:x 0 :y 0 :t-x 1 :t-y 0}]}))
-
-(def default-curve-spread (map->CurveSpread {:points [{:x 0 :y 0 :t-x 1 :t-y 0}] :spread 0}))
 
 (defn- q-round [v]
   (let [f 10e6]

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -249,7 +249,7 @@
 (defmethod create-property-control! CurveSpread [_ _ property-fn]
   (let [^ToggleButton toggle-button (make-curve-toggler property-fn)
         fields [{:get-fn (fn [c] (second (first (properties/curve-vals c))))
-                 :set-fn (fn [c v] (properties/->curve-spread [[0 v 1 0]] (:spread c)))
+                 :set-fn (fn [c v] (properties/->curve-spread [[0.0 v 1.0 0.0]] (:spread c)))
                  :control toggle-button}
                 {:label "+/-" :path [:spread]}]
         [^HBox box update-ui-fn] (create-multi-keyed-textfield! fields property-fn)
@@ -258,13 +258,14 @@
                        (update-ui-fn values message read-only?)
                        (let [curved? (boolean (< 1 (count (properties/curve-vals (first values)))))]
                          (.setSelected toggle-button curved?)
+                         (ui/editable! toggle-button (some? (first values)))
                          (ui/disable! text-field curved?)))]
     [box update-ui-fn]))
 
 (defmethod create-property-control! Curve [_ _ property-fn]
   (let [^ToggleButton toggle-button (make-curve-toggler property-fn)
         fields [{:get-fn (fn [c] (second (first (properties/curve-vals c))))
-                 :set-fn (fn [c v] (properties/->curve [[0 v 1 0]]))
+                 :set-fn (fn [c v] (properties/->curve [[0.0 v 1.0 0.0]]))
                  :control toggle-button}]
         [^HBox box update-ui-fn] (create-multi-keyed-textfield! fields property-fn)
           ^TextField text-field (some #(and (instance? TextField %) %) (.getChildren ^HBox (first (.getChildren box))))
@@ -272,6 +273,7 @@
                          (update-ui-fn values message read-only?)
                          (let [curved? (boolean (< 1 (count (properties/curve-vals (first values)))))]
                            (.setSelected toggle-button curved?)
+                           (ui/editable! toggle-button (some? (first values)))
                            (ui/disable! text-field curved?)))]
     [box update-ui-fn]))
 


### PR DESCRIPTION
* Technical changes
  - Don't allow changing curves unless we have an initial value
  - (Unrelated) Remove weird faulty double definition of
  default-curve, default-curve-spread
  - Implement :sanitize-fn for particlefx files that adds default
  properties for modifiers if none are supplied.