### PR TITLE
DEFEDIT-1605 Box selection in gui scene causes exception in outline view

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -849,8 +849,9 @@
 
 (defn select-indices!
   [^TreeView tree-view indices]
-  (-> (.getSelectionModel tree-view)
-      (.selectIndices (int (first indices)) (int-array (rest indices)))))
+  (let [selection-model (.getSelectionModel tree-view)]
+    (doseq [^long index indices]
+      (.select selection-model index))))
 
 (extend-type TreeView
   CollectionView


### PR DESCRIPTION
Fixes https://github.com/defold/editor2-issues/issues/2511

Apparently the MultipleSelectionModel used in the javafx TreeView
cannot handle certain changes in selection. This workaround selects the rows one by one.