### PR TITLE
Issue 5141 utf8 prefs

### DIFF
--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -36,7 +36,7 @@
      (transit/write writer value)
      (.toString out)))
 
-(defn- read-transit [s]
+(defn- read-transit [^String s]
   (let [stream (ByteArrayInputStream. (.getBytes s StandardCharsets/UTF_8))
         reader (transit/reader stream :json {:handlers read-handlers})]
     (transit/read reader)))

--- a/editor/src/clj/editor/prefs.clj
+++ b/editor/src/clj/editor/prefs.clj
@@ -17,8 +17,9 @@
             [service.log :as log]
             [cognitect.transit :as transit])
   (:import [java.util.prefs Preferences]
-           [java.io ByteArrayOutputStream StringBufferInputStream]
-           [javafx.scene.paint Color]))
+           [java.io ByteArrayOutputStream ByteArrayInputStream StringBufferInputStream]
+           [javafx.scene.paint Color]
+           [java.nio.charset StandardCharsets]))
 
 (set! *warn-on-reflection* true)
 
@@ -36,7 +37,8 @@
      (.toString out)))
 
 (defn- read-transit [s]
-  (let [reader (transit/reader (StringBufferInputStream. s) :json {:handlers read-handlers})]
+  (let [stream (ByteArrayInputStream. (.getBytes s StandardCharsets/UTF_8))
+        reader (transit/reader stream :json {:handlers read-handlers})]
     (transit/read reader)))
 
 (defprotocol PreferenceStore

--- a/editor/test/editor/prefs_test.clj
+++ b/editor/test/editor/prefs_test.clj
@@ -20,9 +20,12 @@
         c (Color/web "#11223344")]
     (prefs/set-prefs p "foo" [1 2 3])
     (prefs/set-prefs p "color" c)
+    (prefs/set-prefs p "utf8stuff" "/foo/τεστ")
     (is (= [1 2 3] (prefs/get-prefs p "foo" nil)))
     (is (= "unknown" (prefs/get-prefs p "___----does-not-exists" "unknown")))
-    (is (= c (prefs/get-prefs p "color" nil)))))
+    (is (= c (prefs/get-prefs p "color" nil)))
+    (is (= "/foo/τεστ" (prefs/get-prefs p "utf8stuff" nil)))
+    ))
 
 (deftest prefs-load-test
   (let [p (prefs/load-prefs "test/resources/test_prefs.json")]


### PR DESCRIPTION
This is actually about fixing utf8 support in prefs.  To my understanding, any preference in UTF8 (more than one byte per char) will break the editor. This was the root issue behind #5141.

### Issue internals

There is some back-and-forth regarding encodings, but it allowed for a minimal modification. Let me explain.

After a pref is read and converted from UTF8 (in the file) to java's internal encoding (i think that is called utf16) it is parsed as json. This parsing relies on InputStream interface and uses StringBufferInputStream. This implementation for some weird reason expects a string of UTF8 in the constructor. It doesn't get it and it fails. No wonder why this is depracated :-).

I've replaced StringBufferInputStream with ByteArrayInputStream. The latter is constructed using  a byte[] and the encoding can be specified here. So, i encoded the pref back in UTF8 and handed it to ByteArrayInputStream as such. 

### Tests

I reproduced the issue using unit test and confirmed the test passes after the fix. I also checked the application itself and it works ok. There is a warning displayed though when the patched code is executed (in the test or in the actual app):

    Reflection warning, editor/prefs.clj:40:39 - call to method getBytes can't be resolved (target class is unknown).

I wouldn't consider it alarming but my clojure-fu is not to be trusted :-)






