### PR TITLE
Call the release step when the editor has been archived

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -42,4 +42,8 @@ jobs:
       {
         name: 'Archive editor',
         run: 'ci/ci.sh archive-editor'
+      },
+      {
+        name: 'Release editor',
+        run: 'ci/ci.sh release'
       }]


### PR DESCRIPTION
This in combination with `make_release` argument here:

https://github.com/defold/defold/blob/dev/ci/ci.py#L308-L318

Will create releases from editor-dev but not DEFEDIT-*