### PR TITLE
Disable editor performance tests by setting an environment variable

### DIFF
--- a/editor/test/integration/perf_test.clj
+++ b/editor/test/integration/perf_test.clj
@@ -3,7 +3,7 @@
             [dynamo.graph :as g]
             [integration.test-util :as test-util]
             [internal.node :as in]
-            [support.test-support :refer [with-clean-system]]))
+            [support.test-support :refer [enable-performance-tests with-clean-system]]))
 
 (defn- gui-node [scene id]
   (let [id->node (->> (get-in (g/node-value scene :node-outline) [:children 0])
@@ -28,17 +28,18 @@
      (let [end# (clock)]
        (/ (- end# start#) ~(second binding)))))
 
-(deftest gui-template-outline-perf
-  (binding [in/*check-schemas* false]
-    (testing "drag-pull-outline"
-      (test-util/with-loaded-project
-        (let [node-id (test-util/resource-node project "/gui/scene.gui")
-              box (gui-node node-id "sub_scene/sub_box")]
-          ;; WARM-UP
-          (dotimes [i 50]
-            (drag-pull-outline! node-id box i))
-          (System/gc)
-          ;; GO!
-          (let [elapsed (measure [i 20]
-                          (drag-pull-outline! node-id box i))]
-            (is (< elapsed 14))))))))
+(when enable-performance-tests
+  (deftest gui-template-outline-perf
+    (binding [in/*check-schemas* false]
+      (testing "drag-pull-outline"
+        (test-util/with-loaded-project
+          (let [node-id (test-util/resource-node project "/gui/scene.gui")
+                box (gui-node node-id "sub_scene/sub_box")]
+            ;; WARM-UP
+            (dotimes [i 50]
+              (drag-pull-outline! node-id box i))
+            (System/gc)
+            ;; GO!
+            (let [elapsed (measure [i 20]
+                                   (drag-pull-outline! node-id box i))]
+              (is (< elapsed 14)))))))))

--- a/editor/test/support/test_support.clj
+++ b/editor/test/support/test_support.clj
@@ -4,6 +4,10 @@
             [clojure.java.io :as io]
             [internal.system :as is]))
 
+(def enable-performance-tests
+  (nil? (get (System/getenv)
+             "DEFOLD_EDITOR_DISABLE_PERFORMANCE_TESTS")))
+
 (defmacro with-clean-system
   [& forms]
   (let [configuration (if (map? (first forms)) (first forms) {:cache-size 1000})


### PR DESCRIPTION
### User-facing changes
* None

### Technical changes
* Setting the `DEFOLD_EDITOR_DISABLE_PERFORMANCE_TESTS` environment variable to any value disables the often-failing `gui-template-outline-perf` test.