### PR TITLE
Ed2 review fixes

### DIFF
--- a/editor/src/clj/editor/form_view.clj
+++ b/editor/src/clj/editor/form_view.clj
@@ -215,7 +215,6 @@
                             (update-fn file)))]
     (ui/add-style! box "composite-property-control-container")
     (ui/on-action! browse-button (fn [_] (when-let [file (dialogs/make-file-dialog (or title "Select File") filter nil (.getWindow (.getScene browse-button)))]
-
                                            (set path (.getAbsolutePath file)))))
     (ui/on-action! text commit-fn)
     (ui/auto-commit! text commit-fn)

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -91,11 +91,7 @@
               bob-project (Project. (DefaultFileSystem.) proj-path "build/default")]
           (doseq [[key val] bob-args]
             (.setOption bob-project key val))
-          "If \"Publish Live Update content\" was checked, add corresponding flag to bob"
-          (.setOption bob-project "liveupdate" (let [shouldPublish? (.hasOption bob-project "liveupdate")]
-                                                    (if shouldPublish?
-                                                      "true"
-                                                      "false")))
+          (.setOption bob-project "liveupdate" (.option bob-project "liveupdate" "no"))
           (let [scanner (ClassLoaderScanner.)]
             (doseq [pkg ["com.dynamo.bob" "com.dynamo.bob.pipeline"]]
               (.scan bob-project scanner pkg)))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -82,7 +82,7 @@
     (assoc :type :list :element {:type :url :default "http://url.to/library"})
 
     (= :comma-separated-list (:type setting))
-    (assoc :type :list :element {:type :string :default (or (:default setting) ("item1, item2"))})))
+    (assoc :type :list :element {:type :string :default (or (:default setting) "item1, item2")})))
 
 (defn- make-form-section [category-name category-info settings]
   {:title (or (:title category-info) category-name)


### PR DESCRIPTION
* Fixed default string value for engine-versions comma separated list
* Fixed liveupdate args passed to bob when bundling
* Removed newlines and whitespaces