### PR TITLE
DEF-3265 Script Instance Context

### DIFF
--- a/engine/facebook/src/facebook_gameroom.cpp
+++ b/engine/facebook/src/facebook_gameroom.cpp
@@ -6,9 +6,117 @@
 #include "facebook_private.h"
 #include "facebook_analytics.h"
 
+
+/**
+ * 20170507 Dan Engelbrecht
+ * This implementation uses knowledge of the insides of the dmScript::LuaCallbackInfo
+ * and the API has changed. To avoid to big changes on too many platforms the old
+ * lua callback utilities has been copied in to this file.
+ * 
+ * We want to move away from this but the individual platforms also relies on the
+ * specifics on the LuaCallbackInfo structs content so these changes should be done
+ * in separate PR. 
+ */ 
+
+struct LegacyLuaCallbackInfo
+{
+    LegacyLuaCallbackInfo() : m_L(0), m_Callback(LUA_NOREF), m_Self(LUA_NOREF) {}
+    lua_State* m_L;
+    int        m_Callback;
+    int        m_Self;
+};
+
+void LegacyRegisterCallback(lua_State* L, int index, LegacyLuaCallbackInfo* cbk)
+{
+    if(cbk->m_Callback != LUA_NOREF)
+    {
+        dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Callback);
+        dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Self);
+    }
+
+    cbk->m_L = dmScript::GetMainThread(L);
+
+    luaL_checktype(L, index, LUA_TFUNCTION);
+    lua_pushvalue(L, index);
+    cbk->m_Callback = dmScript::Ref(L, LUA_REGISTRYINDEX);
+
+    dmScript::GetInstance(L);
+    cbk->m_Self = dmScript::Ref(L, LUA_REGISTRYINDEX);
+}
+
+bool LegacyIsValidCallback(LegacyLuaCallbackInfo* cbk)
+{
+    if (cbk->m_Callback == LUA_NOREF ||
+        cbk->m_Self == LUA_NOREF ||
+        cbk->m_L == NULL) {
+        return false;
+    }
+    return true;
+}
+
+void LegacyUnregisterCallback(LegacyLuaCallbackInfo* cbk)
+{
+    if(cbk->m_Callback != LUA_NOREF)
+    {
+        dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Callback);
+        dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Self);
+        cbk->m_Callback = LUA_NOREF;
+        cbk->m_Self = LUA_NOREF;
+        cbk->m_L = 0;
+    }
+    else
+    {
+        if (cbk->m_L)
+            luaL_error(cbk->m_L, "Failed to unregister callback (it was not registered)");
+        else
+            dmLogWarning("Failed to unregister callback (it was not registered)");
+    }
+}
+
+bool LegacyInvokeCallback(LegacyLuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context)
+{
+    if(cbk->m_Callback == LUA_NOREF)
+    {
+        luaL_error(cbk->m_L, "Failed to invoke callback (it was not registered)");
+        return false;
+    }
+
+    lua_State* L = cbk->m_L;
+    DM_LUA_STACK_CHECK(L, 0);
+
+    lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_Callback);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_Self); // Setup self (the script instance)
+    lua_pushvalue(L, -1);
+    dmScript::SetInstance(L);
+
+    if (!dmScript::IsInstanceValid(L))
+    {
+        lua_pop(L, 2);
+        DM_LUA_ERROR("Could not run callback because the instance has been deleted");
+        return false;
+    }
+
+    int user_args_start = lua_gettop(L);
+
+    if (fn)
+        fn(L, user_context);
+
+    int user_args_end = lua_gettop(L);
+
+    int number_of_arguments = 1 + user_args_end - user_args_start; // instance + number of arguments that the user pushed
+    int ret = dmScript::PCall(L, number_of_arguments, 0);
+    if (ret != 0) {
+        dmLogError("Error running callback: %s", lua_tostring(L,-1));
+        lua_pop(L, 1);
+        return false;
+    }
+
+    return true;
+}
+
 struct GameroomFB
 {
-    dmScript::LuaCallbackInfo m_Callback;
+    LegacyLuaCallbackInfo m_Callback;
 } g_GameroomFB;
 
 static const dmhash_t g_DialogFeed = dmHashBufferNoReverse64("feed", 4);
@@ -18,6 +126,7 @@ static const dmhash_t g_DialogAppRequest = dmHashBufferNoReverse64("apprequest",
 ////////////////////////////////////////////////////////////////////////////////
 // Functions for running callbacks; dialog and login results
 //
+
 
 struct LoginResultArguments
 {
@@ -42,7 +151,7 @@ static void RunLoginResultCallback(lua_State* L, int result, const char* error)
 {
     DM_LUA_STACK_CHECK(L, 0);
 
-    if (!dmScript::IsValidCallback(&g_GameroomFB.m_Callback)) {
+    if (!LegacyIsValidCallback(&g_GameroomFB.m_Callback)) {
         dmLogError("No callback set for login result.");
         return;
     }
@@ -51,9 +160,9 @@ static void RunLoginResultCallback(lua_State* L, int result, const char* error)
     args.m_Result = result;
     args.m_Error = error;
 
-    dmScript::InvokeCallback(&g_GameroomFB.m_Callback, PutLoginResultArguments, (void*)&args);
+    LegacyInvokeCallback(&g_GameroomFB.m_Callback, PutLoginResultArguments, (void*)&args);
 
-    dmScript::UnregisterCallback(&g_GameroomFB.m_Callback);
+    LegacyUnregisterCallback(&g_GameroomFB.m_Callback);
 }
 
 struct AppRequestArguments
@@ -87,7 +196,7 @@ static void PutAppRequestArguments(lua_State* L, void* user_context)
 
 static void RunAppRequestCallback(const char* request_id, const char* to)
 {
-    if (!dmScript::IsValidCallback(&g_GameroomFB.m_Callback)) {
+    if (!LegacyIsValidCallback(&g_GameroomFB.m_Callback)) {
         dmLogError("No callback set for dialog result.");
         return;
     }
@@ -96,9 +205,9 @@ static void RunAppRequestCallback(const char* request_id, const char* to)
     args.m_RequestId = request_id;
     args.m_To = to;
 
-    dmScript::InvokeCallback(&g_GameroomFB.m_Callback, PutAppRequestArguments, (void*)&args);
+    LegacyInvokeCallback(&g_GameroomFB.m_Callback, PutAppRequestArguments, (void*)&args);
 
-    dmScript::UnregisterCallback(&g_GameroomFB.m_Callback);
+    LegacyUnregisterCallback(&g_GameroomFB.m_Callback);
 }
 
 static void PutFeedArguments(lua_State* L, void* user_context)
@@ -114,14 +223,14 @@ static void PutFeedArguments(lua_State* L, void* user_context)
 
 static void RunFeedCallback(const char* post_id)
 {
-    if (!dmScript::IsValidCallback(&g_GameroomFB.m_Callback)) {
+    if (!LegacyIsValidCallback(&g_GameroomFB.m_Callback)) {
         dmLogError("No callback set for dialog result.");
         return;
     }
 
-    dmScript::InvokeCallback(&g_GameroomFB.m_Callback, PutFeedArguments, (void*)post_id);
+    LegacyInvokeCallback(&g_GameroomFB.m_Callback, PutFeedArguments, (void*)post_id);
 
-    dmScript::UnregisterCallback(&g_GameroomFB.m_Callback);
+    LegacyUnregisterCallback(&g_GameroomFB.m_Callback);
 }
 
 static void PutDialogErrorArguments(lua_State* L, void* user_context)
@@ -135,14 +244,14 @@ static void PutDialogErrorArguments(lua_State* L, void* user_context)
 
 static void RunDialogErrorCallback(const char* error_str)
 {
-    if (!dmScript::IsValidCallback(&g_GameroomFB.m_Callback)) {
+    if (!LegacyIsValidCallback(&g_GameroomFB.m_Callback)) {
         dmLogError("No callback set for dialog result.");
         return;
     }
 
-    dmScript::InvokeCallback(&g_GameroomFB.m_Callback, PutDialogErrorArguments, (void*)error_str);
+    LegacyInvokeCallback(&g_GameroomFB.m_Callback, PutDialogErrorArguments, (void*)error_str);
 
-    dmScript::UnregisterCallback(&g_GameroomFB.m_Callback);
+    LegacyUnregisterCallback(&g_GameroomFB.m_Callback);
 }
 
 
@@ -203,8 +312,8 @@ void PlatformFacebookLoginWithReadPermissions(lua_State* L, const char** permiss
     }
     DM_LUA_STACK_CHECK(L, 0);
 
-    if (dmScript::IsValidCallback(&g_GameroomFB.m_Callback)) {
-        dmScript::UnregisterCallback(&g_GameroomFB.m_Callback);
+    if (LegacyIsValidCallback(&g_GameroomFB.m_Callback)) {
+        LegacyUnregisterCallback(&g_GameroomFB.m_Callback);
     }
 
     g_GameroomFB.m_Callback.m_Callback = callback;
@@ -221,8 +330,8 @@ void PlatformFacebookLoginWithPublishPermissions(lua_State* L, const char** perm
     }
     DM_LUA_STACK_CHECK(L, 0);
 
-    if (dmScript::IsValidCallback(&g_GameroomFB.m_Callback)) {
-        dmScript::UnregisterCallback(&g_GameroomFB.m_Callback);
+    if (LegacyIsValidCallback(&g_GameroomFB.m_Callback)) {
+        LegacyUnregisterCallback(&g_GameroomFB.m_Callback);
     }
 
     g_GameroomFB.m_Callback.m_Callback = callback;

--- a/engine/facebook/src/facebook_gameroom.cpp
+++ b/engine/facebook/src/facebook_gameroom.cpp
@@ -26,7 +26,7 @@ struct LuaCallbackInfo
     int        m_Self;
 };
 
-void RegisterCallback(lua_State* L, int index, LuaCallbackInfo* cbk)
+static void RegisterCallback(lua_State* L, int index, LuaCallbackInfo* cbk)
 {
     if(cbk->m_Callback != LUA_NOREF)
     {
@@ -46,7 +46,7 @@ void RegisterCallback(lua_State* L, int index, LuaCallbackInfo* cbk)
 
 typedef void (*LuaCallbackUserFn)(lua_State* L, void* user_context);
 
-bool IsValidCallback(LuaCallbackInfo* cbk)
+static bool IsValidCallback(LuaCallbackInfo* cbk)
 {
     if (cbk->m_Callback == LUA_NOREF ||
         cbk->m_Self == LUA_NOREF ||
@@ -56,7 +56,7 @@ bool IsValidCallback(LuaCallbackInfo* cbk)
     return true;
 }
 
-void UnregisterCallback(LuaCallbackInfo* cbk)
+static void UnregisterCallback(LuaCallbackInfo* cbk)
 {
     if(cbk->m_Callback != LUA_NOREF)
     {
@@ -75,7 +75,7 @@ void UnregisterCallback(LuaCallbackInfo* cbk)
     }
 }
 
-bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context)
+static bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context)
 {
     if(cbk->m_Callback == LUA_NOREF)
     {
@@ -94,7 +94,7 @@ bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_conte
     if (!dmScript::IsInstanceValid(L))
     {
         lua_pop(L, 2);
-        DM_LUA_ERROR("Could not run callback because the instance has been deleted");
+        dmLogWarning("Invalid script instance, failed to invoke callback");
         return false;
     }
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -334,7 +334,7 @@ namespace dmGameObject
         return 1;
     }
 
-    static int ScriptGetInstanceContextTable(lua_State* L)
+    static int ScriptGetInstanceContextTableRef(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
 
@@ -343,7 +343,7 @@ namespace dmGameObject
         ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
         if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
+            lua_pushnumber(L, i->m_ContextTableReference);
         }
         else
         {
@@ -360,15 +360,15 @@ namespace dmGameObject
 
     static const luaL_reg ScriptInstance_meta[] =
     {
-        {"__gc",                                    ScriptInstance_gc},
-        {"__tostring",                              ScriptInstance_tostring},
-        {"__index",                                 ScriptInstance_index},
-        {"__newindex",                              ScriptInstance_newindex},
-        {dmScript::META_TABLE_GET_URL,              ScriptInstanceGetURL},
-        {dmScript::META_TABLE_GET_USER_DATA,        ScriptInstanceGetUserData},
-        {dmScript::META_TABLE_RESOLVE_PATH,         ScriptInstanceResolvePath},
-        {dmScript::META_TABLE_IS_VALID,             ScriptInstanceIsValid},
-        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE, ScriptGetInstanceContextTable},
+        {"__gc",                                        ScriptInstance_gc},
+        {"__tostring",                                  ScriptInstance_tostring},
+        {"__index",                                     ScriptInstance_index},
+        {"__newindex",                                  ScriptInstance_newindex},
+        {dmScript::META_TABLE_GET_URL,                  ScriptInstanceGetURL},
+        {dmScript::META_TABLE_GET_USER_DATA,            ScriptInstanceGetUserData},
+        {dmScript::META_TABLE_RESOLVE_PATH,             ScriptInstanceResolvePath},
+        {dmScript::META_TABLE_IS_VALID,                 ScriptInstanceIsValid},
+        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, ScriptGetInstanceContextTableRef},
         {0, 0}
     };
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -334,6 +334,53 @@ namespace dmGameObject
         return 1;
     }
 
+    static int ScriptInstanceSetContextValue(lua_State* L)
+    {
+        const int self_index = 1;
+        const int key_index = 2;
+        const int value_index = 3;
+
+        int top = lua_gettop(L);
+
+        ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
+        if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        {
+            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
+            dmScript::SetValueToTable(L, -1, key_index, value_index);
+        }
+
+        lua_pop(L, 1);
+
+        assert(top == lua_gettop(L));
+
+        return 0;
+    }
+
+    static int ScriptInstanceGetContextValue(lua_State* L)
+    {
+        const int self_index = 1;
+        const int key_index = 2;
+
+        int top = lua_gettop(L);
+
+        ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
+        if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        {
+            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
+            dmScript::GetValueFromTable(L, -1, key_index);
+
+            lua_insert(L, -2);
+            lua_pop(L, 1);
+        }
+        else
+        {
+            lua_pushnil(L);
+        }
+
+        assert(top + 1 == lua_gettop(L));
+        return 1;
+    }
+
     static const luaL_reg ScriptInstance_methods[] =
     {
         {0,0}
@@ -341,14 +388,16 @@ namespace dmGameObject
 
     static const luaL_reg ScriptInstance_meta[] =
     {
-        {"__gc",                            ScriptInstance_gc},
-        {"__tostring",                      ScriptInstance_tostring},
-        {"__index",                         ScriptInstance_index},
-        {"__newindex",                      ScriptInstance_newindex},
-        {dmScript::META_TABLE_GET_URL,      ScriptInstanceGetURL},
-        {dmScript::META_TABLE_GET_USER_DATA,ScriptInstanceGetUserData},
-        {dmScript::META_TABLE_RESOLVE_PATH, ScriptInstanceResolvePath},
-        {dmScript::META_TABLE_IS_VALID,     ScriptInstanceIsValid},
+        {"__gc",                                    ScriptInstance_gc},
+        {"__tostring",                              ScriptInstance_tostring},
+        {"__index",                                 ScriptInstance_index},
+        {"__newindex",                              ScriptInstance_newindex},
+        {dmScript::META_TABLE_GET_URL,              ScriptInstanceGetURL},
+        {dmScript::META_TABLE_GET_USER_DATA,        ScriptInstanceGetUserData},
+        {dmScript::META_TABLE_RESOLVE_PATH,         ScriptInstanceResolvePath},
+        {dmScript::META_TABLE_IS_VALID,             ScriptInstanceIsValid},
+        {dmScript::META_TABLE_SET_CONTEXT_VALUE,    ScriptInstanceSetContextValue},
+        {dmScript::META_TABLE_GET_CONTEXT_VALUE,    ScriptInstanceGetContextValue},
         {0, 0}
     };
 
@@ -2044,6 +2093,7 @@ bail:
         memset(script_instance, 0, sizeof(ScriptInstance));
         script_instance->m_InstanceReference = LUA_NOREF;
         script_instance->m_ScriptDataReference = LUA_NOREF;
+        script_instance->m_ContextTableReference = LUA_NOREF;
     }
 
     HScriptInstance NewScriptInstance(HScript script, HInstance instance, uint16_t component_index)
@@ -2062,6 +2112,9 @@ bail:
 
         lua_newtable(L);
         i->m_ScriptDataReference = dmScript::Ref( L, LUA_REGISTRYINDEX );
+
+        lua_newtable(L);
+        i->m_ContextTableReference = dmScript::Ref( L, LUA_REGISTRYINDEX );
 
         i->m_Instance = instance;
         i->m_ComponentIndex = component_index;
@@ -2091,6 +2144,7 @@ bail:
         int top = lua_gettop(L);
         (void) top;
 
+        dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_ContextTableReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_ScriptDataReference);
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -346,10 +346,11 @@ namespace dmGameObject
         if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            dmScript::SetValueToTable(L, -1, key_index, value_index);
+            lua_pushvalue(L, key_index);
+            lua_pushvalue(L, value_index);
+            lua_settable(L, -3);
+            lua_pop(L, 1);
         }
-
-        lua_pop(L, 1);
 
         assert(top == lua_gettop(L));
 
@@ -367,8 +368,8 @@ namespace dmGameObject
         if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            dmScript::GetValueFromTable(L, -1, key_index);
-
+            lua_pushvalue(L, key_index);
+            lua_gettable(L, -2);
             lua_insert(L, -2);
             lua_pop(L, 1);
         }

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -334,11 +334,9 @@ namespace dmGameObject
         return 1;
     }
 
-    static int ScriptInstanceSetContextValue(lua_State* L)
+    static int ScriptGetInstanceContextTable(lua_State* L)
     {
         const int self_index = 1;
-        const int key_index = 2;
-        const int value_index = 3;
 
         int top = lua_gettop(L);
 
@@ -346,32 +344,6 @@ namespace dmGameObject
         if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            lua_pushvalue(L, key_index);
-            lua_pushvalue(L, value_index);
-            lua_settable(L, -3);
-            lua_pop(L, 1);
-        }
-
-        assert(top == lua_gettop(L));
-
-        return 0;
-    }
-
-    static int ScriptInstanceGetContextValue(lua_State* L)
-    {
-        const int self_index = 1;
-        const int key_index = 2;
-
-        int top = lua_gettop(L);
-
-        ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-        {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            lua_pushvalue(L, key_index);
-            lua_gettable(L, -2);
-            lua_insert(L, -2);
-            lua_pop(L, 1);
         }
         else
         {
@@ -397,8 +369,7 @@ namespace dmGameObject
         {dmScript::META_TABLE_GET_USER_DATA,        ScriptInstanceGetUserData},
         {dmScript::META_TABLE_RESOLVE_PATH,         ScriptInstanceResolvePath},
         {dmScript::META_TABLE_IS_VALID,             ScriptInstanceIsValid},
-        {dmScript::META_TABLE_SET_CONTEXT_VALUE,    ScriptInstanceSetContextValue},
-        {dmScript::META_TABLE_GET_CONTEXT_VALUE,    ScriptInstanceGetContextValue},
+        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE, ScriptGetInstanceContextTable},
         {0, 0}
     };
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -336,12 +336,12 @@ namespace dmGameObject
 
     static int ScriptGetInstanceContextTable(lua_State* L)
     {
+        DM_LUA_STACK_CHECK(L, 1);
+
         const int self_index = 1;
 
-        int top = lua_gettop(L);
-
         ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_Instance != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
         }
@@ -350,7 +350,6 @@ namespace dmGameObject
             lua_pushnil(L);
         }
 
-        assert(top + 1 == lua_gettop(L));
         return 1;
     }
 

--- a/engine/gameobject/src/gameobject/gameobject_script.h
+++ b/engine/gameobject/src/gameobject/gameobject_script.h
@@ -58,6 +58,7 @@ namespace dmGameObject
         Instance*   m_Instance;
         int         m_InstanceReference;
         int         m_ScriptDataReference;
+        int         m_ContextTableReference;
         uint16_t    m_ComponentIndex;
         HProperties m_Properties;
         uint16_t    m_Update : 1;

--- a/engine/gameobject/src/gameobject/test/script/instance_context.go_pb
+++ b/engine/gameobject/src/gameobject/test/script/instance_context.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/instance_context.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/script/instance_context.script
+++ b/engine/gameobject/src/gameobject/test/script/instance_context.script
@@ -1,0 +1,7 @@
+function init(self)
+    test_set_instance_context()
+end
+
+function update(self)
+    test_get_instance_context()
+end

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -299,6 +299,7 @@ namespace dmGui
         scene->m_InstanceReference = LUA_NOREF;
         scene->m_DataReference = LUA_NOREF;
         scene->m_RefTableReference = LUA_NOREF;
+        scene->m_ContextTableReference = LUA_NOREF;
     }
 
     HScene NewScene(HContext context, const NewSceneParams* params)
@@ -327,6 +328,9 @@ namespace dmGui
 
         lua_newtable(L);
         scene->m_DataReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
+
+        lua_newtable(L);
+        scene->m_ContextTableReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
 
         scene->m_Context = context;
         scene->m_Script = 0x0;
@@ -401,6 +405,7 @@ namespace dmGui
         dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_InstanceReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_DataReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+        dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
 
         dmArray<HScene>& scenes = scene->m_Context->m_Scenes;
         uint32_t scene_count = scenes.Size();

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -298,7 +298,6 @@ namespace dmGui
         memset(scene, 0, sizeof(Scene));
         scene->m_InstanceReference = LUA_NOREF;
         scene->m_DataReference = LUA_NOREF;
-        scene->m_RefTableReference = LUA_NOREF;
         scene->m_ContextTableReference = LUA_NOREF;
     }
 
@@ -322,15 +321,13 @@ namespace dmGui
         scene->m_InstanceReference = dmScript::Ref( L, LUA_REGISTRYINDEX );
 
         // Here we create a custom table to hold the references created by this gui scene
-        // Don't interact with this table with other functions than dmScript::Ref/dmScript::Unref
+        // It is also the "Instance Context Table" used to by META_TABLE_SET_CONTEXT_VALUE
+        // and META_TABLE_GET_CONTEXT_VALUE implementaion
         lua_newtable(L);
-        scene->m_RefTableReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
+        scene->m_ContextTableReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
 
         lua_newtable(L);
         scene->m_DataReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
-
-        lua_newtable(L);
-        scene->m_ContextTableReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
 
         scene->m_Context = context;
         scene->m_Script = 0x0;
@@ -404,7 +401,6 @@ namespace dmGui
 
         dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_InstanceReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_DataReference);
-        dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
 
         dmArray<HScene>& scenes = scene->m_Context->m_Scenes;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -253,7 +253,6 @@ namespace dmGui
     {
         int                     m_InstanceReference;
         int                     m_DataReference;
-        int                     m_RefTableReference;
         int                     m_ContextTableReference;
         Context*                m_Context;
         Script*                 m_Script;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -254,6 +254,7 @@ namespace dmGui
         int                     m_InstanceReference;
         int                     m_DataReference;
         int                     m_RefTableReference;
+        int                     m_ContextTableReference;
         Context*                m_Context;
         Script*                 m_Script;
         dmIndexPool16           m_NodePool;

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -167,12 +167,12 @@ namespace dmGui
 
     static int GuiScriptGetInstanceContextTable(lua_State* L)
     {
+        DM_LUA_STACK_CHECK(L, 1);
+
         const int self_index = 1;
 
-        int top = lua_gettop(L);
-
         Scene* i = (Scene*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
         }
@@ -181,7 +181,6 @@ namespace dmGui
             lua_pushnil(L);
         }
 
-        assert(top + 1 == lua_gettop(L));
         return 1;
     }
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -63,9 +63,9 @@ namespace dmGui
 
     static const luaL_reg GuiScript_meta[] =
     {
-        {dmScript::META_TABLE_GET_URL,      GuiScriptGetURL},
-        {dmScript::META_TABLE_RESOLVE_PATH, GuiScriptResolvePath},
-        {dmScript::META_TABLE_IS_VALID,     GuiScriptIsValid},
+        {dmScript::META_TABLE_GET_URL,              GuiScriptGetURL},
+        {dmScript::META_TABLE_RESOLVE_PATH,         GuiScriptResolvePath},
+        {dmScript::META_TABLE_IS_VALID,             GuiScriptIsValid},
         {0, 0}
     };
 
@@ -165,6 +165,53 @@ namespace dmGui
         return 1;
     }
 
+    static int GuiScriptInstanceSetContextValue(lua_State* L)
+    {
+        const int self_index = 1;
+        const int key_index = 2;
+        const int value_index = 3;
+
+        int top = lua_gettop(L);
+
+        Scene* i = (Scene*)lua_touserdata(L, self_index);
+        if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        {
+            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
+            dmScript::SetValueToTable(L, -1, key_index, value_index);
+        }
+
+        lua_pop(L, 1);
+
+        assert(top == lua_gettop(L));
+
+        return 0;
+    }
+
+    static int GuiScriptInstanceGetContextValue(lua_State* L)
+    {
+        const int self_index = 1;
+        const int key_index = 2;
+
+        int top = lua_gettop(L);
+
+        Scene* i = (Scene*)lua_touserdata(L, self_index);
+        if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        {
+            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
+            dmScript::GetValueFromTable(L, -1, key_index);
+
+            lua_insert(L, -2);
+            lua_pop(L, 1);
+        }
+        else
+        {
+            lua_pushnil(L);
+        }
+
+        assert(top + 1 == lua_gettop(L));
+        return 1;
+    }
+
     static const luaL_reg GuiScriptInstance_methods[] =
     {
         {0,0}
@@ -172,13 +219,15 @@ namespace dmGui
 
     static const luaL_reg GuiScriptInstance_meta[] =
     {
-        {"__gc",        GuiScriptInstance_gc},
-        {"__tostring",  GuiScriptInstance_tostring},
-        {"__index",     GuiScriptInstance_index},
-        {"__newindex",  GuiScriptInstance_newindex},
-        {dmScript::META_TABLE_GET_URL,      GuiScriptInstanceGetURL},
-        {dmScript::META_TABLE_RESOLVE_PATH, GuiScriptInstanceResolvePath},
-        {dmScript::META_TABLE_IS_VALID,     GuiScriptInstanceIsValid},
+        {"__gc",                                    GuiScriptInstance_gc},
+        {"__tostring",                              GuiScriptInstance_tostring},
+        {"__index",                                 GuiScriptInstance_index},
+        {"__newindex",                              GuiScriptInstance_newindex},
+        {dmScript::META_TABLE_GET_URL,              GuiScriptInstanceGetURL},
+        {dmScript::META_TABLE_RESOLVE_PATH,         GuiScriptInstanceResolvePath},
+        {dmScript::META_TABLE_IS_VALID,             GuiScriptInstanceIsValid},
+        {dmScript::META_TABLE_SET_CONTEXT_VALUE,    GuiScriptInstanceSetContextValue},
+        {dmScript::META_TABLE_GET_CONTEXT_VALUE,    GuiScriptInstanceGetContextValue},
         {0, 0}
     };
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -595,7 +595,7 @@ namespace dmGui
 
         int ref = (int) (((uintptr_t) curve->userdata2) & 0xffffffff);
 
-        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
         dmScript::Unref(L, -1, ref);
         lua_pop(L, 1);
 
@@ -615,7 +615,7 @@ namespace dmGui
         int callback_ref = (int) ((uintptr_t) userdata1 & 0xffffffff);
         int node_ref = (int) ((uintptr_t) userdata2 & 0xffffffff);
 
-        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
 
         if( finished )
         {
@@ -1030,7 +1030,7 @@ namespace dmGui
             curve.type = dmEasing::TYPE_FLOAT_VECTOR;
             curve.vector = dmScript::CheckVector(L, 4);
 
-            lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+            lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
             lua_pushvalue(L, 4);
 
             curve.release_callback = LuaCurveRelease;
@@ -1052,7 +1052,7 @@ namespace dmGui
             delay = (float) lua_tonumber(L, 6);
             if (lua_isfunction(L, 7))
             {
-                lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+                lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
                 lua_pushvalue(L, 7);
                 animation_complete_ref = dmScript::Ref(L, -2);
                 lua_pushvalue(L, 1);
@@ -1563,7 +1563,7 @@ namespace dmGui
         int animation_complete_ref = LUA_NOREF;
         if (lua_isfunction(L, 3))
         {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+            lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
             lua_pushvalue(L, 3);
             animation_complete_ref = dmScript::Ref(L, -2);
             lua_pushvalue(L, 1);
@@ -3581,7 +3581,7 @@ namespace dmGui
         {
             if (lua_isfunction(L, 5))
             {
-                lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+                lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
                 lua_pushvalue(L, 5);
                 animation_complete_ref = dmScript::Ref(L, -2);
                 lua_pushvalue(L, 1);
@@ -3680,7 +3680,7 @@ namespace dmGui
         {
             if (lua_isfunction(L, 5))
             {
-                lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_RefTableReference);
+                lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
                 lua_pushvalue(L, 5);
                 animation_complete_ref = dmScript::Ref(L, -2);
                 lua_pushvalue(L, 1);

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -177,10 +177,11 @@ namespace dmGui
         if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            dmScript::SetValueToTable(L, -1, key_index, value_index);
+            lua_pushvalue(L, key_index);
+            lua_pushvalue(L, value_index);
+            lua_settable(L, -3);
+            lua_pop(L, 1);
         }
-
-        lua_pop(L, 1);
 
         assert(top == lua_gettop(L));
 
@@ -198,8 +199,8 @@ namespace dmGui
         if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            dmScript::GetValueFromTable(L, -1, key_index);
-
+            lua_pushvalue(L, key_index);
+            lua_gettable(L, -2);
             lua_insert(L, -2);
             lua_pop(L, 1);
         }

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -63,9 +63,9 @@ namespace dmGui
 
     static const luaL_reg GuiScript_meta[] =
     {
-        {dmScript::META_TABLE_GET_URL,              GuiScriptGetURL},
-        {dmScript::META_TABLE_RESOLVE_PATH,         GuiScriptResolvePath},
-        {dmScript::META_TABLE_IS_VALID,             GuiScriptIsValid},
+        {dmScript::META_TABLE_GET_URL,      GuiScriptGetURL},
+        {dmScript::META_TABLE_RESOLVE_PATH, GuiScriptResolvePath},
+        {dmScript::META_TABLE_IS_VALID,     GuiScriptIsValid},
         {0, 0}
     };
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -165,11 +165,9 @@ namespace dmGui
         return 1;
     }
 
-    static int GuiScriptInstanceSetContextValue(lua_State* L)
+    static int GuiScriptGetInstanceContextTable(lua_State* L)
     {
         const int self_index = 1;
-        const int key_index = 2;
-        const int value_index = 3;
 
         int top = lua_gettop(L);
 
@@ -177,32 +175,6 @@ namespace dmGui
         if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            lua_pushvalue(L, key_index);
-            lua_pushvalue(L, value_index);
-            lua_settable(L, -3);
-            lua_pop(L, 1);
-        }
-
-        assert(top == lua_gettop(L));
-
-        return 0;
-    }
-
-    static int GuiScriptInstanceGetContextValue(lua_State* L)
-    {
-        const int self_index = 1;
-        const int key_index = 2;
-
-        int top = lua_gettop(L);
-
-        Scene* i = (Scene*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_Context != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-        {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            lua_pushvalue(L, key_index);
-            lua_gettable(L, -2);
-            lua_insert(L, -2);
-            lua_pop(L, 1);
         }
         else
         {
@@ -227,8 +199,7 @@ namespace dmGui
         {dmScript::META_TABLE_GET_URL,              GuiScriptInstanceGetURL},
         {dmScript::META_TABLE_RESOLVE_PATH,         GuiScriptInstanceResolvePath},
         {dmScript::META_TABLE_IS_VALID,             GuiScriptInstanceIsValid},
-        {dmScript::META_TABLE_SET_CONTEXT_VALUE,    GuiScriptInstanceSetContextValue},
-        {dmScript::META_TABLE_GET_CONTEXT_VALUE,    GuiScriptInstanceGetContextValue},
+        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE, GuiScriptGetInstanceContextTable},
         {0, 0}
     };
 

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -1195,6 +1195,40 @@ TEST_F(dmGuiScriptTest, SetBoneNodeProperties)
         DeleteSpineDummyData(dummy_data);
 }
 
+TEST_F(dmGuiScriptTest, TestInstanceContext)
+{
+    lua_State* L = dmGui::GetLuaState(m_Context);
+
+    dmGui::NewSceneParams params;
+    params.m_MaxNodes = 64;
+    params.m_MaxAnimations = 32;
+    params.m_UserData = this;
+    params.m_RigContext = m_RigContext;
+    dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+
+    dmGui::InitScene(scene);
+
+    lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_InstanceReference);
+    dmScript::SetInstance(L);
+
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+
+    lua_pushstring(L, "__my_context_value");
+    lua_pushnumber(L, 81233);
+    ASSERT_TRUE(dmScript::SetInstanceContextValue(L));
+
+    lua_pushstring(L, "__my_context_value");
+    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    ASSERT_EQ(81233, lua_tonumber(L, -1));
+    lua_pop(L, 1);
+
+    dmGui::DeleteScene(scene);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+    ASSERT_FALSE(dmScript::IsInstanceValid(L));
+}
+
 int main(int argc, char **argv)
 {
     dmDDF::RegisterAllTypes();

--- a/engine/iap/src/iap_gameroom.cpp
+++ b/engine/iap/src/iap_gameroom.cpp
@@ -45,8 +45,8 @@ struct IAP
 {
     IAP()
      : m_ListCallback(0x0)
-     : m_PremiumCallback(0x0)
-     : m_Listener(0x0)
+     , m_PremiumCallback(0x0)
+     , m_Listener(0x0)
      , m_PendingTransactions()
     {
         m_PendingTransactions.SetCapacity(4);

--- a/engine/iap/src/iap_gameroom.cpp
+++ b/engine/iap/src/iap_gameroom.cpp
@@ -155,7 +155,7 @@ static void RunPremiumCallback(bool has_premium)
 
     dmScript::InvokeCallback(g_IAP.m_PremiumCallback, PutPremiumArguments, (void*)&has_premium);
 
-    dmScript::UnregisterCallback(g_IAP.m_PremiumCallback);
+    dmScript::DeleteCallback(g_IAP.m_PremiumCallback);
     g_IAP.m_PremiumCallback = 0x0;
 }
 
@@ -208,7 +208,8 @@ static int IAP_List_WrapperCB(lua_State* L)
     int top = lua_gettop(L);
     if (top < 2) {
         dmScript::InvokeCallback(g_IAP.m_ListCallback, PutListWrapperErrorArguments, NULL);
-        dmScript::UnregisterCallback(g_IAP.m_ListCallback);
+        dmScript::DeleteCallback(g_IAP.m_ListCallback);
+        g_IAP.m_ListCallback = 0x0;
         return 0;
     }
 
@@ -216,7 +217,7 @@ static int IAP_List_WrapperCB(lua_State* L)
     dmScript::InvokeCallback(g_IAP.m_ListCallback, PutListWrapperResultArguments, NULL);
 
     // Clear IAP callback info so iap.list can be called once again.
-    dmScript::UnregisterCallback(g_IAP.m_ListCallback);
+    dmScript::DeleteCallback(g_IAP.m_ListCallback);
     g_IAP.m_ListCallback = 0x0;
 
     return 0;
@@ -255,7 +256,7 @@ static int IAP_List(lua_State* L)
         return 0;
     }
 
-    g_IAP.m_ListCallback = dmScript::RegisterCallback(L, 2);
+    g_IAP.m_ListCallback = dmScript::CreateCallback(L, 2);
 
     // Push wrapper callback
     lua_pushcfunction(L, IAP_List_WrapperCB);
@@ -354,7 +355,7 @@ static int IAP_HasPremium(lua_State* L)
     }
 
     luaL_checktype(L, 1, LUA_TFUNCTION);
-    g_IAP.m_PremiumCallback = dmScript::RegisterCallback(L, 1);
+    g_IAP.m_PremiumCallback = dmScript::CreateCallback(L, 1);
 
     fbg_HasLicense();
 
@@ -432,7 +433,7 @@ static int IAP_SetListener(lua_State* L)
 
     luaL_checktype(L, 1, LUA_TFUNCTION);
 
-    g_IAP.m_Listener = dmScript::RegisterCallback(L, 1);
+    g_IAP.m_Listener = dmScript::CreateCallback(L, 1);
 
     // On first set listener, trigger process old ones.
     if (!g_IAP.m_PendingTransactions.Empty()) {

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -287,11 +287,9 @@ namespace dmRender
         return 1;
     }
 
-    static int RenderScriptInstanceSetContextValue(lua_State* L)
+    static int RenderScriptGetInstanceContextTable(lua_State* L)
     {
         const int self_index = 1;
-        const int key_index = 2;
-        const int value_index = 3;
 
         int top = lua_gettop(L);
 
@@ -299,32 +297,6 @@ namespace dmRender
         if (i != 0x0 && i->m_RenderContext != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            lua_pushvalue(L, key_index);
-            lua_pushvalue(L, value_index);
-            lua_settable(L, -3);
-            lua_pop(L, 1);
-        }
-
-        assert(top == lua_gettop(L));
-
-        return 0;
-    }
-
-    static int RenderScriptInstanceGetContextValue(lua_State* L)
-    {
-        const int self_index = 1;
-        const int key_index = 2;
-
-        int top = lua_gettop(L);
-
-        RenderScriptInstance* i = (RenderScriptInstance*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_RenderContext != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-        {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            lua_pushvalue(L, key_index);
-            lua_gettable(L, -2);
-            lua_insert(L, -2);
-            lua_pop(L, 1);
         }
         else
         {
@@ -349,8 +321,7 @@ namespace dmRender
         {dmScript::META_TABLE_GET_URL,              RenderScriptInstanceGetURL},
         {dmScript::META_TABLE_RESOLVE_PATH,         RenderScriptInstanceResolvePath},
         {dmScript::META_TABLE_IS_VALID,             RenderScriptInstanceIsValid},
-        {dmScript::META_TABLE_SET_CONTEXT_VALUE,    RenderScriptInstanceSetContextValue},
-        {dmScript::META_TABLE_GET_CONTEXT_VALUE,    RenderScriptInstanceGetContextValue},
+        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE, RenderScriptGetInstanceContextTable},
         {0, 0}
     };
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -287,7 +287,7 @@ namespace dmRender
         return 1;
     }
 
-    static int RenderScriptGetInstanceContextTable(lua_State* L)
+    static int RenderScriptGetInstanceContextTableRef(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
 
@@ -296,7 +296,7 @@ namespace dmRender
         RenderScriptInstance* i = (RenderScriptInstance*)lua_touserdata(L, self_index);
         if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
+            lua_pushnumber(L, i->m_ContextTableReference);
         }
         else
         {
@@ -313,14 +313,14 @@ namespace dmRender
 
     static const luaL_reg RenderScriptInstance_meta[] =
     {
-        {"__gc",                                    RenderScriptInstance_gc},
-        {"__tostring",                              RenderScriptInstance_tostring},
-        {"__index",                                 RenderScriptInstance_index},
-        {"__newindex",                              RenderScriptInstance_newindex},
-        {dmScript::META_TABLE_GET_URL,              RenderScriptInstanceGetURL},
-        {dmScript::META_TABLE_RESOLVE_PATH,         RenderScriptInstanceResolvePath},
-        {dmScript::META_TABLE_IS_VALID,             RenderScriptInstanceIsValid},
-        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE, RenderScriptGetInstanceContextTable},
+        {"__gc",                                        RenderScriptInstance_gc},
+        {"__tostring",                                  RenderScriptInstance_tostring},
+        {"__index",                                     RenderScriptInstance_index},
+        {"__newindex",                                  RenderScriptInstance_newindex},
+        {dmScript::META_TABLE_GET_URL,                  RenderScriptInstanceGetURL},
+        {dmScript::META_TABLE_RESOLVE_PATH,             RenderScriptInstanceResolvePath},
+        {dmScript::META_TABLE_IS_VALID,                 RenderScriptInstanceIsValid},
+        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, RenderScriptGetInstanceContextTableRef},
         {0, 0}
     };
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -289,12 +289,12 @@ namespace dmRender
 
     static int RenderScriptGetInstanceContextTable(lua_State* L)
     {
+        DM_LUA_STACK_CHECK(L, 1);
+
         const int self_index = 1;
 
-        int top = lua_gettop(L);
-
         RenderScriptInstance* i = (RenderScriptInstance*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_RenderContext != 0x0 && i->m_ContextTableReference != LUA_NOREF)
+        if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
         }
@@ -303,7 +303,6 @@ namespace dmRender
             lua_pushnil(L);
         }
 
-        assert(top + 1 == lua_gettop(L));
         return 1;
     }
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -299,10 +299,11 @@ namespace dmRender
         if (i != 0x0 && i->m_RenderContext != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            dmScript::SetValueToTable(L, -1, key_index, value_index);
+            lua_pushvalue(L, key_index);
+            lua_pushvalue(L, value_index);
+            lua_settable(L, -3);
+            lua_pop(L, 1);
         }
-
-        lua_pop(L, 1);
 
         assert(top == lua_gettop(L));
 
@@ -320,8 +321,8 @@ namespace dmRender
         if (i != 0x0 && i->m_RenderContext != 0x0 && i->m_ContextTableReference != LUA_NOREF)
         {
             lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-            dmScript::GetValueFromTable(L, -1, key_index);
-
+            lua_pushvalue(L, key_index);
+            lua_gettable(L, -2);
             lua_insert(L, -2);
             lua_pop(L, 1);
         }

--- a/engine/render/src/render/render_script.h
+++ b/engine/render/src/render/render_script.h
@@ -40,6 +40,7 @@ namespace dmRender
         uint32_t                    m_PredicateCount;
         int                         m_InstanceReference;
         int                         m_RenderScriptDataReference;
+        int                         m_ContextTableReference;
     };
 
     void InitializeRenderScriptContext(RenderScriptContext& context, dmScript::HContext script_context, uint32_t command_buffer_size);

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -856,6 +856,36 @@ TEST_F(dmRenderScriptTest, TestURL)
     dmRender::DeleteRenderScript(m_Context, render_script);
 }
 
+TEST_F(dmRenderScriptTest, TestInstanceContext)
+{
+    lua_State* L = m_Context->m_RenderScriptContext.m_LuaState;
+
+    const char* script =
+        "";
+
+    dmRender::HRenderScript render_script = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, render_script_instance->m_InstanceReference);
+    dmScript::SetInstance(L);
+    ASSERT_TRUE(dmScript::IsInstanceValid(L));
+
+    lua_pushstring(L, "__my_context_value");
+    lua_pushnumber(L, 81233);
+    ASSERT_TRUE(dmScript::SetInstanceContextValue(L));
+
+    lua_pushstring(L, "__my_context_value");
+    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    ASSERT_EQ(81233, lua_tonumber(L, -1));
+    lua_pop(L, 1);
+
+    dmRender::DeleteRenderScriptInstance(render_script_instance);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+
+    lua_pushnil(L);
+    dmScript::SetInstance(L);
+    ASSERT_FALSE(dmScript::IsInstanceValid(L));
+}
+
 int main(int argc, char **argv)
 {
     dmDDF::RegisterAllTypes();

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -40,11 +40,11 @@ namespace dmScript
     const char* INSTANCE_NAME = "__dm_script_instance__";
     const int MAX_PPRINT_TABLE_CALL_DEPTH = 32;
 
-    const char* META_TABLE_RESOLVE_PATH         = "__resolve_path";
-    const char* META_TABLE_GET_URL              = "__get_url";
-    const char* META_TABLE_GET_USER_DATA        = "__get_user_data";
-    const char* META_TABLE_IS_VALID             = "__is_valid";
-    const char* META_GET_INSTANCE_CONTEXT_TABLE = "__get_instance_context_table";
+    const char* META_TABLE_RESOLVE_PATH             = "__resolve_path";
+    const char* META_TABLE_GET_URL                  = "__get_url";
+    const char* META_TABLE_GET_USER_DATA            = "__get_user_data";
+    const char* META_TABLE_IS_VALID                 = "__is_valid";
+    const char* META_GET_INSTANCE_CONTEXT_TABLE_REF = "__get_instance_context_table_ref";
 
     // A debug value for profiling lua references
     int g_LuaReferenceCount = 0;
@@ -586,25 +586,38 @@ namespace dmScript
         // [-2] value
         // [-1] instance
 
-        if (GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE)) {
+        if (GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF)) {
             // [-4] key
             // [-3] value
             // [-2] instance
-            // [-1] META_GET_INSTANCE_CONTEXT_TABLE()
+            // [-1] META_GET_INSTANCE_CONTEXT_TABLE_REF()
 
             lua_pushvalue(L, -2);
             // [-5] key
             // [-4] value
             // [-3] instance
-            // [-2] META_GET_INSTANCE_CONTEXT_TABLE()
+            // [-2] META_GET_INSTANCE_CONTEXT_TABLE_REF()
             // [-1] instance
 
             lua_call(L, 1, 1);
             // [-4] key
             // [-3] value
             // [-2] instance
-            // [-1] instance context table
+            // [-1] instance context table ref
+            assert(lua_type(L, -1) == LUA_TNUMBER);
+
+            int context_table_ref = lua_tonumber(L, -1);
+            lua_pop(L, 1);
+            // [-3] key
+            // [-2] value
+            // [-1] instance
+
+            lua_rawgeti(L, LUA_REGISTRYINDEX, context_table_ref);
             assert(lua_type(L, -1) == LUA_TTABLE);
+            // [-4] key
+            // [-3] value
+            // [-2] instance
+            // [-1] instance context table
 
             lua_pushvalue(L, -4);
             // [-5] key
@@ -646,54 +659,68 @@ namespace dmScript
         // [-2] key
         // [-1] instance
 
-        if (GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE)) {
+        if (GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF)) {
             // [-3] key
             // [-2] instance
-            // [-1] META_GET_INSTANCE_CONTEXT_TABLE()
+            // [-1] META_GET_INSTANCE_CONTEXT_TABLE_REF()
 
             lua_pushvalue(L, -2);
             // [-4] key
             // [-3] instance
-            // [-2] META_GET_INSTANCE_CONTEXT_TABLE()
+            // [-2] META_GET_INSTANCE_CONTEXT_TABLE_REF()
             // [-1] instance
 
             lua_call(L, 1, 1);
             // [-3] key
             // [-2] instance
-            // [-1] instance context table
-            if(lua_type(L, -1) == LUA_TTABLE)
-            {
-                lua_pushvalue(L, -3);
-                // [-4] key
-                // [-3] instance
-                // [-2] instance context table
-                // [-1] key
-
-                lua_gettable(L, -2);
-                // [-4] key
-                // [-3] instance
-                // [-2] instance context table
-                // [-1] value
-
-                lua_insert(L, -4);
-                // [-4] value
-                // [-3] key
-                // [-2] instance
-                // [-1] instance context table
-
-                lua_pop(L, 3);
-                // [-1] value
-
-                assert(top == lua_gettop(L));
-                return true;
-            }
-            else
+            // [-1] instance context table ref
+            if(lua_type(L, -1) != LUA_TNUMBER)
             {
                 lua_pop(L, 3);
-
                 assert(top - 1 == lua_gettop(L));
                 return false;
             }
+
+            int context_table_ref = lua_tonumber(L, -1);
+            lua_pop(L, 1);
+            // [-3] key
+            // [-2] instance
+
+            lua_rawgeti(L, LUA_REGISTRYINDEX, context_table_ref);
+            // [-3] key
+            // [-2] instance
+            // [-1] instance context table
+
+            if(lua_type(L, -1) != LUA_TTABLE)
+            {
+                lua_pop(L, 3);
+                assert(top - 1 == lua_gettop(L));
+                return false;
+            }
+
+            lua_pushvalue(L, -3);
+            // [-4] key
+            // [-3] instance
+            // [-2] instance context table
+            // [-1] key
+
+            lua_gettable(L, -2);
+            // [-4] key
+            // [-3] instance
+            // [-2] instance context table
+            // [-1] value
+
+            lua_insert(L, -4);
+            // [-4] value
+            // [-3] key
+            // [-2] instance
+            // [-1] instance context table
+
+            lua_pop(L, 3);
+            // [-1] value
+
+            assert(top == lua_gettop(L));
+            return true;
         }
 
         lua_pop(L, 2);
@@ -836,48 +863,117 @@ namespace dmScript
         }
     }
 
-    void RegisterCallback(lua_State* L, int index, LuaCallbackInfo* cbk)
+    LuaCallbackInfo* CreateCallback(lua_State* L, int callback_stack_index)
     {
-        if(cbk->m_Callback != LUA_NOREF)
+        luaL_checktype(L, callback_stack_index, LUA_TFUNCTION);
+
+        DM_LUA_STACK_CHECK(L, 0);
+
+        GetInstance(L);
+        // [-1] instance
+
+        if (!GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF)) {
+            lua_pop(L, 1);
+            return 0x0;
+        }
+        // [-2] instance
+        // [-1] META_GET_INSTANCE_CONTEXT_TABLE_REF()
+
+        lua_pushvalue(L, -2);
+        // [-3] instance
+        // [-2] META_GET_INSTANCE_CONTEXT_TABLE_REF()
+        // [-1] instance
+
+        lua_call(L, 1, 1);
+        // [-2] instance
+        // [-1] instance context table ref
+        assert(lua_type(L, -1) == LUA_TNUMBER);
+
+        int context_table_ref = lua_tonumber(L, -1);
+        lua_pop(L, 2);
+
+        lua_pushvalue(L, callback_stack_index);
+        // [-1] callback
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, context_table_ref);
+        // [-2] callback
+        // [-1] context table
+        if (lua_type(L, -1) != LUA_TTABLE)
         {
-            dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Callback);
-            dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Self);
+            lua_pop(L, 2);
+            return 0x0;
         }
 
-        cbk->m_L = dmScript::GetMainThread(L);
+        lua_insert(L, -2);
+        // [-2] context table
+        // [-1] callback
 
-        luaL_checktype(L, index, LUA_TFUNCTION);
-        lua_pushvalue(L, index);
-        cbk->m_Callback = dmScript::Ref(L, LUA_REGISTRYINDEX);
+        LuaCallbackInfo* cbk = (LuaCallbackInfo*)lua_newuserdata(L, sizeof(LuaCallbackInfo));
+        // [-3] context table
+        // [-2] callback
+        // [-1] LuaCallbackInfo
+
+        cbk->m_L = dmScript::GetMainThread(L);
+        cbk->m_ContextTableRef = context_table_ref;
+        
+        cbk->m_CallbackInfoRef = luaL_ref(L, -3);
+        // [-2] context table
+        // [-1] callback
+
+        cbk->m_Callback = luaL_ref(L, -2);
+        // [-1] context table
 
         dmScript::GetInstance(L);
-        cbk->m_Self = dmScript::Ref(L, LUA_REGISTRYINDEX);
-    }
+        // [-1] context table
+        // [-2] instance
+
+        cbk->m_Self = luaL_ref(L, -2);
+        // [-1] context table
+
+        lua_pop(L, 1);
+
+        return cbk;
+     }
 
     bool IsValidCallback(LuaCallbackInfo* cbk)
     {
-        if (cbk->m_Callback == LUA_NOREF ||
-            cbk->m_Self == LUA_NOREF ||
-            cbk->m_L == NULL) {
+        if (cbk == NULL ||
+            cbk->m_L == NULL ||
+            cbk->m_ContextTableRef == LUA_NOREF ||
+            cbk->m_CallbackInfoRef == LUA_NOREF ||
+            cbk->m_Callback == LUA_NOREF ||
+            cbk->m_Self == LUA_NOREF) {
             return false;
         }
         return true;
     }
 
-    void UnregisterCallback(LuaCallbackInfo* cbk)
+    void DeleteCallback(LuaCallbackInfo* cbk)
     {
-        if(cbk->m_Callback != LUA_NOREF)
+        lua_State* L = cbk->m_L;
+        DM_LUA_STACK_CHECK(L, 0);
+
+        if(cbk->m_ContextTableRef != LUA_NOREF)
         {
-            dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Callback);
-            dmScript::Unref(cbk->m_L, LUA_REGISTRYINDEX, cbk->m_Self);
-            cbk->m_Callback = LUA_NOREF;
+            lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_ContextTableRef);
+            if (lua_type(L, -1) == LUA_TTABLE)
+            {
+                dmScript::Unref(L, -1, cbk->m_Self);
+                dmScript::Unref(L, -1, cbk->m_Callback);
+                dmScript::Unref(L, -1, cbk->m_CallbackInfoRef);
+            }
             cbk->m_Self = LUA_NOREF;
-            cbk->m_L = 0;
+            cbk->m_Callback = LUA_NOREF;
+            cbk->m_CallbackInfoRef = LUA_NOREF;
+            cbk->m_ContextTableRef = LUA_NOREF;
+
+            lua_pop(L, 1);
+            return;
         }
         else
         {
-            if (cbk->m_L)
-                luaL_error(cbk->m_L, "Failed to unregister callback (it was not registered)");
+            if (L)
+                luaL_error(L, "Failed to unregister callback (it was not registered)");
             else
                 dmLogWarning("Failed to unregister callback (it was not registered)");
         }
@@ -885,7 +981,7 @@ namespace dmScript
 
     bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context)
     {
-        if(cbk->m_Callback == LUA_NOREF)
+        if(cbk->m_ContextTableRef == LUA_NOREF)
         {
             luaL_error(cbk->m_L, "Failed to invoke callback (it was not registered)");
             return false;
@@ -894,14 +990,53 @@ namespace dmScript
         lua_State* L = cbk->m_L;
         DM_LUA_STACK_CHECK(L, 0);
 
-        lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_Callback);
-        lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_Self); // Setup self (the script instance)
+        lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_ContextTableRef);
+        // [-1] context table
+
+        if (lua_type(L, -1) != LUA_TTABLE)
+        {
+            lua_pop(L, 1);
+            DM_LUA_ERROR("Could not run callback because the callback has been deleted");
+            return false;
+        }
+
+        const int context_table_stack_index = lua_gettop(L);
+
+        lua_rawgeti(L, context_table_stack_index, cbk->m_Callback);
+        // [-2] context table
+        // [-1] callback
+        if (lua_type(L, -1) != LUA_TFUNCTION)
+        {
+            lua_pop(L, 2);
+            DM_LUA_ERROR("Could not run callback because the callback has been deleted");
+            return false;
+        }
+
+        lua_rawgeti(L, context_table_stack_index, cbk->m_Self); // Setup self (the script instance)
+        // [-3] context table
+        // [-2] callback
+        // [-1] self
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 3);
+            DM_LUA_ERROR("Could not run callback because the callback has been deleted");
+            return false;
+        }
+
         lua_pushvalue(L, -1);
+        // [-4] context table
+        // [-3] callback
+        // [-2] self
+        // [-1] self
+
         dmScript::SetInstance(L);
+        // [-3] context table
+        // [-2] callback
+        // [-1] self
 
         if (!dmScript::IsInstanceValid(L))
         {
-            lua_pop(L, 2);
+            lua_pop(L, 3);
             DM_LUA_ERROR("Could not run callback because the instance has been deleted");
             return false;
         }
@@ -916,10 +1051,18 @@ namespace dmScript
         int number_of_arguments = 1 + user_args_end - user_args_start; // instance + number of arguments that the user pushed
         int ret = dmScript::PCall(L, number_of_arguments, 0);
         if (ret != 0) {
+            // [-2] context table
+            // [-1] error string
             dmLogError("Error running callback: %s", lua_tostring(L,-1));
+
+            lua_pop(L, 1);
+            // [-1] context table
+
             lua_pop(L, 1);
             return false;
         }
+        // [-1] context table
+        lua_pop(L, 1);
 
         return true;
     }

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -576,11 +576,10 @@ namespace dmScript
 
     bool SetInstanceContextValue(lua_State* L)
     {
+        DM_LUA_STACK_CHECK(L, -2);
+
         // [-2] key
         // [-1] value
-
-        int top = lua_gettop(L);
-        (void)top;
 
         GetInstance(L);
         // [-3] key
@@ -629,12 +628,10 @@ namespace dmScript
             // [-1] instance context table
 
             lua_pop(L, 4);
-            assert(top - 2 == lua_gettop(L));
             return true;
         }
         lua_pop(L, 3);
 
-        assert(top - 2 == lua_gettop(L));
         return false;
     }
 

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -805,7 +805,7 @@ namespace dmScript
 
     LuaStackCheck::LuaStackCheck(lua_State* L, int diff) : m_L(L), m_Top(lua_gettop(L)), m_Diff(diff)
     {
-        assert(m_Diff >= 0);
+        assert(m_Diff >= -m_Top);
     }
 
     int LuaStackCheck::Error(const char* fmt, ... )
@@ -817,14 +817,14 @@ namespace dmScript
         lua_pushvfstring(m_L, fmt, argp);
         va_end(argp);
         lua_concat(m_L, 2);
-        m_Diff = -1;
+        m_Diff = -0x800000;
         return lua_error(m_L);
     }
 
     void LuaStackCheck::Verify(int diff)
     {
-        uint32_t expected = m_Top + diff;
-        uint32_t actual = lua_gettop(m_L);
+        int32_t expected = m_Top + diff;
+        int32_t actual = lua_gettop(m_L);
         if (expected != actual)
         {
             dmLogError("Unbalanced Lua stack, expected (%d), actual (%d)", expected, actual);
@@ -834,7 +834,7 @@ namespace dmScript
 
     LuaStackCheck::~LuaStackCheck()
     {
-        if (m_Diff >= 0) {
+        if (m_Diff != -0x800000) {
             Verify(m_Diff);
         }
     }

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -683,53 +683,6 @@ namespace dmScript
         return false;
     }
 
-    void SetValueToTable(lua_State* L, int table_stack_index, int key_stack_index, int value_stack_index)
-    {
-        int top = lua_gettop(L);
-        int abs_table_index = table_stack_index > 0 ? table_stack_index : top + table_stack_index + 1;
-        int abs_key_index = key_stack_index > 0 ? key_stack_index : top + key_stack_index + 1;
-        int abs_value_index = value_stack_index > 0 ? value_stack_index : top + value_stack_index + 1;
-
-        // [-1] context table or NIL
-        assert(lua_type(L, abs_table_index) == LUA_TTABLE);
-
-        lua_pushvalue(L, abs_key_index);
-        // [-2] context table
-        // [-1] key
-
-        lua_pushvalue(L, abs_value_index);
-        // [-3] context table
-        // [-2] key
-        // [-1] value
-
-        lua_settable(L, abs_table_index);
-        // [-1] context table
-
-        assert(top == lua_gettop(L));
-    }
-
-    void GetValueFromTable(lua_State* L, int table_stack_index, int key_stack_index)
-    {
-        int top = lua_gettop(L);
-
-        int abs_table_index = table_stack_index > 0 ? table_stack_index : top + table_stack_index + 1;
-        int abs_key_index = key_stack_index > 0 ? key_stack_index : top + key_stack_index + 1;
-
-        // [-1] context table
-
-        assert(lua_type(L, abs_table_index) == LUA_TTABLE);
-
-        lua_pushvalue(L, abs_key_index);
-        // [-2] context table
-        // [-1] key
-
-        lua_gettable(L, abs_table_index);
-        // [-2] context table
-        // [-1] value
-
-        assert(top + 1 == lua_gettop(L));
-    }
-
     static int BacktraceErrorHandler(lua_State *m_state) {
         if (!lua_isstring(m_state, 1))
             return 1;

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -808,6 +808,7 @@ namespace dmScript
 
     void Unref(lua_State* L, int table, int reference)
     {
+        assert(g_LuaReferenceCount > 0);
         --g_LuaReferenceCount;
         luaL_unref(L, table, reference);
     }
@@ -958,9 +959,9 @@ namespace dmScript
             lua_rawgeti(L, LUA_REGISTRYINDEX, cbk->m_ContextTableRef);
             if (lua_type(L, -1) == LUA_TTABLE)
             {
-                dmScript::Unref(L, -1, cbk->m_Self);
-                dmScript::Unref(L, -1, cbk->m_Callback);
-                dmScript::Unref(L, -1, cbk->m_CallbackInfoRef);
+                luaL_unref(L, -1, cbk->m_Self);
+                luaL_unref(L, -1, cbk->m_Callback);
+                luaL_unref(L, -1, cbk->m_CallbackInfoRef);
             }
             cbk->m_Self = LUA_NOREF;
             cbk->m_Callback = LUA_NOREF;

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -519,18 +519,15 @@ namespace dmScript
     */
     uint32_t GetLuaGCCount(lua_State* L);
 
-    struct LuaCallbackInfo
-    {
-        LuaCallbackInfo() : m_L(0), m_ContextTableRef(LUA_NOREF), m_Callback(LUA_NOREF), m_Self(LUA_NOREF) {}
-        lua_State* m_L;
-        int        m_ContextTableRef;
-        int        m_CallbackInfoRef;
-        int        m_Callback;
-        int        m_Self;
-    };
+    struct LuaCallbackInfo;
 
     /** Register a Lua callback. Stores the current Lua state plus references to the script instance (self) and the callback
      * Expects SetInstance() to have been called prior to using this method
+     * 
+     * The allocated data is created on the stack and references to the instances own context table.
+     * 
+     * If the callback is not explicitly deleted with DeleteCallback the references and data will stay around until
+     * the instance set with SetInstance() prior to the call is deleted.
     */
     LuaCallbackInfo* CreateCallback(lua_State* L, int callback_stack_index);
 
@@ -538,7 +535,7 @@ namespace dmScript
     */
     bool IsValidCallback(LuaCallbackInfo* cbk);
 
-    /** Unregisters a Lua callback
+    /** Deletes the Lua callback
     */
     void DeleteCallback(LuaCallbackInfo* cbk);
 
@@ -547,7 +544,7 @@ namespace dmScript
     typedef void (*LuaCallbackUserFn)(lua_State* L, void* user_context);
 
     /** Invokes a Lua callback. User can pass a custom function for pushing extra Lua arguments to the stack, prior to the call
-    * Returns true on success and false on failure. In case of failure, and error will be logged.
+    * Returns true on success and false on failure. In case of failure, an error will be logged.
     */
     bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context);
 

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -43,8 +43,7 @@ namespace dmScript
     extern const char* META_TABLE_GET_URL;
     extern const char* META_TABLE_GET_USER_DATA;
     extern const char* META_TABLE_IS_VALID;
-    extern const char* META_TABLE_SET_CONTEXT_VALUE;
-    extern const char* META_TABLE_GET_CONTEXT_VALUE;
+    extern const char* META_GET_INSTANCE_CONTEXT_TABLE;
 
     /**
      * Create and return a new context.

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -365,10 +365,10 @@ namespace dmScript
     bool GetUserData(lua_State* L, uintptr_t* out_user_data, const char* user_type);
 
     /**
-     * Set value by key using the META_TABLE_SET_CONTEXT_VALUE meta table function
+     * Set value by key using the META_GET_INSTANCE_CONTEXT_TABLE meta table function
      * 
      * Expects SetInstance() to have been set with an value that has a meta table
-     * with META_TABLE_SET_CONTEXT_VALUE method.
+     * with META_GET_INSTANCE_CONTEXT_TABLE method.
      *
      * @param L Lua state
      * @return true if the value could be store under the key
@@ -382,10 +382,10 @@ namespace dmScript
     bool SetInstanceContextValue(lua_State* L);
 
     /**
-     * Get value by key using the META_TABLE_GET_CONTEXT_VALUE meta table function
+     * Get value by key using the META_GET_INSTANCE_CONTEXT_TABLE meta table function
      *
      * Expects SetInstance() to have been set with an value that has a meta table
-     * with META_TABLE_GET_CONTEXT_VALUE method.
+     * with META_GET_INSTANCE_CONTEXT_TABLE method.
      * 
      * @param L Lua state
      * 

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -43,6 +43,8 @@ namespace dmScript
     extern const char* META_TABLE_GET_URL;
     extern const char* META_TABLE_GET_USER_DATA;
     extern const char* META_TABLE_IS_VALID;
+    extern const char* META_TABLE_SET_CONTEXT_VALUE;
+    extern const char* META_TABLE_GET_CONTEXT_VALUE;
 
     /**
      * Create and return a new context.
@@ -362,6 +364,82 @@ namespace dmScript
      * @return true if the user data could be found
      */
     bool GetUserData(lua_State* L, uintptr_t* out_user_data, const char* user_type);
+
+    /**
+     * Set value by key using the META_TABLE_SET_CONTEXT_VALUE meta table function
+     * 
+     * Expects SetInstance() to have been set with an value that has a meta table
+     * with META_TABLE_SET_CONTEXT_VALUE method.
+     *
+     * @param L Lua state
+     * @return true if the value could be store under the key
+     * 
+     * Lua stack on entry
+     *  [-2] key
+     *  [-1] value
+     * 
+     * Lua stack on exit
+    */
+    bool SetInstanceContextValue(lua_State* L);
+
+    /**
+     * Get value by key using the META_TABLE_GET_CONTEXT_VALUE meta table function
+     *
+     * Expects SetInstance() to have been set with an value that has a meta table
+     * with META_TABLE_GET_CONTEXT_VALUE method.
+     * 
+     * @param L Lua state
+     * 
+     * Lua stack on entry
+     *  [-1] key
+     * 
+     * Lua stack on exit
+     *  [-1] value or LUA_NIL
+    */
+    bool GetInstanceContextValue(lua_State* L);
+
+    /**
+     * Set value by key in the table at location table_stack_index
+     *
+     * Stack indexes can be either relative or absolute. The stack is
+     * unchanged by the operation.
+     * 
+     * @param L Lua state
+     * @param table_stack_index index into Lua stack for the table
+     * @param key_stack_index index into Lua stack for the key
+     * @param value_stack_index index into Lua stack for the value
+     * 
+     * Lua stack on entry
+     *  [table_stack_index] table
+     *  [key_stack_index] key
+     *  [value_stack_index] value
+     * 
+     * Lua stack on exit
+     *  [table_stack_index] table
+     *  [key_stack_index] key
+     *  [value_stack_index] value
+    */
+    void SetValueToTable(lua_State* L, int table_stack_index, int key_stack_index, int value_stack_index);
+
+    /**
+     * Get value by key in the table at location table_stack_index
+     *
+     * Stack indexes can be either relative or absolute.
+     * 
+     * @param L Lua state
+     * @param table_stack_index index into Lua stack for the table
+     * @param key_stack_index index into Lua stack for the key
+     * 
+     * Lua stack on entry
+     *  [table_stack_index] table
+     *  [key_stack_index] key
+     * 
+     * Lua stack on exit
+     *  [table_stack_index] table
+     *  [key_stack_index] key
+     *  [-1] value or LUA_NIL
+    */
+    void GetValueFromTable(lua_State* L, int table_stack_index, int key_stack_index);
 
     dmMessage::Result ResolveURL(lua_State* L, const char* url, dmMessage::URL* out_url, dmMessage::URL* default_url);
 

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -398,49 +398,6 @@ namespace dmScript
     */
     bool GetInstanceContextValue(lua_State* L);
 
-    /**
-     * Set value by key in the table at location table_stack_index
-     *
-     * Stack indexes can be either relative or absolute. The stack is
-     * unchanged by the operation.
-     * 
-     * @param L Lua state
-     * @param table_stack_index index into Lua stack for the table
-     * @param key_stack_index index into Lua stack for the key
-     * @param value_stack_index index into Lua stack for the value
-     * 
-     * Lua stack on entry
-     *  [table_stack_index] table
-     *  [key_stack_index] key
-     *  [value_stack_index] value
-     * 
-     * Lua stack on exit
-     *  [table_stack_index] table
-     *  [key_stack_index] key
-     *  [value_stack_index] value
-    */
-    void SetValueToTable(lua_State* L, int table_stack_index, int key_stack_index, int value_stack_index);
-
-    /**
-     * Get value by key in the table at location table_stack_index
-     *
-     * Stack indexes can be either relative or absolute.
-     * 
-     * @param L Lua state
-     * @param table_stack_index index into Lua stack for the table
-     * @param key_stack_index index into Lua stack for the key
-     * 
-     * Lua stack on entry
-     *  [table_stack_index] table
-     *  [key_stack_index] key
-     * 
-     * Lua stack on exit
-     *  [table_stack_index] table
-     *  [key_stack_index] key
-     *  [-1] value or LUA_NIL
-    */
-    void GetValueFromTable(lua_State* L, int table_stack_index, int key_stack_index);
-
     dmMessage::Result ResolveURL(lua_State* L, const char* url, dmMessage::URL* out_url, dmMessage::URL* default_url);
 
     /**

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -521,31 +521,36 @@ namespace dmScript
 
     struct LuaCallbackInfo;
 
-    /** Register a Lua callback. Stores the current Lua state plus references to the script instance (self) and the callback
-     * Expects SetInstance() to have been called prior to using this method
+    /** Register a Lua callback. Stores the current Lua state plus references to the
+     * script instance (self) and the callback Expects SetInstance() to have been called
+     * prior to using this method.
      * 
-     * The allocated data is created on the stack and references to the instances own context table.
+     * The allocated data is created on the Lua stack and references are made against the
+     * instances own context table.
      * 
-     * If the callback is not explicitly deleted with DeleteCallback the references and data will stay around until
-     * the instance set with SetInstance() prior to the call is deleted.
-    */
+     * If the callback is not explicitly deleted with DeleteCallback() the references and
+     * data will stay around until the script instance is deleted.
+     */
     LuaCallbackInfo* CreateCallback(lua_State* L, int callback_stack_index);
 
     /** Check if Lua callback is valid.
-    */
+     */
     bool IsValidCallback(LuaCallbackInfo* cbk);
 
     /** Deletes the Lua callback
-    */
+     */
     void DeleteCallback(LuaCallbackInfo* cbk);
 
     /** A helper function for the user to easily push Lua stack arguments prior to invoking the callback
-    */
+     */
     typedef void (*LuaCallbackUserFn)(lua_State* L, void* user_context);
 
-    /** Invokes a Lua callback. User can pass a custom function for pushing extra Lua arguments to the stack, prior to the call
-    * Returns true on success and false on failure. In case of failure, an error will be logged.
-    */
+    /** Invokes a Lua callback. User can pass a custom function for pushing extra Lua arguments
+     * to the stack, prior to the call
+     * Returns true on success and false on failure. In case of failure, an error will be logged.
+     * 
+     * The function takes care of setting up and restoring the current instance.
+     */
     bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context);
 
     /**

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -43,7 +43,7 @@ namespace dmScript
     extern const char* META_TABLE_GET_URL;
     extern const char* META_TABLE_GET_USER_DATA;
     extern const char* META_TABLE_IS_VALID;
-    extern const char* META_GET_INSTANCE_CONTEXT_TABLE;
+    extern const char* META_GET_INSTANCE_CONTEXT_TABLE_REF;
 
     /**
      * Create and return a new context.
@@ -365,10 +365,10 @@ namespace dmScript
     bool GetUserData(lua_State* L, uintptr_t* out_user_data, const char* user_type);
 
     /**
-     * Set value by key using the META_GET_INSTANCE_CONTEXT_TABLE meta table function
+     * Set value by key using the META_GET_INSTANCE_CONTEXT_TABLE_REF meta table function
      * 
      * Expects SetInstance() to have been set with an value that has a meta table
-     * with META_GET_INSTANCE_CONTEXT_TABLE method.
+     * with META_GET_INSTANCE_CONTEXT_TABLE_REF method.
      *
      * @param L Lua state
      * @return true if the value could be store under the key
@@ -382,10 +382,10 @@ namespace dmScript
     bool SetInstanceContextValue(lua_State* L);
 
     /**
-     * Get value by key using the META_GET_INSTANCE_CONTEXT_TABLE meta table function
+     * Get value by key using the META_GET_INSTANCE_CONTEXT_TABLE_REF meta table function
      *
      * Expects SetInstance() to have been set with an value that has a meta table
-     * with META_GET_INSTANCE_CONTEXT_TABLE method.
+     * with META_GET_INSTANCE_CONTEXT_TABLE_REF method.
      * 
      * @param L Lua state
      * 
@@ -521,15 +521,18 @@ namespace dmScript
 
     struct LuaCallbackInfo
     {
-        LuaCallbackInfo() : m_L(0), m_Callback(LUA_NOREF), m_Self(LUA_NOREF) {}
+        LuaCallbackInfo() : m_L(0), m_ContextTableRef(LUA_NOREF), m_Callback(LUA_NOREF), m_Self(LUA_NOREF) {}
         lua_State* m_L;
+        int        m_ContextTableRef;
+        int        m_CallbackInfoRef;
         int        m_Callback;
         int        m_Self;
     };
 
     /** Register a Lua callback. Stores the current Lua state plus references to the script instance (self) and the callback
+     * Expects SetInstance() to have been called prior to using this method
     */
-    void RegisterCallback(lua_State* L, int index, LuaCallbackInfo* cbk);
+    LuaCallbackInfo* CreateCallback(lua_State* L, int callback_stack_index);
 
     /** Check if Lua callback is valid.
     */
@@ -537,7 +540,7 @@ namespace dmScript
 
     /** Unregisters a Lua callback
     */
-    void UnregisterCallback(LuaCallbackInfo* cbk);
+    void DeleteCallback(LuaCallbackInfo* cbk);
 
     /** A helper function for the user to easily push Lua stack arguments prior to invoking the callback
     */

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -164,11 +164,9 @@ static int TestIsValid(lua_State* L)
     return 1;
 }
 
-static int TestSetContextValue(lua_State* L)
+static int TestGetContextTable(lua_State* L)
 {
     const int self_index = 1;
-    const int key_index = 2;
-    const int value_index = 3;
 
     int top = lua_gettop(L);
 
@@ -176,32 +174,7 @@ static int TestSetContextValue(lua_State* L)
     if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
     {
         lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-        lua_pushvalue(L, key_index);
-        lua_pushvalue(L, value_index);
-        lua_settable(L, -3);
-        lua_pop(L, 1);
-    }
-
-    assert(top == lua_gettop(L));
-
-    return 0;
-}
-
-static int TestGetContextValue(lua_State* L)
-{
-    const int self_index = 1;
-    const int key_index = 2;
-
-    int top = lua_gettop(L);
-
-    TestDummy* i = (TestDummy*)lua_touserdata(L, self_index);
-    if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-    {
-        lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_ContextTableReference);
-        lua_pushvalue(L, key_index);
-        lua_gettable(L, -2);
-        lua_insert(L, -2);
-        lua_pop(L, 1);
+        assert(lua_type(L, -1) == LUA_TTABLE);
     }
     else
     {
@@ -209,6 +182,7 @@ static int TestGetContextValue(lua_State* L)
     }
 
     assert(top + 1 == lua_gettop(L));
+
     return 1;
 }
 
@@ -229,8 +203,7 @@ static const luaL_reg Test_meta[] =
     {dmScript::META_TABLE_GET_USER_DATA,        TestGetUserData},
     {dmScript::META_TABLE_RESOLVE_PATH,         TestResolvePath},
     {dmScript::META_TABLE_IS_VALID,             TestIsValid},
-    {dmScript::META_TABLE_SET_CONTEXT_VALUE,    TestSetContextValue},
-    {dmScript::META_TABLE_GET_CONTEXT_VALUE,    TestGetContextValue},
+    {dmScript::META_GET_INSTANCE_CONTEXT_TABLE, TestGetContextTable},
     {"__tostring",                              TestToString},
     {0, 0}
 };
@@ -331,7 +304,7 @@ TEST_F(ScriptTest, TestUserType) {
     dummy->m_ContextTableReference = LUA_NOREF;
 
     lua_pushstring(L, "__context_value_4711_");
-    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    ASSERT_FALSE(dmScript::GetInstanceContextValue(L));
     ASSERT_EQ(LUA_TNIL, lua_type(L, -1));
     lua_pop(L, 1);
 


### PR DESCRIPTION
Adds meta functions for getting and setting instance local context values in GameObject, GUI and Render using a common API.

Updated the script callback helpers to allow automatic freeing of refs/data when a script instance is deleted.