### PR TITLE
DEF-3695 dmHttpClientTest.ThreadStress fails intermittently

### DIFF
--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -484,7 +484,8 @@ namespace dmConnectionPool
         // in-use connections.
         DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
         uint32_t count = 0;
-        for (uint32_t i=0;i!=pool->m_Connections.Size();i++) {
+        uint32_t n = pool->m_Connections.Size();
+        for (uint32_t i=0; i != n; i++) {
             Connection* c = &pool->m_Connections[i];
             if (c->m_State == STATE_INUSE) {
                 count++;
@@ -501,7 +502,22 @@ namespace dmConnectionPool
 
     void Reopen(HPool pool)
     {
+        // This function is used by tests to restore usage of a pool
+        // We purge any live connections so the test does not run out
+        // of connection pool items
         DM_MUTEX_SCOPED_LOCK(pool->m_Mutex);
+        uint32_t n = pool->m_Connections.Size();
+        for (uint32_t i=0; i != n; i++) {
+            Connection* c = &pool->m_Connections[i];
+            if (c->m_State == STATE_CONNECTED)
+            {
+                dmSocket::Delete(c->m_Socket);
+                if (c->m_SSLConnection) {
+                    ssl_free(c->m_SSLConnection);
+                }
+                c->Clear();
+            }
+        }
         pool->m_AllowNewConnections = 1;
     }
 }

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -399,7 +399,12 @@ static void HttpStressThread(void* param)
 
 TEST_P(dmHttpClientTest, ThreadStress)
 {
-    const int thread_count = 16;
+    // Shut down and reopen the connection pool so we can use it to it's full extent
+    // on each pass
+    ASSERT_EQ(0, dmHttpClient::ShutdownConnectionPool());
+    dmHttpClient::ReopenConnectionPool();
+
+    const int thread_count = 32;    // This is the maximum number of items in the connection pool, can't go any higher than that
     dmThread::Thread threads[thread_count];
     HttpStressHelper* helpers[thread_count];
 

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -404,7 +404,7 @@ TEST_P(dmHttpClientTest, ThreadStress)
     ASSERT_EQ(0, dmHttpClient::ShutdownConnectionPool());
     dmHttpClient::ReopenConnectionPool();
 
-    const int thread_count = 32;    // This is the maximum number of items in the connection pool, can't go any higher than that
+    const int thread_count = 16;    // 32 is the maximum number of items in the connection pool, stay below that
     dmThread::Thread threads[thread_count];
     HttpStressHelper* helpers[thread_count];
 


### PR DESCRIPTION
Make sure we clear out the http connection pool before starting stress tests