### PR TITLE
DEFEDIT-1475 Ignore /resources/doc/

### DIFF
--- a/editor/.gitignore
+++ b/editor/.gitignore
@@ -20,4 +20,4 @@ pom.xml.asc
 /log.txt
 /.project
 /.pydevproject
-/resources/doc/*
+/resources/doc/


### PR DESCRIPTION
We used to ignore /resources/doc/* but that apparently causes git clean to remove generated documentation.