### PR TITLE
DEFEDIT-1489 Defold Editor (x64) crashing unexpectedly

### DIFF
--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -496,7 +496,7 @@ the `do-gl` macro from `editor.gl`."
             [_ sz tp] position-attribute]
         (gl/gl-bind-buffer gl GL/GL_ARRAY_BUFFER vbo)
         (gl/gl-enable-vertex-attrib-array gl position-index)
-        (gl/gl-vertex-attrib-pointer gl 0 ^int sz ^int (gl-types tp) false ^int stride ^long position-offset)))))
+        (gl/gl-vertex-attrib-pointer gl ^int position-index ^int sz ^int (gl-types tp) false ^int stride ^long position-offset)))))
 
 (defn- unbind-vertex-buffer! [^GL2 gl request-id ^PersistentVertexBuffer vertex-buffer]
   (let [vbo (scene-cache/request-object! ::vbo request-id gl vertex-buffer)

--- a/editor/src/clj/editor/gl/vertex.clj
+++ b/editor/src/clj/editor/gl/vertex.clj
@@ -495,8 +495,8 @@ the `do-gl` macro from `editor.gl`."
             position-offset (nth offsets position-index)
             [_ sz tp] position-attribute]
         (gl/gl-bind-buffer gl GL/GL_ARRAY_BUFFER vbo)
-        (gl/gl-vertex-attrib-pointer gl 0 ^int sz ^int (gl-types tp) false ^int stride ^long position-offset)
-        (gl/gl-enable-vertex-attrib-array gl position-index)))))
+        (gl/gl-enable-vertex-attrib-array gl position-index)
+        (gl/gl-vertex-attrib-pointer gl 0 ^int sz ^int (gl-types tp) false ^int stride ^long position-offset)))))
 
 (defn- unbind-vertex-buffer! [^GL2 gl request-id ^PersistentVertexBuffer vertex-buffer]
   (let [vbo (scene-cache/request-object! ::vbo request-id gl vertex-buffer)
@@ -510,8 +510,8 @@ the `do-gl` macro from `editor.gl`."
     (gl/gl-bind-buffer gl GL/GL_ARRAY_BUFFER vbo)
     (let [attributes (:attributes (.layout vertex-buffer))
           attrib-locs (vertex-locate-attribs gl shader attributes)]
-      (vertex-attrib-pointers gl shader attributes)
-      (vertex-enable-attribs gl attrib-locs))))
+      (vertex-enable-attribs gl attrib-locs)
+      (vertex-attrib-pointers gl shader attributes))))
 
 (defn- unbind-vertex-buffer-with-shader! [^GL2 gl ^PersistentVertexBuffer vertex-buffer shader]
   (let [attributes (:attributes (.layout vertex-buffer))

--- a/editor/src/clj/editor/gl/vertex2.clj
+++ b/editor/src/clj/editor/gl/vertex2.clj
@@ -213,7 +213,7 @@
             {:keys [components type]} position-attribute]
         (gl/gl-bind-buffer gl GL/GL_ARRAY_BUFFER vbo)
         (gl/gl-enable-vertex-attrib-array gl position-index)
-        (gl/gl-vertex-attrib-pointer gl 0 ^int components ^int (gl-types type) false ^int stride ^long position-offset)))))
+        (gl/gl-vertex-attrib-pointer gl ^int position-index ^int components ^int (gl-types type) false ^int stride ^long position-offset)))))
 
 (defn- unbind-vertex-buffer! [^GL2 gl request-id ^VertexBuffer vertex-buffer shader]
   (let [[vbo _] (request-vbo gl request-id vertex-buffer shader)

--- a/editor/src/clj/editor/gl/vertex2.clj
+++ b/editor/src/clj/editor/gl/vertex2.clj
@@ -212,8 +212,8 @@
             position-offset (nth offsets position-index)
             {:keys [components type]} position-attribute]
         (gl/gl-bind-buffer gl GL/GL_ARRAY_BUFFER vbo)
-        (gl/gl-vertex-attrib-pointer gl 0 ^int components ^int (gl-types type) false ^int stride ^long position-offset)
-        (gl/gl-enable-vertex-attrib-array gl position-index)))))
+        (gl/gl-enable-vertex-attrib-array gl position-index)
+        (gl/gl-vertex-attrib-pointer gl 0 ^int components ^int (gl-types type) false ^int stride ^long position-offset)))))
 
 (defn- unbind-vertex-buffer! [^GL2 gl request-id ^VertexBuffer vertex-buffer shader]
   (let [[vbo _] (request-vbo gl request-id vertex-buffer shader)
@@ -225,8 +225,8 @@
 (defn- bind-vertex-buffer-with-shader! [^GL2 gl request-id ^VertexBuffer vertex-buffer shader]
   (let [[vbo attrib-locs] (request-vbo gl request-id vertex-buffer shader)]
     (gl/gl-bind-buffer gl GL/GL_ARRAY_BUFFER vbo)
-    (vertex-attrib-pointers gl shader (:attributes (.vertex-description vertex-buffer)) attrib-locs)
-    (vertex-enable-attribs gl attrib-locs)))
+    (vertex-enable-attribs gl attrib-locs)
+    (vertex-attrib-pointers gl shader (:attributes (.vertex-description vertex-buffer)) attrib-locs)))
 
 (defn- unbind-vertex-buffer-with-shader! [^GL2 gl request-id ^VertexBuffer vertex-buffer shader]
   (let [[_ attrib-locs] (request-vbo gl request-id vertex-buffer shader)]

--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -73,9 +73,9 @@
   (vec3 position))
 
 (shader/defshader vertex-shader
-  (attribute vec4 position)
+  (attribute vec3 position)
   (defn void main []
-    (setq gl_Position (* gl_ModelViewProjectionMatrix position))))
+    (setq gl_Position (* gl_ModelViewProjectionMatrix (vec4 position 1.0)))))
 
 (shader/defshader fragment-shader
   (uniform vec4 color)


### PR DESCRIPTION
Fixes defold/editor2-issues#2118
According to gl debug logs this seems to happen when drawing in the
selection pass. This is also the only code path where we use
glVertexPointer instead of glVertexAttribPointer. This commit is an
attempt at a workaround for a possibly buggy driver.