### PR TITLE
Skip lipo step if there's only one architecture

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -121,6 +121,11 @@ public class IOSBundler implements IBundler {
 
     private void lipoBinaries(File resultFile, List<File> binaries)
     throws IOException, CompileExceptionError {
+        if (binaries.size() == 1) {
+            FileUtils.copyFile(binaries.get(0), resultFile);
+            return;
+        }
+
         String exe = resultFile.getPath();
         List<String> lipoArgList = new ArrayList<String>();
         lipoArgList.add(Bob.getExe(Platform.getHostPlatform(), "lipo"));


### PR DESCRIPTION
This helps mitigate #5409 (and unblocks me from not being able to build for iOS on CI). There really is no need to pass a single binary through `lipo -create` and this step would fail on non-macOS platforms.
