### PR TITLE
DEFEDIT-1393 Particle effect emitters are not sorted on z-value

### DIFF
--- a/editor/src/clj/editor/gl.clj
+++ b/editor/src/clj/editor/gl.clj
@@ -72,6 +72,7 @@
 (defmacro gl-enable [gl cap]                                             `(.glEnable ~gl ~cap))
 (defmacro gl-disable [gl cap]                                            `(.glDisable ~gl ~cap))
 (defmacro gl-cull-face [gl mode]                                         `(.glCullFace ~gl ~mode))
+(defmacro gl-blend-func [gl sfactor dfactor]                             `(.glBlendFunc ~gl ~sfactor ~dfactor))
 
 (defn gl-get-integer-v
   [^GL2 gl ^Integer param sz]
@@ -282,3 +283,11 @@
             (+ ptr 3 name-count)
             (conj names name))))
       names)))
+
+(defn set-blend-mode [^GL gl blend-mode]
+  ;; Assumes pre-multiplied source/destination
+  ;; Equivalent of defold/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+  (case blend-mode
+    :blend-mode-alpha (gl-blend-func gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
+    (:blend-mode-add :blend-mode-add-alpha) (gl-blend-func gl GL/GL_ONE GL/GL_ONE)
+    :blend-mode-mult (gl-blend-func gl GL/GL_DST_COLOR GL/GL_ONE_MINUS_SRC_ALPHA)))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -221,10 +221,7 @@
                              (vtx/use-with ::tris vb shader))]
         (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
           (clipping/setup-gl gl clipping-state)
-          (case blend-mode
-            :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
-            (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
-            :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+          (gl/set-blend-mode gl blend-mode)
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 vcount)
           (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)
           (clipping/restore-gl gl clipping-state))))))

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -114,10 +114,7 @@
       (let [shader (or material-shader shader)
             vertex-binding (vtx/use-with ::tris vb shader)]
         (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
-          (case blend-mode
-            :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
-            (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
-            :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+          (gl/set-blend-mode gl blend-mode)
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 vcount)
           (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA))))))
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -309,33 +309,6 @@
 
 (def ^:private circle-steps 32)
 
-(defn- gen-vertex [^Matrix4d wt ^Point3d pt x y [cr cg cb]]
-  (.set pt x y 0)
-  (.transform wt pt)
-  [(.x pt) (.y pt) (.z pt) cr cg cb 1])
-
-(defn- conj-2d-cone! [vbuf ^Matrix4d wt ^Point3d pt type size color]
-  (let [[sx sy _] size
-        hsx (* sx 0.5)
-        xl (gen-vertex wt pt (- hsx) sy color)
-        xr (gen-vertex wt pt hsx sy color)
-        c (gen-vertex wt pt 0.0 0.0 color)]
-    (-> vbuf (conj! c) (conj! xr) (conj! xr) (conj! xl) (conj! xl) (conj! c))))
-
-(defn- gen-vertex-buffer
-  [vcount renderables count]
-  (let [tmp-point (Point3d.)]
-    (loop [renderables renderables
-           vbuf (->color-vtx vcount)]
-      (if-let [renderable (first renderables)]
-        (let [color (if (:selected renderable) selected-color color)
-              world-transform (:world-transform renderable)
-              user-data (:user-data renderable)
-              type (:type user-data)
-              size (:size user-data)]
-          (recur (rest renderables) (conj-2d-cone! vbuf world-transform tmp-point type size color)))
-        (persistent! vbuf)))))
-
 (def circle-geom-data (let [ps (->> geom/origin-geom
                                  (geom/transl [0 0.5 0])
                                  (geom/circling 64))]
@@ -363,21 +336,53 @@
                                                              (geom/scale [size-x size-y 1] cone-geom-data))}
                     :emitter-type-box {:label "Box"
                                        :geom-data-world (fn [size-x size-y _]
-                                                     (geom/scale [size-x size-y 1] box-geom-data))}})
+                                                          (geom/scale [size-x size-y 1] box-geom-data))}})
+
+(defn- convert-blend-mode [blend-mode-index]
+  (protobuf/pb-enum->val (.getValueDescriptor (Particle$BlendMode/valueOf ^int blend-mode-index))))
+
+(defn- render-emitters-sim [^GL2 gl render-args renderables rcount]
+  (doseq [renderable renderables]
+    (let [{:keys [emitter-sim-data emitter-index color]} (:user-data renderable)
+          pfx-sim-request-id (some-> renderable :updatable :node-id)]
+      (when-let [pfx-sim (when (and emitter-sim-data pfx-sim-request-id)
+                           (some-> (:pfx-sim (scene-cache/lookup-object ::pfx-sim pfx-sim-request-id nil)) deref))]
+        (plib/gen-emitter-vertex-data pfx-sim emitter-index color)
+        (let [context (:context pfx-sim)
+              vbuf (plib/get-emitter-vertex-data pfx-sim emitter-index)]
+          (when-let [render-data (plib/render-emitter pfx-sim emitter-index)]
+            (let [gpu-texture (:gpu-texture emitter-sim-data)
+                  shader (:shader emitter-sim-data)
+                  vtx-binding (vtx/use-with context vbuf shader)
+                  blend-mode (convert-blend-mode (:blend-mode render-data))]
+              (gl/with-gl-bindings gl render-args [gpu-texture shader vtx-binding]
+                (gl/set-blend-mode gl blend-mode)
+                (gl/gl-draw-arrays gl GL/GL_TRIANGLES (:v-index render-data) (:v-count render-data))
+                (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))))))))
+
+(defn- render-emitters [^GL2 gl render-args renderables rcount]
+  (let [pass (:pass render-args)]
+    (condp = pass
+      pass/outline (render-lines gl render-args renderables count)
+      pass/selection (render-lines gl render-args renderables count)
+      pass/transparent (render-emitters-sim gl render-args renderables count))))
 
 (g/defnk produce-emitter-scene
-  [_node-id transform aabb type emitter-key-size-x emitter-key-size-y emitter-key-size-z child-scenes]
+  [_node-id transform aabb type emitter-sim-data emitter-index emitter-key-size-x emitter-key-size-y emitter-key-size-z child-scenes]
   (let [emitter-type (emitter-types type)]
     {:node-id _node-id
      :transform transform
      :aabb aabb
-     :renderable {:render-fn render-lines
+     :renderable {:render-fn render-emitters
                   :batch-key nil
                   :select-batch-key _node-id
                   :user-data {:type type
+                              :emitter-sim-data emitter-sim-data
+                              :emitter-index emitter-index
+                              :color [1.0 1.0 1.0 1.0]
                               :geom-data-world (apply (:geom-data-world emitter-type)
                                                  (mapv props/sample [emitter-key-size-x emitter-key-size-y emitter-key-size-z]))}
-                  :passes [pass/outline pass/selection]}
+                  :passes [pass/outline pass/selection pass/transparent]}
      :children child-scenes}))
 
 (g/defnode EmitterProperties
@@ -549,6 +554,8 @@
   (input texture-set g/Any)
   (input gpu-texture g/Any)
   (input dep-build-targets g/Any :array)
+  (input emitter-indices g/Any)
+  (output emitter-index g/Any (g/fnk [_node-id emitter-indices] (emitter-indices _node-id)))
   (output build-targets g/Any (g/fnk [_node-id tile-source material animation anim-ids dep-build-targets]
                                 (or (when-let [errors (->> [(validation/prop-error :fatal _node-id :tile-source validation/prop-nil? tile-source "Image")
                                                             (validation/prop-error :fatal _node-id :material validation/prop-nil? material "Material")
@@ -632,40 +639,12 @@
                   :dep-resources dep-resources}
       :deps dep-build-targets}]))
 
-(defn- convert-blend-mode [blend-mode-index]
-  (protobuf/pb-enum->val (.getValueDescriptor (Particle$BlendMode/valueOf ^int blend-mode-index))))
+(defn- render-pfx [^GL2 gl render-args renderables count])
 
-(defn- render-emitter [emitter-sim-data ^GL gl render-args context vbuf emitter-index blend-mode v-index v-count]
-  (when-some [sim-data (get emitter-sim-data emitter-index)]
-    (let [gpu-texture (:gpu-texture sim-data)
-          shader (:shader sim-data)
-          vtx-binding (vtx/use-with context vbuf shader)
-          blend-mode (convert-blend-mode blend-mode)]
-      (gl/with-gl-bindings gl render-args [gpu-texture shader vtx-binding]
-        (case blend-mode
-          :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
-          (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
-          :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
-        (gl/gl-draw-arrays gl GL/GL_TRIANGLES v-index v-count)
-        (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))))
-
-(defn- render-pfx [^GL2 gl render-args renderables count]
-  (doseq [renderable renderables]
-    (when-let [node-id (some-> renderable :updatable :node-id)]
-      (when-let [pfx-sim-ref (:pfx-sim (scene-cache/lookup-object ::pfx-sim node-id nil))]
-        (let [user-data (:user-data renderable)
-              pfx-sim (swap! pfx-sim-ref plib/gen-vertex-data (:color user-data))
-              emitter-sim-data (:emitter-sim-data user-data)
-              context (:context pfx-sim)
-              vbuf (:vbuf pfx-sim)]
-          (plib/render pfx-sim (partial render-emitter emitter-sim-data gl render-args context vbuf)))))))
-
-(g/defnk produce-scene [_node-id child-scenes emitter-sim-data scene-updatable]
+(g/defnk produce-scene [_node-id child-scenes scene-updatable]
   (let [scene {:node-id _node-id
                :renderable {:render-fn render-pfx
                             :batch-key nil
-                            :user-data {:emitter-sim-data emitter-sim-data
-                                        :color [1.0 1.0 1.0 1.0]}
                             :passes [pass/transparent pass/selection]}
                :aabb (reduce geom/aabb-union (geom/null-aabb) (filter #(not (nil? %)) (map :aabb child-scenes)))
                :children child-scenes}]
@@ -692,7 +671,8 @@
                      [:id :ids]
                      [:build-targets :dep-build-targets]]]
       (g/connect emitter-id from self-id to))
-    (for [[from to] [[:default-tex-params :default-tex-params]]]
+    (for [[from to] [[:default-tex-params :default-tex-params]
+                     [:emitter-indices :emitter-indices]]]
       (g/connect self-id from emitter-id to))
     (when resolve-id?
       (g/update-property emitter-id :id outline/resolve-id (g/node-value self-id :ids)))))
@@ -715,6 +695,14 @@
                                {:emitters emitter-msgs :modifiers modifier-msgs}))
   (output rt-pb-data g/Any :cached (g/fnk [pb-data] (particle-fx-transform pb-data)))
   (output emitter-sim-data g/Any :cached (gu/passthrough emitter-sim-data))
+  (output emitter-indices g/Any :cached (g/fnk [nodes]
+                                               (into {}
+                                                     (comp
+                                                       (filter #(g/node-instance? EmitterNode %))
+                                                       (map-indexed (fn [index emitter-node]
+                                                                      [emitter-node index])))
+                                                     nodes)))
+                                                 
   (output build-targets g/Any :cached produce-build-targets)
   (output scene g/Any :cached produce-scene)
   (output scene-updatable g/Any :cached produce-scene-updatable)
@@ -923,14 +911,16 @@
 (defn- make-pfx-sim [_ data]
   (let [[max-emitter-count max-particle-count rt-pb-data world-transform] data]
     {:pfx-sim (atom (plib/make-sim max-emitter-count max-particle-count rt-pb-data [world-transform]))
-     :protobuf-msg rt-pb-data}))
+     :protobuf-msg rt-pb-data
+     :max-particle-count max-particle-count}))
 
 (defn- update-pfx-sim [_ pfx-sim data]
-  (let [[max-emitter-count max-particle-count rt-pb-data world-transform] data
+  (let [[_max-emitter-count max-particle-count rt-pb-data _world-transform] data
         pfx-sim-ref (:pfx-sim pfx-sim)]
-    (when (not= rt-pb-data (:protobuf-msg pfx-sim))
-      (swap! pfx-sim-ref plib/reload rt-pb-data))
-    (assoc pfx-sim :protobuf-msg rt-pb-data)))
+    (when (or (not= rt-pb-data (:protobuf-msg pfx-sim))
+              (not= max-particle-count (:max-particle-count pfx-sim)))
+      (swap! pfx-sim-ref plib/reload rt-pb-data max-particle-count))
+    (assoc pfx-sim :protobuf-msg rt-pb-data :max-particle-count max-particle-count)))
 
 (defn- destroy-pfx-sims [_ pfx-sims _]
   (doseq [pfx-sim pfx-sims]

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -797,10 +797,7 @@
                   shader (get user-data :shader render/shader-tex-tint)
                   vertex-binding (vtx/use-with ::spine-trans vb shader)]
               (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
-                (case blend-mode
-                  :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
-                  (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
-                  :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+                (gl/set-blend-mode gl blend-mode)
                 (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))
                 (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA))))
           (when-let [vb (gen-skeleton-vb renderables)]

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -144,10 +144,7 @@
             gpu-texture (:gpu-texture user-data)
             blend-mode (:blend-mode user-data)]
         (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
-          (case blend-mode
-            :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
-            (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
-            :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+          (gl/set-blend-mode gl blend-mode)
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* count 6))
           (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))
 

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -135,10 +135,7 @@
         (when vbuf
           (let [vertex-binding (vtx/use-with node-id vbuf shader)]
             (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
-              (case blend-mode
-                :blend-mode-alpha (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
-                (:blend-mode-add :blend-mode-add-alpha) (.glBlendFunc gl GL/GL_ONE GL/GL_ONE)
-                :blend-mode-mult (.glBlendFunc gl GL/GL_ZERO GL/GL_SRC_COLOR))
+              (gl/set-blend-mode gl blend-mode)
               ;; TODO: can't use selected because we also need to know when nothing is selected
               #_(if selected
                   (shader/set-uniform shader gl "tint" (Vector4d. 1.0 1.0 1.0 1.0))

--- a/editor/test/integration/particlefx_test.clj
+++ b/editor/test/integration/particlefx_test.clj
@@ -49,15 +49,14 @@
                (plib/simulate sim 1/60 fetch-anim-fn transforms)
                (is (not (plib/sleeping? sim))))
       (testing "Stats"
-               (let [stats (-> sim
+               (let [sim (-> sim
                              (plib/simulate 1/60 fetch-anim-fn transforms)
-                             (plib/simulate 1/60 fetch-anim-fn transforms)
-                             (plib/gen-vertex-data [1.0 1.0 1.0 1.0])
-                             (plib/stats))]
+                             (plib/simulate 1/60 fetch-anim-fn transforms))
+                     stats (do (plib/gen-emitter-vertex-data sim 0 [1.0 1.0 1.0 1.0])
+                               (plib/stats sim))]
                  (is (< 0 (:particles (plib/stats sim))))))
       (testing "Rendering"
-               (plib/render sim (fn [texture-index blend-mode v-index v-count]
-                                  (is (= 12 v-count)))))
+        (is (= 12 (:v-count (plib/render-emitter sim 0)))))
       (testing "Dispose"
                (plib/destroy-sim sim)))))
 


### PR DESCRIPTION
* User facing changes
  - setting z on emitters changes presentation in scene view

* Technical changes
  - split emitters into separate renderables
  - unrelated: change implementation of multiply blend mode