### PR TITLE
DEFEDIT-1450 Detect the editor and engine revisions from the Git repo in dev builds

### DIFF
--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -49,9 +49,17 @@
   ^String []
   (System/getProperty "defold.editor.sha1"))
 
+(defn set-defold-editor-sha1! [^String sha1]
+  (assert (not-empty sha1))
+  (System/setProperty "defold.editor.sha1" sha1))
+
 (defn defold-engine-sha1
   ^String []
   (System/getProperty "defold.engine.sha1"))
+
+(defn set-defold-engine-sha1! [^String sha1]
+  (assert (not-empty sha1))
+  (System/setProperty "defold.engine.sha1" sha1))
 
 (defn defold-build-time
   ^String []


### PR DESCRIPTION
Detect the editor and engine revisions from the Git repo in dev builds. This will make dev builds of the editor capable of building native extensions without modifications.