### PR TITLE
DEFEDIT Detect stable engine sha1 from repo on dev branch

### DIFF
--- a/editor/src/clj/util/repo.clj
+++ b/editor/src/clj/util/repo.clj
@@ -1,0 +1,28 @@
+(ns util.repo
+  (:require [clojure.java.shell :as shell]
+            [clojure.string :as string])
+  (:import (java.io IOException)))
+
+(defn- try-shell-command! [command & args]
+  (try
+    (let [{:keys [out err]} (apply shell/sh command args)]
+      (when (empty? err)
+        (string/trim-newline out)))
+    (catch IOException _
+      ;; The specified command does not exist.
+      nil)))
+
+(def detect-engine-sha1
+  (memoize
+    (fn detect-engine-sha1 []
+      (some->> (try-shell-command! "git" "log" "--format=%H" "--max-count=5" "../VERSION")
+               string/split-lines
+               not-empty
+               (keep #(try-shell-command! "git" "show" (str % ":VERSION")))
+               (map string/trim-newline)
+               (some (partial try-shell-command! "git" "rev-list" "-n" "1"))))))
+
+(def detect-editor-sha1
+  (memoize
+    (fn detect-editor-sha1 []
+      (try-shell-command! "git" "rev-list" "-n" "1" "HEAD"))))

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -1,6 +1,5 @@
 (ns integration.engine.native-extensions-test
   (:require
-   [clojure.java.shell :as shell]
    [clojure.string :as string]
    [clojure.test :refer :all]
    [integration.test-util :as test-util]
@@ -10,24 +9,13 @@
    [editor.defold-project :as project]
    [editor.engine.native-extensions :as native-extensions]
    [editor.fs :as fs]
-   [editor.system :as system]
-   [editor.resource :as resource])
+   [editor.resource :as resource]
+   [util.repo :as repo])
   (:import
-   [java.io File IOException]))
-
-(defn- try-shell-command! [command & args]
-  (try
-    (let [{:keys [out err]} (apply shell/sh command args)]
-      (when (empty? err)
-        (string/trim-newline out)))
-    (catch IOException _
-      ;; The specified command does not exist.
-      nil)))
+   [java.io File]))
 
 (defn fix-engine-sha1 [f]
-  (let [old-sha1 (system/defold-engine-sha1)
-        version (string/trim-newline (slurp "../VERSION"))
-        engine-sha1 (try-shell-command! "git" "rev-list" "-n" "1" version)]
+  (let [engine-sha1 (repo/detect-engine-sha1)]
     (with-redefs [editor.system/defold-engine-sha1 (constantly engine-sha1)]
       (f))))
 


### PR DESCRIPTION
Fixes `native-extensions-test/async-build-on-build-server` test on the `dev` branch.

### Tested:
* `lein test` works on `dev` branch.
* `lein test` works on `editor-dev` branch.
* Stable engine sha1 appears in About dialog on `dev` branch.
* Stable engine sha1 appears in About dialog on `editor-dev` branch.