### PR TITLE
Issue-4821 Respect texture compression option when bundling application

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -11,6 +11,7 @@
     [editor.resource :as resource]
     [editor.system :as system]
     [editor.ui :as ui]
+    [editor.prefs :as prefs]
     [editor.workspace :as workspace])
   (:import
     [com.dynamo.bob ClassLoaderScanner IProgress IResourceScanner Project TaskResult]
@@ -142,6 +143,7 @@
               (.isDirectory output-directory)))
   (assert (string? (not-empty platform)))
   (let [build-server-url (native-extensions/get-build-server-url prefs)
+        compress-textures? (prefs/get-prefs prefs "general-enable-texture-compression" false)
         build-report-path (.getAbsolutePath (io/file output-directory "report.html"))
         bundle-output-path (.getAbsolutePath output-directory)
         defold-sdk-sha1 (or (system/defold-engine-sha1) "")
@@ -152,8 +154,7 @@
              ;; From AbstractBundleHandler
              "archive" "true"
              "bundle-output" bundle-output-path
-             "texture-compression" "true"
-
+             "texture-compression" (if compress-textures? "true" "false")
              ;; From BundleGenericHandler
              "build-server" build-server-url
              "defoldsdk" defold-sdk-sha1


### PR DESCRIPTION
**Closes**: #4821 
**Before**: editor didn't pass texture compression option from preferences to bob
**After**: editor passes the option to bob

**Note**: This is the first time I see clojure, so this might be not the best way to solve this issue :(

**Tests**: 
I tested this by configuring logger in OSXBundler.java to write to files, and then logging texture compression option that gets to bob from the editor like this `logger.info("Texture compression: " + project.option("texture-compression", "default"));`.

Then I built editor, switched texture compression option in the editor, made sure it doesn't change in the log output.
Then I messed with clojure function mentioned in the issue and made sure changing texture compression option in the editor changes log output.

**Points for discussion**: If needed, I will add unit tests for this, but it might take some time :) 
