### PR TITLE
Issue-3342 Allow spaces in "go.property  (...)"

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
@@ -126,28 +126,30 @@ public class LuaScannerTest {
     public void testProps() throws Exception {
         List<Property> properties = scanProperties("test_props.lua");
 
-        assertEquals(7, properties.size());
+        assertEquals(8, properties.size());
         assertProperty(properties, "prop1", new Double(0), 10);
         assertProperty(properties, "prop2", new Double(0), 13);
         assertProperty(properties, "prop3", new Double(0), 14);
         assertProperty(properties, "prop4", new Double(0), 15);
-        assertEquals(Status.INVALID_ARGS, properties.get(4).status);
-        assertPropertyStatus(properties, "three_args", Status.INVALID_VALUE, 18);
-        assertPropertyStatus(properties, "unknown_type", Status.INVALID_VALUE, 19);
+        assertProperty(properties, "prop5", new Double(0), 16);
+        assertEquals(Status.INVALID_ARGS, properties.get(5).status);
+        assertPropertyStatus(properties, "three_args", Status.INVALID_VALUE, 19);
+        assertPropertyStatus(properties, "unknown_type", Status.INVALID_VALUE, 20);
     }
 
     @Test
     public void testPropsStripped() throws Exception {
         String source = getFile("test_props.lua");
         List<Property> properties = LuaScanner.scanProperties(source);
-        assertEquals(7, properties.size());
+        assertEquals(8, properties.size());
         assertProperty(properties, "prop1", new Double(0), 10);
         assertProperty(properties, "prop2", new Double(0), 13);
         assertProperty(properties, "prop3", new Double(0), 14);
         assertProperty(properties, "prop4", new Double(0), 15);
-        assertEquals(Status.INVALID_ARGS, properties.get(4).status);
-        assertPropertyStatus(properties, "three_args", Status.INVALID_VALUE, 18);
-        assertPropertyStatus(properties, "unknown_type", Status.INVALID_VALUE, 19);
+        assertProperty(properties, "prop5", new Double(0), 16);
+        assertEquals(Status.INVALID_ARGS, properties.get(5).status);
+        assertPropertyStatus(properties, "three_args", Status.INVALID_VALUE, 19);
+        assertPropertyStatus(properties, "unknown_type", Status.INVALID_VALUE, 20);
         source = LuaScanner.stripProperties(source);
         properties = LuaScanner.scanProperties(source);
         assertEquals(0, properties.size());

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/test_props.lua
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/test_props.lua
@@ -14,6 +14,7 @@ go.property("prop1", 0)
   go.property( "prop2" ,  0 )  
 go.property('prop3',  0 )  
 go.property('prop4', 0) -- trailing comment
+go.property  ('prop5', 0)
 
 go.property(invalid_string, 2)
 go.property("three_args", 1, 2)

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaScanner.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaScanner.java
@@ -56,7 +56,7 @@ public class LuaScanner {
     private static Pattern requirePattern4 = Pattern.compile(beforeRequire + "require\\s*?\\(\\s*?'(.*?)'\\s*?\\)" + afterRequire,
              Pattern.DOTALL | Pattern.MULTILINE);
 
-    private static Pattern propertyDeclPattern = Pattern.compile("go.property\\((.*?)\\);?(\\s*?--.*?)?$");
+    private static Pattern propertyDeclPattern = Pattern.compile("go.property\\s*?\\((.*?)\\);?(\\s*?--.*?)?$");
     private static Pattern propertyArgsPattern = Pattern.compile("[\"'](.*?)[\"']\\s*,(.*)");
 
     // http://docs.python.org/dev/library/re.html#simulating-scanf


### PR DESCRIPTION
**Issue**: #3342 
**Before**: bob didn't parse properties with spaces between property and braces in `go.property (...)` method call.
**After**: bob becomes more forgiving to spaces in property declaration.

**Note**: I tested with unit tests only. It seems that I need to setup html5 target to reproduce this in real environment. I will do it shortly. Also I ran only `LuaScannerTest`, because it seems some other bob tests require all engine targets to be built to pass, I don't think it will cause regression in other tests though.

**Points for discussion**: I don't think there is a need for non-greedy match here, but I did it anyway, because this is how it is done in require pattern above.