### PR TITLE
docs(resource): fix for missing @param

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -46,6 +46,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.material
+ * @param path [type:string] a path string to the source version of the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -69,6 +70,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.font
+ * @param path [type:string] a path string to the source version of the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -92,6 +94,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.texture
+ * @param path [type:string] a path string to the source version of the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -115,6 +118,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.atlas
+ * @param path [type:string] a path string to the source version of the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -138,6 +142,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.buffer
+ * @param path [type:string] a path string to the source version of the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -161,6 +166,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.tile_source
+ * @param path [type:string] a path string to the source version of the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -46,7 +46,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.material
- * @param path [type:string] a path string to the source version of the resource
+ * @param path [type:string] optional resource path string to the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -70,7 +70,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.font
- * @param path [type:string] a path string to the source version of the resource
+ * @param path [type:string] optional resource path string to the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -94,7 +94,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.texture
- * @param path [type:string] a path string to the source version of the resource
+ * @param path [type:string] optional resource path string to the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -118,7 +118,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.atlas
- * @param path [type:string] a path string to the source version of the resource
+ * @param path [type:string] optional resource path string to the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -142,7 +142,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.buffer
- * @param path [type:string] a path string to the source version of the resource
+ * @param path [type:string] optional resource path string to the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *
@@ -166,7 +166,7 @@ namespace dmGameSystem
  * [icon:attention] This function can only be called within [ref:go.property] function calls.
  *
  * @name resource.tile_source
- * @param path [type:string] a path string to the source version of the resource
+ * @param path [type:string] optional resource path string to the resource
  * @return path [type:hash] a path hash to the binary version of the resource
  * @examples
  *


### PR DESCRIPTION
I am unsure of the exact wording to use here, however the samples all imply that you require a path to use this function, and the documentation for each method is missing the @param calling out the required path.

Happy to update verbiage used if you see it not being fit or accurate.