### PR TITLE
Issue-4768 Skip editor tests on engine feature branches

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -227,9 +227,22 @@ jobs:
         run: 'ci/ci.sh --keychain-cert="${{env.MACOS_CERTIFICATE}}" --keychain-cert-pass="${{env.MACOS_CERTIFICATE_PASS}}" install'
       },
       {
-        name: 'Build editor',
-        if: (github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_editor != true)),
+        name: 'Build and test editor',
+        if: (
+            (github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'repository_dispatch'))
+            && (github.event.client_payload.skip_editor != true)
+            && ((github.ref == "dev") || (github.ref == "beta") || (github.ref == "master"))
+        ),
         run: 'ci/ci.sh build-editor'
+      },
+      {
+        name: 'Build editor',
+        if: (
+            (github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'repository_dispatch'))
+            && (github.event.client_payload.skip_editor != true)
+            && ((github.ref != "dev") && (github.ref != "beta") && (github.ref != "master"))
+        ),
+        run: 'ci/ci.sh build-editor --skip-test'
       },
       {
         name: 'Notarize editor',

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -227,22 +227,9 @@ jobs:
         run: 'ci/ci.sh --keychain-cert="${{env.MACOS_CERTIFICATE}}" --keychain-cert-pass="${{env.MACOS_CERTIFICATE_PASS}}" install'
       },
       {
-        name: 'Build and test editor',
-        if: (
-            (github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'repository_dispatch'))
-            && (github.event.client_payload.skip_editor != true)
-            && ((github.ref == "dev") || (github.ref == "beta") || (github.ref == "master"))
-        ),
-        run: 'ci/ci.sh build-editor'
-      },
-      {
         name: 'Build editor',
-        if: (
-            (github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'repository_dispatch'))
-            && (github.event.client_payload.skip_editor != true)
-            && ((github.ref != "dev") && (github.ref != "beta") && (github.ref != "master"))
-        ),
-        run: 'ci/ci.sh build-editor --skip-test'
+        if: (github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_editor != true)),
+        run: 'ci/ci.sh build-editor'
       },
       {
         name: 'Notarize editor',

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -171,7 +171,7 @@ def build_engine(platform, with_valgrind = False, with_asan = False, with_vanill
     call(cmd)
 
 
-def build_editor2(channel = None, engine_artifacts = None):
+def build_editor2(channel = None, engine_artifacts = None, skip_tests = False):
     opts = []
 
     if engine_artifacts:
@@ -179,6 +179,9 @@ def build_editor2(channel = None, engine_artifacts = None):
 
     if channel:
         opts.append('--channel=%s' % channel)
+
+    if skip_tests:
+        opts.append('--skip-tests')
 
     opts_string = ' '.join(opts)
     call('python scripts/build.py distclean install_ext build_editor2 --platform=%s %s' % (platform_from_host(), opts_string))
@@ -283,6 +286,7 @@ def main(argv):
 
     # configure build flags based on the branch
     release_channel = None
+    skip_editor_tests = False
     if branch == "master":
         engine_channel = "stable"
         editor_channel = "editor-alpha"
@@ -316,6 +320,7 @@ def main(argv):
         engine_channel = None
         editor_channel = None
         make_release = False
+        skip_editor_tests = True
         engine_artifacts = args.engine_artifacts or "archived"
 
     print("Using branch={} engine_channel={} editor_channel={} engine_artifacts={}".format(branch, engine_channel, editor_channel, engine_artifacts))
@@ -335,7 +340,7 @@ def main(argv):
                 skip_builtins = args.skip_builtins,
                 skip_docs = args.skip_docs)
         elif command == "build-editor":
-            build_editor2(channel = editor_channel, engine_artifacts = engine_artifacts)
+            build_editor2(channel = editor_channel, engine_artifacts = engine_artifacts, skip_tests = skip_editor_tests)
         elif command == "notarize-editor":
             notarize_editor2(
                 notarization_username = args.notarization_username,


### PR DESCRIPTION
The editor tests are run on:

* master
* beta
* dev
* editor-dev
* DEFEDIT-*

Any other branch is considered an engine feature branch where editor tests doesn't have to run. This saves approx 4 minutes of time when building the editor.

We could take this one step further and not run editor tests on dev and beta as well, but I feel it's better to have some additional checks there, especially when merging to beta.