### PR TITLE
DEFEDIT-1379 Build HTML5 fails with response code 400 when using any dependencies

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -193,9 +193,9 @@
                           "bundle-output" (str output-path)
                           "build-server" build-server-url
                           "defoldsdk" defold-sdk-sha1
-                          "local-launch" "true"}
-                         email (assoc "email" email)
-                         auth (assoc "auth" auth)
+                          "local-launch" "true"
+                          "email" (or email "")
+                          "auth" (or auth "")}
                          compress-archive? (assoc "compress" "true"))]
     (bob-build! project bob-commands bob-args)))
 


### PR DESCRIPTION
* User facing changes
  - You no longer need to be logged in to access dependencies on github
* Technical changes
  - Always supply email and auth (fallback to "") when calling bob