### PR TITLE
DEF-3607 fix pprint single values

### DIFF
--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -57,8 +57,8 @@ static dmLogServer* g_dmLogServer = 0;
 static dmLogSeverity g_LogLevel = DM_LOG_SEVERITY_USER_DEBUG;
 static int g_TotalBytesLogged = 0;
 static FILE* g_LogFile = 0;
-static dmCustomLogCallback g_CustomLogCallback = 0x0;
-static void* g_CustomLogCallbackUserData = 0x0;
+static dmCustomLogCallback g_CustomLogCallback = 0;
+static void* g_CustomLogCallbackUserData = 0;
 
 // create and bind the server socket, will reuse old port if supplied handle valid
 static void dmLogInitSocket( dmSocket::Socket& server_socket )

--- a/engine/dlib/src/dlib/log.h
+++ b/engine/dlib/src/dlib/log.h
@@ -75,6 +75,21 @@ void dmLogSetlevel(dmLogSeverity severity);
 void dmSetLogFile(const char* path);
 
 /**
+ * Callback declaration for dmSetCustomLogCallback
+ */
+typedef void (*dmCustomLogCallback)(void* user_data, const char* s);
+
+/**
+ * Sets a custom callback for log output, if this function is set output
+ * will only be sent to this callback.
+ * Useful for testing purposes to validate logging output from a test
+ * Calling dmSetCustomLogCallback with (0x0, 0x0) will restore normal operation
+ * @param callback the callback to call with output, once per logging call
+ * @param user_data user data pointer that is provided as context in the callback
+ */
+void dmSetCustomLogCallback(dmCustomLogCallback callback, void* user_data);
+
+/**
  * iOS specific print function that wraps NSLog to be able to
  * output logging to the device/XCode log.
  *

--- a/engine/dlib/src/test/test_log.cpp
+++ b/engine/dlib/src/test/test_log.cpp
@@ -100,10 +100,7 @@ static void TestLogCaptureCallback(void* user_data, const char* log)
 {
     dmArray<char>* log_output = (dmArray<char>*)user_data;
     uint32_t len = (uint32_t)strlen(log);
-    if (log_output->Capacity() < log_output->Size() + len + 1)
-    {
-        log_output->SetCapacity(log_output->Size() + len + 1);
-    }
+    log_output->SetCapacity(log_output->Size() + len + 1);
     log_output->PushArray(log, len);
 }
 

--- a/engine/dlib/src/test/test_log.cpp
+++ b/engine/dlib/src/test/test_log.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <map>
 #include <gtest/gtest.h>
+#include "../dlib/array.h"
 #include "../dlib/hash.h"
 #include "../dlib/log.h"
 #include "../dlib/dstrings.h"
@@ -93,6 +94,40 @@ TEST(dmLog, LogFile)
     ASSERT_TRUE(strstr(tmp, "TESTING_LOG") != 0);
     dmSys::Unlink(path);
     fclose(f);
+}
+
+static void TestLogCaptureCallback(void* user_data, const char* log)
+{
+    dmArray<char>* log_output = (dmArray<char>*)user_data;
+    uint32_t len = (uint32_t)strlen(log);
+    if (log_output->Capacity() < log_output->Size() + len + 1)
+    {
+        log_output->SetCapacity(log_output->Size() + len + 1);
+    }
+    log_output->PushArray(log, len);
+}
+
+TEST(dmLog, TestCapture)
+{
+    dmArray<char> log_output;
+    dmSetCustomLogCallback(TestLogCaptureCallback, &log_output);
+    dmLogDebug("This is a debug message");
+    dmLogInfo("This is a info message");
+    dmLogWarning("This is a warning message");
+    dmLogError("This is a error message");
+    dmLogFatal("This is a fata message");
+
+    log_output.Push(0);
+
+    const char* ExpectedOutput =
+                "INFO:DLIB: This is a info message\n"
+                "WARNING:DLIB: This is a warning message\n"
+                "ERROR:DLIB: This is a error message\n"
+                "FATAL:DLIB: This is a fata message\n";
+
+    ASSERT_STREQ(ExpectedOutput,
+                log_output.Begin());
+    dmSetCustomLogCallback(0x0, 0x0);
 }
 
 int main(int argc, char **argv)

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -363,7 +363,7 @@ namespace dmScript
 
         if (printed_tables.Get((uintptr_t)table_data) != 0x0)
         {
-            printer->Printf("{ ... } -- %p\n", table_data);
+            printer->Printf("{ ... } --[[%p]]", table_data);
             return 0;
         }
 
@@ -382,7 +382,7 @@ namespace dmScript
         if(lua_next(L, -2) == 0)
         {
             // [-1] table
-            printer->Printf("{ } -- %p\n", table_data);
+            printer->Printf("{ } --[[%p]]", table_data);
             lua_pop(L, 1);
             return 0;
         }
@@ -390,11 +390,13 @@ namespace dmScript
         // [-3] table
         // [-2] key
         // [-1] value
-        printer->Printf("{ -- %p\n", table_data);
+        printer->Printf("{ --[[%p]]", table_data);
         printer->Indent(2);
 
+        bool is_first = true;
         do
         {
+            printer->Printf("%s\n", is_first ? "" : ",");
             int value_type = lua_type(L, -1);
 
             const char* key_string = PushValueAsString(L, -2);
@@ -419,7 +421,7 @@ namespace dmScript
             }
             else if (value_type == LUA_TSTRING)
             {
-                printer->Printf("\"%s\",\n", lua_tostring(L, -1));
+                printer->Printf("\"%s\"", lua_tostring(L, -1));
             }
             else
             {
@@ -433,7 +435,7 @@ namespace dmScript
                 // [-2] value
                 // [-1] value name
 
-                printer->Printf("%s,\n", value_string);
+                printer->Printf("%s", value_string);
                 lua_pop(L, 1);
                 // [-3] table
                 // [-2] key
@@ -443,12 +445,14 @@ namespace dmScript
             lua_pop(L, 1);
             // [-2] table
             // [-1] key
+            is_first = false;
         } while (lua_next(L, -2) != 0);
 
         // [-1] table
 
         printer->Indent(-2);
-        printer->Printf("},\n");
+        printer->Printf("\n");
+        printer->Printf("}");
 
         printed_tables.Erase((uintptr_t)table_data);
 
@@ -508,16 +512,16 @@ namespace dmScript
                     printer.Printf("\n");
                 }
                 DoLuaPPrintTable(L, s, &printer, printed_tables);
+                printer.Printf("%s", (n > s) ? ",\n" : "");
             }
             else
             {
                 const char* value_str = PushValueAsString(L, s);
-                if (value_str = 0x0)
                 if (value_str == 0x0)
                 {
                     return luaL_error(L, LUA_QL("tostring") " must return a string to " LUA_QL("print"));
                 }
-                printer.Printf("%s,\n", value_str);
+                printer.Printf("%s%s", value_str, (n > s) ? ",\n" : "");
                 lua_pop(L, 1);
             }
         }

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -513,6 +513,7 @@ namespace dmScript
             {
                 const char* value_str = PushValueAsString(L, s);
                 if (value_str = 0x0)
+                if (value_str == 0x0)
                 {
                     return luaL_error(L, LUA_QL("tostring") " must return a string to " LUA_QL("print"));
                 }

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -39,7 +39,7 @@ protected:
     {
         char* read_ptr = str;
         char* write_ptr = str;
-        const char* address_prefix = " --[[0x";
+        const char* address_prefix = " --[[0";
         size_t address_prefix_length = strlen(address_prefix);
         char* addr_ptr = strstr(str, address_prefix);
         while (addr_ptr != 0x0)
@@ -50,7 +50,12 @@ protected:
             {
                 *write_ptr++ = *read_ptr++;
             }
-            read_ptr = strstr(read_ptr, "]]");
+            char* address_end = strstr(read_ptr, "]]");
+            if (address_end && (address_end - read_ptr) <= 16)
+            {
+                // Only skip if it was actually short enough to be an address
+                read_ptr = address_end;
+            }
             addr_ptr = strstr(read_ptr, address_prefix);
         }
         strcpy(write_ptr, read_ptr);
@@ -124,9 +129,9 @@ TEST_F(ScriptTest, TestPPrint)
         "DEBUG:SCRIPT: 123\n"
         "DEBUG:SCRIPT: smore\n"
         "DEBUG:SCRIPT: \n"
-        "{ --[[0x]]\n"
-        "  1 = { --[[0x]]\n"
-        "    y = { --[[0x]]\n"
+        "{ --[[0]]\n"
+        "  1 = { --[[0]]\n"
+        "    y = { --[[0]]\n"
         "      m = vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1),\n"
         "      q = vmath.quat(0, 0, 0, 1),\n"
         "      n = vmath.vector3(0, 0, 0)\n"
@@ -135,13 +140,13 @@ TEST_F(ScriptTest, TestPPrint)
         "    z = 3\n"
         "  },\n"
         "  2 = \"hello\",\n"
-        "  3 = { } --[[0x]],\n"
+        "  3 = { } --[[0]],\n"
         "  foo = 123\n"
         "}\n"
         "DEBUG:SCRIPT: \n"
-        "{ --[[0x]]\n"
-        "  1 = { --[[0x]]\n"
-        "    y = { --[[0x]]\n"
+        "{ --[[0]]\n"
+        "  1 = { --[[0]]\n"
+        "    y = { --[[0]]\n"
         "      m = vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1),\n"
         "      q = vmath.quat(0, 0, 0, 1),\n"
         "      n = vmath.vector3(0, 0, 0)\n"
@@ -150,11 +155,11 @@ TEST_F(ScriptTest, TestPPrint)
         "    z = 3\n"
         "  },\n"
         "  2 = \"hello\",\n"
-        "  3 = { } --[[0x]],\n"
+        "  3 = { } --[[0]],\n"
         "  foo = 123\n"
         "},\n"
         "more,\n"
-        "{ --[[0x]]\n"
+        "{ --[[0]]\n"
         "  b = 2,\n"
         "  a = 1,\n"
         "  c = 3\n"
@@ -178,10 +183,10 @@ TEST_F(ScriptTest, TestCircularRefPPrint)
     const char* ExpectedOutput = 
         "DEBUG:SCRIPT: testing pprint with circular ref\n"
         "DEBUG:SCRIPT: \n"
-        "{ --[[0x]]\n"
+        "{ --[[0]]\n"
         "  foo = \"an old man was telling stories of circular references.\",\n"
-        "  gnu = { --[[0x]]\n"
-        "    gnat = { ... } --[[0x]],\n"
+        "  gnu = { --[[0]]\n"
+        "    gnat = { ... } --[[0]],\n"
         "    bar = \"It was a dark and stormy night,\"\n"
         "  }\n"
         "}\n";

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -51,7 +51,7 @@ protected:
                 *write_ptr++ = *read_ptr++;
             }
             char* address_end = strstr(read_ptr, "]]");
-            if (address_end && (address_end - read_ptr) <= 16)
+            if (address_end && (address_end - read_ptr) <= 18)
             {
                 // Only skip if it was actually short enough to be an address
                 read_ptr = address_end;

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -22,6 +22,7 @@ class ScriptTest : public ::testing::Test
 protected:
     virtual void SetUp()
     {
+        dmSetCustomLogCallback(LogCallback, this);
         m_Context = dmScript::NewContext(0x0, 0, true);
         dmScript::Initialize(m_Context);
         L = dmScript::GetLuaState(m_Context);
@@ -31,10 +32,53 @@ protected:
     {
         dmScript::Finalize(m_Context);
         dmScript::DeleteContext(m_Context);
+        dmSetCustomLogCallback(0x0, 0x0);
+    }
+
+    const char* RemoveTableAddresses(char* str)
+    {
+        char* read_ptr = str;
+        char* write_ptr = str;
+        const char* address_prefix = " --[[0x";
+        size_t address_prefix_length = strlen(address_prefix);
+        char* addr_ptr = strstr(str, address_prefix);
+        while (addr_ptr != 0x0)
+        {
+            uintptr_t offset = addr_ptr - read_ptr;
+            size_t copy_length = offset + address_prefix_length;
+            while (copy_length --)
+            {
+                *write_ptr++ = *read_ptr++;
+            }
+            read_ptr = strstr(read_ptr, "]]");
+            addr_ptr = strstr(read_ptr, address_prefix);
+        }
+        strcpy(write_ptr, read_ptr);
+        return str;
+    }
+
+    char* GetLog()
+    {
+        m_Log.Push('\0');
+        return m_Log.Begin();
+    }
+
+    void AppendToLog(const char* log)
+    {
+        uint32_t len = strlen(log);
+        m_Log.SetCapacity(m_Log.Size() + len + 1);
+        m_Log.PushArray(log, len);
+    }
+
+    static void LogCallback(void* user_data, const char* log)
+    {
+        ScriptTest* i = (ScriptTest*)user_data;
+        i->AppendToLog(log);
     }
 
     dmScript::HContext m_Context;
     lua_State* L;
+    dmArray<char> m_Log;
 };
 
 bool RunFile(lua_State* L, const char* filename)
@@ -66,6 +110,7 @@ TEST_F(ScriptTest, TestPrint)
     ASSERT_TRUE(RunString(L, "print(\"test\", \"multiple\")"));
 
     ASSERT_EQ(top, lua_gettop(L));
+    ASSERT_STREQ("DEBUG:SCRIPT: test print\nDEBUG:SCRIPT: test\tmultiple\n", GetLog());
 }
 
 TEST_F(ScriptTest, TestPPrint)
@@ -73,6 +118,54 @@ TEST_F(ScriptTest, TestPPrint)
     int top = lua_gettop(L);
     ASSERT_TRUE(RunFile(L, "test_script.luac"));
     ASSERT_EQ(top, lua_gettop(L));
+
+    const char* ExpectedOutput = 
+        "DEBUG:SCRIPT: testing pprint\n"
+        "DEBUG:SCRIPT: 123\n"
+        "DEBUG:SCRIPT: smore\n"
+        "DEBUG:SCRIPT: \n"
+        "{ --[[0x]]\n"
+        "  1 = { --[[0x]]\n"
+        "    y = { --[[0x]]\n"
+        "      m = vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1),\n"
+        "      q = vmath.quat(0, 0, 0, 1),\n"
+        "      n = vmath.vector3(0, 0, 0)\n"
+        "    },\n"
+        "    x = 1,\n"
+        "    z = 3\n"
+        "  },\n"
+        "  2 = \"hello\",\n"
+        "  3 = { } --[[0x]],\n"
+        "  foo = 123\n"
+        "}\n"
+        "DEBUG:SCRIPT: \n"
+        "{ --[[0x]]\n"
+        "  1 = { --[[0x]]\n"
+        "    y = { --[[0x]]\n"
+        "      m = vmath.matrix4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1),\n"
+        "      q = vmath.quat(0, 0, 0, 1),\n"
+        "      n = vmath.vector3(0, 0, 0)\n"
+        "    },\n"
+        "    x = 1,\n"
+        "    z = 3\n"
+        "  },\n"
+        "  2 = \"hello\",\n"
+        "  3 = { } --[[0x]],\n"
+        "  foo = 123\n"
+        "},\n"
+        "more,\n"
+        "{ --[[0x]]\n"
+        "  b = 2,\n"
+        "  a = 1,\n"
+        "  c = 3\n"
+        "},\n"
+        "77,\n"
+        "78,\n"
+        "79,\n"
+        "80\n"
+        "DEBUG:SCRIPT: 5\n";
+
+    ASSERT_STREQ(ExpectedOutput, RemoveTableAddresses(GetLog()));
 }
 
 
@@ -81,6 +174,19 @@ TEST_F(ScriptTest, TestCircularRefPPrint)
     int top = lua_gettop(L);
     ASSERT_TRUE(RunFile(L, "test_circular_ref_pprint.luac"));
     ASSERT_EQ(top, lua_gettop(L));
+
+    const char* ExpectedOutput = 
+        "DEBUG:SCRIPT: testing pprint with circular ref\n"
+        "DEBUG:SCRIPT: \n"
+        "{ --[[0x]]\n"
+        "  foo = \"an old man was telling stories of circular references.\",\n"
+        "  gnu = { --[[0x]]\n"
+        "    gnat = { ... } --[[0x]],\n"
+        "    bar = \"It was a dark and stormy night,\"\n"
+        "  }\n"
+        "}\n";
+
+    ASSERT_STREQ(ExpectedOutput, RemoveTableAddresses(GetLog()));
 }
 
 TEST_F(ScriptTest, TestPPrintTruncate)
@@ -88,6 +194,11 @@ TEST_F(ScriptTest, TestPPrintTruncate)
     int top = lua_gettop(L);
     ASSERT_TRUE(RunFile(L, "test_pprint_truncate.luac"));
     ASSERT_EQ(top, lua_gettop(L));
+    const char* log = GetLog();
+    const char* truncate_message_addr = strstr(log, "...\n[Output truncated]\n");
+    ASSERT_NE((const char*)0x0, truncate_message_addr);
+    truncate_message_addr += 23;
+    ASSERT_EQ(0, *truncate_message_addr);
 }
 
 TEST_F(ScriptTest, TestRandom)

--- a/engine/script/src/test/test_script.lua
+++ b/engine/script/src/test/test_script.lua
@@ -1,14 +1,19 @@
 -- pprint
 print("testing pprint")
 pprint(123)
+pprint("smore")
 m = vmath.matrix4()
 local t = {
     foo = 123,
     { x = 1,
       y = { n = vmath.vector3(), q = vmath.quat(0,0,0,1), m = vmath.matrix4() },
       z = 3 },
-    "hello"
+    "hello",
+    { }
 }
 pprint(t)
 
 pprint(t, "more", {a = 1, b = 2, c = 3}, 77, 78, 79, 80)
+
+local n = 5
+pprint(n)


### PR DESCRIPTION
Fix single value output printing “(null)”
Now uses —[[0xf2r39]] to show addresses since we need to add chars after the pointer
Improved formatting - only put commas where we really should and avoid unnecessary line breaks, you should now be able to just pick log output and paste in as lua table.
