### PR TITLE
DEFEDIT-1488 Wrong field type for group in sound editor

### DIFF
--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -80,7 +80,7 @@
                          :type :boolean}
                         {:path [:group]
                          :label "Group"
-                         :type :number}
+                         :type :string}
                         {:path [:gain]
                          :label "Gain"
                          :type :number}]}]


### PR DESCRIPTION
Fixes defold/editor2-issues#2115
Group is string not number.