### PR TITLE
DEF-3758: Spawned tilemap and collisions not working properly

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -176,24 +176,9 @@ namespace dmGameSystem
 
     static void SetupEmptyTileGrid(CollisionWorld* world, CollisionComponent* component)
     {
-        CollisionObjectResource* resource = component->m_Resource;
-        if (resource->m_TileGrid)
+        if (component->m_Resource->m_TileGrid)
         {
-            TileGridResource* tile_grid_resource = resource->m_TileGridResource;
-            dmArray<dmPhysics::HCollisionShape2D>& shapes = resource->m_TileGridResource->m_GridShapes;
-            uint32_t shape_count = shapes.Size();
-            dmPhysics::HullFlags flags;
-
-            for (uint32_t i = 0; i < shape_count; ++i)
-            {
-                for (uint32_t y = 0; y < tile_grid_resource->m_RowCount; ++y)
-                {
-                    for (uint32_t x = 0; x < tile_grid_resource->m_ColumnCount; ++x)
-                    {
-                        dmPhysics::SetGridShapeHull(component->m_Object2D, i, y, x, 0xffffffff, flags);
-                    }
-                }
-            }
+            dmPhysics::ClearGridShapeHulls(component->m_Object2D);
         }
     }
 
@@ -207,11 +192,12 @@ namespace dmGameSystem
             uint32_t shape_count = shapes.Size();
             dmPhysics::HullFlags flags;
 
+            TextureSetResource* texture_set_resource = tile_grid_resource->m_TextureSet;
+            dmGameSystemDDF::TextureSet* tile_set = texture_set_resource->m_TextureSet;
+
             for (uint32_t i = 0; i < shape_count; ++i)
             {
                 dmGameSystemDDF::TileLayer* layer = &tile_grid->m_Layers[i];
-                TextureSetResource* texture_set_resource = tile_grid_resource->m_TextureSet;
-                dmGameSystemDDF::TextureSet* tile_set = texture_set_resource->m_TextureSet;
 
                 // Set non-empty tiles
                 uint32_t cell_count = layer->m_Cell.m_Count;

--- a/engine/physics/src/box2d/Box2D/Collision/Shapes/b2GridShape.cpp
+++ b/engine/physics/src/box2d/Box2D/Collision/Shapes/b2GridShape.cpp
@@ -366,6 +366,13 @@ uint32 b2GridShape::CalculateCellMask(b2Fixture* fixture, uint32 row, uint32 col
     return mask;
 }
 
+void b2GridShape::ClearCellData()
+{
+    uint32 cellCount = m_rowCount * m_columnCount;
+    memset(m_cells, B2GRIDSHAPE_EMPTY_CELL, sizeof(Cell) * cellCount);
+    memset(m_cellFlags, 0x0, sizeof(CellFlags) * cellCount);
+}
+
 void b2GridShape::SetCellHull(b2Body* body, uint32 row, uint32 column, uint32 hull, b2GridShape::CellFlags flags)
 {
     assert(m_type == b2Shape::e_grid);

--- a/engine/physics/src/box2d/Box2D/Collision/Shapes/b2GridShape.h
+++ b/engine/physics/src/box2d/Box2D/Collision/Shapes/b2GridShape.h
@@ -100,6 +100,8 @@ public:
 
     void SetCellHull(b2Body* body, uint32 row, uint32 column, uint32 hull, CellFlags flags);
 
+    void ClearCellData();
+
     uint32 CalculateCellMask(b2Fixture* fixture, uint32 row, uint32 column);
 
     b2Vec2  m_position;

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -458,6 +458,8 @@ namespace dmPhysics
                                      uint32_t cell_width, uint32_t cell_height,
                                      uint32_t row_count, uint32_t column_count);
 
+    void ClearGridShapeHulls(HCollisionObject2D collision_object);
+
     /**
      * Set hull for cell in grid-shape
      * @param collision_object collision object

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -435,6 +435,19 @@ namespace dmPhysics
         return new b2GridShape((b2HullSet*) hull_set, p, cell_width * scale, cell_height * scale, row_count, column_count);
     }
 
+    void ClearGridShapeHulls(HCollisionObject2D collision_object)
+    {
+        b2Body* body = (b2Body*) collision_object;
+        b2Fixture* fixture = body->GetFixtureList();
+        while (fixture != 0x0)
+        {
+            assert(fixture->GetShape()->GetType() == b2Shape::e_grid);
+            b2GridShape* grid_shape = (b2GridShape*) fixture->GetShape();
+            grid_shape->ClearCellData();
+            fixture = fixture->GetNext();
+        }
+    }
+
     void SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
     {
         b2Body* body = (b2Body*) collision_object;


### PR DESCRIPTION
This PR splits the SetupTileGrid function into two: 

* SetupEmptyTileGrid - clears the tilegrid to unused tiles
* SetupTileGrid - Sets the cells in the tilegrid to the values from the ddf

This fixes an issue where a cell was set to a value with the set_tile script function in script init function that was spawned from a factory. The tile wast then reset by the SetupTileGrid function at a later stage when the factory had finished spawning the object.