### PR TITLE
Discard lingering sound instances with few frames left - fixes #5270

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1174,6 +1174,12 @@ namespace dmSound
                     instance->m_FrameCount += decoded / stride;
 
                 } else {
+					
+					if  (instance->m_FrameCount < instance->m_Speed) {
+						// since this is the last mix and no more frames will be added, trailing frames will linger on forever
+						// if they are less than m_Speed. We will truncate them to avoid this. 
+						instance->m_FrameCount = 0;
+					}
                     instance->m_EndOfStream = 1;
                 }
             }

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -738,6 +738,7 @@ TEST_P(dmSoundTestSpeedTest, Speed)
     do {
         r = dmSound::Update();
         ASSERT_EQ(dmSound::RESULT_OK, r);
+        ASSERT_LT(g_LoopbackDevice->m_NumWrites, 500); // probably will never end
     } while (dmSound::IsPlaying(instance));
 
     // The loop back device will have time to write out another output buffer while the
@@ -804,6 +805,16 @@ const TestParams params_speed_test[] = {
             2048,
             0.0f,
             0.5f),
+	TestParams("loopback",
+			MONO_TONE_440_44100_88200_WAV,		// sound
+            MONO_TONE_440_44100_88200_WAV_SIZE,	// uint32_t sound_size
+            dmSound::SOUND_DATA_TYPE_WAV,		// SoundDataType type
+            440,								// uint32_t tone_rate
+            44100,								// uint32_t mix_rate
+            88200,								// uint32_t frame_count
+            1999,								// uint32_t buffer_frame_count
+            0.0f,								// float pan
+            3.999909297f),						// float speed - this strange number will result in having remainder frames at the end of mixing
 };
 INSTANTIATE_TEST_CASE_P(dmSoundTestSpeedTest, dmSoundTestSpeedTest, jc_test_values_in(params_speed_test));
 #endif


### PR DESCRIPTION
Fixes bug #5270 

### Unit test

  - It was hard to reproduce the issue using jc_test and existing sound samples in the test suite. Probably because of the size of the samples. In any case, i ended up doing it by accurately fine tuning the sound speed in the test data.
  - After reproducing the issue in the test with proper sound data, i realized that the way the `dmSoundTestSpeedTest` test is structured now would block the test suite forever. So, to detect the error, i used a guard value (500) on the`g_LoopbackDevice->m_NumWrites`. This keeps increasing if the SoundInstance is not finished. For all existing tests this value is less than 90 so a value of 500 is far off from what we typically expect. I think it's not ideal but i settled to that to avoid polluting the suite with a more dedicated test. 

Note, I run the new sound test case without applying the patch. It broke as expected.
I applied the patch and ran it again. It passed.


