### PR TITLE
DEFEDIT-1667 Evict entries from cache in low-memory conditions

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -1,18 +1,16 @@
 (ns dynamo.graph
   "Main api for graph and node"
   (:refer-clojure :exclude [deftype constantly])
-  (:require [clojure.set :as set]
-            [clojure.tools.macro :as ctm]
+  (:require [clojure.tools.macro :as ctm]
             [cognitect.transit :as transit]
             [internal.util :as util]
             [internal.cache :as c]
             [internal.graph :as ig]
             [internal.graph.types :as gt]
-            [internal.graph.error-values :as ie]
+            [internal.low-memory :as low-memory]
             [internal.node :as in]
             [internal.system :as is]
             [internal.transaction :as it]
-            [plumbing.core :as pc]
             [potemkin.namespaces :as namespaces]
             [schema.core :as s])
   (:import [internal.graph.error_values ErrorValue]
@@ -1178,9 +1176,10 @@
 ;; Boot, initialization, and facade
 ;; ---------------------------------------------------------------------------
 (defn initialize!
-  "Set up the initial system including graphs, caches, and dispoal queues"
+  "Set up the initial system including graphs, caches, and disposal queues"
   [config]
-  (reset! *the-system* (is/make-system config)))
+  (reset! *the-system* (is/make-system config))
+  (low-memory/add-callback! clear-system-cache!))
 
 (defn make-graph!
   "Create a new graph in the system with optional values of `:history` and `:volatility`. If no

--- a/editor/src/clj/internal/low_memory.clj
+++ b/editor/src/clj/internal/low_memory.clj
@@ -1,0 +1,61 @@
+(ns internal.low-memory
+  (:import [java.lang.management ManagementFactory MemoryNotificationInfo MemoryPoolMXBean MemoryType]
+           [javax.management NotificationEmitter NotificationListener]))
+
+;; Low memory detection system based on
+;; https://www.javaspecialists.eu/archive/Issue092.html
+
+(set! *warn-on-reflection* true)
+
+(def ^:private memory-usage-threshold 0.8)
+
+(def ^:private callback-fns-atom (atom []))
+
+(def ^:private ^NotificationListener notification-listener
+  (reify NotificationListener
+    (handleNotification [_ notification _]
+      (when (= (.getType notification)
+               MemoryNotificationInfo/MEMORY_THRESHOLD_EXCEEDED)
+        (doseq [callback-fn @callback-fns-atom]
+          (callback-fn))))))
+
+(defn- find-tenured-generation-pool
+  ^MemoryPoolMXBean []
+  ;; The tenured generation pool is the pool that hosts all the objects that
+  ;; survived garbage collection. This is the pool we want to monitor. It is
+  ;; the first pool of type HEAP that supports a usage threshold.
+  (some (fn [^MemoryPoolMXBean pool]
+          (when (and (= MemoryType/HEAP (.getType pool))
+                     (.isUsageThresholdSupported pool))
+            pool))
+        (ManagementFactory/getMemoryPoolMXBeans)))
+
+(def ^:private ensure-notification-listener!
+  (memoize
+    (fn ensure-notification-listener! []
+      (when-some [tenured-generation-pool (find-tenured-generation-pool)]
+        (let [^NotificationEmitter notification-emitter (ManagementFactory/getMemoryMXBean)
+              usage-threshold (-> tenured-generation-pool .getUsage .getMax (* memory-usage-threshold) long)]
+          (.setUsageThreshold tenured-generation-pool usage-threshold)
+          (.addNotificationListener notification-emitter notification-listener nil nil))))))
+
+(defn add-callback!
+  "Add a callback function that will be invoked when low memory conditions are
+  detected. The callback-fn should take no arguments, and should do whatever it
+  can to clean up non-critical resources that might be hogging memory."
+  [callback-fn]
+  (assert (ifn? callback-fn))
+  (ensure-notification-listener!)
+  (swap! callback-fns-atom conj callback-fn)
+  nil)
+
+(defn remove-callback!
+  "Remove a callback function from the list of functions that will be invoked
+  when low memory conditions are detected."
+  [callback-fn]
+  (assert (ifn? callback-fn))
+  (swap! callback-fns-atom
+         (fn [callback-fns]
+           (filterv (partial not= callback-fn)
+                    callback-fns)))
+  nil)


### PR DESCRIPTION
Partial fix for defold/editor2-issues#2549

Also addressed by #3007.

### User-facing changes
* Clear the cache when we detect low-memory conditions. This hopefully frees up some memory and avoids an `OutOfMemoryError`.

### Testing recommendations
To test, you might want to hack a low-ish max heap like `-Xmx2g` into the `config` file, then open a large project and look at a bunch of `.atlas` tabs in the editor. Building and rebuilding the project would usually trigger an `OutOfMemoryError` after that.