### PR TITLE
DEFEDIT-1494 IllegalArgumentException after zooming in/out

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2372,6 +2372,7 @@
 
         ;; Remove callbacks when our tab is closed.
         (ui/on-closed! tab (fn [_]
+                             (ui/kill-event-dispatch! canvas)
                              (ui/timer-stop! repainter)
                              (dispose-goto-line-bar! goto-line-bar)
                              (dispose-find-bar! find-bar)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -938,7 +938,9 @@
                            (let [drawable (gl/offscreen-drawable w h)]
                              (ui/user-data! image-view ::view-id view-id)
                              (register-event-handler! this view-id)
-                             (ui/on-closed! (:tab opts) (fn [_] (dispose-scene-view! view-id)))
+                             (ui/on-closed! (:tab opts) (fn [_]
+                                                          (ui/kill-event-dispatch! this)
+                                                          (dispose-scene-view! view-id)))
                              (g/set-property! view-id :drawable drawable :async-copier (make-copier viewport))
                              (frame-selection view-id false)))))
                      (catch Throwable error

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -321,6 +321,16 @@
      (handle [~'this ~event]
        ~@body)))
 
+(defmacro event-dispatcher [event tail & body]
+  `(reify EventDispatcher
+     (dispatchEvent [~'this ~event ~tail]
+       ~@body)))
+
+(def null-event-dispatcher (event-dispatcher event tail))
+
+(defn kill-event-dispatch! [^Node target]
+  (.setEventDispatcher target null-event-dispatcher))
+
 (defmacro change-listener [observable old-val new-val & body]
   `(reify ChangeListener
      (changed [~'this ~observable ~old-val ~new-val]


### PR DESCRIPTION
This happens in the scene and code view if you scroll with an apple mouse and close the tab while
the inertia is still keeping the scroll going. Don't fully understand why javafx chooses to dispatch events to nodes that should no longer be part of the scene hierarchy (closed tab). This workaround sets a custom "null" event dispatcher for the views when the tab closes. This way we don't have to track every single event listener and unregister manually.