### PR TITLE
Issue 3243: Fix issue with dmSysGetUserPreferredLanguage()

### DIFF
--- a/engine/dlib/src/dlib/js/library_sys.js
+++ b/engine/dlib/src/dlib/js/library_sys.js
@@ -42,7 +42,7 @@ var LibraryDmSys = {
 
         dmSysGetUserPreferredLanguage: function(defaultlang) {
             var jsdefault = UTF8ToString(defaultlang);
-            var preferred = navigator == undefined ? jsdefault : (navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage || navigator.browserLanguage || navigator.systemLanguage || jsdefault) );
+            var preferred = navigator == undefined ? jsdefault : (navigator.languages ? (navigator.languages[0] || jsdefault) : (navigator.language || navigator.userLanguage || navigator.browserLanguage || navigator.systemLanguage || jsdefault) );
             var buffer = _malloc(preferred.length + 1);
             Module.stringToUTF8(preferred, buffer, preferred.length + 1);
             return buffer;


### PR DESCRIPTION
Some mobile Android users with outdated browsers like Samsung Internet 6.0 are getting this error in my HTML5 game:
![image](https://user-images.githubusercontent.com/193258/104850407-ef528700-58ff-11eb-98ea-37d593a07a95.png)

To sum up, the error happens on line 46 in `engine/dlib/src/dlib/js/library_sys.js`.

I don't know if `navigator.languages` is empty, or `navigator.languages[0]` is null. This PR tries to handle both possible sources of the undefined value.
