### PR TITLE
Fix for broken error messages when doing go.get() in certain cases

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -576,14 +576,16 @@ namespace dmGameObject
             return 1;
         case dmGameObject::PROPERTY_RESULT_NOT_FOUND:
             {
-                // The supplied URL parameter don't need to be a string,
-                // we let Lua handle the "conversion" to string using concatenation.
-                lua_pushliteral(L, "");
-                lua_pushvalue(L, 1);
-                lua_concat(L, 2);
-                const char* name = lua_tostring(L, -1);
-                lua_pop(L, 1);
-                return luaL_error(L, "'%s' does not have any property called '%s'", name, dmHashReverseSafe64(property_id));
+                const char* path = dmHashReverseSafe64(target.m_Path);
+                const char* property = dmHashReverseSafe64(property_id);
+                if (target.m_Fragment)
+                {
+                    return luaL_error(L, "'%s#%s' does not have any property called '%s'", path, dmHashReverseSafe64(target.m_Fragment), property);
+                }
+                else
+                {
+                    return luaL_error(L, "'%s' does not have any property called '%s'", path, property);
+                }
             }
         case dmGameObject::PROPERTY_RESULT_COMP_NOT_FOUND:
             return luaL_error(L, "could not find component '%s' when resolving '%s'", dmHashReverseSafe64(target.m_Fragment), lua_tostring(L, 1));


### PR DESCRIPTION
The old solution could crash the engine or fail to produce an error message. The crash happened on the line doing lua_concat(L, 2);

I printed the stack and it happened when concatenating a string and userdata. When I printed the metatable of the userdata it seemed to be a hash. I can't understand why lua_concat() would fail though...

Anyway, here's results with broken version of error handler and with my changes. Given that there's a game object with id "foo" with a script component with id "script" but with no script property "name". Old version:

* go.get(nil, "name") -> ERROR:SCRIPT: attempt to concatenate a nil value
* go.get(hash("/foo"), "name) -> Crash
* go.get(msg.url("/foo#script"), "name") -> ERROR:SCRIPT: bad argument #1 to '?' (string expected, got userdata)
* go.get(msg.url("/foo"), "name") -> ERROR:SCRIPT: bad argument #1 to '?' (string expected, got userdata)
* go.get("#", "name") -> ERROR:SCRIPT: /spritesize/test.script:5: '#' does not have any property called 'name'

With my changes:

* go.get(nil, "name") -> ERROR:SCRIPT: /spritesize/test.script:4: '/foo#script' does not have any property called 'name'
* go.get(hash("/foo"), "name) -> ERROR:SCRIPT: /spritesize/test.script:3: '/foo' does not have any property called 'name'
* go.get(msg.url("/foo#script"), "name") -> ERROR:SCRIPT: /spritesize/test.script:2: '/foo#script' does not have any property called 'name'
* go.get("#", "name") -> ERROR:SCRIPT: /spritesize/test.script:5: '/foo#script' does not have any property called 'name'
