### PR TITLE
Issue 4506 bundle symbols

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -743,11 +743,8 @@ public class Project {
 
     private static boolean deleteDirectory(File directoryToBeDeleted) {
         File[] allContents = directoryToBeDeleted.listFiles();
-            System.out.println("MAWE: deleteDirectory: " + directoryToBeDeleted.getAbsolutePath());
         if (allContents != null) {
-
             for (File file : allContents) {
-            System.out.println("MAWE:   file: " + file.getAbsolutePath());
                 deleteDirectory(file);
             }
         }
@@ -756,7 +753,6 @@ public class Project {
 
     private void cleanEngine(Platform platform, File dir) throws IOException, CompileExceptionError {
         if (!dir.exists()) {
-            System.out.println("MAWE: Dir not found: " + dir.getAbsolutePath());
             return;
         }
 
@@ -764,9 +760,7 @@ public class Project {
         List<String> defaultNames = platform.formatBinaryName("dmengine");
         for (String defaultName : defaultNames) {
             File exe = new File(FilenameUtils.concat(dir.getAbsolutePath(), defaultName));
-            System.out.println("MAWE: Exe name: " + exe.getAbsolutePath());
             if (exe.exists()) {
-            System.out.println("MAWE: Exe found found... deleting ");
                 Project.deleteDirectory(dir);
                 break;
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -670,17 +670,9 @@ public class Project {
 
             List<ExtenderResource> allSource = ExtenderUtil.getExtensionSources(this, platform, appmanifestOptions);
 
-            //File classesDexFile = null;
-            //File proguardMappingFile = null;
             File tmpDir = null;
 
             if (platform.equals(Platform.Armv7Android) || platform.equals(Platform.Arm64Android)) {
-                // If we are building for Android, We output a mapping file per architechture
-                // so that the user can select which of the mapping files are more suitable,
-                // since they can diff between architechtures
-                String mappingsName = "mapping-" + (platform.equals(Platform.Armv7Android) ? "armv7" : "arm64") + ".txt";
-                //proguardMappingFile = new File(FilenameUtils.concat(buildDir.getAbsolutePath(), mappingsName));
-
                 // NOTE:
                 // We previously only generated and sent Android resources for at most one arch,
                 // to avoid sending and building these twice.
@@ -691,9 +683,6 @@ public class Project {
                     androidResourcesGenerated = true;
 
                     Bob.initAndroid(); // extract resources
-
-                    // If we are building for Android, we expect a classes.dex file to be returned as well.
-                    //classesDexFile = new File(FilenameUtils.concat(buildDir.getAbsolutePath(), "classes.dex"));
 
                     List<String> resDirs = new ArrayList<>();
                     List<String> extraPackages = new ArrayList<>();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -204,7 +204,7 @@ public class HTML5Bundler implements IBundler {
 
         // Same value as engine is compiled with; 268435456
         int customHeapSize = projectProperties.getIntValue("html5", "heap_size", 256) * 1024 * 1024;
-        
+
         {// Deprecated method of setting the heap sie. For backwards compatibility
             if (projectProperties.getBooleanValue("html5", "set_custom_heap_size", false)) {
                 Integer size = projectProperties.getIntValue("html5", "custom_heap_size");
@@ -281,6 +281,18 @@ public class HTML5Bundler implements IBundler {
             } else {
                 throw new RuntimeException("Unknown extension '" + binExtension + "' of engine binary.");
             }
+        }
+
+        // Copy debug symbols if they were generated
+        String zipDir = FilenameUtils.concat(extenderExeDir, Platform.JsWeb.getExtenderPair());
+        File bundleSymbols = new File(zipDir, "dmengine.js.symbols");
+        if (!bundleSymbols.exists()) {
+            zipDir = FilenameUtils.concat(extenderExeDir, Platform.WasmWeb.getExtenderPair());
+            bundleSymbols = new File(zipDir, "dmengine.js.symbols");
+        }
+        if (bundleSymbols.exists()) {
+            File symbolsOut = new File(appDir, enginePrefix + ".symbols");
+            FileUtils.copyFile(bundleSymbols, symbolsOut);
         }
 
         for (File bin : binsWasm) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -353,11 +353,26 @@ public class IOSBundler implements IBundler {
         }
 
         BundleHelper.throwIfCanceled(canceled);
+
         // Copy Executable
         File destExecutable = new File(appDir, exeName);
         FileUtils.copyFile(new File(exe), destExecutable);
         destExecutable.setExecutable(true);
         logger.log(Level.INFO, "Bundle binary: " + getFileDescription(destExecutable));
+
+        // Copy debug symbols
+        String zipDir = FilenameUtils.concat(extenderExeDir, Platform.Armv7Darwin.getExtenderPair());
+        File buildSymbols = new File(zipDir, "dmengine.dSYM");
+        if (buildSymbols.exists()) {
+            String symbolsDir = String.format("%s.dSYM", title);
+
+            File bundleSymbols = new File(bundleDir, symbolsDir);
+            FileUtils.copyDirectory(buildSymbols, bundleSymbols);
+            // Also rename the executable
+            File bundleExeOld = new File(bundleSymbols, FilenameUtils.concat("Contents", FilenameUtils.concat("Resources", FilenameUtils.concat("DWARF", "dmengine"))));
+            File symbolExe = new File(bundleExeOld.getParent(), destExecutable.getName());
+            bundleExeOld.renameTo(symbolExe);
+        }
 
         // Sign (only if identity and provisioning profile set)
         // iOS simulator can install non signed apps

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
@@ -30,12 +30,16 @@ public class LinuxBundler implements IBundler {
         if (bundleExes.size() > 1) {
             throw new IOException("Invalid number of binaries for Linux when bundling: " + bundleExes.size());
         }
+
+        // Copy executable
         File bundleExe = bundleExes.get(0);
-
         File exeOut = new File(appDir, exeName + ".x86_64");
-
         FileUtils.copyFile(bundleExe, exeOut);
         exeOut.setExecutable(true);
+
+        // Currently the stripping is left out from here
+        // This is because the user can easily make a copy of the executable,
+        // and then call "strip" to produce a slim executable
     }
 
     @Override

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
@@ -103,6 +103,20 @@ public class OSXBundler implements IBundler {
         File exeOut = new File(macosDir, exeName);
         FileUtils.copyFile(bundleExe, exeOut);
         exeOut.setExecutable(true);
+
+        // Copy debug symbols
+        String zipDir = FilenameUtils.concat(extenderExeDir, platform.getExtenderPair());
+        File buildSymbols = new File(zipDir, "dmengine.dSYM");
+        if (buildSymbols.exists()) {
+            String symbolsDir = String.format("%s.dSYM", BundleHelper.projectNameToBinaryName(title));
+
+            File bundleSymbols = new File(bundleDir, symbolsDir);
+            FileUtils.copyDirectory(buildSymbols, bundleSymbols);
+            // Also rename the executable
+            File bundleExeOld = new File(bundleSymbols, FilenameUtils.concat("Contents", FilenameUtils.concat("Resources", FilenameUtils.concat("DWARF", "dmengine"))));
+            File symbolExe = new File(bundleExeOld.getParent(), exeOut.getName());
+            bundleExeOld.renameTo(symbolExe);
+        }
     }
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -17,8 +19,11 @@ import com.dynamo.bob.Project;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.util.BobProjectProperties;
+import com.dynamo.bob.util.Exec;
+import com.dynamo.bob.util.Exec.Result;
 
 public class OSXBundler implements IBundler {
+    private static Logger logger = Logger.getLogger(IOSBundler.class.getName());
     public static final String ICON_NAME = "icon.icns";
 
     private void copyIcon(BobProjectProperties projectProperties, File projectRoot, File resourcesDir) throws IOException {
@@ -36,6 +41,7 @@ public class OSXBundler implements IBundler {
 
         final Platform platform = Platform.X86_64Darwin;
         final String variant = project.option("variant", Bob.VARIANT_RELEASE);
+        final boolean strip_executable = project.hasOption("strip-executable");
 
         BobProjectProperties projectProperties = project.getProjectProperties();
         String title = projectProperties.getStringValue("project", "title", "Unnamed");
@@ -116,6 +122,16 @@ public class OSXBundler implements IBundler {
             File bundleExeOld = new File(bundleSymbols, FilenameUtils.concat("Contents", FilenameUtils.concat("Resources", FilenameUtils.concat("DWARF", "dmengine"))));
             File symbolExe = new File(bundleExeOld.getParent(), exeOut.getName());
             bundleExeOld.renameTo(symbolExe);
+        }
+
+        BundleHelper.throwIfCanceled(canceled);
+        // Strip executable
+        if( strip_executable )
+        {
+            Result stripResult = Exec.execResult(Bob.getExe(platform, "strip_ios"), exeOut.getPath()); // Using the same executable
+            if (stripResult.ret != 0) {
+                logger.log(Level.SEVERE, "Error executing strip command:\n" + new String(stripResult.stdOutErr));
+            }
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
@@ -108,7 +108,7 @@ public class OSXBundler implements IBundler {
         String zipDir = FilenameUtils.concat(extenderExeDir, platform.getExtenderPair());
         File buildSymbols = new File(zipDir, "dmengine.dSYM");
         if (buildSymbols.exists()) {
-            String symbolsDir = String.format("%s.dSYM", BundleHelper.projectNameToBinaryName(title));
+            String symbolsDir = String.format("%s.dSYM", title);
 
             File bundleSymbols = new File(bundleDir, symbolsDir);
             FileUtils.copyDirectory(buildSymbols, bundleSymbols);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/OSXBundler.java
@@ -23,7 +23,7 @@ import com.dynamo.bob.util.Exec;
 import com.dynamo.bob.util.Exec.Result;
 
 public class OSXBundler implements IBundler {
-    private static Logger logger = Logger.getLogger(IOSBundler.class.getName());
+    private static Logger logger = Logger.getLogger(OSXBundler.class.getName());
     public static final String ICON_NAME = "icon.icns";
 
     private void copyIcon(BobProjectProperties projectProperties, File projectRoot, File resourcesDir) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
@@ -79,7 +79,7 @@ public class Win32Bundler implements IBundler {
         FileUtils.copyFileToDirectory(new File(openal_dll), appDir);
         FileUtils.copyFileToDirectory(new File(wrap_oal_dll), appDir);
 
-        // Copy debug symbols if it was generated
+        // Copy debug symbols if they were generated
         String zipDir = FilenameUtils.concat(extenderExeDir, platform.getExtenderPair());
         File bundlePdb = new File(zipDir, "dmengine.pdb");
         if (bundlePdb.exists()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
@@ -79,6 +79,14 @@ public class Win32Bundler implements IBundler {
         FileUtils.copyFileToDirectory(new File(openal_dll), appDir);
         FileUtils.copyFileToDirectory(new File(wrap_oal_dll), appDir);
 
+        // Copy debug symbols if it was generated
+        String zipDir = FilenameUtils.concat(extenderExeDir, platform.getExtenderPair());
+        File bundlePdb = new File(zipDir, "dmengine.pdb");
+        if (bundlePdb.exists()) {
+            File pdbOut = new File(appDir, "dmengine.pdb");
+            FileUtils.copyFile(bundlePdb, pdbOut);
+        }
+
         BundleHelper.throwIfCanceled(canceled);
 
         // Copy bundle resources into bundle directory


### PR DESCRIPTION
* Results of remote engine build is now unzipped in its entirety
* Made sure that remote built projects can get the debug symbols more easily accessible.
* OSX binary is now also stripped in release mode (~6.5mb -> ~4.5mb)

