### PR TITLE
Issue-4308 HTTP requests fails when on an IPv6 fails

### DIFF
--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -384,6 +384,12 @@ namespace dmConnectionPool
         dmSocket::Address address;
         bool gethost_did_succeed;
 
+        // This function would previously not specify ipv4 and/or ipv6 when calling GetHostByName.
+        // GetHostByName would then assume both ipv4 and ipv6 and always prefer and return an ipv4
+        // address.
+        // Connecting to the returned address would fail when on an ipv6 network.
+        // This is why when calling DoDial we now have the ability to specify ipv4 and/or ipv6 so
+        // that the caller can try to connect first to ipv4 and then to ipv6 if ipv4 failed.
         if (dns_channel)
         {
             gethost_did_succeed = dmDNS::GetHostByName(host, &address, dns_channel, ipv4, ipv6) == dmDNS::RESULT_OK;
@@ -441,12 +447,14 @@ namespace dmConnectionPool
 
     Result Dial(HPool pool, const char* host, uint16_t port, dmDNS::HChannel dns_channel, bool ssl, int timeout, HConnection* connection, dmSocket::Result* sock_res)
     {
+        // try connecting to the host using ipv4 first
         uint64_t dial_started = dmTime::GetTime();
         Result r = DoDial(pool, host, port, dns_channel, ssl, timeout, connection, sock_res, 1, 0);
         if (r == RESULT_OK || r == RESULT_SHUT_DOWN || r == RESULT_OUT_OF_RESOURCES)
         {
             return r;
         }
+        // ipv4 connection failed - reduce timeout (if needed) and try using ipv6 instead
         if (timeout > 0)
         {
             timeout = timeout - (int)(dmTime::GetTime() - dial_started);

--- a/engine/dlib/src/dlib/connection_pool.cpp
+++ b/engine/dlib/src/dlib/connection_pool.cpp
@@ -452,7 +452,7 @@ namespace dmConnectionPool
             timeout = timeout - (int)(dmTime::GetTime() - dial_started);
             if (timeout <= 0)
             {
-                return RESULT_TIMEDOUT;
+                return RESULT_SOCKET_ERROR;
             }
         }
         return DoDial(pool, host, port, dns_channel, ssl, timeout, connection, sock_res, 0, 1);


### PR DESCRIPTION
Fixes #4308 

The connection code always called GetHostByName specifying ipv4&ipv6 true. This caused GetHostByName to always prefer and return an ipv4 address. Connecting to this address failed on an ipv6 network such as K-QA_ipv6. The connection code will now first try to connect using ipv4 and if that fails try ipv6.