### PR TITLE
DEFEDIT-1381 Refresh assets tree faster in projects with many dependencies on Windows

### DIFF
--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -65,7 +65,7 @@ ordinary paths."
 
 (defn sort-resource-tree [{:keys [children] :as tree}]
   (let [sorted-children (sort-by (fn [r]
-                                   [(not (resource/read-only? r))
+                                   [(resource/file-resource? r)
                                     ({:folder 0 :file 1} (resource/source-type r))
                                     (when-let [node-name (resource/resource-name r)]
                                       (string/lower-case node-name))])


### PR DESCRIPTION
Potential fix for defold/editor2-issues#1830

### User-facing changes
* On Windows, shortens the time after saving that the editor is unresponsive for projects with lots of dependencies.