### PR TITLE
DEF-3728 - Fixes for crashes related to push.schedule on mobile.

### DIFF
--- a/engine/push/src/java/com/defold/push/LocalNotificationReceiver.java
+++ b/engine/push/src/java/com/defold/push/LocalNotificationReceiver.java
@@ -59,9 +59,15 @@ public class LocalNotificationReceiver extends WakefulBroadcastReceiver {
                 int largeIconId = extras.getInt("largeIcon");
                 if (smallIconId == 0) {
                     smallIconId = info.icon;
+                    if (smallIconId == 0) {
+                        smallIconId = android.R.color.transparent;
+                    }
                 }
                 if (largeIconId == 0) {
                     largeIconId = info.icon;
+                    if (largeIconId == 0) {
+                        largeIconId = android.R.color.transparent;
+                    }
                 }
 
                 // Get bitmap for large icon resource

--- a/engine/push/src/push_android.cpp
+++ b/engine/push/src/push_android.cpp
@@ -178,6 +178,14 @@ static int Push_Schedule(lua_State* L)
     const char* payload = 0;
     if (top > 3) {
         payload = luaL_checkstring(L, 4);
+
+        // Verify that the payload is valid and can be delivered later on.
+        char payload_err[128];
+        if (!dmPush::VerifyPayload(L, payload, payload_err, sizeof(payload_err))) {
+            lua_pushnil(L);
+            lua_pushstring(L, payload_err);
+            return 2;
+        }
     }
 
     // param: notification_settings
@@ -644,6 +652,7 @@ void HandlePushMessageResult(const Command* cmd, bool local)
 
         dmScript::PCall(L, 4, 0);
     } else {
+        lua_pop(L, 2);
         dmLogError("Failed to parse push response (%d)", r);
     }
     dmJson::Free(&doc);

--- a/engine/push/src/push_ios.mm
+++ b/engine/push/src/push_ios.mm
@@ -573,7 +573,16 @@ int Push_Schedule(lua_State* L)
     NSMutableDictionary* userdata = [NSMutableDictionary dictionaryWithCapacity:2];
     userdata[@"id"] = [NSNumber numberWithInt:g_Push.m_ScheduledID];
     if (top > 3) {
-        userdata[@"payload"] = [NSString stringWithUTF8String:luaL_checkstring(L, 4)];
+        const char* payload = luaL_checkstring(L, 4);
+        userdata[@"payload"] = [NSString stringWithUTF8String:payload];
+
+        // Verify that the payload is valid and can be delivered later on.
+        char payload_err[128];
+        if (!dmPush::VerifyPayload(L, payload, payload_err, sizeof(payload_err))) {
+            lua_pushnil(L);
+            lua_pushstring(L, payload_err);
+            return 2;
+        }
     } else {
         userdata[@"payload"] = nil;
     }

--- a/engine/push/src/push_utils.cpp
+++ b/engine/push/src/push_utils.cpp
@@ -1,0 +1,26 @@
+#include <dlib/dstrings.h>
+
+#include "push_utils.h"
+
+bool dmPush::VerifyPayload(lua_State* L, const char* payload, char* error_str_out, size_t error_str_size)
+{
+    int top = lua_gettop(L);
+    bool success = false;
+
+    dmJson::Document doc;
+    dmJson::Result r = dmJson::Parse(payload, &doc);
+    if (r == dmJson::RESULT_OK && doc.m_NodeCount > 0) {
+        if (dmScript::JsonToLua(L, &doc, 0, error_str_out, error_str_size) >= 0) {
+            success = true;
+        }
+        // JsonToLua will push Lua values on the stack, but they will not be used
+        // since we only want to verify that the JSON can be converted to Lua here.
+        lua_pop(L, lua_gettop(L) - top);
+    } else {
+        DM_SNPRINTF(error_str_out, error_str_size, "Failed to parse JSON payload string (%d).", r);
+        dmJson::Free(&doc);
+    }
+
+    assert(top == lua_gettop(L));
+    return success;
+}

--- a/engine/push/src/push_utils.h
+++ b/engine/push/src/push_utils.h
@@ -1,7 +1,14 @@
 #ifndef DM_PUSH_UTILS
 #define DM_PUSH_UTILS
 
+#include <script/script.h>
+
 #define DM_PUSH_EXTENSION_ORIGIN_REMOTE 0
 #define DM_PUSH_EXTENSION_ORIGIN_LOCAL  1
+
+namespace dmPush
+{
+    bool VerifyPayload(lua_State* L, const char* payload, char* error_str_out, size_t error_str_size);
+}
 
 #endif

--- a/engine/push/src/wscript
+++ b/engine/push/src/wscript
@@ -12,9 +12,9 @@ def build(bld):
     source = []
 
     if re.match('arm.*?darwin', bld.env.PLATFORM):
-        source += ['push_ios.mm']
+        source += ['push_ios.mm', 'push_utils.cpp']
     elif re.match('arm.*?android', bld.env.PLATFORM):
-        source += ['push_android.cpp']
+        source += ['push_android.cpp', 'push_utils.cpp']
 
         classpath = ['%s/ext/share/java/android.jar' % bld.env.DYNAMO_HOME,
                      '%s/ext/share/java/android-support-v4.jar' % bld.env.DYNAMO_HOME,


### PR DESCRIPTION
- Fixed Android crash related to missing push icons. (It will fallback
  to a transparent image if no push icons are set.)
- Added JSON and JsonToLua verification when a push is scheduled instead
  of only when triggered. This means that the user can get an error
  when scheduling a push instead of a error-log-print once the push is
  triggered.