### PR TITLE
Make editor report a build error on non-existent custom resource

### DIFF
--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -103,8 +103,11 @@
 
 (defn- find-custom-resources [resource-map custom-paths]
   (->> (flatten (keep (fn [custom-path]
-                        (when-let [base-resource (resource-map custom-path)]
-                          (resource/resource-seq base-resource)))
+                        (let [base-resource (resource-map custom-path)]
+                          (if base-resource
+                            (resource/resource-seq base-resource)
+                            (throw (ex-info (format "Custom resource not found: '%s'" custom-path)
+                                            {})))))
                       custom-paths))
        (distinct)
        (filter file-resource?)))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -179,15 +179,15 @@
   (output custom-build-targets g/Any :cached
           (g/fnk [_node-id resource-map settings-map]
                  (let [custom-paths (parse-custom-resource-paths (get settings-map ["project" "custom_resources"]))]
-                    (try
-                      (map (partial make-custom-build-target _node-id)
-                            (find-custom-resources resource-map custom-paths))
-                      (catch Throwable error
-                        (g/map->error
-                          {:_node-id _node-id
-                            :_label :custom-build-targets
-                            :message (ex-message error)
-                            :severity :fatal}))))))
+                   (try
+                     (map (partial make-custom-build-target _node-id)
+                          (find-custom-resources resource-map custom-paths))
+                     (catch Throwable error
+                       (g/map->error
+                         {:_node-id _node-id
+                          :_label :custom-build-targets
+                          :message (ex-message error)
+                          :severity :fatal}))))))
 
   (output outline g/Any :cached
           (g/fnk [_node-id] {:node-id _node-id :label "Game Project" :icon game-project-icon}))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -179,8 +179,15 @@
   (output custom-build-targets g/Any :cached
           (g/fnk [_node-id resource-map settings-map]
                  (let [custom-paths (parse-custom-resource-paths (get settings-map ["project" "custom_resources"]))]
-                   (map (partial make-custom-build-target _node-id)
-                        (find-custom-resources resource-map custom-paths)))))
+                    (try
+                      (map (partial make-custom-build-target _node-id)
+                            (find-custom-resources resource-map custom-paths))
+                      (catch Throwable error
+                        (g/map->error
+                          {:_node-id _node-id
+                            :_label :custom-build-targets
+                            :message (ex-message error)
+                            :severity :fatal}))))))
 
   (output outline g/Any :cached
           (g/fnk [_node-id] {:node-id _node-id :label "Game Project" :icon game-project-icon}))


### PR DESCRIPTION
Comment from matgis-king:

This original description is outdated. The resulting discussion resulted in us deciding this should be a build error in both the editor and Bob, so we decided to change it to a build error in the editor as well.

----------

If you specified a file that doesn't exist in `custom_resources`, bob would try to bundle it and crash. The editor just skips that file without a complaint (which is a behaviour we actually rely upon with an `env.lua` file in some of our projects, which is `.gitignore`-d and could potentially be missing unless the dev creates it to override some settings).

This PR adds the same `isFile()` check that the editor uses to bob.

I can repro this issue reliably by trying to compile https://github.com/dapetcu21/crit-boilerplate with bob on macOS. I only tested the fix on macOS (it doesn't seem like it could cause an issue on Win/Linux).

Update: Tested and it doesn't break when some of the `custom_resources` files are symlinks.