### PR TITLE
Add space between arguments generated from .script_apis

### DIFF
--- a/editor/src/clj/editor/script_api.clj
+++ b/editor/src/clj/editor/script_api.clj
@@ -71,7 +71,7 @@
   ([params]
    (build-param-string params false))
   ([params remove-optional?]
-   (str "(" (string/join "," (param-names params remove-optional?)) ")")))
+   (str "(" (string/join ", " (param-names params remove-optional?)) ")")))
 
 (defmethod convert "function"
   [{:keys [ns name desc parameters]}]


### PR DESCRIPTION
Auto-complete doesn't put a space between arguments of functions defined in .script_api files, unlike all builtin functions