### PR TITLE
DEFEDIT-1460 Change signature of g/override

### DIFF
--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -265,40 +265,40 @@
                                                          (map (fn [m]
                                                                 [(:id m) (into {} (map (fn [p] [(properties/user-name->key (:id p)) [(:type p) (properties/str->go-prop (:value p) (:type p))]])
                                                                                        (:properties m)))])
-                                                              (:overrides new-value)))
-                               override (g/override basis go-node {:traverse? or-go-traverse?})
-                               id-mapping (:id-mapping override)
-                               or-node (get id-mapping go-node)
-                               component-ids (g/node-value go-node :component-ids evaluation-context)
-                               id-mapping (fn [id]
-                                            (-> id
-                                              component-ids
-                                              (g/node-value :source-id evaluation-context)
-                                              id-mapping))]
+                                                              (:overrides new-value)))]
                            (concat
                              connect-tx-data
-                             (:tx-data override)
-                             (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                               (for [[from to] [[:_node-id                 :source-id]
-                                                [:resource                 :source-resource]
-                                                [:node-outline             :source-outline]
-                                                [:scene                    :scene]
-                                                [:ddf-component-properties :ddf-component-properties]]
-                                     :when (contains? outputs from)]
-                                 (g/connect or-node from self to)))
-                             (for [[from to] [[:build-targets :source-build-targets]]]
-                               (g/connect go-node from self to))
-                             (for [[from to] [[:url :base-url]]]
-                               (g/connect self from or-node to))
-                             (for [[id p] component-overrides
-                                   [key [type value]] p
-                                   :let [comp-id (id-mapping id)]]
-                               (let [refd-component (component-ids id)
-                                     refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
-                                     original-type (get-in refd-component-props [key :type])
-                                     override-type (script/go-prop-type->property-types type)]
-                                 (when (= original-type override-type)
-                                   (g/set-property comp-id key value)))))))))))
+                             (g/override go-node {:traverse? or-go-traverse?}
+                                         (fn [evaluation-context id-mapping]
+                                           (let [or-node (get id-mapping go-node)
+                                                 component-ids (g/node-value go-node :component-ids evaluation-context)
+                                                 id-mapping (fn [id]
+                                                              (-> id
+                                                                component-ids
+                                                                (g/node-value :source-id evaluation-context)
+                                                                id-mapping))]
+                                             (concat
+                                               (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                                                 (for [[from to] [[:_node-id                 :source-id]
+                                                                  [:resource                 :source-resource]
+                                                                  [:node-outline             :source-outline]
+                                                                  [:scene                    :scene]
+                                                                  [:ddf-component-properties :ddf-component-properties]]
+                                                       :when (contains? outputs from)]
+                                                   (g/connect or-node from self to)))
+                                               (for [[from to] [[:build-targets :source-build-targets]]]
+                                                 (g/connect go-node from self to))
+                                               (for [[from to] [[:url :base-url]]]
+                                                 (g/connect self from or-node to))
+                                               (for [[id p] component-overrides
+                                                     [key [type value]] p
+                                                     :let [comp-id (id-mapping id)]]
+                                                 (let [refd-component (component-ids id)
+                                                       refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
+                                                       original-type (get-in refd-component-props [key :type])
+                                                       override-type (script/go-prop-type->property-types type)]
+                                                   (when (= original-type override-type)
+                                                     (g/set-property comp-id key value)))))))))))))))
             (dynamic error (g/fnk [_node-id source-resource]
                                   (path-error _node-id source-resource))))
 
@@ -504,40 +504,40 @@
                    basis (:basis evaluation-context)
                    project (project/get-project basis self)]
                (when-some [{connect-tx-data :tx-data coll-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
-                 (let [override (g/override basis coll-node {:traverse? or-coll-traverse?})
-                       id-mapping (:id-mapping override)
-                       go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
-                       component-overrides (for [{:keys [id properties]} (:overrides new-value)
-                                                 :let [comp-ids (-> id
-                                                                  go-inst-ids
-                                                                  (g/node-value :source-id evaluation-context)
-                                                                  (g/node-value :component-ids evaluation-context))]
-                                                 :when comp-ids
-                                                 {:keys [id properties]} properties
-                                                 :let [comp-id (-> id
-                                                                 comp-ids
-                                                                 (g/node-value :source-id evaluation-context))]
-                                                 p properties]
-                                             [(id-mapping comp-id) (properties/user-name->key (:id p)) (properties/str->go-prop (:value p) (:type p))])
-                       or-node (get id-mapping coll-node)]
-                   (concat
-                     connect-tx-data
-                     (:tx-data override)
-                     (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                       (for [[from to] [[:_node-id       :source-id]
-                                        [:resource       :source-resource]
-                                        [:node-outline   :source-outline]
-                                        [:scene          :scene]
-                                        [:ddf-properties :ddf-properties]
-                                        [:go-inst-ids    :go-inst-ids]]
-                             :when (contains? outputs from)]
-                         (g/connect or-node from self to)))
-                     (for [[from to] [[:build-targets :build-targets]]]
-                       (g/connect coll-node from self to))
-                     (for [[from to] [[:url :base-url]]]
-                       (g/connect self from or-node to))
-                     (for [[comp-id label value] component-overrides]
-                       (g/set-property comp-id label value)))))))))
+                 (concat
+                   connect-tx-data
+                   (g/override coll-node {:tranverse? or-coll-traverse?}
+                               (fn [evaluation-context id-mapping]
+                                 (let [go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
+                                       component-overrides (for [{:keys [id properties]} (:overrides new-value)
+                                                                 :let [comp-ids (-> id
+                                                                                  go-inst-ids
+                                                                                  (g/node-value :source-id evaluation-context)
+                                                                                  (g/node-value :component-ids evaluation-context))]
+                                                                 :when comp-ids
+                                                                 {:keys [id properties]} properties
+                                                                 :let [comp-id (-> id
+                                                                                 comp-ids
+                                                                                 (g/node-value :source-id evaluation-context))]
+                                                                 p properties]
+                                                             [(id-mapping comp-id) (properties/user-name->key (:id p)) (properties/str->go-prop (:value p) (:type p))])
+                                       or-node (get id-mapping coll-node)]
+                                   (concat
+                                     (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                                       (for [[from to] [[:_node-id       :source-id]
+                                                        [:resource       :source-resource]
+                                                        [:node-outline   :source-outline]
+                                                        [:scene          :scene]
+                                                        [:ddf-properties :ddf-properties]
+                                                        [:go-inst-ids    :go-inst-ids]]
+                                             :when (contains? outputs from)]
+                                         (g/connect or-node from self to)))
+                                     (for [[from to] [[:build-targets :build-targets]]]
+                                       (g/connect coll-node from self to))
+                                     (for [[from to] [[:url :base-url]]]
+                                       (g/connect self from or-node to))
+                                     (for [[comp-id label value] component-overrides]
+                                       (g/set-property comp-id label value))))))))))))
     (dynamic error (g/fnk [_node-id source-resource]
                           (path-error _node-id source-resource)))
     (dynamic edit-type (g/fnk [source-resource]

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -268,27 +268,27 @@
                          (let [basis (:basis evaluation-context)
                                project (project/get-project basis self)]
                            (when-some [{connect-tx-data :tx-data comp-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
-                             (let [override (g/override basis comp-node {:traverse? (constantly true)})
-                                   id-mapping (:id-mapping override)
-                                   or-node (get id-mapping comp-node)
-                                   comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
-                               (concat
-                                 connect-tx-data
-                                 (:tx-data override)
-                                 (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
-                                   (for [[from to] [[:_node-id :source-id]
-                                                    [:resource :source-resource]
-                                                    [:node-outline :source-outline]
-                                                    [:_properties :source-properties]
-                                                    [:scene :scene]
-                                                    [:build-targets :source-build-targets]]
-                                         :when (contains? outputs from)]
-                                     (g/connect or-node from self to)))
-                                 (for [[label [type value]] (:overrides new-value)]
-                                   (let [original-type (get-in comp-props [label :type])
-                                         override-type (script/go-prop-type->property-types type)]
-                                     (when (= original-type override-type)
-                                       (g/set-property or-node label value))))))))
+                             (concat
+                               connect-tx-data
+                               (g/override comp-node {:traverse? (constantly true)}
+                                           (fn [evaluation-context id-mapping]
+                                             (let [or-node (get id-mapping comp-node)
+                                                   comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
+                                               (concat
+                                                 (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
+                                                   (for [[from to] [[:_node-id :source-id]
+                                                                    [:resource :source-resource]
+                                                                    [:node-outline :source-outline]
+                                                                    [:_properties :source-properties]
+                                                                    [:scene :scene]
+                                                                    [:build-targets :source-build-targets]]
+                                                         :when (contains? outputs from)]
+                                                     (g/connect or-node from self to)))
+                                                 (for [[label [type value]] (:overrides new-value)]
+                                                   (let [original-type (get-in comp-props [label :type])
+                                                         override-type (script/go-prop-type->property-types type)]
+                                                     (when (= original-type override-type)
+                                                       (g/set-property or-node label value)))))))))))
                          (project/resource-setter evaluation-context self (:resource old-value) (:resource new-value)
                                                   [:resource :source-resource]
                                                   [:node-outline :source-outline]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1070,48 +1070,48 @@
                          [])
                        (if (and new-value (:resource new-value))
                          (when-some [{connect-tx-data :tx-data scene-node :node-id} (project/connect-resource-node evaluation-context project (:resource new-value) self [])]
-                           (let [properties-by-node-id (comp (or (:overrides new-value) {})
-                                                             (into {} (map (fn [[k v]] [v k]))
-                                                                   (g/node-value scene-node :node-ids evaluation-context)))
-                                 override (g/override basis scene-node {:traverse? (fn [basis [src src-label tgt tgt-label]]
-                                                                                     (if (not= src current-scene)
-                                                                                       (or (g/node-instance? basis GuiNode src)
-                                                                                           (g/node-instance? basis NodeTree src)
-                                                                                           (g/node-instance? basis GuiSceneNode src)
-                                                                                           (g/node-instance? basis LayoutsNode src)
-                                                                                           (g/node-instance? basis LayoutNode src))
-                                                                                       false))
-                                                                        :properties-by-node-id properties-by-node-id})
-                                 id-mapping (:id-mapping override)
-                                 or-scene (get id-mapping scene-node)]
-                             (concat
-                               connect-tx-data
-                               (:tx-data override)
-                               (for [[from to] [[:node-ids :node-ids]
-                                                [:node-outline :template-outline]
-                                                [:template-scene :template-scene]
-                                                [:build-targets :template-build-targets]
-                                                [:build-errors :child-build-errors]
-                                                [:resource :template-resource]
-                                                [:pb-msg :scene-pb-msg]
-                                                [:rt-pb-msg :scene-rt-pb-msg]
-                                                [:node-overrides :template-overrides]]]
-                                 (g/connect or-scene from self to))
-                               (for [[from to] [[:layer-names :layer-names]
-                                                [:texture-gpu-textures :aux-texture-gpu-textures]
-                                                [:texture-anim-datas :aux-texture-anim-datas]
-                                                [:texture-names :aux-texture-names]
-                                                [:font-shaders :aux-font-shaders]
-                                                [:font-datas :aux-font-datas]
-                                                [:font-names :aux-font-names]
-                                                [:spine-scene-element-ids :aux-spine-scene-element-ids]
-                                                [:spine-scene-infos :aux-spine-scene-infos]
-                                                [:spine-scene-names :aux-spine-scene-names]
-                                                [:particlefx-infos :aux-particlefx-infos]
-                                                [:particlefx-resource-names :aux-particlefx-resource-names]
-                                                [:template-prefix :id-prefix]
-                                                [:current-layout :current-layout]]]
-                                 (g/connect self from or-scene to)))))
+                           (concat
+                             connect-tx-data
+                             (let [properties-by-node-id (comp (or (:overrides new-value) {})
+                                                               (into {} (map (fn [[k v]] [v k]))
+                                                                     (g/node-value scene-node :node-ids evaluation-context)))]
+                               (g/override scene-node {:traverse? (fn [basis [src src-label tgt tgt-label]]
+                                                                    (if (not= src current-scene)
+                                                                      (or (g/node-instance? basis GuiNode src)
+                                                                          (g/node-instance? basis NodeTree src)
+                                                                          (g/node-instance? basis GuiSceneNode src)
+                                                                          (g/node-instance? basis LayoutsNode src)
+                                                                          (g/node-instance? basis LayoutNode src))
+                                                                      false))
+                                                       :properties-by-node-id properties-by-node-id}
+                                           (fn [evaluation-context id-mapping]
+                                             (let [or-scene (get id-mapping scene-node)]
+                                               (concat
+                                                 (for [[from to] [[:node-ids :node-ids]
+                                                                  [:node-outline :template-outline]
+                                                                  [:template-scene :template-scene]
+                                                                  [:build-targets :template-build-targets]
+                                                                  [:build-errors :child-build-errors]
+                                                                  [:resource :template-resource]
+                                                                  [:pb-msg :scene-pb-msg]
+                                                                  [:rt-pb-msg :scene-rt-pb-msg]
+                                                                  [:node-overrides :template-overrides]]]
+                                                   (g/connect or-scene from self to))
+                                                 (for [[from to] [[:layer-names :layer-names]
+                                                                  [:texture-gpu-textures :aux-texture-gpu-textures]
+                                                                  [:texture-anim-datas :aux-texture-anim-datas]
+                                                                  [:texture-names :aux-texture-names]
+                                                                  [:font-shaders :aux-font-shaders]
+                                                                  [:font-datas :aux-font-datas]
+                                                                  [:font-names :aux-font-names]
+                                                                  [:spine-scene-element-ids :aux-spine-scene-element-ids]
+                                                                  [:spine-scene-infos :aux-spine-scene-infos]
+                                                                  [:spine-scene-names :aux-spine-scene-names]
+                                                                  [:particlefx-infos :aux-particlefx-infos]
+                                                                  [:particlefx-resource-names :aux-particlefx-resource-names]
+                                                                  [:template-prefix :id-prefix]
+                                                                  [:current-layout :current-layout]]]
+                                                   (g/connect self from or-scene to)))))))))
                          []))))))
 
   (display-order (into base-display-order [:template]))
@@ -1661,31 +1661,29 @@
                    (let [basis (:basis evaluation-context)
                          scene (ffirst (g/targets-of basis self :_node-id))
                          node-tree (g/node-value scene :node-tree evaluation-context)
-                         or-data new-value
-                         override (g/override basis node-tree {:traverse? (fn [basis [src src-label tgt tgt-label]]
-                                                                            (or (g/node-instance? basis GuiNode src)
-                                                                                (g/node-instance? basis NodeTree src)
-                                                                                (g/node-instance? basis GuiSceneNode src)))})
-                         id-mapping (:id-mapping override)
-                         or-node-tree (get id-mapping node-tree)
-                         node-mapping (comp id-mapping (g/node-value node-tree :node-ids evaluation-context))]
-                     (concat
-                       (:tx-data override)
-                       (for [[from to] [[:node-overrides :layout-overrides]
-                                        [:node-msgs :node-msgs]
-                                        [:node-rt-msgs :node-rt-msgs]
-                                        [:node-outline :node-tree-node-outline]
-                                        [:scene :node-tree-scene]]]
-                         (g/connect or-node-tree from self to))
+                         or-data new-value]
+                     (g/override node-tree {:traverse? (fn [basis [src src-label tgt tgt-label]]
+                                                         (or (g/node-instance? basis GuiNode src)
+                                                             (g/node-instance? basis NodeTree src)
+                                                             (g/node-instance? basis GuiSceneNode src)))}
+                                 (fn [evaluation-context id-mapping]
+                                   (let [or-node-tree (get id-mapping node-tree)
+                                         node-mapping (comp id-mapping (g/node-value node-tree :node-ids evaluation-context))]
+                                     (concat
+                                       (for [[from to] [[:node-overrides :layout-overrides]
+                                                        [:node-msgs :node-msgs]
+                                                        [:node-rt-msgs :node-rt-msgs]
+                                                        [:node-outline :node-tree-node-outline]
+                                                        [:scene :node-tree-scene]]]
+                                         (g/connect or-node-tree from self to))
 
-                       (for [[from to] [[:id-prefix :id-prefix]]]
-                         (g/connect self from or-node-tree to))
-                       (for [[id data] or-data
-                             :let [node-id (node-mapping id)]
-                             :when node-id
-                             [label value] data]
-                         (g/set-property node-id label value)))))))
-
+                                       (for [[from to] [[:id-prefix :id-prefix]]]
+                                         (g/connect self from or-node-tree to))
+                                       (for [[id data] or-data
+                                             :let [node-id (node-mapping id)]
+                                             :when node-id
+                                             [label value] data]
+                                         (g/set-property node-id label value))))))))))
   (input name-counts NameCounts)
   (input layout-overrides g/Any :cascade-delete)
   (input node-msgs g/Any)

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -48,18 +48,26 @@
   [{:type     :delete-node
     :node-id  node-id}])
 
-(defn new-override
+(defn- new-override
   [override-id root-id traverse-fn]
   [{:type :new-override
     :override-id override-id
     :root-id root-id
     :traverse-fn traverse-fn}])
 
-(defn override-node
+(defn- override-node
   [original-node-id override-node-id]
   [{:type        :override-node
     :original-node-id original-node-id
     :override-node-id override-node-id}])
+
+(defn override
+  [root-id traverse-fn init-fn properties-by-node-id]
+  [{:type :override
+    :root-id root-id
+    :traverse-fn traverse-fn
+    :init-fn init-fn
+    :properties-by-node-id properties-by-node-id}])
 
 (defn transfer-overrides [from-id->to-id]
   [{:type         :transfer-overrides
@@ -171,6 +179,9 @@
 
 (defn- next-node-id [ctx gid]
   (is/next-node-id* (:node-id-generators ctx) gid))
+
+(defn- next-override-id [ctx gid]
+  (is/next-override-id* (:override-id-generator ctx) gid))
 
 (defmulti perform
   "A multimethod used for defining methods that perform the individual
@@ -313,12 +324,37 @@
   [ctx {:keys [original-node-id override-node-id]}]
   (ctx-override-node ctx original-node-id override-node-id))
 
-(declare apply-tx ctx-add-node)
+(declare apply-tx)
+
+(defmethod perform :override
+  [ctx {:keys [root-id traverse-fn init-fn properties-by-node-id]}]
+  (let [basis (:basis ctx)
+        graph-id (gt/node-id->graph-id root-id)
+        node-ids (ig/pre-traverse basis [root-id] traverse-fn)
+        override-id (next-override-id ctx graph-id)
+        override-nodes (mapv #(in/make-override-node override-id (next-node-id ctx graph-id) % (properties-by-node-id %)) node-ids)
+        override-node-ids (map gt/node-id override-nodes)
+        original-node-id->override-node-id (zipmap node-ids override-node-ids)
+        new-override-nodes-tx-data (map new-node override-nodes)
+        new-override-tx-data (concat
+                               (new-override override-id root-id traverse-fn)
+                               (map
+                                 (fn [node-id override-node-id]
+                                   (override-node node-id override-node-id))
+                                 node-ids
+                                 override-node-ids))]
+    (as-> ctx ctx'
+      (apply-tx ctx' (concat new-override-nodes-tx-data
+                             new-override-tx-data))
+      (apply-tx ctx' (init-fn (in/custom-evaluation-context {:basis (:basis ctx')})
+                              original-node-id->override-node-id)))))
 
 (defn- node-id->override-id [basis node-id]
   (->> node-id
     (gt/node-by-id-at basis)
     gt/override-id))
+
+(declare ctx-add-node)
 
 (defn- ctx-make-override-nodes [ctx override-id node-ids]
   (reduce (fn [ctx node-id]
@@ -651,20 +687,21 @@
              :graphs-modified (into graphs-modified (map gt/node-id->graph-id nodes-modified)))))
 
 (defn new-transaction-context
-  [basis node-id-generators]
-  {:basis               basis
-   :nodes-affected      {}
-   :nodes-added         []
-   :nodes-modified      #{}
-   :nodes-deleted       {}
-   :outputs-modified    #{}
-   :graphs-modified     #{}
-   :successors-changed  {}
-   :node-id-generators node-id-generators
-   :completed           []
-   :txid                (new-txid)
-   :tx-data-context     (atom {})
-   :deferred-setters    []})
+  [basis node-id-generators override-id-generator]
+  {:basis                 basis
+   :nodes-affected        {}
+   :nodes-added           []
+   :nodes-modified        #{}
+   :nodes-deleted         {}
+   :outputs-modified      #{}
+   :graphs-modified       #{}
+   :successors-changed    {}
+   :node-id-generators    node-id-generators
+   :override-id-generator override-id-generator
+   :completed             []
+   :txid                  (new-txid)
+   :tx-data-context       (atom {})
+   :deferred-setters      []})
 
 (defn- update-successors
   [{:keys [successors-changed] :as ctx}]

--- a/editor/test/editor/properties_test.clj
+++ b/editor/test/editor/properties_test.clj
@@ -111,7 +111,7 @@
                      (g/transact
                        (g/make-nodes world [user-node [UserProps :user-properties {:properties {:int {:edit-type {:type g/Int} :value 1}}
                                                                                    :display-order [:int]}]]
-                                     (:tx-data (g/override user-node)))))
+                                     (g/override user-node))))
                    property (fn [n] (-> [n] (coalesce-nodes) (first) (second)))]
                (is (not (properties/overridden? (property linked-node))))
                (is (every? #(= 1 %) (properties/values (property linked-node))))

--- a/editor/test/internal/copy_paste_test.clj
+++ b/editor/test/internal/copy_paste_test.clj
@@ -314,7 +314,7 @@
                                                              (g/connect component :component-id game-object :component-id-pairs)
                                                              (g/connect game-object :base-url component :base-url)
                                                              (g/connect game-object :id-counts component :id-counts)))
-          [or-game-object] (g/tx-nodes-added (g/transact (:tx-data (g/override game-object))))]
+          [or-game-object] (g/tx-nodes-added (g/transact (g/override game-object)))]
 
       ;; Override a property.
       (g/set-property! or-game-object :test-property "override-value")

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -851,7 +851,6 @@
 
 (defn- override [node-id]
   (-> (g/override node-id {})
-    :tx-data
     tx-nodes))
 
 (deftest overridden-properties

--- a/editor/test/internal/graph/graph_test.clj
+++ b/editor/test/internal/graph/graph_test.clj
@@ -116,7 +116,7 @@
 (deftest graph-override-cleanup
   (with-clean-system
     (let [[original override] (tx-nodes (g/make-nodes world [n (TestNode :val "original")]
-                                                      (:tx-data (g/override n))))
+                                                      (g/override n)))
           basis (is/basis system)]
       (is (= override (first (ig/get-overrides basis original))))
       (g/transact (g/delete-node original))


### PR DESCRIPTION
* Technical changes
  - g/override now only returns a single :override transaction. All
  the traversal etc takes place during execution of the transaction
  step. To perform initialization of the override, you can supply an
  init-fn (with evaluation-context & id-mapping as args) that returns
  additional transaction steps to be performed at that point in the
  transaction execution.