### PR TITLE
Make the domain name of editor updates configurable

### DIFF
--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -11,14 +11,14 @@ editor_sha1 =
 engine_sha1 =
 time =
 channel =
-archive =
+archive_domain =
 [launcher]
 jdk = ${bootstrap.resourcespath}/packages/jdk11.0.1-p1
 java = ${launcher.jdk}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Main
 debug = 1
-vmargs = -Dfile.encoding=UTF-8,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Ddefold.archive=${build.archive},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
+vmargs = -Dfile.encoding=UTF-8,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Ddefold.archive.domain=${build.archive_domain},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -11,13 +11,14 @@ editor_sha1 =
 engine_sha1 =
 time =
 channel =
+archive =
 [launcher]
 jdk = ${bootstrap.resourcespath}/packages/jdk11.0.1-p1
 java = ${launcher.jdk}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Main
 debug = 1
-vmargs = -Dfile.encoding=UTF-8,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
+vmargs = -Dfile.encoding=UTF-8,-Djna.nosys=true,-Ddefold.launcherpath=${bootstrap.launcherpath},-Ddefold.resourcespath=${bootstrap.resourcespath},-Ddefold.version=${build.version},-Ddefold.editor.sha1=${build.editor_sha1},-Ddefold.engine.sha1=${build.engine_sha1},-Ddefold.buildtime=${build.time},-Ddefold.channel=${build.channel},-Ddefold.archive=${build.archive},-Djava.net.preferIPv4Stack=true,-Dsun.net.client.defaultConnectTimeout=30000,-Dsun.net.client.defaultReadTimeout=30000,-Djogl.texture.notexrect=true,-Dglass.accessible.force=false,--illegal-access=warn,--add-opens=java.base/java.lang=ALL-UNNAMED,--add-opens=java.desktop/sun.awt=ALL-UNNAMED,--add-opens=java.desktop/sun.java2d.opengl=ALL-UNNAMED,--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED
 [platform]
 osx = -Xdock:icon=${bootstrap.resourcespath}/logo.icns,-Xdock:name=Defold
 windows =

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -332,6 +332,7 @@ def create_bundle(options):
         config.set('build', 'engine_sha1', options.engine_sha1)
         config.set('build', 'version', options.version)
         config.set('build', 'time', datetime.datetime.now().isoformat())
+        config.set('build', 'archive', "d.defold.com")
 
         if options.channel:
             config.set('build', 'channel', options.channel)

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -332,7 +332,7 @@ def create_bundle(options):
         config.set('build', 'engine_sha1', options.engine_sha1)
         config.set('build', 'version', options.version)
         config.set('build', 'time', datetime.datetime.now().isoformat())
-        config.set('build', 'archive', "d.defold.com")
+        config.set('build', 'archive_domain', "d.defold.com")
 
         if options.channel:
             config.set('build', 'channel', options.channel)

--- a/editor/src/clj/editor/connection_properties.clj
+++ b/editor/src/clj/editor/connection_properties.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -19,5 +19,5 @@
    :google-analytics {:tid "UA-83690-7"}
    :git-issues {:url "https://github.com/defold/defold"}
    :native-extensions {:build-server-url "https://build.defold.com"}
-   :updater {:download-url-template "https://d.defold.com/archive/%s/%s/editor2/Defold-%s.zip"
-             :update-url-template "https://d.defold.com/editor2/channels/%s/update-v3.json"}})
+   :updater {:download-url-template "https://%s/archive/%s/%s/editor2/Defold-%s.zip"
+             :update-url-template "https://%s/editor2/channels/%s/update-v3.json"}})

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -73,9 +73,9 @@
   ^String []
   (System/getProperty "defold.engine.sha1"))
 
-(defn defold-archive
+(defn defold-archive-domain
   ^String []
-  (or (System/getProperty "defold.archive")
+  (or (System/getProperty "defold.archive.domain")
       "d.defold.com"))
 
 (defn set-defold-engine-sha1! [^String sha1]

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -72,6 +72,11 @@
 (defn defold-engine-sha1
   ^String []
   (System/getProperty "defold.engine.sha1"))
+
+(defn defold-archive
+  ^String []
+  (or (System/getProperty "defold.archive")
+      "d.defold.com"))
 
 (defn set-defold-engine-sha1! [^String sha1]
   (assert (not-empty sha1))

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -30,11 +30,11 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- download-url [sha1 channel ^Platform platform]
-  (format (get-in connection-properties [:updater :download-url-template]) sha1 channel (.getPair platform)))
+(defn- download-url [archive sha1 channel ^Platform platform]
+  (format (get-in connection-properties [:updater :download-url-template]) archive sha1 channel (.getPair platform)))
 
-(defn- update-url [channel]
-  (format (get-in connection-properties [:updater :update-url-template]) channel))
+(defn- update-url [archive channel]
+  (format (get-in connection-properties [:updater :update-url-template]) archive channel))
 
 (def ^:private ^File support-dir
   (.getCanonicalFile (.toFile (Editor/getSupportPath))))
@@ -187,7 +187,8 @@
   {:pre [(can-download-update? updater)]}
   (let [{:keys [state-atom platform channel]} updater
         {:keys [current-download server-sha1]} @state-atom
-        url (download-url server-sha1 channel platform)
+        archive (system/defold-archive)
+        url (download-url archive server-sha1 channel platform)
         zip-file (create-temp-zip-file)
         cancelled-atom (atom false)
         track-progress! (fn [progress]
@@ -290,7 +291,8 @@
 
 (defn- check! [updater]
   (let [{:keys [channel state-atom]} updater
-        url (update-url channel)]
+        archive (system/defold-archive)
+        url (update-url archive channel)]
     (try
       (log/info :message "Checking for updates" :url url)
       (with-open [reader (io/reader url)]

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -30,11 +30,11 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- download-url [archive sha1 channel ^Platform platform]
-  (format (get-in connection-properties [:updater :download-url-template]) archive sha1 channel (.getPair platform)))
+(defn- download-url [archive-domain sha1 channel ^Platform platform]
+  (format (get-in connection-properties [:updater :download-url-template]) archive-domain sha1 channel (.getPair platform)))
 
-(defn- update-url [archive channel]
-  (format (get-in connection-properties [:updater :update-url-template]) archive channel))
+(defn- update-url [archive-domain channel]
+  (format (get-in connection-properties [:updater :update-url-template]) archive-domain channel))
 
 (def ^:private ^File support-dir
   (.getCanonicalFile (.toFile (Editor/getSupportPath))))
@@ -187,8 +187,8 @@
   {:pre [(can-download-update? updater)]}
   (let [{:keys [state-atom platform channel]} updater
         {:keys [current-download server-sha1]} @state-atom
-        archive (system/defold-archive)
-        url (download-url archive server-sha1 channel platform)
+        archive-domain (system/defold-archive-domain)
+        url (download-url archive-domain server-sha1 channel platform)
         zip-file (create-temp-zip-file)
         cancelled-atom (atom false)
         track-progress! (fn [progress]
@@ -291,8 +291,8 @@
 
 (defn- check! [updater]
   (let [{:keys [channel state-atom]} updater
-        archive (system/defold-archive)
-        url (update-url archive channel)]
+        archive-domain (system/defold-archive-domain)
+        url (update-url archive-domain channel)]
     (try
       (log/info :message "Checking for updates" :url url)
       (with-open [reader (io/reader url)]

--- a/editor/tasks/leiningen/builtins.clj
+++ b/editor/tasks/leiningen/builtins.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -15,12 +15,12 @@
             [leiningen.util.http-cache :as http-cache]))
 
 (defn- builtins-zip
-  [sha]
+  [archive sha]
   (if sha
-    (http-cache/download (format "https://d.defold.com/archive/%s/engine/share/builtins.zip" sha))
+    (http-cache/download (format "https://%s/archive/%s/engine/share/builtins.zip" archive sha))
     (io/file (format "%s/share/builtins.zip" (get (System/getenv) "DYNAMO_HOME")))))
 
 (defn builtins [project & [git-sha]]
   (let [sha (or git-sha (:engine project))]
-    (io/copy (builtins-zip sha)
+    (io/copy (builtins-zip (get project :archive) sha)
              (io/file "generated-resources/builtins.zip"))))

--- a/editor/tasks/leiningen/builtins.clj
+++ b/editor/tasks/leiningen/builtins.clj
@@ -21,6 +21,7 @@
     (io/file (format "%s/share/builtins.zip" (get (System/getenv) "DYNAMO_HOME")))))
 
 (defn builtins [project & [git-sha]]
-  (let [sha (or git-sha (:engine project))]
-    (io/copy (builtins-zip (get project :archive) sha)
+  (let [sha (or git-sha (:engine project))
+        archive-domain (get project :archive-domain)]
+    (io/copy (builtins-zip archive-domain sha)
              (io/file "generated-resources/builtins.zip"))))

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -69,10 +69,12 @@
   $DYNAMO_HOME if none given.
 
   Arguments:
-    - version: dynamo-home, archived, archived-stable or a sha."
-  [project & [version]]
+    - version: dynamo-home, archived, archived-stable or a sha.
+    - archive: domain where engine artifacts are stored"
+  [project & [version archive]]
   (let [git-sha (resolve-version version)
-        project (assoc project :engine git-sha)]
-    (println (format "Initializing editor with version '%s', resolved to '%s'" version git-sha))
+        archive (or archive "d.defold.com")
+        project (assoc project :archive archive :engine git-sha)]
+    (println (format "Initializing editor with version '%s', resolved to '%s'. Using archive '%s'" version (get project :engine) (get project :archive)))
     (doseq [task+args init-tasks]
       (main/resolve-and-apply project task+args))))

--- a/editor/tasks/leiningen/init.clj
+++ b/editor/tasks/leiningen/init.clj
@@ -70,11 +70,11 @@
 
   Arguments:
     - version: dynamo-home, archived, archived-stable or a sha.
-    - archive: domain where engine artifacts are stored"
-  [project & [version archive]]
+    - archive-domain: domain where engine artifacts are stored"
+  [project & [version archive-domain]]
   (let [git-sha (resolve-version version)
-        archive (or archive "d.defold.com")
-        project (assoc project :archive archive :engine git-sha)]
-    (println (format "Initializing editor with version '%s', resolved to '%s'. Using archive '%s'" version (get project :engine) (get project :archive)))
+        archive-domain (or archive-domain "d.defold.com")
+        project (assoc project :archive-domain archive-domain :engine git-sha)]
+    (println (format "Initializing editor with version '%s', resolved to '%s'. Using archive domain '%s'." version (get project :engine) (get project :archive-domain)))
     (doseq [task+args init-tasks]
       (main/resolve-and-apply project task+args))))

--- a/editor/tasks/leiningen/local_jars.clj
+++ b/editor/tasks/leiningen/local_jars.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -34,9 +34,9 @@
     string/trim))
 
 (defn bob-artifact-file ^File
-  [git-sha]
+  [archive git-sha]
   (let [f (when git-sha
-            (http-cache/download (format "https://d.defold.com/archive/%s/bob/bob.jar" git-sha)))]
+            (http-cache/download (format "https://%s/archive/%s/bob/bob.jar" archive git-sha)))]
     (or f (io/file (dynamo-home) "share/java/bob.jar"))))
 
 (defn local-jars
@@ -45,7 +45,7 @@
   (let [sha (or git-sha (:engine project))
         jar-decls (conj jar-decls {:artifact-id "bob"
                                    :group-id "com.defold.lib"
-                                   :jar-file (.getAbsolutePath (bob-artifact-file sha))
+                                   :jar-file (.getAbsolutePath (bob-artifact-file (get project :archive) sha))
                                    :version "1.0"})]
     (doseq [{:keys [group-id artifact-id version jar-file]} (sort-by :jar-file jar-decls)]
       (main/info (format "Installing %s" jar-file))

--- a/editor/tasks/leiningen/local_jars.clj
+++ b/editor/tasks/leiningen/local_jars.clj
@@ -43,9 +43,10 @@
   "Install local jar dependencies into the ~/.m2 Maven repository."
   [project & [git-sha]]
   (let [sha (or git-sha (:engine project))
+        archive-domain (get project :archive-domain)
         jar-decls (conj jar-decls {:artifact-id "bob"
                                    :group-id "com.defold.lib"
-                                   :jar-file (.getAbsolutePath (bob-artifact-file (get project :archive) sha))
+                                   :jar-file (.getAbsolutePath (bob-artifact-file archive-domain sha))
                                    :version "1.0"})]
     (doseq [{:keys [group-id artifact-id version jar-file]} (sort-by :jar-file jar-decls)]
       (main/info (format "Installing %s" jar-file))

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -73,13 +73,13 @@
    "bundle-resources/_defold"                          "_defold"})
 
 (defn engine-artifact-files
-  [archive git-sha]
+  [archive-domain git-sha]
   (into {} (for [[platform dirs] engine-artifacts
                  [dir files] dirs
                  file files]
              (let [engine-src-dirname (platform->engine-src-dirname platform)
                    src (if (some? git-sha)
-                         (http-cache/download (format "https://%s/archive/%s/engine/%s/%s" archive git-sha engine-src-dirname file))
+                         (http-cache/download (format "https://%s/archive/%s/engine/%s/%s" archive-domain git-sha engine-src-dirname file))
                          (io/file (dynamo-home) dir engine-src-dirname file))
                    dest (io/file platform dir file)]
                [src dest]))))
@@ -135,8 +135,8 @@
     (extract-jogl-native-dep jogl-native-dep pack-path)))
 
 (defn copy-artifacts
-  [pack-path archive git-sha]
-  (let [files (merge (engine-artifact-files archive git-sha)
+  [pack-path archive-domain git-sha]
+  (let [files (merge (engine-artifact-files archive-domain git-sha)
                      (artifact-files))]
     (doseq [[src dest] files]
       (let [dest (io/file pack-path dest)]
@@ -151,7 +151,8 @@
   "Pack all files that need to be unpacked at runtime into `pack-path`."
   [{:keys [dependencies packing] :as project} & [git-sha]]
   (let [sha (or git-sha (:engine project))
+        archive-domain (get project :archive-domain)
         {:keys [pack-path]} packing]
     (FileUtils/deleteQuietly (io/file pack-path))
-    (copy-artifacts pack-path (get project :archive) sha)
+    (copy-artifacts pack-path archive-domain sha)
     (pack-jogl-natives pack-path dependencies)))

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -73,13 +73,13 @@
    "bundle-resources/_defold"                          "_defold"})
 
 (defn engine-artifact-files
-  [git-sha]
+  [archive git-sha]
   (into {} (for [[platform dirs] engine-artifacts
                  [dir files] dirs
                  file files]
              (let [engine-src-dirname (platform->engine-src-dirname platform)
                    src (if (some? git-sha)
-                         (http-cache/download (format "https://d.defold.com/archive/%s/engine/%s/%s" git-sha engine-src-dirname file))
+                         (http-cache/download (format "https://%s/archive/%s/engine/%s/%s" archive git-sha engine-src-dirname file))
                          (io/file (dynamo-home) dir engine-src-dirname file))
                    dest (io/file platform dir file)]
                [src dest]))))
@@ -135,8 +135,8 @@
     (extract-jogl-native-dep jogl-native-dep pack-path)))
 
 (defn copy-artifacts
-  [pack-path git-sha]
-  (let [files (merge (engine-artifact-files git-sha)
+  [pack-path archive git-sha]
+  (let [files (merge (engine-artifact-files archive git-sha)
                      (artifact-files))]
     (doseq [[src dest] files]
       (let [dest (io/file pack-path dest)]
@@ -153,5 +153,5 @@
   (let [sha (or git-sha (:engine project))
         {:keys [pack-path]} packing]
     (FileUtils/deleteQuietly (io/file pack-path))
-    (copy-artifacts pack-path sha)
+    (copy-artifacts pack-path (get project :archive) sha)
     (pack-jogl-natives pack-path dependencies)))

--- a/editor/tasks/leiningen/ref_doc.clj
+++ b/editor/tasks/leiningen/ref_doc.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -37,10 +37,10 @@
           (io/copy (.getInputStream zip entry) dest))))))
 
 (defn- ref-doc-zip
-  "Get the ref-doc.zip from either d.defold.com or DYNAMO_HOME."
-  [sha]
+  "Get the ref-doc.zip from either S3 archive or DYNAMO_HOME."
+  [archive sha]
   (if sha
-    (http-cache/download (format "https://d.defold.com/archive/%s/engine/share/ref-doc.zip" sha))
+    (http-cache/download (format "https://%s/archive/%s/engine/share/ref-doc.zip" archive sha))
     (io/file (format "%s/share/ref-doc.zip" (get (System/getenv) "DYNAMO_HOME")))))
 
 (defn ref-doc [project & [git-sha]]
@@ -48,5 +48,5 @@
     (delete-dir out-path)
     (.mkdirs (io/file out-path))
     (let [sha (or git-sha (:engine project))]
-      (unzip (ref-doc-zip sha)
+      (unzip (ref-doc-zip (get project :archive) sha)
              out-path))))

--- a/editor/tasks/leiningen/ref_doc.clj
+++ b/editor/tasks/leiningen/ref_doc.clj
@@ -47,6 +47,7 @@
   (let [out-path "resources/doc"]
     (delete-dir out-path)
     (.mkdirs (io/file out-path))
-    (let [sha (or git-sha (:engine project))]
-      (unzip (ref-doc-zip (get project :archive) sha)
+    (let [sha (or git-sha (:engine project))
+          archive-domain (get project :archive-domain)]
+      (unzip (ref-doc-zip archive-domain sha)
              out-path))))

--- a/editor/test/editor/updater_test.clj
+++ b/editor/test/editor/updater_test.clj
@@ -38,12 +38,12 @@
 
 (defn- test-urls-fixture [f]
   (with-redefs [updater/download-url
-                (fn [archive sha1 channel ^Platform platform]
+                (fn [archive-domain sha1 channel ^Platform platform]
                   (format "http://localhost:%s/archive/%s/%s/editor2/Defold-%s.zip"
                           test-port sha1 channel (.getPair platform)))
 
                 updater/update-url
-                (fn [archive channel]
+                (fn [archive-domain channel]
                   (format "http://localhost:%s/editor2/channels/%s/update-v3.json"
                           test-port channel))]
     (f)))

--- a/editor/test/editor/updater_test.clj
+++ b/editor/test/editor/updater_test.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -38,12 +38,12 @@
 
 (defn- test-urls-fixture [f]
   (with-redefs [updater/download-url
-                (fn [sha1 channel ^Platform platform]
+                (fn [archive sha1 channel ^Platform platform]
                   (format "http://localhost:%s/archive/%s/%s/editor2/Defold-%s.zip"
                           test-port sha1 channel (.getPair platform)))
 
                 updater/update-url
-                (fn [channel]
+                (fn [archive channel]
                   (format "http://localhost:%s/editor2/channels/%s/update-v3.json"
                           test-port channel))]
     (f)))


### PR DESCRIPTION
It should be possible to use something other than d.defold.com for the domain name. This first part of the PR takes care of the editor side of things. Next up is to also update build.py and the archive_* functions.