### PR TITLE
Issue-3202 Support for negative numeric keys

### DIFF
--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -197,25 +197,15 @@ namespace dmScript
         {
             if (buffer_end - buffer < 4)
                 luaL_error(L, "table too large");
-            if (index > 0xffffffff) {
+            if (index < 0)
+                index = -index;
+            if (index > 0xffffffff)
                 luaL_error(L, "index out of bounds, max is %d", 0xffffffff);
-            }
-            if (index >= 0)
-            {
-                uint32_t key = (uint32_t)index;
-                *buffer++ = (uint8_t)(key & 0x000000FF);
-                *buffer++ = (uint8_t)((key & 0x0000FF00) >> 8);
-                *buffer++ = (uint8_t)((key & 0x00FF0000) >> 16);
-                *buffer++ = (uint8_t)((key & 0xFF000000) >> 24);
-            }
-            else
-            {
-                int32_t key = (int32_t)index;
-                *buffer++ = (uint8_t)(key & 0x000000FF);
-                *buffer++ = (uint8_t)((key & 0x0000FF00) >> 8);
-                *buffer++ = (uint8_t)((key & 0x00FF0000) >> 16);
-                *buffer++ = (uint8_t)((key & 0xFF000000) >> 24);
-            }
+            uint32_t key = (uint32_t)index;
+            *buffer++ = (uint8_t)(key & 0xFF);
+            *buffer++ = (uint8_t)((key >> 8) & 0xFF);
+            *buffer++ = (uint8_t)((key >> 16) & 0xFF);
+            *buffer++ = (uint8_t)((key >> 24) & 0xFF);
         }
         else
         {
@@ -585,16 +575,13 @@ namespace dmScript
             uint8_t b2 = (uint8_t)*buffer++;
             uint8_t b3 = (uint8_t)*buffer++;
             uint8_t b4 = (uint8_t)*buffer++;
-            if (key_type == LUA_TNUMBER)
+            uint32_t index = b4 << 24 | b3 << 16 | b2 << 8 | b1;
+            lua_Number number = index;
+            if (key_type == LUA_TNEGATIVENUMBER)
             {
-                uint32_t index = b4 << 24 | b3 << 16 | b2 << 8 | b1;
-                lua_pushnumber(L, (lua_Number)index);
+                number = -number;
             }
-            else if (key_type == LUA_TNEGATIVENUMBER)
-            {
-                int32_t index = b4 << 24 | b3 << 16 | b2 << 8 | b1;
-                lua_pushnumber(L, (lua_Number)index);
-            }
+            lua_pushnumber(L, number);
         }
         else
         {

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -27,6 +27,11 @@ typedef uint16_t uint16_t_1_align;
 typedef uint32_t uint32_t_1_align;
 #endif
 
+// custom type when writing negative numbers as keys
+// the rest of the types used when serializing a table come from lua.h
+// make sure this type has a value quite a bit higher than the types in lua.h
+#define LUA_TNEGATIVENUMBER 64
+
 namespace dmScript
 {
     const int TABLE_MAGIC = 0x42544448;
@@ -176,13 +181,12 @@ namespace dmScript
         return supported;
     }
 
-    static char* WriteEncodedNumber(lua_State* L, const TableHeader& header, char* buffer, const char* buffer_end)
+    static char* WriteEncodedIndex(lua_State* L, lua_Number index, const TableHeader& header, char* buffer, const char* buffer_end)
     {
         if (0 == header.m_Version)
         {
             if (buffer_end - buffer < 2)
                 luaL_error(L, "table too large");
-            lua_Number index = lua_tonumber(L, -2);
             if (index > 0xffff)
                 luaL_error(L, "index out of bounds, max is %d", 0xffff);
             uint16_t key = (uint16_t)index;
@@ -191,19 +195,30 @@ namespace dmScript
         }
         else if (3 == header.m_Version)
         {
-            lua_Number index = lua_tonumber(L, -2);
+            if (buffer_end - buffer < 4)
+                luaL_error(L, "table too large");
             if (index > 0xffffffff) {
                 luaL_error(L, "index out of bounds, max is %d", 0xffffffff);
             }
-            uint32_t key = (uint32_t)index;
-            *buffer++ = (uint8_t)(key & 0x000000FF);
-            *buffer++ = (uint8_t)((key & 0x0000FF00) >> 8);
-            *buffer++ = (uint8_t)((key & 0x00FF0000) >> 16);
-            *buffer++ = (uint8_t)((key & 0xFF000000) >> 24);
+            if (index >= 0)
+            {
+                uint32_t key = (uint32_t)index;
+                *buffer++ = (uint8_t)(key & 0x000000FF);
+                *buffer++ = (uint8_t)((key & 0x0000FF00) >> 8);
+                *buffer++ = (uint8_t)((key & 0x00FF0000) >> 16);
+                *buffer++ = (uint8_t)((key & 0xFF000000) >> 24);
+            }
+            else
+            {
+                int32_t key = (int32_t)index;
+                *buffer++ = (uint8_t)(key & 0x000000FF);
+                *buffer++ = (uint8_t)((key & 0x0000FF00) >> 8);
+                *buffer++ = (uint8_t)((key & 0x00FF0000) >> 16);
+                *buffer++ = (uint8_t)((key & 0xFF000000) >> 24);
+            }
         }
         else
         {
-            lua_Number index = lua_tonumber(L, -2);
             if (index > 0xffffffff) {
                 luaL_error(L, "index out of bounds, max is %d", 0xffffffff);
             }
@@ -309,16 +324,18 @@ namespace dmScript
                 luaL_error(L, "buffer (%d bytes) too small for table, exceeded at key for element #%d", buffer_size, count);
             }
 
-            (*buffer++) = (char) key_type;
-            (*buffer++) = (char) value_type;
-
             if (key_type == LUA_TSTRING)
             {
+                (*buffer++) = (char) LUA_TSTRING;
+                (*buffer++) = (char) value_type;
                 buffer += SaveTSTRING(L, -2, buffer, buffer_size, buffer_end, count);
             }
             else if (key_type == LUA_TNUMBER)
             {
-                buffer = WriteEncodedNumber(L, header, buffer, buffer_end);
+                lua_Number key = lua_tonumber(L, -2);
+                (*buffer++) = (char) (key >= 0 ? LUA_TNUMBER : LUA_TNEGATIVENUMBER);
+                (*buffer++) = (char) value_type;
+                buffer = WriteEncodedIndex(L, key, header, buffer, buffer_end);
             }
 
             switch (value_type)
@@ -547,28 +564,48 @@ namespace dmScript
         return buffer;
     }
 
-    static const char* ReadEncodedNumber(lua_State* L, const TableHeader& header, const char* buffer)
+    static const char* ReadEncodedIndex(lua_State* L, char key_type, const TableHeader& header, const char* buffer)
     {
         if (0 == header.m_Version)
         {
+            if (key_type != LUA_TNUMBER)
+            {
+                luaL_error(L, "Unknown key type %d", key_type);
+            }
             lua_pushnumber(L, *((uint16_t_1_align *)buffer));
             buffer += 2;
         }
         else if (3 == header.m_Version)
         {
-            uint32_t b1 = (uint32_t)*buffer++;
-            uint32_t b2 = (uint32_t)(*buffer++) << 8;
-            uint32_t b3 = (uint32_t)(*buffer++) << 16;
-            uint32_t b4 = (uint32_t)(*buffer++) << 24;
-            int32_t value = b4 | b3 | b2 | b1;
-            lua_pushnumber(L, value);
+            if (key_type != LUA_TNUMBER && key_type != LUA_TNEGATIVENUMBER)
+            {
+                luaL_error(L, "Unknown key type %d", key_type);
+            }
+            uint8_t b1 = (uint8_t)*buffer++;
+            uint8_t b2 = (uint8_t)*buffer++;
+            uint8_t b3 = (uint8_t)*buffer++;
+            uint8_t b4 = (uint8_t)*buffer++;
+            if (key_type == LUA_TNUMBER)
+            {
+                uint32_t index = b4 << 24 | b3 << 16 | b2 << 8 | b1;
+                lua_pushnumber(L, (lua_Number)index);
+            }
+            else if (key_type == LUA_TNEGATIVENUMBER)
+            {
+                int32_t index = b4 << 24 | b3 << 16 | b2 << 8 | b1;
+                lua_pushnumber(L, (lua_Number)index);
+            }
         }
         else
         {
-            uint32_t value;
-            if(DecodeMSB(value, buffer))
+            if (key_type != LUA_TNUMBER)
             {
-                lua_pushnumber(L, value);
+                luaL_error(L, "Unknown key type %d", key_type);
+            }
+            uint32_t index;
+            if(DecodeMSB(index, buffer))
+            {
+                lua_pushnumber(L, index);
             }
             else
             {
@@ -681,11 +718,11 @@ namespace dmScript
 
                 CHECK_PUSHTABLE_OOB("key string", logger, buffer, buffer_end, count, depth);
             }
-            else if (key_type == LUA_TNUMBER)
+            else if (key_type == LUA_TNUMBER || key_type == LUA_TNEGATIVENUMBER)
             {
                 PushTableLogString(logger, "KN");
 
-                buffer = ReadEncodedNumber(L, header, buffer);
+                buffer = ReadEncodedIndex(L, key_type, header, buffer);
                 CHECK_PUSHTABLE_OOB("key number", logger, buffer, buffer_end, count, depth);
             }
 

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -199,7 +199,7 @@ TEST_F(LuaTableTest, VerifySinTable01)
 
 TEST_F(LuaTableTest, TestSerializeLargeNumbers)
 {
-    lua_Number numbers[] = {0, -1, -2147483648, 4294967295, 0x1234, 0x8765, 0xffff, 0x12345678, 0x7fffffff, 0x87654321, 268435456, 0xffffffff, 0xfffffffe};
+    lua_Number numbers[] = {0, -1, -4294967295, 4294967295, 0x1234, 0x8765, 0xffff, 0x12345678, 0x7fffffff, 0x87654321, 268435456, 0xffffffff, 0xfffffffe};
     const uint32_t count = sizeof(numbers) / sizeof(lua_Number);
 
     lua_newtable(L);

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -154,7 +154,7 @@ TEST_F(LuaTableTest, AttemptReadUnsupportedVersion)
     int result = lua_cpcall(L, ReadUnsupportedVersion, 0x0);
     ASSERT_NE(0, result);
     char str[256];
-    dmSnPrintf(str, sizeof(str), "Unsupported serialized table data: version = 0x%x (current = 0x%x)", 818192, 2);
+    dmSnPrintf(str, sizeof(str), "Unsupported serialized table data: version = 0x%x (current = 0x%x)", 818192, 3);
     ASSERT_STREQ(str, lua_tostring(L, -1));
     // pop error message
     lua_pop(L, 1);
@@ -199,8 +199,8 @@ TEST_F(LuaTableTest, VerifySinTable01)
 
 TEST_F(LuaTableTest, TestSerializeLargeNumbers)
 {
-    uint32_t numbers[] = {0, 0x1234, 0x8765, 0xffff, 0x12345678, 0x7fffffff, 0x87654321, 268435456, 0xffffffff, 0xfffffffe};
-    const uint32_t count = sizeof(numbers) / sizeof(uint32_t);
+    lua_Number numbers[] = {0, -1, -2147483648, 4294967295, 0x1234, 0x8765, 0xffff, 0x12345678, 0x7fffffff, 0x87654321, 268435456, 0xffffffff, 0xfffffffe};
+    const uint32_t count = sizeof(numbers) / sizeof(lua_Number);
 
     lua_newtable(L);
     for (uint32_t i=0;i!=count;i++)
@@ -217,13 +217,13 @@ TEST_F(LuaTableTest, TestSerializeLargeNumbers)
 
     dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
 
-    uint32_t found[count] = { 0 };
+    lua_Number found[count] = { 0 };
 
     lua_pushnil(L);
     while (lua_next(L, -2) != 0)
     {
-        uint32_t key = (uint32_t) lua_tonumber(L, -1);
-        uint32_t value = (uint32_t) lua_tonumber(L, -2);
+        lua_Number value = lua_tonumber(L, -1);
+        lua_Number key = lua_tonumber(L, -2);
         ASSERT_EQ(key, value);
 
         for (uint32_t i=0;i!=count;i++)

--- a/engine/script/src/test/test_script_table.lua
+++ b/engine/script/src/test/test_script_table.lua
@@ -15,6 +15,12 @@ local function save(path)
 	t["hash"] 	= hash("hashed value")
 	t["url"] 	= msg.url("a", "b", "c")
 
+	if TABLE_VERSION_CURRENT > 2 then
+		-- test negative numeric keys
+		t[-123] = "minus_onetwothree"
+		t[123] 	= "plus_oneonetwothree"
+	end
+
 	-- note that the binary strings won't print ok before the fix
 	pprint(t)
 
@@ -51,6 +57,11 @@ local function load(path)
 	assert( t["number"] == 0.5 )
 	assert( t["hash"] == hash("hashed value") )
 	assert( t["url"] == msg.url("a", "b", "c") )
+
+	if TABLE_VERSION_CURRENT > 2 then
+		assert( t[-123] == "minus_onetwothree" )
+		assert( t[123] == "plus_onetwothree" )
+	end
 
 end
 


### PR DESCRIPTION
New version
Don't bother with trying to optimize number of bytes written for numeric keys. Always write four bytes.