### PR TITLE
DEFEDIT-4221 Tree view improvements

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -719,6 +719,7 @@
         entered-handler (ui/event-handler e (drag-entered e))
         exited-handler (ui/event-handler e (drag-exited e))]
     (doto tree-view
+      (ui/customize-tree-view! {:double-click-expand? true})
       (ui/bind-double-click! :open)
       (ui/bind-key-commands! {"Enter" :open
                               "F2" :rename})

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -233,6 +233,7 @@
 
 (defn make-build-errors-view [^TreeView errors-tree open-resource-fn]
   (doto errors-tree
+    (ui/customize-tree-view! {:double-click-expand? false})
     (.setShowRoot false)
     (ui/cell-factory! make-tree-cell)
     (ui/on-double! (fn [_]

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -213,6 +213,7 @@
 (defn- setup-variables-view!
   [^TreeView debugger-variables]
   (doto debugger-variables
+    (ui/customize-tree-view! {:double-click-expand? true})
     (.setShowRoot false)
     (ui/cell-factory! (fn [{:keys [display-name display-value]}]
                         {:graphic (doto (HBox.)

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -502,6 +502,7 @@
   (let [drag-entered-handler (ui/event-handler e (drag-entered proj-graph outline-view e))
         drag-exited-handler (ui/event-handler e (drag-exited e))]
     (doto tree-view
+      (ui/customize-tree-view! {:double-click-expand? false})
       (.. getSelectionModel (setSelectionMode SelectionMode/MULTIPLE))
       (.setEventDispatcher (ui/make-shortcut-dispatcher tree-view [(ui/key-combo "Space")]))
       (.setOnDragDetected (ui/event-handler e (drag-detected proj-graph outline-view e)))

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -125,6 +125,7 @@
       (.setAlignment Pos/CENTER_LEFT))))
 
 (defn- init-search-in-files-tree-view! [^TreeView tree-view]
+  (ui/customize-tree-view! tree-view {:double-click-expand? false})
   (.setSelectionMode (.getSelectionModel tree-view) SelectionMode/MULTIPLE)
   (.setShowRoot tree-view false)
   (.setRoot tree-view (doto (TreeItem.)


### PR DESCRIPTION
### User-facing changes
* Alt-clicking on a disclosure arrow recursively toggles expansion state for all children in tree views.
* Double-clicking on a parent file no longer collapses its children while opening it from the Build Errors, Outline, and Search Results views.
* Double-clicking the disclosure arrow of an unselected folder in the Assets pane no longer opens the selected files.