### PR TITLE
DEFEDIT-1458 Change signature of project/connect-resource-node

### DIFF
--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -124,7 +124,7 @@
                            (g/disconnect project :nil-resource self :animation-resources)))
                        (for [new-resource new-value]
                          (if new-resource
-                           (project/connect-resource-node evaluation-context project new-resource self connections)
+                           (:tx-data (project/connect-resource-node evaluation-context project new-resource self connections))
                            (g/connect project :nil-resource self :animation-resources)))))))
             (dynamic visible (g/constantly false)))
 

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -245,9 +245,9 @@
                        (gu/disconnect-all basis self :module-completion-infos)
                        (for [module new-value]
                          (let [path (lua/lua-module->path module)]
-                           (project/connect-resource-node evaluation-context project path self
-                                                          [[:build-targets :dep-build-targets]
-                                                           [:completion-info :module-completion-infos]]))))))))
+                           (:tx-data (project/connect-resource-node evaluation-context project path self
+                                                                    [[:build-targets :dep-build-targets]
+                                                                     [:completion-info :module-completion-infos]])))))))))
 
   (property script-properties g/Any
             (default [])

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -260,45 +260,45 @@
                      (let [new-resource (:resource new-value)
                            basis (:basis evaluation-context)
                            project (project/get-project basis self)]
-                           (when-some [{connect-tx-data :tx-data go-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
-                             (let [component-overrides (into {}
-                                                             (map (fn [m]
-                                                                    [(:id m) (into {} (map (fn [p] [(properties/user-name->key (:id p)) [(:type p) (properties/str->go-prop (:value p) (:type p))]])
-                                                                                           (:properties m)))])
-                                                                  (:overrides new-value)))
-                                   override (g/override basis go-node {:traverse? or-go-traverse?})
-                                   id-mapping (:id-mapping override)
-                                   or-node (get id-mapping go-node)
-                                   component-ids (g/node-value go-node :component-ids evaluation-context)
-                                   id-mapping (fn [id]
-                                                (-> id
-                                                  component-ids
-                                                  (g/node-value :source-id evaluation-context)
-                                                  id-mapping))]
-                               (concat
-                                 connect-tx-data
-                                 (:tx-data override)
-                                 (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                                   (for [[from to] [[:_node-id                 :source-id]
-                                                    [:resource                 :source-resource]
-                                                    [:node-outline             :source-outline]
-                                                    [:scene                    :scene]
-                                                    [:ddf-component-properties :ddf-component-properties]]
-                                         :when (contains? outputs from)]
-                                     (g/connect or-node from self to)))
-                                 (for [[from to] [[:build-targets :source-build-targets]]]
-                                   (g/connect go-node from self to))
-                                 (for [[from to] [[:url :base-url]]]
-                                   (g/connect self from or-node to))
-                                 (for [[id p] component-overrides
-                                       [key [type value]] p
-                                       :let [comp-id (id-mapping id)]]
-                                   (let [refd-component (component-ids id)
-                                         refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
-                                         original-type (get-in refd-component-props [key :type])
-                                         override-type (script/go-prop-type->property-types type)]
-                                     (when (= original-type override-type)
-                                       (g/set-property comp-id key value)))))))))))
+                       (when-some [{connect-tx-data :tx-data go-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                         (let [component-overrides (into {}
+                                                         (map (fn [m]
+                                                                [(:id m) (into {} (map (fn [p] [(properties/user-name->key (:id p)) [(:type p) (properties/str->go-prop (:value p) (:type p))]])
+                                                                                       (:properties m)))])
+                                                              (:overrides new-value)))
+                               override (g/override basis go-node {:traverse? or-go-traverse?})
+                               id-mapping (:id-mapping override)
+                               or-node (get id-mapping go-node)
+                               component-ids (g/node-value go-node :component-ids evaluation-context)
+                               id-mapping (fn [id]
+                                            (-> id
+                                              component-ids
+                                              (g/node-value :source-id evaluation-context)
+                                              id-mapping))]
+                           (concat
+                             connect-tx-data
+                             (:tx-data override)
+                             (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                               (for [[from to] [[:_node-id                 :source-id]
+                                                [:resource                 :source-resource]
+                                                [:node-outline             :source-outline]
+                                                [:scene                    :scene]
+                                                [:ddf-component-properties :ddf-component-properties]]
+                                     :when (contains? outputs from)]
+                                 (g/connect or-node from self to)))
+                             (for [[from to] [[:build-targets :source-build-targets]]]
+                               (g/connect go-node from self to))
+                             (for [[from to] [[:url :base-url]]]
+                               (g/connect self from or-node to))
+                             (for [[id p] component-overrides
+                                   [key [type value]] p
+                                   :let [comp-id (id-mapping id)]]
+                               (let [refd-component (component-ids id)
+                                     refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
+                                     original-type (get-in refd-component-props [key :type])
+                                     override-type (script/go-prop-type->property-types type)]
+                                 (when (= original-type override-type)
+                                   (g/set-property comp-id key value)))))))))))
             (dynamic error (g/fnk [_node-id source-resource]
                                   (path-error _node-id source-resource))))
 
@@ -503,41 +503,41 @@
              (let [new-resource (:resource new-value)
                    basis (:basis evaluation-context)
                    project (project/get-project basis self)]
-                   (when-some [{connect-tx-data :tx-data coll-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
-                     (let [override (g/override basis coll-node {:traverse? or-coll-traverse?})
-                           id-mapping (:id-mapping override)
-                           go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
-                           component-overrides (for [{:keys [id properties]} (:overrides new-value)
-                                                     :let [comp-ids (-> id
-                                                                      go-inst-ids
-                                                                      (g/node-value :source-id evaluation-context)
-                                                                      (g/node-value :component-ids evaluation-context))]
-                                                     :when comp-ids
-                                                     {:keys [id properties]} properties
-                                                     :let [comp-id (-> id
-                                                                     comp-ids
-                                                                     (g/node-value :source-id evaluation-context))]
-                                                     p properties]
-                                                 [(id-mapping comp-id) (properties/user-name->key (:id p)) (properties/str->go-prop (:value p) (:type p))])
-                           or-node (get id-mapping coll-node)]
-                       (concat
-                         connect-tx-data
-                         (:tx-data override)
-                         (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                           (for [[from to] [[:_node-id       :source-id]
-                                            [:resource       :source-resource]
-                                            [:node-outline   :source-outline]
-                                            [:scene          :scene]
-                                            [:ddf-properties :ddf-properties]
-                                            [:go-inst-ids    :go-inst-ids]]
-                                 :when (contains? outputs from)]
-                             (g/connect or-node from self to)))
-                         (for [[from to] [[:build-targets :build-targets]]]
-                           (g/connect coll-node from self to))
-                         (for [[from to] [[:url :base-url]]]
-                           (g/connect self from or-node to))
-                         (for [[comp-id label value] component-overrides]
-                           (g/set-property comp-id label value)))))))))
+               (when-some [{connect-tx-data :tx-data coll-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                 (let [override (g/override basis coll-node {:traverse? or-coll-traverse?})
+                       id-mapping (:id-mapping override)
+                       go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
+                       component-overrides (for [{:keys [id properties]} (:overrides new-value)
+                                                 :let [comp-ids (-> id
+                                                                  go-inst-ids
+                                                                  (g/node-value :source-id evaluation-context)
+                                                                  (g/node-value :component-ids evaluation-context))]
+                                                 :when comp-ids
+                                                 {:keys [id properties]} properties
+                                                 :let [comp-id (-> id
+                                                                 comp-ids
+                                                                 (g/node-value :source-id evaluation-context))]
+                                                 p properties]
+                                             [(id-mapping comp-id) (properties/user-name->key (:id p)) (properties/str->go-prop (:value p) (:type p))])
+                       or-node (get id-mapping coll-node)]
+                   (concat
+                     connect-tx-data
+                     (:tx-data override)
+                     (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                       (for [[from to] [[:_node-id       :source-id]
+                                        [:resource       :source-resource]
+                                        [:node-outline   :source-outline]
+                                        [:scene          :scene]
+                                        [:ddf-properties :ddf-properties]
+                                        [:go-inst-ids    :go-inst-ids]]
+                             :when (contains? outputs from)]
+                         (g/connect or-node from self to)))
+                     (for [[from to] [[:build-targets :build-targets]]]
+                       (g/connect coll-node from self to))
+                     (for [[from to] [[:url :base-url]]]
+                       (g/connect self from or-node to))
+                     (for [[comp-id label value] component-overrides]
+                       (g/set-property comp-id label value)))))))))
     (dynamic error (g/fnk [_node-id source-resource]
                           (path-error _node-id source-resource)))
     (dynamic edit-type (g/fnk [source-resource]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -257,47 +257,48 @@
                      (if-let [old-source (g/node-value self :source-id evaluation-context)]
                        (g/delete-node old-source)
                        [])
-                     (let [new-resource (:resource new-value)]
-                       (let [basis (:basis evaluation-context)
-                             project (project/get-project basis self)]
-                         (project/connect-resource-node evaluation-context project new-resource self []
-                                                        (fn [go-node]
-                                                          (let [component-overrides (into {} (map (fn [m]
-                                                                                                    [(:id m) (into {} (map (fn [p] [(properties/user-name->key (:id p)) [(:type p) (properties/str->go-prop (:value p) (:type p))]])
-                                                                                                                           (:properties m)))])
-                                                                                                  (:overrides new-value)))
-                                                                override (g/override basis go-node {:traverse? or-go-traverse?})
-                                                                id-mapping (:id-mapping override)
-                                                                or-node (get id-mapping go-node)
-                                                                component-ids (g/node-value go-node :component-ids evaluation-context)
-                                                                id-mapping (fn [id]
-                                                                             (-> id
-                                                                                 component-ids
-                                                                                 (g/node-value :source-id evaluation-context)
-                                                                                 id-mapping))]
-                                                            (concat
-                                                              (:tx-data override)
-                                                              (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                                                                (for [[from to] [[:_node-id                 :source-id]
-                                                                                 [:resource                 :source-resource]
-                                                                                 [:node-outline             :source-outline]
-                                                                                 [:scene                    :scene]
-                                                                                 [:ddf-component-properties :ddf-component-properties]]
-                                                                      :when (contains? outputs from)]
-                                                                  (g/connect or-node from self to)))
-                                                              (for [[from to] [[:build-targets :source-build-targets]]]
-                                                                (g/connect go-node from self to))
-                                                              (for [[from to] [[:url :base-url]]]
-                                                                (g/connect self from or-node to))
-                                                              (for [[id p] component-overrides
-                                                                    [key [type value]] p
-                                                                    :let [comp-id (id-mapping id)]]
-                                                                (let [refd-component (component-ids id)
-                                                                      refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
-                                                                      original-type (get-in refd-component-props [key :type])
-                                                                      override-type (script/go-prop-type->property-types type)]
-                                                                  (when (= original-type override-type)
-                                                                    (g/set-property comp-id key value)))))))))))))
+                     (let [new-resource (:resource new-value)
+                           basis (:basis evaluation-context)
+                           project (project/get-project basis self)]
+                           (when-some [{connect-tx-data :tx-data go-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                             (let [component-overrides (into {}
+                                                             (map (fn [m]
+                                                                    [(:id m) (into {} (map (fn [p] [(properties/user-name->key (:id p)) [(:type p) (properties/str->go-prop (:value p) (:type p))]])
+                                                                                           (:properties m)))])
+                                                                  (:overrides new-value)))
+                                   override (g/override basis go-node {:traverse? or-go-traverse?})
+                                   id-mapping (:id-mapping override)
+                                   or-node (get id-mapping go-node)
+                                   component-ids (g/node-value go-node :component-ids evaluation-context)
+                                   id-mapping (fn [id]
+                                                (-> id
+                                                  component-ids
+                                                  (g/node-value :source-id evaluation-context)
+                                                  id-mapping))]
+                               (concat
+                                 connect-tx-data
+                                 (:tx-data override)
+                                 (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                                   (for [[from to] [[:_node-id                 :source-id]
+                                                    [:resource                 :source-resource]
+                                                    [:node-outline             :source-outline]
+                                                    [:scene                    :scene]
+                                                    [:ddf-component-properties :ddf-component-properties]]
+                                         :when (contains? outputs from)]
+                                     (g/connect or-node from self to)))
+                                 (for [[from to] [[:build-targets :source-build-targets]]]
+                                   (g/connect go-node from self to))
+                                 (for [[from to] [[:url :base-url]]]
+                                   (g/connect self from or-node to))
+                                 (for [[id p] component-overrides
+                                       [key [type value]] p
+                                       :let [comp-id (id-mapping id)]]
+                                   (let [refd-component (component-ids id)
+                                         refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
+                                         original-type (get-in refd-component-props [key :type])
+                                         override-type (script/go-prop-type->property-types type)]
+                                     (when (= original-type override-type)
+                                       (g/set-property comp-id key value)))))))))))
             (dynamic error (g/fnk [_node-id source-resource]
                                   (path-error _node-id source-resource))))
 
@@ -499,44 +500,44 @@
              (if-let [old-source (g/node-value self :source-id evaluation-context)]
                (g/delete-node old-source)
                [])
-             (let [new-resource (:resource new-value)]
-               (let [basis (:basis evaluation-context)
-                     project (project/get-project basis self)]
-                 (project/connect-resource-node evaluation-context project new-resource self []
-                                                (fn [coll-node]
-                                                  (let [override (g/override basis coll-node {:traverse? or-coll-traverse?})
-                                                        id-mapping (:id-mapping override)
-                                                        go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
-                                                        component-overrides (for [{:keys [id properties]} (:overrides new-value)
-                                                                                  :let [comp-ids (-> id
-                                                                                                   go-inst-ids
-                                                                                                   (g/node-value :source-id evaluation-context)
-                                                                                                   (g/node-value :component-ids evaluation-context))]
-                                                                                  :when comp-ids
-                                                                                  {:keys [id properties]} properties
-                                                                                  :let [comp-id (-> id
-                                                                                                  comp-ids
-                                                                                                  (g/node-value :source-id evaluation-context))]
-                                                                                  p properties]
-                                                                              [(id-mapping comp-id) (properties/user-name->key (:id p)) (properties/str->go-prop (:value p) (:type p))])
-                                                        or-node (get id-mapping coll-node)]
-                                                    (concat
-                                                      (:tx-data override)
-                                                      (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                                                        (for [[from to] [[:_node-id       :source-id]
-                                                                         [:resource       :source-resource]
-                                                                         [:node-outline   :source-outline]
-                                                                         [:scene          :scene]
-                                                                         [:ddf-properties :ddf-properties]
-                                                                         [:go-inst-ids    :go-inst-ids]]
-                                                              :when (contains? outputs from)]
-                                                          (g/connect or-node from self to)))
-                                                      (for [[from to] [[:build-targets :build-targets]]]
-                                                        (g/connect coll-node from self to))
-                                                      (for [[from to] [[:url :base-url]]]
-                                                        (g/connect self from or-node to))
-                                                      (for [[comp-id label value] component-overrides]
-                                                        (g/set-property comp-id label value)))))))))))
+             (let [new-resource (:resource new-value)
+                   basis (:basis evaluation-context)
+                   project (project/get-project basis self)]
+                   (when-some [{connect-tx-data :tx-data coll-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                     (let [override (g/override basis coll-node {:traverse? or-coll-traverse?})
+                           id-mapping (:id-mapping override)
+                           go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
+                           component-overrides (for [{:keys [id properties]} (:overrides new-value)
+                                                     :let [comp-ids (-> id
+                                                                      go-inst-ids
+                                                                      (g/node-value :source-id evaluation-context)
+                                                                      (g/node-value :component-ids evaluation-context))]
+                                                     :when comp-ids
+                                                     {:keys [id properties]} properties
+                                                     :let [comp-id (-> id
+                                                                     comp-ids
+                                                                     (g/node-value :source-id evaluation-context))]
+                                                     p properties]
+                                                 [(id-mapping comp-id) (properties/user-name->key (:id p)) (properties/str->go-prop (:value p) (:type p))])
+                           or-node (get id-mapping coll-node)]
+                       (concat
+                         connect-tx-data
+                         (:tx-data override)
+                         (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                           (for [[from to] [[:_node-id       :source-id]
+                                            [:resource       :source-resource]
+                                            [:node-outline   :source-outline]
+                                            [:scene          :scene]
+                                            [:ddf-properties :ddf-properties]
+                                            [:go-inst-ids    :go-inst-ids]]
+                                 :when (contains? outputs from)]
+                             (g/connect or-node from self to)))
+                         (for [[from to] [[:build-targets :build-targets]]]
+                           (g/connect coll-node from self to))
+                         (for [[from to] [[:url :base-url]]]
+                           (g/connect self from or-node to))
+                         (for [[comp-id label value] component-overrides]
+                           (g/set-property comp-id label value)))))))))
     (dynamic error (g/fnk [_node-id source-resource]
                           (path-error _node-id source-resource)))
     (dynamic edit-type (g/fnk [source-resource]

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -678,28 +678,31 @@
       [tx-data-context' created-resource-node-id creation-tx-data])))
 
 (defn connect-resource-node
-  ([evaluation-context project path-or-resource consumer-node connections]
-   (connect-resource-node evaluation-context project path-or-resource consumer-node connections nil))
-  ([evaluation-context project path-or-resource consumer-node connections attach-fn]
-   ;; TODO: This is typically run from a property setter, where currently the
-   ;; evaluation-context does not contain a cache. This makes resource lookups
-   ;; very costly as they need to produce the lookup maps every time.
-   ;; In large projects, this has a huge impact on load time. To work around
-   ;; this, we use the default, cached evaluation-context to resolve resources.
-   ;; This has been reported as DEFEDIT-1411.
-   (g/with-auto-evaluation-context default-evaluation-context
-     (when-some [resource (resolve-path-or-resource project path-or-resource default-evaluation-context)]
-       (let [[node-id creation-tx-data] (if-some [existing-resource-node-id (get-resource-node project resource default-evaluation-context)]
-                                          [existing-resource-node-id nil]
-                                          (thread-util/swap-rest! (:tx-data-context evaluation-context) ensure-resource-node-created project resource))
-             node-type (resource-node-type resource)]
-         (concat
-           creation-tx-data
-           (when (or creation-tx-data *load-cache*)
-             (load-node project node-id node-type resource))
-           (connect-if-output node-type node-id consumer-node connections)
-           (when (some? attach-fn)
-             (attach-fn node-id))))))))
+  "Creates transaction steps for creating `connections` between the
+  corresponding node for `path-or-resource` and `consumer-node`. If
+  there is no corresponding node for `path-or-resource`, transactions
+  for creating and loading the node will be included. Returns map with
+  transactions in :tx-data and node-id corresponding to
+  `path-or-resource` in :node-id"
+  [evaluation-context project path-or-resource consumer-node connections]
+  ;; TODO: This is typically run from a property setter, where currently the
+  ;; evaluation-context does not contain a cache. This makes resource lookups
+  ;; very costly as they need to produce the lookup maps every time.
+  ;; In large projects, this has a huge impact on load time. To work around
+  ;; this, we use the default, cached evaluation-context to resolve resources.
+  ;; This has been reported as DEFEDIT-1411.
+  (g/with-auto-evaluation-context default-evaluation-context
+    (when-some [resource (resolve-path-or-resource project path-or-resource default-evaluation-context)]
+      (let [[node-id creation-tx-data] (if-some [existing-resource-node-id (get-resource-node project resource default-evaluation-context)]
+                                         [existing-resource-node-id nil]
+                                         (thread-util/swap-rest! (:tx-data-context evaluation-context) ensure-resource-node-created project resource))
+            node-type (resource-node-type resource)]
+        {:node-id node-id
+         :tx-data (concat
+                    creation-tx-data
+                    (when (or creation-tx-data *load-cache*)
+                      (load-node project node-id node-type resource))
+                    (connect-if-output node-type node-id consumer-node connections))}))))
 
 (deftype ProjectResourceListener [project-id]
   resource/ResourceListener
@@ -759,4 +762,4 @@
   (let [project (get-project (:basis evaluation-context) self)]
     (concat
       (when old-value (disconnect-resource-node evaluation-context project old-value self connections))
-      (when new-value (connect-resource-node evaluation-context project new-value self connections)))))
+      (when new-value (:tx-data (connect-resource-node evaluation-context project new-value self connections))))))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -267,28 +267,28 @@
                        (if override?
                          (let [basis (:basis evaluation-context)
                                project (project/get-project basis self)]
-                               (when-some [{connect-tx-data :tx-data comp-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
-                                 (let [override (g/override basis comp-node {:traverse? (constantly true)})
-                                       id-mapping (:id-mapping override)
-                                       or-node (get id-mapping comp-node)
-                                       comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
-                                   (concat
-                                     connect-tx-data
-                                     (:tx-data override)
-                                     (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                                       (for [[from to] [[:_node-id :source-id]
-                                                        [:resource :source-resource]
-                                                        [:node-outline :source-outline]
-                                                        [:_properties :source-properties]
-                                                        [:scene :scene]
-                                                        [:build-targets :source-build-targets]]
-                                             :when (contains? outputs from)]
-                                         (g/connect or-node from self to)))
-                                     (for [[label [type value]] (:overrides new-value)]
-                                       (let [original-type (get-in comp-props [label :type])
-                                             override-type (script/go-prop-type->property-types type)]
-                                         (when (= original-type override-type)
-                                           (g/set-property or-node label value))))))))
+                           (when-some [{connect-tx-data :tx-data comp-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                             (let [override (g/override basis comp-node {:traverse? (constantly true)})
+                                   id-mapping (:id-mapping override)
+                                   or-node (get id-mapping comp-node)
+                                   comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
+                               (concat
+                                 connect-tx-data
+                                 (:tx-data override)
+                                 (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                                   (for [[from to] [[:_node-id :source-id]
+                                                    [:resource :source-resource]
+                                                    [:node-outline :source-outline]
+                                                    [:_properties :source-properties]
+                                                    [:scene :scene]
+                                                    [:build-targets :source-build-targets]]
+                                         :when (contains? outputs from)]
+                                     (g/connect or-node from self to)))
+                                 (for [[label [type value]] (:overrides new-value)]
+                                   (let [original-type (get-in comp-props [label :type])
+                                         override-type (script/go-prop-type->property-types type)]
+                                     (when (= original-type override-type)
+                                       (g/set-property or-node label value))))))))
                          (project/resource-setter evaluation-context self (:resource old-value) (:resource new-value)
                                                   [:resource :source-resource]
                                                   [:node-outline :source-outline]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -267,28 +267,28 @@
                        (if override?
                          (let [basis (:basis evaluation-context)
                                project (project/get-project basis self)]
-                           (project/connect-resource-node evaluation-context project new-resource self []
-                                                          (fn [comp-node]
-                                                            (let [override (g/override basis comp-node {:traverse? (constantly true)})
-                                                                  id-mapping (:id-mapping override)
-                                                                  or-node (get id-mapping comp-node)
-                                                                  comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
-                                                              (concat
-                                                                (:tx-data override)
-                                                                (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                                                                  (for [[from to] [[:_node-id :source-id]
-                                                                                   [:resource :source-resource]
-                                                                                   [:node-outline :source-outline]
-                                                                                   [:_properties :source-properties]
-                                                                                   [:scene :scene]
-                                                                                   [:build-targets :source-build-targets]]
-                                                                        :when (contains? outputs from)]
-                                                                    (g/connect or-node from self to)))
-                                                                (for [[label [type value]] (:overrides new-value)]
-                                                                  (let [original-type (get-in comp-props [label :type])
-                                                                        override-type (script/go-prop-type->property-types type)]
-                                                                    (when (= original-type override-type)
-                                                                      (g/set-property or-node label value)))))))))
+                               (when-some [{connect-tx-data :tx-data comp-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                                 (let [override (g/override basis comp-node {:traverse? (constantly true)})
+                                       id-mapping (:id-mapping override)
+                                       or-node (get id-mapping comp-node)
+                                       comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
+                                   (concat
+                                     connect-tx-data
+                                     (:tx-data override)
+                                     (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                                       (for [[from to] [[:_node-id :source-id]
+                                                        [:resource :source-resource]
+                                                        [:node-outline :source-outline]
+                                                        [:_properties :source-properties]
+                                                        [:scene :scene]
+                                                        [:build-targets :source-build-targets]]
+                                             :when (contains? outputs from)]
+                                         (g/connect or-node from self to)))
+                                     (for [[label [type value]] (:overrides new-value)]
+                                       (let [original-type (get-in comp-props [label :type])
+                                             override-type (script/go-prop-type->property-types type)]
+                                         (when (= original-type override-type)
+                                           (g/set-property or-node label value))))))))
                          (project/resource-setter evaluation-context self (:resource old-value) (:resource new-value)
                                                   [:resource :source-resource]
                                                   [:node-outline :source-outline]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1058,8 +1058,8 @@
             (dynamic error (g/fnk [_node-id template-resource]
                              (prop-resource-error _node-id :template template-resource "Template")))
             (value (g/fnk [_node-id id template-resource template-overrides]
-                          (let [overrides (into {} (map (fn [[k v]] [(subs k (inc (count id))) v]) template-overrides))]
-                            {:resource template-resource :overrides overrides})))
+                     (let [overrides (into {} (map (fn [[k v]] [(subs k (inc (count id))) v]) template-overrides))]
+                       {:resource template-resource :overrides overrides})))
             (set (fn [evaluation-context self old-value new-value]
                    (let [basis (:basis evaluation-context)
                          project (project/get-project basis self)
@@ -1069,49 +1069,49 @@
                          (g/delete-node current-scene)
                          [])
                        (if (and new-value (:resource new-value))
-                         (project/connect-resource-node evaluation-context project (:resource new-value) self []
-                                                        (fn [scene-node]
-                                                          (let [properties-by-node-id (comp (or (:overrides new-value) {})
-                                                                                        (into {} (map (fn [[k v]] [v k]))
-                                                                                          (g/node-value scene-node :node-ids evaluation-context)))
-                                                                override (g/override basis scene-node {:traverse? (fn [basis [src src-label tgt tgt-label]]
-                                                                                                                    (if (not= src current-scene)
-                                                                                                                      (or (g/node-instance? basis GuiNode src)
-                                                                                                                          (g/node-instance? basis NodeTree src)
-                                                                                                                          (g/node-instance? basis GuiSceneNode src)
-                                                                                                                          (g/node-instance? basis LayoutsNode src)
-                                                                                                                          (g/node-instance? basis LayoutNode src))
-                                                                                                                      false))
-                                                                                                       :properties-by-node-id properties-by-node-id})
-                                                                id-mapping (:id-mapping override)
-                                                                or-scene (get id-mapping scene-node)]
-                                                            (concat
-                                                              (:tx-data override)
-                                                              (for [[from to] [[:node-ids :node-ids]
-                                                                               [:node-outline :template-outline]
-                                                                               [:template-scene :template-scene]
-                                                                               [:build-targets :template-build-targets]
-                                                                               [:build-errors :child-build-errors]
-                                                                               [:resource :template-resource]
-                                                                               [:pb-msg :scene-pb-msg]
-                                                                               [:rt-pb-msg :scene-rt-pb-msg]
-                                                                               [:node-overrides :template-overrides]]]
-                                                                (g/connect or-scene from self to))
-                                                              (for [[from to] [[:layer-names :layer-names]
-                                                                               [:texture-gpu-textures :aux-texture-gpu-textures]
-                                                                               [:texture-anim-datas :aux-texture-anim-datas]
-                                                                               [:texture-names :aux-texture-names]
-                                                                               [:font-shaders :aux-font-shaders]
-                                                                               [:font-datas :aux-font-datas]
-                                                                               [:font-names :aux-font-names]
-                                                                               [:spine-scene-element-ids :aux-spine-scene-element-ids]
-                                                                               [:spine-scene-infos :aux-spine-scene-infos]
-                                                                               [:spine-scene-names :aux-spine-scene-names]
-                                                                               [:particlefx-infos :aux-particlefx-infos]
-                                                                               [:particlefx-resource-names :aux-particlefx-resource-names]
-                                                                               [:template-prefix :id-prefix]
-                                                                               [:current-layout :current-layout]]]
-                                                                (g/connect self from or-scene to))))))
+                         (when-some [{connect-tx-data :tx-data scene-node :node-id} (project/connect-resource-node evaluation-context project (:resource new-value) self [])]
+                           (let [properties-by-node-id (comp (or (:overrides new-value) {})
+                                                             (into {} (map (fn [[k v]] [v k]))
+                                                                   (g/node-value scene-node :node-ids evaluation-context)))
+                                 override (g/override basis scene-node {:traverse? (fn [basis [src src-label tgt tgt-label]]
+                                                                                     (if (not= src current-scene)
+                                                                                       (or (g/node-instance? basis GuiNode src)
+                                                                                           (g/node-instance? basis NodeTree src)
+                                                                                           (g/node-instance? basis GuiSceneNode src)
+                                                                                           (g/node-instance? basis LayoutsNode src)
+                                                                                           (g/node-instance? basis LayoutNode src))
+                                                                                       false))
+                                                                        :properties-by-node-id properties-by-node-id})
+                                 id-mapping (:id-mapping override)
+                                 or-scene (get id-mapping scene-node)]
+                             (concat
+                               connect-tx-data
+                               (:tx-data override)
+                               (for [[from to] [[:node-ids :node-ids]
+                                                [:node-outline :template-outline]
+                                                [:template-scene :template-scene]
+                                                [:build-targets :template-build-targets]
+                                                [:build-errors :child-build-errors]
+                                                [:resource :template-resource]
+                                                [:pb-msg :scene-pb-msg]
+                                                [:rt-pb-msg :scene-rt-pb-msg]
+                                                [:node-overrides :template-overrides]]]
+                                 (g/connect or-scene from self to))
+                               (for [[from to] [[:layer-names :layer-names]
+                                                [:texture-gpu-textures :aux-texture-gpu-textures]
+                                                [:texture-anim-datas :aux-texture-anim-datas]
+                                                [:texture-names :aux-texture-names]
+                                                [:font-shaders :aux-font-shaders]
+                                                [:font-datas :aux-font-datas]
+                                                [:font-names :aux-font-names]
+                                                [:spine-scene-element-ids :aux-spine-scene-element-ids]
+                                                [:spine-scene-infos :aux-spine-scene-infos]
+                                                [:spine-scene-names :aux-spine-scene-names]
+                                                [:particlefx-infos :aux-particlefx-infos]
+                                                [:particlefx-resource-names :aux-particlefx-resource-names]
+                                                [:template-prefix :id-prefix]
+                                                [:current-layout :current-layout]]]
+                                 (g/connect self from or-scene to)))))
                          []))))))
 
   (display-order (into base-display-order [:template]))

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -153,7 +153,7 @@
                            (g/disconnect project :nil-resource self :texture-resources)))
                        (for [r new-value]
                          (if r
-                           (project/connect-resource-node evaluation-context project r self connections)
+                           (:tx-data (project/connect-resource-node evaluation-context project r self connections))
                            (g/connect project :nil-resource self :texture-resources)))))))
             (dynamic visible (g/constantly false)))
   (property skeleton resource/Resource

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -26,7 +26,7 @@
                          (project/disconnect-resource-node evaluation-context project old-value self connections)
                          (g/disconnect project :nil-resource self :material-resource))
                        (if new-value
-                         (project/connect-resource-node evaluation-context project new-value self connections)
+                         (:tx-data (project/connect-resource-node evaluation-context project new-value self connections))
                          (g/connect project :nil-resource self :material-resource))))))
            (dynamic visible (g/constantly false)))
 

--- a/editor/test/editor/defold_project_test.clj
+++ b/editor/test/editor/defold_project_test.clj
@@ -21,7 +21,7 @@
   (property source-resource resource/Resource
             (set (fn [evaluation-context self _old-value new-value]
                    (let [project (project/get-project (:basis evaluation-context) self)]
-                     (project/connect-resource-node evaluation-context project new-value self [[:value :value-input]])))))
+                     (:tx-data (project/connect-resource-node evaluation-context project new-value self [[:value :value-input]]))))))
   (input value-input g/Str))
 
 (g/defnode BNode


### PR DESCRIPTION
* Technical changes
  - project/connect-resource-node now returns map with :tx-data and
  :node-id instead of taking continuation function passed as arg
  - changed all uses of connect-resource-node accordingly