### PR TITLE
DEFEDIT-1670 Improve cache efficiency

### DIFF
--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -7,6 +7,7 @@
             [editor.prefs :as prefs]
             [editor.properties-view :as properties-view]
             [internal.graph :as ig]
+            [internal.system :as is]
             [internal.util :as util])
   (:import [clojure.lang MapEntry]
            [javafx.stage Window]))
@@ -125,6 +126,8 @@
 (defn console-view []
   (-> (view-of-type console/ConsoleNode) (g/targets-of :lines) ffirst))
 
+(def ^:private node-type-key (comp :k g/node-type*))
+
 (defn- node-value-type-symbol [node-value-type]
   (symbol (if-some [^Class class (:class (deref node-value-type))]
             (.getSimpleName class)
@@ -198,7 +201,7 @@
                      node-successors))]
      (util/group-into (sorted-map)
                       (sorted-set)
-                      (comp :k (partial g/node-type* basis) key)
+                      (comp (partial node-type-key basis) key)
                       val
                       (mapcat select
                               (successor-tree basis node-id label))))))
@@ -226,7 +229,7 @@
   ([basis node-id label]
    (util/group-into (sorted-map)
                     (sorted-set)
-                    (comp :k (partial g/node-type* basis) key)
+                    (comp (partial node-type-key basis) key)
                     val
                     (mapcat (fn [[node-id node-successors]]
                               (map (fn [[label]]
@@ -247,3 +250,39 @@
            (for [[node-id labels] label-seqs-by-node-id
                  label labels]
              (direct-successor-types basis node-id label)))))
+
+(defn ordered-occurrences
+  "Returns a sorted list of [occurrence-count entry]. The list is sorted by
+  occurrence count in descending order."
+  [coll]
+  (sort (fn [[occurrence-count-a entry-a] [occurrence-count-b entry-b]]
+          (cond (< occurrence-count-a occurrence-count-b) 1
+                (< occurrence-count-b occurrence-count-a) -1
+                (and (instance? Comparable entry-a)
+                     (instance? Comparable entry-b)) (compare entry-a entry-b)
+                :else 0))
+        (map (fn [[entry occurrence-count]]
+               (pair occurrence-count entry))
+             (frequencies coll))))
+
+(defn cached-output-report
+  "Returns a sorted list of what node outputs are in the system cache in the
+  format [entry-occurrence-count [node-type-key output-label]]. The list is
+  sorted by entry occurrence count in descending order."
+  []
+  (let [system @g/*the-system*
+        basis (is/basis system)]
+    (ordered-occurrences
+      (map (fn [[[node-id output-label]]]
+             (let [node-type-key (node-type-key basis node-id)]
+               (pair node-type-key output-label)))
+           (is/system-cache system)))))
+
+(defn cached-output-name-report
+  "Returns a sorted list of what output names are in the system cache in the
+  format [entry-occurrence-count output-label]. The list is sorted by entry
+  occurrence count in descending order."
+  []
+  (ordered-occurrences
+    (map (comp second key)
+         (is/system-cache @g/*the-system*))))

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -754,6 +754,15 @@
   ([] (is/default-evaluation-context @*the-system*))
   ([options] (is/custom-evaluation-context @*the-system* options)))
 
+(defn pruned-evaluation-context
+  "Selectively filters out cache entries from the supplied evaluation context.
+  Returns a new evaluation context with only the cache entries that passed the
+  cache-entry-pred predicate. The predicate function will be called with
+  node-id, output-label, evaluation-context and should return true if the
+  cache entry for the output-label should remain in the cache."
+  [evaluation-context cache-entry-pred]
+  (in/pruned-evaluation-context evaluation-context cache-entry-pred))
+
 (defn update-cache-from-evaluation-context!
   [evaluation-context]
   (swap! *the-system* is/update-cache-from-evaluation-context evaluation-context)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -716,6 +716,15 @@
         (workspace/save-build-cache! workspace)
         build-results))))
 
+(defn- cached-build-target-output? [node-id label evaluation-context]
+  (and (= :build-targets label)
+       (project/project-resource-node? node-id evaluation-context)))
+
+(defn- update-system-cache-build-targets! [evaluation-context]
+  ;; To avoid cache churn, we only transfer the most important entries to the system cache.
+  (let [pruned-evaluation-context (g/pruned-evaluation-context evaluation-context cached-build-target-output?)]
+    (g/update-cache-from-evaluation-context! pruned-evaluation-context)))
+
 (defn- build-handler [project workspace prefs web-server build-errors-view main-stage tool-tab-pane]
   (let [project-directory (io/file (workspace/project-path workspace))
         evaluation-context (g/make-evaluation-context)
@@ -725,7 +734,7 @@
     (async-build! project evaluation-context prefs {:debug? false} (workspace/artifact-map workspace)
                   (make-render-task-progress :build)
                   (fn [build-results engine-descriptor build-engine-exception]
-                    (g/update-cache-from-evaluation-context! evaluation-context)
+                    (update-system-cache-build-targets! evaluation-context)
                     (when (handle-build-results! workspace render-build-error! build-results)
                       (when engine-descriptor
                         (show-console! main-scene tool-tab-pane)
@@ -755,7 +764,7 @@ If you do not specifically require different script states, consider changing th
     (async-build! project evaluation-context prefs {:debug? true} (workspace/artifact-map workspace)
                   (make-render-task-progress :build)
                   (fn [build-results engine-descriptor build-engine-exception]
-                    (g/update-cache-from-evaluation-context! evaluation-context)
+                    (update-system-cache-build-targets! evaluation-context)
                     (when (handle-build-results! workspace render-build-error! build-results)
                       (when engine-descriptor
                         (when-let [target (launch-built-project! engine-descriptor project-directory prefs web-server true)]
@@ -770,7 +779,7 @@ If you do not specifically require different script states, consider changing th
     (async-build! project evaluation-context prefs {:debug? true :engine? false} (workspace/artifact-map workspace)
                   (make-render-task-progress :build)
                   (fn [build-results _ _]
-                    (g/update-cache-from-evaluation-context! evaluation-context)
+                    (update-system-cache-build-targets! evaluation-context)
                     (when (handle-build-results! workspace render-build-error! build-results)
                       (let [target (targets/selected-target prefs)]
                         (when (targets/controllable-target? target)
@@ -862,7 +871,7 @@ If you do not specifically require different script states, consider changing th
     (build-errors-view/clear-build-errors build-errors-view)
     (async-build! project evaluation-context prefs opts old-artifact-map render-build-progress!
                   (fn [{:keys [error artifact-map etags]} _ _]
-                    (g/update-cache-from-evaluation-context! evaluation-context)
+                    (update-system-cache-build-targets! evaluation-context)
                     (if (some? error)
                       (render-build-error! error)
                       (do

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -213,10 +213,10 @@
   (output ddf-message g/Any (g/fnk [maybe-image-resource order]
                               {:image (resource/resource->proj-path maybe-image-resource) :order order}))
   (output scene g/Any :cached produce-image-scene)
-  (output build-errors g/Any :cached (g/fnk [_node-id id id-counts maybe-image-resource]
-                                       (g/package-errors _node-id
-                                                         (validate-image-resource _node-id maybe-image-resource)
-                                                         (validate-image-id _node-id id id-counts)))))
+  (output build-errors g/Any (g/fnk [_node-id id id-counts maybe-image-resource]
+                               (g/package-errors _node-id
+                                                 (validate-image-resource _node-id maybe-image-resource)
+                                                 (validate-image-id _node-id id id-counts)))))
 
 (defn- sort-by-and-strip-order [images]
   (->> images
@@ -350,14 +350,14 @@
   (output ddf-message g/Any :cached produce-anim-ddf)
   (output updatable g/Any :cached produce-animation-updatable)
   (output scene g/Any :cached produce-animation-scene)
-  (output own-build-errors g/Any :cached (g/fnk [_node-id fps id id-counts]
-                                           (g/package-errors _node-id
-                                                             (validate-animation-id _node-id id id-counts)
-                                                             (validate-animation-fps _node-id fps))))
-  (output build-errors g/Any :cached (g/fnk [_node-id child-build-errors own-build-errors]
-                                       (g/package-errors _node-id
-                                                         child-build-errors
-                                                         own-build-errors))))
+  (output own-build-errors g/Any (g/fnk [_node-id fps id id-counts]
+                                   (g/package-errors _node-id
+                                                     (validate-animation-id _node-id id id-counts)
+                                                     (validate-animation-fps _node-id fps))))
+  (output build-errors g/Any (g/fnk [_node-id child-build-errors own-build-errors]
+                               (g/package-errors _node-id
+                                                 child-build-errors
+                                                 own-build-errors))))
 
 (g/defnk produce-save-value [margin inner-padding extrude-borders img-ddf anim-ddf]
   {:margin margin
@@ -579,19 +579,18 @@
                                                                              {:node-type    AtlasAnimation
                                                                               :tx-attach-fn attach-animation-to-atlas}]}))
   (output save-value       g/Any          :cached produce-save-value)
-  (output build-errors     g/Any          :cached produce-build-errors)
   (output build-targets    g/Any          :cached produce-build-targets)
   (output updatable        g/Any          (g/fnk [] nil))
   (output scene            g/Any          :cached produce-scene)
-  (output own-build-errors g/Any          :cached (g/fnk [_node-id extrude-borders inner-padding margin]
-                                                    (g/package-errors _node-id
-                                                                      (validate-margin _node-id margin)
-                                                                      (validate-inner-padding _node-id inner-padding)
-                                                                      (validate-extrude-borders _node-id extrude-borders))))
-  (output build-errors     g/Any          :cached (g/fnk [_node-id child-build-errors own-build-errors]
-                                                    (g/package-errors _node-id
-                                                                      child-build-errors
-                                                                      own-build-errors))))
+  (output own-build-errors g/Any          (g/fnk [_node-id extrude-borders inner-padding margin]
+                                            (g/package-errors _node-id
+                                                              (validate-margin _node-id margin)
+                                                              (validate-inner-padding _node-id inner-padding)
+                                                              (validate-extrude-borders _node-id extrude-borders))))
+  (output build-errors     g/Any          (g/fnk [_node-id child-build-errors own-build-errors]
+                                            (g/package-errors _node-id
+                                                              child-build-errors
+                                                              own-build-errors))))
 
 (defn- make-image-nodes
   [attach-fn parent image-resources]

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -662,7 +662,7 @@
                                               [:resource :source-resource]
                                               [:node-outline :source-outline]
                                               [:proto-msg :proto-msg]
-                                              [:save-data :source-save-data]
+                                              [:undecorated-save-data :source-save-data]
                                               [:build-targets :source-build-targets]
                                               [:scene :scene]
                                               [:ddf-component-properties :ddf-component-properties]])

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -585,7 +585,7 @@
                                             :transform transform
                                             :aabb geom/empty-bounding-box
                                             :renderable {:passes [pass/selection]})))
-  (output build-targets g/Any :cached produce-coll-inst-build-targets)
+  (output build-targets g/Any produce-coll-inst-build-targets)
   (output sub-ddf-properties g/Any :cached (g/fnk [id ddf-properties]
                                                   (map (fn [m] (update m :id (fn [s] (format "%s/%s" id s)))) ddf-properties)))
   (output go-inst-ids g/Any :cached (g/fnk [id go-inst-ids] (into {} (map (fn [[k v]] [(format "%s/%s" id k) v]) go-inst-ids)))))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -734,14 +734,33 @@
         (settings-core/get-setting ["project" "dependencies"])
         (library/parse-library-uris))))
 
+(def ^:private embedded-resource? (comp nil? resource/proj-path))
+
+(defn project-resource-node? [node-id evaluation-context]
+  (let [basis (:basis evaluation-context)]
+    (and (g/node-instance? basis resource-node/ResourceNode node-id)
+         (not (embedded-resource? (g/node-value node-id :resource evaluation-context))))))
+
+(defn- cached-save-data-output? [node-id label evaluation-context]
+  (case label
+    (:save-data :source-value) (project-resource-node? node-id evaluation-context)
+    false))
+
+(defn update-system-cache-save-data! [evaluation-context]
+  ;; To avoid cache churn, we only transfer the most important entries to the system cache.
+  (let [pruned-evaluation-context (g/pruned-evaluation-context evaluation-context cached-save-data-output?)]
+    (g/update-cache-from-evaluation-context! pruned-evaluation-context)))
+
 (defn- cache-save-data! [project]
   ;; Save data is required for the Search in Files feature so we pull
   ;; it in the background here to cache it.
   (let [evaluation-context (g/make-evaluation-context)]
     (future
-      ;; TODO progress reporting
-      (g/node-value project :save-data evaluation-context)
-      (ui/run-later (g/update-cache-from-evaluation-context! evaluation-context)))))
+      (error-reporting/catch-all!
+        ;; TODO: Progress reporting.
+        (g/node-value project :save-data evaluation-context)
+        (ui/run-later
+          (update-system-cache-save-data! evaluation-context))))))
 
 (defn open-project! [graph workspace-id game-project-resource render-progress! login-fn]
   (let [dependencies (read-dependencies game-project-resource)

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as string]
    [dynamo.graph :as g]
+   [editor.defold-project :as project]
    [editor.resource :as resource]
    [editor.ui :as ui]
    [util.text-util :as text-util]
@@ -77,7 +78,8 @@
                                                  save-data))))
                                      (g/node-value project :nodes evaluation-context))
                                (sort-by save-data-sort-key))]
-          (ui/run-later (g/update-cache-from-evaluation-context! evaluation-context))
+          (ui/run-later
+            (project/update-system-cache-save-data! evaluation-context))
           save-data)
         (catch Throwable error
           (report-error! error)

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -125,7 +125,7 @@
               (render-save-progress! progress/done)
               (ui/run-later
                 (try
-                  (g/update-cache-from-evaluation-context! evaluation-context)
+                  (project/update-system-cache-save-data! evaluation-context)
                   (g/update-property! workspace :resource-snapshot resource-watch/update-snapshot-status updated-file-resource-status-map-entries)
                   (project/invalidate-save-data-source-values! save-data)
                   (when (some? changes-view)

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -205,17 +205,16 @@
                                    :aabb geom/empty-bounding-box
                                    :renderable {:passes [pass/selection]}})))
   (output build-resource resource/Resource (g/fnk [source-build-targets] (:resource (first source-build-targets))))
-  (output build-targets g/Any :cached (g/fnk [_node-id source-build-targets build-resource rt-ddf-message transform]
-                                             (if-let [target (first source-build-targets)]
-                                               (let [target (->> (assoc target :resource build-resource)
-                                                                 (wrap-if-raw-sound _node-id))]
-                                                 [(bt/with-content-hash
-                                                    (assoc target
-                                                      :instance-data
-                                                      {:resource (:resource target)
-                                                       :instance-msg rt-ddf-message
-                                                       :transform transform}))])
-                                               [])))
+  (output build-targets g/Any (g/fnk [_node-id source-build-targets build-resource rt-ddf-message transform]
+                                (when-some [target (first source-build-targets)]
+                                  (let [target (->> (assoc target :resource build-resource)
+                                                    (wrap-if-raw-sound _node-id))]
+                                    [(bt/with-content-hash
+                                       (assoc target
+                                         :instance-data
+                                         {:resource (:resource target)
+                                          :instance-msg rt-ddf-message
+                                          :transform transform}))]))))
   (output _properties g/Properties :cached produce-component-properties))
 
 (g/defnode EmbeddedComponent

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -492,7 +492,7 @@
                                               [:resource :source-resource]
                                               [:_properties :source-properties]
                                               [:node-outline :source-outline]
-                                              [:save-data :save-data]
+                                              [:undecorated-save-data :save-data]
                                               [:scene :scene]
                                               [:build-targets :source-build-targets]])
                   (attach-embedded-component self comp-node)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -626,17 +626,19 @@
   (output transform-properties g/Any scene/produce-scalable-transform-properties)
   (output node-msg g/Any produce-node-msg)
   (input node-msgs g/Any :array)
-  (output node-msgs g/Any :cached (g/fnk [node-msgs node-msg] (into [node-msg]
-                                                                    (->> node-msgs
-                                                                         (sort-by #(get-in % [0 :child-index]))
-                                                                         flatten
-                                                                         (map #(dissoc % :child-index))))))
+  (output node-msgs g/Any (g/fnk [node-msgs node-msg]
+                            (into [node-msg]
+                                  (map #(dissoc % :child-index))
+                                  (flatten
+                                    (sort-by #(get-in % [0 :child-index])
+                                             node-msgs)))))
   (input node-rt-msgs g/Any :array)
-  (output node-rt-msgs g/Any :cached (g/fnk [node-rt-msgs node-msg] (into [node-msg]
-                                                                          (->> node-rt-msgs
-                                                                               (sort-by #(get-in % [0 :child-index]))
-                                                                               flatten
-                                                                               (map #(dissoc % :child-index))))))
+  (output node-rt-msgs g/Any (g/fnk [node-rt-msgs node-msg]
+                               (into [node-msg]
+                                     (map #(dissoc % :child-index))
+                                     (flatten
+                                       (sort-by #(get-in % [0 :child-index])
+                                                node-rt-msgs)))))
   (output aabb g/Any :abstract)
   (output scene-children g/Any :cached (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
   (output scene-updatable g/Any (g/constantly nil))
@@ -664,7 +666,7 @@
 
   (input node-ids IDMap :array)
   (output id g/Str (g/fnk [id-prefix id] (str id-prefix id)))
-  (output node-ids IDMap :cached (g/fnk [_node-id id node-ids] (reduce merge {id _node-id} node-ids)))
+  (output node-ids IDMap (g/fnk [_node-id id node-ids] (reduce merge {id _node-id} node-ids)))
 
   (input node-overrides g/Any :array)
   (output node-overrides g/Any :cached (g/fnk [node-overrides id _overridden-properties]
@@ -673,15 +675,15 @@
   (input current-layout g/Str)
   (output current-layout g/Str (gu/passthrough current-layout))
   (input child-build-errors g/Any :array)
-  (output build-errors-gui-node g/Any :cached (g/fnk [_node-id id id-counts layer layer-names]
-                                                (g/package-errors _node-id
-                                                                  (prop-unique-id-error _node-id :id id id-counts "Id")
-                                                                  (validate-layer false _node-id layer-names layer))))
+  (output build-errors-gui-node g/Any (g/fnk [_node-id id id-counts layer layer-names]
+                                        (g/package-errors _node-id
+                                                          (prop-unique-id-error _node-id :id id id-counts "Id")
+                                                          (validate-layer false _node-id layer-names layer))))
   (output own-build-errors g/Any (gu/passthrough build-errors-gui-node))
-  (output build-errors g/Any :cached (g/fnk [_node-id own-build-errors child-build-errors]
-                                       (g/package-errors _node-id
-                                                         child-build-errors
-                                                         own-build-errors)))
+  (output build-errors g/Any (g/fnk [_node-id own-build-errors child-build-errors]
+                               (g/package-errors _node-id
+                                                 child-build-errors
+                                                 own-build-errors)))
   (input template-build-targets g/Any :array)
   (output template-build-targets g/Any (gu/passthrough template-build-targets)))
 
@@ -798,10 +800,10 @@
   (output texture-size g/Any (g/fnk [anim-data]
                                     (when (some? anim-data)
                                       [(double (:width anim-data)) (double (:height anim-data)) 0.0])))
-  (output build-errors-shape-node g/Any :cached (g/fnk [build-errors-visual-node _node-id texture texture-names]
-                                                  (g/package-errors _node-id
-                                                                    build-errors-visual-node
-                                                                    (validate-texture _node-id texture-names texture))))
+  (output build-errors-shape-node g/Any (g/fnk [build-errors-visual-node _node-id texture texture-names]
+                                          (g/package-errors _node-id
+                                                            build-errors-visual-node
+                                                            (validate-texture _node-id texture-names texture))))
   (output own-build-errors g/Any (gu/passthrough build-errors-shape-node)))
 
 (defmethod update-gui-resource-reference [::ShapeNode :texture]
@@ -1106,10 +1108,10 @@
                    (cond-> user-data
                      (not= :clipping-mode-none clipping-mode)
                      (assoc :clipping {:mode clipping-mode :inverted clipping-inverted :visible clipping-visible})))))
-  (output own-build-errors g/Any :cached (g/fnk [_node-id build-errors-shape-node perimeter-vertices]
-                                           (g/package-errors _node-id
-                                                             build-errors-shape-node
-                                                             (validate-perimeter-vertices _node-id perimeter-vertices)))))
+  (output own-build-errors g/Any (g/fnk [_node-id build-errors-shape-node perimeter-vertices]
+                                   (g/package-errors _node-id
+                                                     build-errors-shape-node
+                                                     (validate-perimeter-vertices _node-id perimeter-vertices)))))
 
 ;; Text nodes
 
@@ -1186,10 +1188,10 @@
                                           font-data (assoc :offset (let [[x y] (pivot-offset pivot aabb-size)
                                                                          h (second aabb-size)]
                                                                      [x (+ y (- h (get-in font-data [:font-map :max-ascent])))])))))
-  (output own-build-errors g/Any :cached (g/fnk [_node-id build-errors-visual-node font font-names]
-                                           (g/package-errors _node-id
-                                                             build-errors-visual-node
-                                                             (validate-font _node-id font-names font)))))
+  (output own-build-errors g/Any (g/fnk [_node-id build-errors-visual-node font font-names]
+                                   (g/package-errors _node-id
+                                                     build-errors-visual-node
+                                                     (validate-font _node-id font-names font)))))
 
 (defmethod update-gui-resource-reference [::TextNode :font]
   [_ evaluation-context node-id old-name new-name]
@@ -1359,10 +1361,10 @@
                                                  :child-index child-index
                                                  :layer-index layer-index
                                                  :user-data {:color color+alpha :inherit-alpha inherit-alpha}}))
-  (output own-build-errors g/Any :cached (g/fnk [_node-id build-errors-gui-node template-resource]
-                                           (g/package-errors _node-id
-                                                             build-errors-gui-node
-                                                             (prop-resource-error _node-id :template template-resource "Template")))))
+  (output own-build-errors g/Any (g/fnk [_node-id build-errors-gui-node template-resource]
+                                   (g/package-errors _node-id
+                                                     build-errors-gui-node
+                                                     (prop-resource-error _node-id :template template-resource "Template")))))
 
 ;; Spine nodes
 
@@ -1461,12 +1463,12 @@
       (let [pb-msg (first node-msgs)
             rt-pb-msgs (into node-rt-msgs [(update pb-msg :spine-skin (fn [skin] (or skin "")))])]
         (into rt-pb-msgs bone-node-msgs))))
-  (output own-build-errors g/Any :cached (g/fnk [_node-id build-errors-visual-node spine-anim-ids spine-default-animation spine-skin-ids spine-skin spine-scene spine-scene-names]
-                                           (g/package-errors _node-id
-                                                             build-errors-visual-node
-                                                             (validate-spine-scene _node-id spine-scene-names spine-scene)
-                                                             (validate-spine-default-animation _node-id spine-scene-names spine-anim-ids spine-default-animation spine-scene)
-                                                             (validate-spine-skin _node-id spine-scene-names spine-skin-ids spine-skin spine-scene)))))
+  (output own-build-errors g/Any (g/fnk [_node-id build-errors-visual-node spine-anim-ids spine-default-animation spine-skin-ids spine-skin spine-scene spine-scene-names]
+                                   (g/package-errors _node-id
+                                                     build-errors-visual-node
+                                                     (validate-spine-scene _node-id spine-scene-names spine-scene)
+                                                     (validate-spine-default-animation _node-id spine-scene-names spine-anim-ids spine-default-animation spine-scene)
+                                                     (validate-spine-skin _node-id spine-scene-names spine-skin-ids spine-skin spine-scene)))))
 
 (defmethod update-gui-resource-reference [::SpineNode :spine-scene]
   [_ evaluation-context node-id old-name new-name]
@@ -1541,10 +1543,10 @@
                                              :aabb aabb
                                              :transform transform)
                                            (update :children (fnil into []) scene-children)))))
-  (output own-build-errors g/Any :cached (g/fnk [_node-id build-errors-visual-node particlefx particlefx-resource-names]
-                                           (g/package-errors _node-id
-                                                             build-errors-visual-node
-                                                             (validate-particlefx-resource _node-id particlefx-resource-names particlefx)))))
+  (output own-build-errors g/Any (g/fnk [_node-id build-errors-visual-node particlefx particlefx-resource-names]
+                                   (g/package-errors _node-id
+                                                     build-errors-visual-node
+                                                     (validate-particlefx-resource _node-id particlefx-resource-names particlefx)))))
 
 (defmethod update-gui-resource-reference [::ParticleFXNode :particlefx]
   [_ evaluation-context node-id old-name new-name]
@@ -1625,23 +1627,23 @@
   (input dep-build-targets g/Any)
   (output dep-build-targets g/Any (gu/passthrough dep-build-targets))
 
-  (output node-outline outline/OutlineData (g/fnk [_node-id name texture-resource build-errors]
-                                             (cond-> {:node-id _node-id
-                                                      :node-outline-key name
-                                                      :label name
-                                                      :icon texture-icon
-                                                      :outline-error? (g/error-fatal? build-errors)}
-                                                     (resource/openable-resource? texture-resource) (assoc :link texture-resource :outline-show-link? true))))
+  (output node-outline outline/OutlineData :cached (g/fnk [_node-id name texture-resource build-errors]
+                                                     (cond-> {:node-id _node-id
+                                                              :node-outline-key name
+                                                              :label name
+                                                              :icon texture-icon
+                                                              :outline-error? (g/error-fatal? build-errors)}
+                                                             (resource/openable-resource? texture-resource) (assoc :link texture-resource :outline-show-link? true))))
   (output pb-msg g/Any (g/fnk [name texture-resource]
                          {:name name
                           :texture (resource/resource->proj-path texture-resource)}))
   (output texture-anim-datas TextureAnimDatas :cached produce-texture-anim-datas)
   (output texture-gpu-textures GuiResourceTextures :cached produce-texture-gpu-textures)
   (output texture-names GuiResourceNames :cached produce-texture-names)
-  (output build-errors g/Any :cached (g/fnk [_node-id name name-counts texture]
-                                       (g/package-errors _node-id
-                                                         (prop-unique-id-error _node-id :name name name-counts "Name")
-                                                         (prop-resource-error _node-id :texture texture "Texture")))))
+  (output build-errors g/Any (g/fnk [_node-id name name-counts texture]
+                               (g/package-errors _node-id
+                                                 (prop-unique-id-error _node-id :name name name-counts "Name")
+                                                 (prop-resource-error _node-id :texture texture "Texture")))))
 
 (g/defnode FontNode
   (inherits outline/OutlineNode)
@@ -1669,7 +1671,7 @@
   (input font-shader ShaderLifecycle :substitute (constantly nil))
 
   (input dep-build-targets g/Any)
-  (output dep-build-targets g/Any :cached (gu/passthrough dep-build-targets))
+  (output dep-build-targets g/Any (gu/passthrough dep-build-targets))
 
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id name font-resource build-errors]
                                                      (cond-> {:node-id _node-id
@@ -1692,10 +1694,10 @@
                                          (when (some? font-data)
                                            {name font-data})))
   (output font-names GuiResourceNames (g/fnk [name] (sorted-set name)))
-  (output build-errors g/Any :cached (g/fnk [_node-id name name-counts font]
-                                       (g/package-errors _node-id
-                                                         (prop-unique-id-error _node-id :name name name-counts "Name")
-                                                         (prop-resource-error _node-id :font font "Font")))))
+  (output build-errors g/Any (g/fnk [_node-id name name-counts font]
+                               (g/package-errors _node-id
+                                                 (prop-unique-id-error _node-id :name name name-counts "Name")
+                                                 (prop-resource-error _node-id :font font "Font")))))
 
 (g/defnode LayerNode
   (inherits outline/OutlineNode)
@@ -1716,9 +1718,9 @@
   (output pb-msg g/Any (g/fnk [name child-index]
                               {:name name
                                :child-index child-index}))
-  (output build-errors g/Any :cached (g/fnk [_node-id name name-counts]
-                                       (g/package-errors _node-id
-                                                         (prop-unique-id-error _node-id :name name name-counts "Name")))))
+  (output build-errors g/Any (g/fnk [_node-id name name-counts]
+                               (g/package-errors _node-id
+                                                 (prop-unique-id-error _node-id :name name name-counts "Name")))))
 
 (g/defnk produce-spine-scene-element-ids [name spine-anim-ids spine-scene spine-scene-structure]
   ;; If the referenced spine-scene-resource is missing, we don't return an entry.
@@ -1774,7 +1776,7 @@
   (input spine-scene-structure g/Any :substitute (constantly nil))
   (input spine-scene-pb g/Any :substitute (constantly nil))
 
-  (output dep-build-targets g/Any :cached (gu/passthrough dep-build-targets))
+  (output dep-build-targets g/Any (gu/passthrough dep-build-targets))
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id name spine-scene-resource build-errors]
                                                           (cond-> {:node-id _node-id
                                                                    :node-outline-key name
@@ -1788,10 +1790,10 @@
   (output spine-scene-element-ids SpineSceneElementIds :cached produce-spine-scene-element-ids)
   (output spine-scene-infos SpineSceneInfos :cached produce-spine-scene-infos)
   (output spine-scene-names GuiResourceNames (g/fnk [name] (sorted-set name)))
-  (output build-errors g/Any :cached (g/fnk [_node-id name name-counts spine-scene]
-                                       (g/package-errors _node-id
-                                                         (prop-unique-id-error _node-id :name name name-counts "Name")
-                                                         (prop-resource-error _node-id :spine-scene spine-scene "Spine Scene")))))
+  (output build-errors g/Any (g/fnk [_node-id name name-counts spine-scene]
+                               (g/package-errors _node-id
+                                                 (prop-unique-id-error _node-id :name name name-counts "Name")
+                                                 (prop-resource-error _node-id :spine-scene spine-scene "Spine Scene")))))
 
 (g/defnode ParticleFXResource
   (inherits outline/OutlineNode)
@@ -1817,7 +1819,7 @@
   (input dep-build-targets g/Any)
   (input particlefx-scene g/Any :substitute (g/constantly nil))
 
-  (output dep-build-targets g/Any :cached (gu/passthrough dep-build-targets))
+  (output dep-build-targets g/Any (gu/passthrough dep-build-targets))
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id name particlefx-resource build-errors]
                                                      (cond-> {:node-id _node-id
                                                               :node-outline-key name
@@ -1831,10 +1833,10 @@
   (output particlefx-resource-names GuiResourceNames (g/fnk [name] (sorted-set name)))
   (output particlefx-infos g/Any (g/fnk [name particlefx-scene]
                                    {name {:particlefx-scene particlefx-scene}}))
-  (output build-errors g/Any :cached (g/fnk [_node-id name name-counts particlefx]
-                                       (g/package-errors _node-id
-                                                         (prop-unique-id-error _node-id :name name name-counts "Name")
-                                                         (prop-resource-error _node-id :particlefx particlefx "Particle FX")))))
+  (output build-errors g/Any (g/fnk [_node-id name name-counts particlefx]
+                               (g/package-errors _node-id
+                                                 (prop-unique-id-error _node-id :name name name-counts "Name")
+                                                 (prop-resource-error _node-id :particlefx particlefx "Particle FX")))))
 
 (def ^:private non-overridable-fields #{:template :id :parent})
 
@@ -1900,9 +1902,9 @@
   (output layout-scene g/Any (g/fnk [name node-tree-scene] [name node-tree-scene]))
   (input id-prefix g/Str)
   (output id-prefix g/Str (gu/passthrough id-prefix))
-  (output build-errors g/Any :cached (g/fnk [_node-id name name-counts]
-                                       (g/package-errors _node-id
-                                                         (prop-unique-id-error _node-id :name name name-counts "Name")))))
+  (output build-errors g/Any (g/fnk [_node-id name name-counts]
+                               (g/package-errors _node-id
+                                                 (prop-unique-id-error _node-id :name name name-counts "Name")))))
 
 (defmacro gen-outline-fnk [label node-outline-key order sort-children? child-reqs]
   `(g/fnk [~'_node-id ~'child-outlines]
@@ -2314,9 +2316,9 @@
   (output rt-pb-msg g/Any :cached produce-rt-pb-msg)
   (output save-value g/Any (gu/passthrough pb-msg))
   (input template-build-targets g/Any :array)
-  (output own-build-errors g/Any :cached produce-own-build-errors)
+  (output own-build-errors g/Any produce-own-build-errors)
   (input build-errors g/Any :array)
-  (output build-errors g/Any :cached produce-build-errors)
+  (output build-errors g/Any produce-build-errors)
   (output build-targets g/Any :cached produce-build-targets)
   (input layout-node-outlines g/Any :array)
   (output layout-node-outlines g/Any :cached (g/fnk [layout-node-outlines] (into {} layout-node-outlines)))

--- a/editor/src/clj/editor/spine.clj
+++ b/editor/src/clj/editor/spine.clj
@@ -923,7 +923,7 @@
   (input scene-structure g/Any)
 
   (output save-value g/Any produce-save-value)
-  (output own-build-errors g/Any :cached produce-scene-own-build-errors)
+  (output own-build-errors g/Any produce-scene-own-build-errors)
   (output build-targets g/Any :cached produce-scene-build-targets)
   (output spine-scene-pb g/Any :cached produce-spine-scene-pb)
   (output main-scene g/Any :cached produce-main-scene)
@@ -1090,7 +1090,7 @@
                                                              (assoc :link spine-scene :outline-reference? false))))
   (output model-pb g/Any produce-model-pb)
   (output save-value g/Any (gu/passthrough model-pb))
-  (output own-build-errors g/Any :cached produce-model-own-build-errors)
+  (output own-build-errors g/Any produce-model-own-build-errors)
   (output build-targets g/Any :cached produce-model-build-targets))
 
 

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -475,8 +475,8 @@
                 [1 :node-outline 0 :source-outline]
                 [1 :proto-msg 0 :proto-msg]
                 [1 :resource 0 :source-resource]
-                [1 :save-data 0 :source-save-data]
-                [1 :scene 0 :scene]]
+                [1 :scene 0 :scene]
+                [1 :undecorated-save-data 0 :source-save-data]]
                (sort arcs)))))))
 
 (deftest drag-drop-between-referenced-collections


### PR DESCRIPTION
### User-facing changes
* Improved build times after saving a large project.
* Improved save times after building a large project.

### Technical changes
* Added some cache-inspection functions to the `dev` module.
* We now only cache the `:build-targets` output on project file `ResourceNodes`. Build target outputs on nodes inside the file are not cached.
* We no longer cache `:build-errors` and related outputs, since they are cached in downstream outputs.
* We no longer cache a bunch of outputs that eventually end up in either build targets or save data in the `Gui` module.
* We no longer evaluate and cache the `:dirty?` and `:source-value` outputs on embedded resources when building. This appears to have been an oversight. An `:undecorated-save-data` output has been added to the base `ResourceNode` to achieve this.
* Building or saving the project now only transfers the most important results to the system cache upon completion. This improves cache efficiency overall at the cost of slightly longer build / save times for modified resources.