### PR TITLE
Fix test not cleaning up temporary file

### DIFF
--- a/engine/resource/src/test/test_resource_archive.cpp
+++ b/engine/resource/src/test/test_resource_archive.cpp
@@ -243,6 +243,7 @@ TEST(dmResourceArchive, ShiftInsertResource)
     free(resource);
     dmResourceArchive::Delete(archive);
     FreeMutableIndexData((void*&)arci_copy);
+    remove(resource_filename);
 }
 
 TEST(dmResourceArchive, NewArchiveIndexFromCopy)


### PR DESCRIPTION
There was a test that would leave an `engine/resource/test_resource_liveupdate.arcd` file laying around after it finished and git would complain.