### PR TITLE
DEFEDIT-4660 Updated editor particlefx vertex format to match runtime

### DIFF
--- a/editor/src/clj/editor/particle_lib.clj
+++ b/editor/src/clj/editor/particle_lib.clj
@@ -21,8 +21,8 @@
 
 (vertex/defvertex vertex-format
   (vec3 position)
-  (vec4.ubyte color true)
-  (vec2.ushort texcoord0 true))
+  (vec4 color true)
+  (vec2 texcoord0 true))
 
 (defn- create-context [max-emitter-count max-particle-count]
   (ParticleLibrary/Particle_CreateContext max-emitter-count max-particle-count))


### PR DESCRIPTION
Fixes #4660 
Fixes defold/editor2-issues#2912

### Technical changes
A vertex format change was introduced in the runtime with 6116a0767ff9787c2f88c5732d063670eaa3ace0, which was part of Vulkan - Rendertarget support (#4562). We forgot to update the vertex format in the editor, so it would assert when rendering particles due to the size mismatch.

The changes made to `particle.h`in #4562 for reference:
https://github.com/defold/defold/commit/6116a0767ff9787c2f88c5732d063670eaa3ace0#diff-2148a65fc848c1fd3a8b778ff43c184c