### PR TITLE
Make sure assets and libs are copied to the right folder in the AAB base zip on all platforms

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -467,20 +467,20 @@ public class AndroidBundler implements IBundler {
 
             // copy extension and bundle resoources
             Map<String, IResource> bundleResources = ExtenderUtil.collectBundleResources(project, getArchitectures(project));
-            final String assetsPath = "assets" + File.separator;
-            final String libPath = "lib" + File.separator;
-            final String resPath = "res" + File.separator;
+            final String assetsPath = "assets/";
+            final String libPath = "lib/";
+            final String resPath = "res/";
             for (String filename : bundleResources.keySet()) {
                 IResource resource = bundleResources.get(filename);
                 // remove initial file separator if it exists
-                if (filename.startsWith(File.separator)) {
+                if (filename.startsWith("/")) {
                     filename = filename.substring(1);
                 }
                 // files starting with "res/" should be ignored as they are copied in a separate step below
                 if (filename.startsWith(resPath)) {
                     continue;
                 }
-                // files starting with "assets/" and "libs/" should be copied as-is to their respective dirs
+                // files starting with "assets/" and "lib/" should be copied as-is to their respective dirs
                 // other files should be copied to the to the root/ dir
                 File file = null;
                 if (filename.startsWith(assetsPath) || filename.startsWith(libPath)) {


### PR DESCRIPTION
We can't use File.separator since ExtenderUtil always returns paths with forward slash.