### PR TITLE
Issue-4821 Make width of variant and compression choice boxes the same on all devices

### DIFF
--- a/editor/styling/stylesheets/modules/_bundle-dialog.scss
+++ b/editor/styling/stylesheets/modules/_bundle-dialog.scss
@@ -31,7 +31,7 @@
     }
 
     .choice-box, .text-field {
-      -fx-min-width: 165px;
+      -fx-pref-width: 165px;
 
       &.error { -fx-border-color: $error-severity-fatal; }
       &.warning { -fx-border-color: $error-severity-warning; }


### PR DESCRIPTION
issue #4821 

**Before:** I were setting min-width for choice boxes to make them same size. It didn't look right on @matgis-king's imac. It looked ok on our laptops.

Macbook vs iMac:
![mojave_catalina_min_width](https://user-images.githubusercontent.com/23015779/84080070-44cacb00-a9e4-11ea-936b-f6026149326e.gif)

**Now:** It should look the same everywhere.

**Note:** The issue seems to be that javafx computes preferred width for a control based on many system parameters (like screen resolution): https://stackoverflow.com/a/58203727/1218218
This might make labels different size on different systems.

The best solution should be to reorganize layout in and use vbox node to make dropdowns the same size. But this feels like a bit too much of a change: https://docs.oracle.com/javafx/2/layout/size_align.htm 

Since we already use --fx-pref-width on other elements in the same stylesheet, I've just set --fx-pref-width manually for dropdowns as well to fix the issue.

**Points for discussion:** Maybe we shouldn't use pref-width as it is best practice not to use it and go with v-box. It needs to be tested by @matgis-king.