### PR TITLE
Issue 5825: Crash handler context fix

### DIFF
--- a/engine/crash/src/backtrace_android.cpp
+++ b/engine/crash/src/backtrace_android.cpp
@@ -95,6 +95,7 @@ namespace dmCrash
     void HandlerSetExtraInfoCallback(FCallstackExtraInfoCallback cbk, void* ctx)
     {
         g_CrashExtraInfoCallback = cbk;
+        g_CrashExtraInfoCallbackCtx = ctx;
     }
 
     void OnCrash(int signo, siginfo_t const *si, const ucontext *uc)
@@ -197,6 +198,8 @@ namespace dmCrash
         }
 
         WriteCrash(g_FilePath, &g_AppState);
+
+        LogCallstack(g_AppState.m_Extra);
     }
 
     void WriteDump()

--- a/engine/crash/src/backtrace_execinfo.cpp
+++ b/engine/crash/src/backtrace_execinfo.cpp
@@ -86,7 +86,7 @@ namespace dmCrash
 
         WriteCrash(g_FilePath, &g_AppState);
 
-        printf("\n%s\n", g_AppState.m_Extra);
+        LogCallstack(g_AppState.m_Extra);
     }
 
     void WriteDump()

--- a/engine/crash/src/backtrace_execinfo.cpp
+++ b/engine/crash/src/backtrace_execinfo.cpp
@@ -42,11 +42,11 @@ namespace dmCrash
     void HandlerSetExtraInfoCallback(FCallstackExtraInfoCallback cbk, void* ctx)
     {
         g_CrashExtraInfoCallback = cbk;
+        g_CrashExtraInfoCallbackCtx = ctx;
     }
 
     void OnCrash(int signo)
     {
-        dmLogInfo("Using libunwind.a");
         if (!g_CrashDumpEnabled)
             return;
 

--- a/engine/crash/src/backtrace_jsweb.cpp
+++ b/engine/crash/src/backtrace_jsweb.cpp
@@ -74,5 +74,7 @@ extern "C" void JSWriteDump(char* json_stacktrace) {
         }
         dmCrash::WriteCrash(dmCrash::g_FilePath, &dmCrash::g_AppState);
         dmJson::Free(&doc);
+
+        dmCrash::LogCallstack(dmCrash::g_AppState.m_Extra);
     }
 }

--- a/engine/crash/src/backtrace_win32.cpp
+++ b/engine/crash/src/backtrace_win32.cpp
@@ -195,10 +195,7 @@ namespace dmCrash
 
         WriteCrash(g_FilePath, &g_AppState);
 
-        bool is_debug_mode = dLib::IsDebugMode();
-        dLib::SetDebugMode(true);
-        dmLogError("CALL STACK:\n\n%s\n", g_AppState.m_Extra);
-        dLib::SetDebugMode(is_debug_mode);
+        LogCallstack(g_AppState.m_Extra);
     }
 
     void WriteDump()

--- a/engine/crash/src/crash.cpp
+++ b/engine/crash/src/crash.cpp
@@ -11,6 +11,7 @@
 // specific language governing permissions and limitations under the License.
 
 #include <signal.h>
+#include <dlib/dlib.h>
 #include <dlib/log.h>
 #include <dlib/sys.h>
 #include <dlib/dstrings.h>
@@ -314,5 +315,31 @@ namespace dmCrash
 
         return 0;
     }
+
+    void LogCallstack(char* extras)
+    {
+        bool is_debug_mode = dLib::IsDebugMode();
+        dLib::SetDebugMode(true);
+        dmLogError("CALL STACK:\n\n");
+
+        char* p = extras;
+        char* end = extras + strlen(extras);
+        while( p < end )
+        {
+            char* lineend = strchr(p, '\n');
+            if (!lineend)
+                lineend = strchr(p, '\r');
+            if (lineend && lineend < end)
+                *lineend = 0;
+
+            dmLogError("%s\n", p);
+
+            p = lineend+1;
+        }
+
+        dmLogError("\n");
+        dLib::SetDebugMode(is_debug_mode);
+    }
+
 }
 

--- a/engine/crash/src/crash_private.h
+++ b/engine/crash/src/crash_private.h
@@ -78,6 +78,8 @@ namespace dmCrash
     void PlatformPurge();
     void HandlerSetExtraInfoCallback(FCallstackExtraInfoCallback cbk, void* ctx);
 
+    void LogCallstack(char* extras); // split the extras into separate lines and logs them
+
     extern AppState g_AppState;
     extern char g_FilePath[AppState::FILEPATH_MAX];
 }

--- a/engine/crash/src/wscript
+++ b/engine/crash/src/wscript
@@ -40,7 +40,7 @@ def build(bld):
     if 'darwin' in bld.env['PLATFORM']:
         load_addrs = 'load_addrs_mach.cpp'
 
-    if bld.env['PLATFORM'] in ['x86_64-darwin']:
+    if bld.env['PLATFORM'] in ['x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios']:
         sig_handler = 'backtrace_libunwind.cpp'
 
     if 'win32' in bld.env['PLATFORM']:

--- a/engine/crash/src/wscript
+++ b/engine/crash/src/wscript
@@ -40,7 +40,7 @@ def build(bld):
     if 'darwin' in bld.env['PLATFORM']:
         load_addrs = 'load_addrs_mach.cpp'
 
-    if bld.env['PLATFORM'] in ['x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios']:
+    if bld.env['PLATFORM'] in ['x86_64-darwin']:
         sig_handler = 'backtrace_libunwind.cpp'
 
     if 'win32' in bld.env['PLATFORM']:

--- a/scripts/symbolicate.py
+++ b/scripts/symbolicate.py
@@ -1,10 +1,10 @@
 # Copyright 2020 The Defold Foundation
 # Licensed under the Defold License version 1.0 (the "License"); you may not use
 # this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License, together with FAQs at
 # https://www.defold.com/license
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -35,7 +35,7 @@ def parse_stacktrace(cd, slide, load_addr):
 
 def get_address_map(stack_trace):
     addresses = reduce(lambda x,y: x + y,  [ [ y[1] for y in x ] for x in stack_trace ], [])
-    out = run_cmd('atos -arch armv7 -o "%s" %s' % (sys.argv[2], ' '.join(['0x%x' % a for a in addresses])))[1:-2]
+    out = run_cmd('atos -arch arm64 -o "%s" %s' % (sys.argv[2], ' '.join(['0x%x' % a for a in addresses])))[1:-2]
     lst = [ s.strip().replace(',', '') for s in  out.split('\n') ]
     address_map = {}
     for i,s in enumerate(lst):


### PR DESCRIPTION
For platforms using backtrace_execinfo
Moved iOS to backtrace_libunwind