### PR TITLE
Issue 5469: Script callback destroy fix

### DIFF
--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -196,6 +196,12 @@ void computeIconifiedState()
     // A good detailed overview over the recommended app flow is found here:
     //   https://developer.nvidia.com/fixing-common-android-lifecycle-issues-games
     _glfwWin.iconified = !(g_AppResumed && g_AppFocused && _glfwWinAndroid.surface != EGL_NO_SURFACE);
+
+    LOGV("iconified: %s    (resume: %s, focus: %s, surface: %s)",
+        _glfwWin.iconified?"YES":"no",
+        g_AppResumed?"YES":"no",
+        g_AppFocused?"YES":"no",
+        (_glfwWinAndroid.surface != EGL_NO_SURFACE )?"YES":"no");
 }
 
 GLFWAPI int32_t glfwAndroidWindowOpened()

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1605,10 +1605,7 @@ namespace dmScript
         }
         else
         {
-            if (L)
-                luaL_error(L, "Failed to unregister callback (it was not registered)");
-            else
-                dmLogWarning("Failed to unregister callback (it was not registered)");
+            dmLogWarning("Failed to unregister callback (it was not registered)");
         }
     }
 


### PR DESCRIPTION
If the callback was not setup, or it's destroyed a second time, the error could occur.