### PR TITLE
HTML5: FileLoader doesn't call callbacks on retry

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -30,7 +30,7 @@ var FileLoader = {
                         return;
                     }
                     currentAttempt = currentAttempt + 1;
-                    setTimeout(obj.send, FileLoader.options.retryInterval);
+                    setTimeout(obj.send.bind(obj), FileLoader.options.retryInterval);
                 };
                 xhr.onload = function(e) {
                     if (onload) onload(xhr, e);


### PR DESCRIPTION
I would love to see this fix in the Defold 1.2.182 BETA, if it's possible.

`dmloader.js` FileLoader doesn't call callbacks on retry because `setTimeout` set `this` to `window` object, the original object is lost. This PR fixes it.

![image](https://user-images.githubusercontent.com/193258/115536516-8c77df80-a2a2-11eb-9e2b-a978285d9a2e.png)
