### PR TITLE
DEF-3705

### DIFF
--- a/engine/engine/src/test/tile/coll.script
+++ b/engine/engine/src/test/tile/coll.script
@@ -44,16 +44,16 @@ function init(self)
     -- Tile index out-of-range
     ret = pcall(function() tilemap.set_tile("#tilemap", "layer", 0, 0, -1) end)
     assert(ret == false)
-    ret = pcall(function() tilemap.set_tile("#tilemap", "layer", 0, 0, 1) end)
+    ret = pcall(function() tilemap.set_tile("#tilemap", "layer", 0, 0, 4) end)
     assert(ret == false)
 
     -- verify hashed string works as argument to layer
     tile = tilemap.get_tile("#tilemap", "layer", 1, 1)
     assert(tile == 0)
-    res = tilemap.set_tile("#tilemap", hash("layer"), 1, 1, 1)
+    res = tilemap.set_tile("#tilemap", hash("layer"), 1, 1, 0)
     assert(res == true)
     tile = tilemap.get_tile("#tilemap", hash("layer"), 1, 1)
-    assert(tile == 1)
+    assert(tile == 0)
 
     -- Set tile out-of-range. Test for previous bug
     msg.post("#tilemap", "set_tile", {layer_id = hash("layer"), position = go.get_position(), dx = 1})

--- a/engine/engine/src/test/tile/coll.script
+++ b/engine/engine/src/test/tile/coll.script
@@ -35,12 +35,17 @@ function init(self)
     -- Flips
     res = tilemap.set_tile("#tilemap", "layer", 1, 1, 0, true, true)
     assert(res == true)
-    -- out of range
+    -- Cell index out of range
     res = tilemap.set_tile("#tilemap", "layer", 1, 2, 0)
     assert(res == false)
     -- Invalid layer
     res = tilemap.set_tile("#tilemap", "not_found_layer", 0, 0, 0)
     assert(res == false)
+    -- Tile index out-of-range
+    ret = pcall(function() tilemap.set_tile("#tilemap", "layer", 0, 0, -1) end)
+    assert(ret == false)
+    ret = pcall(function() tilemap.set_tile("#tilemap", "layer", 0, 0, 1) end)
+    assert(ret == false)
 
     -- verify hashed string works as argument to layer
     tile = tilemap.get_tile("#tilemap", "layer", 1, 1)

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -177,17 +177,18 @@ namespace dmGameSystem
         int y = luaL_checkinteger(L, 4) - 1;
         int lua_tile  = luaL_checkinteger(L, 5);
 
+        // Range check: tile indices that fall outside of the valid limits will crash the engine
+        if (lua_tile < 0 || lua_tile >= resource->m_TextureSet->m_TextureSet->m_TileCount)
+        {
+            return luaL_error(L, "tilemap.set_tile called with out-of-range tile index (%d)", lua_tile);
+        }
+
         /*
          * NOTE AND BEWARE: Empty tile is encoded as 0xffffffff
          * That's why tile-index is subtracted by 1
          * See B2GRIDSHAPE_EMPTY_CELL in b2GridShape.h
          */
         uint16_t tile = ((uint16_t) lua_tile) - 1;
-
-        if (lua_tile < 0 || lua_tile >= resource->m_TextureSet->m_TextureSet->m_TileCount)
-        {
-            return luaL_error(L, "tilemap.set_tile called with out-of-range tile index (%d)", lua_tile);
-        }
 
         int32_t cell_x = x - resource->m_MinCellX, cell_y = y - resource->m_MinCellY;
         if (cell_x < 0 || cell_x >= (int32_t)resource->m_ColumnCount || cell_y < 0 || cell_y >= (int32_t)resource->m_RowCount)

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -175,12 +175,20 @@ namespace dmGameSystem
 
         int x = luaL_checkinteger(L, 3) - 1;
         int y = luaL_checkinteger(L, 4) - 1;
+        int lua_tile  = luaL_checkinteger(L, 5);
+
         /*
          * NOTE AND BEWARE: Empty tile is encoded as 0xffffffff
          * That's why tile-index is subtracted by 1
          * See B2GRIDSHAPE_EMPTY_CELL in b2GridShape.h
          */
-        uint32_t tile = ((uint16_t) luaL_checkinteger(L, 5)) - 1;
+        uint16_t tile = ((uint16_t) lua_tile) - 1;
+
+        if (lua_tile < 0 || lua_tile >= resource->m_TextureSet->m_TextureSet->m_TileCount)
+        {
+            return luaL_error(L, "tilemap.set_tile called with out-of-range tile index (%d)", lua_tile);
+        }
+
         int32_t cell_x = x - resource->m_MinCellX, cell_y = y - resource->m_MinCellY;
         if (cell_x < 0 || cell_x >= (int32_t)resource->m_ColumnCount || cell_y < 0 || cell_y >= (int32_t)resource->m_RowCount)
         {


### PR DESCRIPTION
Passing in an invalid tile index crashes the engine with no user feedback. Now, an error will be raised when this happens instead. 