### PR TITLE
DEFEDIT-4221 Restore Expand All feature on tree items

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -500,7 +500,7 @@
   (let [drag-entered-handler (ui/event-handler e (drag-entered proj-graph outline-view e))
         drag-exited-handler (ui/event-handler e (drag-exited e))]
     (doto tree-view
-      (ui/customize-tree-view! {:double-click-expand? false})
+      (ui/customize-tree-view! {:double-click-expand? true})
       (.. getSelectionModel (setSelectionMode SelectionMode/MULTIPLE))
       (.setOnDragDetected (ui/event-handler e (drag-detected proj-graph outline-view e)))
       (.setOnDragOver (ui/event-handler e (drag-over proj-graph outline-view e)))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -1,22 +1,20 @@
 (ns editor.outline-view
-  (:require
-   [dynamo.graph :as g]
-   [editor.app-view :as app-view]
-   [editor.error-reporting :as error-reporting]
-   [editor.handler :as handler]
-   [editor.jfx :as jfx]
-   [editor.outline :as outline]
-   [editor.resource :as resource]
-   [editor.types :as types]
-   [editor.ui :as ui])
-  (:import
-   (com.defold.control TreeCell)
-   (javafx.collections FXCollections ObservableList)
-   (javafx.event Event)
-   (javafx.scene Node)
-   (javafx.scene.control SelectionMode TreeItem TreeView)
-   (javafx.scene.input Clipboard DataFormat DragEvent MouseEvent TransferMode)
-   (javafx.util Callback)))
+  (:require [dynamo.graph :as g]
+            [editor.app-view :as app-view]
+            [editor.error-reporting :as error-reporting]
+            [editor.handler :as handler]
+            [editor.jfx :as jfx]
+            [editor.outline :as outline]
+            [editor.resource :as resource]
+            [editor.types :as types]
+            [editor.ui :as ui])
+  (:import [com.defold.control TreeCell]
+           [javafx.collections FXCollections ObservableList]
+           [javafx.event Event]
+           [javafx.scene Node]
+           [javafx.scene.control SelectionMode TreeItem TreeView]
+           [javafx.scene.input Clipboard DataFormat DragEvent MouseEvent TransferMode]
+           [javafx.util Callback]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -11,13 +11,11 @@
    [editor.ui :as ui])
   (:import
    (com.defold.control TreeCell)
-   (editor.outline ItemIterator)
-   (javafx.collections FXCollections ObservableList ListChangeListener ListChangeListener$Change)
+   (javafx.collections FXCollections ObservableList)
    (javafx.event Event)
-   (javafx.scene Scene Node Parent)
-   (javafx.scene.control Button Cell ColorPicker Label TextField TitledPane TextArea TreeView TreeItem Menu MenuItem MenuBar Tab ProgressBar SelectionMode)
-   (javafx.scene.input Clipboard ClipboardContent DragEvent TransferMode DataFormat)
-   (javafx.scene.input MouseEvent)
+   (javafx.scene Node)
+   (javafx.scene.control SelectionMode TreeItem TreeView)
+   (javafx.scene.input Clipboard DataFormat DragEvent MouseEvent TransferMode)
    (javafx.util Callback)))
 
 (set! *warn-on-reflection* true)
@@ -504,7 +502,6 @@
     (doto tree-view
       (ui/customize-tree-view! {:double-click-expand? false})
       (.. getSelectionModel (setSelectionMode SelectionMode/MULTIPLE))
-      (.setEventDispatcher (ui/make-shortcut-dispatcher tree-view [(ui/key-combo "Space")]))
       (.setOnDragDetected (ui/event-handler e (drag-detected proj-graph outline-view e)))
       (.setOnDragOver (ui/event-handler e (drag-over proj-graph outline-view e)))
       (.setOnDragDropped (ui/event-handler e (error-reporting/catch-all! (drag-dropped proj-graph app-view outline-view e))))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -21,7 +21,6 @@
    [com.defold.control TreeCell]
    [com.sun.javafx.application PlatformImpl]
    [com.sun.javafx.event DirectEvent]
-   [com.sun.javafx.scene KeyboardShortcutsHandler SceneEventDispatcher]
    [java.awt Desktop Desktop$Action]
    [java.io File IOException]
    [java.net URI]
@@ -32,12 +31,12 @@
    [javafx.beans.value ChangeListener ObservableValue]
    [javafx.collections FXCollections ListChangeListener ObservableList]
    [javafx.css Styleable]
-   [javafx.event ActionEvent Event EventDispatchChain EventDispatcher EventHandler EventTarget]
+   [javafx.event ActionEvent Event EventDispatcher EventHandler EventTarget]
    [javafx.fxml FXMLLoader]
    [javafx.geometry Orientation]
-   [javafx.scene Parent Node Scene Group ImageCursor]
-   [javafx.scene.control ButtonBase Cell CheckBox ChoiceBox ColorPicker ComboBox ComboBoxBase Control ContextMenu Separator SeparatorMenuItem Label Labeled ListView ToggleButton TextInputControl TreeTableView TreeView TreeItem Toggle Menu MenuBar MenuItem MultipleSelectionModel CheckMenuItem ProgressBar TableView TabPane Tab TextField Tooltip SelectionMode SelectionModel SplitPane]
-   [javafx.scene.input Clipboard ContextMenuEvent DragEvent KeyCombination KeyEvent MouseButton MouseEvent]
+   [javafx.scene Group Node Parent Scene]
+   [javafx.scene.control ButtonBase Cell CheckBox CheckMenuItem ChoiceBox ColorPicker ComboBox ComboBoxBase ContextMenu Control Label Labeled ListView Menu MenuBar MenuItem MultipleSelectionModel ProgressBar SelectionMode SelectionModel Separator SeparatorMenuItem Tab TableView TabPane TextField TextInputControl Toggle ToggleButton Tooltip TreeItem TreeTableView TreeView]
+   [javafx.scene.input Clipboard ContextMenuEvent DragEvent KeyCode KeyCombination KeyEvent MouseButton MouseEvent]
    [javafx.scene.image Image ImageView]
    [javafx.scene.layout AnchorPane Pane HBox]
    [javafx.scene.shape SVGPath]
@@ -960,6 +959,23 @@
     (when-not (= -1 row)
       (.scrollTo tree-view row))))
 
+(defn- custom-tree-view-key-pressed! [^KeyEvent event]
+  ;; The TreeView control consumes Space key presses internally and does
+  ;; something weird and undesirable to the selection. Instead, we consume and
+  ;; redirect the keypress to the Scene root so that we can use the Space key
+  ;; for keyboard shortcuts even if a TreeView has input focus.
+  (when (and (= KeyCode/SPACE (.getCode event))
+             (not (or (.isAltDown event)
+                      (.isControlDown event)
+                      (.isMetaDown event)
+                      (.isShiftDown event))))
+    (let [^Node source (.getSource event)]
+      (when (instance? Node source)
+        (when-some [scene-root (some-> source .getScene .getRoot)]
+          (let [redirected-event (.copyFor event source scene-root)]
+            (.consume event)
+            (.fireEvent scene-root redirected-event)))))))
+
 (defn- custom-tree-view-mouse-pressed! [^MouseEvent event]
   (when (= MouseButton/PRIMARY (.getButton event))
     (let [target (.getTarget event)]
@@ -979,6 +995,10 @@
                   (doseq [^TreeItem tree-item (tree-item-seq tree-item)]
                     (.setExpanded tree-item new-expanded-state)))))))))))
 
+(def ^:private custom-tree-view-key-pressed-event-filter
+  (event-handler event
+    (custom-tree-view-key-pressed! event)))
+
 (def ^:private custom-tree-view-mouse-pressed-event-filter
   (event-handler event
     (custom-tree-view-mouse-pressed! event)))
@@ -990,6 +1010,8 @@
 (defn customize-tree-view!
   "Customize the behavior of the supplied tree-view for our purposes. Currently
   the following customizations are applied:
+  * The Space key no longer does something weird to the selection. Instead we
+    redirect it to the Scene root so it can be used for keyboard shortcuts.
   * Alt-clicking on an items disclosure arrow toggles expansion state for all
     child items recursively.
 
@@ -997,9 +1019,9 @@
   * :double-click-expand?
     If true, double-clicking will toggle expansion of a tree item."
   [^TreeView tree-view opts]
-  ;; TEMPORARILY DISABLED because it breaks non-selected item expansion in the Outline.
-  #_(.addEventFilter tree-view MouseEvent/MOUSE_PRESSED custom-tree-view-mouse-pressed-event-filter)
-  #_(when-not (:double-click-expand? opts)
+  (.addEventFilter tree-view KeyEvent/KEY_PRESSED custom-tree-view-key-pressed-event-filter)
+  (.addEventFilter tree-view MouseEvent/MOUSE_PRESSED custom-tree-view-mouse-pressed-event-filter)
+  (when-not (:double-click-expand? opts)
     (.addEventFilter tree-view MouseEvent/MOUSE_RELEASED ignore-event-filter)))
 
 (extend-protocol HasSelectionModel
@@ -1366,10 +1388,6 @@
                       (when (double-click-event? e)
                         (run-command node command user-data false (fn [] (.consume e))))))))
 
-(defn key-combo
-  [^String acc]
-  (KeyCombination/keyCombination acc))
-
 (defn bind-key! [^Node node acc f]
   (let [combo (KeyCombination/keyCombination acc)]
     (.addEventFilter node KeyEvent/KEY_PRESSED
@@ -1416,51 +1434,6 @@
                                                                   binding
                                                                   [binding {}])]
                                         (run-command node command user-data true #(.consume event))))))))
-
-(defn- ^KeyboardShortcutsHandler keyboard-shortcuts-handler
-  [^Node node]
-  (let [scene (.getScene node)
-        ^SceneEventDispatcher scene-dispatcher (.getEventDispatcher scene)
-        ^KeyboardShortcutsHandler shortcuts-handler (.getKeyboardShortcutsHandler scene-dispatcher)]
-    shortcuts-handler))
-
-(def ^EventDispatchChain noop-dispatch-chain 
-  (reify EventDispatchChain
-    (append [this dispatcher] (throw (UnsupportedOperationException. "not supported")))
-    (dispatchEvent [this event] event)
-    (prepend [this dispatcher] (throw (UnsupportedOperationException. "not supported")))))
-
-(defn- make-shortcut-dispatcher*
-  [^EventDispatcher original-dispatcher ^KeyboardShortcutsHandler shortcuts-handler key-combos]
-  (reify EventDispatcher
-    (dispatchEvent [this event tail]
-      ;; First, dispatch downwards chain after this node
-      (when-some [event' (.dispatchEvent tail event)]
-        ;; If we got an event back, it wasn't consumed on either
-        ;; capturing or bubbling phase by anyone downwards this node
-        (if (and (= KeyEvent/KEY_PRESSED (.getEventType event'))
-                 (some #(.match ^KeyCombination % ^KeyEvent event') key-combos))
-          ;; If event is a key pressed event and matches one of the
-          ;; key-combinations we wish to redirect, call the bubbling
-          ;; phase of the shortcuts handler directly.
-          (.dispatchBubblingEvent shortcuts-handler event')
-          ;; If not, call original dispatcher, with a noop-chain, ie.
-          ;; without capturing/bubbling downwards (because we've
-          ;; already done that part), but let the capturing/bubbling
-          ;; phase continue as it would've.
-          (.dispatchEvent original-dispatcher event' noop-dispatch-chain))))))
-
-(defn make-shortcut-dispatcher
-  "Given a `Node` and a collection of `KeyCombination`s, return an
-  `EventDispatcher` that will redirect `KeyEvent`s that match any of the
-  `KeyCombination`s to the global shortcut handler on the `Scene`. This can be
-  used to override default shortcuts on the node."
-  [^Node node key-combos]
-  (let [shortcuts-handler (keyboard-shortcuts-handler node)
-        original-dispatcher (.getEventDispatcher node)]
-    (make-shortcut-dispatcher* original-dispatcher shortcuts-handler key-combos)))
-
-
 
 ;;--------------------------------------------------------------------
 ;; menus


### PR DESCRIPTION
### Technical changes
At one point in the past, we discovered that the `TreeView` control would consume <kbd>Space</kbd> key presses internally and do something weird and undesirable with the `TreeView` selection.

We wanted to use the <kbd>Space</kbd> key for keyboard shortcuts like starting and stopping playback of particle effects, among other things. A special `shortcut-dispatcher` was introduced to redirect <kbd>Space</kbd> key presses from the Outline `TreeView` to the `KeyboardShortcutsHandler`.

It seems this custom event dispatch mechanism was interfering with the mouse press event filter I added to the `TreeView` to catch disclosure arrow clicks. In this PR I removed the custom `shortcut-dispatcher` and instead used a regular event filter to re-post any <kbd>Space</kbd> key press events from `TreeViews` to the scene root.