### PR TITLE
DEFEDIT-1577 Middle mouse button box-selection in the code editor

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -514,6 +514,22 @@
       :drawn-line-count drawn-line-count
       :dropped-line-count dropped-line-count)))
 
+(defn- x->doc-x
+  ^double [^LayoutInfo layout ^double x]
+  (- x (.x ^Rect (.canvas layout)) (.scroll-x layout)))
+
+(defn- y->doc-y
+  ^double [^LayoutInfo layout ^double y]
+  (- y (.y ^Rect (.canvas layout)) (.scroll-y layout)))
+
+(defn- doc-x->x
+  ^double [^LayoutInfo layout ^double doc-x]
+  (+ doc-x (.x ^Rect (.canvas layout)) (.scroll-x layout)))
+
+(defn- doc-y->y
+  ^double [^LayoutInfo layout ^double doc-y]
+  (+ doc-y (.y ^Rect (.canvas layout)) (.scroll-y layout)))
+
 (defn row->y
   ^double [^LayoutInfo layout ^long row]
   (+ (.scroll-y-remainder layout)
@@ -534,7 +550,7 @@
 
 (defn x->col
   ^long [^LayoutInfo layout ^double x ^String line]
-  (let [line-x (- x (.x ^Rect (.canvas layout)) (.scroll-x layout))
+  (let [line-x (x->doc-x layout x)
         line-length (count line)]
     (loop [col 0
            start-x 0.0]
@@ -1989,12 +2005,16 @@
 
 ;; -----------------------------------------------------------------------------
 
-(defn scroll [lines scroll-x scroll-y layout delta-x delta-y]
-  (let [new-scroll-x (limit-scroll-x layout (+ ^double scroll-x (Math/ceil delta-x)))
-        new-scroll-y (limit-scroll-y layout (count lines) (+ ^double scroll-y (Math/ceil delta-y)))]
-    (cond-> nil
-            (not= scroll-x new-scroll-x) (assoc :scroll-x new-scroll-x)
-            (not= scroll-y new-scroll-y) (assoc :scroll-y new-scroll-y))))
+(defn scroll [lines scroll-x scroll-y layout ^GestureInfo gesture-start delta-x delta-y]
+  ;; Disallow mouse wheel scrolling during middle-button box-selection.
+  (when (or (nil? gesture-start)
+            (not (and (= :box-selection (.type gesture-start))
+                      (= :middle (.button gesture-start)))))
+    (let [new-scroll-x (limit-scroll-x layout (+ ^double scroll-x (Math/ceil delta-x)))
+          new-scroll-y (limit-scroll-y layout (count lines) (+ ^double scroll-y (Math/ceil delta-y)))]
+      (cond-> nil
+              (not= scroll-x new-scroll-x) (assoc :scroll-x new-scroll-x)
+              (not= scroll-y new-scroll-y) (assoc :scroll-y new-scroll-y)))))
 
 (defn key-typed [indent-level-pattern indent-string grammar lines cursor-ranges regions layout typed]
   (case typed
@@ -2067,8 +2087,17 @@
 
       nil)))
 
+(defn- begin-box-selection [lines ^LayoutInfo layout button click-count x y]
+  (let [unadjusted-from-cursor (canvas->cursor layout lines x y)
+        from-cursor (adjust-cursor lines unadjusted-from-cursor)]
+    {:cursor-ranges [(Cursor->CursorRange from-cursor)]
+     :gesture-start (gesture-info :box-selection button click-count x y
+                                  :from-doc-x (x->doc-x layout x)
+                                  :from-doc-y (y->doc-y layout y))}))
+
 (defn mouse-pressed [lines cursor-ranges regions ^LayoutInfo layout button click-count x y alt-key? shift-key? shortcut-key?]
-  (when (= :primary button)
+  (case button
+    :primary
     (cond
       ;; Click in the gutter to toggle breakpoints.
       (and (< ^double x (.x ^Rect (.canvas layout)))
@@ -2115,9 +2144,7 @@
 
       ;; Move cursor and prepare for box selection.
       (and alt-key? (not shift-key?) (= 1 click-count))
-      (let [from-cursor (canvas->cursor layout lines x y)]
-        {:cursor-ranges [(Cursor->CursorRange (adjust-cursor lines from-cursor))]
-         :gesture-start (gesture-info :box-selection button click-count x y)})
+      (begin-box-selection lines layout button click-count x y)
 
       ;; Move cursor and prepare for drag-selection.
       (and (not alt-key?) (not shift-key?) (>= 3 ^long click-count))
@@ -2130,10 +2157,19 @@
                           (concat-cursor-ranges cursor-ranges [cursor-range])
                           [cursor-range])
          :gesture-start (gesture-info :cursor-range-selection button click-count x y
-                                      :reference-cursor-range cursor-range)}))))
+                                      :reference-cursor-range cursor-range)}))
+
+    :middle
+    (cond
+      ;; Move cursor and prepare for box selection.
+      (and (not alt-key?) (not shift-key?) (not shortcut-key?) (= 1 click-count))
+      (begin-box-selection lines layout button click-count x y))
+
+    :secondary
+    nil))
 
 (defn- mouse-gesture [lines cursor-ranges ^LayoutInfo layout ^GestureInfo gesture-start x y]
-  (when (= :primary (:button gesture-start))
+  (when (not= :secondary (.button gesture-start))
     (case (.type gesture-start)
       ;; Dragging the horizontal scroll tab.
       :scroll-tab-x-drag
@@ -2163,11 +2199,13 @@
       ;; Box selection.
       :box-selection
       (let [^Rect canvas-rect (.canvas layout)
-            range-inverted? (< ^double x (.x gesture-start))
-            min-row (y->row layout (min ^double y (.y gesture-start)))
-            max-row (y->row layout (max ^double y (.y gesture-start)))
-            ^double min-x (if range-inverted? x (.x gesture-start))
-            ^double max-x (if range-inverted? (.x gesture-start) x)
+            from-x (doc-x->x layout (:from-doc-x gesture-start))
+            from-y (doc-y->y layout (:from-doc-y gesture-start))
+            range-inverted? (< ^double x from-x)
+            min-row (y->row layout (min ^double y from-y))
+            max-row (y->row layout (max ^double y from-y))
+            ^double min-x (if range-inverted? x from-x)
+            ^double max-x (if range-inverted? from-x x)
             line-min-x (- min-x (.x canvas-rect) (.scroll-x layout))
             glyph-metrics (.glyph layout)
             tab-stops (.tab-stops layout)

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1458,6 +1458,7 @@
                                       (get-property view-node :scroll-x)
                                       (get-property view-node :scroll-y)
                                       (get-property view-node :layout)
+                                      (get-property view-node :gesture-start)
                                       (.getDeltaX event)
                                       (.getDeltaY event)))
     (hide-suggestions! view-node)))


### PR DESCRIPTION
### User-facing changes
* You can now use the middle mouse button to perform box selections in the code editor.
* Box selections now behave correctly when scrolling away from the drag start.