### PR TITLE
Cleanup of includes in dlib

### DIFF
--- a/engine/crash/src/load_addrs_proc_smap.cpp
+++ b/engine/crash/src/load_addrs_proc_smap.cpp
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 #include <link.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <dlib/log.h>
 #include <dlib/dstrings.h>
 #include "crash_private.h"

--- a/engine/dlib/src/dlib/array.cpp
+++ b/engine/dlib/src/dlib/array.cpp
@@ -1,7 +1,6 @@
 #include "array.h"
 
 #include <assert.h>
-#include <string.h>
 
 namespace dmArrayUtil
 {

--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -1,19 +1,17 @@
 
-#include <dmsdk/dlib/buffer.h>
+#include "buffer.h"
 
-#include <dlib/log.h>
-#include <dlib/memory.h>
-#include <dlib/math.h>
+#include "memory.h"
+#include "log.h"
 
-#include <string.h>
 #include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if defined(_WIN32)
 #include <malloc.h>
 #define alloca(_SIZE) _alloca(_SIZE)
 #endif
-
-#include <stdio.h>
 
 namespace dmBuffer
 {

--- a/engine/dlib/src/dlib/condition_variable.cpp
+++ b/engine/dlib/src/dlib/condition_variable.cpp
@@ -1,5 +1,6 @@
-#include <assert.h>
 #include "condition_variable.h"
+
+#include <assert.h>
 
 namespace dmConditionVariable
 {

--- a/engine/dlib/src/dlib/condition_variable.h
+++ b/engine/dlib/src/dlib/condition_variable.h
@@ -1,7 +1,7 @@
 #ifndef DM_CONDITION_VARIABLE_H
 #define DM_CONDITION_VARIABLE_H
 
-#include <dlib/mutex.h>
+#include "mutex.h"
 
 #if defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__)
 #include <pthread.h>

--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -1,20 +1,15 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <setjmp.h>
-#include <string.h>
-#include <ctype.h>
-#include <assert.h>
-#include <sys/stat.h>
-#include "hash.h"
-#include "log.h"
-#include "http_client.h"
-#include "uri.h"
-
 #include "configfile.h"
+
+#include <setjmp.h>
+#include <sys/stat.h>
+
 #include "array.h"
-#include "dstrings.h"
+#include "hash.h"
+#include "http_client.h"
+#include "log.h"
 #include "math.h"
 #include "sys.h"
+#include "uri.h"
 
 namespace dmConfigFile
 {

--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -1,13 +1,10 @@
-#include <stdlib.h>
-#include <stdio.h>
 #include "connection_pool.h"
-#include "hashtable.h"
+
 #include "array.h"
-#include "time.h"
+#include "hash.h"
 #include "log.h"
 #include "mutex.h"
-#include "hash.h"
-#include "../axtls/ssl/os_port.h"
+#include "time.h"
 #include "../axtls/ssl/ssl.h"
 
 namespace dmConnectionPool

--- a/engine/dlib/src/dlib/connection_pool.h
+++ b/engine/dlib/src/dlib/connection_pool.h
@@ -1,8 +1,7 @@
 #ifndef DM_CONNECTION_POOL
 #define DM_CONNECTION_POOL
 
-#include <stdint.h>
-#include <dlib/socket.h>
+#include "socket.h"
 
 /**
  * Connection pooling

--- a/engine/dlib/src/dlib/crypt.cpp
+++ b/engine/dlib/src/dlib/crypt.cpp
@@ -1,9 +1,10 @@
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-#include "shared_library.h"
 #include "crypt.h"
+
+#include <assert.h>
+#include <string.h>
+
 #include "endian.h"
+#include "shared_library.h"
 
 namespace dmCrypt
 {

--- a/engine/dlib/src/dlib/dlib.cpp
+++ b/engine/dlib/src/dlib/dlib.cpp
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include "dlib.h"
 
 namespace dLib

--- a/engine/dlib/src/dlib/dstrings.cpp
+++ b/engine/dlib/src/dlib/dstrings.cpp
@@ -1,8 +1,9 @@
+#include "dstrings.h"
+
 #include <assert.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <string.h>
-
-#include "dstrings.h"
 
 #if defined(_WIN32)
 #include <stdlib.h>

--- a/engine/dlib/src/dlib/dstrings.h
+++ b/engine/dlib/src/dlib/dstrings.h
@@ -1,7 +1,7 @@
 #ifndef DM_DSTRINGS_H
 #define DM_DSTRINGS_H
 
-#include <stdio.h>
+#include <stddef.h>
 
 /**
  * Size-bounded string formating. Resulting string is guaranteed to be 0-terminated.

--- a/engine/dlib/src/dlib/easing.cpp
+++ b/engine/dlib/src/dlib/easing.cpp
@@ -1,6 +1,3 @@
-#include <assert.h>
-#include <stdio.h>
-#include <dlib/math.h>
 #include "easing.h"
 
 namespace dmEasing

--- a/engine/dlib/src/dlib/hash.cpp
+++ b/engine/dlib/src/dlib/hash.cpp
@@ -1,13 +1,10 @@
-#include <stdio.h>
-#include <stddef.h>
-#include <string.h>
-#include "dlib.h"
 #include "hash.h"
-#include "mutex.h"
-#include "hashtable.h"
-#include "array.h"
-#include "index_pool.h"
+
 #include "align.h"
+#include "array.h"
+#include "hashtable.h"
+#include "index_pool.h"
+#include "mutex.h"
 
 struct ReverseHashEntry
 {

--- a/engine/dlib/src/dlib/hashtable.h
+++ b/engine/dlib/src/dlib/hashtable.h
@@ -2,9 +2,8 @@
 #define DM_HASHTABLE_H
 
 #include <assert.h>
-#include <stdint.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 /**
  * Hashtable with chaining for collision resolution, memcpy-copy semantics and 32-bit indicies instead of pointers. (NUMA-friendly)

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -1,22 +1,20 @@
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include "dstrings.h"
 #include "http_cache.h"
-#include "log.h"
-#include "sys.h"
-#include "hashtable.h"
-#include "hash.h"
-#include "math.h"
-#include "time.h"
-#include "mutex.h"
-#include "index_pool.h"
+
 #include "array.h"
-#include "poolallocator.h"
+#include "dstrings.h"
+#include "hash.h"
+#include "hashtable.h"
+#include "index_pool.h"
+#include "log.h"
+#include "math.h"
+#include "mutex.h"
 #include "path.h"
+#include "poolallocator.h"
+#include "sys.h"
+#include "time.h"
+
+#include <errno.h>
+#include <sys/stat.h>
 
 namespace dmHttpCache
 {

--- a/engine/dlib/src/dlib/http_cache.h
+++ b/engine/dlib/src/dlib/http_cache.h
@@ -1,6 +1,9 @@
 #ifndef DM_HTTP_CACHE_H
 #define DM_HTTP_CACHE_H
 
+#include <stdint.h>
+#include <stdio.h>
+
 namespace dmHttpCache
 {
     /**

--- a/engine/dlib/src/dlib/http_cache_verify.cpp
+++ b/engine/dlib/src/dlib/http_cache_verify.cpp
@@ -1,13 +1,8 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
+#include "http_cache_verify.h"
 
+#include "http_client.h"
 #include "log.h"
 #include "time.h"
-#include "math.h"
-#include "dstrings.h"
-#include "http_cache_verify.h"
 
 namespace dmHttpCacheVerify
 {

--- a/engine/dlib/src/dlib/http_cache_verify.h
+++ b/engine/dlib/src/dlib/http_cache_verify.h
@@ -1,9 +1,8 @@
 #ifndef DM_HTTP_CACHE_VERIFY_H
 #define DM_HTTP_CACHE_VERIFY_H
 
-#include <dlib/http_client.h>
-#include <dlib/http_cache.h>
-#include <dlib/uri.h>
+#include "http_cache.h"
+#include "uri.h"
 
 namespace dmHttpCacheVerify
 {

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -1,26 +1,16 @@
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include "math.h"
-#include "./socket.h"
-#include "./socks_proxy.h"
 #include "http_client.h"
+
+#include "connection_pool.h"
+#include "dstrings.h"
 #include "http_client_private.h"
 #include "log.h"
-#include "sys.h"
-#include "dstrings.h"
-#include "uri.h"
-#include "path.h"
-#include "time.h"
-#include "connection_pool.h"
+#include "math.h"
 #include "mutex.h"
-#include "../axtls/ssl/os_port.h"
+#include "time.h"
 #include "../axtls/ssl/ssl.h"
+
+#include <assert.h>
+#include <stdlib.h>
 
 namespace dmHttpClient
 {

--- a/engine/dlib/src/dlib/http_client.h
+++ b/engine/dlib/src/dlib/http_client.h
@@ -1,9 +1,8 @@
 #ifndef DM_HTTP_CLIENT_H
 #define DM_HTTP_CLIENT_H
 
-#include <stdint.h>
-#include <dlib/socket.h>
-#include <dlib/http_cache.h>
+#include "http_cache.h"
+#include "socket.h"
 
 namespace dmHttpClient
 {

--- a/engine/dlib/src/dlib/http_client_private.cpp
+++ b/engine/dlib/src/dlib/http_client_private.cpp
@@ -1,7 +1,9 @@
+#include "http_client_private.h"
+
+#include "dstrings.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "dlib/dstrings.h"
-#include "http_client_private.h"
 
 namespace dmHttpClientPrivate
 {

--- a/engine/dlib/src/dlib/http_server.cpp
+++ b/engine/dlib/src/dlib/http_server.cpp
@@ -1,15 +1,14 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include "array.h"
-#include "log.h"
-#include "socket.h"
-#include "math.h"
-#include "time.h"
-#include "dstrings.h"
 #include "http_server.h"
+
+#include "array.h"
+#include "dstrings.h"
 #include "http_server_private.h"
+#include "log.h"
+#include "math.h"
 #include "network_constants.h"
+#include "time.h"
+
+#include <stdlib.h>
 
 namespace dmHttpServer
 {

--- a/engine/dlib/src/dlib/http_server.h
+++ b/engine/dlib/src/dlib/http_server.h
@@ -1,7 +1,7 @@
 #ifndef DM_HTTP_SERVER_H
 #define DM_HTTP_SERVER_H
 
-#include <dlib/socket.h>
+#include "socket.h"
 
 namespace dmHttpServer
 {

--- a/engine/dlib/src/dlib/http_server_private.cpp
+++ b/engine/dlib/src/dlib/http_server_private.cpp
@@ -1,7 +1,9 @@
+#include "http_server_private.h"
+
+#include "dstrings.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "dlib/dstrings.h"
-#include "http_server_private.h"
 
 namespace dmHttpServerPrivate
 {

--- a/engine/dlib/src/dlib/image.cpp
+++ b/engine/dlib/src/dlib/image.cpp
@@ -1,5 +1,6 @@
-#include <dlib/log.h>
 #include "image.h"
+
+#include "log.h"
 
 #define STBI_NO_HDR
 #define STBI_NO_STDIO

--- a/engine/dlib/src/dlib/index_pool.h
+++ b/engine/dlib/src/dlib/index_pool.h
@@ -1,10 +1,8 @@
 #ifndef DM_INDEX_POOL_H
 #define DM_INDEX_POOL_H
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <assert.h>
-
+#include <stdlib.h>
 
 /**
  * Index pool class.

--- a/engine/dlib/src/dlib/json.cpp
+++ b/engine/dlib/src/dlib/json.cpp
@@ -1,10 +1,11 @@
+#include "json.h"
+
+#include "math.h"
+#include "utf8.h"
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include "json.h"
-#include "math.h"
-#include "utf8.h"
 
 extern "C"
 {

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -1,20 +1,16 @@
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
-#include <assert.h>
-#include "dlib.h"
-#include "array.h"
-#include "dstrings.h"
 #include "log.h"
-#include "socket.h"
-#include "message.h"
-#include "thread.h"
-#include "math.h"
-#include "time.h"
-#include "path.h"
-#include "sys.h"
-#include "network_constants.h"
 
+#include "array.h"
+#include "dlib.h"
+#include "dstrings.h"
+#include "math.h"
+#include "message.h"
+#include "network_constants.h"
+#include "socket.h"
+#include "thread.h"
+#include "time.h"
+
+#include <stdarg.h>
 #ifdef ANDROID
 #include <android/log.h>
 #endif

--- a/engine/dlib/src/dlib/lz4.cpp
+++ b/engine/dlib/src/dlib/lz4.cpp
@@ -1,5 +1,5 @@
-#include <assert.h>
 #include "lz4.h"
+
 #include "../lz4/lz4.h"
 #include "../lz4/lz4hc.h"
 

--- a/engine/dlib/src/dlib/lz4.h
+++ b/engine/dlib/src/dlib/lz4.h
@@ -1,8 +1,9 @@
 #ifndef DM_LZ4LIB
 #define DM_LZ4LIB
 
-#include <stdint.h>
 #include "shared_library.h"
+
+#include <stdint.h>
 
 #define DMLZ4_MAX_OUTPUT_SIZE (1 << 30)
 

--- a/engine/dlib/src/dlib/math.h
+++ b/engine/dlib/src/dlib/math.h
@@ -5,7 +5,6 @@
 #define _USE_MATH_DEFINES
 #endif
 #include <math.h>
-#include <stdlib.h>
 #include <stdint.h>
 #if defined(_MSC_VER)
 #undef _USE_MATH_DEFINES

--- a/engine/dlib/src/dlib/md5.cpp
+++ b/engine/dlib/src/dlib/md5.cpp
@@ -1,6 +1,6 @@
-#include <stdint.h>
-#include <string.h>
 #include "md5.h"
+
+#include <string.h>
 
 // NOTE: Based on MD5 in axTLS. See licensing for axTLS
 

--- a/engine/dlib/src/dlib/md5.h
+++ b/engine/dlib/src/dlib/md5.h
@@ -1,6 +1,8 @@
 #ifndef DM_MD5
 #define DM_MD5
 
+#include <stdint.h>
+
 namespace dmMD5
 {
     /// Number of bytes in md5 checksum

--- a/engine/dlib/src/dlib/memory.cpp
+++ b/engine/dlib/src/dlib/memory.cpp
@@ -1,6 +1,8 @@
 #include "memory.h"
-#include <stdlib.h>
+
 #include <errno.h>
+#include <stdlib.h>
+
 #if defined(__ANDROID__) || defined(_MSC_VER)
 #include <malloc.h>
 #endif

--- a/engine/dlib/src/dlib/memprofile.cpp
+++ b/engine/dlib/src/dlib/memprofile.cpp
@@ -1,23 +1,23 @@
-#include <stdio.h>
-#include <assert.h>
-#include <stdint.h>
-#include <string.h>
-#include "profile.h"
 #include "memprofile.h"
 
-#if !(defined(_MSC_VER) || defined(ANDROID) || defined(__EMSCRIPTEN__) || defined(__AVM2__))
 
-#include <stdlib.h>
-#include <dlfcn.h>
-#include <execinfo.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <pthread.h>
 #include "dlib.h"
 #include "profile.h"
 #include "shared_library.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if !(defined(_MSC_VER) || defined(ANDROID) || defined(__EMSCRIPTEN__) || defined(__AVM2__))
+
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #ifdef __MACH__
 #include <malloc/malloc.h>

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -1,15 +1,11 @@
-#include <assert.h>
-#include <string.h>
 #include "message.h"
-#include "atomic.h"
-#include "hash.h"
+
+#include "condition_variable.h"
 #include "hashtable.h"
 #include "profile.h"
-#include "array.h"
-#include "mutex.h"
-#include "condition_variable.h"
-#include "dstrings.h"
-#include <dlib/static_assert.h>
+#include "static_assert.h"
+
+#include <assert.h>
 
 namespace dmMessage
 {

--- a/engine/dlib/src/dlib/message.h
+++ b/engine/dlib/src/dlib/message.h
@@ -1,10 +1,10 @@
 #ifndef DM_MESSAGE_H
 #define DM_MESSAGE_H
 
-#include <stdint.h>
-#include <dlib/hash.h>
+#include "align.h"
+#include "hash.h"
+
 #include <string.h>
-#include <dlib/align.h>
 
 namespace dmMessage
 {

--- a/engine/dlib/src/dlib/mutex.cpp
+++ b/engine/dlib/src/dlib/mutex.cpp
@@ -1,5 +1,6 @@
-#include <assert.h>
 #include "mutex.h"
+
+#include <assert.h>
 
 namespace dmMutex
 {

--- a/engine/dlib/src/dlib/object_pool.h
+++ b/engine/dlib/src/dlib/object_pool.h
@@ -2,8 +2,7 @@
 #ifndef DM_OBJECT_POOL_H
 #define DM_OBJECT_POOL_H
 
-#include <dlib/array.h>
-#include <dlib/index_pool.h>
+#include "array.h"
 
 /**
  * Object pool data-structure with the following properties

--- a/engine/dlib/src/dlib/path.cpp
+++ b/engine/dlib/src/dlib/path.cpp
@@ -1,9 +1,10 @@
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
 #include "path.h"
-#include "math.h"
+
 #include "dstrings.h"
+#include "math.h"
+
+#include <assert.h>
+#include <string.h>
 
 namespace dmPath
 {

--- a/engine/dlib/src/dlib/poolallocator.cpp
+++ b/engine/dlib/src/dlib/poolallocator.cpp
@@ -1,8 +1,8 @@
-#include <stdint.h>
-#include <assert.h>
-#include <string.h>
-#include <new>
 #include "poolallocator.h"
+
+#include <assert.h>
+#include <new>
+#include <string.h>
 
 namespace dmPoolAllocator
 {

--- a/engine/dlib/src/dlib/poolallocator.h
+++ b/engine/dlib/src/dlib/poolallocator.h
@@ -1,6 +1,8 @@
 #ifndef DM_POOL_ALLOCATOR_H
 #define DM_POOL_ALLOCATOR_H
 
+#include <stdint.h>
+
 namespace dmPoolAllocator
 {
     /**

--- a/engine/dlib/src/dlib/pprint.cpp
+++ b/engine/dlib/src/dlib/pprint.cpp
@@ -1,10 +1,11 @@
-#include <assert.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
+#include "pprint.h"
 
 #include "math.h"
-#include "pprint.h"
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
 
 namespace dmPPrint
 {

--- a/engine/dlib/src/dlib/pprint.h
+++ b/engine/dlib/src/dlib/pprint.h
@@ -1,8 +1,6 @@
 #ifndef DM_PPRINT_H
 #define DM_PPRINT_H
 
-#include <stdint.h>
-
 namespace dmPPrint
 {
     /**

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -1,17 +1,16 @@
-#include <algorithm>
-#include <string.h>
-#include "dlib.h"
+#include "profile.h"
 
-#include "hashtable.h"
+#include "array.h"
+#include "dlib.h"
+#include "dstrings.h"
 #include "hash.h"
+#include "hashtable.h"
+#include "log.h"
+#include "math.h"
 #include "spinlock.h"
 #include "stringpool.h"
-#include "math.h"
-#include "time.h"
 #include "thread.h"
-#include "dstrings.h"
-#include "array.h"
-#include "profile.h"
+#include "time.h"
 
 namespace dmProfile
 {

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -1,7 +1,10 @@
 #ifndef DM_PROFILE_H
 #define DM_PROFILE_H
 
+#include "atomic.h"
+
 #include <stdint.h>
+
 #if defined(_WIN32)
 #include "safe_windows.h"
 #elif  defined(__EMSCRIPTEN__)
@@ -9,10 +12,6 @@
 #else
 #include <sys/time.h>
 #endif
-#include <dlib/array.h>
-#include <dlib/log.h>
-#include <dlib/atomic.h>
-#include <dlib/dlib.h>
 
 #define DM_PROFILE_PASTE(x, y) x ## y
 #define DM_PROFILE_PASTE2(x, y) DM_PROFILE_PASTE(x, y)

--- a/engine/dlib/src/dlib/socket.cpp
+++ b/engine/dlib/src/dlib/socket.cpp
@@ -1,9 +1,11 @@
 #include "socket.h"
-#include "math.h"
+
 #include "dstrings.h"
 #include "log.h"
-#include <assert.h>
+#include "math.h"
+#include "socket_private.h"
 
+#include <assert.h>
 #include <fcntl.h>
 #include <string.h>
 
@@ -12,20 +14,18 @@
 #endif
 
 #if defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__) || defined(__AVM2__)
-#include <unistd.h>
-#include <sys/socket.h>
+
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #endif
 
 #if defined(_WIN32)
 #include <Winsock2.h>
 #endif
-
-#include "log.h"
-#include "socket_private.h"
 
 // Helper and utility functions
 namespace dmSocket

--- a/engine/dlib/src/dlib/socket.h
+++ b/engine/dlib/src/dlib/socket.h
@@ -1,9 +1,9 @@
 #ifndef DM_SOCKET_H
 #define DM_SOCKET_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <stdio.h>
 #include <ostream>
 
 #if defined(__linux__) || defined(__MACH__) || defined(ANDROID) || defined(__EMSCRIPTEN__) || defined(__AVM2__)

--- a/engine/dlib/src/dlib/socks_proxy.cpp
+++ b/engine/dlib/src/dlib/socks_proxy.cpp
@@ -1,6 +1,8 @@
-#include <stdlib.h>
-#include "socket.h"
 #include "socks_proxy.h"
+
+#include "socket.h"
+
+#include <stdlib.h>
 
 namespace dmSocksProxy
 {

--- a/engine/dlib/src/dlib/ssdp.cpp
+++ b/engine/dlib/src/dlib/ssdp.cpp
@@ -1,24 +1,23 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <algorithm>
-#include <string.h>
-
 #include "ssdp.h"
-#include <dlib/ssdp_private.h>
 
 #include "array.h"
 #include "dstrings.h"
-#include "socket.h"
 #include "hash.h"
 #include "hashtable.h"
-#include "time.h"
-#include "log.h"
-#include "template.h"
-#include "http_server_private.h"
 #include "http_client_private.h"
 #include "http_server.h"
+#include "http_server_private.h"
+#include "log.h"
 #include "network_constants.h"
+#include "socket.h"
+#include "ssdp_private.h"
+#include "template.h"
+#include "time.h"
+
+#include <algorithm>
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
 
 namespace dmSSDP
 {

--- a/engine/dlib/src/dlib/ssdp.h
+++ b/engine/dlib/src/dlib/ssdp.h
@@ -1,8 +1,9 @@
 #ifndef DM_SSDP
 #define DM_SSDP
 
+#include "hash.h"
+
 #include <string.h>
-#include <dlib/hash.h>
 
 /**
  * Simple Service Discovery Protocol

--- a/engine/dlib/src/dlib/ssdp_private.h
+++ b/engine/dlib/src/dlib/ssdp_private.h
@@ -1,15 +1,13 @@
 #ifndef DM_SSDP_PRIVATE
 #define DM_SSDP_PRIVATE
 
-#include <dlib/http_server_private.h>
-#include <dlib/http_client_private.h>
-#include <dlib/http_server.h>
-#include <dlib/socket.h>
-#include <dlib/array.h>
-#include <dlib/hash.h>
-#include <dlib/hashtable.h>
-#include <dlib/time.h>
-#include <dlib/template.h>
+#include "array.h"
+#include "hashtable.h"
+#include "http_client_private.h"
+#include "http_server.h"
+#include "http_server_private.h"
+#include "template.h"
+#include "time.h"
 
 namespace dmSSDP
 {

--- a/engine/dlib/src/dlib/stringpool.cpp
+++ b/engine/dlib/src/dlib/stringpool.cpp
@@ -1,10 +1,10 @@
+#include "stringpool.h"
+
+#include "hash.h"
+#include "hashtable.h"
+
 #include <assert.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include "../dlib/hash.h"
-#include "../dlib/hashtable.h"
-#include "stringpool.h"
 
 namespace dmStringPool
 {

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -1,32 +1,31 @@
-#include <assert.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <time.h>
 #include "sys.h"
-#include "log.h"
+
 #include "dstrings.h"
 #include "hash.h"
-#include "path.h"
+#include "log.h"
 #include "math.h"
+#include "path.h"
 #include "time.h"
 
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #ifdef _WIN32
+#include <direct.h>
+#include <io.h>
 #include <Shlobj.h>
 #include <Shellapi.h>
-#include <io.h>
-#include <direct.h>
 #else
-#include <unistd.h>
-#include <sys/utsname.h>
-#include <sys/mman.h>
 #include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/utsname.h>
+#include <unistd.h>
 #endif
-
-#include <sys/types.h>
-#include <sys/stat.h>
 
 #ifndef S_ISREG
 #define S_ISREG(mode) (((mode)&S_IFMT) == S_IFREG)
@@ -40,10 +39,10 @@
 #endif
 
 #ifdef __ANDROID__
-#include <jni.h>
-#include <android_native_app_glue.h>
-#include <sys/types.h>
 #include <android/asset_manager.h>
+#include <android_native_app_glue.h>
+#include <jni.h>
+#include <sys/types.h>
 // By convention we have a global variable called g_AndroidApp
 // This is currently created in glfw..
 // Application life-cycle should perhaps be part of dlib instead

--- a/engine/dlib/src/dlib/sys.h
+++ b/engine/dlib/src/dlib/sys.h
@@ -1,8 +1,9 @@
 #ifndef DM_SYS_H
 #define DM_SYS_H
 
-#include <string.h>
+#include <stdint.h>
 #include <stdlib.h> // free
+#include <string.h>
 
 namespace dmSys
 {

--- a/engine/dlib/src/dlib/template.cpp
+++ b/engine/dlib/src/dlib/template.cpp
@@ -1,8 +1,10 @@
-#include <string.h>
-#include "math.h"
 #include "template.h"
-#include "log.h"
+
 #include "dstrings.h"
+#include "log.h"
+#include "math.h"
+
+#include <string.h>
 
 namespace dmTemplate
 {

--- a/engine/dlib/src/dlib/thread.cpp
+++ b/engine/dlib/src/dlib/thread.cpp
@@ -1,5 +1,6 @@
-#include <assert.h>
 #include "thread.h"
+
+#include <assert.h>
 
 namespace dmThread
 {

--- a/engine/dlib/src/dlib/thread.h
+++ b/engine/dlib/src/dlib/thread.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 #if defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__) || defined(__AVM2__)
-#include <pthread.h>
 #include <limits.h>
+#include <pthread.h>
 #include <unistd.h>
 namespace dmThread
 {

--- a/engine/dlib/src/dlib/transform.h
+++ b/engine/dlib/src/dlib/transform.h
@@ -1,9 +1,11 @@
 #ifndef DM_TRANSFORM_H
 #define DM_TRANSFORM_H
 
-#include <assert.h>
-#include <vectormath/cpp/vectormath_aos.h>
 #include "math.h"
+
+#include <vectormath/cpp/vectormath_aos.h>
+
+#include <assert.h>
 
 namespace dmTransform
 {

--- a/engine/dlib/src/dlib/uri.cpp
+++ b/engine/dlib/src/dlib/uri.cpp
@@ -1,10 +1,12 @@
+#include "uri.h"
+
+#include "dstrings.h"
+#include "math.h"
+
 #include <assert.h>
-#include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
-#include "dlib/dstrings.h"
-#include "dlib/math.h"
-#include "dlib/uri.h"
+#include <string.h>
 
 /*
  * TODO:

--- a/engine/dlib/src/dlib/uri.h
+++ b/engine/dlib/src/dlib/uri.h
@@ -1,6 +1,8 @@
 #ifndef DM_URI_H
 #define DM_URI_H
 
+#include <stdint.h>
+
 namespace dmURI
 {
     /**

--- a/engine/dlib/src/dlib/utf8.h
+++ b/engine/dlib/src/dlib/utf8.h
@@ -2,7 +2,6 @@
 #define DM_UTF8
 
 #include <stdint.h>
-#include <stdlib.h>
 
 namespace dmUtf8
 {

--- a/engine/dlib/src/dlib/uuid.cpp
+++ b/engine/dlib/src/dlib/uuid.cpp
@@ -1,3 +1,10 @@
+#include "uuid.h"
+
+#include "log.h"
+
+#include <assert.h>
+#include <stdint.h>
+
 #ifdef _WIN32
 
 /*
@@ -12,12 +19,7 @@ typedef unsigned long (__stdcall* NtAllocateUuidsProto)(void* time  /* 8 bytes *
 
 #elif !defined(ANDROID) && !defined(__EMSCRIPTEN__) && !defined(__AVM2__)
 #include <uuid/uuid.h>
-#endif
-
-#include <stdint.h>
-#include <assert.h>
-#include "log.h"
-#include "uuid.h"
+#endif // _WIN32
 
 namespace dmUUID
 {

--- a/engine/dlib/src/dlib/uuid.h
+++ b/engine/dlib/src/dlib/uuid.h
@@ -1,6 +1,8 @@
 #ifndef DM_UUID
 #define DM_UUID
 
+#include <stdint.h>
+
 namespace dmUUID
 {
     union UUID

--- a/engine/dlib/src/dlib/vmath.h
+++ b/engine/dlib/src/dlib/vmath.h
@@ -1,11 +1,13 @@
 #ifndef DM_VMATH_H
 #define DM_VMATH_H
 
-#include <vectormath/cpp/vectormath_aos.h>
 #include "math.h"
 #include "trig_lookup.h"
 
+#include <vectormath/cpp/vectormath_aos.h>
+
 #include <assert.h>
+#include <stdlib.h>
 
 /**
  * Collection of vector math functions.

--- a/engine/dlib/src/dlib/web_server.cpp
+++ b/engine/dlib/src/dlib/web_server.cpp
@@ -1,12 +1,13 @@
-#include <string.h>
-#include <stdint.h>
-#include "hash.h"
-#include "log.h"
-#include "hashtable.h"
+#include "web_server.h"
+
 #include "array.h"
 #include "dstrings.h"
-#include "web_server.h"
+#include "hash.h"
+#include "hashtable.h"
 #include "http_server.h"
+#include "log.h"
+
+#include <string.h>
 
 namespace dmWebServer
 {

--- a/engine/dlib/src/dlib/web_server.h
+++ b/engine/dlib/src/dlib/web_server.h
@@ -1,7 +1,7 @@
 #ifndef DM_WEB_SERVER_H
 #define DM_WEB_SERVER_H
 
-#include <dlib/socket.h>
+#include "socket.h"
 
 namespace dmWebServer
 {

--- a/engine/dlib/src/dlib/webp.cpp
+++ b/engine/dlib/src/dlib/webp.cpp
@@ -1,7 +1,9 @@
-#include <assert.h>
-#include "webp/webp/decode.h"
 #include "webp.h"
-#include <dlib/log.h>
+
+#include "log.h"
+#include "webp/webp/decode.h"
+
+#include <assert.h>
 
 namespace dmWebP
 {

--- a/engine/dlib/src/dlib/webp.h
+++ b/engine/dlib/src/dlib/webp.h
@@ -1,7 +1,7 @@
 #ifndef DM_WEBP
 #define DM_WEBP
 
-#include <stdint.h>
+#include <stddef.h>
 
 namespace dmWebP
 {

--- a/engine/dlib/src/dlib/zlib.cpp
+++ b/engine/dlib/src/dlib/zlib.cpp
@@ -1,6 +1,8 @@
-#include <assert.h>
 #include "zlib.h"
+
 #include "../zlib/zlib.h"
+
+#include <assert.h>
 
 namespace dmZlib
 {


### PR DESCRIPTION
Rules:

- Corresponding header file for source file should be included first to prove that header file includes all necessary dependencies
- Only include what is necessary
- Order the includes alphabetically, first local includes, then relative includes and finally system includes
- Local header files should be included with double quotes and not include relative paths unless required
