### PR TITLE
DEF-3862 Reduce profiler overhead on script function call

### DIFF
--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -409,6 +409,34 @@ namespace dmMessage
         return RESULT_OK;
     }
 
+    static char* ConcatString(char* w_ptr, const char* w_ptr_end, const char* str)
+    {
+        while ((w_ptr != w_ptr_end) && *str)
+        {
+            *w_ptr++ = *str++;
+        }
+        return w_ptr;
+    }
+
+    static const char* GetProfilerString(const char* socket_name, uint32_t* out_profiler_hash)
+    {
+        const char* profiler_string = 0;
+        if (dmProfile::g_IsInitialized)
+        {
+            char buffer[128];
+            char* w_ptr = buffer;
+            const char* w_ptr_end = &buffer[sizeof(buffer) - 1];
+            w_ptr = ConcatString(w_ptr, w_ptr_end, "Dispatch ");
+            w_ptr = ConcatString(w_ptr, w_ptr_end, socket_name);
+            uint32_t str_len = (uint32_t)(w_ptr - buffer);
+            *w_ptr++ = 0;
+            uint32_t hash = dmProfile::GetNameHash(buffer, str_len);
+            profiler_string = dmProfile::Internalize(buffer, str_len, hash);
+            *out_profiler_hash = hash;
+        }
+        return profiler_string;
+    }
+
     uint32_t InternalDispatch(HSocket socket, DispatchCallback dispatch_callback, void* user_ptr, bool blocking)
     {
         MessageSocket* s = AcquireSocket(socket);
@@ -432,7 +460,9 @@ namespace dmMessage
             }
         }
 
-        DM_PROFILE_FMT(Message, "Dispatch %s", s->m_Name);
+        uint32_t profiler_hash = 0;
+        const char* profiler_string = GetProfilerString(s->m_Name, &profiler_hash);
+        DM_PROFILE_DYN(Message, profiler_string, profiler_hash);
 
         uint32_t dispatch_count = 0;
 

--- a/engine/dlib/src/dlib/message.cpp
+++ b/engine/dlib/src/dlib/message.cpp
@@ -409,6 +409,9 @@ namespace dmMessage
         return RESULT_OK;
     }
 
+    // Fast length limited string concatenation that assume we already point to
+    // the end of the string. Returns the new end of the string so we do not need
+    // to calculate the length of the input string or output string
     static char* ConcatString(char* w_ptr, const char* w_ptr_end, const char* str)
     {
         while ((w_ptr != w_ptr_end) && *str)
@@ -418,6 +421,7 @@ namespace dmMessage
         return w_ptr;
     }
 
+    // Low level string concatenation to void the overhead of DM_SNPRINTF and having to call strlen
     static const char* GetProfilerString(const char* socket_name, uint32_t* out_profiler_hash)
     {
         const char* profiler_string = 0;

--- a/engine/dlib/src/dlib/profile.h
+++ b/engine/dlib/src/dlib/profile.h
@@ -23,7 +23,7 @@
 /**
  * Profile macro.
  * scope_name is the scope name. Must be a literal
- * name is the sample name. Must be literal, to use non-literal name use DM_PROFILE_FMT
+ * name is the sample name. Must be literal, to use non-literal name use DM_PROFILE_DYN
  */
 #define DM_PROFILE(scope_name, name)
 #undef DM_PROFILE
@@ -31,11 +31,11 @@
 /**
  * Profile macro.
  * scope_name is the scope name. Must be a literal
- * fmt is the String format, uses printf formatting limited to 128 characters
- * Has overhead due to printf style formatting and hashing of the formatted string
+ * name is the sample name. Can be non-literal, use DM_PROFILE if you know it is a literal
+ * name_hash is the hash of the sample name obtained via dmProfile::GetNameHash()
  */
-#define DM_PROFILE_FMT(scope_name, fmt, ...)
-#undef DM_PROFILE_FMT
+#define DM_PROFILE_DYN(scope_name, name, name_hash)
+#undef DM_PROFILE_DYN
 
 /**
  * Profile counter macro
@@ -57,7 +57,7 @@
     #define DM_INTERNALIZE(name) 0
     #define DM_PROFILE_SCOPE(scope_instance_name, name)
     #define DM_PROFILE(scope_name, name)
-    #define DM_PROFILE_FMT(scope_name, fmt, ...)
+    #define DM_PROFILE_DYN(scope_name, name, name_hash)
     #define DM_COUNTER(name, amount)
     #define DM_COUNTER_DYN(counter_index, amount)
 #else
@@ -72,18 +72,9 @@
         static const uint32_t DM_PROFILE_PASTE2(hash, __LINE__)        = dmProfile::g_IsInitialized ? dmProfile::GetNameHash(name, (uint32_t)strlen(name)) : 0; \
         DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), name, DM_PROFILE_PASTE2(hash, __LINE__))
 
-    #define DM_PROFILE_FMT(scope_name, fmt, ...) \
+    #define DM_PROFILE_DYN(scope_name, name, name_hash) \
         static const uint32_t DM_PROFILE_PASTE2(scope_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateScope(#scope_name) : 0xffffffffu; \
-        const char* DM_PROFILE_PASTE2(name, __LINE__)                  = 0; \
-        static uint32_t DM_PROFILE_PASTE2(hash, __LINE__)              = 0; \
-        if (DM_PROFILE_PASTE2(scope_index, __LINE__) != 0xffffffffu) { \
-            char buffer[128]; \
-            DM_SNPRINTF(buffer, sizeof(buffer), fmt, __VA_ARGS__); \
-            uint32_t name_length = strlen(buffer); \
-            DM_PROFILE_PASTE2(hash, __LINE__) = dmProfile::GetNameHash(buffer, name_length); \
-            DM_PROFILE_PASTE2(name, __LINE__) = dmProfile::Internalize(buffer, name_length, DM_PROFILE_PASTE2(hash, __LINE__)); \
-        } \
-        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), DM_PROFILE_PASTE2(name, __LINE__), DM_PROFILE_PASTE2(hash, __LINE__))
+        DM_PROFILE_SCOPE(DM_PROFILE_PASTE2(scope_index, __LINE__), name, name_hash)
 
     #define DM_COUNTER(name, amount) \
         static uint32_t DM_PROFILE_PASTE2(counter_index, __LINE__) = dmProfile::g_IsInitialized ? dmProfile::AllocateCounter(name) : 0xffffffffu; \

--- a/engine/dlib/src/test/test_profile.cpp
+++ b/engine/dlib/src/test/test_profile.cpp
@@ -391,16 +391,26 @@ TEST(dmProfile, DynamicScope)
     dmProfile::HProfile profile = dmProfile::Begin();
     dmProfile::Release(profile);
 
+    char names[3][128];
+    DM_SNPRINTF(names[0], sizeof(names[0]), "%s@%s", "test.script", FUNCTION_NAMES[0]);
+    DM_SNPRINTF(names[1], sizeof(names[1]), "%s@%s", "test.script", FUNCTION_NAMES[1]);
+    DM_SNPRINTF(names[2], sizeof(names[2]), "%s@%s", "test.script", FUNCTION_NAMES[2]);
+    uint32_t names_hash[3] = {
+        dmProfile::GetNameHash(names[0], strlen(names[0])),
+        dmProfile::GetNameHash(names[1], strlen(names[1])),
+        dmProfile::GetNameHash(names[2], strlen(names[2]))
+    };
+
     for (uint i = 0; i < 10 ; ++i)
     {
         {
-            DM_PROFILE_FMT(Scope1, "%s@%s", "test.script", FUNCTION_NAMES[0]);
-            DM_PROFILE_FMT(Scope2, "%s@%s", "test.script", FUNCTION_NAMES[1]);
+            DM_PROFILE_DYN(Scope1, names[0], names_hash[0]);
+            DM_PROFILE_DYN(Scope2, names[1], names_hash[1]);
         }
         {
-            DM_PROFILE_FMT(Scope2, "%s@%s", "test.script", FUNCTION_NAMES[2]);
+            DM_PROFILE_DYN(Scope2, names[2], names_hash[2]);
         }
-        DM_PROFILE_FMT(Scope1, "%s@%s", "test.script", FUNCTION_NAMES[0]);
+        DM_PROFILE_DYN(Scope1, names[0], names_hash[0]);
     }
 
     std::vector<dmProfile::Sample> samples;

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -113,7 +113,9 @@ namespace dmGameObject
             }
 
             {
-                DM_PROFILE_FMT(Script, "%s@%s", SCRIPT_FUNCTION_NAMES[script_function], script->m_LuaModule->m_Source.m_Filename);
+                uint32_t profiler_hash = 0;
+                const char* profiler_string = dmScript::GetProfilerString(L, 0, script->m_LuaModule->m_Source.m_Filename, SCRIPT_FUNCTION_NAMES[script_function], 0, &profiler_hash);
+                DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     result = SCRIPT_RESULT_FAILED;
@@ -299,34 +301,11 @@ namespace dmGameObject
 
             dmScript::PushURL(L, params.m_Message->m_Sender);
 
-            const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE];
-            const char* function_source = script_instance->m_Script->m_LuaModule->m_Source.m_Filename;
-            char function_line_number_buffer[16];
-
-            if (dmProfile::g_IsInitialized)
-            {
-                if (is_callback)
-                {
-                    dmScript::LuaFunctionInfo fi;
-                    if (dmScript::GetLuaFunctionRefInfo(L, -5, &fi))
-                    {
-                        function_source = fi.m_FileName;
-                        if (fi.m_OptionalName)
-                        {
-                            function_name = fi.m_OptionalName;
-                        }
-                        else
-                        {
-                            DM_SNPRINTF(function_line_number_buffer, sizeof(function_line_number_buffer), "l(%d)", fi.m_LineNumber);
-                            function_name = function_line_number_buffer;
-                        }
-                    }
-                }
-            }
-
             // An on_message function shouldn't return anything.
             {
-                DM_PROFILE_FMT(Script, "%s%s%s%s@%s", function_name, message_name ? "[" : "", message_name ? message_name : "", message_name ? "]" : "", function_source);
+                uint32_t profiler_hash = 0;
+                const char* profiler_string = dmScript::GetProfilerString(L, -5, script_instance->m_Script->m_LuaModule->m_Source.m_Filename, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], message_name, &profiler_hash);
+                DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {
                     result = UPDATE_RESULT_UNKNOWN_ERROR;
@@ -531,7 +510,9 @@ namespace dmGameObject
             int input_ret = lua_gettop(L) - arg_count;
             int ret;
             {
-                DM_PROFILE_FMT(Script, "%s@%s", SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], script_instance->m_Script->m_LuaModule->m_Source.m_Filename);
+                uint32_t profiler_hash = 0;
+                const char* profiler_string = dmScript::GetProfilerString(L, 0, script_instance->m_Script->m_LuaModule->m_Source.m_Filename, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT], 0, &profiler_hash);
+                DM_PROFILE_DYN(Message, profiler_string, profiler_hash);
                 ret = dmScript::PCall(L, arg_count, LUA_MULTRET);
             }
             const char* function_name = SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONINPUT];

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -304,7 +304,7 @@ namespace dmGameObject
             // An on_message function shouldn't return anything.
             {
                 uint32_t profiler_hash = 0;
-                const char* profiler_string = dmScript::GetProfilerString(L, -5, script_instance->m_Script->m_LuaModule->m_Source.m_Filename, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], message_name, &profiler_hash);
+                const char* profiler_string = dmScript::GetProfilerString(L, is_callback ? -5 : 0, script_instance->m_Script->m_LuaModule->m_Source.m_Filename, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], message_name, &profiler_hash);
                 DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, 4, 0) != 0)
                 {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1818,32 +1818,10 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
             Result result = RESULT_OK;
 
-            const char* function_source = scene->m_Script->m_SourceFileName;
-            const char* function_name = SCRIPT_FUNCTION_NAMES[script_function];
-            char function_line_number_buffer[16];
-
-            if (dmProfile::g_IsInitialized)
             {
-                if (custom_ref != LUA_NOREF)
-                {
-                    dmScript::LuaFunctionInfo fi;
-                    if (dmScript::GetLuaFunctionRefInfo(L, -5, &fi))
-                    {
-                        function_source = fi.m_FileName;
-                        if (fi.m_OptionalName)
-                        {
-                            function_name = fi.m_OptionalName;
-                        }
-                        else
-                        {
-                            DM_SNPRINTF(function_line_number_buffer, sizeof(function_line_number_buffer), "l(%d)", fi.m_LineNumber);
-                            function_name = function_line_number_buffer;
-                        }
-                    }
-                }
-            }
-            {
-                DM_PROFILE_FMT(Script, "%s%s%s%s@%s", function_name, message_name ? "[" : "", message_name ? message_name : "", message_name ? "]" : "", function_source);
+                uint32_t profiler_hash = 0;
+                const char* profiler_string = dmScript::GetProfilerString(L, -5, scene->m_Script->m_SourceFileName, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], message_name, &profiler_hash);
+                DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1820,7 +1820,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
             {
                 uint32_t profiler_hash = 0;
-                const char* profiler_string = dmScript::GetProfilerString(L, -5, scene->m_Script->m_SourceFileName, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], message_name, &profiler_hash);
+                const char* profiler_string = dmScript::GetProfilerString(L, custom_ref != LUA_NOREF ? -5 : 0, scene->m_Script->m_SourceFileName, SCRIPT_FUNCTION_NAMES[SCRIPT_FUNCTION_ONMESSAGE], message_name, &profiler_hash);
                 DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, arg_count, LUA_MULTRET) != 0)
                 {

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2813,7 +2813,9 @@ bail:
             }
 
             {
-                DM_PROFILE_FMT(Script, "%s%s%s%s@%s", RENDER_SCRIPT_FUNCTION_NAMES[script_function], message_name ? "[" : "", message_name ? message_name : "", message_name ? "]" : "", script->m_SourceFileName);
+                uint32_t profiler_hash = 0;
+                const char* profiler_string = dmScript::GetProfilerString(L, 0, script->m_SourceFileName, RENDER_SCRIPT_FUNCTION_NAMES[script_function], message_name, &profiler_hash);
+                DM_PROFILE_DYN(Script, profiler_string, profiler_hash);
                 if (dmScript::PCall(L, arg_count, 0) != 0)
                 {
                     assert(top == lua_gettop(L));

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1450,6 +1450,9 @@ namespace dmScript
         return false;
     }
 
+    // Fast length limited string concatenation that assume we already point to
+    // the end of the string. Returns the new end of the string so we do not need
+    // to calculate the length of the input string or output string
     static char* ConcatString(char* w_ptr, const char* w_ptr_end, const char* str)
     {
         while ((w_ptr != w_ptr_end) && *str)
@@ -1459,6 +1462,14 @@ namespace dmScript
         return w_ptr;
     }
 
+    /**
+    * To reduce the overhead of the profiler when calling lua functions we avoid using DM_SNPRINTF.
+    * DM_SNPRINTF uses vsnprintf with variable number of arguments but we only need string concatenation for
+    * the most part. Also, we use our knownledge when building the string to get the string length directly
+    * without resorting to strlen.
+    * Building this string is particularly expensive on low end devices and using this more optimal way reduces
+    * the overhead of the profiler when enabled.
+    */
     const char* GetProfilerString(lua_State* L, int optional_callback_index, const char* source_file_name, const char* function_name, const char* optional_message_name, uint32_t* out_profiler_hash)
     {
         const char* profiler_string = 0;

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -667,25 +667,6 @@ namespace dmScript
      */
     bool InvokeCallback(LuaCallbackInfo* cbk, LuaCallbackUserFn fn, void* user_context);
 
-    /** Information about a function, in which file and at what line it is defined
-     * Use with GetLuaFunctionRefInfo
-     */
-    struct LuaFunctionInfo
-    {
-        const char* m_FileName;
-        const char* m_OptionalName;
-        int m_LineNumber;
-    };
-
-    /**
-     * Get information about where a Lua function is defined
-     * @param L lua state
-     * @param stack_index which index on the stack that contains the lua function ref
-     * @param out_function_info pointer to the function information that is filled out
-     * @return true on success, out_function_info is only touched if the function succeeds
-     */
-    bool GetLuaFunctionRefInfo(lua_State* L, int stack_index, LuaFunctionInfo* out_function_info);
-
     /**
      * Get an integer value at a specific key in a table.
      * @param L lua state
@@ -705,6 +686,18 @@ namespace dmScript
      * @return String value at key, or the default value if not found or invalid value type.
      */
     const char* GetTableStringValue(lua_State* L, int table_index, const char* key, const char* default_value);
+
+    /**
+     * Build a profiler function name string and calculate its hash.
+     * @param L lua state
+     * @param optional_callback_index Index of optional function ref on Lua stack - zero if no callback on stack
+     * @param source_file_name Default source file name (may be overriden by callback info)
+     * @param function_name Default function name (may be overriden by callback info)
+     * @param optional_message_name Optional message name
+     * @param out_profiler_hash Pointer to resulting string hash
+     * @return Pointer to internalized string - the string is safe to use until profiler in finalized, null if profiling is disabled
+     */
+    const char* GetProfilerString(lua_State* L, int optional_callback_index, const char* source_file_name, const char* function_name, const char* optional_message_name, uint32_t* out_profiler_hash);
 }
 
 


### PR DESCRIPTION
Removed PROFILE_FMT and replaced with PROFILE_DYN, we now build the strings outside to reduce profiler overhead and clean up some code duplication.

Saves about 5-7% on an iPhone5s in Message passing test.