### PR TITLE
Issue 4311 sys.get ifaddrs()

### DIFF
--- a/engine/dlib/src/dlib/darwin/socket_darwin.cpp
+++ b/engine/dlib/src/dlib/darwin/socket_darwin.cpp
@@ -45,7 +45,7 @@ namespace dmSocket
                 continue;
 
             int family = ifa->ifa_addr->sa_family;
-            if (!(family == AF_LINK || family == AF_INET)) {
+            if (!(family == AF_LINK || family == AF_INET || family == AF_INET6)) {
                 continue;
             }
 

--- a/engine/dlib/src/dlib/darwin/socket_darwin.cpp
+++ b/engine/dlib/src/dlib/darwin/socket_darwin.cpp
@@ -53,25 +53,15 @@ namespace dmSocket
                 continue;
             }
 
-            IfAddr* a = 0;
-            for (uint32_t i = 0; i < *count; ++i) {
-                if (strcmp(ifa->ifa_name, addresses[i].m_Name) == 0) {
-                    a = &addresses[i];
-                    break;
-                }
+            if (*count >= addresses_count) {
+                dmLogWarning("Can't fill all if-addresses. Supplied buffer too small.");
+                break;
             }
 
-            if (!a) {
-                if (*count < addresses_count) {
-                    a = &addresses[*count];
-                    memset(a, 0, sizeof(*a));
-                    dmStrlCpy(a->m_Name, ifa->ifa_name, sizeof(a->m_Name));
-                    *count = *count + 1;
-                } else {
-                    dmLogWarning("Can't fill all if-addresses. Supplied buffer too small.");
-                    return;
-                }
-            }
+            IfAddr* a = &addresses[*count];
+            memset(a, 0, sizeof(*a));
+            dmStrlCpy(a->m_Name, ifa->ifa_name, sizeof(a->m_Name));
+            *count = *count + 1;
 
             a->m_Address.m_family = DOMAIN_MISSING;
 

--- a/engine/dlib/src/dlib/win32/socket_win32.cpp
+++ b/engine/dlib/src/dlib/win32/socket_win32.cpp
@@ -18,6 +18,7 @@ namespace dmSocket
         PIP_ADAPTER_ADDRESSES paddresses = (IP_ADAPTER_ADDRESSES*) buffer;
         ULONG out_buf_len = sizeof(buffer);
         PIP_ADAPTER_ADDRESSES pcurraddresses = NULL;
+        PIP_ADAPTER_UNICAST_ADDRESS punicast = NULL;
         DWORD ret = GetAdaptersAddresses(family, flags, NULL, paddresses, &out_buf_len);
 
         if (ret == ERROR_BUFFER_OVERFLOW) {
@@ -29,30 +30,44 @@ namespace dmSocket
             pcurraddresses = paddresses;
             while (pcurraddresses && *count < addresses_count) {
                 if (pcurraddresses->IfType != IF_TYPE_SOFTWARE_LOOPBACK) {
-                    if (pcurraddresses->FirstUnicastAddress) {
-                        IfAddr* a = &addresses[*count];
-                        memset(a, 0, sizeof(*a));
+                    punicast = pcurraddresses->FirstUnicastAddress;
+                    if (punicast) {
+                        for (i = 0; punicast != NULL; i++) {
+                            IfAddr* a = &addresses[*count];
+                            memset(a, 0, sizeof(*a));
 
-                        wcstombs(a->m_Name, pcurraddresses->FriendlyName, sizeof(a->m_Name));
-                        a->m_Name[sizeof(a->m_Name)-1] = 0;
-                        sockaddr_in* ia = (sockaddr_in*) pcurraddresses->FirstUnicastAddress->Address.lpSockaddr;
-                        a->m_Flags |= FLAGS_INET;
-                        a->m_Address.m_family = DOMAIN_IPV4;
-                        *IPv4(&a->m_Address) = ia->sin_addr.s_addr;
+                            wcstombs(a->m_Name, pcurraddresses->FriendlyName, sizeof(a->m_Name));
+                            a->m_Name[sizeof(a->m_Name)-1] = 0;
 
-                        a->m_Flags |= FLAGS_LINK;
-                        a->m_MacAddress[0] = pcurraddresses->PhysicalAddress[0];
-                        a->m_MacAddress[1] = pcurraddresses->PhysicalAddress[1];
-                        a->m_MacAddress[2] = pcurraddresses->PhysicalAddress[2];
-                        a->m_MacAddress[3] = pcurraddresses->PhysicalAddress[3];
-                        a->m_MacAddress[4] = pcurraddresses->PhysicalAddress[4];
-                        a->m_MacAddress[5] = pcurraddresses->PhysicalAddress[5];
+                            if (pcurraddresses->OperStatus == IfOperStatusUp) {
+                                a->m_Flags |= FLAGS_UP;
+                                a->m_Flags |= FLAGS_RUNNING;
+                            }
 
-                        if (pcurraddresses->OperStatus == IfOperStatusUp) {
-                            a->m_Flags |= FLAGS_UP;
-                            a->m_Flags |= FLAGS_RUNNING;
+                            if (punicast->Address.lpSockaddr->sa_family == AF_INET) {
+                                a->m_Flags |= FLAGS_INET;
+                                a->m_Address.m_family = DOMAIN_IPV4;
+                                sockaddr_in *ia = (sockaddr_in *)punicast->Address.lpSockaddr;
+                                *IPv4(&a->m_Address) = ia->sin_addr.s_addr;
+                            }
+                            else if (punicast->Address.lpSockaddr->sa_family == AF_INET6) {
+                                a->m_Flags |= FLAGS_INET;
+                                a->m_Address.m_family = DOMAIN_IPV6;
+                                sockaddr_in6 *ia = (sockaddr_in6 *)punicast->Address.lpSockaddr;
+                                memcpy(IPv6(&a->m_Address), &ia->sin6_addr, sizeof(struct in6_addr));
+                            }
+                            else {
+                                a->m_Flags |= FLAGS_LINK;
+                                a->m_MacAddress[0] = pcurraddresses->PhysicalAddress[0];
+                                a->m_MacAddress[1] = pcurraddresses->PhysicalAddress[1];
+                                a->m_MacAddress[2] = pcurraddresses->PhysicalAddress[2];
+                                a->m_MacAddress[3] = pcurraddresses->PhysicalAddress[3];
+                                a->m_MacAddress[4] = pcurraddresses->PhysicalAddress[4];
+                                a->m_MacAddress[5] = pcurraddresses->PhysicalAddress[5];
+                            }
+                            punicast = punicast->Next;
+                            *count = *count + 1;
                         }
-                        *count = *count + 1;
                     }
                 }
                 pcurraddresses = pcurraddresses->Next;

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -716,11 +716,11 @@ union SaveLoadBuffer
             lua_rawset(L, -3);
 
             lua_pushliteral(L, "family");
-            if (ifa->m_Address.m_Family == dmSocket::DOMAIN_IPV4)
+            if (ifa->m_Address.m_family == dmSocket::DOMAIN_IPV4)
             {
                 lua_pushstring(L, "ipv4");
             }
-            else if (ifa->m_Address.m_Family == dmSocket::DOMAIN_IPV6)
+            else if (ifa->m_Address.m_family == dmSocket::DOMAIN_IPV6)
             {
                 lua_pushstring(L, "ipv6");
             }

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -63,7 +63,7 @@ union SaveLoadBuffer
      * This size reflects the output file size which must not exceed this limit.
      * Additionally, the total number of rows that any one table may contain is limited to 65536
      * (i.e. a 16 bit range). When tables are used to represent arrays, the values of
-     * keys are permitted to fall within a 32 bit range, supporting sparse arrays, however 
+     * keys are permitted to fall within a 32 bit range, supporting sparse arrays, however
      * the limit on the total number of rows remains in effect.
      *
      * @name sys.save
@@ -715,8 +715,22 @@ union SaveLoadBuffer
             }
             lua_rawset(L, -3);
 
-            lua_pushliteral(L, "mac");
+            lua_pushliteral(L, "family");
+            if (ifa->m_Address.m_Family == dmSocket::DOMAIN_IPV4)
+            {
+                lua_pushstring(L, "ipv4");
+            }
+            else if (ifa->m_Address.m_Family == dmSocket::DOMAIN_IPV6)
+            {
+                lua_pushstring(L, "ipv6");
+            }
+            else
+            {
+                lua_pushnil(L);
+            }
+            lua_rawset(L, -3);
 
+            lua_pushliteral(L, "mac");
             if (ifa->m_Flags & dmSocket::FLAGS_LINK)
             {
                 char tmp[64];
@@ -908,7 +922,7 @@ union SaveLoadBuffer
 
         dmMessage::URL url;
         GetSystemURL(&url);
- 
+
         dmMessage::Result result = dmMessage::Post(0, &url, dmSystemDDF::Exit::m_DDFDescriptor->m_NameHash, 0, (uintptr_t) dmSystemDDF::Exit::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(result == dmMessage::RESULT_OK);
 
@@ -954,7 +968,7 @@ union SaveLoadBuffer
 
         dmMessage::URL url;
         GetSystemURL(&url);
- 
+
         dmMessage::Result result = dmMessage::Post(0, &url, dmSystemDDF::Reboot::m_DDFDescriptor->m_NameHash, 0, (uintptr_t) dmSystemDDF::Reboot::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(result == dmMessage::RESULT_OK);
 
@@ -979,7 +993,7 @@ union SaveLoadBuffer
     * @examples
     *
     * Setting the swap intervall to swap every v-blank
-    *  
+    *
     * ```lua
     * sys.set_vsync_swap_interval(1)
     * ```
@@ -993,7 +1007,7 @@ union SaveLoadBuffer
 
         dmMessage::URL url;
         GetSystemURL(&url);
- 
+
         dmMessage::Result result = dmMessage::Post(0, &url, dmSystemDDF::SetVsync::m_DDFDescriptor->m_NameHash, 0, (uintptr_t) dmSystemDDF::SetVsync::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(result == dmMessage::RESULT_OK);
 
@@ -1010,9 +1024,9 @@ union SaveLoadBuffer
     * @name sys.set_update_frequency
     * @param frequency target frequency. 60 for 60 fps
     * @examples
-    * 
+    *
     * Setting the update frequency to 60 frames per second
-    *  
+    *
     * ```lua
     * sys.set_update_frequency(60)
     * ```
@@ -1026,7 +1040,7 @@ union SaveLoadBuffer
 
         dmMessage::URL url;
         GetSystemURL(&url);
- 
+
         dmMessage::Result result = dmMessage::Post(0, &url, dmSystemDDF::SetUpdateFrequency::m_DDFDescriptor->m_NameHash, 0, (uintptr_t) dmSystemDDF::SetUpdateFrequency::m_DDFDescriptor, &msg, sizeof(msg), 0);
         assert(result == dmMessage::RESULT_OK);
 


### PR DESCRIPTION
Include AF_INET6 for macOS
Include all addresses of an interface on macOS
Include all addressed of an interface on windows and distinguish between link, ipv4 and ipv6

Fixes #4311 