### PR TITLE
DEF-3898 Local push notification crash

### DIFF
--- a/engine/push/src/push_utils.cpp
+++ b/engine/push/src/push_utils.cpp
@@ -13,6 +13,9 @@ bool dmPush::VerifyPayload(lua_State* L, const char* payload, char* error_str_ou
     if (r == dmJson::RESULT_OK && doc.m_NodeCount > 0) {
         if (dmScript::JsonToLua(L, &doc, 0, error_str_out, error_str_size) >= 0) {
             success = true;
+            // JsonToLua will push Lua values on the stack, but they will not be used       
+            // since we only want to verify that the JSON can be converted to Lua here.        
+            lua_pop(L, lua_gettop(L) - top);
         }
     } else {
         DM_SNPRINTF(error_str_out, error_str_size, "Failed to parse JSON payload string (%d).", r);


### PR DESCRIPTION
Restore original code for removing elements from stack:
            // JsonToLua will push Lua values on the stack, but they will not be used       
            // since we only want to verify that the JSON can be converted to Lua here.  