### PR TITLE
DEF-3763: Hot-reloading fonts with changed cache texture size produces wrong result

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1909,9 +1909,13 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         texture->m_Params = params;
         if (!params.m_SubUpdate) {
             SetTextureParams(texture, params.m_MinFilter, params.m_MagFilter, params.m_UWrap, params.m_VWrap);
+
+            if (params.m_MipMap == 0)
+            {
+                texture->m_Width  = params.m_Width;
+                texture->m_Height = params.m_Height;
+            }
         }
-
-
 
         GLenum gl_format;
         GLenum gl_type = DMGRAPHICS_TYPE_UNSIGNED_BYTE;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -288,6 +288,7 @@ namespace dmRender
                 return;
         };
 
+        font_map->m_CacheCursor = 0;
         font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
         memset(font_map->m_Cache, 0, sizeof(Glyph*) * cell_count);
 
@@ -853,8 +854,8 @@ namespace dmRender
         float cache_cell_height_ratio = 0.0;
 
         if (font_map->m_Texture) {
-            float cache_width  = (float) dmGraphics::GetOriginalTextureWidth(font_map->m_Texture);
-            float cache_height = (float) dmGraphics::GetOriginalTextureHeight(font_map->m_Texture);
+            float cache_width  = (float) dmGraphics::GetTextureWidth(font_map->m_Texture);
+            float cache_height = (float) dmGraphics::GetTextureHeight(font_map->m_Texture);
 
             im_recip /= cache_width;
             ih_recip /= cache_height;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -288,7 +288,6 @@ namespace dmRender
                 return;
         };
 
-        font_map->m_CacheCursor = 0;
         font_map->m_Cache = (Glyph**)malloc(sizeof(Glyph*) * cell_count);
         memset(font_map->m_Cache, 0, sizeof(Glyph*) * cell_count);
 


### PR DESCRIPTION
This PR fixes an issue with hot-reloading a font resource that changes the texture dimension of the backing cache texture. It appears that when using the SetTexture function, the texture dimensions are never updated. 