### PR TITLE
DEF-1593-bugfix - Fixes bug with movement direction orientation mode.

### DIFF
--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -613,7 +613,7 @@ namespace dmParticle
             return;
 
         Instance* inst = GetInstance(context, instance);
-        
+
         if (IsSleeping(inst))
             return;
 
@@ -1316,6 +1316,7 @@ namespace dmParticle
             for (uint32_t i = 0; i < count; ++i)
             {
                 Particle* particle = &particles[i];
+                particle->SetRotation(particle->GetSourceRotation() * dmVMath::QuatFromAngle(2, DEG_RAD * properties[PARTICLE_KEY_ROTATION]));
                 if (lengthSqr(particle->m_Velocity) > EPSILON)
                 {
                     Vector3 vel_norm = normalize(particle->m_Velocity);

--- a/engine/particle/src/test/movement_orientation.particlefx
+++ b/engine/particle/src/test/movement_orientation.particlefx
@@ -1,0 +1,225 @@
+emitters {
+  id: "emitter"
+  mode: PLAY_MODE_ONCE
+  duration: 0.16
+  space: EMISSION_SPACE_WORLD
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.70710677
+    w: 0.70710677
+  }
+  tile_source:        "particle.tilesource"
+  animation:          ""
+  material:           "particle.material"
+  blend_mode: BLEND_MODE_ADD
+  particle_orientation: PARTICLE_ORIENTATION_MOVEMENT_DIRECTION
+  inherit_velocity: 0.0
+  max_particle_count: 128
+  type: EMITTER_TYPE_2DCONE
+  start_delay: 0.0
+  properties {
+    key: EMITTER_KEY_SPAWN_RATE
+    points {
+      x: 0.0
+      y: 10.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_X
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_Y
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_SIZE_Z
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_LIFE_TIME
+    points {
+      x: 0.0
+      y: 2.5
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SPEED
+    points {
+      x: 0.0
+      y: 100.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_SIZE
+    points {
+      x: 0.0
+      y: 20.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_RED
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_GREEN
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_BLUE
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_ALPHA
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_ROTATION
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_STRETCH_FACTOR_X
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  properties {
+    key: EMITTER_KEY_PARTICLE_STRETCH_FACTOR_Y
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+    spread: 0.0
+  }
+  particle_properties {
+    key: PARTICLE_KEY_SCALE
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_RED
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_GREEN
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_BLUE
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_ALPHA
+    points {
+      x: 0.0
+      y: 1.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  particle_properties {
+    key: PARTICLE_KEY_ROTATION
+    points {
+      x: 0.0
+      y: 0.0
+      t_x: 1.0
+      t_y: 0.0
+    }
+  }
+  size_mode: SIZE_MODE_MANUAL
+  start_delay_spread: 0.0
+  duration_spread: 0.0
+  stretch_with_velocity: false
+  start_offset: 0.0
+}

--- a/engine/particle/src/test/test_particle.cpp
+++ b/engine/particle/src/test/test_particle.cpp
@@ -862,6 +862,46 @@ TEST_F(ParticleTest, ParticleApplyLifeRotationToMovementDirection)
 }
 
 /**
+* Verify particle keeps rotation along movement direction.
+*
+* DEF-1593 made some refactoring to the dmParticle::Simulate function
+* that broke the "movement direction" orientation mode.
+* With these changes the rotation was never reset to source rotation
+* before movement direction was calculated which made the rotation
+* accumulate the movement direction instead.
+*
+*  This test verifies the subsequent change fixes this.
+*/
+TEST_F(ParticleTest, ParticleMovementDirection)
+{
+    float dt = 0.16f;
+
+    ASSERT_TRUE(LoadPrototype("movement_orientation.particlefxc", &m_Prototype));
+    dmParticle::HInstance instance = dmParticle::CreateInstance(m_Context, m_Prototype, 0x0);
+    dmParticle::Emitter* e = GetEmitter(m_Context, instance, 0);
+
+    dmParticle::StartInstance(m_Context, instance);
+
+    dmParticle::Update(m_Context, dt, 0x0);
+    Quat q = e->m_Particles[0].GetRotation();
+
+    ASSERT_EQ(0.0f, q.getX());
+    ASSERT_EQ(0.0f, q.getY());
+    ASSERT_NEAR(0.70710677, q.getZ(), EPSILON);
+    ASSERT_NEAR(0.70710677, q.getW(), EPSILON);
+
+    dmParticle::Update(m_Context, dt, 0x0);
+    q = e->m_Particles[0].GetRotation();
+
+    ASSERT_EQ(0.0f, q.getX());
+    ASSERT_EQ(0.0f, q.getY());
+    ASSERT_NEAR(0.70710677, q.getZ(), EPSILON);
+    ASSERT_NEAR(0.70710677, q.getW(), EPSILON);
+
+    dmParticle::DestroyInstance(m_Context, instance);
+}
+
+/**
 * Verify particle rotation using static angular velocity.
 */
 TEST_F(ParticleTest, ParticleAngularVelocity)


### PR DESCRIPTION
DEF-1593 did some refactoring inside dmParticle::Simulate that broke
how the movement direction orientation mode worked.