### PR TITLE
Make CFBundleName configurable

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -701,6 +701,11 @@ public class BundleHelper {
         return properties;
     }
 
+    private String derivedBundleName() {
+        String title = projectProperties.getStringValue("project", "title", "dmengine");
+        return title.substring(0, Math.min(title.length(), 15));
+    }
+
     public Map<String, Object> createOSXManifestProperties(String exeName) throws IOException {
         Map<String, Object> properties = new HashMap<>();
         properties.put("exe-name", exeName);
@@ -708,6 +713,8 @@ public class BundleHelper {
         String applicationLocalizationsStr = projectProperties.getStringValue("osx", "localizations", null);
         List<String> applicationLocalizations = createArrayFromString(applicationLocalizationsStr);
         properties.put("application-localizations", applicationLocalizations);
+
+        properties.put("bundle-name", projectProperties.getStringValue("osx", "bundle_name", derivedBundleName()));
 
         return properties;
     }
@@ -725,6 +732,7 @@ public class BundleHelper {
         properties.put("exe-name", exeName);
         properties.put("url-schemes", urlSchemes);
         properties.put("application-queries-schemes", applicationQueriesSchemes);
+        properties.put("bundle-name", projectProperties.getStringValue("ios", "bundle_name", derivedBundleName()));
 
         List<String> orientationSupport = new ArrayList<String>();
         if(projectProperties.getBooleanValue("display", "dynamic_orientation", false)==false) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -372,6 +372,10 @@ bundle_identifier.type = string
 bundle_identifier.help = bundle identifier (CFBundleIdentifier)
 bundle_identifier.default = example.unnamed
 
+bundle_name.type = string
+bundle_name.help = bundle short name (CFBundleName). max 15 characters
+bundle_name.default =
+
 infoplist.type = resource
 infoplist.help = custom Info.plist template file
 infoplist.default = /builtins/manifests/ios/Info.plist
@@ -490,6 +494,10 @@ infoplist.default = /builtins/manifests/osx/Info.plist
 bundle_identifier.type = string
 bundle_identifier.help = bundle identifier (CFBundleIdentifier)
 bundle_identifier.default = example.unnamed
+
+bundle_name.type = string
+bundle_name.help = bundle short name (CFBundleName). max 15 characters
+bundle_name.default =
 
 default_language.type = string
 default_language.help = default language and region (CFBundleDevelopmentRegion)

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -549,6 +549,9 @@
    :help "bundle identifier (CFBundleIdentifier)",
    :default "example.unnamed",
    :path ["ios" "bundle_identifier"]}
+  {:type :string,
+   :help "bundle short name (CFBundleName). max 15 characters",
+   :path ["ios" "bundle_name"]}
   {:type :resource,
    :filter "plist",
    :preserve-extension true,
@@ -746,6 +749,9 @@
    :help "bundle identifier (CFBundleIdentifier)",
    :default "example.unnamed",
    :path ["osx" "bundle_identifier"]}
+  {:type :string,
+   :help "bundle short name (CFBundleName). max 15 characters",
+   :path ["osx" "bundle_name"]}
   {:type :resource,
    :filter "plist",
    :preserve-extension true,

--- a/engine/engine/content/builtins/manifests/ios/Info.plist
+++ b/engine/engine/content/builtins/manifests/ios/Info.plist
@@ -47,7 +47,7 @@
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>
-        <string>dmengine</string>
+        <string>{{bundle-name}}</string>
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>

--- a/engine/engine/content/builtins/manifests/osx/Info.plist
+++ b/engine/engine/content/builtins/manifests/osx/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>unnamed</string>
+	<string>{{bundle-name}}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
`CFBundleName` is currently always set to `unnamed` on macOS and `dmengine` on iOS.

This plist property doesn't do much (`CFBundleDisplayName` is usually shown to the user, which Defold currently sets correctly), but it's still used in a few places. Notably, on macOS it's used the app menu bar (Defold games would always show up as "unnamed"). On iOS it's not really used apart from (allegedly) Watch app titles. Also, I found someone complaining about [this bug that occurs when CFBundleName is not unique across apps](https://www.reddit.com/r/iOSProgramming/comments/812o36/apple_uses_cfbundlename_to_differentiate_between/).

This PR makes `CFBundleName` default to the first 15 characters of `project.title` (although I suspect the 15-char limit Apple mentions in their docs is probably legacy cruft, since I see System Preferences.app clearly having more than 15 chars in its menu bar) and also exposes it to `game.project` in case the user wants to customise it.

<img width="136" alt="Screenshot 2020-06-27 at 21 30 43" src="https://user-images.githubusercontent.com/428060/85929589-cc5a7a00-b8be-11ea-94b1-b5462830991d.png">
