### PR TITLE
DEF-1183 Script Extensions

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1202,19 +1202,18 @@ bail:
                         return;
                     }
 
-
-                    /* Extension updates */
+                    /* Script context updates */
                     if (engine->m_SharedScriptContext) {
-                        dmScript::UpdateExtensions(engine->m_SharedScriptContext);
+                        dmScript::Update(engine->m_SharedScriptContext);
                     } else {
                         if (engine->m_GOScriptContext) {
-                            dmScript::UpdateExtensions(engine->m_GOScriptContext);
+                            dmScript::Update(engine->m_GOScriptContext);
                         }
                         if (engine->m_RenderScriptContext) {
-                            dmScript::UpdateExtensions(engine->m_RenderScriptContext);
+                            dmScript::Update(engine->m_RenderScriptContext);
                         }
                         if (engine->m_GuiScriptContext) {
-                            dmScript::UpdateExtensions(engine->m_GuiScriptContext);
+                            dmScript::Update(engine->m_GuiScriptContext);
                         }
                     }
 
@@ -1268,7 +1267,7 @@ bail:
 
                     if (engine->m_RenderScriptPrototype)
                     {
-                        dmRender::UpdateRenderScriptInstance(engine->m_RenderScriptPrototype->m_Instance);
+                        dmRender::UpdateRenderScriptInstance(engine->m_RenderScriptPrototype->m_Instance, dt);
                     }
                     else
                     {

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -21,7 +21,10 @@ namespace dmGameObject
     {
         if (params.m_World != 0x0)
         {
-            *params.m_World = new ScriptWorld();
+            ScriptWorld* w = new ScriptWorld();
+            w->m_ScriptWorld = dmScript::NewScriptWorld((dmScript::HContext)params.m_Context);
+            *params.m_World = w;
+
             return CREATE_RESULT_OK;
         }
         else
@@ -34,7 +37,9 @@ namespace dmGameObject
     {
         if (params.m_World != 0x0)
         {
-            delete (ScriptWorld*)params.m_World;
+            ScriptWorld* w = (ScriptWorld*)params.m_World;
+            dmScript::DeleteScriptWorld(w->m_ScriptWorld);
+            delete w;
             return CREATE_RESULT_OK;
         }
         else
@@ -53,7 +58,7 @@ namespace dmGameObject
             return CREATE_RESULT_UNKNOWN_ERROR;
         }
 
-        HScriptInstance script_instance = NewScriptInstance(script, params.m_Instance, params.m_ComponentIndex);
+        HScriptInstance script_instance = NewScriptInstance(script_world, script, params.m_Instance, params.m_ComponentIndex);
         SetPropertySet(script_instance->m_Properties, PROPERTY_LAYER_PROTOTYPE, params.m_PropertySet);
         if (script_instance == 0x0)
         {
@@ -196,6 +201,8 @@ namespace dmGameObject
         RunScriptParams run_params;
         run_params.m_UpdateContext = params.m_UpdateContext;
         ScriptWorld* script_world = (ScriptWorld*)params.m_World;
+        dmScript::UpdateScriptWorld(script_world->m_ScriptWorld, params.m_UpdateContext->m_DT);
+
         uint32_t size = script_world->m_Instances.Size();
         for (uint32_t i = 0; i < size; ++i)
         {

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -151,6 +151,7 @@ namespace dmGameObject
 
     ScriptWorld::ScriptWorld()
     : m_Instances()
+    , m_ScriptWorld(0x0)
     {
         // TODO: How to configure? It should correspond to collection instance count
         m_Instances.SetCapacity(1024);
@@ -2054,7 +2055,7 @@ bail:
         script_instance->m_ContextTableReference = LUA_NOREF;
     }
 
-    HScriptInstance NewScriptInstance(HScript script, HInstance instance, uint16_t component_index)
+    HScriptInstance NewScriptInstance(ScriptWorld* script_world, HScript script, HInstance instance, uint16_t component_index)
     {
         lua_State* L = script->m_LuaState;
 
@@ -2075,6 +2076,7 @@ bail:
         i->m_ContextTableReference = dmScript::Ref( L, LUA_REGISTRYINDEX );
 
         i->m_Instance = instance;
+        i->m_ScriptWorld = script_world->m_ScriptWorld;
         i->m_ComponentIndex = component_index;
         NewPropertiesParams params;
         params.m_ResolvePathCallback = ScriptInstanceResolvePathCB;
@@ -2086,6 +2088,12 @@ bail:
         lua_setmetatable(L, -2);
 
         lua_pop(L, 1);
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_InstanceReference);
+        dmScript::SetInstance(L);
+        dmScript::InitializeInstance(L, i->m_ScriptWorld);
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
 
         assert(top == lua_gettop(L));
 
@@ -2101,6 +2109,12 @@ bail:
 
         int top = lua_gettop(L);
         (void) top;
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
+        dmScript::SetInstance(L);
+        dmScript::FinalizeInstance(L, script_instance->m_ScriptWorld);
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
 
         dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_ContextTableReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);

--- a/engine/gameobject/src/gameobject/gameobject_script.h
+++ b/engine/gameobject/src/gameobject/gameobject_script.h
@@ -56,6 +56,7 @@ namespace dmGameObject
     {
         HScript     m_Script;
         Instance*   m_Instance;
+        dmScript::HScriptWorld m_ScriptWorld;
         int         m_InstanceReference;
         int         m_ScriptDataReference;
         int         m_ContextTableReference;
@@ -70,6 +71,7 @@ namespace dmGameObject
         ScriptWorld();
 
         dmArray<ScriptInstance*> m_Instances;
+        dmScript::HScriptWorld m_ScriptWorld;
     };
 
     void    InitializeScript(HRegister regist, dmScript::HContext context);
@@ -78,7 +80,7 @@ namespace dmGameObject
     bool    ReloadScript(HScript script, dmLuaDDF::LuaModule* lua_module);
     void    DeleteScript(HScript script);
 
-    HScriptInstance NewScriptInstance(HScript script, HInstance instance, uint16_t component_index);
+    HScriptInstance NewScriptInstance(ScriptWorld* script_world, HScript script, HInstance instance, uint16_t component_index);
     void            DeleteScriptInstance(HScriptInstance script_instance);
 
     PropertyResult PropertiesToLuaTable(HInstance instance, HScript script, const HProperties properties, lua_State* L, int index);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -132,6 +132,8 @@ namespace dmGameSystem
         gui_world->m_MaxParticleCount = gui_context->m_MaxParticleCount;
         gui_world->m_ParticleContext = dmParticle::CreateContext(gui_world->m_MaxParticleFXCount, gui_world->m_MaxParticleCount);
 
+        gui_world->m_ScriptWorld = dmScript::NewScriptWorld(gui_context->m_ScriptContext);
+
         *params.m_World = gui_world;
         return dmGameObject::CREATE_RESULT_OK;
     }
@@ -162,6 +164,8 @@ namespace dmGameSystem
         dmGraphics::DeleteTexture(gui_world->m_WhiteTexture);
 
         dmRig::DeleteContext(gui_world->m_RigContext);
+
+        dmScript::DeleteScriptWorld(gui_world->m_ScriptWorld);
 
         delete gui_world;
         return dmGameObject::CREATE_RESULT_OK;
@@ -553,6 +557,7 @@ namespace dmGameSystem
         scene_params.m_FetchRigSceneDataCallback = &FetchRigSceneDataCallback;
         scene_params.m_RigEventDataCallback = &RigEventDataCallback;
         scene_params.m_OnWindowResizeCallback = &OnWindowResizeCallback;
+        scene_params.m_ScriptWorld = gui_world->m_ScriptWorld;
         gui_component->m_Scene = dmGui::NewScene(scene_resource->m_GuiContext, &scene_params);
         dmGui::HScene scene = gui_component->m_Scene;
 
@@ -1667,6 +1672,8 @@ namespace dmGameSystem
     dmGameObject::UpdateResult CompGuiUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result)
     {
         GuiWorld* gui_world = (GuiWorld*)params.m_World;
+
+        dmScript::UpdateScriptWorld(gui_world->m_ScriptWorld, params.m_UpdateContext->m_DT);
 
         dmRig::Update(gui_world->m_RigContext, params.m_UpdateContext->m_DT);
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui.h
@@ -74,6 +74,7 @@ namespace dmGameSystem
         uint32_t                         m_RenderedParticlesSize;
         float                            m_DT;
         dmRig::HRigContext               m_RigContext;
+        dmScript::ScriptWorld*           m_ScriptWorld;
     };
 
     typedef BoxVertex ParticleGuiVertex;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -306,6 +306,8 @@ namespace dmGui
         // 16 is hard cap for the same reason as above
         params->m_MaxLayers = 16;
         params->m_AdjustReference = dmGui::ADJUST_REFERENCE_LEGACY;
+
+        params->m_ScriptWorld = 0x0;
     }
 
     static void ResetScene(HScene scene) {
@@ -374,6 +376,7 @@ namespace dmGui
         scene->m_FetchRigSceneDataCallback = params->m_FetchRigSceneDataCallback;
         scene->m_RigEventDataCallback = params->m_RigEventDataCallback;
         scene->m_OnWindowResizeCallback = params->m_OnWindowResizeCallback;
+        scene->m_ScriptWorld = params->m_ScriptWorld;
 
         scene->m_Layers.Put(DEFAULT_LAYER, scene->m_NextLayerIndex++);
 
@@ -389,7 +392,10 @@ namespace dmGui
         luaL_getmetatable(L, GUI_SCRIPT_INSTANCE);
         lua_setmetatable(L, -2);
 
-        lua_pop(L, 1);
+        dmScript::SetInstance(L);
+        dmScript::InitializeInstance(L, scene->m_ScriptWorld);
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
 
         assert(top == lua_gettop(L));
 
@@ -399,6 +405,12 @@ namespace dmGui
     void DeleteScene(HScene scene)
     {
         lua_State*L = scene->m_Context->m_LuaState;
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, scene->m_InstanceReference);
+        dmScript::SetInstance(L);
+        dmScript::FinalizeInstance(L, scene->m_ScriptWorld);
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
 
         for (uint32_t i = 0; i < scene->m_Nodes.Size(); ++i)
         {

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -177,6 +177,7 @@ namespace dmGui
         RigEventDataCallback m_RigEventDataCallback;
         OnWindowResizeCallback m_OnWindowResizeCallback;
         AdjustReference m_AdjustReference;
+        dmScript::ScriptWorld* m_ScriptWorld;
 
         NewSceneParams()
         {

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -287,6 +287,7 @@ namespace dmGui
         uint16_t                m_ResChanged : 1;
         uint32_t                m_Width;
         uint32_t                m_Height;
+        dmScript::ScriptWorld*  m_ScriptWorld;
         FetchTextureSetAnimCallback m_FetchTextureSetAnimCallback;
         FetchRigSceneDataCallback m_FetchRigSceneDataCallback;
         RigEventDataCallback    m_RigEventDataCallback;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -109,6 +109,7 @@ namespace dmRender
 
         context->m_ScriptContext = params.m_ScriptContext;
         InitializeRenderScriptContext(context->m_RenderScriptContext, params.m_ScriptContext, params.m_CommandBufferSize);
+        context->m_ScriptWorld = dmScript::NewScriptWorld(context->m_ScriptContext);
 
         context->m_DebugRenderer.m_RenderContext = 0;
         if (params.m_VertexProgramData != 0 && params.m_VertexProgramDataSize != 0 &&
@@ -137,6 +138,7 @@ namespace dmRender
         if (render_context == 0x0) return RESULT_INVALID_CONTEXT;
 
         FinalizeRenderScriptContext(render_context->m_RenderScriptContext, script_context);
+        dmScript::DeleteScriptWorld(render_context->m_ScriptWorld);
         FinalizeDebugRenderer(render_context);
         FinalizeTextContext(render_context);
         dmMessage::DeleteSocket(render_context->m_Socket);

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -289,7 +289,7 @@ namespace dmRender
     void                    ClearRenderScriptInstanceMaterials(HRenderScriptInstance render_script_instance);
     RenderScriptResult      InitRenderScriptInstance(HRenderScriptInstance render_script_instance);
     RenderScriptResult      DispatchRenderScriptInstance(HRenderScriptInstance render_script_instance);
-    RenderScriptResult      UpdateRenderScriptInstance(HRenderScriptInstance render_script_instance);
+    RenderScriptResult      UpdateRenderScriptInstance(HRenderScriptInstance render_script_instance, float dt);
     void                    OnReloadRenderScriptInstance(HRenderScriptInstance render_script_instance);
 
     // Material

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -202,6 +202,7 @@ namespace dmRender
         RenderScriptContext         m_RenderScriptContext;
         dmArray<RenderTargetSetup>  m_RenderTargets;
         dmArray<RenderObject*>      m_RenderObjects;
+        dmScript::ScriptWorld*      m_ScriptWorld;
 
         dmArray<RenderListEntry>    m_RenderList;
         dmArray<RenderListDispatch> m_RenderListDispatch;

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2575,6 +2575,7 @@ bail:
         ResetRenderScriptInstance(i);
         i->m_PredicateCount = 0;
         i->m_RenderScript = render_script;
+        i->m_ScriptWorld = render_context->m_ScriptWorld;
         i->m_RenderContext = render_context;
         i->m_CommandBuffer.SetCapacity(render_context->m_RenderScriptContext.m_CommandBufferSize);
         i->m_Materials.SetCapacity(16, 8);
@@ -2591,7 +2592,10 @@ bail:
         luaL_getmetatable(L, RENDER_SCRIPT_INSTANCE);
         lua_setmetatable(L, -2);
 
-        lua_pop(L, 1);
+        dmScript::SetInstance(L);
+        dmScript::InitializeInstance(L, i->m_ScriptWorld);
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
 
         assert(top == lua_gettop(L));
 
@@ -2604,6 +2608,12 @@ bail:
 
         int top = lua_gettop(L);
         (void) top;
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, render_script_instance->m_InstanceReference);
+        dmScript::SetInstance(L);
+        dmScript::FinalizeInstance(L, render_script_instance->m_ScriptWorld);
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
 
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_InstanceReference);
         dmScript::Unref(L, LUA_REGISTRYINDEX, render_script_instance->m_RenderScriptDataReference);
@@ -2751,10 +2761,13 @@ bail:
         return context.m_Result;
     }
 
-    RenderScriptResult UpdateRenderScriptInstance(HRenderScriptInstance instance)
+    RenderScriptResult UpdateRenderScriptInstance(HRenderScriptInstance instance, float dt)
     {
         DM_PROFILE(RenderScript, "UpdateRSI");
         instance->m_CommandBuffer.SetSize(0);
+
+        dmScript::UpdateScriptWorld(instance->m_ScriptWorld, dt);
+
         RenderScriptResult result = RunScript(instance, RENDER_SCRIPT_FUNCTION_UPDATE, 0x0);
 
         if (instance->m_CommandBuffer.Size() > 0)

--- a/engine/render/src/render/render_script.h
+++ b/engine/render/src/render/render_script.h
@@ -37,6 +37,7 @@ namespace dmRender
         Predicate*                  m_Predicates[MAX_PREDICATE_COUNT];
         RenderContext*              m_RenderContext;
         HRenderScript               m_RenderScript;
+        dmScript::ScriptWorld*      m_ScriptWorld;
         uint32_t                    m_PredicateCount;
         int                         m_InstanceReference;
         int                         m_RenderScriptDataReference;

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -211,7 +211,7 @@ TEST_F(dmRenderScriptTest, TestRenderScriptMessage)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_FAILED, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_FAILED, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmRenderDDF::WindowResized window_resize;
     window_resize.m_Width = 1;
@@ -227,7 +227,7 @@ TEST_F(dmRenderScriptTest, TestRenderScriptMessage)
     ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::GetSocket(dmRender::RENDER_SOCKET_NAME, &receiver.m_Socket));
     ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::Post(&sender, &receiver, message_id, 0, descriptor, &window_resize, data_size, 0));
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmRender::DeleteRenderScriptInstance(render_script_instance);
     dmRender::DeleteRenderScript(m_Context, render_script);
@@ -253,11 +253,11 @@ TEST_F(dmRenderScriptTest, TestRenderScriptUserMessage)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_FAILED, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_FAILED, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmRender::DeleteRenderScriptInstance(render_script_instance);
     dmRender::DeleteRenderScript(m_Context, render_script);
@@ -283,7 +283,7 @@ TEST_F(dmRenderScriptTest, TestLuaState)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmArray<dmRender::Command>& commands = render_script_instance->m_CommandBuffer;
     ASSERT_EQ(11u, commands.Size());
@@ -401,7 +401,7 @@ TEST_F(dmRenderScriptTest, TestLuaRenderTarget)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmArray<dmRender::Command>& commands = render_script_instance->m_CommandBuffer;
     ASSERT_EQ(2u, commands.Size());
@@ -490,7 +490,7 @@ TEST_F(dmRenderScriptTest, TestLuaClear)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmArray<dmRender::Command>& commands = render_script_instance->m_CommandBuffer;
     ASSERT_EQ(1u, commands.Size());
@@ -523,7 +523,7 @@ TEST_F(dmRenderScriptTest, TestStencilBufferCleared)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
     ASSERT_EQ(0u, m_Context->m_StencilBufferCleared);
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
     ASSERT_EQ(0u, m_Context->m_StencilBufferCleared);
     dmRender::DeleteRenderScriptInstance(render_script_instance);
     dmRender::DeleteRenderScript(m_Context, render_script);
@@ -537,7 +537,7 @@ TEST_F(dmRenderScriptTest, TestStencilBufferCleared)
     render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
     ASSERT_EQ(0u, m_Context->m_StencilBufferCleared);
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
     ASSERT_EQ(1u, m_Context->m_StencilBufferCleared);
     dmRender::DeleteRenderScriptInstance(render_script_instance);
     dmRender::DeleteRenderScript(m_Context, render_script);
@@ -685,7 +685,7 @@ TEST_F(dmRenderScriptTest, TestLuaWindowSize)
     dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmRender::DeleteRenderScriptInstance(render_script_instance);
     dmRender::DeleteRenderScript(m_Context, render_script);
@@ -745,7 +745,7 @@ TEST_F(dmRenderScriptTest, TestPostToSelf)
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
 
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
 
     dmRender::DeleteRenderScriptInstance(render_script_instance);
     dmRender::DeleteRenderScript(m_Context, render_script);
@@ -768,19 +768,19 @@ TEST_F(dmRenderScriptTest, TestDrawText)
     // We do three updates here,
     // First update: A "draw_text" message is sent
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
     dmRender::FlushTexts(m_Context, 0, 0, true);
 
     // Second update: "draw_text" is processed, but no glyphs are in font cache,
     //                they are marked as missing and uploaded. A new "draw_text" also is sent.
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
     dmRender::FlushTexts(m_Context, 0, 0, true);
 
     // Third update: The second "draw_text" is processed, this time the glyphs are uploaded
     //               and the text is drawn.
     ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::DispatchRenderScriptInstance(render_script_instance));
-    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance));
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::UpdateRenderScriptInstance(render_script_instance, 0.0f));
     dmRender::FlushTexts(m_Context, 0, 0, true);
 
     ASSERT_NE(0u, m_Context->m_TextContext.m_TextEntries.Size());

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -30,6 +30,8 @@ namespace dmLuaDDF
 namespace dmScript
 {
     typedef struct Context* HContext;
+    typedef struct ScriptWorld* HScriptWorld;
+    typedef struct ScriptExtension* HScriptExtension;
 
     enum Result
     {
@@ -73,6 +75,31 @@ namespace dmScript
      * Delete an existing context.
      */
     void DeleteContext(HContext context);
+
+    /**
+     * Use a ScriptExtension to hook into various callbacks of the script lifetime
+     * 
+     * For callbacks you do not care for, set them to 0x0
+     */
+    struct ScriptExtension
+    {
+        // Called when the context has completed Initialize(HContext context)
+        void (*Initialize)(HContext context);
+        // Called one each game frame
+        void (*Update)(HContext context);
+        // Called just before the context completes Finalize(HContext context)
+        void (*Finalize)(HContext context);
+        // Called when a new "world" has been created (a Collection, GUI Scene etc)
+        void (*NewScriptWorld)(HScriptWorld script_world);
+        // Called just before deleting the script world
+        void (*DeleteScriptWorld)(HScriptWorld script_world);
+        // Called once a frame for the world, dt is local time delta (affected by slo-mo etc)
+        void (*UpdateScriptWorld)(HScriptWorld script_world, float dt);
+        // Called when a script instance has been created
+        void (*InitializeScriptInstance)(lua_State* L, HScriptWorld script_world);
+        // Called just before a script instance is deleted
+        void (*FinalizeScriptInstance)(lua_State* L, HScriptWorld script_world);
+    };
 
     /**
      * Callback used to resolve paths.
@@ -126,10 +153,20 @@ namespace dmScript
     void Initialize(HContext context);
 
     /**
+     * Register a script extension to the context.
+     * The script_extensions lifetime should wrap the lifetime of the context,
+     * usually you would supply a pointer to a static instance of the script_extension
+     * 
+     * @param context script context
+     * @param script_extension the implementation of the HScriptExtension
+     */
+    void RegisterScriptExtension(HContext context, HScriptExtension script_extension);
+
+    /**
      * Updates the extensions initalized in this script context.
      * @param context script contetx
      */
-    void UpdateExtensions(HContext context);
+    void Update(HContext context);
 
     /**
      * Finalize script libraries
@@ -379,6 +416,58 @@ namespace dmScript
      */
     bool GetUserData(lua_State* L, uintptr_t* out_user_data, const char* user_type);
 
+
+    /**
+     * Returns an identifier that identifies the current instance set by SetInstance().
+     * The id is guarranteed to be unique among the currently alive script instances.
+     * 
+     * @param L Lua state
+     * @return unique identifier for the instance
+     */
+    uintptr_t GetInstanceId(lua_State* L);
+
+    /**
+     * Create a "world" for this script, normally this matches a GO collection,
+     * GUI scene or a RenderWorld.
+     * 
+     * @param context Script context
+     * @return the script world
+     */
+    HScriptWorld NewScriptWorld(HContext context);
+
+    /**
+     * Delete the script world
+     * 
+     * @param script_world The script world created with NewScriptWorld
+     */
+    void DeleteScriptWorld(HScriptWorld script_world);
+
+    /**
+     * Update the script world
+     * 
+     * @param script_world the script world created with NewScriptWorld
+     * @param dt the delta time in the world in seconds
+     */
+    void UpdateScriptWorld(HScriptWorld script_world, float dt);
+ 
+    /**
+     * Sets up the instance with associated data, expects SetInstance to have been
+     * called prior to this function
+     * 
+     * @param L Lua state
+     * @param script_world the script world
+     */
+    void InitializeInstance(lua_State* L, HScriptWorld script_world);
+
+    /**
+     * Removes the instance associated data, expects SetInstance to have been
+     * called prior to this function
+     * 
+     * @param L Lua state
+     * @param script_world the script world
+     */
+    void FinalizeInstance(lua_State* L, HScriptWorld script_world);
+
     /**
      * Set value by key using the META_GET_INSTANCE_CONTEXT_TABLE_REF meta table function
      * 
@@ -459,6 +548,34 @@ namespace dmScript
      *  [-1] value or LUA_NIL
      */
     void ResolveInInstance(lua_State* L, int ref);
+
+    HContext GetScriptWorldContext(HScriptWorld script_world);
+
+    /**
+     * Set value by key in the context table associated with the script world
+     * 
+     * @param script_world the script world created with NewScriptWorld
+     * 
+     * Lua stack on entry
+     *  [-2] key
+     *  [-1] value
+     * 
+     * Lua stack on exit
+    */
+    void SetScriptWorldContextValue(HScriptWorld script_world);
+
+    /**
+     * Get value by key from the context table associated with the script world
+     * 
+     * @param script_world the script world created with NewScriptWorld
+     * 
+     * Lua stack on entry
+     *  [-1] key
+     * 
+     * Lua stack on exit
+     *  [-1] value
+    */
+    void GetScriptWorldContextValue(HScriptWorld script_world);
 
     dmMessage::Result ResolveURL(lua_State* L, const char* url, dmMessage::URL* out_url, dmMessage::URL* default_url);
 

--- a/engine/script/src/script_private.h
+++ b/engine/script/src/script_private.h
@@ -18,16 +18,20 @@ namespace dmScript
     };
 
     #define DM_SCRIPT_MAX_EXTENSIONS (sizeof(uint32_t) * 8 * 16)
+
+    typedef struct ScriptExtension* HScriptExtension;
+
     struct Context
     {
-        dmConfigFile::HConfig   m_ConfigFile;
-        dmResource::HFactory    m_ResourceFactory;
-        dmHashTable64<Module>   m_Modules;
-        dmHashTable64<Module*>  m_PathToModule;
-        dmHashTable64<int>      m_HashInstances;
-        lua_State*              m_LuaState;
-        bool                    m_EnableExtensions;
-        uint32_t                m_InitializedExtensions[DM_SCRIPT_MAX_EXTENSIONS / (8 * sizeof(uint32_t))];
+        dmConfigFile::HConfig       m_ConfigFile;
+        dmResource::HFactory        m_ResourceFactory;
+        dmHashTable64<Module>       m_Modules;
+        dmHashTable64<Module*>      m_PathToModule;
+        dmHashTable64<int>          m_HashInstances;
+        dmArray<HScriptExtension>   m_ScriptExtensions;
+        lua_State*                  m_LuaState;
+        uint32_t                    m_InitializedExtensions[DM_SCRIPT_MAX_EXTENSIONS / (8 * sizeof(uint32_t))];
+        bool                        m_EnableExtensions;
     };
 
     bool ResolvePath(lua_State* L, const char* path, uint32_t path_size, dmhash_t& out_hash);


### PR DESCRIPTION
Added dmScript::ScriptWorld and dmScript::ScriptExtension to be able to hook into lifetimes of Script Context, ScriptWorld (new concept) and Script Instances.