### PR TITLE
fix misplaced docstrings

### DIFF
--- a/editor/src/clj/camel_snake_kebab.clj
+++ b/editor/src/clj/camel_snake_kebab.clj
@@ -24,9 +24,10 @@
        (join "|")
        re-pattern))
 
-(defn convert-case [first-fn rest-fn sep s]
+(defn convert-case
   "Converts the case of a string according to the rule for the first
   word, remaining words, and the separator."
+  [first-fn rest-fn sep s]
   (let [[first & rest] (split s word-separator-pattern)]
     (join sep (cons (first-fn first) (map rest-fn rest)))))
 

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -164,12 +164,14 @@
   ([transaction node-id output]
     (boolean (get-in transaction [:outputs-modified node-id output]))))
 
-(defn is-added? [transaction node-id]
+(defn is-added?
   "Returns a boolean if a node was added as a result of a transaction given a tx-result and node."
+  [transaction node-id]
   (contains? (:nodes-added transaction) node-id))
 
-(defn is-deleted? [transaction node-id]
+(defn is-deleted?
   "Returns a boolean if a node was delete as a result of a transaction given a tx-result and node."
+  [transaction node-id]
   (contains? (:nodes-deleted transaction) node-id))
 
 (defn outputs-modified
@@ -183,7 +185,7 @@
   (:basis transaction))
 
 (defn pre-transaction-basis
-  "Returns the original, statrting basis from the result of a transaction given a tx-result"
+  "Returns the original, starting basis from the result of a transaction given a tx-result"
   [transaction]
   (:original-basis transaction))
 

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -181,9 +181,9 @@
      :body           payload}))
 
 (defn- query-cached-files
-  [server-url resource-nodes-by-upload-path evaluation-context]
   "Asks the server what files it already has.
   This is to avoid uploading big files that rarely change"
+  [server-url resource-nodes-by-upload-path evaluation-context]
   (let [items (mapv (fn [[upload-path resource-node]]
                       (let [key (g/node-value resource-node :sha256 evaluation-context)]
                         {:path upload-path :key key}))
@@ -200,8 +200,8 @@
         items))))
 
 (defn- make-cached-info-map
-  [ne-cache-info]
   "Parse the json doc into a mapping 'path' -> 'cached'"
+  [ne-cache-info]
   (into {}
         (map (fn [info]
                [(get info "path")

--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -50,8 +50,9 @@
 ; Implementation based on:
 ; http://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection
 ; In case the line is parallel with the plane, nil is returned.
-(defn line-plane-intersection [^Point3d line-pos ^Vector3d line-dir ^Point3d plane-pos ^Vector3d plane-normal]
+(defn line-plane-intersection
   "Returns the position at which the line intersects the plane. If the line and plane are parallel, nil is returned."
+  [^Point3d line-pos ^Vector3d line-dir ^Point3d plane-pos ^Vector3d plane-normal]
   (let [norm-dir-dot (.dot line-dir plane-normal)]
     (when (> (Math/abs norm-dir-dot) epsilon-sq)
       (let [diff (doto (Vector3d.) (.sub line-pos plane-pos))

--- a/editor/src/clj/editor/texture/pack_max_rects.clj
+++ b/editor/src/clj/editor/texture/pack_max_rects.clj
@@ -41,9 +41,9 @@
 
 ; find the best free-rect into which to place rect
 (s/defn score-rects :- [[(s/one s/Int "score") (s/one Rect "free-rect")]]
-  [free-rects :- [Rect] {:keys [width height] :as rect} :- Rect]
   "Sort the free-rects according to how well rect fits into them.
    A 'good fit' means the least amount of leftover area."
+  [free-rects :- [Rect] {:keys [width height] :as rect} :- Rect]
   (reverse (sort-by first (map score-rect free-rects (repeat rect)))))
 
 (s/defn place-in :- Rect

--- a/editor/src/clj/editor/util.clj
+++ b/editor/src/clj/editor/util.clj
@@ -15,13 +15,13 @@
 ;; See http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug
 
 (defn lower-case*
-  [^CharSequence s]
   "Like clojure.string/lower-case but using root locale."
+  [^CharSequence s]
   (.. s toString (toLowerCase Locale/ROOT)))
 
 (defn upper-case*
-  [^CharSequence s]
   "Like clojure.string/upper-case but using root locale."
+  [^CharSequence s]
   (.. s toString (toUpperCase Locale/ROOT)))
 
 (defn capitalize*

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -1101,12 +1101,13 @@
           (gt/node-type basis)
           in/input-dependencies))
 
-(defn- update-graph-successors [old-successors basis graph-id graph changes]
+(defn- update-graph-successors
   "The purpose of this fn is to build a data structure that reflects which set of node-id + outputs that can be reached from the incoming changes (map of node-id + outputs)
    For a specific node-id-a + output-x, add:
      the internal input-dependencies, i.e. outputs consuming the given output
      the closest override-nodes, i.e. override-node-a + output-x, as they can be potential dependents
      all connected nodes, where node-id-a + output-x => [[node-id-b + input-y] ...] => [[node-id-b + output+z] ...]"
+  [old-successors basis graph-id graph changes]
   (let [node-id->overrides (or (:node->overrides graph) (constantly nil))
         ;; Transducer to collect override-id's
         override-id-xf (keep #(some->> %

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -112,8 +112,9 @@
                (groups-container-prepare groups-container)
                coll)))))
 
-(defn filterm [pred m]
-  "like filter but applys the predicate to each key value pair of the map"
+(defn filterm
+  "like filter but applies the predicate to each key value pair of the map"
+  [pred m]
   (into {} (filter pred m)))
 
 (defn key-set

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -56,10 +56,11 @@
      (mapv file-tree-helper (sort-by #(.getName %) (filter #(not (.isHidden %)) (.listFiles entry))))}
     (.getName entry)))
 
-(defn file-tree [^File dir]
+(defn file-tree
   "Returns a vector of file tree entries below dir. A file entry is represented
   as a String file name. A directory entry is represented as a single-entry map
   where the key is the directory name and the value is a vector of tree entries."
+  [^File dir]
   (second (first (file-tree-helper dir))))
 
 (defn make-file-tree!
@@ -580,8 +581,8 @@
                0x45 0x4E 0x44 0xAE  0x42 0x60 0x82]))
 
 (defn make-png-resource!
-  [workspace proj-path]
   "Adds a PNG image file to the workspace. Returns the created FileResource."
+  [workspace proj-path]
   (assert (integer? workspace))
   (assert (.startsWith proj-path "/"))
   (let [resource (resource workspace proj-path)]


### PR DESCRIPTION
A few docsctrings are placed after the binding form in the source code.