### PR TITLE
Physics 2D: Add the weld joint

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -109,6 +109,17 @@ namespace dmGameSystem
      * @variable
      */
 
+    /*# weld joint type
+     *
+     * The following properties are available when connecting a joint of `JOINT_TYPE_WELD` type:
+     * @param reference_angle [type:number] [mark:READ ONLY]The bodyB angle minus bodyA angle in the reference state (radians).
+     * @param frequency [type:number] The mass-spring-damper frequency in Hertz. Rotation only. Disable softness with a value of 0.
+     * @param damping [type:number] The damping ratio. 0 = no damping, 1 = critical damping.
+     *
+     * @name physics.JOINT_TYPE_WELD
+     * @variable
+     */
+
     struct PhysicsScriptContext
     {
         dmMessage::HSocket m_Socket;
@@ -603,6 +614,12 @@ namespace dmGameSystem
                 }
                 break;
 
+            case dmPhysics::JOINT_TYPE_WELD:
+                UnpackFloatParam(L, table_index, "reference_angle", params.m_WeldJointParams.m_ReferenceAngle);
+                UnpackFloatParam(L, table_index, "frequency", params.m_WeldJointParams.m_FrequencyHz);
+                UnpackFloatParam(L, table_index, "damping", params.m_WeldJointParams.m_DampingRatio);
+                break;
+
             default:
                 DM_LUA_ERROR("property table not implemented for joint type %d", type)
                 return;
@@ -781,6 +798,13 @@ namespace dmGameSystem
 
                     lua_pushnumber(L, joint_params.m_SliderJointParams.m_JointTranslation); lua_setfield(L, -2, "joint_translation");
                     lua_pushnumber(L, joint_params.m_SliderJointParams.m_JointSpeed); lua_setfield(L, -2, "joint_speed");
+                }
+                break;
+            case dmPhysics::JOINT_TYPE_WELD:
+                {
+                    lua_pushnumber(L, joint_params.m_WeldJointParams.m_ReferenceAngle); lua_setfield(L, -2, "reference_angle");
+                    lua_pushnumber(L, joint_params.m_WeldJointParams.m_FrequencyHz); lua_setfield(L, -2, "frequency");
+                    lua_pushnumber(L, joint_params.m_WeldJointParams.m_DampingRatio); lua_setfield(L, -2, "damping");
                 }
                 break;
             default:
@@ -1095,6 +1119,7 @@ namespace dmGameSystem
         SETCONSTANT(JOINT_TYPE_FIXED)
         SETCONSTANT(JOINT_TYPE_HINGE)
         SETCONSTANT(JOINT_TYPE_SLIDER)
+        SETCONSTANT(JOINT_TYPE_WELD)
 
  #undef SETCONSTANT
 

--- a/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/joint_test.script
@@ -49,6 +49,8 @@ function init(self)
     physics.destroy_joint(self.a_coll, self.joint_id)
     physics.create_joint(physics.JOINT_TYPE_SLIDER, self.a_coll, self.joint_id, zp, self.b_coll, zp)
     physics.destroy_joint(self.a_coll, self.joint_id)
+    physics.create_joint(physics.JOINT_TYPE_WELD, self.a_coll, self.joint_id, zp, self.b_coll, zp)
+    physics.destroy_joint(self.a_coll, self.joint_id)
 
     -- Recreate with joint specific parameters + verify properties
     local properties = {}
@@ -74,6 +76,11 @@ function init(self)
     assert(properties.enable_motor)
     assert(properties.lower_translation == 10)
     assert(properties.upper_translation == 20)
+    physics.destroy_joint(self.a_coll, self.joint_id)
+
+    physics.create_joint(physics.JOINT_TYPE_WELD, self.a_coll, self.joint_id, zp, self.b_coll, zp, { reference_angle = 1 })
+    properties = physics.get_joint_properties(self.a_coll, self.joint_id)
+    assert(properties.reference_angle == 1)
     physics.destroy_joint(self.a_coll, self.joint_id)
 end
 
@@ -122,6 +129,7 @@ local joint_type_to_string = {
     [physics.JOINT_TYPE_FIXED] = "JOINT_TYPE_FIXED",
     [physics.JOINT_TYPE_HINGE] = "JOINT_TYPE_HINGE",
     [physics.JOINT_TYPE_SLIDER] = "JOINT_TYPE_SLIDER",
+    [physics.JOINT_TYPE_WELD] = "JOINT_TYPE_WELD",
 }
 
 -- list of test
@@ -310,6 +318,43 @@ local joint_tests = {
             local length = vmath.length(p_a - p_b)
             assert_near(10, length)
             assert_near(10, p_b.x)
+
+            -- Cleanup, for next test
+            physics.destroy_joint(self.a_coll, self.joint_id)
+        end
+    },
+    {
+        joint_type = physics.JOINT_TYPE_WELD,
+        test_func = function(self, dt)
+            go.set_position(zp, self.a)
+            new_b_obj(self, vmath.vector3(5,0,0))
+
+            -- Setup WELD joint with reference angle 0.314
+            physics.create_joint(physics.JOINT_TYPE_WELD, self.a_coll, self.joint_id, zp, self.b_coll, vmath.vector3(-10,0,0), { reference_angle = 0.314 })
+
+            -- give it a few updates to let the physics sim settle
+            coroutine.yield()
+            coroutine.yield()
+
+            -- Verify that position for B is at ~length 10 from A
+            local p_a = go.get_position(self.a)
+            local p_b = go.get_position(self.b)
+            local length = vmath.length(p_a - p_b)
+            assert_near(length, 10)
+            assert_near(p_b.x, 9.511)
+
+            -- Move A
+            go.set_position(vmath.vector3(5,0,0), self.a)
+
+            -- give it a few updates to let the physics sim settle
+            coroutine.yield()
+            coroutine.yield()
+
+            -- Verify that position for B is STILL at ~length 10
+            local p_a = go.get_position(self.a)
+            local p_b = go.get_position(self.b)
+            local length = vmath.length(p_a - p_b)
+            assert_near(length, 10)
 
             -- Cleanup, for next test
             physics.destroy_joint(self.a_coll, self.joint_id)

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -42,6 +42,7 @@ namespace dmPhysics
         JOINT_TYPE_FIXED,
         JOINT_TYPE_HINGE,
         JOINT_TYPE_SLIDER,
+        JOINT_TYPE_WELD,
         JOINT_TYPE_COUNT
     };
 
@@ -1259,6 +1260,13 @@ namespace dmPhysics
                 float m_MaxMotorForce;
                 float m_MotorSpeed;
             } m_SliderJointParams;
+
+            struct
+            {
+                float m_ReferenceAngle;
+                float m_FrequencyHz;
+                float m_DampingRatio;
+            } m_WeldJointParams;
         };
 
         ConnectJointParams()
@@ -1299,6 +1307,11 @@ namespace dmPhysics
                     m_SliderJointParams.m_EnableMotor = false;
                     m_SliderJointParams.m_MaxMotorForce = 0.0f;
                     m_SliderJointParams.m_MotorSpeed = 0.0f;
+                    break;
+                case JOINT_TYPE_WELD:
+                    m_WeldJointParams.m_ReferenceAngle = 0.0f;
+                    m_WeldJointParams.m_FrequencyHz = 0.0f;
+                    m_WeldJointParams.m_DampingRatio = 0.0f;
                     break;
                 default:
                     break;

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -1353,6 +1353,20 @@ namespace dmPhysics
                     joint = world->m_World.CreateJoint(&jointDef);
                 }
                 break;
+            case dmPhysics::JOINT_TYPE_WELD:
+                {
+                    b2WeldJointDef jointDef;
+                    jointDef.bodyA            = b2_obj_a;
+                    jointDef.bodyB            = b2_obj_b;
+                    jointDef.localAnchorA     = pa;
+                    jointDef.localAnchorB     = pb;
+                    jointDef.referenceAngle   = params.m_WeldJointParams.m_ReferenceAngle;
+                    jointDef.frequencyHz      = params.m_WeldJointParams.m_FrequencyHz;
+                    jointDef.dampingRatio     = params.m_WeldJointParams.m_DampingRatio;
+                    jointDef.collideConnected = params.m_CollideConnected;
+                    joint = world->m_World.CreateJoint(&jointDef);
+                }
+                break;
             default:
                 return 0x0;
         }
@@ -1398,6 +1412,13 @@ namespace dmPhysics
                     typed_joint->EnableMotor(params.m_SliderJointParams.m_EnableMotor);
                     typed_joint->SetMaxMotorForce(params.m_SliderJointParams.m_MaxMotorForce * scale);
                     typed_joint->SetMotorSpeed(params.m_SliderJointParams.m_MotorSpeed);
+                }
+                break;
+            case dmPhysics::JOINT_TYPE_WELD:
+                {
+                    b2WeldJoint* typed_joint = (b2WeldJoint*)joint;
+                    typed_joint->SetFrequency(params.m_WeldJointParams.m_FrequencyHz);
+                    typed_joint->SetDampingRatio(params.m_WeldJointParams.m_DampingRatio);
                 }
                 break;
             default:
@@ -1466,6 +1487,16 @@ namespace dmPhysics
                     // Read only properties
                     params.m_SliderJointParams.m_JointTranslation = typed_joint->GetJointTranslation();
                     params.m_SliderJointParams.m_JointSpeed = typed_joint->GetJointSpeed();
+                }
+                break;
+            case dmPhysics::JOINT_TYPE_WELD:
+                {
+                    b2WeldJoint* typed_joint = (b2WeldJoint*)joint;
+                    params.m_WeldJointParams.m_FrequencyHz = typed_joint->GetFrequency();
+                    params.m_WeldJointParams.m_DampingRatio = typed_joint->GetDampingRatio();
+
+                    // Read only properties
+                    params.m_WeldJointParams.m_ReferenceAngle = typed_joint->GetReferenceAngle();
                 }
                 break;
             default:

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -1102,6 +1102,27 @@ TYPED_TEST(PhysicsTest, JointGeneral)
     DeleteJoint2D(TestFixture::m_World, joint);
     joint = 0x0;
 
+    //////////////////////////////////////////////////////////////
+    // Create WELD joint
+    joint_type = dmPhysics::JOINT_TYPE_WELD;
+    joint_params = dmPhysics::ConnectJointParams(joint_type);
+    joint = dmPhysics::CreateJoint2D(TestFixture::m_World, static_co, p_zero, dynamic_co, p_zero, joint_type, joint_params);
+    ASSERT_NE((dmPhysics::HJoint)0x0, joint);
+
+    // Update WELD joint
+    joint_params.m_WeldJointParams.m_DampingRatio = 1.0f;
+    r = dmPhysics::SetJointParams2D(TestFixture::m_World, joint, joint_type, joint_params);
+    ASSERT_TRUE(r);
+
+    // Get WELD joint params
+    r = dmPhysics::GetJointParams2D(TestFixture::m_World, joint, joint_type, joint_params);
+    ASSERT_TRUE(r);
+    ASSERT_NEAR(1.0f, joint_params.m_WeldJointParams.m_DampingRatio, FLT_EPSILON);
+
+    // Delete WELD joint
+    DeleteJoint2D(TestFixture::m_World, joint);
+    joint = 0x0;
+
 
     (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, static_co);
     (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, dynamic_co);
@@ -1290,6 +1311,52 @@ TYPED_TEST(PhysicsTest, JointHinge)
     }
 
     // Delete HINGE joint
+    DeleteJoint2D(TestFixture::m_World, joint);
+    joint = 0x0;
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, static_co);
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, dynamic_co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape_a);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape_b);
+
+}
+
+TYPED_TEST(PhysicsTest, JointWeld)
+{
+    VisualObject vo_a;
+    dmPhysics::CollisionObjectData data;
+    vo_a.m_Position.setX(-2.0f);
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_KINEMATIC;
+    data.m_Mass = 0.0f;
+    data.m_UserData = &vo_a;
+    typename TypeParam::CollisionShapeType shape_a = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType static_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape_a, 1u);
+
+    VisualObject vo_b;
+    vo_b.m_Position.setX(2.0f);
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_DYNAMIC;
+    data.m_Mass = 1.0f;
+    data.m_UserData = &vo_b;
+    typename TypeParam::CollisionShapeType shape_b = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType dynamic_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape_b, 1u);
+
+    // Create WELD joint
+    dmPhysics::JointType joint_type = dmPhysics::JOINT_TYPE_WELD;
+    Vectormath::Aos::Point3 p_1(5.0f, 0.0f, 0.0f);
+    Vectormath::Aos::Point3 p_2(-5.0f, 0.0f, 0.0f);
+    dmPhysics::ConnectJointParams joint_params(joint_type);
+    joint_params.m_WeldJointParams.m_ReferenceAngle = 0.314f;
+    dmPhysics::HJoint joint = dmPhysics::CreateJoint2D(TestFixture::m_World, static_co, p_1, dynamic_co, p_2, joint_type, joint_params);
+    ASSERT_NE((dmPhysics::HJoint)0x0, joint);
+
+    for (uint32_t i = 0; i < 40; ++i)
+    {
+        (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+        ASSERT_NEAR(-2.0f, vo_a.m_Position.getX(), FLT_EPSILON);
+        ASSERT_NEAR(7.75f, vo_b.m_Position.getX(), 0.01f);
+    }
+
+    // Delete WELD joint
     DeleteJoint2D(TestFixture::m_World, joint);
     joint = 0x0;
 


### PR DESCRIPTION
I would like to have [the weld joint type](https://box2d.org/documentation/classb2_weld_joint.html) and use it in our physics game.

This PR adds it to the engine. I tested it, and it runs very well! The following video is captured from a Defold game:

https://user-images.githubusercontent.com/193258/112644123-20968880-8e56-11eb-88a0-81e51ecc28c3.mp4

