### PR TITLE
Issue-4831 Pass nil to window.set_listener() to unsubscribe

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_window.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_window.cpp
@@ -135,7 +135,7 @@ static void RunCallback(CallbackInfo* cbinfo)
  *
  * @name window.set_listener
  *
- * @param callback [type:function(self, event, data)] A callback which receives info about window events. Pass an empty function if you no longer wish to receive callbacks.
+ * @param callback [type:function(self, event, data)] A callback which receives info about window events. Pass an empty function or nil if you no longer wish to receive callbacks.
  *
  * `self`
  * : [type:object] The calling script
@@ -180,6 +180,13 @@ static void RunCallback(CallbackInfo* cbinfo)
 static int SetListener(lua_State* L)
 {
     WindowInfo* window_info = &g_Window;
+
+    luaL_checkany(L, 1);
+    if (lua_isnoneornil(L, 1)) {
+        ClearListener(&window_info->m_Listener);
+        return 0;
+    }
+
     luaL_checktype(L, 1, LUA_TFUNCTION);
     lua_pushvalue(L, 1);
     int cb = dmScript::Ref(L, LUA_REGISTRYINDEX);

--- a/engine/gamesys/src/gamesys/scripts/script_window.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_window.cpp
@@ -179,10 +179,12 @@ static void RunCallback(CallbackInfo* cbinfo)
  */
 static int SetListener(lua_State* L)
 {
+    luaL_checkany(L, 1);
+
     WindowInfo* window_info = &g_Window;
 
-    luaL_checkany(L, 1);
-    if (lua_isnoneornil(L, 1)) {
+    if (lua_isnil(L, 1))
+    {
         ClearListener(&window_info->m_Listener);
         return 0;
     }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -698,6 +698,15 @@ TEST_F(WindowEventTest, Test)
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 
+    // Set test state 4
+    input_action.m_Value = 4.0f;
+    dmGameObject::DispatchInput(m_Collection, &input_action, 1);
+
+    dmGameSystem::OnWindowFocus(false);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
     // Set final test state, check that all tests passed
     input_action.m_Value = 0.0f;
     dmGameObject::DispatchInput(m_Collection, &input_action, 1);

--- a/engine/gamesys/src/gamesys/test/window/window_events.script
+++ b/engine/gamesys/src/gamesys/test/window/window_events.script
@@ -1,5 +1,5 @@
 local test_state = 0
-local numtests = 3
+local numtests = 4
 local error = 0
 
 local function test_eq( a, b )
@@ -18,8 +18,17 @@ local function test_neq( a, b )
     assert( a ~= b )
 end
 
+local function test_unsubscribed()
+    if test_state == 4 then
+        error = 1
+        print("unsubscribe failed")
+    end
+    assert( test_state ~= 4 )
+end
+
 function window_callback(self, event, data)
     test_neq( test_state, 0 )
+    test_unsubscribed()
 
     if test_state == 1 then
         test_eq( event, window.WINDOW_EVENT_FOCUS_LOST )
@@ -53,5 +62,8 @@ function on_input(self, action_id, action)
     if test_state == 0 then
         -- final call, check all tests passed
         test_eq( numtests, 0 )
+    elseif test_state == 4 then
+        window.set_listener(nil)
+        numtests = numtests - 1;
     end
 end


### PR DESCRIPTION
**Before**: you were required to pass empty function to `window.set_listener` to imitate unsubscribtion.

**Now**: you can pass nil to `window.set_listener` to unsubscribe.

**Original request**: https://forum.defold.com/t/incoming-call/65087/9?u=britzl 

**Issue**: https://github.com/defold/defold/issues/4831

Issue description already contains alternatives considered to this solution.
