### PR TITLE
 DEFEDIT-1419 Close open editor tabs when deleting resources

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1146,9 +1146,6 @@ If you do not specifically require different script states, consider changing th
             refresh-timer (ui/->timer "refresh-app-view"
                                       (fn [_ _]
                                         (when-not (ui/ui-disabled?)
-                                          (let [tab-panes (.getItems editor-tabs-split)
-                                                open-views (g/node-value app-view :open-views)]
-                                            (remove-invalid-tabs! tab-panes open-views))
                                           (let [refresh-requested? (ui/user-data app-scene ::ui/refresh-requested?)
                                                 tick (.getAndIncrement refresh-tick)]
                                             (when refresh-requested?

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -96,8 +96,9 @@
 (defn- find-tab [^TabPane tabs id]
   (some #(and (= id (.getId ^Tab %)) %) (.getTabs tabs)))
 
-(defn- handle-resource-changes! [app-scene changes-view]
+(defn- handle-resource-changes! [app-scene tab-panes open-views changes-view]
   (ui/user-data! app-scene ::ui/refresh-requested? true)
+  (app-view/remove-invalid-tabs! tab-panes open-views)
   (changes-view/refresh! changes-view))
 
 (defn- install-pending-update-check-timer! [^Stage stage ^Label label update-context]
@@ -213,7 +214,9 @@
 
       (workspace/add-resource-listener! workspace (reify resource/ResourceListener
                                                     (handle-changes [_ _ _]
-                                                      (handle-resource-changes! scene changes-view))))
+                                                      (let [open-views (g/node-value app-view :open-views)
+                                                            panes (.getItems ^SplitPane editor-tabs-split)]
+                                                        (handle-resource-changes! scene panes open-views changes-view)))))
 
       (ui/run-later
         (app-view/restore-split-positions! stage prefs))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -96,8 +96,8 @@
 (defn- find-tab [^TabPane tabs id]
   (some #(and (= id (.getId ^Tab %)) %) (.getTabs tabs)))
 
-(defn- handle-resource-changes! [tab-panes open-views changes-view]
-  (app-view/remove-invalid-tabs! tab-panes open-views)
+(defn- handle-resource-changes! [app-scene changes-view]
+  (ui/user-data! app-scene ::ui/refresh-requested? true)
   (changes-view/refresh! changes-view))
 
 (defn- install-pending-update-check-timer! [^Stage stage ^Label label update-context]
@@ -213,9 +213,7 @@
 
       (workspace/add-resource-listener! workspace (reify resource/ResourceListener
                                                     (handle-changes [_ _ _]
-                                                      (let [open-views (g/node-value app-view :open-views)
-                                                            panes (.getItems ^SplitPane editor-tabs-split)]
-                                                        (handle-resource-changes! panes open-views changes-view)))))
+                                                      (handle-resource-changes! scene changes-view))))
 
       (ui/run-later
         (app-view/restore-split-positions! stage prefs))

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -57,6 +57,7 @@
   (output dirty? g/Bool (g/fnk [cleaned-save-value source-value editable?]
                           (and editable? (some? cleaned-save-value) (not= cleaned-save-value source-value))))
   (output node-id+resource g/Any :unjammable (g/fnk [_node-id resource] [_node-id resource]))
+  (output valid-node-id+resource g/Any (g/fnk [_node-id resource] [_node-id resource])) ; Jammed when defective.
   (output own-build-errors g/Any (g/constantly nil))
   (output build-targets g/Any (g/constantly []))
   (output node-outline outline/OutlineData :cached

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1546,7 +1546,7 @@
                                                                                       (when-let [handler-ctx (handler/active (:command new) command-contexts (:user-data new))]
                                                                                         (when (handler/enabled? handler-ctx)
                                                                                           (handler/run handler-ctx)
-                                                                                          (refresh scene)))))))
+                                                                                          (user-data! scene ::refresh-requested? true)))))))
                                                    (.add (.getChildren hbox) (jfx/get-image-view (:icon menu-item) 16))
                                                    (.add (.getChildren hbox) cb)
                                                    hbox)
@@ -1569,7 +1569,7 @@
                                                                             (when-let [handler-ctx (handler/active command command-contexts user-data)]
                                                                               (when (handler/enabled? handler-ctx)
                                                                                 (handler/run handler-ctx)
-                                                                                (refresh scene)))))))
+                                                                                (user-data! scene ::refresh-requested? true)))))))
                                                    button)))]
                           (when command
                             (.setId child (name command)))

--- a/editor/src/clj/editor/view.clj
+++ b/editor/src/clj/editor/view.clj
@@ -17,5 +17,5 @@
 (defn connect-resource-node [view resource-node]
   (concat
     (g/connect resource-node :_node-id view :resource-node)
-    (g/connect resource-node :node-id+resource view :node-id+resource)
+    (g/connect resource-node :valid-node-id+resource view :node-id+resource)
     (g/connect resource-node :dirty? view :dirty?)))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -198,7 +198,6 @@
   (let [node-id (project/get-resource-node project path)
         views-by-node-id (let [views (g/node-value app-view :open-views)]
                            (zipmap (map :resource-node (vals views)) (keys views)))
-        resource (g/node-value node-id :resource)
         view (get views-by-node-id node-id)]
     (if view
       (do
@@ -209,7 +208,7 @@
         (g/transact
           (concat
             (g/connect node-id :_node-id view :resource-node)
-            (g/connect node-id :node-id+resource view :node-id+resource)
+            (g/connect node-id :valid-node-id+resource view :node-id+resource)
             (g/connect view :view-data app-view :open-views)
             (g/set-property app-view :active-view view)))
         (app-view/select! app-view [node-id])


### PR DESCRIPTION
Fixes defold/editor2-issues#2066
Fixes defold/editor2-issues#2072
Fixes defold/editor2-issues#2085
Fixes defold/editor2-issues#2086
Fixes defold/editor2-issues#2087
Fixes defold/editor2-issues#2091
Fixes defold/editor2-issues#2101
Fixes defold/editor2-issues#2105
Fixes defold/editor2-issues#2122

### Technical changes
* Merged app-view UI refresh timers into a single timer in order to guarantee the update order of UI elements. This ensures invalid editor tabs have been closed before evaluating handlers.