### PR TITLE
Sending 0 bytes is ok, which also means that a return code of 0 is ok

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -346,7 +346,7 @@ namespace dmHttpClient
         k++;
         if (response->m_SSLConnection != 0) {
             int r = 0;
-            while( ( r = mbedtls_ssl_write(response->m_SSLConnection, (const uint8_t*) buffer, length) ) <= 0 )
+            while( ( r = mbedtls_ssl_write(response->m_SSLConnection, (const uint8_t*) buffer, length) ) < 0 )
             {
                 if (r == MBEDTLS_ERR_SSL_WANT_WRITE ||
                     r == MBEDTLS_ERR_SSL_WANT_READ) {


### PR DESCRIPTION
Documentation says that the return value can be "The (non-negative) number of bytes actually written if successful (may be less than len)"

The documentation also notes that "Attempting to write 0 bytes will result in an empty TLS application record being sent" and "If this function returns something other than a non-negative value, you must stop using the SSL context"