### PR TITLE
DEF-3530 Fixed hot reload cache from stalling on old data

### DIFF
--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -23,7 +23,7 @@ namespace dmHttpCache
     // Magic file header for index file
     const uint32_t MAGIC = 0xCAAAAAAC;
     // Current index file version
-    const uint32_t VERSION = 6;
+    const uint32_t VERSION = 7;
 
     // Maximum number of cache entry creations in flight
     const uint32_t MAX_CACHE_CREATORS = 16;
@@ -37,6 +37,8 @@ namespace dmHttpCache
         uint32_t m_Version;
         // Checksum of the index payload, ie the data that follows the header
         uint64_t m_Checksum;
+        uint32_t m_SizeOfEntry;     // Making sure the size is double checked
+        uint32_t m_SizeOfFileEntry; // Making sure the size is double checked
     };
 
     /*
@@ -163,6 +165,14 @@ namespace dmHttpCache
         }
     }
 
+    static bool IsValidHeader(IndexHeader* header)
+    {
+         return header->m_Magic == MAGIC &&
+                header->m_Version == VERSION &&
+                header->m_SizeOfEntry == (uint32_t)sizeof(Entry) &&
+                header->m_SizeOfFileEntry == (uint32_t)sizeof(FileEntry);
+    }
+
     Result Open(NewParams* params, HCache* cache)
     {
         const char* path = params->m_Path;
@@ -208,13 +218,13 @@ namespace dmHttpCache
             void* buffer = malloc(size);
             (void)fread(buffer, 1, size, f);
             IndexHeader* header = (IndexHeader*) buffer;
-            if (size < (sizeof(IndexHeader)))
+            if (size < (sizeof(IndexHeader)) || !IsValidHeader(header))
             {
                 dmLogError("Invalid cache index file '%s'. Removing file.", cache_file);
                 // We remove the file and return RESULT_OK
                 dmSys::Unlink(cache_file);
             }
-            else if (header->m_Magic == MAGIC && header->m_Version == VERSION)
+            else
             {
                 uint64_t checksum = dmHashBuffer64((void*) (((uintptr_t) buffer) + sizeof(IndexHeader)), size - sizeof(IndexHeader));
                 if (checksum != header->m_Checksum)
@@ -249,13 +259,6 @@ namespace dmHttpCache
                         }
                     }
                 }
-            }
-            else
-            {
-                if (((uint32_t*) buffer)[0] != MAGIC)
-                    dmLogError("Invalid cache index file '%s'. Removing file.", cache_file);
-                // We remove the file and return RESULT_OK
-                dmSys::Unlink(cache_file);
             }
             free(buffer);
             fclose(f);
@@ -315,6 +318,8 @@ namespace dmHttpCache
         header.m_Magic = MAGIC;
         header.m_Version = VERSION;
         header.m_Checksum = 0;
+        header.m_SizeOfEntry = (uint32_t)sizeof(Entry);
+        header.m_SizeOfFileEntry = (uint32_t)sizeof(FileEntry);
         size_t n_written = fwrite(&header, 1, sizeof(header), f);
         if (n_written != sizeof(header))
         {
@@ -393,6 +398,22 @@ namespace dmHttpCache
         return RESULT_OK;
     }
 
+    static const char* GetRelativePath(const char* _uri)
+    {
+        // Make the URI port independent (e.g. http://127.0.0.1:34567//build/default/player/cannon.goc)
+        const char* uri = _uri;
+        uri = strstr(uri, "://");
+        if (uri) {
+            uri += 3;                       // 127.0.0.1:34567//build/default/player/cannon.goc
+            uri = strchr(uri, '/');         // //build/default/player/cannon.goc
+            while (uri && uri[0] == '/')
+                uri++;                      // build/default/player/cannon.goc
+        } else {
+            uri = _uri;
+        }
+        return uri;
+    }
+
     Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, HCacheCreator* cache_creator)
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
@@ -403,6 +424,7 @@ namespace dmHttpCache
             return RESULT_INVAL;
         }
 
+        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
 
         HashState64 hash_state;
@@ -625,6 +647,7 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0)
@@ -646,6 +669,7 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0)
@@ -664,6 +688,7 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        uri = GetRelativePath(uri);
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
         dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));
@@ -708,6 +733,7 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0)
@@ -725,6 +751,7 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
+        uri = GetRelativePath(uri);
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
         dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));

--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -398,22 +398,6 @@ namespace dmHttpCache
         return RESULT_OK;
     }
 
-    static const char* GetRelativePath(const char* _uri)
-    {
-        // Make the URI port independent (e.g. http://127.0.0.1:34567//build/default/player/cannon.goc)
-        const char* uri = _uri;
-        uri = strstr(uri, "://");
-        if (uri) {
-            uri += 3;                       // 127.0.0.1:34567//build/default/player/cannon.goc
-            uri = strchr(uri, '/');         // //build/default/player/cannon.goc
-            while (uri && uri[0] == '/')
-                uri++;                      // build/default/player/cannon.goc
-        } else {
-            uri = _uri;
-        }
-        return uri;
-    }
-
     Result Begin(HCache cache, const char* uri, const char* etag, uint32_t max_age, HCacheCreator* cache_creator)
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
@@ -424,7 +408,6 @@ namespace dmHttpCache
             return RESULT_INVAL;
         }
 
-        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
 
         HashState64 hash_state;
@@ -647,7 +630,6 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
-        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0)
@@ -669,7 +651,6 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
-        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0)
@@ -688,7 +669,6 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
-        uri = GetRelativePath(uri);
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
         dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));
@@ -733,7 +713,6 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
-        uri = GetRelativePath(uri);
         uint64_t uri_hash = dmHashString64(uri);
         Entry* entry = cache->m_CacheTable.Get(uri_hash);
         if (entry != 0)
@@ -751,7 +730,6 @@ namespace dmHttpCache
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
 
-        uri = GetRelativePath(uri);
         HashState64 hash_state;
         dmHashInit64(&hash_state, false);
         dmHashUpdateBuffer64(&hash_state, uri, strlen(uri));


### PR DESCRIPTION
Made the version check a bit more robust.
Also made the cache reusable between editor runs (different port number)