### PR TITLE
DEFEDIT-1639 Load our version of PVRTexLib explicitly in Bob.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
@@ -44,10 +44,14 @@ public class TexcLibrary {
             // TODO: sad with a platform specific hack and placing dependency knowledge here but...
             if (platform == Platform.X86Linux || platform == Platform.X86_64Linux) {
                 Bob.verbose("Loading PVRTexLib from:'%s'", pvrTextLibPath);
-                System.load(pvrTextLibPath);		
+                System.load(pvrTextLibPath);
             }
             else if (platform == Platform.X86_64Win32 || platform == Platform.X86Win32) {
-                Bob.getLib(platform, "msvcr120"); // dependency of PVRTexLib
+                final String msvcrlib = Bob.getLib(platform, "msvcr120"); // dependency of PVRTexLib
+                // Make sure our version is loaded. Windows will do the lookup
+                // for transitive dependencies, not jna, so we need to do this
+                // explicitly or it will not be found.
+                System.load(msvcrlib);
             }
 
             Native.register("texc_shared");


### PR DESCRIPTION
Explicitly load PVRTexLib in Bob to make sure we are using our version.
https://jira.int.midasplayer.com/browse/DEFEDIT-1639