### PR TITLE
DEFEDIT-4622 Fixed exception during build when stripping go.property declarations

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -392,14 +392,16 @@
                   (assert (not (neg? paren-count)))
                   (if (pos? paren-count)
                     (recur cursor-ranges (next tokens) paren-count consumed)
-                    (let [[_ start-row start-col] (first consumed)
-                          [_ end-row end-col] token
-                          end-col (+ ^long end-col (count text))
+                    (let [next-tokens (next tokens)
+                          [next-text :as next-token] (first next-tokens)
+                          [_ start-row start-col] (first consumed)
+                          [end-text end-row end-col] (if (= ";" next-text) next-token token)
+                          end-col (+ ^long end-col (count end-text))
                           start-cursor (data/->Cursor start-row start-col)
                           end-cursor (data/->Cursor end-row end-col)
                           cursor-range (data/->CursorRange start-cursor end-cursor)]
                       (recur (conj! cursor-ranges cursor-range)
-                             (next tokens)
+                             next-tokens
                              0
                              []))))
             (recur cursor-ranges (next tokens) paren-count consumed)))

--- a/editor/test/editor/code/script_test.clj
+++ b/editor/test/editor/code/script_test.clj
@@ -251,4 +251,28 @@
      "end"]
     ["do"
      "                          "
-     "end"]))
+     "end"]
+
+    ["go.property();"]
+    ["              "]
+
+    ["go.property()"
+     ";"]
+    ["             "
+     " "]
+
+    ["go.property(); -- comment"]
+    ["               -- comment"]
+
+    ["go.property()"
+     "; -- comment"]
+    ["             "
+     "  -- comment"]
+
+    ["go.property('name;', resource.texture('/image.png'));"]
+    ["                                                     "]
+
+    ["go.property('name;',"
+     "            123456); -- comment"]
+    ["                    "
+     "                     -- comment"]))


### PR DESCRIPTION
Fixes #4622
Fixes defold/editor2-issues/issues/2887

When we replace `go.property` declarations with whitespace during the build process we can end up with two consecutive semicolons only separated by whitespace. This is not valid Lua syntax, and will fail to compile and trip an `assert`. The stripping needs to consume the trailing semicolon if present.

### User-facing changes
* An exception is no longer thrown when two or more `go.property` lines in a script end with a semicolon.