### PR TITLE
DEFEDIT-1503 Workaround for non-unique __tostring

### DIFF
--- a/editor/bundle-resources/_defold/debugger/edn.lua
+++ b/editor/bundle-resources/_defold/debugger/edn.lua
@@ -48,9 +48,9 @@ local function str(val)
     if success then
       return res_or_error .. " " .. addr
     else
-      return "<foreign scene node>" .. " " .. addr
+      return "<foreign scene node> " .. addr
     end
-  elseif (type(val) == "table") and has_custom_tostring(val) then
+  elseif type(val) == "table" and has_custom_tostring(val) then
     return tostring(val) .. " " .. get_prefixed_addr("table: ", raw_tostring(val))
   else
     return tostring(val)

--- a/editor/bundle-resources/_defold/debugger/edn.lua
+++ b/editor/bundle-resources/_defold/debugger/edn.lua
@@ -17,11 +17,41 @@ local escape_char_map = {
   ["\t" ] = "\\t",
 }
 
+local function raw_tostring(val)
+  local old_mt = debug.getmetatable(val)
+  debug.setmetatable(val, nil)
+  local raw_str = tostring(val)
+  debug.setmetatable(val, old_mt)
+  return raw_str
+end
+
+local function has_custom_tostring(val)
+  local mt = debug.getmetatable(val)
+  return mt ~= nil and mt.__tostring ~= nil
+end
+
+local function get_prefixed_addr(prefix, raw_string)
+  local b, e = string.find(raw_string, prefix)
+  if e ~= nil then
+    return string.sub(raw_string, e)
+  else
+    return ""
+  end
+end
+
 local function str(val)
   -- Can't call tostring on NodeProxy unless called from owning Gui script. See:
   -- https://jira.int.midasplayer.com/browse/DEF-532
   if getmetatable(val) == NodeProxy then
-    return "GuiNode"
+    local addr = get_prefixed_addr("userdata: ", raw_tostring(val))
+    local success, res_or_error = pcall(function () return tostring(val) end)
+    if success then
+      return res_or_error .. " " .. addr
+    else
+      return "<foreign scene node>" .. " " .. addr
+    end
+  elseif (type(val) == "table") and has_custom_tostring(val) then
+    return tostring(val) .. " " .. get_prefixed_addr("table: ", raw_tostring(val))
   else
     return tostring(val)
   end
@@ -64,7 +94,7 @@ local function encode_table_value(val, stack)
   stack[val] = true
 
   for k, v in pairs(val) do
-      table.insert(res, encode_key(k, stack) .. " " .. encode_value(v, stack))
+    table.insert(res, encode_key(k, stack) .. " " .. encode_value(v, stack))
   end
 
   stack[val] = nil
@@ -73,17 +103,17 @@ local function encode_table_value(val, stack)
 end
 
 local function encode_table_ref(val, stack)
-   return "#lua/tableref{:tostring \"" .. str(val) .. "\"}"
+  return "#lua/tableref{:tostring \"" .. str(val) .. "\"}"
 end
 
 local function make_tagged_string_encoder(tag)
-    return function(val)
-        return tag .. encode_string(str(val))
-    end
+  return function(val)
+    return tag .. encode_string(str(val))
+  end
 end
 
 local function encode_userdata(val)
-    return "#lua/userdata" .. encode_string(str(val))
+  return "#lua/userdata" .. encode_string(str(val))
 end
 
 local function encode_function(val)
@@ -113,14 +143,24 @@ end
 encode_key = function(val, stack)
   local t = type(val)
   if t == "table" then
-     return encode_table_ref(val, stack)
+    return encode_table_ref(val, stack)
   else
-     return encode_value(val, stack)
+    return encode_value(val, stack)
   end
 end
 
 function M.encode(val)
-  return encode_value(val)
+  local err_trace
+  local success, error_or_result = xpcall(function () return encode_value(val) end, function (err) err_trace = debug.traceback(); return err end)
+  if success then
+    return error_or_result
+  else
+    print("Debugger: " .. error_or_result)
+    if err_trace ~= nil then
+      print(err_trace)
+    end
+    return encode_nil()
+  end
 end
 
 return M


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/2343, https://github.com/defold/editor2-issues/issues/2316, https://github.com/defold/editor2-issues/issues/2016

Custom __tostring implementations that return non-unique (per object)
strings causes duplicate map keys in the values serialized and sent to
the debugger. Also a slightly friendlier presentation of gui nodes.