### PR TITLE
Issue 5029: Updated to Emscripten 1.39.20 (fixed javascript size issue)

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -75,7 +75,7 @@ PACKAGES_LINUX_TOOLCHAIN="clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04"
 PACKAGES_CCTOOLS_PORT="cctools-port-darwin14-3f979bbcd7ee29d79fb93f829edf3d1d16441147-linux"
 
 NODE_MODULE_LIB_DIR = os.path.join("ext", "lib", "node_modules")
-EMSCRIPTEN_VERSION_STR = "1.39.16"
+EMSCRIPTEN_VERSION_STR = "1.39.20"
 EMSCRIPTEN_SDK = "sdk-{0}-64bit".format(EMSCRIPTEN_VERSION_STR)
 PACKAGES_EMSCRIPTEN_SDK="emsdk-{0}".format(EMSCRIPTEN_VERSION_STR)
 SHELL = os.environ.get('SHELL', 'bash')

--- a/scripts/package/package_emscripten.sh
+++ b/scripts/package/package_emscripten.sh
@@ -14,7 +14,7 @@
 
 set -e
 
-VERSION=1.39.16
+VERSION=1.39.20
 URL=https://github.com/emscripten-core/emsdk/archive/${VERSION}.tar.gz
 PLATFORM=`uname`
 PLATFORM="$(tr [A-Z] [a-z] <<< "$PLATFORM")"

--- a/share/extender/build.yml
+++ b/share/extender/build.yml
@@ -300,11 +300,11 @@ platforms:
 
   js-web:
     env:
-        EM_CACHE:               "{{env.EMSCRIPTEN_CACHE_1_39_16}}"
-        EM_CONFIG:              "{{env.EMSCRIPTEN_CONFIG_1_39_16}}"
-        PATH:                   "{{env.EMSCRIPTEN_PATH_1_39_16}}:{{env.PATH}}"
-        EMSCRIPTEN_HOME:        "{{env.EMSCRIPTEN_HOME_1_39_16}}"
-        EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_1_39_16}}"
+        EM_CACHE:               "{{env.EMSCRIPTEN_CACHE_1_39_20}}"
+        EM_CONFIG:              "{{env.EMSCRIPTEN_CONFIG_1_39_20}}"
+        PATH:                   "{{env.EMSCRIPTEN_PATH_1_39_20}}:{{env.PATH}}"
+        EMSCRIPTEN_HOME:        "{{env.EMSCRIPTEN_HOME_1_39_20}}"
+        EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_1_39_20}}"
         MANIFEST_MERGE_TOOL:    "{{env.MANIFEST_MERGE_TOOL}}"
     context:
         engineJsLibs: ["glfw", "sys", "script", "sound"]
@@ -334,11 +334,11 @@ platforms:
 
   wasm-web:
     env:
-        EM_CACHE:               "{{env.EMSCRIPTEN_CACHE_1_39_16}}"
-        EM_CONFIG:              "{{env.EMSCRIPTEN_CONFIG_1_39_16}}"
-        PATH:                   "{{env.EMSCRIPTEN_PATH_1_39_16}}:{{env.PATH}}"
-        EMSCRIPTEN_HOME:        "{{env.EMSCRIPTEN_HOME_1_39_16}}"
-        EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_1_39_16}}"
+        EM_CACHE:               "{{env.EMSCRIPTEN_CACHE_1_39_20}}"
+        EM_CONFIG:              "{{env.EMSCRIPTEN_CONFIG_1_39_20}}"
+        PATH:                   "{{env.EMSCRIPTEN_PATH_1_39_20}}:{{env.PATH}}"
+        EMSCRIPTEN_HOME:        "{{env.EMSCRIPTEN_HOME_1_39_20}}"
+        EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_1_39_20}}"
         MANIFEST_MERGE_TOOL:    "{{env.MANIFEST_MERGE_TOOL}}"
     context:
         engineJsLibs: ["glfw", "sys", "script", "sound"]


### PR DESCRIPTION
Executable size went back from `7768766` bytes to `4426271`