### PR TITLE
Map extension -> resource type case insensitive

### DIFF
--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -25,7 +25,7 @@
 (defn- prefix-animation-id [animation-resource animation]
   (update animation :id (fn [^String id]
                           (cond
-                            (and (= "animationset" (resource/ext animation-resource))
+                            (and (= "animationset" (resource/type-ext animation-resource))
                                  (neg? (.indexOf id "/")))
                             (str (resource/base-name animation-resource) "/" id)
 

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -362,7 +362,7 @@
   (run [selection workspace]
     (let [resource (first selection)
           dir? (= :folder (resource/source-type resource))
-          extension (:ext (resource/resource-type resource))
+          extension (resource/ext resource)
           name (if dir?
                  (resource/resource-name resource)
                  (if (seq extension)

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -77,10 +77,10 @@
   [{:node-id _node-id
     :resource (workspace/make-build-resource resource)
     :build-fn build-shader
-    :user-data {:lines lines :resource-ext (resource/ext resource)}}])
+    :user-data {:lines lines :resource-ext (resource/type-ext resource)}}])
 
 (g/defnk produce-full-source [resource lines]
-  (make-full-source (resource/ext resource) lines))
+  (make-full-source (resource/type-ext resource) lines))
 
 (g/defnode ShaderNode
   (inherits r/CodeEditorResourceNode)

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -98,7 +98,7 @@
             xform (comp (map thread-util/abortable-identity!)
                         (filter (fn [{:keys [resource]}]
                                   (or (empty? file-ext-pats)
-                                      (let [ext (resource/ext resource)]
+                                      (let [ext (resource/type-ext resource)]
                                         (some #(re-matches % ext) file-ext-pats)))))
                         (map (fn [{:keys [resource] :as save-data}]
                                {:resource resource

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -387,7 +387,7 @@
         accept-fn    (or (:accept-fn options) (constantly true))
         items        (into []
                            (filter #(and (= :file (resource/source-type %))
-                                         (accepted-ext (resource/ext %))
+                                         (accepted-ext (resource/type-ext %))
                                          (not (resource/internal? %))
                                          (accept-fn %)))
                            (g/node-value workspace :resource-list))

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -421,7 +421,7 @@
                                            {}))))
 
 (defn load-font-source [project self resource]
-  (when (= (resource/ext resource) "fnt")
+  (when (= (resource/type-ext resource) "fnt")
     (let [bm-font (BMFont.)]
       (with-open [bm-stream (io/input-stream resource)]
         (.parse bm-font bm-stream))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -53,7 +53,7 @@
 (defn- wrap-if-raw-sound [_node-id target]
   (let [resource (:resource (:resource target))
         source-path (resource/proj-path resource)
-        ext (resource/ext resource)]
+        ext (resource/type-ext resource)]
     (if (sound/supported-audio-formats ext)
       (let [workspace (project/workspace (project/get-project _node-id))
             res-type  (workspace/get-resource-type workspace "sound")

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -38,7 +38,7 @@
   (if-let [node (project/get-resource-node project (:url request))]
     (let [resource      (g/node-value node :resource)
           resource-type (resource/resource-type resource)
-          resource-ext  (resource/ext resource)
+          resource-ext  (resource/type-ext resource)
           view-types    (map :id (:view-types resource-type))]
       (cond
         (some #{:html} view-types)

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -34,6 +34,9 @@
   (resource-hash [this])
   (openable? [this]))
 
+(defn type-ext [resource]
+  (string/lower-case (ext resource)))
+
 (defn openable-resource? [value]
   ;; A resource is considered openable if its kind can be opened. Typically this
   ;; is a resource that is part of the project and is not a directory. Note
@@ -77,7 +80,7 @@
   Resource
   (children [this] children)
   (ext [this] ext)
-  (resource-type [this] (get (g/node-value workspace :resource-types) ext))
+  (resource-type [this] (get (g/node-value workspace :resource-types) (type-ext this)))
   (source-type [this] source-type)
   (exists? [this] (.exists (io/file this)))
   (read-only? [this] (not (.canWrite (io/file this))))
@@ -139,7 +142,7 @@
   Resource
   (children [this] nil)
   (ext [this] ext)
-  (resource-type [this] (get (g/node-value workspace :resource-types) ext))
+  (resource-type [this] (get (g/node-value workspace :resource-types) (type-ext this)))
   (source-type [this] :file)
   (exists? [this] true)
   (read-only? [this] false)
@@ -169,7 +172,7 @@
   Resource
   (children [this] children)
   (ext [this] (FilenameUtils/getExtension name))
-  (resource-type [this] (get (g/node-value workspace :resource-types) (ext this)))
+  (resource-type [this] (get (g/node-value workspace :resource-types) (type-ext this)))
   (source-type [this] (if (zero? (count children)) :file :folder))
   (exists? [this] (not (nil? data)))
   (read-only? [this] true)

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -44,7 +44,7 @@
 
 (defn prop-resource-ext? [v ext name]
   (or (prop-resource-missing? v name)
-      (when-not (= (resource/ext v) ext)
+      (when-not (= (resource/type-ext v) ext)
         (format "%s '%s' is not of type .%s" name (resource/resource->proj-path v) ext))))
 
 (defn prop-member-of? [v val-set message]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -93,7 +93,6 @@ ordinary paths."
 (defn register-resource-type [workspace & {:keys [textual? ext build-ext node-type load-fn dependencies-fn read-fn write-fn icon view-types view-opts tags tag-opts template label stateless?]}]
   (let [resource-type {:textual? (true? textual?)
                        :editable? (some? (some editable-view-type? view-types))
-                       :ext ext
                        :build-ext (if (nil? build-ext) (str ext "c") build-ext)
                        :node-type node-type
                        :load-fn load-fn
@@ -109,8 +108,8 @@ ordinary paths."
                        :label label
                        :stateless? (if (nil? stateless?) (nil? load-fn) stateless?)}
         resource-types (if (string? ext)
-                         [(assoc resource-type :ext ext)]
-                         (map (fn [ext] (assoc resource-type :ext ext)) ext))]
+                         [(assoc resource-type :ext (string/lower-case ext))]
+                         (map (fn [ext] (assoc resource-type :ext (string/lower-case ext))) ext))]
     (for [resource-type resource-types]
       (g/update-property workspace :resource-types assoc (:ext resource-type) resource-type))))
 


### PR DESCRIPTION
* User facing changes
  - The editor ignores case on file extension when determining resource type
* Technical changes
  - Introduce resource/type-ext returning lower-case of actual extension. Use type-ext everywhere we check if a resource is of a particular type, or lookup a resource type.