### PR TITLE
loopcount implementation in engine and editor - ref #3514

### DIFF
--- a/engine/gamesys/proto/sound_ddf.proto
+++ b/engine/gamesys/proto/sound_ddf.proto
@@ -14,4 +14,5 @@ message SoundDesc
     optional float  gain        = 4 [default = 1.0];
     optional float  pan         = 5 [default = 0.0];
     optional float  speed       = 6 [default = 1.0];
+    optional int32  loopcount   = 7 [default = 0];
 }

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -386,7 +386,7 @@ namespace dmGameSystem
                     dmSound::SetParameter(entry.m_SoundInstance, dmSound::PARAMETER_GAIN, Vectormath::Aos::Vector4(gain, 0, 0, 0));
                     dmSound::SetParameter(entry.m_SoundInstance, dmSound::PARAMETER_PAN, Vectormath::Aos::Vector4(pan, 0, 0, 0));
                     dmSound::SetParameter(entry.m_SoundInstance, dmSound::PARAMETER_SPEED, Vectormath::Aos::Vector4(speed, 0, 0, 0));
-                    dmSound::SetLooping(entry.m_SoundInstance, sound->m_Looping);
+                    dmSound::SetLooping(entry.m_SoundInstance, sound->m_Looping, (sound->m_Looping && !sound->m_Loopcount) ? -1 : sound->m_Loopcount ); // loopcounter semantics differ a bit from loopcount. If -1, it means loopforever, otherwise it contains the # of loops remaining.
 
                     entry.m_Listener = params.m_Message->m_Sender;
                 }

--- a/engine/gamesys/src/gamesys/resources/res_sound.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_sound.cpp
@@ -35,6 +35,7 @@ namespace dmGameSystem
             Sound* s = new Sound();
             s->m_SoundData = sound_data;
             s->m_Looping = sound_desc->m_Looping;
+            s->m_Loopcount = sound_desc->m_Loopcount;
             s->m_GroupHash = dmHashString64(sound_desc->m_Group);
             s->m_Gain = sound_desc->m_Gain;
             s->m_Pan = sound_desc->m_Pan;

--- a/engine/gamesys/src/gamesys/resources/res_sound.h
+++ b/engine/gamesys/src/gamesys/resources/res_sound.h
@@ -29,6 +29,7 @@ namespace dmGameSystem
         float               m_Gain;
         float               m_Pan;
         float               m_Speed;
+        uint8_t             m_Loopcount;
         uint8_t             m_Looping:1;
     };
 

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -171,6 +171,7 @@ namespace dmSound
         uint8_t     m_EndOfStream : 1;
         uint8_t     m_Playing : 1;
         uint8_t     : 5;
+        int8_t      m_Loopcounter; // if set to 3, there will be 3 loops effectively playing the sound 4 times.
     };
 
     struct SoundGroup
@@ -791,10 +792,11 @@ namespace dmSound
         return sound_instance->m_Playing; // && !sound_instance->m_EndOfStream;
     }
 
-    Result SetLooping(HSoundInstance sound_instance, bool looping)
+    Result SetLooping(HSoundInstance sound_instance, bool looping, int8_t loopcounter)
     {
         DM_MUTEX_OPTIONAL_SCOPED_LOCK(g_SoundSystem->m_Mutex);
         sound_instance->m_Looping = (uint32_t) looping;
+        sound_instance->m_Loopcounter = loopcounter;
         return RESULT_OK;
     }
 
@@ -1152,8 +1154,11 @@ namespace dmSound
 
             if (instance->m_FrameCount < sound->m_FrameCount) {
 
-                if (instance->m_Looping) {
+                if (instance->m_Looping && instance->m_Loopcounter != 0) {
                     dmSoundCodec::Reset(sound->m_CodecContext, instance->m_Decoder);
+                    if ( instance->m_Loopcounter > 0 ) {
+                        instance->m_Loopcounter --;
+                    }
 
                     uint32_t n = sound->m_FrameCount - instance->m_FrameCount;
                     if (!is_muted)

--- a/engine/sound/src/sound.h
+++ b/engine/sound/src/sound.h
@@ -124,7 +124,7 @@ namespace dmSound
     bool IsPlaying(HSoundInstance sound_instance);
     uint32_t GetAndIncreasePlayCounter();
 
-    Result SetLooping(HSoundInstance sound_instance, bool looping);
+    Result SetLooping(HSoundInstance sound_instance, bool looping, int8_t loopcount);
 
     Result SetParameter(HSoundInstance sound_instance, Parameter parameter, const Vectormath::Aos::Vector4& value);
     Result GetParameter(HSoundInstance sound_instance, Parameter parameter, Vectormath::Aos::Vector4& value);

--- a/engine/sound/src/sound_null.cpp
+++ b/engine/sound/src/sound_null.cpp
@@ -206,9 +206,10 @@ namespace dmSound
         return sound_instance->m_Playing == 1;
     }
 
-    Result SetLooping(HSoundInstance sound_instance, bool looping)
+    Result SetLooping(HSoundInstance sound_instance, bool looping, int8_t loopcount)
     {
         sound_instance->m_Looping = looping ? 1 : 0;
+        // loopcount is ignored
         return RESULT_OK;
     }
 

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -266,6 +266,10 @@ class dmSoundTestGroupRampTest : public dmSoundTest
 {
 };
 
+class dmSoundTestLoopingTest :  public dmSoundTest
+{
+};
+
 class dmSoundMixerTest : public dmSoundTest2
 {
 };
@@ -397,6 +401,60 @@ void DeviceLoopbackStop(dmSound::HDevice device)
 {
 
 }
+
+#if !defined(GITHUB_CI) || (defined(GITHUB_CI) && !(defined(WIN32) || defined(__MACH__)))
+TEST_P(dmSoundTestLoopingTest, Loopcount)
+{
+    TestParams params = GetParam();
+    dmSound::Result r;
+    dmSound::HSoundData sd = 0;
+    dmSound::NewSoundData(params.m_Sound, params.m_SoundSize, params.m_Type, &sd, 1234);
+
+    printf("tone: %d, rate: %d, frames: %d\n", params.m_ToneRate, params.m_MixRate, params.m_FrameCount);
+
+    dmSound::HSoundInstance instance = 0;
+    r = dmSound::NewSoundInstance(sd, &instance);
+    ASSERT_EQ(dmSound::RESULT_OK, r);
+    ASSERT_NE((dmSound::HSoundInstance) 0, instance);
+
+    int8_t loopcount = 5;
+    r = dmSound::SetLooping(instance, 1, loopcount);
+    ASSERT_EQ(dmSound::RESULT_OK, r);
+
+
+    r = dmSound::Play(instance);
+    ASSERT_EQ(dmSound::RESULT_OK, r);
+    printf("Playing: %d\n", dmSound::IsPlaying(instance));
+
+    do {
+        r = dmSound::Update();
+    } while (dmSound::IsPlaying(instance));
+    r = dmSound::DeleteSoundInstance(instance);
+    ASSERT_EQ(dmSound::RESULT_OK, r);
+
+    // This is set up by observation: after first iteration, m_Time is 164.
+    // For each loop done afterwards, another 172 is added. 
+    ASSERT_EQ(g_LoopbackDevice->m_Time, 164 + 172*loopcount); 
+
+    r = dmSound::DeleteSoundData(sd);
+    ASSERT_EQ(dmSound::RESULT_OK, r);
+}
+
+const TestParams params_looping_test[] = {
+    TestParams("loopback",
+            MONO_TONE_440_44100_88200_WAV,
+            MONO_TONE_440_44100_88200_WAV_SIZE,
+            dmSound::SOUND_DATA_TYPE_WAV,
+            440,
+            44100,
+            88200,
+            2048,
+            0.0f,
+            2.0f)
+};
+INSTANTIATE_TEST_CASE_P(dmSoundTestLoopingTest, dmSoundTestLoopingTest, jc_test_values_in(params_looping_test));
+#endif
+
 
 #if !defined(GITHUB_CI) || (defined(GITHUB_CI) && !(defined(WIN32) || defined(__MACH__)))
 TEST_P(dmSoundVerifyTest, Mix)


### PR DESCRIPTION
This is about the addition of loopcount property to sound module. See #3514.

### Editor

* In editor, the loopcount field is added below `looping` field. It is an integer field ranging from 0..127.
* By default, and for old projects it has the value of 0. When looping is enabled this means _loop forever_.
* If set to N>0, N loops will be made, resulting in hearing the sound N+1 times in total. So, For loopcount = 1, the sound will be played once + once more as a looped iteration. 

### Engine

* In the engine the same semantics have been kept for the `loopcount` field in the sound resource (res_sound.cpp).
* When a new SoundInstance is created, a differently named field is used for counting the loops. It's the `loopcounter` and starts from `loopcount` counting down to zero.  Since all values ranging from loopcount down to 0 are reserved for a finite number of loops, i've used the -1 value in the to mean _loop forever_. This lead to the use of a signed integer and the use of 0..127 range in the editor.
* I noticed that `looping` is locked through a mutex in SetLooping()  

    https://github.com/otsakir/defold/blob/Issue-3514_loop-control-squashed/engine/sound/src/sound.cpp#L799

    I currently don't fully understand the threading model of defold but In theory there is small chance of some minor mess since `loopcounter` is also moified here:

    https://github.com/otsakir/defold/blob/Issue-3514_loop-control-squashed/engine/sound/src/sound.cpp#L1160

    However, SetLooping() is currently only called once, when SoundInstance is initialized. So, i don't think we should worry about that.

* There has been a new unit test added for loopcount. There was no existing test for the _looping_ field. It relies on g_LoopbackDevice->m_Time. I assumed that this is deterministic between different test environments since the input data is fixed. I didn't find any tests regarding looping in editor and didn't provide one either. I'm not sure how to test this :-/ in editor.

### Manual tests

I've tested the operation of the feature in a sample project. I played with looping and loopcount fields and seemed to behave correctly. I also created a project with looping enabled in an old editor and imported it to the patched editor. It played worked as expected (played forever).

### Other concerns

Some discrepancies regarding the overall sound component operation in editor were observed. They are not related to this loopcount and possibly are already known. I'll try to get these pieces together and try to start a thread in the forum at some point. They mostly have to with the sound component as a file VS embedded directly in the main collection, some differences in the center view VS the view on the right side etc.

