### PR TITLE
DEFEDIT-1563 Fixes to spine objects in gui scenes

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1436,11 +1436,10 @@
   (output gpu-texture TextureLifecycle (g/constantly nil))
   (output scene-renderable-user-data g/Any :cached
     (g/fnk [spine-scene-scene spine-skin color+alpha clipping-mode clipping-inverted clipping-visible]
-      (let [user-data (-> spine-scene-scene
-                          (get-in [:renderable :user-data])
-                          (assoc :renderable-tags #{:gui-spine})
-                          (assoc :color color+alpha)
-                          (assoc :skin spine-skin))]
+      (let [user-data (assoc (get-in spine-scene-scene [:renderable :user-data])
+                        :color color+alpha
+                        :renderable-tags #{:gui-spine}
+                        :skin spine-skin)]
         (cond-> user-data
           (not= :clipping-mode-none clipping-mode)
           (assoc :clipping {:mode clipping-mode :inverted clipping-inverted :visible clipping-visible})))))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -15,9 +15,7 @@
             [editor.gl.texture :as texture]
             [editor.gui-clipping :as clipping]
             [editor.defold-project :as project]
-            [editor.progress :as progress]
             [editor.scene :as scene]
-            [editor.scene-cache :as scene-cache]
             [editor.scene-picking :as scene-picking]
             [editor.workspace :as workspace]
             [editor.math :as math]
@@ -38,16 +36,12 @@
             [editor.validation :as validation])
   (:import [com.dynamo.gui.proto Gui$SceneDesc Gui$SceneDesc$AdjustReference Gui$NodeDesc Gui$NodeDesc$Type Gui$NodeDesc$XAnchor Gui$NodeDesc$YAnchor
             Gui$NodeDesc$Pivot Gui$NodeDesc$AdjustMode Gui$NodeDesc$BlendMode Gui$NodeDesc$ClippingMode Gui$NodeDesc$PieBounds Gui$NodeDesc$SizeMode]
+           [com.jogamp.opengl GL GL2]
            [editor.gl.shader ShaderLifecycle]
            [editor.gl.texture TextureLifecycle]
-           [editor.gl.vertex2 VertexBuffer]
            [editor.types AABB]
-           [com.jogamp.opengl GL GL2 GLContext GLDrawableFactory]
-           [javax.vecmath Matrix4d Point3d Quat4d Vector3d]
            [java.awt.image BufferedImage]
-           [com.defold.editor.pipeline TextureSetGenerator$UVTransform]
-           [org.apache.commons.io FilenameUtils]))
-
+           [javax.vecmath Quat4d Vector3d]))
 
 (set! *warn-on-reflection* true)
 
@@ -1445,7 +1439,7 @@
       (let [user-data (-> spine-scene-scene
                           (get-in [:renderable :user-data])
                           (assoc :renderable-tags #{:gui-spine})
-                          (assoc :color (premul color+alpha))
+                          (assoc :color color+alpha)
                           (assoc :skin spine-skin))]
         (cond-> user-data
           (not= :clipping-mode-none clipping-mode)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1441,11 +1441,12 @@
                                                       (spine-scene-infos "")))))
   (output gpu-texture TextureLifecycle (g/constantly nil))
   (output scene-renderable-user-data g/Any :cached
-    (g/fnk [spine-scene-scene color+alpha clipping-mode clipping-inverted clipping-visible]
+    (g/fnk [spine-scene-scene spine-skin color+alpha clipping-mode clipping-inverted clipping-visible]
       (let [user-data (-> spine-scene-scene
-                        (get-in [:renderable :user-data])
-                        (assoc :renderable-tags #{:gui-spine})
-                        (assoc :color (premul color+alpha)))]
+                          (get-in [:renderable :user-data])
+                          (assoc :renderable-tags #{:gui-spine})
+                          (assoc :color (premul color+alpha))
+                          (assoc :skin spine-skin))]
         (cond-> user-data
           (not= :clipping-mode-none clipping-mode)
           (assoc :clipping {:mode clipping-mode :inverted clipping-inverted :visible clipping-visible})))))

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -724,8 +724,8 @@
                              skin-color (:slot-color mesh)
                              mesh-color (:mesh-color mesh)
                              final-color (mapv * skin-color tint-color mesh-color)
-                             alpha (nth final-color 3)
-                             final-color (assoc (mapv #(* % alpha) final-color) 1 alpha)]
+                             alpha (final-color 3)
+                             final-color (assoc (mapv (partial * alpha) final-color) 3 alpha)]
                          (assoc mesh :color final-color)))))
           (:mesh-slots skin))))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#1832
Fixes defold/editor2-issues#2428

### User-facing changes
* Spine objects in gui scenes are now drawn using the selected skin.
* Spine objects in gui scenes are now color-tinted correctly in scene views.