### PR TITLE
Build script fixes to add more granularity to channel selection

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -331,12 +331,12 @@ def release_to_github_markdown(token = None, repo = None, sha1 = None):
     call(cmd)
 
 
-def build_sdk(channel = None):
+def build_sdk(archive_channel):
     args = "python scripts/build.py build_sdk".split()
     opts = []
 
     if channel:
-        opts.append("--channel=%s" % channel)
+        opts.append("--archive-channel=%s" % archive_channel)
 
     cmd = ' '.join(args + opts)
     call(cmd)

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -335,7 +335,7 @@ def build_sdk(archive_channel):
     args = "python scripts/build.py build_sdk".split()
     opts = []
 
-    if channel:
+    if archive_channel:
         opts.append("--archive-channel=%s" % archive_channel)
 
     cmd = ' '.join(args + opts)

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -319,8 +319,8 @@ def create_bundle(options):
         config.set('build', 'version', options.version)
         config.set('build', 'time', datetime.datetime.now().isoformat())
 
-        if options.channel:
-            config.set('build', 'channel', options.channel)
+        if options.update_channel:
+            config.set('build', 'channel', options.update_channel)
 
         with open('%s/config' % resources_dir, 'wb') as f:
             config.write(f)
@@ -482,9 +482,9 @@ Commands:
                       default = None,
                       help = 'Version to set in editor config when creating the bundle')
 
-    parser.add_option('--channel', dest='channel',
+    parser.add_option('--update-channel', dest='update_channel',
                       default = None,
-                      help = 'Channel to set in editor config when creating the bundle')
+                      help = 'Channel to set in editor config when creating the bundle. Used when editor is checking for updates.')
 
     parser.add_option('--engine-artifacts', dest='engine_artifacts',
                       default = 'auto',


### PR DESCRIPTION
There's three different variables available now:

--archive-channel This is used when archiving artefacts to s3 (engine, bob, editor) or when downloading artefacts from s3
--release-channel This is used by the "release" command of build.py. It controls to which channel a release is made.
--editor-update-channel This is the channel written to the "config" file of the editor. It decides where the editor is looking for updates.

There is no default value for any of the above variables. We previously had a problem that "stable" was the default value. This resulted in editor builds from DEFEDIT-* branches ended up in d.defold.com/archive/stable where they would be kept forever.