### PR TITLE
DEFEDIT-1463 Graph arcs-by-head/tail broken for complex override chains

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -93,7 +93,7 @@
    nil)
   ([sys-atom node-id]
    (let [outputs (cached-outputs (node-type* node-id))
-         entries (map #(do [node-id %]) outputs)]
+         entries (map (partial vector node-id) outputs)]
      (dosync (alter (:cache @sys-atom) c/cache-invalidate entries))
      nil)))
 
@@ -953,7 +953,7 @@
   [node]
   (let [labels (-> (node-type* node)
                    (in/output-labels))]
-    (invalidate-outputs! (map #(do [node %]) labels))))
+    (invalidate-outputs! (map (partial vector node) labels))))
 
 (defn node-instance*?
   "Returns true if the node is a member of a given type, including

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -508,7 +508,7 @@
             (g/mark-defective node flaw))))
 
       (let [all-outputs (mapcat (fn [node]
-                                  (map (fn [[output _]] [node output]) (gu/outputs node)))
+                                  (map (fn [[output _]] [node output]) (gu/explicit-outputs node)))
                                 (:invalidate-outputs plan))]
         (g/invalidate-outputs! all-outputs))
 

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -15,9 +15,6 @@
 (defn array-subst-remove-errors [arr]
   (vec (remove g/error? arr)))
 
-(defn outputs [node]
-  (mapv #(do [(second (gt/head %)) (gt/tail %)]) (gt/arcs-by-head (g/now) node)))
-
 (defn explicit-outputs [node]
-    ;; don't include arcs from override-original nodes
-  (mapv #(do [(second (gt/head %)) (gt/tail %)]) (ig/explicit-arcs-by-source (g/now) node)))
+  ;; don't include arcs from override-original nodes
+  (mapv (fn [[_ src-label tgt-id tgt-label]] [src-label [tgt-id tgt-label]]) (g/explicit-outputs node)))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -290,14 +290,11 @@
 ;;
 ;; Example: Implicit arcs where target override chain has intermediate overrides.
 ;;
-;;    O/template2,template,landscape   ~~> I/template,landscape2,square,landscape1
+;;    O/template,landscape2            ~> I/template,landscape2,square,landscape1
 ;;                                    ~
 ;;                                    ~
-;;    O/template,landscape2           ~
-;;                                   ~
-;;                                   ~
 ;;    O/landscape2                   ~ ~> I/landscape2,square,landscape1
-;;                                  ~~~
+;;                                   ~~
 ;;                                  ~
 ;;                        O/square ~~~~~> I/square,landscape1
 ;;
@@ -324,7 +321,7 @@
 ;;
 ;; We create the square override, including both O and
 ;; I/landscape1. Since there is an implicit arc between O and
-;; I/landscape, there will be an implicit arc between their override
+;; I/landscape1, there will be an implicit arc between their override
 ;; nodes O/square and I/square,landscape1.
 ;;
 ;; We create the landscape2 override, including the original O and
@@ -335,11 +332,8 @@
 ;; O/square.
 ;;
 ;; We create the template override, including O/landscape2 and
-;; I/landscape2,quare,landscape1. I/template,landscape2,square,landscape1
+;; I/landscape2,square,landscape1. I/template,landscape2,square,landscape1
 ;; "still" has an implicit arc from O/square.
-;;
-;; We create the template2 override. Nothing much happens. Just added
-;; for confusion :)
 ;;
 ;; The common rule in these examples is that for the implicit arcs to a
 ;; particular target node, the source node override chain should be the

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -1,23 +1,335 @@
 (ns internal.graph
   (:require [clojure.set :as set]
+            [clojure.core.reducers :as r]
             [internal.graph.types :as gt]
             [schema.core :as s]
             [internal.util :as util]
-            [internal.node :as in]))
+            [internal.node :as in])
+  (:import [internal.graph.types Arc]
+           [clojure.lang IPersistentSet]))
+
+;; A brief braindump on Overrides.
+;;
+;; Overrides is how we implement instancing or "templates" in the
+;; editor. Currently it is used in collections for sub collections and
+;; referenced game objects, in game objects for referenced components,
+;; and in GUIs for templates (sub-GUIs) and layouts.
+;;
+;; What we want in "graphy" terms is a node that looks like some original
+;; node - the thing being instantiated - except that we can change some
+;; or all of it's properties, or connect something else to it's inputs.
+;;
+;; In most cases, the thing being instantiated is not implemented as a
+;; single node, but rather one conceptual root node (often a resource
+;; node) and a cluster of private helper nodes owned via :cascade-delete
+;; inputs.
+;;
+;; An _Override_ is a set of override nodes, each derived from an
+;; original node. The set of nodes being _overridden_ is defined by a
+;; traversal predicate and an original root node. When creating an
+;; override, we start from the root node and recursively traverse the
+;; :cascade-delete inputs "backwards" provided the arcs match the
+;; traversal predicate, and for each node we reach - create a
+;; corresponding override node. The purpose of the traversal predicate is
+;; to make sure we cover the "hidden" private nodes - as far as
+;; necessary.
+;;
+;; Once an _override_ has been created, the graph / transaction system
+;; makes sure that any structural change to the original nodes is
+;; reflected in the override. If we connect something to a
+;; :cascade-delete input of a node that has been overridden, the
+;; traversal will restart from that node and we might create a new
+;; override node for the newly connected node. When disconnecting, any
+;; corresponding override node will be deleted. Deleting the original
+;; root node will delete the whole override.
+;;
+;; For override nodes, special rules apply for evaluation of properties
+;; and finding input- and output arcs.
+;;
+;; The properties of override nodes report the same value as the
+;; corresponding original, unless we explicitly set it to something else.
+;; Once set, the new value will be reported. We can clear the property to
+;; "revert" to the original behaviour - report the value of the original.
+;;
+;; For arcs, here are some reasonable expectations:
+;;
+;; * Creating an override should not affect the observable behaviour of
+;; the original nodes. Any `node-value` should report the same value
+;; before and after. There is an assumption here that the behaviour of
+;; nodes never depend on what other nodes their outputs are connected to.
+;;
+;; * Just after creating an override, the override nodes should report
+;; roughly the same property values (and output results) as their
+;; corresponding original nodes - except for any node-id references and
+;; the _properties output which f.e. contains information about the
+;; original values.
+;;
+;; * Similar to how the property values work, we want to be able to connect
+;; something else as input to an override node, and also revert to the
+;; original input.
+;;
+;; For this to work, we introduced the idea of explicit and implicit
+;; arcs.
+;;
+;; Any arc established with `connect` between override- or normal nodes
+;; is an _explicit_ arc. Explicit arcs can also be `disconnect`'ed. If
+;; you `connect` something else to a non-:array input, the old _explicit_
+;; arc to that input is silently disconnected (deleted).
+;;
+;; An _implicit_ arc is derived from an _explicit_ or _implicit_ arc and
+;; is only relevant for override nodes. You cannot `disconnect` an
+;; _implicit_ arc. However, if you `connect` something else to an input
+;; that used to have one or more _implicit_ arcs connected, the new
+;; _explicit_ arc will shadow the _implicit_ arcs. Later `disconnect`ing
+;; the _explicit_ arc will effectively revert to the _implicit_ arcs.
+;;
+;; The `node-value` mechanism does not differentiate between _explicit_
+;; and _implicit_ arcs. When the value of an input is needed, we look for
+;; all arcs (zero or one if non-:array input) connected to the input and
+;; get the value(s) from the corresponding source node and output.
+;;
+;; In some cases one wants to find only the _explicit_ arcs, and for that
+;; we have `explicit-outputs` and `-inputs`.
+;;
+;; How implicit arcs appear is described in examples below.
+;;
+;;
+;; Example: Nodes O and I both included in an override. There may be
+;; other nodes but we focus on O and I.
+;;
+;; (/override1 after a node means that node is an override node in the
+;; override with id "override1". In practice overrides have numerical ids)
+;;
+;; Say we have two nodes O and I with an explicit arc between them:
+;;
+;;    O:output-label ---> I:input-label
+;;
+;; If we create an override including both nodes, we get this situation:
+;;
+;;    O/override1:output-label ~~~> I/override1:input-label
+;;    |                             |
+;;    V                             V
+;;    O:output-label -------------> I:input-label
+;;
+;; Here, O is the original node of O/override1 and vice versa for I. The arc
+;; between O and I is still _explicit_.
+;;
+;; Between O/override1 and I/override1 there is now an _implicit_
+;; arc. This makes sense, because if we change a property of
+;; O/override1 that value could affect I/override1. If we ask
+;; O/override1 for it's outgoing arcs from output-label, we should get
+;; at least an arc to I/override1:input-label - and vice verse for
+;; incoming arcs to I/override1:input-label. The outgoing arcs from
+;; O:output-label however, should _not_ include
+;; I/override1:input-label. Incoming arcs to I:input-label also
+;; does not include O/override1:output-label.
+;;
+;;
+;; Example: Nodes O and I, only I included in an override.
+;;
+;; Say only I is included in the override (we skip the override arrows):
+;;
+;;                     ~> I/override1:input-label
+;;                    ~
+;;                   ~
+;;    O:output-label ---> I:input-label
+;;
+;; Here, an override was created but we were not really interested in
+;; changing anything about O. In that case, it makes sense that
+;; I/override1 "still" gets its input from O. Outgoing arcs from
+;; O:output-label now include both I:input-label and I/override1:input-label,
+;; but this should not affect the behaviour of O since it's an
+;; output. Incoming arcs to I/override1:input-label is O:output-label.
+;;
+;;
+;;
+;; Example: Nodes O and I, only O included in an override.
+;;
+;;    O/override1:output-label
+;;
+;;
+;;    O:output-label ---> I:input-label
+;;
+;; Here, since I was not included in the override, the most reasonable
+;; option is to simply drop the arc. An _implicit_ connection between O/override1
+;; and I could affect the behaviour of I - not what we want.
+;;
+;;
+;;
+;; Nodes can take part in several overrides, that is, have several
+;; override nodes:
+;;
+;;     O/override1    O/override2   O/override3
+;;     |              |             |
+;;      \             V            /
+;;       -----------> O <----------
+;;
+;; Also, we can create an override with an override node as root:
+;;
+;;                    O/override2
+;;                    |
+;;                    V
+;;                    O/override1
+;;                    |
+;;                    V
+;;                    O
+;;
+;; To complicate matters, there is no rule that an override may only
+;; cover nodes "at the same level" - from the same override (or actual
+;; real nodes).
+;;
+;;
+;;                    O/template                I/template
+;;                    |                         |
+;;                    V                         |
+;;                    O/landscape               |
+;;                    |                         |
+;;                    V                         V
+;;                    O                         I
+;;
+;; Here, O/template and I/template are part of the same override
+;; O/template also has an intermediate O/landscape override node along
+;; its chain to the real node O.
+;;
+;;
+;; This together also means that several override nodes in an override
+;; can have a common original node along the chain towards the real node.
+;;
+;;
+;;     O/override7    O/override7   O/override7
+;;     |              |             |
+;;     O/override5    |             |
+;;     |              |             |
+;;     O/override4    O/override6   |
+;;     |              |             |
+;;     O/override1    O/override2   O/override3
+;;     |              |             |
+;;      \             V            /
+;;       -----------> O <----------
+;;
+;; To be precise, it's not enough to annotate the nodes with /"override
+;; name" - the top nodes above are different nodes, and we should include
+;; the whole override chain back to the real node.
+;;
+;;     O/override7,5,4,1  O/override7,6,2   O/override7,3
+;;     |                  |                 |
+;;    ...                ...               ...
+;;
+;;
+;; These facts very much complicate the definition of _implicit_ arcs.
+;;
+;;
+;;
+;; Example: Implicit arcs where source override chain differs.
+;;
+;;    O/template,landscape    -> I/template
+;;                           ~
+;;                         ~
+;;    O/landscape        ~
+;;                     ~
+;;                   ~
+;;    O:output-label ---------> I:input-label
+;;
+;; Now, what produces input to I/template:input-label. Simple?
+;; O:output-label. When we created the "landscape" override, we did not
+;; include I. O/landscape does not affect I, and even though
+;; O/template,landscape leads to O along the override chain - it's in no
+;; way related to I/template. So there is an _implicit_ arc between
+;; O:output-label and I/template:input-label.
+;;
+;;
+;; Example: Implicit arcs where source override chain differs.
+;;
+;;    O/template2,template,landscape      I/template2,landscape
+;;                                     ~>
+;;                                  ~
+;;    O/template,landscape      ~
+;;                          ~
+;;                      ~
+;;    O/landscape    ~~~~~~~~~~~~~~~~~~~> I/landscape
+;;
+;;
+;;    O:output-label -------------------> I:input-label
+;;
+;; This time, since I was included in the landscape override, there is an
+;; _implicit_ arc between O/landscape:output-label and
+;; I/landscape:input-label. This _implicit_ arc is still relevant for
+;; I/template2, so there is also an _implicit_ arc between
+;; O/landscape:output-label and I/template2,landscape:input-label.
+;;
+;;
+;; Example: Implicit arcs where target override chain has intermediate overrides.
+;;
+;;    O/template2,template,landscape      I/template,landscape2,landscape1
+;;                                   ~~~>
+;;                               ~~~
+;;    O/template,landscape2   ~~~
+;;                         ~~~
+;;                      ~~~
+;;    O/landscape2  ~~~~~~~~~~~~~~~~~~~>  I/landscape2,landscape1
+;;
+;;
+;;                                 ~~~~>  I/landscape1
+;;                            ~~~~~
+;;                      ~~~~~
+;;    O:output-label -------------------> I:input-label
+;;
+;;
+;; Here, as before there is an implicit arc O:output-label to
+;; I/landscape1:input-label. What about I/landscape2,landscape1?  Since
+;; both O and I/landscape1 are included in the landscape2 override, the
+;; implicit arc between them is still relevant for their override
+;; nodes. Thus there is an implicit arc O/landscape2:output-label to
+;; I/landscape2,landscape1:input-label. Further up, there is also an
+;; implicit arc O/landscape2:output-label to
+;; I/template,landscape2,landscape1:input-label.
+;;
+;;
+;; Example: Implicit arcs where target override chain has intermediate overrides.
+;;
+;;    O/template2,template,landscape      I/template,landscape2,square,landscape1
+;;
+;;
+;;    O/template,landscape2
+;;
+;;
+;;  O/square     O/landscape2             I/landscape2,square,landscape1
+;;
+;;
+;;                                        I/square,landscape1
+;;
+;;
+;;                                        I/landscape1
+;;
+;;
+;;    O:output-label -------------------> I:input-label
+;;
+;;
+;; Here, similar to before, there is an implicit arc
+;; O/square:output-label to I/square,landscape1:input-label. And O/square
+;; remains the source for the implicit arcs to I/landscape2,square,landscape1 and
+;; I/template,landscape2,square,landscape1.
+;;
+;; The common rule in these examples is that for the implicit arcs to a
+;; particular target node, the source node override chain should be the
+;; longest and first possible subsequence of the target node override
+;; chain.
 
 (set! *warn-on-reflection* true)
 
-(defrecord ArcBase [source target sourceLabel targetLabel]
-  gt/Arc
-  (head [_] [source sourceLabel])
-  (tail [_] [target targetLabel]))
-
 (definline ^:private arc
   [source target source-label target-label]
-  `(ArcBase. ~source ~target ~source-label ~target-label))
+  `(Arc. ~source ~target ~source-label ~target-label))
+
+(defn arcs->tuples [arcs]
+  (into [] (map (fn [^Arc arc]
+                  [(.source arc) (.sourceLabel arc) (.target arc) (.targetLabel arc)]))
+        arcs))
+
 
 (defn arc-endpoints-p [p arc]
-  (and (p (.source ^ArcBase arc)) (p (.target ^ArcBase arc))))
+  (and (p (.source ^Arc arc))
+       (p (.target ^Arc arc))))
 
 (defn- rebuild-sarcs
   [basis graph-state]
@@ -26,9 +338,9 @@
         all-arcs (mapcat (fn [g] (mapcat (fn [[nid label-tarcs]] (mapcat second label-tarcs))
                                          (:tarcs g)))
                          all-graphs)
-        all-arcs-filtered (filter (fn [^ArcBase arc] (= (gt/node-id->graph-id (.source arc)) gid)) all-arcs)]
+        all-arcs-filtered (filter (fn [^Arc arc] (= (gt/node-id->graph-id (.source arc)) gid)) all-arcs)]
     (reduce
-      (fn [sarcs arc] (update-in sarcs [(.source ^ArcBase arc) (.sourceLabel ^ArcBase arc)] util/conjv arc))
+      (fn [sarcs arc] (update-in sarcs [(.source ^Arc arc) (.sourceLabel ^Arc arc)] util/conjv arc))
       {}
       all-arcs-filtered)))
 
@@ -46,7 +358,7 @@
 (defn add-node    [g id n] (assoc-in g [:nodes id] n))
 
 (definline node-id->graph [basis node-id] `(get (:graphs ~basis) (gt/node-id->graph-id ~node-id)))
-(definline graph->node [graph node-id] `(get (:nodes ~graph) ~node-id))
+(definline node-id->node [graph node-id] `(get (:nodes ~graph) ~node-id))
 
 (defn- overrides [graph node-id]
   (get (:node->overrides graph) node-id))
@@ -56,52 +368,52 @@
 (defn graph-remove-node
   ([g n]
     (graph-remove-node g n (some-> (get-in g [:nodes n]) gt/original)))
-  ([g n original]
-    (graph-remove-node g n original false))
-  ([g n original original-deleted?]
+  ([g n original-id]
+    (graph-remove-node g n original-id false))
+  ([g n original-id original-deleted?]
     (if (contains? (:nodes g) n)
       (let [g (reduce (fn [g or-n] (graph-remove-node g or-n n true)) g (overrides g n))
             sarcs (mapcat second (get-in g [:sarcs n]))
             tarcs (mapcat second (get-in g [:tarcs n]))
-            override-id (when original (gt/override-id (get-in g [:nodes n])))
-            override (when original (get-in g [:overrides override-id]))]
+            override-id (when original-id (gt/override-id (get-in g [:nodes n])))
+            override (when original-id (get-in g [:overrides override-id]))]
         (-> g
           (cond->
-            (not original-deleted?) (update-in [:node->overrides original] (partial util/removev #{n}))
-            (and override (= original (:root-id override))) (update :overrides dissoc override-id))
+            (not original-deleted?) (update-in [:node->overrides original-id] (partial util/removev #{n}))
+            (and override (= original-id (:root-id override))) (update :overrides dissoc override-id))
          (update :nodes dissoc n)
          (update :node->overrides dissoc n)
          (update :sarcs dissoc n)
-         (update :sarcs (fn [s] (reduce (fn [s ^ArcBase arc]
+         (update :sarcs (fn [s] (reduce (fn [s ^Arc arc]
                                           (update-in s [(.source arc) (.sourceLabel arc)]
-                                            (fn [arcs] (util/removev (fn [^ArcBase arc] (= n (.target arc))) arcs))))
+                                            (fn [arcs] (util/removev (fn [^Arc arc] (= n (.target arc))) arcs))))
                                   s tarcs)))
          (update :tarcs dissoc n)
-         (update :tarcs (fn [s] (reduce (fn [s ^ArcBase arc]
+         (update :tarcs (fn [s] (reduce (fn [s ^Arc arc]
                                           (update-in s [(.target arc) (.targetLabel arc)]
-                                            (fn [arcs] (util/removev (fn [^ArcBase arc] (= n (.source arc))) arcs))))
+                                            (fn [arcs] (util/removev (fn [^Arc arc] (= n (.source arc))) arcs))))
                                   s sarcs)))))
       g)))
 
-(defn- arc-cross-graph? [^ArcBase arc]
+(defn- arc-cross-graph? [^Arc arc]
   (not= (gt/node-id->graph-id (.source arc)) (gt/node-id->graph-id (.target arc))))
 
 (defn- arcs-remove-node [arcs node-id]
-  (util/removev (fn [^ArcBase arc] (or (= node-id (.source arc))
+  (util/removev (fn [^Arc arc] (or (= node-id (.source arc))
                                      (= node-id (.target arc)))) arcs))
 
 (defn basis-remove-node
   ([basis n]
     (basis-remove-node basis n (some-> (get-in basis [:graphs (gt/node-id->graph-id n) :nodes n]) gt/original)))
-  ([basis n original]
-    (basis-remove-node basis n original false))
-  ([basis n original original-deleted?]
+  ([basis n original-id]
+    (basis-remove-node basis n original-id false))
+  ([basis n original-id original-deleted?]
     (let [g (node-id->graph basis n)
           basis (reduce (fn [basis or-n] (basis-remove-node basis or-n n true)) basis (overrides g n))
           sarcs (mapcat second (get-in g [:sarcs n]))
           tarcs (mapcat second (get-in g [:tarcs n]))
-          override-id (when original (gt/override-id (get-in g [:nodes n])))
-          override (when original (get-in g [:overrides override-id]))
+          override-id (when original-id (gt/override-id (get-in g [:nodes n])))
+          override (when original-id (get-in g [:overrides override-id]))
           ext-sarcs (filterv arc-cross-graph? sarcs)
           ext-tarcs (filterv arc-cross-graph? tarcs)
           basis (-> basis
@@ -109,23 +421,23 @@
                     (fn [g]
                       (-> g
                         (cond->
-                          (not original-deleted?) (update-in [:node->overrides original] (partial util/removev #{n}))
-                          (and override (= original (:root-id override))) (update :overrides dissoc override-id))
+                          (not original-deleted?) (update-in [:node->overrides original-id] (partial util/removev #{n}))
+                          (and override (= original-id (:root-id override))) (update :overrides dissoc override-id))
                         (update :nodes dissoc n)
                         (update :node->overrides dissoc n)
                         (update :sarcs dissoc n)
-                        (update :sarcs (fn [s] (reduce (fn [s ^ArcBase arc]
+                        (update :sarcs (fn [s] (reduce (fn [s ^Arc arc]
                                                          (update-in s [(.source arc) (.sourceLabel arc)] arcs-remove-node n))
                                                  s tarcs)))
                         (update :tarcs dissoc n)
-                        (update :tarcs (fn [s] (reduce (fn [s ^ArcBase arc]
+                        (update :tarcs (fn [s] (reduce (fn [s ^Arc arc]
                                                          (update-in s [(.target arc) (.targetLabel arc)] arcs-remove-node n))
                                                  s sarcs)))))))
-          basis (reduce (fn [basis ^ArcBase arc]
+          basis (reduce (fn [basis ^Arc arc]
                           (let [nid (.target arc)]
                             (update-in basis [:graphs (gt/node-id->graph-id nid) :tarcs nid (.targetLabel arc)] arcs-remove-node n)))
                   basis ext-sarcs)
-          basis (reduce (fn [basis ^ArcBase arc]
+          basis (reduce (fn [basis ^Arc arc]
                           (let [nid (.source arc)]
                             (update-in basis [:graphs (gt/node-id->graph-id nid) :tarcs nid (.sourceLabel arc)] arcs-remove-node n)))
                   basis ext-tarcs)]
@@ -139,24 +451,24 @@
 
 (defn connect-source
   [g source source-label target target-label]
-  (let [from (graph->node g source)]
+  (let [from (node-id->node g source)]
     (assert (not (nil? from)) (str "Attempt to connect " (pr-str source source-label target target-label)))
     (update-in g [:sarcs source source-label] util/conjv (arc source target source-label target-label))))
 
 (defn connect-target
   [g source source-label target target-label]
-  (let [to (graph->node g target)]
+  (let [to (node-id->node g target)]
     (assert (not (nil? to)) (str "Attempt to connect " (pr-str source source-label target target-label)))
     (update-in g [:tarcs target target-label] util/conjv (arc source target source-label target-label))))
 
 (defn disconnect-source
   [g source source-label target target-label]
   (cond-> g
-    (graph->node g source)
+    (node-id->node g source)
     (update-in  [:sarcs source source-label]
                 (fn [arcs]
                   (util/removev
-                    (fn [^ArcBase arc]
+                    (fn [^Arc arc]
                       (and (= source       (.source arc))
                            (= target       (.target arc))
                            (= source-label (.sourceLabel arc))
@@ -166,35 +478,21 @@
 (defn disconnect-target
   [g source source-label target target-label]
   (cond-> g
-    (graph->node g target)
+    (node-id->node g target)
     (update-in [:tarcs target target-label]
                (fn [arcs]
                  (util/removev
-                   (fn [^ArcBase arc]
+                   (fn [^Arc arc]
                      (and (= source       (.source arc))
                           (= target       (.target arc))
                           (= source-label (.sourceLabel arc))
                           (= target-label (.targetLabel arc))))
                    arcs)))))
 
-(defmacro for-graph
-  [gsym bindings & body]
-  (let [loop-vars (into [] (map first (partition 2 bindings)))
-        rfn-args [gsym loop-vars]]
-    `(reduce (fn ~rfn-args ~@body)
-             ~gsym
-             (for [~@bindings]
-               [~@loop-vars]))))
-
 (defn override-by-id
   [basis override-id]
   (get-in basis [:graphs (gt/override-id->graph-id override-id) :overrides override-id]))
 
-
-;; ---------------------------------------------------------------------------
-;; Support for transactions
-;; ---------------------------------------------------------------------------
-(declare multigraph-basis)
 
 ;; ---------------------------------------------------------------------------
 ;; Dependency tracing
@@ -229,133 +527,142 @@
 (defn override-originals [basis node-id]
   (into '() (take-while some? (iterate (partial override-original basis) node-id))))
 
-(defn- override-of [graph node-id or-id]
-  (some #(and (= or-id (gt/override-id (graph->node graph %))) %) (overrides graph node-id)))
-
-(defn- closest-override-of [graph node-id or-path]
-  (if-let [or-id (first or-path)]
-    (if-let [or-node-id (override-of graph node-id or-id)]
-      (closest-override-of graph or-node-id (next or-path))
-      node-id)
-    node-id))
-
-(defn- group-arcs-by-source [arcs]
-  (group-by :sourceLabel arcs))
-
-(defn- group-arcs-by-target [arcs]
-  (group-by :targetLabel arcs))
+(defn- override-of [graph node-id override-id]
+  (some #(and (= override-id (gt/override-id (node-id->node graph %))) %) (overrides graph node-id)))
 
 (defn- node-id->arcs [graph node-id arc-kw]
-  (loop [all-arcs (-> (get graph arc-kw) (get node-id) vals)
-         res []]
-    (if-let [arcs (first all-arcs)]
-      (recur (rest all-arcs) (reduce conj res arcs))
-      res)))
+  (into [] cat (vals (-> graph (get arc-kw) (get node-id)))))
+
+;; This should really be made interface methods of IBasis
 
 (defn- graph-explicit-arcs-by-source
   ([graph src-id]
-    (node-id->arcs graph src-id :sarcs))
+   (node-id->arcs graph src-id :sarcs))
   ([graph src-id src-label]
-    (-> (:sarcs graph)
-      (get src-id)
-      (get src-label))))
+   (-> (:sarcs graph)
+     (get src-id)
+     (get src-label))))
 
 (defn explicit-arcs-by-source
   ([basis src-id]
-    (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id))
+   (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id))
   ([basis src-id src-label]
-    (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id src-label)))
+   (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id src-label)))
 
 (defn- graph-explicit-arcs-by-target
   ([graph tgt-id]
-    (node-id->arcs graph tgt-id :tarcs))
+   (node-id->arcs graph tgt-id :tarcs))
   ([graph tgt-id tgt-label]
-    (-> (:tarcs graph)
-      (get tgt-id)
-      (get tgt-label))))
+   (-> (:tarcs graph)
+     (get tgt-id)
+     (get tgt-label))))
 
 (defn explicit-arcs-by-target
   ([basis tgt-id]
-    (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id))
+   (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id))
   ([basis tgt-id tgt-label]
-    (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id tgt-label)))
+   (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id tgt-label)))
+
+(defn explicit-inputs
+  ([basis node-id]
+   (graph-explicit-arcs-by-target (node-id->graph basis node-id) node-id))
+  ([basis node-id label]
+   (graph-explicit-arcs-by-target (node-id->graph basis node-id) node-id label)))
+
+(defn explicit-outputs
+  ([basis node-id]
+   (graph-explicit-arcs-by-source (node-id->graph basis node-id) node-id))
+  ([basis node-id label]
+   (graph-explicit-arcs-by-source (node-id->graph basis node-id) node-id label)))
 
 (defn explicit-sources
   ([basis tgt-id]
-    (->> (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id)
-      (mapv gt/head)))
+   (mapv gt/head (explicit-inputs basis tgt-id)))
   ([basis tgt-id tgt-label]
-    (->> (graph-explicit-arcs-by-target (node-id->graph basis tgt-id) tgt-id tgt-label)
-      (mapv gt/head))))
+   (mapv gt/head (explicit-inputs basis tgt-id tgt-label))))
 
 (defn explicit-targets
   ([basis src-id]
-    (->> (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id)
-      (mapv gt/tail)))
+   (mapv gt/tail (explicit-outputs basis src-id)))
   ([basis src-id tgt-label]
-    (->> (graph-explicit-arcs-by-source (node-id->graph basis src-id) src-id tgt-label)
-      (mapv gt/tail))))
+   (mapv gt/tail (explicit-outputs basis src-id tgt-label))))
 
-(defn- implicit-overrides [basis node-id label arc-fn override-filter-fn]
-  (let [graph (get (:graphs basis) (gt/node-id->graph-id node-id))]
-    (loop [overrides (overrides graph node-id)
-           res []]
-      (if-let [override (first overrides)]
-        (if (and (override-filter-fn (gt/override-id (gt/node-by-id-at basis override)))
-                 (empty? (arc-fn graph override label)))
-          (let [res (conj res override)
-                res (reduce conj res (implicit-overrides basis override label arc-fn override-filter-fn))]
-            (recur (rest overrides) res))
-          (recur (rest overrides) res))
-        res))))
+(defn inputs
+  ([basis node-id]
+   (gt/arcs-by-tail basis node-id))
+  ([basis node-id label]
+   (gt/arcs-by-tail basis node-id label)))
 
-(defn- implicit-target-arcs [basis arcs override-filter-fn]
-  (loop [arcs arcs
-         res []]
-    (if-let [^ArcBase a (first arcs)]
-      (->> (implicit-overrides basis (.target a) (.targetLabel a) graph-explicit-arcs-by-target override-filter-fn)
-        (reduce (fn [res nid] (conj res (assoc a :target nid))) res)
-        (recur (rest arcs)))
-      res)))
+(defn outputs
+  ([basis node-id]
+   (gt/arcs-by-head basis node-id))
+  ([basis node-id label]
+   (gt/arcs-by-head basis node-id label)))
 
-(defn- basis-arcs-by-tail [basis node-id label]
-  (let [graph (node-id->graph basis node-id)
-        arcs (graph-explicit-arcs-by-target graph node-id label)]
-    (if-let [original (and (empty? arcs) (gt/original-node basis node-id))]
-      (let [node (gt/node-by-id-at basis node-id)
-            or-path [(gt/override-id node)]]
-        (->> (basis-arcs-by-tail basis original label)
-          (mapv (fn [arc]
-                  (let [src-id (:source arc)
-                        src-graph (node-id->graph basis src-id)]
-                    (assoc arc
-                           :source (closest-override-of src-graph src-id or-path)
-                           :target node-id))))))
-      arcs)))
+(defn- lifted-target-arcs [basis override-chain override-node-chain conflicting-chain {target :target target-label :targetLabel :as arc}]
+  (if (seq override-chain)
+    (let [disallowed-override-ids (first conflicting-chain)
+          target-graph (node-id->graph basis target)
+          target-override-node-ids (overrides target-graph target)]
+      (into []
+            (comp
+              ;; only follow what could make the source override chain
+              ;; a subsequence of this target chain - don't traverse
+              ;; up the wrong branch
+              (remove (fn [target-override-node-id]
+                        ;; faster than contains?
+                        (. ^IPersistentSet disallowed-override-ids
+                           (contains (gt/override-id (node-id->node target-graph target-override-node-id))))))
+              ;; An explicit arc shadows/blocks implicit arcs
+              (filter (fn [target-override-node-id]
+                        (nil? (graph-explicit-arcs-by-target target-graph target-override-node-id target-label))))
+              ;; Keep lifting, with different remaining chains
+              ;; depending on if the current target override matches
+              ;; the (current) source.
+              (mapcat (fn [target-override-node-id]
+                        (let [target-override-id (gt/override-id (node-id->node target-graph target-override-node-id))]
+                          (if (= target-override-id (first override-chain))
+                            (lifted-target-arcs basis
+                                                (rest override-chain)
+                                                (rest override-node-chain)
+                                                (rest conflicting-chain)
+                                                (assoc arc
+                                                       :source (first override-node-chain)
+                                                       :target target-override-node-id))
+                            (lifted-target-arcs basis
+                                                override-chain
+                                                override-node-chain
+                                                conflicting-chain
+                                                (assoc arc :target target-override-node-id)))))))
+            target-override-node-ids))
+    [arc]))
 
-(defn- basis-arcs-by-head
-  [basis graph node-id node label override-filter-fn]
-    (let [arcs (graph-explicit-arcs-by-source graph node-id label)]
-      (if-let [original (and (empty? arcs) (gt/original node))]
-        (let [or-id (gt/override-id node)
-              arcs (loop [arcs (basis-arcs-by-head basis graph original (graph->node graph original) label nil)
-                          res []]
-                     (if-let [arc (first arcs)]
-                       (let [tgt-id (:target arc)
-                             tgt-graph (node-id->graph basis tgt-id)]
-                         (if-let [new-target (override-of tgt-graph tgt-id or-id)]
-                           (let [new-arc (assoc arc
-                                                :source node-id
-                                                :target new-target)]
-                             (recur (rest arcs) (conj res new-arc)))
-                           (recur (rest arcs) res)))
-                       res))]
-          arcs)
-        (if override-filter-fn
-          (into arcs (implicit-target-arcs basis arcs override-filter-fn))
-          arcs))))
+(defn- propagate-target-arcs [basis target-arcs]
+  (when (seq target-arcs)
+    (let [source (:source (first target-arcs))
+          source-graph (node-id->graph basis source)
+          source-overrides (into #{} (map (comp gt/override-id #(node-id->node source-graph %))) (overrides source-graph source))]
+      #_(assert (every? #(= source (:source %)) target-arcs))
+      (loop [target-arcs target-arcs
+             result target-arcs]
+        (let [propagated-target-arcs (into []
+                                           (mapcat (fn [{target :target label :targetLabel :as target-arc}]
+                                                     (let [target-graph (node-id->graph basis target)]
+                                                       (into []
+                                                             (comp
+                                                                 (map (partial node-id->node target-graph))
+                                                                 (keep (fn [target-override-node]
+                                                                         ;; no better matching override node, and no shadowing explicit arc
+                                                                         (when (and (not (contains? source-overrides (gt/override-id target-override-node)))
+                                                                                    (nil? (graph-explicit-arcs-by-target target-graph (gt/node-id target-override-node) label)))
+                                                                           (assoc target-arc :target (gt/node-id target-override-node))))))
+                                                             (overrides target-graph target)))))
+                                           target-arcs)]
+          (if (empty? propagated-target-arcs)
+            result
+            (recur propagated-target-arcs
+                   (into result propagated-target-arcs))))))))
 
-(def ^:private none-seen (constantly false))
 (def ^:private set-or-union (fn [s1 s2] (if s1 (set/union s1 s2) s2)))
 (def ^:private merge-with-union (let [red-f (fn [m [k v]] (update m k set-or-union v))]
                                   (completing (fn [m1 m2] (reduce red-f m1 m2)))))
@@ -400,98 +707,160 @@
   gt/IBasis
   (node-by-id-at
       [this node-id]
-    (graph->node (node-id->graph this node-id) node-id))
+    (node-id->node (node-id->graph this node-id) node-id))
 
   (node-by-property
     [_ label value]
     (filter #(= value (get % label)) (mapcat vals graphs)))
 
+  ;; arcs-by-tail and arcs-by-head (should!) always return symmetric
+  ;; results. Generally, we find the explicit arcs along the
+  ;; override chain and then lift/propagate these up the source-
+  ;; and target override trees as far as the source override chain
+  ;; is the earliest and longest possible subsequence of the target
+  ;; override chain, and there is no explicit arcs shadowing the
+  ;; implicitly lifted ones.
+
   (arcs-by-tail
     [this node-id]
     (let [graph (node-id->graph this node-id)
-          arcs (graph-explicit-arcs-by-target graph node-id)]
-      (if-let [original (gt/original-node this node-id)]
-        (let [node (gt/node-by-id-at this node-id)
-              override-id (gt/override-id node)
-              arcs (loop [arcs (group-arcs-by-target arcs)
-                          original original
-                          or-path [override-id]]
-                     (if original
-                       (recur (merge (->> (mapcat second (get-in (node-id->graph this original) [:tarcs original]))
-                                       (map (fn [arc]
-                                              (let [src-id (:source arc)
-                                                    src-graph (node-id->graph this src-id)]
-                                                (-> arc
-                                                  (assoc :source (closest-override-of src-graph src-id or-path))
-                                                  (assoc :target node-id)))))
-                                       (filter :source)
-                                       group-arcs-by-target)
-                                     arcs)
-                              (gt/original-node this original)
-                              (if-let [or-id (gt/override-id (gt/node-by-id-at this original))]
-                                (cons or-id or-path)
-                                or-path))
-                      arcs))]
-          (mapcat second arcs))
-        arcs)))
-  (arcs-by-tail [this node-id label]
-    (basis-arcs-by-tail this node-id label))
+          explicit-arcs+override-chains (loop [node-id node-id
+                                               override-chain '()
+                                               seen-inputs #{}
+                                               result []]
+                                          (let [node (node-id->node graph node-id)
+                                                explicit-arcs (remove #(seen-inputs (:targetLabel %)) (graph-explicit-arcs-by-target graph node-id))
+                                                result' (if (seq explicit-arcs)
+                                                          (conj result [explicit-arcs override-chain])
+                                                          result)]
+                                            (if (gt/original node)
+                                              (recur (gt/original node)
+                                                     (conj override-chain (gt/override-id node))
+                                                     (into seen-inputs (map :targetLabel) explicit-arcs)
+                                                     result')
+                                              result')))]
+      (into []
+            (mapcat (fn [[explicit-arcs override-chain]]
+                      (loop [override-chain override-chain
+                             arcs explicit-arcs]
+                        (if (empty? override-chain)
+                          (into [] (map #(assoc % :target node-id)) arcs)
+                          (recur (rest override-chain)
+                                 (into [] (map (fn [{source :source :as arc}]
+                                                 (assoc arc :source (or (override-of (node-id->graph this source) source (first override-chain)) source))))
+                                       arcs))))))
+            explicit-arcs+override-chains)))
+
+  (arcs-by-tail
+    [this node-id label]
+    (let [graph (node-id->graph this node-id)
+          [override-chain explicit-arcs] (loop [node-id node-id
+                                                chain '()]
+                                           (let [arcs (graph-explicit-arcs-by-target graph node-id label)]
+                                             (if (and (empty? arcs) (gt/original-node this node-id))
+                                               (recur (gt/original-node this node-id)
+                                                      (conj chain (gt/override-id (gt/node-by-id-at this node-id))))
+                                               [chain arcs])))]
+      (when (seq explicit-arcs)
+        (loop [chain override-chain
+               arcs explicit-arcs]
+          (if (empty? chain)
+            (into [] (map #(assoc % :target node-id)) arcs)
+            (recur (rest chain)
+                   (into [] (map (fn [{source :source :as arc}]
+                                   (assoc arc :source (or (override-of (node-id->graph this source) source (first chain)) source))))
+                         arcs)))))))
 
   (arcs-by-head
     [this node-id]
-    (let [arcs (transient [])
-          graph (node-id->graph this node-id)
-          explicit (graph-explicit-arcs-by-source graph node-id)
-          arcs (reduce conj! arcs explicit)
-          override-filter-fn (->> (tree-seq (constantly true) (partial overrides graph) node-id)
-                                     (map #(gt/override-id (graph->node graph %)))
-                                     (into #{})
-                                     complement)
-          implicit-targets (implicit-target-arcs this explicit override-filter-fn)
-          arcs (reduce conj! arcs implicit-targets)
-          node (gt/node-by-id-at this node-id)
-          arcs (if-let [override-ids (and node #{(gt/override-id node)})]
-                 (loop [original (gt/original node)
-                        arcs arcs]
-                   (if original
-                     (let [explicit (graph-explicit-arcs-by-source graph original)
-                           implicit (mapcat (fn [^ArcBase a]
-                                              (map (fn [nid] (assoc a :target nid))
-                                                   (implicit-overrides this (.target a) (.targetLabel a) graph-explicit-arcs-by-target override-ids)))
-                                        explicit)]
-                       (recur (gt/original (gt/node-by-id-at this original)) (reduce conj! arcs implicit)))
-                     arcs))
-                 arcs)]
-      (persistent! arcs)))
+    (let [graph (node-id->graph this node-id)
+          explicit-arcs+override-chains (loop [node-id node-id
+                                               override-chain '()
+                                               override-node-chain '()
+                                               result []]
+                                          (let [node (node-id->node graph node-id)
+                                                explicit-arcs (graph-explicit-arcs-by-source graph node-id)
+                                                result' (if (seq explicit-arcs)
+                                                          (conj result [explicit-arcs override-chain override-node-chain])
+                                                          result)]
+                                            (if (gt/original node)
+                                              (recur (gt/original node)
+                                                     (conj override-chain (gt/override-id node))
+                                                     (conj override-node-chain node-id)
+                                                     result')
+                                              result')))
+          lifted-arcs (into []
+                            (comp
+                              (keep (fn [[explicit-arcs override-chain override-node-chain]]
+                                      #_(assert (every? #(= (:source %) (:source (first explicit-arcs))) explicit-arcs))
+                                      (let [source (:source (first explicit-arcs))
+                                            source-graph (node-id->graph this source)
+                                            conflicting-overrides-chain (mapv (fn [node next-override]
+                                                                                (disj (into #{} (map #(gt/override-id (node-id->node source-graph %)))
+                                                                                            (overrides source-graph node))
+                                                                                      next-override))
+                                                                              (conj override-node-chain source)
+                                                                              override-chain)]
+                                        (not-empty (into [] (mapcat (partial lifted-target-arcs this override-chain override-node-chain conflicting-overrides-chain)) explicit-arcs)))))
+                              cat)
+                            explicit-arcs+override-chains)]
+      #_(when (seq lifted-arcs) (assert (every? #(= (:source %) (:source (first lifted-arcs))) lifted-arcs)))
+      (propagate-target-arcs this lifted-arcs)))
 
   (arcs-by-head
     [this node-id label]
     (let [graph (node-id->graph this node-id)
-          override-filter-fn (->> (tree-seq (constantly true) (partial overrides graph) node-id)
-                               (map #(gt/override-id (graph->node graph %)))
-                               (into #{})
-                               complement)]
-      (basis-arcs-by-head this graph node-id (graph->node graph node-id) label override-filter-fn)))
+          ;; Traverse original chain, rember explicit arcs from the
+          ;; original + the override chain + override node chain from
+          ;; that original to this node.
+          explicit-arcs+override-chains (loop [node-id node-id
+                                               override-chain '()
+                                               override-node-chain '()
+                                               result []]
+                                          (let [node (node-id->node graph node-id)
+                                                explicit-arcs (graph-explicit-arcs-by-source graph node-id label)
+                                                result' (if (seq explicit-arcs)
+                                                          (conj result [explicit-arcs override-chain override-node-chain])
+                                                          result)]
+                                            (if (gt/original node)
+                                              (recur (gt/original node)
+                                                     (conj override-chain (gt/override-id node))
+                                                     (conj override-node-chain node-id)
+                                                     result')
+                                              result')))
+          ;; Looking at the arcs we found, what arcs to new targets
+          ;; are implied by following the override chains
+          ;; at most up to this node?
+          lifted-arcs (into []
+                            (comp
+                              (keep (fn [[explicit-arcs override-chain override-node-chain]]
+                                      #_(assert (every? #(= (:source %) (:source (first explicit-arcs))) explicit-arcs))
+                                      (let [source (:source (first explicit-arcs))
+                                            source-graph (node-id->graph this source)
+                                            ;; conflicting-overrides is to prevent following target
+                                            ;; overrides along the wrong "branches" (for which there may be another
+                                            ;; better -earlier- matching source node).
+                                            conflicting-overrides-chain (mapv (fn [node next-override]
+                                                                                (disj (into #{} (map #(gt/override-id (node-id->node source-graph %)))
+                                                                                            (overrides source-graph node))
+                                                                                      next-override))
+                                                                              (conj override-node-chain source)
+                                                                              override-chain)]
+                                        (not-empty (into [] (mapcat (partial lifted-target-arcs this override-chain override-node-chain conflicting-overrides-chain)) explicit-arcs)))))
+                              cat)
+                            explicit-arcs+override-chains)]
+      ;; Lifted arcs are now valid outgoing arcs from node-id label. But we're still missing
+      ;; some possible targets reachable by following the branches from the respective targets as long
+      ;; as there are no explicit incoming arcs and no "higher" override node of the source in the reached
+      ;; target node override.
+      #_(when (seq lifted-arcs) (assert (every? #(= (:source %) (:source (first lifted-arcs))) lifted-arcs)))
+      (propagate-target-arcs this lifted-arcs)))
 
-  (sources
-    [this node-id]
-    (->> (gt/arcs-by-tail this node-id)
-      (mapv gt/head)))
+  (sources [this node-id] (mapv gt/head (inputs this node-id)))
+  (sources [this node-id label] (mapv gt/head (inputs this node-id label)))
 
-  (sources
-    [this node-id label]
-    (->> (gt/arcs-by-tail this node-id label)
-      (mapv gt/head)))
-
-  (targets
-    [this node-id]
-    (->> (gt/arcs-by-head this node-id)
-      (mapv gt/tail)))
-
-  (targets
-    [this node-id label]
-    (->> (gt/arcs-by-head this node-id label)
-      (mapv gt/tail)))
+  (targets [this node-id] (mapv gt/tail (outputs this node-id)))
+  (targets [this node-id label] (mapv gt/tail (outputs this node-id label)))
 
   (add-node
     [this node]
@@ -521,9 +890,9 @@
     (let [gid      (gt/node-id->graph-id override-node-id)]
       (update-in this [:graphs gid :node->overrides original-node-id] util/conjv override-node-id)))
 
-  (override-node-clear [this original-id]
-    (let [gid (gt/node-id->graph-id original-id)]
-      (update-in this [:graphs gid :node->overrides] dissoc original-id)))
+  (override-node-clear [this original-id-id]
+    (let [gid (gt/node-id->graph-id original-id-id)]
+      (update-in this [:graphs gid :node->overrides] dissoc original-id-id)))
 
   (add-override
     [this override-id override]
@@ -541,7 +910,7 @@
           src-graph     (get graphs src-gid)
           tgt-gid       (gt/node-id->graph-id tgt-id)
           tgt-graph     (get graphs tgt-gid)
-          tgt-node      (graph->node tgt-graph tgt-id)
+          tgt-node      (node-id->node tgt-graph tgt-id)
           tgt-type      (gt/node-type tgt-node this)]
       (assert (<= (:_volatility src-graph 0) (:_volatility tgt-graph 0)))
       (assert (in/has-input? tgt-type tgt-label) (str "No label " tgt-label " exists on node " tgt-node))
@@ -597,8 +966,7 @@
 
 (defn- sarcs->arcs [sarcs]
   (into #{}
-        (comp (map vals)
-              cat
+        (comp (mapcat vals)
               cat)
         (vals sarcs)))
 
@@ -617,56 +985,72 @@
     (gt/node-type basis)
     in/input-dependencies))
 
-;; The purpose of this fn is to build a data structure that reflects which set of node-id + outputs that can be reached from the incoming changes (map of node-id + outputs)
-;; For a specific node-id-a + output-x, add:
-;;   the internal input-dependencies, i.e. outputs consuming the given output
-;;   the closest override-nodes, i.e. override-node-a + output-x, as they can be potential dependents
-;;   all connected nodes, where node-id-a + output-x => [[node-id-b + input-y] ...] => [[node-id-b + output+z] ...]
-(defn- update-graph-successors [succs basis gid graph changes]
+(defn- update-graph-successors [old-successors basis gid graph changes]
   (let [node-id->overrides (or (:node->overrides graph) (constantly nil))
         ;; Transducer to collect override-id's
         override-id-xf (keep #(some->> %
-                                (graph->node graph)
-                                (gt/override-id)))]
-    (reduce (fn [succs [node-id labels]]
-              (if-let [node (gt/node-by-id-at basis node-id)]
-                (let [;; Support data and functions
-                      node-type (gt/node-type node basis)
-                      deps-by-label (or (in/input-dependencies node-type) (constantly nil))
-                      node-and-overrides (tree-seq (constantly true) node-id->overrides node-id)
-                      override-filter-fn (complement (into #{} override-id-xf node-and-overrides))
-                      overrides (node-id->overrides node-id)
-                      labels (or labels (in/output-labels node-type))
-                      repeat-node-id (repeat node-id)]
-                  (update succs node-id
-                    (fn [succs]
-                      (let [succs (or succs {})]
-                        (reduce (fn [succs label]
-                                  (let [single-label #{label}
-                                        dep-labels (get deps-by-label label)
-                                        ;; The internal dependent outputs
-                                        deps (cond-> (transient {})
-                                               (and dep-labels (> (count dep-labels) 0)) (assoc! node-id dep-labels))
-                                        ;; The closest overrides
-                                        deps (transduce (map #(vector % single-label)) conj! deps overrides)
-                                        ;; The connected nodes and their outputs
-                                        deps (transduce (keep (fn [^ArcBase arc]
-                                                                (let [tgt-id (.target arc)
-                                                                      tgt-label (.targetLabel arc)]
-                                                                  (when-let [dep-labels (get (input-deps basis tgt-id) tgt-label)]
-                                                                    [tgt-id dep-labels]))))
-                                               conj! deps (basis-arcs-by-head basis graph node-id node label override-filter-fn))]
-                                    (assoc succs label (persistent! deps))))
-                          succs labels)))))
-                ;; Clean-up missing nodes from the data structure
-                (dissoc succs node-id)))
-      succs changes)))
+                                (node-id->node graph)
+                                (gt/override-id)))
+        changes+old-node-successors (mapv (fn [[node-id labels]]
+                                            [node-id labels (old-successors node-id)])
+                                          changes)
+        [new-successors removed-successors] (r/fold
+                                              (fn combinef
+                                                ([] [{} []])
+                                                ([a b] [(merge (first a) (first b))
+                                                        (into (second a) (second b))]))
+                                              (fn reducef
+                                                ([] [{} []])
+                                                ([[new-acc remove-acc] [node-id labels old-node-successors]]
+                                                 (let [new-node-successors (if-let [node (gt/node-by-id-at basis node-id)]
+                                                                             (let [;; Support data and functions
+                                                                                   node-type (gt/node-type node basis)
+                                                                                   deps-by-label (or (in/input-dependencies node-type) {})
+                                                                                   node-and-overrides (tree-seq (constantly true) node-id->overrides node-id)
+                                                                                   override-filter-fn (complement (into #{} override-id-xf node-and-overrides))
+                                                                                   overrides (node-id->overrides node-id)
+                                                                                   labels (or labels (in/output-labels node-type))
+                                                                                   arcs-by-head (if (> (count labels) 1)
+                                                                                                  (let [arcs (gt/arcs-by-head basis node-id)
+                                                                                                        arcs-by-source-label (group-by #(.sourceLabel ^Arc %) arcs)]
+                                                                                                    (fn [_ _ label]
+                                                                                                      (arcs-by-source-label label)))
+                                                                                                  (fn [basis node-id label]
+                                                                                                    (gt/arcs-by-head basis node-id label)))]
+                                                                               (reduce (fn [new-node-successors label]
+                                                                                         (let [single-label #{label}
+                                                                                               dep-labels (get deps-by-label label)
+                                                                                               ;; The internal dependent outputs
+                                                                                               deps (cond-> (transient {})
+                                                                                                      (and dep-labels (> (count dep-labels) 0))
+                                                                                                      (assoc! node-id dep-labels))
+                                                                                               ;; The closest overrides
+                                                                                               deps (transduce (map #(vector % single-label)) conj! deps overrides)
+                                                                                               ;; The connected nodes and their outputs
+                                                                                               deps (transduce (keep (fn [^Arc arc]
+                                                                                                                       (let [tgt-id (.target arc)
+                                                                                                                             tgt-label (.targetLabel arc)]
+                                                                                                                         (when-let [dep-labels (get (input-deps basis tgt-id) tgt-label)]
+                                                                                                                           [tgt-id dep-labels]))))
+                                                                                                               conj!
+                                                                                                               deps
+                                                                                                               (arcs-by-head basis node-id label))]
+                                                                                           (assoc new-node-successors label (persistent! deps))))
+                                                                                       (or old-node-successors {})
+                                                                                       labels))
+                                                                             nil)]
+                                                   (if (nil? new-node-successors)
+                                                     [new-acc (conj remove-acc node-id)]
+                                                     [(assoc new-acc node-id new-node-successors) remove-acc]))))
+                                              changes+old-node-successors)]
+    (apply dissoc (merge old-successors new-successors) removed-successors)))
 
 (defn update-successors
   [basis changes]
-  (let [changes (vec changes)]
-    (reduce (fn [basis [gid changes]]
-              (if-let [graph (get (:graphs basis) gid)]
-                (update-in basis [:graphs gid :successors] update-graph-successors basis gid graph changes)
-                basis))
-      basis (group-by (comp gt/node-id->graph-id first) changes))))
+  ;; changes = {node-id #{outputs?}]}
+  (reduce (fn [basis [gid changes]]
+            (if-let [graph (get (:graphs basis) gid)]
+              (update-in basis [:graphs gid :successors] update-graph-successors basis gid graph changes)
+              basis))
+          basis
+          (group-by (comp gt/node-id->graph-id first) changes)))

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -4,9 +4,10 @@
 
 (set! *warn-on-reflection* true)
 
-(defprotocol Arc
-  (head [this] "returns [source-node source-label]")
-  (tail [this] "returns [target-node target-label]"))
+(defrecord Arc [source target sourceLabel targetLabel])
+
+(defn head [^Arc arc] [(.source arc) (.sourceLabel arc)])
+(defn tail [^Arc arc] [(.target arc) (.targetLabel arc)])
 
 (defn node-id? [v] (integer? v))
 

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -113,7 +113,8 @@
                              ;; map -> vec
                              (into [] (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))]
       (alter (:cache sys) c/cache-invalidate cache-entries)
-      (alter (:invalidate-counters sys) bump-invalidate-counters cache-entries))))
+      (alter (:invalidate-counters sys) bump-invalidate-counters cache-entries)
+      cache-entries)))
 
 (defn step-through-history!
   [step-function sys graph-id]

--- a/editor/test/dynamo/integration/override_test.clj
+++ b/editor/test/dynamo/integration/override_test.clj
@@ -444,7 +444,7 @@
                           {:resource template-resource :overrides source-overrides}))
             (set (fn [evaluation-context self old-value new-value]
                    (let [basis (:basis evaluation-context)
-                         current-scene (g/node-feeding-into self :template-resource)]
+                         current-scene (g/node-feeding-into basis self :template-resource)]
                      (concat
                        (if current-scene
                          (g/delete-node current-scene)
@@ -480,7 +480,7 @@
   (property nodes g/Any
             (set (fn [evaluation-context self _ new-value]
                    (let [basis (:basis evaluation-context)
-                         current-tree (g/node-feeding-into self :node-tree)]
+                         current-tree (g/node-feeding-into basis self :node-tree)]
                      (concat
                        (if current-tree
                          (g/delete-node current-tree)
@@ -933,7 +933,7 @@
         (is (= 1 (count (keep g/node-by-id all-script-nodes))))
         (is (empty? (mapcat g/overrides all-script-nodes)))))))
 
-(defn remove-idx [v ix]
+(defn- remove-idx [v ix]
   (into (subvec v 0 ix) (subvec v (inc ix))))
 
 (defn- all-system-nodes []
@@ -962,7 +962,7 @@
         (doseq [node all-nodes]
           (let [outputs (g/outputs node)
                 outputs-freqs (frequencies outputs)
-                merged-outputs (reduce conj [] (apply concat (vals (node-outputs node))))
+                merged-outputs (into [] cat (vals (node-outputs node)))
                 merged-outputs-freqs (frequencies merged-outputs)
                 freq-diff [:all-merged (not-empty (set/difference (set outputs-freqs) (set merged-outputs-freqs)))
                            :merged-all (not-empty (set/difference (set merged-outputs-freqs) (set outputs-freqs)))]]
@@ -971,7 +971,7 @@
         (doseq [node all-nodes]
           (let [inputs (g/inputs node)
                 inputs-freqs (frequencies inputs)
-                merged-inputs (apply concat (vals (node-inputs node)))
+                merged-inputs (into [] cat (vals (node-inputs node)))
                 merged-inputs-freqs (frequencies merged-inputs)
                 freq-diff [:all-merged (not-empty (set/difference (set inputs-freqs) (set merged-inputs-freqs)))
                            :merged-all (not-empty (set/difference (set merged-inputs-freqs) (set inputs-freqs)))]]
@@ -993,3 +993,4 @@
         (let [output-freqs (frequencies (mapcat g/outputs all-nodes))
               input-freqs (frequencies (mapcat g/inputs all-nodes))]
           (is (= output-freqs input-freqs)))))))
+

--- a/editor/test/internal/graph/graph_test.clj
+++ b/editor/test/internal/graph/graph_test.clj
@@ -27,7 +27,7 @@
         id     (inc (count (:nodes g)))
         g      (ig/add-node g id v)
         g      (ig/graph-remove-node g id nil)]
-    (is (nil? (ig/graph->node g id)))
+    (is (nil? (ig/node-id->node g id)))
     (is (empty? (filter #(= "Any ig/node value" %) (ig/node-values g))))))
 
 (defn targets [g n l] (map gt/tail (get-in g [:sarcs n l])))
@@ -36,7 +36,7 @@
 (defn- source-arcs-without-targets
   [g]
   (for [source                (ig/node-ids g)
-        source-label          (-> (ig/graph->node g source) g/node-type in/output-labels)
+        source-label          (-> (ig/node-id->node g source) g/node-type in/output-labels)
         [target target-label] (targets g source source-label)
         :when                 (not (some #(= % [source source-label]) (sources g target target-label)))]
     [source source-label]))
@@ -44,7 +44,7 @@
 (defn- target-arcs-without-sources
   [g]
   (for [target                (ig/node-ids g)
-        target-label          (-> (ig/graph->node g target) g/node-type in/input-labels)
+        target-label          (-> (ig/node-id->node g target) g/node-type in/input-labels)
         [source source-label] (sources g target target-label)
         :when                 (not (some #(= % [target target-label]) (targets g source source-label)))]
     [target target-label]))
@@ -64,8 +64,8 @@
         g      (ig/add-node g id {:number 0})
         g'     (ig/transform-node g id update-in [:number] inc)]
     (is (not= g g'))
-    (is (= 1 (:number (ig/graph->node g' id))))
-    (is (= 0 (:number (ig/graph->node g id))))))
+    (is (= 1 (:number (ig/node-id->node g' id))))
+    (is (= 0 (:number (ig/node-id->node g id))))))
 
 (g/deftype T1        String)
 (g/deftype T1-array  [String])

--- a/editor/test/resources/override_project/.gitignore
+++ b/editor/test/resources/override_project/.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/override_project/README.md
+++ b/editor/test/resources/override_project/README.md
@@ -1,0 +1,13 @@
+# Welcome to Defold
+
+This project was created from the "empty" project template.
+
+The settings in ["game.project"](defold://open?path=/game.project) are all the default. A bootstrap empty ["main.collection"](defold://open?path=/main/main.collection) is included.
+
+Check out [the documentation pages](https://defold.com/learn) for examples, tutorials, manuals and API docs.
+
+If you run into trouble, help is available in [our forum](https://forum.defold.com).
+
+Happy Defolding!
+
+---

--- a/editor/test/resources/override_project/game.project
+++ b/editor/test/resources/override_project/game.project
@@ -1,0 +1,13 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[project]
+title = Test project for arcs + overrides
+

--- a/editor/test/resources/override_project/input/game.input_binding
+++ b/editor/test/resources/override_project/input/game.input_binding
@@ -1,0 +1,4 @@
+mouse_trigger {
+  input: MOUSE_BUTTON_1
+  action: "touch"
+}

--- a/editor/test/resources/override_project/main/button2.gui
+++ b/editor/test/resources/override_project/main/button2.gui
@@ -1,0 +1,336 @@
+script: ""
+fonts {
+  name: "system_font"
+  font: "/builtins/fonts/system_font.font"
+}
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_AUTO
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.10196079
+    y: 0.3019608
+    z: 0.10196079
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Sample"
+  font: "system_font"
+  id: "text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "box"
+  layer: ""
+  inherit_alpha: true
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: false
+  text_leading: 1.0
+  text_tracking: 0.0
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 480.0
+    y: 320.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "unaffected"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_AUTO
+}
+material: "/builtins/materials/gui.material"
+layouts {
+  name: "Portrait"
+  nodes {
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    scale {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    size {
+      x: 200.0
+      y: 100.0
+      z: 0.0
+      w: 1.0
+    }
+    color {
+      x: 0.10196079
+      y: 0.3019608
+      z: 0.10196079
+      w: 1.0
+    }
+    type: TYPE_TEXT
+    blend_mode: BLEND_MODE_ALPHA
+    text: "S\n"
+  "a\n"
+  "m\n"
+  "p\n"
+  "l\n"
+  "e"
+    font: "system_font"
+    id: "text"
+    xanchor: XANCHOR_NONE
+    yanchor: YANCHOR_NONE
+    pivot: PIVOT_CENTER
+    outline {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    shadow {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    adjust_mode: ADJUST_MODE_FIT
+    line_break: false
+    parent: "box"
+    layer: ""
+    inherit_alpha: true
+    clipping_mode: CLIPPING_MODE_NONE
+    clipping_visible: true
+    clipping_inverted: false
+    alpha: 1.0
+    outline_alpha: 1.0
+    shadow_alpha: 1.0
+    overridden_fields: 8
+    template_node_child: false
+    text_leading: 1.0
+    text_tracking: 0.0
+    size_mode: SIZE_MODE_MANUAL
+  }
+}
+layouts {
+  name: "Landscape"
+  nodes {
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    scale {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    size {
+      x: 200.0
+      y: 100.0
+      z: 0.0
+      w: 1.0
+    }
+    color {
+      x: 0.10196079
+      y: 0.3019608
+      z: 0.10196079
+      w: 1.0
+    }
+    type: TYPE_TEXT
+    blend_mode: BLEND_MODE_ALPHA
+    text: "S a m p l e"
+    font: "system_font"
+    id: "text"
+    xanchor: XANCHOR_NONE
+    yanchor: YANCHOR_NONE
+    pivot: PIVOT_CENTER
+    outline {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    shadow {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    adjust_mode: ADJUST_MODE_FIT
+    line_break: false
+    parent: "box"
+    layer: ""
+    inherit_alpha: true
+    clipping_mode: CLIPPING_MODE_NONE
+    clipping_visible: true
+    clipping_inverted: false
+    alpha: 1.0
+    outline_alpha: 1.0
+    shadow_alpha: 1.0
+    overridden_fields: 8
+    template_node_child: false
+    text_leading: 1.0
+    text_tracking: 0.0
+    size_mode: SIZE_MODE_MANUAL
+  }
+}
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/editor/test/resources/override_project/main/child.gui
+++ b/editor/test/resources/override_project/main/child.gui
@@ -1,0 +1,118 @@
+script: ""
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/main/grandchild.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 564.0
+    y: 241.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "original"
+  font: "system_font"
+  id: "template/text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+material: "/builtins/materials/gui.material"
+layouts {
+  name: "Landscape"
+}
+layouts {
+  name: "Portrait"
+}
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/editor/test/resources/override_project/main/grandchild.gui
+++ b/editor/test/resources/override_project/main/grandchild.gui
@@ -1,0 +1,82 @@
+script: ""
+fonts {
+  name: "system_font"
+  font: "/builtins/fonts/system_font.font"
+}
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 564.0
+    y: 241.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "original"
+  font: "system_font"
+  id: "text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: false
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+material: "/builtins/materials/gui.material"
+layouts {
+  name: "Landscape"
+}
+layouts {
+  name: "Portrait"
+}
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/editor/test/resources/override_project/main/hud.gui
+++ b/editor/test/resources/override_project/main/hud.gui
@@ -1,0 +1,332 @@
+script: ""
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/main/panel2.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 157.0
+    y: 210.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template/template"
+  parent: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/main/button2.gui"
+  template_node_child: true
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "template/template/box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "template/template"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_AUTO
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.10196079
+    y: 0.3019608
+    z: 0.10196079
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Sample HUD"
+  font: "system_font"
+  id: "template/template/text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "template/template/box"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  overridden_fields: 8
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 480.0
+    y: 320.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "template/template/unaffected"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "template/template"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_AUTO
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Default layout"
+  font: "system_font"
+  id: "template/text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+material: "/builtins/materials/gui.material"
+layouts {
+  name: "Landscape"
+}
+layouts {
+  name: "Portrait"
+}
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/editor/test/resources/override_project/main/main.collection
+++ b/editor/test/resources/override_project/main/main.collection
@@ -1,0 +1,37 @@
+name: "default"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"hud\"\n"
+  "  component: \"/main/hud.gui\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/editor/test/resources/override_project/main/panel2.gui
+++ b/editor/test/resources/override_project/main/panel2.gui
@@ -1,0 +1,486 @@
+script: ""
+fonts {
+  name: "system_font"
+  font: "/builtins/fonts/system_font.font"
+}
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 1.0
+}
+nodes {
+  position {
+    x: 157.0
+    y: 210.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/main/button2.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "template/box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "template"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_AUTO
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.10196079
+    y: 0.3019608
+    z: 0.10196079
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Sample"
+  font: "system_font"
+  id: "template/text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "template/box"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 480.0
+    y: 320.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: ""
+  id: "template/unaffected"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "template"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_AUTO
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Default layout"
+  font: "system_font"
+  id: "text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: false
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+material: "/builtins/materials/gui.material"
+layouts {
+  name: "Portrait"
+  nodes {
+    position {
+      x: 158.0
+      y: 307.0
+      z: 0.0
+      w: 1.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    scale {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    size {
+      x: 200.0
+      y: 100.0
+      z: 0.0
+      w: 1.0
+    }
+    color {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    type: TYPE_TEXT
+    blend_mode: BLEND_MODE_ALPHA
+    text: "Portrait"
+    font: "system_font"
+    id: "text"
+    xanchor: XANCHOR_NONE
+    yanchor: YANCHOR_NONE
+    pivot: PIVOT_CENTER
+    outline {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    shadow {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    adjust_mode: ADJUST_MODE_FIT
+    line_break: false
+    layer: ""
+    inherit_alpha: true
+    alpha: 1.0
+    outline_alpha: 1.0
+    shadow_alpha: 1.0
+    overridden_fields: 1
+    overridden_fields: 8
+    template_node_child: false
+    text_leading: 1.0
+    text_tracking: 0.0
+  }
+}
+layouts {
+  name: "Landscape"
+  nodes {
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    scale {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    size {
+      x: 200.0
+      y: 100.0
+      z: 0.0
+      w: 1.0
+    }
+    color {
+      x: 0.10196079
+      y: 0.3019608
+      z: 0.10196079
+      w: 1.0
+    }
+    type: TYPE_TEXT
+    blend_mode: BLEND_MODE_ALPHA
+    text: "Sample"
+    font: "system_font"
+    id: "template/text"
+    xanchor: XANCHOR_NONE
+    yanchor: YANCHOR_NONE
+    pivot: PIVOT_CENTER
+    outline {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    shadow {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    adjust_mode: ADJUST_MODE_FIT
+    line_break: false
+    parent: "template/box"
+    layer: ""
+    inherit_alpha: true
+    alpha: 1.0
+    outline_alpha: 1.0
+    shadow_alpha: 1.0
+    overridden_fields: 5
+    template_node_child: true
+    text_leading: 1.0
+    text_tracking: 0.0
+  }
+  nodes {
+    position {
+      x: 154.0
+      y: 321.0
+      z: 0.0
+      w: 1.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    scale {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    size {
+      x: 200.0
+      y: 100.0
+      z: 0.0
+      w: 1.0
+    }
+    color {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    type: TYPE_TEXT
+    blend_mode: BLEND_MODE_ALPHA
+    text: "Landscape"
+    font: "system_font"
+    id: "text"
+    xanchor: XANCHOR_NONE
+    yanchor: YANCHOR_NONE
+    pivot: PIVOT_CENTER
+    outline {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    shadow {
+      x: 1.0
+      y: 1.0
+      z: 1.0
+      w: 1.0
+    }
+    adjust_mode: ADJUST_MODE_FIT
+    line_break: false
+    layer: ""
+    inherit_alpha: true
+    alpha: 1.0
+    outline_alpha: 1.0
+    shadow_alpha: 1.0
+    overridden_fields: 1
+    overridden_fields: 8
+    template_node_child: false
+    text_leading: 1.0
+    text_tracking: 0.0
+  }
+}
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/editor/test/resources/override_project/main/parent.gui
+++ b/editor/test/resources/override_project/main/parent.gui
@@ -1,0 +1,158 @@
+script: ""
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/main/child.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "template/template"
+  parent: "template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/main/grandchild.gui"
+  template_node_child: true
+}
+nodes {
+  position {
+    x: 564.0
+    y: 241.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "original"
+  font: "system_font"
+  id: "template/template/text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "template/template"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+material: "/builtins/materials/gui.material"
+layouts {
+  name: "Landscape"
+}
+layouts {
+  name: "Portrait"
+}
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512


### PR DESCRIPTION
Fixed implementations of arcs-by-head and arcs-by-tail for more
complex override nestings. We seemed to be to strict about the
correspondence between the source and target override chains.