### PR TITLE
Expose CFBundleVersion for iOS and macOS

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -729,6 +729,9 @@ public class BundleHelper {
         properties.put("url-schemes", urlSchemes);
         properties.put("application-queries-schemes", applicationQueriesSchemes);
         properties.put("bundle-name", projectProperties.getStringValue("ios", "bundle_name", derivedBundleName()));
+        properties.put("build-number", projectProperties.getStringValue("ios", "build_number", 
+            projectProperties.getStringValue("project", "version", "1.0")
+        ));
 
         String launchScreen = projectProperties.getStringValue("ios", "launch_screen", "LaunchScreen");
         properties.put("launch-screen", FilenameUtils.getBaseName(launchScreen));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -729,7 +729,7 @@ public class BundleHelper {
         properties.put("url-schemes", urlSchemes);
         properties.put("application-queries-schemes", applicationQueriesSchemes);
         properties.put("bundle-name", projectProperties.getStringValue("ios", "bundle_name", derivedBundleName()));
-        properties.put("build-number", projectProperties.getStringValue("ios", "build_number", 
+        properties.put("bundle-version", projectProperties.getStringValue("ios", "bundle_version", 
             projectProperties.getStringValue("project", "version", "1.0")
         ));
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -363,7 +363,6 @@ bundle_name.default =
 
 build_number.type = string
 build_number.help = build number (CFBundleVersion). numeric or x.y.z
-build_number.default = 1
 
 infoplist.type = resource
 infoplist.help = custom Info.plist template file

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -361,8 +361,8 @@ bundle_name.type = string
 bundle_name.help = bundle short name (CFBundleName). max 15 characters
 bundle_name.default =
 
-build_number.type = string
-build_number.help = build number (CFBundleVersion). numeric or x.y.z
+bundle_version.type = string
+bundle_version.help = build number (CFBundleVersion). numeric or x.y.z
 
 infoplist.type = resource
 infoplist.help = custom Info.plist template file
@@ -491,9 +491,9 @@ bundle_name.type = string
 bundle_name.help = bundle short name (CFBundleName). max 15 characters
 bundle_name.default =
 
-build_number.type = string
-build_number.help = build number (CFBundleVersion). numeric or x.y.z
-build_number.default = 1
+bundle_version.type = string
+bundle_version.help = build number (CFBundleVersion). numeric or x.y.z
+bundle_version.default = 1
 
 default_language.type = string
 default_language.help = default language and region (CFBundleDevelopmentRegion)

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -361,6 +361,10 @@ bundle_name.type = string
 bundle_name.help = bundle short name (CFBundleName). max 15 characters
 bundle_name.default =
 
+build_number.type = string
+build_number.help = build number (CFBundleVersion). numeric or x.y.z
+build_number.default = 1
+
 infoplist.type = resource
 infoplist.help = custom Info.plist template file
 infoplist.default = /builtins/manifests/ios/Info.plist
@@ -487,6 +491,10 @@ bundle_identifier.default = example.unnamed
 bundle_name.type = string
 bundle_name.help = bundle short name (CFBundleName). max 15 characters
 bundle_name.default =
+
+build_number.type = string
+build_number.help = build number (CFBundleVersion). numeric or x.y.z
+build_number.default = 1
 
 default_language.type = string
 default_language.help = default language and region (CFBundleDevelopmentRegion)

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -452,7 +452,6 @@
    :path ["ios" "bundle_name"]}
   {:type :string,
    :help "build number (CFBundleVersion). numeric or x.y.z",
-   :default "1",
    :path ["ios" "build_number"]}
   {:type :resource,
    :filter "plist",

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -450,6 +450,10 @@
   {:type :string,
    :help "bundle short name (CFBundleName). max 15 characters",
    :path ["ios" "bundle_name"]}
+  {:type :string,
+   :help "build number (CFBundleVersion). numeric or x.y.z",
+   :default "1",
+   :path ["ios" "build_number"]}
   {:type :resource,
    :filter "plist",
    :preserve-extension true,
@@ -654,6 +658,10 @@
   {:type :string,
    :help "bundle short name (CFBundleName). max 15 characters",
    :path ["osx" "bundle_name"]}
+  {:type :string,
+   :help "build number (CFBundleVersion). numeric or x.y.z",
+   :default "1",
+   :path ["osx" "build_number"]}
   {:type :resource,
    :filter "plist",
    :preserve-extension true,

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -452,7 +452,7 @@
    :path ["ios" "bundle_name"]}
   {:type :string,
    :help "build number (CFBundleVersion). numeric or x.y.z",
-   :path ["ios" "build_number"]}
+   :path ["ios" "bundle_version"]}
   {:type :resource,
    :filter "plist",
    :preserve-extension true,
@@ -660,7 +660,7 @@
   {:type :string,
    :help "build number (CFBundleVersion). numeric or x.y.z",
    :default "1",
-   :path ["osx" "build_number"]}
+   :path ["osx" "bundle_version"]}
   {:type :resource,
    :filter "plist",
    :preserve-extension true,

--- a/engine/engine/content/builtins/manifests/ios/Info.plist
+++ b/engine/engine/content/builtins/manifests/ios/Info.plist
@@ -56,7 +56,7 @@
                 <string>iPhoneOS</string>
         </array>
         <key>CFBundleVersion</key>
-        <string>{{project.version}}</string>
+        <string>{{ios.build_number}}</string>
         <key>DTCompiler</key>
         <string>com.apple.compilers.llvm.clang.1_0</string>
         <key>DTPlatformBuild</key>

--- a/engine/engine/content/builtins/manifests/ios/Info.plist
+++ b/engine/engine/content/builtins/manifests/ios/Info.plist
@@ -56,7 +56,7 @@
                 <string>iPhoneOS</string>
         </array>
         <key>CFBundleVersion</key>
-        <string>{{ios.build_number}}</string>
+        <string>{{build-number}}</string>
         <key>DTCompiler</key>
         <string>com.apple.compilers.llvm.clang.1_0</string>
         <key>DTPlatformBuild</key>

--- a/engine/engine/content/builtins/manifests/ios/Info.plist
+++ b/engine/engine/content/builtins/manifests/ios/Info.plist
@@ -56,7 +56,7 @@
                 <string>iPhoneOS</string>
         </array>
         <key>CFBundleVersion</key>
-        <string>{{build-number}}</string>
+        <string>{{bundle-version}}</string>
         <key>DTCompiler</key>
         <string>com.apple.compilers.llvm.clang.1_0</string>
         <key>DTPlatformBuild</key>

--- a/engine/engine/content/builtins/manifests/osx/Info.plist
+++ b/engine/engine/content/builtins/manifests/osx/Info.plist
@@ -29,7 +29,7 @@
 		<string>{{.}}</string>{{/application-localizations}}
 	</array>
 	<key>CFBundleVersion</key>
-	<string>{{osx.build_number}}</string>
+	<string>{{osx.bundle_version}}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.7</string>
 	<key>NSMainNibFile</key>

--- a/engine/engine/content/builtins/manifests/osx/Info.plist
+++ b/engine/engine/content/builtins/manifests/osx/Info.plist
@@ -29,7 +29,7 @@
 		<string>{{.}}</string>{{/application-localizations}}
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>{{osx.build_number}}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.7</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
On iOS and macOS, there are two "versions" in Info.plist:

* `CFBundleShortVersionString`: This is the user-facing version string. It can be anything, but it's usually `major.minor.patch`.
* `CFBundleVersion`: This is what Xcode refers to as the "Build number". On iOS, you have to increment this with every submitted build to the App Store (even for builds that failed review), so it may diverge from the user-facing string. On macOS I read somewhere that launchd uses it in some capacity to know which app to launch when there are multiple versions installed. According to Apple docs, this needs to be strictly in the `major.minor.patch` format, but I noticed most people (ourselves included, Xcode's default value of `1` included) use just the major value (effectivelly making it a simple monotonically-increasing number).

This PR exposes `CFBundleVersion` as `ios.build_number` and `osx.build_number` respectively as `game.project` properties. On macOS, it defaults to `1` and on iOS it defaults to `project.version`, making the change backwards compatible.
