### PR TITLE
Fixes #4149 - Crash on win32 when closing engine window.

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1263,7 +1263,9 @@ namespace dmSound
     void OnWindowFocus(bool focus)
     {
         SoundSystem* sound = g_SoundSystem;
-        sound->m_HasWindowFocus = focus;
+        if (sound) {
+            sound->m_HasWindowFocus = focus;
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #4149