### PR TITLE
DEFEDIT-4551 Updated code editor interactions to be more in-line with VSCode

### DIFF
--- a/editor/src/clj/editor/code/resource.clj
+++ b/editor/src/clj/editor/code/resource.clj
@@ -13,7 +13,9 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 (def TCursor (s/record Cursor {:row Long :col Long}))
-(def TCursorRange (s/record CursorRange {:from TCursor :to TCursor}))
+(def TCursorRange (s/record CursorRange {:from TCursor
+                                         :to TCursor
+                                         (s/optional-key :dragged) s/Bool}))
 (def TRegion (s/record CursorRange {:from TCursor
                                     :to TCursor
                                     :type s/Keyword

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1498,6 +1498,7 @@
   (refresh-mouse-cursor! view-node event)
   (set-properties! view-node :selection
                    (data/mouse-released (get-property view-node :lines)
+                                        (get-property view-node :cursor-ranges)
                                         (get-property view-node :visible-regions)
                                         (get-property view-node :layout)
                                         (get-property view-node :minimap-layout)


### PR DESCRIPTION
Fixes #4551

### User-facing changes
* Changed modifier key for adding cursors in the code editor from <kbd>Command</kbd> / <kbd>Ctrl</kbd> to <kbd>Alt</kbd>.
* <kbd>Alt</kbd>-dragging no longer performs box selection in the code editor - use middle mouse drag!
* You can now <kbd>Alt</kbd>-drag to add a new selection in the code editor.