### PR TITLE
Vulkan - Always build the vulkan graphics system

### DIFF
--- a/engine/engine/wscript
+++ b/engine/engine/wscript
@@ -69,8 +69,9 @@ namespace dmEngineVersion
         if Options.options.with_vulkan and architecture == 'x86_64':
             conf.env.append_value('LINKFLAGS', ['-framework', 'Metal', '-framework', 'Foundation', '-framework', 'QuartzCore', '-framework', 'IOSurface'])
 
-            # Note: To get validation layers to work, replace MoltenVK with 'vulkan'. For more info, see README.md in engine/graphics/src/vulkan
-            conf.env.append_value('LINKFLAGS', ['-l', 'MoltenVK'])
+            # Link with vulkan.dylib if the env is set (see graphics/vulkan/README.md) for more information
+            validation = int(os.environ.get('DM_VULKAN_VALIDATION','0'))
+            conf.env.append_value('LINKFLAGS', ['-l', validation and 'vulkan' or 'MoltenVK'])
 
             # Metal deps requires libc++ stdlib. Remove once we've updated to use libc++ std
             conf.env.append_value('LINKFLAGS', ['-l', 'c++'])

--- a/engine/graphics/src/vulkan/README.md
+++ b/engine/graphics/src/vulkan/README.md
@@ -11,8 +11,8 @@ the flag needs to be set for the graphics system to poll for support.
 By default, we link the engine with a static version of the MoltenVK library, which doesn't
 have any support for. To get validation layers to work on OSX and iOS platforms,
 you need to copy the vulkan dylib files from the SDK (typically resides under `<path-to-sdk>/macOS/lib/)`
-to the `$DYNAMO_HOME/tmp/share/lib/x86_64-darwin` directory
-and link with the vulkan library instead of MoltenVK in the `engine/engine/wscript` file. However, you don't need to copy the actual
+to the `$DYNAMO_HOME/tmp/share/lib/x86_64-darwin` directory, the `engine/engine/wscript` will link with
+the dylib library when `DM_VULKAN_VALIDATION` is set. You don't need to copy the actual
 validation layer libraries, since they will be automatically picked up by the loader from the paths
 specified in the manifest files.
 

--- a/engine/graphics/src/vulkan/linux/graphics_vulkan_linux_surface.cpp
+++ b/engine/graphics/src/vulkan/linux/graphics_vulkan_linux_surface.cpp
@@ -1,8 +1,8 @@
 #include <string.h>
 
-#include <graphics/glfw/glfw_native.h>
-#include <vulkan/vulkan_xcb.h>
+#include "../graphics_vulkan_defines.h"
 #include <vulkan/vulkan.h>
+#include <graphics/glfw/glfw_native.h>
 
 #include <dlib/math.h>
 #include <dlib/array.h>
@@ -11,7 +11,6 @@
 #include <X11/Xlib-xcb.h>
 
 #include "../../graphics.h"
-
 #include "../graphics_vulkan_private.h"
 
 namespace dmGraphics

--- a/engine/graphics/src/wscript
+++ b/engine/graphics/src/wscript
@@ -21,26 +21,25 @@ def build(bld):
     else:
          obj.source.append('opengl/async/job_queue_threaded.cpp');
 
-    if Options.options.with_vulkan:
-      obj = bld.new_task_gen(features = 'ddf cxx cstaticlib',
-                             includes = ['. vulkan', '../proto'],
-                             proto_gen_py = True,
-                             protoc_includes = '../proto',
-                             uselib = 'DDF DLIB',
-                             target = 'graphics_vulkan')
+    obj = bld.new_task_gen(features = 'ddf cxx cstaticlib',
+                           includes = ['. vulkan', '../proto'],
+                           proto_gen_py = True,
+                           protoc_includes = '../proto',
+                           uselib = 'DDF DLIB',
+                           target = 'graphics_vulkan')
 
-      obj.find_sources_in_dirs('. vulkan ../proto/graphics')
+    obj.find_sources_in_dirs('. vulkan ../proto/graphics')
 
-      if bld.env.PLATFORM == 'x86_64-darwin':
-        obj.source.append('vulkan/macosx/graphics_vulkan_macosx_surface.mm')
-      elif bld.env.PLATFORM == 'armv7-darwin' or bld.env.PLATFORM == 'arm64-darwin':
-        obj.source.append('vulkan/ios/graphics_vulkan_ios_surface.mm')
-      elif bld.env.PLATFORM == 'armv7-android' or bld.env.PLATFORM == 'arm64-android':
-        obj.source.append('vulkan/android/graphics_vulkan_android_surface.cpp')
-      elif bld.env.PLATFORM == 'x86_64-linux':
-        obj.source.append('vulkan/linux/graphics_vulkan_linux_surface.cpp')
-      elif bld.env.PLATFORM == 'x86_64-win32' or bld.env.PLATFORM == 'win32':
-        obj.source.append('vulkan/win32/graphics_vulkan_win32_surface.cpp')
+    if bld.env.PLATFORM == 'x86_64-darwin':
+      obj.source.append('vulkan/macosx/graphics_vulkan_macosx_surface.mm')
+    elif bld.env.PLATFORM == 'armv7-darwin' or bld.env.PLATFORM == 'arm64-darwin':
+      obj.source.append('vulkan/ios/graphics_vulkan_ios_surface.mm')
+    elif bld.env.PLATFORM == 'armv7-android' or bld.env.PLATFORM == 'arm64-android':
+      obj.source.append('vulkan/android/graphics_vulkan_android_surface.cpp')
+    elif bld.env.PLATFORM == 'x86_64-linux':
+      obj.source.append('vulkan/linux/graphics_vulkan_linux_surface.cpp')
+    elif bld.env.PLATFORM == 'x86_64-win32' or bld.env.PLATFORM == 'win32':
+      obj.source.append('vulkan/win32/graphics_vulkan_win32_surface.cpp')
 
     obj = bld.new_task_gen(features = 'ddf cxx cstaticlib',
                            includes = ['. null', '../proto'],


### PR DESCRIPTION
This PR adds building the vulkan library by default when building the engine. This means that we are opening up building a vulkan backed engine by using the extender in the future.

(side-note: To do that completely however, we have to restructure a bit in the window implementations in glfw so we can add the vulkan bits to the cocoa and ios window code.)