### PR TITLE
DEFEDIT-1500 Missing referenced .go or .collection prevents project from loading

### DIFF
--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -240,6 +240,11 @@
   (or (validation/prop-error :fatal node-id :path validation/prop-nil? resource "Path")
       (validation/prop-error :fatal node-id :path validation/prop-resource-not-exists? resource "Path")))
 
+(defn- substitute-error [val-or-error substitute]
+  (if-not (g/error? val-or-error)
+    val-or-error
+    substitute))
+
 (g/defnode ReferencedGOInstanceNode
   (inherits GameObjectInstanceNode)
 
@@ -271,9 +276,9 @@
                              (g/override go-node {:traverse? or-go-traverse?}
                                          (fn [evaluation-context id-mapping]
                                            (let [or-node (get id-mapping go-node)
-                                                 component-ids (g/node-value go-node :component-ids evaluation-context)
+                                                 component-ids (substitute-error (g/node-value go-node :component-ids evaluation-context) {})
                                                  id-mapping (fn [id]
-                                                              (-> id
+                                                              (some-> id
                                                                 component-ids
                                                                 (g/node-value :source-id evaluation-context)
                                                                 id-mapping))]
@@ -292,7 +297,8 @@
                                                  (g/connect self from or-node to))
                                                (for [[id p] component-overrides
                                                      [key [type value]] p
-                                                     :let [comp-id (id-mapping id)]]
+                                                     :let [comp-id (id-mapping id)]
+                                                     :when (some? comp-id)]
                                                  (let [refd-component (component-ids id)
                                                        refd-component-props (:properties (g/node-value refd-component :_properties evaluation-context))
                                                        original-type (get-in refd-component-props [key :type])
@@ -508,9 +514,9 @@
                    connect-tx-data
                    (g/override coll-node {:traverse? or-coll-traverse?}
                                (fn [evaluation-context id-mapping]
-                                 (let [go-inst-ids (g/node-value coll-node :go-inst-ids evaluation-context)
+                                 (let [go-inst-ids (substitute-error (g/node-value coll-node :go-inst-ids evaluation-context) {})
                                        component-overrides (for [{:keys [id properties]} (:overrides new-value)
-                                                                 :let [comp-ids (-> id
+                                                                 :let [comp-ids (some-> id
                                                                                   go-inst-ids
                                                                                   (g/node-value :source-id evaluation-context)
                                                                                   (g/node-value :component-ids evaluation-context))]


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/2346

* Technical changes
  - When using g/node-value inside the g/override callback, make sure
  to check for graph error values.