### PR TITLE
DEFEDIT-3575: Remove padding from max ascent/descent for DF fonts in Editor2

### DIFF
--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -573,8 +573,8 @@
      :material (str (:material font-desc) "c")
      :shadow-x (:shadow-x font-desc)
      :shadow-y (:shadow-y font-desc)
-     :max-ascent (+ (float (.getMaxAscent font-metrics)) padding)
-     :max-descent (+ (float (.getMaxDescent font-metrics)) padding)
+     :max-ascent (.getMaxAscent font-metrics)
+     :max-descent (.getMaxDescent font-metrics)
      :image-format (:output-format font-desc)
      :sdf-spread sdf-spread
      :sdf-outline (let [outline-edge (- (/ ^double (:outline-width font-desc) sdf-spread))]

--- a/engine/engine/src/test/def-3575/def-3575-bitmap.font
+++ b/engine/engine/src/test/def-3575/def-3575-bitmap.font
@@ -3,5 +3,8 @@ material: "/builtins/fonts/system_font.material"
 size: 14
 antialias: 1
 alpha: 1.0
+outline_alpha: 1.0
+outline_width: 4.0
 shadow_alpha: 1.0
 shadow_blur: 2
+output_format: TYPE_BITMAP

--- a/engine/engine/src/test/def-3575/def-3575-df.font
+++ b/engine/engine/src/test/def-3575/def-3575-df.font
@@ -1,0 +1,16 @@
+font: "/builtins/fonts/vera_mo_bd.ttf"
+material: "/builtins/fonts/system_font.material"
+size: 14
+antialias: 1
+alpha: 1.0
+outline_alpha: 1.0
+outline_width: 4.0
+shadow_alpha: 1.0
+shadow_blur: 2
+shadow_x: 0.0
+shadow_y: 0.0
+extra_characters: ""
+output_format: TYPE_DISTANCE_FIELD
+all_chars: false
+cache_width: 0
+cache_height: 0

--- a/engine/engine/src/test/def-3575/def-3575.go
+++ b/engine/engine/src/test/def-3575/def-3575.go
@@ -1,5 +1,5 @@
 embedded_components {
-  id: "label"
+  id: "label_bitmap"
   type: "label"
   data: "size {\n"
   "  x: 128.0\n"
@@ -37,7 +37,61 @@ embedded_components {
   "blend_mode: BLEND_MODE_ALPHA\n"
   "line_break: false\n"
   "text: \"Label\"\n"
-  "font: \"/def-3575/def-3575.font\"\n"
+  "font: \"/def-3575/def-3575-bitmap.font\"\n"
+  "material: \"/builtins/fonts/label.material\"\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}
+embedded_components {
+  id: "label_distance_field"
+  type: "label"
+  data: "size {\n"
+  "  x: 128.0\n"
+  "  y: 32.0\n"
+  "  z: 0.0\n"
+  "  w: 0.0\n"
+  "}\n"
+  "scale {\n"
+  "  x: 1.0\n"
+  "  y: 1.0\n"
+  "  z: 1.0\n"
+  "  w: 0.0\n"
+  "}\n"
+  "color {\n"
+  "  x: 1.0\n"
+  "  y: 1.0\n"
+  "  z: 1.0\n"
+  "  w: 1.0\n"
+  "}\n"
+  "outline {\n"
+  "  x: 0.0\n"
+  "  y: 0.0\n"
+  "  z: 0.0\n"
+  "  w: 1.0\n"
+  "}\n"
+  "shadow {\n"
+  "  x: 0.0\n"
+  "  y: 0.0\n"
+  "  z: 0.0\n"
+  "  w: 1.0\n"
+  "}\n"
+  "leading: 1.0\n"
+  "tracking: 0.0\n"
+  "pivot: PIVOT_CENTER\n"
+  "blend_mode: BLEND_MODE_ALPHA\n"
+  "line_break: false\n"
+  "text: \"Label\"\n"
+  "font: \"/def-3575/def-3575-df.font\"\n"
   "material: \"/builtins/fonts/label.material\"\n"
   ""
   position {

--- a/engine/engine/src/test/def-3575/def-3575.script
+++ b/engine/engine/src/test/def-3575/def-3575.script
@@ -1,37 +1,59 @@
 function init(self)
     local label_str = ""
 
-	for i = 32, 127 do
-		label_str = label_str .. string.char(i)
-	end
+    for i = 32, 127 do
+        label_str = label_str .. string.char(i)
+    end
 
-	label.set_text("#label", label_str)
+    label.set_text("#label_bitmap", label_str)
+    label.set_text("#label_distance_field", label_str)
 end
 
 function update(self, dt)
+    -- Values are taken from the output from label.get_text_metrics from defold version 1.2.138
+    -- The base settings used are:
+    --  font: "/builtins/fonts/vera_mo_bd.ttf"
+    --  size: 14
+    --  antialias: 1
+    --  alpha: 1.0
+    --  outline_alpha: 1.0
+    --  outline_width: 4.0
+    --  shadow_alpha: 1.0
+    --  shadow_blur: 2
 
-	-- Values are taken from the output from label.get_text_metrics from defold version 1.2.138
-	-- The settings used are:
-	-- 	font: "/builtins/fonts/vera_mo_bd.ttf"
-	-- 	size: 14
-	-- 	antialias: 1
-	-- 	alpha: 1.0
-	-- 	shadow_alpha: 1.0
-	-- 	shadow_blur: 2
+    local function test_label_metrics(label_name,test_metrics)
+        -- Test that we are getting the expected value back from get_text_metrics
+        local metrics = label.get_text_metrics("#" .. label_name)
 
-	local metrics_valid ={
-		max_ascent  = 13,
-		width       = 771,
-		height      = 17,
-		max_descent = 4
-	}
+        return test_metrics.max_ascent  == metrics.max_ascent and
+               test_metrics.max_descent == metrics.max_descent and
+               test_metrics.width       == metrics.width and
+               test_metrics.height      == metrics.height
+    end
 
-	-- Test that we are getting the expected value back from get_text_metrics
-	local metrics = label.get_text_metrics("#label")
-	local success = metrics_valid.max_ascent  == metrics.max_ascent and
-			        metrics_valid.max_descent == metrics.max_descent and
-			        metrics_valid.width       == metrics.width and
-			        metrics_valid.height      == metrics.height
+    local function test_label_bitmap()
+        local metrics_valid = {
+            max_ascent  = 13,
+            width       = 775,
+            height      = 17,
+            max_descent = 4
+        }
+
+        return test_label_metrics("label_bitmap", metrics_valid)
+    end
+
+    local function test_label_df()
+        local metrics_valid ={
+              max_ascent = 13,
+              width = 776,
+              height = 17,
+              max_descent = 4,
+        }
+
+        return test_label_metrics("label_distance_field", metrics_valid)
+    end
+
+    local success = test_label_bitmap() and test_label_df()
 
     if success then
         msg.post("@system:", "exit", { code = 0 })


### PR DESCRIPTION
This PR resets the line leading that was fixed in def3575 but was missing for distance field fonts. The engine test was also updated to support a test case for df fonts. 