### PR TITLE
DEF-3758: Hot-Reloading atlas used in GUI doesn't work

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -401,8 +401,23 @@ namespace dmGameSystem
         for (uint32_t i = 0; i < scene_resource->m_GuiTextureSets.Size(); ++i)
         {
             const char* name = scene_desc->m_Textures[i].m_Name;
+
+            void* texture_source;
             dmGraphics::HTexture texture = scene_resource->m_GuiTextureSets[i].m_Texture;
-            dmGui::Result r = dmGui::AddTexture(scene, name, (void*) texture, (void*) scene_resource->m_GuiTextureSets[i].m_TextureSet, dmGraphics::GetOriginalTextureWidth(texture), dmGraphics::GetOriginalTextureHeight(texture));
+            dmGui::NodeTextureType texture_source_type;
+
+            if (scene_resource->m_GuiTextureSets[i].m_TextureSet)
+            {
+                texture_source_type = dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET;
+                texture_source      = (void*)scene_resource->m_GuiTextureSets[i].m_TextureSet;
+            }
+            else
+            {
+                texture_source_type = dmGui::NODE_TEXTURE_TYPE_TEXTURE;
+                texture_source      = (void*)texture;
+            }
+
+            dmGui::Result r = dmGui::AddTexture(scene, name, texture_source, texture_source_type, dmGraphics::GetOriginalTextureWidth(texture), dmGraphics::GetOriginalTextureHeight(texture));
             if (r != dmGui::RESULT_OK) {
                 dmLogError("Unable to add texture '%s' to scene (%d)", name,  r);
                 return false;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1689,7 +1689,7 @@ namespace dmGameSystem
         out_data->m_MeshSet = rig_res->m_MeshSetRes->m_MeshSet;
         out_data->m_AnimationSet = rig_res->m_AnimationSetRes->m_AnimationSet;
         out_data->m_Texture = rig_res->m_TextureSet->m_Texture;
-        out_data->m_TextureSet = rig_res->m_TextureSet->m_TextureSet;
+        out_data->m_TextureSet = rig_res->m_TextureSet;
         out_data->m_PoseIdxToInfluence = &rig_res->m_PoseIdxToInfluence;
         out_data->m_TrackIdxToPose     = &rig_res->m_TrackIdxToPose;
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -738,6 +738,22 @@ namespace dmGameSystem
         ApplyStencilClipping(gui_context, state, params.m_StencilTestParams);
     }
 
+    static dmGraphics::HTexture GetNodeTexture(dmGui::HScene scene, dmGui::HNode node)
+    {
+        dmGui::NodeTextureType texture_type;
+        void* result = dmGui::GetNodeTexture(scene, node, &texture_type);
+
+        if (texture_type == dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET)
+        {
+            TextureSetResource* texture_set_res = (TextureSetResource*) result;
+            assert(texture_set_res);
+
+            return texture_set_res->m_Texture;
+        }
+
+        return (dmGraphics::HTexture) result;
+    }
+
     void RenderTextNodes(dmGui::HScene scene,
                          const dmGui::RenderEntry* entries,
                          const Matrix4* node_transforms,
@@ -979,9 +995,9 @@ namespace dmGameSystem
         ApplyStencilClipping(gui_context, stencil_scopes[0], ro);
 
         // Set default texture
-        void* texture = dmGui::GetNodeTexture(scene, first_node);
+        dmGraphics::HTexture texture = dmGameSystem::GetNodeTexture(scene, first_node);
         if (texture) {
-            ro.m_Textures[0] = (dmGraphics::HTexture) texture;
+            ro.m_Textures[0] = texture;
         } else {
             ro.m_Textures[0] = gui_world->m_WhiteTexture;
         }
@@ -1050,9 +1066,9 @@ namespace dmGameSystem
         ro.m_Material = (dmRender::HMaterial) dmGui::GetMaterial(scene);
 
         // Set default texture
-        void* texture = dmGui::GetNodeTexture(scene, first_node);
+        dmGraphics::HTexture texture = dmGameSystem::GetNodeTexture(scene, first_node);
         if (texture)
-            ro.m_Textures[0] = (dmGraphics::HTexture) texture;
+            ro.m_Textures[0] = texture;
         else
             ro.m_Textures[0] = gui_world->m_WhiteTexture;
 
@@ -1271,9 +1287,9 @@ namespace dmGameSystem
         ro.m_Material = (dmRender::HMaterial) dmGui::GetMaterial(scene);
 
         // Set default texture
-        void* texture = dmGui::GetNodeTexture(scene, first_node);
+        dmGraphics::HTexture texture = dmGameSystem::GetNodeTexture(scene, first_node);
         if (texture)
-            ro.m_Textures[0] = (dmGraphics::HTexture) texture;
+            ro.m_Textures[0] = texture;
         else
             ro.m_Textures[0] = gui_world->m_WhiteTexture;
 
@@ -1452,7 +1468,7 @@ namespace dmGameSystem
         dmGui::HNode first_node = entries[0].m_Node;
         dmGui::BlendMode prev_blend_mode = dmGui::GetNodeBlendMode(scene, first_node);
         dmGui::NodeType prev_node_type = dmGui::GetNodeType(scene, first_node);
-        void* prev_texture = dmGui::GetNodeTexture(scene, first_node);
+        dmGraphics::HTexture prev_texture = dmGameSystem::GetNodeTexture(scene, first_node);
         void* prev_font = dmGui::GetNodeFont(scene, first_node);
         const dmGui::StencilScope* prev_stencil_scope = stencil_scopes[0];
         uint32_t prev_emitter_batch_key = 0;
@@ -1475,7 +1491,7 @@ namespace dmGameSystem
 
             dmGui::BlendMode blend_mode = dmGui::GetNodeBlendMode(scene, node);
             dmGui::NodeType node_type = dmGui::GetNodeType(scene, node);
-            void* texture = dmGui::GetNodeTexture(scene, node);
+            dmGraphics::HTexture texture = dmGameSystem::GetNodeTexture(scene, node);
             void* font = dmGui::GetNodeFont(scene, node);
             const dmGui::StencilScope* stencil_scope = stencil_scopes[i];
             uint32_t emitter_batch_key = 0;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -472,6 +472,15 @@ namespace dmGui
             {
                 nodes[i].m_Node.m_Texture = texture;
                 nodes[i].m_Node.m_TextureSet = textureset;
+
+                if (textureset)
+                {
+                    nodes[i].m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE_SET;
+                }
+                else
+                {
+                    nodes[i].m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE;
+                }
             }
         }
         return RESULT_OK;
@@ -494,6 +503,7 @@ namespace dmGui
                     CancelNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
                 }
                 node.m_Texture = 0;
+                node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
             }
         }
     }
@@ -512,6 +522,7 @@ namespace dmGui
                 CancelNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
             }
             node.m_Texture = 0;
+            node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
         }
     }
 
@@ -1003,6 +1014,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 Node& node = nodes[j].m_Node;
                 if (DynamicTexture* texture = scene->m_DynamicTextures.Get(node.m_TextureHash)) {
                     node.m_Texture = texture->m_Handle;
+                    node.m_TextureType = NODE_TEXTURE_TYPE_DYNAMIC;
                 }
             }
         }
@@ -1020,6 +1032,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                 Node& node = nodes[j].m_Node;
                 if (node.m_TextureHash == texture_hash) {
                     node.m_Texture = 0;
+                    node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
                     // Do not break here. Texture may be used multiple times.
                 }
             }
@@ -2097,6 +2110,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         node->m_Node.m_TextureHash = 0;
         node->m_Node.m_Texture = 0;
         node->m_Node.m_TextureSet = 0;
+        node->m_Node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
         node->m_Node.m_TextureSetAnimDesc.Init();
         node->m_Node.m_FlipbookAnimHash = 0;
         node->m_Node.m_FlipbookAnimPosition = 0.0f;
@@ -2596,16 +2610,17 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         return n->m_Node.m_Properties[PROPERTY_TEXT_PARAMS].getY();
     }
 
-    void* GetNodeTexture(HScene scene, HNode node)
+    void* GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut)
     {
         InternalNode* n = GetNode(scene, node);
-        return n->m_Node.m_Texture;
-    }
+        *textureTypeOut = n->m_Node.m_TextureType;
 
-    void* GetNodeTextureSet(HScene scene, HNode node)
-    {
-        InternalNode* n = GetNode(scene, node);
-        return n->m_Node.m_TextureSet;
+        if (n->m_Node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
+        {
+            return n->m_Node.m_TextureSet;
+        }
+
+        return n->m_Node.m_Texture;
     }
 
     dmhash_t GetNodeTextureId(HScene scene, HNode node)
@@ -2629,6 +2644,16 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             n->m_Node.m_TextureHash = texture_id;
             n->m_Node.m_Texture = texture_info->m_Texture;
             n->m_Node.m_TextureSet = texture_info->m_TextureSet;
+
+            if (texture_info->m_TextureSet)
+            {
+                n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE_SET;
+            }
+            else
+            {
+                n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE;
+            }
+
             if((n->m_Node.m_SizeMode != SIZE_MODE_MANUAL) && (n->m_Node.m_NodeType != NODE_TYPE_SPINE) && (n->m_Node.m_NodeType != NODE_TYPE_PARTICLEFX) && (texture_info->m_Texture))
             {
                 n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture_info->m_OriginalWidth;
@@ -2639,6 +2664,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             n->m_Node.m_TextureHash = texture_id;
             n->m_Node.m_Texture = texture->m_Handle;
             n->m_Node.m_TextureSet = 0x0;
+            n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_DYNAMIC;
             if((n->m_Node.m_SizeMode != SIZE_MODE_MANUAL) && (n->m_Node.m_NodeType != NODE_TYPE_SPINE) && (n->m_Node.m_NodeType != NODE_TYPE_PARTICLEFX))
             {
                 n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture->m_Width;
@@ -2648,6 +2674,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         }
         n->m_Node.m_Texture = 0;
         n->m_Node.m_TextureSet = 0;
+        n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
         return RESULT_RESOURCE_NOT_FOUND;
     }
 
@@ -2771,6 +2798,15 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         // Set spine texture and textureset
         n->m_Node.m_Texture = rig_data.m_Texture;
         n->m_Node.m_TextureSet = rig_data.m_TextureSet;
+
+        if (rig_data.m_TextureSet)
+        {
+            n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE_SET;
+        }
+        else
+        {
+            n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE;
+        }
 
         // Create bone child nodes
         if (generate_bones) {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -457,30 +457,21 @@ namespace dmGui
         return scene->m_UserData;
     }
 
-    Result AddTexture(HScene scene, const char* texture_name, void* texture, void* textureset, uint32_t original_width, uint32_t original_height)
+    Result AddTexture(HScene scene, const char* texture_name, void* texture, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
     {
         if (scene->m_Textures.Full())
             return RESULT_OUT_OF_RESOURCES;
 
         uint64_t texture_hash = dmHashString64(texture_name);
-        scene->m_Textures.Put(texture_hash, TextureInfo(texture, textureset, original_width, original_height));
+        scene->m_Textures.Put(texture_hash, TextureInfo(texture, texture_type, original_width, original_height));
         uint32_t n = scene->m_Nodes.Size();
         InternalNode* nodes = scene->m_Nodes.Begin();
         for (uint32_t i = 0; i < n; ++i)
         {
             if (nodes[i].m_Node.m_TextureHash == texture_hash)
             {
-                nodes[i].m_Node.m_Texture = texture;
-                nodes[i].m_Node.m_TextureSet = textureset;
-
-                if (textureset)
-                {
-                    nodes[i].m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE_SET;
-                }
-                else
-                {
-                    nodes[i].m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE;
-                }
+                nodes[i].m_Node.m_Texture     = texture;
+                nodes[i].m_Node.m_TextureType = texture_type;
             }
         }
         return RESULT_OK;
@@ -497,12 +488,12 @@ namespace dmGui
             Node& node = nodes[i].m_Node;
             if (node.m_TextureHash == texture_name_hash)
             {
-                if(node.m_TextureSet)
+                if (node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
                 {
-                    node.m_TextureSet = 0;
                     CancelNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
                 }
-                node.m_Texture = 0;
+
+                node.m_Texture     = 0;
                 node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
             }
         }
@@ -516,9 +507,8 @@ namespace dmGui
         for (uint32_t i = 0; i < n; ++i)
         {
             Node& node = nodes[i].m_Node;
-            if(node.m_TextureSet)
+            if (node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
             {
-                node.m_TextureSet = 0;
                 CancelNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
             }
             node.m_Texture = 0;
@@ -932,7 +922,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     inline void CalculateNodeSize(InternalNode* in)
     {
         Node& n = in->m_Node;
-        if((n.m_SizeMode == SIZE_MODE_MANUAL) || (n.m_NodeType == NODE_TYPE_SPINE) || (n.m_NodeType == NODE_TYPE_PARTICLEFX) || (n.m_TextureSet == 0x0) || (n.m_TextureSetAnimDesc.m_TexCoords == 0x0))
+        if((n.m_SizeMode == SIZE_MODE_MANUAL) || (n.m_NodeType == NODE_TYPE_SPINE) || (n.m_NodeType == NODE_TYPE_PARTICLEFX) || (n.m_TextureType != NODE_TEXTURE_TYPE_TEXTURE_SET) || (n.m_TextureSetAnimDesc.m_TexCoords == 0x0))
             return;
         TextureSetAnimDesc* anim_desc = &n.m_TextureSetAnimDesc;
         int32_t anim_frames = anim_desc->m_End - anim_desc->m_Start;
@@ -2109,7 +2099,6 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         node->m_Node.m_HasResetPoint = false;
         node->m_Node.m_TextureHash = 0;
         node->m_Node.m_Texture = 0;
-        node->m_Node.m_TextureSet = 0;
         node->m_Node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
         node->m_Node.m_TextureSetAnimDesc.Init();
         node->m_Node.m_FlipbookAnimHash = 0;
@@ -2614,12 +2603,6 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     {
         InternalNode* n = GetNode(scene, node);
         *textureTypeOut = n->m_Node.m_TextureType;
-
-        if (n->m_Node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
-        {
-            return n->m_Node.m_TextureSet;
-        }
-
         return n->m_Node.m_Texture;
     }
 
@@ -2632,29 +2615,20 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     dmhash_t GetNodeFlipbookAnimId(HScene scene, HNode node)
     {
         InternalNode* n = GetNode(scene, node);
-        return n->m_Node.m_TextureSet == 0x0 ? 0x0 : n->m_Node.m_FlipbookAnimHash;
+        return n->m_Node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET ? n->m_Node.m_FlipbookAnimHash : 0x0;
     }
 
     Result SetNodeTexture(HScene scene, HNode node, dmhash_t texture_id)
     {
         InternalNode* n = GetNode(scene, node);
-        if(n->m_Node.m_TextureSet)
+        if (n->m_Node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
             CancelNodeFlipbookAnim(scene, node);
         if (TextureInfo* texture_info = scene->m_Textures.Get(texture_id)) {
             n->m_Node.m_TextureHash = texture_id;
-            n->m_Node.m_Texture = texture_info->m_Texture;
-            n->m_Node.m_TextureSet = texture_info->m_TextureSet;
+            n->m_Node.m_Texture = texture_info->m_TextureSource;
+            n->m_Node.m_TextureType = texture_info->m_TextureSourceType;
 
-            if (texture_info->m_TextureSet)
-            {
-                n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE_SET;
-            }
-            else
-            {
-                n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE;
-            }
-
-            if((n->m_Node.m_SizeMode != SIZE_MODE_MANUAL) && (n->m_Node.m_NodeType != NODE_TYPE_SPINE) && (n->m_Node.m_NodeType != NODE_TYPE_PARTICLEFX) && (texture_info->m_Texture))
+            if((n->m_Node.m_SizeMode != SIZE_MODE_MANUAL) && (n->m_Node.m_NodeType != NODE_TYPE_SPINE) && (n->m_Node.m_NodeType != NODE_TYPE_PARTICLEFX) && (texture_info->m_TextureSource))
             {
                 n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture_info->m_OriginalWidth;
                 n->m_Node.m_Properties[PROPERTY_SIZE][1] = texture_info->m_OriginalHeight;
@@ -2663,7 +2637,6 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         } else if (DynamicTexture* texture = scene->m_DynamicTextures.Get(texture_id)) {
             n->m_Node.m_TextureHash = texture_id;
             n->m_Node.m_Texture = texture->m_Handle;
-            n->m_Node.m_TextureSet = 0x0;
             n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_DYNAMIC;
             if((n->m_Node.m_SizeMode != SIZE_MODE_MANUAL) && (n->m_Node.m_NodeType != NODE_TYPE_SPINE) && (n->m_Node.m_NodeType != NODE_TYPE_PARTICLEFX))
             {
@@ -2673,7 +2646,6 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             return RESULT_OK;
         }
         n->m_Node.m_Texture = 0;
-        n->m_Node.m_TextureSet = 0;
         n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
         return RESULT_RESOURCE_NOT_FOUND;
     }
@@ -2796,16 +2768,15 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         }
 
         // Set spine texture and textureset
-        n->m_Node.m_Texture = rig_data.m_Texture;
-        n->m_Node.m_TextureSet = rig_data.m_TextureSet;
-
         if (rig_data.m_TextureSet)
         {
             n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE_SET;
+            n->m_Node.m_Texture = rig_data.m_TextureSet;
         }
         else
         {
             n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_TEXTURE;
+            n->m_Node.m_Texture = rig_data.m_Texture;
         }
 
         // Create bone child nodes
@@ -3468,7 +3439,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         {
             if (TextureInfo* texture_info = scene->m_Textures.Get(n->m_Node.m_TextureHash))
             {
-                if(texture_info->m_Texture)
+                if(texture_info->m_TextureSource)
                 {
                     n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture_info->m_OriginalWidth;
                     n->m_Node.m_Properties[PROPERTY_SIZE][1] = texture_info->m_OriginalHeight;
@@ -3707,14 +3678,14 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             dmLogError("PlayNodeFlipbookAnim called with node in scene with no FetchTextureSetAnimCallback set.");
             return FETCH_ANIMATION_CALLBACK_ERROR;
         }
-        return fetch_anim_callback(n->m_Node.m_TextureSet, anim, &n->m_Node.m_TextureSetAnimDesc);
+        return fetch_anim_callback(n->m_Node.m_Texture, anim, &n->m_Node.m_TextureSetAnimDesc);
     }
 
     static inline void UpdateTextureSetAnimData(HScene scene, InternalNode* n)
     {
         // if we got a textureset (i.e. texture animation), we want to update the animation in case it is reloaded
         uint64_t anim_hash = n->m_Node.m_FlipbookAnimHash;
-        if(n->m_Node.m_TextureSet == 0 || anim_hash == 0)
+        if(n->m_Node.m_TextureType != NODE_TEXTURE_TYPE_TEXTURE_SET || anim_hash == 0)
             return;
 
         // update animationdata, compare state to current and early bail if equal
@@ -3758,7 +3729,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             dmLogError("PlayNodeFlipbookAnim called with invalid anim name.");
             return RESULT_INVAL_ERROR;
         }
-        if(n->m_Node.m_TextureSet == 0x0)
+        if(n->m_Node.m_TextureType != NODE_TEXTURE_TYPE_TEXTURE_SET)
         {
             dmLogError("PlayNodeFlipbookAnim called with node not containing animation.");
             return RESULT_INVAL_ERROR;
@@ -3806,7 +3777,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     {
         InternalNode* in = GetNode(scene, node);
         Node& n = in->m_Node;
-        if(n.m_TextureSet == 0x0 || n.m_TextureSetAnimDesc.m_TexCoords == 0x0)
+        if(n.m_TextureType != NODE_TEXTURE_TYPE_TEXTURE_SET || n.m_TextureSetAnimDesc.m_TexCoords == 0x0)
             return 0;
         TextureSetAnimDesc* anim_desc = &n.m_TextureSetAnimDesc;
         int32_t anim_frames = anim_desc->m_End - anim_desc->m_Start;

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -559,7 +559,7 @@ namespace dmGui
      * @param original_height Original Height of the texture
      * @return Outcome of the operation
      */
-    Result AddTexture(HScene scene, const char* texture_name, void* texture, void* textureset, uint32_t original_width, uint32_t original_height);
+    Result AddTexture(HScene scene, const char* texture_name, void* texture, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height);
 
     /**
      * Removes a texture with the specified name from the scene.

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -321,14 +321,6 @@ namespace dmGui
         NODE_TYPE_PARTICLEFX = 5,
     };
 
-    enum NodeTextureType
-    {
-        NODE_TEXTURE_TYPE_NONE,
-        NODE_TEXTURE_TYPE_TEXTURE,
-        NODE_TEXTURE_TYPE_TEXTURE_SET,
-        NODE_TEXTURE_TYPE_DYNAMIC
-    };
-
     // NOTE: These enum values are duplicated in scene desc in gamesys (gui_ddf.proto)
     // Don't forget to change gui_ddf.proto if you change here
     enum XAnchor
@@ -385,6 +377,15 @@ namespace dmGui
     {
         PIEBOUNDS_RECTANGLE = 0,
         PIEBOUNDS_ELLIPSE   = 1,
+    };
+
+    // This enum denotes what kind of texture type the m_Texture pointer is referencing.
+    enum NodeTextureType
+    {
+        NODE_TEXTURE_TYPE_NONE,
+        NODE_TEXTURE_TYPE_TEXTURE,
+        NODE_TEXTURE_TYPE_TEXTURE_SET,
+        NODE_TEXTURE_TYPE_DYNAMIC
     };
 
     /**

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -321,6 +321,14 @@ namespace dmGui
         NODE_TYPE_PARTICLEFX = 5,
     };
 
+    enum NodeTextureType
+    {
+        NODE_TEXTURE_TYPE_NONE,
+        NODE_TEXTURE_TYPE_TEXTURE,
+        NODE_TEXTURE_TYPE_TEXTURE_SET,
+        NODE_TEXTURE_TYPE_DYNAMIC
+    };
+
     // NOTE: These enum values are duplicated in scene desc in gamesys (gui_ddf.proto)
     // Don't forget to change gui_ddf.proto if you change here
     enum XAnchor
@@ -936,7 +944,7 @@ namespace dmGui
     void SetNodeTextTracking(HScene scene, HNode node, float tracking);
     float GetNodeTextTracking(HScene scene, HNode node);
 
-    void* GetNodeTexture(HScene scene, HNode node);
+    void* GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut);
     dmhash_t GetNodeTextureId(HScene scene, HNode node);
     Result SetNodeTexture(HScene scene, HNode node, dmhash_t texture_id);
     Result SetNodeTexture(HScene scene, HNode node, const char* texture_id);

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -132,6 +132,7 @@ namespace dmGui
         uint64_t    m_TextureHash;
         void*       m_Texture;
         void*       m_TextureSet;
+        NodeTextureType m_TextureType;
 
         TextureSetAnimDesc m_TextureSetAnimDesc;
         uint64_t    m_FlipbookAnimHash;

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -131,7 +131,6 @@ namespace dmGui
 
         uint64_t    m_TextureHash;
         void*       m_Texture;
-        void*       m_TextureSet;
         NodeTextureType m_TextureType;
 
         TextureSetAnimDesc m_TextureSetAnimDesc;
@@ -217,9 +216,14 @@ namespace dmGui
 
     struct TextureInfo
     {
-        TextureInfo(void* texture, void *textureset, uint32_t original_width, uint32_t original_height) : m_Texture(texture), m_TextureSet(textureset), m_OriginalWidth(original_width), m_OriginalHeight(original_height) {}
-        void*   m_Texture;
-        void*   m_TextureSet;
+        TextureInfo(void* texture_source, NodeTextureType texture_source_type, uint32_t original_width, uint32_t original_height) 
+        : m_TextureSource(texture_source)
+        , m_TextureSourceType(texture_source_type)
+        , m_OriginalWidth(original_width)
+        , m_OriginalHeight(original_height) {}
+        
+        void*    m_TextureSource;
+        NodeTextureType m_TextureSourceType;
         uint32_t m_OriginalWidth : 16;
         uint32_t m_OriginalHeight : 16;
     };

--- a/engine/gui/src/test/guidemo.cpp
+++ b/engine/gui/src/test/guidemo.cpp
@@ -61,7 +61,8 @@ void MyRenderNodes(dmGui::HScene scene,
                 break;
         }
 
-        if (dmGui::GetNodeTexture(scene, node))
+        dmGui::NodeTextureType texture_type;
+        if (dmGui::GetNodeTexture(scene, node, &texture_type))
         {
             glEnable(GL_TEXTURE_2D);
             glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);

--- a/engine/gui/src/test/guidemo.cpp
+++ b/engine/gui/src/test/guidemo.cpp
@@ -199,7 +199,7 @@ int main(void)
         fread(buf, 1, file_size, f);
         fclose(f);
 
-        dmGui::AddTexture(scene, "checker", (void*)(uintptr_t) checker_texture, 0, 2, 2);
+        dmGui::AddTexture(scene, "checker", (void*)(uintptr_t) checker_texture, dmGui::NODE_TEXTURE_TYPE_TEXTURE, 2, 2);
 
         dmLuaDDF::LuaSource luaSource;
         memset(&luaSource, 0x00, sizeof(luaSource));

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -838,10 +838,10 @@ TEST_F(dmGuiTest, Layouts)
 
 TEST_F(dmGuiTest, SizeMode)
 {
-    int t1, ts1;
+    int t1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, (void*) &ts1, 1, 1);
+    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX);
@@ -864,10 +864,10 @@ TEST_F(dmGuiTest, SizeMode)
 
 TEST_F(dmGuiTest, FlipbookAnim)
 {
-    int t1, ts1;
+    int t1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, (void*) &ts1, 1, 1);
+    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX);
@@ -917,7 +917,7 @@ TEST_F(dmGuiTest, FlipbookAnim)
     fb_id = dmGui::GetNodeFlipbookAnimId(m_Scene, node);
     ASSERT_EQ(0, fb_id);
 
-    r = dmGui::AddTexture(m_Scene, "t2", (void*) &t1, 0, 1, 1);
+    r = dmGui::AddTexture(m_Scene, "t2", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
@@ -930,11 +930,10 @@ TEST_F(dmGuiTest, FlipbookAnim)
 TEST_F(dmGuiTest, TextureFontLayer)
 {
     int t1, t2;
-    int ts1, ts2;
     int f1, f2;
 
-    dmGui::AddTexture(m_Scene, "t1", (void*) &t1, (void*) &ts1, 1, 1);
-    dmGui::AddTexture(m_Scene, "t2", (void*) &t2, (void*) &ts2, 1, 1);
+    dmGui::AddTexture(m_Scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    dmGui::AddTexture(m_Scene, "t2", (void*) &t2, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     dmGui::AddFont(m_Scene, "f1", &f1);
     dmGui::AddFont(m_Scene, "f2", &f2);
     dmGui::AddLayer(m_Scene, "l1");
@@ -958,9 +957,8 @@ TEST_F(dmGuiTest, TextureFontLayer)
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
-    dmGui::AddTexture(m_Scene, "t2", (void*) &t1, (void*) &ts1, 1, 1);
+    dmGui::AddTexture(m_Scene, "t2", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(&t1, m_Scene->m_Nodes[node & 0xffff].m_Node.m_Texture);
-    ASSERT_EQ(&ts1, m_Scene->m_Nodes[node & 0xffff].m_Node.m_TextureSet);
 
     dmGui::RemoveTexture(m_Scene, "t2");
     ASSERT_EQ((void*)0, m_Scene->m_Nodes[node & 0xffff].m_Node.m_Texture);
@@ -1029,8 +1027,9 @@ static void DynamicRenderNodes(dmGui::HScene scene, const dmGui::RenderEntry* no
     uint32_t* count = (uint32_t*) context;
     for (uint32_t i = 0; i < node_count; ++i) {
         dmGui::HNode node = nodes[i].m_Node;
+        dmGui::NodeTextureType node_texture_type;
         dmhash_t id = dmGui::GetNodeTextureId(scene, node);
-        if ((id == dmHashString64("t1") || id == dmHashString64("t2")) && dmGui::GetNodeTexture(scene, node)) {
+        if ((id == dmHashString64("t1") || id == dmHashString64("t2")) && dmGui::GetNodeTexture(scene, node, &node_texture_type)) {
             *count = *count + 1;
         }
     }
@@ -1185,7 +1184,7 @@ TEST_F(dmGuiTest, ScriptFlipbookAnim)
     int t1, ts1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, (void*) &ts1, 1, 1);
+    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     const char* id = "n";
@@ -1229,7 +1228,7 @@ TEST_F(dmGuiTest, ScriptTextureFontLayer)
     int t, ts;
     int f;
 
-    dmGui::AddTexture(m_Scene, "t", (void*) &t, (void*) &ts, 1, 1);
+    dmGui::AddTexture(m_Scene, "t", (void*) &t, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     dmGui::AddFont(m_Scene, "f", &f);
     dmGui::AddLayer(m_Scene, "l");
 
@@ -2739,8 +2738,8 @@ TEST_F(dmGuiTest, Bug352)
 {
     dmGui::AddFont(m_Scene, "big_score", 0);
     dmGui::AddFont(m_Scene, "score", 0);
-    dmGui::AddTexture(m_Scene, "left_hud", 0,0, 1, 1);
-    dmGui::AddTexture(m_Scene, "right_hud", 0,0, 1, 1);
+    dmGui::AddTexture(m_Scene, "left_hud", 0, dmGui::NODE_TEXTURE_TYPE_NONE, 1, 1);
+    dmGui::AddTexture(m_Scene, "right_hud", 0, dmGui::NODE_TEXTURE_TYPE_NONE, 1, 1);
 
     dmGui::Result r;
     r = dmGui::SetScript(m_Script, LuaSourceFromStr((const char*)BUG352_LUA, BUG352_LUA_SIZE));

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -835,6 +835,56 @@ TEST_F(dmGuiTest, Layouts)
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
+TEST_F(dmGuiTest, NodeTextureType)
+{
+    int t1, t2;
+    void* raw_tex;
+    dmGui::Result r;
+    dmGui::NodeTextureType node_texture_type;
+    uint64_t fb_id;
+
+    // Test NODE_TEXTURE_TYPE_TEXTURE_SET: Create and get type
+    r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(0,0,0), Vector3(0,0,0), dmGui::NODE_TYPE_BOX);
+    ASSERT_NE((dmGui::HNode) 0, node);
+
+    r = dmGui::SetNodeTexture(m_Scene, node, "t1");
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    raw_tex = dmGui::GetNodeTexture(m_Scene, node, &node_texture_type);
+    ASSERT_EQ(raw_tex, &t1);
+    ASSERT_EQ(node_texture_type, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET);
+
+    // Test NODE_TEXTURE_TYPE_TEXTURE_SET: Playing flipbook animation
+    r = dmGui::PlayNodeFlipbookAnim(m_Scene, node, "ta1", 0x0);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    fb_id = dmGui::GetNodeFlipbookAnimId(m_Scene, node);
+    ASSERT_EQ(dmHashString64("ta1"), fb_id);
+
+    // Test NODE_TEXTURE_TYPE_TEXTURE: Create and get type
+    r = dmGui::AddTexture(m_Scene, "t2", (void*) &t2, dmGui::NODE_TEXTURE_TYPE_TEXTURE, 1, 1);
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    r = dmGui::SetNodeTexture(m_Scene, node, "t2");
+    ASSERT_EQ(r, dmGui::RESULT_OK);
+
+    raw_tex = dmGui::GetNodeTexture(m_Scene, node, &node_texture_type);
+    ASSERT_EQ(raw_tex, &t2);
+    ASSERT_EQ(node_texture_type, dmGui::NODE_TEXTURE_TYPE_TEXTURE);
+
+    // Test NODE_TEXTURE_TYPE_TEXTURE: Playing flipbook animation should not work!
+    r = dmGui::PlayNodeFlipbookAnim(m_Scene, node, "ta2", 0x0);
+    ASSERT_EQ(r, dmGui::RESULT_INVAL_ERROR);
+    ASSERT_EQ(dmGui::GetNodeFlipbookAnimId(m_Scene, node), 0);
+
+    // Test NODE_TEXTURE_TYPE_NONE: Removing known texture should reset node texture types
+    dmGui::RemoveTexture(m_Scene, "t2");
+    dmGui::GetNodeTexture(m_Scene, node, &node_texture_type);
+    ASSERT_EQ(node_texture_type, dmGui::NODE_TEXTURE_TYPE_NONE);
+}
 
 TEST_F(dmGuiTest, SizeMode)
 {
@@ -917,7 +967,7 @@ TEST_F(dmGuiTest, FlipbookAnim)
     fb_id = dmGui::GetNodeFlipbookAnimId(m_Scene, node);
     ASSERT_EQ(0, fb_id);
 
-    r = dmGui::AddTexture(m_Scene, "t2", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE, 1, 1);
+    r = dmGui::AddTexture(m_Scene, "t2", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
@@ -1181,7 +1231,7 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
 
 TEST_F(dmGuiTest, ScriptFlipbookAnim)
 {
-    int t1, ts1;
+    int t1;
     dmGui::Result r;
 
     r = dmGui::AddTexture(m_Scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
@@ -1225,7 +1275,7 @@ TEST_F(dmGuiTest, ScriptFlipbookAnim)
 
 TEST_F(dmGuiTest, ScriptTextureFontLayer)
 {
-    int t, ts;
+    int t;
     int f;
 
     dmGui::AddTexture(m_Scene, "t", (void*) &t, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -482,8 +482,8 @@ TEST_F(dmGuiScriptTest, TestSizeMode)
 
     dmGui::Result result;
 
-    int t1, ts1;
-    result = dmGui::AddTexture(scene, "t1", (void*) &t1, (void*) &ts1, 1, 1);
+    int t1;
+    result = dmGui::AddTexture(scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_NONE, 1, 1);
     ASSERT_EQ(result, dmGui::RESULT_OK);
 
     const char* src =

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -483,7 +483,7 @@ TEST_F(dmGuiScriptTest, TestSizeMode)
     dmGui::Result result;
 
     int t1;
-    result = dmGui::AddTexture(scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_NONE, 1, 1);
+    result = dmGui::AddTexture(scene, "t1", (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(result, dmGui::RESULT_OK);
 
     const char* src =


### PR DESCRIPTION
This PR changes the way textures and texture sets are referenced in gui.cpp. Instead of (potentially) storing a pointer to a texture and a texture set in the gui nodes, we only store a single pointer. The pointer will either point to a  HTexture or a texture set resource. When comp_gui asks to get the texture from the node, a texure type enum is returned aswell which denotes what is stored in the pointer. This way, we can always retrieve the latest internal texture from a texture set when it has been updated by hot-reloading for example.