### PR TITLE
Small rewrite to avoid tons of warnings when building android

### DIFF
--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -301,6 +301,7 @@ namespace dmProfile
         {
             if (!g_IsInitialized)
             {
+                m_Sample = 0;
                 return;
             }
 
@@ -323,7 +324,7 @@ namespace dmProfile
 
         inline ~ProfileScope()
         {
-            if (!g_IsInitialized)
+            if (m_Sample == 0)
             {
                 return;
             }


### PR DESCRIPTION
Keep getting “variable may not be initialised” warning on m_Sample on each profile scope use