### PR TITLE
DEFEDIT Show selected spine skin in gui scenes

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1409,11 +1409,12 @@
                                                       (spine-scene-infos "")))))
   (output gpu-texture TextureLifecycle (g/constantly nil))
   (output scene-renderable-user-data g/Any :cached
-    (g/fnk [spine-scene-scene color+alpha clipping-mode clipping-inverted clipping-visible]
+    (g/fnk [spine-scene-scene spine-skin color+alpha clipping-mode clipping-inverted clipping-visible]
       (let [user-data (-> spine-scene-scene
-                        (get-in [:renderable :user-data])
-                        (assoc :renderable-tags #{:gui-spine})
-                        (assoc :color (premul color+alpha)))]
+                          (get-in [:renderable :user-data])
+                          (assoc :renderable-tags #{:gui-spine})
+                          (assoc :color (premul color+alpha))
+                          (assoc :skin spine-skin))]
         (cond-> user-data
           (not= :clipping-mode-none clipping-mode)
           (assoc :clipping {:mode clipping-mode :inverted clipping-inverted :visible clipping-visible})))))


### PR DESCRIPTION
### User-facing changes
* Use the selected spine skin when rendering gui scenes in the editor.