### PR TITLE
DEF-3095 Bitmap font outline respects width

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -156,7 +156,7 @@ public class Fontc {
 
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
-            outlineStroke = new BasicStroke((float)Math.ceil(fontDesc.getOutlineWidth() * 2.0));
+            outlineStroke = new BasicStroke(fontDesc.getOutlineWidth() * 2.0f);
         }
 
         font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
@@ -285,7 +285,7 @@ public class Fontc {
         float sdf_spread = 0.0f;
         float edge = 0.75f;
         if (fontDesc.getAntialias() != 0)
-            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)Math.ceil(fontDesc.getOutlineWidth());
+            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)(fontDesc.getOutlineWidth());
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -156,7 +156,7 @@ public class Fontc {
 
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
-            outlineStroke = new BasicStroke(fontDesc.getOutlineWidth());
+            outlineStroke = new BasicStroke((float)Math.ceil(fontDesc.getOutlineWidth() * 2.0));
         }
 
         font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
@@ -285,7 +285,7 @@ public class Fontc {
         float sdf_spread = 0.0f;
         float edge = 0.75f;
         if (fontDesc.getAntialias() != 0)
-            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)Math.ceil(fontDesc.getOutlineWidth() * 0.5f);
+            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)Math.ceil(fontDesc.getOutlineWidth());
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
 

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -287,14 +287,15 @@
             (.clearRect 0 0 (.getWidth image) (.getHeight image))
             (.translate dx dy))]
     (if antialias
-      (let [^Shape outline (.getOutline glyph-vector 0 0)]
+      (let [^Shape outline (.getOutline glyph-vector 0 0)
+            stroke-width (* 2.0 font-desc-outline-width)]
         (when (> font-desc-shadow-alpha 0.0)
           (when (> font-desc-alpha 0.0)
             (.setPaint g (Color. 0.0 0.0 (* font-desc-shadow-alpha font-desc-alpha)))
             (.fill g outline))
           (when (and (> font-desc-outline-width 0.0)
                      (> font-desc-outline-alpha 0.0))
-            (let [outline-stroke (BasicStroke. font-desc-outline-width)]
+            (let [outline-stroke (BasicStroke. stroke-width)]
               (.setPaint g (Color. 0.0 0.0 (* font-desc-shadow-alpha font-desc-outline-alpha)))
               (.setStroke g outline-stroke)
               (.draw g outline)))
@@ -304,7 +305,7 @@
         (.setComposite g blend-composite)
         (when (and (> font-desc-outline-width 0.0)
                    (> font-desc-outline-alpha 0.0))
-          (let [outline-stroke (BasicStroke. font-desc-outline-width)]
+          (let [outline-stroke (BasicStroke. stroke-width)]
             (.setPaint g outline-color)
             (.setStroke g outline-stroke)
             (.draw g outline)))
@@ -378,7 +379,7 @@
         font-metrics (font-metrics font)
         padding (if antialias
                   (+ (min (int 4) ^int (:shadow-blur font-desc))
-                     (int (Math/ceil (* ^double (:outline-width font-desc) 0.5))))
+                     (int (:outline-width font-desc)))
                   0)
         glyph-cell-padding 1
         channel-count (if (and (> ^double (:outline-width font-desc) 0.0)
@@ -517,7 +518,7 @@
         semi-glyphs (ttf-semi-glyphs font-desc font antialias)
         font-metrics (font-metrics font)
         padding (+ (int (if antialias
-                          (Math/ceil (* ^double (:outline-width font-desc) 0.5))
+                          (int (:outline-width font-desc))
                           0))
                    1)
         channel-count 1

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -160,7 +160,7 @@ public class Fontc {
 
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
-            outlineStroke = new BasicStroke((float)Math.ceil(fontDesc.getOutlineWidth() * 2.0));
+            outlineStroke = new BasicStroke(fontDesc.getOutlineWidth() * 2.0f);
         }
 
         font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
@@ -290,7 +290,7 @@ public class Fontc {
         float edge = 0.75f;
         int shadowBlur = fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? 0 : fontDesc.getShadowBlur();
         if (fontDesc.getAntialias() != 0)
-            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)Math.ceil(fontDesc.getOutlineWidth());
+            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)(fontDesc.getOutlineWidth());
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
 

--- a/editor/src/java/com/defold/editor/pipeline/Fontc.java
+++ b/editor/src/java/com/defold/editor/pipeline/Fontc.java
@@ -160,7 +160,7 @@ public class Fontc {
 
 
         if (fontDesc.getOutlineWidth() > 0.0f) {
-            outlineStroke = new BasicStroke(fontDesc.getOutlineWidth());
+            outlineStroke = new BasicStroke((float)Math.ceil(fontDesc.getOutlineWidth() * 2.0));
         }
 
         font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
@@ -290,7 +290,7 @@ public class Fontc {
         float edge = 0.75f;
         int shadowBlur = fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD ? 0 : fontDesc.getShadowBlur();
         if (fontDesc.getAntialias() != 0)
-            padding = Math.min(4, shadowBlur) + (int)Math.ceil(fontDesc.getOutlineWidth() * 0.5f);
+            padding = Math.min(4, fontDesc.getShadowBlur()) + (int)Math.ceil(fontDesc.getOutlineWidth());
         if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD) {
             padding++; // to give extra range for the outline.
 


### PR DESCRIPTION
Setting outline width to 1 now renders a 1 pixel outline instead of a 0.5 pixel outline in bitmap fonts.
Adjusted padding to match (which fixes clipping on distance field fonts with outlines)

Also updated the reference file editor/src/java/com/defold/editor/pipeline/Fontc.java to match just for completeness.