### PR TITLE
DEF-2191 Callback memory leaks

### DIFF
--- a/engine/dlib/src/dlib/message.h
+++ b/engine/dlib/src/dlib/message.h
@@ -39,11 +39,17 @@ namespace dmMessage
         /// Socket
         HSocket     m_Socket;
         /// Lua function reference for callback dispatching.
-        /// The value is ref + 2 as LUA_NOREF is defined as -2 as
-        /// we the convention of zero for default values.
+        /// The value is ref - LUA_NOREF as LUA_NOREF is defined as -2
+        /// and we have the convention of zero for default values.
+        /// To get the actual ref, do ref + LUA_NOREF
         /// It's unfortunate that we have to add lua related
         /// functionality here though.
-        int         m_Function;
+        ///
+        /// This is a ref done in the instance local context table
+        /// using dmScript::RefInInstance() so when the corresponding
+        /// script instance dies it will be automatically cleaned up
+        /// if the cleanup callback is not called
+        int         m_FunctionRef;
 
         int         _padding;
 

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -224,9 +224,9 @@ namespace dmGameObject
 
         int function_ref;
         bool is_callback = false;
-        if (params.m_Message->m_Receiver.m_Function) {
-            // NOTE: By convention m_Function is the ref + 2, see message.h in dlib
-            function_ref = params.m_Message->m_Receiver.m_Function - 2;
+        if (params.m_Message->m_Receiver.m_FunctionRef) {
+            // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+            function_ref = params.m_Message->m_Receiver.m_FunctionRef + LUA_NOREF;
             is_callback = true;
         } else {
             function_ref = script_instance->m_Script->m_FunctionReferences[SCRIPT_FUNCTION_ONMESSAGE];
@@ -242,9 +242,12 @@ namespace dmGameObject
             lua_rawgeti(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
             dmScript::SetInstance(L);
 
-            lua_rawgeti(L, LUA_REGISTRYINDEX, function_ref);
             if (is_callback) {
-                dmScript::Unref(L, LUA_REGISTRYINDEX, function_ref);
+                dmScript::ResolveInInstance(L, function_ref);
+            }
+            else
+            {
+                lua_rawgeti(L, LUA_REGISTRYINDEX, function_ref);
             }
             lua_rawgeti(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
 
@@ -271,6 +274,11 @@ namespace dmGameObject
             if (ret != 0)
             {
                 result = UPDATE_RESULT_UNKNOWN_ERROR;
+            }
+
+            if (is_callback)
+            {
+                dmScript::UnrefInInstance(L, function_ref);
             }
 
             lua_pushnil(L);

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1145,9 +1145,6 @@ namespace dmGameObject
         dmScript::LuaCallbackInfo* cbk = (dmScript::LuaCallbackInfo*)userdata1;
         if (dmScript::IsValidCallback(cbk))
         {
-            lua_State* L = cbk->m_L;
-            DM_LUA_STACK_CHECK(L, 0);
-
             dmMessage::URL url;
             url.m_Socket = instance->m_Collection->m_ComponentSocket;
             url.m_Path = instance->m_Identifier;

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -273,7 +273,7 @@ namespace dmGameObject
         ScriptInstance* i = ScriptInstance_Check(L);
         lua_pop(L, 1);
         Instance* instance = i->m_Instance;
-        out_url->m_Function = 0;
+        out_url->m_FunctionRef = 0;
         out_url->m_Socket = instance->m_Collection->m_ComponentSocket;
         out_url->m_Path = instance->m_Identifier;
         out_url->m_Fragment = instance->m_Prototype->m_Components[i->m_ComponentIndex].m_Id;
@@ -296,7 +296,7 @@ namespace dmGameObject
         ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, 1);
         Instance* instance = i->m_Instance;
         dmMessage::URL url;
-        url.m_Function = 0;
+        url.m_FunctionRef = 0;
         url.m_Socket = instance->m_Collection->m_ComponentSocket;
         url.m_Path = instance->m_Identifier;
         url.m_Fragment = instance->m_Prototype->m_Components[i->m_ComponentIndex].m_Id;
@@ -2165,9 +2165,9 @@ const char* TYPE_NAMES[PROPERTY_TYPE_COUNT] = {
         for (uint32_t i = 0; i < count; ++i)
         {
             /*
-             * NOTE/TODO: var above is reused and URL::m_Function must
+             * NOTE/TODO: var above is reused and URL::m_FunctionRef must
              * always be zero or a valid lua-reference. By reusing a union-type here, PropertyVar,
-             * m_Function could have an invalid value. We could move PropertyVar var inside every
+             * m_FunctionRef could have an invalid value. We could move PropertyVar var inside every
              * loop but the problem and risk is illustrated here.
              */
             var = PropertyVar();

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -341,14 +341,7 @@ namespace dmGameObject
         const int self_index = 1;
 
         ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-        {
-            lua_pushnumber(L, i->m_ContextTableReference);
-        }
-        else
-        {
-            lua_pushnil(L);
-        }
+        lua_pushnumber(L, i ? i->m_ContextTableReference : LUA_NOREF);
 
         return 1;
     }

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -482,8 +482,10 @@ int TestGetInstanceContext(lua_State* L)
     }
 
     lua_pushstring(L, "__my_context_value");
-    if(!dmScript::GetInstanceContextValue(L))
+    dmScript::GetInstanceContextValue(L);
+    if (lua_isnil(L, -1))
     {
+        lua_pop(L, 1);
         return 0;
     }
     lua_Number number = lua_tonumber(L, -1);

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -167,7 +167,7 @@ namespace dmGameSystem
                 {
                     return;
                 }
-                receiver.m_Function = 0;
+                receiver.m_FunctionRef = 0;
 
                 if (!dmMessage::IsSocketValid(receiver.m_Socket))
                 {

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -4,6 +4,7 @@
 #include <dlib/message.h>
 
 #include <render/render.h>
+#include <script/script.h>
 
 #include <gameobject/gameobject.h>
 
@@ -21,14 +22,10 @@ namespace dmGameSystem
         EmitterStateChangedScriptData()
         {
             memset(this, 0, sizeof(*this));
-            m_LuaCallbackRef = LUA_NOREF;
-            m_LuaSelfRef = LUA_NOREF;
         }
 
         dmhash_t m_ComponentId;
-        int m_LuaCallbackRef;
-        int m_LuaSelfRef;
-        lua_State* m_L;
+        dmScript::LuaCallbackInfo* m_CallbackInfo;
     };
 
     /**

--- a/engine/gamesys/src/gamesys/resources/res_gui.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui.cpp
@@ -207,6 +207,10 @@ namespace dmGameSystem
 
     void ReleaseResources(dmResource::HFactory factory, GuiSceneResource* resource)
     {
+        for (uint32_t j = 0; j < resource->m_ParticlePrototypes.Size(); ++j)
+        {
+            dmResource::Release(factory, resource->m_ParticlePrototypes[j]);
+        }
         for (uint32_t j = 0; j < resource->m_RigScenes.Size(); ++j)
         {
             dmResource::Release(factory, resource->m_RigScenes[j]);

--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -147,8 +147,8 @@ namespace dmGameSystem
             if (lua_isfunction(L, 5))
             {
                 lua_pushvalue(L, 5);
-                // see message.h for why 2 is added
-                sender.m_Function = luaL_ref(L, LUA_REGISTRYINDEX) + 2;
+                // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 
@@ -287,8 +287,8 @@ namespace dmGameSystem
             if (lua_isfunction(L, 5))
             {
                 lua_pushvalue(L, 5);
-                // see message.h for why 2 is added
-                sender.m_Function = dmScript::Ref(L, LUA_REGISTRYINDEX) + 2;
+                // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 

--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -178,8 +178,8 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
-        sender.m_Function = 0;
-        receiver.m_Function = 0;
+        sender.m_FunctionRef = 0;
+        receiver.m_FunctionRef = 0;
 
         if (top > 1 && !lua_isnil(L, 2))
         {

--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -67,39 +67,47 @@ namespace dmGameSystem
     {
         EmitterStateChangedScriptData data = *(EmitterStateChangedScriptData*)(user_data);
 
-        if (data.m_LuaCallbackRef != LUA_NOREF)
+        if (data.m_CallbackInfo)
         {
-            int top = lua_gettop(data.m_L);
+            DM_LUA_STACK_CHECK(data.m_CallbackInfo->m_L, 0);
 
-            lua_rawgeti(data.m_L, LUA_REGISTRYINDEX, data.m_LuaCallbackRef);
-            lua_rawgeti(data.m_L, LUA_REGISTRYINDEX, data.m_LuaSelfRef);
-            lua_pushvalue(data.m_L, -1); // SetInstance [-1, +0, e]
-            dmScript::SetInstance(data.m_L);
-
-            if (!dmScript::IsInstanceValid(data.m_L))
+            if (!dmScript::IsValidCallback(data.m_CallbackInfo))
             {
                 dmLogError("Could not run particlefx callback because the instance has been deleted.");
-                lua_pop(data.m_L, 2);
-                assert(top == lua_gettop(data.m_L));
                 return;
             }
 
-            dmScript::PushHash(data.m_L, data.m_ComponentId);
-            dmScript::PushHash(data.m_L, emitter_id);
-            lua_pushnumber(data.m_L, emitter_state);
+            struct Args
+            {
+                Args(dmhash_t component_id, dmhash_t emitter_id, dmParticle::EmitterState emitter_state)
+                    : m_ComponentId(component_id), m_EmitterId(emitter_id), m_EmitterState(emitter_state)
+                {}
+                dmhash_t m_ComponentId;
+                dmhash_t m_EmitterId;
+                dmParticle::EmitterState m_EmitterState;
 
-            (void) dmScript::PCall(data.m_L, 4, 0);
+                static void LuaCallbackCustomArgs(lua_State* L, void* user_args)
+                {
+                    Args* args = (Args*)user_args;
+                    dmScript::PushHash(L, args->m_ComponentId);
+                    dmScript::PushHash(L, args->m_EmitterId);
+                    lua_pushnumber(L, args->m_EmitterState);
+                }
+            };
+
+            Args args(data.m_ComponentId, emitter_id, emitter_state);
+
+            if (!dmScript::InvokeCallback(data.m_CallbackInfo, Args::LuaCallbackCustomArgs, &args))
+            {
+                dmLogError("Could not run particlefx callback because the instance has been deleted.");
+            }
 
             // The last emitter belonging to this particlefx har gone to sleep, release lua reference.
             if(num_awake_emitters == 0 && emitter_state == dmParticle::EMITTER_STATE_SLEEPING)
             {
-                dmScript::Unref(data.m_L, LUA_REGISTRYINDEX, data.m_LuaCallbackRef);
-                dmScript::Unref(data.m_L, LUA_REGISTRYINDEX, data.m_LuaSelfRef);
-                data.m_LuaCallbackRef = LUA_NOREF;
-                data.m_LuaSelfRef = LUA_NOREF;
+                dmScript::DeleteCallback(data.m_CallbackInfo);
+                data.m_CallbackInfo = 0x0;
             }
-
-            assert(top == lua_gettop(data.m_L));
         }
         else
         {
@@ -162,6 +170,8 @@ namespace dmGameSystem
             return luaL_error(L, "particlefx.play expects atleast URL as parameter");
         }
 
+        DM_LUA_STACK_CHECK(L, 0);
+
         EmitterStateChangedScriptData data;
         char msg_buf[sizeof(dmParticle::EmitterStateChanged) + sizeof(EmitterStateChangedScriptData)];
         uint32_t msg_size = 0;
@@ -175,11 +185,12 @@ namespace dmGameSystem
 
         if (top > 1 && !lua_isnil(L, 2))
         {
-            int callback = dmScript::Ref(L, LUA_REGISTRYINDEX); // pops value from lua stack
-            lua_pushnil(L); // push nil to lua stack to restore stack size (necessary? or just ditch the assert below?)
-
-            dmScript::GetInstance(L);
-            int self = dmScript::Ref(L, LUA_REGISTRYINDEX);
+            data.m_CallbackInfo = dmScript::CreateCallback(dmScript::GetMainThread(L), -1);
+            if (data.m_CallbackInfo == 0x0)
+            {
+                return luaL_error(L, "particlefx.play failed to crate callback");
+                return 0;
+            }
 
             // path-only url (e.g. "/level/particlefx") has empty fragment, and relative path (e.g. "#particlefx") has non-empty fragment.
             if(receiver.m_Fragment == 0)
@@ -190,10 +201,6 @@ namespace dmGameSystem
             {
                 data.m_ComponentId = receiver.m_Fragment;
             }
-
-            data.m_LuaCallbackRef = callback;
-            data.m_LuaSelfRef = self;
-            data.m_L = dmScript::GetMainThread(L);
 
             dmParticle::EmitterStateChanged fun;
             fun = EmitterStateChangedCallback;
@@ -214,7 +221,6 @@ namespace dmGameSystem
             msg_size,
             0);
 
-        assert(top == lua_gettop(L));
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -69,8 +69,6 @@ namespace dmGameSystem
 
         if (data.m_CallbackInfo)
         {
-            DM_LUA_STACK_CHECK(data.m_CallbackInfo->m_L, 0);
-
             if (!dmScript::IsValidCallback(data.m_CallbackInfo))
             {
                 dmLogError("Could not run particlefx callback because the instance has been deleted.");

--- a/engine/gamesys/src/gamesys/scripts/script_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_spine_model.cpp
@@ -152,8 +152,8 @@ namespace dmGameSystem
             if (lua_isfunction(L, 5))
             {
                 lua_pushvalue(L, 5);
-                // see message.h for why 2 is added
-                sender.m_Function = dmScript::Ref(L, LUA_REGISTRYINDEX) + 2;
+                // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 
@@ -290,8 +290,8 @@ namespace dmGameSystem
             if (lua_isfunction(L, 5))
             {
                 lua_pushvalue(L, 5);
-                // see message.h for why 2 is added
-                sender.m_Function = dmScript::Ref(L, LUA_REGISTRYINDEX) + 2;
+                // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -580,30 +580,37 @@ namespace dmGui
         lua_State* L = scene->m_Context->m_LuaState;
         DM_LUA_STACK_CHECK(L, 0);
 
-        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_InstanceReference);
-        dmScript::SetInstance(L);
-
-        int callback_ref = (int) ((uintptr_t) userdata1 & 0xffffffff);
+        dmScript::LuaCallbackInfo* cbk = (dmScript::LuaCallbackInfo*)userdata1;
         int node_ref = (int) ((uintptr_t) userdata2 & 0xffffffff);
 
-        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
-
-        if( finished )
+        if( finished && dmScript::IsValidCallback(cbk))
         {
-            lua_rawgeti(L, -1, callback_ref);
-            lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_InstanceReference);
-            lua_rawgeti(L, -3, node_ref);
-            assert(lua_type(L, -3) == LUA_TFUNCTION);
+            struct Args
+            {
+                Args(HScene scene, int node_ref)
+                    : m_Scene(scene), m_NodeRef(node_ref)
+                {}
+                HScene m_Scene;
+                int m_NodeRef;
 
-            dmScript::PCall(L, 2, 0);
+                static void LuaCallbackCustomArgs(lua_State* L, void* user_args)
+                {
+                    Args* args = (Args*)user_args;
+                    lua_rawgeti(L, LUA_REGISTRYINDEX, args->m_Scene->m_ContextTableReference);
+                    lua_rawgeti(L, -1, args->m_NodeRef);
+                    lua_insert(L, -2);
+                    lua_pop(L, 1);
+                }
+            };
+            
+            Args args(scene, node_ref);
+            dmScript::InvokeCallback(cbk, Args::LuaCallbackCustomArgs, &args);
         }
 
-        dmScript::Unref(L, -1, callback_ref);
-        dmScript::Unref(L, -1, node_ref);
+        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
+        luaL_unref(L, -1, node_ref);
         lua_pop(L, 1);
-
-        lua_pushnil(L);
-        dmScript::SetInstance(L);
+        dmScript::DeleteCallback(cbk);
     }
 
     /*# once forward
@@ -1016,18 +1023,19 @@ namespace dmGui
 
         lua_Number duration = luaL_checknumber(L, 5);
         float delay = 0.0f;
+
         int node_ref = LUA_NOREF;
-        int animation_complete_ref = LUA_NOREF;
+        dmScript::LuaCallbackInfo* cbk = 0x0;
         if (lua_isnumber(L, 6))
         {
             delay = (float) lua_tonumber(L, 6);
             if (lua_isfunction(L, 7))
             {
+                cbk = dmScript::CreateCallback(L, 7);
+
                 lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
-                lua_pushvalue(L, 7);
-                animation_complete_ref = dmScript::Ref(L, -2);
                 lua_pushvalue(L, 1);
-                node_ref = dmScript::Ref(L, -2);
+                node_ref = luaL_ref(L, -2);
                 lua_pop(L, 1);
             }
         } else if (!lua_isnone(L, 6)) {
@@ -1040,10 +1048,10 @@ namespace dmGui
             playback = (Playback) luaL_checkinteger(L, 8);
         }
 
-        if (animation_complete_ref == LUA_NOREF) {
+        if (cbk == 0x0) {
             AnimateNodeHash(scene, hnode, property_hash, to, curve, playback, (float) duration, delay, 0, 0, 0);
         } else {
-            AnimateNodeHash(scene, hnode, property_hash, to, curve, playback, (float) duration, delay, &LuaAnimationComplete, (void*) animation_complete_ref, (void*) node_ref);
+            AnimateNodeHash(scene, hnode, property_hash, to, curve, playback, (float) duration, delay, &LuaAnimationComplete, cbk, (void*) node_ref);
         }
         return 0;
     }
@@ -1531,14 +1539,13 @@ namespace dmGui
         (void)n;
 
         int node_ref = LUA_NOREF;
-        int animation_complete_ref = LUA_NOREF;
+        dmScript::LuaCallbackInfo* cbk = 0x0;
         if (lua_isfunction(L, 3))
         {
+            cbk = dmScript::CreateCallback(L, 3);
             lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
-            lua_pushvalue(L, 3);
-            animation_complete_ref = dmScript::Ref(L, -2);
             lua_pushvalue(L, 1);
-            node_ref = dmScript::Ref(L, -2);
+            node_ref = luaL_ref(L, -2);
             lua_pop(L, 1);
         }
 
@@ -1546,8 +1553,8 @@ namespace dmGui
         {
             const char* anim_id = luaL_checkstring(L, 2);
             Result r;
-            if(animation_complete_ref != LUA_NOREF)
-                r = PlayNodeFlipbookAnim(scene, hnode, anim_id, &LuaAnimationComplete, (void*) animation_complete_ref, (void*) node_ref);
+            if(cbk != 0x0)
+                r = PlayNodeFlipbookAnim(scene, hnode, anim_id, &LuaAnimationComplete, cbk, (void*) node_ref);
             else
                 r = PlayNodeFlipbookAnim(scene, hnode, anim_id);
             if (r != RESULT_OK)
@@ -1559,8 +1566,8 @@ namespace dmGui
         {
             dmhash_t anim_id = dmScript::CheckHash(L, 2);
             Result r;
-            if(animation_complete_ref != LUA_NOREF)
-                r = PlayNodeFlipbookAnim(scene, hnode, anim_id, &LuaAnimationComplete, (void*) animation_complete_ref, (void*) node_ref);
+            if(cbk != 0x0)
+                r = PlayNodeFlipbookAnim(scene, hnode, anim_id, &LuaAnimationComplete, cbk, (void*) node_ref);
             else
                 r = PlayNodeFlipbookAnim(scene, hnode, anim_id);
             if (r != RESULT_OK)
@@ -3547,28 +3554,28 @@ namespace dmGui
         float playback_rate = 1.0f;
 
         int node_ref = LUA_NOREF;
-        int animation_complete_ref = LUA_NOREF;
+        dmScript::LuaCallbackInfo* cbk = 0x0;
         if (top > 4)
         {
             if (lua_isfunction(L, 5))
             {
+                cbk = dmScript::CreateCallback(L, 5);
+
                 lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
-                lua_pushvalue(L, 5);
-                animation_complete_ref = dmScript::Ref(L, -2);
                 lua_pushvalue(L, 1);
-                node_ref = dmScript::Ref(L, -2);
+                node_ref = luaL_ref(L, -2);
                 lua_pop(L, 1);
             }
         }
 
         dmGui::Result res;
-        if (animation_complete_ref == LUA_NOREF)
+        if (cbk == 0x0)
         {
             res = dmGui::PlayNodeSpineAnim(scene, hnode, anim_id, (dmGui::Playback)playback, blend_duration, offset, playback_rate, 0, 0, 0);
         }
         else
         {
-            res = dmGui::PlayNodeSpineAnim(scene, hnode, anim_id, (dmGui::Playback)playback, blend_duration, offset, playback_rate, &LuaAnimationComplete, (void*) animation_complete_ref, (void*) node_ref);
+            res = dmGui::PlayNodeSpineAnim(scene, hnode, anim_id, (dmGui::Playback)playback, blend_duration, offset, playback_rate, &LuaAnimationComplete, cbk, (void*) node_ref);
         }
 
         if (res == RESULT_WRONG_TYPE)
@@ -3625,8 +3632,6 @@ namespace dmGui
         lua_Integer playback = luaL_checkinteger(L, 3);
         lua_Number blend_duration = 0.0, offset = 0.0, playback_rate = 1.0;
 
-        int node_ref = LUA_NOREF;
-        int animation_complete_ref = LUA_NOREF;
         if (top > 3) // table with args, parse
         {
             luaL_checktype(L, 4, LUA_TTABLE);
@@ -3647,27 +3652,29 @@ namespace dmGui
             lua_pop(L, 1);
         }
 
+        int node_ref = LUA_NOREF;
+        dmScript::LuaCallbackInfo* cbk = 0x0;
         if (top > 4) // completed cb
         {
             if (lua_isfunction(L, 5))
             {
+                cbk = dmScript::CreateCallback(L, 5);
+
                 lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_ContextTableReference);
-                lua_pushvalue(L, 5);
-                animation_complete_ref = dmScript::Ref(L, -2);
                 lua_pushvalue(L, 1);
-                node_ref = dmScript::Ref(L, -2);
+                node_ref = luaL_ref(L, -2);
                 lua_pop(L, 1);
             }
         }
 
         dmGui::Result res;
-        if (animation_complete_ref == LUA_NOREF)
+        if (cbk == 0x0)
         {
             res = dmGui::PlayNodeSpineAnim(scene, hnode, anim_id, (dmGui::Playback)playback, blend_duration, offset, playback_rate, 0, 0, 0);
         }
         else
         {
-            res = dmGui::PlayNodeSpineAnim(scene, hnode, anim_id, (dmGui::Playback)playback, blend_duration, offset, playback_rate, &LuaAnimationComplete, (void*) animation_complete_ref, (void*) node_ref);
+            res = dmGui::PlayNodeSpineAnim(scene, hnode, anim_id, (dmGui::Playback)playback, blend_duration, offset, playback_rate, &LuaAnimationComplete, cbk, (void*) node_ref);
         }
 
         if (res == RESULT_WRONG_TYPE)

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -172,14 +172,7 @@ namespace dmGui
         const int self_index = 1;
 
         Scene* i = (Scene*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-        {
-            lua_pushnumber(L, i->m_ContextTableReference);
-        }
-        else
-        {
-            lua_pushnil(L);
-        }
+        lua_pushnumber(L, i ? i->m_ContextTableReference : LUA_NOREF);
 
         return 1;
     }

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -1218,7 +1218,7 @@ TEST_F(dmGuiScriptTest, TestInstanceContext)
     ASSERT_TRUE(dmScript::SetInstanceContextValue(L));
 
     lua_pushstring(L, "__my_context_value");
-    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    dmScript::GetInstanceContextValue(L);
     ASSERT_EQ(81233, lua_tonumber(L, -1));
     lua_pop(L, 1);
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -294,14 +294,7 @@ namespace dmRender
         const int self_index = 1;
 
         RenderScriptInstance* i = (RenderScriptInstance*)lua_touserdata(L, self_index);
-        if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-        {
-            lua_pushnumber(L, i->m_ContextTableReference);
-        }
-        else
-        {
-            lua_pushnil(L);
-        }
+        lua_pushnumber(L, i ? i->m_ContextTableReference : LUA_NOREF);
 
         return 1;
     }

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -874,7 +874,7 @@ TEST_F(dmRenderScriptTest, TestInstanceContext)
     ASSERT_TRUE(dmScript::SetInstanceContextValue(L));
 
     lua_pushstring(L, "__my_context_value");
-    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    dmScript::GetInstanceContextValue(L);
     ASSERT_EQ(81233, lua_tonumber(L, -1));
     lua_pop(L, 1);
 

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1118,13 +1118,12 @@ namespace dmScript
 
         int number_of_arguments = 1 + user_args_end - user_args_start; // instance + number of arguments that the user pushed
         int ret = PCall(L, number_of_arguments, 0);
-        if (ret != 0) {
-            // [-3] old instance
-            // [-2] context table
-            // [-1] error string
-            dmLogError("Error running callback: %s", lua_tostring(L,-1));
 
-            lua_pop(L, 2);
+        if (ret != 0) {
+            // [-2] old instance
+            // [-1] context table
+
+            lua_pop(L, 1);
             // [-1] old instance
 
             SetInstance(L);

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -574,158 +574,197 @@ namespace dmScript
         return false;
     }
 
+    static void GetInstanceContextTable(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+
+        GetInstance(L);
+        // [-1] instance
+
+        if (!GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF))
+        {
+            lua_pop(L, 1);
+            lua_pushnil(L);
+            return;
+        }
+        // [-2] instance
+        // [-1] META_GET_INSTANCE_CONTEXT_TABLE_REF()
+
+        lua_insert(L, -2);
+        // [-2] META_GET_INSTANCE_CONTEXT_TABLE_REF()
+        // [-1] instance
+
+        lua_call(L, 1, 1);
+        // [-1] instance context table ref or LUA_NOREF
+        assert(lua_type(L, -1) == LUA_TNUMBER);
+
+        int context_table_ref = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+
+        if (context_table_ref == LUA_NOREF)
+        {
+            lua_pushnil(L);
+            // [-1] LUA_NIL
+            return;
+        }
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, context_table_ref);
+        assert(lua_type(L, -1) == LUA_TTABLE);
+        // [-1] instance context table
+    }
+
     bool SetInstanceContextValue(lua_State* L)
     {
-        DM_LUA_STACK_CHECK(L, -2);
-
         // [-2] key
         // [-1] value
 
-        GetInstance(L);
+        DM_LUA_STACK_CHECK(L, -2);
+
+        GetInstanceContextTable(L);
         // [-3] key
         // [-2] value
-        // [-1] instance
+        // [-1] instance context table or LUA_NIL
 
-        if (GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF)) {
-            // [-4] key
-            // [-3] value
-            // [-2] instance
-            // [-1] META_GET_INSTANCE_CONTEXT_TABLE_REF()
-
-            lua_pushvalue(L, -2);
-            // [-5] key
-            // [-4] value
-            // [-3] instance
-            // [-2] META_GET_INSTANCE_CONTEXT_TABLE_REF()
-            // [-1] instance
-
-            lua_call(L, 1, 1);
-            // [-4] key
-            // [-3] value
-            // [-2] instance
-            // [-1] instance context table ref
-            assert(lua_type(L, -1) == LUA_TNUMBER);
-
-            int context_table_ref = lua_tonumber(L, -1);
-            lua_pop(L, 1);
-            // [-3] key
-            // [-2] value
-            // [-1] instance
-
-            lua_rawgeti(L, LUA_REGISTRYINDEX, context_table_ref);
-            assert(lua_type(L, -1) == LUA_TTABLE);
-            // [-4] key
-            // [-3] value
-            // [-2] instance
-            // [-1] instance context table
-
-            lua_pushvalue(L, -4);
-            // [-5] key
-            // [-4] value
-            // [-3] instance
-            // [-2] instance context table
-            // [-1] key
-
-            lua_pushvalue(L, -4);
-            // [-6] key
-            // [-5] value
-            // [-4] instance
-            // [-3] instance context table
-            // [-2] key
-            // [-1] value
-
-            lua_settable(L, -3);
-            // [-4] key
-            // [-3] value
-            // [-2] instance
-            // [-1] instance context table
-
-            lua_pop(L, 4);
-            return true;
+        if (lua_isnil(L, -1))
+        {
+            lua_pop(L, 3);
+            return false;
         }
-        lua_pop(L, 3);
+        // [-3] key
+        // [-2] value
+        // [-1] instance context table
 
-        return false;
+        lua_insert(L, -3);
+        // [-3] instance context table
+        // [-2] key
+        // [-1] value
+
+        lua_settable(L, -3);
+        // [-1] instance context table
+
+        lua_pop(L, 1);
+        return true;
     }
 
-    bool GetInstanceContextValue(lua_State* L)
+    void GetInstanceContextValue(lua_State* L)
     {
         // [-1] key
+        DM_LUA_STACK_CHECK(L, 0);
 
-        int top = lua_gettop(L);
-        (void)top;
-
-        GetInstance(L);
+        GetInstanceContextTable(L);
         // [-2] key
-        // [-1] instance
+        // [-1] instance context table or LUA_NIL
 
-        if (GetMetaFunction(L, -1, META_GET_INSTANCE_CONTEXT_TABLE_REF)) {
-            // [-3] key
-            // [-2] instance
-            // [-1] META_GET_INSTANCE_CONTEXT_TABLE_REF()
-
-            lua_pushvalue(L, -2);
-            // [-4] key
-            // [-3] instance
-            // [-2] META_GET_INSTANCE_CONTEXT_TABLE_REF()
-            // [-1] instance
-
-            lua_call(L, 1, 1);
-            // [-3] key
-            // [-2] instance
-            // [-1] instance context table ref
-            if(lua_type(L, -1) != LUA_TNUMBER)
-            {
-                lua_pop(L, 3);
-                assert(top - 1 == lua_gettop(L));
-                return false;
-            }
-
-            int context_table_ref = lua_tonumber(L, -1);
-            lua_pop(L, 1);
-            // [-3] key
-            // [-2] instance
-
-            lua_rawgeti(L, LUA_REGISTRYINDEX, context_table_ref);
-            // [-3] key
-            // [-2] instance
-            // [-1] instance context table
-
-            if(lua_type(L, -1) != LUA_TTABLE)
-            {
-                lua_pop(L, 3);
-                assert(top - 1 == lua_gettop(L));
-                return false;
-            }
-
-            lua_pushvalue(L, -3);
-            // [-4] key
-            // [-3] instance
-            // [-2] instance context table
+        if (lua_isnil(L, -1))
+        {
+            // [-2] key
+            // [-1] LUA_NIL
+            lua_insert(L, -2);
+            // [-2] LUA_NIL
             // [-1] key
 
-            lua_gettable(L, -2);
-            // [-4] key
-            // [-3] instance
-            // [-2] instance context table
-            // [-1] value
+            lua_pop(L, 1);
+            // [-1] LUA_NIL
 
-            lua_insert(L, -4);
-            // [-4] value
-            // [-3] key
-            // [-2] instance
-            // [-1] instance context table
-
-            lua_pop(L, 3);
-            // [-1] value
-
-            assert(top == lua_gettop(L));
-            return true;
+            return;
         }
+        // [-2] key
+        // [-1] instance context table
 
-        lua_pop(L, 2);
-        assert(top - 1 == lua_gettop(L));
-        return false;
+        lua_insert(L, -2);
+        // [-2] instance context table
+        // [-1] key
+
+        lua_gettable(L, -2);
+        // [-2] instance context table
+        // [-1] value
+
+        lua_insert(L, -2);
+        // [-2] value
+        // [-1] instance context table
+        
+        lua_pop(L, 1);
+        // [-1] value
+    }
+
+    int RefInInstance(lua_State* L)
+    {
+        // [-1] value
+        DM_LUA_STACK_CHECK(L, -1);
+
+        GetInstanceContextTable(L);
+        // [-2] value
+        // [-1] instance context table or LUA_NIL
+        
+        if (lua_isnil(L, -1))
+        {
+            // [-2] value
+            // [-1] LUA_NIL
+
+            lua_pop(L, 2);
+            return LUA_NOREF;
+        }
+        // [-2] value
+        // [-1] instance context table
+
+        lua_insert(L, -2);
+        // [-2] instance context table
+        // [-1] value
+
+        int instance_ref = luaL_ref(L, -2);
+        // [-1] instance context table
+
+        lua_pop(L, 1);
+
+        return instance_ref;
+    }
+
+    void UnrefInInstance(lua_State* L, int ref)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+
+        GetInstanceContextTable(L);
+        // [-1] instance context table or LUA_NIL
+        
+        if (lua_isnil(L, -1))
+        {
+            // [-1] LUA_NIL
+
+            lua_pop(L, 1);
+            return;
+        }
+        // [-1] instance context table
+
+        luaL_unref(L, -1, ref);
+        // [-1] instance context table
+
+        lua_pop(L, 1);
+    }
+
+    void ResolveInInstance(lua_State* L, int ref)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+
+        GetInstanceContextTable(L);
+        // [-1] instance context table or LUA_NIL
+        
+        if (lua_isnil(L, -1))
+        {
+            // [-1] LUA_NIL
+            return;
+        }
+        // [-1] instance context table
+
+        lua_rawgeti(L, -1, ref);
+        // [-2] instance context table
+        // [-1] value
+
+        lua_insert(L, -2);
+        // [-2] value
+        // [-1] instance context table
+
+        lua_pop(L, 1);
+        // [-1] value
     }
 
     static int BacktraceErrorHandler(lua_State *m_state) {

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -412,8 +412,52 @@ namespace dmScript
     */
     void GetInstanceContextValue(lua_State* L);
 
+    /**
+     * Creates a reference to the value at top of stack, the ref is done in the
+     * current instances context table.
+     * 
+     * Expects SetInstance() to have been set with an value that has a meta table
+     * with META_GET_INSTANCE_CONTEXT_TABLE_REF method.
+     * 
+     * @param L Lua state
+     * @return lua ref to value or LUA_NOREF
+     * 
+     * Lua stack on entry
+     *  [-1] value
+     * 
+     * Lua stack on exit
+    */
     int RefInInstance(lua_State* L);
+
+    /**
+     * Deletes the instance local lua reference
+     * 
+     * Expects SetInstance() to have been set with an value that has a meta table
+     * with META_GET_INSTANCE_CONTEXT_TABLE_REF method.
+     * 
+     * @param L Lua state
+     * @param ref the instance local ref
+     * 
+     * Lua stack on entry
+     * 
+     * Lua stack on exit
+     */
     void UnrefInInstance(lua_State* L, int ref);
+
+    /**
+     * Resolves the instance local ref and pushes it to top of stack
+     * 
+     * Expects SetInstance() to have been set with an value that has a meta table
+     * with META_GET_INSTANCE_CONTEXT_TABLE_REF method.
+     * 
+     * @param L Lua state
+     * @param ref the instance local ref
+     * 
+     * Lua stack on entry
+     * 
+     * Lua stack on exit
+     *  [-1] value or LUA_NIL
+     */
     void ResolveInInstance(lua_State* L, int ref);
 
     dmMessage::Result ResolveURL(lua_State* L, const char* url, dmMessage::URL* out_url, dmMessage::URL* default_url);

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -43,6 +43,21 @@ namespace dmScript
     extern const char* META_TABLE_GET_URL;
     extern const char* META_TABLE_GET_USER_DATA;
     extern const char* META_TABLE_IS_VALID;
+
+    /**
+     * Implementor should return a Ref to the instance context table.
+     * 
+     * CAUTION! The implementation should *NOT* create a new ref, it
+     * should return an existing one. If it does not have one, it should
+     * return LUA_NOREF
+     * 
+     * Lua stack on entry
+     *  [-1] instance
+     * 
+     * Lua stack on exit
+     *  [-1] ref to instance context table or LUA_NOREF
+     * 
+     */
     extern const char* META_GET_INSTANCE_CONTEXT_TABLE_REF;
 
     /**
@@ -395,7 +410,11 @@ namespace dmScript
      * Lua stack on exit
      *  [-1] value or LUA_NIL
     */
-    bool GetInstanceContextValue(lua_State* L);
+    void GetInstanceContextValue(lua_State* L);
+
+    int RefInInstance(lua_State* L);
+    void UnrefInInstance(lua_State* L, int ref);
+    void ResolveInInstance(lua_State* L, int ref);
 
     dmMessage::Result ResolveURL(lua_State* L, const char* url, dmMessage::URL* out_url, dmMessage::URL* default_url);
 

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -105,9 +105,9 @@ namespace dmScript
             const char* method = luaL_checkstring(L, 2);
             luaL_checktype(L, 3, LUA_TFUNCTION);
             lua_pushvalue(L, 3);
-            // NOTE: + 2 as LUA_NOREF is defined as - 2 and 0 is interpreted as uninitialized
-            int callback = dmScript::Ref(L, LUA_REGISTRYINDEX) + 2;
-            sender.m_Function = callback;
+            // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+            int callback = dmScript::RefInInstance(L) - LUA_NOREF;
+            sender.m_FunctionRef = callback;
 
             char* headers = 0;
             int headers_length = 0;

--- a/engine/script/src/script_http_js.cpp
+++ b/engine/script/src/script_http_js.cpp
@@ -96,9 +96,9 @@ namespace dmScript
             const char* method = luaL_checkstring(L, 2);
             luaL_checktype(L, 3, LUA_TFUNCTION);
             lua_pushvalue(L, 3);
-            // NOTE: + 2 as LUA_NOREF is defined as - 2 and 0 is interpreted as uninitialized
-            int callback = dmScript::Ref(L, LUA_REGISTRYINDEX) + 2;
-            sender.m_Function = callback;
+            // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+            int callback = dmScript::RefInInstance(L) - LUA_NOREF;
+            sender.m_FunctionRef = callback;
 
             dmArray<char> h;
             h.SetCapacity(4 * 1024);

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -648,9 +648,9 @@ namespace dmScript
             return dmMessage::RESULT_OK;
         }
 
-        // Make sure that m_Function is 0. A value != 0 is probably a bug due to
+        // Make sure that m_FunctionRef is 0. A value != 0 is probably a bug due to
         // reused PropertyVar (union) or use of char-buffers with uninitialized data
-        assert(out_url->m_Function == 0);
+        assert(out_url->m_FunctionRef == 0);
         dmMessage::StringURL string_url;
         dmMessage::Result result = dmMessage::ParseURL(url, &string_url);
         if (result != dmMessage::RESULT_OK)

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -171,14 +171,7 @@ static int TestGetContextTableRef(lua_State* L)
     int top = lua_gettop(L);
 
     TestDummy* i = (TestDummy*)lua_touserdata(L, self_index);
-    if (i != 0x0 && i->m_ContextTableReference != LUA_NOREF)
-    {
-        lua_pushnumber(L, i->m_ContextTableReference);
-    }
-    else
-    {
-        lua_pushnil(L);
-    }
+    lua_pushnumber(L, i ? i->m_ContextTableReference : LUA_NOREF);
 
     assert(top + 1 == lua_gettop(L));
 
@@ -285,26 +278,26 @@ TEST_F(ScriptTest, TestUserType) {
     ASSERT_TRUE(dmScript::SetInstanceContextValue(L));
 
     lua_pushstring(L, "__context_value_4711_");
-    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    dmScript::GetInstanceContextValue(L);
     ASSERT_EQ(4711, lua_tonumber(L, -1));
     lua_pop(L, 1);
 
     lua_pushstring(L, "__context_value_666_");
-    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
+    dmScript::GetInstanceContextValue(L);
     ASSERT_EQ(666, lua_tonumber(L, -1));
     lua_pop(L, 1);
 
     lua_pushstring(L, "__context_value_invalid_");
-    ASSERT_TRUE(dmScript::GetInstanceContextValue(L));
-    ASSERT_EQ(LUA_TNIL, lua_type(L, -1));
+    dmScript::GetInstanceContextValue(L);
+    ASSERT_TRUE(lua_isnil(L, -1));
     lua_pop(L, 1);
 
     dmScript::Unref(L, LUA_REGISTRYINDEX, dummy->m_ContextTableReference);
     dummy->m_ContextTableReference = LUA_NOREF;
 
     lua_pushstring(L, "__context_value_4711_");
-    ASSERT_FALSE(dmScript::GetInstanceContextValue(L));
-    ASSERT_EQ(LUA_TNIL, lua_type(L, -1));
+    dmScript::GetInstanceContextValue(L);
+    ASSERT_TRUE(lua_isnil(L, -1));
     lua_pop(L, 1);
 
     // Destruction
@@ -314,7 +307,9 @@ TEST_F(ScriptTest, TestUserType) {
     lua_pushnil(L);
     dmScript::SetInstance(L);
     lua_pushstring(L, "__context_value_4711_");
-    ASSERT_FALSE(dmScript::GetInstanceContextValue(L));
+    dmScript::GetInstanceContextValue(L);
+    ASSERT_TRUE(lua_isnil(L, -1));
+    lua_pop(L, 1);
 }
 
 #undef ASSERT_EQ_URL

--- a/engine/script/src/test/test_script_http.cpp
+++ b/engine/script/src/test/test_script_http.cpp
@@ -22,10 +22,21 @@ extern "C"
 
 #define DEFAULT_URL "__default_url"
 
+struct ScriptInstance
+{
+    int m_InstanceReference;
+    int m_ContextTableReference;
+};
+
 int ResolvePathCallback(lua_State* L)
 {
-    uint32_t* user_data = (uint32_t*)lua_touserdata(L, 1);
-    assert(*user_data == 1);
+    DM_LUA_STACK_CHECK(L, 1);
+
+    const int self_index = 1;
+
+    ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
+    assert(i);
+    assert(i->m_ContextTableReference != LUA_NOREF);
     const char* path = luaL_checkstring(L, 2);
     dmScript::PushHash(L, dmHashString64(path));
     return 1;
@@ -33,16 +44,34 @@ int ResolvePathCallback(lua_State* L)
 
 int GetURLCallback(lua_State* L)
 {
-    uint32_t* user_data = (uint32_t*)lua_touserdata(L, 1);
-    assert(*user_data == 1);
+    DM_LUA_STACK_CHECK(L, 1);
+
+    const int self_index = 1;
+
+    ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
+    assert(i);
+    assert(i->m_ContextTableReference != LUA_NOREF);
     lua_getglobal(L, DEFAULT_URL);
+    return 1;
+}
+
+int GetInstaceContextTableRef(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 1);
+
+    const int self_index = 1;
+
+    ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, self_index);
+    lua_pushnumber(L, i ? i->m_ContextTableReference : LUA_NOREF);
+
     return 1;
 }
 
 static const luaL_reg META_TABLE[] =
 {
-    {dmScript::META_TABLE_RESOLVE_PATH, ResolvePathCallback},
-    {dmScript::META_TABLE_GET_URL,      GetURLCallback},
+    {dmScript::META_TABLE_RESOLVE_PATH,             ResolvePathCallback},
+    {dmScript::META_TABLE_GET_URL,                  GetURLCallback},
+    {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, GetInstaceContextTableRef},
     {0, 0}
 };
 
@@ -79,8 +108,11 @@ protected:
 
         int top = lua_gettop(L);
         (void)top;
-        uint32_t* user_data = (uint32_t*)lua_newuserdata(L, 4);
-        *user_data = 1;
+        ScriptInstance* script_instance = (ScriptInstance*)lua_newuserdata(L, sizeof(ScriptInstance));
+        lua_pushvalue(L, -1);
+        script_instance->m_InstanceReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
+        lua_newtable(L);
+        script_instance->m_ContextTableReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
         luaL_newmetatable(L, "ScriptMsgTest");
         luaL_register(L, 0, META_TABLE);
         lua_setmetatable(L, -2);
@@ -93,6 +125,12 @@ protected:
 
     virtual void TearDown()
     {
+        dmScript::GetInstance(L);
+        ScriptInstance* script_instance = (ScriptInstance*)lua_touserdata(L, -1);
+        dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_ContextTableReference);
+        dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
+        lua_pop(L, 1);
+
         lua_pushnil(L);
         dmScript::SetInstance(L);
 
@@ -137,14 +175,17 @@ void DispatchCallbackDDF(dmMessage::Message *message, void* user_ptr)
     assert(message->m_Descriptor != 0);
     dmDDF::Descriptor* descriptor = (dmDDF::Descriptor*)message->m_Descriptor;
 
-    int ref = message->m_Receiver.m_Function - 2;
-    lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
-    dmScript::Unref(L, LUA_REGISTRYINDEX, ref);
+    // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+    int ref = message->m_Receiver.m_FunctionRef + LUA_NOREF;
+    dmScript::ResolveInInstance(L, ref);
     lua_gc(L, LUA_GCCOLLECT, 0);
 
     dmScript::PushDDF(L, descriptor, (const char*)&message->m_Data[0]);
     int ret = dmScript::PCall(L, 1, 0);
     test->m_NumberOfFails += ret == 0 ? 0 : 1;
+
+    dmScript::UnrefInInstance(L, ref);
+
     ASSERT_EQ(0, ret);
 }
 

--- a/engine/tracking/src/tracking.cpp
+++ b/engine/tracking/src/tracking.cpp
@@ -53,9 +53,9 @@ namespace dmTracking
 
         const int self_index = 1;
 
-        script = (Script*)lua_touserdata(L, self_index);
+        Script* script = (Script*)lua_touserdata(L, self_index);
         lua_pop(L, 1);
-        lua_pushnumber(L, script && script->m_Context, script->m_Context.m_ContextableReference);
+        lua_pushnumber(L, script && script->m_Context ? script->m_Context->m_ContextTableReference : LUA_NOREF);
         return 1;
     }
 

--- a/engine/tracking/src/tracking.cpp
+++ b/engine/tracking/src/tracking.cpp
@@ -23,6 +23,7 @@ namespace dmTracking
         dmScript::HContext m_ScriptCtx;
         dmMessage::HSocket m_Socket;
         int m_ContextReference;
+        int m_ContextTableReference;
     };
 
     struct Script
@@ -46,6 +47,18 @@ namespace dmTracking
         return 1;
     }
 
+    static int TrackingGetInstanceContextTableRef(lua_State* L)
+    {
+        dmScript::GetInstance(L);
+
+        const int self_index = 1;
+
+        script = (Script*)lua_touserdata(L, self_index);
+        lua_pop(L, 1);
+        lua_pushnumber(L, script && script->m_Context, script->m_Context.m_ContextableReference);
+        return 1;
+    }
+
     static const luaL_reg TrackingScript_methods[] =
     {
         {0,0}
@@ -53,7 +66,8 @@ namespace dmTracking
 
     static const luaL_reg TrackingScript_meta[] =
     {
-        {dmScript::META_TABLE_GET_URL,      TrackingScriptGetURL},
+        {dmScript::META_TABLE_GET_URL,                  TrackingScriptGetURL},
+        {dmScript::META_GET_INSTANCE_CONTEXT_TABLE_REF, TrackingGetInstanceContextTableRef},
         {0, 0}
     };
 
@@ -81,6 +95,8 @@ namespace dmTracking
         luaL_getmetatable(L, TRACKING_SCRIPT);
         lua_setmetatable(L, -2);
         ctx->m_ContextReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
+        lua_newtable(L);
+        ctx->m_ContextTableReference = dmScript::Ref(L, LUA_REGISTRYINDEX);
 
         int top = lua_gettop(L);
         if (luaL_loadbuffer(L, (const char*)TRACKING_LUA, TRACKING_LUA_SIZE, "tracking.lua") != 0)
@@ -135,7 +151,10 @@ namespace dmTracking
 
     void Delete(HContext context)
     {
+        lua_State* L = dmScript::GetLuaState(context->m_ScriptCtx);
         dmScript::Finalize(context->m_ScriptCtx);
+        dmScript::Unref(L, LUA_REGISTRYINDEX, context->m_ContextTableReference);
+        dmScript::Unref(L, LUA_REGISTRYINDEX, context->m_ContextReference);
         dmScript::DeleteContext(context->m_ScriptCtx);
         dmMessage::Consume(context->m_Socket);
         dmMessage::DeleteSocket(context->m_Socket);
@@ -145,12 +164,13 @@ namespace dmTracking
     static void DispatchCallback(dmMessage::Message *message, void* user_ptr)
     {
         HContext context = (HContext) user_ptr;
-        if (message->m_Receiver.m_Function)
+        if (message->m_Receiver.m_FunctionRef)
         {
             lua_State* L = dmScript::GetLuaState(context->m_ScriptCtx);
-            const int ref = message->m_Receiver.m_Function - 2;
+            // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
+            const int ref = message->m_Receiver.m_FunctionRef + LUA_NOREF;
 
-            lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+            dmScript::ResolveInInstance(L, ref);
             assert(lua_isfunction(L, -1));
             lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextReference);
 


### PR DESCRIPTION
DEF-2191, DEF-3247 Make lua refs instance local instead of global

Changed global Lua refs in message callbacks to use instance local refs - dangling callbacks will be cleaned up on instance destruction

Change callback helpers to only to instance local refs - dangling callbacks will be cleaned up on instance destruction