### PR TITLE
Fixes for CI

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'DEFEDIT-*'
+      - 'editor-dev'
 
 env:
   S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -5,6 +5,7 @@ on:
      branches:
        - '*'
        - '!DEFEDIT-*'
+       - '!editor-dev'
   repository_dispatch: {}
 
 env:

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -286,7 +286,7 @@ def main(argv):
     if branch == "master":
         engine_channel = "stable"
         editor_channel = "editor-alpha"
-        release_channel = engine_channel
+        release_channel = "editor-stable"
         make_release = False
         engine_artifacts = args.engine_artifacts or "archived"
     elif branch == "beta":


### PR DESCRIPTION
Master should release to editor-stable
The editor-dev branch should not build engine+bob+sdk