### PR TITLE
Defedit 1589 make particle rendering faster

### DIFF
--- a/editor/src/clj/editor/gl.clj
+++ b/editor/src/clj/editor/gl.clj
@@ -273,7 +273,11 @@
 
 (defmacro gl-vertex-2f   [gl x y]       `(.glVertex2f ~gl ~x ~y))
 (defmacro gl-vertex-3d   [gl x y z]     `(.glVertex3d ~gl ~x ~y ~z))
-(defmacro gl-vertex-3dv  [gl vtx off]   `(.glVertex3dv ~gl ~vtx ~off))
+(defmacro gl-vertex-3dv
+  ([gl vtx]
+   `(.glVertex3dv ~gl ~vtx))
+  ([gl vtx off]
+   `(.glVertex3dv ~gl ~vtx ~off)))
 
 (defmacro gl-translate-f [gl x y z]     `(.glTranslatef ~gl ~x ~y ~z))
 

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -386,7 +386,7 @@ This must be submitted to the driver for compilation before you can use it. See
 (defrecord ShaderLifecycle [request-id verts frags uniforms]
   GlBind
   (bind [_this gl render-args]
-    (let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags])]
+    (let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags (map first uniforms)])]
       (.glUseProgram ^GL2 gl program)
       (when-not (zero? program)
         (doseq [[name val] uniforms
@@ -404,13 +404,13 @@ This must be submitted to the driver for compilation before you can use it. See
 
   ShaderVariables
   (get-attrib-location [this gl name]
-    (when-let [[program _] (scene-cache/request-object! ::shader request-id gl [verts frags])]
+    (when-let [[program _] (scene-cache/request-object! ::shader request-id gl [verts frags (map first uniforms)])]
       (if (zero? program)
         -1
         (gl/gl-get-attrib-location ^GL2 gl program name))))
 
   (set-uniform [this gl name val]
-    (when-let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags])]
+    (when-let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags (map first uniforms)])]
       (when (and (not (zero? program)) (= program (gl/gl-current-program gl)))
         (let [loc (uniform-locs name (.glGetUniformLocation ^GL2 gl program name))]
           (try
@@ -461,15 +461,15 @@ of GLSL strings and returns an object that satisfies GlBind and GlEnable."
                   [(str "#line " (count code-directive-lines))]
                   code-non-directive-lines))))
 
-(defn- make-shader-program [^GL2 gl [verts frags uniforms]]
+(defn- make-shader-program [^GL2 gl [verts frags uniform-names]]
   (let [vs (make-vertex-shader gl verts)]
     (try
       (let [fs (make-fragment-shader gl frags)]
         (try
           (let [program (make-program gl vs fs)
                 uniform-locs (into {}
-                                   (map (fn [[uniform-name _]] [uniform-name (.glGetUniformLocation ^GL2 gl program uniform-name)]))
-                                   uniforms)]
+                                   (map (fn [uniform-name] [uniform-name (.glGetUniformLocation ^GL2 gl program uniform-name)]))
+                                   uniform-names)]
             [program uniform-locs])
           (finally
             (delete-shader gl fs)))) ; flag shaders for deletion: they will be deleted immediately, or when we delete the program to which they are attached

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -386,7 +386,7 @@ This must be submitted to the driver for compilation before you can use it. See
 (defrecord ShaderLifecycle [request-id verts frags uniforms]
   GlBind
   (bind [_this gl render-args]
-    (let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags (map first uniforms)])]
+    (let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags (into #{} (map first) uniforms)])]
       (.glUseProgram ^GL2 gl program)
       (when-not (zero? program)
         (doseq [[name val] uniforms
@@ -404,13 +404,13 @@ This must be submitted to the driver for compilation before you can use it. See
 
   ShaderVariables
   (get-attrib-location [this gl name]
-    (when-let [[program _] (scene-cache/request-object! ::shader request-id gl [verts frags (map first uniforms)])]
+    (when-let [[program _] (scene-cache/request-object! ::shader request-id gl [verts frags (into #{} (map first) uniforms)])]
       (if (zero? program)
         -1
         (gl/gl-get-attrib-location ^GL2 gl program name))))
 
   (set-uniform [this gl name val]
-    (when-let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags (map first uniforms)])]
+    (when-let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags (into #{} (map first) uniforms)])]
       (when (and (not (zero? program)) (= program (gl/gl-current-program gl)))
         (let [loc (uniform-locs name (.glGetUniformLocation ^GL2 gl program name))]
           (try

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -386,7 +386,7 @@ This must be submitted to the driver for compilation before you can use it. See
 (defrecord ShaderLifecycle [request-id verts frags uniforms]
   GlBind
   (bind [_this gl render-args]
-    (let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags uniforms])]
+    (let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags])]
       (.glUseProgram ^GL2 gl program)
       (when-not (zero? program)
         (doseq [[name val] uniforms
@@ -404,13 +404,13 @@ This must be submitted to the driver for compilation before you can use it. See
 
   ShaderVariables
   (get-attrib-location [this gl name]
-    (when-let [[program _] (scene-cache/request-object! ::shader request-id gl [verts frags uniforms])]
+    (when-let [[program _] (scene-cache/request-object! ::shader request-id gl [verts frags])]
       (if (zero? program)
         -1
         (gl/gl-get-attrib-location ^GL2 gl program name))))
 
   (set-uniform [this gl name val]
-    (when-let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags uniforms])]
+    (when-let [[program uniform-locs] (scene-cache/request-object! ::shader request-id gl [verts frags])]
       (when (and (not (zero? program)) (= program (gl/gl-current-program gl)))
         (let [loc (uniform-locs name (.glGetUniformLocation ^GL2 gl program name))]
           (try

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -9,7 +9,7 @@
             [editor.types :as types])
   (:import com.jogamp.opengl.GL2
            [editor.types AABB Camera]
-           [java.nio ByteBuffer DoubleBuffer]
+           [java.nio ByteBuffer ByteOrder DoubleBuffer]
            [javax.vecmath Matrix3d Point3d Vector4d]))
 
 (set! *warn-on-reflection* true)
@@ -21,7 +21,9 @@
 (def z-axis-color colors/scene-grid-z-axis)
 
 (defn- make-grid-vertex-buffer [_1 _2]
-  (.asDoubleBuffer (ByteBuffer/allocateDirect (* 3 8))))
+  (-> (ByteBuffer/allocateDirect (* 3 8))
+    (.order (ByteOrder/nativeOrder))
+    (.asDoubleBuffer)))
 
 (scene-cache/register-object-cache! ::grid-vertex make-grid-vertex-buffer identity identity)
 

--- a/editor/src/clj/editor/grid.clj
+++ b/editor/src/clj/editor/grid.clj
@@ -1,15 +1,16 @@
 (ns editor.grid
   (:require [dynamo.graph :as g]
+            [editor.camera :as c]
             [editor.colors :as colors]
             [editor.geom :as geom]
             [editor.gl :as gl]
-            [editor.types :as types]
-            [editor.camera :as c]
-            [editor.validation :as validation]
-            [editor.gl.pass :as pass])
-  (:import [editor.types AABB Camera]
-           [com.jogamp.opengl GL GL2]
-           [javax.vecmath Vector3d Vector4d Matrix3d Matrix4d Point3d]))
+            [editor.gl.pass :as pass]
+            [editor.scene-cache :as scene-cache]
+            [editor.types :as types])
+  (:import com.jogamp.opengl.GL2
+           [editor.types AABB Camera]
+           [java.nio ByteBuffer DoubleBuffer]
+           [javax.vecmath Matrix3d Point3d Vector4d]))
 
 (set! *warn-on-reflection* true)
 
@@ -19,28 +20,32 @@
 (def y-axis-color colors/scene-grid-y-axis)
 (def z-axis-color colors/scene-grid-z-axis)
 
+(defn- make-grid-vertex-buffer [_1 _2]
+  (.asDoubleBuffer (ByteBuffer/allocateDirect (* 3 8))))
+
+(scene-cache/register-object-cache! ::grid-vertex make-grid-vertex-buffer identity identity)
+
 (defn render-grid-axis
-  [^GL2 gl ^doubles vx uidx start stop size vidx min max]
+  [^GL2 gl ^DoubleBuffer vx uidx start stop size vidx min max]
   (doseq [u (range start stop size)]
-      (aset vx uidx ^double u)
-      (aset vx vidx ^double min)
-      (gl/gl-vertex-3dv gl vx 0)
-      (aset vx vidx ^double max)
-      (gl/gl-vertex-3dv gl vx 0)))
+      (.put vx uidx ^double u)
+      (.put vx vidx ^double min)
+      (gl/gl-vertex-3dv gl vx)
+      (.put vx vidx ^double max)
+      (gl/gl-vertex-3dv gl vx)))
 
 (defn render-grid
   [gl fixed-axis size aabb]
-  ;; draw across
   (let [min-values (geom/as-array (types/min-p aabb))
-        max-values  (geom/as-array (types/max-p aabb))
-        u-axis      (mod (inc fixed-axis) 3)
-        u-min       (nth min-values u-axis)
-        u-max       (nth max-values u-axis)
-        v-axis      (mod (inc u-axis) 3)
-        v-min       (nth min-values v-axis)
-        v-max       (nth max-values v-axis)
-        vertex      (double-array 3)]
-    (aset vertex fixed-axis 0.0)
+        max-values (geom/as-array (types/max-p aabb))
+        u-axis (mod (inc fixed-axis) 3)
+        u-min (nth min-values u-axis)
+        u-max (nth max-values u-axis)
+        v-axis (mod (inc u-axis) 3)
+        v-min (nth min-values v-axis)
+        v-max (nth max-values v-axis)
+        vertex ^DoubleBuffer (scene-cache/request-object! ::grid-vertex :grid-vertex {} nil)]
+    (.put vertex fixed-axis 0.0)
     (render-grid-axis gl vertex u-axis u-min u-max size v-axis v-min v-max)
     (render-grid-axis gl vertex v-axis v-min v-max size u-axis u-min u-max)))
 
@@ -170,3 +175,4 @@
             (default 0))
   (output grids      g/Any :cached update-grids)
   (output renderable pass/RenderData :cached grid-renderable))
+


### PR DESCRIPTION
Didn't manage to do anything about particles specifically.
I did a couple of general improvements and I have some findings.
Improvements:
1. Grid rendering should now be faster because it uses direct ByteBuffers for transfer instead of arrays.
2. Shaders should not recompile any more just because input values changed.
Two ideas for further improvements:
1. Copy less between GL and JFX. I tried to find a way to improve this but I cannot find a good way. There seems to be no way to get lower level access to JFX pixels than WritableImage which we already use.
2. Clojure data structures such as lazy sequences take significant time each frame but this is also difficult because they are spread out all over so any individual change will have a small impact.