### PR TITLE
Allow to use jpg, gif, svg as splash image for HTML5 build

### DIFF
--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -722,7 +722,7 @@
    :label "Custom .css"
    :path ["html5" "cssfile"]}
   {:type :resource,
-   :filter "png"
+   :filter ["gif", "jpg", "png", "svg"],
    :preserve-extension true,
    :help "custom html splash screen image",
    :path ["html5" "splash_image"]}


### PR DESCRIPTION
Now, developers can select only PNG files via the "Select Resource" menu to use as a splash screen.

This PR adds the "jpg", "gif", "svg" file types - the most common image file formats on the web.

