### PR TITLE
DEFEDIT-1430 Visibility filters - Don't make pfx & spines part of GUI elements

### DIFF
--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -179,7 +179,7 @@
             offset (pivot-offset pivot size)
             lines (mapv conj (apply concat (take 4 (partition 2 1 (cycle (geom/transl offset [[0 0] [w 0] [w h] [0 h]]))))) (repeat 0))]
         (assoc scene :renderable {:render-fn render-tris
-                                  :tags #{:label}
+                                  :tags #{:text}
                                   :batch-key {:blend-mode blend-mode :gpu-texture gpu-texture :material-shader material-shader}
                                   :select-batch-key _node-id
                                   :user-data {:material-shader material-shader
@@ -190,7 +190,7 @@
                                   :passes [pass/transparent pass/selection]}
                :children [{:node-id _node-id
                            :renderable {:render-fn render-lines
-                                        :tags #{:label :outline}
+                                        :tags #{:text :outline}
                                         :batch-key ::outline
                                         :user-data {:line-data lines}
                                         :passes [pass/outline]}}]))

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -36,13 +36,18 @@
 
 (def ^:private tag-toggles-info
   [{:label "Collision Shapes" :tag :collision-shape}
-   {:label "GUI Elements" :tag :gui}
+   #_{:label "GUI Elements" :tag :gui}
+   {:label "GUI Bounds" :tag :gui-bounds}
+   {:label "GUI Shapes" :tag :gui-shape}
+   {:label "GUI Particle Effects" :tag :gui-particlefx}
+   {:label "GUI Spine Scenes" :tag :gui-spine}
+   {:label "GUI Text" :tag :gui-text}
    {:label "Models" :tag :model}
    {:label "Particle Effects" :tag :particlefx}
    {:label "Skeletons" :tag :skeleton}
    {:label "Spine Scenes" :tag :spine}
    {:label "Sprites" :tag :sprite}
-   {:label "Text" :tag :label}
+   {:label "Text" :tag :text}
    {:label "Tile Maps" :tag :tilemap}])
 
 (def toggleable-tags (into #{} (map :tag) tag-toggles-info))


### PR DESCRIPTION
* User facing changes
  - More granular visibility filtering options for gui.

* Technical changes
  - More tags + never filter out clipping renderables