### PR TITLE
DEFEDIT-1470 Make naming more consistent in graph related namespaces

### DIFF
--- a/editor/src/clj/editor/gviz.clj
+++ b/editor/src/clj/editor/gviz.clj
@@ -46,9 +46,9 @@
   (let [nodes (set nodes)]
     (seq (into #{} (mapcat (fn [[_ graph]]
                           (->>
-                            (concat (filter (fn [a] (or (nodes (:source a)) (nodes (:target a)))) (flatten-arcs (:sarcs graph)))
-                                    (filter #(or (nodes (:source %)) (nodes (:target %))) (flatten-arcs (:tarcs graph))))
-                            (map (fn [a] [(:source a) (:sourceLabel a) (:target a) (:targetLabel a)]))))
+                            (concat (filter (fn [a] (or (nodes (:source-id a)) (nodes (:target-id a)))) (flatten-arcs (:sarcs graph)))
+                                    (filter #(or (nodes (:source-id %)) (nodes (:target-id %))) (flatten-arcs (:tarcs graph))))
+                            (map (fn [a] [(:source-id a) (:source-label a) (:target-id a) (:target-label a)]))))
                            (:graphs basis))))))
 
 (defn escape-field-label [label]

--- a/editor/src/clj/internal/cache.clj
+++ b/editor/src/clj/internal/cache.clj
@@ -24,22 +24,22 @@
 ;; Mutators
 ;; ----------------------------------------
 (defn- encache
-  [c kvs]
+  [cache kvs]
   (if-let [kv (first kvs)]
-    (recur (cc/miss c (first kv) (second kv)) (next kvs))
-    c))
+    (recur (cc/miss cache (first kv) (second kv)) (next kvs))
+    cache))
 
 (defn- hits
-  [c ks]
+  [cache ks]
   (if-let [k (first ks)]
-    (recur (cc/hit c k) (next ks))
-    c))
+    (recur (cc/hit cache k) (next ks))
+    cache))
 
 (defn- evict
-  [c ks]
+  [cache ks]
   (if-let [k (first ks)]
-    (recur (cc/evict c k) (next ks))
-    c))
+    (recur (cc/evict cache k) (next ks))
+    cache))
 
 ;; ----------------------------------------
 ;; Interface

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -4,10 +4,10 @@
 
 (set! *warn-on-reflection* true)
 
-(defrecord Arc [source target sourceLabel targetLabel])
+(defrecord Arc [source-id source-label target-id target-label])
 
-(defn head [^Arc arc] [(.source arc) (.sourceLabel arc)])
-(defn tail [^Arc arc] [(.target arc) (.targetLabel arc)])
+(defn source [^Arc arc] [(.source-id arc) (.source-label arc)])
+(defn target [^Arc arc] [(.target-id arc) (.target-label arc)])
 
 (defn node-id? [v] (integer? v))
 
@@ -31,8 +31,8 @@
 (defprotocol IBasis
   (node-by-id-at    [this node-id])
   (node-by-property [this label value])
-  (arcs-by-head     [this node-id] [this node-id label])
-  (arcs-by-tail     [this node-id] [this node-id label])
+  (arcs-by-source   [this node-id] [this node-id label])
+  (arcs-by-target   [this node-id] [this node-id label])
   (sources          [this node-id] [this node-id label])
   (targets          [this node-id] [this node-id label])
   (add-node         [this value]                 "returns [basis real-value]")
@@ -43,9 +43,9 @@
   (add-override     [this override-id override])
   (delete-override  [this override-id])
   (replace-override [this override-id value])
-  (connect          [this src-id src-label tgt-id tgt-label])
-  (disconnect       [this src-id src-label tgt-id tgt-label])
-  (connected?       [this src-id src-label tgt-id tgt-label])
+  (connect          [this source-id source-label target-id target-label])
+  (disconnect       [this source-id source-label target-id target-label])
+  (connected?       [this source-id source-label target-id target-label])
   (dependencies     [this outputs-by-node-ids]
     "Follow arcs through the graphs, from outputs to the inputs
      connected to them, and from those inputs to the downstream

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -734,13 +734,13 @@
   (let [multivalued? (vector? original-form)
         form (if multivalued? (first original-form) original-form)
         autotype (cond
-                       (util/protocol-symbol? form) `(->ProtocolType ~form (s/protocol ~form))
-                       (util/class-symbol? form) `(->ClassType ~form ~form))
+                   (util/protocol-symbol? form) `(->ProtocolType ~form (s/protocol ~form))
+                   (util/class-symbol? form) `(->ClassType ~form ~form))
         typeref (cond
-                       (ref? form) form
-                       (util/protocol-symbol? form) (named->vtr form)
-                       (util/class-symbol? form) (named->vtr (.getName ^Class (resolve form)))
-                       (named? form) (named->vtr form))]
+                  (ref? form) form
+                  (util/protocol-symbol? form) (named->vtr form)
+                  (util/class-symbol? form) (named->vtr (.getName ^Class (resolve form)))
+                  (named? form) (named->vtr form))]
     (assert (not (nil? typeref))
             (str "defnode " where " requires a value type but was supplied with '"
                  original-form "' which cannot be used as a type"))
@@ -844,14 +844,14 @@
                   (contains? internal-keys klabel)
                   (update :flags #(conj (or % #{}) :internal)))
         outdef (-> propdef
-                    (dissoc :setter :dynamics :value)
-                    (assoc :fn
-                           (if-let [evaluator (-> propdef :value :fn)]
-                             evaluator
-                             `(dynamo.graph/fnk [~'this ~label] (get ~'this ~klabel)))))
+                 (dissoc :setter :dynamics :value)
+                 (assoc :fn
+                        (if-let [evaluator (-> propdef :value :fn)]
+                          evaluator
+                          `(dynamo.graph/fnk [~'this ~label] (get ~'this ~klabel)))))
         desc {:property {klabel propdef}
-                 :property-order-decl (if (contains? internal-keys klabel) [] [klabel])
-                 :output {klabel outdef}}]
+              :property-order-decl (if (contains? internal-keys klabel) [] [klabel])
+              :output {klabel outdef}}]
     desc))
 
 (def ^:private output-flags #{:cached :abstract :unjammable})
@@ -1189,7 +1189,7 @@
 (defn- collect-base-property-value-form
   [self-name ctx-name nodeid-sym description prop-name]
   (let [property-definition (get-in description [:property prop-name])
-        default?            (not (:value property-definition))]
+        default? (not (:value property-definition))]
     (if default?
       (with-tracer-calls-form self-name ctx-name prop-name :raw-property
         (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~prop-name)))
@@ -1202,16 +1202,16 @@
 (defn- collect-property-value-form
   [self-name ctx-name nodeid-sym description prop]
   (let [property-definition (get-in description [:property prop])
-        default?            (not (:value property-definition))
+        default? (not (:value property-definition))
         get-expr (if default?
-                              (with-tracer-calls-form self-name ctx-name prop :raw-property
-                                (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~prop)))
-                              (with-tracer-calls-form self-name ctx-name prop :property
-                                (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym prop description
-                                                                             (get-in property-definition [:value :arguments])
-                                                                             (check-dry-run-form ctx-name
-                                                                                                 `(var ~(dollar-name (:name description) [:property prop :value]))
-                                                                                                 `(constantly nil)))))]
+                   (with-tracer-calls-form self-name ctx-name prop :raw-property
+                     (check-dry-run-form ctx-name `(gt/get-property ~self-name (:basis ~ctx-name) ~prop)))
+                   (with-tracer-calls-form self-name ctx-name prop :property
+                     (call-with-error-checked-fnky-arguments-form self-name ctx-name nodeid-sym prop description
+                                                                  (get-in property-definition [:value :arguments])
+                                                                  (check-dry-run-form ctx-name
+                                                                                      `(var ~(dollar-name (:name description) [:property prop :value]))
+                                                                                      `(constantly nil)))))]
     get-expr))
 
 (defn- fnk-argument-form
@@ -1446,10 +1446,10 @@
       `(fn [~self-name ~ctx-name]
          (let [~nodeid-sym (gt/node-id ~self-name)
                ~display-order (-> (gt/node-type ~self-name (:basis ~ctx-name))
-                                  (property-display-order))
+                                (property-display-order))
                ~value-map ~(apply merge {}
-                                      (for [[p _] (filter (comp external-property? val) props)]
-                                        {p (property-value-exprs self-name ctx-name nodeid-sym description p (get props p))}))]
+                                  (for [[p _] (filter (comp external-property? val) props)]
+                                    {p (property-value-exprs self-name ctx-name nodeid-sym description p (get props p))}))]
            ~(check-dry-run-form ctx-name (assemble-properties-map-form nodeid-sym value-map display-order)))))))
 
 (defn- node-input-value-function-form
@@ -1504,11 +1504,11 @@
           (when-not (:dry-run evaluation-context)
             (let [static-props (all-properties type)
                   props (reduce-kv (fn [p k v]
-                                             (if (and (not (contains? static-props k))
-                                                      (= original-id (:node-id v)))
-                                               (assoc-in p [:properties k :value] (:value v))
-                                               p))
-                                           props orig-props)]
+                                     (if (and (not (contains? static-props k))
+                                              (= original-id (:node-id v)))
+                                       (assoc-in p [:properties k :value] (:value v))
+                                       p))
+                                   props orig-props)]
               (reduce (fn [props [k v]]
                         (let [prop-type (get-in props [:properties k :type])]
                           (if (nil? (s/check (prop-type->schema prop-type) v))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -17,16 +17,16 @@
 (def ^:private maximum-disposal-backlog 2500)
 (def ^:private history-size-max         60)
 
-(prefer-method print-method java.util.Map               clojure.lang.IDeref)
+(prefer-method print-method java.util.Map clojure.lang.IDeref)
 (prefer-method print-method clojure.lang.IPersistentMap clojure.lang.IDeref)
-(prefer-method print-method clojure.lang.IRecord        clojure.lang.IDeref)
+(prefer-method print-method clojure.lang.IRecord clojure.lang.IDeref)
 
 (defn- integer-counter
   []
   (AtomicLong. 0))
 
 (defn- new-history []
-  {:tape       (conj (h/paper-tape history-size-max) [])})
+  {:tape (conj (h/paper-tape history-size-max) [])})
 
 (defrecord HistoryState [label graph sequence-label cache-keys])
 
@@ -41,8 +41,8 @@
   [tape new-state]
   (let [old-state (h/ivalue tape)]
     (conj
-     (h/truncate (h/iprev tape))
-     (history-state-merge-cache-keys new-state old-state))))
+      (h/truncate (h/iprev tape))
+      (history-state-merge-cache-keys new-state old-state))))
 
 (defn =*
   "Comparison operator that treats nil as not equal to anything."
@@ -51,11 +51,11 @@
   ([x y & more] (reduce =* (=* x y) more)))
 
 (defn merge-or-push-history
-  [history gref old-graph new-graph outputs-modified]
+  [history graph-ref old-graph new-graph outputs-modified]
   (let [new-state (history-state new-graph (set outputs-modified))
-        tape-op   (if (=* (:tx-sequence-label new-graph) (:tx-sequence-label old-graph))
-                    merge-into-top
-                    conj)]
+        tape-op (if (=* (:tx-sequence-label new-graph) (:tx-sequence-label old-graph))
+                  merge-into-top
+                  conj)]
     (update history :tape tape-op new-state)))
 
 (defn undo-stack [history-ref]
@@ -67,30 +67,30 @@
        vec))
 
 (defn time-warp [history-ref system-snapshot graph outputs-to-refresh]
-  (let [gid (:_gid graph)
+  (let [graph-id (:_graph-id graph)
         graphs (graphs system-snapshot)]
     (let [pseudo-basis (ig/multigraph-basis (map-vals deref graphs))
           {hydrated-basis :basis
            hydrated-outputs-to-refresh :outputs-to-refresh} (ig/hydrate-after-undo pseudo-basis graph)
           outputs-to-refresh (into (or outputs-to-refresh #{}) hydrated-outputs-to-refresh)
           changes (->> outputs-to-refresh
-                    (group-by first)
-                    (map (fn [[node-id labels]] [node-id (set (map second labels))]))
-                    (into {}))
+                       (group-by first)
+                       (map (fn [[node-id labels]] [node-id (set (map second labels))]))
+                       (into {}))
           warped-basis (ig/update-successors hydrated-basis changes)]
-      {:graph (get-in warped-basis [:graphs gid])
+      {:graph (get-in warped-basis [:graphs graph-id])
        :outputs-to-refresh outputs-to-refresh})))
 
-(defn last-graph     [s]     (-> s :last-graph))
-(defn system-cache   [s]     (some-> s :cache deref))
-(defn graphs         [s]     (-> s :graphs))
-(defn graph-ref      [s gid] (-> s :graphs (get gid)))
-(defn graph          [s gid] (some-> s (graph-ref gid) deref))
-(defn graph-time     [s gid] (-> s (graph gid) :tx-id))
-(defn graph-history  [s gid] (-> s :history (get gid)))
-(defn basis          [s]     (ig/multigraph-basis (map-vals deref (graphs s))))
-(defn id-generators  [s]     (-> s :id-generators))
-(defn override-id-generator [s] (-> s :override-id-generator))
+(defn last-graph            [system]     (-> system :last-graph))
+(defn system-cache          [system]     (some-> system :cache deref))
+(defn graphs                [system]     (-> system :graphs))
+(defn graph-ref             [system graph-id] (-> system :graphs (get graph-id)))
+(defn graph                 [system graph-id] (some-> system (graph-ref graph-id) deref))
+(defn graph-time            [system graph-id] (-> system (graph graph-id) :tx-id))
+(defn graph-history         [system graph-id] (-> system :history (get graph-id)))
+(defn basis                 [system]     (ig/multigraph-basis (map-vals deref (graphs system))))
+(defn id-generators         [system]     (-> system :id-generators))
+(defn override-id-generator [system]     (-> system :override-id-generator))
 
 (defn- bump-invalidate-counters
   [invalidate-map entries]
@@ -100,38 +100,38 @@
   "Invalidate the given outputs and _everything_ that could be
   affected by them. Outputs are specified as pairs of [node-id label]
   for both the argument and return value."
-  [sys outputs]
+  [system outputs]
   ;; 'dependencies' takes a map, where outputs is a vec of node-id+label pairs
   (dosync
-    (let [basis (basis sys)
+    (let [basis (basis system)
           cache-entries (->> outputs
                              ;; vec -> map, [[node-id label]] -> {node-id #{labels}}
-                             (reduce (fn [m [nid l]]
-                                       (update m nid (fn [s l] (if s (conj s l) #{l})) l))
+                             (reduce (fn [m [node-id label]]
+                                       (update m node-id (fn [label-set label] (if label-set (conj label-set label) #{label})) label))
                                      {})
                              (gt/dependencies basis)
                              ;; map -> vec
-                             (into [] (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))]
-      (alter (:cache sys) c/cache-invalidate cache-entries)
-      (alter (:invalidate-counters sys) bump-invalidate-counters cache-entries)
+                             (into [] (mapcat (fn [[node-id labels]] (mapv #(vector node-id %) labels)))))]
+      (alter (:cache system) c/cache-invalidate cache-entries)
+      (alter (:invalidate-counters system) bump-invalidate-counters cache-entries)
       cache-entries)))
 
 (defn step-through-history!
-  [step-function sys graph-id]
+  [step-function system graph-id]
   (dosync
-   (let [graph-ref (graph-ref sys graph-id)
-         history-ref (graph-history sys graph-id)
-         {:keys [tape]} @history-ref
-         prior-state              (h/ivalue tape)
-         tape                     (step-function tape)
-         next-state               (h/ivalue tape)
-         outputs-to-refresh       (into (:cache-keys prior-state) (:cache-keys next-state))]
-     (when next-state
-       (let [{:keys [graph outputs-to-refresh]} (time-warp history-ref sys (:graph next-state) outputs-to-refresh)]
-         (ref-set graph-ref graph)
-         (alter history-ref assoc :tape tape)
-         (invalidate-outputs! sys outputs-to-refresh)
-         outputs-to-refresh)))))
+    (let [graph-ref (graph-ref system graph-id)
+          history-ref (graph-history system graph-id)
+          {:keys [tape]} @history-ref
+          prior-state (h/ivalue tape)
+          tape (step-function tape)
+          next-state (h/ivalue tape)
+          outputs-to-refresh (into (:cache-keys prior-state) (:cache-keys next-state))]
+      (when next-state
+        (let [{:keys [graph outputs-to-refresh]} (time-warp history-ref system (:graph next-state) outputs-to-refresh)]
+          (ref-set graph-ref graph)
+          (alter history-ref assoc :tape tape)
+          (invalidate-outputs! system outputs-to-refresh)
+          outputs-to-refresh)))))
 
 (def undo-history! (partial step-through-history! h/iprev))
 (def cancel-history! (partial step-through-history! h/drop-current))
@@ -145,10 +145,10 @@
        vec))
 
 (defn clear-history!
-  [sys graph-id]
-  (let [history-ref (graph-history sys graph-id)]
+  [system graph-id]
+  (let [history-ref (graph-history system graph-id)]
     (dosync
-      (let [graph         (graph sys graph-id)
+      (let [graph (graph system graph-id)
             initial-state (history-state graph #{})]
         (alter history-ref update :tape (fn [tape]
                                           (conj (empty tape) initial-state)))))))
@@ -162,153 +162,153 @@
     (when ok-to-cancel? (cancel-history! system-snapshot graph-id))))
 
 (defn- make-initial-graph
-  [{graph :initial-graph :or {graph (assoc (ig/empty-graph) :_gid 0)}}]
+  [{graph :initial-graph :or {graph (assoc (ig/empty-graph) :_graph-id 0)}}]
   graph)
 
 (defn make-cache
   [{cache-size :cache-size :or {cache-size maximum-cached-items}}]
   (c/make-cache cache-size))
 
-(defn next-available-gid
-  [s]
-  (let [used (into #{} (keys (graphs s)))]
+(defn- next-available-graph-id
+  [system]
+  (let [used (into #{} (keys (graphs system)))]
     (first (drop-while used (range 0 gt/MAX-GROUP-ID)))))
 
 (defn next-node-id*
-  [id-generators gid]
-  (gt/make-node-id gid (.getAndIncrement ^AtomicLong (get id-generators gid))))
+  [id-generators graph-id]
+  (gt/make-node-id graph-id (.getAndIncrement ^AtomicLong (get id-generators graph-id))))
 
 (defn next-node-id
-  [s gid]
-  (next-node-id* (id-generators s) gid))
+  [system graph-id]
+  (next-node-id* (id-generators system) graph-id))
 
 (defn next-override-id*
-  [override-id-generator gid]
-  (gt/make-override-id gid (.getAndIncrement ^AtomicLong override-id-generator)))
+  [override-id-generator graph-id]
+  (gt/make-override-id graph-id (.getAndIncrement ^AtomicLong override-id-generator)))
 
 (defn next-override-id
-  [s gid]
-  (next-override-id* (override-id-generator s) gid))
+  [system graph-id]
+  (next-override-id* (override-id-generator system) graph-id))
 
 (defn- attach-graph*!
-  [s gref]
-  (let [gid (next-available-gid s)]
-    (dosync (alter gref assoc :_gid gid))
-    (-> s
-        (assoc :last-graph gid)
-        (update-in [:id-generators] assoc gid (integer-counter))
-        (update-in [:graphs] assoc gid gref))))
+  [system graph-ref]
+  (let [graph-id (next-available-graph-id system)]
+    (dosync (alter graph-ref assoc :_graph-id graph-id))
+    (-> system
+        (assoc :last-graph graph-id)
+        (update-in [:id-generators] assoc graph-id (integer-counter))
+        (update-in [:graphs] assoc graph-id graph-ref))))
 
 (defn attach-graph!
-  [s g]
-  (attach-graph*! s (ref g)))
+  [system graph]
+  (attach-graph*! system (ref graph)))
 
 (defn attach-graph-with-history!
-  [s g]
-  (let [gref (ref g)
-        href (ref (new-history))]
-    (-> s
-      (attach-graph*! gref)
-      (update :history assoc (:_gid @gref) href))))
+  [system graph]
+  (let [graph-ref (ref graph)
+        history-ref (ref (new-history))]
+    (-> system
+        (attach-graph*! graph-ref)
+        (update :history assoc (:_graph-id @graph-ref) history-ref))))
 
 (defn detach-graph
-  [s g]
-  (let [gid (if (map? g) (:_gid g) g)]
-    (-> s
-      (update :graphs dissoc gid)
-      (update :history dissoc gid))))
+  [system graph]
+  (let [graph-id (if (map? graph) (:_graph-id graph) graph)]
+    (-> system
+        (update :graphs dissoc graph-id)
+        (update :history dissoc graph-id))))
 
 (defn make-system
   [configuration]
-  (let [initial-graph  (make-initial-graph configuration)
-        cache          (make-cache configuration)]
-    (-> {:graphs         {}
-         :id-generators  {}
+  (let [initial-graph (make-initial-graph configuration)
+        cache (make-cache configuration)]
+    (-> {:graphs {}
+         :id-generators {}
          :override-id-generator (integer-counter)
-         :cache          (ref cache)
+         :cache (ref cache)
          :invalidate-counters (ref {})
-         :user-data      (ref {})}
+         :user-data (ref {})}
         (attach-graph! initial-graph))))
 
-(defn- has-history? [sys graph-id] (not (nil? (graph-history sys graph-id))))
+(defn- has-history? [system graph-id] (not (nil? (graph-history system graph-id))))
 (def ^:private meaningful-change? contains?)
 
 (defn- remember-change!
-  [sys graph-id before after outputs-modified]
-  (alter (graph-history sys graph-id) merge-or-push-history (graph-ref sys graph-id) before after outputs-modified))
+  [system graph-id before after outputs-modified]
+  (alter (graph-history system graph-id) merge-or-push-history (graph-ref system graph-id) before after outputs-modified))
 
 (defn merge-graphs!
-  [sys post-tx-graphs significantly-modified-graphs outputs-modified nodes-deleted]
+  [system post-tx-graphs significantly-modified-graphs outputs-modified nodes-deleted]
   (dosync
     (let [outputs-modified (group-by #(gt/node-id->graph-id (first %)) outputs-modified)]
       (doseq [[graph-id graph] post-tx-graphs]
-        (let [start-tx    (:tx-id graph -1)
-              sidereal-tx (graph-time sys graph-id)]
+        (let [start-tx (:tx-id graph -1)
+              sidereal-tx (graph-time system graph-id)]
           (if (< start-tx sidereal-tx)
             ;; graph was modified concurrently by a different transaction.
             (throw (ex-info "Concurrent modification of graph"
-                     {:_gid graph-id :start-tx start-tx :sidereal-tx sidereal-tx}))
-            (let [gref   (graph-ref sys graph-id)
-                  before @gref
-                  after  (update-in graph [:tx-id] util/safe-inc)
-                  after  (if (not (meaningful-change? significantly-modified-graphs graph-id))
-                           (assoc after :tx-sequence-label (:tx-sequence-label before))
-                           after)]
-              (when (and (has-history? sys graph-id) (meaningful-change? significantly-modified-graphs graph-id))
-                (remember-change! sys graph-id before after (outputs-modified graph-id)))
-              (ref-set gref after))))))
-    (alter (:cache sys) c/cache-invalidate outputs-modified)
-    (alter (:invalidate-counters sys) bump-invalidate-counters outputs-modified)
-    (alter (:user-data sys) (fn [user-data]
-                              (reduce (fn [user-data node-id]
-                                        (let [gid (gt/node-id->graph-id node-id)]
-                                          (update user-data gid dissoc node-id)))
-                                      user-data (keys nodes-deleted))))))
+                            {:_graph-id graph-id :start-tx start-tx :sidereal-tx sidereal-tx}))
+            (let [graph-ref (graph-ref system graph-id)
+                  before @graph-ref
+                  after (update-in graph [:tx-id] util/safe-inc)
+                  after (if (not (meaningful-change? significantly-modified-graphs graph-id))
+                          (assoc after :tx-sequence-label (:tx-sequence-label before))
+                          after)]
+              (when (and (has-history? system graph-id) (meaningful-change? significantly-modified-graphs graph-id))
+                (remember-change! system graph-id before after (outputs-modified graph-id)))
+              (ref-set graph-ref after))))))
+    (alter (:cache system) c/cache-invalidate outputs-modified)
+    (alter (:invalidate-counters system) bump-invalidate-counters outputs-modified)
+    (alter (:user-data system) (fn [user-data]
+                                 (reduce (fn [user-data node-id]
+                                           (let [graph-id (gt/node-id->graph-id node-id)]
+                                             (update user-data graph-id dissoc node-id)))
+                                         user-data (keys nodes-deleted))))))
 
 (defn basis-graphs-identical? [basis1 basis2]
-  (let [gids (keys (:graphs basis1))]
-    (and (= gids (keys (:graphs basis2)))
+  (let [graph-ids (keys (:graphs basis1))]
+    (and (= graph-ids (keys (:graphs basis2)))
          (every? true? (map identical?
-                            (map (:graphs basis1) gids)
-                            (map (:graphs basis2) gids))))))
+                            (map (:graphs basis1) graph-ids)
+                            (map (:graphs basis2) graph-ids))))))
 
-(defn default-evaluation-context [sys]
+(defn default-evaluation-context [system]
   (dosync
-    (in/default-evaluation-context (basis sys)
-                                   (system-cache sys)
-                                   @(:invalidate-counters sys))))
+    (in/default-evaluation-context (basis system)
+                                   (system-cache system)
+                                   @(:invalidate-counters system))))
 
 (defn custom-evaluation-context
   ;; Basis & cache options:
   ;;  * only supplying a cache makes no sense and is a programmer error
-  ;;  * if neither is supplied, use from sys
-  ;;  * if only given basis it's not at all certain that sys cache is
+  ;;  * if neither is supplied, use from system
+  ;;  * if only given basis it's not at all certain that system cache is
   ;;    derived from the given basis. One safe case is if the graphs of
-  ;;    basis "==" graphs of sys. If so, we use the sys cache.
+  ;;    basis "==" graphs of system. If so, we use the system cache.
   ;;  * if given basis & cache we assume the cache is derived from the basis
   ;; We can only later on update the cache if we have invalidate-counters from
   ;; when the evaluation context was created, and those are only merged if
-  ;; we're using the sys basis & cache.
-  [sys options]
+  ;; we're using the system basis & cache.
+  [system options]
   (assert (not (and (some? (:cache options)) (nil? (:basis options)))))
-  (let [sys-options (dosync
-                      {:basis (basis sys)
-                       :cache (system-cache sys)
-                       :initial-invalidate-counters @(:invalidate-counters sys)})
+  (let [system-options (dosync
+                         {:basis (basis system)
+                          :cache (system-cache system)
+                          :initial-invalidate-counters @(:invalidate-counters system)})
         options (merge
                   options
                   (cond
                     (and (nil? (:cache options)) (nil? (:basis options)))
-                    sys-options
+                    system-options
 
                     (and (nil? (:cache options))
                          (some? (:basis options))
-                         (basis-graphs-identical? (:basis options) (:basis sys-options)))
-                    sys-options))]
+                         (basis-graphs-identical? (:basis options) (:basis system-options)))
+                    system-options))]
     (in/custom-evaluation-context options)))
 
 (defn update-cache-from-evaluation-context!
-  [sys evaluation-context]
+  [system evaluation-context]
   (dosync
     ;; We assume here that the evaluation context was created from
     ;; the system but they may have diverged, making some cache
@@ -323,8 +323,8 @@
     ;; initial-invalidate-counters to compare with, and we dont even try to
     ;; update the cache.
     (when-let [initial-invalidate-counters (:initial-invalidate-counters evaluation-context)]
-      (let [cache (:cache sys)
-            invalidate-counters @(:invalidate-counters sys)
+      (let [cache (:cache system)
+            invalidate-counters @(:invalidate-counters system)
             evaluation-context-hits @(:hits evaluation-context)
             evaluation-context-misses @(:local evaluation-context)]
         (if (identical? invalidate-counters initial-invalidate-counters) ; nice case
@@ -344,50 +344,50 @@
   cache, then return that value. Otherwise, produce the value by
   gathering inputs to call a production function, invoke the function,
   maybe cache the value that was produced, and return it."
-  [sys node-or-node-id label evaluation-context]
+  [system node-or-node-id label evaluation-context]
   (in/node-value node-or-node-id label evaluation-context))
 
 (defn node-property-value [node-or-node-id label evaluation-context]
   (in/node-property-value node-or-node-id label evaluation-context))
 
-(defn user-data [sys node-id key]
-  (let [gid (gt/node-id->graph-id node-id)]
-    (get-in @(:user-data sys) [gid node-id key])))
+(defn user-data [system node-id key]
+  (let [graph-id (gt/node-id->graph-id node-id)]
+    (get-in @(:user-data system) [graph-id node-id key])))
 
-(defn user-data! [sys node-id key value]
+(defn user-data! [system node-id key value]
   (dosync
-    (let [gid (gt/node-id->graph-id node-id)]
-      (alter (:user-data sys) assoc-in [gid node-id key] value))))
+    (let [graph-id (gt/node-id->graph-id node-id)]
+      (alter (:user-data system) assoc-in [graph-id node-id key] value))))
 
-(defn user-data-swap! [sys node-id key f & args]
+(defn user-data-swap! [system node-id key f & args]
   (dosync
-    (let [gid (gt/node-id->graph-id node-id)
-          path [gid node-id key]
-          user-data (apply alter (:user-data sys) update-in path f args)]
+    (let [graph-id (gt/node-id->graph-id node-id)
+          path [graph-id node-id key]
+          user-data (apply alter (:user-data system) update-in path f args)]
       (get-in user-data path))))
 
-(defn clone-system [s]
+(defn clone-system [system]
   (dosync 
-    {:graphs (into {} (map (fn [[gid gref]] [gid (ref (deref gref))]))
-                   (:graphs s))
-     :history (into {} (map (fn [[gid href]] [gid (ref (deref href))]))
-                    (:history s))
-     :id-generators (into {} (map (fn [[gid ^AtomicLong gen]] [gid (AtomicLong. (.longValue gen))]))
-                          (:id-generators s))
-     :override-id-generator (AtomicLong. (.longValue ^AtomicLong (:override-id-generator s)))
-     :cache (ref (deref (:cache s)))
-     :user-data (ref (deref (:user-data s)))
-     :invalidate-counters (ref (deref (:invalidate-counters s)))
-     :last-graph (:last-graph s)}))
+    {:graphs (into {} (map (fn [[graph-id graph-ref]] [graph-id (ref (deref graph-ref))]))
+                   (:graphs system))
+     :history (into {} (map (fn [[graph-id history-ref]] [graph-id (ref (deref history-ref))]))
+                    (:history system))
+     :id-generators (into {} (map (fn [[graph-id ^AtomicLong gen]] [graph-id (AtomicLong. (.longValue gen))]))
+                          (:id-generators system))
+     :override-id-generator (AtomicLong. (.longValue ^AtomicLong (:override-id-generator system)))
+     :cache (ref (deref (:cache system)))
+     :user-data (ref (deref (:user-data system)))
+     :invalidate-counters (ref (deref (:invalidate-counters system)))
+     :last-graph (:last-graph system)}))
 
 (defn system= [s1 s2]
   (dosync
-    (and (= (map (fn [[gid gref]] [gid (deref gref)]) (:graphs s1))
-            (map (fn [[gid gref]] [gid (deref gref)]) (:graphs s2)))
-         (= (map (fn [[gid href]] [gid (deref href)]) (:history s1))
-            (map (fn [[gid href]] [gid (deref href)]) (:history s2)))
-         (= (map (fn [[gid ^AtomicLong gen]] [gid (.longValue gen)]) (:id-generators s1))
-            (map (fn [[gid ^AtomicLong gen]] [gid (.longValue gen)]) (:id-generators s2)))
+    (and (= (map (fn [[graph-id graph-ref]] [graph-id (deref graph-ref)]) (:graphs s1))
+            (map (fn [[graph-id graph-ref]] [graph-id (deref graph-ref)]) (:graphs s2)))
+         (= (map (fn [[graph-id history-ref]] [graph-id (deref history-ref)]) (:history s1))
+            (map (fn [[graph-id history-ref]] [graph-id (deref history-ref)]) (:history s2)))
+         (= (map (fn [[graph-id ^AtomicLong gen]] [graph-id (.longValue gen)]) (:id-generators s1))
+            (map (fn [[graph-id ^AtomicLong gen]] [graph-id (.longValue gen)]) (:id-generators s2)))
          (= (.longValue ^AtomicLong (:override-id-generator s1))
             (.longValue ^AtomicLong (:override-id-generator s2)))
          (= (deref (:cache s1)) (deref (:cache s2)))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -81,16 +81,16 @@
       {:graph (get-in warped-basis [:graphs graph-id])
        :outputs-to-refresh outputs-to-refresh})))
 
-(defn last-graph            [system]     (-> system :last-graph))
-(defn system-cache          [system]     (some-> system :cache deref))
-(defn graphs                [system]     (-> system :graphs))
+(defn last-graph            [system]          (-> system :last-graph))
+(defn system-cache          [system]          (some-> system :cache deref))
+(defn graphs                [system]          (-> system :graphs))
 (defn graph-ref             [system graph-id] (-> system :graphs (get graph-id)))
 (defn graph                 [system graph-id] (some-> system (graph-ref graph-id) deref))
 (defn graph-time            [system graph-id] (-> system (graph graph-id) :tx-id))
 (defn graph-history         [system graph-id] (-> system :history (get graph-id)))
-(defn basis                 [system]     (ig/multigraph-basis (map-vals deref (graphs system))))
-(defn id-generators         [system]     (-> system :id-generators))
-(defn override-id-generator [system]     (-> system :override-id-generator))
+(defn basis                 [system]          (ig/multigraph-basis (map-vals deref (graphs system))))
+(defn id-generators         [system]          (-> system :id-generators))
+(defn override-id-generator [system]          (-> system :override-id-generator))
 
 (defn- bump-invalidate-counters
   [invalidate-map entries]

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -301,7 +301,7 @@
 
 (defn- flag-successors-changed [ctx changes]
   (let [successors (get ctx :successors-changed)]
-    (assoc ctx :successors-changed (reduce (fn [succuccessors [node-id label]]
+    (assoc ctx :successors-changed (reduce (fn [successors [node-id label]]
                                              (if-let [node-succ (get successors node-id #{})]
                                                (assoc successors node-id (conj node-succ label))
                                                successors))
@@ -468,13 +468,13 @@
         (-> ctx
             (update :basis property-default-setter node-id node property old-value new-value)
             (cond->
-                (not= old-value new-value)
+              (not= old-value new-value)
               (cond->
-                  (not override-node?) (mark-output-activated node-id property)
-                  override-node? (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
-                                                                   (not (gt/property-overridden? node property)) (conj :_overridden-properties)))
-                  (not (nil? setter-fn))
-                  ((fn [ctx] (apply-tx ctx (call-setter-fn ctx property setter-fn (:basis ctx) node-id old-value new-value)))))))))))
+                (not override-node?) (mark-output-activated node-id property)
+                override-node? (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
+                                                                 (not (gt/property-overridden? node property)) (conj :_overridden-properties)))
+                (not (nil? setter-fn))
+                ((fn [ctx] (apply-tx ctx (call-setter-fn ctx property setter-fn (:basis ctx) node-id old-value new-value)))))))))))
 
 (defn- apply-defaults [ctx node]
   (let [node-id (gt/node-id node)

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -34,19 +34,19 @@
 (defn new-node
   "*transaction step* - add a node to a graph"
   [node]
-  [{:type     :create-node
-    :node     node}])
+  [{:type :create-node
+    :node node}])
 
 (defn become
   [node-id to-node]
-  [{:type     :become
-    :node-id  node-id
-    :to-node  to-node}])
+  [{:type :become
+    :node-id node-id
+    :to-node to-node}])
 
 (defn delete-node
   [node-id]
-  [{:type     :delete-node
-    :node-id  node-id}])
+  [{:type :delete-node
+    :node-id node-id}])
 
 (defn- new-override
   [override-id root-id traverse-fn]
@@ -57,7 +57,7 @@
 
 (defn- override-node
   [original-node-id override-node-id]
-  [{:type        :override-node
+  [{:type :override-node
     :original-node-id original-node-id
     :override-node-id override-node-id}])
 
@@ -70,7 +70,7 @@
     :properties-by-node-id properties-by-node-id}])
 
 (defn transfer-overrides [from-id->to-id]
-  [{:type         :transfer-overrides
+  [{:type :transfer-overrides
     :from-id->to-id from-id->to-id}])
 
 (defn update-property
@@ -78,23 +78,23 @@
   function f (with optional args) to be performed on the current value
   of the property."
   [node-id pr f args]
-  [{:type     :update-property
-    :node-id  node-id
+  [{:type :update-property
+    :node-id node-id
     :property pr
-    :fn       f
-    :args     args}])
+    :fn f
+    :args args}])
 
 (defn clear-property
   [node-id pr]
-  [{:type     :clear-property
-    :node-id  node-id
+  [{:type :clear-property
+    :node-id node-id
     :property pr}])
 
 (defn update-graph-value
-  [gid f args]
+  [graph-id f args]
   [{:type :update-graph-value
-    :gid  gid
-    :fn   f
+    :graph-id graph-id
+    :fn f
     :args args}])
 
 (defn callback
@@ -104,41 +104,39 @@
     :args args}])
 
 (defn connect
-  "*transaction step* - Creates a transaction step connecting a source node and label (`from-resource from-label`) and a target node and label
-(`to-resource to-label`). It returns a value suitable for consumption by [[perform]]."
-  [from-node-id from-label to-node-id to-label]
-  [{:type         :connect
-    :source-id    from-node-id
-    :source-label from-label
-    :target-id    to-node-id
-    :target-label to-label}])
+  "*transaction step* - Creates a transaction step connecting a source node and label  and a target node and label. It returns a value suitable for consumption by [[perform]]."
+  [source-id source-label target-id target-label]
+  [{:type :connect
+    :source-id source-id
+    :source-label source-label
+    :target-id target-id
+    :target-label target-label}])
 
 (defn disconnect
   "*transaction step* - The reverse of [[connect]]. Creates a
   transaction step disconnecting a source node and label
-  (`from-resource from-label`) from a target node and label
-  (`to-resource to-label`). It returns a value suitable for consumption
+  from a target node and label. It returns a value suitable for consumption
   by [[perform]]."
-  [from-node-id from-label to-node-id to-label]
-  [{:type         :disconnect
-    :source-id    from-node-id
-    :source-label from-label
-    :target-id    to-node-id
-    :target-label to-label}])
+  [source-id source-label target-id target-label]
+  [{:type :disconnect
+    :source-id source-id
+    :source-label source-label
+    :target-id target-id
+    :target-label target-label}])
 
 (defn disconnect-sources
-  [basis target-node target-label]
-  (for [[src-node src-label] (gt/sources basis target-node target-label)]
-    (disconnect src-node src-label target-node target-label)))
+  [basis target-id target-label]
+  (for [[source-id source-label] (gt/sources basis target-id target-label)]
+    (disconnect source-id source-label target-id target-label)))
 
 (defn label
   [label]
-  [{:type  :label
+  [{:type :label
     :label label}])
 
 (defn sequence-label
   [seq-label]
-  [{:type  :sequence-label
+  [{:type :sequence-label
     :label seq-label}])
 
 (defn invalidate
@@ -177,11 +175,11 @@
                        in/output-labels)]
     (update ctx :nodes-affected assoc node-id (set all-labels))))
 
-(defn- next-node-id [ctx gid]
-  (is/next-node-id* (:node-id-generators ctx) gid))
+(defn- next-node-id [ctx graph-id]
+  (is/next-node-id* (:node-id-generators ctx) graph-id))
 
-(defn- next-override-id [ctx gid]
-  (is/next-override-id* (:override-id-generator ctx) gid))
+(defn- next-override-id [ctx graph-id]
+  (is/next-override-id* (:override-id-generator ctx) graph-id))
 
 (defmulti perform
   "A multimethod used for defining methods that perform the individual
@@ -201,24 +199,24 @@
 (def ^:private ctx-disconnect)
 
 (defn- ctx-disconnect-arc [ctx arc]
-  (let [[src-id src-label] (gt/head arc)
-        [tgt-id tgt-label] (gt/tail arc)]
-    (ctx-disconnect ctx src-id src-label tgt-id tgt-label)))
+  (let [[source-id source-label] (gt/source arc)
+        [target-id target-label] (gt/target arc)]
+    (ctx-disconnect ctx source-id source-label target-id target-label)))
 
-(defn- disconnect-inputs [ctx tgt-id tgt-label]
-  (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-target (:basis ctx) tgt-id tgt-label)))
+(defn- disconnect-inputs [ctx target-id target-label]
+  (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-target (:basis ctx) target-id target-label)))
 
-(defn- disconnect-all-inputs [ctx tgt-id]
-  (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-target (:basis ctx) tgt-id)))
+(defn- disconnect-all-inputs [ctx target-id]
+  (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-target (:basis ctx) target-id)))
 
-(defn- disconnect-outputs [ctx src-id src-label]
-  (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-source (:basis ctx) src-id src-label)))
+(defn- disconnect-outputs [ctx source-id source-label]
+  (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-source (:basis ctx) source-id source-label)))
 
 (defn- disconnect-stale [ctx node-id old-node new-node labels-fn disconnect-fn]
   (let [basis (:basis ctx)
         stale-labels (set/difference
-                      (-> old-node (gt/node-type basis) labels-fn)
-                      (-> new-node (gt/node-type basis) labels-fn))]
+                       (-> old-node (gt/node-type basis) labels-fn)
+                       (-> new-node (gt/node-type basis) labels-fn))]
     (loop [ctx ctx
            labels stale-labels]
       (if-let [label (first labels)]
@@ -238,10 +236,10 @@
   (if-let [old-node (gt/node-by-id-at (:basis ctx) node-id)] ; nil if node was deleted in this transaction
     (let [new-node (merge to-node (dissoc old-node :node-type))]
       (-> ctx
-        (disconnect-stale-inputs node-id old-node new-node)
-        (disconnect-stale-outputs node-id old-node new-node)
-        (update :basis replace-node node-id new-node)
-        (mark-all-outputs-activated node-id)))
+          (disconnect-stale-inputs node-id old-node new-node)
+          (disconnect-stale-outputs node-id old-node new-node)
+          (update :basis replace-node node-id new-node)
+          (mark-all-outputs-activated node-id)))
     ctx))
 
 (defn- delete-single
@@ -251,28 +249,28 @@
       (let [targets (ig/explicit-targets basis node-id)]
         (-> (reduce (fn [ctx [node-id input]]
                       (mark-input-activated ctx node-id input))
-              ctx targets)
-          (disconnect-all-inputs node-id)
-          (mark-all-outputs-activated node-id)
-          (update :basis gt/delete-node node-id)
-          (assoc-in [:nodes-deleted node-id] node)
-          (update :nodes-added (partial filterv #(not= node-id %)))))
+                    ctx targets)
+            (disconnect-all-inputs node-id)
+            (mark-all-outputs-activated node-id)
+            (update :basis gt/delete-node node-id)
+            (assoc-in [:nodes-deleted node-id] node)
+            (update :nodes-added (partial filterv #(not= node-id %)))))
       ctx)))
 
 (def ^:private reduce-conj (partial reduce conj))
 
 (defn- cascade-delete-sources
   [basis node-id]
-  (if-let [n (gt/node-by-id-at basis node-id)]
-    (let [override-id (gt/override-id n)]
-      (loop [inputs (some-> n
-                      (gt/node-type basis)
-                      in/cascade-deletes)
+  (if-let [node (gt/node-by-id-at basis node-id)]
+    (let [override-id (gt/override-id node)]
+      (loop [inputs (some-> node
+                            (gt/node-type basis)
+                            in/cascade-deletes)
              result (vec (ig/get-overrides basis node-id))]
         (if-let [input (first inputs)]
           (let [explicit (map first (ig/explicit-sources basis node-id input))
-                implicit (filter (fn [node-id] (when-let [n (gt/node-by-id-at basis node-id)]
-                                                 (= override-id (gt/override-id n))))
+                implicit (filter (fn [node-id] (when-let [node (gt/node-by-id-at basis node-id)]
+                                                 (= override-id (gt/override-id node))))
                                  (map first (gt/sources basis node-id input)))]
             (recur (rest inputs) (-> result (reduce-conj explicit) (reduce-conj implicit))))
           result)))
@@ -293,21 +291,21 @@
 (defmethod perform :new-override
   [ctx {:keys [override-id root-id traverse-fn]}]
   (-> ctx
-    (update :basis gt/add-override override-id (ig/make-override root-id traverse-fn))))
+      (update :basis gt/add-override override-id (ig/make-override root-id traverse-fn))))
 
-(defn- flag-all-successors-changed [ctx nodes]
-  (let [succ (get ctx :successors-changed)]
-    (assoc ctx :successors-changed (reduce (fn [succ nid]
-                                             (assoc succ nid nil))
-                                           succ nodes))))
+(defn- flag-all-successors-changed [ctx node-ids]
+  (let [successors (get ctx :successors-changed)]
+    (assoc ctx :successors-changed (reduce (fn [successors node-id]
+                                             (assoc successors node-id nil))
+                                           successors node-ids))))
 
 (defn- flag-successors-changed [ctx changes]
-  (let [succ (get ctx :successors-changed)]
-    (assoc ctx :successors-changed (reduce (fn [succ [nid label]]
-                                             (if-let [node-succ (get succ nid #{})]
-                                               (assoc succ nid (conj node-succ label))
-                                               succ))
-                                           succ changes))))
+  (let [successors (get ctx :successors-changed)]
+    (assoc ctx :successors-changed (reduce (fn [succuccessors [node-id label]]
+                                             (if-let [node-succ (get successors node-id #{})]
+                                               (assoc successors node-id (conj node-succ label))
+                                               successors))
+                                           successors changes))))
 
 (defn- ctx-override-node [ctx original-node-id override-node-id]
   (assert (= (gt/node-id->graph-id original-node-id) (gt/node-id->graph-id override-node-id))
@@ -351,8 +349,8 @@
 
 (defn- node-id->override-id [basis node-id]
   (->> node-id
-    (gt/node-by-id-at basis)
-    gt/override-id))
+       (gt/node-by-id-at basis)
+       gt/override-id))
 
 (declare ctx-add-node)
 
@@ -361,26 +359,26 @@
             (let [basis (:basis ctx)]
               (if (some #(= override-id (node-id->override-id basis %)) (ig/get-overrides basis node-id))
                 ctx
-                (let [gid (gt/node-id->graph-id node-id)
-                     new-sub-id (next-node-id ctx gid)
-                     new-sub-node (in/make-override-node override-id new-sub-id node-id {})]
-                 (-> ctx
-                   (ctx-add-node new-sub-node)
-                   (ctx-override-node node-id new-sub-id))))))
+                (let [graph-id (gt/node-id->graph-id node-id)
+                      new-override-node-id (next-node-id ctx graph-id)
+                      new-override-node (in/make-override-node override-id new-override-node-id node-id {})]
+                  (-> ctx
+                      (ctx-add-node new-override-node)
+                      (ctx-override-node node-id new-override-node-id))))))
           ctx node-ids))
 
 (defn- populate-overrides [ctx node-id]
   (let [basis (:basis ctx)
         override-nodes (ig/get-overrides basis node-id)]
     (reduce (fn [ctx override-node-id]
-              (let [oid (node-id->override-id basis override-node-id)
-                    o (ig/override-by-id basis oid)
-                    traverse-fn (:traverse-fn o)
+              (let [override-id (node-id->override-id basis override-node-id)
+                    override (ig/override-by-id basis override-id)
+                    traverse-fn (:traverse-fn override)
                     node-ids (subvec (ig/pre-traverse basis [node-id] traverse-fn) 1)]
                 (reduce populate-overrides
-                        (ctx-make-override-nodes ctx oid node-ids)
+                        (ctx-make-override-nodes ctx override-id node-ids)
                         override-nodes)))
-      ctx override-nodes)))
+            ctx override-nodes)))
 
 (defmethod perform :transfer-overrides
   [ctx {:keys [from-id->to-id]}]
@@ -456,27 +454,27 @@
   (let [basis (:basis ctx)
         node-type (gt/node-type node basis)
         value-type (some-> (in/property-type node-type property) deref in/schema s/maybe)]
-   (if-let [validation-error (and in/*check-schemas* value-type (s/check value-type new-value))]
-     (do
-       (in/warn-output-schema node-id node-type property new-value value-type validation-error)
-       (throw (ex-info "SCHEMA-VALIDATION"
-                   {:node-id          node-id
-                    :type             node-type
-                    :property         property
-                    :expected         value-type
-                    :actual           new-value
-                    :validation-error validation-error})))
-     (let [setter-fn (in/property-setter node-type property)]
-       (-> ctx
-         (update :basis property-default-setter node-id node property old-value new-value)
-         (cond->
-           (not= old-value new-value)
-           (cond->
-             (not override-node?) (mark-output-activated node-id property)
-             override-node? (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
-                                                              (not (gt/property-overridden? node property)) (conj :_overridden-properties)))
-             (not (nil? setter-fn))
-             ((fn [ctx] (apply-tx ctx (call-setter-fn ctx property setter-fn (:basis ctx) node-id old-value new-value)))))))))))
+    (if-let [validation-error (and in/*check-schemas* value-type (s/check value-type new-value))]
+      (do
+        (in/warn-output-schema node-id node-type property new-value value-type validation-error)
+        (throw (ex-info "SCHEMA-VALIDATION"
+                        {:node-id node-id
+                         :type node-type
+                         :property property
+                         :expected value-type
+                         :actual new-value
+                         :validation-error validation-error})))
+      (let [setter-fn (in/property-setter node-type property)]
+        (-> ctx
+            (update :basis property-default-setter node-id node property old-value new-value)
+            (cond->
+                (not= old-value new-value)
+              (cond->
+                  (not override-node?) (mark-output-activated node-id property)
+                  override-node? (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
+                                                                   (not (gt/property-overridden? node property)) (conj :_overridden-properties)))
+                  (not (nil? setter-fn))
+                  ((fn [ctx] (apply-tx ctx (call-setter-fn ctx property setter-fn (:basis ctx) node-id old-value new-value)))))))))))
 
 (defn- apply-defaults [ctx node]
   (let [node-id (gt/node-id node)
@@ -492,13 +490,13 @@
 
 (defn- ctx-add-node [ctx node]
   (let [[basis-after full-node] (gt/add-node (:basis ctx) node)
-        node-id                 (gt/node-id full-node)]
+        node-id (gt/node-id full-node)]
     (-> ctx
-      (assoc :basis basis-after)
-      (apply-defaults node)
-      (update :nodes-added conj node-id)
-      (assoc-in [:successors-changed node-id] nil)
-      (mark-all-outputs-activated node-id))))
+        (assoc :basis basis-after)
+        (apply-defaults node)
+        (update :nodes-added conj node-id)
+        (assoc-in [:successors-changed node-id] nil)
+        (mark-all-outputs-activated node-id))))
 
 (defmethod perform :create-node [ctx {:keys [node]}]
   (when (and *tx-debug* (nil? (gt/node-id node))) (println "NIL NODE ID: " node))
@@ -530,10 +528,10 @@
     (if-let [node (gt/node-by-id-at basis node-id)] ; nil if node was deleted in this transaction
       (let [dynamic? (not (contains? (some-> (gt/node-type node basis) in/all-properties) property))]
         (-> ctx
-          (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
-                                            (and (gt/original node) (gt/property-overridden? node property)) (conj :_overridden-properties)))
-          (update :basis replace-node node-id (gt/clear-property node basis property))
-          (ctx-set-property-to-nil node-id node property)))
+            (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
+                                              (and (gt/original node) (gt/property-overridden? node property)) (conj :_overridden-properties)))
+            (update :basis replace-node node-id (gt/clear-property node basis property))
+            (ctx-set-property-to-nil node-id node property)))
       ctx)))
 
 (defmethod perform :callback [ctx {:keys [fn args]}]
@@ -553,25 +551,25 @@
       ctx)))
 
 (defn- assert-type-compatible
-  [basis src-id src-node src-label tgt-id tgt-node tgt-label]
-  (let [output-nodetype (gt/node-type src-node basis)
-        output-valtype  (in/output-type output-nodetype src-label)
-        input-nodetype  (gt/node-type tgt-node basis)
-        input-valtype   (in/input-type input-nodetype tgt-label)]
+  [basis source-id source-node source-label target-id target-node target-label]
+  (let [output-nodetype (gt/node-type source-node basis)
+        output-valtype (in/output-type output-nodetype source-label)
+        input-nodetype (gt/node-type target-node basis)
+        input-valtype (in/input-type input-nodetype target-label)]
     (assert output-valtype
             (format "Attempting to connect %s (a %s) %s to %s (a %s) %s, but %s does not have an output or property named %s"
-                    src-id (in/type-name output-nodetype) src-label
-                    tgt-id (in/type-name input-nodetype) tgt-label
-                    (in/type-name output-nodetype) src-label))
+                    source-id (in/type-name output-nodetype) source-label
+                    target-id (in/type-name input-nodetype) target-label
+                    (in/type-name output-nodetype) source-label))
     (assert input-valtype
             (format "Attempting to connect %s (a %s) %s to %s (a %s) %s, but %s does not have an input named %s"
-                    src-id (in/type-name output-nodetype) src-label
-                    tgt-id (in/type-name input-nodetype) tgt-label
-                    (in/type-name input-nodetype) tgt-label))
+                    source-id (in/type-name output-nodetype) source-label
+                    target-id (in/type-name input-nodetype) target-label
+                    (in/type-name input-nodetype) target-label))
     (assert (in/type-compatible? output-valtype input-valtype)
             (format "Attempting to connect %s (a %s) %s to %s (a %s) %s, but %s and %s are not have compatible types."
-                    src-id (in/type-name output-nodetype) src-label
-                    tgt-id (in/type-name input-nodetype) tgt-label
+                    source-id (in/type-name output-nodetype) source-label
+                    target-id (in/type-name input-nodetype) target-label
                     (:k output-valtype) (:k input-valtype)))))
 
 (defn- ctx-connect [ctx source-id source-label target-id target-label]
@@ -597,17 +595,17 @@
   (let [basis (:basis ctx)
         target (gt/node-by-id-at basis target-id)]
     (if (contains? (in/cascade-deletes (gt/node-type target basis)) target-label)
-      (let [src-or-nodes (map (partial gt/node-by-id-at basis) (ig/get-overrides basis source-id))]
-        (loop [tgt-overrides (ig/get-overrides basis target-id)
+      (let [source-override-nodes (map (partial gt/node-by-id-at basis) (ig/get-overrides basis source-id))]
+        (loop [target-override-node-ids (ig/get-overrides basis target-id)
                ctx ctx]
-          (if-let [or (first tgt-overrides)]
+          (if-let [target-override-id (first target-override-node-ids)]
             (let [basis (:basis ctx)
-                  or-node (gt/node-by-id-at basis or)
-                  override-id (gt/override-id or-node)
-                  tgt-ors (filter #(= override-id (gt/override-id %)) src-or-nodes)
-                  traverse-fn (ig/override-traverse-fn basis override-id)
-                  to-delete (ig/pre-traverse basis (mapv gt/node-id tgt-ors) traverse-fn)]
-              (recur (rest tgt-overrides)
+                  target-override-node (gt/node-by-id-at basis target-override-id)
+                  target-override-id (gt/override-id target-override-node)
+                  source-override-nodes-in-target-override (filter #(= target-override-id (gt/override-id %)) source-override-nodes)
+                  traverse-fn (ig/override-traverse-fn basis target-override-id)
+                  to-delete (ig/pre-traverse basis (mapv gt/node-id source-override-nodes-in-target-override) traverse-fn)]
+              (recur (rest target-override-node-ids)
                      (reduce ctx-delete-node ctx to-delete)))
             ctx)))
       ctx)))
@@ -624,10 +622,10 @@
   (ctx-disconnect ctx source-id source-label target-id target-label))
 
 (defmethod perform :update-graph-value
-  [ctx {:keys [gid fn args]}]
+  [ctx {:keys [graph-id fn args]}]
   (-> ctx
-      (update-in [:basis :graphs gid :graph-values] #(apply fn % args))
-      (update :graphs-modified conj gid)))
+      (update-in [:basis :graphs graph-id :graph-values] #(apply fn % args))
+      (update :graphs-modified conj graph-id)))
 
 (defmethod perform :label
   [ctx {:keys [label]}]
@@ -645,7 +643,7 @@
 
 (defn- apply-tx
   [ctx actions]
-  (loop [ctx     ctx
+  (loop [ctx ctx
          actions actions]
     (if (seq actions)
       (if-let [action (first actions)]
@@ -688,20 +686,20 @@
 
 (defn new-transaction-context
   [basis node-id-generators override-id-generator]
-  {:basis                 basis
-   :nodes-affected        {}
-   :nodes-added           []
-   :nodes-modified        #{}
-   :nodes-deleted         {}
-   :outputs-modified      #{}
-   :graphs-modified       #{}
-   :successors-changed    {}
-   :node-id-generators    node-id-generators
+  {:basis basis
+   :nodes-affected {}
+   :nodes-added []
+   :nodes-modified #{}
+   :nodes-deleted {}
+   :outputs-modified #{}
+   :graphs-modified #{}
+   :successors-changed {}
+   :node-id-generators node-id-generators
    :override-id-generator override-id-generator
-   :completed             []
-   :txid                  (new-txid)
-   :tx-data-context       (atom {})
-   :deferred-setters      []})
+   :completed []
+   :txid (new-txid)
+   :tx-data-context (atom {})
+   :deferred-setters []})
 
 (defn- update-successors
   [{:keys [successors-changed] :as ctx}]
@@ -713,8 +711,8 @@
   ;; afterwards, it will have the transitive closure of all [node-id output] pairs
   ;; reachable from the original collection.
   (let [outputs-modified (->> (:nodes-affected ctx)
-                           (gt/dependencies (:basis ctx))
-                           (into [] (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))]
+                              (gt/dependencies (:basis ctx))
+                              (into [] (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))]
     (assoc ctx :outputs-modified outputs-modified)))
 
 (defn transact*

--- a/editor/test/internal/graph/graph_test.clj
+++ b/editor/test/internal/graph/graph_test.clj
@@ -30,8 +30,8 @@
     (is (nil? (ig/node-id->node g id)))
     (is (empty? (filter #(= "Any ig/node value" %) (ig/node-values g))))))
 
-(defn targets [g n l] (map gt/tail (get-in g [:sarcs n l])))
-(defn sources [g n l] (map gt/head (get-in g [:tarcs n l])))
+(defn targets [g n l] (map gt/target (get-in g [:sarcs n l])))
+(defn sources [g n l] (map gt/source (get-in g [:tarcs n l])))
 
 (defn- source-arcs-without-targets
   [g]

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -37,7 +37,7 @@
     (ts/with-clean-system
       (let [gid        (g/make-graph!)
             all-graphs (u/map-vals deref (graphs))
-            all-gids   (into #{} (map :_gid (vals all-graphs)))]
+            all-gids   (into #{} (map :_graph-id (vals all-graphs)))]
         (is (= 2 (count all-graphs)))
         (is (all-gids gid)))))
 
@@ -52,7 +52,7 @@
     (ts/with-clean-system
       (let [gid (g/make-graph!)
             g'  (graph gid)]
-        (is (= (:_gid g') gid))))))
+        (is (= (:_graph-id g') gid))))))
 
 (deftest tx-id
   (testing "graph time advances with transactions"


### PR DESCRIPTION
* head/tail renamed to source/target
* loads of function argument and let-binding naming changes
* Arc fields renamed, also using .field instead of :field for access
  in some critical paths