### PR TITLE
DEF-3122 - Fixed issue with mouse emulation on mobile.

### DIFF
--- a/engine/glfw/lib/input.c
+++ b/engine/glfw/lib/input.c
@@ -318,7 +318,7 @@ GLFWAPI int GLFWAPIENTRY glfwGetTouch(GLFWTouch* touch, int count, int* out_coun
     for (i = 0; i < GLFW_MAX_TOUCH; ++i) {
         GLFWTouch* t = &_glfwInput.Touch[i];
         if (t->Reference) {
-            touch[touchCount++] = *t;
+            touch[touchCount] = *t;
 
             int phase = t->Phase;
             if (phase == GLFW_PHASE_ENDED || phase == GLFW_PHASE_CANCELLED) {
@@ -336,6 +336,7 @@ GLFWAPI int GLFWAPIENTRY glfwGetTouch(GLFWTouch* touch, int count, int* out_coun
                 t->Phase = GLFW_PHASE_ENDED;
             }
 
+            touchCount++;
         }
     }
 

--- a/engine/glfw/lib/input.c
+++ b/engine/glfw/lib/input.c
@@ -76,7 +76,7 @@ GLFWAPI int GLFWAPIENTRY glfwGetMouseButton( int button )
         return GLFW_RELEASE;
     }
 
-    if( _glfwInput.MouseButton[ button ] == GLFW_STICK )
+    if( _glfwInput.MouseButton[ button ] == GLFW_STICK || _glfwInput.MouseButton[ button ] == GLFW_CLICKED )
     {
         // Sticky mode: release mouse button now
         _glfwInput.MouseButton[ button ] = GLFW_RELEASE;

--- a/engine/glfw/lib/internal.h
+++ b/engine/glfw/lib/internal.h
@@ -49,6 +49,7 @@
 
 // Internal key and button state/action definitions
 #define GLFW_STICK 2
+#define GLFW_CLICKED 3
 
 
 //========================================================================

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -250,9 +250,16 @@ void _glfwInputMouseClick( int button, int action )
 {
     if( button >= 0 && button <= GLFW_MOUSE_BUTTON_LAST )
     {
-        // Register mouse button action
-        if( action == GLFW_RELEASE && _glfwInput.StickyMouseButtons )
+        if (_glfwInput.MouseButton[ button ] == GLFW_CLICKED) {
+            return;
+        }
+
+        if( action == GLFW_RELEASE && _glfwInput.MouseButton[ button ] == GLFW_PRESS )
         {
+            _glfwInput.MouseButton[ button ] = GLFW_CLICKED;
+        } else if( action == GLFW_RELEASE && _glfwInput.StickyMouseButtons )
+        {
+            // Register mouse button action
             _glfwInput.MouseButton[ button ] = GLFW_STICK;
         }
         else


### PR DESCRIPTION
Original issue title: `Touch controls are buggy when "Magnification Gestures" are enabled`.

This PR fixes an issue where mouse click emulation on mobile could sometime miss taps (press+release) that occurred within one frame. We had a previous fix for this but it was only done for multi touch handling.

The fix is to catch presses and releases that occurred within one frame and marking them as "clicked" (`GLFW_CLICKED`). When a mouse input is polled (through `glfwGetMouseButton`) that is in the "clicked phase" will first report `GLFW_PRESS` and set the same button to `GLFW_RELEASE` for next frame.