### PR TITLE
Reduce compiler warnings

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -287,7 +287,7 @@ def default_flags(self):
                 '-L%s' % stl_lib])
     elif 'web' == build_util.get_target_os() and 'js' == build_util.get_target_architecture():
         for f in ['CCFLAGS', 'CXXFLAGS']:
-            self.env.append_value(f, ['-DGL_ES_VERSION_2_0', '-DGOOGLE_PROTOBUF_NO_RTTI', '-fno-exceptions', '-fno-rtti', '-Wno-warn-absolute-paths', '-D__STDC_LIMIT_MACROS', '-DDDF_EXPOSE_DESCRIPTORS',
+            self.env.append_value(f, ['-DGL_ES_VERSION_2_0', '-DGOOGLE_PROTOBUF_NO_RTTI', '-fno-exceptions', '-fno-rtti', '-D__STDC_LIMIT_MACROS', '-DDDF_EXPOSE_DESCRIPTORS',
                                       '-DGTEST_USE_OWN_TR1_TUPLE=1', '-Wall', '-s', 'EXPORTED_FUNCTIONS=["_JSWriteDump", "_main"]',
                                       '-I%s/system/lib/libcxxabi/include' % EMSCRIPTEN_ROOT]) # gtest uses cxxabi.h and for some reason, emscripten doesn't find it (https://github.com/kripken/emscripten/issues/3484)
 

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -267,7 +267,7 @@ def default_flags(self):
                                       '-fpic', '-ffunction-sections', '-fstack-protector',
                                       '-D__ARM_ARCH_5__', '-D__ARM_ARCH_5T__', '-D__ARM_ARCH_5E__', '-D__ARM_ARCH_5TE__', '-DGOOGLE_PROTOBUF_NO_RTTI',
                                       '-Wno-psabi', '-march=armv7-a', '-mfloat-abi=softfp', '-mfpu=vfp', '-fvisibility=hidden',
-                                      '-fomit-frame-pointer', '-fno-strict-aliasing', '-finline-limit=64', '-fno-exceptions', '-fno-rtti', '-funwind-tables',
+                                      '-fomit-frame-pointer', '-fno-strict-aliasing', '-finline-limit=64', '-fno-exceptions', '-funwind-tables',
                                       '-I%s/android-ndk-r%s/sources/android/native_app_glue' % (ANDROID_ROOT, ANDROID_NDK_VERSION),
                                       '-I%s/android-ndk-r%s/sources/android/cpufeatures' % (ANDROID_ROOT, ANDROID_NDK_VERSION),
                                       '-I%s/tmp/android-ndk-r%s/platforms/android-%s/arch-arm/usr/include' % (ANDROID_ROOT, ANDROID_NDK_VERSION, ANDROID_NDK_API_VERSION),
@@ -275,6 +275,8 @@ def default_flags(self):
                                       '-I%s' % stl_arch,
                                       '--sysroot=%s' % sysroot,
                                       '-DANDROID', '-Wa,--noexecstack'])
+            if f == 'CXXFLAGS':
+                self.env.append_value(f, ['-fno-rtti'])
 
         # TODO: Should be part of shared libraries
         # -Wl,-soname,libnative-activity.so -shared

--- a/engine/adtruth/src/adtruth_android.cpp
+++ b/engine/adtruth/src/adtruth_android.cpp
@@ -162,7 +162,7 @@ static void RunLoadCallback(lua_State* L, int callback, int self, const char* er
 
         PushError(L, error);
 
-        int ret = dmScript::PCall(L, 2, 0);
+        (void)dmScript::PCall(L, 2, 0);
         assert(top == lua_gettop(L));
     } else {
         dmLogError("No callback set");

--- a/engine/adtruth/src/adtruth_ios.mm
+++ b/engine/adtruth/src/adtruth_ios.mm
@@ -126,7 +126,7 @@ static int AdTruth_Load(lua_State* L)
 {
     int top = lua_gettop(L);
 
-    const const char* url = luaL_checkstring(L, 1);
+    const char* url = luaL_checkstring(L, 1);
 
     if (g_AdTruth.m_Callback != LUA_NOREF) {
         dmScript::Unref(L, LUA_REGISTRYINDEX, g_AdTruth.m_Callback);

--- a/engine/crash/src/backtrace_android.cpp
+++ b/engine/crash/src/backtrace_android.cpp
@@ -138,12 +138,12 @@ namespace dmCrash
         g_AppState.m_Signum = signo;
 
         uint32_t offset = 0;
-        for (int i = 0;i < dmMath::Min(g_AppState.m_PtrCount, AppState::PTRS_MAX); ++i)
+        for (uint32_t i = 0;i < dmMath::Min(g_AppState.m_PtrCount, AppState::PTRS_MAX); ++i)
         {
             // Write each pointer on a separate line, much like backtrace_symbols_fd.
             char stacktrace[128] = { 0 };
             int written = snprintf(stacktrace, sizeof(stacktrace), "#%d %p\n", i, g_AppState.m_Ptr[i]);
-            if (written > 0 && written < sizeof(stacktrace))
+            if (written > 0 && (size_t)written < sizeof(stacktrace))
             {
                 uint32_t stacktrace_length = strnlen(stacktrace, sizeof(stacktrace));
                 if (offset + stacktrace_length < dmCrash::AppState::EXTRA_MAX - 1)

--- a/engine/dlib/src/axtls/ssl/os_port.h
+++ b/engine/dlib/src/axtls/ssl/os_port.h
@@ -160,7 +160,9 @@ EXP_FUNC int STDCALL ax_open(const char *pathname, int flags);
 	#else
 		#error "Unsupported platform"
 	#endif
-	#define be64toh(x) ((((uint64_t)ntohl(x)) << 32) | ntohl(x >> 32))
+	#if !defined(be64toh)
+		#define be64toh(x) ((((uint64_t)ntohl(x)) << 32) | ntohl(x >> 32))
+	#endif
 #else
 	#define be64toh(x) (x)
 #endif

--- a/engine/dlib/src/axtls/ssl/os_port.h
+++ b/engine/dlib/src/axtls/ssl/os_port.h
@@ -103,7 +103,6 @@ extern "C" {
 #define strdup(A)               _strdup(A)
 #define chroot(A)               _chdir(A)
 #define chdir(A)                _chdir(A)
-#define alloca(A)               _alloca(A)
 #ifndef lseek
 #define lseek(A,B,C)            _lseek(A,B,C)
 #endif

--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -10,7 +10,6 @@
 
 #if defined(_WIN32)
 #include <malloc.h>
-#define alloca(_SIZE) _alloca(_SIZE)
 #endif
 
 #include <stdio.h>

--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -311,7 +311,7 @@ namespace dmConnectionPool
         }
 
         uint64_t handshakestart = dmTime::GetTime();
-        if( timeout > 0 && (handshakestart - connectstart) > timeout )
+        if( timeout > 0 && (handshakestart - connectstart) > (uint64_t)timeout )
         {
             r = RESULT_SOCKET_ERROR;
             dmSocket::Delete(c->m_Socket);

--- a/engine/dlib/src/dlib/hashtable.h
+++ b/engine/dlib/src/dlib/hashtable.h
@@ -198,7 +198,7 @@ public:
             uint32_t entry_ptr = m_HashTable[bucket_index];
             if (entry_ptr == 0xffffffff)
             {
-                m_HashTable[bucket_index] = entry - m_InitialEntries; // Store the index of the entry
+                m_HashTable[bucket_index] = (uint32_t)(uintptr_t)(entry - m_InitialEntries); // Store the index of the entry
             }
             else
             {
@@ -212,7 +212,7 @@ public:
                 assert(prev_entry->m_Next == 0xffffffff);
 
                 // Link prev entry to this
-                prev_entry->m_Next = entry - m_InitialEntries;
+                prev_entry->m_Next = (uint32_t)(uintptr_t)(entry - m_InitialEntries);
             }
         }
 
@@ -297,7 +297,7 @@ public:
                 if (prev_e == 0)
                 {
                     // Relink
-                    m_HashTable[bucket_index] = e->m_Next;;
+                    m_HashTable[bucket_index] = e->m_Next;
                 }
                 else
                 {

--- a/engine/dlib/src/dlib/hashtable.h
+++ b/engine/dlib/src/dlib/hashtable.h
@@ -102,7 +102,7 @@ public:
      */
     uint32_t Capacity()
     {
-        return m_InitialEntriesEnd - m_InitialEntries;
+        return (uint32_t)(uintptr_t)(m_InitialEntriesEnd - m_InitialEntries);
     }
 
     /**
@@ -430,13 +430,13 @@ private:
         // Empty list of entries?
         if (m_FreeEntries == 0xffffffff)
         {
-            m_FreeEntries = e - m_InitialEntries;
+            m_FreeEntries = (uint32_t)(uintptr_t)(e - m_InitialEntries);
             e->m_Next = 0xffffffff;
         }
         else
         {
             e->m_Next = m_FreeEntries;
-            m_FreeEntries = e - m_InitialEntries;
+            m_FreeEntries = (uint32_t)(uintptr_t)(e - m_InitialEntries);
         }
     }
 

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -206,7 +206,7 @@ namespace dmHttpCache
             size_t size = ftell(f);
             fseek(f, 0, SEEK_SET);
             void* buffer = malloc(size);
-            fread(buffer, 1, size, f);
+            (void)fread(buffer, 1, size, f);
             IndexHeader* header = (IndexHeader*) buffer;
             if (size < (sizeof(IndexHeader)))
             {

--- a/engine/dlib/src/dlib/socket.cpp
+++ b/engine/dlib/src/dlib/socket.cpp
@@ -169,7 +169,7 @@ namespace dmSocket
         // Implements the Hamming Distance algorithm.
         // https://en.wikipedia.org/wiki/Hamming_distance
         uint32_t difference = 0;
-        for (int i = 0; i < (sizeof(a.m_address) / sizeof(uint32_t)); ++i)
+        for (uint32_t i = 0; i < (sizeof(a.m_address) / sizeof(uint32_t)); ++i)
         {
             uint32_t current = a.m_address[i] ^ b.m_address[i];
             while (current != 0)

--- a/engine/dlib/src/dlib/socket.h
+++ b/engine/dlib/src/dlib/socket.h
@@ -8,7 +8,7 @@
 
 #if defined(__linux__) || defined(__MACH__) || defined(ANDROID) || defined(__EMSCRIPTEN__) || defined(__AVM2__)
 #include <sys/socket.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/select.h>
 #include <netinet/in.h>
 #elif defined(_WIN32)

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -900,7 +900,7 @@ namespace dmSys
                 AAsset_close(asset);
                 return RESULT_INVAL;
             }
-            int nread = AAsset_read(asset, buffer, asset_size);
+            uint32_t nread = (uint32_t)AAsset_read(asset, buffer, asset_size);
             AAsset_close(asset);
             if (nread != asset_size) {
                 return RESULT_IO;

--- a/engine/dlib/src/dlib/vmath.h
+++ b/engine/dlib/src/dlib/vmath.h
@@ -79,7 +79,7 @@ namespace dmVMath
             {
                 Vectormath::Aos::Vector3 r(0.0f, 0.0f, 0.0f);
                 // the sum of the values yields one value, as the others are 0
-                r.setElem(mask >> 1, atan2(q0+q1+q2, q3) * 2.0f * DEG_FACTOR);
+                r.setElem(mask >> 1, atan2f(q0+q1+q2, q3) * 2.0f * DEG_FACTOR);
                 return r;
             }
         }
@@ -92,13 +92,13 @@ namespace dmVMath
         float test = q0 * q1 + q2 * q3;
         if (test > limit)
         {
-            r1 = 2.0f * atan2(q0, q3);
+            r1 = 2.0f * atan2f(q0, q3);
             r2 = (float) M_PI_2;
             r0 = 0.0f;
         }
         else if (test < -limit)
         {
-            r1 = -2.0f * atan2(q0, q3);
+            r1 = -2.0f * atan2f(q0, q3);
             r2 = (float) -M_PI_2;
             r0 = 0.0f;
         }
@@ -107,9 +107,9 @@ namespace dmVMath
             float sq0 = q0 * q0;
             float sq1 = q1 * q1;
             float sq2 = q2 * q2;
-            r1 = atan2(2.0f * q1 * q3 - 2.0f * q0 * q2, 1.0f - 2.0f * sq1 - 2.0f * sq2);
-            r2 = asin(2.0f * test);
-            r0 = atan2(2.0f * q0 * q3 - 2.0f * q1 * q2, 1.0f - 2.0f * sq0 - 2.0f * sq2);
+            r1 = atan2f(2.0f * q1 * q3 - 2.0f * q0 * q2, 1.0f - 2.0f * sq1 - 2.0f * sq2);
+            r2 = asinf(2.0f * test);
+            r0 = atan2f(2.0f * q0 * q3 - 2.0f * q1 * q2, 1.0f - 2.0f * sq0 - 2.0f * sq2);
         }
         return Vectormath::Aos::Vector3(r0, r1, r2) * DEG_FACTOR;
     }

--- a/engine/dlib/src/dmsdk/dlib/array.h
+++ b/engine/dlib/src/dmsdk/dlib/array.h
@@ -377,13 +377,13 @@ const T& dmArray<T>::Back() const
 template <typename T>
 uint32_t dmArray<T>::Size() const
 {
-    return (uint32_t)(m_End - m_Front);
+    return (uint32_t)(uintptr_t)(m_End - m_Front);
 }
 
 template <typename T>
 uint32_t dmArray<T>::Capacity() const
 {
-    return (uint32_t)(m_Back - m_Front);
+    return (uint32_t)(uintptr_t)(m_Back - m_Front);
 }
 
 template <typename T>
@@ -401,7 +401,7 @@ bool dmArray<T>::Empty() const
 template <typename T>
 uint32_t dmArray<T>::Remaining() const
 {
-    return m_Back - m_End;
+    return (uint32_t)(uintptr_t)(m_Back - m_End);
 }
 
 template <typename T>

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1123,9 +1123,13 @@ bail:
         engine->m_RunResult.m_ExitCode = 0;
 
         // uint64_t target_frametime = (uint64_t)((1.f / engine->m_UpdateFrequency) * 1000000.0);
+
+#if !(defined(__arm__) || defined(__arm64__) || defined(__EMSCRIPTEN__))
         uint64_t target_frametime = 1000000 / engine->m_UpdateFrequency;
-        uint64_t time = dmTime::GetTime();
         uint64_t prev_flip_time = engine->m_FlipTime;
+#endif
+
+        uint64_t time = dmTime::GetTime();
 
         float fps = engine->m_UpdateFrequency;
         float fixed_dt = 1.0f / fps;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -323,7 +323,6 @@ namespace dmGameObject
         HRegister regist = collection->m_Register;
 
         dmMutex::Lock(regist->m_Mutex);
-        bool found = false;
         for (uint32_t i = 0; i < regist->m_Collections.Size(); ++i)
         {
             // TODO This design is not really thought through, since it modifies the m_Collections
@@ -339,7 +338,6 @@ namespace dmGameObject
                     regist->m_Collections[j] = regist->m_Collections[j+1];
                 }
                 regist->m_Collections.SetSize(regist->m_Collections.Size() - 1);
-                found = true;
                 break;
             }
         }

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -858,7 +858,7 @@ namespace dmGameSystem
 
         // Offset capacity to fit vertices for all emitters we are about to render
         uint32_t vertex_count = 0;
-        for (int i = 0; i < node_count; ++i)
+        for (uint32_t i = 0; i < node_count; ++i)
         {
             dmGui::HNode node = entries[i].m_Node;
             if (dmGui::GetNodeIsBone(scene, node)) {
@@ -882,7 +882,7 @@ namespace dmGameSystem
         ParticleGuiVertex *vb_begin = gui_world->m_ClientVertexBuffer.End();
         ParticleGuiVertex *vb_end = vb_begin;
         // One RO, but generate vertex data for each entry (emitter)
-        for (int i = 0; i < node_count; ++i)
+        for (uint32_t i = 0; i < node_count; ++i)
         {
             dmGui::HNode node = entries[i].m_Node;
             if (dmGui::GetNodeIsBone(scene, node)) {
@@ -1368,7 +1368,7 @@ namespace dmGameSystem
             }
 
             uint32_t sizeBefore = gui_world->m_ClientVertexBuffer.Size();
-            for (int j=0;j!=generate;j++)
+            for (uint32_t j = 0; j != generate; j++)
             {
                 float a;
                 if (j == (generate-1))

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -88,7 +88,7 @@ namespace dmGameSystem
         LabelWorld* world = (LabelWorld*)params.m_World;
 
         LabelComponent* components = world->m_Components.m_Objects.Begin();
-        for (int i = 0; i < world->m_Components.m_Objects.Size(); ++i )
+        for (uint32_t i = 0; i < world->m_Components.m_Objects.Size(); ++i )
         {
             LabelComponent& component = components[i];
             if (component.m_UserAllocatedText)

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -300,7 +300,7 @@ namespace dmGameSystem
             if (c.m_AddedToUpdate)
             {
                 uint32_t emitter_count = dmParticle::GetEmitterCount(c.m_ParticlePrototype);
-                for (int j = 0; j < emitter_count; ++j)
+                for (uint32_t j = 0; j < emitter_count; ++j)
                 {
                     dmParticle::EmitterRenderData* render_data;
                     dmParticle::GetEmitterRenderData(particle_context, c.m_ParticleInstance, j, &render_data);

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -116,7 +116,7 @@ namespace dmGameSystem
             void* indices = (void*)malloc(indices_count * size_type);
             if (sprite_world->m_Is16BitIndex) {
                 uint16_t* index = (uint16_t*)indices;
-                for(int32_t i = 0, v = 0; i < indices_count; i += 6, v += 4)
+                for(uint32_t i = 0, v = 0; i < indices_count; i += 6, v += 4)
                 {
                     *index++ = v;
                     *index++ = v+1;
@@ -127,7 +127,7 @@ namespace dmGameSystem
                 }
             } else {
                 uint32_t* index = (uint32_t*)indices;
-                for(int32_t i = 0, v = 0; i < indices_count; i += 6, v += 4)
+                for(uint32_t i = 0, v = 0; i < indices_count; i += 6, v += 4)
                 {
                     *index++ = v;
                     *index++ = v+1;

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -346,7 +346,7 @@ namespace dmGameSystem
 
     void DestroyImage(ImageDesc* image_desc)
     {
-        for (int i = 0; i < m_MaxMipCount; ++i)
+        for (uint32_t i = 0; i < m_MaxMipCount; ++i)
         {
             if(image_desc->m_DecompressedData[i])
                 delete[] image_desc->m_DecompressedData[i];

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -37,6 +37,7 @@ namespace dmGameSystem
                 return dmWebP::TEXTURE_ENCODE_FORMAT_L8A8;
             default:
                 assert(0);
+                return (dmWebP::TextureEncodeFormat)-1;
         }
     }
 
@@ -80,6 +81,7 @@ namespace dmGameSystem
             */
             default:
                 assert(0);
+                return (dmGraphics::TextureFormat)-1;
         }
     }
 

--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -570,7 +570,7 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
             case AKEYCODE_SPACE: _glfwInputKey( GLFW_KEY_SPACE, glfw_action ); break;
             case AKEYCODE_GRAVE: _glfwInputKey( '`', glfw_action ); break;
             case AKEYCODE_MINUS: _glfwInputKey( '-', glfw_action ); break;
-            case AKEYCODE_EQUALS: _glfwInputKey( "=", glfw_action ); break;
+            case AKEYCODE_EQUALS: _glfwInputKey( '=', glfw_action ); break;
             case AKEYCODE_LEFT_BRACKET: _glfwInputKey( '[', glfw_action ); break;
             case AKEYCODE_RIGHT_BRACKET: _glfwInputKey( ']', glfw_action ); break;
             case AKEYCODE_BACKSLASH: _glfwInputKey( '\\', glfw_action ); break;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1809,7 +1809,7 @@ static void LogFrameBufferError(GLenum status)
         GLenum gl_format;
         GLenum gl_type = DMGRAPHICS_TYPE_UNSIGNED_BYTE;
         // Only used for uncompressed formats
-        GLint internal_format;
+        GLint internal_format = -1;
         switch (params.m_Format)
         {
         case TEXTURE_FORMAT_LUMINANCE:

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -27,6 +27,9 @@
 
 namespace dmGui
 {
+    const dmhash_t DEFAULT_LAYER = dmHashString64("");
+    const dmhash_t DEFAULT_LAYOUT = dmHashString64("");
+
     const uint16_t INVALID_INDEX = 0xffff;
 
     const uint32_t INITIAL_SCENE_COUNT = 32;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -27,7 +27,11 @@
 
 namespace dmGui
 {
+    /**
+     * Default layer id
+     */
     const dmhash_t DEFAULT_LAYER = dmHashString64("");
+
     const dmhash_t DEFAULT_LAYOUT = dmHashString64("");
 
     const uint16_t INVALID_INDEX = 0xffff;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -523,7 +523,7 @@ namespace dmGui
         }
 
         const uint8_t* read_buffer = buffer+buffer_size;
-        for (int y = 0; y < height; ++y)
+        for (uint32_t y = 0; y < height; ++y)
         {
             read_buffer -= stride;
             memcpy(out_buffer, read_buffer, stride);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -44,12 +44,12 @@ namespace dmGui
     /**
      * Default layer id
      */
-    const dmhash_t DEFAULT_LAYER = dmHashString64("");
+    extern const dmhash_t DEFAULT_LAYER;
 
     /**
      * Default layout id
      */
-    const dmhash_t DEFAULT_LAYOUT = dmHashString64("");
+    extern const dmhash_t DEFAULT_LAYOUT;
 
     /**
      * Animation

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -42,11 +42,6 @@ namespace dmGui
     const HNode INVALID_HANDLE = 0;
 
     /**
-     * Default layer id
-     */
-    extern const dmhash_t DEFAULT_LAYER;
-
-    /**
      * Default layout id
      */
     extern const dmhash_t DEFAULT_LAYOUT;

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -282,7 +282,7 @@ namespace dmInput
                     GamepadConfig config;
                     config.m_DeadZone = gamepad_map.m_DeadZone;
                     memset(config.m_Inputs, 0, sizeof(config.m_Inputs));
-                    for (int32_t j = 0; j < (sizeof(config.m_Inputs) / sizeof(struct GamepadInput)); ++j)
+                    for (uint32_t j = 0; j < (sizeof(config.m_Inputs) / sizeof(struct GamepadInput)); ++j)
                     {
                         config.m_Inputs[j].m_Index = (uint16_t)~0;
                     }

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -455,8 +455,6 @@ namespace dmPhysics
                 }
                 if (max_distance >= context->m_TriggerEnterLimit)
                 {
-                    float* f = object_a->getWorldTransform().getOrigin().m_floats;
-                    f = object_b->getWorldTransform().getOrigin().m_floats;
                     add_data.m_ObjectA = object_a;
                     add_data.m_UserDataA = object_a->getUserPointer();
                     add_data.m_ObjectB = object_b;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -774,7 +774,6 @@ namespace dmRender
     {
         float width = 0;
         const char* cursor = text;
-        const Glyph* first = 0;
         const Glyph* last = 0;
         for (int i = 0; i < n; ++i)
         {
@@ -784,8 +783,6 @@ namespace dmRender
                 continue;
             }
 
-            if (i == 0)
-                first = g;
             last = g;
             // NOTE: We round advance here just as above in DrawText
             width += (int16_t) (g->m_Advance + tracking);

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -195,7 +195,7 @@ namespace dmRender
         }
     }
 
-    void ApplyMaterialSampler(dmRender::HRenderContext render_context, HMaterial material, int unit, dmGraphics::HTexture texture)
+    void ApplyMaterialSampler(dmRender::HRenderContext render_context, HMaterial material, uint32_t unit, dmGraphics::HTexture texture)
     {
         dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
         dmArray<Sampler>& samplers = material->m_Samplers;
@@ -332,7 +332,7 @@ namespace dmRender
             return -1;
     }
 
-    void SetMaterialSampler(HMaterial material, dmhash_t name_hash, int16_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter)
+    void SetMaterialSampler(HMaterial material, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter)
     {
         dmArray<Sampler>& samplers = material->m_Samplers;
 

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -200,7 +200,7 @@ namespace dmRender
     void RenderListSubmit(HRenderContext render_context, RenderListEntry *begin, RenderListEntry *end)
     {
         // Insert the used up indices into the sort buffer.
-        assert(end - begin <= render_context->m_RenderListSortIndices.Remaining());
+        assert(end - begin <= (intptr_t)render_context->m_RenderListSortIndices.Remaining());
 
         // Transform pointers back to indices.
         RenderListEntry *base = render_context->m_RenderList.Begin();

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -296,7 +296,7 @@ namespace dmRender
     HMaterial                       NewMaterial(dmRender::HRenderContext render_context, dmGraphics::HVertexProgram vertex_program, dmGraphics::HFragmentProgram fragment_program);
     void                            DeleteMaterial(dmRender::HRenderContext render_context, HMaterial material);
     void                            ApplyMaterialConstants(dmRender::HRenderContext render_context, HMaterial material, const RenderObject* ro);
-    void                            ApplyMaterialSampler(dmRender::HRenderContext render_context, HMaterial material, int unit, dmGraphics::HTexture texture);
+    void                            ApplyMaterialSampler(dmRender::HRenderContext render_context, HMaterial material, uint32_t unit, dmGraphics::HTexture texture);
 
     dmGraphics::HProgram            GetMaterialProgram(HMaterial material);
     dmGraphics::HVertexProgram      GetMaterialVertexProgram(HMaterial material);
@@ -327,7 +327,7 @@ namespace dmRender
     bool                            GetMaterialProgramConstantElement(HMaterial material, dmhash_t name_hash, uint32_t element_index, float& out_value);
     void                            SetMaterialProgramConstant(HMaterial material, dmhash_t name_hash, Vectormath::Aos::Vector4 constant);
     int32_t                         GetMaterialConstantLocation(HMaterial material, dmhash_t name_hash);
-    void                            SetMaterialSampler(HMaterial material, dmhash_t name_hash, int16_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter);
+    void                            SetMaterialSampler(HMaterial material, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter);
     HRenderContext                  GetMaterialRenderContext(HMaterial material);
 
     uint64_t                        GetMaterialUserData1(HMaterial material);

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -203,7 +203,7 @@ static void HttpHeader(dmHttpClient::HResponse response, void* user_data, int st
         if (factory->m_HttpContentLength < 0) {
             dmLogError("Content-Length negative (%d)", factory->m_HttpContentLength);
         } else {
-            if (factory->m_HttpBuffer->Capacity() < factory->m_HttpContentLength) {
+            if (factory->m_HttpBuffer->Capacity() < (uint32_t)factory->m_HttpContentLength) {
                 factory->m_HttpBuffer->SetCapacity(factory->m_HttpContentLength);
             }
             factory->m_HttpBuffer->SetSize(0);
@@ -1050,7 +1050,7 @@ static Result DoLoadResourceLocked(HFactory factory, const char* path, const cha
             return factory->m_HttpFactoryResult;
 
         // Only check content-length if status != 304 (NOT MODIFIED)
-        if (factory->m_HttpStatus != 304 && factory->m_HttpContentLength != -1 && factory->m_HttpContentLength != factory->m_HttpTotalBytesStreamed)
+        if (factory->m_HttpStatus != 304 && factory->m_HttpContentLength != -1 && factory->m_HttpContentLength != (int32_t)factory->m_HttpTotalBytesStreamed)
         {
             dmLogError("Expected content length differs from actually streamed for resource %s (%d != %d)", factory_path, factory->m_HttpContentLength, factory->m_HttpTotalBytesStreamed);
         }

--- a/engine/resource/src/resource_archive.cpp
+++ b/engine/resource/src/resource_archive.cpp
@@ -81,7 +81,7 @@ namespace dmResourceArchive
         uint8_t* bundled_hashes = (!bundled_archive_container->m_IsMemMapped) ? bundled_archive_container->m_Hashes : (uint8_t*)((uintptr_t)bundled_archive_container->m_ArchiveIndex + bundled_hash_offset);
 
         // Count number of liveupdate entries to cache
-        for (int i = 0; i < entry_count; ++i)
+        for (uint32_t i = 0; i < entry_count; ++i)
         {
             EntryData& e = entries[i];
             if (JAVA_TO_C(e.m_Flags) & ENTRY_FLAG_LIVEUPDATE_DATA)
@@ -121,7 +121,7 @@ namespace dmResourceArchive
         uint8_t* lu_hashes = (uint8_t*)malloc(hash_length * lu_entry_count);
         EntryData* lu_entries = (EntryData*)malloc(sizeof(EntryData) * lu_entry_count);
         uint32_t lu_counter = 0;
-        for (int i = 0; i < entry_count; ++i)
+        for (uint32_t i = 0; i < entry_count; ++i)
         {
             EntryData& e = entries[i];
             if (JAVA_TO_C(e.m_Flags) & ENTRY_FLAG_LIVEUPDATE_DATA)
@@ -174,7 +174,7 @@ namespace dmResourceArchive
         NewArchiveIndexFromCopy(reloaded_index, bundled_archive_container, lu_entries->m_Count);
         uint32_t hash_len = lu_entries->m_HashLen;
         uint8_t* reloaded_hashes = (uint8_t*)(uintptr_t(reloaded_index) + JAVA_TO_C(reloaded_index->m_HashOffset));
-        for (int i = 0; i < lu_entries->m_Count; ++i)
+        for (uint32_t i = 0; i < lu_entries->m_Count; ++i)
         {
             int insert_index = -1;
             const uint8_t* hash = (const uint8_t*)((uintptr_t)lu_entries->m_Hashes + hash_len * i);
@@ -557,7 +557,7 @@ namespace dmResourceArchive
         // Shift hashes after insertion_index down
         uint8_t* hash_shift_src = (uint8_t*)((uintptr_t)hashes + DMRESOURCE_MAX_HASH * insertion_index);
         uint8_t* hash_shift_dst = (uint8_t*)((uintptr_t)hash_shift_src + DMRESOURCE_MAX_HASH);
-        if (insertion_index < entry_count) // no need to memmove if inserting at tail
+        if ((uint32_t)insertion_index < entry_count) // no need to memmove if inserting at tail
         {
             uint32_t size_to_shift = (entry_count - insertion_index) * DMRESOURCE_MAX_HASH;
             memmove((void*)hash_shift_dst, (void*)hash_shift_src, size_to_shift);
@@ -567,7 +567,7 @@ namespace dmResourceArchive
         // Shift entry datas
         uint8_t* entries_shift_src = (uint8_t*)((uintptr_t)entries + sizeof(EntryData) * insertion_index);
         uint8_t* entries_shift_dst = (uint8_t*)((uintptr_t)entries_shift_src + sizeof(EntryData));
-        if (insertion_index < entry_count)
+        if ((uint32_t)insertion_index < entry_count)
         {
             uint32_t size_to_shift = (entry_count - insertion_index) * sizeof(EntryData);
             memmove(entries_shift_dst, entries_shift_src, size_to_shift);

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -635,7 +635,7 @@ namespace dmRig
             }
 
             // Make sure we have enough space in the draw order deltas scratch buffer.
-            int slot_count = instance->m_MeshSet->m_SlotCount;
+            uint32_t slot_count = instance->m_MeshSet->m_SlotCount;
             int slot_changed = 0;
             if (context->m_ScratchDrawOrderDeltas.Capacity() < slot_count) {
                 context->m_ScratchDrawOrderDeltas.OffsetCapacity(slot_count - context->m_ScratchDrawOrderDeltas.Capacity());
@@ -643,7 +643,7 @@ namespace dmRig
             context->m_ScratchDrawOrderDeltas.SetSize(slot_count);
 
             // Reset draw order deltas to "unchanged" constant.
-            for (int i = 0; i < slot_count; i++) {
+            for (uint32_t i = 0; i < slot_count; i++) {
                 instance->m_DrawOrder[i] = i;
                 context->m_ScratchDrawOrderDeltas[i] = SIGNAL_DELTA_UNCHANGED;
             }
@@ -717,12 +717,11 @@ namespace dmRig
                 dmArray<IKTarget>& ik_targets = instance->m_IKTargets;
 
 
-                for (int32_t i = 0; i < count; ++i) {
+                for (uint32_t i = 0; i < count; ++i) {
                     const dmRigDDF::IK* ik = &skeleton->m_Iks[i];
 
                     // transform local space hiearchy for pose
                     dmTransform::Transform parent_t = GetPoseTransform(bind_pose, pose, pose[ik->m_Parent], ik->m_Parent);
-                    dmTransform::Transform parent_t_local = parent_t;
                     dmTransform::Transform target_t = GetPoseTransform(bind_pose, pose, pose[ik->m_Target], ik->m_Target);
                     const uint32_t parent_parent_index = skeleton->m_Bones[ik->m_Parent].m_Parent;
                     dmTransform::Transform parent_parent_t;
@@ -959,7 +958,7 @@ namespace dmRig
     // https://github.com/EsotericSoftware/spine-runtimes/blob/387b0afb80a775970c48099042be769e50258440/spine-c/spine-c/src/spine/SkeletonJson.c#L430
     static void UpdateSlotDrawOrder(dmArray<int32_t>& draw_order, dmArray<int32_t>& deltas, int changed, dmArray<int32_t>& unchanged)
     {
-        int slot_count = draw_order.Size();
+        uint32_t slot_count = draw_order.Size();
 
         // Make sure we have enough capacity to store our unchanged slots list.
         if (unchanged.Capacity() < slot_count) {
@@ -967,13 +966,13 @@ namespace dmRig
         }
         unchanged.SetSize(slot_count);
 
-        for (int i = 0; i < slot_count; i++) {
+        for (uint32_t i = 0; i < slot_count; i++) {
             draw_order[i] = -1;
         }
 
         int original_index = 0;
         int unchanged_index = 0;
-        for (int slot_index = 0; slot_index < slot_count; slot_index++)
+        for (int slot_index = 0; slot_index < (int)slot_count; slot_index++)
         {
             int32_t delta = deltas[slot_index];
             if (delta != SIGNAL_DELTA_UNCHANGED) {
@@ -986,7 +985,7 @@ namespace dmRig
             }
         }
 
-        while (original_index < slot_count) {
+        while (original_index < (int)slot_count) {
             unchanged[unchanged_index++] = original_index++;
         }
 
@@ -1216,7 +1215,7 @@ namespace dmRig
 
     static void PoseToInfluence(const dmArray<uint32_t>& pose_idx_to_influence, const dmArray<Matrix4>& in_pose, dmArray<Matrix4>& out_pose)
     {
-        for (int i = 0; i < pose_idx_to_influence.Size(); ++i)
+        for (uint32_t i = 0; i < pose_idx_to_influence.Size(); ++i)
         {
             uint32_t j = pose_idx_to_influence[i];
             out_pose[j] = in_pose[i];
@@ -1312,8 +1311,8 @@ namespace dmRig
             return vertex_data_out;
 
         } else if (mesh_slot_count == 1) {
-            int active_attachment = instance->m_MeshSlotPose[0].m_ActiveAttachment;
-            if (active_attachment == -1 || mesh_entry->m_MeshSlots[0].m_MeshAttachments[active_attachment] == -1) {
+            int32_t active_attachment = instance->m_MeshSlotPose[0].m_ActiveAttachment;
+            if (active_attachment == -1 || mesh_entry->m_MeshSlots[0].m_MeshAttachments[(uint32_t)active_attachment] == (uint32_t)-1) {
                 return vertex_data_out;
             }
         }
@@ -1679,7 +1678,7 @@ namespace dmRig
         uint32_t anim_bone_list_count = animationset.m_BoneList.m_Count;
         uint32_t mesh_bone_list_count = meshset.m_BoneList.m_Count;
 
-        for (int bi = 0; bi < bone_count; ++bi)
+        for (uint32_t bi = 0; bi < bone_count; ++bi)
         {
             uint64_t bone_id = skeleton.m_Bones[bi].m_Id;
 

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -10,6 +10,7 @@ namespace dmRig
     static const uint32_t INVALID_BONE_INDEX = 0xffff;
     static const float CURSOR_EPSILON = 0.0001f;
     static const int SIGNAL_DELTA_UNCHANGED = 0x10cced; // Used to indicate if a draw order was unchanged for a certain slot
+    static const uint32_t INVALID_ATTACHMENT_INDEX = (uint32_t)-1;
 
     static const float white[] = {1.0f, 1.0f, 1.0, 1.0f};
 
@@ -958,7 +959,7 @@ namespace dmRig
     // https://github.com/EsotericSoftware/spine-runtimes/blob/387b0afb80a775970c48099042be769e50258440/spine-c/spine-c/src/spine/SkeletonJson.c#L430
     static void UpdateSlotDrawOrder(dmArray<int32_t>& draw_order, dmArray<int32_t>& deltas, int changed, dmArray<int32_t>& unchanged)
     {
-        uint32_t slot_count = draw_order.Size();
+        int slot_count = draw_order.Size();
 
         // Make sure we have enough capacity to store our unchanged slots list.
         if (unchanged.Capacity() < slot_count) {
@@ -966,13 +967,13 @@ namespace dmRig
         }
         unchanged.SetSize(slot_count);
 
-        for (uint32_t i = 0; i < slot_count; i++) {
+        for (int i = 0; i < slot_count; i++) {
             draw_order[i] = -1;
         }
 
         int original_index = 0;
         int unchanged_index = 0;
-        for (int slot_index = 0; slot_index < (int)slot_count; slot_index++)
+        for (int slot_index = 0; slot_index < slot_count; slot_index++)
         {
             int32_t delta = deltas[slot_index];
             if (delta != SIGNAL_DELTA_UNCHANGED) {
@@ -985,7 +986,7 @@ namespace dmRig
             }
         }
 
-        while (original_index < (int)slot_count) {
+        while (original_index < slot_count) {
             unchanged[unchanged_index++] = original_index++;
         }
 
@@ -1012,12 +1013,12 @@ namespace dmRig
             MeshSlotPose* mesh_slot_pose = &instance->m_MeshSlotPose[slot_index];
 
             // Get attachment index for current slot
-            int active_attachment = mesh_slot_pose->m_ActiveAttachment;
-            if (active_attachment >= 0) {
+            uint32_t active_attachment = mesh_slot_pose->m_ActiveAttachment;
+            if (active_attachment != INVALID_ATTACHMENT_INDEX) {
 
                 // Check if there is any mesh on current attachment
-                int mesh_attachment_index = mesh_slot_pose->m_MeshSlot->m_MeshAttachments[active_attachment];
-                if (mesh_attachment_index >= 0) {
+                uint32_t mesh_attachment_index = mesh_slot_pose->m_MeshSlot->m_MeshAttachments[active_attachment];
+                if (mesh_attachment_index != INVALID_ATTACHMENT_INDEX) {
                     const Mesh* mesh_attachment = &instance->m_MeshSet->m_MeshAttachments[mesh_attachment_index];
                     vertex_count += mesh_attachment->m_Indices.m_Count;
                 }
@@ -1311,8 +1312,8 @@ namespace dmRig
             return vertex_data_out;
 
         } else if (mesh_slot_count == 1) {
-            int32_t active_attachment = instance->m_MeshSlotPose[0].m_ActiveAttachment;
-            if (active_attachment == -1 || mesh_entry->m_MeshSlots[0].m_MeshAttachments[(uint32_t)active_attachment] == (uint32_t)-1) {
+            uint32_t active_attachment = instance->m_MeshSlotPose[0].m_ActiveAttachment;
+            if (active_attachment == INVALID_ATTACHMENT_INDEX || mesh_entry->m_MeshSlots[0].m_MeshAttachments[active_attachment] == INVALID_ATTACHMENT_INDEX) {
                 return vertex_data_out;
             }
         }
@@ -1390,12 +1391,12 @@ namespace dmRig
             const dmRigDDF::MeshSlot* mesh_slot = mesh_slot_pose->m_MeshSlot;
 
             // Get active attachment in the current slot.
-            int active_attachment = mesh_slot_pose->m_ActiveAttachment;
-            if (active_attachment >= 0) {
+            uint32_t active_attachment = mesh_slot_pose->m_ActiveAttachment;
+            if (active_attachment != INVALID_ATTACHMENT_INDEX) {
 
                 // Check if the attachment point has a mesh assigned
-                int mesh_attachment_index = mesh_slot->m_MeshAttachments[active_attachment];
-                if (mesh_attachment_index >= 0)
+                uint32_t mesh_attachment_index = mesh_slot->m_MeshAttachments[active_attachment];
+                if (mesh_attachment_index != INVALID_ATTACHMENT_INDEX)
                 {
                     // Lookup the mesh from the list of all the available meshes.
                     const Mesh* mesh_attachment = &instance->m_MeshSet->m_MeshAttachments[mesh_attachment_index];

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -10,7 +10,7 @@ namespace dmRig
     static const uint32_t INVALID_BONE_INDEX = 0xffff;
     static const float CURSOR_EPSILON = 0.0001f;
     static const int SIGNAL_DELTA_UNCHANGED = 0x10cced; // Used to indicate if a draw order was unchanged for a certain slot
-    static const uint32_t INVALID_ATTACHMENT_INDEX = (uint32_t)-1;
+    static const uint32_t INVALID_ATTACHMENT_INDEX = 0xffffffffu;
 
     static const float white[] = {1.0f, 1.0f, 1.0, 1.0f};
 
@@ -962,7 +962,7 @@ namespace dmRig
         int slot_count = draw_order.Size();
 
         // Make sure we have enough capacity to store our unchanged slots list.
-        if (unchanged.Capacity() < slot_count) {
+        if (unchanged.Capacity() < (uint32_t)slot_count) {
             unchanged.OffsetCapacity(slot_count - unchanged.Capacity());
         }
         unchanged.SetSize(slot_count);

--- a/engine/script/src/script_buffer.cpp
+++ b/engine/script/src/script_buffer.cpp
@@ -562,11 +562,11 @@ namespace dmScript
                                         dststream->m_TypeCount, dmBuffer::GetValueTypeString(dststream->m_Type), srcstream->m_TypeCount, dmBuffer::GetValueTypeString(srcstream->m_Type) );
             }
 
-            if( (dstoffset + count) > dststream->m_Count * dststream->m_TypeCount )
+            if( (uint32_t)(dstoffset + count) > dststream->m_Count * dststream->m_TypeCount )
             {
                 return DM_LUA_ERROR("Trying to write too many values: Stream length: %d, Offset: %d, Values to copy: %d", dststream->m_Count, dstoffset, count);
             }
-            if( (srcoffset + count) > srcstream->m_Count * srcstream->m_TypeCount )
+            if( (uint32_t)(srcoffset + count) > srcstream->m_Count * srcstream->m_TypeCount )
             {
                 return DM_LUA_ERROR("Trying to read too many values: Stream length: %d, Offset: %d, Values to copy: %d", srcstream->m_Count, srcoffset, count);
             }
@@ -628,11 +628,11 @@ namespace dmScript
         uint32_t srccount;
         dmBuffer::GetCount(dstbuffer, &dstcount);
         dmBuffer::GetCount(srcbuffer, &srccount);
-        if( (dstoffset + count) > dstcount )
+        if( (dstoffset + count) > (int)dstcount )
         {
             return DM_LUA_ERROR("Trying to write too many elements: Destination buffer length: %u, Offset: %u, Values to copy: %u", dstcount, dstoffset, count);
         }
-        if( (srcoffset + count) > srccount )
+        if( (srcoffset + count) > (int)srccount )
         {
             return DM_LUA_ERROR("Trying to read too many elements: Destination buffer length: %u, Offset: %u, Values to copy: %u", dstcount, dstoffset, count);
         }
@@ -849,7 +849,7 @@ namespace dmScript
         DM_LUA_STACK_CHECK(L, 1);
         BufferStream* stream = CheckStream(L, 1);
         int index = luaL_checkinteger(L, 2) - 1;
-        if (index < 0 || index >= stream->m_Count * stream->m_TypeCount)
+        if (index < 0 || index >= (int)(stream->m_Count * stream->m_TypeCount))
         {
             if (stream->m_Count > 0)
             {
@@ -870,7 +870,7 @@ namespace dmScript
         DM_LUA_STACK_CHECK(L, 0);
         BufferStream* stream = CheckStream(L, 1);
         int index = luaL_checkinteger(L, 2) - 1;
-        if (index < 0 || index >= stream->m_Count * stream->m_TypeCount)
+        if (index < 0 || index >= (int)(stream->m_Count * stream->m_TypeCount))
         {
             if (stream->m_Count > 0)
             {

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -209,7 +209,7 @@ namespace dmScript
         size_t value_len = 0;
         const char* value = lua_tolstring(L, index, &value_len);
         uint32_t total_size = value_len + sizeof(uint32_t);
-        if (buffer_end - buffer < total_size)
+        if (buffer_end - buffer < (intptr_t)total_size)
         {
             luaL_error(L, "buffer (%d bytes) too small for table, exceeded at '%s' for element #%d", buffer_size, value, count);
         }
@@ -224,7 +224,7 @@ namespace dmScript
     static uint32_t LoadOldTSTRING(lua_State* L, const char* buffer, const char* buffer_end, uint32_t count)
     {
         uint32_t total_size = strlen(buffer) + 1;
-        if (buffer_end - buffer < total_size)
+        if (buffer_end - buffer < (intptr_t)total_size)
         {
             luaL_error(L, "Reading outside of buffer at element #%d (string): wanted to read: %d   bytes left: %d", count, total_size, (uint32_t)(buffer_end - buffer));
         }
@@ -239,7 +239,7 @@ namespace dmScript
         uint32_t_1_align* u32ptr = (uint32_t_1_align*)buffer;
         size_t value_len = (size_t)*u32ptr;
         uint32_t total_size = value_len + sizeof(uint32_t);
-        if (buffer_end - buffer < total_size)
+        if (buffer_end - buffer < (intptr_t)total_size)
         {
             luaL_error(L, "Reading outside of buffer at element #%d (string): wanted to read: %d   bytes left: %d", count, total_size, (uint32_t)(buffer_end - buffer));
         }


### PR DESCRIPTION
- Exclude -fno-rtti option from compilation of c files
- Change string to char type for equal sign in android input
- Removed unused variables
- Remove double const declaration
- Move platform specific variables in same scope as usage
- Fix unitiallized/no return path warnings
- Fix type conversion warnings
- Remove obsolete -Wno-warn-absolute-paths command line option for web
- Explicitly use float versions of atan2 and assign
- Don’t define be64toh if it already exists (it does on Linux)
- Win32 no longer requires declaration of alloca()
- Moved dmGui::DEFAULT_LAYER and DEFAULT_LAYOUT value to cpp file
- Use atan2f and asinf float versions explicitly to avoid cast from double to float

### Warnings
Target | Pre | Post
-------|-----|------
engine-win32 | 1668 | 885
engine-win32-64 | 2202 | 1316
engine-linux | 441 | 285
engine-linux-64 | 281 | 138
engine-js-web | 1379 | 120
engine-android | 484 | 145

### Log lines
Target | Pre | Post
-------|-----|------
engine-win32 | 17696 | 16409
engine-win32-64 | 18925 | 16801
engine-linux | 13682 | 12859
engine-linux-64 | 4231 | 3495
engine-js-web | 5063 | 3360
engine-android | 6125 | 5336