### PR TITLE
Allow requesting full screen on a custom DOM node

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -709,11 +709,11 @@ var Module = {
         }
     },
 
-    toggleFullscreen: function() {
+    toggleFullscreen: function(element) {
         if (GLFW.isFullscreen) {
             GLFW.cancelFullScreen();
         } else {
-            GLFW.requestFullScreen();
+            GLFW.requestFullScreen(element);
         }
     },
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -659,6 +659,12 @@ var Module = {
         Module.persistentStorage = params["persistent_storage"];
         Module["TOTAL_MEMORY"] = params["custom_heap_size"];
 
+        var fullScreenContainer = params["full_screen_container"];
+        if (typeof fullScreenContainer === "string") {
+            fullScreenContainer = document.querySelector(fullScreenContainer);
+        }
+        Module.fullScreenContainer = fullScreenContainer || Module.canvas;
+
         if (Module.hasWebGLSupport()) {
             // Override game keys
             CanvasInput.addToCanvas(Module.canvas);

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -43,6 +43,10 @@
 		vertical-align: bottom;
 	}
 
+	#canvas-container {
+		position: relative;
+	}
+
 	canvas:focus, canvas:active {
 		outline: none;
 		border: 0;
@@ -66,7 +70,9 @@
 
 <body>
 	<div id="app-container" class="canvas-app-container">
-		<canvas id="canvas" class="canvas-app-canvas" tabindex="1" width="{{display.width}}" height="{{display.height}}"></canvas>
+		<div id="canvas-container" class="canvas-app-canvas-container">
+			<canvas id="canvas" class="canvas-app-canvas" tabindex="1" width="{{display.width}}" height="{{display.height}}"></canvas>
+		</div>
 		<div class="buttons-background">
 {{#html5.show_fullscreen_button}}
 			<div class="button" onclick="Module.toggleFullscreen();">Fullscreen</div>
@@ -86,6 +92,7 @@
 		},
 		engine_arguments: [{{#DEFOLD_ENGINE_ARGUMENTS}}"{{.}}",{{/DEFOLD_ENGINE_ARGUMENTS}}],
 		custom_heap_size: {{DEFOLD_HEAP_SIZE}},
+		full_screen_container: "#canvas-container",
 		disable_context_menu: true
 	}
 

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -438,21 +438,22 @@ var LibraryGLFW = {
       GLFW.prevHeight = 0;
     },
 
-    requestFullScreen: function() {
-      if (!Module["canvas"]) {
+    requestFullScreen: function(element) {
+      element = element || Module["fullScreenContainer"] || Module["canvas"];
+      if (!element) {
         return;
       }
       document.addEventListener('fullscreenchange', GLFW.onFullScreenEventChange, true);
       document.addEventListener('mozfullscreenchange', GLFW.onFullScreenEventChange, true);
       document.addEventListener('webkitfullscreenchange', GLFW.onFullScreenEventChange, true);
       document.addEventListener('msfullscreenchange', GLFW.onFullScreenEventChange, true);
-      var RFS = Module["canvas"]['requestFullscreen'] ||
-                Module["canvas"]['requestFullScreen'] ||
-                Module["canvas"]['mozRequestFullScreen'] ||
-                Module["canvas"]['webkitRequestFullScreen'] ||
-                Module["canvas"]['msRequestFullScreen'] ||
+      var RFS = element['requestFullscreen'] ||
+                element['requestFullScreen'] ||
+                element['mozRequestFullScreen'] ||
+                element['webkitRequestFullScreen'] ||
+                element['msRequestFullScreen'] ||
                 (function() {});
-      RFS.apply(Module["canvas"], []);
+      RFS.apply(element, []);
     },
 
     cancelFullScreen: function() {


### PR DESCRIPTION
In a HTML5 game there are situations when you want other DOM elements to overlay your game (things like an ad, a video or some settings page made with web technologies). This is very easy to do in windowed mode with CSS but once you're in full screen mode, nothing outside the canvas is being rendered by the browser.

The solution to this is to request full screen mode on a parent of the canvas and render your overlays as siblings within the same parent.

This PR adds two ways of achieving that:
* Momentarily by passing an optional DOM element to `Module.toggleFullScreen(elem)`
* As configuration, by setting `Module.fullScreenContainer` to an arbitrary DOM node

As an extra step, I would also add the before-mentioned parent container around the canvas to the HTML template, but I'm afraid to make changes like that as not to break backwards compatibility somehow. If any game (like ours) needs this feature, it's pretty easy for them to add the container themselves. On the upside, if the container is there by default, that would open up a place for native extensions to show arbitrary DOM UIs.