### PR TITLE
DEF-3772 msg post optimisations

### DIFF
--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -454,25 +454,38 @@ namespace dmMessage
         uint32_t path_size = 0;
         const char* fragment = 0x0;
         uint32_t fragment_size = 0;
-        const char* socket_end = strchr(uri, ':');
-        const char* fragment_start = strchr(uri, '#');
-        if (fragment_start != 0x0)
+
+        const char* socket_end = 0;
+        const char* fragment_start = 0;
+        const char* scan = uri;
+        while (*scan)
         {
-            if (fragment_start < socket_end)
+            switch(*scan)
             {
-                return RESULT_MALFORMED_URL;
+                case ':':
+                    if (socket_end != 0)
+                    {
+                        return RESULT_MALFORMED_URL;
+                    }
+                    if (fragment_start != 0)
+                    {
+                        return RESULT_MALFORMED_URL;
+                    }
+                    socket_end = scan;
+                    break;
+                case '#':
+                    if (fragment_start != 0)
+                    {
+                        return RESULT_MALFORMED_URL;
+                    }
+                    fragment_start = scan;
+                    break;
             }
-            if (fragment_start != strrchr(uri, '#'))
-            {
-                return RESULT_MALFORMED_URL;
-            }
-        }
+            ++scan;
+        };
+
         if (socket_end != 0x0)
         {
-            if (socket_end != strrchr(uri, ':'))
-            {
-                return RESULT_MALFORMED_URL;
-            }
             socket_size = socket_end - uri;
             if (socket_size >= 64)
             {
@@ -481,15 +494,17 @@ namespace dmMessage
             socket = uri;
             path = socket_end + 1;
         }
+
+        uint32_t uri_length = (uint32_t)(scan - uri);
         if (fragment_start != 0x0)
         {
             fragment = fragment_start + 1;
-            fragment_size = strlen(uri) - (fragment - uri);
+            fragment_size = uri_length - (fragment - uri);
             path_size = fragment_start - path;
         }
         else
         {
-            path_size = strlen(uri) - (path - uri);
+            path_size = uri_length - (path - uri);
         }
         out_url->m_Socket = socket;
         out_url->m_SocketSize = socket_size;

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -342,6 +342,8 @@ namespace dmMessage
         new_message->m_DestroyCallback = destroy_callback;
         memcpy(&new_message->m_Data[0], message_data, message_data_size);
 
+        bool is_first_message = !s->m_Header;
+
         if (!s->m_Header)
         {
             s->m_Header = new_message;
@@ -353,7 +355,10 @@ namespace dmMessage
             s->m_Tail = new_message;
         }
 
-        dmConditionVariable::Signal(s->m_Condition);
+        if (is_first_message)
+        {
+            dmConditionVariable::Signal(s->m_Condition);
+        }
         dmMutex::Unlock(s->m_Mutex);
         return RESULT_OK;
     }

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -2,13 +2,6 @@
 #define DM_PROFILE_H
 
 #include <stdint.h>
-#if defined(_WIN32)
-#include "safe_windows.h"
-#elif  defined(__EMSCRIPTEN__)
-#include <emscripten.h>
-#else
-#include <sys/time.h>
-#endif
 #include <dlib/array.h>
 #include <dlib/log.h>
 #include <dlib/atomic.h>
@@ -344,51 +337,27 @@ namespace dmProfile
         Sample*     m_Sample;
         inline ProfileScope(Scope* scope, const char* name)
         {
-            if (!g_IsInitialized)
+            if (g_IsInitialized)
+            {
+                StartScope(scope, name);
+            }
+            else
             {
                 m_Sample = 0;
-                return;
             }
-
-            uint64_t start;
-#if defined(_WIN32)
-            QueryPerformanceCounter((LARGE_INTEGER *)&start);
-#elif defined(__EMSCRIPTEN__)
-            start = (uint64_t)(emscripten_get_now() * 1000.0);
-#else
-            timeval tv;
-            gettimeofday(&tv, 0);
-            start = tv.tv_sec * 1000000 + tv.tv_usec;
-#endif
-            Sample*s = AllocateSample();
-            s->m_Name = name;
-            s->m_Scope = scope;
-            s->m_Start = (uint32_t)(start - g_BeginTime);
-            m_Sample = s;
+            
         }
-
-
 
         inline ~ProfileScope()
         {
-            if (m_Sample == 0)
+            if (m_Sample)
             {
-                return;
+                EndScope();
             }
-
-            uint64_t end;
-#if defined(_WIN32)
-            QueryPerformanceCounter((LARGE_INTEGER *) &end);
-#elif defined(__EMSCRIPTEN__)
-            end = (uint64_t)(emscripten_get_now() * 1000.0);
-#else
-            timeval tv;
-            gettimeofday(&tv, 0);
-            end = tv.tv_sec * 1000000 + tv.tv_usec;
-#endif
-            ANALYZE_USE_POINTER(m_Sample);
-            m_Sample->m_Elapsed = (uint32_t)(end - g_BeginTime) - m_Sample->m_Start;
         }
+
+        void StartScope(Scope* scope, const char* name);
+        void EndScope();
     };
 
 }

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -69,6 +69,11 @@ namespace dmGameObject
     static bool InitCollection(Collection* collection);
     static bool FinalCollection(Collection* collection);
 
+    Prototype::~Prototype()
+    {
+        free(m_Components);
+    }
+
     InputAction::InputAction()
     {
         memset(this, 0, sizeof(InputAction));
@@ -593,7 +598,7 @@ namespace dmGameObject
     static HInstance AllocInstance(Prototype* proto, const char* prototype_name) {
         // Count number of component userdata fields required
         uint32_t component_instance_userdata_count = 0;
-        for (uint32_t i = 0; i < proto->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < proto->m_ComponentCount; ++i)
         {
             Prototype::Component* component = &proto->m_Components[i];
             ComponentType* component_type = component->m_Type;
@@ -675,11 +680,11 @@ namespace dmGameObject
         uint32_t components_created = 0;
         uint32_t next_component_instance_data = 0;
         bool ok = true;
-        if (proto->m_Components.Size() > 0xFFFF ) {
-            dmLogWarning("Too many components in game object: %u (max is 65536)", proto->m_Components.Size());
+        if (proto->m_ComponentCount > 0xFFFF ) {
+            dmLogWarning("Too many components in game object: %u (max is 65536)", proto->m_ComponentCount);
             return false;
         }
-        for (uint32_t i = 0; i < proto->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < proto->m_ComponentCount; ++i)
         {
             Prototype::Component* component = &proto->m_Components[i];
             ComponentType* component_type = component->m_Type;
@@ -752,7 +757,7 @@ namespace dmGameObject
     static void DestroyComponents(Collection* collection, HInstance instance) {
         HPrototype prototype = instance->m_Prototype;
         uint32_t next_component_instance_data = 0;
-        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < prototype->m_ComponentCount; ++i)
         {
             Prototype::Component* component = &prototype->m_Components[i];
             ComponentType* component_type = component->m_Type;
@@ -921,7 +926,7 @@ namespace dmGameObject
 
                 uint32_t next_component_instance_data = 0;
                 Prototype* prototype = instance->m_Prototype;
-                for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+                for (uint32_t i = 0; i < prototype->m_ComponentCount; ++i)
                 {
                     Prototype::Component* component = &prototype->m_Components[i];
                     ComponentType* component_type = component->m_Type;
@@ -978,8 +983,8 @@ namespace dmGameObject
     static bool SetScriptPropertiesFromBuffer(HInstance instance, const char *prototype_name, uint8_t* property_buffer, uint32_t property_buffer_size)
     {
         uint32_t next_component_instance_data = 0;
-        dmArray<Prototype::Component>& components = instance->m_Prototype->m_Components;
-        uint32_t count = components.Size();
+        Prototype::Component* components = instance->m_Prototype->m_Components;
+        uint32_t count = instance->m_Prototype->m_ComponentCount;
         for (uint32_t i = 0; i < count; ++i) {
             Prototype::Component& component = components[i];
             ComponentType* component_type = component.m_Type;
@@ -1242,8 +1247,8 @@ namespace dmGameObject
                 created.Push(instance);
                 // Set properties
                 uint32_t component_instance_data_index = 0;
-                dmArray<Prototype::Component>& components = instance->m_Prototype->m_Components;
-                uint32_t comp_count = components.Size();
+                Prototype::Component* components = instance->m_Prototype->m_Components;
+                uint32_t comp_count = instance->m_Prototype->m_ComponentCount;
                 for (uint32_t comp_i = 0; comp_i < comp_count; ++comp_i)
                 {
                     Prototype::Component& component = components[comp_i];
@@ -1507,7 +1512,7 @@ namespace dmGameObject
     {
         uint32_t next_component_instance_data = 0;
         Prototype* prototype = instance->m_Prototype;
-        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < prototype->m_ComponentCount; ++i)
         {
             Prototype::Component* component = &prototype->m_Components[i];
             ComponentType* component_type = component->m_Type;
@@ -1624,7 +1629,7 @@ namespace dmGameObject
     {
         uint32_t next_component_instance_data = 0;
         Prototype* prototype = instance->m_Prototype;
-        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < prototype->m_ComponentCount; ++i)
         {
             Prototype::Component* component = &prototype->m_Components[i];
             ComponentType* component_type = component->m_Type;
@@ -1924,7 +1929,7 @@ namespace dmGameObject
     Result GetComponentIndex(HInstance instance, dmhash_t component_id, uint16_t* component_index)
     {
         assert(instance != 0x0);
-        for (uint32_t i = 0; i < instance->m_Prototype->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < instance->m_Prototype->m_ComponentCount; ++i)
         {
             Prototype::Component* component = &instance->m_Prototype->m_Components[i];
             if (component->m_Id == component_id)
@@ -1939,7 +1944,7 @@ namespace dmGameObject
     Result GetComponentId(HInstance instance, uint16_t component_index, dmhash_t* component_id)
     {
         assert(instance != 0x0);
-        if (component_index < instance->m_Prototype->m_Components.Size())
+        if (component_index < instance->m_Prototype->m_ComponentCount)
         {
             *component_id = instance->m_Prototype->m_Components[component_index].m_Id;
             return RESULT_OK;
@@ -2176,7 +2181,6 @@ namespace dmGameObject
             Prototype::Component* component = &prototype->m_Components[component_index];
             ComponentType* component_type = component->m_Type;
             assert(component_type);
-            uint32_t component_type_index = component->m_TypeIndex;
 
             if (component_type->m_OnMessageFunction)
             {
@@ -2201,7 +2205,7 @@ namespace dmGameObject
                     DM_PROFILE(GameObject, "OnMessageFunction");
                     ComponentOnMessageParams params;
                     params.m_Instance = instance;
-                    params.m_World = collection->m_ComponentWorlds[component_type_index];
+                    params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                     params.m_Context = component_type->m_Context;
                     params.m_UserData = component_instance_data;
                     params.m_Message = message;
@@ -2219,12 +2223,11 @@ namespace dmGameObject
         else // broadcast
         {
             uint32_t next_component_instance_data = 0;
-            for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+            for (uint32_t i = 0; i < prototype->m_ComponentCount; ++i)
             {
                 Prototype::Component* component = &prototype->m_Components[i];
                 ComponentType* component_type = component->m_Type;
                 assert(component_type);
-                uint32_t component_type_index = component->m_TypeIndex;
 
                 if (component_type->m_OnMessageFunction)
                 {
@@ -2237,7 +2240,7 @@ namespace dmGameObject
                         DM_PROFILE(GameObject, "OnMessageFunction");
                         ComponentOnMessageParams params;
                         params.m_Instance = instance;
-                        params.m_World = collection->m_ComponentWorlds[component_type_index];
+                        params.m_World = collection->m_ComponentWorlds[component->m_TypeIndex];
                         params.m_Context = component_type->m_Context;
                         params.m_UserData = component_instance_data;
                         params.m_Message = message;
@@ -2618,7 +2621,7 @@ namespace dmGameObject
                 {
                     HInstance instance = collection->m_InputFocusStack[stack_size - 1 - k];
                     Prototype* prototype = instance->m_Prototype;
-                    uint32_t components_size = prototype->m_Components.Size();
+                    uint32_t components_size = prototype->m_ComponentCount;
 
                     InputResult res = INPUT_RESULT_IGNORED;
                     uint32_t next_component_instance_data = 0;
@@ -3127,7 +3130,7 @@ namespace dmGameObject
             uint16_t component_index;
             if (RESULT_OK == GetComponentIndex(instance, component_id, &component_index))
             {
-                dmArray<Prototype::Component>& components = instance->m_Prototype->m_Components;
+                Prototype::Component* components = instance->m_Prototype->m_Components;
                 Prototype::Component& component = components[component_index];
                 ComponentType* type = component.m_Type;
                 if (type->m_GetPropertyFunction)
@@ -3327,7 +3330,7 @@ namespace dmGameObject
             uint16_t component_index;
             if (RESULT_OK == GetComponentIndex(instance, component_id, &component_index))
             {
-                dmArray<Prototype::Component>& components = instance->m_Prototype->m_Components;
+                Prototype::Component* components = instance->m_Prototype->m_Components;
                 Prototype::Component& component = components[component_index];
                 ComponentType* type = component.m_Type;
                 if (type->m_SetPropertyFunction)
@@ -3448,7 +3451,7 @@ namespace dmGameObject
                     RecreateInstance(collection, index, (Prototype*)params.m_Resource->m_PrevResource, (Prototype*)params.m_Resource->m_Resource, params.m_Name);
                 } else {
                     uint32_t next_component_instance_data = 0;
-                    for (uint32_t j = 0; j < instance->m_Prototype->m_Components.Size(); ++j)
+                    for (uint32_t j = 0; j < instance->m_Prototype->m_ComponentCount; ++j)
                     {
                         Prototype::Component& component = instance->m_Prototype->m_Components[j];
                         ComponentType* type = component.m_Type;

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -25,6 +25,12 @@ namespace dmGameObject
 
     struct Prototype
     {
+        Prototype()
+            : m_Components(0)
+            , m_ComponentCount(0)
+        {
+        }
+        ~Prototype();
         struct Component
         {
             Component(void* resource,
@@ -58,7 +64,8 @@ namespace dmGameObject
             PropertySet     m_PropertySet;
         };
 
-        dmArray<Component>     m_Components;
+        Component*  m_Components;
+        uint32_t    m_ComponentCount;
     };
 
     // Invalid instance index. Implies that maximum number of instances is 32766 (ie 0x7fff - 1)

--- a/engine/gameobject/src/gameobject/gameobject_profile.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_profile.cpp
@@ -64,7 +64,7 @@ bool IterateGameObjects(HCollection hcollection, FGameObjectIterator callback, v
 bool IterateComponents(HInstance instance, FGameComponentIterator callback, void* user_ctx)
 {
     Prototype* prototype = instance->m_Prototype;
-    for (uint32_t k = 0; k < prototype->m_Components.Size(); ++k)
+    for (uint32_t k = 0; k < prototype->m_ComponentCount; ++k)
     {
         Prototype::Component* component = &prototype->m_Components[k];
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -403,8 +403,8 @@ namespace dmGameObject
         // TODO: We should probably not store user-data sparse.
         // A lot of loops just to find user-data such as the code below
         assert(instance != 0x0);
-        const dmArray<Prototype::Component>& components = instance->m_Prototype->m_Components;
-        uint32_t n = components.Size();
+        const Prototype::Component* components = instance->m_Prototype->m_Components;
+        uint32_t n = instance->m_Prototype->m_ComponentCount;
         uint32_t component_instance_data = 0;
         for (uint32_t i = 0; i < n; ++i)
         {

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -120,8 +120,8 @@ namespace dmGameObject
             if (result) {
                 // Set properties
                 uint32_t component_instance_data_index = 0;
-                dmArray<Prototype::Component>& components = instance->m_Prototype->m_Components;
-                uint32_t comp_count = components.Size();
+                Prototype::Component* components = instance->m_Prototype->m_Components;
+                uint32_t comp_count = instance->m_Prototype->m_ComponentCount;
                 for (uint32_t comp_i = 0; comp_i < comp_count; ++comp_i)
                 {
                     Prototype::Component& component = components[comp_i];

--- a/engine/gameobject/src/gameobject/res_prototype.cpp
+++ b/engine/gameobject/src/gameobject/res_prototype.cpp
@@ -12,7 +12,7 @@ namespace dmGameObject
 {
     static void ReleaseResources(dmResource::HFactory factory, Prototype* prototype)
     {
-        for (uint32_t i = 0; i < prototype->m_Components.Size(); ++i)
+        for (uint32_t i = 0; i < prototype->m_ComponentCount; ++i)
         {
             Prototype::Component& c = prototype->m_Components[i];
             dmResource::Release(factory, c.m_Resource);
@@ -21,7 +21,13 @@ namespace dmGameObject
     }
 
     static dmResource::Result AcquireResources(dmResource::HFactory factory, dmGameObject::HRegister regist, dmGameObjectDDF::PrototypeDesc* proto_desc, Prototype* proto, const char* filename) {
-        proto->m_Components.SetCapacity(proto_desc->m_Components.m_Count);
+        proto->m_ComponentCount = 0;
+        proto->m_Components = 0;
+        if (proto_desc->m_Components.m_Count == 0)
+        {
+            return dmResource::RESULT_OK;
+        }
+        proto->m_Components = (Prototype::Component*)malloc(sizeof(Prototype::Component) * proto_desc->m_Components.m_Count);
 
         for (uint32_t i = 0; i < proto_desc->m_Components.m_Count; ++i)
         {
@@ -35,7 +41,7 @@ namespace dmGameObject
             if (fact_e == dmResource::RESULT_OK)
             {
                 id = dmHashString64(component_desc.m_Id);
-                for (uint32_t j = 0; j < proto->m_Components.Size(); ++j)
+                for (uint32_t j = 0; j < proto->m_ComponentCount; ++j)
                 {
                     if (proto->m_Components[j].m_Id == id)
                     {
@@ -82,7 +88,7 @@ namespace dmGameObject
                 {
                     return dmResource::RESULT_FORMAT_ERROR;
                 }
-                proto->m_Components.Push(c);
+                proto->m_Components[proto->m_ComponentCount++] = c;
             }
         }
         return dmResource::RESULT_OK;
@@ -147,7 +153,12 @@ namespace dmGameObject
         dmResource::Result r = AcquireResources(params.m_Factory, regist, proto_desc, temp, params.m_Filename);
         if (dmResource::RESULT_OK == r) {
             Prototype* proto = (Prototype*) params.m_Resource->m_Resource;
-            proto->m_Components.Swap(temp->m_Components);
+            Prototype::Component* c = proto->m_Components;
+            uint32_t i = proto->m_ComponentCount;
+            proto->m_Components = temp->m_Components;
+            proto->m_ComponentCount = temp->m_ComponentCount;
+            temp->m_Components = c;
+            temp->m_ComponentCount = i;
             params.m_Resource->m_PrevResource = temp;
         } else {
             ReleaseResources(params.m_Factory, temp);

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -103,8 +103,8 @@ public:
 
 static void SetProperties(dmGameObject::HInstance instance)
 {
-    dmArray<dmGameObject::Prototype::Component>& components = instance->m_Prototype->m_Components;
-    uint32_t count = components.Size();
+    dmGameObject::Prototype::Component* components = instance->m_Prototype->m_Components;
+    uint32_t count = instance->m_Prototype->m_ComponentCount;
     uint32_t component_instance_data_index = 0;
     dmGameObject::ComponentSetPropertiesParams params;
     params.m_Instance = instance;

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -500,15 +500,6 @@ namespace dmScript
             message_id = CheckHash(L, 2);
         }
 
-        if (!dmMessage::IsSocketValid(receiver.m_Socket))
-        {
-            char receiver_buffer[64];
-            url_tostring(&receiver, receiver_buffer, 64);
-            char sender_buffer[64];
-            url_tostring(&sender, sender_buffer, 64);
-            return luaL_error(L, "Could not send message '%s' from '%s' to '%s'.", dmHashReverseSafe64(message_id), sender_buffer, receiver_buffer);
-        }
-
         DM_ALIGNED(16) char data[MAX_MESSAGE_DATA_SIZE];
         uint32_t data_size = 0;
 
@@ -552,7 +543,15 @@ namespace dmScript
         assert(top == lua_gettop(L));
 
         dmMessage::Result result = dmMessage::Post(&sender, &receiver, message_id, 0, (uintptr_t) desc, data, data_size, 0);
-        if (result != dmMessage::RESULT_OK)
+        if (result == dmMessage::RESULT_SOCKET_NOT_FOUND)
+        {
+            char receiver_buffer[64];
+            url_tostring(&receiver, receiver_buffer, 64);
+            char sender_buffer[64];
+            url_tostring(&sender, sender_buffer, 64);
+            return luaL_error(L, "Could not send message '%s' from '%s' to '%s'.", dmHashReverseSafe64(message_id), sender_buffer, receiver_buffer);
+        }
+        else if (result != dmMessage::RESULT_OK)
         {
             return luaL_error(L, "Could not send message to %s.", dmMessage::GetSocketName(receiver.m_Socket));
         }

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -714,13 +714,25 @@ namespace dmScript
         }
         else
         {
-            // Initial check for global urls to avoid resolving etc
+
+            const char* url = 0;
+            dmMessage::StringURL string_url;
+            dmMessage::Result parse_url_result;
             if (lua_isstring(L, index))
             {
-                dmMessage::StringURL string_url;
-                const char* url = lua_tostring(L, index);
-                dmMessage::Result result = dmMessage::ParseURL(url, &string_url);
-                if (result == dmMessage::RESULT_OK)
+                // Make sure we get and parse the url only once
+                url = lua_tostring(L, index);
+                parse_url_result = dmMessage::ParseURL(url, &string_url);
+                if (parse_url_result != dmMessage::RESULT_OK)
+                {
+                    url = 0;
+                }
+            }
+
+            // Initial check for global urls to avoid resolving etc
+            if (url != 0)
+            {
+                if (parse_url_result == dmMessage::RESULT_OK)
                 {
                     if (IsURLGlobal(&string_url))
                     {
@@ -764,14 +776,11 @@ namespace dmScript
             {
                 *out_url = default_url;
             }
-            else if (lua_isstring(L, index))
+            else if (url != 0)
             {
-                const char* url = lua_tostring(L, index);
-
                 dmMessage::ResetURL(*out_url);
-                dmMessage::StringURL string_url;
-                dmMessage::Result result = dmMessage::ParseURL(url, &string_url);
-                if (result == dmMessage::RESULT_OK)
+                dmMessage::Result result = parse_url_result;
+                if (parse_url_result == dmMessage::RESULT_OK)
                 {
                     result = ResolveURL(L, url, out_url, &default_url);
                 }


### PR DESCRIPTION
Various macro level optimisations to reduce overhead when posting messages

- Rewrote ParseURL to not do multiple strchr/strrchr but instead scan the url string once
- Refactored ProfileScope since it was not properly inlined and added a function call even in release mode
- When posting a message, only signal the condition-variable if the message queue is empty
- Removed dmMessage:IsSocketValid explicit call removed since it takes a mutex and the validation will be down for us in dmMessage::Post
- Make sure to get/parse a string url once per call only
- Prototype::m_Components are iterated quite heavily thought the code, changed from dmArray to play array to avoid lots of assert() calls

Hard to measure exact gain, but looks like roughly 3-5% better in my extreme test cases.
Lots looks better when looking through Instruments but hard to build a real test case with absolute numbers.