### PR TITLE
DEFEDIT-1664 Fix update link in Welcome dialog

### DIFF
--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
   :cursive.formatting/imports-use-vectors true
   :dynamo.graph/precluding-errors :only-indent
   :dynamo.graph/with-auto-evaluation-context :only-indent
+  :dynamo.graph/with-auto-or-fake-evaluation-context :only-indent
   :dynamo.graph/with-system :only-indent
   :editor.analytics-test/with-config! :only-indent
   :editor.file-test/with-temp-dir :only-indent

--- a/editor/emacs_clojure_indent.el
+++ b/editor/emacs_clojure_indent.el
@@ -6,6 +6,7 @@
   (fnk 1)
   (precluding-errors 1)
   (with-auto-evaluation-context 1)
+  (with-auto-or-fake-evaluation-context 1)
   (with-system 1)
   (with-config! 1)
   (with-temp-dir 1)

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -765,6 +765,16 @@
      (update-cache-from-evaluation-context! ~ec)
      result#))
 
+(def fake-system (is/make-system {:cache-size 0}))
+
+(defmacro with-auto-or-fake-evaluation-context [ec & body]
+  `(let [real-system# @*the-system*
+         ~ec (is/default-evaluation-context (or real-system# fake-system))
+         result# (do ~@body)]
+     (when (some? real-system#)
+       (update-cache-from-evaluation-context! ~ec))
+     result#))
+
 (defn invalidate-counter
   ([node-id output]
    (get (:invalidate-counters @*the-system*) [node-id output]))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1719,7 +1719,7 @@
 
 (defn refresh
   [^Scene scene]
-  (g/with-auto-evaluation-context evaluation-context
+  (g/with-auto-or-fake-evaluation-context evaluation-context
     (refresh-menus! scene (or (user-data scene :command->shortcut) {}) evaluation-context)
     (refresh-toolbars! scene evaluation-context)))
 

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1181,15 +1181,10 @@
                                 on-open))
                 (make-menu-command scene id label icon style-classes acc user-data command enabled? check)))))))))
 
-(defn- make-menu-items
-  ([^Scene scene menu command-contexts command->shortcut]
-   (g/with-auto-evaluation-context evaluation-context
-     (make-menu-items scene menu command-contexts command->shortcut evaluation-context)))
-  ([^Scene scene menu command-contexts command->shortcut evaluation-context]
-   (->> menu
-        (keep (fn [item]
-                (make-menu-item scene item command-contexts command->shortcut evaluation-context)))
-        (vec))))
+(defn- make-menu-items [^Scene scene menu command-contexts command->shortcut evaluation-context]
+  (into []
+        (keep #(make-menu-item scene % command-contexts command->shortcut evaluation-context))
+        menu))
 
 (defn- make-context-menu ^ContextMenu [menu-items]
   (let [context-menu (ContextMenu.)]
@@ -1211,7 +1206,9 @@
     (.consume event)
     (let [node ^Node (.getTarget event)
           scene ^Scene (.getScene node)
-          cm (make-context-menu (make-menu-items scene (menu/realize-menu menu-id) (contexts scene false) (or (user-data scene :command->shortcut) {})))]
+          menu-items (g/with-auto-or-fake-evaluation-context evaluation-context
+                       (make-menu-items scene (menu/realize-menu menu-id) (contexts scene false) (or (user-data scene :command->shortcut) {}) evaluation-context))
+          cm (make-context-menu menu-items)]
       (doto (.getItems cm)
         (refresh-separator-visibility)
         (refresh-menu-item-styles))

--- a/editor/test/editor/ui_test.clj
+++ b/editor/test/editor/ui_test.clj
@@ -1,5 +1,6 @@
 (ns editor.ui-test
   (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
             [editor.handler :as handler]
             [editor.menu :as menu]
             [editor.ui :as ui]
@@ -44,6 +45,10 @@
   (succeeding-selection [this] [])
   (alt-selection [this] []))
 
+(defn- make-menu-items [scene menu-id command-context]
+  (g/with-auto-evaluation-context evaluation-context
+    (#'ui/make-menu-items scene (#'menu/realize-menu menu-id) [command-context] {} evaluation-context)))
+
 (deftest menu-test
   (test-support/with-clean-system
     (ui/extend-menu ::my-menu nil
@@ -64,9 +69,8 @@
 
     (let [root (Pane.)
           scene (ui/run-now (Scene. root))
-          selection-provider (TestSelectionProvider. [])
           command-context {:name :global :env {:selection []}}]
-     (let [menu-items (#'ui/make-menu-items scene (#'menu/realize-menu ::my-menu) [command-context] {})]
+     (let [menu-items (make-menu-items scene ::my-menu command-context)]
        (is (= 1 (count menu-items)))
        (is (instance? Menu (first menu-items)))
        (is (= 2 (count (.getItems (first menu-items)))))
@@ -90,7 +94,7 @@
                                                  :user-data 2}])))
 
     (let [command-context {:name :global :env {}}]
-      (let [menu-items (#'ui/make-menu-items nil (#'menu/realize-menu ::my-menu) [command-context] {})]
+      (let [menu-items (make-menu-items nil ::my-menu command-context)]
         (is (= 1 (count menu-items)))
         (is (= 1 (count (.getItems (first menu-items)))))))))
 


### PR DESCRIPTION
Fixes defold/editor2-issues#2547
Fixes defold/editor2-issues#2562

### User-facing changes
* The **Update Available** link in the Welcome dialog works again.