### PR TITLE
Update JavaFX version

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -17,7 +17,7 @@ java = ${launcher.jdk}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Main
 debug = 1
-vmargs = -Djdk.gtk.version=2,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
+vmargs = -Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -65,34 +65,34 @@
 
                      [cljfx "1.3.4"]
 
-                     [org.openjfx/javafx-base "12"]
-                     [org.openjfx/javafx-base "12" :classifier "linux"]
-                     [org.openjfx/javafx-base "12" :classifier "mac"]
-                     [org.openjfx/javafx-base "12" :classifier "win"]
-                     [org.openjfx/javafx-controls "12"]
-                     [org.openjfx/javafx-controls "12" :classifier "linux"]
-                     [org.openjfx/javafx-controls "12" :classifier "mac"]
-                     [org.openjfx/javafx-controls "12" :classifier "win"]
-                     [org.openjfx/javafx-graphics "12"]
-                     [org.openjfx/javafx-graphics "12" :classifier "linux"]
-                     [org.openjfx/javafx-graphics "12" :classifier "mac"]
-                     [org.openjfx/javafx-graphics "12" :classifier "win"]
-                     [org.openjfx/javafx-media "12"]
-                     [org.openjfx/javafx-media "12" :classifier "linux"]
-                     [org.openjfx/javafx-media "12" :classifier "mac"]
-                     [org.openjfx/javafx-media "12" :classifier "win"]
-                     [org.openjfx/javafx-web "12"]
-                     [org.openjfx/javafx-web "12" :classifier "linux"]
-                     [org.openjfx/javafx-web "12" :classifier "mac"]
-                     [org.openjfx/javafx-web "12" :classifier "win"]
-                     [org.openjfx/javafx-fxml "12"]
-                     [org.openjfx/javafx-fxml "12" :classifier "linux"]
-                     [org.openjfx/javafx-fxml "12" :classifier "mac"]
-                     [org.openjfx/javafx-fxml "12" :classifier "win"]
-                     [org.openjfx/javafx-swing "12"]
-                     [org.openjfx/javafx-swing "12" :classifier "linux"]
-                     [org.openjfx/javafx-swing "12" :classifier "mac"]
-                     [org.openjfx/javafx-swing "12" :classifier "win"]
+                     [org.openjfx/javafx-base "13-ea+11"]
+                     [org.openjfx/javafx-base "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-base "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-base "13-ea+11" :classifier "win"]
+                     [org.openjfx/javafx-controls "13-ea+11"]
+                     [org.openjfx/javafx-controls "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-controls "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-controls "13-ea+11" :classifier "win"]
+                     [org.openjfx/javafx-graphics "13-ea+11"]
+                     [org.openjfx/javafx-graphics "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-graphics "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-graphics "13-ea+11" :classifier "win"]
+                     [org.openjfx/javafx-media "13-ea+11"]
+                     [org.openjfx/javafx-media "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-media "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-media "13-ea+11" :classifier "win"]
+                     [org.openjfx/javafx-web "13-ea+11"]
+                     [org.openjfx/javafx-web "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-web "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-web "13-ea+11" :classifier "win"]
+                     [org.openjfx/javafx-fxml "13-ea+11"]
+                     [org.openjfx/javafx-fxml "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-fxml "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-fxml "13-ea+11" :classifier "win"]
+                     [org.openjfx/javafx-swing "13-ea+11"]
+                     [org.openjfx/javafx-swing "13-ea+11" :classifier "linux"]
+                     [org.openjfx/javafx-swing "13-ea+11" :classifier "mac"]
+                     [org.openjfx/javafx-swing "13-ea+11" :classifier "win"]
 
                      [org.jogamp.gluegen/gluegen-rt               "2.3.2"]
                      [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-linux-amd64"]
@@ -190,7 +190,6 @@
                                 :proto-paths       ["test/proto"]
                                 :resource-paths    ["test/resources"]
                                 :jvm-opts          ["-Ddefold.unpack.path=tmp/unpack"
-                                                    "-Djdk.gtk.version=2"
                                                     "-Ddefold.nrepl=true"
                                                     "-Ddefold.log.dir="
                                                     "-Djogl.debug.DebugGL" ; TraceGL is also useful
@@ -203,5 +202,4 @@
                                                     ;; From https://github.com/clojure-goes-fast/clj-async-profiler/blob/master/README.md
                                                     "-Djdk.attach.allowAttachSelf"   ; Required for attach to running process.
                                                     "-XX:+UnlockDiagnosticVMOptions" ; Required for DebugNonSafepoints.
-                                                    "-XX:+DebugNonSafepoints"]}}     ; Without this, there is a high chance that simple inlined methods will not appear in the profile.
-)
+                                                    "-XX:+DebugNonSafepoints"]}})     ; Without this, there is a high chance that simple inlined methods will not appear in the profile.


### PR DESCRIPTION
In anticipation for [our fix](https://github.com/javafxports/openjdk-jfx/pull/544) slowly getting its way into JavaFX, I decided to update used JavaFX version. Please try it!

Note about property `jdk.gtk.version` and its removal:
This is a property for linux version of JavaFX which picks used gtk version. It was set to `2` for a couple of reasons:
- javafx with more actual gtk version had broken drag and drop support, for example it didn't work in Outline;
- it also crashed on Ubuntu with Wayland which I happen to have at home.

This property became problematic in recent version of JavaFX because it got some fixes for dialogs on some linuxes ([such as Manjaro](https://forum.defold.com/t/cant-open-app-on-dell-xps-with-manjaro-kde/51706)) being 1 pixel wide: it also introduced [a regression](https://github.com/javafxports/openjdk-jfx/issues/475) that all dialogs on linux appear in top left corner of a screen instead of being centered.

Fortunately, both issues that were preventing us from using more modern gtk [are solved](https://hg.openjdk.java.net/openjfx/13-dev/rt/) in latest JavaFX version, so we can safely remove it.