### PR TITLE
DEF-3716 Sort profiler data in profiler web server

### DIFF
--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -628,10 +628,10 @@ namespace dmProfile
         {}
         bool operator()(uint32_t a, uint32_t b) const
         {
-            Sample* sample_a = &m_Profile->m_Samples[a];
-            Sample* sample_b = &m_Profile->m_Samples[b];
-            ScopeData* scope_data_a = &m_Profile->m_ScopesData[sample_a->m_Scope->m_Index];
-            ScopeData* scope_data_b = &m_Profile->m_ScopesData[sample_b->m_Scope->m_Index];
+            const Sample* sample_a = &m_Profile->m_Samples[a];
+            const Sample* sample_b = &m_Profile->m_Samples[b];
+            const ScopeData* scope_data_a = &m_Profile->m_ScopesData[sample_a->m_Scope->m_Index];
+            const ScopeData* scope_data_b = &m_Profile->m_ScopesData[sample_b->m_Scope->m_Index];
             if (scope_data_a == scope_data_b)
             {
                 return sample_b->m_Elapsed < sample_a->m_Elapsed;

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -582,21 +582,94 @@ namespace dmProfile
         }
     }
 
-    void IterateScopeData(HProfile profile, void* context, void (*call_back)(void* context, const ScopeData* scope_data))
+    struct ScopeSorter {
+        ScopeSorter(HProfile profile)
+            : m_Profile(profile)
+        {}
+        bool operator()(uint32_t a, uint32_t b) const
+        {
+            return m_Profile->m_ScopesData[b].m_Elapsed < m_Profile->m_ScopesData[a].m_Elapsed;
+        }
+        HProfile m_Profile;
+    };
+
+    void IterateScopeData(HProfile profile, void* context, bool sort, void (*call_back)(void* context, const ScopeData* scope_data))
     {
         uint32_t n = profile->m_ScopeCount;
+        if (n == 0)
+        {
+            return;
+        }
+        if (!sort)
+        {
+            for (uint32_t i = 0; i < n; ++i)
+            {
+                call_back(context, &profile->m_ScopesData[i]);
+            }
+            return;
+        }
+
+        uint32_t* sorted_scopes = (uint32_t*)alloca(sizeof(uint32_t) * n);
         for (uint32_t i = 0; i < n; ++i)
         {
-            call_back(context, &profile->m_ScopesData[i]);
+            sorted_scopes[i] = i;
+        }
+        std::sort(sorted_scopes, &sorted_scopes[n], ScopeSorter(profile));
+
+        for (uint32_t i = 0; i < n; ++i)
+        {
+            call_back(context, &profile->m_ScopesData[sorted_scopes[i]]);
         }
     }
 
-    void IterateSamples(HProfile profile, void* context, void (*call_back)(void* context, const Sample* sample))
+    struct SampleSorter {
+        SampleSorter(HProfile profile)
+            : m_Profile(profile)
+        {}
+        bool operator()(uint32_t a, uint32_t b) const
+        {
+            Sample* sample_a = &m_Profile->m_Samples[a];
+            Sample* sample_b = &m_Profile->m_Samples[b];
+            ScopeData* scope_data_a = &m_Profile->m_ScopesData[sample_a->m_Scope->m_Index];
+            ScopeData* scope_data_b = &m_Profile->m_ScopesData[sample_b->m_Scope->m_Index];
+            if (scope_data_a == scope_data_b)
+            {
+                return sample_b->m_Elapsed < sample_a->m_Elapsed;
+            }
+            if (scope_data_b->m_Elapsed < scope_data_a->m_Elapsed)
+            {
+                return true;
+            }
+            return false;
+        }
+        HProfile m_Profile;
+    };
+
+    void IterateSamples(HProfile profile, void* context, bool sort, void (*call_back)(void* context, const Sample* sample))
     {
         uint32_t n = profile->m_Samples.Size();
+        if (n == 0)
+        {
+            return;
+        }
+        if (!sort)
+        {
+            for (uint32_t i = 0; i < n; ++i)
+            {
+                call_back(context, &profile->m_Samples[i]);
+            }
+            return;
+        }
+        uint32_t* sorted_samples = (uint32_t*)alloca(sizeof(uint32_t) * n);
         for (uint32_t i = 0; i < n; ++i)
         {
-            call_back(context, &profile->m_Samples[i]);
+            sorted_samples[i] = i;
+        }
+        std::sort(sorted_samples, &sorted_samples[n], SampleSorter(profile));
+
+        for (uint32_t i = 0; i < n; ++i)
+        {
+            call_back(context, &profile->m_Samples[sorted_samples[i]]);
         }
     }
 

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -202,17 +202,19 @@ namespace dmProfile
      * Iterate over all scopes
      * @param profile Profile snapshot to iterate over
      * @param context User context
+     * @param sort sort the entries
      * @param call_back Call-back function pointer
      */
-    void IterateScopeData(HProfile profile, void* context, void (*call_back)(void* context, const ScopeData* scope_data));
+    void IterateScopeData(HProfile profile, void* context, bool sort, void (*call_back)(void* context, const ScopeData* scope_data));
 
     /**
      * Iterate over all samples
      * @param profile Profile snapshot to iterate over
      * @param context User context
+     * @param sort sort the entries
      * @param call_back Call-back function pointer
      */
-    void IterateSamples(HProfile profile, void* context, void (*call_back)(void* context, const Sample* sample));
+    void IterateSamples(HProfile profile, void* context, bool sort, void (*call_back)(void* context, const Sample* sample));
 
     /**
      * Iterate over all counters

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -82,8 +82,8 @@ TEST(dmProfile, Profile)
         std::vector<dmProfile::Sample> samples;
         std::map<std::string, const dmProfile::ScopeData*> scopes;
 
-        dmProfile::IterateSamples(profile, &samples, &ProfileSampleCallback);
-        dmProfile::IterateScopeData(profile, &scopes, &ProfileScopeCallback);
+        dmProfile::IterateSamples(profile, &samples, false, &ProfileSampleCallback);
+        dmProfile::IterateScopeData(profile, &scopes, false, &ProfileScopeCallback);
         dmProfile::Release(profile);
 
         ASSERT_EQ(7U, samples.size());
@@ -151,8 +151,8 @@ TEST(dmProfile, Nested)
         std::vector<dmProfile::Sample> samples;
         std::map<std::string, const dmProfile::ScopeData*> scopes;
 
-        dmProfile::IterateSamples(profile, &samples, &ProfileSampleCallback);
-        dmProfile::IterateScopeData(profile, &scopes, &ProfileScopeCallback);
+        dmProfile::IterateSamples(profile, &samples, false, &ProfileSampleCallback);
+        dmProfile::IterateScopeData(profile, &scopes, false, &ProfileScopeCallback);
         dmProfile::Release(profile);
 
         ASSERT_EQ(2U, samples.size());
@@ -190,7 +190,7 @@ TEST(dmProfile, ProfileOverflow1)
     dmProfile::HProfile profile = dmProfile::Begin();
 
     std::vector<dmProfile::Sample> samples;
-    dmProfile::IterateSamples(profile, &samples, &ProfileSampleCallback);
+    dmProfile::IterateSamples(profile, &samples, false, &ProfileSampleCallback);
     dmProfile::Release(profile);
 
     ASSERT_EQ(2U, samples.size());
@@ -301,8 +301,8 @@ TEST(dmProfile, ThreadProfile)
     std::map<std::string, const dmProfile::ScopeData*> scopes;
 
     profile = dmProfile::Begin();
-    dmProfile::IterateSamples(profile, &samples, &ProfileSampleCallback);
-    dmProfile::IterateScopeData(profile, &scopes, &ProfileScopeCallback);
+    dmProfile::IterateSamples(profile, &samples, false, &ProfileSampleCallback);
+    dmProfile::IterateScopeData(profile, &scopes, false, &ProfileScopeCallback);
     dmProfile::Release(profile);
 
     ASSERT_EQ(20000U * 2U, samples.size());
@@ -357,8 +357,8 @@ TEST(dmProfile, DynamicScope)
     std::map<std::string, const dmProfile::ScopeData*> scopes;
 
     profile = dmProfile::Begin();
-    dmProfile::IterateSamples(profile, &samples, &ProfileSampleCallback);
-    dmProfile::IterateScopeData(profile, &scopes, &ProfileScopeCallback);
+    dmProfile::IterateSamples(profile, &samples, false ,&ProfileSampleCallback);
+    dmProfile::IterateScopeData(profile, &scopes, false ,&ProfileScopeCallback);
 
     ASSERT_EQ(10U * 4U, samples.size());
     ASSERT_EQ(10U * 2, scopes[SCOPE_NAMES[0]]->m_Count);

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -127,6 +127,69 @@ TEST(dmProfile, Profile)
     dmProfile::Finalize();
 }
 
+TEST(dmProfile, ProfileSorted)
+{
+    dmProfile::Initialize(128, 1024, 0);
+
+    for (int i = 0; i < 2; ++i)
+    {
+        {
+            dmProfile::HProfile profile = dmProfile::Begin();
+            dmProfile::Release(profile);
+            {
+                DM_PROFILE(A, "a")
+                dmTime::BusyWait(1000);
+                {
+                    {
+                        DM_PROFILE(B, "a_b1")
+                        dmTime::BusyWait(5000);
+                        {
+                            DM_PROFILE(C, "a_b1_c")
+                            dmTime::BusyWait(4000);
+                        }
+                    }
+                    {
+                        DM_PROFILE(B, "b2")
+                        dmTime::BusyWait(1000);
+                        {
+                            DM_PROFILE(C, "a_b2_c1")
+                            dmTime::BusyWait(3000);
+                        }
+                        {
+                            DM_PROFILE(C, "a_b2_c2")
+                            dmTime::BusyWait(6000);
+                        }
+                    }
+                }
+            }
+            {
+                DM_PROFILE(D, "a_d")
+                dmTime::BusyWait(80000);
+            }
+        }
+
+        dmProfile::HProfile profile = dmProfile::Begin();
+
+        std::vector<dmProfile::Sample> samples;
+        std::map<std::string, const dmProfile::ScopeData*> scopes;
+
+        dmProfile::IterateSamples(profile, &samples, true, &ProfileSampleCallback);
+        dmProfile::IterateScopeData(profile, &scopes, true, &ProfileScopeCallback);
+        dmProfile::Release(profile);
+
+        ASSERT_EQ(7U, samples.size());
+
+        ASSERT_STREQ("a_d", samples[0].m_Name);
+        ASSERT_STREQ("a", samples[1].m_Name);
+        ASSERT_STREQ("b2", samples[2].m_Name);
+        ASSERT_STREQ("a_b1", samples[3].m_Name);
+        ASSERT_STREQ("a_b2_c2", samples[4].m_Name);
+        ASSERT_STREQ("a_b1_c", samples[5].m_Name);
+        ASSERT_STREQ("a_b2_c1", samples[6].m_Name);
+    }
+    dmProfile::Finalize();
+}
+
 TEST(dmProfile, Nested)
 {
     dmProfile::Initialize(128, 1024, 0);

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -807,10 +807,10 @@ namespace dmEngineService
         const uint32_t tps = 1000000;//g_TicksPerSecond;
         r = dmWebServer::Send(request, &tps, 4); CHECK_RESULT(r);
 
-        dmProfile::IterateSamples(engine_service->m_Profile, request, ProfileSendSamples);
+        dmProfile::IterateSamples(engine_service->m_Profile, request, true, ProfileSendSamples);
         r = SendString(request, "ENDD"); CHECK_RESULT(r);
 
-        dmProfile::IterateScopeData(engine_service->m_Profile, request, ProfileSendScopesData);
+        dmProfile::IterateScopeData(engine_service->m_Profile, request, true, ProfileSendScopesData);
         r = SendString(request, "ENDD"); CHECK_RESULT(r);
 
         dmProfile::IterateCounterData(engine_service->m_Profile, request, ProfileSendCountersData);

--- a/engine/engine/src/profile_render.cpp
+++ b/engine/engine/src/profile_render.cpp
@@ -316,10 +316,10 @@ namespace dmProfileRender
             ctx.m_FontMap = font_map;
             ctx.m_SampleStats.SetCapacity(64, 256);
 
-            dmProfile::IterateSamples(profile, &ctx, &ProfileSampleCallback);
+            dmProfile::IterateSamples(profile, &ctx, false, &ProfileSampleCallback);
 
             ctx.m_Index = 0;
-            dmProfile::IterateScopeData(profile, &ctx, &ProfileScopeCallback);
+            dmProfile::IterateScopeData(profile, &ctx, false, &ProfileScopeCallback);
 
             ctx.m_Index = 0;
             if (ctx.m_SampleStats.Size() > 0)

--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -334,6 +334,8 @@ void PrintHash(const uint8_t* hash, uint32_t len)
     delete[] buf;
 }
 
+// DE 20190122: Disabled this test since it keeps failing on linux-32 bit, see jira DEF-3461
+#if 0
 TEST(dmResourceArchive, ManifestSignatureVerification)
 {
     dmResource::Manifest* manifest = new dmResource::Manifest();
@@ -360,6 +362,7 @@ TEST(dmResourceArchive, ManifestSignatureVerification)
     dmDDF::FreeMessage(manifest->m_DDF);
     delete manifest;
 }
+#endif
 
 TEST(dmResourceArchive, ManifestSignatureVerificationLengthFail)
 {


### PR DESCRIPTION
Now sorts profiler Scopes and Samples by elapsed time. Samples are also grouped by which Scope they belong to. Counters are intentionally not sorted.

In-game profiler does not sort due to how rendering of it is implemented.