### PR TITLE
Graphics call verify option

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -171,6 +171,10 @@ texture_profiles.type = resource
 texture_profiles.help = specify which texture profiles (format, mipmaps and max textures size) to use for which resource path
 texture_profiles.default = /builtins/graphics/default.texture_profiles
 
+verify_graphics_calls.type = bool
+verify_graphics_calls.help = verify the return value after each graphics call
+verify_graphics_calls.default = 1
+
 [sound]
 help = Sound related settings
 

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -240,6 +240,11 @@
    "specify which texture profiles (format, mipmaps and max textures size) to use for which resource path",
    :default "/builtins/graphics/default.texture_profiles",
    :path ["graphics" "texture_profiles"]}
+  {:type :boolean,
+   :help
+   "verify the return value after each graphics call",
+   :default true,
+   :path ["graphics" "verify_graphics_calls"]}
   {:type :number,
    :help
    "seconds to wait before treating a held down keyboard-key to start repeating itself",

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -508,7 +508,7 @@ namespace dmEngine
 
         // The default is 1, and the only way to know if the property is manually set, is if it's 0
         // since the values are always written to the project file
-        if (0 == dmConfigFile::GetInt(engine->m_Config, "graphics.verify_graphics_calls", 1);
+        if (0 == dmConfigFile::GetInt(engine->m_Config, "graphics.verify_graphics_calls", 1))
             verify_graphics_calls = false;
 
         bool renderdoc_support = false;

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -505,6 +505,12 @@ namespace dmEngine
 
         // Catch engine specific arguments
         bool verify_graphics_calls = dLib::IsDebugMode();
+
+        // The default is 1, and the only way to know if the property is manually set, is if it's 0
+        // since the values are always written to the project file
+        if (0 == dmConfigFile::GetInt(engine->m_Config, "graphics.verify_graphics_calls", 1);
+            verify_graphics_calls = false;
+
         bool renderdoc_support = false;
         const char verify_graphics_calls_arg[] = "--verify-graphics-calls=";
         const char renderdoc_support_arg[] = "--renderdoc";


### PR DESCRIPTION
https://forum.defold.com/t/ios-crash-on-app-focus-gain-in-dmgraphics-clear-dmgraphics-context-unsigned-int-unsigned-char-unsigned-char-unsigned-char-unsigned-char-float-unsigned-int/64609

In order to help occasional debugging, we might want to allow disabling the graphics calls verification.