### PR TITLE
DEFEDIT-1466 Hot reload everything

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -97,8 +97,8 @@
                   :command :referencing-files}
                  {:label "Dependencies..."
                   :command :dependencies}
-                 {:label "Hot Reload"
-                  :command :hot-reload}
+                 {:label "Hot Reload File"
+                  :command :hot-reload-file}
                  {:label :separator}
                  {:label "New"
                   :command :new-file

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -75,8 +75,8 @@
                   :command :referencing-files}
                  {:label "Dependencies..."
                   :command :dependencies}
-                 {:label "Hot Reload"
-                  :command :hot-reload}
+                 {:label "Hot Reload File"
+                  :command :hot-reload-file}
                  {:label :separator}
                  {:label "View Diff"
                   :icon "icons/32/Icons_S_06_arrowup.png"

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -80,22 +80,22 @@
   [build-targets]
   (into {} (map #(let [key (target-key %)] [key (assoc % :key key)])) build-targets))
 
-(defn- flatten-build-targets
+(defn flatten-build-targets
   "Breadth first traversal / collection of build-targets and their child :deps,
   skipping seen targets identified by target-key."
   [build-targets]
   (loop [targets build-targets
          queue []
          seen #{}
-         result []]
+         result (transient [])]
     (if-let [t (first targets)]
       (let [key (target-key t)]
         (if (contains? seen key)
           (recur (rest targets) queue seen result)
-          (recur (rest targets) (conj queue (flatten (:deps t))) (conj seen key) (conj result t))))
+          (recur (rest targets) (conj queue (flatten (:deps t))) (conj seen key) (conj! result t))))
       (if-let [targets (first queue)]
         (recur targets (rest queue) seen result)
-        result))))
+        (persistent! result)))))
 
 (defn- make-build-targets-by-key
   [build-targets]


### PR DESCRIPTION
### User-facing changes
* The Hot Reload command now reloads all modified files.
* It is still possible to Hot Reload a specific file from the context menus.

### Technical changes
* Hot Reload now sends reload messages to the running engine for all the changed `BuildResources`. Referenced resources are reloaded before referencing resources.