### PR TITLE
DEFEDIT-1394 Fixed script errors not reporting line numbers during build

### DIFF
--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -124,7 +124,7 @@
   (let [{:keys [image-generators texture-profile compress?]} user-data
         images (generate-images image-generators)]
     (g/precluding-errors
-      (filter g/error? (vals images))
+      (vals images)
       (let [texture-images (tex-gen/make-cubemap-texture-images images texture-profile compress?)
             cubemap-texture-image (tex-gen/assemble-cubemap-texture-images texture-images)]
         {:resource resource

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -28,8 +28,8 @@
 (defn- build-texture [resource dep-resources user-data]
   (let [{:keys [content-generator texture-profile compress?]} user-data
         image ((:f content-generator) (:args content-generator))]
-    (if (g/error? image)
-      image
+    (g/precluding-errors
+      [image]
       (let [texture-image (tex-gen/make-texture-image image texture-profile compress?)]
         {:resource resource
          :content  (protobuf/pb->bytes texture-image)}))))

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -176,8 +176,12 @@
                         (let [result (or cached-artifact
                                          (let [dep-resources (make-dep-resources deps build-targets-by-key)
                                                build-result (build-fn resource dep-resources user-data)]
+                                           ;; Error results are assumed to be error-aggregates.
+                                           ;; We need to inject the node-id of the source build
+                                           ;; target into the causes, since the build-fn will
+                                           ;; not have access to the node-id.
                                            (if (g/error? build-result)
-                                             (assoc build-result :_node-id node-id)
+                                             (update build-result :causes (partial map #(assoc % :_node-id node-id)))
                                              (to-disk! build-result key))))]
                           (render-progress! (swap! progress progress/advance))
                           result)))

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -101,7 +101,7 @@
   (some->> errors
            (map unpack-if-package)
            flatten
-           (remove nil?)
+           (filter #(instance? ErrorValue %))
            not-empty
            error-aggregate))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#1824
Fixes defold/editor2-issues#1902

### Technical changes
* If a `:build-fn` returns an error, it must be an `error-aggregate`. This is because we need to decorate the `:causes` rather than the aggregate `ErrorValue` with the source `node-id` for the build errors view to link to the error correctly.