### PR TITLE
Removed more test data builds when using "--skip-build-tests"

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -185,6 +185,8 @@ def default_flags(self):
     opt_level = Options.options.opt_level
     if opt_level == "2" and 'web' == build_util.get_target_os() and 'js' == build_util.get_target_architecture():
         opt_level = "3" # emscripten highest opt level
+    elif opt_level == "0" and 'win' in build_util.get_target_os():
+        opt_level = "d" # how to disable optimizations in windows
 
     FLAG_ST = '/%s' if 'win' == build_util.get_target_os() else '-%s'
 

--- a/engine/engine/content/wscript
+++ b/engine/engine/content/wscript
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 import os, shutil, zipfile
-
-import Node
+import Node, Options
 
 def set_options(opt):
     pass
@@ -43,12 +42,13 @@ def build(bld):
     for d in ['fonts', 'input', 'render', 'materials', 'graphics', 'scripts']:
         bld.install_files('${PREFIX}/content/builtins/%s' % d, 'builtins/%s/*' % d)
 
-    bld.new_task_gen(name = 'bob-engine',
-                     source = bld.path.ant_glob('builtins/**'),
-                     target = 'bob-engine.jar',
-                     rule = package_bob,
-                     always = True)
-    bld.install_files('${PREFIX}/share/java', 'bob-engine.jar')
+    if not Options.options.skip_build_tests:
+        bld.new_task_gen(name = 'bob-engine',
+                         source = bld.path.ant_glob('builtins/**'),
+                         target = 'bob-engine.jar',
+                         rule = package_bob,
+                         always = True)
+        bld.install_files('${PREFIX}/share/java', 'bob-engine.jar')
 
 
 def configure(conf):

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -21,6 +21,8 @@ def build(bld):
         source = 'test_engine.cpp',
         target = 'test_engine')
 
+    obj.install_path = None
+
     # Psapi.lib is needed by ProfilerExt
     if 'win32' in bld.env.BUILD_PLATFORM:
         obj.env.append_value('LINKFLAGS', ['Psapi.lib'])
@@ -34,4 +36,3 @@ def build(bld):
                      source = '../../content/bob-engine.jar wscript',
                      always = True)
 
-    obj.install_path = None

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 import os, re
 from waf_dynamo import copy_file_task, apidoc_extract_task
+import Options
 
 def set_options(opt):
     pass
@@ -178,7 +179,8 @@ def build(bld):
         task = copy_file_task(bld, "%s/wrap_oal.dll" % src_dir)
         task.install_path = install_path
 
-    bld.add_subdirs('test')
+    if not Options.options.skip_build_tests:
+        bld.add_subdirs('test')
 
 def configure(conf):
     pass

--- a/engine/engine/wscript
+++ b/engine/engine/wscript
@@ -10,6 +10,7 @@ import os, sys, re, subprocess
 import waf_ddf, waf_graphics, waf_dynamo, waf_gamesys, waf_physics, waf_render, waf_resource
 from BuildUtility import BuildUtility, BuildUtilityException, create_build_utility
 import Logs
+import Options
 
 def init():
     pass
@@ -169,7 +170,6 @@ def build(bld):
             if (os.path.exists(filePath)):
                 bld.install_files('${PREFIX}/bin/js-web', filePath)
 
-import Options
 def shutdown():
     # unit tests disabled on win32 for now
     if sys.platform != "win32":

--- a/engine/resource/src/wscript
+++ b/engine/resource/src/wscript
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import os
+import Options
 
 def configure(conf):
     pass
@@ -27,7 +28,9 @@ def build(bld):
 
     resource.find_sources_in_dirs('../proto')
 
-    bld.add_subdirs('test')
+    if not Options.options.skip_build_tests:
+        bld.add_subdirs('test')
+
     bld.install_files('${PREFIX}/include/resource', 'resource.h')
     bld.install_files('${PREFIX}/include/resource', 'resource_archive.h')
     bld.install_files('${PREFIX}/lib/python', 'waf_resource.py')

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import os, sys, re
+import Options
 
 def configure(conf):
     pass
@@ -62,4 +63,5 @@ def build(bld):
         sound.defines = '_XBOX'
         sound_null.defines = '_XBOX'
 
-    bld.add_subdirs('test')
+    if not Options.options.skip_build_tests:
+        bld.add_subdirs('test')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -169,6 +169,7 @@ class Configuration(object):
                  skip_codesign = False,
                  skip_docs = False,
                  skip_builtins = False,
+                 skip_bob_light = False,
                  disable_ccache = False,
                  no_colors = False,
                  archive_path = None,
@@ -203,6 +204,7 @@ class Configuration(object):
         self.skip_codesign = skip_codesign
         self.skip_docs = skip_docs
         self.skip_builtins = skip_builtins
+        self.skip_bob_light = skip_bob_light
         self.disable_ccache = disable_ccache
         self.no_colors = no_colors
         self.archive_path = archive_path
@@ -741,12 +743,13 @@ class Configuration(object):
             self._build_engine_lib(args, 'dlib', 'darwin', skip_tests = True)
         if host == 'x86_64-win32' and self.target_platform != 'win32':
             self._build_engine_lib(args, 'dlib', 'win32', skip_tests = True)
-        # We must build bob-light, which builds content during the engine build
-        # There also seems to be a strange dep between having it built and building dlib for the target, even when target == host
-        for lib in ['dlib', 'texc']:
-            skip_tests = host != self.target_platform
-            self._build_engine_lib(args, lib, host, skip_tests = skip_tests)
-        self.build_bob_light()
+        if not self.skip_bob_light:
+            # We must build bob-light, which builds content during the engine build
+            # There also seems to be a strange dep between having it built and building dlib for the target, even when target == host
+            for lib in ['dlib', 'texc']:
+                skip_tests = host != self.target_platform
+                self._build_engine_lib(args, lib, host, skip_tests = skip_tests)
+            self.build_bob_light()
         # Target libs to build
         engine_libs = list(ENGINE_LIBS)
         if host != self.target_platform:
@@ -1897,6 +1900,11 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       default = False,
                       help = 'skip building builtins when building the engine. Default is false')
 
+    parser.add_option('--skip-bob-light', dest='skip_bob_light',
+                      action = 'store_true',
+                      default = False,
+                      help = 'skip building bob-light when building the engine. Default is false')
+
     parser.add_option('--disable-ccache', dest='disable_ccache',
                       action = 'store_true',
                       default = False,
@@ -1950,6 +1958,7 @@ To pass on arbitrary options to waf: build.py OPTIONS COMMANDS -- WAF_OPTIONS
                       skip_codesign = options.skip_codesign,
                       skip_docs = options.skip_docs,
                       skip_builtins = options.skip_builtins,
+                      skip_bob_light = options.skip_bob_light,
                       disable_ccache = options.disable_ccache,
                       no_colors = options.no_colors,
                       archive_path = options.archive_path,


### PR DESCRIPTION
Added "--skip-bob-light" flag to skip building bob -light when you know you already have it
Fixed "/Od" for windows builds when using "--opt-level=0"
Build went from 120s to 50s on my iMac.