### PR TITLE
DEFEDIT-1659 Use 75% of physical memory for Xmx parameter

### DIFF
--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -74,13 +74,17 @@ static uint64_t GetTotalRAM() {
   return value;
 }
 
-static void GetThreeQuartersRAMStr(char* buf) {
+static void GetThreeQuartersRAMStr(char* buf, uint64_t cap) {
 #if defined(__linux__)
   const char* fmt = "-Xmx%lu";
 #else
   const char* fmt = "-Xmx%llu";
 #endif
-  double d_total_ram = (double)GetTotalRAM();
+  uint64_t total_ram = GetTotalRAM();
+  if(total_ram > cap) {
+    total_ram = cap;
+  }
+  double d_total_ram = (double)total_ram;
   double d_seventyfive_percent_ram = 0.75 * d_total_ram;
   sprintf(buf, fmt, (uint64_t)d_seventyfive_percent_ram);
 }
@@ -229,7 +233,7 @@ int Launch(int argc, char **argv) {
     }
 
     char ram_str_buf[100];
-    GetThreeQuartersRAMStr(ram_str_buf);
+    GetThreeQuartersRAMStr(ram_str_buf, 8589934592ull); // Max 8 gigs.
     args[i++] = ram_str_buf;
 
     args[i++] = (char*) main;

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -80,12 +80,12 @@ static void GetThreeQuartersRAMStr(char* buf, uint64_t cap) {
 #else
   const char* fmt = "-Xmx%llu";
 #endif
-  uint64_t total_ram = GetTotalRAM();
-  if(total_ram > cap) {
-    total_ram = cap;
-  }
-  double d_total_ram = (double)total_ram;
+  uint64_t d_cap = (double)cap;
+  double d_total_ram = (double)GetTotalRAM();
   double d_seventyfive_percent_ram = 0.75 * d_total_ram;
+  if(d_seventyfive_percent_ram > d_cap) {
+    d_seventyfive_percent_ram = d_cap;
+  }
   sprintf(buf, fmt, (uint64_t)d_seventyfive_percent_ram);
 }
 

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -2,6 +2,7 @@
 #include "macos_events.h"
 #include <assert.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -23,6 +24,14 @@
 #include <dlib/safe_windows.h>
 #endif
 
+#ifdef __MACH__
+#include <sys/sysctl.h>
+#endif
+
+#ifdef __linux__
+#include <sys/sysinfo.h>
+#endif
+
 // bootstrap.resourcespath must default to resourcespath of the installation
 #define RESOURCES_PATH_KEY ("bootstrap.resourcespath")
 #define LAUNCHER_PATH_KEY ("bootstrap.launcherpath")
@@ -41,6 +50,40 @@ static int setenv(const char *name, const char *value, int overwrite)
   }
 }
 #endif
+
+// We want to set the Xmx parameter of the JVM to 75% of the system physical
+// memory to support large projects. Default is 25%. This parameter has to be
+// set at start so we need to find out the amount of memory here in the
+// launcher.
+static uint64_t GetTotalRAM() {
+  uint64_t value = 0;
+#if defined(__MACH__)
+  int mib [] = { CTL_HW, HW_MEMSIZE };
+  size_t length = sizeof(value);
+  sysctl(mib, 2, &value, &length, NULL, 0);
+#elif defined(_WIN32)
+  MEMORYSTATUSEX memstat;
+  memstat.dwLength = sizeof(MEMORYSTATUSEX);
+  GlobalMemoryStatusEx(&memstat);
+  value = memstat.ullTotalPhys;
+#elif defined(__linux__)
+  struct sysinfo sinfo;
+  sysinfo(&sinfo);
+  value = sinfo.totalram;
+#endif
+  return value;
+}
+
+static void GetThreeQuartersRAMStr(char* buf) {
+#if defined(__linux__)
+  const char* fmt = "-Xmx%lu";
+#else
+  const char* fmt = "-Xmx%llu";
+#endif
+  double d_total_ram = (double)GetTotalRAM();
+  double d_seventyfive_percent_ram = 0.75 * d_total_ram;
+  sprintf(buf, fmt, (uint64_t)d_seventyfive_percent_ram);
+}
 
 struct ReplaceContext
 {
@@ -184,6 +227,10 @@ int Launch(int argc, char **argv) {
         args[i++] = s;
         s = dmStrTok(0, ",", &last);
     }
+
+    char ram_str_buf[100];
+    GetThreeQuartersRAMStr(ram_str_buf);
+    args[i++] = ram_str_buf;
 
     args[i++] = (char*) main;
 #if defined(__MACH__)


### PR DESCRIPTION
Partial fix for defold/editor2-issues#2549

https://jira.int.midasplayer.com/browse/DEFEDIT-1659