### PR TITLE
Use default google dns servers if no servers were found

### DIFF
--- a/engine/dlib/src/dlib/dns.cpp
+++ b/engine/dlib/src/dlib/dns.cpp
@@ -32,6 +32,8 @@ namespace dmDNS
 
     // These servers will be used if ares can't find any dns servers
     // in the system configuration, or if we get the default loopback address.
+    // Please note that ares won't accept server strings with spaces after the comma,
+    // i.e "server1, server2", instead it has to be "server1,server2".
     static const char* DEFAULT_DNS_SERVERS = "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844";
 
     static inline Result AresStatusToDNSResult(uint32_t ares_status)

--- a/engine/dlib/src/dlib/dns.cpp
+++ b/engine/dlib/src/dlib/dns.cpp
@@ -30,6 +30,10 @@ namespace dmDNS
         int32_atomic_t  m_Running;
     };
 
+    // These servers will be used if ares can't find any dns servers
+    // in the system configuration, or if we get the default loopback address.
+    static const char* DEFAULT_DNS_SERVERS = "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844";
+
     static inline Result AresStatusToDNSResult(uint32_t ares_status)
     {
         Result res;
@@ -176,6 +180,46 @@ namespace dmDNS
         ares_freeaddrinfo(info);
     }
 
+    static void ConfigureChannel(Channel* channel)
+    {
+        struct ares_addr_port_node* servers = 0;
+        ares_get_servers_ports(channel->m_Handle, &servers);
+
+        if (servers)
+        {
+            uint16_t server_count = 1;
+            struct ares_addr_port_node* next = servers->next;
+            struct in_addr ch_addr = servers->addr.addr4;
+
+            while(next)
+            {
+                server_count++;
+                next = next->next;
+            }
+
+            // Check if we got the default configuration, i.e no servers found
+            // when ares configured the channel. We can't send in default channels
+            // as option when initializing the channel since in that case ares
+            // won't look for system dns severs on certain platforms..
+            //
+            // These options are specified in init_by_defaults(..) in ares_init.c
+            if (server_count      == 1 &&
+                servers->family   == AF_INET &&
+                ch_addr.s_addr    == htonl(INADDR_LOOPBACK) &&
+                servers->udp_port == 0 &&
+                servers->tcp_port == 0)
+            {
+                ares_set_servers_csv(channel->m_Handle, DEFAULT_DNS_SERVERS);
+            }
+
+            ares_free_data(servers);
+        }
+        else
+        {
+            ares_set_servers_csv(channel->m_Handle, DEFAULT_DNS_SERVERS);
+        }
+    }
+
     Result Initialize()
     {
         if (ares_library_init(ARES_LIB_INIT_ALL) != ARES_SUCCESS)
@@ -201,13 +245,15 @@ namespace dmDNS
 
     Result NewChannel(HChannel* channel)
     {
-        Channel* dns_channel = new Channel();
-
-        if (ares_init(&dns_channel->m_Handle) != ARES_SUCCESS)
+        ares_channel handle;
+        if (ares_init(&handle) != ARES_SUCCESS)
         {
-            delete dns_channel;
             return RESULT_INIT_ERROR;
         }
+
+        Channel* dns_channel = new Channel();
+        dns_channel->m_Handle = handle;
+        ConfigureChannel(dns_channel);
 
         dns_channel->m_Running = 1;
         *channel = dns_channel;
@@ -236,8 +282,10 @@ namespace dmDNS
 
     Result RefreshChannel(HChannel channel)
     {
-        if (channel && ares_init(&((Channel*)channel)->m_Handle) == ARES_SUCCESS)
+        Channel* dns_channel = (Channel*)channel;
+        if (channel && ares_init(&dns_channel->m_Handle) == ARES_SUCCESS)
         {
+            ConfigureChannel(dns_channel);
             return RESULT_OK;
         }
 


### PR DESCRIPTION
This PR sets the default google DNS servers for an ares channel if no server was found on the client device.