### PR TITLE
DEF-1081 new sprite and sound message wrappers

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -486,7 +486,7 @@ namespace dmGameSystem
                     dmMessage::URL receiver = component->m_Listener;
                     if (!GetSender(component, &sender))
                     {
-                        dmLogError("Could not send animation_done to listener because of incomplete component.");
+                        dmLogError("Could not send animation_done to listener.");
                         return;
                     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -243,7 +243,7 @@ namespace dmGameSystem
      *     local url = msg.url("#model")
      *     local play_properties = { blend_duration = 0.1 }
      *     -- first blend during 0.1 sec into the jump, then during 0.2 s into the run animation
-     *     model.play_anim(url, "open", go.PLAYBACK_ONCE_FORWARD, play_properties, anim_done)
+     *     model.play_anim(url, "jump", go.PLAYBACK_ONCE_FORWARD, play_properties, anim_done)
      * end
      * ```
      */

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -8,7 +8,9 @@
 
 #include <sound/sound.h>
 
-#include "../gamesys.h"
+#include "gamesys.h"
+#include "gamesys_ddf.h"
+#include "../gamesys_private.h"
 
 #include "script_sound.h"
 
@@ -328,6 +330,38 @@ namespace dmGameSystem
         return 1;
     }
 
+    int Sound_PlaySound(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        dmGameObject::HInstance instance = CheckGoInstance(L);
+        float delay = luaL_checknumber(L, 2);
+        float gain = luaL_checknumber(L, 3);
+
+        dmGameSystemDDF::PlaySound msg;
+        msg.m_Delay = delay;
+        msg.m_Gain = gain;
+
+        dmMessage::URL receiver;
+        dmMessage::URL sender;
+        dmScript::ResolveURL(L, 1, &receiver, &sender);
+
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+    }
+
+    int Sound_StopSound(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        dmGameObject::HInstance instance = CheckGoInstance(L);
+
+        dmGameSystemDDF::StopSound msg;
+
+        dmMessage::URL receiver;
+        dmMessage::URL sender;
+        dmScript::ResolveURL(L, 1, &receiver, &sender);
+
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+    }
+
     static const luaL_reg SOUND_FUNCTIONS[] =
     {
         {"is_music_playing", Sound_IsMusicPlaying},
@@ -338,6 +372,8 @@ namespace dmGameSystem
         {"get_groups", Sound_GetGroups},
         {"get_group_name", Sound_GetGroupName},
         {"is_phone_call_active", Sound_IsPhoneCallActive},
+        {"play_sound", Sound_PlaySound},
+        {"stop_sound", Sound_StopSound},
         {0, 0}
     };
 

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -447,7 +447,7 @@ namespace dmGameSystem
         int top = lua_gettop(L);
 
         dmGameObject::HInstance instance = CheckGoInstance(L);
-        dmhash_t id_hash = dmScript::CheckHashOrString(L, 2);
+        dmhash_t id_hash = dmScript::CheckHashOrString(L, 1);
         float gain = luaL_checknumber(L, 2);
 
         dmMessage::URL receiver;

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -366,6 +366,7 @@ namespace dmGameSystem
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        return 0;
     }
 
     /*# stop a playing a sound(s)
@@ -393,6 +394,7 @@ namespace dmGameSystem
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        return 0;
     }
 
     /*# set sound gain

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -342,7 +342,7 @@ namespace dmGameSystem
      * @param url [type:string|hash|url] the sound that should play
      * @param [play_properties] [type:table] optional table with properties:
      * `delay`
-     * : [type:number] delay in seconds before the sound starts playing, default is .
+     * : [type:number] delay in seconds before the sound starts playing, default is 0.
      *
      * `gain`
      * : [type:number] sound gain between 0 and 1, default is 1.

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -331,7 +331,7 @@ namespace dmGameSystem
     }
 
     /*# plays a sound
-     * Make the spound component play its sound. Multiple voices is support. The limit is set to 32 voices per sound component.
+     * Make the sound component play its sound. Multiple voices is supported. The limit is set to 32 voices per sound component.
      *
      * [icon:attention] Note that gain is in linear scale, between 0 and 1.
      * To get the dB value from the gain, use the formula `20 * log(gain)`.
@@ -340,22 +340,43 @@ namespace dmGameSystem
      *
      * @name sound.play_sound
      * @param url [type:string|hash|url] the sound that should play
-     * @param [delay] [type:number] delay in seconds before the sound starts playing, default is 0.
-     * @param [gain] [type:number] sound gain between 0 and 1, default is 1.
+     * @param [play_properties] [type:table] optional table with properties:
+     * `delay`
+     * : [type:number] delay in seconds before the sound starts playing, default is .
+     *
+     * `gain`
+     * : [type:number] sound gain between 0 and 1, default is 1.
+     * 
      * @examples
      *
      * Assuming the script belongs to an instance with a sound-component with id "sound", this will make the component play its sound after 1 second:
      *
      * ```lua
-     * sound.play_sound("#sound", delay = 1, gain = 0.5)
+     * sound.play_sound("#sound", { delay = 1, gain = 0.5 } )
      * ```
      */
     int Sound_PlaySound(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
         dmGameObject::HInstance instance = CheckGoInstance(L);
-        float delay = luaL_checknumber(L, 2);
-        float gain = luaL_checknumber(L, 3);
+
+        float delay = 0.0f, gain = 1.0f;
+
+        if (top > 1) // table with args
+        {
+            luaL_checktype(L, 2, LUA_TTABLE);
+            lua_pushvalue(L, 2);
+
+            lua_getfield(L, -1, "delay");
+            delay = lua_isnil(L, -1) ? 0.0 : luaL_checknumber(L, -1);
+            lua_pop(L, 1);
+
+            lua_getfield(L, -1, "gain");
+            gain = lua_isnil(L, -1) ? 1.0 : luaL_checknumber(L, -1);
+            lua_pop(L, 1);
+
+            lua_pop(L, 1);
+        }
 
         dmGameSystemDDF::PlaySound msg;
         msg.m_Delay = delay;

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -330,6 +330,26 @@ namespace dmGameSystem
         return 1;
     }
 
+    /*# plays a sound
+     * Make the spound component play its sound. Multiple voices is support. The limit is set to 32 voices per sound component.
+     *
+     * [icon:attention] Note that gain is in linear scale, between 0 and 1.
+     * To get the dB value from the gain, use the formula `20 * log(gain)`.
+     * Inversely, to find the linear value from a dB value, use the formula
+     * <code>10<sup>db/20</sup></code>.
+     *
+     * @name sound.play_sound
+     * @param url [type:string|hash|url] the sound that should play
+     * @param [delay] [type:number] delay in seconds before the sound starts playing, default is 0.
+     * @param [gain] [type:number] sound gain between 0 and 1, default is 1.
+     * @examples
+     *
+     * Assuming the script belongs to an instance with a sound-component with id "sound", this will make the component play its sound after 1 second:
+     *
+     * ```lua
+     * sound.play_sound("#sound", delay = 1, gain = 0.5)
+     * ```
+     */
     int Sound_PlaySound(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -348,6 +368,19 @@ namespace dmGameSystem
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
     }
 
+    /*# stop a playing a sound(s)
+     * Stop playing all active voices
+     *
+     * @name sound.stop_sound
+     * @param url [type:string|hash|url] the sound that should stop
+     * @examples
+     *
+     * Assuming the script belongs to an instance with a sound-component with id "sound", this will make the component stop all playing voices:
+     *
+     * ```lua
+     * sound.stop_sound("#sound")
+     * ```
+     */
     int Sound_StopSound(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -362,6 +395,46 @@ namespace dmGameSystem
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
     }
 
+    /*# set sound gain
+     * Set gain on all active playing voices of a sound.
+     *
+     * [icon:attention] Note that gain is in linear scale, between 0 and 1.
+     * To get the dB value from the gain, use the formula `20 * log(gain)`.
+     * Inversely, to find the linear value from a dB value, use the formula
+     * <code>10<sup>db/20</sup></code>.
+     *
+     * @message
+     * @name sound.set_gain
+     * @param url [type:string|hash|url] the sound to set the gain of
+     * @param [gain] [type:number] sound gain between 0 and 1, default is 1.
+     * @examples
+     *
+     * Assuming the script belongs to an instance with a sound-component with id "sound", this will set the gain to 0.5
+     *
+     * ```lua
+     * sound.set_gain("#sound", gain = 0.5)
+     * ```
+     */
+    int Sound_SetGain(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 0);
+        int top = lua_gettop(L);
+
+        dmGameObject::HInstance instance = CheckGoInstance(L);
+        dmhash_t id_hash = dmScript::CheckHashOrString(L, 2);
+        float gain = luaL_checknumber(L, 2);
+
+        dmMessage::URL receiver;
+        dmMessage::URL sender;
+        dmScript::ResolveURL(L, 1, &receiver, &sender);
+
+        dmGameSystemDDF::SetGain msg;
+        msg.m_Gain = gain;
+
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::SetGain::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::SetGain::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        return 0;
+    }
+
     static const luaL_reg SOUND_FUNCTIONS[] =
     {
         {"is_music_playing", Sound_IsMusicPlaying},
@@ -374,6 +447,7 @@ namespace dmGameSystem
         {"is_phone_call_active", Sound_IsPhoneCallActive},
         {"play_sound", Sound_PlaySound},
         {"stop_sound", Sound_StopSound},
+        {"set_gain", Sound_SetGain},
         {0, 0}
     };
 

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -338,24 +338,24 @@ namespace dmGameSystem
      * Inversely, to find the linear value from a dB value, use the formula
      * <code>10<sup>db/20</sup></code>.
      *
-     * @name sound.play_sound
+     * @name sound.play
      * @param url [type:string|hash|url] the sound that should play
      * @param [play_properties] [type:table] optional table with properties:
      * `delay`
      * : [type:number] delay in seconds before the sound starts playing, default is 0.
      *
      * `gain`
-     * : [type:number] sound gain between 0 and 1, default is 1.
+     * : [type:number] sound gain between 0 and 1, default is 1. The final gain of the sound will be a combination of this gain, the group gain and the master gain.
      * 
      * @examples
      *
      * Assuming the script belongs to an instance with a sound-component with id "sound", this will make the component play its sound after 1 second:
      *
      * ```lua
-     * sound.play_sound("#sound", { delay = 1, gain = 0.5 } )
+     * sound.play("#sound", { delay = 1, gain = 0.5 } )
      * ```
      */
-    int Sound_PlaySound(lua_State* L)
+    int Sound_Play(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
@@ -395,17 +395,18 @@ namespace dmGameSystem
     /*# stop a playing a sound(s)
      * Stop playing all active voices
      *
-     * @name sound.stop_sound
+     * @name sound.stop
      * @param url [type:string|hash|url] the sound that should stop
+     * 
      * @examples
      *
      * Assuming the script belongs to an instance with a sound-component with id "sound", this will make the component stop all playing voices:
      *
      * ```lua
-     * sound.stop_sound("#sound")
+     * sound.stop("#sound")
      * ```
      */
-    int Sound_StopSound(lua_State* L)
+    int Sound_Stop(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
         dmGameObject::HInstance instance = CheckGoInstance(L);
@@ -431,13 +432,13 @@ namespace dmGameSystem
      * @message
      * @name sound.set_gain
      * @param url [type:string|hash|url] the sound to set the gain of
-     * @param [gain] [type:number] sound gain between 0 and 1, default is 1.
+     * @param [gain] [type:number] sound gain between 0 and 1. The final gain of the sound will be a combination of this gain, the group gain and the master gain.
      * @examples
      *
      * Assuming the script belongs to an instance with a sound-component with id "sound", this will set the gain to 0.5
      *
      * ```lua
-     * sound.set_gain("#sound", gain = 0.5)
+     * sound.set_gain("#sound", 0.5)
      * ```
      */
     int Sound_SetGain(lua_State* L)
@@ -470,8 +471,8 @@ namespace dmGameSystem
         {"get_groups", Sound_GetGroups},
         {"get_group_name", Sound_GetGroupName},
         {"is_phone_call_active", Sound_IsPhoneCallActive},
-        {"play_sound", Sound_PlaySound},
-        {"stop_sound", Sound_StopSound},
+        {"play", Sound_Play},
+        {"stop", Sound_Stop},
         {"set_gain", Sound_SetGain},
         {0, 0}
     };

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -358,6 +358,8 @@ namespace dmGameSystem
     int Sound_PlaySound(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
+        int top = lua_gettop(L);
+
         dmGameObject::HInstance instance = CheckGoInstance(L);
 
         float delay = 0.0f, gain = 1.0f;

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -317,14 +317,15 @@ namespace dmGameSystem
      *   if message_id == hash("model_animation_done") then
      *     if message.id == hash("jump") then
      *       -- open animation done, chain with "run"
-     *       sprite.play_anim(url, "run")
+     *       sprite.play_animation(url, "run")
      *     end
      *   end
      * end
      * 
      * ```lua
      * function init(self)
-     *   sprite.play_animation("#sprite", "jump", anim_done)
+     *   local url = msg.url("#sprite")
+     *   sprite.play_animation(url, "jump", anim_done)
      * end
      * ```
      */

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -288,7 +288,7 @@ namespace dmGameSystem
      * the animation has completed playing. If no function is provided,
      * a [ref:animation_done] message is sent to the script that started the animation.
      * 
-     * @name sprite.play_animation
+     * @name sprite.play_flipbook
      * @param url [type:string|hash|url] the sprite that should play the animation
      * @param id hash name hash of the animation to play
      * @param [complete_function] [type:function(self, message_id, message, sender))] function to call when the animation has completed.
@@ -317,7 +317,7 @@ namespace dmGameSystem
      *   if message_id == hash("model_animation_done") then
      *     if message.id == hash("jump") then
      *       -- open animation done, chain with "run"
-     *       sprite.play_animation(url, "run")
+     *       sprite.play_flipbook(url, "run")
      *     end
      *   end
      * end
@@ -325,11 +325,11 @@ namespace dmGameSystem
      * ```lua
      * function init(self)
      *   local url = msg.url("#sprite")
-     *   sprite.play_animation(url, "jump", anim_done)
+     *   sprite.play_flipbook(url, "jump", anim_done)
      * end
      * ```
      */
-    int SpriteComp_PlayAnimation(lua_State* L)
+    int SpriteComp_PlayFlipBook(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
@@ -365,7 +365,7 @@ namespace dmGameSystem
             {"set_constant",    SpriteComp_SetConstant},
             {"reset_constant",  SpriteComp_ResetConstant},
             {"set_scale",       SpriteComp_SetScale},
-            {"play_animation",  SpriteComp_PlayAnimation},
+            {"play_flipbook",  SpriteComp_PlayFlipBook},
             {0, 0}
     };
 

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -306,6 +306,7 @@ namespace dmGameSystem
      */
     int SpriteComp_PlayAnimation(lua_State* L)
     {
+        DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
 
         dmGameObject::HInstance instance = CheckGoInstance(L);
@@ -329,7 +330,6 @@ namespace dmGameSystem
         msg.m_Id = id_hash;
 
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlayAnimation::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
-        assert(top == lua_gettop(L));
         return 0;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -281,6 +281,33 @@ namespace dmGameSystem
         return 0;
     }
 
+    /*# Play an animation on a sprite component
+     * Play an animation on a sprite component from its tile set
+     * 
+     * @name sprit.play_animation
+     * @param url [type:string|hash|url] the sprite that should play the animation
+     * @param id hash name hash of the animation to play
+     * @param callback?
+     */
+    int SpriteComp_PlayAnimation(lua_State* L)
+    {
+        int top = lua_gettop(L);
+
+        dmGameObject::HInstance instance = CheckGoInstance(L);
+        dmhash_t id_hash = dmScript::CheckHashOrString(L, 2);
+
+        dmGameSystemDDF::PlayAnimation msg;
+        msg.m_Id = id_hash;
+
+        dmMessage::URL receiver;
+        dmMessage::URL sender;
+        dmScript::ResolveURL(L, 1, &receiver, &sender);
+
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlayAnimation::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PlayAnimation::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        assert(top == lua_gettop(L));
+        return 0;
+    }
+
     static const luaL_reg SPRITE_COMP_FUNCTIONS[] =
     {
             {"set_hflip",       SpriteComp_SetHFlip},
@@ -288,6 +315,7 @@ namespace dmGameSystem
             {"set_constant",    SpriteComp_SetConstant},
             {"reset_constant",  SpriteComp_ResetConstant},
             {"set_scale",       SpriteComp_SetScale},
+            {"play_animation",  SpriteComp_PlayAnimation},
             {0, 0}
     };
 

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -284,6 +284,10 @@ namespace dmGameSystem
     /*# Play an animation on a sprite component
      * Play an animation on a sprite component from its tile set
      * 
+     * An optional completion callback function can be provided that will be called when
+     * the animation has completed playing. If no function is provided,
+     * a [ref:animation_done] message is sent to the script that started the animation.
+     * 
      * @name sprite.play_animation
      * @param url [type:string|hash|url] the sprite that should play the animation
      * @param id hash name hash of the animation to play
@@ -303,6 +307,26 @@ namespace dmGameSystem
      *
      * `sender`
      * : [type:url] The invoker of the callback: the sprite component.
+     * @examples
+     * 
+     * The following examples assumes that the model has id "sprite".
+     * 
+     * How to play the "jump" animation followed by the "run" animation:
+     * 
+     * local function anim_done(self, message_id, message, sender)
+     *   if message_id == hash("model_animation_done") then
+     *     if message.id == hash("jump") then
+     *       -- open animation done, chain with "run"
+     *       sprite.play_anim(url, "run")
+     *     end
+     *   end
+     * end
+     * 
+     * ```lua
+     * function init(self)
+     *   sprite.play_animation("#sprite", "jump", anim_done)
+     * end
+     * ```
      */
     int SpriteComp_PlayAnimation(lua_State* L)
     {


### PR DESCRIPTION
Added Lua functions that wraps messages: 

sprite.play_animation(url, id, [callback])
sound.play(url, delay, gain)
sound.stop(url)
sound.set_gain(url, gain)

Added support for optional callback sprite.play_animation AnimationDone response message.

Small correction for model.play_anim docs.