### PR TITLE
Make editor only check for update once per hour

### DIFF
--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -344,7 +344,7 @@
         downloaded-sha1 (when (.exists update-sha1-file)
                           (slurp update-sha1-file))
         initial-update-delay 1000
-        update-delay 60000]
+        update-delay 3600000]
     (if (or (string/blank? channel) (string/blank? sha1))
       (do
         (log/info :message "Automatic updates disabled" :channel channel :sha1 sha1)


### PR DESCRIPTION
The initial update check is still fast.

Having the editor check for updates once per minute may have been more useful during the rapid editor update times but today it is not useful.