### PR TITLE
Update used antlr version

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -39,7 +39,10 @@
                      [org.codehaus.jackson/jackson-mapper-asl     "1.9.13"]
                      [org.eclipse.jgit/org.eclipse.jgit           "4.2.0.201601211800-r"
                       :exclusions [org.apache.httpcomponents/httpclient]] ; jgit -> 4.3.6, amazonica -> 4.5.2
-                     [clj-antlr                                   "0.2.2"]
+                     [clj-antlr                                   "0.2.2"
+                      :exclusions [org.antlr/antlr4 org.antlr/antlr4-runtime]]
+                     [org.antlr/antlr4 "4.7.2"]
+                     [org.antlr/antlr4-runtime "4.7.2"]
                      [org.apache.commons/commons-compress         "1.18"]
 
                      [net.java.dev.jna/jna                        "4.1.0"]


### PR DESCRIPTION
Example code that significantly slowed down parser in previous antlr version:
```lua
function on_message(self, message_id, message, sender)
	-- Add message-handling code here
	-- Remove this function if not needed
	if self.can_damaged_frame ~= self.current_frame and 
	self.can_hit_frame ~= self.current_frame and 
	(message.other_id == hash("/can") or
	message.other_id == hash("/can_1") or
	message.other_id == hash("/can_2") or
	message.other_id == hash("/can_3") or
	message.other_id == hash("/can_4") or
	message.other_id == hash("/can_5") or
	message.other_id == hash("/can_6") or
	message.other_id == hash("/can_7") or
	message.other_id == hash("/can_8") or
	message.other_id == hash("/can_9") or
	message.other_id == hash("/can_10") or
	message.other_id == hash("/can_11") or 
	message.other_id == hash("/can_12") or) then 
		pprint(message)
	end
end
```
Try copypasting `message.other_id == hash("/can_12") or` at the end of code block in parenthesis in current editor vs this branch.

Haven't found any breaking changes in [release notes](https://github.com/antlr/antlr4/releases) since previous version (was 4.2.2). Tried a bunch of lua files (seems we use antlr only to parse lua) and haven't found any problem on editing them.