### PR TITLE
Issue-3181 Gui box with no texture assigned renders extra vertices

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1139,7 +1139,6 @@ namespace dmGameSystem
             // we skip sprite trimming on slice 9 nodes
             if (!use_slice_nine && use_geometries)
             {
-                dmLogWarning("Not a nine splice path.");
                 int32_t frame_index = dmGui::GetNodeAnimationFrame(scene, node);
                 frame_index = texture_set_ddf->m_FrameIndices[frame_index];
 
@@ -1187,9 +1186,41 @@ namespace dmGameSystem
                 continue;
             }
 
-            rendered_vert_count += verts_per_node;
+            const float* tc = dmGui::GetNodeFlipbookAnimUV(scene, node);
 
-            float us[4], vs[4], xs[4], ys[4];
+            // we skip sprite trimming on slice 9 nodes
+            if(!tc)
+            {
+                BoxVertex v00;
+                v00.SetColor(pm_color);
+                v00.SetPosition(node_transforms[i] * Vectormath::Aos::Point3(0, 0, 0));
+                v00.SetUV(0, 0);
+
+                BoxVertex v10;
+                v10.SetColor(pm_color);
+                v10.SetPosition(node_transforms[i] * Vectormath::Aos::Point3(0, 1, 0));
+                v10.SetUV(1, 0);
+
+                BoxVertex v01;
+                v01.SetColor(pm_color);
+                v01.SetPosition(node_transforms[i] * Vectormath::Aos::Point3(1, 0, 0));
+                v01.SetUV(0, 1);
+
+                BoxVertex v11;
+                v11.SetColor(pm_color);
+                v11.SetPosition(node_transforms[i] * Vectormath::Aos::Point3(1, 1, 0));
+                v11.SetUV(1, 1);
+
+                gui_world->m_ClientVertexBuffer.Push(v00);
+                gui_world->m_ClientVertexBuffer.Push(v10);
+                gui_world->m_ClientVertexBuffer.Push(v11);
+                gui_world->m_ClientVertexBuffer.Push(v00);
+                gui_world->m_ClientVertexBuffer.Push(v11);
+                gui_world->m_ClientVertexBuffer.Push(v01);
+
+                rendered_vert_count += 6;
+                continue;
+            }
 
             //   0 1     2 3
             // 0 *-*-----*-*
@@ -1203,151 +1234,107 @@ namespace dmGameSystem
             // 3 *-*-----*-*
 
             // v are '1-v'
+            float us[4], vs[4], xs[4], ys[4];
             xs[0] = ys[0] = 0;
             xs[3] = ys[3] = 1;
 
-            const float* tc = dmGui::GetNodeFlipbookAnimUV(scene, node);
-            if(tc)
+            // disable slice9 computation below a certain dimension
+            // (avoid div by zero)
+            const float s9_min_dim = 0.001f;
+
+            const float su = 1.0f / org_width;
+            const float sv = 1.0f / org_height;
+            const float sx = size.getX() > s9_min_dim ? 1.0f / size.getX() : 0;
+            const float sy = size.getY() > s9_min_dim ? 1.0f / size.getY() : 0;
+
+            static const uint32_t uvIndex[2][4] = {{0,1,2,3}, {3,2,1,0}};
+            bool uv_rotated = tc[0] != tc[2] && tc[3] != tc[5];
+            bool flip_u, flip_v;
+            GetNodeFlipbookAnimUVFlip(scene, node, flip_u, flip_v);
+            if(uv_rotated)
             {
-                //has animation
-                dmLogWarning("Texture coordinates path.");
-
-                // disable slice9 computation below a certain dimension
-                // (avoid div by zero)
-                const float s9_min_dim = 0.001f;
-
-                const float su = 1.0f / org_width;
-                const float sv = 1.0f / org_height;
-                const float sx = size.getX() > s9_min_dim ? 1.0f / size.getX() : 0;
-                const float sy = size.getY() > s9_min_dim ? 1.0f / size.getY() : 0;
-
-                static const uint32_t uvIndex[2][4] = {{0,1,2,3}, {3,2,1,0}};
-                bool uv_rotated = tc[0] != tc[2] && tc[3] != tc[5];
-                bool flip_u, flip_v;
-                GetNodeFlipbookAnimUVFlip(scene, node, flip_u, flip_v);
-                if(uv_rotated)
-                {
-                    const uint32_t *uI = flip_v ? uvIndex[1] : uvIndex[0];
-                    const uint32_t *vI = flip_u ? uvIndex[1] : uvIndex[0];
-                    us[uI[0]] = tc[0];
-                    us[uI[1]] = tc[0] + (su * slice9.getW());
-                    us[uI[2]] = tc[2] - (su * slice9.getY());
-                    us[uI[3]] = tc[2];
-                    vs[vI[0]] = tc[1];
-                    vs[vI[1]] = tc[1] - (sv * slice9.getX());
-                    vs[vI[2]] = tc[5] + (sv * slice9.getZ());
-                    vs[vI[3]] = tc[5];
-                }
-                else
-                {
-                    const uint32_t *uI = flip_u ? uvIndex[1] : uvIndex[0];
-                    const uint32_t *vI = flip_v ? uvIndex[1] : uvIndex[0];
-                    us[uI[0]] = tc[0];
-                    us[uI[1]] = tc[0] + (su * slice9.getX());
-                    us[uI[2]] = tc[4] - (su * slice9.getZ());
-                    us[uI[3]] = tc[4];
-                    vs[vI[0]] = tc[1];
-                    vs[vI[1]] = tc[1] + (sv * slice9.getW());
-                    vs[vI[2]] = tc[3] - (sv * slice9.getY());
-                    vs[vI[3]] = tc[3];
-                }
-
-                xs[1] = sx * slice9.getX();
-                xs[2] = 1 - sx * slice9.getZ();
-                ys[1] = sy * slice9.getW();
-                ys[2] = 1 - sy * slice9.getY();
-
-                const Matrix4* transform = &node_transforms[i];
-                Vectormath::Aos::Vector4 pts[4][4];
-                for (int y=0;y<4;y++)
-                {
-                    for (int x=0;x<4;x++)
-                    {
-                        pts[y][x] = (*transform * Vectormath::Aos::Point3(xs[x], ys[y], 0));
-                    }
-                }
-
-                BoxVertex v00, v10, v01, v11;
-                v00.SetColor(pm_color);
-                v10.SetColor(pm_color);
-                v01.SetColor(pm_color);
-                v11.SetColor(pm_color);
-
-                for (int y=0;y<3;y++)
-                {
-                    for (int x=0;x<3;x++)
-                    {
-                        const int x0 = x;
-                        const int x1 = x+1;
-                        const int y0 = y;
-                        const int y1 = y+1;
-                        v00.SetPosition(pts[y0][x0]);
-                        v10.SetPosition(pts[y0][x1]);
-                        v01.SetPosition(pts[y1][x0]);
-                        v11.SetPosition(pts[y1][x1]);
-                        if(uv_rotated)
-                        {
-                            v00.SetUV(us[y0], vs[x0]);
-                            v10.SetUV(us[y0], vs[x1]);
-                            v01.SetUV(us[y1], vs[x0]);
-                            v11.SetUV(us[y1], vs[x1]);
-                        }
-                        else
-                        {
-                            v00.SetUV(us[x0], vs[y0]);
-                            v10.SetUV(us[x1], vs[y0]);
-                            v01.SetUV(us[x0], vs[y1]);
-                            v11.SetUV(us[x1], vs[y1]);
-                        }
-                        gui_world->m_ClientVertexBuffer.Push(v00);
-                        gui_world->m_ClientVertexBuffer.Push(v10);
-                        gui_world->m_ClientVertexBuffer.Push(v11);
-                        gui_world->m_ClientVertexBuffer.Push(v00);
-                        gui_world->m_ClientVertexBuffer.Push(v11);
-                        gui_world->m_ClientVertexBuffer.Push(v01);
-                    }
-                }
+                const uint32_t *uI = flip_v ? uvIndex[1] : uvIndex[0];
+                const uint32_t *vI = flip_u ? uvIndex[1] : uvIndex[0];
+                us[uI[0]] = tc[0];
+                us[uI[1]] = tc[0] + (su * slice9.getW());
+                us[uI[2]] = tc[2] - (su * slice9.getY());
+                us[uI[3]] = tc[2];
+                vs[vI[0]] = tc[1];
+                vs[vI[1]] = tc[1] - (sv * slice9.getX());
+                vs[vI[2]] = tc[5] + (sv * slice9.getZ());
+                vs[vI[3]] = tc[5];
             }
             else
             {
-                dmLogWarning("Empty path.");
-
-                us[0] = 0;
-                us[3] = 1;
-                vs[0] = 0;
-                vs[3] = 1;
-
-                Vectormath::Aos::Vector4 pts[4][4];
-                const Matrix4* transform = &node_transforms[i];
-
-                pts[0][0] = (*transform * Vectormath::Aos::Point3(xs[0], ys[0], 0));
-                pts[0][3] = (*transform * Vectormath::Aos::Point3(xs[0], ys[3], 0));
-                pts[3][0] = (*transform * Vectormath::Aos::Point3(xs[3], ys[0], 0));
-                pts[3][3] = (*transform * Vectormath::Aos::Point3(xs[3], ys[3], 0));
-
-                BoxVertex v00, v10, v01, v11;
-                v00.SetColor(pm_color);
-                v10.SetColor(pm_color);
-                v01.SetColor(pm_color);
-                v11.SetColor(pm_color);
-
-                v00.SetPosition(pts[0][0]);
-                v10.SetPosition(pts[0][3]);
-                v01.SetPosition(pts[3][0]);
-                v11.SetPosition(pts[3][3]);
-
-                v00.SetUV(us[0], vs[0]);
-                v10.SetUV(us[3], vs[0]);
-                v01.SetUV(us[0], vs[3]);
-                v11.SetUV(us[3], vs[3]);
-
-                gui_world->m_ClientVertexBuffer.Push(v00);
-                gui_world->m_ClientVertexBuffer.Push(v10);
-                gui_world->m_ClientVertexBuffer.Push(v11);
-                gui_world->m_ClientVertexBuffer.Push(v00);
-                gui_world->m_ClientVertexBuffer.Push(v11);
-                gui_world->m_ClientVertexBuffer.Push(v01);
+                const uint32_t *uI = flip_u ? uvIndex[1] : uvIndex[0];
+                const uint32_t *vI = flip_v ? uvIndex[1] : uvIndex[0];
+                us[uI[0]] = tc[0];
+                us[uI[1]] = tc[0] + (su * slice9.getX());
+                us[uI[2]] = tc[4] - (su * slice9.getZ());
+                us[uI[3]] = tc[4];
+                vs[vI[0]] = tc[1];
+                vs[vI[1]] = tc[1] + (sv * slice9.getW());
+                vs[vI[2]] = tc[3] - (sv * slice9.getY());
+                vs[vI[3]] = tc[3];
             }
+
+            xs[1] = sx * slice9.getX();
+            xs[2] = 1 - sx * slice9.getZ();
+            ys[1] = sy * slice9.getW();
+            ys[2] = 1 - sy * slice9.getY();
+
+            const Matrix4* transform = &node_transforms[i];
+            Vectormath::Aos::Vector4 pts[4][4];
+            for (int y=0;y<4;y++)
+            {
+                for (int x=0;x<4;x++)
+                {
+                    pts[y][x] = (*transform * Vectormath::Aos::Point3(xs[x], ys[y], 0));
+                }
+            }
+
+            BoxVertex v00, v10, v01, v11;
+            v00.SetColor(pm_color);
+            v10.SetColor(pm_color);
+            v01.SetColor(pm_color);
+            v11.SetColor(pm_color);
+
+            for (int y=0;y<3;y++)
+            {
+                for (int x=0;x<3;x++)
+                {
+                    const int x0 = x;
+                    const int x1 = x+1;
+                    const int y0 = y;
+                    const int y1 = y+1;
+                    v00.SetPosition(pts[y0][x0]);
+                    v10.SetPosition(pts[y0][x1]);
+                    v01.SetPosition(pts[y1][x0]);
+                    v11.SetPosition(pts[y1][x1]);
+                    if(uv_rotated)
+                    {
+                        v00.SetUV(us[y0], vs[x0]);
+                        v10.SetUV(us[y0], vs[x1]);
+                        v01.SetUV(us[y1], vs[x0]);
+                        v11.SetUV(us[y1], vs[x1]);
+                    }
+                    else
+                    {
+                        v00.SetUV(us[x0], vs[y0]);
+                        v10.SetUV(us[x1], vs[y0]);
+                        v01.SetUV(us[x0], vs[y1]);
+                        v11.SetUV(us[x1], vs[y1]);
+                    }
+                    gui_world->m_ClientVertexBuffer.Push(v00);
+                    gui_world->m_ClientVertexBuffer.Push(v10);
+                    gui_world->m_ClientVertexBuffer.Push(v11);
+                    gui_world->m_ClientVertexBuffer.Push(v00);
+                    gui_world->m_ClientVertexBuffer.Push(v11);
+                    gui_world->m_ClientVertexBuffer.Push(v01);
+                }
+            }
+
+            rendered_vert_count += verts_per_node;
         }
         ro.m_VertexCount = rendered_vert_count;
     }
@@ -1689,7 +1676,7 @@ namespace dmGameSystem
                                         gui_world->m_ClientVertexBuffer.Size() * sizeof(BoxVertex),
                                         gui_world->m_ClientVertexBuffer.Begin(),
                                         dmGraphics::BUFFER_USAGE_STREAM_DRAW);
-        DM_COUNTER("GUI.VertexCount", gui_world->m_ClientVertexBuffer.Size());
+        DM_COUNTER("Gui.VertexCount", gui_world->m_ClientVertexBuffer.Size());
     }
 
     static dmGraphics::TextureFormat ToGraphicsFormat(dmImage::Type type) {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1232,9 +1232,9 @@ namespace dmGameSystem
             // 2 *-*-----*-*
             //   | |  w  | |
             // 3 *-*-----*-*
+            float us[4], vs[4], xs[4], ys[4];
 
             // v are '1-v'
-            float us[4], vs[4], xs[4], ys[4];
             xs[0] = ys[0] = 0;
             xs[3] = ys[3] = 1;
 
@@ -1298,7 +1298,6 @@ namespace dmGameSystem
             v10.SetColor(pm_color);
             v01.SetColor(pm_color);
             v11.SetColor(pm_color);
-
             for (int y=0;y<3;y++)
             {
                 for (int x=0;x<3;x++)

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1139,6 +1139,7 @@ namespace dmGameSystem
             // we skip sprite trimming on slice 9 nodes
             if (!use_slice_nine && use_geometries)
             {
+                dmLogWarning("Not a nine splice path.");
                 int32_t frame_index = dmGui::GetNodeAnimationFrame(scene, node);
                 frame_index = texture_set_ddf->m_FrameIndices[frame_index];
 
@@ -1188,21 +1189,12 @@ namespace dmGameSystem
 
             rendered_vert_count += verts_per_node;
 
-            // disable slice9 computation below a certain dimension
-            // (avoid div by zero)
-            const float s9_min_dim = 0.001f;
-
-            const float su = 1.0f / org_width;
-            const float sv = 1.0f / org_height;
-            const float sx = size.getX() > s9_min_dim ? 1.0f / size.getX() : 0;
-            const float sy = size.getY() > s9_min_dim ? 1.0f / size.getY() : 0;
-
             float us[4], vs[4], xs[4], ys[4];
 
-            //   0  1      2  3
+            //   0 1     2 3
             // 0 *-*-----*-*
             //   | |  y  | |
-            // 1 *--*----*-*
+            // 1 *-*-----*-*
             //   | |     | |
             //   |x|     |z|
             //   | |     | |
@@ -1213,12 +1205,24 @@ namespace dmGameSystem
             // v are '1-v'
             xs[0] = ys[0] = 0;
             xs[3] = ys[3] = 1;
-            bool uv_rotated;
+
             const float* tc = dmGui::GetNodeFlipbookAnimUV(scene, node);
             if(tc)
             {
+                //has animation
+                dmLogWarning("Texture coordinates path.");
+
+                // disable slice9 computation below a certain dimension
+                // (avoid div by zero)
+                const float s9_min_dim = 0.001f;
+
+                const float su = 1.0f / org_width;
+                const float sv = 1.0f / org_height;
+                const float sx = size.getX() > s9_min_dim ? 1.0f / size.getX() : 0;
+                const float sy = size.getY() > s9_min_dim ? 1.0f / size.getY() : 0;
+
                 static const uint32_t uvIndex[2][4] = {{0,1,2,3}, {3,2,1,0}};
-                uv_rotated = tc[0] != tc[2] && tc[3] != tc[5];
+                bool uv_rotated = tc[0] != tc[2] && tc[3] != tc[5];
                 bool flip_u, flip_v;
                 GetNodeFlipbookAnimUVFlip(scene, node, flip_u, flip_v);
                 if(uv_rotated)
@@ -1247,73 +1251,102 @@ namespace dmGameSystem
                     vs[vI[2]] = tc[3] - (sv * slice9.getY());
                     vs[vI[3]] = tc[3];
                 }
+
+                xs[1] = sx * slice9.getX();
+                xs[2] = 1 - sx * slice9.getZ();
+                ys[1] = sy * slice9.getW();
+                ys[2] = 1 - sy * slice9.getY();
+
+                const Matrix4* transform = &node_transforms[i];
+                Vectormath::Aos::Vector4 pts[4][4];
+                for (int y=0;y<4;y++)
+                {
+                    for (int x=0;x<4;x++)
+                    {
+                        pts[y][x] = (*transform * Vectormath::Aos::Point3(xs[x], ys[y], 0));
+                    }
+                }
+
+                BoxVertex v00, v10, v01, v11;
+                v00.SetColor(pm_color);
+                v10.SetColor(pm_color);
+                v01.SetColor(pm_color);
+                v11.SetColor(pm_color);
+
+                for (int y=0;y<3;y++)
+                {
+                    for (int x=0;x<3;x++)
+                    {
+                        const int x0 = x;
+                        const int x1 = x+1;
+                        const int y0 = y;
+                        const int y1 = y+1;
+                        v00.SetPosition(pts[y0][x0]);
+                        v10.SetPosition(pts[y0][x1]);
+                        v01.SetPosition(pts[y1][x0]);
+                        v11.SetPosition(pts[y1][x1]);
+                        if(uv_rotated)
+                        {
+                            v00.SetUV(us[y0], vs[x0]);
+                            v10.SetUV(us[y0], vs[x1]);
+                            v01.SetUV(us[y1], vs[x0]);
+                            v11.SetUV(us[y1], vs[x1]);
+                        }
+                        else
+                        {
+                            v00.SetUV(us[x0], vs[y0]);
+                            v10.SetUV(us[x1], vs[y0]);
+                            v01.SetUV(us[x0], vs[y1]);
+                            v11.SetUV(us[x1], vs[y1]);
+                        }
+                        gui_world->m_ClientVertexBuffer.Push(v00);
+                        gui_world->m_ClientVertexBuffer.Push(v10);
+                        gui_world->m_ClientVertexBuffer.Push(v11);
+                        gui_world->m_ClientVertexBuffer.Push(v00);
+                        gui_world->m_ClientVertexBuffer.Push(v11);
+                        gui_world->m_ClientVertexBuffer.Push(v01);
+                    }
+                }
             }
             else
             {
-                uv_rotated = false;
+                dmLogWarning("Empty path.");
+
                 us[0] = 0;
-                us[1] = su * slice9.getX();
-                us[2] = 1 - su * slice9.getZ();
                 us[3] = 1;
                 vs[0] = 0;
-                vs[1] = sv * slice9.getW();
-                vs[2] = 1 - sv * slice9.getY();
                 vs[3] = 1;
-            }
 
-            xs[1] = sx * slice9.getX();
-            xs[2] = 1 - sx * slice9.getZ();
-            ys[1] = sy * slice9.getW();
-            ys[2] = 1 - sy * slice9.getY();
+                Vectormath::Aos::Vector4 pts[4][4];
+                const Matrix4* transform = &node_transforms[i];
 
-            const Matrix4* transform = &node_transforms[i];
-            Vectormath::Aos::Vector4 pts[4][4];
-            for (int y=0;y<4;y++)
-            {
-                for (int x=0;x<4;x++)
-                {
-                    pts[y][x] = (*transform * Vectormath::Aos::Point3(xs[x], ys[y], 0));
-                }
-            }
+                pts[0][0] = (*transform * Vectormath::Aos::Point3(xs[0], ys[0], 0));
+                pts[0][3] = (*transform * Vectormath::Aos::Point3(xs[0], ys[3], 0));
+                pts[3][0] = (*transform * Vectormath::Aos::Point3(xs[3], ys[0], 0));
+                pts[3][3] = (*transform * Vectormath::Aos::Point3(xs[3], ys[3], 0));
 
-            BoxVertex v00, v10, v01, v11;
-            v00.SetColor(pm_color);
-            v10.SetColor(pm_color);
-            v01.SetColor(pm_color);
-            v11.SetColor(pm_color);
-            for (int y=0;y<3;y++)
-            {
-                for (int x=0;x<3;x++)
-                {
-                    const int x0 = x;
-                    const int x1 = x+1;
-                    const int y0 = y;
-                    const int y1 = y+1;
-                    v00.SetPosition(pts[y0][x0]);
-                    v10.SetPosition(pts[y0][x1]);
-                    v01.SetPosition(pts[y1][x0]);
-                    v11.SetPosition(pts[y1][x1]);
-                    if(uv_rotated)
-                    {
-                        v00.SetUV(us[y0], vs[x0]);
-                        v10.SetUV(us[y0], vs[x1]);
-                        v01.SetUV(us[y1], vs[x0]);
-                        v11.SetUV(us[y1], vs[x1]);
-                    }
-                    else
-                    {
-                        v00.SetUV(us[x0], vs[y0]);
-                        v10.SetUV(us[x1], vs[y0]);
-                        v01.SetUV(us[x0], vs[y1]);
-                        v11.SetUV(us[x1], vs[y1]);
-                    }
-                    gui_world->m_ClientVertexBuffer.Push(v00);
-                    gui_world->m_ClientVertexBuffer.Push(v10);
-                    gui_world->m_ClientVertexBuffer.Push(v11);
-                    gui_world->m_ClientVertexBuffer.Push(v00);
-                    gui_world->m_ClientVertexBuffer.Push(v11);
-                    gui_world->m_ClientVertexBuffer.Push(v01);
-                }
+                BoxVertex v00, v10, v01, v11;
+                v00.SetColor(pm_color);
+                v10.SetColor(pm_color);
+                v01.SetColor(pm_color);
+                v11.SetColor(pm_color);
+
+                v00.SetPosition(pts[0][0]);
+                v10.SetPosition(pts[0][3]);
+                v01.SetPosition(pts[3][0]);
+                v11.SetPosition(pts[3][3]);
+
+                v00.SetUV(us[0], vs[0]);
+                v10.SetUV(us[3], vs[0]);
+                v01.SetUV(us[0], vs[3]);
+                v11.SetUV(us[3], vs[3]);
+
+                gui_world->m_ClientVertexBuffer.Push(v00);
+                gui_world->m_ClientVertexBuffer.Push(v10);
+                gui_world->m_ClientVertexBuffer.Push(v11);
+                gui_world->m_ClientVertexBuffer.Push(v00);
+                gui_world->m_ClientVertexBuffer.Push(v11);
+                gui_world->m_ClientVertexBuffer.Push(v01);
             }
         }
         ro.m_VertexCount = rendered_vert_count;
@@ -1656,6 +1689,7 @@ namespace dmGameSystem
                                         gui_world->m_ClientVertexBuffer.Size() * sizeof(BoxVertex),
                                         gui_world->m_ClientVertexBuffer.Begin(),
                                         dmGraphics::BUFFER_USAGE_STREAM_DRAW);
+        DM_COUNTER("GUI.VertexCount", gui_world->m_ClientVertexBuffer.Size());
     }
 
     static dmGraphics::TextureFormat ToGraphicsFormat(dmImage::Type type) {


### PR DESCRIPTION
closes #3181 

**Before:** GUI box with no texture assigned was rendered as 9 sliced rectangle with white texture, and took 54 vertices.
**Now:** GUI box with no texture assigned renders as white rectangle, and takes 6 vertices.

**Note:** Indices are not used for rendering GUI box node for historical reasons. If Gui box is rendered with full sprite trimming it might take 18 vertices to render (I am still checking if sprite trimming is relevant for GUI)

**Tests:**
Texture, no 9 slice params:
<img width="806" alt="Screen Shot 2020-06-05 at 02 34 09" src="https://user-images.githubusercontent.com/23015779/83945297-696f4900-a812-11ea-8ab1-bea06e9c039a.png">

No texture, no 9 slice params:
<img width="674" alt="Screen Shot 2020-06-05 at 02 35 06" src="https://user-images.githubusercontent.com/23015779/83945303-72f8b100-a812-11ea-94ba-c64e1ab53c0b.png">

No texture, with 9 slice params:
<img width="740" alt="Screen Shot 2020-06-05 at 02 36 54" src="https://user-images.githubusercontent.com/23015779/83945311-7e4bdc80-a812-11ea-83e4-ca57cc93fb95.png">

Texture, with 9 slice params:
<img width="729" alt="Screen Shot 2020-06-05 at 02 39 39" src="https://user-images.githubusercontent.com/23015779/83945316-84da5400-a812-11ea-958a-38417aaceae3.png">

Pay attention to **Gui.VertexCount** counter to see the number of vertices rendered.

**Points for discussion:** I've left the **Gui.VertexCount** counter in the code for the PR cause I think it might be useful for debugging later.