### PR TITLE
DEFEDIT-887 Local-space manipulators toggle in scene view

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -100,6 +100,7 @@
   (property tool-tab-pane TabPane)
   (property auto-pulls g/Any)
   (property active-tool g/Keyword)
+  (property manip-space g/Keyword)
 
   (input open-views g/Any :array)
   (input open-dirty-views g/Any :array)
@@ -1079,7 +1080,7 @@ If you do not specifically require different script states, consider changing th
     (.setUseSystemMenuBar menu-bar true)
     (.setTitle stage (make-title))
     (let [editor-tab-pane (TabPane.)
-          app-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph AppView :stage stage :editor-tabs-split editor-tabs-split :active-tab-pane editor-tab-pane :tool-tab-pane tool-tab-pane :active-tool :move))))]
+          app-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph AppView :stage stage :editor-tabs-split editor-tabs-split :active-tab-pane editor-tab-pane :tool-tab-pane tool-tab-pane :active-tool :move :manip-space :world))))]
       (.add (.getItems editor-tabs-split) editor-tab-pane)
       (configure-editor-tab-pane! editor-tab-pane app-scene app-view)
       (ui/observe (.focusOwnerProperty app-scene)

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -4,7 +4,7 @@
             [editor.math :as math])
   (:import [com.defold.util Geometry]
            [editor.types Rect AABB]
-           [javax.vecmath Point2d Point3d Point4d Vector4d Vector3d Quat4d Matrix4d]
+           [javax.vecmath Point2d Point3d Point4d Vector4d Vector3d Quat4d Matrix3d Matrix4d]
            [com.defold.editor.pipeline TextureSetGenerator$UVTransform]))
 
 (set! *warn-on-reflection* true)
@@ -164,6 +164,8 @@
     (.transform tfm p)
     p))
 
+(def ^Quat4d NoRotation (Quat4d. 0.0 0.0 0.0 1.0))
+(def ^Matrix3d Identity3d (doto (Matrix3d.) (.setIdentity)))
 (def ^Matrix4d Identity4d (doto (Matrix4d.) (.setIdentity)))
 
 ; -------------------------------------

--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -130,13 +130,13 @@
 (defn quat->euler [^Quat4d quat]
   (quat-components->euler (.getX quat) (.getY quat) (.getZ quat) (.getW quat)))
 
-(defn ^Vector3d rotate [^Quat4d rotation ^Vector3d v]
+(defn rotate ^Vector3d [^Quat4d rotation ^Vector3d v]
   (let [q (doto (Quat4d.) (.set (Vector4d. v)))
         _ (.mul q rotation q)
         _ (.mulInverse q rotation)]
     (Vector3d. (.getX q) (.getY q) (.getZ q))))
 
-(defn ^Vector3d transform-vector [^Matrix4d mat ^Vector3d v]
+(defn transform-vector ^Vector3d [^Matrix4d mat ^Vector3d v]
   (let [v' (Vector3d. v)]
     (.transform mat v')
     v'))

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -928,6 +928,7 @@
   (property brush g/Any (default (make-brush 0)))
 
   (input active-tool g/Keyword)
+  (input manip-space g/Keyword)
   (input camera g/Any)
   (input viewport g/Any)
   (input selected-renderables g/Any)

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -791,6 +791,7 @@
 
   ;; tool-controller contract
   (input active-tool g/Keyword)
+  (input manip-space g/Keyword)
   (input camera g/Any)
   (input viewport g/Any)
   (input selected-renderables g/Any)

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -223,6 +223,7 @@
            :render-key
            :selected
            :user-data
+           :world-rotation
            :world-transform} (set (keys renderable))))
   (is (instance? AABB (:aabb renderable)))
   (is (some? (:node-id renderable)))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -181,7 +181,7 @@
 
 (defn setup-app-view! [project]
   (let [view-graph (make-view-graph!)]
-    (-> (g/make-nodes view-graph [app-view [MockAppView :active-tool :move]]
+    (-> (g/make-nodes view-graph [app-view [MockAppView :active-tool :move :manip-space :world]]
           (g/connect project :_node-id app-view :project-id)
           (for [label [:selected-node-ids-by-resource-node :selected-node-properties-by-resource-node :sub-selections-by-resource-node]]
             (g/connect project label app-view label)))


### PR DESCRIPTION
### User-facing changes
* You can now toggle between World Space and Local Space for the Scene View manipulators from the Edit menu.

### Known issues
* Local Space manipulator axises will be wrong if negative scale is applied. To deal with this we would likely want to use separate `:position`, `:rotation` and `:scale` in place of a single `:transform` for our renderables. Note that the `math/split-mat4` function does not currently extract correct rotations from negative-scale objects either.