### PR TITLE
DEFEDIT-1506 Sign iOS App fails: "missing dashboard client"

### DIFF
--- a/editor/src/clj/editor/bundle.clj
+++ b/editor/src/clj/editor/bundle.clj
@@ -295,7 +295,7 @@
         identities (find-identities)
         result (atom nil)]
 
-    (ui/context! root :dialog {:root root :workspace workspace :prefs prefs :controls controls :stage stage :project project :result result} nil)
+    (ui/context! root :dialog {:root root :workspace workspace :prefs prefs :dashboard-client dashboard-client :controls controls :stage stage :project project :result result} nil)
     (ui/cell-factory! (:identities controls) (fn [i] {:text (second i)}))
 
     (ui/text! (:provisioning-profile controls) (prefs/get-prefs prefs "last-provisioning-profile" ""))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/2365

* Technical changes
  - Missing dashboard-client in context for sign ios app dialog