### PR TITLE
Issue #4144 Both armv7 and arm64 are included by default when building Android custom engines

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/PlatformArchitectures.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/PlatformArchitectures.java
@@ -5,7 +5,7 @@ public enum PlatformArchitectures {
     Windows(new String[] {"x86_64-win32", "x86-win32"}, new String[] {"x86_64-win32", "x86-win32"}),
     Linux(new String[] {"x86_64-linux"}, new String[] {"x86_64-linux"}),
     iOS(new String[] {"arm64-darwin", "armv7-darwin", "x86_64-ios"}, new String[] {"arm64-darwin", "armv7-darwin"}),
-    Android(new String[] {"arm64-android", "armv7-android"}, new String[] {"armv7-android"}),
+    Android(new String[] {"arm64-android", "armv7-android"}, new String[] {"armv7-android","arm64-android"}),
     Web(new String[] {"js-web", "wasm-web"}, new String[] {"js-web", "wasm-web"});
 
     String[] architectures;


### PR DESCRIPTION
Fixes #4144 