### PR TITLE
DEFEDIT-1493 Remember Search in Files dialog settings between sessions

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1472,10 +1472,10 @@ If you do not specifically require different script states, consider changing th
       (query-and-open! workspace project app-view prefs term))))
 
 (handler/defhandler :search-in-files :global
-  (run [project app-view search-results-view]
+  (run [project app-view prefs search-results-view]
     (when-let [term (get-view-text-selection (g/node-value app-view :active-view-info))]
-      (search-results-view/set-search-term! term))
-    (search-results-view/show-search-in-files-dialog! search-results-view project)))
+      (search-results-view/set-search-term! prefs term))
+    (search-results-view/show-search-in-files-dialog! search-results-view project prefs)))
 
 (defn- bundle! [changes-view build-errors-view project prefs platform bundle-options]
   (console/clear-console!)


### PR DESCRIPTION
### User-facing changes
* We now remember the search term and file types settings in the Search in Files dialog between editing sessions.