### PR TITLE
[QRT][Crash] - All applications from the Defold branch that have the FB login option crash when the user logs in to FB (DEF-3959)

### DIFF
--- a/engine/glfw/lib/ios/ios_window.m
+++ b/engine/glfw/lib/ios/ios_window.m
@@ -114,7 +114,7 @@ id<UIApplicationDelegate> g_AppDelegates[MAX_APP_DELEGATES];
 int g_AppDelegatesCount = 0;
 id<UIApplicationDelegate> g_ApplicationDelegate = 0;
 
-@interface AppDelegateProxy : NSObject <UIApplicationDelegate>
+@interface AppDelegateProxy: NSObject
 
 @end
 
@@ -173,7 +173,7 @@ id<UIApplicationDelegate> g_ApplicationDelegate = 0;
     }
 
     if (!invoked) {
-        [super forwardInvocation:anInvocation];
+        [g_ApplicationDelegate forwardInvocation:anInvocation];
     }
 }
 
@@ -188,12 +188,12 @@ id<UIApplicationDelegate> g_ApplicationDelegate = 0;
         }
     }
 
-    return [super respondsToSelector: aSelector];
+    return [g_ApplicationDelegate respondsToSelector: aSelector];
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
 {
-    NSMethodSignature* signature = [super methodSignatureForSelector:aSelector];
+    NSMethodSignature* signature = [g_ApplicationDelegate methodSignatureForSelector:aSelector];
 
     if (!signature)
     {
@@ -1331,8 +1331,8 @@ _GLFWwin g_Savewin;
     _glfwWin.window = window;
 
     UIApplication* app = [UIApplication sharedApplication];
-    AppDelegateProxy* proxy = [[AppDelegateProxy alloc] init];
     g_ApplicationDelegate = [app.delegate retain];
+    AppDelegateProxy* proxy = [AppDelegateProxy alloc];
     app.delegate = proxy;
 
     for (int i = 0; i < g_AppDelegatesCount; ++i) {
@@ -1733,5 +1733,4 @@ GLFWAPI void glfwAccelerometerEnable()
     [[UIAccelerometer sharedAccelerometer] setDelegate:_glfwWin.viewController];
     g_AccelerometerEnabled = 1;
 }
-
 


### PR DESCRIPTION
*Description:* When the user starts an app like DefoldTest, or Blossom or Pet Rescue Puzzle; and logs in to FB, the apps crash 100% of the time.

*Steps to reproduce:*
 # Install any one of the above mentioned example apps
 # Reach the FB login section and enter credentials
 # Notice the apps crash to home every time.

*Expected result:* Apps should be stable at all times

*Actual result:* Apps are not stable and crash

 

*Notes*
1. Please review the attached file

2. Issue only occurs on iOS builds, Android seems to be unaffected. Tested on build 1.2.155 on Blossom, Presto and DefoldTest on several devices:
6S+ fw 12.1.4, iPad 3 fw 9.3.5, 5S fw 10.2.1, 7+ fw 12.2 and an 8+ fw 12.2
