### PR TITLE
DEFEDIT-1391 Parallelise compile phase of building

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -723,14 +723,29 @@
   "Creates a tree trace of the evaluation of the form
   {:node-id ... :output-type ... :label ... :state ... :dependencies [{...} ...]}
 
-  You can also pass in a function to decorate the steps. For timing for instance:
+  You can also pass in a function to decorate the steps.
 
+    Timing:
     (defn timing-decorator [step state]
       (case state
         :begin (assoc step :start-time (System/currentTimeMillis))
         (:end :fail) (-> step
                          (assoc :elapsed (- (System/currentTimeMillis) (:start-time step)))
                          (dissoc :start-time))))
+
+    Weight:
+    (defn weight-decorator [step state]
+      (case state
+        :begin step
+        :end (assoc step :weight (+ 1 (reduce + 0 (map :weight (:dependencies step)))))
+        :fail (assoc step :weight 0)))
+
+    Depth:
+    (defn- depth-decorator [step state]
+      (case state
+        :begin step
+        :end (assoc step :depth (+ 1 (or (:depth (first (:dependencies step))) 0)))
+        :fail (assoc step :depth 0)))
 
     (g/node-value node :output (g/make-evaluation-context {:tracer (g/make-tree-tracer result-atom timing-decorator)}))"
   ([result-atom]

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -273,37 +273,60 @@
 
 (defn make-collect-progress-steps-tracer [steps-atom]
   (fn [state node output-type label]
-    (when (= [state output-type label] [:begin :output :build-targets])
-      (swap! steps-atom conj [node output-type label]))))
+    (when (and (= label :build-targets) (= state :begin) (= output-type :output))
+      (swap! steps-atom conj node))))
 
-(defn make-progress-tracer [steps-atom node-id->resource-path render-progress!]
-  (let [steps-left (atom @steps-atom)
-        progress (atom (progress/make "" (count @steps-atom)))]
+(defn make-progress-tracer [step-count node-id->resource-path render-progress!]
+  (let [steps-done (atom #{})
+        progress (atom (progress/make "" step-count))]
     (fn [state node output-type label]
-      (when (and (= [state output-type label] [:begin :output :build-targets])
-                 (= (first @steps-left) [node output-type label]))
-        (swap! steps-left rest)
+      (cond
+        (and (= label :build-targets) (= state :begin) (= output-type :output))
         (let [new-message (if-let [path (node-id->resource-path node)]
                             (str "Compiling " path)
                             (or (progress/message @progress) ""))]
-          (swap! progress progress/advance 1 new-message))
-        (render-progress! @progress)))))
+          (swap! progress progress/with-message new-message)
+          (render-progress! @progress))
+
+        (and (= label :build-targets) (= state :end) (= output-type :output))
+        (let [already-done (loop []
+                             (let [old @steps-done
+                                   new (conj old node)]
+                               (if (compare-and-set! steps-done old new)
+                                 (get old node)
+                                 (recur))))]
+          (when-not already-done
+            (swap! progress progress/advance 1)
+            (render-progress! @progress)))))))
+
+(defn- batched-pmap [f batches]
+  (->> batches
+       (pmap (fn [batch] (doall (map f batch))))
+       (reduce concat)
+       doall))
+
+(defn- available-processors []
+  (.. Runtime getRuntime availableProcessors))
 
 (defn build!
   [project node evaluation-context extra-build-targets old-artifact-map render-progress!]
-  (let [steps                  (atom [])
-        collect-tracer         (make-collect-progress-steps-tracer steps)
-        _                      (g/node-value node :build-targets (assoc evaluation-context :dry-run true :tracer collect-tracer))
+  (let [steps (atom [])
+        collect-tracer (make-collect-progress-steps-tracer steps)
+        _ (g/node-value node :build-targets (assoc evaluation-context :dry-run true :tracer collect-tracer))
         node-id->resource-path (clojure.set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context))
-        progress-tracer        (make-progress-tracer steps node-id->resource-path (progress/nest-render-progress render-progress! (progress/make "" 10) 7))
-        node-build-targets     (g/node-value node :build-targets (assoc evaluation-context :tracer progress-tracer))
-        build-targets          (cond-> node-build-targets
-                                 (seq extra-build-targets)
-                                 (into extra-build-targets))
-        build-dir              (workspace/build-path (workspace project))]
+        step-count (count @steps)
+        progress-tracer (make-progress-tracer step-count node-id->resource-path (progress/nest-render-progress render-progress! (progress/make "" 10) 5))
+        evaluation-context-with-progress-trace (assoc evaluation-context :tracer progress-tracer)
+        prewarm-partitions (partition-all (max (quot step-count (+ (available-processors) 2)) 1000) (reverse @steps))
+        _ (batched-pmap (fn [node-id] (g/node-value node-id :build-targets evaluation-context-with-progress-trace)) prewarm-partitions)
+        node-build-targets (g/node-value node :build-targets evaluation-context)
+        build-targets (cond-> node-build-targets
+                        (seq extra-build-targets)
+                        (into extra-build-targets))
+        build-dir (workspace/build-path (workspace project))]
     (if (g/error? build-targets)
       {:error build-targets}
-      (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 7) 3)))))
+      (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5)))))
 
 (handler/defhandler :undo :global
   (enabled? [project-graph] (g/has-undo? project-graph))

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -592,32 +592,32 @@
       ;; NOTE! If we're seriously unlucky a gc could make these tests
       ;; fail by collecting the result held in a WeakReference
 
-      ;; check "wat" is temp cached
-      (g/transact
-        (concat
-          (g/connect wat-producer :produce consumer :in1)
-          (g/connect wat-producer :produce consumer :in2)))
+      (testing "check non-nil value is temp cached"
+        (g/transact
+          (concat
+            (g/connect wat-producer :produce consumer :in1)
+            (g/connect wat-producer :produce consumer :in2)))
 
-      (reset! production-count 0)
-      (is (= (g/node-value consumer :result) "watwat"))
-      (is (= @production-count 1))
+        (reset! production-count 0)
+        (is (= (g/node-value consumer :result) "watwat"))
+        (is (= @production-count 1)))
 
-      ;, check nil is temp cached
-      (g/transact
-        (concat
-          (g/connect nil-producer :produce consumer :in1)
-          (g/connect nil-producer :produce consumer :in2)))
+      (testing "check nil is temp cached"
+        (g/transact
+          (concat
+            (g/connect nil-producer :produce consumer :in1)
+            (g/connect nil-producer :produce consumer :in2)))
 
-      (reset! production-count 0)
-      (is (= (g/node-value consumer :result) ""))
-      (is (= @production-count 1))
+        (reset! production-count 0)
+        (is (= (g/node-value consumer :result) ""))
+        (is (= @production-count 1)))
 
 
-      ;; check :no-local-temp is respected
-      (reset! production-count 0)
-      (is (= (g/node-value consumer :result (g/make-evaluation-context {:no-local-temp true})) ""))
-      (is (= @production-count 2))
+      (testing "check :no-local-temp is respected"
+        (reset! production-count 0)
+        (is (= (g/node-value consumer :result (g/make-evaluation-context {:no-local-temp true})) ""))
+        (is (= @production-count 2))
 
-      (reset! production-count 0)
-      (is (= (g/node-value consumer :result (g/make-evaluation-context {:no-local-temp false})) ""))
-      (is (= @production-count 1)))))
+        (reset! production-count 0)
+        (is (= (g/node-value consumer :result (g/make-evaluation-context {:no-local-temp false})) ""))
+        (is (= @production-count 1))))))


### PR DESCRIPTION
* User facing changes
  - Slightly faster builds on large projects
  - Possibly higher memory consumption from further caching during
  node-value, but should be reclaimable as we use weak references

* Technical changes
  - We evaluate :build-targets of resource nodes in parallel using the
  same evaluation context to "prewarm" the :local and :local-temp
  caches before we evaluate :build-targets of the game project
  node. This rougly halves the time taken.
  - evaluation-context now contains a :local-temp cache containing the
  results of all non :cached outputs so we typically only evaluate
  them once during one node-value invocation (or rather as long as we
  use the same evaluation-context). The values are kept in
  WeakReference's so they can be reclaimed, in which case the output
  might be re-evaluated. Can be disabled by passing :no-local-temp
  when creating the evaluation-context.