### PR TITLE
Install PyYAML with PIP

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -521,8 +521,8 @@ class Configuration(object):
             installed_packages.update(target_package_paths)
 
         print("Installing python eggs")
-        run.env_command(self._form_env(), ['easy_install', '-q', '-d', join(self.ext, 'lib', 'python'), 'requests'])
-        run.env_command(self._form_env(), ['easy_install', '-q', '-d', join(self.ext, 'lib', 'python'), 'pyaml'])
+        run.env_command(self._form_env(), ['python', '-m', 'easy_install', '-q', '-d', join(self.ext, 'lib', 'python'), 'pip'])
+        run.env_command(self._form_env(), ['python', '-m', 'pip', '-q', '-q', 'install', '-t', join(self.ext, 'lib', 'python'), 'requests', 'pyaml'])
         for egg in glob(join(self.defold_root, 'packages', '*.egg')):
             self._log('Installing %s' % basename(egg))
             run.env_command(self._form_env(), ['python', '-m', 'easy_install', '-q', '-d', join(self.ext, 'lib', 'python'), '-N', egg])


### PR DESCRIPTION
I tried following the install guide on a fresh macOS 11.0 VM. Installing PyYAML with `easy_install` fails. I think it's because `easy_install` expects PyYAML's `setup.py` to generate an egg, but it generates a wheel instead. It works fine if installed with `pip`, so in this PR I'm installing `pip` locally if it isn't present (it isn't on stock macOS 11.0), then installing `pyaml` with `pip`. 

As far as testing goes, I rolled back the VM, applied this patch and went through the setup and an engine build with no hitches.