### PR TITLE
Fix FileLoader's undefined behaviour of error handling

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -25,12 +25,12 @@ var FileLoader = {
                     if (onprogress) onprogress(xhr, e);
                 };
                 xhr.onerror = function(e) {
-                    if (currentAttempt == FileLoader.retryCount) {
+                    if (currentAttempt == FileLoader.options.retryCount) {
                         if (onerror) onerror(xhr, e);
                         return;
                     }
                     currentAttempt = currentAttempt + 1;
-                    setTimeout(obj.send, FileLoader.retryInterval);
+                    setTimeout(obj.send, FileLoader.options.retryInterval);
                 };
                 xhr.onload = function(e) {
                     if (onload) onload(xhr, e);


### PR DESCRIPTION
There is a small typo in `dmloader.js`. This pull request fixes it.

![image](https://user-images.githubusercontent.com/193258/101265797-6e2d9f00-375a-11eb-8545-f6f084e9837b.png)

