### PR TITLE
Don't strip modules with security providers

### DIFF
--- a/editor/jlink-options
+++ b/editor/jlink-options
@@ -2,15 +2,18 @@
 --add-modules=java.desktop # editor use java.awt.*
 --add-modules=java.management # used by amazonica
 --add-modules=java.naming # used by slf4j
+--add-modules=java.security.jgss # needed for https to work?
 --add-modules=java.scripting # needed for fxml
 --add-modules=java.sql # clojure needs it
 --add-modules=java.xml
+--add-modules=java.xml.crypto # needed for https to work?
 --add-modules=jdk.crypto.ec # needed for https to work
---add-modules=jdk.httpserver # used by util.http-server
---add-modules=jdk.unsupported # javafx uses Unsafe
---add-modules=jdk.zipfs # used to extract packaged natives
---add-modules=jdk.xml.dom # needed for web view (.md files)
 --add-modules=jdk.jsobject # needed for web view (.md files)
+--add-modules=jdk.httpserver # used by util.http-server
+--add-modules=jdk.security.jgss # needed for https to work?
+--add-modules=jdk.unsupported # javafx uses Unsafe
+--add-modules=jdk.xml.dom # needed for web view (.md files)
+--add-modules=jdk.zipfs # used to extract packaged natives
 --no-man-pages
 --dedup-legal-notices=error-if-not-same-content
 --no-header-files


### PR DESCRIPTION
Since I can't reproduce it on my machine, and I'm not a security expert, it's mostly a guess: we could strip some security stuff from jdk that might be needed for some https connections.
There is a security mechanism in java and various modules can provide additional security possibilities called [security provider](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/Provider.html). There is a list of modules on [jlink](https://docs.oracle.com/javase/9/tools/jlink.htm) documentation for java 9 that add various security providers. Some of them are not present in jdk 11, and I had a look at other:
- `jdk.crypto.ec` (described as Sun Elliptic Curve provider (EC, ECDSA, ECDH)) was already present and needed for https access;
- added `java.xml.crypto` described as: XMLDSig (DOM XMLSignatureFactory; DOM KeyInfoFactory; C14N 1.0, C14N 1.1, Exclusive C14N, Base64, Enveloped, XPath, XPath2, XSLT TransformServices);
- didn't add `java.security.sasl` described as: Sun SASL provider(implements client mechanisms for: DIGEST-MD5, EXTERNAL, PLAIN, CRAM-MD5, NTLM; server mechanisms for: DIGEST-MD5, CRAM-MD5, NTLM), because provider added by it (observable by `(java.security.Security/getProviders)`) was already present before;
- didn't add `jdk.crypto.cryptoki`, since it added a provider described as "Unconfigured and unusable PKCS11 provider"
- added `java.security.jgss` — provided security provider described as SunJGSS: Sun (Kerberos v5, SPNEGO);
- didn't add `java.smartcardio` because it looks irrelevant, looks like something related to [smart-cards](https://docs.oracle.com/javase/7/docs/jre/api/security/smartcardio/spec/javax/smartcardio/package-summary.html)
- added `jdk.security.jgss`, which adds provider described as JDK SASL provider(implements client and server mechanisms for GSSAPI).

Also sorted added modules, so it might look confusing. 

I suggest we release it and see if ssl problems go away, and if they are not, we can revert it back.

Notes:
- there is `cacerts` file which is the same in both stripped and full-blown jdks no matter the modules
- jdk size increased from 55 to 57 MB