### PR TITLE
Defedit 1558 - Multi select fix for Linux and Windows

### DIFF
--- a/editor/src/clj/editor/scene_selection.clj
+++ b/editor/src/clj/editor/scene_selection.clj
@@ -92,7 +92,7 @@
     (select-fn selection op-seq)))
 
 (def mac-toggle-modifiers #{:shift :meta})
-(def other-toggle-modifiers #{:control})
+(def other-toggle-modifiers #{:shift})
 (def toggle-modifiers (if system/mac? mac-toggle-modifiers other-toggle-modifiers))
 
 (def ^Integer min-pick-size 10)


### PR DESCRIPTION
Control+mouse conflicts with view rotation so we use shift instead. "Linear" selection does not make sense here anyway.