### PR TITLE
Make input stack capacity configurable

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -275,6 +275,9 @@ help = Collection related settings
 max_instances.type = integer
 max_instances.help = max number of instances per collection, 1024 by default
 max_instances.default = 1024
+max_input_stack_entries.type = integer
+max_input_stack_entries.help = max number of game objects in the input stack, 16 by default
+max_input_stack_entries.default = 16
 
 [collection_proxy]
 help = Collection proxy related settings

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -294,6 +294,10 @@
    :help "max number of instances per collection, 1024 by default",
    :default 1024,
    :path ["collection" "max_instances"]}
+  {:type :integer,
+   :help "max number of game objects in the input stack, 16 by default",
+   :default 16,
+   :path ["collection" "max_input_stack_entries"]}
   {:type :number,
    :help "global gain (volume), 0 - 1, 1 by default",
    :default 1.0,

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -790,6 +790,7 @@ namespace dmEngine
             dmLogFatal("Failed to set max instance count for collections (%d)", go_result);
             return false;
         }
+        dmGameObject::SetInputStackDefaultCapacity(engine->m_Register, dmConfigFile::GetInt(engine->m_Config, dmGameObject::COLLECTION_MAX_INPUT_STACK_ENTRIES_KEY, dmGameObject::DEFAULT_MAX_INPUT_STACK_CAPACITY));
 
         dmRender::RenderContextParams render_params;
         render_params.m_MaxRenderTypes = 16;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -244,7 +244,7 @@ namespace dmGameObject
         regist->m_DefaultInputStackCapacity = capacity;
     }
 
-    uint32_t GetInputStackDefaultCapacity(HRegister regist)
+    static uint32_t GetInputStackDefaultCapacity(HRegister regist)
     {
         assert(regist != 0x0);
         return regist->m_DefaultInputStackCapacity;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -42,6 +42,7 @@
 namespace dmGameObject
 {
     const char* COLLECTION_MAX_INSTANCES_KEY = "collection.max_instances";
+    const char* COLLECTION_MAX_INPUT_STACK_ENTRIES_KEY = "collection.max_input_stack_entries";
     const dmhash_t UNNAMED_IDENTIFIER = dmHashBuffer64("__unnamed__", strlen("__unnamed__"));
     const char* ID_SEPARATOR = "/";
     const uint32_t MAX_DISPATCH_ITERATION_COUNT = 10;
@@ -158,6 +159,7 @@ namespace dmGameObject
     {
         m_ComponentTypeCount = 0;
         m_DefaultCollectionCapacity = DEFAULT_MAX_COLLECTION_CAPACITY;
+        m_DefaultInputStackCapacity = DEFAULT_MAX_INPUT_STACK_CAPACITY;
         m_Mutex = dmMutex::New();
         m_SocketToCollection.SetCapacity(15, 17);
     }
@@ -182,7 +184,7 @@ namespace dmGameObject
         return new Register();
     }
 
-    Collection::Collection(dmResource::HFactory factory, HRegister regist, uint32_t max_instances)
+    Collection::Collection(dmResource::HFactory factory, HRegister regist, uint32_t max_instances, uint32_t max_input_stack_entries)
     {
         m_Factory = factory;
         m_Register = regist;
@@ -193,8 +195,7 @@ namespace dmGameObject
         m_WorldTransforms.SetCapacity(max_instances);
         m_WorldTransforms.SetSize(max_instances);
         m_IDToInstance.SetCapacity(dmMath::Max(1U, max_instances/3), max_instances);
-        // TODO: Un-hard-code
-        m_InputFocusStack.SetCapacity(16);
+        m_InputFocusStack.SetCapacity(max_input_stack_entries);
         m_NameHash = 0;
         m_ComponentSocket = 0;
         m_FrameSocket = 0;
@@ -237,6 +238,18 @@ namespace dmGameObject
         return regist->m_DefaultCollectionCapacity;
     }
 
+    void SetInputStackDefaultCapacity(HRegister regist, uint32_t capacity)
+    {
+        assert(regist != 0x0);
+        regist->m_DefaultInputStackCapacity = capacity;
+    }
+
+    uint32_t GetInputStackDefaultCapacity(HRegister regist)
+    {
+        assert(regist != 0x0);
+        return regist->m_DefaultInputStackCapacity;
+    }
+
     void DeleteRegister(HRegister regist)
     {
         uint32_t collection_count = regist->m_Collections.Size();
@@ -253,7 +266,7 @@ namespace dmGameObject
 
     Collection* AllocCollection(const char* name, HRegister regist, uint32_t max_instances)
     {
-        Collection* collection = new Collection(0, 0, max_instances);
+        Collection* collection = new Collection(0, 0, max_instances, GetInputStackDefaultCapacity(regist));
         collection->m_Mutex = dmMutex::New();
 
         for (uint32_t i = 0; i < regist->m_ComponentTypeCount; ++i)

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -37,12 +37,18 @@ namespace dmGameObject
     /// Default max instances in collection
     const uint32_t DEFAULT_MAX_COLLECTION_CAPACITY = 1024;
 
+    /// Default max instances in input stack
+    const uint32_t DEFAULT_MAX_INPUT_STACK_CAPACITY = 16;
+
     // Value for an invalid instance index, this must be the same as defined in
     // gamesys_ddf.proto for Create#index.
     const uint32_t INVALID_INSTANCE_POOL_INDEX = 0xffffffff;
 
     /// Config key to use for tweaking maximum number of instances in a collection
     extern const char* COLLECTION_MAX_INSTANCES_KEY;
+
+    /// Config key to use for tweaking the maximum capacity of the input stack
+    extern const char* COLLECTION_MAX_INPUT_STACK_ENTRIES_KEY;
 
     /// Instance handle
     typedef struct Instance* HInstance;
@@ -715,6 +721,20 @@ namespace dmGameObject
      * @return Default capacity
      */
     uint32_t GetCollectionDefaultCapacity(HRegister regist);
+
+    /**
+     * Set default input stack capacity of collections in this register. This does not affect existing collections.
+     * @param regist Register
+     * @param capacity Default capacity of collections in this register.
+     */
+    void SetInputStackDefaultCapacity(HRegister regist, uint32_t capacity);
+
+    /**
+     * Get default input stack capacity of collections in this register.
+     * @param regist Register
+     * @return Default capacity
+     */
+    uint32_t GetInputStackDefaultCapacity(HRegister regist);
 
     /**
      * Delete a component type register

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -730,13 +730,6 @@ namespace dmGameObject
     void SetInputStackDefaultCapacity(HRegister regist, uint32_t capacity);
 
     /**
-     * Get default input stack capacity of collections in this register.
-     * @param regist Register
-     * @return Default capacity
-     */
-    uint32_t GetInputStackDefaultCapacity(HRegister regist);
-
-    /**
      * Delete a component type register
      * @param regist Register to delete
      */

--- a/engine/gameobject/src/gameobject/gameobject_private.h
+++ b/engine/gameobject/src/gameobject/gameobject_private.h
@@ -210,6 +210,7 @@ namespace dmGameObject
         dmArray<Collection*>        m_Collections;
         // Default capacity of collections
         uint32_t                    m_DefaultCollectionCapacity;
+        uint32_t                    m_DefaultInputStackCapacity;
 
         dmHashTable64<Collection*>  m_SocketToCollection;
 
@@ -223,7 +224,7 @@ namespace dmGameObject
     const uint32_t MAX_HIERARCHICAL_DEPTH = 128;
     struct Collection
     {
-        Collection(dmResource::HFactory factory, HRegister regist, uint32_t max_instances);
+        Collection(dmResource::HFactory factory, HRegister regist, uint32_t max_instances, uint32_t max_input_stack_entries);
 
         // Resource factory
         dmResource::HFactory     m_Factory;


### PR DESCRIPTION
The input stack limit of 16 is very limitative for complex scenes. For example, a complex scene with more than 16 GUIs, each a different panel displaying different information (a situation which cannot be handled very well with a common input manager).

This PR makes the limit configurable through `collection.max_input_stack_entries`.
