### PR TITLE
DEFEDIT-1510 Silent failure if exception during NE build

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -456,10 +456,15 @@
 (defn clear-build-launch-progress! []
   (render-main-task-progress! progress/done))
 
-(defn- launch-engine! [engine project-directory prefs debug?]
+(defn- decorate-target [engine-descriptor target]
+  (assoc target :engine-id (:id engine-descriptor)))
+
+(defn- launch-engine! [engine-descriptor project-directory prefs debug?]
   (try
     (report-build-launch-progress! "Launching engine...")
-    (let [launched-target (->> (engine/launch! engine project-directory prefs debug?)
+    (let [engine (engine/install-engine! project-directory engine-descriptor)
+          launched-target (->> (engine/launch! engine project-directory prefs debug?)
+                               (decorate-target engine-descriptor)
                                (targets/add-launched-target!)
                                (targets/select-target! prefs))]
       (report-build-launch-progress! (format "Launched %s" (targets/target-message-label launched-target)))
@@ -500,29 +505,25 @@
 
 (def ^:private build-in-progress? (atom false))
 
-(defn- launch-built-project! [engine project-directory prefs web-server debug?]
-  (let [selected-target (targets/selected-target prefs)]
+(defn- launch-built-project! [engine-descriptor project-directory prefs web-server debug?]
+  (let [selected-target (targets/selected-target prefs)
+        launch-new-engine! (fn []
+                             (targets/kill-launched-targets!)
+                             (let [launched-target (launch-engine! engine-descriptor project-directory prefs debug?)
+                                   log-stream      (:log-stream launched-target)]
+                               (reset-console-stream! log-stream)
+                               (reset-remote-log-pump-thread! nil)
+                               (start-log-pump! log-stream (make-launched-log-sink launched-target))
+                               launched-target))]
     (try
       (cond
         (not selected-target)
-        (do (targets/kill-launched-targets!)
-            (let [launched-target (launch-engine! engine project-directory prefs debug?)
-                  log-stream      (:log-stream launched-target)]
-              (reset-console-stream! log-stream)
-              (reset-remote-log-pump-thread! nil)
-              (start-log-pump! log-stream (make-launched-log-sink launched-target))
-              launched-target))
+        (launch-new-engine!)
 
         (not (targets/controllable-target? selected-target))
         (do
           (assert (targets/launched-target? selected-target))
-          (targets/kill-launched-targets!)
-          (let [launched-target (launch-engine! engine project-directory prefs debug?)
-                log-stream      (:log-stream launched-target)]
-            (reset-console-stream! log-stream)
-            (reset-remote-log-pump-thread! nil)
-            (start-log-pump! log-stream (make-launched-log-sink launched-target))
-            launched-target))
+          (launch-new-engine!))
 
         (and (targets/controllable-target? selected-target) (targets/remote-target? selected-target))
         (do
@@ -534,13 +535,18 @@
         :else
         (do
           (assert (and (targets/controllable-target? selected-target) (targets/launched-target? selected-target)))
-          (reset-console-stream! (:log-stream selected-target))
-          (reset-remote-log-pump-thread! nil)
-          ;; Launched target log pump already
-          ;; running to keep engine process
-          ;; from halting because stdout/err is
-          ;; not consumed.
-          (reboot-engine! selected-target web-server debug?)))
+          (if (= (:id engine-descriptor) (:engine-id selected-target))
+            (do
+              ;; We're running "the same" engine and can reuse the
+              ;; running process by rebooting
+              (reset-console-stream! (:log-stream selected-target))
+              (reset-remote-log-pump-thread! nil)
+              ;; Launched target log pump already
+              ;; running to keep engine process
+              ;; from halting because stdout/err is
+              ;; not consumed.
+              (reboot-engine! selected-target web-server debug?))
+            (launch-new-engine!))))
       (catch Exception e
         (log/warn :exception e)
         (dialogs/make-error-dialog (format "Launching %s Failed"
@@ -592,12 +598,12 @@
         evaluation-context (g/make-evaluation-context)]
     (async-build! project evaluation-context prefs {:debug? false} (workspace/artifact-map workspace)
                   (make-render-task-progress :build)
-                  (fn [build-results engine build-engine-exception]
+                  (fn [build-results engine-descriptor build-engine-exception]
                     (g/update-cache-from-evaluation-context! evaluation-context)
                     (when (handle-build-results! workspace build-errors-view build-results)
-                      (when engine
+                      (when engine-descriptor
                         (console/show! console-view)
-                        (launch-built-project! engine project-directory prefs web-server false))
+                        (launch-built-project! engine-descriptor project-directory prefs web-server false))
                       (when build-engine-exception
                         (log/warn :exception build-engine-exception)
                         (engine-build-errors/handle-build-error! (make-render-build-error build-errors-view) project evaluation-context build-engine-exception)))))))
@@ -627,11 +633,11 @@ If you do not specifically require different script states, consider changing th
             evaluation-context (g/make-evaluation-context)]
         (async-build! project evaluation-context prefs {:debug? true} (workspace/artifact-map workspace)
                       (make-render-task-progress :build)
-                      (fn [build-results engine build-engine-exception]
+                      (fn [build-results engine-descriptor build-engine-exception]
                         (g/update-cache-from-evaluation-context! evaluation-context)
                         (when (handle-build-results! workspace build-errors-view build-results)
-                          (when engine
-                            (when-let [target (launch-built-project! engine project-directory prefs web-server true)]
+                          (when engine-descriptor
+                            (when-let [target (launch-built-project! engine-descriptor project-directory prefs web-server true)]
                               (when (nil? (debug-view/current-session debug-view))
                                 (debug-view/start-debugger! debug-view project (:address target "localhost")))))
                           (when build-engine-exception

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -15,7 +15,6 @@
   (:import
    (java.io File)
    (java.net URI)
-   (java.util.zip ZipFile)
    (java.security MessageDigest)
    (javax.ws.rs.core MediaType)
    (org.apache.commons.codec.binary Hex)
@@ -44,42 +43,42 @@
   md)
 
 (defn- cache-key
-  [^String platform ^String sdk-version resource-nodes evaluation-context]
+  [^String extender-platform ^String sdk-version resource-nodes evaluation-context]
   (-> (DigestUtils/getSha256Digest)
-      (DigestUtils/updateDigest platform)
+      (DigestUtils/updateDigest extender-platform)
       (DigestUtils/updateDigest (or sdk-version ""))
       (hash-resources! resource-nodes evaluation-context)
       (.digest)
       (Hex/encodeHexString)))
 
 (defn- cache-file ^File
-  [cache-dir platform]
-  (doto (io/file cache-dir platform "build.zip")
+  [cache-dir extender-platform]
+  (doto (io/file cache-dir extender-platform "build.zip")
     (fs/create-parent-directories!)))
 
 (defn- cache-file-hash ^File
-  [cache-dir platform]
-  (doto (io/file cache-dir platform "build.hash")
+  [cache-dir extender-platform]
+  (doto (io/file cache-dir extender-platform "build.hash")
     (fs/create-parent-directories!)))
 
 (defn- cache-dir ^File
-  [project-path]
-  (doto (io/file project-path ".internal" "cache" "engine-archives")
+  [project-directory]
+  (doto (io/file project-directory ".internal" "cache" "engine-archives")
     (fs/create-parent-directories!)))
 
 (defn- cached-engine-archive
-  [cache-dir platform key]
-  (let [cache-file (cache-file cache-dir platform)
-        cache-file-hash (cache-file-hash cache-dir platform)]
+  [cache-dir extender-platform key]
+  (let [cache-file (cache-file cache-dir extender-platform)
+        cache-file-hash (cache-file-hash cache-dir extender-platform)]
     (when (and (.exists cache-file)
                (.exists cache-file-hash)
                (= key (slurp cache-file-hash)))
       cache-file)))
 
 (defn- cache-engine-archive!
-  [cache-dir platform key ^File engine-archive]
-  (let [cache-file (cache-file cache-dir platform)
-        cache-file-hash (cache-file-hash cache-dir platform)]
+  [cache-dir extender-platform key ^File engine-archive]
+  (let [cache-file (cache-file cache-dir extender-platform)
+        cache-file-hash (cache-file-hash cache-dir extender-platform)]
     (fs/move-file! engine-archive cache-file)
     (spit cache-file-hash key)
     cache-file))
@@ -153,8 +152,8 @@
 ;;; Extender API
 
 (defn- build-url
-  [platform sdk-version]
-  (format "/build/%s/%s" platform (or sdk-version "")))
+  [extender-platform sdk-version]
+  (format "/build/%s/%s" extender-platform (or sdk-version "")))
 
 (defn- resource-node-content-stream ^java.io.InputStream
   [resource-node evaluation-context]
@@ -208,7 +207,7 @@
         ne-cache-info))
 
 (defn- build-engine-archive ^File
-  [server-url platform sdk-version resource-nodes-by-upload-path evaluation-context]
+  [server-url extender-platform sdk-version resource-nodes-by-upload-path evaluation-context]
   ;; NOTE:
   ;; sdk-version is likely to be nil unless you're running a bundled editor.
   ;; In this case things will only work correctly if you're running a local
@@ -224,7 +223,7 @@
                  (.setConnectTimeout (int connect-timeout-ms))
                  (.setReadTimeout (int read-timeout-ms)))
         api-root (.resource client (URI. server-url))
-        build-resource (.path api-root (build-url platform sdk-version))
+        build-resource (.path api-root (build-url extender-platform sdk-version))
         builder (.accept build-resource #^"[Ljavax.ws.rs.core.MediaType;" (into-array MediaType []))
         ne-cache-info (query-cached-files server-url resource-nodes-by-upload-path evaluation-context)
         ne-cache-info-map (make-cached-info-map ne-cache-info)]
@@ -242,44 +241,7 @@
             (io/copy (.getEntityInputStream cr) engine-archive)
             engine-archive)
           (let [log (.getEntity cr String)]
-            (throw (engine-build-errors/build-error platform status log))))))))
-
-(defn- find-or-build-engine-archive
-  [cache-dir server-url platform sdk-version resource-nodes-by-upload-path evaluation-context]
-  (let [key (cache-key platform sdk-version (map second (sort-by first resource-nodes-by-upload-path)) evaluation-context)]
-    (or (cached-engine-archive cache-dir platform key)
-        (let [engine-archive (build-engine-archive server-url platform sdk-version resource-nodes-by-upload-path evaluation-context)]
-          (cache-engine-archive! cache-dir platform key engine-archive)))))
-
-(defn- ensure-empty-unpack-dir!
-  [project-path platform]
-  (let [dir (io/file project-path "build" platform)]
-    (fs/delete-directory! dir {:missing :ignore})
-    (fs/create-directories! dir)
-    dir))
-
-(def ^:private dmengine-dependencies
-  {"x86_64-win32" #{"OpenAL32.dll" "wrap_oal.dll"}
-   "x86-win32"    #{"OpenAL32.dll" "wrap_oal.dll"}})
-
-(defn- copy-dmengine-dependencies!
-  [unpack-dir platform]
-  (let [bundled-engine-dir (io/file (system/defold-unpack-path) platform "bin")]
-    (doseq [dep (dmengine-dependencies platform)]
-      (fs/copy! (io/file bundled-engine-dir dep) (io/file unpack-dir dep)))))
-
-(defn- unpack-dmengine
-  [^File engine-archive project-path platform]
-  (with-open [zip-file (ZipFile. engine-archive)]
-    (let [suffix (.getExeSuffix (Platform/getHostPlatform))
-          dmengine-entry (.getEntry zip-file (format "dmengine%s" suffix))
-          stream (.getInputStream zip-file dmengine-entry)
-          unpack-dir (ensure-empty-unpack-dir! project-path platform)
-          engine-file (io/file unpack-dir (format "dmengine%s" suffix))]
-      (io/copy stream engine-file)
-      (fs/set-executable! engine-file)
-      (copy-dmengine-dependencies! unpack-dir platform)
-      engine-file)))
+            (throw (engine-build-errors/build-error extender-platform status log))))))))
 
 (defn get-build-server-url
   ^String [prefs]
@@ -310,17 +272,18 @@
   (not (empty? (merge (extension-roots project evaluation-context)
                       (global-resource-nodes-by-upload-path project evaluation-context)))))
 
-(defn get-engine
-  [project evaluation-context platform build-server]
+(defn get-engine-archive [project evaluation-context platform build-server-url]
   (if-not (supported-platform? platform)
     (throw (engine-build-errors/unsupported-platform-error platform))
-    (let [project-path (workspace/project-path (project/workspace project evaluation-context) evaluation-context)]
-      (unpack-dmengine (find-or-build-engine-archive (cache-dir project-path)
-                                                     build-server
-                                                     (get-in extender-platforms [platform :platform])
-                                                     (system/defold-engine-sha1)
-                                                     (merge (global-resource-nodes-by-upload-path project evaluation-context)
-                                                            (extension-resource-nodes-by-upload-path project evaluation-context platform))
-                                                     evaluation-context)
-                       project-path
-                       platform))))
+    (let [extender-platform (get-in extender-platforms [platform :platform])
+          project-directory (workspace/project-path (project/workspace project evaluation-context) evaluation-context)
+          cache-dir (cache-dir project-directory)
+          resource-nodes-by-upload-path (merge (global-resource-nodes-by-upload-path project evaluation-context)
+                                               (extension-resource-nodes-by-upload-path project evaluation-context platform))
+          sdk-version (system/defold-engine-sha1)
+          key (cache-key extender-platform sdk-version (map second (sort-by first resource-nodes-by-upload-path)) evaluation-context)]
+      (if-let [cached-archive (cached-engine-archive cache-dir extender-platform key)]
+        {:id {:type :custom :version key} :cached true :engine-archive cached-archive :extender-platform extender-platform}
+        (let [temp-archive (build-engine-archive build-server-url extender-platform sdk-version resource-nodes-by-upload-path evaluation-context)
+              engine-archive (cache-engine-archive! cache-dir extender-platform key temp-archive)]
+          {:id {:type :custom :version key} :engine-archive engine-archive :extender-platform extender-platform})))))

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -100,8 +100,8 @@
       (fn [exit-event-loop!]
         (app-view/async-build! project evaluation-context prefs {} {}
                                (constantly nil)
-                               (fn [build-results engine build-engine-exception]
-                                 (deliver result [build-results engine build-engine-exception])
+                               (fn [build-results engine-descriptor build-engine-exception]
+                                 (deliver result [build-results engine-descriptor build-engine-exception])
                                  (exit-event-loop!)))))
     (deref result)))
 
@@ -113,23 +113,31 @@
       (assert (= (native-extensions/get-build-server-url test-prefs) "https://build-stage.defold.com"))
       (testing "clean project builds on server"
         (g/with-auto-evaluation-context evaluation-context
-          (let [[{:keys [error artifacts artifact-map etags] :as build-results} ^File engine build-engine-exception] (blocking-async-build! project evaluation-context test-prefs)]
+          (let [[{:keys [error artifacts artifact-map etags] :as build-results} engine-descriptor build-engine-exception] (blocking-async-build! project evaluation-context test-prefs)]
             (is (nil? error))
             (is (not-empty artifacts))
             (is (not-empty artifact-map))
             (is (not-empty etags))
             (is (nil? build-engine-exception))
-            (is (some? engine))
-            (is (and engine (.exists engine))))))
+            (is (some? engine-descriptor))
+            (is (not (contains? engine-descriptor :cached)))
+            (is (and engine-descriptor (.exists (:engine-archive engine-descriptor)))))))
+      (testing "rebuild uses cached engine archive"
+        (g/with-auto-evaluation-context evaluation-context
+          (let [[_build-results engine-descriptor build-engine-exception] (blocking-async-build! project evaluation-context test-prefs)]
+            (is (nil? build-engine-exception))
+            (is (some? engine-descriptor))
+            (is (contains? engine-descriptor :cached))
+            (is (and engine-descriptor (.exists (:engine-archive engine-descriptor)))))))
       (testing "bad code breaks build on server"
         (let [script (project/get-resource-node project "/printer/src/main.cpp")]
           (g/update-property! script :modified-lines conj "ought to break")
           (g/with-auto-evaluation-context evaluation-context
-            (let [[{:keys [error artifacts artifact-map etags] :as build-results} ^File engine ^Exception build-engine-exception] (blocking-async-build! project evaluation-context test-prefs)]
+            (let [[{:keys [error artifacts artifact-map etags] :as build-results} engine-descriptor ^Exception build-engine-exception] (blocking-async-build! project evaluation-context test-prefs)]
               (is (nil? error))
               (is (not-empty artifacts))
               (is (not-empty artifact-map))
               (is (not-empty etags))
               (is (some? build-engine-exception))
               (is (and build-engine-exception (string/includes? (.getMessage build-engine-exception) "ought to break")))
-              (is (nil? engine)))))))))
+              (is (nil? engine-descriptor)))))))))


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/2366

Technical changes
 - Keep track of the engine version we launch so we can determine if we
   need to launch a new one or can reboot an already running
   engine. Before replacing the dmengine, make sure to kill any running
   engine so the executable is not locked (Windows).

User facing changes
 - Rebuilding a project with native extensions while the engine is running no longer silently fails 