### PR TITLE
DEF-3499 - Fixed issue with sys.get_application_info() on Android.

### DIFF
--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -796,19 +796,14 @@ namespace dmSys
         JNIEnv* env = 0;
         activity->vm->AttachCurrentThread( &env, 0);
 
-        jclass native_activity_class = env->FindClass("android/app/NativeActivity");
-        jmethodID methodID_func = env->GetMethodID(native_activity_class, "getPackageManager", "()Landroid/content/pm/PackageManager;");
-        jobject package_manager = env->CallObjectMethod(activity->clazz, methodID_func);
-        jclass pm_class = env->GetObjectClass(package_manager);
-        jmethodID methodID_pm = env->GetMethodID(pm_class, "getPackageInfo", "(Ljava/lang/String;I)Landroid/content/pm/PackageInfo;");
+        jclass def_activity_class = env->GetObjectClass(activity->clazz);
+        jmethodID isAppInstalled = env->GetMethodID(def_activity_class, "isAppInstalled", "(Ljava/lang/String;)Z");
         jstring str_url = env->NewStringUTF(id);
-        env->CallObjectMethod(package_manager, methodID_pm, str_url);
-        jthrowable exception = env->ExceptionOccurred();
-        env->ExceptionClear();
+        jboolean installed = env->CallBooleanMethod(activity->clazz, isAppInstalled, str_url);
         env->DeleteLocalRef(str_url);
+
         activity->vm->DetachCurrentThread();
 
-        bool installed = exception == NULL;
         info->m_Installed = installed;
         return installed;
     }

--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -28,6 +28,8 @@ import android.text.InputType;
 import android.view.inputmethod.CompletionInfo;
 import android.view.ViewGroup;
 
+import android.content.pm.PackageInfo;
+
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
 import com.google.android.gms.common.*;
 
@@ -83,6 +85,16 @@ public class DefoldActivity extends NativeActivity {
     private static boolean activityVisible;
     public static boolean isActivityVisible() {
         return activityVisible;
+    }
+
+    public boolean isAppInstalled(String appPackageName) {
+        PackageManager packageManager = this.getPackageManager();
+        try {
+            PackageInfo info = packageManager.getPackageInfo(appPackageName, 0);
+            return info != null;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
     }
 
     private static final String TAG = "DefoldActivity";
@@ -506,6 +518,6 @@ public class DefoldActivity extends NativeActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         nativeOnActivityResult(this, requestCode,resultCode, data);
     }
-    
+
     public static native void nativeOnActivityResult(Activity activity, int requestCode, int resultCode, Intent data);
 }


### PR DESCRIPTION
Moved logic from C++ into Java side to poll if application bundle id
was installed.

Some Android devices did not report correct data when this logic was
performed on the C++ side through JNI.