### PR TITLE
DEFEDIT-1582 Improve Search in Files dialog performance by batching TreeView inserts

### DIFF
--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -50,15 +50,14 @@
 (defn- find-matches [pattern save-data]
   (when-some [lines (line-coll save-data)]
     (into []
-          (comp (keep (fn [{:keys [line row pos]}]
-                        (let [matcher (re-matcher pattern line)]
-                          (when (.matches matcher)
-                            {:line row
-                             :caret-position pos
-                             :match (str (apply str (take-last 24 (string/triml (.group matcher 1))))
-                                         (.group matcher 2)
-                                         (apply str (take 24 (string/trimr (.group matcher 3)))))}))))
-                (take 10))
+          (keep (fn [{:keys [line row pos]}]
+                  (let [matcher (re-matcher pattern line)]
+                    (when (.matches matcher)
+                      {:line row
+                       :caret-position pos
+                       :match (str (apply str (take-last 24 (string/triml (.group matcher 1))))
+                                   (.group matcher 2)
+                                   (apply str (take 24 (string/trimr (.group matcher 3)))))}))))
           lines)))
 
 (defn- save-data-sort-key [entry]

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -72,8 +72,17 @@
                               (when-not (empty? search-results)
                                 (doseq [^TreeView tree-view tree-views
                                         :let [tree-children (.getChildren (.getRoot tree-view))
-                                              first-match? (.isEmpty tree-children)]]
+                                              first-match? (.isEmpty tree-children)
+                                              focus-model (.getFocusModel tree-view)
+                                              ;; focus model slows adding childrend drastically
+                                              ;; if there is a focused item
+                                              ;; removing focus before adding and then
+                                              ;; restoring it results in same behavior
+                                              ;; with much better performance
+                                              focused-index (.getFocusedIndex focus-model)]]
+                                  (.focus focus-model -1)
                                   (.addAll tree-children ^Collection (mapv make-result-tree-item search-results))
+                                  (.focus focus-model focused-index)
                                   (when first-match?
                                     (.clearAndSelect (.getSelectionModel tree-view) 1)))))))]
     (doseq [^TreeView tree-view tree-views]

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -74,7 +74,7 @@
                                         :let [tree-children (.getChildren (.getRoot tree-view))
                                               first-match? (.isEmpty tree-children)
                                               focus-model (.getFocusModel tree-view)
-                                              ;; focus model slows adding childrend drastically
+                                              ;; focus model slows adding children drastically
                                               ;; if there is a focused item
                                               ;; removing focus before adding and then
                                               ;; restoring it results in same behavior

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -44,7 +44,7 @@
     (.addAll (.getChildren resource-item) ^Collection match-items)
     resource-item))
 
-(defn- results->tree-items+done? [results]
+(defn- results->search-results+done? [results]
   (loop [[result & more] results
          tree-items (transient [])]
     (cond
@@ -55,7 +55,7 @@
       [(persistent! tree-items) true]
 
       :else
-      (recur more (conj! tree-items (make-result-tree-item result))))))
+      (recur more (conj! tree-items result)))))
 
 (defn- start-tree-update-timer! [tree-views search-in-progress results-fn]
   (let [timer (ui/->timer 5 "tree-update-timer"
@@ -65,15 +65,15 @@
                             (when (< 0.2 elapsed-time)
                               (ui/visible! search-in-progress true))
 
-                            (let [[tree-items done?] (results->tree-items+done? (results-fn))]
+                            (let [[search-results done?] (results->search-results+done? (results-fn))]
                               (when done?
                                 (.stop timer)
                                 (ui/visible! search-in-progress false))
-                              (when-not (empty? tree-items)
+                              (when-not (empty? search-results)
                                 (doseq [^TreeView tree-view tree-views
                                         :let [tree-children (.getChildren (.getRoot tree-view))
                                               first-match? (.isEmpty tree-children)]]
-                                  (.addAll tree-children ^Collection tree-items)
+                                  (.addAll tree-children ^Collection (mapv make-result-tree-item search-results))
                                   (when first-match?
                                     (.clearAndSelect (.getSelectionModel tree-view) 1)))))))]
     (doseq [^TreeView tree-view tree-views]


### PR DESCRIPTION
As seen on this beautiful flamegraph, actual performance bottleneck in *Search in Files* is in TreeView, not an actual search. I implemented batching for adding new TreeView nodes and results were very impressive.
![](https://gist.github.com/vlaaad/98c1eb6b7e1deba7353f7873e19b07ce/raw/2495671f9d128e139ddd30a320527ccf9968d834/search-flame-graph.svg?sanitize=true)