### PR TITLE
DEF-3336 lua callback double delete

### DIFF
--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -479,7 +479,7 @@ namespace dmScript
             InvokeCallback(callback, LuaTimerCallbackArgsCB, &args);
         }
 
-        if (event_type != TIMER_EVENT_TRIGGER_WILL_REPEAT)
+        if ((event_type != TIMER_EVENT_TRIGGER_WILL_REPEAT) && IsValidCallback(callback))
         {
             DeleteCallback(callback);
         }


### PR DESCRIPTION
If the InvokeCallback function calls timer.cancel() the callback will already be deleted and should be deleted again