### PR TITLE
issue-5730 - Duplicate symbols (Texture::Texture) when building vulkan extension on windows

### DIFF
--- a/engine/graphics/src/vulkan/graphics_native.cpp
+++ b/engine/graphics/src/vulkan/graphics_native.cpp
@@ -238,6 +238,7 @@ namespace dmGraphics
                 free(context->m_DynamicOffsetBuffer);
             }
 
+            delete context->m_SwapChain->m_ResolveTexture;
             delete context->m_SwapChain;
         }
     }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -478,7 +478,7 @@ namespace dmGraphics
             // multisampling enabled.
             VkImageView& vk_image_view_swap      = swapChain->m_ImageViews[i];
             VkImageView& vk_image_view_depth     = context->m_MainTextureDepthStencil.m_Handle.m_ImageView;
-            VkImageView& vk_image_view_resolve   = swapChain->m_ResolveTexture.m_Handle.m_ImageView;
+            VkImageView& vk_image_view_resolve   = swapChain->m_ResolveTexture->m_Handle.m_ImageView;
             VkImageView  vk_image_attachments[3];
             uint8_t num_attachments;
 
@@ -875,6 +875,7 @@ namespace dmGraphics
 
         uint16_t validation_layers_count;
         const char** validation_layers = GetValidationLayers(&validation_layers_count, context->m_UseValidationLayers, context->m_RenderDocSupport);
+        Texture* resolveTexture = new Texture;
 
         if (selected_device == NULL)
         {
@@ -929,8 +930,9 @@ namespace dmGraphics
         vk_closest_multisample_flag = GetClosestSampleCountFlag(selected_device, BUFFER_TYPE_COLOR_BIT | BUFFER_TYPE_DEPTH_BIT, params->m_Samples);
 
         // Create swap chain
+        InitializeVulkanTexture(resolveTexture);
         context->m_SwapChainCapabilities.Swap(selected_swap_chain_capabilities);
-        context->m_SwapChain = new SwapChain(context->m_WindowSurface, vk_closest_multisample_flag, context->m_SwapChainCapabilities, selected_queue_family);
+        context->m_SwapChain = new SwapChain(context->m_WindowSurface, vk_closest_multisample_flag, context->m_SwapChainCapabilities, selected_queue_family, resolveTexture);
 
         res = UpdateSwapChain(&context->m_PhysicalDevice, &context->m_LogicalDevice, &created_width, &created_height, want_vsync, context->m_SwapChainCapabilities, context->m_SwapChain);
         if (res != VK_SUCCESS)
@@ -2948,7 +2950,9 @@ bail:
 
     static HTexture VulkanNewTexture(HContext context, const TextureCreationParams& params)
     {
-        Texture* tex       = new Texture;
+        Texture* tex = new Texture;
+        InitializeVulkanTexture(tex);
+
         tex->m_Type        = params.m_Type;
         tex->m_Width       = params.m_Width;
         tex->m_Height      = params.m_Height;

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -18,23 +18,6 @@
 
 namespace dmGraphics
 {
-    /*
-	Texture::Texture()
-        : m_Type(TEXTURE_TYPE_2D)
-        , m_GraphicsFormat(TEXTURE_FORMAT_RGBA)
-        , m_DeviceBuffer(VK_IMAGE_USAGE_SAMPLED_BIT)
-        , m_Width(0)
-        , m_Height(0)
-        , m_OriginalWidth(0)
-        , m_OriginalHeight(0)
-        , m_MipMapCount(0)
-        , m_TextureSamplerIndex(0)
-        , m_Destroyed(0)
-    {
-        memset(&m_Handle, 0, sizeof(m_Handle));
-    }
-    */
-
     void InitializeVulkanTexture(Texture* t)
     {
         t->m_Type                = TEXTURE_TYPE_2D;

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -18,6 +18,7 @@
 
 namespace dmGraphics
 {
+    /*
 	Texture::Texture()
         : m_Type(TEXTURE_TYPE_2D)
         , m_GraphicsFormat(TEXTURE_FORMAT_RGBA)
@@ -31,6 +32,22 @@ namespace dmGraphics
         , m_Destroyed(0)
     {
         memset(&m_Handle, 0, sizeof(m_Handle));
+    }
+    */
+
+    void InitializeVulkanTexture(Texture* t)
+    {
+        t->m_Type                = TEXTURE_TYPE_2D;
+        t->m_GraphicsFormat      = TEXTURE_FORMAT_RGBA;
+        t->m_DeviceBuffer        = VK_IMAGE_USAGE_SAMPLED_BIT;
+        t->m_Width               = 0;
+        t->m_Height              = 0;
+        t->m_OriginalWidth       = 0;
+        t->m_OriginalHeight      = 0;
+        t->m_MipMapCount         = 0;
+        t->m_TextureSamplerIndex = 0;
+        t->m_Destroyed           = 0;
+        memset(&t->m_Handle, 0, sizeof(t->m_Handle));
     }
 
     RenderTarget::RenderTarget(const uint32_t rtId)

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -33,6 +33,7 @@ namespace dmGraphics
 
     struct DeviceBuffer
     {
+        DeviceBuffer(){}
         DeviceBuffer(const VkBufferUsageFlags usage)
         : m_MappedDataPtr(0)
         , m_Usage(usage)
@@ -62,8 +63,6 @@ namespace dmGraphics
 
     struct Texture
     {
-    	Texture();
-
         struct VulkanHandle
         {
             VkImage     m_Image;
@@ -348,7 +347,7 @@ namespace dmGraphics
     {
         dmArray<VkImage>      m_Images;
         dmArray<VkImageView>  m_ImageViews;
-        Texture               m_ResolveTexture;
+        Texture*              m_ResolveTexture;
         const VkSurfaceKHR    m_Surface;
         const QueueFamily     m_QueueFamily;
         VkSurfaceFormatKHR    m_SurfaceFormat;
@@ -358,7 +357,8 @@ namespace dmGraphics
         uint8_t               m_ImageIndex;
 
         SwapChain(const VkSurfaceKHR surface, VkSampleCountFlagBits vk_sample_flag,
-            const SwapChainCapabilities& capabilities, const QueueFamily queueFamily);
+            const SwapChainCapabilities& capabilities, const QueueFamily queueFamily,
+            Texture* resolveTexture);
         VkResult Advance(VkDevice vk_device, VkSemaphore);
         bool     HasMultiSampling();
     };
@@ -527,6 +527,7 @@ namespace dmGraphics
 
     // called from OpenWindow
     bool InitializeVulkan(HContext context, const WindowParams* params);
+    void InitializeVulkanTexture(Texture* t);
 
     void OnWindowResize(int width, int height);
     int OnWindowClose();


### PR DESCRIPTION
This PR fixes part 1 of #5730 by removing the texture constructor in the vulkan lib.