### PR TITLE
Issue 5450: Changing wording of donations to Development Fund

### DIFF
--- a/editor/resources/tips.txt
+++ b/editor/resources/tips.txt
@@ -6,8 +6,8 @@
 # News
 
 Did you know? [Defold now supports Nintendo Switch](https://defold.com/manuals/nintendo-switch/)!
-Contribute toward the Defold Foundation [development fund](https://defold.com/community-donations/) to ensure the long term sustainability of Defold.
-Sponsor the Defold Foundation with a [corporate partnerships](https://defold.com/corporate-partnerships/) to ensure the long term sustainability of Defold.
+The Defold Foundation [development fund](https://defold.com/community-donations/) ensures the long term sustainability of Defold.
+[Corporate partnerships](https://defold.com/corporate-partnerships/) ensure the long term sustainability of Defold.
 
 # Useful links
 

--- a/editor/resources/tips.txt
+++ b/editor/resources/tips.txt
@@ -6,7 +6,8 @@
 # News
 
 Did you know? [Defold now supports Nintendo Switch](https://defold.com/manuals/nintendo-switch/)!
-The Defold Foundation relies on [community donations](https://defold.com/community-donations/) and [corporate partnerships](https://defold.com/corporate-partnerships/) to ensure the long term sustainability of Defold.
+Contribute toward the Defold Foundation [development fund](https://defold.com/community-donations/) to ensure the long term sustainability of Defold.
+Sponsor the Defold Foundation with a [corporate partnerships](https://defold.com/corporate-partnerships/) to ensure the long term sustainability of Defold.
 
 # Useful links
 

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1261,7 +1261,7 @@ If you do not specifically require different script states, consider changing th
                {:label "Search Issues"
                 :command :search-issues}
                {:label :separator}
-               {:label "Donate"
+               {:label "Development Fund"
                 :command :donate}
                {:label :separator}
                {:label "About"

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1116,7 +1116,7 @@ If you do not specifically require different script states, consider changing th
     (ui/text! (:editor-sha1 controls) (or (system/defold-editor-sha1) "No editor sha1"))
     (ui/text! (:engine-sha1 controls) (or (system/defold-engine-sha1) "No engine sha1"))
     (ui/text! (:time controls) (or (system/defold-build-time) "No build time"))
-    (UIUtil/stringToTextFlowNodes (:sponsor-push controls) "Support the continued development of Defold\n[Become a community sponsor](https://www.defold.com/community-donations)!")
+    (UIUtil/stringToTextFlowNodes (:sponsor-push controls) "[Defold Foundation Development Fund](https://www.defold.com/community-donations)")
     (ui/title! stage "About")
     (.setScene stage scene)
     (ui/show! stage)))


### PR DESCRIPTION
This is for the Steam build to remove direct calls to action. Valve does not like the word "Donate" but seems to be ok with "Development Fund" in other software.

These changes are a compromise between having a Steam version and not needing a special build for Steam.

Fixes https://github.com/defold/defold/issues/5450