### PR TITLE
Editor fixes for mesh buffers

### DIFF
--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -68,10 +68,6 @@
   (when (and anim-ids (not-any? #(= animation %) anim-ids))
     (format "'%s' could not be found in the specified image" animation)))
 
-(defn prop-stream-missing? [stream stream-ids]
-  (when (and stream-ids (not-any? #(= stream %) stream-ids))
-    (format "Stream '%s' could not be found in the specified buffer" stream)))
-
 (defn prop-outside-range? [[min max] v name]
   (let [tmpl (if (integer? min)
                "'%s' must be between %d and %d"


### PR DESCRIPTION
### User-facing changes
* Fixes camera clip plane calculation in the editor when no Position Stream has been specified.
* Not specifying Position Stream and Normal Stream is now a build error when using a material with a world-space Vertex Space setting.