### PR TITLE
DEFEDIT-1486 Fix faint underscore characters in code examples

### DIFF
--- a/editor/resources/markdown.css
+++ b/editor/resources/markdown.css
@@ -45,6 +45,7 @@ pre {
 
 pre > code {
     border: none;
+    line-height: 1.5em;
 }
 
 img {


### PR DESCRIPTION
Underscore characters in code examples were cropped out by the default line height.