### PR TITLE
Update dmloader.js to support IE11

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -84,7 +84,12 @@ var FileLoader = {
         request.onload = function(xhr, e) {
             if (xhr.readyState === 4) {
                 if (xhr.status === 200) {
-                    onload(xhr.response);
+                    var res = xhr.response;
+                    if (responseType == "json" && typeof res === "string") {
+                        onload(JSON.parse(res));
+                    } else {
+                        onload(res);
+                    }
                 } else {
                     onerror("Error loading '" + url + "' (" + e + ")");
                 }


### PR DESCRIPTION
I did this PR because IE11 doesn't honour `responseType: 'json'`. 

Now it runs well on IE11 with that fix.

_Ref: https://github.com/naugtur/xhr/issues/123#issuecomment-499067229_