### PR TITLE
Issue-3315 Fix label rotation

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -257,12 +257,7 @@ namespace dmGameSystem
         return dmGameObject::CREATE_RESULT_OK;
     }
 
-    Matrix4 CompLabelLocalTransform(
-        const Point3& position,
-        const Quat& rotation,
-        const Vector3& scale,
-        const Vector3& size,
-        uint32_t pivot)
+    Matrix4 CompLabelLocalTransform(const Point3& position, const Quat& rotation, const Vector3& scale, const Vector3& size, uint32_t pivot)
     {
         // Move pivot to (0,0). Rotate around (0,0). Move pivot to position.
         return dmTransform::ToMatrix4(

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -257,6 +257,22 @@ namespace dmGameSystem
         return dmGameObject::CREATE_RESULT_OK;
     }
 
+    Matrix4 CompLabelLocalTransform(
+        const Point3& position,
+        const Quat& rotation,
+        const Vector3& scale,
+        const Vector3& size,
+        uint32_t pivot)
+    {
+        // Move pivot to (0,0). Rotate around (0,0). Move pivot to position.
+        return dmTransform::ToMatrix4(
+            dmTransform::Mul(
+                dmTransform::Transform(Vector3(position), rotation, 1.0f),
+                dmTransform::Transform(CalcPivotDelta(pivot, mulPerElem(scale, size)), Quat::identity(), 1.0f)
+            )
+        );
+    }
+
     static void UpdateTransforms(LabelWorld* world, bool sub_pixels)
     {
         DM_PROFILE(Label, "UpdateTransforms");
@@ -270,7 +286,7 @@ namespace dmGameSystem
             if (!c->m_Enabled || !c->m_AddedToUpdate)
                 continue;
 
-            Matrix4 local = dmTransform::ToMatrix4(dmTransform::Transform(Vector3(c->m_Position + CalcPivotDelta(c->m_Pivot, mulPerElem(c->m_Scale, c->m_Size))), c->m_Rotation, 1.0));
+            Matrix4 local = CompLabelLocalTransform(c->m_Position, c->m_Rotation, c->m_Scale, c->m_Size, c->m_Pivot);
             Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
             Matrix4 w;
 

--- a/engine/gamesys/src/gamesys/components/comp_label.h
+++ b/engine/gamesys/src/gamesys/components/comp_label.h
@@ -53,7 +53,12 @@ namespace dmGameSystem
 
     const char* CompLabelGetText(const LabelComponent* component);
 
-
+    Vectormath::Aos::Matrix4 CompLabelLocalTransform(
+        const Vectormath::Aos::Point3& position,
+        const Vectormath::Aos::Quat& rotation,
+        const Vectormath::Aos::Vector3& scale,
+        const Vectormath::Aos::Vector3& size,
+        uint32_t pivot);
 }
 
 #endif // DM_GAMESYS_COMP_LABEL_H

--- a/engine/gamesys/src/gamesys/components/comp_label.h
+++ b/engine/gamesys/src/gamesys/components/comp_label.h
@@ -53,12 +53,7 @@ namespace dmGameSystem
 
     const char* CompLabelGetText(const LabelComponent* component);
 
-    Vectormath::Aos::Matrix4 CompLabelLocalTransform(
-        const Vectormath::Aos::Point3& position,
-        const Vectormath::Aos::Quat& rotation,
-        const Vectormath::Aos::Vector3& scale,
-        const Vectormath::Aos::Vector3& size,
-        uint32_t pivot);
+    Vectormath::Aos::Matrix4 CompLabelLocalTransform(const Vectormath::Aos::Point3& position, const Vectormath::Aos::Quat& rotation, const Vectormath::Aos::Vector3& scale, const Vectormath::Aos::Vector3& size, uint32_t pivot);
 }
 
 #endif // DM_GAMESYS_COMP_LABEL_H

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1585,172 +1585,66 @@ INSTANTIATE_TEST_CASE_P(SpineModel, ComponentTest, jc_test_values_in(valid_spine
 
 /* Label */
 
-const float TEST_EPS = 0.00001;
+void AssertPointEquals(const Vector4& p, float x, float y)
+{
+    static const float test_epsilon = 0.000001f;
+    EXPECT_NEAR(p.getX(), x, test_epsilon);
+    EXPECT_NEAR(p.getY(), y, test_epsilon);
+}
 
-TEST(Label, LabelMovesWhenSwitchingPivot) {
-    Point3 position(0.0, 0.0, 0.0);
-    Vector3 size(2.0, 2.0, 0.0);
-    Vector3 scale(1.0, 1.0, 0.0);
-
-    Point3 bottom_left(0.0, 0.0, 0.0);
-    Point3 top_left(0.0, size.getY(), 0.0);
-    Point3 top_right(size.getX(), size.getY(), 0.0);
-    Point3 bottom_right(size.getX(), 0.0, 0.0);
-
-    Vector4 bottom_left_result;
-    Vector4 top_left_result;
-    Vector4 top_right_result;
-    Vector4 bottom_right_result;
-    Matrix4 mat;
-
+TEST_F(LabelTest, LabelMovesWhenSwitchingPivot) 
+{
     // pivot = center
-    mat = dmGameSystem::CompLabelLocalTransform(position, Quat::identity(), scale, size, 0);
+    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(m_position, Quat::identity(), m_scale, m_size, 0);
 
-    bottom_left_result = mat * bottom_left;
-    EXPECT_NEAR(bottom_left_result.getX(), -1.0, TEST_EPS);
-    EXPECT_NEAR(bottom_left_result.getY(), -1.0, TEST_EPS);
-
-    top_left_result = mat * top_left;
-    EXPECT_NEAR(top_left_result.getX(), -1.0, TEST_EPS);
-    EXPECT_NEAR(top_left_result.getY(), 1.0, TEST_EPS);
-
-    top_right_result = mat * top_right;
-    EXPECT_NEAR(top_right_result.getX(), 1.0, TEST_EPS);
-    EXPECT_NEAR(top_right_result.getY(), 1.0, TEST_EPS);
-
-    bottom_right_result = mat * bottom_right;
-    EXPECT_NEAR(bottom_right_result.getX(), 1.0, TEST_EPS);
-    EXPECT_NEAR(bottom_right_result.getY(), -1.0, TEST_EPS);
+    AssertPointEquals(mat * m_bottom_left, -1.0, -1.0);
+    AssertPointEquals(mat * m_top_left, -1.0, 1.0);
+    AssertPointEquals(mat * m_top_right, 1.0, 1.0);
+    AssertPointEquals(mat * m_bottom_right, 1.0, -1.0);
 
     // pivot = north east
-    mat = dmGameSystem::CompLabelLocalTransform(position, Quat::identity(), scale, size, 2);
+    mat = dmGameSystem::CompLabelLocalTransform(m_position, Quat::identity(), m_scale, m_size, 2);
 
-    bottom_left_result = mat * bottom_left;
-    EXPECT_NEAR(bottom_left_result.getX(), -2.0, TEST_EPS);
-    EXPECT_NEAR(bottom_left_result.getY(), -2.0, TEST_EPS);
-
-    top_left_result = mat * top_left;
-    EXPECT_NEAR(top_left_result.getX(), -2.0, TEST_EPS);
-    EXPECT_NEAR(top_left_result.getY(), 0.0, TEST_EPS);
-
-    top_right_result = mat * top_right;
-    EXPECT_NEAR(top_right_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(top_right_result.getY(), 0.0, TEST_EPS);
-
-    bottom_right_result = mat * bottom_right;
-    EXPECT_NEAR(bottom_right_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(bottom_right_result.getY(), -2.0, TEST_EPS);
+    AssertPointEquals(mat * m_bottom_left, -2.0, -2.0);
+    AssertPointEquals(mat * m_top_left, -2.0, 0.0);
+    AssertPointEquals(mat * m_top_right, 0.0, 0.0);
+    AssertPointEquals(mat * m_bottom_right, 0.0, -2.0);
 
     // pivot = west
-    mat = dmGameSystem::CompLabelLocalTransform(position, Quat::identity(), scale, size, 7);
+    mat = dmGameSystem::CompLabelLocalTransform(m_position, Quat::identity(), m_scale, m_size, 7);
 
-    bottom_left_result = mat * bottom_left;
-    EXPECT_NEAR(bottom_left_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(bottom_left_result.getY(), -1.0, TEST_EPS);
-
-    top_left_result = mat * top_left;
-    EXPECT_NEAR(top_left_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(top_left_result.getY(), 1.0, TEST_EPS);
-
-    top_right_result = mat * top_right;
-    EXPECT_NEAR(top_right_result.getX(), 2.0, TEST_EPS);
-    EXPECT_NEAR(top_right_result.getY(), 1.0, TEST_EPS);
-
-    bottom_right_result = mat * bottom_right;
-    EXPECT_NEAR(bottom_right_result.getX(), 2.0, TEST_EPS);
-    EXPECT_NEAR(bottom_right_result.getY(), -1.0, TEST_EPS);
+    AssertPointEquals(mat * m_bottom_left, 0.0, -1.0);
+    AssertPointEquals(mat * m_top_left, 0.0, 1.0);
+    AssertPointEquals(mat * m_top_right, 2.0, 1.0);
+    AssertPointEquals(mat * m_bottom_right, 2.0, -1.0);
 }
 
-TEST(Label, LabelMovesWhenChangingPosition) {
-    Vector3 size(2.0, 2.0, 0.0);
-    Vector3 scale(1.0, 1.0, 0.0);
-
-    Point3 bottom_left(0.0, 0.0, 0.0);
-    Point3 top_left(0.0, size.getY(), 0.0);
-    Point3 top_right(size.getX(), size.getY(), 0.0);
-    Point3 bottom_right(size.getX(), 0.0, 0.0);
-
-    Vector4 bottom_left_result;
-    Vector4 top_left_result;
-    Vector4 top_right_result;
-    Vector4 bottom_right_result;
-    Matrix4 mat;
-
+TEST_F(LabelTest, LabelMovesWhenChangingPosition) {
     // pivot = center
-    mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), Quat::identity(), scale, size, 0);
+    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), Quat::identity(), m_scale, m_size, 0);
 
-    bottom_left_result = mat * bottom_left;
-    EXPECT_NEAR(bottom_left_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(bottom_left_result.getY(), 0.0, TEST_EPS);
-
-    top_left_result = mat * top_left;
-    EXPECT_NEAR(top_left_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(top_left_result.getY(), 2.0, TEST_EPS);
-
-    top_right_result = mat * top_right;
-    EXPECT_NEAR(top_right_result.getX(), 2.0, TEST_EPS);
-    EXPECT_NEAR(top_right_result.getY(), 2.0, TEST_EPS);
-
-    bottom_right_result = mat * bottom_right;
-    EXPECT_NEAR(bottom_right_result.getX(), 2.0, TEST_EPS);
-    EXPECT_NEAR(bottom_right_result.getY(), 0.0, TEST_EPS);
+    AssertPointEquals(mat * m_bottom_left, 0.0, 0.0);
+    AssertPointEquals(mat * m_top_left, 0.0, 2.0);
+    AssertPointEquals(mat * m_top_right, 2.0, 2.0);
+    AssertPointEquals(mat * m_bottom_right, 2.0, 0.0);
 }
 
-TEST(Label, LabelRotatesAroundPivot) {
-    Vector3 size(2.0, 2.0, 0.0);
-    Vector3 scale(1.0, 1.0, 0.0);
+TEST_F(LabelTest, LabelRotatesAroundPivot) {
+    // pivot = center, rotation = -180
+    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), m_rotation, m_scale, m_size, 0);
 
-    Point3 bottom_left(0.0, 0.0, 0.0);
-    Point3 top_left(0.0, size.getY(), 0.0);
-    Point3 top_right(size.getX(), size.getY(), 0.0);
-    Point3 bottom_right(size.getX(), 0.0, 0.0);
+    AssertPointEquals(mat * m_bottom_left, 2.0, 2.0);
+    AssertPointEquals(mat * m_top_left, 2.0, 0.0);
+    AssertPointEquals(mat * m_top_right, 0.0, 0.0);
+    AssertPointEquals(mat * m_bottom_right, 0.0, 2.0);
 
-    Vector4 bottom_left_result;
-    Vector4 top_left_result;
-    Vector4 top_right_result;
-    Vector4 bottom_right_result;
-    Matrix4 mat;
+    // pivot = north west, rotation = -180
+    mat = dmGameSystem::CompLabelLocalTransform(Point3(-1.0, -2.0, 0.0), m_rotation, m_scale, m_size, 8);
 
-    Quat rotation = dmVMath::EulerToQuat(Vector3(0, 0, -180));
-    rotation = normalize(rotation);
-
-    // pivot = center
-    mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), rotation, scale, size, 0);
-
-    bottom_left_result = mat * bottom_left;
-    EXPECT_NEAR(bottom_left_result.getX(), 2.0, TEST_EPS);
-    EXPECT_NEAR(bottom_left_result.getY(), 2.0, TEST_EPS);
-
-    top_left_result = mat * top_left;
-    EXPECT_NEAR(top_left_result.getX(), 2.0, TEST_EPS);
-    EXPECT_NEAR(top_left_result.getY(), 0.0, TEST_EPS);
-
-    top_right_result = mat * top_right;
-    EXPECT_NEAR(top_right_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(top_right_result.getY(), 0.0, TEST_EPS);
-
-    bottom_right_result = mat * bottom_right;
-    EXPECT_NEAR(bottom_right_result.getX(), 0.0, TEST_EPS);
-    EXPECT_NEAR(bottom_right_result.getY(), 2.0, TEST_EPS);
-
-    // pivot = north west
-    mat = dmGameSystem::CompLabelLocalTransform(Point3(-1.0, -2.0, 0.0), rotation, scale, size, 8);
-
-    bottom_left_result = mat * bottom_left;
-    EXPECT_NEAR(bottom_left_result.getX(), -1.0, TEST_EPS);
-    EXPECT_NEAR(bottom_left_result.getY(), 0.0, TEST_EPS);
-
-    top_left_result = mat * top_left;
-    EXPECT_NEAR(top_left_result.getX(), -1.0, TEST_EPS);
-    EXPECT_NEAR(top_left_result.getY(), -2.0, TEST_EPS);
-
-    top_right_result = mat * top_right;
-    EXPECT_NEAR(top_right_result.getX(), -3.0, TEST_EPS);
-    EXPECT_NEAR(top_right_result.getY(), -2.0, TEST_EPS);
-
-    bottom_right_result = mat * bottom_right;
-    EXPECT_NEAR(bottom_right_result.getX(), -3.0, TEST_EPS);
-    EXPECT_NEAR(bottom_right_result.getY(), 0.0, TEST_EPS);
+    AssertPointEquals(mat * m_bottom_left, -1.0, 0.0);
+    AssertPointEquals(mat * m_top_left, -1.0, -2.0);
+    AssertPointEquals(mat * m_top_right, -3.0, -2.0);
+    AssertPointEquals(mat * m_bottom_right, -3.0, 0.0);
 }
 
 const char* valid_label_resources[] = {"/label/valid.labelc"};

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1734,7 +1734,7 @@ TEST(Label, LabelRotatesAroundPivot) {
     EXPECT_NEAR(bottom_right_result.getY(), 2.0, TEST_EPS);
 
     // pivot = north west
-    mat = dmGameSystem::CompLabelLocalTransform(Point3(-2.0, -1.0, 0.0), rotation, scale, size, 0);
+    mat = dmGameSystem::CompLabelLocalTransform(Point3(-1.0, -2.0, 0.0), rotation, scale, size, 8);
 
     bottom_left_result = mat * bottom_left;
     EXPECT_NEAR(bottom_left_result.getX(), -1.0, TEST_EPS);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -27,6 +27,7 @@
 #include <gameobject/gameobject_ddf.h>
 #include "../proto/gamesys_ddf.h"
 #include "../proto/sprite_ddf.h"
+#include "../components/comp_label.h"
 
 namespace dmGameSystem
 {
@@ -1583,6 +1584,174 @@ const char* valid_spine_gos[] = {"/spine/valid_spine.goc"};
 INSTANTIATE_TEST_CASE_P(SpineModel, ComponentTest, jc_test_values_in(valid_spine_gos));
 
 /* Label */
+
+const float TEST_EPS = 0.00001;
+
+TEST(Label, LabelMovesWhenSwitchingPivot) {
+    Point3 position(0.0, 0.0, 0.0);
+    Vector3 size(2.0, 2.0, 0.0);
+    Vector3 scale(1.0, 1.0, 0.0);
+
+    Point3 bottom_left(0.0, 0.0, 0.0);
+    Point3 top_left(0.0, size.getY(), 0.0);
+    Point3 top_right(size.getX(), size.getY(), 0.0);
+    Point3 bottom_right(size.getX(), 0.0, 0.0);
+
+    Vector4 bottom_left_result;
+    Vector4 top_left_result;
+    Vector4 top_right_result;
+    Vector4 bottom_right_result;
+    Matrix4 mat;
+
+    // pivot = center
+    mat = dmGameSystem::CompLabelLocalTransform(position, Quat::identity(), scale, size, 0);
+
+    bottom_left_result = mat * bottom_left;
+    EXPECT_NEAR(bottom_left_result.getX(), -1.0, TEST_EPS);
+    EXPECT_NEAR(bottom_left_result.getY(), -1.0, TEST_EPS);
+
+    top_left_result = mat * top_left;
+    EXPECT_NEAR(top_left_result.getX(), -1.0, TEST_EPS);
+    EXPECT_NEAR(top_left_result.getY(), 1.0, TEST_EPS);
+
+    top_right_result = mat * top_right;
+    EXPECT_NEAR(top_right_result.getX(), 1.0, TEST_EPS);
+    EXPECT_NEAR(top_right_result.getY(), 1.0, TEST_EPS);
+
+    bottom_right_result = mat * bottom_right;
+    EXPECT_NEAR(bottom_right_result.getX(), 1.0, TEST_EPS);
+    EXPECT_NEAR(bottom_right_result.getY(), -1.0, TEST_EPS);
+
+    // pivot = north east
+    mat = dmGameSystem::CompLabelLocalTransform(position, Quat::identity(), scale, size, 2);
+
+    bottom_left_result = mat * bottom_left;
+    EXPECT_NEAR(bottom_left_result.getX(), -2.0, TEST_EPS);
+    EXPECT_NEAR(bottom_left_result.getY(), -2.0, TEST_EPS);
+
+    top_left_result = mat * top_left;
+    EXPECT_NEAR(top_left_result.getX(), -2.0, TEST_EPS);
+    EXPECT_NEAR(top_left_result.getY(), 0.0, TEST_EPS);
+
+    top_right_result = mat * top_right;
+    EXPECT_NEAR(top_right_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(top_right_result.getY(), 0.0, TEST_EPS);
+
+    bottom_right_result = mat * bottom_right;
+    EXPECT_NEAR(bottom_right_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(bottom_right_result.getY(), -2.0, TEST_EPS);
+
+    // pivot = west
+    mat = dmGameSystem::CompLabelLocalTransform(position, Quat::identity(), scale, size, 7);
+
+    bottom_left_result = mat * bottom_left;
+    EXPECT_NEAR(bottom_left_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(bottom_left_result.getY(), -1.0, TEST_EPS);
+
+    top_left_result = mat * top_left;
+    EXPECT_NEAR(top_left_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(top_left_result.getY(), 1.0, TEST_EPS);
+
+    top_right_result = mat * top_right;
+    EXPECT_NEAR(top_right_result.getX(), 2.0, TEST_EPS);
+    EXPECT_NEAR(top_right_result.getY(), 1.0, TEST_EPS);
+
+    bottom_right_result = mat * bottom_right;
+    EXPECT_NEAR(bottom_right_result.getX(), 2.0, TEST_EPS);
+    EXPECT_NEAR(bottom_right_result.getY(), -1.0, TEST_EPS);
+}
+
+TEST(Label, LabelMovesWhenChangingPosition) {
+    Vector3 size(2.0, 2.0, 0.0);
+    Vector3 scale(1.0, 1.0, 0.0);
+
+    Point3 bottom_left(0.0, 0.0, 0.0);
+    Point3 top_left(0.0, size.getY(), 0.0);
+    Point3 top_right(size.getX(), size.getY(), 0.0);
+    Point3 bottom_right(size.getX(), 0.0, 0.0);
+
+    Vector4 bottom_left_result;
+    Vector4 top_left_result;
+    Vector4 top_right_result;
+    Vector4 bottom_right_result;
+    Matrix4 mat;
+
+    // pivot = center
+    mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), Quat::identity(), scale, size, 0);
+
+    bottom_left_result = mat * bottom_left;
+    EXPECT_NEAR(bottom_left_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(bottom_left_result.getY(), 0.0, TEST_EPS);
+
+    top_left_result = mat * top_left;
+    EXPECT_NEAR(top_left_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(top_left_result.getY(), 2.0, TEST_EPS);
+
+    top_right_result = mat * top_right;
+    EXPECT_NEAR(top_right_result.getX(), 2.0, TEST_EPS);
+    EXPECT_NEAR(top_right_result.getY(), 2.0, TEST_EPS);
+
+    bottom_right_result = mat * bottom_right;
+    EXPECT_NEAR(bottom_right_result.getX(), 2.0, TEST_EPS);
+    EXPECT_NEAR(bottom_right_result.getY(), 0.0, TEST_EPS);
+}
+
+TEST(Label, LabelRotatesAroundPivot) {
+    Vector3 size(2.0, 2.0, 0.0);
+    Vector3 scale(1.0, 1.0, 0.0);
+
+    Point3 bottom_left(0.0, 0.0, 0.0);
+    Point3 top_left(0.0, size.getY(), 0.0);
+    Point3 top_right(size.getX(), size.getY(), 0.0);
+    Point3 bottom_right(size.getX(), 0.0, 0.0);
+
+    Vector4 bottom_left_result;
+    Vector4 top_left_result;
+    Vector4 top_right_result;
+    Vector4 bottom_right_result;
+    Matrix4 mat;
+
+    Quat rotation = dmVMath::EulerToQuat(Vector3(0, 0, -180));
+    rotation = normalize(rotation);
+
+    // pivot = center
+    mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), rotation, scale, size, 0);
+
+    bottom_left_result = mat * bottom_left;
+    EXPECT_NEAR(bottom_left_result.getX(), 2.0, TEST_EPS);
+    EXPECT_NEAR(bottom_left_result.getY(), 2.0, TEST_EPS);
+
+    top_left_result = mat * top_left;
+    EXPECT_NEAR(top_left_result.getX(), 2.0, TEST_EPS);
+    EXPECT_NEAR(top_left_result.getY(), 0.0, TEST_EPS);
+
+    top_right_result = mat * top_right;
+    EXPECT_NEAR(top_right_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(top_right_result.getY(), 0.0, TEST_EPS);
+
+    bottom_right_result = mat * bottom_right;
+    EXPECT_NEAR(bottom_right_result.getX(), 0.0, TEST_EPS);
+    EXPECT_NEAR(bottom_right_result.getY(), 2.0, TEST_EPS);
+
+    // pivot = north west
+    mat = dmGameSystem::CompLabelLocalTransform(Point3(-2.0, -1.0, 0.0), rotation, scale, size, 0);
+
+    bottom_left_result = mat * bottom_left;
+    EXPECT_NEAR(bottom_left_result.getX(), -1.0, TEST_EPS);
+    EXPECT_NEAR(bottom_left_result.getY(), 0.0, TEST_EPS);
+
+    top_left_result = mat * top_left;
+    EXPECT_NEAR(top_left_result.getX(), -1.0, TEST_EPS);
+    EXPECT_NEAR(top_left_result.getY(), -2.0, TEST_EPS);
+
+    top_right_result = mat * top_right;
+    EXPECT_NEAR(top_right_result.getX(), -3.0, TEST_EPS);
+    EXPECT_NEAR(top_right_result.getY(), -2.0, TEST_EPS);
+
+    bottom_right_result = mat * bottom_right;
+    EXPECT_NEAR(bottom_right_result.getX(), -3.0, TEST_EPS);
+    EXPECT_NEAR(bottom_right_result.getY(), 0.0, TEST_EPS);
+}
 
 const char* valid_label_resources[] = {"/label/valid.labelc"};
 INSTANTIATE_TEST_CASE_P(Label, ResourceTest, jc_test_values_in(valid_label_resources));

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1595,56 +1595,56 @@ void AssertPointEquals(const Vector4& p, float x, float y)
 TEST_F(LabelTest, LabelMovesWhenSwitchingPivot) 
 {
     // pivot = center
-    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(m_position, Quat::identity(), m_scale, m_size, 0);
+    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(m_Position, Quat::identity(), m_Scale, m_Size, 0);
 
-    AssertPointEquals(mat * m_bottom_left, -1.0, -1.0);
-    AssertPointEquals(mat * m_top_left, -1.0, 1.0);
-    AssertPointEquals(mat * m_top_right, 1.0, 1.0);
-    AssertPointEquals(mat * m_bottom_right, 1.0, -1.0);
+    AssertPointEquals(mat * m_BottomLeft, -1.0, -1.0);
+    AssertPointEquals(mat * m_TopLeft, -1.0, 1.0);
+    AssertPointEquals(mat * m_TopRight, 1.0, 1.0);
+    AssertPointEquals(mat * m_BottomRight, 1.0, -1.0);
 
     // pivot = north east
-    mat = dmGameSystem::CompLabelLocalTransform(m_position, Quat::identity(), m_scale, m_size, 2);
+    mat = dmGameSystem::CompLabelLocalTransform(m_Position, Quat::identity(), m_Scale, m_Size, 2);
 
-    AssertPointEquals(mat * m_bottom_left, -2.0, -2.0);
-    AssertPointEquals(mat * m_top_left, -2.0, 0.0);
-    AssertPointEquals(mat * m_top_right, 0.0, 0.0);
-    AssertPointEquals(mat * m_bottom_right, 0.0, -2.0);
+    AssertPointEquals(mat * m_BottomLeft, -2.0, -2.0);
+    AssertPointEquals(mat * m_TopLeft, -2.0, 0.0);
+    AssertPointEquals(mat * m_TopRight, 0.0, 0.0);
+    AssertPointEquals(mat * m_BottomRight, 0.0, -2.0);
 
     // pivot = west
-    mat = dmGameSystem::CompLabelLocalTransform(m_position, Quat::identity(), m_scale, m_size, 7);
+    mat = dmGameSystem::CompLabelLocalTransform(m_Position, Quat::identity(), m_Scale, m_Size, 7);
 
-    AssertPointEquals(mat * m_bottom_left, 0.0, -1.0);
-    AssertPointEquals(mat * m_top_left, 0.0, 1.0);
-    AssertPointEquals(mat * m_top_right, 2.0, 1.0);
-    AssertPointEquals(mat * m_bottom_right, 2.0, -1.0);
+    AssertPointEquals(mat * m_BottomLeft, 0.0, -1.0);
+    AssertPointEquals(mat * m_TopLeft, 0.0, 1.0);
+    AssertPointEquals(mat * m_TopRight, 2.0, 1.0);
+    AssertPointEquals(mat * m_BottomRight, 2.0, -1.0);
 }
 
 TEST_F(LabelTest, LabelMovesWhenChangingPosition) {
     // pivot = center
-    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), Quat::identity(), m_scale, m_size, 0);
+    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), Quat::identity(), m_Scale, m_Size, 0);
 
-    AssertPointEquals(mat * m_bottom_left, 0.0, 0.0);
-    AssertPointEquals(mat * m_top_left, 0.0, 2.0);
-    AssertPointEquals(mat * m_top_right, 2.0, 2.0);
-    AssertPointEquals(mat * m_bottom_right, 2.0, 0.0);
+    AssertPointEquals(mat * m_BottomLeft, 0.0, 0.0);
+    AssertPointEquals(mat * m_TopLeft, 0.0, 2.0);
+    AssertPointEquals(mat * m_TopRight, 2.0, 2.0);
+    AssertPointEquals(mat * m_BottomRight, 2.0, 0.0);
 }
 
 TEST_F(LabelTest, LabelRotatesAroundPivot) {
     // pivot = center, rotation = -180
-    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), m_rotation, m_scale, m_size, 0);
+    Matrix4 mat = dmGameSystem::CompLabelLocalTransform(Point3(1.0, 1.0, 1.0), m_Rotation, m_Scale, m_Size, 0);
 
-    AssertPointEquals(mat * m_bottom_left, 2.0, 2.0);
-    AssertPointEquals(mat * m_top_left, 2.0, 0.0);
-    AssertPointEquals(mat * m_top_right, 0.0, 0.0);
-    AssertPointEquals(mat * m_bottom_right, 0.0, 2.0);
+    AssertPointEquals(mat * m_BottomLeft, 2.0, 2.0);
+    AssertPointEquals(mat * m_TopLeft, 2.0, 0.0);
+    AssertPointEquals(mat * m_TopRight, 0.0, 0.0);
+    AssertPointEquals(mat * m_BottomRight, 0.0, 2.0);
 
     // pivot = north west, rotation = -180
-    mat = dmGameSystem::CompLabelLocalTransform(Point3(-1.0, -2.0, 0.0), m_rotation, m_scale, m_size, 8);
+    mat = dmGameSystem::CompLabelLocalTransform(Point3(-1.0, -2.0, 0.0), m_Rotation, m_Scale, m_Size, 8);
 
-    AssertPointEquals(mat * m_bottom_left, -1.0, 0.0);
-    AssertPointEquals(mat * m_top_left, -1.0, -2.0);
-    AssertPointEquals(mat * m_top_right, -3.0, -2.0);
-    AssertPointEquals(mat * m_bottom_right, -3.0, 0.0);
+    AssertPointEquals(mat * m_BottomLeft, -1.0, 0.0);
+    AssertPointEquals(mat * m_TopLeft, -1.0, -2.0);
+    AssertPointEquals(mat * m_TopRight, -3.0, -2.0);
+    AssertPointEquals(mat * m_BottomRight, -3.0, 0.0);
 }
 
 const char* valid_label_resources[] = {"/label/valid.labelc"};

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -436,3 +436,30 @@ protected:
     lua_State* L;
     dmBuffer::HBuffer m_Buffer;
 };
+
+class LabelTest : public jc_test_base_class {
+protected:
+    void SetUp() 
+    {
+        m_position = Point3(0.0);
+        m_size = Vector3(2.0, 2.0, 0.0);
+        m_scale = Vector3(1.0, 1.0, 0.0);
+
+        m_bottom_left = Point3(0.0, 0.0, 0.0);
+        m_top_left = Point3(0.0, m_size.getY(), 0.0);
+        m_top_right = Point3(m_size.getX(), m_size.getY(), 0.0);
+        m_bottom_right = Point3(m_size.getX(), 0.0, 0.0);
+
+        m_rotation = dmVMath::EulerToQuat(Vector3(0, 0, -180));
+        m_rotation = normalize(m_rotation);
+    }
+
+    Vectormath::Aos::Quat m_rotation;
+    Vectormath::Aos::Point3 m_position;
+    Vectormath::Aos::Point3 m_bottom_left;
+    Vectormath::Aos::Point3 m_top_left;
+    Vectormath::Aos::Point3 m_top_right;
+    Vectormath::Aos::Point3 m_bottom_right;
+    Vectormath::Aos::Vector3 m_size;
+    Vectormath::Aos::Vector3 m_scale;
+};

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -437,29 +437,30 @@ protected:
     dmBuffer::HBuffer m_Buffer;
 };
 
-class LabelTest : public jc_test_base_class {
+class LabelTest : public jc_test_base_class 
+{
 protected:
-    void SetUp() 
+    virtual void SetUp()
     {
-        m_position = Point3(0.0);
-        m_size = Vector3(2.0, 2.0, 0.0);
-        m_scale = Vector3(1.0, 1.0, 0.0);
+        m_Position = Vectormath::Aos::Point3(0.0);
+        m_Size = Vectormath::Aos::Vector3(2.0, 2.0, 0.0);
+        m_Scale = Vectormath::Aos::Vector3(1.0, 1.0, 0.0);
 
-        m_bottom_left = Point3(0.0, 0.0, 0.0);
-        m_top_left = Point3(0.0, m_size.getY(), 0.0);
-        m_top_right = Point3(m_size.getX(), m_size.getY(), 0.0);
-        m_bottom_right = Point3(m_size.getX(), 0.0, 0.0);
+        m_BottomLeft = Vectormath::Aos::Point3(0.0, 0.0, 0.0);
+        m_TopLeft = Vectormath::Aos::Point3(0.0, m_Size.getY(), 0.0);
+        m_TopRight = Vectormath::Aos::Point3(m_Size.getX(), m_Size.getY(), 0.0);
+        m_BottomRight = Vectormath::Aos::Point3(m_Size.getX(), 0.0, 0.0);
 
-        m_rotation = dmVMath::EulerToQuat(Vector3(0, 0, -180));
-        m_rotation = normalize(m_rotation);
+        m_Rotation = dmVMath::EulerToQuat(Vectormath::Aos::Vector3(0, 0, -180));
+        m_Rotation = normalize(m_Rotation);
     }
 
-    Vectormath::Aos::Quat m_rotation;
-    Vectormath::Aos::Point3 m_position;
-    Vectormath::Aos::Point3 m_bottom_left;
-    Vectormath::Aos::Point3 m_top_left;
-    Vectormath::Aos::Point3 m_top_right;
-    Vectormath::Aos::Point3 m_bottom_right;
-    Vectormath::Aos::Vector3 m_size;
-    Vectormath::Aos::Vector3 m_scale;
+    Vectormath::Aos::Quat m_Rotation;
+    Vectormath::Aos::Point3 m_Position;
+    Vectormath::Aos::Point3 m_BottomLeft;
+    Vectormath::Aos::Point3 m_TopLeft;
+    Vectormath::Aos::Point3 m_TopRight;
+    Vectormath::Aos::Point3 m_BottomRight;
+    Vectormath::Aos::Vector3 m_Size;
+    Vectormath::Aos::Vector3 m_Scale;
 };


### PR DESCRIPTION
**Issue**: #3315 
**Before**: label component was not rotating around the pivot point.
**After**: label is rotating correctly.

**Points for discussion**: I don't like code repetition in tests - I will try to refactor them, but suggestions are welcome. It seems that CompLabelLocalTransform function is not quite related to Label, and it should be renamed and moved to some utils place, if you have a good name and place for this function - please suggest. I also don't like how many parameters it takes - we can discuss possible improvements to this.
