### PR TITLE
Fix form view styling issues

### DIFF
--- a/editor/.idea/leiningen.xml
+++ b/editor/.idea/leiningen.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="LeiningenProjectSettings">
-    <option name="leiningenVersion" value="2.8.3" />
     <option name="selectedProfiles">
       <list>
         <option value="base" />

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -27,7 +27,9 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private cell-height 28)
+(def ^:private line-height 27)
+
+(def ^:private cell-height (inc line-height))
 
 (g/defnk produce-form-view [renderer form-data ui-state]
   (renderer {:form-data form-data
@@ -884,11 +886,11 @@
                                  :desc {:fx/type :table-view
                                         :style-class ["table-view" "cljfx-table-view"]
                                         :editable true
-                                        :fixed-cell-size cell-height
-                                        :pref-height (+ cell-height ;; header
+                                        :fixed-cell-size line-height
+                                        :pref-height (+ line-height ;; header
                                                         2   ;; insets
                                                         9   ;; bottom scrollbar
-                                                        (* cell-height
+                                                        (* line-height
                                                            (max 1 (count value))))
                                         :columns (mapv #(table-column % field)
                                                        columns)
@@ -1025,7 +1027,7 @@
                         :children
                         [{:fx/type :h-box
                           :spacing 4
-                          :pref-height cell-height
+                          :pref-height line-height
                           :children (cond-> [{:fx/type :label
                                               :h-box/margin {:top 5}
                                               :text (:label field)}]
@@ -1107,7 +1109,7 @@
                    :grid-pane/column 2
                    :visible visible
                    :managed visible
-                   :min-height cell-height
+                   :min-height line-height
                    :alignment :center-left
                    :children [(cond-> field
                                       :always
@@ -1149,8 +1151,8 @@
                                                   :min-width 150
                                                   :max-width 150}
                                                  {:fx/type :column-constraints
-                                                  :min-width cell-height
-                                                  :max-width cell-height}
+                                                  :min-width line-height
+                                                  :max-width line-height}
                                                  {:fx/type :column-constraints
                                                   :hgrow :always
                                                   :min-width 200

--- a/editor/styling/stylesheets/components/_cljfx-form.css
+++ b/editor/styling/stylesheets/components/_cljfx-form.css
@@ -59,8 +59,8 @@
 }
 
 .cljfx-form-text-field {
-  -fx-border-radius: 2px;
-  -fx-background-radius: 2px;
+  -fx-border-radius: 2px !important;
+  -fx-background-radius: 2px  !important;
 }
 
 .cljfx-form-check-box > .box {


### PR DESCRIPTION
I messed up styling to make editable text fields fit into list cells. Now I separated cell height to line height for "one-line" form elements and cell height that is used specifically in cells.

Also fixed round borders getting square.