### PR TITLE
Always build GLFW variant with Vulkan support (Darwin)

### DIFF
--- a/engine/glfw/lib/wscript_build
+++ b/engine/glfw/lib/wscript_build
@@ -2,34 +2,23 @@
 import sys, re, os
 import Options
 
-defines = []
-if Options.options.with_vulkan:
-    defines.append('DM_USE_VULKAN')
-
-dmglfw = bld.new_task_gen(  features = 'cc cstaticlib',
-                            defines = defines,
-                            target = 'dmglfw')
+dmglfw = bld.new_task_gen(features = 'cc cstaticlib',
+                          target   = 'dmglfw')
 
 platform = bld.env.PLATFORM
+darwin_vulkan_desktop = False
+darwin_vulkan_mobile  = False
 
 if platform == 'darwin' or platform == 'x86_64-darwin':
     dmglfw.find_sources_in_dirs('. cocoa')
     dmglfw.includes = '. cocoa'
-
-    if Options.options.with_vulkan:
-        dmglfw.source.remove(os.path.join('cocoa','cocoa_window.m'))
-    else:
-        dmglfw.source.remove(os.path.join('cocoa','cocoa_window_vulkan.m'))
-
+    dmglfw.source.remove(os.path.join('cocoa','cocoa_window_vulkan.m'))
+    darwin_vulkan_desktop = True
 elif platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
     dmglfw.find_sources_in_dirs('. ios ios/app')
     dmglfw.includes = '. ios'
-
-    if not platform == 'x86_64-ios' and Options.options.with_vulkan:
-        dmglfw.source.remove(os.path.join('ios','app','EAGLView.m'))
-    else:
-        dmglfw.source.remove(os.path.join('ios','app','VulkanView.m'))
-
+    dmglfw.source.remove(os.path.join('ios','app','VulkanView.m'))
+    darwin_vulkan_mobile = True
 elif re.match('arm.*?android', platform):
     dmglfw.find_sources_in_dirs('. android')
     dmglfw.includes = '. android'
@@ -42,3 +31,16 @@ elif 'win32' in platform:
 elif 'web' in platform:
     dmglfw.find_sources_in_dirs('js-web')
     dmglfw.includes = 'js-web .'
+
+if darwin_vulkan_desktop or darwin_vulkan_mobile:
+    dmglfw = bld.new_task_gen(features = 'cc cstaticlib',
+                              defines  = ['DM_USE_VULKAN'],
+                              target   = 'dmglfw_vulkan')
+    if darwin_vulkan_desktop:
+        dmglfw.find_sources_in_dirs('. cocoa')
+        dmglfw.includes = '. cocoa'
+        dmglfw.source.remove(os.path.join('cocoa','cocoa_window.m'))
+    elif darwin_vulkan_mobile:
+        dmglfw.find_sources_in_dirs('. ios ios/app')
+        dmglfw.includes = '. ios'
+        dmglfw.source.remove(os.path.join('ios','app','EAGLView.m'))


### PR DESCRIPTION
This is needed on darwin platforms to produce a dmengine with vulkan as graphics layer.