### PR TITLE
DEFEDIT-1687 Use CursorRanges in ErrorValues instead of line numbers

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -20,7 +20,7 @@
 
 (namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id node-id? produce-value node-by-id-at])
 
-(namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate flatten-errors package-errors precluding-errors unpack-errors worse-than])
+(namespaces/import-vars [internal.graph.error-values error-info error-warning error-fatal ->error error? error-info? error-warning? error-fatal? error-aggregate flatten-errors map->error package-errors precluding-errors unpack-errors worse-than])
 
 (namespaces/import-vars [internal.node value-type-schema value-type? isa-node-type? value-type-dispatch-value has-input? has-output? has-property? type-compatible? merge-display-order NodeType supertypes declared-properties declared-property-labels declared-inputs declared-outputs cached-outputs input-dependencies input-cardinality cascade-deletes substitute-for input-type output-type input-labels output-labels property-display-order])
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -6,6 +6,7 @@
             [editor.bundle :as bundle]
             [editor.bundle-dialog :as bundle-dialog]
             [editor.changes-view :as changes-view]
+            [editor.code.data :refer [CursorRange->line-number]]
             [editor.console :as console]
             [editor.debug-view :as debug-view]
             [editor.defold-project :as project]
@@ -1462,9 +1463,10 @@ If you do not specifically require different script states, consider changing th
                                                    (prefs/get-prefs prefs "code-custom-editor" "")
                                                    string/trim)]
                                      (and (not (string/blank? ed-pref)) ed-pref)))]
-         (let [arg-tmpl (string/trim (if (:line opts) (prefs/get-prefs prefs "code-open-file-at-line" "{file}:{line}") (prefs/get-prefs prefs "code-open-file" "{file}")))
+         (let [cursor-range (:cursor-range opts)
+               arg-tmpl (string/trim (if cursor-range (prefs/get-prefs prefs "code-open-file-at-line" "{file}:{line}") (prefs/get-prefs prefs "code-open-file" "{file}")))
                arg-sub (cond-> {:file (resource/abs-path resource)}
-                               (:line opts) (assoc :line (:line opts)))
+                               cursor-range (assoc :line (CursorRange->line-number cursor-range)))
                args (->> (string/split arg-tmpl #" ")
                          (map #(substitute-args % arg-sub)))]
            (doto (ProcessBuilder. ^List (cons custom-editor args))

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2522,17 +2522,13 @@
                   (ui/run-later (slog/smoke-log "code-view-visible")))
     view-node))
 
-(defn- focus-view! [view-node {:keys [row col start-col end-col]}]
+(defn- focus-view! [view-node opts]
   (.requestFocus ^Node (g/node-value view-node :canvas))
-  (when (some? row)
-    (let [start-col (or start-col col 0)
-          end-col (or end-col start-col)
-          start-cursor (data/->Cursor row start-col)
-          end-cursor (data/->Cursor row end-col)]
-      (set-properties! view-node :navigation
-                       (data/select-and-frame (get-property view-node :lines)
-                                              (get-property view-node :layout)
-                                              (data/->CursorRange start-cursor end-cursor))))))
+  (when-some [cursor-range (:cursor-range opts)]
+    (set-properties! view-node :navigation
+                     (data/select-and-frame (get-property view-node :lines)
+                                            (get-property view-node :layout)
+                                            cursor-range))))
 
 (defn register-view-types [workspace]
   (workspace/register-view-type workspace

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -497,8 +497,7 @@
                                (when (and (resource/openable-resource? resource)
                                           (resource/exists? resource))
                                  (let [opts (when-some [row (:row region)]
-                                              {:line (inc (long row))
-                                               :row row})]
+                                              {:cursor-range (data/Cursor->CursorRange (data/->Cursor row 0))})]
                                    (open-resource-fn resource opts))))))
         repainter (ui/->timer "repaint-console-view" (fn [_ elapsed-time]
                                                        (when (and (.isSelected console-tab) (not (ui/ui-disabled?)))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -34,8 +34,9 @@
 
 (def ^:dynamic *load-cache* nil)
 
-(def ^:private TBreakpoint {:resource s/Any
-                            :line     Long})
+(def ^:private TBreakpoint
+  {:resource s/Any
+   :row Long})
 
 (g/deftype Breakpoints [TBreakpoint])
 

--- a/editor/src/clj/editor/engine/build_errors.clj
+++ b/editor/src/clj/editor/engine/build_errors.clj
@@ -1,13 +1,12 @@
 (ns editor.engine.build-errors
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.code.data :refer [line-number->CursorRange]]
             [editor.defold-project :as project]
             [editor.field-expression :as field-expression]
-            [editor.resource :as resource]
-            [editor.workspace :as workspace]
-            [dynamo.graph :as g])
-  (:import [clojure.lang IExceptionInfo]
-           [com.dynamo.bob CompileExceptionError LibraryException MultipleCompileException MultipleCompileException$Info Task TaskResult]
+            [editor.resource :as resource])
+  (:import [com.dynamo.bob CompileExceptionError LibraryException MultipleCompileException MultipleCompileException$Info Task TaskResult]
            [com.dynamo.bob.bundle BundleHelper$ResourceInfo]
            [com.dynamo.bob.fs IResource]
            [org.apache.commons.io FilenameUtils]))
@@ -24,21 +23,21 @@
 (defprotocol ErrorInfoProvider
   (error-message [this] "Returns a non-empty string describing the issue.")
   (error-path [this] "Returns a slash-prefixed project-relative path to the offending resource, or nil if the issue does not relate to a particular resource.")
-  (error-line [this] "Returns a 1-based index denoting the offending line in the resource. Can be nil or zero if the issue does not relate to a particular line.")
+  (error-range [this] "Returns a CursorRange denoting the offending region in the file. Can be nil if the issue does not relate to a particular region.")
   (error-severity [this] "Returns either :info, :warning, or :fatal."))
 
 (extend-type CompileExceptionError
   ErrorInfoProvider
   (error-message [this] (.getMessage this))
   (error-path [this] (some->> this .getResource .getPath (str "/")))
-  (error-line [this] (.getLineNumber this))
+  (error-range [this] (line-number->CursorRange (.getLineNumber this)))
   (error-severity [_this] :fatal))
 
 (extend-type MultipleCompileException$Info
   ErrorInfoProvider
   (error-message [this] (.getMessage this))
   (error-path [this] (some->> this .getResource .getPath (str "/")))
-  (error-line [this] (.getLineNumber this))
+  (error-range [this] (line-number->CursorRange (.getLineNumber this)))
   (error-severity [this] (condp = (.getSeverity this)
                            MultipleCompileException$Info/SEVERITY_ERROR :fatal
                            MultipleCompileException$Info/SEVERITY_WARNING :warning
@@ -48,7 +47,7 @@
   ErrorInfoProvider
   (error-message [this] (.message this))
   (error-path [this] (some->> this .resource (str "/")))
-  (error-line [this] (.lineNumber this))
+  (error-range [this] (line-number->CursorRange (.lineNumber this)))
   (error-severity [this] (condp = (.severity this)
                            "error" :fatal
                            "warning" :warning
@@ -63,26 +62,25 @@
   (error-path [this]
     (when-some [^IResource resource (some->> this .getTask root-task .getInputs first)]
       (str "/" (.getPath resource))))
-  (error-line [this] (.getLineNumber this))
+  (error-range [this] (line-number->CursorRange (.getLineNumber this)))
   (error-severity [_this] :fatal))
 
 (defn- error-info-provider->cause [project evaluation-context e]
   (let [node-id (when-let [path (error-path e)]
                   (project/get-resource-node project path evaluation-context))
-        line (error-line e)
-        value (when (and (integer? line) (pos? line))
-                (reify IExceptionInfo
-                  (getData [_]
-                    {:line line})))
+        cursor-range (error-range e)
         message (error-message e)
-        adjusted-message (if (string/ends-with? (string/lower-case message) "internal server error")
+        adjusted-message (if (or (string/blank? message)
+                                 (string/ends-with? message "internal server error"))
                            no-information-message
-                           message)
+                           (string/trim message))
         severity (error-severity e)]
-    {:_node-id node-id
-     :value value
-     :message adjusted-message
-     :severity severity}))
+    (g/map->error
+      {:_node-id node-id
+       :message adjusted-message
+       :severity severity
+       :user-data (when cursor-range
+                    {:cursor-range cursor-range})})))
 
 (def ^:private invalid-lib-re #"(?m)^Invalid lib in extension '(.+?)'.*$")
 (def ^:private manifest-ext-name-re1 #"(?m)^name:\s*\"(.+)\"\s*$") ; Double-quoted name
@@ -93,9 +91,10 @@
   (assert (string? (not-empty manifest-ext-name)))
   (let [manifest-ext-resource (manifest-ext-resources-by-name manifest-ext-name)
         node-id (project/get-resource-node project manifest-ext-resource evaluation-context)]
-    {:_node-id node-id
-     :message all
-     :severity :fatal}))
+    (g/map->error
+      {:_node-id node-id
+       :message all
+       :severity :fatal})))
 
 (defn- try-parse-manifest-ext-name [resource]
   (when (satisfies? io/IOFactory resource)
@@ -255,17 +254,17 @@
                                  :lines (next lines)
                                  :included-from? false})]
     (reduce
-     (fn [state action]
-       (case action
-         :conj-message (assoc state :current (merge-compilation-messages current line))
-         :conj-message-to-previous (merge state {:current (merge-compilation-messages (last acc) (merge-compilation-messages current line))
-                                                 :acc (pop acc)})
-         :included-from (assoc state :included-from? true)
-         :replace-file (assoc state :current (merge (:current state) (select-keys line [:file :line])))
-         :replace-type (assoc state :current (assoc (:current state) :type (:type line)))
-         :conj-entry (assoc state :acc (conj-compilation-entry acc current))))
-     next-state
-     actions)))
+      (fn [state action]
+        (case action
+          :conj-message (assoc state :current (merge-compilation-messages current line))
+          :conj-message-to-previous (merge state {:current (merge-compilation-messages (last acc) (merge-compilation-messages current line))
+                                                  :acc (pop acc)})
+          :included-from (assoc state :included-from? true)
+          :replace-file (assoc state :current (merge (:current state) (select-keys line [:file :line])))
+          :replace-type (assoc state :current (assoc (:current state) :type (:type line)))
+          :conj-entry (assoc state :acc (conj-compilation-entry acc current))))
+      next-state
+      actions)))
 
 (defn- ignore-line-and-start-next-entry
   [state original-ext-manifest-file]
@@ -374,7 +373,7 @@
   (reify ErrorInfoProvider
     (error-message [_] (:message error))
     (error-path [_] (:file error))
-    (error-line [_] (:line error))
+    (error-range [_] (line-number->CursorRange (:line error) (:column error)))
     (error-severity [_]
       (case (:type error)
         :warning :warning
@@ -397,14 +396,19 @@
   ;; control we use currently does not cope well with multi-line strings.
   (let [node-id (first (extension-manifest-node-ids project evaluation-context))]
     (or (when-let [log-lines (seq (drop-while string/blank? (string/split-lines (string/trim-newline log))))]
-          (vec (map-indexed (fn [index log-line]
-                              {:_node-id node-id
-                               :message log-line
-                               :severity (if (zero? index) :fatal :info)})
-                            log-lines)))
-        [{:_node-id node-id
-          :message no-information-message
-          :severity :fatal}])))
+          (into []
+                (map-indexed (fn [index log-line]
+                               (g/map->error
+                                 {:_node-id node-id
+                                  :message log-line
+                                  :severity (if (zero? index)
+                                              :fatal
+                                              :info)})))
+                log-lines))
+        [(g/map->error
+           {:_node-id node-id
+            :message no-information-message
+            :severity :fatal})])))
 
 (defn failed-tasks-error-causes [project evaluation-context failed-tasks]
   (mapv (partial error-info-provider->cause project evaluation-context)
@@ -419,9 +423,10 @@
   (= ::unsupported-platform-error (:type (ex-data exception))))
 
 (defn unsupported-platform-error-causes [project evaluation-context]
-  [{:_node-id (first (extension-manifest-node-ids project evaluation-context))
-    :message "Native Extensions are not yet supported for the target platform"
-    :severity :fatal}])
+  [(g/map->error
+     {:_node-id (first (extension-manifest-node-ids project evaluation-context))
+      :message "Native Extensions are not yet supported for the target platform"
+      :severity :fatal})])
 
 (defn missing-resource-error [prop-name referenced-proj-path referencing-node-id]
   (ex-info (format "%s '%s' could not be found" prop-name referenced-proj-path)
@@ -433,9 +438,10 @@
   (= ::missing-resource-error (:type (ex-data exception))))
 
 (defn- missing-resource-error-causes [^Throwable exception]
-  [{:_node-id (:node-id (ex-data exception))
-    :message (.getMessage exception)
-    :severity :fatal}])
+  [(g/map->error
+     {:_node-id (:node-id (ex-data exception))
+      :message (.getMessage exception)
+      :severity :fatal})])
 
 (defn build-error [platform status log]
   (ex-info (format "Failed to build engine, status %d: %s" status log)
@@ -462,17 +468,18 @@
 (defn- multiple-compile-exception-error-causes [project evaluation-context ^MultipleCompileException exception]
   (let [log (.getRawLog exception)
         ext-manifest-file (find-ext-manifest-relative-to-resource
-                           project
-                           (buildpath->projpath (.getPath (.getContextResource exception)))
-                           evaluation-context)]
+                            project
+                            (buildpath->projpath (.getPath (.getContextResource exception)))
+                            evaluation-context)]
     (or (try-parse-invalid-lib-error-causes project evaluation-context log)
         (try-parse-compiler-error-causes project evaluation-context log ext-manifest-file)
         (generic-extension-error-causes project evaluation-context log))))
 
 (defn- library-exception-error-causes [project evaluation-context ^Throwable exception]
-  [{:_node-id (project/get-resource-node project "/game.project" evaluation-context)
-    :message (.getMessage exception)
-    :severity :fatal}])
+  [(g/map->error
+     {:_node-id (project/get-resource-node project "/game.project" evaluation-context)
+      :message (.getMessage exception)
+      :severity :fatal})])
 
 (defn handle-build-error! [render-error! project evaluation-context exception]
   (cond

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -1,6 +1,7 @@
 (ns editor.search-results-view
   (:require [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.code.data :as data]
             [editor.core :as core]
             [editor.defold-project-search :as project-search]
             [editor.jfx :as jfx]
@@ -157,12 +158,15 @@
                     [item {}])
                   (let [resource (:resource item)]
                     (when (resource/exists? resource)
-                      ;; NOTE: :line and :caret-position are here to support
-                      ;; Open in External Editor and Open as Text, respectively.
-                      ;; :row, :start-col and :end-col are used by the code editor.
-                      (let [opts (-> item
-                                     (select-keys [:row :start-col :end-col :caret-position])
-                                     (assoc :line (inc (:row item))))]
+                      (let [row (:row item)
+                            cursor-range (data/->CursorRange (data/->Cursor row (:start-col item))
+                                                             (data/->Cursor row (:end-col item)))
+                            ;; NOTE:
+                            ;; :caret-position is here to support Open as Text.
+                            ;; We might want to remove it now that all text
+                            ;; files are opened using the code editor.
+                            opts {:caret-position (:caret-position item)
+                                  :cursor-range cursor-range}]
                         [resource opts]))))))
         selection))
 

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -24,6 +24,13 @@
 (def error-warning (partial error-value :warning))
 (def error-fatal   (partial error-value :fatal))
 
+(defn map->error [m]
+  (assert (if-some [node-id (:_node-id m)] (gt/node-id? node-id) true))
+  (assert (if-some [label (:_label m)] (keyword? label) true))
+  (assert (if-some [severity (:severity m)] (contains? severity-levels severity) true))
+  (assert (if-some [message (:message m)] (string? message) true))
+  (map->ErrorValue m))
+
 (defn ->error
   ([node-id label severity value message]
     (->error node-id label severity value message nil))


### PR DESCRIPTION
Fixes defold/editor2-issues#1838
Fixed defold/editor2-issues#2330
Fixes defold/editor2-issues#2535
Fixes defold/editor2-issues#2542

### User-facing changes
* Fixed remaining issues where code files would not open to a specific line number.
* The debugger now frames the stopped line again.
* Bundle error messages are now trimmed so that there will be no unsightly extra newlines around the error in the Build Errors view.
* Fixed `NullPointerException` from call to `string/lower-case` when Bob produces an error with a `nil` error message.

### Technical changes
* We now use a `CursorRange` in errors to denote the region to focus on when opening files. This used to be represented as a one-based `:line` number only.
* The `ErrorInfoProvider` protocol was changed to have an `error-range` function instead of an `error-line` function.
* `ErrorValues` now use `{:user-data {:cursor-range ...}}` everywhere a `CursorRange` is associated with an error. This used to be specified using a reified `ExceptionInfo` instance with `{:line ...}` `ex-data`.
* Added `g/map->error` so that `ErrorValues` can be more easily constructed from maps.
* We now avoid using the term `line` to represent a line-number in the code. Instead, the term `row` is used, and will always denote a zero-based row index. The term `line` is consistently used to represent a `String` line in a document.
* Systems that need one-based line numbers, such as Opening a file in an external editor now use the zero-based `:row` from the cursor-range.