### PR TITLE
DEFEDIT-1436 Font compile failure logging

### DIFF
--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -18,7 +18,8 @@
             [editor.material :as material]
             [editor.validation :as validation]
             [editor.gl.pass :as pass]
-            [schema.core :as schema])
+            [schema.core :as schema]
+            [service.log :as log])
   (:import [com.dynamo.render.proto Font$FontDesc Font$FontMap Font$FontTextureFormat]
            [com.defold.editor.pipeline BMFont]
            [editor.types AABB]
@@ -376,7 +377,9 @@
       (try
         (font-gen/generate pb-msg font font-resource-resolver)
         (catch Exception error
-          (g/->error _node-id :font :fatal font (str "Failed to generate bitmap from Font. " (.getMessage error)))))))
+          (let [message (str "Failed to generate bitmap from Font. " (.getMessage error))]
+            (log/error :msg message :exception error)
+            (g/->error _node-id :font :fatal font message))))))
 
 
 (defn- make-font-resource-resolver [font resource-map]

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -148,7 +148,7 @@
                      (catch FileNotFoundException e
                        (throw (ex-info (str "Could not find BMFont image resource: " path) {:path path} e)))
                      (catch IOException e
-                       (throw (ex-info (str "Error while reading BMFont image resource" {:path path} e))))))
+                       (throw (ex-info (str "Error while reading BMFont image resource:" path) {:path path} e)))))
         channel-count 4
         glyph-extents (make-glyph-extents channel-count padding glyph-cell-padding semi-glyphs)
         cache-cell-wh (max-glyph-cell-wh glyph-extents)


### PR DESCRIPTION
We need more info to diagnose the cause of DEFEDIT-1436.

### Technical changes
* Log errors produced by `font-gen/generate`.
* (Unrelated) Fixed incorrect arity to `ex-info` from fallback `IOExceptions` in `compile-fnt-bitmap`.