### PR TITLE
DEF-3249 - Mismatch in precision keywords between builtin "model.vp" and "model.fp".

### DIFF
--- a/engine/engine/content/builtins/materials/model.fp
+++ b/engine/engine/content/builtins/materials/model.fp
@@ -5,7 +5,6 @@ varying mediump vec4 var_light;
 
 uniform lowp sampler2D tex0;
 uniform lowp vec4 tint;
-uniform lowp vec4 light;
 
 void main()
 {


### PR DESCRIPTION
The uniform `light` was defined as `mediump` in `model.vp` but `lowp` in `model.fp`. Since `light` was not used in the fragment shader, we simply remove the duplicate/conflicting definition.

HTML5 builds did not like conflicting precision on the same uniform.