### PR TITLE
DEF-3575 - Fonts occasionally crash the engine

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -379,16 +379,14 @@ public class Fontc {
             if (glyph.width <= 0.0f) {
                 continue;
             }
+
             int ascent  = glyph.ascent;
             int descent = glyph.descent;
+            int width   = glyph.width + padding * 2 + cell_padding * 2;
 
-            int width = glyph.width + padding * 2 + cell_padding * 2;
-            // int height = ascent + descent + padding * 2 + cell_padding * 2;
-
-            cell_width = Math.max(cell_width, width);
-
-            cell_max_ascent = Math.max(cell_max_ascent,ascent);
-            cell_max_descent = Math.max(cell_max_descent,descent);
+            cell_width       = Math.max(cell_width, width);
+            cell_max_ascent  = Math.max(cell_max_ascent, ascent);
+            cell_max_descent = Math.max(cell_max_descent, descent);
         }
 
         cell_height       = cell_max_ascent + cell_max_descent + padding * 2 + cell_padding * 2;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -367,23 +367,32 @@ public class Fontc {
         int cell_width = 0;
         int cell_height = 0;
 
+        // Find max glyph ascent and descent for each glyph. This is needed
+        // since we cannot fully trust or use the values from the getMaxAscent / getMaxDescent
+        // These values are are used both for determining the cache cell size as well
+        // as y-offset in the cache subimage update routines.
+        int cell_max_ascent  = 0;
+        int cell_max_descent = 0;
+
         for (int i = 0; i < glyphs.size(); i++) {
             Glyph glyph = glyphs.get(i);
             if (glyph.width <= 0.0f) {
                 continue;
             }
+            int ascent  = glyph.ascent;
+            int descent = glyph.descent;
+
             int width = glyph.width + padding * 2 + cell_padding * 2;
-            int height = glyph.ascent + glyph.descent + padding * 2 + cell_padding * 2;
+            // int height = ascent + descent + padding * 2 + cell_padding * 2;
+
             cell_width = Math.max(cell_width, width);
-            cell_height = Math.max(cell_height, height);
+
+            cell_max_ascent = Math.max(cell_max_ascent,ascent);
+            cell_max_descent = Math.max(cell_max_descent,descent);
         }
 
-        // Add padding to min/max ascent since we add corresponding padding to each glyph later
-        // Note that the fontMapBuilder max/min descents will be updated later with these values
-        int fontMapMaxAscent  = (int) fontMapBuilder.getMaxAscent() + padding;
-        int fontMapMaxDescent = (int) fontMapBuilder.getMaxDescent() + padding;
-
-        cell_height = fontMapMaxAscent + fontMapMaxDescent + cell_padding * 2;
+        cell_height       = cell_max_ascent + cell_max_descent + padding * 2 + cell_padding * 2;
+        cell_max_ascent  += padding;
 
         // Some hardware don't like doing subimage updates on non-aligned cell positions.
         if (channelCount == 3) {
@@ -449,16 +458,12 @@ public class Fontc {
                 glyph.cache_entry_offset = dataOffset;
                 // Get raster data from rendered glyph and store in glyph data bank
                 int dataSizeOut = (glyphImage.getWidth() + cell_padding * 2) * (glyphImage.getHeight() + cell_padding * 2) * channelCount;
+
+                repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
                 for (int y = 0; y < glyphImage.getHeight(); y++) {
 
-                    if (y == 0) {
-                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
-                    }
+                    repeatedWrite(glyphDataBank, channelCount, clearData);
                     for (int x = 0; x < glyphImage.getWidth(); x++) {
-
-                        if (x == 0) {
-                            repeatedWrite(glyphDataBank, channelCount, clearData);
-                        }
 
                         int color = glyphImage.getRGB(x, y);
                         int blue  = (color) & 0xff;
@@ -481,16 +486,11 @@ public class Fontc {
                                 glyphDataBank.write((byte)alpha);
                             }
                         }
-
-                        if (x == glyphImage.getWidth()-1) {
-                            repeatedWrite(glyphDataBank, channelCount, clearData);
-                        }
-
                     }
-                    if (y == glyphImage.getHeight()-1) {
-                        repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
-                    }
+
+                    repeatedWrite(glyphDataBank, channelCount, clearData);
                 }
+                repeatedWrite(glyphDataBank, (glyphImage.getWidth() + cell_padding * 2) * channelCount, clearData);
                 dataOffset += dataSizeOut;
                 glyph.cache_entry_size = dataOffset - glyph.cache_entry_offset;
             }
@@ -512,8 +512,7 @@ public class Fontc {
         fontMapBuilder.setCacheCellWidth(cell_width);
         fontMapBuilder.setCacheCellHeight(cell_height);
         fontMapBuilder.setGlyphChannels(channelCount);
-        fontMapBuilder.setMaxAscent(fontMapMaxAscent);
-        fontMapBuilder.setMaxDescent(fontMapMaxDescent);
+        fontMapBuilder.setCacheCellMaxAscent(cell_max_ascent);
 
         BufferedImage previewImage = null;
         if (preview) {

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -645,7 +645,7 @@
 (defn- make-glyph-cache
   [^GL2 gl params]
   (let [{:keys [font-map texture]} params
-        {:keys [cache-width cache-height cache-cell-width cache-cell-height max-ascent]} font-map
+        {:keys [cache-width cache-height cache-cell-width cache-cell-height cache-cell-max-ascent]} font-map
         data-format (glyph-channels->data-format (:glyph-channels font-map))
         size (* (int (/ cache-width cache-cell-width)) (int (/ cache-height cache-cell-height)))
         w (int (/ cache-width cache-cell-width))
@@ -662,7 +662,7 @@
                                (if-not (< cell size)
                                  (assoc m glyph ::not-available)
                                  (let [x (* (mod cell w) cache-cell-width)
-                                       y (+ (* (int (/ cell w)) cache-cell-height) (- max-ascent (:ascent glyph)))
+                                       y (+ (* (int (/ cell w)) cache-cell-height) (- cache-cell-max-ascent (:ascent glyph)))
                                        p (* 2 (:glyph-padding font-map))
                                        w (+ (:width glyph) p)
                                        h (+ (:ascent glyph) (:descent glyph) p)

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -206,6 +206,7 @@
      :glyph-padding glyph-cell-padding
      :cache-cell-width (:width cache-cell-wh)
      :cache-cell-height (:height cache-cell-wh)
+     :cache-cell-max-ascent :max-ascent
      :glyph-channels channel-count
      :glyph-data (ByteString/copyFrom glyph-data-bank)}))
 
@@ -391,14 +392,20 @@
                                (> ^double (:outline-alpha font-desc) 0.0))
                         3 1)
         glyph-extents (make-glyph-extents channel-count padding glyph-cell-padding semi-glyphs)
-        line-height (+ (.getMaxAscent font-metrics) (.getMaxDescent font-metrics))
+        ;; Note: We need to diverge between placing glyphs within the cache and placing them
+        ;;       when rendering. For the cache placement, we need to know the _actual_
+        ;;       max ascent/descent of a glyph set and not just rely on the values we get from
+        ;;       the font-metrics as they yield wrong values sometimes. For backwards compat, we
+        ;;       place the glyph quads in the same way as before.
+        ^long cache-cell-max-ascent (reduce max 0 (map :ascent semi-glyphs))
+        ^long cache-cell-max-descent (reduce max 0 (map :descent semi-glyphs))
+        line-height (+ cache-cell-max-ascent cache-cell-max-descent)
         ;; BOB: "Some hardware don't like doing subimage updates on non-aligned cell positions."
         cache-cell-wh (cond-> (max-glyph-cell-wh glyph-extents line-height padding glyph-cell-padding)
                         (= channel-count 3)
                         (update :width #(* (int (Math/ceil (/ ^double % 4.0))) 4)))
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)]
-    
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
               (let [^BufferedImage glyph-image (let [face-color (Color. ^double (:alpha font-desc) 0.0 0.0)
@@ -440,14 +447,15 @@
      :material (str (:material font-desc) "c")
      :shadow-x (:shadow-x font-desc)
      :shadow-y (:shadow-y font-desc)
-     :max-ascent (+ (float (.getMaxAscent font-metrics)) padding)
-     :max-descent (+ (float (.getMaxDescent font-metrics)) padding)
+     :max-ascent (.getMaxAscent font-metrics)
+     :max-descent (.getMaxDescent font-metrics)
      :image-format (:output-format font-desc)
      :cache-width (:width cache-wh)
      :cache-height (:height cache-wh)
      :glyph-padding glyph-cell-padding
      :cache-cell-width (:width cache-cell-wh)
      :cache-cell-height (:height cache-cell-wh)
+     :cache-cell-max-ascent (+ cache-cell-max-ascent padding)
      :glyph-channels channel-count
      :glyph-data (ByteString/copyFrom glyph-data-bank)}))
 
@@ -531,7 +539,10 @@
         sdf-spread (+ (Math/sqrt 2.0) ^double (:outline-width font-desc))
         edge 0.75
         glyph-extents (make-glyph-extents channel-count padding glyph-cell-padding semi-glyphs)
-        line-height (+ (.getMaxAscent font-metrics) (.getMaxDescent font-metrics))
+        ;; Note: see comment in compile-ttf-bitmap regarding the cache ascent/descent
+        ^long cache-cell-max-ascent (reduce max 0 (map :ascent semi-glyphs))
+        ^long cache-cell-max-descent (reduce max 0 (map :descent semi-glyphs))
+        line-height (+ cache-cell-max-ascent cache-cell-max-descent)
         cache-cell-wh (max-glyph-cell-wh glyph-extents line-height padding glyph-cell-padding)
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)]
@@ -572,6 +583,7 @@
      :glyph-padding glyph-cell-padding
      :cache-cell-width (:width cache-cell-wh)
      :cache-cell-height (:height cache-cell-wh)
+     :cache-cell-max-ascent (+ cache-cell-max-ascent padding)
      :glyph-channels channel-count
      :glyph-data (ByteString/copyFrom glyph-data-bank)
      :alpha (:alpha font-desc)

--- a/engine/engine/src/test/def-3575/def-3575.collection
+++ b/engine/engine/src/test/def-3575/def-3575.collection
@@ -1,0 +1,16 @@
+name: "main"
+instances {
+  id: "main"
+  prototype: "/def-3575/def-3575.go"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/engine/src/test/def-3575/def-3575.font
+++ b/engine/engine/src/test/def-3575/def-3575.font
@@ -1,0 +1,7 @@
+font: "/builtins/fonts/vera_mo_bd.ttf"
+material: "/builtins/fonts/system_font.material"
+size: 14
+antialias: 1
+alpha: 1.0
+shadow_alpha: 1.0
+shadow_blur: 2

--- a/engine/engine/src/test/def-3575/def-3575.go
+++ b/engine/engine/src/test/def-3575/def-3575.go
@@ -1,0 +1,58 @@
+embedded_components {
+  id: "label"
+  type: "label"
+  data: "size {\n"
+  "  x: 128.0\n"
+  "  y: 32.0\n"
+  "  z: 0.0\n"
+  "  w: 0.0\n"
+  "}\n"
+  "scale {\n"
+  "  x: 1.0\n"
+  "  y: 1.0\n"
+  "  z: 1.0\n"
+  "  w: 0.0\n"
+  "}\n"
+  "color {\n"
+  "  x: 1.0\n"
+  "  y: 1.0\n"
+  "  z: 1.0\n"
+  "  w: 1.0\n"
+  "}\n"
+  "outline {\n"
+  "  x: 0.0\n"
+  "  y: 0.0\n"
+  "  z: 0.0\n"
+  "  w: 1.0\n"
+  "}\n"
+  "shadow {\n"
+  "  x: 0.0\n"
+  "  y: 0.0\n"
+  "  z: 0.0\n"
+  "  w: 1.0\n"
+  "}\n"
+  "leading: 1.0\n"
+  "tracking: 0.0\n"
+  "pivot: PIVOT_CENTER\n"
+  "blend_mode: BLEND_MODE_ALPHA\n"
+  "line_break: false\n"
+  "text: \"Label\"\n"
+  "font: \"/def-3575/def-3575.font\"\n"
+  "material: \"/builtins/fonts/label.material\"\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}
+components {
+  id: "script"
+  component: "/def-3575/def-3575.script"
+}

--- a/engine/engine/src/test/def-3575/def-3575.script
+++ b/engine/engine/src/test/def-3575/def-3575.script
@@ -10,10 +10,19 @@ end
 
 function update(self, dt)
 
-	local metrics_valid = {
-		max_ascent = 13,
-		width = 771,
-		height = 17,
+	-- Values are taken from the output from label.get_text_metrics from defold version 1.2.138
+	-- The settings used are:
+	-- 	font: "/builtins/fonts/vera_mo_bd.ttf"
+	-- 	size: 14
+	-- 	antialias: 1
+	-- 	alpha: 1.0
+	-- 	shadow_alpha: 1.0
+	-- 	shadow_blur: 2
+
+	local metrics_valid ={
+		max_ascent  = 13,
+		width       = 771,
+		height      = 17,
 		max_descent = 4
 	}
 

--- a/engine/engine/src/test/def-3575/def-3575.script
+++ b/engine/engine/src/test/def-3575/def-3575.script
@@ -1,0 +1,36 @@
+function init(self)
+    local label_str = ""
+
+	for i = 32, 127 do
+		label_str = label_str .. string.char(i)
+	end
+
+	label.set_text("#label", label_str)
+end
+
+function update(self, dt)
+
+	local success = false
+
+	local metrics_valid = {
+		max_ascent = 13,
+		width = 771,
+		height = 17,
+		max_descent = 4
+	}
+
+	local metrics = label.get_text_metrics("#label")
+
+	success = metrics_valid.max_ascent  == metrics.max_ascent and
+			  metrics_valid.max_descent == metrics.max_descent and
+			  metrics_valid.width       == metrics.width and
+			  metrics_valid.height      == metrics.height
+
+	pprint(metrics,metrics_valid)
+
+    if success then
+        msg.post("@system:", "exit", { code = 0 })
+    else
+        msg.post("@system:", "exit", { code = 1 })
+    end
+end

--- a/engine/engine/src/test/def-3575/def-3575.script
+++ b/engine/engine/src/test/def-3575/def-3575.script
@@ -10,8 +10,6 @@ end
 
 function update(self, dt)
 
-	local success = false
-
 	local metrics_valid = {
 		max_ascent = 13,
 		width = 771,
@@ -19,14 +17,12 @@ function update(self, dt)
 		max_descent = 4
 	}
 
+	-- Test that we are getting the expected value back from get_text_metrics
 	local metrics = label.get_text_metrics("#label")
-
-	success = metrics_valid.max_ascent  == metrics.max_ascent and
-			  metrics_valid.max_descent == metrics.max_descent and
-			  metrics_valid.width       == metrics.width and
-			  metrics_valid.height      == metrics.height
-
-	pprint(metrics,metrics_valid)
+	local success = metrics_valid.max_ascent  == metrics.max_ascent and
+			        metrics_valid.max_descent == metrics.max_descent and
+			        metrics_valid.width       == metrics.width and
+			        metrics_valid.height      == metrics.height
 
     if success then
         msg.post("@system:", "exit", { code = 0 })

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -180,6 +180,12 @@ TEST_F(EngineTest, DEF_3456)
     ASSERT_EQ(0, dmEngine::Launch(sizeof(argv)/sizeof(argv[0]), (char**)argv, 0, 0, 0));
 }
 
+TEST_F(EngineTest, DEF_3575)
+{
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/def-3575/def-3575.collectionc", "--config=dmengine.unload_builtins=0", CONTENT_ROOT "/game.projectc"};
+    ASSERT_EQ(0, dmEngine::Launch(sizeof(argv)/sizeof(argv[0]), (char**)argv, 0, 0, 0));
+}
+
 TEST_F(EngineTest, SpineAnim)
 {
     const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/spine_anim/spine.collectionc", "--config=dmengine.unload_builtins=0", CONTENT_ROOT "/game.projectc"};

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -60,6 +60,7 @@ namespace dmGameSystem
 
         params.m_CacheCellWidth = ddf->m_CacheCellWidth;
         params.m_CacheCellHeight = ddf->m_CacheCellHeight;
+        params.m_CacheCellMaxAscent = ddf->m_CacheCellMaxAscent;
         params.m_CacheCellPadding = ddf->m_GlyphPadding;
 
         params.m_ImageFormat = ddf->m_ImageFormat;

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -922,6 +922,9 @@ namespace dmGraphics
     void SetTexture(HTexture texture, const TextureParams& params)
     {
         assert(texture);
+        assert(!params.m_SubUpdate || params.m_SubUpdate && (params.m_X + params.m_Width <= texture->m_Width));
+        assert(!params.m_SubUpdate || params.m_SubUpdate && (params.m_Y + params.m_Height <= texture->m_Height));
+
         if (texture->m_Data != 0x0)
             delete [] (char*)texture->m_Data;
         texture->m_Format = params.m_Format;

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -422,6 +422,44 @@ TEST_F(dmGraphicsTest, TestTexture)
     dmGraphics::DeleteTexture(texture);
 }
 
+TEST_F(dmGraphicsTest, TestSetTextureBounds)
+{
+    dmGraphics::TextureCreationParams creation_params;
+    dmGraphics::TextureParams params;
+
+    creation_params.m_Width = WIDTH;
+    creation_params.m_Height = HEIGHT;
+    creation_params.m_OriginalWidth = WIDTH;
+    creation_params.m_OriginalHeight = HEIGHT;
+
+    params.m_DataSize  = WIDTH * HEIGHT;
+    params.m_Data      = new char[params.m_DataSize];
+    params.m_Width     = WIDTH;
+    params.m_Height    = HEIGHT;
+    params.m_Format    = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+    params.m_SubUpdate = true;
+    params.m_X         = WIDTH / 2;
+    params.m_Y         = HEIGHT / 2;
+
+    dmGraphics::HTexture texture = dmGraphics::NewTexture(m_Context, creation_params);
+    ASSERT_DEATH_IF_SUPPORTED(dmGraphics::SetTexture(texture, params),"");
+
+    delete [] (char*)params.m_Data;
+
+    params.m_X         = 0;
+    params.m_Y         = 0;
+    params.m_Width     = WIDTH + 1;
+    params.m_Height    = HEIGHT + 1;
+    params.m_DataSize  = params.m_Width * params.m_Height;
+    params.m_Data      = new char[params.m_DataSize];
+
+    ASSERT_DEATH_IF_SUPPORTED(dmGraphics::SetTexture(texture, params),"");
+
+    delete [] (char*)params.m_Data;
+
+    dmGraphics::DeleteTexture(texture);
+}
+
 TEST_F(dmGraphicsTest, TestMaxTextureSize)
 {
     ASSERT_NE(dmGraphics::GetMaxTextureSize(m_Context), 0);

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -76,4 +76,6 @@ message FontMap
     optional float alpha = 21 [default = 1.0];
     optional float outline_alpha = 22 [default = 1.0];
     optional float shadow_alpha = 23 [default = 1.0];
+
+    optional uint32 cache_cell_max_ascent = 24;
 }

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -65,6 +65,7 @@ namespace dmRender
         , m_CacheRows(0)
         , m_CacheCellWidth(0)
         , m_CacheCellHeight(0)
+        , m_CacheCellMaxAscent(0)
         , m_CacheCellPadding(0)
         {
 
@@ -108,6 +109,7 @@ namespace dmRender
 
         uint32_t                m_CacheCellWidth;
         uint32_t                m_CacheCellHeight;
+        uint32_t                m_CacheCellMaxAscent;
         uint8_t                 m_CacheCellPadding;
     };
 
@@ -157,6 +159,7 @@ namespace dmRender
 
         font_map->m_CacheCellWidth = params.m_CacheCellWidth;
         font_map->m_CacheCellHeight = params.m_CacheCellHeight;
+        font_map->m_CacheCellMaxAscent = params.m_CacheCellMaxAscent;
         font_map->m_CacheCellPadding = params.m_CacheCellPadding;
 
         font_map->m_CacheColumns = params.m_CacheWidth / params.m_CacheCellWidth;
@@ -245,6 +248,7 @@ namespace dmRender
 
         font_map->m_CacheCellWidth = params.m_CacheCellWidth;
         font_map->m_CacheCellHeight = params.m_CacheCellHeight;
+        font_map->m_CacheCellMaxAscent = params.m_CacheCellMaxAscent;
         font_map->m_CacheCellPadding = params.m_CacheCellPadding;
 
         font_map->m_CacheColumns = params.m_CacheWidth / params.m_CacheCellWidth;
@@ -592,7 +596,7 @@ namespace dmRender
                     int16_t cache_cell_padding = (int16_t)font_map->m_CacheCellPadding;
 
                     // Calculate y-offset in cache-cell space by moving glyphs down to baseline
-                    int16_t px_cell_offset_y = font_map->m_MaxAscent - ascent;
+                    int16_t px_cell_offset_y = font_map->m_CacheCellMaxAscent - ascent;
 
                     if (!g->m_InCache) {
                         AddGlyphToCache(font_map, text_context, g, px_cell_offset_y);

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -89,6 +89,7 @@ namespace dmRender
 
         uint32_t m_CacheCellWidth;
         uint32_t m_CacheCellHeight;
+        uint32_t m_CacheCellMaxAscent;
         uint8_t m_CacheCellPadding;
 
         dmRenderDDF::FontTextureFormat m_ImageFormat;


### PR DESCRIPTION
Engine crashes in debug due to an inconsistency between glyph ascent / descent and the font_maps maxAscent and minDescent values. Since we have previously changed the behaviour of updating the font cache by placing glyphs on the baseline based on maxAscent, we must ensure that the values used in the offset calculation is valid. 

Technical changes:

* Glyph cache placement uses the analytical maxAscent value to offset into the cache
* Added graphics system test that does bounds checking for sub-texture updates
* Added engine test that checks that the font metrics are the same as previous versions (this was accidentally changed in the 1.2.39 release)