### PR TITLE
Revert fix for building Bob with JDK 11.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.xml
@@ -158,12 +158,13 @@
             </tarfileset>
         </copy>
 
+        <!-- extdirs="foo" is set to avoid automatic inclusion of ext-jars and
+             specifically vecmath.jar on OSX -->
         <javac srcdir="generated"
                destdir="${classes.dir}"
+               extdirs="foo"
                includeantruntime="false"
-               encoding="UTF-8"
-               target="1.8"
-               source="1.8">
+               encoding="UTF-8">
             <classpath>
                 <path refid="classpath"/>
             </classpath>
@@ -171,11 +172,10 @@
         </javac>
 
         <javac destdir="${classes.dir}"
+               extdirs="foo"
                includeantruntime="false"
                debug="true"
-               encoding="UTF-8"
-               target="1.8"
-               source="1.8">
+               encoding="UTF-8">
             <src path="src"/>
             <include name="com/**"/>
             <exclude name="com/dynamo/bob/*Osgi*"/>


### PR DESCRIPTION
We need to build it with JDK 8 apparently :(