### PR TITLE
Issue-#3392 - Retrieve a game object's world transform matrix. (DEF-1548)

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1156,6 +1156,32 @@ namespace dmGameObject
         return 1;
     }
 
+    /*# gets the game object instance world transform matrix
+     *
+     * @name go.get_world_transform
+     * @param [id] [type:string|hash|url] optional id of the game object instance to get the world transform for, by default the instance of the calling script
+     * @return transform [type:matrix4] instance world transform
+     * @examples
+     *
+     * Get the world transform of the game object instance the script is attached to:
+     *
+     * ```lua
+     * local m = go.get_world_transform()
+     * ```
+     *
+     * Get the world transform of another game object instance with id "x":
+     *
+     * ```lua
+     * local m = go.get_world_transform("x")
+     * ```
+     */
+    int Script_GetWorldTransform(lua_State* L)
+    {
+        Instance* instance = ResolveInstance(L,1);
+        dmScript::PushMatrix4(L, dmGameObject::GetWorldMatrix(instance));
+        return 1;
+    }
+
     /*# gets the id of an instance
      * Returns or constructs an instance identifier. The instance id is a hash
      * of the absolute path to the instance.
@@ -1837,6 +1863,7 @@ namespace dmGameObject
         {"get_world_rotation",      Script_GetWorldRotation},
         {"get_world_scale",         Script_GetWorldScale},
         {"get_world_scale_uniform", Script_GetWorldScaleUniform},
+        {"get_world_transform",     Script_GetWorldTransform},
         {"get_id",                  Script_GetId},
         {"animate",                 Script_Animate},
         {"cancel_animations",       Script_CancelAnimations},

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -796,6 +796,10 @@ TEST_F(HierarchyTest, TestTransformGettersFromScript)
 
     // Test 3: go.get_world_transform(child)
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmGameObject::Delete(m_Collection, controller, false);
+    dmGameObject::Delete(m_Collection, parent, false);
+    dmGameObject::Delete(m_Collection, child, false);
 }
 
 TEST_F(HierarchyTest, TestHierarchyFromScript)
@@ -847,8 +851,6 @@ TEST_F(HierarchyTest, TestHierarchyFromScript)
     dmGameObject::SetParent(controller, parent);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_EQ((void*)0, dmGameObject::GetParent(controller));
-
-    ASSERT_TRUE(dmGameObject::Final(m_Collection));
 
     dmGameObject::Delete(m_Collection, controller, false);
     dmGameObject::Delete(m_Collection, parent, false);

--- a/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
+++ b/engine/gameobject/src/gameobject/test/hierarchy/test_gameobject_hierarchy.cpp
@@ -762,6 +762,42 @@ TEST_F(HierarchyTest, TestHierarchyBonesMulti)
     dmGameObject::Delete(m_Collection, c2, false);
 }
 
+TEST_F(HierarchyTest, TestTransformGettersFromScript)
+{
+    dmGameObject::HInstance controller = dmGameObject::New(m_Collection, "/transform.goc");
+    dmGameObject::HInstance parent     = dmGameObject::New(m_Collection, "/go.goc");
+    dmGameObject::HInstance child      = dmGameObject::New(m_Collection, "/go.goc");
+
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, controller, "controller"));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, parent, "parent"));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameObject::SetIdentifier(m_Collection, child, "child"));
+
+    dmGameObject::SetPosition(parent, Point3(12,4,2));
+    dmGameObject::SetPosition(child, Point3(-12,-4,-2));
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    // Test 0: go.get_world_position(child)
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmGameObject::SetScale(parent, Vector3(100, 99, 1));
+    dmGameObject::SetScale(child,  Vector3(1.0/100.0, 1.0/99.0, 1.0));
+
+    // Test 1: go.get_world_scale(child)
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    const float rot_90_deg = 3.14159265f / 2.0f;
+
+    dmGameObject::SetRotation(parent, Quat::rotationZ(rot_90_deg));
+    dmGameObject::SetRotation(child, Quat::rotationZ(-rot_90_deg));
+
+    // Test 2: go.get_world_rotation(child)
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    // Test 3: go.get_world_transform(child)
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+}
+
 TEST_F(HierarchyTest, TestHierarchyFromScript)
 {
     dmGameObject::HInstance controller = dmGameObject::New(m_Collection, "/parenting.goc");

--- a/engine/gameobject/src/gameobject/test/hierarchy/transform.go_pb
+++ b/engine/gameobject/src/gameobject/test/hierarchy/transform.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/transform.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/hierarchy/transform.script
+++ b/engine/gameobject/src/gameobject/test/hierarchy/transform.script
@@ -1,0 +1,66 @@
+local EPSILON = 0.001
+
+function make_transform(p,r,s)
+	local trans = vmath.matrix4()
+	local scale = vmath.matrix4()
+	local rot   = vmath.matrix4_from_quat(r)
+
+	scale.m00 = s.x
+	scale.m11 = s.y
+	scale.m22 = s.z
+
+	trans.m03 = p.x
+	trans.m13 = p.y
+	trans.m23 = p.z
+
+	return trans * rot * scale
+end
+
+function init(self)
+	self.child_id  = go.get_id("child")
+	self.parent_id = go.get_id("parent")
+	self.stage     = 0
+
+	go.set_parent(self.child_id, self.parent_id)
+end
+
+function assert_near_vector3(a,b)
+	assert(math.abs(a.x-b.x) < EPSILON)
+	assert(math.abs(a.y-b.y) < EPSILON)
+	assert(math.abs(a.z-b.z) < EPSILON)
+end
+
+function assert_near_vector4(a,b)
+	assert(math.abs(a.x-b.x) < EPSILON)
+	assert(math.abs(a.y-b.y) < EPSILON)
+	assert(math.abs(a.z-b.z) < EPSILON)
+	assert(math.abs(a.w-b.w) < EPSILON)
+end
+
+function assert_near_mat4(a,b)
+	assert_near_vector4(a.c0,b.c0)
+	assert_near_vector4(a.c1,b.c1)
+	assert_near_vector4(a.c2,b.c2)
+	assert_near_vector4(a.c3,b.c3)
+end
+
+function update(self)
+	if self.stage == 0 then
+		assert_near_vector3(go.get_world_position(self.child_id),vmath.vector3())
+	elseif self.stage == 1 then
+		assert_near_vector3(go.get_world_scale(self.child_id),vmath.vector3(1,1,1))
+	elseif self.stage == 2 then
+		assert_near_vector4(go.get_world_rotation(self.child_id),vmath.quat())
+	elseif self.stage == 3 then
+		local pmat       = go.get_world_transform(self.parent_id)
+		local cpos       = go.get_position(self.child_id)
+		local crot       = go.get_rotation(self.child_id)
+		local csca       = go.get_scale(self.child_id)
+		local cmat       = make_transform(cpos,crot,csca)
+		local cmat_world = pmat * cmat
+
+		assert_near_mat4(go.get_world_transform(self.child_id), cmat_world)
+	end
+
+	self.stage = self.stage + 1
+end


### PR DESCRIPTION
Fixes #3392 

This PR adds:
* Added new script function go.get_world_transform([id]) that returns the world matrix of a gameobject
