### PR TITLE
DEFEDIT-4498 Fix disappearing brush cursor in tile map editor

### DIFF
--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -574,8 +574,8 @@
         (recur (next corners)
                (min distance near)
                (max distance far)))
-      [(max 1.0 (- near 0.0001))
-       (max 10.0 (+ far 0.0001))])))
+      [(max 1.0 (- near 0.001))
+       (max 10.0 (+ far 0.001))])))
 
 (g/defnk produce-camera [_node-id local-camera scene-aabb viewport]
   (let [filter-fn (or (:filter-fn local-camera) identity)

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -24,7 +24,6 @@
             [editor.scene-picking :as scene-picking]
             [editor.tile-map-grid :as tile-map-grid]
             [editor.tile-source :as tile-source]
-            [editor.ui :as ui]
             [editor.validation :as validation]
             [editor.workspace :as workspace])
   (:import [com.dynamo.tile.proto Tile$TileGrid Tile$TileGrid$BlendMode Tile$TileLayer]
@@ -244,11 +243,26 @@
 (g/defnk produce-layer-scene
   [_node-id id cell-map texture-set-data z gpu-texture shader blend-mode visible]
   (when visible
-    (let [{:keys [aabb vbuf]} (gen-layer-render-data cell-map texture-set-data)]
+    (let [{:keys [aabb vbuf]} (gen-layer-render-data cell-map texture-set-data)
+          transform (doto (Matrix4d.) (.set (Vector3d. 0.0 0.0 z)))
+
+          ;; The visibility-aabb is used to determine the scene extents. We use
+          ;; it to adjust the camera near and far clip planes to encompass the
+          ;; scene. When editing, layers that do not yet have any tiles on them
+          ;; will produce an empty aabb which will not expand the scene extents.
+          ;; To ensure empty layers will push the scene extents and not be
+          ;; outside the camera clip planes, we give them a small bounding box.
+          ;; This makes the brush for yet-to-be-painted tiles visible.
+          visibility-aabb
+          (if (geom/empty-aabb? aabb)
+            (geom/make-aabb (Point3d. 0.0 0.0 0.0)
+                            (Point3d. 0.001 0.001 0.0))
+            aabb)]
       {:node-id _node-id
        :node-outline-key id
-       :transform (doto (Matrix4d.) (.set (Vector3d. 0.0 0.0 z)))
+       :transform transform
        :aabb aabb
+       :visibility-aabb visibility-aabb
        :renderable {:render-fn render-layer
                     :tags #{:tilemap}
                     :user-data {:node-id _node-id
@@ -523,7 +537,9 @@
 
 (defn render-brush-outline
   [^GL2 gl render-args renderables count]
-  (let [user-data (:user-data (first renderables))
+  (let [renderable (first renderables)
+        world-transform (:world-transform renderable)
+        user-data (:user-data renderable)
         [x y] (:cell user-data)
         {:keys [width height]} (:brush user-data)
         [tile-width tile-height] (:tile-dimensions user-data)]
@@ -534,14 +550,16 @@
             y1 (+ y0 (* height tile-height))
             z 0.0
             c (double-array (map #(/ % 255.0) [255 255 255]))]
-        (.glColor3d gl (nth c 0) (nth c 1) (nth c 2))
-        (.glBegin gl GL2/GL_LINE_LOOP)
-        (.glVertex3d gl x0 y0 z)
-        (.glVertex3d gl x1 y0 z)
-        (.glVertex3d gl x1 y1 z)
-        (.glVertex3d gl x0 y1 z)
-        (.glEnd gl)))))
-
+        (.glMatrixMode gl GL2/GL_MODELVIEW)
+        (gl/gl-push-matrix gl
+          (gl/gl-mult-matrix-4d gl world-transform)
+          (.glColor3d gl (nth c 0) (nth c 1) (nth c 2))
+          (.glBegin gl GL2/GL_LINE_LOOP)
+          (.glVertex3d gl x0 y0 z)
+          (.glVertex3d gl x1 y0 z)
+          (.glVertex3d gl x1 y1 z)
+          (.glVertex3d gl x0 y1 z)
+          (.glEnd gl))))))
 
 (defn conj-brush-quad!
   [vbuf {:keys [tile h-flip v-flip]} uvs w h x y]
@@ -586,14 +604,17 @@
         [w h] (:tile-dimensions user-data)
         vbuf (gen-brush-vbuf brush uvs w h)
         vb (vtx/use-with ::brush vbuf tex-shader)
-        brush-transform (doto (Matrix4d. geom/Identity4d)
-                          (.set (Vector3d. (* x w) (* y h) 0)))]
+        ^Matrix4d layer-transform (:world-transform renderable)
+        local-transform (doto (Matrix4d. geom/Identity4d)
+                          (.set (Vector3d. (* x w) (* y h) 0)))
+        brush-transform (doto (Matrix4d. local-transform)
+                          (.mul layer-transform))]
     (.glMatrixMode gl GL2/GL_MODELVIEW)
     (gl/gl-push-matrix gl
-                       (gl/gl-mult-matrix-4d gl brush-transform)
-                       (gl/with-gl-bindings gl render-args [gpu-texture tex-shader vb]
-                         (shader/set-uniform tex-shader gl "texture_sampler" 0)
-                         (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf))))))
+      (gl/gl-mult-matrix-4d gl brush-transform)
+      (gl/with-gl-bindings gl render-args [gpu-texture tex-shader vb]
+        (shader/set-uniform tex-shader gl "texture_sampler" 0)
+        (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf))))))
 
 
 ;; palette
@@ -817,15 +838,16 @@
     (render-palette-background gl viewport)
     (.glMatrixMode gl GL2/GL_MODELVIEW)
     (gl/gl-push-matrix gl
-                       (gl/gl-mult-matrix-4d gl palette-transform)
-                       (render-palette-tiles gl render-args tile-source-attributes texture-set-data gpu-texture)
-                       (render-palette-grid gl render-args tile-source-attributes)
-                       (render-palette-active gl render-args tile-source-attributes palette-tile))))
-
+      (gl/gl-mult-matrix-4d gl palette-transform)
+      (render-palette-tiles gl render-args tile-source-attributes texture-set-data gpu-texture)
+      (render-palette-grid gl render-args tile-source-attributes)
+      (render-palette-active gl render-args tile-source-attributes palette-tile))))
 
 (defn render-editor-select-outline
   [^GL2 gl render-args renderables count]
-  (let [user-data (:user-data (first renderables))
+  (let [renderable (first renderables)
+        world-transform (:world-transform renderable)
+        user-data (:user-data renderable)
         [sx sy] (:start user-data)
         [ex ey] (:end user-data)
         [tile-width tile-height] (:tile-dimensions user-data)]
@@ -836,13 +858,16 @@
             y1 (* tile-height (inc (max-l sy ey)))
             z 0.0
             c (double-array (map #(/ % 255.0) [255 255 255]))]
-        (.glColor3d gl (nth c 0) (nth c 1) (nth c 2))
-        (.glBegin gl GL2/GL_LINE_LOOP)
-        (.glVertex3d gl x0 y0 z)
-        (.glVertex3d gl x1 y0 z)
-        (.glVertex3d gl x1 y1 z)
-        (.glVertex3d gl x0 y1 z)
-        (.glEnd gl)))))
+        (.glMatrixMode gl GL2/GL_MODELVIEW)
+        (gl/gl-push-matrix gl
+          (gl/gl-mult-matrix-4d gl world-transform)
+          (.glColor3d gl (nth c 0) (nth c 1) (nth c 2))
+          (.glBegin gl GL2/GL_LINE_LOOP)
+          (.glVertex3d gl x0 y0 z)
+          (.glVertex3d gl x1 y0 z)
+          (.glVertex3d gl x1 y1 z)
+          (.glVertex3d gl x0 y1 z)
+          (.glEnd gl))))))
 
 (defn render-editor-select
   [^GL2 gl render-args renderables n]
@@ -873,14 +898,14 @@
                               :palette-tile palette-tile}}]})
 
 (g/defnk produce-editor-renderables
-  [active-layer op op-select-start op-select-end current-tile tile-dimensions brush viewport texture-set-data gpu-texture]
-  (when active-layer
+  [active-layer-renderable op op-select-start op-select-end current-tile tile-dimensions brush viewport texture-set-data gpu-texture]
+  (when active-layer-renderable
     {pass/transparent (cond
                         (= :select op)
                         []
 
                         current-tile
-                        [{:world-transform (Matrix4d. geom/Identity4d)
+                        [{:world-transform (:world-transform active-layer-renderable)
                           :render-fn render-editor
                           :user-data {:cell current-tile
                                       :brush brush
@@ -888,13 +913,13 @@
                                       :texture-set-data texture-set-data
                                       :gpu-texture gpu-texture}}])
      pass/outline     (cond
-                        (= :select op) [{:world-transform (Matrix4d. geom/Identity4d)
+                        (= :select op) [{:world-transform (:world-transform active-layer-renderable)
                                          :render-fn render-editor-select
                                          :user-data {:start op-select-start
                                                      :end op-select-end
                                                      :tile-dimensions tile-dimensions}}]
                         current-tile
-                        [{:world-transform (Matrix4d. geom/Identity4d)
+                        [{:world-transform (:world-transform active-layer-renderable)
                           :render-fn render-editor
                           :user-data {:cell current-tile
                                       :brush brush
@@ -1070,11 +1095,14 @@
   (input tile-dimensions g/Any)
 
   (output active-layer g/Any
+          (g/fnk [active-layer-renderable]
+            (:node-id active-layer-renderable)))
+
+  (output active-layer-renderable g/Any
           (g/fnk [selected-renderables]
             (->> selected-renderables
                  (filter #(g/node-instance? LayerNode (:node-id %)))
-                 single
-                 :node-id)))
+                 single)))
 
   (output current-tile g/Any
           (g/fnk [cursor-world-pos tile-dimensions]


### PR DESCRIPTION
Fixes #4498
Fixes defold/editor2-issues#2762

### User-facing changes
* The tile map brush cursor and selection outlines will draw correctly on Z-offset layers.

### Technical changes
* The tile map cursor brush is now drawn at the correct Z depth for the active layer.
* Empty tile map layers produce a tiny `:visibility-aabb` so they will expand the camera clip planes.
* The extra "padding" used to push the camera near and far planes apart was increased due to floating-point precision issues.