### PR TITLE
DEF-3739: Font cache uniform not set in collection view in editor 2

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1147,7 +1147,10 @@
                  (let [[w h] aabb-size
                        offset (pivot-offset pivot aabb-size)
                        lines (mapv conj (apply concat (take 4 (partition 2 1 (cycle (geom/transl offset [[0 0] [w 0] [w h] [0 h]]))))) (repeat 0))
-                       font-shader (or (font-shaders font) (font-shaders ""))]
+                       font-map (get-in text-data [:font-data :font-map])
+                       texture-recip-uniform (font/get-texture-recip-uniform font-map)
+                       font-shader (or (font-shaders font) (font-shaders ""))
+                       font-shader (assoc-in font-shader [:uniforms "texture_size_recip"] texture-recip-uniform)]
                    ;; The material-shader output is used to propagate the shader
                    ;; from the GuiSceneNode to our child nodes. Thus we cannot
                    ;; simply overload the material-shader output on this node.

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -170,7 +170,10 @@
   [_node-id aabb gpu-texture material-shader blend-mode pivot text-data scale]
   (let [scene {:node-id _node-id
                :aabb aabb
-               :transform (math/->mat4-scale scale)}]
+               :transform (math/->mat4-scale scale)}
+        font-map (get-in text-data [:font-data :font-map])
+        texture-recip-uniform (font/get-texture-recip-uniform font-map)
+        material-shader (assoc-in material-shader [:uniforms "texture_size_recip"] texture-recip-uniform)]
     (if text-data
       (let [min (types/min-p aabb)
             max (types/max-p aabb)

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -551,8 +551,9 @@
     (testing "uses shader and texture params from assigned material "
       (with-prop [node-id material-prop (workspace/resolve-workspace-resource workspace "/materials/test_samplers.material")]
         (let [scene-data (g/node-value node-id :scene)]
-          (is (= (get-in scene-data shader-path)
-                 (g/node-value material-node :shader)))
+          ;; Additional uniforms might be introduced during rendering.
+          (is (= (dissoc (get-in scene-data shader-path) :uniforms)
+                 (dissoc (g/node-value material-node :shader) :uniforms)))
           (is (= (get-in scene-data (conj gpu-texture-path :params))
-                   (material/sampler->tex-params  (first (g/node-value material-node :samplers))))))))))
+                   (material/sampler->tex-params (first (g/node-value material-node :samplers))))))))))
 


### PR DESCRIPTION
* This PR updates the font cache shader uniform for the GUI text nodes and the label component
* user-facing: font gradients should now display correctly in the GUI and collection views in the ed2