### PR TITLE
DEF-3713 Add missing profiler script scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ In that web app manager, you can see the console output, take screenshots or sho
 
 **TODO**
 
-* Investigate mutex and dmProfile overhead. Removing DM_PROFILE, DM_COUNTER_HASH, dmMutex::Lock and dmMutex::Unlock from dmMessage::Post resulted in 4x improvement
+* Investigate mutex and dmProfile overhead. Removing DM_PROFILE, DM_COUNTER, dmMutex::Lock and dmMutex::Unlock from dmMessage::Post resulted in 4x improvement
 * Verify that exceptions are disabled
 
 ## Asset loading

--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -272,6 +272,11 @@ namespace dmBuffer
         return ValidateBuffer(GetBuffer(g_BufferContext, hbuffer));
     }
 #else
+    static inline void WriteGuard(void* ptr)
+    {
+        (void*)ptr;
+    }
+
     static inline Result ValidateBuffer(Buffer* buffer)
     {
         (void*)buffer;

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -368,10 +368,11 @@ namespace dmMessage
             dmMutex::Unlock(g_MessageContext->m_Mutex);
             return 0;
         }
-        DM_PROFILE_FMT(Message, "Dispatch %s", s->m_Name);
 
         dmMutex::Lock(s->m_Mutex);
         dmMutex::Unlock(g_MessageContext->m_Mutex);
+
+        DM_PROFILE_FMT(Message, "Dispatch %s", s->m_Name);
 
         MemoryAllocator* allocator = &s->m_Allocator;
 

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -368,7 +368,7 @@ namespace dmMessage
             dmMutex::Unlock(g_MessageContext->m_Mutex);
             return 0;
         }
-        DM_PROFILE(Message, DM_INTERNALIZE(s->m_Name));
+        DM_PROFILE_FMT(Message, "Dispatch %s", s->m_Name);
 
         dmMutex::Lock(s->m_Mutex);
         dmMutex::Unlock(g_MessageContext->m_Mutex);

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -300,12 +300,10 @@ namespace dmMessage
         memset((void*)&url, 0, sizeof(URL));
     }
 
-    uint32_t g_MessagesHash = dmProfile::HashCounterName("Messages");
-
     Result Post(const URL* sender, const URL* receiver, dmhash_t message_id, uintptr_t user_data, uintptr_t descriptor, const void* message_data, uint32_t message_data_size, MessageDestroyCallback destroy_callback)
     {
         DM_PROFILE(Message, "Post")
-        DM_COUNTER_HASH("Messages", g_MessagesHash, 1)
+        DM_COUNTER("Messages", 1)
 
         if (receiver == 0x0)
         {

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -370,7 +370,7 @@ namespace dmMessage
             dmMutex::Unlock(g_MessageContext->m_Mutex);
             return 0;
         }
-        DM_PROFILE(Message, dmProfile::Internalize(s->m_Name));
+        DM_PROFILE(Message, DM_INTERNALIZE(s->m_Name));
 
         dmMutex::Lock(s->m_Mutex);
         dmMutex::Unlock(g_MessageContext->m_Mutex);

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -300,7 +300,7 @@ namespace dmMessage
         memset((void*)&url, 0, sizeof(URL));
     }
 
-    uint32_t g_MessagesHash = dmHashString32("Messages");
+    uint32_t g_MessagesHash = dmProfile::HashCounterName("Messages");
 
     Result Post(const URL* sender, const URL* receiver, dmhash_t message_id, uintptr_t user_data, uintptr_t descriptor, const void* message_data, uint32_t message_data_size, MessageDestroyCallback destroy_callback)
     {

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -9,7 +9,6 @@
 #include "math.h"
 #include "time.h"
 #include "thread.h"
-#include "dstrings.h"
 #include "array.h"
 #include "profile.h"
 
@@ -496,10 +495,14 @@ namespace dmProfile
         }
     }
 
+    uint32_t HashCounterName(const char* name)
+    {
+        return dmHashBufferNoReverse32(name, strlen(name));
+    }
+
     void AddCounter(const char* name, uint32_t amount)
     {
-        uint32_t name_hash = dmHashBufferNoReverse32(name, strlen(name));
-        AddCounterHash(name, name_hash, amount);
+        AddCounterHash(name, HashCounterName(name), amount);
     }
 
     void AddCounterHash(const char* name, uint32_t name_hash, uint32_t amount)
@@ -527,7 +530,7 @@ namespace dmProfile
 
             Counter* c = &g_Counters[new_index];
             c->m_Name = name;
-            c->m_NameHash = dmHashBufferNoReverse32(name, strlen(name));
+            c->m_NameHash = name_hash;
 
             CounterData* cd = &profile->m_CountersData[new_index];
             cd->m_Counter = c;

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -502,13 +502,17 @@ namespace dmProfile
 
     void AddCounter(const char* name, uint32_t amount)
     {
+        // dmProfile::Initialize allocates memory. If memprofile is activated this function is called from overloaded malloc while g_CountersTable is being created. No good!
+        if (!g_IsInitialized)
+        {
+            return;
+        }
         AddCounterHash(name, HashCounterName(name), amount);
     }
 
     void AddCounterHash(const char* name, uint32_t name_hash, uint32_t amount)
     {
-        // dmProfile::Initialize allocates memory. Is memprofile is activated this function is called from overloaded malloc while g_CountersTable is being created. No good!
-        if (!g_IsInitialized || g_Paused)
+        if (g_Paused)
             return;
 
         dmSpinlock::Lock(&g_ProfileLock);

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -50,8 +50,8 @@
  * scope_name is the scope name. Must be a literal
  * fmt String format, uses printf formatting limited to 128 characters
  */
-#define DM_PROFILE_FMT(scope, fmt, ...)
-#undef DM_PROFILE_FMT
+#define DM_PROFILE_SCOPE_FMT(scope, fmt, ...)
+#undef DM_PROFILE_SCOPE_FMT
 
 /**
  * Profile counter macro
@@ -71,11 +71,11 @@
 #undef DM_COUNTER_HASH
 
 #if defined(NDEBUG)
-    #define DM_INTERNALIZE(name)
+    #define DM_INTERNALIZE(name) 0
     #define DM_NAMED_PROFILE(scope_instance_name, scope_name, name)
     #define DM_PROFILE_SCOPE(scope_instance_name, name)
     #define DM_PROFILE(scope_name, name)
-    #define DM_PROFILE_FMT(scope, fmt, ...)
+    #define DM_PROFILE_SCOPE_FMT(scope, fmt, ...)
     #define DM_HASH_COUNTER_NAME(name)
     #define DM_COUNTER(name, amount)
     #define DM_COUNTER_HASH(name, name_hash, amount)
@@ -97,7 +97,7 @@
     #define DM_PROFILE(scope_name, name) \
         DM_NAMED_PROFILE(DM_PROFILE_PASTE2(scope, __LINE__), scope_name, name)
 
-    #define DM_PROFILE_FMT(scope, fmt, ...) \
+    #define DM_PROFILE_SCOPE_FMT(scope, fmt, ...) \
         const char* DM_PROFILE_PASTE2(name, __LINE__) = 0; \
         if (dmProfile::g_IsInitialized) { \
             char buffer[128]; \

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -87,11 +87,7 @@
         dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(scope, name);\
 
     #define DM_NAMED_PROFILE(scope_instance_name, scope_name, name) \
-        static dmProfile::Scope* scope_instance_name = 0; \
-        if (dmProfile::g_IsInitialized && scope_instance_name == 0) \
-        {\
-            scope_instance_name = dmProfile::AllocateScope(#scope_name);\
-        }\
+        static dmProfile::Scope* scope_instance_name = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
         DM_PROFILE_SCOPE(scope_instance_name, name)
 
     #define DM_PROFILE(scope_name, name) \

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -28,15 +28,6 @@
 
 /**
  * Profile macro.
- * scope_instance_name is the name of the scope instance.
- * scope_name is the scope name. Must be a literal
- * name is the sample name. Must be a literal 
- */
-#define DM_NAMED_PROFILE(scope_instance_name, scope_name, name)
-#undef DM_NAMED_PROFILE
-
-/**
- * Profile macro.
  * scope_name is the scope name. Must be a literal
  * name is the sample name. Must be literal, to use non-literal name use DM_PROFILE_FMT
  */
@@ -46,20 +37,11 @@
 /**
  * Profile macro.
  * scope_name is the scope name. Must be a literal
- * fmt String format, uses printf formatting limited to 128 characters
+ * fmt is the String format, uses printf formatting limited to 128 characters
  * Has overhead due to printf style formatting and hashing of the formatted string
  */
 #define DM_PROFILE_FMT(scope_name, fmt, ...)
 #undef DM_PROFILE_FMT
-
-/**
- * Profile macro for dynamic strings.
- * scope is the scope used when creating it using DM_NAMED_PROFILE. Must be a literal
- * fmt String format, uses printf formatting limited to 128 characters
- * Has overhead due to printf style formatting and hashing of the formatted string
- */
-#define DM_NAMED_PROFILE_FMT(scope, fmt, ...)
-#undef DM_NAMED_PROFILE_FMT
 
 /**
  * Profile counter macro
@@ -81,10 +63,8 @@
 #if defined(NDEBUG)
     #define DM_INTERNALIZE(name) 0
     #define DM_PROFILE_SCOPE(scope_instance_name, name)
-    #define DM_NAMED_PROFILE(scope_instance_name, scope_name, name)
     #define DM_PROFILE(scope_name, name)
     #define DM_PROFILE_FMT(scope_name, fmt, ...)
-    #define DM_NAMED_PROFILE_FMT(scope, fmt, ...)
     #define DM_COUNTER(name, amount)
     #define DM_COUNTER_DYN(name, name_hash, amount)
 #else
@@ -94,25 +74,19 @@
     #define DM_PROFILE_SCOPE(scope, name) \
         dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(scope, name);\
 
-    #define DM_NAMED_PROFILE(scope_instance_name, scope_name, name) \
-        static dmProfile::Scope* scope_instance_name = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
-        DM_PROFILE_SCOPE(scope_instance_name, name)
-
     #define DM_PROFILE(scope_name, name) \
-        DM_NAMED_PROFILE(DM_PROFILE_PASTE2(scope, __LINE__), scope_name, name)
+        static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
+        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope, __LINE__), name)
 
-    #define DM_NAMED_PROFILE_FMT(scope, fmt, ...) \
+    #define DM_PROFILE_FMT(scope_name, fmt, ...) \
+        static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
         const char* DM_PROFILE_PASTE2(name, __LINE__) = 0; \
         if (dmProfile::g_IsInitialized) { \
             char buffer[128]; \
             DM_SNPRINTF(buffer, sizeof(buffer), fmt, __VA_ARGS__); \
             DM_PROFILE_PASTE2(name, __LINE__) = dmProfile::Internalize(buffer); \
         } \
-        DM_PROFILE_SCOPE(scope, DM_PROFILE_PASTE2(name, __LINE__))
-
-    #define DM_PROFILE_FMT(scope_name, fmt, ...) \
-        static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
-        DM_NAMED_PROFILE_FMT(DM_PROFILE_PASTE2(scope, __LINE__), fmt, __VA_ARGS__)
+        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope, __LINE__), DM_PROFILE_PASTE2(name, __LINE__))
 
     #define DM_COUNTER(name, amount) \
         if (dmProfile::g_IsInitialized) { \
@@ -124,7 +98,6 @@
         if (dmProfile::g_IsInitialized) { \
             dmProfile::AddCounterHash(name, name_hash, amount); \
         }
-
 #endif
 
 namespace dmProfile

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -242,7 +242,7 @@ TEST(dmProfile, Counter1)
     dmProfile::Finalize();
 }
 
-uint32_t g_c1hash = dmHashString32("c1");
+static uint32_t g_c1hash = dmProfile::HashCounterName("c1");
 void CounterThread(void* arg)
 {
     for (int i = 0; i < 2000; ++i)

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -242,12 +242,11 @@ TEST(dmProfile, Counter1)
     dmProfile::Finalize();
 }
 
-static uint32_t g_c1hash = dmProfile::HashCounterName("c1");
 void CounterThread(void* arg)
 {
     for (int i = 0; i < 2000; ++i)
     {
-        DM_COUNTER_HASH("c1", g_c1hash, 1);
+        DM_COUNTER("c1", 1);
     }
 }
 

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -503,7 +503,7 @@ namespace dmGameObject
             int ret;
             {
                 DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
-                dmScript::PCall(L, arg_count, LUA_MULTRET);
+                ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
             }
             const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT];
             if (ret != 0)

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -83,7 +83,7 @@ namespace dmGameObject
 
     ScriptResult RunScript(lua_State* L, HScript script, ScriptFunction script_function, HScriptInstance script_instance, const RunScriptParams& params)
     {
-        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RunScript");
+        DM_PROFILE(Script, "RunScript");
 
         ScriptResult result = SCRIPT_RESULT_OK;
 
@@ -113,7 +113,7 @@ namespace dmGameObject
             }
 
             {
-                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_FMT(Script, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     result = SCRIPT_RESULT_FAILED;
@@ -228,7 +228,7 @@ namespace dmGameObject
 
     UpdateResult CompScriptOnMessage(const ComponentOnMessageParams& params)
     {
-        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RunScript");
+        DM_PROFILE(Script, "RunScript");
         UpdateResult result = UPDATE_RESULT_OK;
 
         ScriptInstance* script_instance = (ScriptInstance*)*params.m_UserData;
@@ -319,7 +319,7 @@ namespace dmGameObject
 
             // An on_message function shouldn't return anything.
             {
-                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", function_name, function_source);
+                DM_PROFILE_FMT(Script, "%s@%s", function_name, function_source);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -336,7 +336,7 @@ namespace dmGameObject
 
     InputResult CompScriptOnInput(const ComponentOnInputParams& params)
     {
-        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RunScript");
+        DM_PROFILE(Script, "RunScript");
         InputResult result = INPUT_RESULT_IGNORED;
 
         ScriptInstance* script_instance = (ScriptInstance*)*params.m_UserData;
@@ -524,7 +524,7 @@ namespace dmGameObject
             int input_ret = lua_gettop(L) - arg_count;
             int ret;
             {
-                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_FMT(Script, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
                 ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
             }
             const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT];

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -83,7 +83,7 @@ namespace dmGameObject
 
     ScriptResult RunScript(lua_State* L, HScript script, ScriptFunction script_function, HScriptInstance script_instance, const RunScriptParams& params)
     {
-        DM_NAMED_PROFILE(gProfilerRunScriptScope, Script, "RunScript");
+        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RunScript");
 
         ScriptResult result = SCRIPT_RESULT_OK;
 
@@ -113,7 +113,7 @@ namespace dmGameObject
             }
 
             {
-                DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     result = SCRIPT_RESULT_FAILED;
@@ -228,7 +228,7 @@ namespace dmGameObject
 
     UpdateResult CompScriptOnMessage(const ComponentOnMessageParams& params)
     {
-        DM_NAMED_PROFILE(gProfilerRunScriptScope, Script, "RunScript");
+        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RunScript");
         UpdateResult result = UPDATE_RESULT_OK;
 
         ScriptInstance* script_instance = (ScriptInstance*)*params.m_UserData;
@@ -300,7 +300,7 @@ namespace dmGameObject
                 {
                     (void)dmScript::GetLuaFunctionRefInfo(L, -5, &fi);
                 }
-                DM_PROFILE_FMT(gProfilerRunScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
+                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -308,7 +308,7 @@ namespace dmGameObject
             }
             else
             {
-                DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -325,7 +325,7 @@ namespace dmGameObject
 
     InputResult CompScriptOnInput(const ComponentOnInputParams& params)
     {
-        DM_NAMED_PROFILE(gProfilerRunScriptScope, Script, "RunScript");
+        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RunScript");
         InputResult result = INPUT_RESULT_IGNORED;
 
         ScriptInstance* script_instance = (ScriptInstance*)*params.m_UserData;
@@ -513,7 +513,7 @@ namespace dmGameObject
             int input_ret = lua_gettop(L) - arg_count;
             int ret;
             {
-                DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
                 ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
             }
             const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT];

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -303,7 +303,7 @@ namespace dmGameObject
                     dmScript::LuaFunctionInfo fi;
                     if (dmScript::GetLuaFunctionRefInfo(L, -5, &fi))
                     {
-                        function_source = fi.m_ShortFileName;
+                        function_source = fi.m_FileName;
                         if (fi.m_OptionalName)
                         {
                             function_name = fi.m_OptionalName;

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -113,7 +113,7 @@ namespace dmGameObject
             }
 
             {
-                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     result = SCRIPT_RESULT_FAILED;
@@ -319,7 +319,7 @@ namespace dmGameObject
 
             // An on_message function shouldn't return anything.
             {
-                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", function_name, function_source);
+                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", function_name, function_source);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -524,7 +524,7 @@ namespace dmGameObject
             int input_ret = lua_gettop(L) - arg_count;
             int ret;
             {
-                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
                 ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
             }
             const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT];

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -113,7 +113,7 @@ namespace dmGameObject
             }
 
             {
-                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     result = SCRIPT_RESULT_FAILED;
@@ -300,7 +300,7 @@ namespace dmGameObject
                 {
                     (void)dmScript::GetLuaFunctionRefInfo(L, -5, &fi);
                 }
-                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
+                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -308,7 +308,7 @@ namespace dmGameObject
             }
             else
             {
-                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -513,7 +513,7 @@ namespace dmGameObject
             int input_ret = lua_gettop(L) - arg_count;
             int ret;
             {
-                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
                 ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
             }
             const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT];

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -83,8 +83,7 @@ namespace dmGameObject
 
     ScriptResult RunScript(lua_State* L, HScript script, ScriptFunction script_function, HScriptInstance script_instance, const RunScriptParams& params)
     {
-        static dmProfile::Scope* gProfilerRunScriptScope = dmProfile::g_IsInitialized ? dmProfile::AllocateScope("Script") : 0;
-        DM_PROFILE_SCOPE(gProfilerRunScriptScope, "RunScript");
+        DM_NAMED_PROFILE(gProfilerRunScriptScope, Script, "RunScript");
 
         ScriptResult result = SCRIPT_RESULT_OK;
 
@@ -113,15 +112,8 @@ namespace dmGameObject
                 ++arg_count;
             }
 
-            const char* scope_name = 0;
-            if (dmProfile::g_IsInitialized)
             {
-                char buffer[128];
-                DM_SNPRINTF(buffer, sizeof(buffer), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
-                scope_name = dmProfile::Internalize(buffer);
-            }
-            {
-                DM_PROFILE_SCOPE(gProfilerRunScriptScope, scope_name);
+                DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     result = SCRIPT_RESULT_FAILED;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2396,7 +2396,7 @@ namespace dmGameObject
             uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
             ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
 
-            DM_COUNTER(component_type->m_Name, collection->m_ComponentInstanceCount[update_index]);
+            DM_COUNTER_DYN(component_type->m_Name, collection->m_ComponentInstanceCount[update_index]);
 
             // Avoid to call UpdateTransforms for each/all component types.
             if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -484,6 +484,10 @@ namespace dmGameObject
 
         regist->m_ComponentTypes[regist->m_ComponentTypeCount] = type;
         regist->m_ComponentTypesOrder[regist->m_ComponentTypeCount] = regist->m_ComponentTypeCount;
+        if (dmProfile::g_IsInitialized)
+        {
+            regist->m_ComponentNameHash[regist->m_ComponentTypeCount] = dmProfile::HashCounterName(type.m_Name);
+        }
         regist->m_ComponentTypeCount++;
         return RESULT_OK;
     }
@@ -2396,7 +2400,7 @@ namespace dmGameObject
             uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
             ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
 
-            DM_COUNTER_DYN(component_type->m_Name, collection->m_ComponentInstanceCount[update_index]);
+            DM_COUNTER_DYN(component_type->m_Name, collection->m_Register->m_ComponentNameHash[i], collection->m_ComponentInstanceCount[update_index]);
 
             // Avoid to call UpdateTransforms for each/all component types.
             if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2400,7 +2400,7 @@ namespace dmGameObject
             uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
             ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
 
-            DM_COUNTER_DYN(component_type->m_Name, collection->m_Register->m_ComponentNameHash[i], collection->m_ComponentInstanceCount[update_index]);
+            DM_COUNTER_DYN(component_type->m_Name, collection->m_Register->m_ComponentNameHash[update_index], collection->m_ComponentInstanceCount[update_index]);
 
             // Avoid to call UpdateTransforms for each/all component types.
             if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -182,6 +182,7 @@ namespace dmGameObject
         uint32_t                    m_ComponentTypeCount;
         ComponentType               m_ComponentTypes[MAX_COMPONENT_TYPES];
         uint16_t                    m_ComponentTypesOrder[MAX_COMPONENT_TYPES];
+        uint32_t                    m_ComponentNameHash[MAX_COMPONENT_TYPES];
         dmMutex::Mutex              m_Mutex;
 
         // All collections. Protected by m_Mutex

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1140,14 +1140,13 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         CHECK_GL_ERROR
     }
 
-    uint32_t g_DrawCallsHash = dmProfile::HashCounterName("DrawCalls");
 
     void DrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer)
     {
         assert(context);
         assert(index_buffer);
         DM_PROFILE(Graphics, "DrawElements");
-        DM_COUNTER_HASH("DrawCalls", g_DrawCallsHash, 1);
+        DM_COUNTER("DrawCalls", DrawCallsHash, 1);
 
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
         CHECK_GL_ERROR
@@ -1160,7 +1159,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
     {
         assert(context);
         DM_PROFILE(Graphics, "Draw");
-        DM_COUNTER_HASH("DrawCalls", g_DrawCallsHash, 1);
+        DM_COUNTER("DrawCalls", DrawCallsHash, 1);
         glDrawArrays(prim_type, first, count);
         CHECK_GL_ERROR
     }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1146,7 +1146,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         assert(context);
         assert(index_buffer);
         DM_PROFILE(Graphics, "DrawElements");
-        DM_COUNTER("DrawCalls", DrawCallsHash, 1);
+        DM_COUNTER("DrawCalls", 1);
 
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
         CHECK_GL_ERROR
@@ -1159,7 +1159,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
     {
         assert(context);
         DM_PROFILE(Graphics, "Draw");
-        DM_COUNTER("DrawCalls", DrawCallsHash, 1);
+        DM_COUNTER("DrawCalls", 1);
         glDrawArrays(prim_type, first, count);
         CHECK_GL_ERROR
     }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1140,7 +1140,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         CHECK_GL_ERROR
     }
 
-    uint32_t g_DrawCallsHash = dmHashString32("DrawCalls");
+    uint32_t g_DrawCallsHash = dmProfile::HashCounterName("DrawCalls");
 
     void DrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer)
     {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1541,8 +1541,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
     Result RunScript(HScene scene, ScriptFunction script_function, int custom_ref, void* args)
     {
-        static dmProfile::Scope* gProfilerGuiScriptScope = dmProfile::g_IsInitialized ? dmProfile::AllocateScope("Script") : 0;
-        DM_PROFILE_SCOPE(gProfilerGuiScriptScope, "GuiScript");
+        DM_NAMED_PROFILE(gProfilerGuiScriptScope, Script, "GuiScript");
 
         if (scene->m_Script == 0x0)
             return RESULT_OK;
@@ -1793,22 +1792,10 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             }
 
             Result result = RESULT_OK;
-            const char* scope_name = 0;
-            if (dmProfile::g_IsInitialized)
             {
-                if (custom_ref == LUA_NOREF)
-                {
-                    char buffer[128];
-                    DM_SNPRINTF(buffer, sizeof(buffer), "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
-                    scope_name = dmProfile::Internalize(buffer);
-                }
-                else
-                {
-                    scope_name = "<unknown>@<unknown>";
-                }
-            }
-            {
-                DM_PROFILE_SCOPE(gProfilerGuiScriptScope, scope_name);
+                const char* function_name = (custom_ref == LUA_NOREF) ? "<unknown>" : SCRIPT_FUNCTION_NAMES[script_function];
+                const char* file_name = (custom_ref == LUA_NOREF) ? "<unknown>" : scene->m_Script->m_SourceFileName;
+                DM_PROFILE_FMT(gProfilerGuiScriptScope, "%s@%s", function_name, file_name);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));
@@ -4171,7 +4158,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         }
         // m_SourceFileName will be null if profiling is not enabled, this is fine
         // as m_SourceFileName will only be used if profiling is enabled
-        script->m_SourceFileName = dmProfile::Internalize(source->m_Filename);
+        script->m_SourceFileName = DM_INTERNALIZE(source->m_Filename);
 bail:
         assert(top == lua_gettop(L));
         return res;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1541,7 +1541,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
     Result RunScript(HScene scene, ScriptFunction script_function, int custom_ref, void* args)
     {
-        DM_NAMED_PROFILE(ProfilerGuiScriptScope, Script, "GuiScript");
+        DM_PROFILE(Script, "GuiScript");
 
         if (scene->m_Script == 0x0)
             return RESULT_OK;
@@ -1818,7 +1818,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 }
             }
             {
-                DM_NAMED_PROFILE_FMT(ProfilerGuiScriptScope, "%s@%s", function_name, function_source);
+                DM_PROFILE_FMT(Script, "%s@%s", function_name, function_source);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1541,7 +1541,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
     Result RunScript(HScene scene, ScriptFunction script_function, int custom_ref, void* args)
     {
-        DM_NAMED_PROFILE(gProfilerGuiScriptScope, Script, "GuiScript");
+        DM_NAMED_PROFILE(ProfilerGuiScriptScope, Script, "GuiScript");
 
         if (scene->m_Script == 0x0)
             return RESULT_OK;
@@ -1799,7 +1799,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 {
                     (void)dmScript::GetLuaFunctionRefInfo(L, -5, &fi);
                 }
-                DM_PROFILE_FMT(gProfilerGuiScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
+                DM_PROFILE_SCOPE_FMT(gProfilerGuiScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));
@@ -1808,7 +1808,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             }
             else
             {
-                DM_PROFILE_FMT(gProfilerGuiScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
+                DM_PROFILE_SCOPE_FMT(gProfilerGuiScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1793,9 +1793,8 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
             Result result = RESULT_OK;
             {
-                const char* function_name = (custom_ref == LUA_NOREF) ? "<unknown>" : SCRIPT_FUNCTION_NAMES[script_function];
-                const char* file_name = (custom_ref == LUA_NOREF) ? "<unknown>" : scene->m_Script->m_SourceFileName;
-                DM_PROFILE_FMT(gProfilerGuiScriptScope, "%s@%s", function_name, file_name);
+                const char* function_name = (custom_ref == LUA_NOREF) ? "<message_callback>" : SCRIPT_FUNCTION_NAMES[script_function];
+                DM_PROFILE_FMT(gProfilerGuiScriptScope, "%s@%s", function_name, scene->m_Script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1804,7 +1804,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                     dmScript::LuaFunctionInfo fi;
                     if (dmScript::GetLuaFunctionRefInfo(L, -5, &fi))
                     {
-                        function_source = fi.m_ShortFileName;
+                        function_source = fi.m_FileName;
                         if (fi.m_OptionalName)
                         {
                             function_name = fi.m_OptionalName;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1799,7 +1799,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 {
                     (void)dmScript::GetLuaFunctionRefInfo(L, -5, &fi);
                 }
-                DM_PROFILE_SCOPE_FMT(gProfilerGuiScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
+                DM_PROFILE_SCOPE_FMT(ProfilerGuiScriptScope, "%d@%s", fi.m_LineNumber, fi.m_ShortFileName);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));
@@ -1808,7 +1808,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             }
             else
             {
-                DM_PROFILE_SCOPE_FMT(gProfilerGuiScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
+                DM_PROFILE_SCOPE_FMT(ProfilerGuiScriptScope, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], scene->m_Script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1818,7 +1818,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 }
             }
             {
-                DM_PROFILE_SCOPE_FMT(ProfilerGuiScriptScope, "%s@%s", function_name, function_source);
+                DM_NAMED_PROFILE_FMT(ProfilerGuiScriptScope, "%s@%s", function_name, function_source);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2790,7 +2790,7 @@ bail:
             }
 
             {
-                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
+                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2582,7 +2582,7 @@ namespace dmRender
                 result = true;
                 // m_SourceFileName will be null if profiling is not enabled, this is fine
                 // as m_SourceFileName will only be used if profiling is enabled
-                script->m_SourceFileName = dmProfile::Internalize(source->m_Filename);
+                script->m_SourceFileName = DM_INTERNALIZE(source->m_Filename);
             }
             lua_pushnil(L);
             dmScript::SetInstance(L);
@@ -2747,8 +2747,7 @@ bail:
 
     RenderScriptResult RunScript(HRenderScriptInstance script_instance, RenderScriptFunction script_function, void* args)
     {
-        static dmProfile::Scope* gProfilerRunScriptScope = dmProfile::g_IsInitialized ? dmProfile::AllocateScope("Script") : 0;
-        DM_PROFILE_SCOPE(gProfilerRunScriptScope, "RenderScript");
+        DM_NAMED_PROFILE(gProfilerRunScriptScope, Script, "RenderScript");
 
         RenderScriptResult result = RENDER_SCRIPT_RESULT_OK;
         HRenderScript script = script_instance->m_RenderScript;
@@ -2790,15 +2789,8 @@ bail:
                 dmScript::PushURL(L, message->m_Sender);
             }
 
-            const char* scope_name = 0;
-            if (dmProfile::g_IsInitialized)
             {
-                char buffer[128];
-                DM_SNPRINTF(buffer, sizeof(buffer), "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
-                scope_name = dmProfile::Internalize(buffer);
-            }
-            {
-                DM_PROFILE_SCOPE(gProfilerRunScriptScope, scope_name);
+                DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2747,7 +2747,7 @@ bail:
 
     RenderScriptResult RunScript(HRenderScriptInstance script_instance, RenderScriptFunction script_function, void* args)
     {
-        DM_NAMED_PROFILE(gProfilerRunScriptScope, Script, "RenderScript");
+        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RenderScript");
 
         RenderScriptResult result = RENDER_SCRIPT_RESULT_OK;
         HRenderScript script = script_instance->m_RenderScript;
@@ -2790,7 +2790,7 @@ bail:
             }
 
             {
-                DM_PROFILE_FMT(gProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
+                DM_PROFILE_SCOPE_FMT(gProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2790,7 +2790,7 @@ bail:
             }
 
             {
-                DM_PROFILE_SCOPE_FMT(ProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
+                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2747,7 +2747,7 @@ bail:
 
     RenderScriptResult RunScript(HRenderScriptInstance script_instance, RenderScriptFunction script_function, void* args)
     {
-        DM_NAMED_PROFILE(ProfilerRunScriptScope, Script, "RenderScript");
+        DM_PROFILE(Script, "RenderScript");
 
         RenderScriptResult result = RENDER_SCRIPT_RESULT_OK;
         HRenderScript script = script_instance->m_RenderScript;
@@ -2790,7 +2790,7 @@ bail:
             }
 
             {
-                DM_NAMED_PROFILE_FMT(ProfilerRunScriptScope, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
+                DM_PROFILE_FMT(Script, "%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], script->m_SourceFileName);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1469,6 +1469,19 @@ namespace dmScript
         return true;
     }
 
+    bool GetLuaFunctionRefInfo(lua_State* L, int stack_index, LuaFunctionInfo* out_function_info)
+    {
+        lua_Debug ar;
+        lua_pushvalue(L, stack_index);
+        if (lua_getinfo(L, ">S", &ar))
+        {
+            out_function_info->m_ShortFileName = ar.short_src;
+            out_function_info->m_LineNumber = ar.linedefined;
+            return true;
+        }
+        return false;
+    }
+
     const char* GetTableStringValue(lua_State* L, int table_index, const char* key, const char* default_value)
     {
         int top = lua_gettop(L);

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1475,7 +1475,7 @@ namespace dmScript
         lua_pushvalue(L, stack_index);
         if (lua_getinfo(L, ">Sn", &ar))
         {
-            out_function_info->m_ShortFileName = ar.short_src;
+            out_function_info->m_FileName = (ar.source[0] == '@') ? &ar.source[1] : ar.source;
             out_function_info->m_LineNumber = ar.linedefined;
             out_function_info->m_OptionalName = ar.name;
             return true;

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1475,7 +1475,7 @@ namespace dmScript
         lua_pushvalue(L, stack_index);
         if (lua_getinfo(L, ">Sn", &ar))
         {
-            out_function_info->m_FileName = (ar.source[0] == '@') ? &ar.source[1] : ar.source;
+            out_function_info->m_FileName = &ar.source[1];  // Skip source prefix character
             out_function_info->m_LineNumber = ar.linedefined;
             out_function_info->m_OptionalName = ar.name;
             return true;

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -4,6 +4,7 @@
 #include <dlib/log.h>
 #include <dlib/math.h>
 #include <dlib/pprint.h>
+#include <dlib/profile.h>
 #include <extension/extension.h>
 
 #include "script_private.h"
@@ -1449,7 +1450,34 @@ namespace dmScript
         int user_args_end = lua_gettop(L);
 
         int number_of_arguments = 1 + user_args_end - user_args_start; // instance + number of arguments that the user pushed
-        int ret = PCall(L, number_of_arguments, 0);
+
+        const char* function_name = "on_timer";
+        const char* function_source = "?";
+        char function_line_number_buffer[16];
+        if (dmProfile::g_IsInitialized)
+        {
+            dmScript::LuaFunctionInfo fi;
+            if (dmScript::GetLuaFunctionRefInfo(L, -(number_of_arguments + 1), &fi))
+            {
+                function_source = fi.m_FileName;
+                if (fi.m_OptionalName)
+                {
+                    function_name = fi.m_OptionalName;
+                }
+                else
+                {
+                    DM_SNPRINTF(function_line_number_buffer, sizeof(function_line_number_buffer), "l(%d)", fi.m_LineNumber);
+                    function_name = function_line_number_buffer;
+                }
+            }
+        }
+
+
+        int ret;
+        {
+            DM_PROFILE_FMT(Script, "%s@%s", function_name, function_source);
+            ret = PCall(L, number_of_arguments, 0);
+        }
 
         if (ret != 0) {
             // [-2] old instance

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1473,10 +1473,11 @@ namespace dmScript
     {
         lua_Debug ar;
         lua_pushvalue(L, stack_index);
-        if (lua_getinfo(L, ">S", &ar))
+        if (lua_getinfo(L, ">Sn", &ar))
         {
             out_function_info->m_ShortFileName = ar.short_src;
             out_function_info->m_LineNumber = ar.linedefined;
+            out_function_info->m_OptionalName = ar.name;
             return true;
         }
         return false;

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -775,7 +775,7 @@ namespace dmScript
      */
     struct LuaFunctionInfo
     {
-        const char* m_ShortFileName;
+        const char* m_FileName;
         const char* m_OptionalName;
         int m_LineNumber;
     };

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -770,6 +770,24 @@ namespace dmScript
      */
     bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context);
 
+    /** Information about a function, in which file and at what line it is defined
+     * Use with GetLuaFunctionRefInfo
+     */
+    struct LuaFunctionInfo
+    {
+        const char* m_ShortFileName;
+        int m_LineNumber;
+    };
+
+    /**
+     * Get information about where a Lua function is defined
+     * @param L lua state
+     * @param stack_index which index on the stack that contains the lua function ref
+     * @param out_function_info pointer to the function information that is filled out
+     * @return true on success, out_function_info is only touched if the function succeeds
+     */
+    bool GetLuaFunctionRefInfo(lua_State* L, int stack_index, LuaFunctionInfo* out_function_info);
+
     /**
      * Get an integer value at a specific key in a table.
      * @param L lua state

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -776,6 +776,7 @@ namespace dmScript
     struct LuaFunctionInfo
     {
         const char* m_ShortFileName;
+        const char* m_OptionalName;
         int m_LineNumber;
     };
 


### PR DESCRIPTION
Fixed 'on_message' profiling scopes for gui and game_object, now says <function>@source if a named function is used or <line_number>@<source_file> if a lambda was specified in gameobject and gui when a message call-back is invoked. 'on_message' and 'on_input' was completely missing in game_object.

Added DM_INTERNALIZE , DM_PROFILE_FMT and DM_COUNTER_DYN profiler macros.

Added macros to reduce clutter and to remove all profiler string hashing if profiling is disabled.

Removed usage of dmHashString32 for counter hashes, it was inconsistent before - if you did not provide a hash it used dmHashBufferNoReverse32. Now it does automatic one-time hashing using the same hashing function.