### PR TITLE
Msgpost perf tests

### DIFF
--- a/engine/dlib/src/dlib/dstrings.h
+++ b/engine/dlib/src/dlib/dstrings.h
@@ -52,4 +52,13 @@ size_t dmStrlCat(char *dst, const char *src, size_t size);
  */
 int dmStrCaseCmp(const char *s1, const char *s2);
 
+inline char* dmStrAppend(char* w_ptr, const char* w_ptr_end, const char* str)
+{
+	while ((w_ptr != w_ptr_end) && *str)
+	{
+		*w_ptr++ = *str++;
+	}
+	return w_ptr;
+}
+
 #endif //DM_DSTRINGS_H

--- a/engine/dlib/src/dlib/hashtable.h
+++ b/engine/dlib/src/dlib/hashtable.h
@@ -194,7 +194,7 @@ public:
             entry->m_Value = value;
             entry->m_Next = 0xffffffff;
 
-            uint32_t bucket_index = (uint32_t) (key % m_HashTableSize);
+            uint32_t bucket_index = (uint32_t) (((uint32_t)key) % m_HashTableSize);
             uint32_t entry_ptr = m_HashTable[bucket_index];
             if (entry_ptr == 0xffffffff)
             {
@@ -280,7 +280,7 @@ public:
         // Avoid module division by zero
         assert(m_HashTableSize != 0);
 
-        uint32_t bucket_index = key % m_HashTableSize;
+        uint32_t bucket_index = ((uint32_t)key) % m_HashTableSize;
         uint32_t entry_ptr = m_HashTable[bucket_index];
 
         // Empty list?
@@ -390,7 +390,7 @@ private:
         if (!m_HashTableSize)
             return 0;
 
-        uint32_t bucket_index = (uint32_t) (key % m_HashTableSize);
+        uint32_t bucket_index = (uint32_t) (((uint32_t)key) % m_HashTableSize);
         uint32_t bucket = m_HashTable[bucket_index];
 
         uint32_t entry_ptr = bucket;

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -422,7 +422,21 @@ namespace dmMessage
             }
         }
 
-        DM_PROFILE_FMT(Message, "Dispatch %s", s->m_Name);
+        const char* profiler_string = 0;
+        uint32_t profiler_hash = 0;
+        if (dmProfile::g_IsInitialized)
+        {
+            char buffer[128];
+            char* w_ptr = buffer;
+            const char* w_ptr_end = &buffer[sizeof(buffer) - 1];
+            w_ptr = dmStrAppend(w_ptr, w_ptr_end, "Dispatch ");
+            w_ptr = dmStrAppend(w_ptr, w_ptr_end, s->m_Name);
+            uint32_t str_len = (uint32_t)(w_ptr - buffer);
+            *w_ptr++ = 0;
+            profiler_hash = dmProfile::GetNameHash(buffer, str_len);
+            profiler_string = dmProfile::Internalize(buffer, str_len, profiler_hash);
+        }
+        DM_PROFILE_DYN(Message, profiler_string, profiler_hash);
 
         uint32_t dispatch_count = 0;
 

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -5,6 +5,8 @@
 
 #if defined(_WIN32)
 #include "safe_windows.h"
+#elif defined(__APPLE__)
+#include <mach/mach_time.h>
 #elif  defined(__EMSCRIPTEN__)
 #include <emscripten.h>
 #else
@@ -154,6 +156,10 @@ namespace dmProfile
 
 #if defined(_WIN32)
         QueryPerformanceFrequency((LARGE_INTEGER*)&g_TicksPerSecond);
+#elif defined(__APPLE__)
+        mach_timebase_info_data_t info;
+        mach_timebase_info(&info);
+        g_TicksPerSecond = (info.denom * 1000000000ull) / info.numer;
 #endif
         // Set g_BeginTime even if we haven't started since threads may calculate scopes outside of
         // engine Begin()/End() of profiles which happens in Engine::Step() - just so we don't get
@@ -770,6 +776,8 @@ namespace dmProfile
         QueryPerformanceCounter((LARGE_INTEGER*)&now);
 #elif defined(__EMSCRIPTEN__)
         now = (uint64_t)(emscripten_get_now() * 1000.0);
+#elif defined(__APPLE__)
+        now = mach_absolute_time();
 #else
         timeval tv;
         gettimeofday(&tv, 0);

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -391,16 +391,26 @@ TEST(dmProfile, DynamicScope)
     dmProfile::HProfile profile = dmProfile::Begin();
     dmProfile::Release(profile);
 
+    char names[3][128];
+    DM_SNPRINTF(names[0], sizeof(names[0]), "%s@%s", "test.script", FUNCTION_NAMES[0]);
+    DM_SNPRINTF(names[1], sizeof(names[1]), "%s@%s", "test.script", FUNCTION_NAMES[1]);
+    DM_SNPRINTF(names[2], sizeof(names[2]), "%s@%s", "test.script", FUNCTION_NAMES[2]);
+    uint32_t names_hash[3] = {
+        dmProfile::GetNameHash(names[0], strlen(names[0])),
+        dmProfile::GetNameHash(names[1], strlen(names[1])),
+        dmProfile::GetNameHash(names[2], strlen(names[2]))
+    };
+
     for (uint i = 0; i < 10 ; ++i)
     {
         {
-            DM_PROFILE_FMT(Scope1, "%s@%s", "test.script", FUNCTION_NAMES[0]);
-            DM_PROFILE_FMT(Scope2, "%s@%s", "test.script", FUNCTION_NAMES[1]);
+            DM_PROFILE_DYN(Scope1, names[0], names_hash[0]);
+            DM_PROFILE_DYN(Scope2, names[1], names_hash[1]);
         }
         {
-            DM_PROFILE_FMT(Scope2, "%s@%s", "test.script", FUNCTION_NAMES[2]);
+            DM_PROFILE_DYN(Scope2, names[2], names_hash[2]);
         }
-        DM_PROFILE_FMT(Scope1, "%s@%s", "test.script", FUNCTION_NAMES[0]);
+        DM_PROFILE_DYN(Scope1, names[0], names_hash[0]);
     }
 
     std::vector<dmProfile::Sample> samples;

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -228,7 +228,7 @@ namespace dmGameObject
 
     UpdateResult CompScriptOnMessage(const ComponentOnMessageParams& params)
     {
-        DM_PROFILE(Script, "RunScript");
+        DM_PROFILE(Script, "ScriptOnMessage");
         UpdateResult result = UPDATE_RESULT_OK;
 
         ScriptInstance* script_instance = (ScriptInstance*)*params.m_UserData;
@@ -343,7 +343,7 @@ namespace dmGameObject
 
     InputResult CompScriptOnInput(const ComponentOnInputParams& params)
     {
-        DM_PROFILE(Script, "RunScript");
+        DM_PROFILE(Script, "ScriptOnInput");
         InputResult result = INPUT_RESULT_IGNORED;
 
         ScriptInstance* script_instance = (ScriptInstance*)*params.m_UserData;

--- a/engine/gameobject/src/gameobject/gameobject_props_lua.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_props_lua.cpp
@@ -17,11 +17,11 @@ namespace dmGameObject
             case LUA_TBOOLEAN:
                 return PROPERTY_TYPE_BOOLEAN;
             case LUA_TUSERDATA:
-                if (dmScript::IsHash(L, index))
+                if ((*userdata = (void*)dmScript::ToHash(L, index)))
                 {
                     return PROPERTY_TYPE_HASH;
                 }
-                else if (dmScript::IsURL(L, index))
+                else if ((*userdata = (void*)dmScript::ToURL(L, index)))
                 {
                     return PROPERTY_TYPE_URL;
                 }
@@ -59,12 +59,12 @@ namespace dmGameObject
                 out_var.m_Number = lua_tonumber(L, index);
                 return PROPERTY_RESULT_OK;
             case PROPERTY_TYPE_HASH:
-                out_var.m_Hash = dmScript::CheckHash(L, index);
+                out_var.m_Hash = *(dmhash_t*)userdata;
                 return PROPERTY_RESULT_OK;
             case PROPERTY_TYPE_URL:
                 {
                     dmMessage::URL* url = (dmMessage::URL*) out_var.m_URL;
-                    *url = *dmScript::CheckURL(L, index);
+                    *url = *(dmMessage::URL*)userdata;
                 }
                 return PROPERTY_RESULT_OK;
             case PROPERTY_TYPE_VECTOR3:

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -220,15 +220,6 @@ namespace dmGameObject
         return i;
     }
 
-    static int ScriptInstance_gc (lua_State *L)
-    {
-        ScriptInstance* i = ScriptInstance_Check(L, 1);
-        memset(i, 0, sizeof(*i));
-        (void) i;
-        assert(i);
-        return 0;
-    }
-
     static int ScriptInstance_tostring (lua_State *L)
     {
         lua_pushfstring(L, "Script: %p", lua_touserdata(L, 1));
@@ -237,7 +228,7 @@ namespace dmGameObject
 
     static int ScriptInstance_index(lua_State *L)
     {
-        ScriptInstance* i = ScriptInstance_Check(L, 1);
+        ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, 1);
         (void) i;
         assert(i);
 
@@ -252,7 +243,7 @@ namespace dmGameObject
     {
         int top = lua_gettop(L);
 
-        ScriptInstance* i = ScriptInstance_Check(L, 1);
+        ScriptInstance* i = (ScriptInstance*)lua_touserdata(L, 1);
         (void) i;
         assert(i);
 
@@ -353,7 +344,6 @@ namespace dmGameObject
 
     static const luaL_reg ScriptInstance_meta[] =
     {
-        {"__gc",                                        ScriptInstance_gc},
         {"__tostring",                                  ScriptInstance_tostring},
         {"__index",                                     ScriptInstance_index},
         {"__newindex",                                  ScriptInstance_newindex},

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1787,11 +1787,11 @@ namespace dmGameObject
         {
             valid_type = true;
         }
-        else if (dmScript::IsURL(L, 2))
+        else if (dmScript::ToURL(L, 2))
         {
             valid_type = true;
         }
-        else if (dmScript::IsHash(L, 2))
+        else if (dmScript::ToHash(L, 2))
         {
             valid_type = true;
         }

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -71,10 +71,13 @@ namespace dmGameSystem
     }
 
     static dmhash_t CheckGroupName(lua_State* L, int index) {
-        if (lua_isstring(L, index)) {
+        if (lua_isstring(L, index))
+        {
             return dmHashString64(lua_tostring(L, index));
-        } else if (dmScript::IsHash(L, index)) {
-            return dmScript::CheckHash(L, index);
+        }
+        else if (dmhash_t* hash_ptr = dmScript::ToHash(L, index))
+        {
+            return *hash_ptr;
         }
         luaL_argerror(L, index, "hash or string expected");
         return (dmhash_t) 0;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1818,12 +1818,16 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
             Result result = RESULT_OK;
 
-            const char* function_source = scene->m_Script->m_SourceFileName;
-            const char* function_name = SCRIPT_FUNCTION_NAMES[script_function];
-            char function_line_number_buffer[16];
-
+            const char* profiler_string = 0;
+            uint32_t profiler_hash = 0;
             if (dmProfile::g_IsInitialized)
             {
+                char buffer[128];
+                char* w_ptr = buffer;
+                const char* w_ptr_end = &buffer[sizeof(buffer) - 1];
+
+                const char* function_source = scene->m_Script->m_SourceFileName;
+
                 if (custom_ref != LUA_NOREF)
                 {
                     dmScript::LuaFunctionInfo fi;
@@ -1832,18 +1836,41 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                         function_source = fi.m_FileName;
                         if (fi.m_OptionalName)
                         {
-                            function_name = fi.m_OptionalName;
+                            w_ptr = dmStrAppend(w_ptr, w_ptr_end, fi.m_OptionalName);
                         }
                         else
                         {
+                            char function_line_number_buffer[16];
                             DM_SNPRINTF(function_line_number_buffer, sizeof(function_line_number_buffer), "l(%d)", fi.m_LineNumber);
-                            function_name = function_line_number_buffer;
+                            w_ptr = dmStrAppend(w_ptr, w_ptr_end, function_line_number_buffer);
                         }
                     }
+                    else
+                    {
+                        w_ptr = dmStrAppend(w_ptr, w_ptr_end, "<unknown>");
+                    }
+                    
                 }
+                else
+                {
+                    w_ptr = dmStrAppend(w_ptr, w_ptr_end, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE]);
+                }
+                
+                if (message_name)
+                {
+                    w_ptr = dmStrAppend(w_ptr, w_ptr_end, "[");
+                    w_ptr = dmStrAppend(w_ptr, w_ptr_end, message_name);
+                    w_ptr = dmStrAppend(w_ptr, w_ptr_end, "]");
+                }
+                w_ptr = dmStrAppend(w_ptr, w_ptr_end, "@");
+                w_ptr = dmStrAppend(w_ptr, w_ptr_end, function_source);
+                uint32_t str_len = (uint32_t)(w_ptr - buffer);
+                profiler_hash = dmProfile::GetNameHash(buffer, str_len);
+                *w_ptr++ = 0;
+                profiler_string = dmProfile::Internalize(buffer, str_len, profiler_hash);
             }
             {
-                DM_PROFILE_FMT(Script, "%s%s%s%s@%s", function_name, message_name ? "[" : "", message_name ? message_name : "", message_name ? "]" : "", function_source);
+                DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -977,9 +977,12 @@ namespace dmGui
         (void) node;
 
         dmhash_t property_hash;
-        if (dmScript::IsHash(L, 2)) {
-           property_hash = dmScript::CheckHash(L, 2);
-        } else {
+        if (dmhash_t* hash_ptr = dmScript::ToHash(L, 2))
+        {
+           property_hash = *hash_ptr;
+        }
+        else
+        {
            property_hash = dmHashString64(luaL_checkstring(L, 2));
         }
 
@@ -1110,9 +1113,12 @@ namespace dmGui
         (void) node;
 
         dmhash_t property_hash;
-        if (dmScript::IsHash(L, 2)) {
-           property_hash = dmScript::CheckHash(L, 2);
-        } else {
+        if (dmhash_t* hash_ptr = dmScript::ToHash(L, 2))
+        {
+           property_hash = *hash_ptr;
+        }
+        else
+        {
            property_hash = dmHashString64(luaL_checkstring(L, 2));
         }
 

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -96,15 +96,6 @@ namespace dmGui
         return scene;
     }
 
-    static int GuiScriptInstance_gc (lua_State *L)
-    {
-        Scene* i = GuiScriptInstance_Check(L, 1);
-        memset(i, 0, sizeof(*i));
-        (void) i;
-        assert(i);
-        return 0;
-    }
-
     static int GuiScriptInstance_tostring (lua_State *L)
     {
         lua_pushfstring(L, "GuiScript: %p", lua_touserdata(L, 1));
@@ -113,7 +104,7 @@ namespace dmGui
 
     static int GuiScriptInstance_index(lua_State *L)
     {
-        Scene* i = GuiScriptInstance_Check(L, 1);
+        Scene* i = (Scene*)lua_touserdata(L, 1);
         assert(i);
 
         // Try to find value in instance data
@@ -127,7 +118,7 @@ namespace dmGui
     {
         int top = lua_gettop(L);
 
-        Scene* i = GuiScriptInstance_Check(L, 1);
+        Scene* i = (Scene*)lua_touserdata(L, 1);
         assert(i);
 
         lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_DataReference);
@@ -184,7 +175,6 @@ namespace dmGui
 
     static const luaL_reg GuiScriptInstance_meta[] =
     {
-        {"__gc",                                        GuiScriptInstance_gc},
         {"__tostring",                                  GuiScriptInstance_tostring},
         {"__index",                                     GuiScriptInstance_index},
         {"__newindex",                                  GuiScriptInstance_newindex},
@@ -240,11 +230,6 @@ namespace dmGui
         return 0; // Never reached
     }
 
-    static int NodeProxy_gc (lua_State *L)
-    {
-        return 0;
-    }
-
     static int NodeProxy_tostring (lua_State *L)
     {
         DM_LUA_STACK_CHECK(L,1);
@@ -294,7 +279,7 @@ namespace dmGui
 
     static int NodeProxy_index(lua_State *L)
     {
-        InternalNode* n = LuaCheckNode(L, 1, 0);
+        InternalNode* n = (InternalNode*)lua_touserdata(L, 1);
         (void)n;
 
         const char* key = luaL_checkstring(L, 2);
@@ -350,7 +335,6 @@ namespace dmGui
 
     static const luaL_reg NodeProxy_meta[] =
     {
-        {"__gc",       NodeProxy_gc},
         {"__tostring", NodeProxy_tostring},
         {"__index",    NodeProxy_index},
         {"__newindex", NodeProxy_newindex},

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -212,15 +212,6 @@ namespace dmRender
         return i;
     }
 
-    static int RenderScriptInstance_gc (lua_State *L)
-    {
-        RenderScriptInstance* i = RenderScriptInstance_Check(L, 1);
-        memset(i, 0, sizeof(*i));
-        (void) i;
-        assert(i);
-        return 0;
-    }
-
     static int RenderScriptInstance_tostring (lua_State *L)
     {
         lua_pushfstring(L, "RenderScript: %p", lua_touserdata(L, 1));
@@ -306,7 +297,6 @@ namespace dmRender
 
     static const luaL_reg RenderScriptInstance_meta[] =
     {
-        {"__gc",                                        RenderScriptInstance_gc},
         {"__tostring",                                  RenderScriptInstance_tostring},
         {"__index",                                     RenderScriptInstance_index},
         {"__newindex",                                  RenderScriptInstance_newindex},

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -63,7 +63,7 @@ namespace dmRender
 
     static int RenderScriptConstantBuffer_gc (lua_State *L)
     {
-        HNamedConstantBuffer* cb = RenderScriptConstantBuffer_Check(L, 1);
+        HNamedConstantBuffer* cb = (HNamedConstantBuffer*)lua_touserdata(L, 1);
         DeleteNamedConstantBuffer(*cb);
         *cb = 0;
         return 0;
@@ -77,7 +77,7 @@ namespace dmRender
 
     static int RenderScriptConstantBuffer_index(lua_State *L)
     {
-        HNamedConstantBuffer* cb = RenderScriptConstantBuffer_Check(L, 1);
+        HNamedConstantBuffer* cb = (HNamedConstantBuffer*)lua_touserdata(L, 1);
         assert(cb);
 
         const char* name = luaL_checkstring(L, 2);
@@ -98,7 +98,7 @@ namespace dmRender
     static int RenderScriptConstantBuffer_newindex(lua_State *L)
     {
         int top = lua_gettop(L);
-        HNamedConstantBuffer* cb = RenderScriptConstantBuffer_Check(L, 1);
+        HNamedConstantBuffer* cb = (HNamedConstantBuffer*)lua_touserdata(L, 1);
         assert(cb);
 
         const char* name = luaL_checkstring(L, 2);
@@ -223,7 +223,7 @@ namespace dmRender
         int top = lua_gettop(L);
         (void) top;
 
-        RenderScriptInstance* i = RenderScriptInstance_Check(L, 1);
+        RenderScriptInstance* i = (RenderScriptInstance*)lua_touserdata(L, 1);
         assert(i);
 
         // Try to find value in instance data
@@ -241,7 +241,7 @@ namespace dmRender
         int top = lua_gettop(L);
         (void) top;
 
-        RenderScriptInstance* i = RenderScriptInstance_Check(L, 1);
+        RenderScriptInstance* i = (RenderScriptInstance*)lua_touserdata(L, 1);
         assert(i);
 
         lua_rawgeti(L, LUA_REGISTRYINDEX, i->m_RenderScriptDataReference);

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -155,6 +155,11 @@ namespace dmHttpService
                              const char* headers, uint32_t headers_length,
                              const char* response, uint32_t response_length)
     {
+        if (requester == 0)
+        {
+            dmLogWarning("Failed to return http-response. Requester deleted?");
+            return;
+        }
         dmHttpDDF::HttpResponse resp;
         resp.m_Status = status;
         resp.m_Headers = (uint64_t) headers;

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -253,12 +253,12 @@ namespace dmScript
     void PushTable(lua_State*L, const char* data, uint32_t data_size);
 
     /**
-     * Check if the value at #index is a hash
+     * Returns a pointer to a hash at #index if it is the correct type
      * @param L Lua state
      * @param index Index of the value
      * @return pointer to hash  if the value at #index is a hash, null if not
      */
-    dmhash_t* IsHash(lua_State *L, int index);
+    dmhash_t* ToHash(lua_State *L, int index);
 
     /**
      * Push a hash value onto the supplied lua state, will increase the stack by 1.
@@ -321,12 +321,12 @@ namespace dmScript
     dmVMath::FloatVector* CheckVector(lua_State* L, int index);
 
     /**
-     * Check if the value at #index is a URL
+     * Get the value at index as a URL
      * @param L Lua state
      * @param index Index of the value
-     * @return true is value at #index is a URL
+     * @return pointer to the url if the value at #index is a hash, null if not
      */
-    bool IsURL(lua_State *L, int index);
+    dmMessage::URL* ToURL(lua_State *L, int index);
 
     /**
      * Push a URL value onto the supplied lua state, will increase the stack by 1

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -256,9 +256,9 @@ namespace dmScript
      * Check if the value at #index is a hash
      * @param L Lua state
      * @param index Index of the value
-     * @return true if the value at #index is a hash
+     * @return pointer to hash  if the value at #index is a hash, null if not
      */
-    bool IsHash(lua_State *L, int index);
+    dmhash_t* IsHash(lua_State *L, int index);
 
     /**
      * Push a hash value onto the supplied lua state, will increase the stack by 1.

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -29,10 +29,10 @@ namespace dmScript
     #define SCRIPT_TYPE_NAME_HASH "hash"
     #define SCRIPT_HASH_TABLE "__script_hash_table"
 
-    bool IsHash(lua_State *L, int index)
+    dmhash_t* IsHash(lua_State *L, int index)
     {
         void *p = lua_touserdata(L, index);
-        bool result = false;
+        dmhash_t* result = 0;
         if (p != 0x0)
         {  /* value is a userdata? */
             if (lua_getmetatable(L, index))
@@ -40,7 +40,7 @@ namespace dmScript
                 lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_TYPE_NAME_HASH);  /* get correct metatable */
                 if (lua_rawequal(L, -1, -2))
                 {  /* does it have the correct mt? */
-                    result = true;
+                    result = (dmhash_t*)p;
                 }
                 lua_pop(L, 2);  /* remove both metatables */
             }
@@ -72,9 +72,10 @@ namespace dmScript
         int top = lua_gettop(L);
 
         dmhash_t hash;
-        if(IsHash(L, 1))
+        dmhash_t* hash_ptr = IsHash(L, 1);
+        if(hash_ptr)
         {
-            hash = *(dmhash_t*)lua_touserdata(L, 1);
+            hash = *hash_ptr;
         }
         else
         {
@@ -215,9 +216,9 @@ namespace dmScript
     dmhash_t CheckHash(lua_State* L, int index)
     {
         dmhash_t* lua_hash = 0x0;
-        if (IsHash(L, index))
+        lua_hash = IsHash(L, index);
+        if (lua_hash)
         {
-            lua_hash = (dmhash_t*)lua_touserdata(L, index);
             return *lua_hash;
         }
 
@@ -227,10 +228,9 @@ namespace dmScript
 
     dmhash_t CheckHashOrString(lua_State* L, int index)
     {
-        dmhash_t* lua_hash = 0x0;
-        if (IsHash(L, index))
+        dmhash_t* lua_hash = IsHash(L, index);
+        if (lua_hash)
         {
-            lua_hash = (dmhash_t*)lua_touserdata(L, index);
             return *lua_hash;
         }
         else if( lua_type(L, index) == LUA_TSTRING )

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -283,13 +283,6 @@ namespace dmScript
         return 1;
     }
 
-    static int Script_gc (lua_State *L)
-    {
-        dmhash_t hash = CheckHash(L, 1);
-        (void)hash;
-        return 0;
-    }
-
     static int Script_tostring(lua_State* L)
     {
         dmhash_t hash = CheckHash(L, 1);
@@ -376,9 +369,6 @@ namespace dmScript
         luaL_newmetatable(L, SCRIPT_TYPE_NAME_HASH);
 
         luaL_openlib(L, 0x0, ScriptHash_methods, 0);
-        lua_pushstring(L, "__gc");
-        lua_pushcfunction(L, Script_gc);
-        lua_settable(L, -3);
 
         lua_pushstring(L, "__eq");
         lua_pushcfunction(L, Script_eq);

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -29,7 +29,7 @@ namespace dmScript
     #define SCRIPT_TYPE_NAME_HASH "hash"
     #define SCRIPT_HASH_TABLE "__script_hash_table"
 
-    dmhash_t* IsHash(lua_State *L, int index)
+    dmhash_t* ToHash(lua_State *L, int index)
     {
         void *p = lua_touserdata(L, index);
         dmhash_t* result = 0;
@@ -72,8 +72,7 @@ namespace dmScript
         int top = lua_gettop(L);
 
         dmhash_t hash;
-        dmhash_t* hash_ptr = IsHash(L, 1);
-        if(hash_ptr)
+        if(dmhash_t* hash_ptr = ToHash(L, 1))
         {
             hash = *hash_ptr;
         }
@@ -215,11 +214,9 @@ namespace dmScript
 
     dmhash_t CheckHash(lua_State* L, int index)
     {
-        dmhash_t* lua_hash = 0x0;
-        lua_hash = IsHash(L, index);
-        if (lua_hash)
+        if (dmhash_t* hash_ptr = ToHash(L, index))
         {
-            return *lua_hash;
+            return *hash_ptr;
         }
 
         luaL_typerror(L, index, SCRIPT_TYPE_NAME_HASH);
@@ -228,10 +225,9 @@ namespace dmScript
 
     dmhash_t CheckHashOrString(lua_State* L, int index)
     {
-        dmhash_t* lua_hash = IsHash(L, index);
-        if (lua_hash)
+        if (dmhash_t* hash_ptr = ToHash(L, index))
         {
-            return *lua_hash;
+            return *hash_ptr;
         }
         else if( lua_type(L, index) == LUA_TSTRING )
         {
@@ -253,9 +249,8 @@ namespace dmScript
             memcpy(buffer, (void*)s, dmMath::Min<uint32_t>(len, bufferlength));
             buffer[len < bufferlength ? len : bufferlength-1 ] = 0;
         }
-        else if (IsHash(L, index))
+        else if (dmhash_t* hash = ToHash(L, index))
         {
-            dmhash_t* hash = (dmhash_t*)lua_touserdata(L, index);
             const char* s = (const char*)dmHashReverse64(*hash, 0);
             if (s)
             {
@@ -302,9 +297,9 @@ namespace dmScript
 
     static const char* GetStringHelper(lua_State *L, int index, bool& allocated)
     {
-        if (dmScript::IsHash(L, index))
+        if (dmhash_t* hash_ptr = ToHash(L, index))
         {
-            dmhash_t hash = CheckHash(L, index);
+            dmhash_t hash = *hash_ptr;
             const char* reverse = (const char*) dmHashReverse64(hash, 0);
 
             allocated = true;

--- a/engine/script/src/script_http_js.cpp
+++ b/engine/script/src/script_http_js.cpp
@@ -52,6 +52,11 @@ namespace dmScript
                              const char* headers, uint32_t headers_length,
                              const char* response, uint32_t response_length)
     {
+        if (requester == 0)
+        {
+            dmLogWarning("Failed to return http-response. Requester deleted?");
+            return;
+        }
         dmHttpDDF::HttpResponse resp;
         resp.m_Status = status;
         resp.m_Headers = (uint64_t) headers;

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -162,9 +162,10 @@ namespace dmScript
         const char* key = luaL_checkstring(L, 2);
         if (strcmp("socket", key) == 0)
         {
-            if (IsHash(L, 3))
+            dmhash_t* hash_ptr = IsHash(L, 3);
+            if (hash_ptr)
             {
-                url->m_Socket = CheckHash(L, 3);
+                url->m_Socket = *hash_ptr;
             }
             else if (lua_isstring(L, 3))
             {

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -109,7 +109,8 @@ namespace dmScript
 
     static int URL_index(lua_State *L)
     {
-        dmMessage::URL* url = CheckURL(L, 1);
+        dmMessage::URL* url = (dmMessage::URL*)lua_touserdata(L, 1);
+        assert(url);
 
         const char* key = luaL_checkstring(L, 2);
         if (strcmp("socket", key) == 0)

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -53,13 +53,6 @@ namespace dmScript
         return result;
     }
 
-    static int URL_gc(lua_State *L)
-    {
-        dmMessage::URL* url = CheckURL(L, 1);
-        memset(url, 0, sizeof(*url));
-        return 0;
-    }
-
     void url_tostring(const dmMessage::URL* url, char* buffer, uint32_t buffer_size)
     {
         char tmp[32];
@@ -257,7 +250,6 @@ namespace dmScript
 
     static const luaL_reg URL_meta[] =
     {
-        {"__gc",        URL_gc},
         {"__tostring",  URL_tostring},
         {"__concat",    URL_concat},
         {"__index",     URL_index},

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -34,10 +34,10 @@ namespace dmScript
 
     const uint32_t MAX_MESSAGE_DATA_SIZE = 2048;
 
-    bool IsURL(lua_State *L, int index)
+    dmMessage::URL* ToURL(lua_State *L, int index)
     {
         void *p = lua_touserdata(L, index);
-        bool result = false;
+        dmMessage::URL* result = 0;
         if (p != 0x0)
         {  /* value is a userdata? */
             if (lua_getmetatable(L, index))
@@ -45,7 +45,7 @@ namespace dmScript
                 lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_TYPE_NAME_URL);  /* get correct metatable */
                 if (lua_rawequal(L, -1, -2))
                 {  /* does it have the correct mt? */
-                    result = true;
+                    result = (dmMessage::URL*)p;
                 }
                 lua_pop(L, 2);  /* remove both metatables */
             }
@@ -162,8 +162,7 @@ namespace dmScript
         const char* key = luaL_checkstring(L, 2);
         if (strcmp("socket", key) == 0)
         {
-            dmhash_t* hash_ptr = IsHash(L, 3);
-            if (hash_ptr)
+            if (dmhash_t* hash_ptr = ToHash(L, 3))
             {
                 url->m_Socket = *hash_ptr;
             }
@@ -202,9 +201,9 @@ namespace dmScript
             {
                 url->m_Path = 0;
             }
-            else if (IsHash(L, 3))
+            else if (dmhash_t* hash_ptr = ToHash(L, 3))
             {
-                url->m_Path = CheckHash(L, 3);
+                url->m_Path = *hash_ptr;
             }
             else
             {
@@ -221,9 +220,9 @@ namespace dmScript
             {
                 url->m_Fragment = 0;
             }
-            else if (IsHash(L, 3))
+            else if (dmhash_t* hash_ptr = ToHash(L, 3))
             {
-                url->m_Fragment = CheckHash(L, 3);
+                url->m_Fragment = *hash_ptr;
             }
             else
             {
@@ -347,9 +346,9 @@ namespace dmScript
             }
             if (!lua_isnil(L, 1))
             {
-                if (IsHash(L, 1))
+                if (dmhash_t* hash_ptr = ToHash(L, 1))
                 {
-                    url.m_Socket = CheckHash(L, 1);
+                    url.m_Socket = *hash_ptr;
                 }
                 else
                 {
@@ -697,9 +696,9 @@ namespace dmScript
 
     int ResolveURL(lua_State* L, int index, dmMessage::URL* out_url, dmMessage::URL* out_default_url)
     {
-        if (dmScript::IsURL(L, index))
+        if (dmMessage::URL* url_ptr = dmScript::ToURL(L, index))
         {
-            *out_url = *CheckURL(L, index);
+            *out_url = *url_ptr;
             if (out_default_url != 0x0)
             {
                 dmMessage::ResetURL(*out_default_url);
@@ -793,10 +792,10 @@ namespace dmScript
                     }
                 }
             }
-            else if (IsHash(L, index))
+            else if (dmhash_t* hash_ptr = ToHash(L, index))
             {
                 out_url->m_Socket = default_url.m_Socket;
-                out_url->m_Path = CheckHash(L, index);
+                out_url->m_Path = *hash_ptr;
                 out_url->m_Fragment = 0;
             }
             else

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -447,9 +447,9 @@ namespace dmScript
 
                         buffer += sizeof(float) * 16;
                     }
-                    else if (IsHash(L, -1))
+                    else if (dmhash_t* hash_ptr = ToHash(L, -1))
                     {
-                        dmhash_t hash = CheckHash(L, -1);
+                        dmhash_t hash = *hash_ptr;
                         const uint32_t hash_size = sizeof(dmhash_t);
 
                         if (buffer_end - buffer < int32_t(hash_size))
@@ -462,9 +462,8 @@ namespace dmScript
                         memcpy(buffer, (const void*)&hash, hash_size);
                         buffer += hash_size;
                     }
-                    else if (IsURL(L, -1))
+                    else if (dmMessage::URL* url = ToURL(L, -1))
                     {
-                        dmMessage::URL* url = CheckURL(L, -1);
                         const uint32_t url_size = sizeof(dmMessage::URL);
 
                         if (buffer_end - buffer < int32_t(url_size))

--- a/engine/script/src/script_vmath.cpp
+++ b/engine/script/src/script_vmath.cpp
@@ -126,7 +126,7 @@ namespace dmScript
 
     static int Vector_len(lua_State *L)
     {
-        dmVMath::FloatVector* v = CheckVector(L, 1);
+        dmVMath::FloatVector* v = *(dmVMath::FloatVector**)lua_touserdata(L, 1);
 
         lua_pushnumber(L, v->size);
         return 1;
@@ -134,7 +134,7 @@ namespace dmScript
 
     static int Vector_index(lua_State *L)
     {
-        dmVMath::FloatVector* v = CheckVector(L, 1);
+        dmVMath::FloatVector* v = *(dmVMath::FloatVector**)lua_touserdata(L, 1);
 
         int key = luaL_checkinteger(L, 2);
         if (key > 0 && key <= v->size)
@@ -155,7 +155,7 @@ namespace dmScript
 
     static int Vector_newindex(lua_State *L)
     {
-        dmVMath::FloatVector* v = CheckVector(L, 1);
+        dmVMath::FloatVector* v = *(dmVMath::FloatVector**)lua_touserdata(L, 1);
 
         int key = luaL_checkinteger(L, 2);
         if (key > 0 && key <= v->size)
@@ -176,14 +176,14 @@ namespace dmScript
 
     static int Vector_tostring(lua_State *L)
     {
-        dmVMath::FloatVector* v = CheckVector(L, 1);
+        dmVMath::FloatVector* v = *(dmVMath::FloatVector**)lua_touserdata(L, 1);
         lua_pushfstring(L, "%s.%s (size: %d)", SCRIPT_LIB_NAME, SCRIPT_TYPE_NAME_VECTOR, v->size);
         return 1;
     }
 
     static int Vector_gc(lua_State *L)
     {
-        dmVMath::FloatVector* v = CheckVector(L, 1);
+        dmVMath::FloatVector* v = *(dmVMath::FloatVector**)lua_touserdata(L, 1);
         delete v;
         return 0;
     }
@@ -224,14 +224,14 @@ namespace dmScript
 
     static int Vector3_tostring(lua_State *L)
     {
-        Vectormath::Aos::Vector3* v = CheckVector3(L, 1);
+        Vectormath::Aos::Vector3* v = (Vectormath::Aos::Vector3*)lua_touserdata(L, 1);
         lua_pushfstring(L, "vmath.%s(%f, %f, %f)", SCRIPT_TYPE_NAME_VECTOR3, v->getX(), v->getY(), v->getZ());
         return 1;
     }
 
     static int Vector3_index(lua_State *L)
     {
-        Vectormath::Aos::Vector3* v = CheckVector3(L, 1);
+        Vectormath::Aos::Vector3* v = (Vectormath::Aos::Vector3*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (key[0] == 'x')
@@ -257,7 +257,7 @@ namespace dmScript
 
     static int Vector3_newindex(lua_State *L)
     {
-        Vectormath::Aos::Vector3* v = CheckVector3(L, 1);
+        Vectormath::Aos::Vector3* v = (Vectormath::Aos::Vector3*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (key[0] == 'x')
@@ -314,7 +314,7 @@ namespace dmScript
 
     static int Vector3_unm(lua_State *L)
     {
-        Vectormath::Aos::Vector3* v = CheckVector3(L, 1);
+        Vectormath::Aos::Vector3* v = (Vectormath::Aos::Vector3*)lua_touserdata(L, 1);
         PushVector3(L, - *v);
         return 1;
     }
@@ -322,7 +322,7 @@ namespace dmScript
     static int Vector3_concat(lua_State *L)
     {
         const char* s = luaL_checkstring(L, 1);
-        Vectormath::Aos::Vector3* v = CheckVector3(L, 2);
+        Vectormath::Aos::Vector3* v = (Vectormath::Aos::Vector3*)lua_touserdata(L, 2);
         size_t size = 48 + strlen(s);
         char* buffer = new char[size];
         DM_SNPRINTF(buffer, size, "%s[%f, %f, %f]", s, v->getX(), v->getY(), v->getZ());
@@ -364,14 +364,14 @@ namespace dmScript
 
     static int Vector4_tostring(lua_State *L)
     {
-        Vectormath::Aos::Vector4* v = CheckVector4(L, 1);
+        Vectormath::Aos::Vector4* v = (Vectormath::Aos::Vector4*)lua_touserdata(L, 1);
         lua_pushfstring(L, "vmath.%s(%f, %f, %f, %f)", SCRIPT_TYPE_NAME_VECTOR4, v->getX(), v->getY(), v->getZ(), v->getW());
         return 1;
     }
 
     static int Vector4_index(lua_State *L)
     {
-        Vectormath::Aos::Vector4* v = CheckVector4(L, 1);
+        Vectormath::Aos::Vector4* v = (Vectormath::Aos::Vector4*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (key[0] == 'x')
@@ -402,7 +402,7 @@ namespace dmScript
 
     static int Vector4_newindex(lua_State *L)
     {
-        Vectormath::Aos::Vector4* v = CheckVector4(L, 1);
+        Vectormath::Aos::Vector4* v = (Vectormath::Aos::Vector4*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (key[0] == 'x')
@@ -463,7 +463,7 @@ namespace dmScript
 
     static int Vector4_unm(lua_State *L)
     {
-        Vectormath::Aos::Vector4* v = CheckVector4(L, 1);
+        Vectormath::Aos::Vector4* v = (Vectormath::Aos::Vector4*)lua_touserdata(L, 1);
         PushVector4(L, - *v);
         return 1;
     }
@@ -471,7 +471,7 @@ namespace dmScript
     static int Vector4_concat(lua_State *L)
     {
         const char* s = luaL_checkstring(L, 1);
-        Vectormath::Aos::Vector4* v = CheckVector4(L, 2);
+        Vectormath::Aos::Vector4* v = (Vectormath::Aos::Vector4*)lua_touserdata(L, 2);
         size_t size = 64 + strlen(s);
         char* buffer = new char[size];
         DM_SNPRINTF(buffer, size, "%s[%f, %f, %f, %f]", s, v->getX(), v->getY(), v->getZ(), v->getW());
@@ -520,7 +520,7 @@ namespace dmScript
 
     static int Quat_index(lua_State *L)
     {
-        Vectormath::Aos::Quat* q = CheckQuat(L, 1);
+        Vectormath::Aos::Quat* q = (Vectormath::Aos::Quat*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (key[0] == 'x')
@@ -552,7 +552,7 @@ namespace dmScript
 
     static int Quat_newindex(lua_State *L)
     {
-        Vectormath::Aos::Quat* q = CheckQuat(L, 1);
+        Vectormath::Aos::Quat* q = (Vectormath::Aos::Quat*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (key[0] == 'x')
@@ -639,7 +639,7 @@ namespace dmScript
 
     static int Matrix4_index(lua_State *L)
     {
-        Vectormath::Aos::Matrix4* m = CheckMatrix4(L, 1);
+        Vectormath::Aos::Matrix4* m = (Vectormath::Aos::Matrix4*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (strlen(key) == 3)
@@ -666,7 +666,7 @@ namespace dmScript
 
     static int Matrix4_newindex(lua_State *L)
     {
-        Vectormath::Aos::Matrix4* m = CheckMatrix4(L, 1);
+        Vectormath::Aos::Matrix4* m = (Vectormath::Aos::Matrix4*)lua_touserdata(L, 1);
 
         const char* key = luaL_checkstring(L, 2);
         if (strlen(key) == 3)

--- a/engine/script/src/script_vmath.cpp
+++ b/engine/script/src/script_vmath.cpp
@@ -222,15 +222,6 @@ namespace dmScript
         return (Vectormath::Aos::Vector3*)GetUserData(L, index, SCRIPT_TYPE_NAME_VECTOR3);
     }
 
-    static int Vector3_gc(lua_State *L)
-    {
-        Vectormath::Aos::Vector3* v = CheckVector3(L, 1);
-        memset(v, 0, sizeof(*v));
-        (void) v;
-        assert(v);
-        return 0;
-    }
-
     static int Vector3_tostring(lua_State *L)
     {
         Vectormath::Aos::Vector3* v = CheckVector3(L, 1);
@@ -354,7 +345,6 @@ namespace dmScript
     };
     static const luaL_reg Vector3_meta[] =
     {
-        {"__gc",        Vector3_gc},
         {"__tostring",  Vector3_tostring},
         {"__index",     Vector3_index},
         {"__newindex",  Vector3_newindex},
@@ -370,15 +360,6 @@ namespace dmScript
     Vectormath::Aos::Vector4* ToVector4(lua_State *L, int index)
     {
         return (Vectormath::Aos::Vector4*)GetUserData(L, index, SCRIPT_TYPE_NAME_VECTOR4);
-    }
-
-    static int Vector4_gc(lua_State *L)
-    {
-        Vectormath::Aos::Vector4* v = CheckVector4(L, 1);
-        memset(v, 0, sizeof(*v));
-        (void) v;
-        assert(v);
-        return 0;
     }
 
     static int Vector4_tostring(lua_State *L)
@@ -513,7 +494,6 @@ namespace dmScript
     };
     static const luaL_reg Vector4_meta[] =
     {
-        {"__gc",        Vector4_gc},
         {"__tostring",  Vector4_tostring},
         {"__index",     Vector4_index},
         {"__newindex",  Vector4_newindex},
@@ -529,15 +509,6 @@ namespace dmScript
     Vectormath::Aos::Quat* ToQuat(lua_State *L, int index)
     {
         return (Vectormath::Aos::Quat*)GetUserData(L, index, SCRIPT_TYPE_NAME_QUAT);
-    }
-
-    static int Quat_gc(lua_State *L)
-    {
-        Vectormath::Aos::Quat* q = CheckQuat(L, 1);
-        memset(q, 0, sizeof(*q));
-        (void) q;
-        assert(q);
-        return 0;
     }
 
     static int Quat_tostring(lua_State *L)
@@ -641,7 +612,6 @@ namespace dmScript
     };
     static const luaL_reg Quat_meta[] =
     {
-        {"__gc",        Quat_gc},
         {"__tostring",  Quat_tostring},
         {"__index",     Quat_index},
         {"__newindex",  Quat_newindex},
@@ -654,15 +624,6 @@ namespace dmScript
     Vectormath::Aos::Matrix4* ToMatrix4(lua_State *L, int index)
     {
         return (Vectormath::Aos::Matrix4*)GetUserData(L, index, SCRIPT_TYPE_NAME_MATRIX4);
-    }
-
-    static int Matrix4_gc(lua_State *L)
-    {
-        Vectormath::Aos::Matrix4* m = CheckMatrix4(L, 1);
-        memset(m, 0, sizeof(*m));
-        (void) m;
-        assert(m);
-        return 0;
     }
 
     static int Matrix4_tostring(lua_State *L)
@@ -800,7 +761,6 @@ namespace dmScript
     };
     static const luaL_reg Matrix4_meta[] =
     {
-        {"__gc",        Matrix4_gc},
         {"__tostring",  Matrix4_tostring},
         {"__index",     Matrix4_index},
         {"__newindex",  Matrix4_newindex},

--- a/engine/script/src/test/test_script_hash.cpp
+++ b/engine/script/src/test/test_script_hash.cpp
@@ -93,9 +93,9 @@ TEST_F(ScriptHashTest, TestHash)
     lua_pop(L, 1);
 
     dmScript::PushHash(L, dmHashString64("test"));
-    ASSERT_TRUE(dmScript::IsHash(L, -1));
+    ASSERT_TRUE(dmScript::ToHash(L, -1));
     lua_pop(L, 1);
-    ASSERT_FALSE(dmScript::IsHash(L, -1));
+    ASSERT_FALSE(dmScript::ToHash(L, -1));
 
     ASSERT_EQ(top, lua_gettop(L));
 }

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -703,7 +703,7 @@ TEST_F(LuaTableTest, Hash)
     dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
 
     lua_getfield(L, -1, "h");
-    ASSERT_TRUE(dmScript::IsHash(L, -1));
+    ASSERT_TRUE(dmScript::ToHash(L, -1));
     dmhash_t hash2 = dmScript::CheckHash(L, -1);
     ASSERT_EQ(hash, hash2);
     lua_pop(L, 1);
@@ -733,7 +733,7 @@ TEST_F(LuaTableTest, URL)
     dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
 
     lua_getfield(L, -1, "url");
-    ASSERT_TRUE(dmScript::IsURL(L, -1));
+    ASSERT_TRUE(dmScript::ToURL(L, -1));
     dmMessage::URL url2 = *dmScript::CheckURL(L, -1);
     ASSERT_EQ(url.m_Socket, url2.m_Socket);
     ASSERT_EQ(url.m_Path, url2.m_Path);


### PR DESCRIPTION
- Avoid 64-bit modulo in hash table
- Use mac_absolute_time on macos/ios for profiler
- Separate profile scope for CompScriptOnMessage and CompScriptOnInput
- Don’t register lua-gc for objects that don’t need it
- Don’t check that meta table for object is correct when call path is using said meta table
- Avoid double type-check for IsHash/CheckHash
- Inline implementation of CheckUserType, GetUserData and GetURL
- Removed PROFILE_FMT and replaced with PROFILE_DYN

https://docs.google.com/document/d/18l8i-hY8oHcgN4HWu0lGNSsQGfsEJbOjif4y-BFCZ0o/edit?usp=sharing