### PR TITLE
DEF-3817 Profiler size and performance optimisations

### DIFF
--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -399,19 +399,17 @@ namespace dmProfile
         if (!profile)
             return;
 
-        dmSpinlock::Lock(&g_ProfileLock);
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         g_FreeProfiles.Push(profile);
-        dmSpinlock::Unlock(&g_ProfileLock);
     }
 
     uint32_t AllocateScope(const char* name)
     {
-        dmSpinlock::Lock(&g_ProfileLock);
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         if (g_Scopes.Full())
         {
             g_OutOfScopes = true;
-            dmSpinlock::Unlock(&g_ProfileLock);
-            return (uint32_t)-1;
+            return 0xffffffffu;
         }
         else
         {
@@ -422,7 +420,6 @@ namespace dmProfile
             {
                 if (g_Scopes[i].m_NameHash == name_hash)
                 {
-                    dmSpinlock::Unlock(&g_ProfileLock);
                     return i;
                 }
             }
@@ -437,14 +434,13 @@ namespace dmProfile
             s->m_Name = name;
             s->m_NameHash = name_hash;
             s->m_Index = i;
-            dmSpinlock::Unlock(&g_ProfileLock);
             return i;
         }
     }
 
-    // Used when out of samples in order to remove conditional branches
     Sample g_DummySample = { "OUT_OF_SAMPLES", 0, 0, 0, 0 };
-    Sample* AllocateSample()
+
+    static Sample* AllocateNewSample()
     {
         // NOTE: We can't take the spinlock if paused
         // as it might already been taken in dmProfile:Begin()
@@ -455,51 +451,55 @@ namespace dmProfile
             return &g_DummySample;
         }
 
-        dmSpinlock::Lock(&g_ProfileLock);
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         Profile* profile = g_ActiveProfile;
 
         bool full = profile->m_Samples.Full();
         if (full)
         {
             g_OutOfSamples = true;
-            dmSpinlock::Unlock(&g_ProfileLock);
             return &g_DummySample;
         }
-        else
+        profile->m_Samples.SetSize(profile->m_Samples.Size() + 1);
+        Sample* ret = profile->m_Samples.End() - 1;
+        return ret;
+    }
+
+    // Used when out of samples in order to remove conditional branches
+    Sample* AllocateSample()
+    {
+        Sample* ret = AllocateNewSample();
+        if (ret == &g_DummySample)
         {
-            profile->m_Samples.SetSize(profile->m_Samples.Size() + 1);
-            Sample* ret = profile->m_Samples.End() - 1;
-            dmSpinlock::Unlock(&g_ProfileLock);
-
-            void* tls_data = dmThread::GetTlsValue(g_TlsKey);
-            if (tls_data == 0)
-            {
-                // NOTE: We store thread_id + 1. Otherwise we can't differentiate between thread-id 0 and not initialized
-                int32_t next_thread_id = dmAtomicIncrement32(&g_ThreadCount) + 1;
-                void* thread_id = (void*)((uintptr_t)next_thread_id);
-                dmThread::SetTlsValue(g_TlsKey, thread_id);
-                tls_data = thread_id;
-            }
-            intptr_t thread_id = ((intptr_t)tls_data) - 1;
-            assert(thread_id >= 0);
-
-            ret->m_ThreadId = thread_id;
             return ret;
         }
+
+        void* tls_data = dmThread::GetTlsValue(g_TlsKey);
+        if (tls_data == 0)
+        {
+            // NOTE: We store thread_id + 1. Otherwise we can't differentiate between thread-id 0 and not initialized
+            int32_t next_thread_id = dmAtomicIncrement32(&g_ThreadCount) + 1;
+            void* thread_id = (void*)((uintptr_t)next_thread_id);
+            dmThread::SetTlsValue(g_TlsKey, thread_id);
+            tls_data = thread_id;
+        }
+        intptr_t thread_id = ((intptr_t)tls_data) - 1;
+        assert(thread_id >= 0);
+
+        ret->m_ThreadId = thread_id;
+        return ret;
     }
 
     const char* Internalize(const char* string, uint32_t string_length, uint32_t string_hash)
     {
-        dmSpinlock::Lock(&g_ProfileLock);
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         if (g_StringPool)
         {
             const char* s = dmStringPool::Add(g_StringPool, string, string_length, string_hash);
-            dmSpinlock::Unlock(&g_ProfileLock);
             return s;
         }
         else
         {
-            dmSpinlock::Unlock(&g_ProfileLock);
             return "PROFILER NOT INITIALIZED";
         }
     }
@@ -522,77 +522,74 @@ namespace dmProfile
 
         uint32_t name_hash = GetNameHash(name, (uint32_t)strlen(name));
 
-        dmSpinlock::Lock(&g_ProfileLock);
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         Profile* profile = g_ActiveProfile;
 
         uint32_t* counter_index = g_CountersTable.Get(name_hash);
-
-        if (!counter_index)
+        if (counter_index)
         {
-            if (g_Counters.Full())
-            {
-                g_OutOfCounters = true;
-                dmSpinlock::Unlock(&g_ProfileLock);
-                return;
-            }
-
-            uint32_t new_index = g_Counters.Size();
-            g_Counters.SetSize(new_index + 1);
-
-            Counter* c = &g_Counters[new_index];
-            c->m_Name = name;
-            c->m_NameHash = name_hash;
-
-            CounterData* cd = &profile->m_CountersData[new_index];
-            cd->m_Counter = c;
-            cd->m_Value = 0;
-
-            g_CountersTable.Put(c->m_NameHash, new_index);
-
-            counter_index = g_CountersTable.Get(name_hash);
+            profile->m_CountersData[*counter_index].m_Value += amount;
+            return;
         }
 
-        profile->m_CountersData[*counter_index].m_Value += amount;
-        dmSpinlock::Unlock(&g_ProfileLock);
+        if (g_Counters.Full())
+        {
+            g_OutOfCounters = true;
+            return;
+        }
+
+        uint32_t new_index = g_Counters.Size();
+        g_Counters.SetSize(new_index + 1);
+
+        Counter* c = &g_Counters[new_index];
+        c->m_Name = name;
+        c->m_NameHash = name_hash;
+
+        CounterData* cd = &profile->m_CountersData[new_index];
+        cd->m_Counter = c;
+        cd->m_Value = 0;
+
+        g_CountersTable.Put(c->m_NameHash, new_index);
+
+        profile->m_CountersData[new_index].m_Value += amount;
     }
 
     uint32_t AllocateCounter(const char* name)
     {
         if (!g_IsInitialized)
         {
-            return ((uint32_t)-1);
+            return 0xffffffffu;
         }
-        dmSpinlock::Lock(&g_ProfileLock);
+
         uint32_t name_hash = GetNameHash(name, (uint32_t)strlen(name));
+
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         uint32_t* counter_index = g_CountersTable.Get(name_hash);
-        if (!counter_index)
+        if (counter_index)
         {
-            if (g_Counters.Full())
-            {
-                g_OutOfCounters = true;
-                dmSpinlock::Unlock(&g_ProfileLock);
-                return ((uint32_t)-1);
-            }
-
-            uint32_t new_index = g_Counters.Size();
-            g_Counters.SetSize(new_index + 1);
-
-            Counter* c = &g_Counters[new_index];
-            c->m_Name = name;
-            c->m_NameHash = name_hash;
-
-            Profile* profile = g_ActiveProfile;
-            CounterData* cd = &profile->m_CountersData[new_index];
-            cd->m_Counter = c;
-            cd->m_Value = 0;
-
-            g_CountersTable.Put(c->m_NameHash, new_index);
-
-            counter_index = g_CountersTable.Get(name_hash);
+            return *counter_index;
+        }
+        if (g_Counters.Full())
+        {
+            g_OutOfCounters = true;
+            return 0xffffffffu;
         }
 
-        dmSpinlock::Unlock(&g_ProfileLock);
-        return *counter_index;
+        uint32_t new_index = g_Counters.Size();
+        g_Counters.SetSize(new_index + 1);
+
+        Counter* c = &g_Counters[new_index];
+        c->m_Name = name;
+        c->m_NameHash = name_hash;
+
+        Profile* profile = g_ActiveProfile;
+        CounterData* cd = &profile->m_CountersData[new_index];
+        cd->m_Counter = c;
+        cd->m_Value = 0;
+
+        g_CountersTable.Put(c->m_NameHash, new_index);
+
+        return new_index;
     }
 
     void AddCounterIndex(uint32_t counter_index, uint32_t amount)
@@ -600,15 +597,14 @@ namespace dmProfile
         if (g_Paused)
             return;
 
-        if (counter_index == ((uint32_t)-1))
+        if (counter_index == 0xffffffffu)
         {
             return;
         }
 
-        dmSpinlock::Lock(&g_ProfileLock);
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfileLock)
         Profile* profile = g_ActiveProfile;
         profile->m_CountersData[counter_index].m_Value += amount;
-        dmSpinlock::Unlock(&g_ProfileLock);
     }
 
     float GetFrameTime()

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -438,6 +438,7 @@ namespace dmProfile
         }
     }
 
+    // Used when out of samples in order to remove conditional branches
     Sample g_DummySample = { "OUT_OF_SAMPLES", 0, 0, 0, 0 };
 
     static Sample* AllocateNewSample()
@@ -465,7 +466,6 @@ namespace dmProfile
         return ret;
     }
 
-    // Used when out of samples in order to remove conditional branches
     Sample* AllocateSample()
     {
         Sample* ret = AllocateNewSample();

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -68,15 +68,15 @@
         dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(scope_index, name, name_hash);
 
     #define DM_PROFILE(scope_name, name) \
-        static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : (uint32_t)-1; \
+        static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0xffffffffu; \
         static const uint32_t DM_PROFILE_PASTE2(hash, __LINE__)        = dmProfile::g_IsInitialized ? dmProfile::GetNameHash(name, (uint32_t)strlen(name)) : 0; \
         DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), name, DM_PROFILE_PASTE2(hash, __LINE__))
 
     #define DM_PROFILE_FMT(scope_name, fmt, ...) \
-        static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : (uint32_t)-1; \
+        static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0xffffffffu; \
         const char* DM_PROFILE_PASTE2(name, __LINE__)                  = 0; \
         static uint32_t DM_PROFILE_PASTE2(hash, __LINE__)              = 0; \
-        if (DM_PROFILE_PASTE2(scope_index, __LINE__) != (uint32_t)-1) { \
+        if (DM_PROFILE_PASTE2(scope_index, __LINE__) != 0xffffffffu) { \
             char buffer[128]; \
             uint32_t name_length = DM_SNPRINTF(buffer, sizeof(buffer), fmt, __VA_ARGS__); \
             DM_PROFILE_PASTE2(hash, __LINE__) = dmProfile::GetNameHash(buffer, name_length); \
@@ -85,13 +85,13 @@
         DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), DM_PROFILE_PASTE2(name, __LINE__), DM_PROFILE_PASTE2(hash, __LINE__))
 
     #define DM_COUNTER(name, amount) \
-        static uint32_t DM_PROFILE_PASTE2(counter_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateCounter(name) : ((uint32_t)-1); \
-        if (DM_PROFILE_PASTE2(counter_index, __LINE__) != (uint32_t)-1) { \
+        static uint32_t DM_PROFILE_PASTE2(counter_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateCounter(name) : 0xffffffffu; \
+        if (DM_PROFILE_PASTE2(counter_index, __LINE__) != 0xffffffffu) { \
             dmProfile::AddCounterIndex(DM_PROFILE_PASTE2(counter_index, __LINE__), amount);\
         }
 
     #define DM_COUNTER_DYN(counter_index, amount) \
-        if (counter_index != (uint32_t)-1) { \
+        if (counter_index != 0xffffffffu) { \
             dmProfile::AddCounterIndex(counter_index, amount); \
         }
 #endif
@@ -350,7 +350,7 @@ namespace dmProfile
         uint64_t m_StartTick;
         inline ProfileScope(uint32_t scope_index, const char* name, uint32_t name_hash)
         {
-            if (scope_index != (uint32_t)-1)
+            if (scope_index != 0xffffffffu)
             {
                 StartScope(scope_index, name, name_hash);
             }

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -47,11 +47,10 @@
 
 /**
  * Profile counter macro for non-literal strings, caller must provide hash
- * name is the counter name.
- * name_hash is the hash generated with GetNameHash
+ * counter_index is counter index from AllocateCounter.
  * amount is the amount (integer) to add to the specific counter.
  */
-#define DM_COUNTER_DYN(name, name_hash, amount)
+#define DM_COUNTER_DYN(counter_index, amount)
 #undef DM_COUNTER_DYN
 
 #if defined(NDEBUG)
@@ -60,40 +59,40 @@
     #define DM_PROFILE(scope_name, name)
     #define DM_PROFILE_FMT(scope_name, fmt, ...)
     #define DM_COUNTER(name, amount)
-    #define DM_COUNTER_DYN(name, name_hash, amount)
+    #define DM_COUNTER_DYN(counter_index, amount)
 #else
     #define DM_INTERNALIZE(name) \
-        (dmProfile::g_IsInitialized ? dmProfile::Internalize(name) : 0)
+        (dmProfile::g_IsInitialized ? dmProfile::Internalize(name, (uint32_t)strlen(name), dmProfile::GetNameHash(name, (uint32_t)strlen(name))) : 0)
 
-    #define DM_PROFILE_SCOPE(scope, name, name_hash) \
-        dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(scope, name, name_hash);
+    #define DM_PROFILE_SCOPE(scope_index, name, name_hash) \
+        dmProfile::ProfileScope DM_PROFILE_PASTE2(profile_scope, __LINE__)(scope_index, name, name_hash);
 
     #define DM_PROFILE(scope_name, name) \
-        static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
-        static const uint32_t DM_PROFILE_PASTE2(hash, __LINE__)     = dmProfile::GetNameHash(name); \
-        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope, __LINE__), name, DM_PROFILE_PASTE2(hash, __LINE__))
+        static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : (uint32_t)-1; \
+        static const uint32_t DM_PROFILE_PASTE2(hash, __LINE__)        = dmProfile::g_IsInitialized ? dmProfile::GetNameHash(name, (uint32_t)strlen(name)) : 0; \
+        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), name, DM_PROFILE_PASTE2(hash, __LINE__))
 
     #define DM_PROFILE_FMT(scope_name, fmt, ...) \
-        static dmProfile::Scope* DM_PROFILE_PASTE2(scope, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0; \
-        const char* DM_PROFILE_PASTE2(name, __LINE__)               = 0; \
-        static uint32_t DM_PROFILE_PASTE2(hash, __LINE__)           = 0; \
-        if (dmProfile::g_IsInitialized) { \
+        static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : (uint32_t)-1; \
+        const char* DM_PROFILE_PASTE2(name, __LINE__)                  = 0; \
+        static uint32_t DM_PROFILE_PASTE2(hash, __LINE__)              = 0; \
+        if (DM_PROFILE_PASTE2(scope_index, __LINE__) != (uint32_t)-1) { \
             char buffer[128]; \
-            DM_SNPRINTF(buffer, sizeof(buffer), fmt, __VA_ARGS__); \
-            DM_PROFILE_PASTE2(name, __LINE__) = dmProfile::Internalize(buffer); \
-            DM_PROFILE_PASTE2(hash, __LINE__) = dmProfile::GetNameHash(buffer); \
+            uint32_t name_length = DM_SNPRINTF(buffer, sizeof(buffer), fmt, __VA_ARGS__); \
+            DM_PROFILE_PASTE2(hash, __LINE__) = dmProfile::GetNameHash(buffer, name_length); \
+            DM_PROFILE_PASTE2(name, __LINE__) = dmProfile::Internalize(buffer, name_length, DM_PROFILE_PASTE2(hash, __LINE__)); \
         } \
-        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope, __LINE__), DM_PROFILE_PASTE2(name, __LINE__), DM_PROFILE_PASTE2(hash, __LINE__))
+        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), DM_PROFILE_PASTE2(name, __LINE__), DM_PROFILE_PASTE2(hash, __LINE__))
 
     #define DM_COUNTER(name, amount) \
-        if (dmProfile::g_IsInitialized) { \
-            static const uint32_t DM_PROFILE_PASTE2(hash, __LINE__) = dmProfile::GetNameHash(name); \
-            dmProfile::AddCounterHash(name, DM_PROFILE_PASTE2(hash, __LINE__), amount); \
+        static uint32_t DM_PROFILE_PASTE2(counter_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateCounter(name) : ((uint32_t)-1); \
+        if (DM_PROFILE_PASTE2(counter_index, __LINE__) != (uint32_t)-1) { \
+            dmProfile::AddCounterIndex(DM_PROFILE_PASTE2(counter_index, __LINE__), amount);\
         }
 
-    #define DM_COUNTER_DYN(name, name_hash, amount) \
-        if (dmProfile::g_IsInitialized) { \
-            dmProfile::AddCounterHash(name, name_hash, amount); \
+    #define DM_COUNTER_DYN(counter_index, amount) \
+        if (counter_index != (uint32_t)-1) { \
+            dmProfile::AddCounterIndex(counter_index, amount); \
         }
 #endif
 
@@ -266,9 +265,9 @@ namespace dmProfile
     /**
      * Internal function
      * @param name
-     * @return #Scope
+     * @return global scope index
      */
-    Scope* AllocateScope(const char* name);
+    uint32_t AllocateScope(const char* name);
 
     /**
      * Internal function
@@ -280,16 +279,19 @@ namespace dmProfile
      * Create an internalized string. Use this function in DM_PROFILE if the
      * name isn't valid for the life-time of the application
      * @param string string to internalize
+     * @param string_length the length of the string to internalize
+     * @param string_hash the hash of the string to internalize
      * @return internalized string or 0 if profiling is not enabled
      */
-    const char* Internalize(const char* string);
+    const char* Internalize(const char* string, uint32_t string_length, uint32_t string_hash);
 
     /**
      * Generates a hash for the name
      * @param name string to hash
+     * @param string_length length of the name to hash 
      * @return the hash or 0 if profiling is not enabled
      */
-    uint32_t GetNameHash(const char* name);
+    uint32_t GetNameHash(const char* name, uint32_t string_length);
 
     /**
      * Add #amount to counter with #name
@@ -299,12 +301,18 @@ namespace dmProfile
     void AddCounter(const char* name, uint32_t amount);
 
     /**
-     * Add #amount to counter with prehashed name. Faster version of #AddCounter
+     * Creates a counter and returns the global index for the counter
      * @param name Counter name
-     * @param name Counter name hash
+     * @return the counter index
+     */  
+    uint32_t AllocateCounter(const char* name);
+
+    /**
+     * Add #amount to counter at the counter index. Faster version of #AddCounter
+     * @param counter_index Global counter index obtained with #AllocateCounter
      * @param amount Amount to add
      */
-    void AddCounterHash(const char* name, uint32_t name_hash, uint32_t amount);
+    void AddCounterIndex(uint32_t counter_index, uint32_t amount);
 
     /**
      * Get time for the frame total
@@ -340,11 +348,11 @@ namespace dmProfile
     {
         Sample* m_Sample;
         uint64_t m_StartTick;
-        inline ProfileScope(Scope* scope, const char* name, uint32_t name_hash)
+        inline ProfileScope(uint32_t scope_index, const char* name, uint32_t name_hash)
         {
-            if (g_IsInitialized)
+            if (scope_index != (uint32_t)-1)
             {
-                StartScope(scope, name, name_hash);
+                StartScope(scope_index, name, name_hash);
             }
             else
             {
@@ -360,7 +368,7 @@ namespace dmProfile
             }
         }
 
-        void StartScope(Scope* scope, const char* name, uint32_t name_hash);
+        void StartScope(uint32_t scope_index, const char* name, uint32_t name_hash);
         void EndScope();
     };
 

--- a/engine/dlib/src/dlib/stringpool.cpp
+++ b/engine/dlib/src/dlib/stringpool.cpp
@@ -2,7 +2,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "../dlib/hash.h"
 #include "../dlib/hashtable.h"
 #include "stringpool.h"
 
@@ -24,7 +23,7 @@ namespace dmStringPool
 
     struct Pool
     {
-        dmHashTable64<const char*> m_StringTable;
+        dmHashTable32<const char*> m_StringTable;
         Page*                      m_CurrentPage;
     };
 
@@ -47,13 +46,12 @@ namespace dmStringPool
         delete pool;
     }
 
-    const char* Add(HPool pool, const char* string)
+    const char* Add(HPool pool, const char* string, uint32_t string_length, uint32_t string_hash)
     {
-        uint32_t n = strlen(string) + 1;
+        uint32_t n = string_length + 1;
         if (n == 1)
             return "";
 
-        uint64_t string_hash = dmHashString64(string);
         assert(n <= PAGE_SIZE);
 
         const char** tmp = pool->m_StringTable.Get(string_hash);

--- a/engine/dlib/src/dlib/stringpool.h
+++ b/engine/dlib/src/dlib/stringpool.h
@@ -24,7 +24,9 @@ namespace dmStringPool
      * Add string to string pool. Similar functionality to String.intern() in java.
      * The string pool stores only a single copy of each distinct string. Therefore it is
      * guaranteed that two identical strings will have the same pointer value.
-     * @note The identical property is valid if two distinct strings result in two distinct hash values.
+     * @note The identical property is valid if and only if two distinct strings result
+     * in two distinct hash values.
+     * 
      * @param pool String pool
      * @param string String to add to pool
      * @return Pointer to string added

--- a/engine/dlib/src/dlib/stringpool.h
+++ b/engine/dlib/src/dlib/stringpool.h
@@ -24,12 +24,12 @@ namespace dmStringPool
      * Add string to string pool. Similar functionality to String.intern() in java.
      * The string pool stores only a single copy of each distinct string. Therefore it is
      * guaranteed that two identical strings will have the same pointer value.
-     * @note Internally dmHashString64 is used. The identical property is valid iff two distinct strings result in two distinct hash values.
+     * @note The identical property is valid if two distinct strings result in two distinct hash values.
      * @param pool String pool
      * @param string String to add to pool
      * @return Pointer to string added
      */
-    const char* Add(HPool pool, const char* string);
+    const char* Add(HPool pool, const char* string, uint32_t string_length, uint32_t string_hash);
 }
 
 #endif // DM_STRINGPOOL_H

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -426,17 +426,17 @@ TEST(dmProfile, DynamicScope)
     for (size_t i = 0; i < samples.size(); i++)
     {
         dmProfile::Sample* sample = &samples[i];
-        if (sample->m_Scope->m_NameHash == dmProfile::GetNameHash("Scope1"))
+        if (sample->m_Scope->m_NameHash == dmProfile::GetNameHash("Scope1", (uint32_t)strlen("Scope1")))
         {
             ASSERT_STREQ(sample->m_Name, name0);
         }
-        else if (sample->m_Scope->m_NameHash == dmProfile::GetNameHash("Scope2"))
+        else if (sample->m_Scope->m_NameHash == dmProfile::GetNameHash("Scope2", (uint32_t)strlen("Scope2")))
         {
-            if (sample->m_NameHash == dmProfile::GetNameHash(name1))
+            if (sample->m_NameHash == dmProfile::GetNameHash(name1, (uint32_t)strlen(name1)))
             {
                 ASSERT_STREQ(sample->m_Name, name1);
             }
-            else if (sample->m_NameHash == dmProfile::GetNameHash(name2))
+            else if (sample->m_NameHash == dmProfile::GetNameHash(name2, (uint32_t)strlen(name2)))
             {
                 ASSERT_STREQ(sample->m_Name, name2);
             }

--- a/engine/dlib/src/test/test_stringpool.cpp
+++ b/engine/dlib/src/test/test_stringpool.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "dlib/stringpool.h"
+#include "dlib/hash.h"
 
 TEST(dmStringPool, Test01)
 {
@@ -26,7 +27,7 @@ TEST(dmStringPool, Test01)
         }
         n_allocated += n;
 
-        const char* s = dmStringPool::Add(pool, tmp.c_str());
+        const char* s = dmStringPool::Add(pool, tmp.c_str(), tmp.length(), dmHashBufferNoReverse32(tmp.c_str(), tmp.length()));
         strings[s] = std::string(s);
     }
 
@@ -39,8 +40,8 @@ TEST(dmStringPool, Test01)
         ASSERT_STREQ(value.c_str(), key);
 
         // Assert that we get the same pointer back
-        ASSERT_EQ((uintptr_t) key, (uintptr_t) dmStringPool::Add(pool, key));
-        ASSERT_EQ((uintptr_t) key, (uintptr_t) dmStringPool::Add(pool, value.c_str()));
+        ASSERT_EQ((uintptr_t) key, (uintptr_t) dmStringPool::Add(pool, key, strlen(key), dmHashBufferNoReverse32(key, strlen(key))));
+        ASSERT_EQ((uintptr_t) key, (uintptr_t) dmStringPool::Add(pool, value.c_str(), value.length(), dmHashBufferNoReverse32(value.c_str(), value.length())));
     }
 
     // Assert that at least 5 pages are allocated in string-pool

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -489,10 +489,7 @@ namespace dmGameObject
 
         regist->m_ComponentTypes[regist->m_ComponentTypeCount] = type;
         regist->m_ComponentTypesOrder[regist->m_ComponentTypeCount] = regist->m_ComponentTypeCount;
-        if (dmProfile::g_IsInitialized)
-        {
-            regist->m_ComponentNameHash[regist->m_ComponentTypeCount] = dmProfile::GetNameHash(type.m_Name);
-        }
+        regist->m_ComponentProfileCounterIndex[regist->m_ComponentTypeCount] = dmProfile::AllocateCounter(type.m_Name);
         regist->m_ComponentTypeCount++;
         return RESULT_OK;
     }
@@ -2403,7 +2400,7 @@ namespace dmGameObject
             uint16_t update_index = collection->m_Register->m_ComponentTypesOrder[i];
             ComponentType* component_type = &collection->m_Register->m_ComponentTypes[update_index];
 
-            DM_COUNTER_DYN(component_type->m_Name, collection->m_Register->m_ComponentNameHash[update_index], collection->m_ComponentInstanceCount[update_index]);
+            DM_COUNTER_DYN(collection->m_Register->m_ComponentProfileCounterIndex[update_index], collection->m_ComponentInstanceCount[update_index]);
 
             // Avoid to call UpdateTransforms for each/all component types.
             if (component_type->m_ReadsTransforms && collection->m_DirtyTransforms) {

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -189,7 +189,7 @@ namespace dmGameObject
         uint32_t                    m_ComponentTypeCount;
         ComponentType               m_ComponentTypes[MAX_COMPONENT_TYPES];
         uint16_t                    m_ComponentTypesOrder[MAX_COMPONENT_TYPES];
-        uint32_t                    m_ComponentNameHash[MAX_COMPONENT_TYPES];
+        uint32_t                    m_ComponentProfileCounterIndex[MAX_COMPONENT_TYPES];
         dmMutex::HMutex             m_Mutex;
 
         // All collections. Protected by m_Mutex

--- a/engine/profiler/src/profile_render.cpp
+++ b/engine/profiler/src/profile_render.cpp
@@ -108,8 +108,8 @@ namespace dmProfileRender
     }
 
     // These hashes are used so we can filter out the time the engine is waiting for frame buffer flip
-    static const TNameHash VSYNC_WAIT_NAME_HASH   = GetCombinedHash(dmProfile::GetNameHash("VSync"), dmProfile::GetNameHash("Wait"));
-    static const TNameHash ENGINE_FRAME_NAME_HASH = GetCombinedHash(dmProfile::GetNameHash("Engine"), dmProfile::GetNameHash("Frame"));
+    static const TNameHash VSYNC_WAIT_NAME_HASH   = GetCombinedHash(dmProfile::GetNameHash("VSync", (uint32_t)strlen("VSync")), dmProfile::GetNameHash("Wait", (uint32_t)strlen("Wait")));
+    static const TNameHash ENGINE_FRAME_NAME_HASH = GetCombinedHash(dmProfile::GetNameHash("Engine", (uint32_t)strlen("Engine")), dmProfile::GetNameHash("Frame", (uint32_t)strlen("Frame")));
 
     //  float *r, *g, *b; /* red, green, blue in [0,1] */
     //  float h, s, l;    /* hue in [0,360]; saturation, light in [0,1] */


### PR DESCRIPTION
- Counter now uses index to identify instead of hash and thus avoiding hash table lookup on counters
- AllocateScope now returns int to reduce static storage on 64-bit systems (use to be pointer)
- Internalize() and dmStringPool has been refactored to reduce hashing and strlen invocation count
- Changed dmStringPool to use 32 bit hash since the only use case for it is from the profiler which uses 32 bit hash, also it no longer registers the hashes
- Refactored AllocateScope() to reduce time spent while holding lock