### PR TITLE
DEF-3873 - Fixed issue with facebook dialogs not working in non-NE builds.

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -727,7 +727,11 @@ ANDROID_MANIFEST = """<?xml version="1.0" encoding="utf-8"?>
 
     <uses-feature android:required="true" android:glEsVersion="0x00020000" />
     <uses-sdk android:minSdkVersion="%(min_api_level)s" android:targetSdkVersion="%(target_api_level)s" />
-    <application android:label="%(app_name)s" android:hasCode="true" android:debuggable="true">
+    <application
+        android:label="%(app_name)s"
+        android:hasCode="true"
+        android:debuggable="true"
+        android:name="android.support.multidex.MultiDexApplication">
 
         <!-- For Local Notifications -->
         <receiver android:name="com.defold.push.LocalNotificationReceiver" >
@@ -738,10 +742,17 @@ ANDROID_MANIFEST = """<?xml version="1.0" encoding="utf-8"?>
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
+        <!-- Disable Firebase Analytics -->
+        <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
+        <!-- For Facebook -->
+        <meta-data android:name="com.facebook.sdk.ApplicationName"
+            android:value="%(app_name)s" />
+
         <activity android:name="com.dynamo.android.DefoldActivity"
                 android:label="%(app_name)s"
                 android:configChanges="orientation|screenSize|keyboardHidden"
                 android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+                android:screenOrientation="portrait"
                 android:launchMode="singleTask">
             <meta-data android:name="android.app.lib_name"
                     android:value="%(lib_name)s" />
@@ -750,14 +761,21 @@ ANDROID_MANIFEST = """<?xml version="1.0" encoding="utf-8"?>
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="com.dynamo.android.DispatcherActivity" android:theme="@android:style/Theme.NoDisplay">
+        <activity android:name="com.dynamo.android.DispatcherActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity android:name="com.facebook.FacebookActivity"
+          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+          android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+          android:label="%(app_name)s" />
+        <activity android:name="com.defold.iap.IapGooglePlayActivity"
+          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+          android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+          android:label="IAP">
         </activity>
 
-        <!-- For Local Notifications -->
-        <activity android:name="com.defold.push.LocalPushDispatchActivity"
+        <!-- For local and Firebase notifications -->
+        <activity android:name="com.defold.push.PushDispatchActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:launchMode="singleTask"
-            android:noHistory="true"
             android:configChanges="keyboardHidden|orientation|screenSize">
             <intent-filter>
                 <action android:name="com.defold.push.FORWARD" />
@@ -765,38 +783,59 @@ ANDROID_MANIFEST = """<?xml version="1.0" encoding="utf-8"?>
             </intent-filter>
         </activity>
 
-        <!-- For GCM (push) -->
-        <activity android:name="com.defold.push.PushDispatchActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar">
+        <!-- For Firebase Cloud Messaging -->
+        <service android:enabled="true" android:exported="true" android:name="com.defold.push.FirebaseMessagingService">
             <intent-filter>
-                <action android:name="com.defold.push.FORWARD" />
-                <category android:name="com.defold.push" />
+                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             </intent-filter>
-        </activity>
-        <receiver
-            android:name="com.defold.push.GcmBroadcastReceiver"
-            android:permission="com.google.android.c2dm.permission.SEND" >
+        </service>
+        <service android:exported="true" android:name="com.google.firebase.messaging.FirebaseMessagingService">
+            <intent-filter android:priority="-500">
+                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+            </intent-filter>
+        </service>
+        <service android:exported="false" android:name="com.google.firebase.components.ComponentDiscoveryService">
+            <meta-data android:name="com.google.firebase.components:com.google.firebase.analytics.connector.internal.AnalyticsConnectorRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+            <meta-data android:name="com.google.firebase.components:com.google.firebase.iid.Registrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+        </service>
+        <receiver android:exported="true" android:name="com.google.firebase.iid.FirebaseInstanceIdReceiver" android:permission="com.google.android.c2dm.permission.SEND">
             <intent-filter>
-                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                <action android:name="com.defold.push.FORWARD" />
-                <category android:name="com.defold.push" />
+                <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
             </intent-filter>
         </receiver>
 
-        %(extra_activities)s
+        <!-- For IAC Invocations -->
+        <activity android:name="com.defold.iac.IACActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:launchMode="singleTask"
+            android:configChanges="keyboardHidden|orientation|screenSize">
+            <intent-filter>
+               <action android:name="android.intent.action.VIEW" />
+               <category android:name="android.intent.category.DEFAULT" />
+               <category android:name="android.intent.category.BROWSABLE" />
+               <data android:scheme="{{android.package}}" />
+            </intent-filter>
+        </activity>
+
+        <!-- For Amazon IAP -->
+        <receiver android:name="com.amazon.device.iap.ResponseReceiver" >
+            <intent-filter>
+                <action android:name="com.amazon.inapp.purchasing.NOTIFY" android:permission="com.amazon.inapp.purchasing.Permission.NOTIFY" />
+            </intent-filter>
+        </receiver>
+
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <!-- For GCM (push) -->
-    <!-- NOTE: Package name from actual app here! -->
-    <permission android:name="%(package)s.permission.C2D_MESSAGE" android:protectionLevel="signature" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <!-- NOTE: Package name from actual app here! -->
-    <uses-permission android:name="%(package)s.permission.C2D_MESSAGE" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
 
 </manifest>
@@ -822,23 +861,32 @@ def android_package(task):
 
     bld = task.generator.bld
 
-    activities = ''
-    for activity, attr in task.activities:
-        activities += '<activity android:name="%s" %s/>' % (activity, attr)
-
     package = 'com.defold.%s' % task.exe_name
     if task.android_package:
         package = task.android_package
 
     manifest_file = open(task.manifest.bldpath(task.env), 'wb')
-    manifest_file.write(ANDROID_MANIFEST % { 'package' : package, 'app_name' : task.exe_name, 'lib_name' : task.exe_name, 'extra_activities' : activities, 'min_api_level' : ANDROID_MIN_API_LEVEL, 'target_api_level' : ANDROID_TARGET_API_LEVEL })
+    manifest_file.write(ANDROID_MANIFEST % { 'package' : package, 'app_name' : task.exe_name, 'lib_name' : task.exe_name, 'min_api_level' : ANDROID_MIN_API_LEVEL, 'target_api_level' : ANDROID_TARGET_API_LEVEL })
     manifest_file.close()
 
     aapt = '%s/android-sdk/build-tools/%s/aapt' % (ANDROID_ROOT, ANDROID_BUILD_TOOLS_VERSION)
     dx = '%s/android-sdk/build-tools/%s/dx' % (ANDROID_ROOT, ANDROID_BUILD_TOOLS_VERSION)
     dynamo_home = task.env['DYNAMO_HOME']
     android_jar = '%s/ext/share/java/android.jar' % (dynamo_home)
-    res_dirs = glob.glob('%s/ext/share/java/res/*' % (dynamo_home))
+
+    # DEF-3873
+    # Previously we looped over all subfolders in ext/share/java/res and added them to this list.
+    # After the release of 1.2.149 Facebook dialogs stopped working, unless the engine was built
+    # on NE server. It was narrowed down to what order the res dirs were listed in the aapt
+    # argument list and now we use the same order on all places.
+    res_dirs = ["%s/ext/share/java/res/facebook" % dynamo_home,
+                "%s/ext/share/java/res/com.android.support.support-compat-27.1.1" % dynamo_home,
+                "%s/ext/share/java/res/com.android.support.support-core-ui-27.1.1" % dynamo_home,
+                "%s/ext/share/java/res/com.android.support.support-media-compat-27.1.1" % dynamo_home,
+                "%s/ext/share/java/res/com.google.android.gms.play-services-base-16.0.1" % dynamo_home,
+                "%s/ext/share/java/res/com.google.android.gms.play-services-basement-16.0.1" % dynamo_home,
+                "%s/ext/share/java/res/com.google.firebase.firebase-messaging-17.3.4" % dynamo_home]
+
     manifest = task.manifest.abspath(task.env)
     dme_and = os.path.normpath(os.path.join(os.path.dirname(task.manifest.abspath(task.env)), '..', '..'))
     r_java_gen_dir = task.r_java_gen_dir.abspath(task.env)
@@ -866,11 +914,6 @@ def android_package(task):
     for d in res_dirs:
         res_args += ' -S %s' % d
 
-    ret = bld.exec_command('%s package -f -m --output-text-symbols %s --auto-add-overlay -M %s -I %s -J %s --generate-dependencies -G %s %s' % (aapt, bin, manifest, android_jar, gen, os.path.join(bin, 'proguard.txt'), res_args))
-    if ret != 0:
-        error('Error running aapt')
-        return 1
-
     clspath = ':'.join(task.jars)
     dx_jars = []
     for jar in task.jars:
@@ -883,7 +926,7 @@ def android_package(task):
     else:
         extra_packages_cmd = ''
 
-    ret = bld.exec_command('%s package --no-crunch -f --debug-mode --auto-add-overlay -M %s -I %s %s -F %s -m -J %s %s' % (aapt, manifest, android_jar, res_args, ap_, r_java_gen_dir, extra_packages_cmd))
+    ret = bld.exec_command('%s package --no-crunch -f %s -m --debug-mode --auto-add-overlay -M %s -I %s -J %s %s -F %s' % (aapt, extra_packages_cmd, manifest, android_jar, r_java_gen_dir, res_args, ap_))
     if ret != 0:
         error('Error running aapt')
         return 1
@@ -981,8 +1024,7 @@ def create_android_package(self):
     android_package_task.set_inputs(self.link_task.outputs)
     android_package_task.android_package = self.android_package
 
-    Utils.def_attrs(self, activities=[], extra_packages = "")
-    android_package_task.activities = Utils.to_list(self.activities)
+    Utils.def_attrs(self, extra_packages = "")
     android_package_task.extra_packages = Utils.to_list(self.extra_packages)
 
     Utils.def_attrs(self, jars=[])

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -85,8 +85,6 @@ def build(bld):
 
     dynamo_home = os.getenv('DYNAMO_HOME')
 
-    activities=[('com.facebook.FacebookActivity', 'android:theme="@android:style/Theme.Translucent.NoTitleBar" android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation" android:label="dmengine"'),
-                ('com.defold.iap.IapGooglePlayActivity', 'android:theme="@android:style/Theme.Translucent.NoTitleBar" android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation" android:label="IAP"')]
     extra_packages = 'com.facebook:com.google.android.gms:com.google.android.gms.common'
 
     android_jar_paths = ['%s/ext/share/java/facebooksdk.jar' % (dynamo_home),
@@ -115,7 +113,6 @@ def build(bld):
         target = 'dmengine',
         bundleid = 'com.defold.engine',
         source=['main.cpp'],
-        activities = activities,
         extra_packages = extra_packages,
         jars = android_jar_paths)
 
@@ -143,7 +140,6 @@ def build(bld):
         protoc_includes = '../proto',
         target = 'dmengine_release',
         source=['main.cpp'],
-        activities = activities,
         extra_packages = extra_packages,
         jars = android_jar_paths)
 


### PR DESCRIPTION
- Updated the `AndroidManifest.xml` used during local builds.
- Changes so that Android resource folders are explicitly set during local builds, instead of looping over subfolders. (Since this resulted in nondeterministic order of the arguments to `aapt`.)