### PR TITLE
DEF-3557 reduce test times

### DIFF
--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -433,7 +433,7 @@ TEST_P(dmHttpClientTest, ServerTimeout)
         ASSERT_EQ(dmHttpClient::RESULT_OK, r);
         ASSERT_EQ(30, strtol(m_Content.c_str(), 0, 10));
 
-        // NOTE: MaxIdleTime is set to 500ms
+        // NOTE: MaxIdleTime is set to 500ms, see TestHttpServer.cpp line 300
         dmTime::Sleep(1000 * 550);
 
         m_Content = "";
@@ -474,7 +474,7 @@ TEST_P(dmHttpClientTest, ClientTimeout)
 
 TEST_P(dmHttpClientTestSSL, FailedSSLHandshake)
 {
-    for( int i = 0; i < 5; ++i )
+    for( int i = 0; i < 3; ++i )
     {
         uint64_t timeout = 130 * 1000;
         dmHttpClient::SetOptionInt(m_Client, dmHttpClient::OPTION_REQUEST_TIMEOUT, timeout); // microseconds
@@ -539,7 +539,7 @@ void ShutdownThread(void *args)
 TEST_P(dmHttpClientTest, ClientThreadedShutdown)
 {
     bool gotit = false;
-    for (int i=0;i<10;i++) {
+    for (int i=0;i<5;i++) {
         // Create a request that proceeds for a long time and cancel it in-flight with the
         // shutdown thread. If it managed to get the conneciton it will set gotit to true.
         dmThread::Thread thr = dmThread::New(&ShutdownThread, 65536, &gotit, "cst");

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -425,7 +425,7 @@ TEST_P(dmHttpClientTest, CustomRequestHeaders)
 
 TEST_P(dmHttpClientTest, ServerTimeout)
 {
-    for (int i = 0; i < 10; ++i)
+    for (int i = 0; i < 3; ++i)
     {
         dmHttpClient::Result r;
         m_Content = "";
@@ -433,8 +433,8 @@ TEST_P(dmHttpClientTest, ServerTimeout)
         ASSERT_EQ(dmHttpClient::RESULT_OK, r);
         ASSERT_EQ(30, strtol(m_Content.c_str(), 0, 10));
 
-        // NOTE: MaxIdleTime is set to 300ms
-        dmTime::Sleep(1000 * 350);
+        // NOTE: MaxIdleTime is set to 500ms
+        dmTime::Sleep(1000 * 550);
 
         m_Content = "";
         r = dmHttpClient::Get(m_Client, "/add/100/20");
@@ -451,7 +451,7 @@ TEST_P(dmHttpClientTest, ClientTimeout)
     dmHttpClient::SetOptionInt(m_Client, dmHttpClient::OPTION_REQUEST_TIMEOUT, 130 * 1000); // microseconds
 
     char buf[128];
-    for (int i = 0; i < 7; ++i)
+    for (int i = 0; i < 3; ++i)
     {
         dmHttpClient::Result r;
         m_StatusCode = -1;

--- a/engine/dlib/src/test/test_message.cpp
+++ b/engine/dlib/src/test/test_message.cpp
@@ -355,10 +355,22 @@ TEST(dmMessage, Integrity)
     r = dmMessage::NewSocket("my_socket", &receiver.m_Socket);
     ASSERT_EQ(dmMessage::RESULT_OK, r);
 
-    char msg[1024];
-    for (uint32_t size = 1; size <= 128; ++size)
+    const uint32_t MESSAGE_SIZES[] = {
+        1, 2, 4, 7, 9, 31, 32, 33, 511, 512, 513,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE / 3 - 1,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE / 3,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE / 3 + 1,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE / 2 - 1,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE / 2,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE / 2 + 1,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE - 1,
+        dmMessage::DM_MESSAGE_MAX_DATA_SIZE};
+
+    char msg[dmMessage::DM_MESSAGE_MAX_DATA_SIZE];
+    for (uint32_t n = 0; n < (sizeof(MESSAGE_SIZES) / sizeof(uint32_t)); ++n)
     {
-        for (uint32_t iter = 0; iter < 70; ++iter)
+        uint32_t size = MESSAGE_SIZES[n];
+        for (uint32_t iter = 0; iter < 15; ++iter)
         {
             for (uint32_t i = 0; i < size; ++i)
             {

--- a/engine/dlib/src/test/test_message.cpp
+++ b/engine/dlib/src/test/test_message.cpp
@@ -356,7 +356,7 @@ TEST(dmMessage, Integrity)
     ASSERT_EQ(dmMessage::RESULT_OK, r);
 
     char msg[1024];
-    for (uint32_t size = 1; size <= 1024; ++size)
+    for (uint32_t size = 1; size <= 128; ++size)
     {
         for (uint32_t iter = 0; iter < 70; ++iter)
         {

--- a/engine/script/src/test/test_bitop.lua
+++ b/engine/script/src/test/test_bitop.lua
@@ -176,6 +176,9 @@ function test_bitop_md5()
     txt = txt..txt..txt..txt
     txt = txt..txt..txt..txt
 
+    local res = md5(txt)
+    assert(res == 'cd3a68ca4b9b54dee5ad7d74bfe7cb59')
+--[[
     local function bench()
         local n = 80
         repeat
@@ -194,6 +197,7 @@ function test_bitop_md5()
     end
 
     io.write(string.format("MD5 %7.1f ns/char\n", bench()))
+--]]
 end
 
 

--- a/engine/script/src/test/test_bitop.lua
+++ b/engine/script/src/test/test_bitop.lua
@@ -178,26 +178,6 @@ function test_bitop_md5()
 
     local res = md5(txt)
     assert(res == 'cd3a68ca4b9b54dee5ad7d74bfe7cb59')
---[[
-    local function bench()
-        local n = 80
-        repeat
-            local tm = os.clock()
-            local res
-            for i=1,n do
-                res = md5(txt)
-            end
-            print(res)
-            assert(res == 'cd3a68ca4b9b54dee5ad7d74bfe7cb59')
-            tm = os.clock() - tm
-            print(tm)
-            if tm > 1 then return tm*(1000000000/(n*#txt)) end
-            n = n + n
-        until false
-    end
-
-    io.write(string.format("MD5 %7.1f ns/char\n", bench()))
---]]
 end
 
 

--- a/engine/texc/src/test/test_texc.cpp
+++ b/engine/texc/src/test/test_texc.cpp
@@ -246,7 +246,9 @@ TEST_F(TexcTest, Transcode)
 
 TEST_F(TexcTest, TranscodeWebPLossless)
 {
-    dmTexc::HTexture texture = CreateDefaultRGBA32(256, 256);
+    static const uint32_t width = 64;
+    static const uint32_t height = 64;
+    dmTexc::HTexture texture = CreateDefaultRGBA32(width, height);
     dmTexc::Header header;
 
     ASSERT_TRUE(dmTexc::Transcode(texture, dmTexc::PF_L8, dmTexc::CS_LRGB, dmTexc::CL_FAST, dmTexc::CT_WEBP, dmTexc::DT_DEFAULT));
@@ -296,7 +298,9 @@ TEST_F(TexcTest, TranscodeWebPLossless)
 
 TEST_F(TexcTest, TranscodeWebPLossy)
 {
-    dmTexc::HTexture texture = CreateDefaultRGBA32(256, 256);
+    static const uint32_t width = 64;
+    static const uint32_t height = 64;
+    dmTexc::HTexture texture = CreateDefaultRGBA32(width, height);
     dmTexc::Header header;
 
     ASSERT_TRUE(dmTexc::Transcode(texture, dmTexc::PF_L8, dmTexc::CS_LRGB, dmTexc::CL_FAST, dmTexc::CT_WEBP_LOSSY, dmTexc::DT_DEFAULT));
@@ -419,10 +423,12 @@ TEST_F(TexcTest, FlipAxis)
 
 static void TranscodeWebEncodedFormat(dmTexc::PixelFormat format, dmWebP::TextureEncodeFormat encode_format)
 {
-    dmTexc::HTexture texture_default = CreateDefaultRGBA32(256, 256);
+    static const uint32_t width = 64;
+    static const uint32_t height = 64;
+    dmTexc::HTexture texture_default = CreateDefaultRGBA32(width, height);
     ASSERT_TRUE(dmTexc::PreMultiplyAlpha(texture_default));
     ASSERT_TRUE(dmTexc::Transcode(texture_default, format, dmTexc::CS_LRGB, dmTexc::CL_FAST, dmTexc::CT_DEFAULT, dmTexc::DT_NONE));
-    dmTexc::HTexture texture = CreateDefaultRGBA32(256, 256);
+    dmTexc::HTexture texture = CreateDefaultRGBA32(width, height);
     ASSERT_TRUE(dmTexc::PreMultiplyAlpha(texture));
     ASSERT_TRUE(dmTexc::Transcode(texture, format, dmTexc::CS_LRGB, dmTexc::CL_FAST, dmTexc::CT_WEBP, dmTexc::DT_NONE));
 


### PR DESCRIPTION
Use smaller textures when testing WebPLossy
Run fewer iterations dmMessage.Integrity
Reduce test iterations in httpclient tests
Reduced repetition of httpclient tests
Removed benchmarking test for bitop