### PR TITLE
DEF-1858: Right mouse button detection not working in HTML5

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -280,6 +280,19 @@ var CanvasInput = {
 };
 
 /* ********************************************************************* */
+/* Manage context menu                                                   */
+/* ********************************************************************* */
+
+var ContextMenuHider = {
+    null_handler : function(e) {
+        e.preventDefault();
+    },
+    addToCanvas : function(canvas) {
+        canvas.oncontextmenu = this.null_handler;
+    }
+}
+
+/* ********************************************************************* */
 /* Module is Emscripten namespace                                        */
 /* ********************************************************************* */
 
@@ -453,6 +466,9 @@ var Module = {
 
             // Add progress visuals
             Progress.addProgress(Module.canvas);
+
+            // Set context menu handler
+            ContextMenuHider.addToCanvas(Module.canvas);
 
             // Load and assemble archive
             Combine.addCombineCompletedListener(Module.onArchiveFileLoaded);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -280,19 +280,6 @@ var CanvasInput = {
 };
 
 /* ********************************************************************* */
-/* Manage context menu                                                   */
-/* ********************************************************************* */
-
-var ContextMenuHider = {
-    null_handler : function(e) {
-        e.preventDefault();
-    },
-    addToCanvas : function(canvas) {
-        canvas.oncontextmenu = this.null_handler;
-    }
-}
-
-/* ********************************************************************* */
 /* Module is Emscripten namespace                                        */
 /* ********************************************************************* */
 
@@ -474,7 +461,9 @@ var Module = {
             // Add context menu hide-handler if requested
             if (params["disable_context_menu"])
             {
-                ContextMenuHider.addToCanvas(Module.canvas);
+                Module.canvas.oncontextmenu = function(e) {
+                    e.preventDefault();
+                };
             }
 
             // Load and assemble archive

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -431,6 +431,9 @@ var Module = {
     *     'custom_heap_size':
     *         Number of bytes specifying the memory heap size.
     *
+    *     'disable_context_menu':
+    *         Disables the right-click context menu on the canvas element if true.
+    *
     **/
     runApp: function(app_canvas_id, extra_params) {
         app_canvas_id = (typeof app_canvas_id === 'undefined') ?  'canvas' : app_canvas_id;
@@ -441,7 +444,8 @@ var Module = {
             unsupported_webgl_callback: undefined,
             engine_arguments: [],
             persistent_storage: true,
-            custom_heap_size: undefined
+            custom_heap_size: undefined,
+            disable_context_menu: true
         };
 
         for (var k in extra_params) {
@@ -467,8 +471,11 @@ var Module = {
             // Add progress visuals
             Progress.addProgress(Module.canvas);
 
-            // Set context menu handler
-            ContextMenuHider.addToCanvas(Module.canvas);
+            // Add context menu hide-handler if requested
+            if (params["disable_context_menu"])
+            {
+                ContextMenuHider.addToCanvas(Module.canvas);
+            }
 
             // Load and assemble archive
             Combine.addCombineCompletedListener(Module.onArchiveFileLoaded);

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -105,7 +105,8 @@
 		engine_arguments: ["{{DEFOLD_ENGINE_ARGUMENTS}}"],
 		{{/HAS_DEFOLD_ENGINE_ARGUMENTS}}
 		splash_image: "{{DEFOLD_SPLASH_IMAGE}}",
-		custom_heap_size: {{DEFOLD_HEAP_SIZE}}
+		custom_heap_size: {{DEFOLD_HEAP_SIZE}},
+		disable_context_menu: true
 	}
 
 	Module['onRuntimeInitialized'] = function() {


### PR DESCRIPTION
This PR adds an option to the dmloader/html template that enables or disables the right-click context menu. Default behaviour is that the context menu is hidden.