### PR TITLE
DEFEDIT-1640 Make sure deleted nodes are not selected.

### DIFF
--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -3,6 +3,7 @@
             [editor.asset-browser :as asset-browser]
             [editor.changes-view :as changes-view]
             [editor.console :as console]
+            [editor.curve-view :as curve-view]
             [editor.outline-view :as outline-view]
             [editor.prefs :as prefs]
             [editor.properties-view :as properties-view]
@@ -121,6 +122,7 @@
 (def changed-files-view (partial view-of-type changes-view/ChangesView))
 (def outline-view (partial view-of-type outline-view/OutlineView))
 (def properties-view (partial view-of-type properties-view/PropertiesView))
+(def curve-view (partial view-of-type curve-view/CurveView))
 
 (defn console-view []
   (-> (view-of-type console/ConsoleNode) (g/targets-of :lines) ffirst))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -516,13 +516,16 @@
                                 (:invalidate-outputs plan))]
         (g/invalidate-outputs! all-outputs))
 
-      (let [old->new (into {} (map (fn [[p n]] [(old-nodes-by-path p) n]) resource-path->new-node))]
+      (let [old->new (into {} (map (fn [[p n]] [(old-nodes-by-path p) n]) resource-path->new-node))
+            dissoc-deleted (fn [x] (apply dissoc x (:mark-deleted plan)))]
         (g/transact
           (concat
             (let [all-selections (-> (g/node-value project :all-selections)
+                                     (dissoc-deleted)
                                      (remap-selection old->new (comp vector first)))]
               (perform-selection project all-selections))
             (let [all-sub-selections (-> (g/node-value project :all-sub-selections)
+                                         (dissoc-deleted)
                                          (remap-selection old->new (constantly [])))]
               (perform-sub-selection project all-sub-selections)))))
 


### PR DESCRIPTION
This was breaking the curve view because it got an unexpected ErrorValue when
trying to get information from a deleted node that was still selected.

https://jira.int.midasplayer.com/browse/DEFEDIT-1640