### PR TITLE
Add alternative repl launcher

### DIFF
--- a/editor/README_CURSIVE.md
+++ b/editor/README_CURSIVE.md
@@ -40,6 +40,8 @@ Time to open the Defold Editor project. The first time you open it, you'll need 
 
 8. Press **OK** to close the dialog. You should now be able to select the `lein run` configuration and launch the editor from the toolbar. Once you see the Defold Welcome screen, you can select `connect repl` and run that task to connect to the running editor. From the REPL you can evaluate code, redefine functions, or experiment with function calls while the editor is running.
 
+Alternatively to steps 5 and 6, you can create a configuration that starts local nrepl and editor simultaneously: create a local REPL configuration, select **Run with Leiningen** and add `+local-repl` profile.
+
 ## Recommended keyboard shortcuts
 
 The defaults for these might depend on the keymap you selected when installing IntelliJ, but here are some keyboard shortcuts you might find useful when working with Clojure. You can customize the bindings for these from the **Keymap** page in the Preferences dialog.

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -171,6 +171,8 @@
                                 :aot          :all
                                 :omit-source  true
                                 :source-paths ["sidecar"]}
+                      :local-repl {:injections [(future (editor/-main))]
+                                   :repl-options {:init-ns editor}}
                       :release {:jvm-opts          ["-Ddefold.build=release"]}
                       :smoke-test {:jvm-opts ["-Ddefold.smoke.log=true"]}
                       :dev     {:plugins           [[jonase/eastwood "0.3.5" :exclusions [org.clojure/clojure]]]

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -172,7 +172,8 @@
                                 :omit-source  true
                                 :source-paths ["sidecar"]}
                       :local-repl {:injections [(future (editor/-main))]
-                                   :repl-options {:init-ns editor}}
+                                   :repl-options {:init-ns editor}
+                                   :jvm-opts ["-Ddefold.nrepl=false"]}
                       :release {:jvm-opts          ["-Ddefold.build=release"]}
                       :smoke-test {:jvm-opts ["-Ddefold.smoke.log=true"]}
                       :dev     {:plugins           [[jonase/eastwood "0.3.5" :exclusions [org.clojure/clojure]]]
@@ -188,6 +189,7 @@
                                 :resource-paths    ["test/resources"]
                                 :jvm-opts          ["-Ddefold.unpack.path=tmp/unpack"
                                                     "-Djdk.gtk.version=2"
+                                                    "-Ddefold.nrepl=true"
                                                     "-Ddefold.log.dir="
                                                     "-Djogl.debug.DebugGL" ; TraceGL is also useful
                                                     "-Djogl.texture.notexrect=true"

--- a/editor/src/clj/editor/debug.clj
+++ b/editor/src/clj/editor/debug.clj
@@ -87,5 +87,6 @@
 (defn init-debug
   []
   (bb/spit-batches "src/clj" "resources/sorted_clojure_ns_list.edn")
-  (start-server nil))
+  (when (= "true" (System/getProperty "defold.nrepl"))
+    (start-server nil)))
 


### PR DESCRIPTION
I don't like that there are 2 run configurations: one for `lein run`, and one for connected `lein repl`. It's annoying because it separates output to different places: printed stuff is in console tab, evaluation results are in repl tab. I made a small profile so that I can start editor and have a repl in a single configuration. Command line equivalent of such configuration is `lein with-profiles +local-repl repl`