### PR TITLE
Issue 5271 - relax httpcliient nocontent assertion

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -924,7 +924,7 @@ bail:
 
         if (response.m_Status == 204 /* No Content*/)
         {
-            assert(response.m_ContentLength == -1);
+            // assume content length is zero. No need to complain if an invalid response non empty content is received.
             response.m_ContentLength = 0;
         }
 


### PR DESCRIPTION
This is about #5271. This patch is trivial. I just removed the assertion regarding Conent-Length if http status 204 is returned. 

#### Manual tests

* I've reproduced the issue using a custom server that would _return content_ for 204 responses. I got the exception in the log.
* I removed assertion and tested again and verified that the reqeuest was indeed made and application didn't throw any error.
* My dev and target platform  was x86_64-linux.

#### Automated test

* I checked that nothing else had broken by running the unit tests under engine/dlib module. 
* I tried to build an automated test that would detect the bug and pass after the fix. I investigated engine/dlib/src/test/http_server/TestHttpServer.java and  tried modify but jetty refused to return response body if 204 status was defined. For some reason it enforces proper syntax in the response :-). Thoughts ?