### PR TITLE
DEF-DEFEDIT-4300 Skip mesh optimization when loading Collada files in the editor

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaModelBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaModelBuilder.java
@@ -42,7 +42,7 @@ public class ColladaModelBuilder extends Builder<Void>  {
         ByteArrayOutputStream out = new ByteArrayOutputStream(64 * 1024);
         MeshSet.Builder meshSetBuilder = MeshSet.newBuilder();
         try {
-            ColladaUtil.loadMesh(collada_is, meshSetBuilder);
+            ColladaUtil.loadMesh(collada_is, meshSetBuilder, true);
         } catch (XMLStreamException e) {
             throw new CompileExceptionError(task.input(0), e.getLocation().getLineNumber(), "Failed to compile mesh: " + e.getLocalizedMessage(), e);
         } catch (LoaderException e) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
@@ -148,7 +148,7 @@ public class ColladaUtil {
 
     public static boolean load(InputStream is, Rig.MeshSet.Builder meshSetBuilder, Rig.AnimationSet.Builder animationSetBuilder, Rig.Skeleton.Builder skeletonBuilder) throws IOException, XMLStreamException, LoaderException {
         XMLCOLLADA collada = loadDAE(is);
-        loadMesh(collada, meshSetBuilder);
+        loadMesh(collada, meshSetBuilder, true);
         loadSkeleton(collada, skeletonBuilder, new ArrayList<String>());
         loadAnimations(collada, animationSetBuilder, "", new ArrayList<String>());
         return true;
@@ -496,9 +496,9 @@ public class ColladaUtil {
         }
     }
 
-    public static void loadMesh(InputStream is, Rig.MeshSet.Builder meshSetBuilder) throws IOException, XMLStreamException, LoaderException {
+    public static void loadMesh(InputStream is, Rig.MeshSet.Builder meshSetBuilder, boolean optimize) throws IOException, XMLStreamException, LoaderException {
         XMLCOLLADA collada = loadDAE(is);
-        loadMesh(collada, meshSetBuilder);
+        loadMesh(collada, meshSetBuilder, optimize);
     }
 
     private static XMLNode getFirstNodeWithGeoemtry(Collection<XMLVisualScene> scenes) {
@@ -513,7 +513,7 @@ public class ColladaUtil {
         return null;
     }
 
-    public static void loadMesh(XMLCOLLADA collada, Rig.MeshSet.Builder meshSetBuilder) throws IOException, XMLStreamException, LoaderException {
+    public static void loadMesh(XMLCOLLADA collada, Rig.MeshSet.Builder meshSetBuilder, boolean optimize) throws IOException, XMLStreamException, LoaderException {
         if (collada.libraryGeometries.size() != 1) {
             if (collada.libraryGeometries.isEmpty()) {
                 return;
@@ -709,7 +709,7 @@ public class ColladaUtil {
             ci.position = position_indices_list.get(i);
             ci.texcoord0 = texcoord_indices_list.get(i);
             ci.normal = mesh_has_normals ? normal_indices_list.get(i) : 0;
-            int index = shared_vertex_indices.indexOf(ci);
+            int index = optimize ? shared_vertex_indices.indexOf(ci) : -1;
             if(index == -1) {
                 // create new vertex as this is not equal to any existing in generated list
                 mesh_index_list.add(shared_vertex_indices.size());

--- a/editor/src/clj/editor/collada.clj
+++ b/editor/src/clj/editor/collada.clj
@@ -14,7 +14,7 @@
         collada-doc (ColladaUtil/loadDAE stream)
         bone-ids (ArrayList.)
         animation-ids (ArrayList.)]
-    (ColladaUtil/loadMesh collada-doc mesh-set-builder)
+    (ColladaUtil/loadMesh collada-doc mesh-set-builder false)
     (ColladaUtil/loadSkeleton collada-doc skeleton-builder bone-ids)
     (ColladaUtil/loadAnimations collada-doc animation-set-builder "" animation-ids)
     (let [mesh-set (protobuf/pb->map (.build mesh-set-builder))

--- a/editor/src/java/com/defold/editor/pipeline/ColladaUtil.java
+++ b/editor/src/java/com/defold/editor/pipeline/ColladaUtil.java
@@ -148,7 +148,7 @@ public class ColladaUtil {
 
     public static boolean load(InputStream is, Rig.MeshSet.Builder meshSetBuilder, Rig.AnimationSet.Builder animationSetBuilder, Rig.Skeleton.Builder skeletonBuilder) throws IOException, XMLStreamException, LoaderException {
         XMLCOLLADA collada = loadDAE(is);
-        loadMesh(collada, meshSetBuilder);
+        loadMesh(collada, meshSetBuilder, true);
         loadSkeleton(collada, skeletonBuilder, new ArrayList<String>());
         loadAnimations(collada, animationSetBuilder, "", new ArrayList<String>());
         return true;
@@ -496,9 +496,9 @@ public class ColladaUtil {
         }
     }
 
-    public static void loadMesh(InputStream is, Rig.MeshSet.Builder meshSetBuilder) throws IOException, XMLStreamException, LoaderException {
+    public static void loadMesh(InputStream is, Rig.MeshSet.Builder meshSetBuilder, boolean optimize) throws IOException, XMLStreamException, LoaderException {
         XMLCOLLADA collada = loadDAE(is);
-        loadMesh(collada, meshSetBuilder);
+        loadMesh(collada, meshSetBuilder, optimize);
     }
 
     private static XMLNode getFirstNodeWithGeoemtry(Collection<XMLVisualScene> scenes) {
@@ -513,7 +513,7 @@ public class ColladaUtil {
         return null;
     }
 
-    public static void loadMesh(XMLCOLLADA collada, Rig.MeshSet.Builder meshSetBuilder) throws IOException, XMLStreamException, LoaderException {
+    public static void loadMesh(XMLCOLLADA collada, Rig.MeshSet.Builder meshSetBuilder, boolean optimize) throws IOException, XMLStreamException, LoaderException {
         if (collada.libraryGeometries.size() != 1) {
             if (collada.libraryGeometries.isEmpty()) {
                 return;
@@ -709,7 +709,7 @@ public class ColladaUtil {
             ci.position = position_indices_list.get(i);
             ci.texcoord0 = texcoord_indices_list.get(i);
             ci.normal = mesh_has_normals ? normal_indices_list.get(i) : 0;
-            int index = shared_vertex_indices.indexOf(ci);
+            int index = optimize ? shared_vertex_indices.indexOf(ci) : -1;
             if(index == -1) {
                 // create new vertex as this is not equal to any existing in generated list
                 mesh_index_list.add(shared_vertex_indices.size());


### PR DESCRIPTION
### User-facing changes
* Meshes load much, much quicker in the editor.

### Technical changes
* Added an `optimize` boolean flag to the `ColladaUtil.loadMesh` functions.

Bundles made through Bob will still produce optimized meshes, but builds from the editor will not.

In the future we might want to optimize the algorithm used to merge vertices. It becomes incredibly slow for complex meshes.