### PR TITLE
issue-4946: Fixes for 3D collision/trigger events

### DIFF
--- a/engine/physics/src/physics/physics.cpp
+++ b/engine/physics/src/physics/physics.cpp
@@ -1,10 +1,10 @@
 // Copyright 2020 The Defold Foundation
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the


### PR DESCRIPTION
Several fixes to make the 3d physics handle events like the 2D physics:
* Enable trigger_response events for sleeping bodies
* Only send trigger_response if there are any contact points (not just AABB collision)
* Only send collision_response if there are any contact points (not just AABB collision)
* Don't send contact_point_response for trigger objects