### PR TITLE
Fix displayed position of rotated collision objects

### DIFF
--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -354,10 +354,12 @@
         parent-world-translation (math/translation parent-world-transform)
         local-translation (math/translation transform)
         min-scale (min (.-x world-scale) (.-y world-scale) (.-z world-scale))
-        world-translation (-> (math/rotate world-rotation local-translation)
+        world-translation (-> local-translation
                               (math/scale-vector min-scale)
                               (math/add-vector parent-world-translation))
         physics-world-transform (doto (Matrix4d. world-transform)
+                                  (.setRotation (doto (Quat4d. world-rotation)
+                                                  (.negate)))
                                   (.setScale min-scale)
                                   (.setTranslation world-translation))]
     (assoc renderable :world-transform physics-world-transform)))

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -345,23 +345,15 @@
           (gl/gl-draw-arrays gl GL/GL_TRIANGLE_FAN 0 (count vbuf)))))))
 
 (defn unify-scale [renderable]
-  (let [{:keys [^Matrix4d world-transform
+  (let [{:keys [^Quat4d world-rotation
                 ^Vector3d world-scale
-                ^Matrix4d transform
-                ^Quat4d world-rotation
-                ^Matrix4d parent-world-transform]
-         :or {transform geom/Identity4d}} renderable
-        parent-world-translation (math/translation parent-world-transform)
-        local-translation (math/translation transform)
+                ^Vector3d world-translation]} renderable
         min-scale (min (.-x world-scale) (.-y world-scale) (.-z world-scale))
-        world-translation (-> local-translation
-                              (math/scale-vector min-scale)
-                              (math/add-vector parent-world-translation))
-        physics-world-transform (doto (Matrix4d. world-transform)
-                                  (.setRotation (doto (Quat4d. world-rotation)
-                                                  (.negate)))
+        physics-world-transform (doto (Matrix4d.)
+                                  (.setIdentity)
                                   (.setScale min-scale)
-                                  (.setTranslation world-translation))]
+                                  (.setTranslation world-translation)
+                                  (.setRotation world-rotation))]
     (assoc renderable :world-transform physics-world-transform)))
 
 (defn wrap-uniform-scale [render-fn]

--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -138,6 +138,13 @@
         _ (.mulInverse q rotation)]
     (Vector3d. (.getX q) (.getY q) (.getZ q))))
 
+
+(defn transform
+  ^Vector3d [^Matrix4d mat ^Vector3d v]
+  (let [v' (Point3d. v)]
+    (.transform mat v')
+    (Vector3d. v')))
+
 (defn transform-vector
   ^Vector3d [^Matrix4d mat ^Vector3d v]
   (let [v' (Vector3d. v)]
@@ -169,6 +176,12 @@
 (defn translation
   ^Vector3d [^Matrix4d m]
   (let [ret (Vector3d.)]
+    (.get m ret)
+    ret))
+
+(defn rotation
+  ^Quat4d [^Matrix4d m]
+  (let [ret (Quat4d.)]
     (.get m ret)
     ret))
 

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -295,9 +295,9 @@
         world-transform (doto (Matrix4d. parent-world-transform) (.mul local-transform))
         local-transform-unscaled (doto (Matrix4d. local-transform) (.setScale 1.0))
         local-rotation (doto (Quat4d.) (.set local-transform-unscaled))
+        world-translation (math/transform parent-world-transform (math/translation local-transform))
         world-rotation (doto (Quat4d. parent-world-rotation) (.mul local-rotation))
-        world-scale (math/multiply-vector parent-world-scale
-                                          (math/scale local-transform))
+        world-scale (math/multiply-vector parent-world-scale (math/scale local-transform))
         appear-selected? (some? (some selection-set node-id-path)) ; Child nodes appear selected if parent is.
         picking-node-id (or (:picking-node-id scene) (peek node-id-path))
         flat-renderable (-> scene
@@ -308,8 +308,9 @@
                                    :picking-id (alloc-picking-id! picking-node-id)
                                    :tags (:tags renderable)
                                    :render-fn (:render-fn renderable)
-                                   :world-scale world-scale
+                                   :world-translation world-translation
                                    :world-rotation world-rotation
+                                   :world-scale world-scale
                                    :world-transform world-transform
                                    :parent-world-transform parent-world-transform
                                    :selected appear-selected?

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -6,7 +6,7 @@
 
 (defn- sha-from-version-file
   []
-  (let [stable-version (slurp "../VERSION")
+  (let [stable-version (first (string/split  (slurp "../VERSION") #"\n"))
         {:keys [exit out err]} (sh/sh "git" "rev-list" "-n" "1" stable-version)]
     (if (zero? exit)
       (string/trim out)

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -6,7 +6,7 @@
 
 (defn- sha-from-version-file
   []
-  (let [stable-version (first (string/split  (slurp "../VERSION") #"\n"))
+  (let [stable-version (first (string/split-lines  (slurp "../VERSION")))
         {:keys [exit out err]} (sh/sh "git" "rev-list" "-n" "1" stable-version)]
     (if (zero? exit)
       (string/trim out)

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -6,7 +6,7 @@
 
 (defn- sha-from-version-file
   []
-  (let [stable-version (first (string/split-lines  (slurp "../VERSION")))
+  (let [stable-version (first (string/split-lines (slurp "../VERSION")))
         {:keys [exit out err]} (sh/sh "git" "rev-list" "-n" "1" stable-version)]
     (if (zero? exit)
       (string/trim out)

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -78,7 +78,7 @@
                (test-util/mouse-press! view 0 0)
                (is (test-util/selected? app-view resource-node))
                ;; Toggling
-               (let [modifiers (if system/mac? [:meta] [:control])]
+               (let [modifiers (if system/mac? [:meta] [:shift])]
                  (test-util/mouse-click! view 32 32)
                  (is (test-util/selected? app-view go-node))
                  (test-util/mouse-click! view 32 32 modifiers)
@@ -245,7 +245,8 @@
            :user-data
            :world-rotation
            :world-scale
-           :world-transform} (set (keys renderable))))
+           :world-transform
+           :world-translation} (set (keys renderable))))
   (is (instance? AABB (:aabb renderable)))
   (is (some? (:node-id renderable)))
   (is (vector? (:node-id-path renderable)))


### PR DESCRIPTION
Fixes defold/editor2-issues#2494.

I actually have no idea what I've done, but it fixed the issue, and non-uniformly-scaled-and-rotated shapes are displayed as they should.