### PR TITLE
Issue 5613 crackling sounds

### DIFF
--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -780,11 +780,11 @@ namespace dmSound
 
     uint32_t GetAndIncreasePlayCounter()
     {
-    	if (g_SoundSystem->m_PlayCounter == dmSound::INVALID_PLAY_ID)
-    	{
-    		g_SoundSystem->m_PlayCounter = 0;
-    	}
-        return g_SoundSystem->m_PlayCounter++;
+       if (g_SoundSystem->m_PlayCounter == dmSound::INVALID_PLAY_ID)
+       {
+           g_SoundSystem->m_PlayCounter = 0;
+       }
+       return g_SoundSystem->m_PlayCounter++;
     }
 
     bool IsPlaying(HSoundInstance sound_instance)
@@ -1133,7 +1133,7 @@ namespace dmSound
         if (instance->m_FrameCount < sound->m_FrameCount && instance->m_Playing) {
 
             const uint32_t stride = info.m_Channels * (info.m_BitsPerSample / 8);
-            uint32_t n = sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed) - instance->m_FrameCount;
+            uint32_t n = ceil(sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed) - instance->m_FrameCount);
 
             if (!is_muted)
             {
@@ -1179,12 +1179,12 @@ namespace dmSound
                     instance->m_FrameCount += decoded / stride;
 
                 } else {
-					
-					if  (instance->m_FrameCount < instance->m_Speed) {
-						// since this is the last mix and no more frames will be added, trailing frames will linger on forever
-						// if they are less than m_Speed. We will truncate them to avoid this. 
-						instance->m_FrameCount = 0;
-					}
+
+                    if  (instance->m_FrameCount < instance->m_Speed) {
+                        // since this is the last mix and no more frames will be added, trailing frames will linger on forever
+                        // if they are less than m_Speed. We will truncate them to avoid this.
+                        instance->m_FrameCount = 0;
+                    }
                     instance->m_EndOfStream = 1;
                 }
             }

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1139,11 +1139,12 @@ namespace dmSound
         bool is_muted = dmSound::IsMuted(instance);
 
         dmSoundCodec::Result r = dmSoundCodec::RESULT_OK;
+        uint32_t mixed_instance_FrameCount = ceilf(sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed));
 
-        if (instance->m_FrameCount < sound->m_FrameCount && instance->m_Playing) {
+        if (instance->m_FrameCount < mixed_instance_FrameCount && instance->m_Playing) {
 
             const uint32_t stride = info.m_Channels * (info.m_BitsPerSample / 8);
-            uint32_t n = ceilf(sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed) - instance->m_FrameCount); // if the result contains a fractional part and we don't ceil(), we'll end up with a smaller number. Later, when deciding the mix_count in Mix(), a smaller value (integer) will be produced. This will result in leaving a small gap in the mix buffer resulting in sound crackling when the chunk changes.
+            uint32_t n = mixed_instance_FrameCount - instance->m_FrameCount; // if the result contains a fractional part and we don't ceil(), we'll end up with a smaller number. Later, when deciding the mix_count in Mix(), a smaller value (integer) will be produced. This will result in leaving a small gap in the mix buffer resulting in sound crackling when the chunk changes.
 
             if (!is_muted)
             {
@@ -1162,7 +1163,7 @@ namespace dmSound
             assert(decoded % stride == 0);
             instance->m_FrameCount += decoded / stride;
 
-            if (instance->m_FrameCount < sound->m_FrameCount) {
+            if (instance->m_FrameCount < mixed_instance_FrameCount) {
 
                 if (instance->m_Looping && instance->m_Loopcounter != 0) {
                     dmSoundCodec::Reset(sound->m_CodecContext, instance->m_Decoder);
@@ -1170,7 +1171,7 @@ namespace dmSound
                         instance->m_Loopcounter --;
                     }
 
-                    uint32_t n = ceilf(sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed) - instance->m_FrameCount);
+                    uint32_t n = mixed_instance_FrameCount - instance->m_FrameCount;
                     if (!is_muted)
                     {
                         r = dmSoundCodec::Decode(sound->m_CodecContext,

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -1170,7 +1170,7 @@ namespace dmSound
                         instance->m_Loopcounter --;
                     }
 
-                    uint32_t n = sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed) - instance->m_FrameCount;
+                    uint32_t n = ceilf(sound->m_FrameCount * dmMath::Max(1.0f, instance->m_Speed) - instance->m_FrameCount);
                     if (!is_muted)
                     {
                         r = dmSoundCodec::Decode(sound->m_CodecContext,

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -1136,7 +1136,8 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             2.0f,
-            1), // loop once
+            0       // loopcount. Increase it to stress the mix algorithm when testing by listening.
+    ), 
     TestParams("default",
             MONO_TONE_440_32000_64000_WAV,
             MONO_TONE_440_32000_64000_WAV_SIZE,
@@ -1147,7 +1148,8 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             2.0f,
-            1),
+            0
+    ),
     TestParams("default",
             STEREO_TONE_440_32000_64000_WAV,
             STEREO_TONE_440_32000_64000_WAV_SIZE,
@@ -1158,7 +1160,8 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             2.0f,
-            1),
+            0
+    ),
     TestParams("default",
             MONO_TONE_440_44100_88200_WAV,
             MONO_TONE_440_44100_88200_WAV_SIZE,
@@ -1169,7 +1172,8 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             0.5f,
-            1),
+            0
+    ),
     TestParams("default",
             STEREO_TONE_440_32000_64000_WAV,
             STEREO_TONE_440_32000_64000_WAV_SIZE,
@@ -1180,7 +1184,8 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             0.5f,
-            1),
+            0
+    ),
     TestParams("default",
             MONO_TONE_440_44100_88200_WAV,
             MONO_TONE_440_44100_88200_WAV_SIZE,
@@ -1191,7 +1196,8 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             2.159f,     // float speed - this would result in crackling sounds in #5613
-            5),        // loop 10 times
+            5           // loop 5 times
+    ),        
 };
 INSTANTIATE_TEST_CASE_P(dmSoundTestPlaySpeedTest, dmSoundTestPlaySpeedTest, jc_test_values_in(params_test_play_speed_test));
 #endif

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -1156,6 +1156,16 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             0.5f),
+    TestParams("default",
+            MONO_TONE_440_44100_88200_WAV,
+            MONO_TONE_440_44100_88200_WAV_SIZE,
+            dmSound::SOUND_DATA_TYPE_WAV,
+            440,
+            44100,
+            88200,
+            2048,
+            0.0f,
+            1.259f),						// float speed - this would result in crackling sounds in #5613
 };
 INSTANTIATE_TEST_CASE_P(dmSoundTestPlaySpeedTest, dmSoundTestPlaySpeedTest, jc_test_values_in(params_test_play_speed_test));
 #endif

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -87,10 +87,12 @@ struct TestParams
     uint32_t    m_BufferFrameCount;
     float       m_Pan;
     float       m_Speed;
+    uint8_t     m_Loopcount;
 
     TestParams(const char* device_name, void* sound, uint32_t sound_size, SoundDataType type, uint32_t tone_rate, uint32_t mix_rate, uint32_t frame_count, uint32_t buffer_frame_count)
     : m_Pan(0.0f)
     , m_Speed(1.0f)
+    , m_Loopcount(0)
     {
         m_DeviceName = device_name;
         m_Sound = sound;
@@ -116,6 +118,22 @@ struct TestParams
         m_MixRate = mix_rate;
         m_BufferFrameCount = buffer_frame_count;
     }
+    
+    TestParams(const char* device_name, void* sound, uint32_t sound_size, SoundDataType type, uint32_t tone_rate, uint32_t mix_rate,
+                uint32_t frame_count, uint32_t buffer_frame_count, float pan, float speed, uint32_t loopcount)
+    : m_Pan(pan)
+    , m_Speed(speed)
+    , m_Loopcount(loopcount)
+    {
+        m_DeviceName = device_name;
+        m_Sound = sound;
+        m_SoundSize = sound_size;
+        m_Type = type;
+        m_FrameCount = frame_count;
+        m_ToneRate = tone_rate;
+        m_MixRate = mix_rate;
+        m_BufferFrameCount = buffer_frame_count;
+    }    
 
 };
 
@@ -1030,6 +1048,8 @@ TEST_P(dmSoundTestPlaySpeedTest, Play)
     ASSERT_EQ(dmSound::RESULT_OK, r);
     ASSERT_NE((dmSound::HSoundInstance) 0, instance);
 
+    r = dmSound::SetLooping(instance, 1, params.m_Loopcount);
+        
     r = dmSound::SetParameter(instance, dmSound::PARAMETER_GAIN, Vectormath::Aos::Vector4(0.5f,0,0,0));
     ASSERT_EQ(dmSound::RESULT_OK, r);
     r = dmSound::SetParameter(instance, dmSound::PARAMETER_SPEED, Vectormath::Aos::Vector4(params.m_Speed,0,0,0));
@@ -1115,7 +1135,8 @@ const TestParams params_test_play_speed_test[] = {
             88200,
             2048,
             0.0f,
-            2.0f),
+            2.0f,
+            1), // loop once
     TestParams("default",
             MONO_TONE_440_32000_64000_WAV,
             MONO_TONE_440_32000_64000_WAV_SIZE,
@@ -1125,7 +1146,8 @@ const TestParams params_test_play_speed_test[] = {
             64000,
             2048,
             0.0f,
-            2.0f),
+            2.0f,
+            1),
     TestParams("default",
             STEREO_TONE_440_32000_64000_WAV,
             STEREO_TONE_440_32000_64000_WAV_SIZE,
@@ -1135,7 +1157,8 @@ const TestParams params_test_play_speed_test[] = {
             64000,
             2048,
             0.0f,
-            2.0f),
+            2.0f,
+            1),
     TestParams("default",
             MONO_TONE_440_44100_88200_WAV,
             MONO_TONE_440_44100_88200_WAV_SIZE,
@@ -1145,7 +1168,8 @@ const TestParams params_test_play_speed_test[] = {
             88200,
             2048,
             0.0f,
-            0.5f),
+            0.5f,
+            1),
     TestParams("default",
             STEREO_TONE_440_32000_64000_WAV,
             STEREO_TONE_440_32000_64000_WAV_SIZE,
@@ -1155,7 +1179,8 @@ const TestParams params_test_play_speed_test[] = {
             64000,
             2048,
             0.0f,
-            0.5f),
+            0.5f,
+            1),
     TestParams("default",
             MONO_TONE_440_44100_88200_WAV,
             MONO_TONE_440_44100_88200_WAV_SIZE,
@@ -1165,7 +1190,8 @@ const TestParams params_test_play_speed_test[] = {
             88200,
             2048,
             0.0f,
-            1.259f),						// float speed - this would result in crackling sounds in #5613
+            2.159f,     // float speed - this would result in crackling sounds in #5613
+            10),        // loop 10 times
 };
 INSTANTIATE_TEST_CASE_P(dmSoundTestPlaySpeedTest, dmSoundTestPlaySpeedTest, jc_test_values_in(params_test_play_speed_test));
 #endif
@@ -1449,7 +1475,7 @@ const TestParams2 params_mixer_test[] = {
                 2048,
                 true),
 };
-INSTANTIATE_TEST_CASE_P(dmSoundMixerTest, dmSoundMixerTest, jc_test_values_in(params_mixer_test));
+//INSTANTIATE_TEST_CASE_P(dmSoundMixerTest, dmSoundMixerTest, jc_test_values_in(params_mixer_test));
 #endif
 
 DM_DECLARE_SOUND_DEVICE(LoopBackDevice, "loopback", DeviceLoopbackOpen, DeviceLoopbackClose, DeviceLoopbackQueue, DeviceLoopbackFreeBufferSlots, DeviceLoopbackDeviceInfo, DeviceLoopbackRestart, DeviceLoopbackStop);

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -1481,7 +1481,7 @@ const TestParams2 params_mixer_test[] = {
                 2048,
                 true),
 };
-//INSTANTIATE_TEST_CASE_P(dmSoundMixerTest, dmSoundMixerTest, jc_test_values_in(params_mixer_test));
+INSTANTIATE_TEST_CASE_P(dmSoundMixerTest, dmSoundMixerTest, jc_test_values_in(params_mixer_test));
 #endif
 
 DM_DECLARE_SOUND_DEVICE(LoopBackDevice, "loopback", DeviceLoopbackOpen, DeviceLoopbackClose, DeviceLoopbackQueue, DeviceLoopbackFreeBufferSlots, DeviceLoopbackDeviceInfo, DeviceLoopbackRestart, DeviceLoopbackStop);

--- a/engine/sound/src/test/test_sound.cpp
+++ b/engine/sound/src/test/test_sound.cpp
@@ -1191,7 +1191,7 @@ const TestParams params_test_play_speed_test[] = {
             2048,
             0.0f,
             2.159f,     // float speed - this would result in crackling sounds in #5613
-            10),        // loop 10 times
+            5),        // loop 10 times
 };
 INSTANTIATE_TEST_CASE_P(dmSoundTestPlaySpeedTest, dmSoundTestPlaySpeedTest, jc_test_values_in(params_test_play_speed_test));
 #endif


### PR DESCRIPTION
This is a bugfix for #5613.

I supplied some additional info on the problem and the solution as a comment on the issue. 

The mixing process is pretty complicated and though i roughly understood it overall it's hard to explain the exact internals of the failure. In short, when estimating the count of the frames to fetch, the fractional part of the number of frames was not taken into account causing some trouble to the algorithm. This last frame, is now loaded, and this seems to solve it.

* I supplied data for automated tests. I ran the test before the patch and confirmed the failure. I ran it after and it was smooth. I also ran it with stereo data (which uses a different sampling routine) and didn't have problems. I didn't try different sampling rates though (different between mix-buffer and source wav).

* I did most research and solving on 1.2.178 because i had some trouble with opengl support for 1.2.180. I don't think there is much difference though wrt to this part of the sound library. The commit however, as well as the execution of auto tests, was based on the current dev branch.

* I tried to keep short comments in the involved code for key concepts i found. 

* Also, my IDE, replaced automatically some (few) tabs with spaces. I understood only too late to change.

