### PR TITLE
Issue-5640 Fix zero size canvas when open game in separate Chrome tab.

### DIFF
--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -114,6 +114,8 @@
 
 	var is_iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 	var buttonHeight = 0;
+	var prevInnerWidth = -1;
+	var prevInnerHeight = -1;
 {{#html5.show_made_with_defold}}
 	buttonHeight = 42;
 {{/html5.show_made_with_defold}}
@@ -131,6 +133,12 @@
 		var game_canvas = document.getElementById('canvas');
 		var innerWidth = window.innerWidth;
 		var innerHeight = window.innerHeight - buttonHeight;
+		if (prevInnerWidth == innerWidth && prevInnerHeight == innerHeight)
+		{
+			return;
+		}
+		prevInnerWidth = innerWidth;
+		prevInnerHeight = innerHeight;
 		var width = {{display.width}};
 		var height = {{display.height}};
 		var targetRatio = width / height;
@@ -193,6 +201,7 @@
 	resize_game_canvas();
 	window.addEventListener('resize', resize_game_canvas, false);
 	window.addEventListener('orientationchange', resize_game_canvas, false);
+	window.addEventListener('focus', resize_game_canvas, false);
 	</script>
 
 	<script id='engine-start' type='text/javascript'>

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -122,7 +122,6 @@
 {{#html5.show_fullscreen_button}}
 	buttonHeight = 42;
 {{/html5.show_fullscreen_button}}
-	// Resize on init, screen resize and orientation change
 	function resize_game_canvas() {
 		// Hack for iOS when exit from Fullscreen mode
 		if (is_iOS) {


### PR DESCRIPTION
If game is in iFrame and opened in separate Chrome tab without focus (Cmd + click to link and wait a bit page loads) then sometimes canvas has 0x0 size.

It seems like Chrome has some kind of optimisation that load iFrame with 0x0 size if tab is inactive.

When user switch tab to the game iFrame size is fine, but canvas size is 0x0 because we don't have event that re-calculate the size (windows.size doesn't fire when changing iFrame size)

Thanks @aglitchman for help with testing and the way to prevent flickering.

fix: https://github.com/defold/defold/issues/5640