### PR TITLE
DEFEDIT-1491 Assets deleted instead of being renamed if only capitalization changes

### DIFF
--- a/editor/src/clj/editor/git.clj
+++ b/editor/src/clj/editor/git.clj
@@ -483,7 +483,8 @@
 
   Before stashing, we also revert any case-changes if we're running on a
   case-insensitive file system. We will reapply the case-changes when the stash
-  is applied. We must do this, because a stash
+  is applied. If we do not do this, we will lose any remote changes to case-
+  changed files when applying the stash.
 
   Returns nil if there was nothing to stash, or a map with the stash ref and
   the set of file paths that were staged at the time the stash was made."

--- a/editor/test/editor/git_test.clj
+++ b/editor/test/editor/git_test.clj
@@ -1049,6 +1049,37 @@
       (is (= #{"src/foo.cpp"} (:added (git/status git))))
 
       (git/revert git ["src/foo.cpp"])
+      (is (= #{"src/other.cpp"} (all-files (git/status git))))))
+
+  (testing "case-changed"
+    (with-git [git (new-git)]
+      (create-file git "src/main.cpp" "void main() {}")
+      (create-file git "src/other.cpp" "void other() {}")
+      (commit-src git)
+
+      (move-file git "src/main.cpp" "src/MAIN.cpp")
+      (delete-file git "src/other.cpp")
+
+      (is (= #{"src/main.cpp" "src/other.cpp"} (:missing (git/status git))))
+      (is (= #{"src/MAIN.cpp"} (:untracked (git/status git))))
+
+      (git/revert git ["src/MAIN.cpp"])
+      (is (= #{"src/other.cpp"} (all-files (git/status git))))))
+
+  (testing "case-changed and staged"
+    (with-git [git (new-git)]
+      (create-file git "src/main.cpp" "void main() {}")
+      (create-file git "src/other.cpp" "void other() {}")
+      (commit-src git)
+
+      (move-file git "src/main.cpp" "src/MAIN.cpp")
+      (delete-file git "src/other.cpp")
+      (git/stage-all! git)
+
+      (is (= #{"src/main.cpp" "src/other.cpp"} (:removed (git/status git))))
+      (is (= #{"src/MAIN.cpp"} (:added (git/status git))))
+
+      (git/revert git ["src/MAIN.cpp"])
       (is (= #{"src/other.cpp"} (all-files (git/status git)))))))
 
 (deftest locked-files-test

--- a/editor/test/editor/git_test.clj
+++ b/editor/test/editor/git_test.clj
@@ -791,6 +791,7 @@
                        "src/local_modified_remote_moved.txt"
                        "src/remote_deleted.txt"
                        "src/remote_moved.txt"}} (simple-status remote-git)))
+
     (-> remote-git .commit (.setMessage "Remote changes") .call)
 
     ;; Stash conflicting changes on local.
@@ -819,6 +820,7 @@
                        "src/local_deleted_remote_modified.txt"
                        "src/local_moved.txt"
                        "src/local_moved_remote_modified.txt"}} (simple-status local-git)))
+
     (let [stash-info (git/stash! local-git)]
       ;; Verify our working directory is clean.
       (is (= {} (simple-status local-git)))
@@ -925,23 +927,40 @@
 
     ;; The stash is being merged onto the latest commit from the remote, so in
     ;; the :conflicting-stage-state map "us" is the remote and "them" is stash.
-    (is (= {:untracked #{"src/both_CHANGED_case_conflicting.txt"
-                         "src/local_CHANGED_case_remote_modified.txt"
-                         "src/moved/both_moved_conflicting_a.txt"
-                         "src/moved/local_moved.txt"
-                         "src/moved/local_moved_remote_modified.txt"
-                         "src/new/local_added.txt"}
-            :modified #{"src/local_modified.txt"}
-            :conflicting-stage-state {"src/both_modified_conflicting.txt"     :both-modified
-                                      "src/local_deleted_remote_modified.txt" :deleted-by-them
-                                      "src/local_modified_remote_deleted.txt" :deleted-by-us
-                                      "src/local_modified_remote_moved.txt"   :deleted-by-us
-                                      "src/local_moved_remote_modified.txt"   :deleted-by-them
-                                      "src/new/both_added_conflicting.txt"    :both-added}
-            :missing #{"src/both_changed_CASE_conflicting.txt"
-                       "src/local_changed_case_remote_modified.txt"
-                       "src/local_deleted.txt"
-                       "src/local_moved.txt"}} (simple-status local-git)))))
+    (if fs/case-sensitive?
+      (is (= {:untracked #{"src/both_CHANGED_case_conflicting.txt"
+                           "src/local_CHANGED_case_remote_modified.txt"
+                           "src/moved/both_moved_conflicting_a.txt"
+                           "src/moved/local_moved.txt"
+                           "src/moved/local_moved_remote_modified.txt"
+                           "src/new/local_added.txt"}
+              :modified #{"src/local_modified.txt"}
+              :conflicting-stage-state {"src/both_modified_conflicting.txt"          :both-modified
+                                        "src/local_changed_case_remote_modified.txt" :deleted-by-them
+                                        "src/local_deleted_remote_modified.txt"      :deleted-by-them
+                                        "src/local_modified_remote_deleted.txt"      :deleted-by-us
+                                        "src/local_modified_remote_moved.txt"        :deleted-by-us
+                                        "src/local_moved_remote_modified.txt"        :deleted-by-them
+                                        "src/new/both_added_conflicting.txt"         :both-added}
+              :missing #{"src/local_deleted.txt"
+                         "src/local_moved.txt"}} (simple-status local-git)))
+      (is (= {:untracked #{"src/both_CHANGED_case_conflicting.txt"
+                           "src/local_CHANGED_case_remote_modified.txt"
+                           "src/moved/both_moved_conflicting_a.txt"
+                           "src/moved/local_moved.txt"
+                           "src/moved/local_moved_remote_modified.txt"
+                           "src/new/local_added.txt"}
+              :modified #{"src/local_modified.txt"}
+              :conflicting-stage-state {"src/both_modified_conflicting.txt"     :both-modified
+                                        "src/local_deleted_remote_modified.txt" :deleted-by-them
+                                        "src/local_modified_remote_deleted.txt" :deleted-by-us
+                                        "src/local_modified_remote_moved.txt"   :deleted-by-us
+                                        "src/local_moved_remote_modified.txt"   :deleted-by-them
+                                        "src/new/both_added_conflicting.txt"    :both-added}
+              :missing #{"src/both_changed_CASE_conflicting.txt"
+                         "src/local_changed_case_remote_modified.txt"
+                         "src/local_deleted.txt"
+                         "src/local_moved.txt"}} (simple-status local-git))))))
 
 (deftest stash-drop-test
   (with-git [git (new-git)]

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -504,7 +504,7 @@
 
 (defn- test-conflict-resolution [resolve! expected-status expected-contents-by-file-path]
   (with-git [remote-git (init-git)
-             local-git (create-conflict-zoo! remote-git [".internal"])]
+             local-git (create-conflict-zoo! remote-git [".internal"] false)]
     (git/stage-all! remote-git)
     (-> remote-git .commit (.setMessage "Remote commit with conflicting changes") .call)
     (let [prefs (make-prefs)
@@ -552,19 +552,19 @@
   (testing ":pull/conflicts"
     (testing "Use ours"
       (test-conflict-resolution sync/use-ours!
-                                {:changed                #{"src/local_modified.txt"}
-                                 :conflicting-stage-state {"src/both_modified_conflicting.txt"     :both-modified
+                                {:conflicting-stage-state {"src/both_modified_conflicting.txt"     :both-modified
                                                            "src/local_deleted_remote_modified.txt" :deleted-by-them
                                                            "src/local_modified_remote_deleted.txt" :deleted-by-us
                                                            "src/local_modified_remote_moved.txt"   :deleted-by-us
                                                            "src/local_moved_remote_modified.txt"   :deleted-by-them
                                                            "src/new/both_added_conflicting.txt"    :both-added}
-                                 :missing                #{"src/local_deleted_remote_modified.txt"
+                                 :missing                #{"src/local_deleted.txt"
+                                                           "src/local_deleted_remote_modified.txt"
+                                                           "src/local_moved.txt"
                                                            "src/local_moved_remote_modified.txt"}
                                  :modified               #{"src/both_modified_conflicting.txt"
+                                                           "src/local_modified.txt"
                                                            "src/new/both_added_conflicting.txt"}
-                                 :removed                #{"src/local_deleted.txt"
-                                                           "src/local_moved.txt"}
                                  :untracked              #{"src/local_modified_remote_deleted.txt"
                                                            "src/local_modified_remote_moved.txt"
                                                            "src/moved/both_moved_conflicting_a.txt"
@@ -590,15 +590,15 @@
                                  "src/remote_modified.txt"                   "remote_modified, modified by remote."}))
     (testing "Use theirs"
       (test-conflict-resolution sync/use-theirs!
-                                {:changed                #{"src/local_modified.txt"}
-                                 :conflicting-stage-state {"src/both_modified_conflicting.txt"     :both-modified
+                                {:conflicting-stage-state {"src/both_modified_conflicting.txt"     :both-modified
                                                            "src/local_deleted_remote_modified.txt" :deleted-by-them
                                                            "src/local_modified_remote_deleted.txt" :deleted-by-us
                                                            "src/local_modified_remote_moved.txt"   :deleted-by-us
                                                            "src/local_moved_remote_modified.txt"   :deleted-by-them
                                                            "src/new/both_added_conflicting.txt"    :both-added}
-                                 :removed                #{"src/local_deleted.txt"
+                                 :missing                #{"src/local_deleted.txt"
                                                            "src/local_moved.txt"}
+                                 :modified               #{"src/local_modified.txt"}
                                  :untracked              #{"src/moved/both_moved_conflicting_a.txt"
                                                            "src/moved/local_moved.txt"
                                                            "src/moved/local_moved_remote_modified.txt"

--- a/editor/test/editor/sync_test.clj
+++ b/editor/test/editor/sync_test.clj
@@ -505,7 +505,7 @@
 (defn- test-conflict-resolution [resolve! expected-status expected-contents-by-file-path]
   (with-git [remote-git (init-git)
              local-git (create-conflict-zoo! remote-git [".internal"])]
-    (autostage remote-git)
+    (git/stage-all! remote-git)
     (-> remote-git .commit (.setMessage "Remote commit with conflicting changes") .call)
     (let [prefs (make-prefs)
           creds (git/credentials prefs)


### PR DESCRIPTION
Fixes defold/editor2-issues#2308