### PR TITLE
Issue 5523: Update to OpenGLES 3

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -404,7 +404,7 @@ def default_flags(self):
 
         emflags = ['DISABLE_EXCEPTION_CATCHING=1', 'AGGRESSIVE_VARIABLE_ELIMINATION=1', 'PRECISE_F32=2',
                    'EXTRA_EXPORTED_RUNTIME_METHODS=["stringToUTF8","ccall","stackTrace","UTF8ToString","callMain"]',
-                   'ERROR_ON_UNDEFINED_SYMBOLS=1', 'INITIAL_MEMORY=33554432', 'LLD_REPORT_UNDEFINED']
+                   'ERROR_ON_UNDEFINED_SYMBOLS=1', 'INITIAL_MEMORY=33554432', 'LLD_REPORT_UNDEFINED', 'MAX_WEBGL_VERSION=2']
 
         if 'wasm' == build_util.get_target_architecture():
             emflags += ['WASM=1', 'IMPORTED_MEMORY=1', 'ALLOW_MEMORY_GROWTH=1']

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FragmentProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/FragmentProgramBuilder.java
@@ -1,10 +1,10 @@
 // Copyright 2020 The Defold Foundation
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -43,9 +43,6 @@ public class FragmentProgramBuilder extends ShaderProgramBuilder {
 
     public void writeExtraDirectives(PrintWriter writer)
     {
-        writer.println("#ifdef GL_ES");
-        writer.println("precision mediump float;");
-        writer.println("#endif");
         writer.println("#ifndef GL_ES");
         writer.println("#define lowp");
         writer.println("#define mediump");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -80,7 +80,6 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
     abstract void writeExtraDirectives(PrintWriter writer);
 
     private ShaderDesc.Shader.Builder transformGLSL(ByteArrayInputStream is, ES2ToES3Converter.ShaderType shaderType, ShaderDesc.Language shaderLanguage, IResource resource, String resourceOutput, String platform, boolean isDebug)  throws IOException, CompileExceptionError {
-        System.out.printf("MAWE: transformGLSL  language: %d\n", shaderLanguage.getNumber());
         InputStreamReader isr = new InputStreamReader(is);
         BufferedReader reader = new BufferedReader(isr);
         ByteArrayOutputStream os = new ByteArrayOutputStream(is.available() + 128 * 16);
@@ -146,8 +145,6 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
             boolean gles = isGLES(platform);
             int version = gles ? 300 : 140;
             ES2ToES3Converter.Result es3Result = ES2ToES3Converter.transform(source, shaderType, gles ? "es" : "", version, false);
-
-            System.out.printf("MAWE: shader: profile: %s\n%s\n\n", es3Result.shaderProfile, es3Result.output);
             source = es3Result.output;
         }
 

--- a/engine/engine/content/builtins/manifests/ios/Info.plist
+++ b/engine/engine/content/builtins/manifests/ios/Info.plist
@@ -91,7 +91,7 @@
         <key>UIRequiredDeviceCapabilities</key>
         <array>
                 <string>armv7</string>
-                <string>opengles-2</string>
+                <string>opengles-3</string>
         </array>
         <key>CFBundleLocalizations</key>
         <array>{{#application-localizations}}

--- a/engine/glfw/include/GL/glfw.h
+++ b/engine/glfw/include/GL/glfw.h
@@ -161,10 +161,9 @@ extern "C" {
  */
 #if defined(__APPLE_CC__)
 #if defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR)
-#include <OpenGLES/ES1/gl.h>
-#include <OpenGLES/ES2/gl.h>
+#include <OpenGLES/ES3/gl.h>
 #else
- #include <OpenGL/gl.h>
+ #include <OpenGL/gl3.h>
  #ifndef GLFW_NO_GLU
   #include <OpenGL/glu.h>
  #endif

--- a/engine/glfw/lib/android/android_util.c
+++ b/engine/glfw/lib/android/android_util.c
@@ -131,11 +131,6 @@ int init_gl(_GLFWwin_android* win)
      * NOTE: The example simple_gles2 doesn't work with EGL_CONTEXT_CLIENT_VERSION
      * set to 2 in emulator. Might work on real device though
      */
-    const EGLint contextAttribs[] = {
-            EGL_CONTEXT_CLIENT_VERSION, 2, // GLES 2.x support
-            EGL_NONE, // terminator
-    };
-
     EGLint numConfigs;
     EGLConfig config;
     EGLContext context;
@@ -158,7 +153,17 @@ int init_gl(_GLFWwin_android* win)
     CHECK_EGL_ERROR
     ANativeWindow_setBuffersGeometry(win->app->window, 0, 0, format);
 
+    EGLint contextAttribs[] = {
+        EGL_CONTEXT_MAJOR_VERSION, 3,
+        EGL_NONE,
+    };
+
     context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
+    if (context == EGL_NO_CONTEXT)
+    {
+        contextAttribs[0] = 2;
+        context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
+    }
     CHECK_EGL_ERROR
 
     win->display = display;

--- a/engine/glfw/lib/android/android_util.c
+++ b/engine/glfw/lib/android/android_util.c
@@ -161,7 +161,7 @@ int init_gl(_GLFWwin_android* win)
     context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
     if (context == EGL_NO_CONTEXT)
     {
-        contextAttribs[0] = 2;
+        contextAttribs[1] = 2;
         context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
     }
     CHECK_EGL_ERROR

--- a/engine/glfw/lib/carbon/carbon_window.c
+++ b/engine/glfw/lib/carbon/carbon_window.c
@@ -619,13 +619,6 @@ int  _glfwPlatformOpenWindow( int width, int height,
 
     _glfwWin.refreshRate = wndconfig->refreshRate;
 
-    // Fail if OpenGL 3.0 or above was requested
-    if( wndconfig->glMajor > 2 )
-    {
-        fprintf( stderr, "OpenGL 3.0+ is not yet supported on Mac OS X\n" );
-        return GL_FALSE;
-    }
-
     if( _glfwLibrary.Unbundled )
     {
         if( GetCurrentProcess( &psn ) != noErr )

--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -536,12 +536,6 @@ int  _glfwPlatformOpenWindow( int width, int height,
     int colorBits = 0;
     if (_glfwWin.clientAPI == GLFW_OPENGL_API)
     {
-        // Fail if OpenGL 3.0 or above was requested
-        if( wndconfig->glMajor > 2 )
-        {
-            return GL_FALSE;
-        }
-
         // Mac OS X needs non-zero color size, so set resonable values
         colorBits = fbconfig->redBits + fbconfig->greenBits + fbconfig->blueBits;
         if( colorBits == 0 )
@@ -686,6 +680,15 @@ int  _glfwPlatformOpenWindow( int width, int height,
         {
             ADD_ATTR2( NSOpenGLPFASampleBuffers, 1 );
             ADD_ATTR2( NSOpenGLPFASamples, fbconfig->samples );
+        }
+
+        if( wndconfig->glMajor >= 4 )
+        {
+            ADD_ATTR2(NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion4_1Core);
+        }
+        else if( wndconfig->glMajor >= 3 )
+        {
+            ADD_ATTR2(NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core);
         }
 
         ADD_ATTR(0);

--- a/engine/glfw/lib/glext.c
+++ b/engine/glfw/lib/glext.c
@@ -41,11 +41,25 @@
 #define GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT 0x0001
 #endif
 
+#if !defined(GL_MAJOR_VERSION)
+#define GL_MAJOR_VERSION 0x821B
+#define GL_MINOR_VERSION 0x821C
+#endif
+
 #ifndef GL_VERSION_3_2
 #define GL_CONTEXT_CORE_PROFILE_BIT       0x00000001
 #define GL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
 #define GL_CONTEXT_PROFILE_MASK           0x9126
 #endif
+
+static void _ClearGLError()
+{
+    GLint err = glGetError();
+    while (err != 0)
+    {
+        err = glGetError();
+    }
+}
 
 //========================================================================
 // Parses the OpenGL version string and extracts the version number
@@ -53,12 +67,16 @@
 
 void _glfwParseGLVersion( int *major, int *minor, int *rev )
 {
-#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(IOS_SIMULATOR)
-    // Parsing code below is broken for iOS. Just set some values.
-    _glfwWin.glMajor = 1;
-    _glfwWin.glMinor = 0;
-    _glfwWin.glRevision = 0;
-#else
+    glGetIntegerv(GL_MAJOR_VERSION, major);
+    glGetIntegerv(GL_MINOR_VERSION, minor);
+    *rev = 0;
+
+    GLint err = glGetError();
+    if (err == 0) {
+        return;
+    }
+    _ClearGLError();
+
     GLuint _major, _minor = 0, _rev = 0;
     const GLubyte *version;
     const GLubyte *ptr;
@@ -97,7 +115,6 @@ void _glfwParseGLVersion( int *major, int *minor, int *rev )
     *major = _major;
     *minor = _minor;
     *rev = _rev;
-#endif
 }
 
 //========================================================================
@@ -153,7 +170,7 @@ void _glfwRefreshContextParams( void )
     {
         GLint flags;
         glGetIntegerv( GL_CONTEXT_FLAGS, &flags );
-
+        _ClearGLError();
         if( flags & GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT )
         {
             _glfwWin.glForward = GL_TRUE;
@@ -165,7 +182,7 @@ void _glfwRefreshContextParams( void )
     {
         GLint mask;
         glGetIntegerv( GL_CONTEXT_PROFILE_MASK, &mask );
-
+        _ClearGLError();
         if( mask & GL_CONTEXT_COMPATIBILITY_PROFILE_BIT )
         {
             _glfwWin.glProfile = GLFW_OPENGL_COMPAT_PROFILE;

--- a/engine/glfw/lib/ios/app/BaseView.m
+++ b/engine/glfw/lib/ios/app/BaseView.m
@@ -20,7 +20,6 @@
 #include "internal.h"
 
 
-_GLFWwin                    g_Savewin;
 static int                  g_AccelerometerEnabled = 0;
 static double               g_AccelerometerFrequency = 1.0 / 60.0;
 

--- a/engine/glfw/lib/ios/app/BaseView.m
+++ b/engine/glfw/lib/ios/app/BaseView.m
@@ -32,11 +32,10 @@ static BaseView*            g_BaseView = 0;
 
 @implementation BaseView
 
-@synthesize markedTextStyle;
-
 + (Class)layerClass
 {
-    return [CAEAGLLayer class];
+    [self doesNotRecognizeSelector:_cmd];
+    return nil;
 }
 
 - (id) init {

--- a/engine/glfw/lib/ios/app/EAGLView.m
+++ b/engine/glfw/lib/ios/app/EAGLView.m
@@ -1,10 +1,10 @@
 // Copyright 2020 The Defold Foundation
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -85,7 +85,7 @@ static void LogGLError(GLint err)
 
 + (EAGLContext*)initialiseGlContext
 {
-    EAGLContext* ctx = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+    EAGLContext* ctx = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
 
     if (!ctx || ![EAGLContext setCurrentContext:ctx])
     {

--- a/engine/glfw/lib/ios/app/ViewController.m
+++ b/engine/glfw/lib/ios/app/ViewController.m
@@ -1,10 +1,10 @@
 // Copyright 2020 The Defold Foundation
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -18,7 +18,7 @@
 #import "EAGLView.h"
 
 extern int g_IsReboot;
-static int g_view_type = GLFW_OPENGL_API;
+static int g_view_type = GLFW_NO_API;
 
 @implementation ViewController
 

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -490,7 +490,7 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
     wndconfig.highDPI        = _glfwLibrary.hints.highDPI;
     wndconfig.clientAPI      = _glfwLibrary.hints.clientAPI;
 
-    if (wndconfig.clientAPI != GLFW_NO_API)
+    if (wndconfig.clientAPI == GLFW_OPENGL_API)
     {
         if( wndconfig.glMajor == 1 && wndconfig.glMinor > 5 )
         {

--- a/engine/graphics/proto/graphics/graphics_ddf.proto
+++ b/engine/graphics/proto/graphics/graphics_ddf.proto
@@ -159,7 +159,8 @@ message ShaderDesc
     {
         LANGUAGE_GLSL   = 1;
         LANGUAGE_SPIRV  = 2;
-    }
+        LANGUAGE_GLES2  = 3; // while using the backend for WebGL 1 and OpenGLES 2
+     }
 
     enum ShaderDataType
     {

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -307,6 +307,17 @@ static void LogFrameBufferError(GLenum status)
         } \
     } \
 
+
+    #if defined(__MACH__) && ( defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR) )
+    struct ChooseEAGLView
+    {
+        ChooseEAGLView() {
+            // Let's us choose the CAEAGLLayer
+            glfwSetViewType(GLFW_OPENGL_API);
+        }
+    } g_ChooseEAGLView;
+    #endif
+
     static GraphicsAdapterFunctionTable OpenGLRegisterFunctionTable();
     static bool                         OpenGLIsSupported();
     static int8_t          g_null_adapter_priority = 1;
@@ -487,9 +498,6 @@ static void LogFrameBufferError(GLenum status)
 
     static bool OpenGLInitialize()
     {
-#if defined(__MACH__) && ( defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR) )
-        glfwSetViewType(GLFW_OPENGL_API);
-#endif
         // NOTE: We do glfwInit as glfw doesn't cleanup menus properly on OSX.
         return (glfwInit() == GL_TRUE);
     }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -696,12 +696,10 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         glfwOpenWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
         glfwOpenWindowHint(GLFW_FSAA_SAMPLES, params->m_Samples);
 
-        // These is for desktop only. The mobile devices and html5 make their own choice of version
 #if defined(ANDROID)
         // Seems to work fine anyway with out any hints
         // which is good, since we want to fallback from OpenGLES 3 to 2
-#elif defined(__linux__)
-#elif defined(_WIN32)
+#elif defined(_WIN32) || defined(__linux__)
         glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
         glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 3);
 #elif defined(__MACH__)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1928,8 +1928,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
             // TODO: Not available in OpenGL ES.
             // According to this thread it should not be required but honestly I don't quite understand
             // https://devforums.apple.com/message/495216#495216
-            GLenum attributes[1] = {GL_NONE};
-            glDrawBuffers(1, attributes);
+            glDrawBuffer(GL_NONE);
             CHECK_GL_ERROR;
             glReadBuffer(GL_NONE);
             CHECK_GL_ERROR;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2569,7 +2569,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         assert(context);
         assert(texture);
 
-#if !defined(GL_ES_VERSION_3_0) && defined(GL_ES_VERSION_2_0) && !defined(__EMSCRIPTEN__)
+#if !defined(GL_ES_VERSION_3_0) && defined(GL_ES_VERSION_2_0) && !defined(__EMSCRIPTEN__)  && !defined(ANDROID)
         glEnable(GL_TEXTURE_2D);
         CHECK_GL_ERROR;
 #endif
@@ -2586,7 +2586,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
     {
         assert(context);
 
-#if !defined(GL_ES_VERSION_3_0) && defined(GL_ES_VERSION_2_0) && !defined(__EMSCRIPTEN__)
+#if !defined(GL_ES_VERSION_3_0) && defined(GL_ES_VERSION_2_0) && !defined(__EMSCRIPTEN__)  && !defined(ANDROID)
         glEnable(GL_TEXTURE_2D);
         CHECK_GL_ERROR;
 #endif

--- a/engine/graphics/src/opengl/graphics_opengl_defines.h
+++ b/engine/graphics/src/opengl/graphics_opengl_defines.h
@@ -1,10 +1,10 @@
 // Copyright 2020 The Defold Foundation
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -26,7 +26,7 @@
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
 #else
-#include <OpenGL/gl.h>
+#include <OpenGL/gl3.h>
 #endif
 
 #elif defined (_WIN32)
@@ -105,11 +105,15 @@
 // Texture formats
 // Some platforms (e.g Android) supports texture formats even when undefined
 // We check this at runtime through extensions supported
-#if defined(GL_HAS_RENDERDOC_SUPPORT)
+#if defined(GL_RED) && !defined (__EMSCRIPTEN__)
 #define DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE                 (GL_RED)
-#define DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA           (GL_RG)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE                 (GL_LUMINANCE)
+#endif
+
+#if defined(GL_RG) && !defined (__EMSCRIPTEN__)
+#define DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA           (GL_RG)
+#else
 #define DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA           (GL_LUMINANCE_ALPHA)
 #endif
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB                       (GL_RGB)

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -56,6 +56,7 @@ namespace dmGraphics
         uint8_t                 m_WindowOpened : 1;
         uint8_t                 m_VerifyGraphicsCalls : 1;
         uint8_t                 m_RenderDocSupport : 1;
+        uint8_t                 m_LegacyShaderLanguage : 1; // 1 == gles2
     };
 
     static inline void IncreaseModificationVersion(Context* context)

--- a/share/extender/build.yml
+++ b/share/extender/build.yml
@@ -334,7 +334,7 @@ platforms:
         defines:    ["DM_PLATFORM_HTML5", "GL_ES_VERSION_2_0"]
         flags:      ["-fno-exceptions", "-fno-rtti", "-fPIC"]
         linkFlags:  ["--emit-symbol-map", "--memory-init-file", "0", "-lidbfs.js"]
-        emscriptenFlags: ["PRECISE_F32=2", "AGGRESSIVE_VARIABLE_ELIMINATION=1", "INITIAL_MEMORY=33554432", "DISABLE_EXCEPTION_CATCHING=1", "LEGACY_VM_SUPPORT=1", "WASM=0", "EXTRA_EXPORTED_RUNTIME_METHODS=[\"stackTrace\",\"writeStringToMemory\",\"writeArrayToMemory\",\"stringToUTF8\",\"ccall\",\"callMain\",\"UTF8ToString\"]", "EXPORTED_FUNCTIONS=[\"_JSWriteDump\",\"_main\",\"_dmExportedSymbols\"]", "ERROR_ON_UNDEFINED_SYMBOLS=1"]
+        emscriptenFlags: ["PRECISE_F32=2", "AGGRESSIVE_VARIABLE_ELIMINATION=1", "INITIAL_MEMORY=33554432", "DISABLE_EXCEPTION_CATCHING=1", "LEGACY_VM_SUPPORT=1", "WASM=0", "EXTRA_EXPORTED_RUNTIME_METHODS=[\"stackTrace\",\"writeStringToMemory\",\"writeArrayToMemory\",\"stringToUTF8\",\"ccall\",\"callMain\",\"UTF8ToString\"]", "EXPORTED_FUNCTIONS=[\"_JSWriteDump\",\"_main\",\"_dmExportedSymbols\"]", "ERROR_ON_UNDEFINED_SYMBOLS=1","MAX_WEBGL_VERSION=2"]
         libs:       []
 
     exePrefix:      ''
@@ -370,7 +370,7 @@ platforms:
         defines:    ["DM_PLATFORM_HTML5", "GL_ES_VERSION_2_0"]
         flags:      ["-fno-exceptions", "-fno-rtti", "-fPIC"]
         linkFlags:  ["--emit-symbol-map", "--memory-init-file", "0", "-lidbfs.js"]
-        emscriptenFlags: ["PRECISE_F32=2", "AGGRESSIVE_VARIABLE_ELIMINATION=1", "INITIAL_MEMORY=33554432", "IMPORTED_MEMORY=1", "ALLOW_MEMORY_GROWTH=1", "DISABLE_EXCEPTION_CATCHING=1", "WASM=1", "EXTRA_EXPORTED_RUNTIME_METHODS=[\"stackTrace\",\"writeStringToMemory\",\"writeArrayToMemory\",\"stringToUTF8\",\"ccall\",\"callMain\",\"UTF8ToString\"]", "EXPORTED_FUNCTIONS=[\"_JSWriteDump\",\"_main\",\"_dmExportedSymbols\"]", "ERROR_ON_UNDEFINED_SYMBOLS=1"]
+        emscriptenFlags: ["PRECISE_F32=2", "AGGRESSIVE_VARIABLE_ELIMINATION=1", "INITIAL_MEMORY=33554432", "IMPORTED_MEMORY=1", "ALLOW_MEMORY_GROWTH=1", "DISABLE_EXCEPTION_CATCHING=1", "WASM=1", "EXTRA_EXPORTED_RUNTIME_METHODS=[\"stackTrace\",\"writeStringToMemory\",\"writeArrayToMemory\",\"stringToUTF8\",\"ccall\",\"callMain\",\"UTF8ToString\"]", "EXPORTED_FUNCTIONS=[\"_JSWriteDump\",\"_main\",\"_dmExportedSymbols\"]", "ERROR_ON_UNDEFINED_SYMBOLS=1","MAX_WEBGL_VERSION=2"]
         libs:       []
 
     exePrefix:      ''


### PR DESCRIPTION
* Html5: We test WebGL 2 first, then fallback to WebGL 1 (this is done automatically by Emscripten). This fallback costs ~32kb extra.
* Android: We try OpenGLES 3 context first, then fallback to OpenGLES 2. Can control the minimum version allowed in AndroidManifest.xml
* iOS: We always initialize OpenGLES 3
* Desktop: We use OpenGL 3.3 (3.2 on macOS)

Shader versions are now: 300 es for mobile and 140 for desktop