### PR TITLE
DEF-3730 Building bob_light without local engine build fails to bundle texc_shared so

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
+++ b/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
@@ -43,7 +43,7 @@ cp -v $DYNAMO_HOME/archive/${SHA1}/engine/x86_64-win32/texc_shared.dll lib/x86_6
 cp -v $DYNAMO_HOME/ext/lib/win32/PVRTexLib.dll lib/x86-win32/PVRTexLib.dll
 cp -v $DYNAMO_HOME/ext/lib/x86_64-win32/PVRTexLib.dll lib/x86_64-win32/PVRTexLib.dll
 cp -v $DYNAMO_HOME/ext/lib/x86_64-linux/libPVRTexLib.so lib/x86_64-linux/libPVRTexLib.so
-cp -v $DYNAMO_HOME/ext/lib/x86_64-darwin/libPVRTexLib.dylib lib/x86_64-linux/libPVRTexLib.dylib
+cp -v $DYNAMO_HOME/ext/lib/x86_64-darwin/libPVRTexLib.dylib lib/x86_64-darwin/libPVRTexLib.dylib
 
 # Win32 32
 cp -v $DYNAMO_HOME/ext/lib/win32/OpenAL32.dll lib/x86-win32/OpenAL32.dll

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
@@ -42,12 +42,7 @@ public class TexcLibrary {
             Bob.getLib(platform, "PVRTexLib"); // dependency of texc_shared
 
             // TODO: sad with a platform specific hack and placing dependency knowledge here but...
-            if (platform == Platform.X86Linux || platform == Platform.X86_64Linux) {
-                String path = libPath + "/libPVRTexLib.so";
-                Bob.verbose("Loading PVRTexLib:'%s'", path);
-                System.load(path);
-            }
-            else if (platform == Platform.X86_64Win32 || platform == Platform.X86Win32) {
+            if (platform == Platform.X86_64Win32 || platform == Platform.X86Win32) {
                 Bob.getLib(platform, "msvcr120"); // dependency of PVRTexLib
             }
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -779,7 +779,13 @@ class Configuration(object):
         self.exec_env_command(args + plf_args + self.waf_options + skip_build_tests, cwd = cwd)
 
     def build_bob_light(self):
-        self._log('Building bob')
+        self._log('Building bob light')
+
+        cwd = join(self.defold_root, 'com.dynamo.cr/com.dynamo.cr.bob')
+        sha1 = self._git_sha1()
+        if os.path.exists(os.path.join(self.dynamo_home, 'archive', sha1)):
+            self.exec_env_shell_command("./scripts/copy.sh", cwd = cwd)
+
         self.exec_env_shell_command(" ".join([join(self.dynamo_home, 'ext/share/ant/bin/ant'), 'clean', 'install']),
                                     cwd = join(self.defold_root, 'com.dynamo.cr/com.dynamo.cr.bob'))
 


### PR DESCRIPTION
When building cr.editor without a local engine build (using sync_archive) with a clean repo (com.dynamo.cr contains no build files from previous build) running the Bob java test fails.

This is due to bob_light not properly bundling libtexc_shared.so as it can't be found without first building the editor locally before running 'build_editor'.

Second type 'build_editor' runs we luck out and the Bob tests success due to finding libPVRTexLib.so by chance in the archive folder.

This PR makes sure bob_light has the same setup as when building full bob.