### PR TITLE
DEFEDIT-1397 Editor2 GUI scene. Box's order issue

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1232,7 +1232,10 @@
 (def ^:private validate-particlefx-resource (partial validate-required-gui-resource "particlefx '%s' does not exist in the scene" :particlefx))
 
 (defn- move-topmost [scene]
-  (cond-> (update scene :children (partial mapv move-topmost))
+  (cond-> scene
+    (contains? scene :children)
+    (update :children (partial mapv move-topmost))
+
     (contains? scene :renderable)
     (assoc-in [:renderable :topmost?] true)))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#1906



* User facing changes
  - gui nodes now drawn topmost, ordered by gui node order (like in
  outline).

* Technical changes
  - sort nodes properly by :child-index before figuring out :index
  used for render-key
  - make sure child renderables are also make topmost
  - disregard z distance in render-key if renderable is topmost