### PR TITLE
DEFEDIT-4375 Fix 3D particlefx bounding boxes

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -342,12 +342,9 @@
       ;; TODO: We have no mechanism for updating the style nor icon on
       ;; on the toolbar button. For now we piggyback on the state
       ;; update polling to set a style when the filters are active.
-      (let [visibility-filters-enabled? (g/node-value scene-visibility :visibility-filters-enabled?)
-            filtered-renderable-tags (g/node-value scene-visibility :filtered-renderable-tags)
-            filters-active? (and visibility-filters-enabled? (some scene-visibility/toggleable-tags filtered-renderable-tags))]
-        (if filters-active?
-          (ui/add-style! btn "filters-active")
-          (ui/remove-style! btn "filters-active")))
+      (if (scene-visibility/filters-appear-active? scene-visibility)
+        (ui/add-style! btn "filters-active")
+        (ui/remove-style! btn "filters-active"))
       (scene-visibility/settings-visible? btn))))
 
 (def ^:private eye-icon-svg-path

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -369,9 +369,9 @@
 (defn empty-aabb? [^AABB aabb]
   (let [min-p ^Point3d (.min aabb)
         max-p ^Point3d (.max aabb)]
-    (or (= (.x min-p) (.x max-p))
-        (= (.y min-p) (.y max-p))
-        (= (.z min-p) (.z max-p)))))
+    (and (= (.x min-p) (.x max-p))
+         (= (.y min-p) (.y max-p))
+         (= (.z min-p) (.z max-p)))))
 
 ;; From Graphics Gems:
 ;; https://github.com/erich666/GraphicsGems/blob/master/gems/TransBox.c

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2100,7 +2100,7 @@
         h (:height scene-dims)
         scene {:node-id _node-id
                :aabb geom/null-aabb
-               :default-aabb (geom/coords->aabb [0 0 0] [w h 0])
+               :visibility-aabb (geom/coords->aabb [0 0 0] [w h 0])
                :renderable {:render-fn render-lines
                             :tags #{:gui :gui-bounds}
                             :passes [pass/transparent]

--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -166,7 +166,7 @@
     (.scale n)))
 
 (defn add-vector
-  ^Vector3d [^Vector3d v1 ^Vector3d v2]
+  ^Vector3d [^Tuple3d v1 ^Tuple3d v2]
   (doto (Vector3d. v1)
     (.add v2)))
 

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -397,26 +397,19 @@
       pass/selection (render-lines gl render-args renderables count)
       pass/transparent (render-emitters-sim gl render-args renderables count))))
 
-(defn- property-range
-  ^double [prop ^double default]
-  (if (nil? prop)
-    default
-    (let [[^double -r ^double +r] (props/sample-range prop)]
-      (max (Math/abs -r) +r))))
-
 (g/defnk produce-emitter-aabb [type emitter-key-size-x emitter-key-size-y emitter-key-size-z]
   (case type
     (:emitter-type-2dcone :emitter-type-cone)
-    (let [+bx (* 0.5 (property-range emitter-key-size-x 0.0))
-          +by (property-range emitter-key-size-y 0.0)
+    (let [+bx (* 0.5 (props/sample emitter-key-size-x))
+          +by (props/sample emitter-key-size-y)
           -bx (- +bx)]
       (geom/coords->aabb [-bx 0.0 (case type :emitter-type-2dcone 0.0 -bx)]
                          [+bx +by (case type :emitter-type-2dcone 0.0 +bx)]))
 
     :emitter-type-box
-    (let [+bx (* 0.5 (property-range emitter-key-size-x 0.0))
-          +by (* 0.5 (property-range emitter-key-size-y 0.0))
-          +bz (* 0.5 (property-range emitter-key-size-z 0.0))
+    (let [+bx (* 0.5 (props/sample emitter-key-size-x))
+          +by (* 0.5 (props/sample emitter-key-size-y))
+          +bz (* 0.5 (props/sample emitter-key-size-z))
           -bx (- +bx)
           -by (- +by)
           -bz (- +bz)]
@@ -424,10 +417,17 @@
                          [+bx +by +bz]))
 
     (:emitter-type-circle :emitter-type-sphere)
-    (let [+bx (property-range emitter-key-size-x 0.0)
+    (let [+bx (props/sample emitter-key-size-x)
           -bx (- +bx)]
       (geom/coords->aabb [-bx -bx (case type :emitter-type-circle 0.0 -bx)]
                          [+bx +bx (case type :emitter-type-circle 0.0 +bx)]))))
+
+(defn- property-range
+  ^double [prop ^double default]
+  (if (nil? prop)
+    default
+    (let [[^double -r ^double +r] (props/sample-range prop)]
+      (max (Math/abs -r) +r))))
 
 (g/defnk produce-emitter-visibility-aabb
   [type

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -49,7 +49,8 @@
         [x y tx ty]))))
 
 (defprotocol Sampler
-  (sample [this]))
+  (sample [this])
+  (sample-range [this]))
 
 (defn- curve-aabbs
   ([curve]
@@ -102,9 +103,33 @@
                                       y (.getY p)]
                                   (assoc v 0 x 1 y)))))))
 
+(defn curve-vals [curve]
+  (iv/iv-vals (:points curve)))
+
+(defn curve-range [curve]
+  (let [curve-vals (curve-vals curve)]
+    (assert (seq curve-vals) "Invalid curve")
+    (if (= 1 (count curve-vals))
+      (let [sample (curve-vals 0)
+            value (sample 1)] ; Extract Y component.
+        [value value])
+      (let [spline (->spline curve-vals)]
+        (loop [t 0.0
+               min-value Double/MAX_VALUE
+               max-value Double/MIN_VALUE]
+          (let [sample (spline-cp spline t) ; Clamps t to [0, 1] internally.
+                ^double value (sample 1)] ; Extract Y component.
+            (if (>= t 1.0)
+              [(min min-value value)
+               (max max-value value)]
+              (recur (+ t 0.01)
+                     (min min-value value)
+                     (max max-value value)))))))))
+
 (defrecord Curve [points]
   Sampler
   (sample [this] (second (first (iv/iv-vals points))))
+  (sample-range [this] (curve-range this))
   t/GeomCloud
   (t/geom-aabbs [this] (curve-aabbs this))
   (t/geom-aabbs [this ids] (curve-aabbs this ids))
@@ -113,9 +138,11 @@
   (t/geom-update [this ids f] (curve-update this ids f))
   (t/geom-transform [this ids transform] (curve-transform this ids transform)))
 
-(defrecord CurveSpread [points spread]
+(defrecord CurveSpread [points ^double spread]
   Sampler
   (sample [this] (second (first (iv/iv-vals points))))
+  (sample-range [this] (let [[^double min ^double max] (curve-range this)]
+                         [(- min spread) (+ max spread)]))
   t/GeomCloud
   (t/geom-aabbs [this] (curve-aabbs this))
   (t/geom-aabbs [this ids] (curve-aabbs this ids))
@@ -133,9 +160,6 @@
   (CurveSpread. (iv/iv-vec control-points) spread))
 
 (def default-curve-spread (->curve-spread [[0.0 0.0 1.0 0.0]] 0.0))
-
-(defn curve-vals [curve]
-  (iv/iv-vals (:points curve)))
 
 (core/register-read-handler!
  (.getName Curve)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -939,17 +939,19 @@
 
 (defn- fudge-empty-aabb
   ^AABB [^AABB aabb]
-  (let [min-p ^Point3d (.min aabb)
-        max-p ^Point3d (.max aabb)
-        zero-x (= (.x min-p) (.x max-p))
-        zero-y (= (.y min-p) (.y max-p))
-        zero-z (= (.z min-p) (.z max-p))]
-    (geom/coords->aabb [(cond-> (.x min-p) zero-x dec)
-                        (cond-> (.y min-p) zero-y dec)
-                        (cond-> (.z min-p) zero-z dec)]
-                       [(cond-> (.x max-p) zero-x inc)
-                        (cond-> (.y max-p) zero-y inc)
-                        (cond-> (.z max-p) zero-z inc)])))
+  (if (geom/null-aabb? aabb)
+    aabb
+    (let [min-p ^Point3d (.min aabb)
+          max-p ^Point3d (.max aabb)
+          zero-x (= (.x min-p) (.x max-p))
+          zero-y (= (.y min-p) (.y max-p))
+          zero-z (= (.z min-p) (.z max-p))]
+      (geom/coords->aabb [(cond-> (.x min-p) zero-x dec)
+                          (cond-> (.y min-p) zero-y dec)
+                          (cond-> (.z min-p) zero-z dec)]
+                         [(cond-> (.x max-p) zero-x inc)
+                          (cond-> (.y max-p) zero-y inc)
+                          (cond-> (.z max-p) zero-z inc)]))))
 
 (defn frame-selection [view animate?]
   (let [aabb (fudge-empty-aabb (g/node-value view :selected-aabb))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -3,6 +3,7 @@
             [dynamo.graph :as g]
             [editor.background :as background]
             [editor.camera :as c]
+            [editor.colors :as colors]
             [editor.error-reporting :as error-reporting]
             [editor.geom :as geom]
             [editor.gl :as gl]
@@ -20,6 +21,7 @@
             [editor.scene-cache :as scene-cache]
             [editor.scene-picking :as scene-picking]
             [editor.scene-selection :as selection]
+            [editor.scene-shapes :as scene-shapes]
             [editor.scene-text :as scene-text]
             [editor.scene-tools :as scene-tools]
             [editor.system :as system]
@@ -450,8 +452,37 @@
     {:renderables scene-renderables-by-pass
      :selected-renderables selected-renderables}))
 
-(g/defnk produce-aux-render-data [aux-renderables hidden-renderable-tags]
-  (let [aux-renderables-by-pass (apply merge-with concat aux-renderables)
+(g/defnk produce-debug-renderables [^AABB scene-aabb]
+  (let [aabb-min (.min scene-aabb)
+        aabb-max (.max scene-aabb)
+        aabb-mid (-> aabb-min
+                     (math/add-vector aabb-max)
+                     (math/scale-vector 0.5))
+        world-transform (doto (Matrix4d.)
+                          (.setIdentity)
+                          (.setTranslation aabb-mid))
+        color colors/defold-orange
+        aabb-ext [(- (.x aabb-max) (.x aabb-mid))
+                  (- (.y aabb-max) (.y aabb-mid))
+                  (- (.z aabb-max) (.z aabb-mid))]
+        point-scale (float-array aabb-ext)]
+    {pass/transparent
+     [{:world-transform world-transform
+       :render-fn scene-shapes/render-triangles
+       :user-data {:color color
+                   :point-scale point-scale
+                   :geometry scene-shapes/box-triangles}}]
+
+     pass/outline
+     [{:world-transform world-transform
+       :render-fn scene-shapes/render-lines
+       :user-data {:color color
+                   :point-scale point-scale
+                   :geometry scene-shapes/box-lines}}]}))
+
+(g/defnk produce-aux-render-data [aux-renderables debug-renderables hidden-renderable-tags]
+  (assert (map? debug-renderables))
+  (let [aux-renderables-by-pass (apply merge-with concat debug-renderables aux-renderables)
         filtered-aux-renderables-by-pass (into {}
                                                (map (fn [[pass renderables]]
                                                       [pass (remove #(not-empty (set/intersection hidden-renderable-tags (:tags %))) renderables)]))
@@ -482,9 +513,11 @@
                           parent-world-transform
                           (doto (Matrix4d. parent-world-transform)
                             (.mul local-transform)))
-        local-aabb (:aabb scene)
+        local-aabb (or (:visibility-aabb scene)
+                       (:aabb scene))
         union-aabb (if (or (nil? local-aabb)
-                           (geom/null-aabb? local-aabb))
+                           (geom/null-aabb? local-aabb)
+                           (geom/empty-aabb? local-aabb))
                      union-aabb
                      (-> local-aabb
                          (geom/aabb-transform world-transform)
@@ -509,6 +542,7 @@
   (output all-renderables g/Any :abstract)
 
   (output camera-type g/Keyword (g/fnk [camera] (:type camera)))
+  (output debug-renderables g/Any :cached produce-debug-renderables)
   (output scene-render-data g/Any :cached produce-scene-render-data)
   (output aux-render-data g/Any :cached produce-aux-render-data)
 
@@ -522,8 +556,7 @@
                                            (reduce geom/aabb-union geom/null-aabb selected-aabbs)
                                            scene-aabb))))
   (output scene-aabb AABB :cached (g/fnk [scene]
-                                    (or (:default-aabb scene)
-                                        (calculate-scene-aabb geom/null-aabb geom/Identity4d scene))))
+                                    (calculate-scene-aabb geom/null-aabb geom/Identity4d scene)))
   (output renderables-aabb+picking-node-id g/Any :cached produce-renderables-aabb+picking-node-id)
   (output selected-updatables g/Any :cached (g/fnk [selected-renderables]
                                               (into {}
@@ -894,17 +927,19 @@
       (g/set-property camera-node :local-camera end-camera)))
   nil)
 
-(defn- fudge-empty-aabb [^AABB aabb]
-  (if-not (geom/empty-aabb? aabb)
-    aabb
-    (let [min-p ^Point3d (.min aabb)
-          max-p ^Point3d (.max aabb)]
-      (geom/coords->aabb [(- (.x min-p) 1.0)
-                          (- (.y min-p) 1.0)
-                          (- (.z min-p) 1.0)]
-                         [(+ (.x max-p) 1.0)
-                          (+ (.y max-p) 1.0)
-                          (+ (.z max-p) 1.0)]))))
+(defn- fudge-empty-aabb
+  ^AABB [^AABB aabb]
+  (let [min-p ^Point3d (.min aabb)
+        max-p ^Point3d (.max aabb)
+        zero-x (= (.x min-p) (.x max-p))
+        zero-y (= (.y min-p) (.y max-p))
+        zero-z (= (.z min-p) (.z max-p))]
+    (geom/coords->aabb [(cond-> (.x min-p) zero-x dec)
+                        (cond-> (.y min-p) zero-y dec)
+                        (cond-> (.z min-p) zero-z dec)]
+                       [(cond-> (.x max-p) zero-x inc)
+                        (cond-> (.y max-p) zero-y inc)
+                        (cond-> (.z max-p) zero-z inc)])))
 
 (defn frame-selection [view animate?]
   (let [aabb (fudge-empty-aabb (g/node-value view :selected-aabb))

--- a/editor/src/clj/editor/scene_shapes.clj
+++ b/editor/src/clj/editor/scene_shapes.clj
@@ -1,0 +1,299 @@
+(ns editor.scene-shapes
+  "Helpers for rendering of shared object-space vertex buffers that are
+  transformed in the vertex shader."
+  (:require [editor.colors :as colors]
+            [editor.geom :as geom]
+            [editor.gl :as gl]
+            [editor.gl.pass :as pass]
+            [editor.gl.shader :as shader]
+            [editor.gl.vertex2 :as vtx]
+            [editor.math :as math]
+            [editor.scene-picking :as scene-picking])
+  (:import [com.jogamp.opengl GL2]
+           [javax.vecmath Point4d]))
+
+(set! *warn-on-reflection* true)
+
+(vtx/defvertex pos-vtx
+  ;; The W component is multiplied with the point_offset_by_w uniform, which is
+  ;; used to offset the point in local space. We use this to offset the caps of
+  ;; the capsule shape.
+  (vec4 position))
+
+(shader/defshader vertex-shader
+  (uniform mat4 world_view_proj)
+  (uniform vec4 point_scale)
+  (uniform vec4 point_offset_by_w)
+  (attribute vec4 position)
+  (defn void main []
+    (setq vec3 point
+          (+ (* position.xyz
+                point_scale.xyz)
+             (* position.w
+                point_offset_by_w.xyz)))
+    (setq gl_Position
+          (* world_view_proj
+             (vec4 point 1.0)))))
+
+(shader/defshader fragment-shader
+  (uniform vec4 color) ; `color` also used in selection pass to render picking id
+  (defn void main []
+    (setq gl_FragColor color)))
+
+(def shader (shader/make-shader ::shader vertex-shader fragment-shader {"world_view_proj" :world-view-proj}))
+
+(def box-lines
+  {:primitive-type GL2/GL_LINES
+   :vbuf (-> (->pos-vtx 24 :static)
+
+             ;; Pos Z
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+
+             ;; Neg Z
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+
+             ;; Connecting lines
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+
+             (vtx/flip!))})
+
+(def box-triangles
+  {:primitive-type GL2/GL_TRIANGLES
+   :vbuf (-> (->pos-vtx 36 :static)
+
+             ;; We start with the camera-facing face so that we can render just
+             ;; the first face in case we are rendering a 2D box.
+
+             ;; Neg Z
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+
+             ;; Pos Z
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+
+             ;; Neg Y
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+
+             ;; Pos Y
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+
+             ;; Neg X
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! -1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! -1.0 1.0 1.0 0.0)
+
+             ;; Pos X
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 -1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 -1.0 0.0)
+             (pos-vtx-put! 1.0 1.0 1.0 0.0)
+
+             (vtx/flip!))})
+
+(def ^:private disc-perimeter
+  (->> geom/origin-geom
+       (geom/transl [0.0 1.0 0.0])
+       (geom/circling 32)))
+
+(def disc-lines
+  {:primitive-type GL2/GL_LINE_LOOP
+   :vbuf (vtx/flip!
+           (reduce
+             (fn [vbuf [x y _]]
+               (pos-vtx-put! vbuf x y 0.0 0.0))
+             (->pos-vtx (count disc-perimeter) :static)
+             disc-perimeter))})
+
+(def disc-triangles
+  {:primitive-type GL2/GL_TRIANGLE_FAN
+   :vbuf (-> (reduce
+               (fn [vbuf [x y _]]
+                 (pos-vtx-put! vbuf x y 0.0 0.0))
+               (pos-vtx-put!
+                 (->pos-vtx (+ 2 (count disc-perimeter)) :static)
+                 0.0 0.0 0.0 0.0)
+               disc-perimeter)
+             (pos-vtx-put! 0.0 1.0 0.0 0.0)
+             (vtx/flip!))})
+
+(defn- pos-nrm->quad-point
+  ^Point4d [[^double x ^double y ^double z] ^double w]
+  (Point4d. x y z w))
+
+(defn- pos-nrm-face->quad [[v0 v1 v2 _ v4] ^double w]
+  [(pos-nrm->quad-point v0 w)
+   (pos-nrm->quad-point v1 w)
+   (pos-nrm->quad-point v4 w)
+   (pos-nrm->quad-point v2 w)])
+
+(defn- pos-nrm-face->waist-quad [[v0 v1]]
+  [(pos-nrm->quad-point v0 1.0)
+   (pos-nrm->quad-point v1 1.0)
+   (pos-nrm->quad-point v1 -1.0)
+   (pos-nrm->quad-point v0 -1.0)])
+
+(def ^:private capsule-quads
+  (let [capsule-cap-lats 16
+        capsule-cap-longs 32
+        sphere-faces (geom/unit-sphere-pos-nrm capsule-cap-lats capsule-cap-longs)
+        hemisphere-face-count (/ (* capsule-cap-lats capsule-cap-longs) 2)]
+    (concat
+      ;; Top cap
+      (sequence (comp (take hemisphere-face-count)
+                      (map #(pos-nrm-face->quad % 1.0)))
+                sphere-faces)
+
+      ;; Waist
+      (sequence (comp (drop hemisphere-face-count)
+                      (take capsule-cap-longs)
+                      (map pos-nrm-face->waist-quad))
+                sphere-faces)
+
+      ;; Bottom cap
+      (sequence (comp (drop hemisphere-face-count)
+                      (map #(pos-nrm-face->quad % -1.0)))
+                sphere-faces))))
+
+(defn- pos-vtx-put-point! [vbuf ^Point4d point]
+  (pos-vtx-put! vbuf (.x point) (.y point) (.z point) (.w point)))
+
+(def capsule-lines
+  {:primitive-type GL2/GL_LINES
+   :vbuf (vtx/flip!
+           (reduce
+             (fn [vbuf [quad]]
+               (-> vbuf
+                   (pos-vtx-put-point! (quad 0))
+                   (pos-vtx-put-point! (quad 3))))
+             (->pos-vtx (* 2 (/ (count capsule-quads) 4)) :static)
+             (partition 4 capsule-quads)))})
+
+(def capsule-triangles
+  {:primitive-type GL2/GL_TRIANGLES
+   :vbuf (vtx/flip!
+           (reduce
+             (fn [vbuf quad]
+               (-> vbuf
+                   (pos-vtx-put-point! (quad 0))
+                   (pos-vtx-put-point! (quad 1))
+                   (pos-vtx-put-point! (quad 2))
+                   (pos-vtx-put-point! (quad 2))
+                   (pos-vtx-put-point! (quad 3))
+                   (pos-vtx-put-point! (quad 0))))
+             (->pos-vtx (* 6 (count capsule-quads)) :static)
+             capsule-quads))})
+
+(def ^:private shape-alpha 0.1)
+
+(def ^:private selected-shape-alpha 0.3)
+
+(def ^:private no-point-scale (float-array 4 1.0))
+
+(def ^:private no-point-offset-by-w (float-array 4 0.0))
+
+(defn render-lines [^GL2 gl render-args renderables _num-renderables]
+  (assert (not= pass/selection (:pass render-args)) "color not intended for picking")
+  (let [{:keys [selected user-data world-transform]} (first renderables)
+        {:keys [color geometry]} user-data
+        {:keys [primitive-type vbuf]} geometry
+        color (float-array (if selected
+                             colors/selected-outline-color
+                             (colors/alpha color 1.0)))
+        render-args (merge render-args
+                           (math/derive-render-transforms
+                             world-transform
+                             (:view render-args)
+                             (:projection render-args)
+                             (:texture render-args)))
+        point-count (:point-count user-data (count vbuf))
+        point-scale (:point-scale user-data no-point-scale)
+        point-offset-by-w (:point-offset-by-w user-data no-point-offset-by-w)
+        request-id (System/identityHashCode vbuf)
+        vertex-binding (vtx/use-with request-id vbuf shader)]
+    (gl/with-gl-bindings gl render-args [shader vertex-binding]
+      (shader/set-uniform shader gl "point_scale" point-scale)
+      (shader/set-uniform shader gl "point_offset_by_w" point-offset-by-w)
+      (shader/set-uniform shader gl "color" color)
+      (gl/gl-draw-arrays gl primitive-type 0 point-count))))
+
+(defn render-triangles [^GL2 gl render-args renderables _num-renderables]
+  (let [renderable (first renderables)
+        {:keys [selected user-data world-transform]} renderable
+        {:keys [color double-sided geometry]} user-data
+        {:keys [primitive-type vbuf]} geometry
+        color (float-array
+                (cond
+                  (= pass/selection (:pass render-args))
+                  (scene-picking/renderable-picking-id-uniform renderable)
+
+                  selected
+                  (colors/alpha color selected-shape-alpha)
+
+                  :else
+                  (colors/alpha color shape-alpha)))
+        render-args (merge render-args
+                           (math/derive-render-transforms
+                             world-transform
+                             (:view render-args)
+                             (:projection render-args)
+                             (:texture render-args)))
+        point-count (:point-count user-data (count vbuf))
+        point-scale (:point-scale user-data no-point-scale)
+        point-offset-by-w (:point-offset-by-w user-data no-point-offset-by-w)
+        request-id (System/identityHashCode vbuf)
+        vertex-binding (vtx/use-with request-id vbuf shader)]
+    (gl/with-gl-bindings gl render-args [shader vertex-binding]
+      (when-not double-sided
+        (gl/gl-enable gl GL2/GL_CULL_FACE)
+        (gl/gl-cull-face gl GL2/GL_BACK))
+      (shader/set-uniform shader gl "point_scale" point-scale)
+      (shader/set-uniform shader gl "point_offset_by_w" point-offset-by-w)
+      (shader/set-uniform shader gl "color" color)
+      (gl/gl-draw-arrays gl primitive-type 0 point-count)
+      (when-not double-sided
+        (gl/gl-disable gl GL2/GL_CULL_FACE)))))

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -66,8 +66,11 @@
 
     .visibility-toggles-list {
         -fx-background-color: $scene-toolbar-background;
+        -fx-background-radius: 4px;
         -fx-padding: 0px 0px 7px 0px;
+
         > .first-entry {
+            -fx-background-radius: 4px 4px 0px 0px;
             -fx-padding: 10px 8px 10px 8px;
             -fx-background-color: #4d4f54;
         }
@@ -75,6 +78,17 @@
         > HBox {
             -fx-padding: 3px 8px 3px 8px;
         }
+
+        > Separator {
+            -fx-padding: 7px 0px;
+            -fx-background-color: $scene-toolbar-background;
+        }
+    }
+
+    .visibility-toggles-shadow {
+        -fx-background-color: rgba(0, 0, 0, 0.2);
+        -fx-background-radius: 4px;
+        -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 1.0), 16, 0, 0, 0);
     }
 
     SVGPath {

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -273,7 +273,7 @@
 
 (defn- produce-render-data [scene selection aux-renderables camera]
   (let [scene-render-data (scene/produce-scene-render-data {:scene scene :selection selection :hidden-renderable-args [] :hidden-node-outline-key-paths [] :camera camera})
-        aux-render-data (scene/produce-aux-render-data {:aux-renderables aux-renderables :hidden-renderable-tags []})]
+        aux-render-data (scene/produce-aux-render-data {:aux-renderables aux-renderables :internal-renderables {} :hidden-renderable-tags []})]
     (scene/merge-render-datas aux-render-data {} scene-render-data)))
 
 (deftest produce-render-data-test


### PR DESCRIPTION
Fixes defold/editor2-issues#2720

### User-facing changes
* Particle effects using 3D emitters are now visible in the scene view during playback when observed from the default orthographic camera orientation.