### PR TITLE
DEF-3601 Added named profiling scopes for script functions

### DIFF
--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -44,25 +44,28 @@
 #undef DM_COUNTER_HASH
 
 #if defined(NDEBUG)
+    #define DM_PROFILE_SCOPE(scope_instance_name, name)
     #define DM_PROFILE(scope_name, name)
     #define DM_COUNTER(name, amount)
     #define DM_COUNTER_HASH(name, name_hash, amount)
 #else
+    #define DM_PROFILE_SCOPE(scope, name) \
+        dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(scope, name);\
+
     #define DM_PROFILE(scope_name, name) \
         static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = 0; \
         if (dmProfile::g_IsInitialized && DM_PROFILE_PASTE2(scope, __LINE__) == 0) \
         {\
             DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::AllocateScope(#scope_name);\
         }\
-        dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(DM_PROFILE_PASTE2(scope, __LINE__), name);\
+        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope, __LINE__), name)
 
 
     #define DM_COUNTER(name, amount) \
-    dmProfile::AddCounter(name, amount);
+        dmProfile::AddCounter(name, amount);
 
     #define DM_COUNTER_HASH(name, name_hash, amount) \
-    dmProfile::AddCounterHash(name, name_hash, amount);
-
+        dmProfile::AddCounterHash(name, name_hash, amount);
 #endif
 
 namespace dmProfile

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 #include <gtest/gtest.h>
+#include "dlib/dstrings.h"
 #include "dlib/hash.h"
 #include "dlib/profile.h"
 #include "dlib/time.h"
@@ -306,6 +307,81 @@ TEST(dmProfile, ThreadProfile)
 
     ASSERT_EQ(20000U * 2U, samples.size());
     ASSERT_EQ(20000 * 2, scopes["X"]->m_Count);
+
+    dmProfile::Finalize();
+}
+
+TEST(dmProfile, DynamicScope)
+{
+    const char* FUNCTION_NAMES[] = {
+        "FirstFunction",
+        "SecondFunction",
+        "ThirdFunction"
+    };
+
+    const char* SCOPE_NAMES[] = {
+        "Scope1",
+        "Scope2"
+    };
+
+    dmProfile::Initialize(128, 1024 * 1024, 16);
+
+    dmProfile::Scope* scope0 = dmProfile::AllocateScope(SCOPE_NAMES[0]);
+    dmProfile::Scope* scope1 = dmProfile::AllocateScope(SCOPE_NAMES[1]);
+
+    dmProfile::HProfile profile = dmProfile::Begin();
+    dmProfile::Release(profile);
+
+    char name0[128];
+    DM_SNPRINTF(name0, sizeof(name0), "%s@%s", "test.script", FUNCTION_NAMES[0]);
+
+    char name1[128];
+    DM_SNPRINTF(name1, sizeof(name1), "%s@%s", "test.script", FUNCTION_NAMES[1]);
+
+    char name2[128];
+    DM_SNPRINTF(name2, sizeof(name2), "%s@%s", "test.script", FUNCTION_NAMES[2]);
+
+    for (uint i = 0; i < 10 ; ++i)
+    {
+        {
+            DM_PROFILE_SCOPE(scope0, name0);
+            DM_PROFILE_SCOPE(scope1, name1);
+        }
+        {
+            DM_PROFILE_SCOPE(scope1, name2);
+        }
+        DM_PROFILE_SCOPE(scope0, name0);
+    }
+
+    std::vector<dmProfile::Sample> samples;
+    std::map<std::string, const dmProfile::ScopeData*> scopes;
+
+    profile = dmProfile::Begin();
+    dmProfile::IterateSamples(profile, &samples, &ProfileSampleCallback);
+    dmProfile::IterateScopeData(profile, &scopes, &ProfileScopeCallback);
+
+    ASSERT_EQ(10U * 4U, samples.size());
+    ASSERT_EQ(10U * 2, scopes[SCOPE_NAMES[0]]->m_Count);
+    ASSERT_EQ(10U * 2, scopes[SCOPE_NAMES[1]]->m_Count);
+
+    for (size_t i = 0; i < samples.size(); i++)
+    {
+        dmProfile::Sample* sample = &samples[i];
+        if (sample->m_Scope == scope0)
+        {
+            ASSERT_STREQ(sample->m_Name, name0);
+        }
+        else if (sample->m_Scope == scope1)
+        {
+            ASSERT_TRUE(sample->m_Name == name1 || sample->m_Name == name2);
+        }
+        else
+        {
+            ASSERT_TRUE(false);
+        }
+    }
+
+    dmProfile::Release(profile);
 
     dmProfile::Finalize();
 }

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -119,10 +119,12 @@ namespace dmGameObject
                 ++arg_count;
             }
 
-            char scope_name[128];
+            const char* scope_name = 0;
             if (dmProfile::g_IsInitialized)
             {
-                DM_SNPRINTF(scope_name, sizeof(scope_name), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                char buffer[128];
+                DM_SNPRINTF(buffer, sizeof(buffer), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                scope_name = dmProfile::Internalize(buffer);
             }
             {
                 DM_PROFILE_SCOPE(gProfilerRunScriptScope, scope_name);

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -1,6 +1,7 @@
 
 #include "comp_script.h"
 
+#include <dlib/dstrings.h>
 #include <dlib/profile.h>
 
 #include <script/script.h>
@@ -17,8 +18,15 @@ extern "C"
 
 namespace dmGameObject
 {
+    static dmProfile::Scope* gProfilerRunScriptScope = 0;
+
     CreateResult CompScriptNewWorld(const ComponentNewWorldParams& params)
     {
+        if (dmProfile::g_IsInitialized && gProfilerRunScriptScope == 0)
+        {
+            gProfilerRunScriptScope = dmProfile::AllocateScope("Script");
+        }
+
         if (params.m_World != 0x0)
         {
             CompScriptWorld* w = new CompScriptWorld();
@@ -82,7 +90,7 @@ namespace dmGameObject
 
     ScriptResult RunScript(lua_State* L, HScript script, ScriptFunction script_function, HScriptInstance script_instance, const RunScriptParams& params)
     {
-        DM_PROFILE(Script, "RunScript");
+        DM_PROFILE_SCOPE(gProfilerRunScriptScope, "RunScript");
 
         ScriptResult result = SCRIPT_RESULT_OK;
 
@@ -111,10 +119,17 @@ namespace dmGameObject
                 ++arg_count;
             }
 
-            int ret = dmScript::PCall(L, arg_count, 0);
-            if (ret != 0)
+            char scope_name[128];
+            if (dmProfile::g_IsInitialized)
             {
-                result = SCRIPT_RESULT_FAILED;
+                DM_SNPRINTF(scope_name, sizeof(scope_name), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+            }
+            {
+                DM_PROFILE_SCOPE(gProfilerRunScriptScope, scope_name);
+                if (dmScript::PCall(L, arg_count, 0) != 0)
+                {
+                    result = SCRIPT_RESULT_FAILED;
+                }
             }
 
             lua_pushnil(L);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1794,16 +1794,18 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             }
 
             Result result = RESULT_OK;
-            char scope_name[128];
+            const char* scope_name = 0;
             if (dmProfile::g_IsInitialized)
             {
                 if (custom_ref == LUA_NOREF)
                 {
-                    DM_SNPRINTF(scope_name, sizeof(scope_name), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
+                    char buffer[128];
+                    DM_SNPRINTF(buffer, sizeof(buffer), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
+                    scope_name = dmProfile::Internalize(buffer);
                 }
                 else
                 {
-                    DM_SNPRINTF(scope_name, sizeof(scope_name), "<unknown>@<unknown>");
+                    scope_name = "<unknown>@<unknown>";
                 }
             }
             {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -48,6 +48,8 @@ namespace dmGui
     const uint64_t INDEX_SHIFT = CLIPPER_SHIFT + CLIPPER_RANGE;
     const uint64_t LAYER_SHIFT = INDEX_SHIFT + INDEX_RANGE;
 
+    static dmProfile::Scope* gProfilerGuiScriptScope = 0;
+
     static inline void UpdateTextureSetAnimData(HScene scene, InternalNode* n);
 
     static const char* SCRIPT_FUNCTION_NAMES[] =
@@ -1541,6 +1543,8 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
     Result RunScript(HScene scene, ScriptFunction script_function, int custom_ref, void* args)
     {
+        DM_PROFILE_SCOPE(gProfilerGuiScriptScope, "GuiScript");
+
         if (scene->m_Script == 0x0)
             return RESULT_OK;
 
@@ -1789,15 +1793,29 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 break;
             }
 
-            int ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
-
             Result result = RESULT_OK;
-            if (ret != 0)
+            char scope_name[128];
+            if (dmProfile::g_IsInitialized)
             {
-                assert(top == lua_gettop(L));
-                result = RESULT_SCRIPT_ERROR;
+                if (custom_ref == LUA_NOREF)
+                {
+                    DM_SNPRINTF(scope_name, sizeof(scope_name), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
+                }
+                else
+                {
+                    DM_SNPRINTF(scope_name, sizeof(scope_name), "<unknown>@<unknown>");
+                }
             }
-            else
+            {
+                DM_PROFILE_SCOPE(gProfilerGuiScriptScope, scope_name);
+                if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
+                {
+                    assert(top == lua_gettop(L));
+                    result = RESULT_SCRIPT_ERROR;
+                }
+            }
+
+            if (result == RESULT_OK)
             {
                 switch (script_function)
                 {
@@ -4067,10 +4085,16 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
     HScript NewScript(HContext context)
     {
+        if (dmProfile::g_IsInitialized && gProfilerGuiScriptScope == 0)
+        {
+            gProfilerGuiScriptScope = dmProfile::AllocateScope("Script");
+        }
+
         lua_State* L = context->m_LuaState;
         Script* script = (Script*)lua_newuserdata(L, sizeof(Script));
         ResetScript(script);
         script->m_Context = context;
+        script->m_SourceFileName = 0;
 
         luaL_getmetatable(L, GUI_SCRIPT);
         lua_setmetatable(L, -2);
@@ -4147,7 +4171,9 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             lua_pushnil(L);
             lua_setglobal(L, SCRIPT_FUNCTION_NAMES[i]);
         }
-
+        // m_SourceFileName will be null if profiling is not enabled, this is fine
+        // as m_SourceFileName will only be used if profiling is enabled
+        script->m_SourceFileName = dmProfile::Internalize(source->m_Filename);
 bail:
         assert(top == lua_gettop(L));
         return res;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -210,6 +210,7 @@ namespace dmGui
     {
         int         m_FunctionReferences[MAX_SCRIPT_FUNCTION_COUNT];
         Context*    m_Context;
+        const char* m_SourceFileName;
         int         m_InstanceReference;
     };
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2796,10 +2796,12 @@ bail:
                 dmScript::PushURL(L, message->m_Sender);
             }
 
-            char scope_name[128];
+            const char* scope_name = 0;
             if (dmProfile::g_IsInitialized)
             {
-                DM_SNPRINTF(scope_name, sizeof(scope_name), "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
+                char buffer[128];
+                DM_SNPRINTF(buffer, sizeof(buffer), "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
+                scope_name = dmProfile::Internalize(buffer);
             }
             {
                 DM_PROFILE_SCOPE(gProfilerRunScriptScope, scope_name);

--- a/engine/render/src/render/render_script.h
+++ b/engine/render/src/render/render_script.h
@@ -26,6 +26,7 @@ namespace dmRender
     {
         int             m_FunctionReferences[MAX_RENDER_SCRIPT_FUNCTION_COUNT];
         RenderContext*  m_RenderContext;
+        const char*     m_SourceFileName;
         int             m_InstanceReference;
     };
 


### PR DESCRIPTION
This adds "GuiScript" and "RenderScript" scopes that covers all script functions in gui and render respectively. It also adds function scopes for the individual script functions with '<function_name>@<script_file>" to easier identify cpu hogs in scripts.

This first step adds more hashing on each profile function scope on script execution, it should not be much but it is a bit unfortunate.

A more general overhaul would be good to just do the hashing once and use the hash for entering/exiting scopes.