### PR TITLE
DEFEDIT-1467 Build Debug js-web target

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -211,6 +211,7 @@
         compress-archive? (get proj-settings ["project" "compress_archive"])
         [email auth] (login/credentials prefs)]
     (cond-> {"platform" "js-web"
+             "variant" "debug"
              "archive" "true"
              "bundle-output" (str output-path)
              "build-server" build-server-url


### PR DESCRIPTION
Explicitly set debug version when building HTML5 from Build HTML5 menu