### PR TITLE
Issue-4856 Pass controller device name to Lua script

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1188,9 +1188,6 @@ bail:
         input_action.m_GamepadDisconnected = action->m_GamepadDisconnected;
         input_action.m_GamepadConnected = action->m_GamepadConnected;
 
-        input_action.m_GamepadNameCount = action->m_GamepadNameCount;
-        dmStrlCpy(input_action.m_GamepadName, action->m_GamepadName, input_action.m_GamepadNameCount);
-
         input_buffer->Push(input_action);
     }
 
@@ -1207,8 +1204,8 @@ bail:
     {
         dmGameObject::InputAction *ipa = (dmGameObject::InputAction *)a;
         dmGameObject::InputAction *ipb = (dmGameObject::InputAction *)b;
-        bool a_is_text = ipa->m_HasText || ipa->m_TextCount > 0;
-        bool b_is_text = ipb->m_HasText || ipb->m_TextCount > 0;
+        bool a_is_text = ipa->m_HasText;
+        bool b_is_text = ipb->m_HasText;
         return a_is_text - b_is_text;
     }
 

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1188,6 +1188,9 @@ bail:
         input_action.m_GamepadDisconnected = action->m_GamepadDisconnected;
         input_action.m_GamepadConnected = action->m_GamepadConnected;
 
+        input_action.m_GamepadNameCount = action->m_GamepadNameCount;
+        dmStrlCpy(input_action.m_GamepadName, action->m_GamepadName, input_action.m_GamepadNameCount);
+
         input_buffer->Push(input_action);
     }
 

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -376,7 +376,7 @@ namespace dmGameObject
             if (params.m_InputAction->m_GamepadConnected) 
             {
                 lua_pushliteral(L, "gamepad_name");
-                lua_pushstring(L, params.m_InputAction->m_GamepadName);
+                lua_pushstring(L, params.m_InputAction->m_Text);
                 lua_settable(L, action_table);
             }
 
@@ -514,7 +514,7 @@ namespace dmGameObject
                 lua_settable(L, -3);
             }
 
-            if (params.m_InputAction->m_TextCount > 0 || params.m_InputAction->m_HasText)
+            if (params.m_InputAction->m_HasText)
             {
                 int tc = params.m_InputAction->m_TextCount;
                 lua_pushliteral(L, "text");

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -376,7 +376,7 @@ namespace dmGameObject
             if (params.m_InputAction->m_GamepadConnected) 
             {
                 lua_pushliteral(L, "gamepad_name");
-                lua_pushlstring(L, params.m_InputAction->m_GamepadName, params.m_InputAction->m_GamepadNameCount);
+                lua_pushstring(L, params.m_InputAction->m_GamepadName);
                 lua_settable(L, action_table);
             }
 

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -376,7 +376,15 @@ namespace dmGameObject
             if (params.m_InputAction->m_GamepadConnected) 
             {
                 lua_pushliteral(L, "gamepad_name");
-                lua_pushstring(L, params.m_InputAction->m_Text);
+                if (params.m_InputAction->m_TextCount == 0)
+                {
+                    lua_pushstring(L, "");
+                }
+                else
+                {
+                    lua_pushlstring(L, params.m_InputAction->m_Text, params.m_InputAction->m_TextCount);
+                }
+
                 lua_settable(L, action_table);
             }
 

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -373,19 +373,10 @@ namespace dmGameObject
                 lua_settable(L, action_table);
             }
 
-            if (params.m_InputAction->m_GamepadConnected) 
+            if (params.m_InputAction->m_GamepadConnected)
             {
-                lua_pushliteral(L, "gamepad_name");
-                if (params.m_InputAction->m_TextCount == 0)
-                {
-                    lua_pushstring(L, "");
-                }
-                else
-                {
-                    lua_pushlstring(L, params.m_InputAction->m_Text, params.m_InputAction->m_TextCount);
-                }
-
-                lua_settable(L, action_table);
+                lua_pushlstring(L, params.m_InputAction->m_Text, params.m_InputAction->m_TextCount);
+                lua_setfield(L, action_table, "gamepad_name");
             }
 
             if (params.m_InputAction->m_ActionId != 0)

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -366,9 +366,17 @@ namespace dmGameObject
 
             int action_table = lua_gettop(L);
 
-            if (params.m_InputAction->m_IsGamepad) {
+            if (params.m_InputAction->m_IsGamepad) 
+            {
                 lua_pushliteral(L, "gamepad");
                 lua_pushnumber(L, params.m_InputAction->m_GamepadIndex);
+                lua_settable(L, action_table);
+            }
+
+            if (params.m_InputAction->m_GamepadConnected) 
+            {
+                lua_pushliteral(L, "gamepad_name");
+                lua_pushlstring(L, params.m_InputAction->m_GamepadName, params.m_InputAction->m_GamepadNameCount);
                 lua_settable(L, action_table);
             }
 

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -171,10 +171,9 @@ namespace dmGameObject
         dmHID::Touch m_Touch[dmHID::MAX_TOUCH_COUNT];
         /// Number of m_Touch
         int32_t  m_TouchCount;
+        /// Contains text input if m_HasText, and gamepad name if m_GamepadConnected
         char     m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t m_TextCount;
-        char     m_GamepadName[dmHID::MAX_CHAR_COUNT];
-        uint32_t m_GamepadNameCount;
         uint32_t m_GamepadIndex;
         uint8_t  m_IsGamepad : 1;
         uint8_t  m_GamepadDisconnected : 1;

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -173,6 +173,8 @@ namespace dmGameObject
         int32_t  m_TouchCount;
         char     m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t m_TextCount;
+        char     m_GamepadName[dmHID::MAX_CHAR_COUNT];
+        uint32_t m_GamepadNameCount;
         uint32_t m_GamepadIndex;
         uint8_t  m_IsGamepad : 1;
         uint8_t  m_GamepadDisconnected : 1;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1974,6 +1974,9 @@ namespace dmGameSystem
             gui_input_action.m_TextCount = text_count;
             gui_input_action.m_HasText = params.m_InputAction->m_HasText;
 
+            gui_input_action.m_GamepadNameCount = params.m_InputAction->m_GamepadNameCount;
+            dmStrlCpy(gui_input_action.m_GamepadName, params.m_InputAction->m_GamepadName, gui_input_action.m_GamepadNameCount);
+
             bool consumed;
             dmGui::Result gui_result = dmGui::DispatchInput(scene, &gui_input_action, 1, &consumed);
             if (gui_result != dmGui::RESULT_OK)

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1974,9 +1974,6 @@ namespace dmGameSystem
             gui_input_action.m_TextCount = text_count;
             gui_input_action.m_HasText = params.m_InputAction->m_HasText;
 
-            gui_input_action.m_GamepadNameCount = params.m_InputAction->m_GamepadNameCount;
-            dmStrlCpy(gui_input_action.m_GamepadName, params.m_InputAction->m_GamepadName, gui_input_action.m_GamepadNameCount);
-
             bool consumed;
             dmGui::Result gui_result = dmGui::DispatchInput(scene, &gui_input_action, 1, &consumed);
             if (gui_result != dmGui::RESULT_OK)

--- a/engine/gamesys/src/gamesys/test/input/connected_event_test.go
+++ b/engine/gamesys/src/gamesys/test/input/connected_event_test.go
@@ -1,0 +1,30 @@
+components {
+  id: "gui"
+  component: "/input/connected_event_test.gui"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}
+components {
+  id: "script"
+  component: "/input/connected_event_test.script"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/input/connected_event_test.gui
+++ b/engine/gamesys/src/gamesys/test/input/connected_event_test.gui
@@ -1,0 +1,10 @@
+script: "/input/connected_event_test.gui_script"
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+material: "/gui/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512

--- a/engine/gamesys/src/gamesys/test/input/connected_event_test.gui_script
+++ b/engine/gamesys/src/gamesys/test/input/connected_event_test.gui_script
@@ -1,0 +1,29 @@
+local error_message = ""
+
+function init(self)
+	self.error_message = "";
+end
+
+function on_input(self, action_id, action)
+	if action_id == hash("gamepad_connected") then
+		if action.gamepad_name ~= "null_device" then
+			error_message = "non zero connected gamepad_name is passed incorrectly";
+		end
+	elseif action_id == hash("gamepad_connected_0") then
+		if action.gamepad_name ~= "" then
+			error_message = "zero connected gamepad_name is passed incorrectly";
+		end
+	else
+		if action.gamepad_name ~= nil then
+			error_message = "gamepad name is passed when not connected";
+		end
+	end
+end
+
+function update(self, dt)
+	if error_message ~= "" then
+		print(error_message);
+		error_message = "";
+		assert(false);
+	end
+end

--- a/engine/gamesys/src/gamesys/test/input/connected_event_test.gui_script
+++ b/engine/gamesys/src/gamesys/test/input/connected_event_test.gui_script
@@ -1,29 +1,11 @@
-local error_message = ""
-
-function init(self)
-	self.error_message = "";
-end
-
 function on_input(self, action_id, action)
 	if action_id == hash("gamepad_connected") then
-		if action.gamepad_name ~= "null_device" then
-			error_message = "non zero connected gamepad_name is passed incorrectly";
-		end
+		assert(action.gamepad_name == "null_device")
+		assert(action.text == nil)
 	elseif action_id == hash("gamepad_connected_0") then
-		if action.gamepad_name ~= "" then
-			error_message = "zero connected gamepad_name is passed incorrectly";
-		end
+		assert(action.gamepad_name == "")
+		assert(action.text == nil)
 	else
-		if action.gamepad_name ~= nil then
-			error_message = "gamepad name is passed when not connected";
-		end
-	end
-end
-
-function update(self, dt)
-	if error_message ~= "" then
-		print(error_message);
-		error_message = "";
-		assert(false);
+		assert(action.gamepad_name == nil)
 	end
 end

--- a/engine/gamesys/src/gamesys/test/input/connected_event_test.script
+++ b/engine/gamesys/src/gamesys/test/input/connected_event_test.script
@@ -1,0 +1,29 @@
+local error_message = ""
+
+function init(self)
+	self.error_message = "";
+end
+
+function on_input(self, action_id, action)
+	if action_id == hash("gamepad_connected") then
+		if action.gamepad_name ~= "null_device" then
+			error_message = "non zero connected gamepad_name is passed incorrectly";
+		end
+	elseif action_id == hash("gamepad_connected_0") then
+		if action.gamepad_name ~= "" then
+			error_message = "zero connected gamepad_name is passed incorrectly";
+		end
+	else
+		if action.gamepad_name ~= nil then
+			error_message = "gamepad name is passed when not connected";
+		end
+	end
+end
+
+function update(self, dt)
+	if error_message ~= "" then
+		print(error_message);
+		error_message = "";
+		assert(false);
+	end
+end

--- a/engine/gamesys/src/gamesys/test/input/connected_event_test.script
+++ b/engine/gamesys/src/gamesys/test/input/connected_event_test.script
@@ -1,29 +1,11 @@
-local error_message = ""
-
-function init(self)
-	self.error_message = "";
-end
-
 function on_input(self, action_id, action)
 	if action_id == hash("gamepad_connected") then
-		if action.gamepad_name ~= "null_device" then
-			error_message = "non zero connected gamepad_name is passed incorrectly";
-		end
+		assert(action.gamepad_name == "null_device")
+		assert(action.text == nil)
 	elseif action_id == hash("gamepad_connected_0") then
-		if action.gamepad_name ~= "" then
-			error_message = "zero connected gamepad_name is passed incorrectly";
-		end
+		assert(action.gamepad_name == "")
+		assert(action.text == nil)
 	else
-		if action.gamepad_name ~= nil then
-			error_message = "gamepad name is passed when not connected";
-		end
-	end
-end
-
-function update(self, dt)
-	if error_message ~= "" then
-		print(error_message);
-		error_message = "";
-		assert(false);
+		assert(action.gamepad_name == nil)
 	end
 end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -244,9 +244,9 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     //test gamepad connected with device name and connected flag
     dmGameObject::InputAction input_action_connected;
     input_action_connected.m_ActionId = dmHashString64("gamepad_connected");
-    input_action_connected.m_GamepadNameCount = strlen("null_device") + 1;
+    input_action_connected.m_TextCount = strlen("null_device") + 1;
     input_action_connected.m_GamepadConnected = 1;
-    dmStrlCpy(input_action_connected.m_GamepadName, "null_device", input_action_connected.m_GamepadNameCount);
+    dmStrlCpy(input_action_connected.m_Text, "null_device", input_action_connected.m_TextCount);
     dmGameObject::DispatchInput(m_Collection, &input_action_connected, 1);
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
@@ -255,7 +255,7 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     //test gamepad connected with empty device name
     dmGameObject::InputAction input_action_empty;
     input_action_empty.m_ActionId = dmHashString64("gamepad_connected_0");
-    input_action_empty.m_GamepadNameCount = 0;
+    input_action_empty.m_TextCount = 0;
     input_action_empty.m_GamepadConnected = 1;
     dmGameObject::DispatchInput(m_Collection, &input_action_empty, 1);
 
@@ -265,9 +265,9 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     //test gamepad connected with device name and no connected flag
     dmGameObject::InputAction input_action_other;
     input_action_other.m_ActionId = dmHashString64("other_event");
-    input_action_other.m_GamepadNameCount = strlen("null_device") + 1;
+    input_action_other.m_TextCount = strlen("null_device") + 1;
     input_action_other.m_GamepadConnected = 0;
-    dmStrlCpy(input_action_other.m_GamepadName, "null_device", input_action_other.m_GamepadNameCount);
+    dmStrlCpy(input_action_other.m_Text, "null_device", input_action_other.m_TextCount);
     dmGameObject::DispatchInput(m_Collection, &input_action_other, 1);
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -247,8 +247,9 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     input_action_connected.m_TextCount = strlen("null_device") + 1;
     input_action_connected.m_GamepadConnected = 1;
     dmStrlCpy(input_action_connected.m_Text, "null_device", input_action_connected.m_TextCount);
-    dmGameObject::DispatchInput(m_Collection, &input_action_connected, 1);
+    dmGameObject::UpdateResult res = dmGameObject::DispatchInput(m_Collection, &input_action_connected, 1);
 
+    ASSERT_TRUE(res == dmGameObject::UpdateResult::UPDATE_RESULT_OK);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 
@@ -257,8 +258,9 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     input_action_empty.m_ActionId = dmHashString64("gamepad_connected_0");
     input_action_empty.m_TextCount = 0;
     input_action_empty.m_GamepadConnected = 1;
-    dmGameObject::DispatchInput(m_Collection, &input_action_empty, 1);
+    res = dmGameObject::DispatchInput(m_Collection, &input_action_empty, 1);
 
+    ASSERT_TRUE(res == dmGameObject::UpdateResult::UPDATE_RESULT_OK);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 
@@ -268,8 +270,9 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     input_action_other.m_TextCount = strlen("null_device") + 1;
     input_action_other.m_GamepadConnected = 0;
     dmStrlCpy(input_action_other.m_Text, "null_device", input_action_other.m_TextCount);
-    dmGameObject::DispatchInput(m_Collection, &input_action_other, 1);
+    res = dmGameObject::DispatchInput(m_Collection, &input_action_other, 1);
 
+    ASSERT_TRUE(res == dmGameObject::UpdateResult::UPDATE_RESULT_OK);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -222,6 +222,67 @@ TEST_P(ComponentTest, Test)
     dmDDF::FreeMessage(go_ddf);
 }
 
+TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
+{
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory = m_Factory;
+    scriptlibcontext.m_Register = m_Register;
+    scriptlibcontext.m_LuaState = dmScript::GetLuaState(m_ScriptContext);
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    // Spawn the game object with the script we want to call
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/input/connected_event_test.goc", dmHashString64("/gamepad_connected"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    dmGameObject::AcquireInputFocus(m_Collection, go);
+
+    //test gamepad connected with device name and connected flag
+    dmGameObject::InputAction input_action_connected;
+    input_action_connected.m_ActionId = dmHashString64("gamepad_connected");
+    input_action_connected.m_GamepadNameCount = strlen("null_device") + 1;
+    input_action_connected.m_GamepadConnected = 1;
+    dmStrlCpy(input_action_connected.m_GamepadName, "null_device", input_action_connected.m_GamepadNameCount);
+    dmGameObject::DispatchInput(m_Collection, &input_action_connected, 1);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    //test gamepad connected with empty device name
+    dmGameObject::InputAction input_action_empty;
+    input_action_empty.m_ActionId = dmHashString64("gamepad_connected_0");
+    input_action_empty.m_GamepadNameCount = 0;
+    input_action_empty.m_GamepadConnected = 1;
+    dmGameObject::DispatchInput(m_Collection, &input_action_empty, 1);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    //test gamepad connected with device name and no connected flag
+    dmGameObject::InputAction input_action_other;
+    input_action_other.m_ActionId = dmHashString64("other_event");
+    input_action_other.m_GamepadNameCount = strlen("null_device") + 1;
+    input_action_other.m_GamepadConnected = 0;
+    dmStrlCpy(input_action_other.m_GamepadName, "null_device", input_action_other.m_GamepadNameCount);
+    dmGameObject::DispatchInput(m_Collection, &input_action_other, 1);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    // cleanup
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 TEST_P(ComponentTest, TestReloadFail)
 {
     const char* go_name = GetParam();

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1192,9 +1192,8 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     // test gamepad connected with device name and connected flag
     dmGameObject::InputAction input_action_connected;
     input_action_connected.m_ActionId = dmHashString64("gamepad_connected");
-    input_action_connected.m_TextCount = strlen("null_device") + 1;
     input_action_connected.m_GamepadConnected = 1;
-    dmStrlCpy(input_action_connected.m_Text, "null_device", input_action_connected.m_TextCount);
+    input_action_connected.m_TextCount = dmStrlCpy(input_action_connected.m_Text, "null_device", sizeof(input_action_connected.m_Text));
     dmGameObject::UpdateResult res = dmGameObject::DispatchInput(m_Collection, &input_action_connected, 1);
 
     ASSERT_TRUE(res == dmGameObject::UpdateResult::UPDATE_RESULT_OK);
@@ -1215,9 +1214,8 @@ TEST_F(GamepadConnectedTest, TestGamepadConnectedInputEvent)
     // test gamepad connected with device name and no connected flag
     dmGameObject::InputAction input_action_other;
     input_action_other.m_ActionId = dmHashString64("other_event");
-    input_action_other.m_TextCount = strlen("null_device") + 1;
     input_action_other.m_GamepadConnected = 0;
-    dmStrlCpy(input_action_other.m_Text, "null_device", input_action_other.m_TextCount);
+    input_action_other.m_TextCount = dmStrlCpy(input_action_other.m_Text, "null_device", sizeof(input_action_other.m_Text));
     res = dmGameObject::DispatchInput(m_Collection, &input_action_other, 1);
 
     ASSERT_TRUE(res == dmGameObject::UpdateResult::UPDATE_RESULT_OK);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -184,6 +184,12 @@ public:
     virtual ~BoxRenderTest() {}
 };
 
+class GamepadConnectedTest : public GamesysTest<const char*>
+{
+public:
+    virtual ~GamepadConnectedTest() {}
+};
+
 struct ResourcePropParams {
     const char* m_PropertyName;
     const char* m_ResourcePath;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1739,7 +1739,15 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                     if (ia->m_GamepadConnected) 
                     {
                         lua_pushliteral(L, "gamepad_name");
-                        lua_pushstring(L, ia->m_Text);
+                        if (ia->m_TextCount == 0)
+                        {
+                            lua_pushstring(L, "");
+                        } 
+                        else 
+                        {
+                            lua_pushlstring(L, ia->m_Text, ia->m_TextCount);
+                        }
+
                         lua_settable(L, -3);
                     }
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1739,7 +1739,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                     if (ia->m_GamepadConnected) 
                     {
                         lua_pushliteral(L, "gamepad_name");
-                        lua_pushlstring(L, ia->m_GamepadName, ia->m_GamepadNameCount);
+                        lua_pushstring(L, ia->m_GamepadName);
                         lua_settable(L, -3);
                     }
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1738,17 +1738,8 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
 
                     if (ia->m_GamepadConnected) 
                     {
-                        lua_pushliteral(L, "gamepad_name");
-                        if (ia->m_TextCount == 0)
-                        {
-                            lua_pushstring(L, "");
-                        } 
-                        else 
-                        {
-                            lua_pushlstring(L, ia->m_Text, ia->m_TextCount);
-                        }
-
-                        lua_settable(L, -3);
+                        lua_pushlstring(L, ia->m_Text, ia->m_TextCount);
+                        lua_setfield(L, -2, "gamepad_name");
                     }
 
                     if (ia->m_ActionId != 0)

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1736,6 +1736,13 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                         lua_settable(L, -3);
                     }
 
+                    if (ia->m_GamepadConnected) 
+                    {
+                        lua_pushliteral(L, "gamepad_name");
+                        lua_pushlstring(L, ia->m_GamepadName, ia->m_GamepadNameCount);
+                        lua_settable(L, -3);
+                    }
+
                     if (ia->m_ActionId != 0)
                     {
                         lua_pushstring(L, "value");

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1739,7 +1739,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                     if (ia->m_GamepadConnected) 
                     {
                         lua_pushliteral(L, "gamepad_name");
-                        lua_pushstring(L, ia->m_GamepadName);
+                        lua_pushstring(L, ia->m_Text);
                         lua_settable(L, -3);
                     }
 
@@ -1877,7 +1877,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                         lua_settable(L, -3);
                     }
 
-                    if (ia->m_TextCount > 0 || ia->m_HasText)
+                    if (ia->m_HasText)
                     {
                         lua_pushliteral(L, "text");
                         if (ia->m_TextCount == 0) {

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -446,6 +446,8 @@ namespace dmGui
         int32_t  m_TouchCount;
         char     m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t m_TextCount;
+        char     m_GamepadName[dmHID::MAX_CHAR_COUNT];
+        uint32_t m_GamepadNameCount;
         uint32_t m_GamepadIndex;
         uint16_t m_IsGamepad : 1;
         uint16_t m_GamepadDisconnected : 1;

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -444,10 +444,9 @@ namespace dmGui
         dmHID::Touch m_Touch[dmHID::MAX_TOUCH_COUNT];
         /// Number of m_Touch
         int32_t  m_TouchCount;
+        /// Contains text input if m_HasText, and gamepad name if m_GamepadConnected
         char     m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t m_TextCount;
-        char     m_GamepadName[dmHID::MAX_CHAR_COUNT];
-        uint32_t m_GamepadNameCount;
         uint32_t m_GamepadIndex;
         uint16_t m_IsGamepad : 1;
         uint16_t m_GamepadDisconnected : 1;

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -422,7 +422,6 @@ namespace dmInput
         action->m_TouchCount = 0;
         action->m_TextCount = 0;
         action->m_HasText = 0;
-        action->m_GamepadNameCount = 0;
         action->m_GamepadDisconnected = 0;
         action->m_GamepadConnected = 0;
     }
@@ -537,6 +536,7 @@ namespace dmInput
                                 action->m_Text[i] = text_packet->m_Text[i];
                             }
                             action->m_TextCount = text_packet->m_Size;
+                            action->m_HasText = action->m_TextCount > 0;
                         }
                     }
                 }
@@ -558,7 +558,7 @@ namespace dmInput
                                 action->m_Text[i] = marked_packet->m_Text[i];
                             }
                             action->m_TextCount = marked_packet->m_Size;
-                            action->m_HasText = marked_packet->m_HasText;
+                            action->m_HasText = marked_packet->m_HasText || action->m_TextCount > 0;
                         }
                     }
                 }
@@ -692,8 +692,8 @@ namespace dmInput
                                         const char* device_name;
                                         dmHID::GetGamepadDeviceName(gamepad, &device_name);
                                         size_t device_name_length = strlen(device_name) + 1;
-                                        action->m_GamepadNameCount = dmMath::Min(size_t(dmHID::MAX_CHAR_COUNT), device_name_length);
-                                        dmStrlCpy(action->m_GamepadName, device_name, action->m_GamepadNameCount);
+                                        action->m_TextCount = dmMath::Min(size_t(dmHID::MAX_CHAR_COUNT), device_name_length);
+                                        dmStrlCpy(action->m_Text, device_name, action->m_TextCount);
                                     }
                                 }
                             } else {
@@ -884,7 +884,7 @@ namespace dmInput
 
     void ForEachActiveCallback(CallbackData* data, const dmhash_t* key, Action* action)
     {
-        bool active = action->m_Value != 0.0f || action->m_Pressed || action->m_Released || action->m_TextCount > 0 || action->m_TouchCount > 0 || action->m_HasText || action->m_GamepadConnected || action->m_GamepadDisconnected;
+        bool active = action->m_Value != 0.0f || action->m_Pressed || action->m_Released || action->m_TouchCount > 0 || action->m_HasText || action->m_GamepadConnected || action->m_GamepadDisconnected;
         // Mouse move action
         active = active || (*key == 0 && (action->m_DX != 0 || action->m_DY != 0 || action->m_AccelerationSet));
         if (active)

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -692,7 +692,7 @@ namespace dmInput
                                         const char* device_name;
                                         dmHID::GetGamepadDeviceName(gamepad, &device_name);
                                         size_t device_name_length = strlen(device_name) + 1;
-                                        action->m_GamepadNameCount = dmMath::Min(sizeof(action->m_GamepadName), device_name_length);
+                                        action->m_GamepadNameCount = dmMath::Min(size_t(dmHID::MAX_CHAR_COUNT), device_name_length);
                                         dmStrlCpy(action->m_GamepadName, device_name, action->m_GamepadNameCount);
                                     }
                                 }

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -691,7 +691,8 @@ namespace dmInput
                                     {
                                         const char* device_name;
                                         dmHID::GetGamepadDeviceName(gamepad, &device_name);
-                                        action->m_GamepadNameCount = strlen(device_name) + 1;
+                                        size_t device_name_length = strlen(device_name) + 1;
+                                        action->m_GamepadNameCount = dmMath::Min(sizeof(action->m_GamepadName), device_name_length);
                                         dmStrlCpy(action->m_GamepadName, device_name, action->m_GamepadNameCount);
                                     }
                                 }

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -422,6 +422,7 @@ namespace dmInput
         action->m_TouchCount = 0;
         action->m_TextCount = 0;
         action->m_HasText = 0;
+        action->m_GamepadNameCount = 0;
         action->m_GamepadDisconnected = 0;
         action->m_GamepadConnected = 0;
     }
@@ -685,8 +686,15 @@ namespace dmInput
                                 {
                                     action->m_GamepadDisconnected = packet->m_GamepadDisconnected;
                                     action->m_GamepadConnected = packet->m_GamepadConnected;
-                                }
 
+                                    if (action->m_GamepadConnected) 
+                                    {
+                                        const char* device_name;
+                                        dmHID::GetGamepadDeviceName(gamepad, &device_name);
+                                        action->m_GamepadNameCount = strlen(device_name) + 1;
+                                        dmStrlCpy(action->m_GamepadName, device_name, action->m_GamepadNameCount);
+                                    }
+                                }
                             } else {
                                 if (input.m_Index != (uint16_t)~0)
                                 {

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -691,9 +691,7 @@ namespace dmInput
                                     {
                                         const char* device_name;
                                         dmHID::GetGamepadDeviceName(gamepad, &device_name);
-                                        size_t device_name_length = strlen(device_name) + 1;
-                                        action->m_TextCount = dmMath::Min(size_t(dmHID::MAX_CHAR_COUNT), device_name_length);
-                                        dmStrlCpy(action->m_Text, device_name, action->m_TextCount);
+                                        action->m_TextCount = dmStrlCpy(action->m_Text, device_name, sizeof(action->m_Text));
                                     }
                                 }
                             } else {

--- a/engine/input/src/input.h
+++ b/engine/input/src/input.h
@@ -38,6 +38,8 @@ namespace dmInput
         char         m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t     m_TextCount;
         uint32_t     m_HasText;
+        char     m_GamepadName[dmHID::MAX_CHAR_COUNT];
+        uint32_t m_GamepadNameCount;
         uint32_t m_GamepadIndex;
         uint32_t m_IsGamepad : 1;
         uint32_t m_GamepadDisconnected : 1;

--- a/engine/input/src/input.h
+++ b/engine/input/src/input.h
@@ -35,11 +35,10 @@ namespace dmInput
         float m_AccZ;
         dmHID::Touch m_Touch[dmHID::MAX_TOUCH_COUNT];
         int32_t      m_TouchCount;
+        /// Contains text input if m_HasText, and gamepad name if m_GamepadConnected
         char         m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t     m_TextCount;
         uint32_t     m_HasText;
-        char     m_GamepadName[dmHID::MAX_CHAR_COUNT];
-        uint32_t m_GamepadNameCount;
         uint32_t m_GamepadIndex;
         uint32_t m_IsGamepad : 1;
         uint32_t m_GamepadDisconnected : 1;

--- a/engine/input/src/test/test.input_binding
+++ b/engine/input/src/test/test.input_binding
@@ -3,5 +3,6 @@ mouse_trigger { input: MOUSE_BUTTON_LEFT action: "MOUSE_CLICK" }
 gamepad_trigger { input: GAMEPAD_LSTICK_UP action: "GAMEPAD_LSTICK_UP" }
 gamepad_trigger { input: GAMEPAD_RSTICK_UP action: "GAMEPAD_RSTICK_UP" }
 gamepad_trigger { input: GAMEPAD_RSTICK_DOWN action: "GAMEPAD_RSTICK_DOWN" }
+gamepad_trigger { input: GAMEPAD_CONNECTED action: "GAMEPAD_CONNECTED" }
 touch_trigger { input: TOUCH_MULTI action: "TOUCH_1" }
 touch_trigger { input: TOUCH_MULTI action: "TOUCH_2" }

--- a/engine/input/src/test/test_input.cpp
+++ b/engine/input/src/test/test_input.cpp
@@ -82,7 +82,7 @@ TEST_F(InputTest, CreateContext)
 void TextInputCallback(dmhash_t action_id, dmInput::Action* action, void* user_data)
 {
     dmHashTable64<dmInput::Action*>* actions = (dmHashTable64<dmInput::Action*>*)user_data;
-    ASSERT_TRUE(action->m_HasText || action->m_TextCount > 0);
+    ASSERT_TRUE(action->m_HasText);
     actions->Put(action_id, action);
 }
 
@@ -393,7 +393,7 @@ TEST_F(InputTest, GamepadConnectedContainsGamepadName)
 
     dmhash_t action_id = dmHashString64("GAMEPAD_CONNECTED");
     ASSERT_TRUE(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadConnected);
-    ASSERT_STREQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadName, "null_device");
+    ASSERT_STREQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_Text, "null_device");
 
     dmInput::DeleteBinding(binding);
 }
@@ -415,8 +415,8 @@ TEST_F(InputTest, GamepadStickEventNotContainsGamepadName)
     ASSERT_TRUE(dmInput::Pressed(binding->m_GamepadBindings[0], action_id));
     ASSERT_FALSE(dmInput::Released(binding->m_GamepadBindings[0], action_id));
     ASSERT_FALSE(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadConnected);
-    ASSERT_STREQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadName, "");
-    ASSERT_EQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadNameCount, 0);
+    ASSERT_STREQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_Text, "");
+    ASSERT_EQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_TextCount, 0);
 
     dmInput::DeleteBinding(binding);
 }

--- a/engine/input/src/test/test_input.cpp
+++ b/engine/input/src/test/test_input.cpp
@@ -378,6 +378,49 @@ TEST_F(InputTest, Gamepad)
     dmInput::DeleteBinding(binding);
 }
 
+TEST_F(InputTest, GamepadConnectedContainsGamepadName)
+{
+    dmInput::HBinding binding = dmInput::NewBinding(m_Context);
+    dmInput::SetBinding(binding, m_TestDDF);
+
+
+    dmInput::GamepadConfig* map = m_Context->m_GamepadMaps.Get(dmHashString32("null_device"));
+    ASSERT_NE((void*)0x0, (void*)map);
+    
+    dmHID::SetGamepadConnectivity(m_HidContext, 0, true);
+    dmHID::Update(m_HidContext);
+    dmInput::UpdateBinding(binding, m_DT);
+
+    dmhash_t action_id = dmHashString64("GAMEPAD_CONNECTED");
+    ASSERT_TRUE(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadConnected);
+    ASSERT_STREQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadName, "null_device");
+
+    dmInput::DeleteBinding(binding);
+}
+
+TEST_F(InputTest, GamepadStickEventNotContainsGamepadName)
+{
+    dmInput::HBinding binding = dmInput::NewBinding(m_Context);
+    dmInput::SetBinding(binding, m_TestDDF);
+
+    dmInput::GamepadConfig* map = m_Context->m_GamepadMaps.Get(dmHashString32("null_device"));
+    ASSERT_NE((void*)0x0, (void*)map);
+
+    dmHID::SetGamepadAxis(binding->m_GamepadBindings[0]->m_Gamepad, map->m_Inputs[dmInputDDF::GAMEPAD_LSTICK_UP].m_Index, 1.0f);
+    dmHID::Update(m_HidContext);
+    dmInput::UpdateBinding(binding, m_DT);
+
+    dmhash_t action_id = dmHashString64("GAMEPAD_LSTICK_UP");
+    ASSERT_EQ(1.0f, dmInput::GetValue(binding->m_GamepadBindings[0], action_id));
+    ASSERT_TRUE(dmInput::Pressed(binding->m_GamepadBindings[0], action_id));
+    ASSERT_FALSE(dmInput::Released(binding->m_GamepadBindings[0], action_id));
+    ASSERT_FALSE(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadConnected);
+    ASSERT_STREQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadName, "");
+    ASSERT_EQ(binding->m_GamepadBindings[0]->m_Actions.Get(action_id)->m_GamepadNameCount, 0);
+
+    dmInput::DeleteBinding(binding);
+}
+
 TEST_F(InputTest, Touch)
 {
     // Create new contexts to avoid mouse interference

--- a/engine/input/src/test/test_input.cpp
+++ b/engine/input/src/test/test_input.cpp
@@ -383,7 +383,6 @@ TEST_F(InputTest, GamepadConnectedContainsGamepadName)
     dmInput::HBinding binding = dmInput::NewBinding(m_Context);
     dmInput::SetBinding(binding, m_TestDDF);
 
-
     dmInput::GamepadConfig* map = m_Context->m_GamepadMaps.Get(dmHashString32("null_device"));
     ASSERT_NE((void*)0x0, (void*)map);
     


### PR DESCRIPTION
closes #4856 

**Before**: There was no way to get connected gamepad name.

**Now**: You can get connected device name like this:
```lua
function on_input(self, action_id, action)
    if action_id == hash("gamepad_connected") then
        print("Connected gamepad gui: " .. action.gamepad_name);
    end
end
```

This is supported both in `gui_script` and in `script`.

**Testing**:
Tested on the following sample:
[gamepad_connected.zip](https://github.com/defold/defold/files/4840534/gamepad_connected.zip)

Used PS4 controller connected with wire. Connecting with bluetooth doesn't work with DUALSHOCK4 out of the box - it doesn't seem to find the right configuration in `default.gamepads` it seems.

Tested text input for regression on android to get `marked-text` events. Pressed on three symbols (one time on each) for Japanese and English keyboards. Compared output with 1.2.163 version of the engine they are equal:
[1_2_163_input_test.txt](https://github.com/defold/defold/files/4871876/1_2_163_input_test.txt)
[1_2_171_input_test.txt](https://github.com/defold/defold/files/4871877/1_2_171_input_test.txt)

Note: Japanese `marked-text` events look buggy, but they look so in 1.2.163 version as well, so this is not a regression.

**Points for discussion**: 
1. Name of a variable in Lua script containing gamepad name.
2. Length of a field containing gamepad name. (I saw somewhere inside `glfwGetJoystickDeviceId` that this might be limited further to 64 bytes, but not sure about all the platforms)
3. The pull request is a draft because I want to add unit tests to this.