### PR TITLE
DEF-3696: Calling collectionfactory.load() on an empty collection crashes the engine

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
@@ -153,6 +153,14 @@ namespace dmGameSystem
         }
 
         dmGameObjectDDF::CollectionDesc* collection_desc = (dmGameObjectDDF::CollectionDesc*) component->m_Resource->m_CollectionDesc;
+
+        // No need to process this collection further if there's nothing to load
+        if (collection_desc->m_Instances.m_Count == 0)
+        {
+            component->m_Loading = 1;
+            return true;
+        }
+
         dmArray<const char*> names;
         names.SetCapacity(collection_desc->m_Instances.m_Count);
         for (uint32_t i = 0; i < collection_desc->m_Instances.m_Count; ++i)


### PR DESCRIPTION
When taking the dynamic route in CompCollectionFactoryLoad, the preloader expects at least one item to put into the loading hierarchy. In order to conform with the same behaviour as when loading in a non-dynamic collection, we abort the preloading step if there's no instances in the collection ddf. 