### PR TITLE
Give access to outline properties from editor scripts

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -65,7 +65,7 @@
 
                      [org.luaj/luaj-jse "3.0.1"]
 
-                     [cljfx "1.4.3"]
+                     [cljfx "1.5.0"]
 
                      [org.openjfx/javafx-base "14-ea+1"]
                      [org.openjfx/javafx-base "14-ea+1" :classifier "linux"]

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -432,9 +432,8 @@
     (vector? key) (g/update-property node-id prop-kw assoc-in (rest key) new-value)
     :else (g/set-property node-id prop-kw new-value)))
 
-(defn set-value [evaluation-context properties prop-kw new-value]
-  (let [property (get properties prop-kw)
-        {:keys [key value node-id edit-type]} property
+(defn set-value [evaluation-context property prop-kw new-value]
+  (let [{:keys [key value node-id edit-type]} property
         set-fn (:set-fn edit-type)
         from-fn (:from-type edit-type identity)
         new-value (from-fn new-value)]


### PR DESCRIPTION
Approach:
- add `"outline"` query type to select items in outline
- fallback to `:_properties` of outline nodes when getting/setting prop values
- start with supporting simple types of properties, such as ints/numbers/strings/booleans, more complex (such as setting resource) can be done later — need to implement proper validation/coercion there