### PR TITLE
DEFEDIT-1683 Fix for Console links not focusing on line

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -497,7 +497,8 @@
                                (when (and (resource/openable-resource? resource)
                                           (resource/exists? resource))
                                  (let [opts (when-some [row (:row region)]
-                                              {:line (inc (long row))})]
+                                              {:line (inc (long row))
+                                               :row row})]
                                    (open-resource-fn resource opts))))))
         repainter (ui/->timer "repaint-console-view" (fn [_ elapsed-time]
                                                        (when (and (.isSelected console-tab) (not (ui/ui-disabled?)))


### PR DESCRIPTION
### User-facing changes
* Console links will now frame the correct line number again.