### PR TITLE
DEFEDIT-1579 Remove transaction churn caused by blinking Console cursor

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -402,7 +402,7 @@
                                       clear? (assoc :cursor-ranges [data/document-start-cursor-range])
                                       clear? (assoc :invalidated-row 0)
                                       clear? (data/frame-cursor prev-layout))))))
-  (view/repaint-view! view-node elapsed-time))
+  (view/repaint-view! view-node elapsed-time {:cursor-visible? false}))
 
 (def ^:private console-grammar
   {:name "Console"


### PR DESCRIPTION
An invisible blinking cursor was causing unnecessary updates to the Console view.