### PR TITLE
DEF-3138 reset group gain when silence

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1031,7 +1031,7 @@ namespace dmSound
         }
     }
 
-    static Result MixInstances(const MixContext* mix_context) {
+    static void MixInstances(const MixContext* mix_context) {
         DM_PROFILE(Sound, "MixInstances")
         SoundSystem* sound = g_SoundSystem;
 
@@ -1067,23 +1067,18 @@ namespace dmSound
             }
         }
 
-        uint32_t num_playing = 0;
         uint32_t instances = sound->m_Instances.Size();
         for (uint32_t i = 0; i < instances; ++i) {
             SoundInstance* instance = &sound->m_Instances[i];
             if (instance->m_Playing || instance->m_FrameCount > 0)
             {
                 MixInstance(mix_context, instance);
-                num_playing += dmSound::IsMuted(instance) ? 0 : 1;
             }
 
             if (instance->m_EndOfStream && instance->m_FrameCount == 0) {
                 instance->m_Playing = 0;
             }
-
         }
-
-        return num_playing > 0 ? RESULT_OK : RESULT_NOTHING_TO_PLAY;
     }
 
     static void Master(const MixContext* mix_context) {
@@ -1190,7 +1185,7 @@ namespace dmSound
         uint32_t total_buffers = free_slots;
         while (free_slots > 0) {
             MixContext mix_context(current_buffer, total_buffers);
-            Result result = MixInstances(&mix_context);
+            MixInstances(&mix_context);
 
             // DEF-3130 Don't request the audio focus when we know nothing it being played
             // This allows the client to check for sound.is_music_playing() and mute sounds accordingly

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1091,19 +1091,35 @@ namespace dmSound
         SoundGroup* master = &sound->m_Groups[*master_index];
         float* mix_buffer = master->m_MixBuffer;
 
+        if (master->m_Gain.IsZero())
+        {
+            memset(out, 0, n * sizeof(float) * 2);
+            return;
+        }
+
         for (uint32_t i = 0; i < MAX_GROUPS; i++) {
             SoundGroup* g = &sound->m_Groups[i];
+            if (g->m_MixBuffer == 0x0)
+            {
+                continue;
+            }
+            if (g->m_NameHash == MASTER_GROUP_HASH)
+            {
+                continue;
+            }
+            if (g->m_Gain.IsZero())
+            {
+                continue;
+            }
             Ramp ramp = GetRamp(mix_context, &g->m_Gain, n);
-            if (g->m_MixBuffer && g->m_NameHash != MASTER_GROUP_HASH) {
-                for (uint32_t i = 0; i < n; i++) {
-                    float gain = ramp.GetValue(i);
-                    gain = dmMath::Clamp(gain, 0.0f, 1.0f);
+            for (uint32_t i = 0; i < n; i++) {
+                float gain = ramp.GetValue(i);
+                gain = dmMath::Clamp(gain, 0.0f, 1.0f);
 
-                    float s1 = g->m_MixBuffer[2 * i];
-                    float s2 = g->m_MixBuffer[2 * i + 1];
-                    mix_buffer[2 * i] += s1 * gain;
-                    mix_buffer[2 * i + 1] += s2 * gain;
-                }
+                float s1 = g->m_MixBuffer[2 * i];
+                float s2 = g->m_MixBuffer[2 * i + 1];
+                mix_buffer[2 * i] += s1 * gain;
+                mix_buffer[2 * i + 1] += s2 * gain;
             }
         }
 


### PR DESCRIPTION
Reset group gain if no sound instances are playing in the group when setting the group gain.
Also, always get audio focus if we are queueing audio to the device.