### PR TITLE
DEF-3562 font-df distance precision

### DIFF
--- a/engine/engine/content/builtins/fonts/font-df.fp
+++ b/engine/engine/content/builtins/fonts/font-df.fp
@@ -8,7 +8,7 @@ uniform lowp vec4 texture_size_recip;
 
 void main()
 {
-    lowp float distance = texture2D(texture, var_texcoord0).x;
+    mediump float distance = texture2D(texture, var_texcoord0).x;
 
     lowp float sdf_edge = var_sdf_params.x;
     lowp float sdf_outline = var_sdf_params.y;


### PR DESCRIPTION
Using `lowp` precision when reading from sdf texture in built-in fragment shader caused too low precision on some devices (Kindle Fire HD 7 - 2nd Gen).