### PR TITLE
Issue 5639: Added support for BC7 textures on HTML5

### DIFF
--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -252,7 +252,6 @@ namespace dmGraphics
         if (IsFormatRGBA(format))
         {
             TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_BC7);
-            TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_BC3);
             TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_ASTC_4x4);
             TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_ETC2);
             TEST_AND_RETURN(dmGraphics::TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -860,9 +860,9 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         if (params->m_PrintDeviceInfo)
         {
             dmLogInfo("Device: OpenGL");
-            dmLogInfo("Renderer: %s\n", (char *) glGetString(GL_RENDERER));
-            dmLogInfo("Version: %s\n", (char *) glGetString(GL_VERSION));
-            dmLogInfo("Vendor: %s\n", (char *) glGetString(GL_VENDOR));
+            dmLogInfo("Renderer: %s", (char *) glGetString(GL_RENDERER));
+            dmLogInfo("Version: %s", (char *) glGetString(GL_VERSION));
+            dmLogInfo("Vendor: %s", (char *) glGetString(GL_VENDOR));
         }
 
 #if defined(__MACH__) && !( defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR) )
@@ -915,7 +915,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
 
         if (params->m_PrintDeviceInfo && extensions != 0)
         {
-            dmLogInfo("Extensions: %s\n", extensions);
+            dmLogInfo("Extensions: %s", extensions);
         }
 
         DMGRAPHICS_GET_PROC_ADDRESS_EXT(PFN_glInvalidateFramebuffer, "glDiscardFramebuffer", "discard_framebuffer", "glInvalidateFramebuffer", DM_PFNGLINVALIDATEFRAMEBUFFERPROC, extensions);
@@ -956,7 +956,9 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         }
 
         // https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_compression_bptc.txt
-        if (IsExtensionSupported("GL_ARB_texture_compression_bptc", extensions))
+        if (IsExtensionSupported("GL_ARB_texture_compression_bptc", extensions) ||
+            IsExtensionSupported("GL_EXT_texture_compression_bptc", extensions) ||
+            IsExtensionSupported("EXT_texture_compression_bptc", extensions) )
         {
             context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA_BC7;
         }

--- a/engine/graphics/src/transcoder/graphics_transcoder_uastc.cpp
+++ b/engine/graphics/src/transcoder/graphics_transcoder_uastc.cpp
@@ -152,7 +152,7 @@ namespace dmGraphics
         }
 
 #if defined(TEX_TRANSCODE_DEBUG)
-        dmLogInfo("MAWE: Transcoding: %p from %d to %d (%s -> %s)", path, format, transcoder_format, ToString(format), ToString(transcoder_format));
+        dmLogInfo("Transcoding: %p from %d to %d (%s -> %s)", path, format, transcoder_format, ToString(format), ToString(transcoder_format));
 #endif
 
         tr.start_transcoding(ptr, size);


### PR DESCRIPTION
Removed fallback to BC3 since the quality was subpar