### PR TITLE
DEFEDIT-1615 Reuse build cache between editor sessions

### DIFF
--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -82,6 +82,29 @@
 
 (def select-keys-deep #'internal.util/select-keys-deep)
 
+(defn deep-select [value-pred value]
+  (cond
+    (map? value)
+    (not-empty
+      (into (if (record? value)
+              {}
+              (empty value))
+            (keep (fn [[k v]]
+                    (when-some [v' (deep-select value-pred v)]
+                      [k v'])))
+            value))
+
+    (coll? value)
+    (not-empty
+      (into (sorted-map)
+            (keep-indexed (fn [i v]
+                            (when-some [v' (deep-select value-pred v)]
+                              [i v'])))
+            value))
+
+    (value-pred value)
+    value))
+
 (defn views-of-type [node-type]
   (keep (fn [node-id]
           (when (g/node-instance? node-type node-id)

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -20,7 +20,7 @@
 
 (set! *warn-on-reflection* true)
 
-(namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id produce-value node-by-id-at])
+(namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id node-id? produce-value node-by-id-at])
 
 (namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate flatten-errors package-errors precluding-errors unpack-errors worse-than])
 

--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -71,7 +71,7 @@
      :content (protobuf/map->bytes Rig$AnimationSet animation-set-with-hash-ids)}))
 
 (g/defnk produce-animation-set-build-target [_node-id resource animation-set]
-  (bt/update-build-target-key
+  (bt/with-content-hash
     {:node-id _node-id
      :resource (workspace/make-build-resource resource)
      :build-fn build-animation-set

--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -1,6 +1,7 @@
 (ns editor.animation-set
   (:require [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.defold-project :as project]
             [editor.graph-util :as gu]
             [editor.protobuf :as protobuf]
@@ -70,10 +71,11 @@
      :content (protobuf/map->bytes Rig$AnimationSet animation-set-with-hash-ids)}))
 
 (g/defnk produce-animation-set-build-target [_node-id resource animation-set]
-  {:node-id _node-id
-   :resource (workspace/make-build-resource resource)
-   :build-fn build-animation-set
-   :user-data {:animation-set animation-set}})
+  (bt/update-build-target-key
+    {:node-id _node-id
+     :resource (workspace/make-build-resource resource)
+     :build-fn build-animation-set
+     :user-data {:animation-set animation-set}}))
 
 (def ^:private form-sections
   {

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -586,6 +586,7 @@
       (do
         (workspace/artifact-map! workspace artifact-map)
         (workspace/etags! workspace etags)
+        (workspace/save-build-cache! workspace)
         (build-errors-view/clear-build-errors build-errors-view)
         build-results))))
 
@@ -663,7 +664,7 @@ If you do not specifically require different script states, consider changing th
   (enabled? [] (not @build-in-progress?))
   (run [project workspace prefs web-server build-errors-view console-view debug-view]
     (debug-view/detach! debug-view)
-    (workspace/reset-cache! workspace)
+    (workspace/clear-build-cache! workspace)
     (build-handler project workspace prefs web-server build-errors-view console-view)))
 
 (handler/defhandler :build-html5 :global
@@ -732,6 +733,7 @@ If you do not specifically require different script states, consider changing th
                       (do
                         (workspace/artifact-map! workspace artifact-map)
                         (workspace/etags! workspace etags)
+                        (workspace/save-build-cache! workspace)
                         (build-errors-view/clear-build-errors build-errors-view)
                         (try
                           (when-some [updated-build-resources (not-empty (updated-build-resources evaluation-context project old-etags etags "/game.project"))]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -557,6 +557,7 @@
   (reset! build-in-progress? true)
   (future
     (try
+      (render-build-progress! (progress/make "Building project..." 1))
       (let [extra-build-targets (when debug?
                                   (debug-view/build-targets project evaluation-context))
             build-results (ui/with-progress [_ render-build-progress!]
@@ -575,6 +576,7 @@
               (reset! build-in-progress? false)))))
       (catch Throwable t
         (reset! build-in-progress? false)
+        (render-build-progress! progress/done)
         (error-reporting/report-exception! t)))))
 
 (defn- handle-build-results! [workspace build-errors-view build-results]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -74,6 +74,7 @@
         (html-view/register-view-types workspace)))
     (resource-types/register-resource-types! workspace)
     (workspace/resource-sync! workspace)
+    (workspace/load-build-cache! workspace)
     workspace))
 
 (defn- async-reload!

--- a/editor/src/clj/editor/build_target.clj
+++ b/editor/src/clj/editor/build_target.clj
@@ -166,3 +166,10 @@
           .getMessageDigest
           .digest
           digest/bytes->hex))))
+
+(defn build-target-key? [value]
+  (and (string? value)
+       (= 40 (count value))))
+
+(defn update-build-target-key [build-target]
+  (assoc build-target :key (build-target-key build-target)))

--- a/editor/src/clj/editor/build_target.clj
+++ b/editor/src/clj/editor/build_target.clj
@@ -1,0 +1,168 @@
+(ns editor.build-target
+  (:require [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.math :as math]
+            [editor.resource :as resource]
+            [editor.system :as system]
+            [editor.workspace]
+            [util.digest :as digest])
+  (:import [clojure.lang MapEntry Named]
+           [java.io OutputStreamWriter Writer]))
+
+(set! *warn-on-reflection* true)
+
+(defprotocol Digestable
+  (digest! [value writer]))
+
+(defn- pair [a b]
+  (MapEntry/create a b))
+
+(defn- named? [value]
+  (or (instance? Named value)
+      (string? value)))
+
+(defn- node-id-key? [value]
+  (and (named? value)
+       (string/ends-with? (name value) "node-id")))
+
+(defn- node-id-entry? [key value]
+  (and (g/node-id? value)
+       (node-id-key? key)))
+
+(defn- node-id-data-representation [node-id]
+  (if-some [node-type (g/node-type* node-id)]
+    (pair (symbol (:k (g/node-type* node-id)))
+          (g/node-value node-id :sha256))
+    (throw (ex-info (str "Unknown node id in build target: " node-id)
+                    {:node-id node-id}))))
+
+(defn- fn->symbol [fn]
+  (let [class-name (.getName (class fn))]
+    (if (re-find #"__\d+$" class-name)
+      (throw (ex-info (str "Lambda function in build target: " class-name)
+                      {:fn class-name}))
+      (let [[namespace name more] (string/split class-name #"\$")]
+        (assert (empty? more))
+        (symbol (string/replace namespace \_ \-)
+                (string/replace name \_ \-))))))
+
+(defn- digest-raw! [^String value ^Writer writer]
+  (.write writer value))
+
+(defn- digest-sequence! [^String begin digest-entry! ^String end sequence ^Writer writer]
+  (digest-raw! begin writer)
+  (loop [sequence sequence]
+    (when-some [entry (first sequence)]
+      (digest-entry! entry writer)
+      (when-some [remaining (next sequence)]
+        (digest-raw! ", " writer)
+        (recur remaining))))
+  (digest-raw! end writer))
+
+(defn- digest-tagged! [tag-sym value writer]
+  (digest-raw! "#dg/" writer)
+  (digest-raw! (name tag-sym) writer)
+  (digest-raw! " " writer)
+  (digest! value writer))
+
+(defn- digest-resource! [type-sym resource writer]
+  (digest-tagged! type-sym (resource/resource-hash resource) writer))
+
+(defn- digest-map-entry! [[key value] ^Writer writer]
+  (digest! key writer)
+  (digest-raw! " " writer)
+  (if (node-id-entry? key value)
+    (digest-tagged! 'Node (node-id-data-representation value) writer)
+    (digest! value writer)))
+
+(let [simple-digestable-impl {:digest! print-method}
+      simple-digestable-classes [nil
+                                 Boolean
+                                 CharSequence
+                                 Named
+                                 Number]]
+  (doseq [class simple-digestable-classes]
+    (extend class Digestable simple-digestable-impl)))
+
+(extend (Class/forName "[B") Digestable
+  {:digest! (fn digest-byte-array! [value writer]
+              (digest-sequence! "#dg/Bytes [" digest! "]" value writer))})
+
+(extend-protocol Digestable
+  com.google.protobuf.ByteString
+  (digest! [value writer]
+    (digest-sequence! "#dg/ByteString [" digest! "]" (.toByteArray value) writer))
+
+  editor.workspace.BuildResource
+  (digest! [value writer]
+    (digest-resource! 'BuildResource value writer))
+
+  editor.resource.FileResource
+  (digest! [value writer]
+    (digest-resource! 'FileResource value writer))
+
+  editor.resource.MemoryResource
+  (digest! [value writer]
+    (digest-resource! 'MemoryResource value writer))
+
+  editor.resource.ZipResource
+  (digest! [value writer]
+    (digest-resource! 'ZipResource value writer))
+
+  java.io.File
+  (digest! [value writer]
+    (digest-tagged! 'File (str value) writer))
+
+  java.net.URI
+  (digest! [value writer]
+    (digest-tagged! 'URI (str value) writer))
+
+  javax.vecmath.Matrix4d
+  (digest! [value writer]
+    (digest-tagged! 'Matrix4d (math/vecmath->clj value) writer))
+
+  clojure.lang.AFunction
+  (digest! [value writer]
+    (digest-tagged! 'Function (fn->symbol value) writer))
+
+  clojure.lang.IPersistentSet
+  (digest! [value writer]
+    (let [sorted-sequence (if (sorted? value) value (sort value))]
+      (digest-sequence! "#{" digest! "}" sorted-sequence writer)))
+
+  java.util.Map
+  (digest! [value writer]
+    (let [sorted-sequence (if (sorted? value) value (sort-by key value))]
+      (digest-sequence! "{" digest-map-entry! "}" sorted-sequence writer)))
+
+  java.util.List
+  (digest! [value writer]
+    (digest-sequence! "[" digest! "]" value writer))
+
+  Class
+  (digest! [value writer]
+    (digest-tagged! 'Class (symbol (.getName value)) writer)))
+
+(defn build-target-key-components [build-target]
+  [(system/defold-engine-sha1)
+   (:resource (:resource build-target))
+   (:build-fn build-target)
+   (:user-data build-target)])
+
+(defn build-target-key
+  ^String [build-target]
+  (with-open [digest-output-stream (digest/make-digest-output-stream "SHA-1")
+              writer (OutputStreamWriter. digest-output-stream)]
+    (let [key-components (build-target-key-components build-target)]
+      (try
+        (digest! key-components writer)
+        (catch Throwable error
+          (throw (ex-info (str "Failed to digest build target key for resource: " (resource/proj-path (:resource build-target)))
+                          {:build-target build-target
+                           :key-components key-components}
+                          error))))
+      (.flush writer)
+      (-> digest-output-stream
+          .getMessageDigest
+          .digest
+          digest/bytes->hex))))

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -67,7 +67,7 @@
 
 (g/defnk produce-build-targets
   [_node-id resource pb-msg]
-  [(bt/update-build-target-key
+  [(bt/with-content-hash
      {:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-camera

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as s]
             [plumbing.core :as pc]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.defold-project :as project]
             [editor.graph-util :as gu]
             [editor.outline :as outline]
@@ -66,10 +67,11 @@
 
 (g/defnk produce-build-targets
   [_node-id resource pb-msg]
-  [{:node-id _node-id
-    :resource (workspace/make-build-resource resource)
-    :build-fn build-camera
-    :user-data {:pb-msg pb-msg}}])
+  [(bt/update-build-target-key
+     {:node-id _node-id
+      :resource (workspace/make-build-resource resource)
+      :build-fn build-camera
+      :user-data {:pb-msg pb-msg}})])
 
 (defn load-camera [project self resource camera]
   (g/set-property self

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -1,5 +1,6 @@
 (ns editor.code.script
   (:require [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.code.data :as data]
             [editor.code.resource :as r]
             [editor.code-completion :as code-completion]
@@ -174,12 +175,13 @@
                            properties))))))
 
 (g/defnk produce-build-targets [_node-id resource lines user-properties modules dep-build-targets]
-  [{:node-id _node-id
-    :resource (workspace/make-build-resource resource)
-    :build-fn build-script
-    ;; Remove node-id etc from user-properties to avoid creating one build-target per use (override) of the script
-    :user-data {:lines lines :user-properties (clean-user-properties user-properties) :modules modules :proj-path (resource/proj-path resource)}
-    :deps dep-build-targets}])
+  [(bt/update-build-target-key
+     {:node-id _node-id
+      :resource (workspace/make-build-resource resource)
+      :build-fn build-script
+      ;; Remove node-id etc from user-properties to avoid creating one build-target per use (override) of the script
+      :user-data {:lines lines :user-properties (clean-user-properties user-properties) :modules modules :proj-path (resource/proj-path resource)}
+      :deps dep-build-targets})])
 
 (g/defnk produce-completions [completion-info module-completion-infos]
   (code-completion/combine-completions completion-info module-completion-infos))

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -175,7 +175,7 @@
                            properties))))))
 
 (g/defnk produce-build-targets [_node-id resource lines user-properties modules dep-build-targets]
-  [(bt/update-build-target-key
+  [(bt/with-content-hash
      {:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-script

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -1,6 +1,7 @@
 (ns editor.code.shader
   (:require [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.code.resource :as r]
             [editor.gl.shader :as shader]
             [editor.protobuf :as protobuf]
@@ -82,10 +83,11 @@
      :content content}))
 
 (g/defnk produce-build-targets [_node-id resource lines]
-  [{:node-id _node-id
-    :resource (workspace/make-build-resource resource)
-    :build-fn build-shader
-    :user-data {:lines lines :resource-ext (resource/type-ext resource)}}])
+  [(bt/update-build-target-key
+     {:node-id _node-id
+      :resource (workspace/make-build-resource resource)
+      :build-fn build-shader
+      :user-data {:lines lines :resource-ext (resource/type-ext resource)}})])
 
 (g/defnk produce-full-source [resource lines]
   (make-full-source (resource/type-ext resource) lines))

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -83,7 +83,7 @@
      :content content}))
 
 (g/defnk produce-build-targets [_node-id resource lines]
-  [(bt/update-build-target-key
+  [(bt/with-content-hash
      {:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-shader

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -183,7 +183,7 @@
   (output build-targets g/Any (g/fnk [build-resource source-build-targets build-error ddf-message transform]
                                      (let [target (assoc (first source-build-targets)
                                                          :resource build-resource)]
-                                       [(bt/update-build-target-key
+                                       [(bt/with-content-hash
                                           (assoc target
                                             :instance-data
                                             {:resource (:resource target)
@@ -375,7 +375,7 @@
             dep-build-targets (flatten dep-build-targets)
             instance-data (map :instance-data dep-build-targets)
             instance-data (reduce concat instance-data (map #(get-in % [:user-data :instance-data]) sub-build-targets))]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-collection
@@ -478,7 +478,7 @@
             child-ids (reduce (fn [child-ids data] (into child-ids (:children (:instance-msg data)))) #{} instance-data)]
         (update build-targets 0
                 (fn [build-target]
-                  (bt/update-build-target-key
+                  (bt/with-content-hash
                     (assoc-in build-target [:user-data :instance-data]
                               (map #(flatten-instance-data % base-id transform child-ids ddf-properties)
                                    instance-data))))))))

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -58,7 +58,7 @@
       (let [dep-build-targets (flatten dep-build-targets)
             deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
             dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:collection collection]])]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-collection-proxy

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -3,6 +3,7 @@
    [clojure.string :as s]
    [plumbing.core :as pc]
    [dynamo.graph :as g]
+   [editor.build-target :as bt]
    [editor.defold-project :as project]
    [editor.graph-util :as gu]
    [editor.outline :as outline]
@@ -57,12 +58,13 @@
       (let [dep-build-targets (flatten dep-build-targets)
             deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
             dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:collection collection]])]
-        [{:node-id _node-id
-          :resource (workspace/make-build-resource resource)
-          :build-fn build-collection-proxy
-          :user-data {:pb-msg pb-msg
-                      :dep-resources dep-resources}
-          :deps dep-build-targets}])))
+        [(bt/update-build-target-key
+           {:node-id _node-id
+            :resource (workspace/make-build-resource resource)
+            :build-fn build-collection-proxy
+            :user-data {:pb-msg pb-msg
+                        :dep-resources dep-resources}
+            :deps dep-build-targets})])))
 
 (defn load-collection-proxy [project self resource collection-proxy]
   (concat

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -3,6 +3,7 @@
    [clojure.string :as s]
    [dynamo.graph :as g]
    [editor.app-view :as app-view]
+   [editor.build-target :as bt]
    [editor.collision-groups :as collision-groups]
    [editor.defold-project :as project]
    [editor.geom :as geom]
@@ -653,12 +654,13 @@
                          (map #(format "%s shapes are not supported in %s physics" (shape-type-label %) supported-physics-type))
                          (map #(g/->error _node-id :shapes :fatal shapes %)))
                    shapes))]
-      [{:node-id _node-id
-        :resource (workspace/make-build-resource resource)
-        :build-fn build-collision-object
-        :user-data {:pb-msg pb-msg
-                    :dep-resources dep-resources}
-        :deps dep-build-targets}])))
+      [(bt/update-build-target-key
+         {:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-collision-object
+          :user-data {:pb-msg pb-msg
+                      :dep-resources dep-resources}
+          :deps dep-build-targets})])))
 
 (g/defnk produce-collision-group-color
   [collision-groups-data group]

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -654,7 +654,7 @@
                          (map #(format "%s shapes are not supported in %s physics" (shape-type-label %) supported-physics-type))
                          (map #(g/->error _node-id :shapes :fatal shapes %)))
                    shapes))]
-      [(bt/update-build-target-key
+      [(bt/with-content-hash
          {:node-id _node-id
           :resource (workspace/make-build-resource resource)
           :build-fn build-collision-object

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -1,5 +1,6 @@
 (ns editor.cubemap
   (:require [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.defold-project :as project]
             [editor.pipeline.tex-gen :as tex-gen]
             [editor.geom :as geom]
@@ -166,12 +167,13 @@
   (g/precluding-errors
     [(cubemap-images-missing-error _node-id cubemap-image-resources)
      (cubemap-image-sizes-error _node-id cubemap-image-sizes)]
-    [{:node-id _node-id
-      :resource (workspace/make-build-resource resource)
-      :build-fn build-cubemap
-      :user-data {:image-generators cubemap-image-generators
-                  :texture-profile texture-profile
-                  :compress? (:compress? build-settings false)}}]))
+    [(bt/update-build-target-key
+       {:node-id _node-id
+        :resource (workspace/make-build-resource resource)
+        :build-fn build-cubemap
+        :user-data {:image-generators cubemap-image-generators
+                    :texture-profile texture-profile
+                    :compress? (:compress? build-settings false)}})]))
 
 (defmacro cubemap-side-error [property]
   (let [prop-kw (keyword property)

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -167,7 +167,7 @@
   (g/precluding-errors
     [(cubemap-images-missing-error _node-id cubemap-image-resources)
      (cubemap-image-sizes-error _node-id cubemap-image-sizes)]
-    [(bt/update-build-target-key
+    [(bt/with-content-hash
        {:node-id _node-id
         :resource (workspace/make-build-resource resource)
         :build-fn build-cubemap

--- a/editor/src/clj/editor/display_profiles.clj
+++ b/editor/src/clj/editor/display_profiles.clj
@@ -1,6 +1,7 @@
 (ns editor.display-profiles
   (:require [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.geom :as geom]
             [editor.gl :as gl]
             [editor.gl.shader :as shader]
@@ -96,12 +97,13 @@
     {:resource resource :content (protobuf/map->bytes (:pb-class pb-def) pb)}))
 
 (g/defnk produce-build-targets [_node-id resource pb-msg]
-  [{:node-id _node-id
-    :resource (workspace/make-build-resource resource)
-    :build-fn build-pb
-    :user-data {:pb pb-msg
-                :pb-class (:pb-class pb-def)}
-    :deps []}])
+  [(bt/update-build-target-key
+     {:node-id _node-id
+      :resource (workspace/make-build-resource resource)
+      :build-fn build-pb
+      :user-data {:pb pb-msg
+                  :pb-class (:pb-class pb-def)}
+      :deps []})])
 
 (g/defnode DisplayProfilesNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/display_profiles.clj
+++ b/editor/src/clj/editor/display_profiles.clj
@@ -97,7 +97,7 @@
     {:resource resource :content (protobuf/map->bytes (:pb-class pb-def) pb)}))
 
 (g/defnk produce-build-targets [_node-id resource pb-msg]
-  [(bt/update-build-target-key
+  [(bt/with-content-hash
      {:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-pb

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -3,6 +3,7 @@
             [plumbing.core :as pc]
             [dynamo.graph :as g]
             [editor.colors :as colors]
+            [editor.build-target :as bt]
             [editor.defold-project :as project]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
@@ -73,13 +74,14 @@
             dep-resources (map (fn [[label resource]]
                                  [label (get deps-by-resource resource)])
                                [[:prototype prototype]])]
-        [{:node-id _node-id
-          :resource (workspace/make-build-resource resource)
-          :build-fn build-factory
-          :user-data {:pb-msg pb-msg
-                      :pb-type (get-in factory-types [factory-type :pb-type])
-                      :dep-resources dep-resources}
-          :deps dep-build-targets}])))
+        [(bt/update-build-target-key
+           {:node-id _node-id
+            :resource (workspace/make-build-resource resource)
+            :build-fn build-factory
+            :user-data {:pb-msg pb-msg
+                        :pb-type (get-in factory-types [factory-type :pb-type])
+                        :dep-resources dep-resources}
+            :deps dep-build-targets})])))
 
 (defn load-factory
   [factory-type project self resource factory]

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -74,7 +74,7 @@
             dep-resources (map (fn [[label resource]]
                                  [label (get deps-by-resource resource)])
                                [[:prototype prototype]])]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-factory

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -3,6 +3,7 @@
             [clojure.java.io :as io]
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.graph-util :as gu]
             [editor.geom :as geom]
             [editor.gl :as gl]
@@ -481,15 +482,16 @@
                              (remove nil?)
                              (not-empty))]
         (g/error-aggregate errors))
-      [{:node-id _node-id
-        :resource (workspace/make-build-resource resource)
-        :build-fn build-font
-        :user-data {:font font
-                    :type type
-                    :pb-msg pb-msg
-                    :font-resource-map font-resource-map
-                    :font-resource-hashes font-resource-hashes}
-        :deps (flatten dep-build-targets)}]))
+      [(bt/update-build-target-key
+         {:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-font
+          :user-data {:font font
+                      :type type
+                      :pb-msg pb-msg
+                      :font-resource-map font-resource-map
+                      :font-resource-hashes font-resource-hashes}
+          :deps (flatten dep-build-targets)})]))
 
 (g/defnode FontSourceNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -482,7 +482,7 @@
                              (remove nil?)
                              (not-empty))]
         (g/error-aggregate errors))
-      [(bt/update-build-target-key
+      [(bt/with-content-hash
          {:node-id _node-id
           :resource (workspace/make-build-resource resource)
           :build-fn build-font

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -51,6 +51,11 @@
    :rotation rotation
    :data (or (:content save-data) "")})
 
+(defn- build-raw-sound [resource dep-resources user-data]
+  (let [pb (:pb user-data)
+        pb (assoc pb :sound (resource/proj-path (second (first dep-resources))))]
+    {:resource resource :content (protobuf/map->bytes Sound$SoundDesc pb)}))
+
 (defn- wrap-if-raw-sound [_node-id target]
   (let [resource (:resource (:resource target))
         source-path (resource/proj-path resource)
@@ -61,10 +66,7 @@
             pb        {:sound source-path}
             target    {:node-id  _node-id
                        :resource (workspace/make-build-resource (resource/make-memory-resource workspace res-type (protobuf/map->str Sound$SoundDesc pb)))
-                       :build-fn (fn [resource dep-resources user-data]
-                                   (let [pb (:pb user-data)
-                                         pb (assoc pb :sound (resource/proj-path (second (first dep-resources))))]
-                                     {:resource resource :content (protobuf/map->bytes Sound$SoundDesc pb)}))
+                       :build-fn build-raw-sound
                        :deps     [target]}]
         target)
       target)))

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -65,7 +65,7 @@
       (let [workspace (project/workspace (project/get-project _node-id))
             res-type  (workspace/get-resource-type workspace "sound")
             pb        {:sound source-path}
-            target    (bt/update-build-target-key
+            target    (bt/with-content-hash
                         {:node-id _node-id
                          :resource (workspace/make-build-resource (resource/make-memory-resource workspace res-type (protobuf/map->str Sound$SoundDesc pb)))
                          :build-fn build-raw-sound
@@ -209,7 +209,7 @@
                                              (if-let [target (first source-build-targets)]
                                                (let [target (->> (assoc target :resource build-resource)
                                                                  (wrap-if-raw-sound _node-id))]
-                                                 [(bt/update-build-target-key
+                                                 [(bt/with-content-hash
                                                     (assoc target
                                                       :instance-data
                                                       {:resource (:resource target)
@@ -357,7 +357,7 @@
   (or (let [dup-ids (keep (fn [[id count]] (when (> count 1) id)) id-counts)]
         (when (not-empty dup-ids)
           (g/->error _node-id :build-targets :fatal nil (format "the following ids are not unique: %s" (str/join ", " dup-ids)))))
-      [(bt/update-build-target-key
+      [(bt/with-content-hash
          {:node-id _node-id
           :resource (workspace/make-build-resource resource)
           :build-fn build-game-object

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -88,7 +88,7 @@
   (io/make-writer        [this opts] (io/writer resource)))
 
 (defn- make-custom-build-target [node-id resource]
-  (bt/update-build-target-key
+  (bt/with-content-hash
     {:node-id node-id
      :resource (workspace/make-build-resource (CustomResource. resource))
      :build-fn build-custom-resource
@@ -137,7 +137,7 @@
                                                        (when (resource-setting-connections-template (:path resource-setting))
                                                          [(:path resource-setting) (deps-by-source (:value resource-setting))]))
                                                      resource-settings))]
-    [(bt/update-build-target-key
+    [(bt/with-content-hash
        {:node-id _node-id
         :resource (workspace/make-build-resource resource)
         :build-fn build-game-project

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -123,7 +123,8 @@
    ["input" "game_binding"] [[:build-targets :dep-build-targets]]})
 
 (g/defnk produce-build-targets [_node-id resource settings-map meta-info custom-build-targets resource-settings dep-build-targets]
-  (let [dep-build-targets (vec (into (flatten dep-build-targets) custom-build-targets))
+  (let [clean-meta-info (settings-core/remove-to-from-string meta-info)
+        dep-build-targets (vec (into (flatten dep-build-targets) custom-build-targets))
         deps-by-source (into {} (map
                                   (fn [build-target]
                                     (let [build-resource (:resource build-target)
@@ -138,7 +139,7 @@
       :resource (workspace/make-build-resource resource)
       :build-fn build-game-project
       :user-data {:settings-map settings-map
-                  :meta-settings (:settings meta-info)
+                  :meta-settings (:settings clean-meta-info)
                   :path->built-resource-settings path->built-resource-settings}
       :deps dep-build-targets}]))
 

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -5,6 +5,7 @@
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.build-target :as bt]
             [editor.graph-util :as gu]
             [editor.core :as core]
             [editor.geom :as geom]
@@ -39,7 +40,6 @@
            [com.jogamp.opengl GL GL2]
            [editor.gl.shader ShaderLifecycle]
            [editor.gl.texture TextureLifecycle]
-           [editor.types AABB]
            [java.awt.image BufferedImage]
            [javax.vecmath Quat4d Vector3d]))
 
@@ -2157,14 +2157,15 @@
           deps-by-source (into {} (map #(let [res (:resource %)] [(resource/resource->proj-path (:resource res)) res]) dep-build-targets))
           resource-fields (mapcat (fn [field] (if (vector? field) (mapv (fn [i] (into [(first field) i] (rest field))) (range (count (get rt-pb-msg (first field))))) [field])) (:resource-fields def))
           dep-resources (map (fn [label] [label (get deps-by-source (if (vector? label) (get-in rt-pb-msg label) (get rt-pb-msg label)))]) resource-fields)]
-      [{:node-id   _node-id
-        :resource  (workspace/make-build-resource resource)
-        :build-fn  build-pb
-        :user-data {:pb            rt-pb-msg
-                    :pb-class      (:pb-class def)
-                    :def           def
-                    :dep-resources dep-resources}
-        :deps      dep-build-targets}])))
+      [(bt/update-build-target-key
+         {:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-pb
+          :user-data {:pb rt-pb-msg
+                      :pb-class (:pb-class def)
+                      :def def
+                      :dep-resources dep-resources}
+          :deps dep-build-targets})])))
 
 (defn- validate-max-nodes [_node-id max-nodes node-ids]
     (or (validation/prop-error :fatal _node-id :max-nodes (partial validation/prop-outside-range? [1 1024]) max-nodes "Max Nodes")

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2157,7 +2157,7 @@
           deps-by-source (into {} (map #(let [res (:resource %)] [(resource/resource->proj-path (:resource res)) res]) dep-build-targets))
           resource-fields (mapcat (fn [field] (if (vector? field) (mapv (fn [i] (into [(first field) i] (rest field))) (range (count (get rt-pb-msg (first field))))) [field])) (:resource-fields def))
           dep-resources (map (fn [label] [label (get deps-by-source (if (vector? label) (get-in rt-pb-msg label) (get rt-pb-msg label)))]) resource-fields)]
-      [(bt/update-build-target-key
+      [(bt/with-content-hash
          {:node-id _node-id
           :resource (workspace/make-build-resource resource)
           :build-fn build-pb

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -31,7 +31,7 @@
   (assert (contains? image-generator :sha1))
   (let [texture-type (workspace/get-resource-type workspace "texture")
         texture-resource (resource/make-memory-resource workspace texture-type (:sha1 image-generator))]
-    (bt/update-build-target-key
+    (bt/with-content-hash
       {:node-id node-id
        :resource (workspace/make-build-resource texture-resource)
        :build-fn build-texture
@@ -40,7 +40,7 @@
                    :texture-profile texture-profile}})))
 
 (g/defnk produce-build-targets [_node-id resource content-generator texture-profile build-settings]
-  [(bt/update-build-target-key
+  [(bt/with-content-hash
      {:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-texture

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -235,7 +235,7 @@
       (let [dep-build-targets (flatten dep-build-targets)
             deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
             dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:font font] [:material material]])]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-label

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -1,5 +1,6 @@
 (ns editor.label
   (:require [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.colors :as colors]
             [editor.defold-project :as project]
             [editor.font :as font]
@@ -234,12 +235,13 @@
       (let [dep-build-targets (flatten dep-build-targets)
             deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
             dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:font font] [:material material]])]
-        [{:node-id _node-id
-          :resource (workspace/make-build-resource resource)
-          :build-fn build-label
-          :user-data {:proto-msg pb-msg
-                      :dep-resources dep-resources}
-          :deps dep-build-targets}])))
+        [(bt/update-build-target-key
+           {:node-id _node-id
+            :resource (workspace/make-build-resource resource)
+            :build-fn build-label
+            :user-data {:proto-msg pb-msg
+                        :dep-resources dep-resources}
+            :deps dep-build-targets})])))
 
 (g/defnode LabelNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -51,7 +51,7 @@
             dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)])
                                [[:vertex-program vertex-program]
                                 [:fragment-program fragment-program]])]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-material

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -2,6 +2,7 @@
   (:require [editor.protobuf :as protobuf]
             [editor.protobuf-forms :as protobuf-forms]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.graph-util :as gu]
             [editor.geom :as geom]
             [editor.gl :as gl]
@@ -50,12 +51,13 @@
             dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)])
                                [[:vertex-program vertex-program]
                                 [:fragment-program fragment-program]])]
-        [{:node-id _node-id
-          :resource (workspace/make-build-resource resource)
-          :build-fn build-material
-          :user-data {:pb-msg pb-msg
-                      :dep-resources dep-resources}
-          :deps dep-build-targets}])))
+        [(bt/update-build-target-key
+           {:node-id _node-id
+            :resource (workspace/make-build-resource resource)
+            :build-fn build-material
+            :user-data {:pb-msg pb-msg
+                        :dep-resources dep-resources}
+            :deps dep-build-targets})])))
 
 (def ^:private form-data
   (let [constant-values (protobuf/enum-values Material$MaterialDesc$ConstantType)]

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -83,7 +83,7 @@
             deps-by-source (into {} (map #(let [res (:resource %)] [(resource/proj-path (:resource res)) res]) dep-build-targets))
             dep-resources (into (res-fields->resources pb-msg deps-by-source [:rig-scene :material])
                             (filter second (res-fields->resources pb-msg deps-by-source [[:textures]])))]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-pb

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -670,7 +670,7 @@
                                     [field]))
                                 resource-fields)
         dep-resources (map (fn [label] [label (get deps-by-source (if (vector? label) (get-in rt-pb-data label) (get rt-pb-data label)))]) resource-fields)]
-    [(bt/update-build-target-key
+    [(bt/with-content-hash
        {:node-id _node-id
         :resource (workspace/make-build-resource resource)
         :build-fn build-pb

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
+            [editor.build-target :as bt]
             [editor.camera :as camera]
             [editor.colors :as colors]
             [editor.core :as core]
@@ -669,12 +670,13 @@
                                     [field]))
                                 resource-fields)
         dep-resources (map (fn [label] [label (get deps-by-source (if (vector? label) (get-in rt-pb-data label) (get rt-pb-data label)))]) resource-fields)]
-    [{:node-id _node-id
-      :resource (workspace/make-build-resource resource)
-      :build-fn build-pb
-      :user-data {:pb rt-pb-data
-                  :dep-resources dep-resources}
-      :deps dep-build-targets}]))
+    [(bt/update-build-target-key
+       {:node-id _node-id
+        :resource (workspace/make-build-resource resource)
+        :build-fn build-pb
+        :user-data {:pb rt-pb-data
+                    :dep-resources dep-resources}
+        :deps dep-build-targets})]))
 
 (defn- render-pfx [^GL2 gl render-args renderables count])
 

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -1,16 +1,14 @@
 (ns editor.pipeline
-  (:require
-   [clojure.java.io :as io]
-   [editor.fs :as fs]
-   [editor.resource :as resource]
-   [editor.progress :as progress]
-   [editor.protobuf :as protobuf]
-   [editor.workspace :as workspace]
-   [dynamo.graph :as g]
-   [util.digest :as digest])
-  (:import
-   (java.io File)
-   (java.util UUID)))
+  (:require [clojure.java.io :as io]
+            [dynamo.graph :as g]
+            [editor.build-target :as bt]
+            [editor.fs :as fs]
+            [editor.progress :as progress]
+            [editor.protobuf :as protobuf]
+            [editor.resource :as resource]
+            [editor.workspace :as workspace]
+            [util.digest :as digest])
+  (:import [java.io File]))
 
 (set! *warn-on-reflection* true)
 
@@ -70,54 +68,58 @@
 
 ;;--------------------------------------------------------------------
 
-(defn- target-key
-  [target]
-  [(:resource (:resource target))
-   (:build-fn target)
-   (:user-data target)])
-
-(defn- build-targets-by-key
-  [build-targets]
-  (into {} (map #(let [key (target-key %)] [key (assoc % :key key)])) build-targets))
-
 (defn flatten-build-targets
   "Breadth first traversal / collection of build-targets and their child :deps,
-  skipping seen targets identified by target-key."
-  [build-targets]
-  (loop [targets build-targets
-         queue []
-         seen #{}
-         result (transient [])]
-    (if-let [t (first targets)]
-      (let [key (target-key t)]
-        (if (contains? seen key)
-          (recur (rest targets) queue seen result)
-          (recur (rest targets) (conj queue (flatten (:deps t))) (conj seen key) (conj! result t))))
-      (if-let [targets (first queue)]
-        (recur targets (rest queue) seen result)
-        (persistent! result)))))
+  skipping seen targets identified by build-target-key. The returned targets
+  contain the build-target-key."
+  ([build-targets]
+   (flatten-build-targets build-targets #{}))
+  ([build-targets seen-keys]
+   (assert (set? seen-keys))
+   (loop [targets build-targets
+          queue []
+          seen-keys seen-keys
+          result (transient [])]
+     (if-some [target (first targets)]
+       (let [key (bt/build-target-key target)]
+         (if (contains? seen-keys key)
+           (recur (rest targets)
+                  queue
+                  seen-keys
+                  result)
+           (recur (rest targets)
+                  (conj queue (flatten (:deps target)))
+                  (conj seen-keys key)
+                  (conj! result (assoc target :key key)))))
+       (if-some [targets (first queue)]
+         (recur targets
+                (rest queue)
+                seen-keys
+                result)
+         (persistent! result))))))
 
 (defn- make-build-targets-by-key
   [build-targets]
-  (->> build-targets
-       flatten-build-targets
-       build-targets-by-key))
+  (into {}
+        (map (juxt :key identity))
+        (flatten-build-targets build-targets)))
 
 (defn- make-dep-resources
   [deps build-targets-by-key]
   (into {}
         (map (fn [{:keys [resource] :as build-target}]
-               (let [key (target-key build-target)]
+               (let [key (bt/build-target-key build-target)]
                  [resource (:resource (get build-targets-by-key key))])))
         (flatten deps)))
 
-(defn prune-artifacts [artifacts build-targets-by-key]
+(defn prune-artifact-map [artifact-map build-targets-by-key]
   (into {}
-        (filter (fn [[resource result]] (contains? build-targets-by-key (:key result))))
-        artifacts))
+        (filter (fn [[_resource-path result]]
+                  (contains? build-targets-by-key (:key result))))
+        artifact-map))
 
-(defn- valid? [artifact]
-  (when-let [^File f (io/as-file (:resource artifact))]
+(defn- valid? [resource artifact]
+  (when-some [^File f (io/as-file resource)]
     (let [{:keys [mtime size]} artifact]
       (and (.exists f) (= mtime (.lastModified f)) (= size (.length f))))))
 
@@ -126,17 +128,17 @@
   (fs/create-parent-directories! (io/as-file (:resource artifact)))
   (let [^bytes content (:content artifact)]
     (with-open [out (io/output-stream (:resource artifact))]
-       (.write out content))
+      (.write out content))
     (let [^File target-f (io/as-file (:resource artifact))
           mtime (.lastModified target-f)
           size (.length target-f)]
       (-> artifact
-        (dissoc :content)
-        (assoc
-          :key key
-          :mtime mtime
-          :size size
-          :etag (digest/sha1-hex content))))))
+          (dissoc :content)
+          (assoc
+            :key key
+            :mtime mtime
+            :size size
+            :etag (digest/sha1-hex content))))))
 
 (defn- prune-build-dir! [build-dir build-targets-by-key]
   (let [targets (into #{} (map (fn [[_ target]] (io/as-file (:resource target)))) build-targets-by-key)]
@@ -160,7 +162,7 @@
 (defn build!
   [build-targets build-dir old-artifact-map render-progress!]
   (let [build-targets-by-key (make-build-targets-by-key build-targets)
-        pruned-old-artifacts (prune-artifacts old-artifact-map build-targets-by-key)
+        pruned-old-artifact-map (prune-artifact-map old-artifact-map build-targets-by-key)
         progress (atom (progress/make "" (count build-targets-by-key)))]
     (prune-build-dir! build-dir build-targets-by-key)
     (let [{cheap-build-targets false expensive-build-targets true} (group-by expensive? (vals build-targets-by-key))
@@ -169,8 +171,10 @@
           results (batched-pmap
                     (fn [build-target]
                       (let [{:keys [key node-id resource deps build-fn user-data]} build-target
-                            cached-artifact (when-let [artifact (get pruned-old-artifacts resource)]
-                                              (and (valid? artifact) artifact))
+                            resource-path (resource/proj-path resource)
+                            cached-artifact (when-some [artifact (get pruned-old-artifact-map resource-path)]
+                                              (when (valid? resource artifact)
+                                                (assoc artifact :resource resource)))
                             message (str "Building " (resource/proj-path resource))]
                         (render-progress! (swap! progress progress/with-message message))
                         (let [result (or cached-artifact
@@ -187,8 +191,12 @@
                           result)))
                     build-target-batches)
           {successful-results false error-results true} (group-by #(boolean (g/error? %)) results)
-          new-artifact-map (into {} (map (fn [a] [(:resource a) a])) successful-results)
-          etags (into {} (map (fn [a] [(resource/proj-path (:resource a)) (:etag a)])) successful-results)]
+          new-artifact-map (into {}
+                                 (map (fn [artifact]
+                                        [(resource/proj-path (:resource artifact))
+                                         (dissoc artifact :resource)]))
+                                 successful-results)
+          etags (workspace/artifact-map->etags new-artifact-map)]
       (cond-> {:artifacts successful-results
                :artifact-map new-artifact-map
                :etags etags}

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -45,7 +45,7 @@
   {:resource resource :content (protobuf/map->bytes (:pb-class user-data) (:pb user-data))})
 
 (g/defnk produce-build-targets [_node-id resource pb def]
-  [(bt/update-build-target-key
+  [(bt/with-content-hash
      {:node-id _node-id
       :resource (workspace/make-build-resource resource)
       :build-fn build-pb

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -44,11 +44,11 @@
   {:resource resource :content (protobuf/map->bytes (:pb-class user-data) (:pb user-data))})
 
 (g/defnk produce-build-targets [_node-id resource pb def]
-  {:node-id _node-id
-   :resource (workspace/make-build-resource resource)
-   :build-fn build-pb
-   :user-data {:pb pb
-               :pb-class (:pb-class def)}})
+  [{:node-id _node-id
+    :resource (workspace/make-build-resource resource)
+    :build-fn build-pb
+    :user-data {:pb pb
+                :pb-class (:pb-class def)}}])
 
 (g/defnk produce-form-data [_node-id pb def]
   (protobuf-forms/produce-form-data _node-id pb def))

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -1,5 +1,6 @@
 (ns editor.protobuf-types
   (:require [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.graph-util :as gu]
             [editor.protobuf :as protobuf]
             [editor.protobuf-forms :as protobuf-forms]
@@ -44,11 +45,12 @@
   {:resource resource :content (protobuf/map->bytes (:pb-class user-data) (:pb user-data))})
 
 (g/defnk produce-build-targets [_node-id resource pb def]
-  [{:node-id _node-id
-    :resource (workspace/make-build-resource resource)
-    :build-fn build-pb
-    :user-data {:pb pb
-                :pb-class (:pb-class def)}}])
+  [(bt/update-build-target-key
+     {:node-id _node-id
+      :resource (workspace/make-build-resource resource)
+      :build-fn build-pb
+      :user-data {:pb pb
+                  :pb-class (:pb-class def)}})])
 
 (g/defnk produce-form-data [_node-id pb def]
   (protobuf-forms/produce-form-data _node-id pb def))

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -1,6 +1,7 @@
 (ns editor.render-pb
   (:require
    [dynamo.graph :as g]
+   [editor.build-target :as bt]
    [editor.core :as core]
    [editor.graph-util :as gu]
    [editor.resource :as resource]
@@ -128,12 +129,13 @@
                                                  [[:materials i :material]
                                                   (when material (deps-by-source material))])
                                                named-materials))]
-        [{:node-id _node-id
-          :resource (workspace/make-build-resource resource)
-          :build-fn build-render
-          :user-data {:pb-msg pb-msg
-                      :built-resources built-resources}
-          :deps dep-build-targets}])))
+        [(bt/update-build-target-key
+           {:node-id _node-id
+            :resource (workspace/make-build-resource resource)
+            :build-fn build-render
+            :user-data {:pb-msg pb-msg
+                        :built-resources built-resources}
+            :deps dep-build-targets})])))
 
 (g/defnode RenderNode
   (inherits core/Scope)

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -129,7 +129,7 @@
                                                  [[:materials i :material]
                                                   (when material (deps-by-source material))])
                                                named-materials))]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-render

--- a/editor/src/clj/editor/rig.clj
+++ b/editor/src/clj/editor/rig.clj
@@ -21,7 +21,7 @@
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
         skeleton-resource (resource/make-memory-resource workspace skeleton-type (protobuf/map->sha1-hex Rig$Skeleton skeleton))]
-    (bt/update-build-target-key
+    (bt/with-content-hash
       {:node-id node-id
        :resource (workspace/make-build-resource skeleton-resource)
        :build-fn build-skeleton
@@ -39,7 +39,7 @@
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
         animation-set-resource (resource/make-memory-resource workspace animation-set-type (protobuf/map->sha1-hex Rig$AnimationSet animation-set))]
-    (bt/update-build-target-key
+    (bt/with-content-hash
       {:node-id node-id
        :resource (workspace/make-build-resource animation-set-resource)
        :build-fn build-animation-set
@@ -57,7 +57,7 @@
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
         mesh-set-resource (resource/make-memory-resource workspace mesh-set-type (protobuf/map->sha1-hex Rig$MeshSet mesh-set))]
-    (bt/update-build-target-key
+    (bt/with-content-hash
       {:node-id node-id
        :resource (workspace/make-build-resource mesh-set-resource)
        :build-fn build-mesh-set

--- a/editor/src/clj/editor/rig.clj
+++ b/editor/src/clj/editor/rig.clj
@@ -1,5 +1,6 @@
 (ns editor.rig
   (:require
+   [editor.build-target :as bt]
    [editor.defold-project :as project]
    [editor.pipeline :as pipeline]
    [editor.protobuf :as protobuf]
@@ -20,10 +21,11 @@
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
         skeleton-resource (resource/make-memory-resource workspace skeleton-type (protobuf/map->sha1-hex Rig$Skeleton skeleton))]
-    {:node-id   node-id
-     :resource  (workspace/make-build-resource skeleton-resource)
-     :build-fn  build-skeleton
-     :user-data {:skeleton skeleton}}))
+    (bt/update-build-target-key
+      {:node-id node-id
+       :resource (workspace/make-build-resource skeleton-resource)
+       :build-fn build-skeleton
+       :user-data {:skeleton skeleton}})))
 
 
 (defn- build-animation-set
@@ -37,10 +39,11 @@
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
         animation-set-resource (resource/make-memory-resource workspace animation-set-type (protobuf/map->sha1-hex Rig$AnimationSet animation-set))]
-    {:node-id   node-id
-     :resource  (workspace/make-build-resource animation-set-resource)
-     :build-fn  build-animation-set
-     :user-data {:animation-set animation-set}}))
+    (bt/update-build-target-key
+      {:node-id node-id
+       :resource (workspace/make-build-resource animation-set-resource)
+       :build-fn build-animation-set
+       :user-data {:animation-set animation-set}})))
 
 
 (defn- build-mesh-set
@@ -54,10 +57,11 @@
         ;; resource/resource-hash used to name the
         ;; corresponding "generated" build resource.
         mesh-set-resource (resource/make-memory-resource workspace mesh-set-type (protobuf/map->sha1-hex Rig$MeshSet mesh-set))]
-    {:node-id   node-id
-     :resource  (workspace/make-build-resource mesh-set-resource)
-     :build-fn  build-mesh-set
-     :user-data {:mesh-set mesh-set}}))
+    (bt/update-build-target-key
+      {:node-id node-id
+       :resource (workspace/make-build-resource mesh-set-resource)
+       :build-fn build-mesh-set
+       :user-data {:mesh-set mesh-set}})))
 
 (defn make-rig-scene-build-targets
   ([node-id resource pb dep-build-targets resource-keys]

--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -107,6 +107,16 @@
                         meta-setting))
                     settings))))
 
+(defn remove-to-from-string [meta-info]
+  (update-in meta-info [:settings]
+             (fn [settings]
+               (map (fn [meta-setting]
+                      (if (contains? meta-setting :options)
+                        (let [type (:type meta-setting)]
+                          (dissoc meta-setting :from-string :to-string))
+                        meta-setting))
+                    settings))))
+
 (defn load-meta-info [reader]
   (-> (add-type-defaults (edn/read reader))
       (add-to-from-string)))

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -39,7 +39,7 @@
 
 (g/defnk produce-source-build-targets [_node-id resource]
   (try
-    [(bt/update-build-target-key
+    [(bt/with-content-hash
        {:node-id _node-id
         :resource (workspace/make-build-resource resource)
         :build-fn build-sound-source
@@ -115,7 +115,7 @@
             dep-resources (map (fn [[label resource]]
                                  [label (get deps-by-resource resource)])
                                [[:sound sound]])]
-        [(bt/update-build-target-key
+        [(bt/with-content-hash
            {:node-id _node-id
             :resource (workspace/make-build-resource resource)
             :build-fn build-sound

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -3,6 +3,7 @@
             [editor.protobuf :as protobuf]
             [dynamo.graph :as g]
             [util.murmur :as murmur]
+            [editor.build-target :as bt]
             [editor.graph-util :as gu]
             [editor.geom :as geom]
             [editor.material :as material]
@@ -999,12 +1000,13 @@
           deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
           dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:spine-scene spine-scene-resource] [:material material-resource]])
           model-pb (update model-pb :skin (fn [skin] (or skin "")))]
-      [{:node-id _node-id
-        :resource (workspace/make-build-resource resource)
-        :build-fn build-spine-model
-        :user-data {:proto-msg model-pb
-                    :dep-resources dep-resources}
-        :deps dep-build-targets}])))
+      [(bt/update-build-target-key
+         {:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-spine-model
+          :user-data {:proto-msg model-pb
+                      :dep-resources dep-resources}
+          :deps dep-build-targets})])))
 
 (g/defnode SpineModelNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -1000,7 +1000,7 @@
           deps-by-source (into {} (map #(let [res (:resource %)] [(:resource res) res]) dep-build-targets))
           dep-resources (map (fn [[label resource]] [label (get deps-by-source resource)]) [[:spine-scene spine-scene-resource] [:material material-resource]])
           model-pb (update model-pb :skin (fn [skin] (or skin "")))]
-      [(bt/update-build-target-key
+      [(bt/with-content-hash
          {:node-id _node-id
           :resource (workspace/make-build-resource resource)
           :build-fn build-spine-model

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -2,6 +2,7 @@
   ;; switch to released version once https://dev.clojure.org/jira/browse/DIMAP-15 has been fixed
   (:require [clojure.data.int-map-fixed :as int-map]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
             [editor.core :as core]
             [editor.defold-project :as project]
             [editor.geom :as geom]
@@ -380,12 +381,13 @@
                                [label (get deps-by-resource resource)])
                              [[:tile-set tile-source]
                               [:material material]])]
-      [{:node-id _node-id
-        :resource (workspace/make-build-resource resource)
-        :build-fn build-tile-map
-        :user-data {:pb-msg pb-msg
-                    :dep-resources dep-resources}
-        :deps dep-build-targets}])))
+      [(bt/update-build-target-key
+         {:node-id _node-id
+          :resource (workspace/make-build-resource resource)
+          :build-fn build-tile-map
+          :user-data {:pb-msg pb-msg
+                      :dep-resources dep-resources}
+          :deps dep-build-targets})])))
 
 (g/defnode TileMapNode
   (inherits resource-node/ResourceNode)

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -381,7 +381,7 @@
                                [label (get deps-by-resource resource)])
                              [[:tile-set tile-source]
                               [:material material]])]
-      [(bt/update-build-target-key
+      [(bt/with-content-hash
          {:node-id _node-id
           :resource (workspace/make-build-resource resource)
           :build-fn build-tile-map

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [dynamo.graph :as g]
    [editor.app-view :as app-view]
+   [editor.build-target :as bt]
    [editor.camera :as camera]
    [editor.collision-groups :as collision-groups]
    [editor.colors :as colors]
@@ -153,12 +154,13 @@
   (let [workspace (project/workspace (project/get-project _node-id))
         compress? (:compress-textures? build-settings false)
         texture-target (image/make-texture-build-target workspace _node-id packed-image-generator texture-profile compress?)]
-    [{:node-id _node-id
-      :resource (workspace/make-build-resource resource)
-      :build-fn build-texture-set
-      :user-data {:texture-set texture-set
-                  :dep-resources [[:texture (:resource texture-target)]]}
-      :deps [texture-target]}]))
+    [(bt/update-build-target-key
+       {:node-id _node-id
+        :resource (workspace/make-build-resource resource)
+        :build-fn build-texture-set
+        :user-data {:texture-set texture-set
+                    :dep-resources [[:texture (:resource texture-target)]]}
+        :deps [texture-target]})]))
 
 (g/defnk produce-anim-data [texture-set uv-transforms]
   (texture-set/make-anim-data texture-set uv-transforms))

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -154,7 +154,7 @@
   (let [workspace (project/workspace (project/get-project _node-id))
         compress? (:compress-textures? build-settings false)
         texture-target (image/make-texture-build-target workspace _node-id packed-image-generator texture-profile compress?)]
-    [(bt/update-build-target-key
+    [(bt/with-content-hash
        {:node-id _node-id
         :resource (workspace/make-build-resource resource)
         :build-fn build-texture-set

--- a/editor/test/editor/build_target_test.clj
+++ b/editor/test/editor/build_target_test.clj
@@ -1,0 +1,237 @@
+(ns editor.build-target-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [editor.build-target :as bt]
+            [editor.defold-project :as project]
+            [editor.pipeline :as pipeline]
+            [editor.placeholder-resource :refer [PlaceholderResourceNode]]
+            [editor.resource :as resource]
+            [editor.system :as system]
+            [editor.workspace :as workspace]
+            [integration.test-util :as test-util]
+            [support.test-support :refer [with-clean-system]])
+  (:import [com.google.protobuf ByteString]
+           [java.io File StringWriter]
+           [java.net URI]
+           [javax.vecmath Matrix4d]))
+
+(def ^:private project-path "test/resources/all_types_project")
+
+(defn- digest-string [value]
+  (with-open [writer (StringWriter.)]
+    (bt/digest! value writer)
+    (.flush writer)
+    (.toString writer)))
+
+(defn- make-lua-memory-resource [workspace source]
+  (assert (string? source))
+  (let [resource-type (workspace/get-resource-type workspace "lua")]
+    (resource/make-memory-resource workspace resource-type source)))
+
+(deftest digest-strings
+  ;; Here we test the strings that will be hashed during the digest process.
+  ;; Note that the actual digest process writes these strings to a special
+  ;; digest output stream which simply updates the hash value. This saves us
+  ;; from having the entire string representation of an object in memory.
+  (test-util/with-loaded-project project-path
+    (let [file-resource (workspace/find-resource workspace "/test.wav")
+          file-resource-node (project/get-resource-node project file-resource)
+          zip-resource (workspace/find-resource workspace  "/builtins/graphics/particle_blob.png")
+          zip-resource-node (project/get-resource-node project zip-resource)
+          memory-resource (make-lua-memory-resource workspace "return {key = 123}")
+          build-resource (workspace/make-build-resource memory-resource)]
+      (is (resource/exists? file-resource))
+      (is (g/node-id? file-resource-node))
+      (is (resource/exists? zip-resource))
+      (is (g/node-id? zip-resource-node))
+
+      (testing "Simple values"
+        (are [result value]
+          (= result (digest-string value))
+
+          "nil" nil
+          "true" true
+          "false" false
+          "1" 1
+          "1.0" 1.0
+          "1/2" 1/2
+          "64" (byte 64)
+          "\"string\"" "string"
+          ":keyword" :keyword
+          "symbol" 'symbol))
+
+      (testing "Resource values"
+        (are [result value]
+          (= result (digest-string value))
+
+          "#dg/BuildResource -479253108" build-resource
+          "#dg/FileResource 2064822056" file-resource
+          "#dg/MemoryResource -479253108" memory-resource
+          "#dg/ZipResource 1001491596" zip-resource))
+
+      (testing "Other supported values"
+        (are [result value]
+          (= result (digest-string value))
+
+          "#dg/Bytes [0, 32, 64]" (byte-array [0 32 64])
+          "#dg/ByteString [65, 66, 67]" (ByteString/copyFrom "ABC" "UTF-8")
+          "#dg/Class java.io.StringWriter" StringWriter
+          "#dg/File \"readme.txt\"" (File. "readme.txt")
+          "#dg/Function editor.build-target/build-target-key" bt/build-target-key
+          "#dg/Matrix4d [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]" (doto (Matrix4d.) .setIdentity)
+          "#dg/URI \"https://www.defold.com\"" (URI. "https://www.defold.com")))
+
+      (testing "Collections"
+        (are [result value]
+          (= result (digest-string value))
+
+          ;; Sequential
+          "[]" []
+          "[]" (list)
+          "[0, 1, 2]" (range 3)
+          "[:class, #dg/Class java.io.StringWriter]" [:class StringWriter]
+
+          ;; Maps
+          "{}" {}
+          "{}" (sorted-map)
+          "{:a 1, :b 2}" {:a 1 :b 2}
+          "{:a 1, :b 2}" {:b 2 :a 1} ; Keys are always sorted.
+
+          ;; Sets
+          "#{}" #{}
+          "#{}" (sorted-set)
+          "#{:a, :b}" #{:a :b}
+          "#{:a, :b}" #{:b :a})) ; Entries are always sorted.
+
+      (testing "Nested collections"
+        (are [result value]
+          (= result (digest-string value))
+
+          "[[#dg/Class java.lang.Byte]]"
+          [[Byte]]
+
+          "[{#dg/Class java.lang.Byte #dg/Class java.lang.Byte}]"
+          [{Byte Byte}]
+
+          "{[#dg/Class java.lang.Byte] {#dg/Class java.lang.Byte #dg/Class java.lang.Byte}}"
+          {[Byte] {Byte Byte}}))
+
+      (testing "Allowed node id entries in maps"
+        ;; Node ids are only allowed in maps. The key must end with "node-id",
+        ;; and the node must have a :sha256 output. The other tests below will
+        ;; fail in case these restrictions are violated.
+        (are [result value]
+          (and (= result (digest-string value))
+               (= result (digest-string (into (sorted-map) value))))
+
+          "{:node-id #dg/Node [editor.image/ImageNode, \"620a6d01e955915786374a5eaf8250bdd417a99e3839ca935e97c77faef3a431\"]}"
+          {:node-id zip-resource-node}
+
+          "{:_node-id #dg/Node [editor.image/ImageNode, \"620a6d01e955915786374a5eaf8250bdd417a99e3839ca935e97c77faef3a431\"]}"
+          {:_node-id zip-resource-node}
+
+          "{:any-key-that-ends-in-node-id #dg/Node [editor.image/ImageNode, \"620a6d01e955915786374a5eaf8250bdd417a99e3839ca935e97c77faef3a431\"]}"
+          {:any-key-that-ends-in-node-id zip-resource-node}))
+
+      (testing "ByteString UTF-8 code points"
+        (is (= "#dg/ByteString [-30, -122, -110]"
+               (digest-string (ByteString/copyFrom "\u2192" "UTF-8"))))
+        (is (= "\u2192"
+               (.toString (ByteString/copyFrom (byte-array [-30 -122 -110])) "UTF-8")))))))
+
+(defn- built-resource-node? [resource-node]
+  (not (g/node-instance? PlaceholderResourceNode resource-node)))
+
+(defn- build-targets-or-error [resource-node]
+  (when (built-resource-node? resource-node)
+    (try
+      (g/node-value resource-node :build-targets)
+      (catch Throwable error
+        (g/error-fatal (.getMessage error))))))
+
+(defn- all-build-targets [project]
+  (transduce (comp (map second)
+                   (map build-targets-or-error)
+                   (remove g/error?)
+                   (remove empty?))
+             (completing
+               (fn [all-build-targets resource-build-targets]
+                 (let [seen-keys (into #{} (map :key) all-build-targets)]
+                   (into all-build-targets
+                         (pipeline/flatten-build-targets
+                           resource-build-targets seen-keys)))))
+             []
+             (sort-by key
+                      (g/node-value project :nodes-by-resource-path))))
+
+(defn- build-target-keys-by-path [project]
+  (into (sorted-map)
+        (map (juxt (comp resource/proj-path :resource)
+                   :key))
+        (all-build-targets project)))
+
+(deftest build-target-keys-produce-no-errors
+  (test-util/with-loaded-project project-path
+    (let [resource-nodes-by-path (g/node-value project :nodes-by-resource-path)
+          resource-results (keep (fn [[proj-path resource-node]]
+                                   (let [build-targets (build-targets-or-error resource-node)]
+                                     (when (seq build-targets)
+                                       [proj-path build-targets])))
+                                 (sort-by key resource-nodes-by-path))
+          build-target-errors (into (sorted-map)
+                                    (filter (comp g/error? second))
+                                    resource-results)
+          build-target-key-errors (into (sorted-map)
+                                        (keep (fn [[resource-path build-targets]]
+                                                (when-not (g/error? build-targets)
+                                                  (try
+                                                    (pipeline/flatten-build-targets build-targets)
+                                                    nil
+                                                    (catch Throwable error
+                                                      [resource-path (g/error-fatal (.getMessage error))])))))
+                                        resource-results)]
+      (is (= {} build-target-errors))
+      (is (= {} build-target-key-errors)))))
+
+(deftest build-target-keys-are-unaffected-by-node-ids
+  ;; This test ensures the build target keys do not change in case a node id
+  ;; differs between editing sessions. If a node id is needed inside a build
+  ;; target, it must be in a map under a key that ends with "node-id". The
+  ;; node itself must have a :sha256 output. All resource nodes have this.
+  (let [session1-keys-by-path (test-util/with-loaded-project project-path
+                                (build-target-keys-by-path project))
+        session2-keys-by-path (with-clean-system
+                                (g/make-graph!) ; This causes all node ids to differ from session1.
+                                (let [workspace (test-util/setup-workspace! world project-path)
+                                      project (test-util/setup-project! workspace)]
+                                  (build-target-keys-by-path project)))]
+    (doseq [[path session1-key] session1-keys-by-path
+            :let [session2-key (session2-keys-by-path path)]]
+      (is (= session1-key session2-key)))))
+
+(deftest build-target-keys-are-affected-by-engine-revision
+  ;; We cannot safely reuse build artifacts that were compiled for a different
+  ;; version of the engine runtime, since external tools or libraries might have
+  ;; been changed. The converse also hold true. We can safely reuse build
+  ;; artifacts that were produced by the editor to target a particular engine,
+  ;; even if the build function or any of the functions it calls have changed.
+  ;; This means the build cache will be invalidated by engine upgrades, but can
+  ;; be reused as long as only the editor code has changed.
+  (let [defold-engine-sha1 (system/defold-engine-sha1)]
+    (try
+      (let [rev1-keys-by-path (with-clean-system
+                                (system/set-defold-engine-sha1! "1111111111111111111111111111111111111111")
+                                (let [workspace (test-util/setup-workspace! world project-path)
+                                      project (test-util/setup-project! workspace)]
+                                  (build-target-keys-by-path project)))
+            rev2-keys-by-path (with-clean-system
+                                (system/set-defold-engine-sha1! "2222222222222222222222222222222222222222")
+                                (let [workspace (test-util/setup-workspace! world project-path)
+                                      project (test-util/setup-project! workspace)]
+                                  (build-target-keys-by-path project)))]
+        (doseq [[path rev1-key] rev1-keys-by-path
+                :let [rev2-key (rev2-keys-by-path path)]]
+          (is (not= rev1-key rev2-key))))
+      (finally
+        (when (not-empty defold-engine-sha1)
+          (system/set-defold-engine-sha1! defold-engine-sha1))))))

--- a/editor/test/editor/pipeline_test.clj
+++ b/editor/test/editor/pipeline_test.clj
@@ -72,7 +72,7 @@
           (is (= 1 @build-fn-calls))
           (is (= "1" (content (first (:artifacts build-results))))))
         (testing "invokes build-fn when cache is explicitly cleared"
-          (workspace/reset-cache! workspace)
+          (workspace/clear-build-cache! workspace)
           (let [build-results (pipeline-build! workspace build-targets)]
             (is (= 2 @build-fn-calls))
             (is (= "1" (content (first (:artifacts build-results)))))))

--- a/editor/test/resources/all_types_project/liveupdate.settings
+++ b/editor/test/resources/all_types_project/liveupdate.settings
@@ -1,0 +1,1 @@
+[liveupdate]


### PR DESCRIPTION
### User-facing changes
* The Building phase when building can now reuse the on-disk results of a build from a previous editor session as long as the engine revision remains the same.
* The Compiling phase when building is now very slightly longer as the build target contents need to be hashed.
* We now show the progress bar immediately when triggering a build.

### Technical changes
* Build target keys are now SHA-1 hashes and are cached with the build target in the graph.
* The term "build target key" is no longer used. Instead we use the term "content hash".
* The workspace `artifact-map` and `etags` now persist between editor sessions.
* Lambda functions are no longer allowed inside build targets.
* Redefining a referenced `:build-fn` from the REPL will no longer invalidate the build cache entry. Note that this was already the case when redefining a function called from the `:build-fn`. Workaround: Use Rebuild when testing.
* Additional restrictions have been imposed for where node ids can occur inside build targets:
  * The node must have a `:sha256` output. This is already the case for resource nodes.
  * The node id must be inside a map, and the key for the entry must end in "node-id".
* Tests have been added to enforce these new restrictions. All build targets produced from resources inside the `all_types_project` are checked to confirm to the new rules.