### PR TITLE
Revert Issue-4821 Respect texture compression option when bundling

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -11,7 +11,6 @@
     [editor.resource :as resource]
     [editor.system :as system]
     [editor.ui :as ui]
-    [editor.prefs :as prefs]
     [editor.workspace :as workspace])
   (:import
     [com.dynamo.bob ClassLoaderScanner IProgress IResourceScanner Project TaskResult]
@@ -143,7 +142,6 @@
               (.isDirectory output-directory)))
   (assert (string? (not-empty platform)))
   (let [build-server-url (native-extensions/get-build-server-url prefs)
-        compress-textures? (prefs/get-prefs prefs "general-enable-texture-compression" false)
         build-report-path (.getAbsolutePath (io/file output-directory "report.html"))
         bundle-output-path (.getAbsolutePath output-directory)
         defold-sdk-sha1 (or (system/defold-engine-sha1) "")
@@ -154,7 +152,7 @@
              ;; From AbstractBundleHandler
              "archive" "true"
              "bundle-output" bundle-output-path
-             "texture-compression" (if compress-textures? "true" "false")
+             "texture-compression" "true"
              ;; From BundleGenericHandler
              "build-server" build-server-url
              "defoldsdk" defold-sdk-sha1


### PR DESCRIPTION
This change led to unexpected behaviour. We should likely have separate settings for texture compression for builds in the editor vs. when bundling.