### PR TITLE
DEF-3361 Profiler cleanup

### DIFF
--- a/engine/dlib/src/dlib/memprofile.cpp
+++ b/engine/dlib/src/dlib/memprofile.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "profile.h"
 #include "memprofile.h"
+#include "dlib.h"
 
 #if !(defined(_MSC_VER) || defined(ANDROID) || defined(__EMSCRIPTEN__) || defined(__AVM2__))
 
@@ -15,7 +16,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <pthread.h>
-#include "dlib.h"
 #include "profile.h"
 #include "shared_library.h"
 

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -303,12 +303,10 @@ namespace dmMessage
         memset((void*)&url, 0, sizeof(URL));
     }
 
-    uint32_t g_MessagesHash = dmHashString32("Messages");
-
     Result Post(const URL* sender, const URL* receiver, dmhash_t message_id, uintptr_t user_data, uintptr_t descriptor, const void* message_data, uint32_t message_data_size, MessageDestroyCallback destroy_callback)
     {
         DM_PROFILE(Message, "Post")
-        DM_COUNTER_HASH("Messages", g_MessagesHash, 1)
+        DM_COUNTER("Messages", 1)
 
         if (receiver == 0x0)
         {

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <string.h>
 #include "dlib.h"
+#include "log.h"
 
 #include "hashtable.h"
 #include "hash.h"

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -2,10 +2,7 @@
 #define DM_PROFILE_H
 
 #include <stdint.h>
-#include <dlib/array.h>
-#include <dlib/log.h>
 #include <dlib/atomic.h>
-#include <dlib/dlib.h>
 
 #define DM_PROFILE_PASTE(x, y) x ## y
 #define DM_PROFILE_PASTE2(x, y) DM_PROFILE_PASTE(x, y)

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -21,25 +21,15 @@
 
 /**
  * Profile counter macro
- * name is the counter name
+ * name is the counter name - must be a static string constant or an internalized string
  * amount is the amount (integer) to add to the specific counter.
  */
 #define DM_COUNTER(name, amount)
 #undef DM_COUNTER
 
-/**
- * Profile counter macro. Fast version of #DM_COUNTER
- * name is the counter name
- * name_hash is the prehashed name
- * amount is the amount (integer) to add to the specific counter.
- */
-#define DM_COUNTER_HASH(name, name_hash, amount)
-#undef DM_COUNTER_HASH
-
 #if defined(NDEBUG)
     #define DM_PROFILE(scope_name, name)
     #define DM_COUNTER(name, amount)
-    #define DM_COUNTER_HASH(name, name_hash, amount)
 #else
     #define DM_PROFILE(scope_name, name) \
         static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = 0; \
@@ -52,9 +42,6 @@
 
     #define DM_COUNTER(name, amount) \
     dmProfile::AddCounter(name, amount);
-
-    #define DM_COUNTER_HASH(name, name_hash, amount) \
-    dmProfile::AddCounterHash(name, name_hash, amount);
 
 #endif
 
@@ -242,19 +229,11 @@ namespace dmProfile
     const char* Internalize(const char* string);
 
     /**
-     * Add #amount to counter with #name
-     * @param name Counter name
+     * Add #amount to counter with #name.
+     * @param name Counter name - must be a static string constant or an internalized string
      * @param amount Amount to add
      */
     void AddCounter(const char* name, uint32_t amount);
-
-    /**
-     * Add #amount to counter with prehashed name. Faster version of #AddCounter
-     * @param name Counter name
-     * @param name Counter name hash
-     * @param amount Amount to add
-     */
-    void AddCounterHash(const char* name, uint32_t name_hash, uint32_t amount);
 
     /**
      * Get time for the frame total

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -241,12 +241,11 @@ TEST(dmProfile, Counter1)
     dmProfile::Finalize();
 }
 
-uint32_t g_c1hash = dmHashString32("c1");
 void CounterThread(void* arg)
 {
     for (int i = 0; i < 2000; ++i)
     {
-        DM_COUNTER_HASH("c1", g_c1hash, 1);
+        DM_COUNTER("c1", 1);
     }
 }
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1077,14 +1077,12 @@ static void LogFrameBufferError(GLenum status)
         CHECK_GL_ERROR
     }
 
-    uint32_t g_DrawCallsHash = dmHashString32("DrawCalls");
-
     void DrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer)
     {
         assert(context);
         assert(index_buffer);
         DM_PROFILE(Graphics, "DrawElements");
-        DM_COUNTER_HASH("DrawCalls", g_DrawCallsHash, 1);
+        DM_COUNTER("DrawCalls", 1);
 
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
         CHECK_GL_ERROR
@@ -1097,7 +1095,7 @@ static void LogFrameBufferError(GLenum status)
     {
         assert(context);
         DM_PROFILE(Graphics, "Draw");
-        DM_COUNTER_HASH("DrawCalls", g_DrawCallsHash, 1);
+        DM_COUNTER("DrawCalls", 1);
         glDrawArrays(prim_type, first, count);
         CHECK_GL_ERROR
     }


### PR DESCRIPTION
Removed platform specific includes in header.

Moved init/deinit into internal implementation, when profiling is off it is as fast as before, if profiling is on the overhead in init is still one method call (assuming GetNowTicks() and AllocateSample() is inlined), overhead In destructor adds a overhead of a method call.

Replaced string hashing with faster pointer based hashes, name of scopes/counters are already required to be static or internalised.

Removed DM_COUNTER_HASH since hashing a counter/scope name is now very fast (one shift + one multiply).