### PR TITLE
DEF-2477 Add --variant and --strip-executable

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/testappmanifest/myapp.appmanifest
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/testappmanifest/myapp.appmanifest
@@ -1,0 +1,58 @@
+# App manifest generated Fri Sep 14 2018 11:47:00 GMT+0200 (CEST)
+# Settings: Profiler,Release
+platforms:
+    x86_64-osx:
+        context:
+            excludeLibs: ["profilerext","engine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["engine_release"]
+            linkFlags: []
+
+    x86_64-linux:
+        context:
+            excludeLibs: ["profilerext","engine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["engine_release"]
+            linkFlags: []
+
+    js-web:
+        context:
+            excludeLibs: ["profilerext","engine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["engine_release"]
+            linkFlags: []
+
+    x86-win32:
+        context:
+            excludeLibs: ["libprofilerext","libengine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["libengine_release.lib"]
+            linkFlags: []
+
+    x86_64-win32:
+        context:
+            excludeLibs: ["libprofilerext","libengine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["libengine_release.lib"]
+            linkFlags: []
+
+    armv7-android:
+        context:
+            excludeLibs: ["profilerext","engine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["engine_release"]
+            linkFlags: []
+
+    armv7-ios:
+        context:
+            excludeLibs: ["profilerext","engine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["engine_release"]
+            linkFlags: []
+
+    arm64-ios:
+        context:
+            excludeLibs: ["profilerext","engine"]
+            excludeSymbols: ["ProfilerExt"]
+            libs: ["engine_release"]
+            linkFlags: []

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -172,17 +172,27 @@ public class Bob {
         return f.getAbsolutePath();
     }
 
-    public static String getDmengineExeName(Platform platform, boolean debug) {
-        if(debug) {
-            return "dmengine";
+
+   public static String getDmengineExeName(Platform platform, boolean debug, String variant) {
+        if (variant == null || variant.isEmpty())
+        {
+            return debug ? "dmengine" : "dmengine_release";
         }
-        else {
-            return "dmengine_release";
+        switch (variant)
+        {
+            case "release":
+                return "dmengine_release";
+            case "headless":
+                return "dmengine_headless";
+            case "debug":
+                return "dmengine";
+            default:
+                throw new RuntimeException(String.format("Invalid variant %s", variant));
         }
     }
 
-    public static String getDmengineExe(Platform platform, boolean debug) throws IOException {
-        return getExe(platform, getDmengineExeName(platform, debug));
+    public static String getDmengineExe(Platform platform, boolean debug, String variant) throws IOException {
+        return getExe(platform, getDmengineExeName(platform, debug, variant));
     }
 
     public static String getLib(Platform platform, String name) throws IOException {
@@ -221,7 +231,8 @@ public class Bob {
         options.addOption("ce", "certificate", true, "Certificate (Android)");
         options.addOption("pk", "private-key", true, "Private key (Android)");
 
-        options.addOption("d", "debug", false, "Use debug version of dmengine (when bundling)");
+        options.addOption("d", "debug", false, "Use debug version of dmengine (when bundling). Deprecated, use --variant instead");
+        options.addOption(null, "variant", true, "Specify debug, release or headless version of dmengine (when bundling)");
 
         options.addOption("tp", "texture-profiles", true, "Use texture profiles (deprecated)");
         options.addOption("tc", "texture-compression", true, "Use texture compression as specified in texture profiles");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -36,6 +36,10 @@ import com.dynamo.bob.util.LibraryUtil;
 
 public class Bob {
 
+    public static final String VARIANT_DEBUG = "debug";
+    public static final String VARIANT_RELEASE = "release";
+    public static final String VARIANT_HEADLESS = "headless";
+
     private static boolean verbose = false;
     private static File rootFolder = null;
 
@@ -172,27 +176,44 @@ public class Bob {
         return f.getAbsolutePath();
     }
 
-
-   public static String getDmengineExeName(Platform platform, boolean debug, String variant) {
-        if (variant == null || variant.isEmpty())
-        {
-            return debug ? "dmengine" : "dmengine_release";
-        }
+   public static String getDmengineExeName(String variant) {
         switch (variant)
         {
-            case "release":
-                return "dmengine_release";
-            case "headless":
-                return "dmengine_headless";
-            case "debug":
+            case VARIANT_DEBUG:
                 return "dmengine";
+            case VARIANT_RELEASE:
+                return "dmengine_release";
+            case VARIANT_HEADLESS:
+                return "dmengine_headless";
             default:
                 throw new RuntimeException(String.format("Invalid variant %s", variant));
         }
     }
 
-    public static String getDmengineExe(Platform platform, boolean debug, String variant) throws IOException {
-        return getExe(platform, getDmengineExeName(platform, debug, variant));
+    public static String getDmengineExe(Platform platform, String variant) throws IOException {
+        return getExe(platform, getDmengineExeName(variant));
+    }
+
+    public static boolean getStripExecutable(boolean debug_option, boolean strip_executable_option, String variant_option)
+    {
+        if (strip_executable_option)
+        {
+            return true;
+        }
+        if (variant_option == null)
+        {
+            return !debug_option;
+        }
+        return false;
+    }
+
+    public static String getVariant(boolean debug_option, String variant_option)
+    {
+        if (variant_option == null || variant_option.isEmpty())
+        {
+            return debug_option ? VARIANT_DEBUG : VARIANT_RELEASE;
+        }
+        return variant_option;
     }
 
     public static String getLib(Platform platform, String name) throws IOException {
@@ -233,6 +254,7 @@ public class Bob {
 
         options.addOption("d", "debug", false, "Use debug version of dmengine (when bundling). Deprecated, use --variant instead");
         options.addOption(null, "variant", true, "Specify debug, release or headless version of dmengine (when bundling)");
+        options.addOption(null, "strip-executable", false, "Strip the dmengine of debug symbols (when bundling iOS or Android)");
 
         options.addOption("tp", "texture-profiles", true, "Use texture profiles (deprecated)");
         options.addOption("tc", "texture-compression", true, "Use texture compression as specified in texture profiles");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -571,7 +571,8 @@ public class Project {
         String serverURL = this.option("build-server", "https://build.defold.com");
 
         // Get SHA1 and create log file
-        String sdkVersion = this.option("defoldsdk", EngineVersion.sha1);
+        final String sdkVersion = this.option("defoldsdk", EngineVersion.sha1);
+        final String variant = Bob.getVariant(this.hasOption("debug"), this.option("variant", null));
         File logFile = File.createTempFile("build_" + sdkVersion + "_", ".txt");
         logFile.deleteOnExit();
 
@@ -601,7 +602,7 @@ public class Project {
 
             String defaultName = platform.formatBinaryName("dmengine");
             File exe = new File(FilenameUtils.concat(buildDir.getAbsolutePath(), defaultName));
-            List<ExtenderResource> allSource = ExtenderUtil.getExtensionSources(this, platform);
+            List<ExtenderResource> allSource = ExtenderUtil.getExtensionSources(this, platform, variant);
 
 
             File classesDexFile = null;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -65,8 +65,8 @@ public class AndroidBundler implements IBundler {
         Map<String, IResource> bundleResources = ExtenderUtil.collectResources(project, Platform.Armv7Android);
 
         BobProjectProperties projectProperties = project.getProjectProperties();
-        final boolean debug = project.hasOption("debug");
-        final String variant = project.option("variant", null);
+        final String variant = Bob.getVariant(project.hasOption("debug"), project.option("variant", null));
+        final boolean strip_executable = Bob.getStripExecutable(project.hasOption("debug"), project.hasOption("strip-executable"), project.option("variant", null));
 
         String title = projectProperties.getStringValue("project", "title", "Unnamed");
         String exeName = title.replace(' ', '_');
@@ -78,7 +78,7 @@ public class AndroidBundler implements IBundler {
         Platform targetPlatform = Platform.Armv7Android;
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(targetPlatform.getExtenderPair(), targetPlatform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug, variant));
+        File defaultExe = new File(Bob.getDmengineExe(targetPlatform, variant));
         File bundleExe = defaultExe;
         ArrayList<File> classesDex = new ArrayList<File>();
         classesDex.add(new File(Bob.getPath("lib/classes.dex")));
@@ -242,7 +242,7 @@ public class AndroidBundler implements IBundler {
 
             // Strip executable
             String strippedpath = bundleExe.getAbsolutePath();
-            if( !debug )
+            if( strip_executable )
             {
                 File tmp = File.createTempFile(title, "." + bundleExe.getName() + ".stripped");
                 tmp.deleteOnExit();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -66,6 +66,7 @@ public class AndroidBundler implements IBundler {
 
         BobProjectProperties projectProperties = project.getProjectProperties();
         final boolean debug = project.hasOption("debug");
+        final String variant = project.option("variant", null);
 
         String title = projectProperties.getStringValue("project", "title", "Unnamed");
         String exeName = title.replace(' ', '_');
@@ -77,7 +78,7 @@ public class AndroidBundler implements IBundler {
         Platform targetPlatform = Platform.Armv7Android;
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(targetPlatform.getExtenderPair(), targetPlatform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug));
+        File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug, variant));
         File bundleExe = defaultExe;
         ArrayList<File> classesDex = new ArrayList<File>();
         classesDex.add(new File(Bob.getPath("lib/classes.dex")));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -439,7 +439,7 @@ public class BundleHelper {
                         if (info.resource != null && info.resource.endsWith(ExtenderClient.appManifestFilename)) {
                             for (ExtenderResource extResource : allSource) {
                                 if (extResource.getAbsPath().endsWith(info.resource)) {
-                                    issueResource = ((ExtenderUtil.FSAliasResource)extResource).getResource();
+                                    issueResource = ((ExtenderUtil.FSAppManifestResource)extResource).getResource();
                                     info.message = info.message.replace(extResource.getPath(), issueResource.getPath());
                                     break;
                                 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -158,10 +158,9 @@ public class HTML5Bundler implements IBundler {
 
         Platform targetPlatform = Platform.JsWeb;
         Boolean localLaunch = project.option("local-launch", "false").equals("true");
-        final boolean debug = project.hasOption("debug") || localLaunch;
-        final String variant = localLaunch ? null : project.option("variant", null);
+        final String variant = Bob.getVariant(project.hasOption("debug"), project.option("variant", null));
         String title = projectProperties.getStringValue("project", "title", "Unnamed");
-        String js = Bob.getDmengineExe(targetPlatform, debug, variant);
+        String js = Bob.getDmengineExe(targetPlatform, variant);
         String engine = title + '.' + FilenameUtils.getExtension(js);
 
         // Select the native extension executable

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -158,9 +158,10 @@ public class HTML5Bundler implements IBundler {
 
         Platform targetPlatform = Platform.JsWeb;
         Boolean localLaunch = project.option("local-launch", "false").equals("true");
-        Boolean debug = project.hasOption("debug") || localLaunch;
+        final boolean debug = project.hasOption("debug") || localLaunch;
+        final String variant = localLaunch ? null : project.option("variant", null);
         String title = projectProperties.getStringValue("project", "title", "Unnamed");
-        String js = Bob.getDmengineExe(targetPlatform, debug);
+        String js = Bob.getDmengineExe(targetPlatform, debug, variant);
         String engine = title + '.' + FilenameUtils.getExtension(js);
 
         // Select the native extension executable

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -114,7 +114,8 @@ public class IOSBundler implements IBundler {
         // Collect bundle/package resources to be included in .App directory
         Map<String, IResource> bundleResources = ExtenderUtil.collectResources(project, Platform.Arm64Darwin);
 
-        boolean debug = project.hasOption("debug");
+        final boolean debug = project.hasOption("debug");
+        final String variant = project.option("variant", null);
 
         File exeArmv7 = null;
         File exeArm64 = null;
@@ -126,7 +127,7 @@ public class IOSBundler implements IBundler {
         {
             Platform targetPlatform = Platform.Armv7Darwin;
             File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(targetPlatform.getExtenderPair(), targetPlatform.formatBinaryName("dmengine"))));
-            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug));
+            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug, variant));
             exeArmv7 = defaultExe;
             if (extenderExe.exists()) {
                 logger.log(Level.INFO, "Using extender exe for Armv7");
@@ -138,7 +139,7 @@ public class IOSBundler implements IBundler {
         {
             Platform targetPlatform = Platform.Arm64Darwin;
             File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(targetPlatform.getExtenderPair(), targetPlatform.formatBinaryName("dmengine"))));
-            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug));
+            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug, variant));
             exeArm64 = defaultExe;
             if (extenderExe.exists()) {
                 logger.log(Level.INFO, "Using extender exe for Arm64");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -114,8 +114,8 @@ public class IOSBundler implements IBundler {
         // Collect bundle/package resources to be included in .App directory
         Map<String, IResource> bundleResources = ExtenderUtil.collectResources(project, Platform.Arm64Darwin);
 
-        final boolean debug = project.hasOption("debug");
-        final String variant = project.option("variant", null);
+        final String variant = Bob.getVariant(project.hasOption("debug"), project.option("variant", null));
+        final boolean strip_executable = Bob.getStripExecutable(project.hasOption("debug"), project.hasOption("strip-executable"), project.option("variant", null));
 
         File exeArmv7 = null;
         File exeArm64 = null;
@@ -127,7 +127,7 @@ public class IOSBundler implements IBundler {
         {
             Platform targetPlatform = Platform.Armv7Darwin;
             File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(targetPlatform.getExtenderPair(), targetPlatform.formatBinaryName("dmengine"))));
-            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug, variant));
+            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, variant));
             exeArmv7 = defaultExe;
             if (extenderExe.exists()) {
                 logger.log(Level.INFO, "Using extender exe for Armv7");
@@ -139,7 +139,7 @@ public class IOSBundler implements IBundler {
         {
             Platform targetPlatform = Platform.Arm64Darwin;
             File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(targetPlatform.getExtenderPair(), targetPlatform.formatBinaryName("dmengine"))));
-            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, debug, variant));
+            File defaultExe = new File(Bob.getDmengineExe(targetPlatform, variant));
             exeArm64 = defaultExe;
             if (extenderExe.exists()) {
                 logger.log(Level.INFO, "Using extender exe for Arm64");
@@ -304,7 +304,7 @@ public class IOSBundler implements IBundler {
         }
 
         // Strip executable
-        if( !debug )
+        if( strip_executable )
         {
             Result stripResult = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "strip_ios"), exe);
             if (stripResult.ret == 0) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
@@ -21,12 +21,11 @@ public class LinuxBundler implements IBundler {
 
     public void bundleApplicationForPlatform(Platform platform, Project project, File appDir, String title)
             throws IOException, CompileExceptionError {
-        final boolean debug = project.hasOption("debug");
-        final String variant = project.option("variant", null);
+        final String variant = Bob.getVariant(project.hasOption("debug"), project.option("variant", null));
 
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), platform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(platform, debug, variant));
+        File defaultExe = new File(Bob.getDmengineExe(platform, variant));
         File bundleExe = defaultExe;
         if (extenderExe.exists()) {
             bundleExe = extenderExe;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
@@ -21,9 +21,12 @@ public class LinuxBundler implements IBundler {
 
     public void bundleApplicationForPlatform(Platform platform, Project project, File appDir, String title)
             throws IOException, CompileExceptionError {
+        final boolean debug = project.hasOption("debug");
+        final String variant = project.option("variant", null);
+
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), platform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(platform, project.hasOption("debug")));
+        File defaultExe = new File(Bob.getDmengineExe(platform, debug, variant));
         File bundleExe = defaultExe;
         if (extenderExe.exists()) {
             bundleExe = extenderExe;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSX32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSX32Bundler.java
@@ -47,11 +47,12 @@ public class OSX32Bundler implements IBundler {
         File resourcesDir = new File(contentsDir, "Resources");
         File macosDir = new File(contentsDir, "MacOS");
 
-        boolean debug = project.hasOption("debug");
+        final boolean debug = project.hasOption("debug");
+        final String variant = project.option("variant", null);
 
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), platform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(platform, debug));
+        File defaultExe = new File(Bob.getDmengineExe(platform, debug, variant));
         File bundleExe = defaultExe;
         if (extenderExe.exists()) {
             bundleExe = extenderExe;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSX32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSX32Bundler.java
@@ -47,12 +47,11 @@ public class OSX32Bundler implements IBundler {
         File resourcesDir = new File(contentsDir, "Resources");
         File macosDir = new File(contentsDir, "MacOS");
 
-        final boolean debug = project.hasOption("debug");
-        final String variant = project.option("variant", null);
+        final String variant = Bob.getVariant(project.hasOption("debug"), project.option("variant", null));
 
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), platform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(platform, debug, variant));
+        File defaultExe = new File(Bob.getDmengineExe(platform, variant));
         File bundleExe = defaultExe;
         if (extenderExe.exists()) {
             bundleExe = extenderExe;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
@@ -32,12 +32,11 @@ public class Win32Bundler implements IBundler {
         Map<String, IResource> bundleResources = ExtenderUtil.collectResources(project, platform);
 
         BobProjectProperties projectProperties = project.getProjectProperties();
-        final boolean debug = project.hasOption("debug");
-        final String variant = project.option("variant", null);
+        final String variant = Bob.getVariant(project.hasOption("debug"), project.option("variant", null));
 
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), platform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(platform, debug, variant));
+        File defaultExe = new File(Bob.getDmengineExe(platform, variant));
         File bundleExe = defaultExe;
         if (extenderExe.exists()) {
             bundleExe = extenderExe;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
@@ -32,11 +32,12 @@ public class Win32Bundler implements IBundler {
         Map<String, IResource> bundleResources = ExtenderUtil.collectResources(project, platform);
 
         BobProjectProperties projectProperties = project.getProjectProperties();
-        boolean debug = project.hasOption("debug");
+        final boolean debug = project.hasOption("debug");
+        final String variant = project.option("variant", null);
 
         String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
         File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), platform.formatBinaryName("dmengine"))));
-        File defaultExe = new File(Bob.getDmengineExe(platform, debug));
+        File defaultExe = new File(Bob.getDmengineExe(platform, debug, variant));
         File bundleExe = defaultExe;
         if (extenderExe.exists()) {
             bundleExe = extenderExe;

--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/handlers/SignHandler.java
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/handlers/SignHandler.java
@@ -154,8 +154,11 @@ public class SignHandler extends AbstractHandler {
 
 
             try {
-                exeArmv7 = new File(Bob.getDmengineExe(Platform.Armv7Darwin, true));
-                exeArm64 = new File(Bob.getDmengineExe(Platform.Arm64Darwin, true));
+                final boolean debug = project.hasOption("debug");
+                final String variant = option("variant", "debug");
+
+                exeArmv7 = new File(Bob.getDmengineExe(Platform.Armv7Darwin, debug, variant));
+                exeArm64 = new File(Bob.getDmengineExe(Platform.Arm64Darwin, debug, variant));
 
                 final IPreferenceStore store = Activator.getDefault().getPreferenceStore();
                 String nativeExtServerURI = store.getString(PreferenceConstants.P_NATIVE_EXT_SERVER_URI);

--- a/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/handlers/SignHandler.java
+++ b/com.dynamo.cr/com.dynamo.cr.editor/src/com/dynamo/cr/editor/handlers/SignHandler.java
@@ -154,11 +154,10 @@ public class SignHandler extends AbstractHandler {
 
 
             try {
-                final boolean debug = project.hasOption("debug");
-                final String variant = option("variant", "debug");
+                final String variant = Bob.getVariant(true, null);  // We always sign the debug non-stripped executable
 
-                exeArmv7 = new File(Bob.getDmengineExe(Platform.Armv7Darwin, debug, variant));
-                exeArm64 = new File(Bob.getDmengineExe(Platform.Arm64Darwin, debug, variant));
+                exeArmv7 = new File(Bob.getDmengineExe(Platform.Armv7Darwin, variant));
+                exeArm64 = new File(Bob.getDmengineExe(Platform.Arm64Darwin, variant));
 
                 final IPreferenceStore store = Activator.getDefault().getPreferenceStore();
                 String nativeExtServerURI = store.getString(PreferenceConstants.P_NATIVE_EXT_SERVER_URI);


### PR DESCRIPTION
Added two options for Bob

--variant=debug|release|headless
--strip-executable

If --variant and --strip-executable is not given, Bob works exactly as before with the --debug option.
--variant has precedence of over --debug option and if --variant is given stripping of the executable is off unless --strip-executable is given.

--strip-executable has precedence over --debug so if both are given stripping is enabled.