### PR TITLE
Issue-#4172 Sys.load_resource() returns error message as a second argument 

### DIFF
--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -355,7 +355,7 @@ union SaveLoadBuffer
      *
      * Loads a custom resource. Specify the full filename of the resource that you want
      * to load. When loaded, the file data is returned as a string.
-     * If loading fails, the function returns nil.
+     * If loading fails, the function returns nil plus the error message.
      *
      * In order for the engine to include custom resources in the build process, you need
      * to specify them in the "custom_resources" key in your "game.project" settings file.
@@ -367,15 +367,20 @@ union SaveLoadBuffer
      *
      * @name sys.load_resource
      * @param filename [type:string] resource to load, full path
-     * @return data [type:string] loaded data, or nil if the resource could not be loaded
+     * @return data [type:string] loaded data, or `nil` if the resource could not be loaded
+     * @return error [type:string] the error message, or `nil` if no error occurred
      * @examples
      *
      * ```lua
      * -- Load level data into a string
-     * local data = sys.load_resource("/assets/level_data.json")
+     * local data, error = sys.load_resource("/assets/level_data.json")
      * -- Decode json string to a Lua table
-     * local data_table = json.decode(data)
-     * pprint(data_table)
+     * if data then
+     *   local data_table = json.decode(data)
+     *   pprint(data_table)
+     * else
+     *   print(error)
+     * end
      * ```
      */
     int Sys_LoadResource(lua_State* L)
@@ -389,12 +394,16 @@ union SaveLoadBuffer
         uint32_t resource_size;
         dmResource::Result r = dmResource::GetRaw(context->m_ResourceFactory, filename, &resource, &resource_size);
         if (r != dmResource::RESULT_OK) {
-            dmLogWarning("Failed to load resource: %s (%d)", filename, r);
             lua_pushnil(L);
-        } else {
-            lua_pushlstring(L, (const char*) resource, resource_size);
-            free(resource);
+            char* error_msg;
+            asprintf(&error_msg, "Failed to load resource: %s (%d)", filename, r);
+            lua_pushstring(L, error_msg);
+            free(error_msg);
+            assert(top + 2 == lua_gettop(L));
+            return 2;
         }
+        lua_pushlstring(L, (const char*) resource, resource_size);
+        free(resource);
         assert(top + 1 == lua_gettop(L));
         return 1;
     }

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -395,10 +395,7 @@ union SaveLoadBuffer
         dmResource::Result r = dmResource::GetRaw(context->m_ResourceFactory, filename, &resource, &resource_size);
         if (r != dmResource::RESULT_OK) {
             lua_pushnil(L);
-            char* error_msg;
-            asprintf(&error_msg, "Failed to load resource: %s (%d)", filename, r);
-            lua_pushstring(L, error_msg);
-            free(error_msg);
+            lua_pushfstring(L, "Failed to load resource: %s (%d)", filename, r);
             assert(top + 2 == lua_gettop(L));
             return 2;
         }


### PR DESCRIPTION
...instead of the warning message.

Now it works the same way `coroutine.resume()` and other `lua` standard functions.