### PR TITLE
Issue-3181 Pass use_geometry flag from pipeline to texture set DDF for local builds

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -237,7 +237,7 @@ public class TextureSetGenerator {
         for (int i = 0; i < numPoints; ++i) {
 
             // the points are in object space, where origin is at the center of the sprite image
-            // in units [-0.5,0.5].
+            // in units [-0.5,0.5]
             // The polygon has a CCW orientation
             float localU = geometry.getVertices(i * 2 + 0);
             float localV = geometry.getVertices(i * 2 + 1);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -373,11 +373,6 @@ public class TextureSetGenerator {
 
         List<Rect> imageRects = rectanglesFromImages(images, paths);
 
-        int usesSpriteTrimming = 0;
-        for (Integer hullSize : imageHullSizes) {
-            usesSpriteTrimming += hullSize;
-        }
-
         // if all sizes are 0, we still need to generate hull (or rect) data
         // since it will still be part of the new code path if there is another atlas with trimming enabled
         List<SpriteGeometry> imageHulls = new ArrayList<SpriteGeometry>();

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -96,9 +96,7 @@
                                        hull-vertex-count (sprite-trim-mode->hull-vertex-count sprite-trim-mode)]
                                    (TextureSetGenerator/buildConvexHull buffered-image hull-vertex-count)))
                                images)
-        use-geometries (let [hull-sizes (map (fn [{:keys [path sprite-trim-mode]}] 
-                                          (sprite-trim-mode->hull-vertex-count sprite-trim-mode)) images)]
-                         (if (some #(not= :sprite-trim-mode-off (:sprite-trim-mode %)) images) 1 0))
+        use-geometries (if (some #(not= :sprite-trim-mode-off (:sprite-trim-mode %)) images) 1 0)
         result (TextureSetGenerator/calculateLayout
                  rects sprite-geometries use-geometries anim-iterator margin inner-padding extrude-borders
                  true false nil)]

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -201,7 +201,7 @@
                                  (let [sub-image (.getSubimage buffered-image (.x image-rect) (.y image-rect) (.width image-rect) (.height image-rect))]
                                    (TextureSetGenerator/buildConvexHull sub-image hull-vertex-count)))
                                image-rects)
-        use-geometries (if (not= :sprite-trim-mode-off (:sprite-trim-mode hull-vertex-count)) 1 0)
+        use-geometries (if (not= :sprite-trim-mode-off (:sprite-trim-mode tile-source-attributes)) 1 0)
         result (TextureSetGenerator/calculateLayout
                  image-rects
                  sprite-geometries

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -96,8 +96,12 @@
                                        hull-vertex-count (sprite-trim-mode->hull-vertex-count sprite-trim-mode)]
                                    (TextureSetGenerator/buildConvexHull buffered-image hull-vertex-count)))
                                images)
+        hull-sizes (map (fn [{:keys [path sprite-trim-mode] :as _image}]
+                          (sprite-trim-mode->hull-vertex-count sprite-trim-mode))
+                         images)
+        use-geometries (if (nil? (some (complement zero?) hull-sizes)) 0 1)
         result (TextureSetGenerator/calculateLayout
-                 rects sprite-geometries anim-iterator margin inner-padding extrude-borders
+                 rects sprite-geometries use-geometries anim-iterator margin inner-padding extrude-borders
                  true false nil)]
     (doto (.builder result)
       (.setTexture "unknown"))
@@ -200,9 +204,11 @@
                                  (let [sub-image (.getSubimage buffered-image (.x image-rect) (.y image-rect) (.width image-rect) (.height image-rect))]
                                    (TextureSetGenerator/buildConvexHull sub-image hull-vertex-count)))
                                image-rects)
+        use-geometries (if (zero? hull-vertex-count) 0 1)
         result (TextureSetGenerator/calculateLayout
                  image-rects
                  sprite-geometries
+                 use-geometries
                  anim-iterator
                  (:margin tile-source-attributes)
                  (:inner-padding tile-source-attributes)

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -96,10 +96,9 @@
                                        hull-vertex-count (sprite-trim-mode->hull-vertex-count sprite-trim-mode)]
                                    (TextureSetGenerator/buildConvexHull buffered-image hull-vertex-count)))
                                images)
-        hull-sizes (map (fn [{:keys [path sprite-trim-mode] :as _image}]
-                          (sprite-trim-mode->hull-vertex-count sprite-trim-mode))
-                         images)
-        use-geometries (if (nil? (some (complement zero?) hull-sizes)) 0 1)
+        use-geometries (let [hull-sizes (map (fn [{:keys [path sprite-trim-mode]}] 
+                                          (sprite-trim-mode->hull-vertex-count sprite-trim-mode)) images)]
+                         (if (some #(not= :sprite-trim-mode-off (:sprite-trim-mode %)) images) 1 0))
         result (TextureSetGenerator/calculateLayout
                  rects sprite-geometries use-geometries anim-iterator margin inner-padding extrude-borders
                  true false nil)]
@@ -204,7 +203,7 @@
                                  (let [sub-image (.getSubimage buffered-image (.x image-rect) (.y image-rect) (.width image-rect) (.height image-rect))]
                                    (TextureSetGenerator/buildConvexHull sub-image hull-vertex-count)))
                                image-rects)
-        use-geometries (if (zero? hull-vertex-count) 0 1)
+        use-geometries (if (not= :sprite-trim-mode-off (:sprite-trim-mode hull-vertex-count)) 1 0)
         result (TextureSetGenerator/calculateLayout
                  image-rects
                  sprite-geometries

--- a/editor/src/java/com/defold/editor/pipeline/TextureSetGenerator.java
+++ b/editor/src/java/com/defold/editor/pipeline/TextureSetGenerator.java
@@ -282,7 +282,7 @@ public class TextureSetGenerator {
      * 3. Shrink inner rects by previous extrusion
      * 4. Create vertex data for each frame (image) in each animation
      */
-    public static TextureSetResult calculateLayout(List<Rect> images, List<SpriteGeometry> imageHulls,
+    public static TextureSetResult calculateLayout(List<Rect> images, List<SpriteGeometry> imageHulls, int use_geometries,
                                                 AnimIterator iterator,
                                                int margin, int innerPadding, int extrudeBorders,
                                                boolean rotate, boolean useTileGrid, Grid gridSize) {
@@ -311,6 +311,8 @@ public class TextureSetGenerator {
         List<Rect> rects = clipBorders(layout.getRectangles(), extrudeBorders);
 
         Pair<TextureSet.Builder, List<UVTransform>> vertexData = genVertexData(layout.getWidth(), layout.getHeight(), rects, iterator);
+
+        vertexData.left.setUseGeometries(use_geometries);
 
         if (imageHulls != null) {
             for (Rect rect : layout.getRectangles()) {
@@ -370,21 +372,18 @@ public class TextureSetGenerator {
 
         List<Rect> imageRects = rectanglesFromImages(images, paths);
 
-        int usesSpriteTrimming = 0;
-        for (Integer hullSize : imageHullSizes) {
-            usesSpriteTrimming += hullSize;
-        }
-
         // if all sizes are 0, we still need to generate hull (or rect) data
         // since it will still be part of the new code path if there is another atlas with trimming enabled
         List<SpriteGeometry> imageHulls = new ArrayList<SpriteGeometry>();
+        int use_geometries = 0;
         for (int i = 0; i < images.size(); ++i) {
             BufferedImage image = images.get(i);
+            use_geometries |= imageHullSizes.get(i) > 0 ? 1 : 0;
             imageHulls.add(buildConvexHull(image, imageHullSizes.get(i)));
         }
 
         // The layout step will expand the rect, and possibly rotate them
-        TextureSetResult result = calculateLayout(imageRects, imageHulls, iterator,
+        TextureSetResult result = calculateLayout(imageRects, imageHulls, use_geometries, iterator,
                                                         margin, innerPadding, extrudeBorders, rotate, useTileGrid, gridSize);
 
         for (int i = 0; i < images.size(); ++i) {

--- a/editor/src/java/com/defold/editor/pipeline/TextureSetGenerator.java
+++ b/editor/src/java/com/defold/editor/pipeline/TextureSetGenerator.java
@@ -238,6 +238,7 @@ public class TextureSetGenerator {
 
             // the points are in object space, where origin is at the center of the sprite image
             // in units [-0.5,0.5]
+            // The polygon has a CCW orientation
             float localU = geometry.getVertices(i * 2 + 0);
             float localV = geometry.getVertices(i * 2 + 1);
             float localX = localU * originalRectWidth;


### PR DESCRIPTION
**Before**: Use geometry flag determines which path is going to be used for rendering sprite component:

```
if (world->m_UseGeometries)
{
    // renders sprite with the help of vertices generated in build pipeline phase
    ...
}
else
{
    // renders simple rectangle with texture
    ...
}
```

This flag is set like this `sprite_world->m_UseGeometries |= texture_set->m_TextureSet->m_UseGeometries`. In turn `texture_set->m_TextureSet->m_UseGeometries` flag is passed through build pipeline and `texture_set_ddf`. 

The build pipeline sometimes duplicates code for packaging and local builds. In this case the flag was only passed when packaging application and not for local builds which is the issue.

(Please correct me if I am wrong about any of the steps.)

**Now**: I pass `use_geometries` in local builds to `texture_set_ddf`.

**Testing**: 
The issue can be reproduced like this:
1. Find image that build pipeline can generate a proper hull for.
2. Create atlas with this image. Set sprite trimming option to 8 vertices.
3. Add log to the engine. Log `m_UseGeometries` flag.
4. Package your application and run.
Observe: log shows that `m_UseGeometries` flag is set to 1.
5. Build your application locally.
Observe: log shows that `m_UseGeometries` flag is set to 0.

I've tested local builds until got the 1 passed to `m_UseGeometries`.

**Points for discussion**: I am not sure I got the change in `tile-source->texture-set-data` function tested, if you can hint how I get there, please do :) 