### PR TITLE
DEF-532: Node used in wrong scene, pprint error

### DIFF
--- a/editor/bundle-resources/_defold/debugger/edn.lua
+++ b/editor/bundle-resources/_defold/debugger/edn.lua
@@ -43,6 +43,8 @@ local function str(val)
   -- Can't call tostring on NodeProxy unless called from owning Gui script. See:
   -- https://jira.int.midasplayer.com/browse/DEF-532
   if getmetatable(val) == NodeProxy then
+    return tostring(val) .. get_prefixed_addr("userdata: ", raw_tostring(val))
+    --[[
     local addr = get_prefixed_addr("userdata: ", raw_tostring(val))
     local success, res_or_error = pcall(function () return tostring(val) end)
     if success then
@@ -50,6 +52,7 @@ local function str(val)
     else
       return "<foreign scene node> " .. addr
     end
+    ]]--
   elseif type(val) == "table" and has_custom_tostring(val) then
     return tostring(val) .. " " .. get_prefixed_addr("table: ", raw_tostring(val))
   else

--- a/editor/bundle-resources/_defold/debugger/edn.lua
+++ b/editor/bundle-resources/_defold/debugger/edn.lua
@@ -40,8 +40,6 @@ local function get_prefixed_addr(prefix, raw_string)
 end
 
 local function str(val)
-  -- Can't call tostring on NodeProxy unless called from owning Gui script. See:
-  -- https://jira.int.midasplayer.com/browse/DEF-532
   if getmetatable(val) == NodeProxy then
     return tostring(val) .. get_prefixed_addr("userdata: ", raw_tostring(val))
   elseif type(val) == "table" and has_custom_tostring(val) then

--- a/editor/bundle-resources/_defold/debugger/edn.lua
+++ b/editor/bundle-resources/_defold/debugger/edn.lua
@@ -44,15 +44,6 @@ local function str(val)
   -- https://jira.int.midasplayer.com/browse/DEF-532
   if getmetatable(val) == NodeProxy then
     return tostring(val) .. get_prefixed_addr("userdata: ", raw_tostring(val))
-    --[[
-    local addr = get_prefixed_addr("userdata: ", raw_tostring(val))
-    local success, res_or_error = pcall(function () return tostring(val) end)
-    if success then
-      return res_or_error .. " " .. addr
-    else
-      return "<foreign scene node> " .. addr
-    end
-    ]]--
   elseif type(val) == "table" and has_custom_tostring(val) then
     return tostring(val) .. " " .. get_prefixed_addr("table: ", raw_tostring(val))
   else

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -247,8 +247,7 @@ namespace dmGui
 
     static int NodeProxy_tostring (lua_State *L)
     {
-        int top = lua_gettop(L);
-        (void) top;
+        DM_LUA_STACK_CHECK(L,1);
 
         NodeProxy* np = NodeProxy_Check(L, 1);
 
@@ -290,7 +289,6 @@ namespace dmGui
             lua_pushstring(L,"<foreign scene node>");
         }
 
-        assert(top + 1 == lua_gettop(L));
         return 1;
     }
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -249,26 +249,47 @@ namespace dmGui
     {
         int top = lua_gettop(L);
         (void) top;
-        InternalNode* n = LuaCheckNode(L, 1, 0);
-        Vector4 pos = n->m_Node.m_Properties[PROPERTY_POSITION];
-        switch (n->m_Node.m_NodeType)
+
+        NodeProxy* np = NodeProxy_Check(L, 1);
+
+        if (np->m_Scene == GetScene(L))
         {
-            case NODE_TYPE_BOX:
-                lua_pushfstring(L, "box@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
-                break;
-            case NODE_TYPE_TEXT:
-                lua_pushfstring(L, "%s@(%f, %f, %f)", n->m_Node.m_Text, pos.getX(), pos.getY(), pos.getZ());
-                break;
-            case NODE_TYPE_SPINE:
-                lua_pushfstring(L, "spine@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
-                break;
-            case NODE_TYPE_PARTICLEFX:
-                lua_pushfstring(L, "particlefx@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
-                break;
-            default:
-                lua_pushfstring(L, "unknown@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
-                break;
+            InternalNode* n = 0;
+
+            if (IsValidNode(np->m_Scene, np->m_Node))
+            {
+                n = GetNode(np->m_Scene, np->m_Node);
+            }
+            else
+            {
+                luaL_error(L, "Deleted node");
+            }
+
+            Vector4 pos = n->m_Node.m_Properties[PROPERTY_POSITION];
+            switch (n->m_Node.m_NodeType)
+            {
+                case NODE_TYPE_BOX:
+                    lua_pushfstring(L, "box@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
+                    break;
+                case NODE_TYPE_TEXT:
+                    lua_pushfstring(L, "%s@(%f, %f, %f)", n->m_Node.m_Text, pos.getX(), pos.getY(), pos.getZ());
+                    break;
+                case NODE_TYPE_SPINE:
+                    lua_pushfstring(L, "spine@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
+                    break;
+                case NODE_TYPE_PARTICLEFX:
+                    lua_pushfstring(L, "particlefx@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
+                    break;
+                default:
+                    lua_pushfstring(L, "unknown@(%f, %f, %f)", pos.getX(), pos.getY(), pos.getZ());
+                    break;
+            }
         }
+        else
+        {
+            lua_pushstring(L,"<foreign scene node>");
+        }
+
         assert(top + 1 == lua_gettop(L));
         return 1;
     }
@@ -579,7 +600,7 @@ namespace dmGui
         HScene m_Scene;
         int m_NodeRef;
     };
-    
+
     static void LuaCallbackCustomArgsCB(lua_State* L, void* user_args)
     {
         LuaAnimationCompleteArgs* args = (LuaAnimationCompleteArgs*)user_args;


### PR DESCRIPTION
This PR changes behaviour in gui scripts when printing nodes from a different scene. The previous workaround in the debugger can thus be removed. Previously, this would yield a Lua error which would halt the calling script from execution.