### PR TITLE
Added label.get_text()

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -471,6 +471,11 @@ namespace dmGameSystem
         metrics.m_MaxDescent = metrics.m_MaxDescent;
     }
 
+    const char* CompLabelGetText(const LabelComponent* component)
+    {
+        return component->m_Text;
+    }
+
     dmGameObject::PropertyResult CompLabelGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value)
     {
         dmGameObject::PropertyResult result = dmGameObject::PROPERTY_RESULT_NOT_FOUND;

--- a/engine/gamesys/src/gamesys/components/comp_label.h
+++ b/engine/gamesys/src/gamesys/components/comp_label.h
@@ -39,6 +39,8 @@ namespace dmGameSystem
 
     void CompLabelGetTextMetrics(const LabelComponent* component, struct dmRender::TextMetrics& metrics);
 
+    const char* CompLabelGetText(const LabelComponent* component);
+
 
 }
 

--- a/engine/gamesys/src/gamesys/scripts/script_label.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_label.cpp
@@ -252,6 +252,8 @@ static int GetTextMetrics(lua_State* L)
  * @param url [type:string|hash|url] the label to get the text from
  * @return metrics [type:string] the label text
  *
+ * @examples
+ *
  * ```lua
  * function init(self)
  *     local text = label.get_text("#label")

--- a/engine/gamesys/src/gamesys/scripts/script_label.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_label.cpp
@@ -138,6 +138,9 @@ namespace dmGameSystem
  *
  * Sets the text of a label component
  *
+ * [icon:attention] This method uses the message passing that means the value will be set after `dispatch messages` step.
+ * More information is available in the <a href="/manuals/application-lifecycle">Application Lifecycle manual</a>.
+ *
  * @name label.set_text
  * @param url [type:string|hash|url] the label that should have a constant set
  * @param text [type:string] the text
@@ -196,6 +199,8 @@ static int SetText(lua_State* L)
  * - height
  * - max_ascent
  * - max_descent
+ *
+ * @examples
  *
  * ```lua
  * function init(self)

--- a/engine/gamesys/src/gamesys/scripts/script_label.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_label.cpp
@@ -239,9 +239,46 @@ static int GetTextMetrics(lua_State* L)
     return 1;
 }
 
+/*# gets the text for a label
+ *
+ * Gets the text from a label component
+ *
+ * @name label.get_text
+ * @param url [type:string|hash|url] the label to get the text from
+ * @return metrics [type:string] the label text
+ *
+ * ```lua
+ * function init(self)
+ *     local text = label.get_text("#label")
+ *     print(text)
+ * end
+ * ```
+ */
+static int GetText(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 1);
+
+    CheckGoInstance(L);
+
+    dmMessage::URL receiver;
+    dmMessage::URL sender;
+    dmScript::ResolveURL(L, 1, &receiver, &sender);
+
+    dmGameSystem::LabelComponent* component = (dmGameSystem::LabelComponent*)dmGameObject::GetComponentFromURL(receiver);
+    if (!component) {
+        return DM_LUA_ERROR("Could not find instance %s:%s#%s", dmHashReverseSafe64(receiver.m_Socket), dmHashReverseSafe64(receiver.m_Path), dmHashReverseSafe64(receiver.m_Fragment));
+    }
+    
+    const char* value = dmGameSystem::CompLabelGetText(component);
+    lua_pushstring(L, value);
+
+    return 1;
+}
+
 static const luaL_reg Module_methods[] =
 {
     {"set_text", SetText},
+    {"get_text", GetText},
     {"get_text_metrics", GetTextMetrics},
     {0, 0}
 };


### PR DESCRIPTION
The method will be useful for reading values was set in the editor for localization systems.

Because of `label.set_text()` works through message system,`label.get_text()` works the same way as `label.get_text_metrics()`:
```lua
-- we have #label with text `init_text`
gui.set_text("#label", "new_text")
print(gui.get_text("#label")) -- the result will be `init_text` because the text will set after dispatch message event
```
But if a developer does so, it is really strange, because he knows what he set a few lines above.