### PR TITLE
Issue 3419: Add "Screen" blend mode (DEF-1182)

### DIFF
--- a/editor/src/clj/editor/gl.clj
+++ b/editor/src/clj/editor/gl.clj
@@ -365,4 +365,5 @@
   (case blend-mode
     :blend-mode-alpha (gl-blend-func gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
     (:blend-mode-add :blend-mode-add-alpha) (gl-blend-func gl GL/GL_ONE GL/GL_ONE)
-    :blend-mode-mult (gl-blend-func gl GL/GL_DST_COLOR GL/GL_ONE_MINUS_SRC_ALPHA)))
+    :blend-mode-mult (gl-blend-func gl GL/GL_DST_COLOR GL/GL_ONE_MINUS_SRC_ALPHA)
+    :blend-mode-screen (gl-blend-func gl GL/GL_ONE_MINUS_DST_COLOR GL/GL_ONE)))

--- a/engine/gamesys/proto/gui_ddf.proto
+++ b/engine/gamesys/proto/gui_ddf.proto
@@ -33,6 +33,7 @@ message NodeDesc
         BLEND_MODE_ADD       = 1 [(displayName) = "Add"];
         BLEND_MODE_ADD_ALPHA = 2 [(displayName) = "Add Alpha (Deprecated)"];
         BLEND_MODE_MULT      = 3 [(displayName) = "Multiply"];
+        BLEND_MODE_SCREEN    = 4 [(displayName) = "Screen"];
     }
 
     // NOTE: Enum values must correspond to the enum values in dmGui

--- a/engine/gamesys/proto/label_ddf.proto
+++ b/engine/gamesys/proto/label_ddf.proto
@@ -20,6 +20,7 @@ message LabelDesc
         BLEND_MODE_ALPHA     = 0 [(displayName) = "Alpha"];
         BLEND_MODE_ADD       = 1 [(displayName) = "Add"];
         BLEND_MODE_MULT      = 3 [(displayName) = "Multiply"];
+        BLEND_MODE_SCREEN    = 4 [(displayName) = "Screen"];
     }
 
     enum Pivot

--- a/engine/gamesys/proto/spine_ddf.proto
+++ b/engine/gamesys/proto/spine_ddf.proto
@@ -21,6 +21,7 @@ message SpineModelDesc
         BLEND_MODE_ALPHA     = 0 [(displayName) = "Alpha"];
         BLEND_MODE_ADD       = 1 [(displayName) = "Add"];
         BLEND_MODE_MULT      = 3 [(displayName) = "Multiply"];
+        BLEND_MODE_SCREEN    = 4 [(displayName) = "Screen"];
     }
 
     required string spine_scene         = 1 [(resource)=true];

--- a/engine/gamesys/proto/sprite_ddf.proto
+++ b/engine/gamesys/proto/sprite_ddf.proto
@@ -14,6 +14,7 @@ message SpriteDesc
         BLEND_MODE_ADD       = 1 [(displayName) = "Add"];
         BLEND_MODE_ADD_ALPHA = 2 [(displayName) = "Add Alpha (Deprecated)"];
         BLEND_MODE_MULT      = 3 [(displayName) = "Multiply"];
+        BLEND_MODE_SCREEN    = 4 [(displayName) = "Screen"];
     }
 
     required string tile_set            = 1 [(resource)=true];

--- a/engine/gamesys/proto/tile_ddf.proto
+++ b/engine/gamesys/proto/tile_ddf.proto
@@ -99,6 +99,7 @@ message TileGrid
         BLEND_MODE_ADD       = 1 [(displayName) = "Add"];
         BLEND_MODE_ADD_ALPHA = 2 [(displayName) = "Add Alpha (Deprecated)"];
         BLEND_MODE_MULT      = 3 [(displayName) = "Multiply"];
+        BLEND_MODE_SCREEN    = 4 [(displayName) = "Screen"];
     }
 
     required string tile_set        = 1 [(resource)=true];

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -66,13 +66,14 @@ namespace dmGameSystem
 
     static struct BlendModeParticleToGui
     {
-    	dmGui::BlendMode m_Table[4];
+    	dmGui::BlendMode m_Table[5];
     	BlendModeParticleToGui()
     	{
     		m_Table[dmParticleDDF::BLEND_MODE_ALPHA]		= dmGui::BLEND_MODE_ALPHA;
     		m_Table[dmParticleDDF::BLEND_MODE_MULT]			= dmGui::BLEND_MODE_MULT;
     		m_Table[dmParticleDDF::BLEND_MODE_ADD]			= dmGui::BLEND_MODE_ADD;
     		m_Table[dmParticleDDF::BLEND_MODE_ADD_ALPHA]	= dmGui::BLEND_MODE_ADD_ALPHA;
+            m_Table[dmParticleDDF::BLEND_MODE_SCREEN]       = dmGui::BLEND_MODE_SCREEN;
     	}
     } ddf_blendmode_map;
 
@@ -719,6 +720,11 @@ namespace dmGameSystem
             case dmGui::BLEND_MODE_MULT:
                 ro.m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_DST_COLOR;
                 ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+            break;
+
+            case dmGui::BLEND_MODE_SCREEN:
+                ro.m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+                ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE;
             break;
 
             default:

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -399,6 +399,11 @@ namespace dmGameSystem
                 params.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
             break;
 
+            case dmGameSystemDDF::LabelDesc::BLEND_MODE_SCREEN:
+                params.m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+                params.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE;
+            break;
+
             default:
                 dmLogError("Label: Unknown blend mode: %d\n", ddf->m_BlendMode);
                 assert(0);

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -487,6 +487,11 @@ namespace dmGameSystem
                 ro->m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
             break;
 
+            case dmParticleDDF::BLEND_MODE_SCREEN:
+                ro->m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+                ro->m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE;
+            break;
+
             default:
                 dmLogError("Unknown blend mode: %d\n", blend_mode);
             break;

--- a/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_spine_model.cpp
@@ -491,6 +491,11 @@ namespace dmGameSystem
                 ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
             break;
 
+            case dmGameSystemDDF::SpineModelDesc::BLEND_MODE_SCREEN:
+                ro.m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+                ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE;
+            break;
+
             default:
                 dmLogError("Unknown blend mode: %d\n", blend_mode);
                 assert(0);

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -617,6 +617,11 @@ namespace dmGameSystem
                 ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
             break;
 
+            case dmGameSystemDDF::SpriteDesc::BLEND_MODE_SCREEN:
+                ro.m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+                ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE;
+            break;
+
             default:
                 dmLogError("Unknown blend mode: %d\n", blend_mode);
                 assert(0);

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -646,6 +646,11 @@ namespace dmGameSystem
                 ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
             break;
 
+            case dmGameSystemDDF::TileGrid::BLEND_MODE_SCREEN:
+                ro.m_SourceBlendFactor = dmGraphics::BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+                ro.m_DestinationBlendFactor = dmGraphics::BLEND_FACTOR_ONE;
+            break;
+
             default:
                 dmLogError("Unknown blend mode: %d\n", blend_mode);
                 assert(0);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -318,6 +318,7 @@ namespace dmGui
         BLEND_MODE_ADD       = 1,
         BLEND_MODE_ADD_ALPHA = 2,
         BLEND_MODE_MULT      = 3,
+        BLEND_MODE_SCREEN    = 4,
     };
 
     // NOTE: These enum values are duplicated in scene desc in gamesys (gui_ddf.proto)

--- a/engine/particle/proto/particle/particle_ddf.proto
+++ b/engine/particle/proto/particle/particle_ddf.proto
@@ -107,6 +107,8 @@ enum BlendMode
     BLEND_MODE_ADD       = 1 [(displayName) = "Add"];
     BLEND_MODE_ADD_ALPHA = 2 [(displayName) = "Add Alpha (Deprecated)"];
     BLEND_MODE_MULT      = 3 [(displayName) = "Multiply"];
+    BLEND_MODE_SCREEN    = 4 [(displayName) = "Screen"];
+
 }
 
 enum SizeMode


### PR DESCRIPTION
This PR adds Screen blend mode in all locations where Alpha, Add, and Multiply were already provided. It references #3419.

### Implementation
The implementation of Screen is the same as Alpha, Add, and Multiply but with different source and destination blend factors.

### Testing
Tested on Mac desktop builds.

### Notes
With straight alpha where `s` is the source color and `d` is the destination color the Screen formula is
`1 - (1 - s)(1 - d)`
If `s` is premultiplied by alpha `a` and the destination is opaque this becomes
`1 - (1 - s/a)(1 - d)`
Compositing this with the background yields a final color of
`[1 - (1 - s/a)(1 - d)] * a + d (1 - a)`
which reduces down to `s + d - sd` or `s(1-d) + d` or `s + d(1-s)`. So Screen can be achieved by specifying a source blend factor of ONE_MINUS_DST_COLOR and a destination blend factor of ONE.