### PR TITLE
Add basic authorization from userinfo in build server url

### DIFF
--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -1,10 +1,10 @@
 ;; Copyright 2020 The Defold Foundation
 ;; Licensed under the Defold License version 1.0 (the "License"); you may not use
 ;; this file except in compliance with the License.
-;; 
+;;
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -28,6 +28,7 @@
   (:import
    (java.io File)
    (java.net URI)
+   (java.util Base64)
    (java.security MessageDigest)
    (javax.ws.rs.core MediaType)
    (org.apache.commons.codec.binary Hex)
@@ -237,10 +238,14 @@
                  (.setConnectTimeout (int connect-timeout-ms))
                  (.setReadTimeout (int read-timeout-ms)))
         api-root (.resource client (URI. server-url))
+        user-info (.getUserInfo (URI. server-url))
         build-resource (.path api-root (build-url extender-platform sdk-version))
-        builder (.accept build-resource #^"[Ljavax.ws.rs.core.MediaType;" (into-array MediaType []))
+        builder (.getRequestBuilder build-resource)
         ne-cache-info (query-cached-files server-url resource-nodes-by-upload-path evaluation-context)
         ne-cache-info-map (make-cached-info-map ne-cache-info)]
+    (.accept builder #^"[Ljavax.ws.rs.core.MediaType;" (into-array MediaType []))
+    (if (not-empty user-info)
+        (.header builder "Authorization" (str "Basic " (.encodeToString (Base64/getEncoder) (.getBytes user-info)))))
     (with-open [form (FormDataMultiPart.)]
       ; upload the file to the server, basically telling it what we are sending (and what we aren't)
       (.bodyPart form (StreamDataBodyPart. "ne-cache-info.json" (io/input-stream (.getBytes ^String (json/write-str {:files ne-cache-info})))))


### PR DESCRIPTION
If the build server URL contains user info it is parsed and passed as an Authorization header