### PR TITLE
Do not create a DNS channel on iOS

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -384,6 +384,7 @@ def default_flags(self):
                                             '-arch', build_util.get_target_architecture(), '-miphoneos-version-min=%s' % MIN_IOS_SDK_VERSION,
                                             '-isysroot', sys_root, '-isysroot', sys_root])
 
+            self.env.append_value(f, ['-DDM_PLATFORM_IOS'])
             if 'x86_64' == build_util.get_target_architecture():
                 self.env.append_value(f, ['-DIOS_SIMULATOR'])
 

--- a/engine/dlib/src/dlib/thread.cpp
+++ b/engine/dlib/src/dlib/thread.cpp
@@ -90,6 +90,12 @@ namespace dmThread
         assert(ret == 0);
     }
 
+    void Detach(Thread thread)
+    {
+        int ret = pthread_detach(thread);
+        assert(ret == 0);
+    }
+
     TlsKey AllocTls()
     {
         pthread_key_t key;
@@ -210,6 +216,3 @@ namespace dmThread
 #endif
 
 }
-
-
-

--- a/engine/dlib/src/dmsdk/dlib/thread.h
+++ b/engine/dlib/src/dmsdk/dlib/thread.h
@@ -105,11 +105,23 @@ namespace dmThread
 
     /*# join thread
      *
-     * Join thread
+     * Join thread. Waits for the thread specified by thread to terminate.  If
+     * that thread has already terminated, then Join() returns immediately.  The
+     * thread specified by thread must be joinable (see Detach()).
      * @name dmThread::Join
      * @param thread Thread to join
      */
     void Join(Thread thread);
+
+    /*# detach thread
+     *
+     * Detach thread. When a detached thread terminates, its resources are
+     * automatically released back to the system without the need for another
+     * thread to join with the terminated thread.
+     * @name dmThread::Join
+     * @param thread Thread to join
+     */
+    void Detach(Thread thread);
 
     /*# allocate thread local storage key
      * Allocate thread local storage key

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -394,14 +394,28 @@ namespace dmHttpService
             worker->m_Service = service;
             worker->m_CacheFlusher = i == 0 && worker->m_Service->m_HttpCache != 0;
             worker->m_Run = true;
+            worker->m_DNSChannel = 0;
             service->m_Workers.Push(worker);
 
-            if (dmDNS::NewChannel(&worker->m_DNSChannel) != dmDNS::RESULT_OK)
-            {
-                worker->m_DNSChannel = 0;
-            }
+// Do not create a c-ares DNS channel on iOS
+// If we have no DNS channel we will fall back to POSIX getaddrinfo
+// c-ares DNS resolution will trigger a Network Security popup on most
+// residential WiFi setups since the WiFi router will act as a DNS and forward
+// DNS queries to the DNS of the ISP.
+// This will trigger the Network Security popup since c-ares communicates with
+// the router over the local network.
+// getaddrinfo on the other hand seems to be whitelisted in iOS.
+#if !(defined(__MACH__) && (defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR)))
+            dmDNS::NewChannel(&worker->m_DNSChannel);
+#endif
 
             dmThread::Thread t = dmThread::New(&Loop, THREAD_STACK_SIZE, worker, "http");
+// Detach the thread on iOS
+// DNS lookups on iOS are using getaddrinfo which may block for an undefined
+// amount of time. We do not wish to wait for the thread during shutdown
+#if defined(__MACH__) && (defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR))
+            dmThread::Detach(t);
+#endif
             worker->m_Thread = t;
         }
 
@@ -427,7 +441,11 @@ namespace dmHttpService
             url.m_Socket = worker->m_Socket;
             dmDNS::StopChannel(http_service->m_Workers[i]->m_DNSChannel);
             dmMessage::Post(0, &url, 0, 0, (uintptr_t) dmHttpDDF::StopHttp::m_DDFDescriptor, 0, 0, 0);
+// On iOS we detach() the thread on creation so that we don't have to wait for
+// it during shutdown (see above for reason why)
+#if !(defined(__MACH__) && (defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR)))
             dmThread::Join(worker->m_Thread);
+#endif
             dmMessage::DeleteSocket(worker->m_Socket);
             dmDNS::DeleteChannel(worker->m_DNSChannel);
             if (worker->m_Client)

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -405,7 +405,7 @@ namespace dmHttpService
 // This will trigger the Network Security popup since c-ares communicates with
 // the router over the local network.
 // getaddrinfo on the other hand seems to be whitelisted in iOS.
-#if !(defined(__MACH__) && (defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR)))
+#if !defined(DM_PLATFORM_IOS)
             dmDNS::NewChannel(&worker->m_DNSChannel);
 #endif
 
@@ -413,7 +413,7 @@ namespace dmHttpService
 // Detach the thread on iOS
 // DNS lookups on iOS are using getaddrinfo which may block for an undefined
 // amount of time. We do not wish to wait for the thread during shutdown
-#if defined(__MACH__) && (defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR))
+#if defined(DM_PLATFORM_IOS)
             dmThread::Detach(t);
 #endif
             worker->m_Thread = t;
@@ -443,7 +443,7 @@ namespace dmHttpService
             dmMessage::Post(0, &url, 0, 0, (uintptr_t) dmHttpDDF::StopHttp::m_DDFDescriptor, 0, 0, 0);
 // On iOS we detach() the thread on creation so that we don't have to wait for
 // it during shutdown (see above for reason why)
-#if !(defined(__MACH__) && (defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR)))
+#if !defined(DM_PLATFORM_IOS)
             dmThread::Join(worker->m_Thread);
 #endif
             dmMessage::DeleteSocket(worker->m_Socket);


### PR DESCRIPTION
Use getaddrinfo() and don't wait for the thread to finish at shutdown.

Fixes #5287 