### PR TITLE
Issue 5515: Fixed dialog layout when deleting multiple files

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -430,13 +430,16 @@
                 {:title "Delete Files?"
                  :icon :icon/circle-question
                  :header "Are you sure you want to delete these files?"
-                 :content {:fx/type fxui/label
+                 :content {:fx/type :v-box
                            :style-class "dialog-content-padding"
-                           :text (format "You are about to delete: \n%s"
-                                         (->> selection
-                                              (map #(str "\u00A0\u00A0\u2022\u00A0"
-                                                         (resource/resource-name %)))
-                                              (string/join "\n")))}
+                           :children [{:fx/type fxui/label
+                                       :text "You are about to delete:"}
+                                      {:fx/type fxui/text-area
+                                       :text (format "%s"
+                                                     (->> selection
+                                                           (map #(str "\u00A0\u00A0\u2022\u00A0"
+                                                                      (resource/resource-name %)))
+                                                           (string/join "\n")))}]}
                  :buttons [{:text "Cancel"
                             :cancel-button true
                             :default-button true

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -435,11 +435,10 @@
                            :children [{:fx/type fxui/label
                                        :text "You are about to delete:"}
                                       {:fx/type fxui/text-area
-                                       :text (format "%s"
-                                                     (->> selection
-                                                           (map #(str "\u00A0\u00A0\u2022\u00A0"
-                                                                      (resource/resource-name %)))
-                                                           (string/join "\n")))}]}
+                                       :text (->> selection
+                                                    (map #(str "\u00A0\u00A0\u2022\u00A0"
+                                                              (resource/resource-name %)))
+                                                    (string/join "\n"))}]}
                  :buttons [{:text "Cancel"
                             :cancel-button true
                             :default-button true

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -426,19 +426,14 @@
                            {:text "Delete"
                             :variant :danger
                             :result true}]})
-              (dialogs/make-confirmation-dialog
+              (dialogs/make-info-dialog
                 {:title "Delete Files?"
                  :icon :icon/circle-question
                  :header "Are you sure you want to delete these files?"
-                 :content {:fx/type :v-box
-                           :style-class "dialog-content-padding"
-                           :children [{:fx/type fxui/label
-                                       :text "You are about to delete:"}
-                                      {:fx/type fxui/text-area
-                                       :text (->> selection
+                 :content {:text (str "You are about to delete:\n" (->> selection
                                                     (map #(str "\u00A0\u00A0\u2022\u00A0"
                                                               (resource/resource-name %)))
-                                                    (string/join "\n"))}]}
+                                                    (string/join "\n")))}
                  :buttons [{:text "Cancel"
                             :cancel-button true
                             :default-button true


### PR DESCRIPTION
Fixes defold/defold#5515
Changed fxui/label to v-box and split message into label and text-area.
Tested on Windows/Linux