### PR TITLE
Issue-#3140 High-DPI does not work correctly for HTML5 bundles (DEF-2396)

### DIFF
--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -120,12 +120,6 @@
 
 		var app_container = document.getElementById('app-container');
 		var game_canvas = document.getElementById('canvas');
-	{{#display.high_dpi}}
-		var dpi = window.devicePixelRatio || 1;
-	{{/display.high_dpi}}
-	{{^display.high_dpi}}
-		var dpi = 1;
-	{{/display.high_dpi}}
 		var innerWidth = window.innerWidth;
 		var innerHeight = window.innerHeight - buttonHeight;
 		var width = {{display.width}};
@@ -184,8 +178,8 @@
 	{{/DEFOLD_SCALE_MODE_IS_NO_SCALE}}
 		app_container.style.width = width + "px";
 		app_container.style.height = height + buttonHeight + "px";
-		game_canvas.width = width * dpi;
-		game_canvas.height = height * dpi;
+		game_canvas.width = width;
+		game_canvas.height = height;
 	}
 	resize_game_canvas();
 	window.addEventListener('resize', resize_game_canvas, false);

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -72,7 +72,7 @@
 			<div class="button" onclick="Module.toggleFullscreen();">Fullscreen</div>
 {{/html5.show_fullscreen_button}}
 {{#html5.show_made_with_defold}}
-			<div class="link">Made with <a href="https://defold.com/">Defold</a></div>
+			<div class="link">Made with <a href="https://defold.com/" target="_blank">Defold</a></div>
 {{/html5.show_made_with_defold}}
 		</div>
 	</div>

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -51,6 +51,7 @@ var LibraryGLFW = {
     prevNonFSWidth: 0,
     prevNonFSHeight: 0,
     isFullscreen: false,
+    dpi: 1,
 
 /*******************************************************************************
  * DOM EVENT CALLBACKS
@@ -382,8 +383,8 @@ var LibraryGLFW = {
       var height;
       GLFW.isFullscreen = document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"] || document["msIsFullScreen"];
       if (GLFW.isFullscreen) {
-        GLFW.prevNonFSWidth = GLFW.prevWidth;
-        GLFW.prevNonFSHeight = GLFW.prevHeight;
+        GLFW.prevNonFSWidth = GLFW.prevWidth / GLFW.dpi;
+        GLFW.prevNonFSHeight = GLFW.prevHeight / GLFW.dpi;
         width = window.innerWidth;
         height = window.innerHeight;
       } else {
@@ -399,6 +400,9 @@ var LibraryGLFW = {
     },
 
     requestFullScreen: function() {
+      if (!Module["canvas"]) {
+        return;
+      }
       document.addEventListener('fullscreenchange', GLFW.onFullScreenEventChange, true);
       document.addEventListener('mozfullscreenchange', GLFW.onFullScreenEventChange, true);
       document.addEventListener('webkitfullscreenchange', GLFW.onFullScreenEventChange, true);
@@ -560,6 +564,7 @@ var LibraryGLFW = {
     GLFW.params[0x00050001] = 0; // GLFW_PRESENT
     GLFW.params[0x00050002] = 1; // GLFW_AXES
     GLFW.params[0x00050003] = 2; // GLFW_BUTTONS
+    GLFW.params[0x00020019] = 0; //GLFW_WINDOW_HIGH_DPI
 
     GLFW.keys = new Array();
 
@@ -613,6 +618,11 @@ var LibraryGLFW = {
 
   glfwOpenWindowHint: function(target, hint) {
     GLFW.params[target] = hint;
+    if (target == 0x00020019) { //GLFW_WINDOW_HIGH_DPI
+      if (hint != 0) {
+        GLFW.dpi = window.devicePixelRatio || 1;
+      }
+    }
   },
 
   glfwCloseWindow__deps: ['$Browser'],
@@ -652,13 +662,15 @@ var LibraryGLFW = {
     var height = Module['canvas'].height;
 
     if (GLFW.isFullscreen) {
-      width = window.innerWidth;
-      height = window.innerHeight;
+      width = window.innerWidth * GLFW.dpi;
+      height = window.innerHeight * GLFW.dpi;
     }
 
-    if (GLFW.prevWidth != width ||
-        GLFW.prevHeight != height) {
-
+    if (GLFW.prevWidth != width || GLFW.prevHeight != height) {
+      if (!GLFW.isFullscreen) {
+        width = width * GLFW.dpi;
+        height = height * GLFW.dpi;
+      }
       GLFW.prevWidth = width;
       GLFW.prevHeight = height;
       _glfwSetWindowSize(width, height);

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -383,6 +383,8 @@ var LibraryGLFW = {
       var height;
       GLFW.isFullscreen = document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"] || document["msIsFullScreen"];
       if (GLFW.isFullscreen) {
+        // size multiplied in glfwSwapBuffers() function.
+        // if we don't divide here size will be x2 every time when we exit fullscreen
         GLFW.prevNonFSWidth = GLFW.prevWidth / GLFW.dpi;
         GLFW.prevNonFSHeight = GLFW.prevHeight / GLFW.dpi;
         width = window.innerWidth;
@@ -564,7 +566,7 @@ var LibraryGLFW = {
     GLFW.params[0x00050001] = 0; // GLFW_PRESENT
     GLFW.params[0x00050002] = 1; // GLFW_AXES
     GLFW.params[0x00050003] = 2; // GLFW_BUTTONS
-    GLFW.params[0x00020019] = 0; //GLFW_WINDOW_HIGH_DPI
+    GLFW.params[0x00020019] = 0; // GLFW_WINDOW_HIGH_DPI
 
     GLFW.keys = new Array();
 
@@ -618,6 +620,8 @@ var LibraryGLFW = {
 
   glfwOpenWindowHint: function(target, hint) {
     GLFW.params[target] = hint;
+    // if display._high_dpi flag is on in game.project 
+    // we get information about the current pixel ratio from browser 
     if (target == 0x00020019) { //GLFW_WINDOW_HIGH_DPI
       if (hint != 0) {
         GLFW.dpi = window.devicePixelRatio || 1;
@@ -662,6 +666,8 @@ var LibraryGLFW = {
     var height = Module['canvas'].height;
 
     if (GLFW.isFullscreen) {
+      // We don't want to call _glfwSetWindowSize every frame, 
+      // that's why for the fullscreen mode we take into account dpi separately
       width = window.innerWidth * GLFW.dpi;
       height = window.innerHeight * GLFW.dpi;
     }


### PR DESCRIPTION
I hid HDPI logic into the glfw module.
Now HDPI works also for a fullscreen mode.