### PR TITLE
DEF-3725: Set WM_CLASS when setting window title on Linux

### DIFF
--- a/engine/glfw/lib/x11/x11_window.c
+++ b/engine/glfw/lib/x11/x11_window.c
@@ -32,6 +32,7 @@
 
 #include <limits.h>
 #include <assert.h>
+#include <libgen.h>
 
 
 /* Define GLX 1.4 FSAA tokens if not already defined */
@@ -929,14 +930,15 @@ static GLboolean createWindow( int width, int height,
     // Defold extension: Set WM_CLASS property
     //========================================================================
     {
-        char exe_name_buffer[1024];
-        memset(exe_name_buffer, 0, sizeof(exe_name_buffer));
+        char exe_path_buffer[1024];
+        memset(exe_path_buffer, 0, sizeof(exe_path_buffer));
         XClassHint* hints = XAllocClassHint();
 
-        if (readlink("/proc/self/exe", exe_name_buffer, sizeof(exe_name_buffer)-1) >= 0)
+        if (readlink("/proc/self/exe", exe_path_buffer, sizeof(exe_path_buffer)-1) >= 0)
         {
-            hints->res_name  = exe_name_buffer;
-            hints->res_class = exe_name_buffer;
+            char* exe_name   = basename(exe_path_buffer);
+            hints->res_name  = exe_name;
+            hints->res_class = exe_name;
         }
         else
         {
@@ -944,7 +946,7 @@ static GLboolean createWindow( int width, int height,
             hints->res_class = (char*) "dmengine";
         }
 
-        XSetClassHint(_glfwLibrary.display, _glfwLibrary.window, hints);
+        XSetClassHint(_glfwLibrary.display, _glfwWin.window, hints);
         XFree(hints);
     }
 

--- a/engine/glfw/lib/x11/x11_window.c
+++ b/engine/glfw/lib/x11/x11_window.c
@@ -32,7 +32,7 @@
 
 #include <limits.h>
 #include <assert.h>
-#include <libgen.h>
+#include <libgen.h> // Defold Extension for WM_CLASS property
 
 
 /* Define GLX 1.4 FSAA tokens if not already defined */

--- a/engine/glfw/lib/x11/x11_window.c
+++ b/engine/glfw/lib/x11/x11_window.c
@@ -925,6 +925,29 @@ static GLboolean createWindow( int width, int height,
         XFree( hints );
     }
 
+    //========================================================================
+    // Defold extension: Set WM_CLASS property
+    //========================================================================
+    {
+        char exe_name_buffer[1024];
+        memset(exe_name_buffer, 0, sizeof(exe_name_buffer));
+        XClassHint* hints = XAllocClassHint();
+
+        if (readlink("/proc/self/exe", exe_name_buffer, sizeof(exe_name_buffer)-1) >= 0)
+        {
+            hints->res_name  = exe_name_buffer;
+            hints->res_class = exe_name_buffer;
+        }
+        else
+        {
+            hints->res_name  = (char*) "dmengine";
+            hints->res_class = (char*) "dmengine";
+        }
+
+        XSetClassHint(_glfwLibrary.display, _glfwLibrary.window, hints);
+        XFree(hints);
+    }
+
     _glfwPlatformSetWindowTitle( "GLFW Window" );
 
     // Make sure the window is mapped before proceeding


### PR DESCRIPTION
The WM_CLASS can be used by linux window managers to configure how the engine window will be handled. Previously this property was not set, but now we set it to the basename of the binary.