### PR TITLE
DEFEDIT-1398 Cannot see models if using tilemaps

### DIFF
--- a/editor/src/clj/editor/gl/pass.clj
+++ b/editor/src/clj/editor/gl/pass.clj
@@ -101,7 +101,7 @@
     (.glPolygonMode GL/GL_FRONT_AND_BACK GL2/GL_FILL)
     (.glEnable GL/GL_BLEND)
     (.glBlendFunc GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)
-    (.glDisable GL/GL_DEPTH_TEST)
+    (.glEnable GL/GL_DEPTH_TEST)
     (.glDepthMask false)
     (.glDisable GL/GL_SCISSOR_TEST)
     (.glDisable GL/GL_STENCIL_TEST)


### PR DESCRIPTION
Fixes defold/editor2-issues#1628

* User facing changes
  - Models don't end up under other scene elements

* Technical changes
  - We draw transparent objects (pretty much non-models) with
  GL_DEPTH_TEST enabled, so the depth written by the opaque
  pass (models) is respected. Note that the sample 3d render script in
  the manual draws tile/particle with disabled depth testing/writing
  and then models always on top with enabled depth testing/writing. So
  using that there is still a discrepancy between what you see in the
  editor and the engine.