### PR TITLE
Improvements for AAB bundle process

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
@@ -440,6 +440,14 @@ public class AndroidAAB {
 		}
 	}
 
+	/**
+	* Cleanup bundle folder from intermediate folders and artifacts.
+	*/
+	private static void cleanupBundleFolder(File androidResDir, File bundleDir) throws IOException, CompileExceptionError {
+		FileUtils.deleteDirectory(androidResDir);
+		FileUtils.deleteDirectory(new File(bundleDir, "aab"));
+	}
+
 	public static void create(Project project, File bundleDir, ICanceled canceled) throws IOException, CompileExceptionError {
 		Bob.initAndroid(); // extract resources
 
@@ -471,5 +479,8 @@ public class AndroidAAB {
 		if (has_symbols) {
 			copySymbols(project, appDir, title);
 		}
+
+		// STEP 7. Cleanup bundle folder from intermediate folders and artifacts.
+		cleanupBundleFolder(androidResDir, appDir);
 	}
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
@@ -413,11 +413,11 @@ public class AndroidAAB {
 	}
 
 	/**
-	* Sign file using certificate and key 
+	* Sign file using certificate and key
 	* https://developer.android.com/studio/command-line/bundletool
 	*/
 	private static void signFile(Project project, File bundleDir, File signFile, ICanceled canceled) throws IOException, CompileExceptionError {
-		log("Sing " + signFile);
+		log("Sign " + signFile);
 		BundleHelper.throwIfCanceled(canceled);
 
 		String certificate = project.option("certificate", "");
@@ -448,7 +448,7 @@ public class AndroidAAB {
 		}
 		unsignedFile.delete();
 	}
-	
+
 	/**
 	* Copy debug symbols
 	*/
@@ -520,7 +520,7 @@ public class AndroidAAB {
 		// STEP 5. Use bundletool to create AAB from base.zip
 		File baseAab = createBundle(project, appDir, baseZip, canceled);
 
-		//STEP 6. Sing AAB file
+		//STEP 6. Sign AAB file
 		signFile(project, appDir, baseAab, canceled);
 
 		// STEP 7. Copy debug symbols

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
@@ -415,7 +415,7 @@ public class AndroidAAB {
 	/**
 	* Copy debug symbols
 	*/
-	private static void copySymbols(Project project, File bundleDir, String title) throws IOException, CompileExceptionError {
+	private static void copySymbols(Project project, File bundleDir, String title, ICanceled canceled) throws IOException, CompileExceptionError {
 		log("Copy debug symbols");
 		File symbolsDir = new File(bundleDir, title + ".apk.symbols");
 		symbolsDir.mkdirs();
@@ -430,8 +430,11 @@ public class AndroidAAB {
 			}
 			File exe = bundleExe.get(0);
 			File symbolExe = new File(symbolsDir, FilenameUtils.concat("lib/" + platformToLibMap.get(architecture), "lib" + exeName + ".so"));
+			BundleHelper.throwIfCanceled(canceled);
 			FileUtils.copyFile(exe, symbolExe);
 		}
+
+		BundleHelper.throwIfCanceled(canceled);
 
 		File proguardMapping = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(architectures.get(0).getExtenderPair(), "mapping.txt")));
 		if (proguardMapping.exists()) {
@@ -443,7 +446,8 @@ public class AndroidAAB {
 	/**
 	* Cleanup bundle folder from intermediate folders and artifacts.
 	*/
-	private static void cleanupBundleFolder(File androidResDir, File bundleDir) throws IOException, CompileExceptionError {
+	private static void cleanupBundleFolder(Project project, File bundleDir, File androidResDir, ICanceled canceled) throws IOException, CompileExceptionError {
+		BundleHelper.throwIfCanceled(canceled);
 		FileUtils.deleteDirectory(androidResDir);
 		FileUtils.deleteDirectory(new File(bundleDir, "aab"));
 	}
@@ -477,10 +481,10 @@ public class AndroidAAB {
 		// STEP 6. Copy debug symbols
 		final boolean has_symbols = project.hasOption("with-symbols");
 		if (has_symbols) {
-			copySymbols(project, appDir, title);
+			copySymbols(project, appDir, title, canceled);
 		}
 
 		// STEP 7. Cleanup bundle folder from intermediate folders and artifacts.
-		cleanupBundleFolder(androidResDir, appDir);
+		cleanupBundleFolder(project, appDir, androidResDir, canceled);
 	}
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAAB.java
@@ -235,8 +235,8 @@ public class AndroidAAB {
 		log("Compiling resources from " + androidResDir.getAbsolutePath());
 		try {
 			// compile the resources using aapt2 to flat format files
-			File aabDir = new File(bundleDir, "aab");
-			File compiledResourcesDir = createDir(aabDir, "aapt2/compiled_resources");
+			File compiledResourcesDir = Files.createTempDirectory("compiled_resources").toFile();
+			compiledResourcesDir.deleteOnExit();
 
 			// compile the resources for each package
 			for (File packageDir : androidResDir.listFiles(File::isDirectory)) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAPK.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidAPK.java
@@ -305,17 +305,17 @@ public class AndroidAPK {
 
                 ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
                 try {
-                	if (inE.getSize() > 0) {
-	                    int count;
-	                    entryData = new byte[(int) inE.getSize()];
-	                    InputStream stream = zipFileIn.getInputStream(inE);
-	                    while((count = stream.read(entryData, 0, (int)inE.getSize())) != -1) {
-	                        byteOut.write(entryData, 0, count);
-	                        if (zipMethod == ZipEntry.STORED) {
-	                            crc.update(entryData, 0, count);
-	                        }
-	                    }
-                	}
+                    if (inE.getSize() > 0) {
+                        int count;
+                        entryData = new byte[(int) inE.getSize()];
+                        InputStream stream = zipFileIn.getInputStream(inE);
+                        while((count = stream.read(entryData, 0, (int)inE.getSize())) != -1) {
+                            byteOut.write(entryData, 0, count);
+                            if (zipMethod == ZipEntry.STORED) {
+                                crc.update(entryData, 0, count);
+                            }
+                        }
+                    }
                 } finally {
                     if(null != byteOut) {
                         byteOut.close();
@@ -357,6 +357,8 @@ public class AndroidAPK {
         ap3.delete();
         ap4.delete();
         FileUtils.deleteDirectory(tmpResourceDir);
+        FileUtils.deleteDirectory(new File(appDir, "libs"));
+        FileUtils.deleteDirectory(resDir);
 
         // Copy debug symbols
         if (has_symbols) {


### PR DESCRIPTION
- Sign AAB file
- Copy debug symbols into bundle folder
- Cleanup bundle folder from intermediate artefacts

---

According to https://developer.android.com/studio/command-line/bundletool AAB should be signed as well:

>  you can also build your app bundle from the command line and sign it using jarsigner

We use our own tool instead  `jarsigner`. There is no information about aligning. After googling I found that we shouldn't align AAB.