### PR TITLE
Issue-4704 Added missing CFBundleDisplayName to the Info.plist used on macOS bundles

### DIFF
--- a/engine/engine/content/builtins/manifests/osx/Info.plist
+++ b/engine/engine/content/builtins/manifests/osx/Info.plist
@@ -6,6 +6,8 @@
 	<string>11E53</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>{{project.title}}</string>
 	<key>CFBundleExecutable</key>
 	<string>{{exe-name}}</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
Fixes #4704