### PR TITLE
DEF-2532 Fix Extrude Borders for additional source image formats

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -132,7 +132,7 @@ public class TextureUtil {
 
     public static BufferedImage depalettiseImage(BufferedImage src) {
         BufferedImage result = null;
-        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || src.getColorModel().getNumColorComponents() < 3 || src.getColorModel().getComponentSize(0) > 8) {
+        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || BufferedImage.TYPE_BYTE_BINARY == src.getType() || src.getColorModel().getNumColorComponents() < 3 || src.getColorModel().getComponentSize(0) > 8) {
             int width = src.getWidth();
             int height = src.getHeight();
             Color clear = new Color(255,255,255,0);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -132,7 +132,7 @@ public class TextureUtil {
 
     public static BufferedImage depalettiseImage(BufferedImage src) {
         BufferedImage result = null;
-        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || src.getColorModel().getNumColorComponents() < 3) {
+        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || src.getColorModel().getNumColorComponents() < 3 || src.getColorModel().getComponentSize(0) > 8) {
             int width = src.getWidth();
             int height = src.getHeight();
             Color clear = new Color(255,255,255,0);

--- a/editor/src/java/com/defold/editor/pipeline/TextureUtil.java
+++ b/editor/src/java/com/defold/editor/pipeline/TextureUtil.java
@@ -127,7 +127,7 @@ public class TextureUtil {
 
     public static BufferedImage depalettiseImage(BufferedImage src) {
         BufferedImage result = null;
-        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType()) {
+        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || src.getColorModel().getNumColorComponents() < 3 || src.getColorModel().getComponentSize(0) > 8) {
             int width = src.getWidth();
             int height = src.getHeight();
             Color clear = new Color(255,255,255,0);

--- a/editor/src/java/com/defold/editor/pipeline/TextureUtil.java
+++ b/editor/src/java/com/defold/editor/pipeline/TextureUtil.java
@@ -127,7 +127,7 @@ public class TextureUtil {
 
     public static BufferedImage depalettiseImage(BufferedImage src) {
         BufferedImage result = null;
-        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || src.getColorModel().getNumColorComponents() < 3 || src.getColorModel().getComponentSize(0) > 8) {
+        if (BufferedImage.TYPE_BYTE_INDEXED == src.getType() || BufferedImage.TYPE_BYTE_BINARY == src.getType() || src.getColorModel().getNumColorComponents() < 3 || src.getColorModel().getComponentSize(0) > 8) {
             int width = src.getWidth();
             int height = src.getHeight();
             Color clear = new Color(255,255,255,0);


### PR DESCRIPTION
### User-facing changes
* This fixes several cases where adding some types of images to an atlas with Extrude Borders enabled would render incorrectly in bundled game projects.

### Technical changes
* The `depalettiseImage` method that needs to run before the pixel data can be processed in the `extrudeBorders` method will now convert additional types of indexed color formats as well as images with more than 8 bits per channel into `TYPE_4BYTE_ABGR` before processing. Previously it would do this for some palletized image formats, but not all.

### Fixed issues
* Fixes https://github.com/defold/defold/issues/3755
* Likely fixes https://github.com/defold/defold/issues/3694 as well. I was not able to repro the brightness increase, but the image would show up as corrupted before I added the `TYPE_BYTE_BINARY` clause. Given that we're essentially dealing with misinterpretation of pixel data, it seems like the type of corruption could potentially vary depending on the Extrude Borders value or atlas placement?

