### PR TITLE
Remove blue highlight from overridden input fields

### DIFF
--- a/editor/styling/stylesheets/editor.scss
+++ b/editor/styling/stylesheets/editor.scss
@@ -85,12 +85,6 @@ Links:
   -fx-text-color-base: $defold-light-blue;
   -fx-text-fill: $defold-light-blue; }
 
-.overridden .text-field {
-  -fx-text-fill: $defold-light-blue; }
-
-.overridden .color-picker-label .text {
-  -fx-fill: $defold-light-blue; }
-
 .copyable-label, .copyable-label:focused {
   -fx-background-color: transparent;
   -fx-border-width: 0px;


### PR DESCRIPTION
See https://forum.defold.com/t/more-legible-text-for-template-properties/47614/9

Looks like JavaFX bug in applying css rules. Text goes black and blue while clicking different fields. Reloading css without changing anything after this view is shown solves problem. Decided to remove colorizing text input of overridden props because label is enough.