### PR TITLE
DEFEDIT-1432 More progress reporting during load project

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -488,6 +488,11 @@
   (assert node-id)
   (transact (delete-node node-id)))
 
+(defn callback
+  "Call the specified function with args when reaching the transaction step"
+  [f & args]
+  (it/callback f args))
+
 (defn connect
   "Make a connection from an output of the source node to an input on the target node.
    Takes effect when a transaction is applied.

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -44,7 +44,7 @@
 (defn- open-project-with-progress-dialog
   [namespace-loader prefs project update-context newly-created?]
   (ui/modal-progress
-   "Loading project" 100
+   "Loading project"
    (fn [render-progress!]
      (let [namespace-progress (progress/make "Loading editor" 1304) ; magic number from reading namespace-counter after load.
            render-namespace-progress! (progress/nest-render-progress render-progress! (progress/make "Loading" 2))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -89,6 +89,12 @@
     :fn   f
     :args args}])
 
+(defn callback
+  [f args]
+  [{:type :callback
+    :fn f
+    :args args}])
+
 (defn connect
   "*transaction step* - Creates a transaction step connecting a source node and label (`from-resource from-label`) and a target node and label
 (`to-resource to-label`). It returns a value suitable for consumption by [[perform]]."
@@ -493,6 +499,10 @@
           (update :basis replace-node node-id (gt/clear-property node basis property))
           (ctx-set-property-to-nil node-id node property)))
       ctx)))
+
+(defmethod perform :callback [ctx {:keys [fn args]}]
+  (apply fn args)
+  ctx)
 
 (defn- ctx-disconnect-single [ctx target target-id target-label]
   (if (= :one (in/input-cardinality (gt/node-type target (:basis ctx)) target-label))


### PR DESCRIPTION
* User facing changes
  - Loading and processing of resouces reported during project load

* Technical changes
  - Added g/callback, a new transaction step that calls a function
  with supplied arguments
  - Helper function to wrap a progress reporting function in an
  inflight-throttled run-later