### PR TITLE
DEFEDIT-1673 Fix exception when double-clicking already open file after swapping tab panes

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -993,6 +993,11 @@ If you do not specifically require different script states, consider changing th
              other-tabs (.getTabs other-tab-pane)
              active-tab (.get active-tabs active-tab-index)
              other-tab (.get other-tabs other-tab-index)]
+         ;; Fix for DEFEDIT-1673:
+         ;; We need to swap in a dummy tab here so that a tab is never in both
+         ;; TabPanes at once, since the tab lists are observed internally. If we
+         ;; do not, the tabs will lose track of their parent TabPane.
+         (.set other-tabs other-tab-index (Tab.))
          (.set active-tabs active-tab-index other-tab)
          (.set other-tabs other-tab-index active-tab)
          (.select active-tab-pane-selection other-tab)


### PR DESCRIPTION
Fixes defold/editor2-issues#2567

### User-facing changes
* Double-clicking an already open file after swapping tab panes no longer throws an exception.