### PR TITLE
DEF-3292 Fix message callback ref

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -148,7 +148,7 @@ namespace dmGameSystem
             {
                 lua_pushvalue(L, 5);
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
-                sender.m_FunctionRef = dmScript::Ref(L, LUA_REGISTRYINDEX) - LUA_NOREF;
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 
@@ -288,7 +288,7 @@ namespace dmGameSystem
             {
                 lua_pushvalue(L, 5);
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
-                sender.m_FunctionRef = dmScript::Ref(L, LUA_REGISTRYINDEX) - LUA_NOREF;
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 

--- a/engine/gamesys/src/gamesys/scripts/script_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_spine_model.cpp
@@ -153,7 +153,7 @@ namespace dmGameSystem
             {
                 lua_pushvalue(L, 5);
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
-                sender.m_FunctionRef = dmScript::Ref(L, LUA_REGISTRYINDEX) - LUA_NOREF;
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 
@@ -291,7 +291,7 @@ namespace dmGameSystem
             {
                 lua_pushvalue(L, 5);
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
-                sender.m_FunctionRef = dmScript::Ref(L, LUA_REGISTRYINDEX) - LUA_NOREF;
+                sender.m_FunctionRef = dmScript::RefInInstance(L) - LUA_NOREF;
             }
         }
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1885,11 +1885,10 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     Result DispatchMessage(HScene scene, dmMessage::Message* message)
     {
         int custom_ref = LUA_NOREF;
-        bool is_callback = false;
         if (message->m_Receiver.m_FunctionRef) {
             // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
             custom_ref = message->m_Receiver.m_FunctionRef + LUA_NOREF;
-            is_callback = true;
+            // RunScript method will DeRef the custom_ref if it is not LUA_NOREF
         }
 
         Result r = RunScript(scene, SCRIPT_FUNCTION_ONMESSAGE, custom_ref, (void*)message);

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -106,7 +106,7 @@ namespace dmScript
             luaL_checktype(L, 3, LUA_TFUNCTION);
             lua_pushvalue(L, 3);
             // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
-            int callback = dmScript::Ref(L, LUA_REGISTRYINDEX) - LUA_NOREF;
+            int callback = dmScript::RefInInstance(L) - LUA_NOREF;
             sender.m_FunctionRef = callback;
 
             char* headers = 0;

--- a/engine/script/src/script_http_js.cpp
+++ b/engine/script/src/script_http_js.cpp
@@ -97,7 +97,7 @@ namespace dmScript
             luaL_checktype(L, 3, LUA_TFUNCTION);
             lua_pushvalue(L, 3);
             // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
-            int callback = dmScript::Ref(L, LUA_REGISTRYINDEX) - LUA_NOREF;
+            int callback = dmScript::RefInInstance(L) - LUA_NOREF;
             sender.m_FunctionRef = callback;
 
             dmArray<char> h;

--- a/engine/script/src/test/test_script_http.cpp
+++ b/engine/script/src/test/test_script_http.cpp
@@ -177,13 +177,14 @@ void DispatchCallbackDDF(dmMessage::Message *message, void* user_ptr)
 
     // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
     int ref = message->m_Receiver.m_FunctionRef + LUA_NOREF;
-    lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
-    dmScript::Unref(L, LUA_REGISTRYINDEX, ref);
+    dmScript::ResolveInInstance(L, ref);
+    dmScript::UnrefInInstance(L, ref);
     lua_gc(L, LUA_GCCOLLECT, 0);
 
     dmScript::PushDDF(L, descriptor, (const char*)&message->m_Data[0]);
     int ret = dmScript::PCall(L, 1, 0);
     test->m_NumberOfFails += ret == 0 ? 0 : 1;
+
     ASSERT_EQ(0, ret);
 }
 

--- a/engine/tracking/src/tracking.cpp
+++ b/engine/tracking/src/tracking.cpp
@@ -170,7 +170,7 @@ namespace dmTracking
             // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, see message.h in dlib
             const int ref = message->m_Receiver.m_FunctionRef + LUA_NOREF;
 
-            lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+            dmScript::ResolveInInstance(L, ref);
             assert(lua_isfunction(L, -1));
             lua_rawgeti(L, LUA_REGISTRYINDEX, context->m_ContextReference);
 
@@ -189,7 +189,7 @@ namespace dmTracking
                 lua_newtable(L);
             }
             dmScript::PCall(L, 3, LUA_MULTRET);
-            dmScript::Unref(L, LUA_REGISTRYINDEX, ref);
+            dmScript::UnrefInInstance(L, ref);
         }
         else if (message->m_Descriptor != 0)
         {


### PR DESCRIPTION
Make sure we consistently ref, resolve and unref message callback refs in instance context table

Should address DEF-3292, DEF-3289, DEF-3288 and DEF-3290