### PR TITLE
DEF-3276-cleanup-includes-in-log

### DIFF
--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -14,8 +14,6 @@
 #include "path.h"
 #include "sys.h"
 #include "network_constants.h"
-#include "align.h"
-#include "message.h"
 
 #ifdef ANDROID
 #include <android/log.h>


### PR DESCRIPTION
Removed redundant includes in log.cpp