### PR TITLE
DEFEDIT-1434 Clickable script errors in Console

### DIFF
--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -2,6 +2,7 @@
   (:require [dynamo.graph :as g]
             [editor.asset-browser :as asset-browser]
             [editor.changes-view :as changes-view]
+            [editor.console :as console]
             [editor.outline-view :as outline-view]
             [editor.prefs :as prefs]
             [editor.properties-view :as properties-view])
@@ -62,3 +63,6 @@
 (def changed-files-view (partial view-of-type changes-view/ChangesView))
 (def outline-view (partial view-of-type outline-view/OutlineView))
 (def properties-view (partial view-of-type properties-view/PropertiesView))
+
+(defn console-view []
+  (-> (view-of-type console/ConsoleNode) (g/targets-of :lines) ffirst))

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -162,7 +162,7 @@
                                                             bob/html5-url-prefix (partial bob/html5-handler project)})
                                    http-server/start!)
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
-          console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane)
+          console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          (fn [resource selected-node-ids opts]
                                                                            (when (open-resource resource opts)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -162,7 +162,7 @@
                                                             bob/html5-url-prefix (partial bob/html5-handler project)})
                                    http-server/start!)
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
-          console-view         (console/make-console! *view-graph* console-tab console-grid-pane)
+          console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          (fn [resource selected-node-ids opts]
                                                                            (when (open-resource resource opts)

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -2178,7 +2178,8 @@
                                           (some? scroll-x) (assoc :scroll-x scroll-x)
                                           (some? scroll-y) (assoc :scroll-y scroll-y))))]
         (cond-> scroll-properties
-                (not= cursor-ranges new-cursor-ranges) (merge {:cursor-ranges new-cursor-ranges})))
+                (not= cursor-ranges new-cursor-ranges) (merge {:cursor-ranges new-cursor-ranges
+                                                               :hovered-element nil})))
 
       ;; Drag selection.
       :cursor-range-selection
@@ -2206,11 +2207,12 @@
                                  :to (adjust-cursor lines (->Cursor (inc (.row mouse-cursor)) 0)))))
             new-cursor-ranges [cursor-range]]
         (when (not= cursor-ranges new-cursor-ranges)
-          (merge {:cursor-ranges new-cursor-ranges}
+          (merge {:cursor-ranges new-cursor-ranges
+                  :hovered-element nil}
                  (scroll-to-any-cursor layout lines new-cursor-ranges))))
       nil)))
 
-(defn- element-at-position [^LayoutInfo layout x y]
+(defn- element-at-position [lines visible-regions ^LayoutInfo layout x y]
   (cond
     ;; Horizontal scroll tab.
     (some-> (.scroll-tab-x layout) (rect-contains? x y))
@@ -2230,21 +2232,30 @@
     (when-some [^Rect r (.scroll-tab-y layout)]
       (and (<= (.x r) x (+ (.x r) (.w r)))
            (> ^double y (+ (.y r) (* 0.5 (.h r))))))
-    {:type :ui-element :ui-element :scroll-bar-y-down}))
+    {:type :ui-element :ui-element :scroll-bar-y-down}
 
-(defn- mouse-hover [^LayoutInfo layout hovered-element x y]
-  (let [new-hovered-element (element-at-position layout x y)]
+    :else
+    (when-some [clickable-region (some (fn [region]
+                                         (when (and (some? (:on-click! region))
+                                                    (some #(rect-contains? % x y)
+                                                          (cursor-range-rects layout lines region)))
+                                           region))
+                                       visible-regions)]
+      {:type :region :region clickable-region})))
+
+(defn- mouse-hover [lines visible-regions ^LayoutInfo layout hovered-element x y]
+  (let [new-hovered-element (element-at-position lines visible-regions layout x y)]
     (when (not= hovered-element new-hovered-element)
       {:hovered-element new-hovered-element})))
 
-(defn mouse-moved [lines cursor-ranges ^LayoutInfo layout ^GestureInfo gesture-start hovered-element x y]
+(defn mouse-moved [lines cursor-ranges visible-regions ^LayoutInfo layout ^GestureInfo gesture-start hovered-element x y]
   (if (some? gesture-start)
     (mouse-gesture lines cursor-ranges layout gesture-start x y)
-    (mouse-hover layout hovered-element x y)))
+    (mouse-hover lines visible-regions layout hovered-element x y)))
 
-(defn mouse-released [^LayoutInfo layout ^GestureInfo gesture-start button x y]
+(defn mouse-released [lines visible-regions ^LayoutInfo layout ^GestureInfo gesture-start button x y]
   (when (= button (some-> gesture-start :button))
-    (assoc (mouse-hover layout ::force-evaluation x y)
+    (assoc (mouse-hover lines visible-regions layout ::force-evaluation x y)
       :gesture-start nil)))
 
 (defn mouse-exited [^GestureInfo gesture-start hovered-element]

--- a/editor/src/clj/editor/code/util.clj
+++ b/editor/src/clj/editor/code/util.clj
@@ -1,6 +1,7 @@
 (ns editor.code.util
   (:require [clojure.string :as string])
   (:import (clojure.lang MapEntry)
+           (java.util Collections Comparator List)
            (java.util.regex Matcher Pattern)))
 
 (set! *warn-on-reflection* true)
@@ -17,6 +18,59 @@
 
 (defmacro comparisons [& exps]
   (apply comparisons-syntax exps))
+
+(defn- ->insert-index
+  ^long [^long binary-search-result]
+  ;; Collections/binarySearch returns a non-negative value if an exact match is
+  ;; found. Otherwise it returns (-(insertion point) - 1). The insertion point
+  ;; is defined as the point at which the key would be inserted into the list:
+  ;; the index of the first element greater than the key, or list.size() if all
+  ;; elements in the list are less than the specified key.
+  (if (neg? binary-search-result)
+    (Math/abs (inc binary-search-result))
+    (inc binary-search-result)))
+
+(defn find-insert-index
+  "Finds the insertion index in an ordered collection. If the collection is not
+  ordered, the result is undefined. New items will be inserted after exact
+  matches, or between two non-exact matches that each compare differently to
+  item using the supplied comparator."
+  ([coll item]
+   (find-insert-index coll item compare))
+  ([^List coll item ^Comparator comparator]
+   (let [search-result (Collections/binarySearch coll item comparator)]
+     (->insert-index search-result))))
+
+(defn insert
+  "Inserts an item at the specified position in a vector. Shifts the item
+  currently at that position (if any) and any subsequent items to the right
+  (adds one to their indices). Returns the new vector."
+  [coll index item]
+  (into (subvec coll 0 index)
+        (cons item
+              (subvec coll index))))
+
+(defn insert-sort
+  "Inserts an item into an ordered vector. If the collection is not ordered, the
+  result is undefined. The insert index will be determined by comparing items.
+  New items will be inserted after exact matches, or between two non-exact
+  matches that each compare differently to item using the supplied comparator.
+  Returns the new vector."
+  ([coll item]
+   (insert-sort coll item compare))
+  ([coll item comparator]
+   (insert coll (find-insert-index coll item comparator) item)))
+
+(defn last-index-where
+  "Returns the index of the last element in coll where pred returns true,
+  or nil if there was no matching element. The coll must support addressing
+  using nth."
+  [pred coll]
+  (loop [index (dec (count coll))]
+    (when-not (neg? index)
+      (if (pred (nth coll index))
+        index
+        (recur (dec index))))))
 
 (defn pair
   "Returns a two-element collection that implements IPersistentVector."

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1395,7 +1395,7 @@
                      (= :scroll-bar-y-hold-down gesture-type))
                  javafx.scene.Cursor/DEFAULT
 
-                 (= :resource-reference (:type (:region hovered-element)))
+                 (some? (:on-click! (:region hovered-element)))
                  javafx.scene.Cursor/HAND
 
                  (data/rect-contains? (.canvas layout) x y)
@@ -1447,21 +1447,17 @@
 
 (defn handle-mouse-released! [view-node ^MouseEvent event]
   (.consume event)
-  (let [hovered-element (get-property view-node :hovered-element)
-        ^GestureInfo gesture-start (get-property view-node :gesture-start)]
-    (when (= :region (:type hovered-element))
-      (let [region (:region hovered-element)
-            on-click! (:on-click! region)]
-        (on-click! region)))
-    (refresh-mouse-cursor! view-node event)
-    (set-properties! view-node :selection
-                     (data/mouse-released (get-property view-node :lines)
-                                          (get-property view-node :visible-regions)
-                                          (get-property view-node :layout)
-                                          gesture-start
-                                          (mouse-button event)
-                                          (.getX event)
-                                          (.getY event)))))
+  (when-some [{:keys [on-click!] :as hovered-region} (:region (get-property view-node :hovered-element))]
+    (on-click! hovered-region))
+  (refresh-mouse-cursor! view-node event)
+  (set-properties! view-node :selection
+                   (data/mouse-released (get-property view-node :lines)
+                                        (get-property view-node :visible-regions)
+                                        (get-property view-node :layout)
+                                        (get-property view-node :gesture-start)
+                                        (mouse-button event)
+                                        (.getX event)
+                                        (.getY event))))
 
 (defn handle-mouse-exited! [view-node ^MouseEvent event]
   (.consume event)

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -127,6 +127,7 @@
      ["editor.gutter.execution-marker.current" execution-marker-color]
      ["editor.gutter.execution-marker.frame" execution-marker-frame-color]
      ["editor.gutter.shadow" (LinearGradient/valueOf "to right, rgba(0, 0, 0, 0.3) 0%, transparent 100%")]
+     ["editor.indentation.guide" (.deriveColor foreground-color 0.0 1.0 1.0 0.1)]
      ["editor.matching.brace" (Color/valueOf "#A2B0BE")]
      ["editor.minimap.shadow" (LinearGradient/valueOf "to left, rgba(0, 0, 0, 0.2) 0%, transparent 100%")]
      ["editor.minimap.viewed.range" (Color/valueOf "#393C41")]
@@ -134,8 +135,7 @@
      ["editor.scroll.tab.hovered" (.deriveColor foreground-color 0.0 1.0 1.0 0.5)]
      ["editor.whitespace.space" (.deriveColor foreground-color 0.0 1.0 1.0 0.2)]
      ["editor.whitespace.tab" (.deriveColor foreground-color 0.0 1.0 1.0 0.1)]
-     ["editor.whitespace.rogue" (Color/valueOf "#FBCE2F")]
-     ["editor.indentation.guide" (.deriveColor foreground-color 0.0 1.0 1.0 0.1)]]))
+     ["editor.whitespace.rogue" (Color/valueOf "#FBCE2F")]]))
 
 (defn make-color-scheme [ordered-paints-by-pattern]
   (into []
@@ -648,8 +648,8 @@
 (g/defnk produce-visible-cursor-ranges [lines cursor-ranges layout]
   (data/visible-cursor-ranges lines layout cursor-ranges))
 
-(g/defnk produce-visible-regions-by-type [lines regions layout]
-  (group-by :type (data/visible-cursor-ranges lines layout regions)))
+(g/defnk produce-visible-regions [lines regions layout]
+  (data/visible-cursor-ranges lines layout regions))
 
 (g/defnk produce-visible-matching-braces [lines matching-braces layout]
   (data/visible-cursor-ranges lines layout (into [] (mapcat identity) matching-braces)))
@@ -663,7 +663,7 @@
     :current-frame
     (cursor-range-draw-info :word nil frame-color execution-marker)))
 
-(g/defnk produce-cursor-range-draw-infos [color-scheme lines cursor-ranges focus-state layout visible-cursors visible-cursor-ranges visible-regions-by-type visible-matching-braces highlighted-find-term find-case-sensitive? find-whole-word? execution-markers]
+(g/defnk produce-cursor-range-draw-infos [color-scheme lines cursor-ranges focus-state layout visible-cursors visible-cursor-ranges visible-regions visible-matching-braces highlighted-find-term find-case-sensitive? find-whole-word? execution-markers]
   (let [background-color (color-lookup color-scheme "editor.background")
         ^Color selection-background-color (color-lookup color-scheme "editor.selection.background")
         selection-background-color (if (not= :not-focused focus-state) selection-background-color (color-lookup color-scheme "editor.selection.background.inactive"))
@@ -673,6 +673,8 @@
         execution-marker-current-row-color (color-lookup color-scheme "editor.execution-marker.current")
         execution-marker-frame-row-color (color-lookup color-scheme "editor.execution-marker.frame")
         matching-brace-color (color-lookup color-scheme "editor.matching.brace")
+        foreground-color (color-lookup color-scheme "editor.foreground")
+        visible-regions-by-type (group-by :type visible-regions)
         active-tab-trigger-scope-ids (into #{}
                                            (keep (fn [tab-trigger-scope-region]
                                                    (when (some #(data/cursor-range-contains? tab-trigger-scope-region (data/CursorRange->Cursor %))
@@ -685,6 +687,8 @@
              visible-cursor-ranges)
         (map (partial cursor-range-draw-info :underline nil matching-brace-color)
              visible-matching-braces)
+        (map (partial cursor-range-draw-info :underline nil foreground-color)
+             (visible-regions-by-type :resource-reference))
         (map (partial make-execution-marker-draw-info execution-marker-current-row-color execution-marker-frame-row-color)
              execution-markers)
         (cond
@@ -849,7 +853,7 @@
   (output tab-trigger-word-regions-by-scope-id r/RegionGrouping :cached produce-tab-trigger-word-regions-by-scope-id)
   (output visible-cursors r/Cursors :cached produce-visible-cursors)
   (output visible-cursor-ranges r/CursorRanges :cached produce-visible-cursor-ranges)
-  (output visible-regions-by-type r/RegionGrouping :cached produce-visible-regions-by-type)
+  (output visible-regions r/Regions :cached produce-visible-regions)
   (output visible-matching-braces r/CursorRanges :cached produce-visible-matching-braces)
   (output cursor-range-draw-infos CursorRangeDrawInfos :cached produce-cursor-range-draw-infos)
   (output minimap-glyph-metrics data/GlyphMetrics :cached produce-minimap-glyph-metrics)
@@ -1391,6 +1395,9 @@
                      (= :scroll-bar-y-hold-down gesture-type))
                  javafx.scene.Cursor/DEFAULT
 
+                 (= :resource-reference (:type (:region hovered-element)))
+                 javafx.scene.Cursor/HAND
+
                  (data/rect-contains? (.canvas layout) x y)
                  ;; TODO:
                  ;; Currently using an image cursor results in a corrupted mouse pointer under macOS High Sierra.
@@ -1427,25 +1434,34 @@
 
 (defn handle-mouse-moved! [view-node ^MouseDragEvent event]
   (.consume event)
-  (refresh-mouse-cursor! view-node event)
   (set-properties! view-node :selection
                    (data/mouse-moved (get-property view-node :lines)
                                      (get-property view-node :cursor-ranges)
+                                     (get-property view-node :visible-regions)
                                      (get-property view-node :layout)
                                      (get-property view-node :gesture-start)
                                      (get-property view-node :hovered-element)
                                      (.getX event)
-                                     (.getY event))))
+                                     (.getY event)))
+  (refresh-mouse-cursor! view-node event))
 
 (defn handle-mouse-released! [view-node ^MouseEvent event]
   (.consume event)
-  (refresh-mouse-cursor! view-node event)
-  (set-properties! view-node :selection
-                   (data/mouse-released (get-property view-node :layout)
-                                        (get-property view-node :gesture-start)
-                                        (mouse-button event)
-                                        (.getX event)
-                                        (.getY event))))
+  (let [hovered-element (get-property view-node :hovered-element)
+        ^GestureInfo gesture-start (get-property view-node :gesture-start)]
+    (when (= :region (:type hovered-element))
+      (let [region (:region hovered-element)
+            on-click! (:on-click! region)]
+        (on-click! region)))
+    (refresh-mouse-cursor! view-node event)
+    (set-properties! view-node :selection
+                     (data/mouse-released (get-property view-node :lines)
+                                          (get-property view-node :visible-regions)
+                                          (get-property view-node :layout)
+                                          gesture-start
+                                          (mouse-button event)
+                                          (.getX event)
+                                          (.getY event)))))
 
 (defn handle-mouse-exited! [view-node ^MouseEvent event]
   (.consume event)

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -269,17 +269,6 @@
       (pred (first elems)) index
       :else (recur (inc index) (next elems)))))
 
-(defn last-index-where
-  "Returns the index of the last element in coll where pred returns true,
-  or nil if there was no matching element. The coll must support addressing
-  using nth."
-  [pred coll]
-  (loop [index (dec (count coll))]
-    (when-not (neg? index)
-      (if (pred (nth coll index))
-        index
-        (recur (dec index))))))
-
 (defn only
   "Returns the only element in coll, or nil if there are more than one element."
   [coll]

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -269,6 +269,17 @@
       (pred (first elems)) index
       :else (recur (inc index) (next elems)))))
 
+(defn last-index-where
+  "Returns the index of the last element in coll where pred returns true,
+  or nil if there was no matching element. The coll must support addressing
+  using nth."
+  [pred coll]
+  (loop [index (dec (count coll))]
+    (when-not (neg? index)
+      (if (pred (nth coll index))
+        index
+        (recur (dec index))))))
+
 (defn only
   "Returns the only element in coll, or nil if there are more than one element."
   [coll]

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -662,16 +662,19 @@
                         [(c 0 3) (c 0 11)]
                         "\n")))))
 
-(defn- append-distinct-lines [lines regions new-lines]
-  (data/append-distinct-lines lines regions new-lines))
+(defn- append-distinct-lines
+  ([lines regions new-lines]
+   (append-distinct-lines lines regions new-lines (constantly nil)))
+  ([lines regions new-lines sub-regions-fn]
+   (data/append-distinct-lines lines regions new-lines sub-regions-fn)))
 
 (defn- repeat-region [row line repeat-count]
   (assoc (cr [row 0] [row (count line)])
     :type :repeat
     :count repeat-count))
 
-(defn- other-region [row line]
-  (assoc (cr [row 0] [row (count line)])
+(defn- other-region [row col text]
+  (assoc (cr [row col] [row (+ col (count text))])
     :type :other))
 
 (deftest append-distinct-lines-test
@@ -696,22 +699,59 @@
             :regions [(repeat-region 1 "boo" 3)]}
            (append-distinct-lines ["a" "boo"] [(repeat-region 1 "boo" 2)] ["boo"]))))
 
+  (testing "Creates new repeat region if previous repeat region didn't match"
+    (is (= {:lines ["one" "two"]
+            :regions [(repeat-region 0 "one" 2)
+                      (repeat-region 1 "two" 2)]}
+           (append-distinct-lines ["one" "two"]
+                                  [(repeat-region 0 "one" 2)]
+                                  ["two"]))))
+
   (testing "Other regions present"
     (is (= {:lines ["a" "boo"]
             :regions [(repeat-region 1 "boo" 3)
-                      (other-region 1 "boo")]}
+                      (other-region 1 0 "boo")]}
            (append-distinct-lines ["a" "boo"]
                                   [(repeat-region 1 "boo" 2)
-                                   (other-region 1 "boo")]
+                                   (other-region 1 0 "boo")]
                                   ["boo"])))
 
-    (is (= {:lines ["a" "boo"]
-            :regions [(repeat-region 1 "boo" 3)
-                      (other-region 1 "boo")]}
-           (append-distinct-lines ["a" "boo"]
-                                  [(repeat-region 1 "boo" 2)
-                                   (other-region 1 "boo")]
-                                  ["boo"])))))
+    (is (= {:lines ["a" "first second"]
+            :regions [(repeat-region 1 "first second" 2)
+                      (other-region 1 6 "second")]}
+           (append-distinct-lines ["a" "first second"]
+                                  [(other-region 1 6 "second")]
+                                  ["first second"]))))
+
+  (testing "Sub-regions function"
+    (is (= {:lines ["a" "first second"]
+            :regions [(other-region 0 0 "a")
+                      (other-region 1 0 "first")
+                      (other-region 1 6 "second")]}
+           (append-distinct-lines ["a"]
+                                  [(other-region 0 0 "a")]
+                                  ["first second"]
+                                  (fn [row line]
+                                    (is (= 1 row))
+                                    (is (= "first second" line))
+                                    [(other-region row 0 "first")
+                                     (other-region row 6 "second")]))))
+
+    (is (= {:lines ["a" "first second"]
+            :regions [(other-region 0 0 "a")
+                      (other-region 1 0 "first")
+                      (repeat-region 1 "first second" 2)
+                      (other-region 1 6 "second")]}
+           (append-distinct-lines ["a" "first second"]
+                                  [(other-region 0 0 "a")
+                                   (other-region 1 0 "first")
+                                   (other-region 1 6 "second")]
+                                  ["first second"]
+                                  (fn [row line]
+                                    (is (= 1 row))
+                                    (is (= "first second" line))
+                                    [(other-region 1 0 "first")
+                                     (other-region 1 6 "second")]))))))
 
 (deftest delete-test
   (let [backspace (fn [lines cursor-ranges] (data/delete lines cursor-ranges nil (layout-info lines) data/delete-character-before-cursor))

--- a/editor/test/editor/code/util_test.clj
+++ b/editor/test/editor/code/util_test.clj
@@ -1,0 +1,21 @@
+(ns editor.code.util-test
+  (:require [clojure.test :refer :all]
+            [editor.code.util :as util]
+            [integration.test-util :as test-util]))
+
+(deftest last-index-where-test
+  (is (= 3 (util/last-index-where even? (range 1 6))))
+  (is (= 4 (util/last-index-where nil? [:a :b nil :d nil :f])))
+  (is (= 4 (util/last-index-where #(= :a %) (list :a nil :a nil :a))))
+  (is (= 5 (util/last-index-where #(Character/isDigit %) "abc123def")))
+  (is (thrown? UnsupportedOperationException (util/last-index-where (fn [[k _]] (= :d k)) (sorted-map :a 1 :b 2 :c 3 :d 4))))
+  (is (thrown? UnsupportedOperationException (util/last-index-where #(= "f" %) (sorted-set "f" "e" "d" "c" "b" "a"))))
+  (is (nil? (util/last-index-where nil? nil)))
+  (is (nil? (util/last-index-where even? nil)))
+  (is (nil? (util/last-index-where even? [])))
+  (is (nil? (util/last-index-where even? [1 3 5])))
+
+  (testing "stops calling pred after first true"
+    (let [pred (test-util/make-call-logger (constantly true))]
+      (is (= 9 (util/last-index-where pred (range 10))))
+      (is (= 1 (count (test-util/call-logger-calls pred)))))))

--- a/editor/test/editor/console_test.clj
+++ b/editor/test/editor/console_test.clj
@@ -1,0 +1,74 @@
+(ns editor.console-test
+  (:require [clojure.test :refer :all]
+            [editor.console :as console]))
+
+(def ^:private line-sub-regions-pattern (var-get #'console/line-sub-regions-pattern))
+
+(deftest line-sub-regions-pattern-test
+  (are [line matches]
+    (= matches (next (re-find line-sub-regions-pattern line)))
+
+    "/main.lua"            ["/main.lua" nil]
+    "/main.lua:12"         ["/main.lua" "12"]
+    "/dir/main.lua"        ["/dir/main.lua" nil]
+    "/dir/main.lua:12"     ["/dir/main.lua" "12"]
+
+    "</main.lua>"          ["/main.lua" nil]
+    "</main.lua:12>"       ["/main.lua" "12"]
+    "</dir/main.lua>"      ["/dir/main.lua" nil]
+    "</dir/main.lua:12>"   ["/dir/main.lua" "12"]
+
+    "'/main.lua'"          ["/main.lua" nil]
+    "'/main.lua:12'"       ["/main.lua" "12"]
+    "'/dir/main.lua'"      ["/dir/main.lua" nil]
+    "'/dir/main.lua:12'"   ["/dir/main.lua" "12"]
+
+    "`/main.lua`"          ["/main.lua" nil]
+    "`/main.lua:12`"       ["/main.lua" "12"]
+    "`/dir/main.lua`"      ["/dir/main.lua" nil]
+    "`/dir/main.lua:12`"   ["/dir/main.lua" "12"]
+
+    "\"/main.lua\""        ["/main.lua" nil]
+    "\"/main.lua:12\""     ["/main.lua" "12"]
+    "\"/dir/main.lua\""    ["/dir/main.lua" nil]
+    "\"/dir/main.lua:12\"" ["/dir/main.lua" "12"]))
+
+(defn- on-region-click! [_region]
+  nil)
+
+(defn- resource-reference-region
+  ([row col text resource-proj-path]
+   (#'console/make-resource-reference-region row col (+ col (count text)) resource-proj-path on-region-click!))
+  ([row col text resource-proj-path resource-row]
+   (#'console/make-resource-reference-region row col (+ col (count text)) resource-proj-path resource-row on-region-click!)))
+
+(def ^:private resource-map {"/main.lua" 100
+                             "/dir/main.lua" 200})
+
+(defn- append-lines [props lines]
+  ;; Entries are [type line] pairs. We use nil for untyped regular entries.
+  (let [entries (mapv (partial vector nil) lines)]
+    (#'console/append-entries props entries resource-map on-region-click!)))
+
+(deftest append-entries-test
+  (is (= {:lines ["/main.lua"]
+          :regions [(resource-reference-region 0 0 "/main.lua" "/main.lua")]}
+         (append-lines {:lines [""]
+                        :regions []}
+                       ["/main.lua"])))
+  (is (= {:lines ["Syntax error"
+                  "  from </dir/main.lua:33>"]
+          :regions [(resource-reference-region 1 (count "  from <") "/dir/main.lua:33" "/dir/main.lua" 32)]}
+         (append-lines {:lines ["Syntax error"]
+                        :regions []}
+                       ["  from </dir/main.lua:33>"])))
+  (is (= {:lines ["Syntax error"
+                  "  from </dir/main.lua:33>"
+                  "   via '/main.lua:8', '/main.lua:13'"]
+          :regions [(resource-reference-region 1 (count "  from <") "/dir/main.lua:33" "/dir/main.lua" 32)
+                    (resource-reference-region 2 (count "   via '") "/main.lua:8" "/main.lua" 7)
+                    (resource-reference-region 2 (count "   via '/main.lua:8', '") "/main.lua:13" "/main.lua" 12)]}
+         (append-lines {:lines ["Syntax error"
+                                "  from </dir/main.lua:33>"]
+                        :regions [(resource-reference-region 1 (count "  from <") "/dir/main.lua:33" "/dir/main.lua" 32)]}
+                       ["   via '/main.lua:8', '/main.lua:13'"]))))

--- a/editor/test/editor/console_test.clj
+++ b/editor/test/editor/console_test.clj
@@ -9,9 +9,18 @@
     (= matches (next (re-find line-sub-regions-pattern line)))
 
     "/main.lua"            ["/main.lua" nil]
+    "/main.lua:"           ["/main.lua" nil]
     "/main.lua:12"         ["/main.lua" "12"]
     "/dir/main.lua"        ["/dir/main.lua" nil]
+    "/dir/main.lua:"       ["/dir/main.lua" nil]
     "/dir/main.lua:12"     ["/dir/main.lua" "12"]
+
+    " /main.lua "          ["/main.lua" nil]
+    " /main.lua: "         ["/main.lua" nil]
+    " /main.lua:12 "       ["/main.lua" "12"]
+    " /dir/main.lua "      ["/dir/main.lua" nil]
+    " /dir/main.lua: "     ["/dir/main.lua" nil]
+    " /dir/main.lua:12 "   ["/dir/main.lua" "12"]
 
     "</main.lua>"          ["/main.lua" nil]
     "</main.lua:12>"       ["/main.lua" "12"]
@@ -56,6 +65,11 @@
          (append-lines {:lines [""]
                         :regions []}
                        ["/main.lua"])))
+  (is (= {:lines ["/non-existing-resource.lua"]
+          :regions []}
+         (append-lines {:lines [""]
+                        :regions []}
+                       ["/non-existing-resource.lua"])))
   (is (= {:lines ["Syntax error"
                   "  from </dir/main.lua:33>"]
           :regions [(resource-reference-region 1 (count "  from <") "/dir/main.lua:33" "/dir/main.lua" 32)]}

--- a/editor/test/internal/util_test.clj
+++ b/editor/test/internal/util_test.clj
@@ -97,6 +97,7 @@
 (deftest first-index-where-test
   (is (= 1 (first-index-where even? (range 1 4))))
   (is (= 2 (first-index-where nil? [:a :b nil :d])))
+  (is (= 3 (first-index-where #(Character/isDigit %) "abc123def")))
   (is (= 3 (first-index-where (fn [[k _]] (= :d k)) (sorted-map :a 1 :b 2 :c 3 :d 4))))
   (is (= 4 (first-index-where #(= :e %) (list :a nil :c nil :e))))
   (is (= 5 (first-index-where #(= "f" %) (sorted-set "f" "e" "d" "c" "b" "a"))))
@@ -108,6 +109,23 @@
   (testing "stops calling pred after first true"
     (let [pred (test-util/make-call-logger (constantly true))]
       (is (= 0 (first-index-where pred (range 10))))
+      (is (= 1 (count (test-util/call-logger-calls pred)))))))
+
+(deftest last-index-where-test
+  (is (= 3 (last-index-where even? (range 1 6))))
+  (is (= 4 (last-index-where nil? [:a :b nil :d nil :f])))
+  (is (= 4 (last-index-where #(= :a %) (list :a nil :a nil :a))))
+  (is (= 5 (last-index-where #(Character/isDigit %) "abc123def")))
+  (is (thrown? UnsupportedOperationException (last-index-where (fn [[k _]] (= :d k)) (sorted-map :a 1 :b 2 :c 3 :d 4))))
+  (is (thrown? UnsupportedOperationException (last-index-where #(= "f" %) (sorted-set "f" "e" "d" "c" "b" "a"))))
+  (is (nil? (last-index-where nil? nil)))
+  (is (nil? (last-index-where even? nil)))
+  (is (nil? (last-index-where even? [])))
+  (is (nil? (last-index-where even? [1 3 5])))
+
+  (testing "stops calling pred after first true"
+    (let [pred (test-util/make-call-logger (constantly true))]
+      (is (= 9 (last-index-where pred (range 10))))
       (is (= 1 (count (test-util/call-logger-calls pred)))))))
 
 (deftest only-test

--- a/editor/test/internal/util_test.clj
+++ b/editor/test/internal/util_test.clj
@@ -111,23 +111,6 @@
       (is (= 0 (first-index-where pred (range 10))))
       (is (= 1 (count (test-util/call-logger-calls pred)))))))
 
-(deftest last-index-where-test
-  (is (= 3 (last-index-where even? (range 1 6))))
-  (is (= 4 (last-index-where nil? [:a :b nil :d nil :f])))
-  (is (= 4 (last-index-where #(= :a %) (list :a nil :a nil :a))))
-  (is (= 5 (last-index-where #(Character/isDigit %) "abc123def")))
-  (is (thrown? UnsupportedOperationException (last-index-where (fn [[k _]] (= :d k)) (sorted-map :a 1 :b 2 :c 3 :d 4))))
-  (is (thrown? UnsupportedOperationException (last-index-where #(= "f" %) (sorted-set "f" "e" "d" "c" "b" "a"))))
-  (is (nil? (last-index-where nil? nil)))
-  (is (nil? (last-index-where even? nil)))
-  (is (nil? (last-index-where even? [])))
-  (is (nil? (last-index-where even? [1 3 5])))
-
-  (testing "stops calling pred after first true"
-    (let [pred (test-util/make-call-logger (constantly true))]
-      (is (= 9 (last-index-where pred (range 10))))
-      (is (= 1 (count (test-util/call-logger-calls pred)))))))
-
 (deftest only-test
   (is (= :a (only [:a])))
   (is (= :b (only #{:b})))


### PR DESCRIPTION
Fixes defold/editor2-issues#1920
Fixes defold/editor2-issues#2159

### User-facing changes
* You can now click on script errors in the Console to navigate to the source of the error in the editor.