### PR TITLE
Separate stencil states

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -738,14 +738,15 @@ namespace dmGameSystem
 
     static void ApplyStencilClipping(RenderGuiContext* gui_context, const dmGui::StencilScope* state, dmRender::StencilTestParams& stp) {
         if (state != 0x0) {
-            stp.m_Func = dmGraphics::COMPARE_FUNC_EQUAL;
-            stp.m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
-            stp.m_OpDPFail = dmGraphics::STENCIL_OP_REPLACE;
-            stp.m_OpDPPass = dmGraphics::STENCIL_OP_REPLACE;
+            stp.m_Front.m_Func = dmGraphics::COMPARE_FUNC_EQUAL;
+            stp.m_Front.m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
+            stp.m_Front.m_OpDPFail = dmGraphics::STENCIL_OP_REPLACE;
+            stp.m_Front.m_OpDPPass = dmGraphics::STENCIL_OP_REPLACE;
             stp.m_Ref = state->m_RefVal;
             stp.m_RefMask = state->m_TestMask;
             stp.m_BufferMask = state->m_WriteMask;
             stp.m_ColorBufferMask = state->m_ColorMask;
+            stp.m_SeparateFaceStates = 0;
             if (gui_context->m_FirstStencil)
             {
                 // Set the m_ClearBuffer for the first stencil of each scene so that scenes (and components) can share the stencil buffer.
@@ -756,14 +757,15 @@ namespace dmGameSystem
                 stp.m_ClearBuffer = 1;
             }
         } else {
-            stp.m_Func = dmGraphics::COMPARE_FUNC_ALWAYS;
-            stp.m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
-            stp.m_OpDPFail = dmGraphics::STENCIL_OP_KEEP;
-            stp.m_OpDPPass = dmGraphics::STENCIL_OP_KEEP;
+            stp.m_Front.m_Func = dmGraphics::COMPARE_FUNC_ALWAYS;
+            stp.m_Front.m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
+            stp.m_Front.m_OpDPFail = dmGraphics::STENCIL_OP_KEEP;
+            stp.m_Front.m_OpDPPass = dmGraphics::STENCIL_OP_KEEP;
             stp.m_Ref = 0;
             stp.m_RefMask = 0xff;
             stp.m_BufferMask = 0xff;
             stp.m_ColorBufferMask = 0xf;
+            stp.m_SeparateFaceStates = 0;
         }
     }
 

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -584,9 +584,17 @@ namespace dmGraphics
     {
         g_functions.m_SetStencilFunc(context, func, ref, mask);
     }
+    void SetStencilFuncSeparate(HContext context, FaceType face_type, CompareFunc func, uint32_t ref, uint32_t mask)
+    {
+        g_functions.m_SetStencilFuncSeparate(context, face_type, func, ref, mask);
+    }
     void SetStencilOp(HContext context, StencilOp sfail, StencilOp dpfail, StencilOp dppass)
     {
         g_functions.m_SetStencilOp(context, sfail, dpfail, dppass);
+    }
+    void SetStencilOpSeparate(HContext context, FaceType face_type, StencilOp sfail, StencilOp dpfail, StencilOp dppass)
+    {
+        g_functions.m_SetStencilOpSeparate(context, face_type, sfail, dpfail, dppass);
     }
     void SetCullFace(HContext context, FaceType face_type)
     {

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -530,7 +530,9 @@ namespace dmGraphics
     void SetScissor(HContext context, int32_t x, int32_t y, int32_t width, int32_t height);
     void SetStencilMask(HContext context, uint32_t mask);
     void SetStencilFunc(HContext context, CompareFunc func, uint32_t ref, uint32_t mask);
+    void SetStencilFuncSeparate(HContext context, FaceType face_type, CompareFunc func, uint32_t ref, uint32_t mask);
     void SetStencilOp(HContext context, StencilOp sfail, StencilOp dpfail, StencilOp dppass);
+    void SetStencilOpSeparate(HContext context, FaceType face_type, StencilOp sfail, StencilOp dpfail, StencilOp dppass);
     void SetCullFace(HContext context, FaceType face_type);
     void SetPolygonOffset(HContext context, float factor, float units);
 

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -121,7 +121,9 @@ namespace dmGraphics
     typedef void (*SetScissorFn)(HContext context, int32_t x, int32_t y, int32_t width, int32_t height);
     typedef void (*SetStencilMaskFn)(HContext context, uint32_t mask);
     typedef void (*SetStencilFuncFn)(HContext context, CompareFunc func, uint32_t ref, uint32_t mask);
+    typedef void (*SetStencilFuncSeparateFn)(HContext context, FaceType face_type, CompareFunc func, uint32_t ref, uint32_t mask);
     typedef void (*SetStencilOpFn)(HContext context, StencilOp sfail, StencilOp dpfail, StencilOp dppass);
+    typedef void (*SetStencilOpSeparateFn)(HContext context, FaceType face_type, StencilOp sfail, StencilOp dpfail, StencilOp dppass);
     typedef void (*SetCullFaceFn)(HContext context, FaceType face_type);
     typedef void (*SetPolygonOffsetFn)(HContext context, float factor, float units);
     typedef HRenderTarget (*NewRenderTargetFn)(HContext context, uint32_t buffer_type_flags, const TextureCreationParams creation_params[MAX_BUFFER_TYPE_COUNT], const TextureParams params[MAX_BUFFER_TYPE_COUNT]);
@@ -225,7 +227,9 @@ namespace dmGraphics
         SetScissorFn m_SetScissor;
         SetStencilMaskFn m_SetStencilMask;
         SetStencilFuncFn m_SetStencilFunc;
+        SetStencilFuncSeparateFn m_SetStencilFuncSeparate;
         SetStencilOpFn m_SetStencilOp;
+        SetStencilOpSeparateFn m_SetStencilOpSeparate;
         SetCullFaceFn m_SetCullFace;
         SetPolygonOffsetFn m_SetPolygonOffset;
         NewRenderTargetFn m_NewRenderTarget;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -85,6 +85,8 @@ typedef void (APIENTRY * PFNGLBUFFERSUBDATAPROC) (GLenum, GLintptr, GLsizeiptr, 
 typedef void* (APIENTRY * PFNGLMAPBUFFERPROC) (GLenum, GLenum);
 typedef GLboolean (APIENTRY * PFNGLUNMAPBUFFERPROC) (GLenum);
 typedef void (APIENTRY * PFNGLACTIVETEXTUREPROC) (GLenum);
+typedef void (APIENTRY * PFNGLSTENCILFUNCSEPARATEPROC) (GLenum, GLenum, GLint, GLuint);
+typedef void (APIENTRY * PFNGLSTENCILOPSEPARATEPROC) (GLenum, GLenum, GLenum, GLenum);
 
 PFNGLGENPROGRAMARBPROC glGenProgramsARB = NULL;
 PFNGLBINDPROGRAMARBPROC glBindProgramARB = NULL;
@@ -114,6 +116,8 @@ PFNGLMAPBUFFERPROC glMapBufferARB = NULL;
 PFNGLUNMAPBUFFERPROC glUnmapBufferARB = NULL;
 PFNGLACTIVETEXTUREPROC glActiveTexture = NULL;
 PFNGLCHECKFRAMEBUFFERSTATUSPROC glCheckFramebufferStatus = NULL;
+PFNGLSTENCILFUNCSEPARATEPROC glStencilFuncSeparate = NULL;
+PFNGLSTENCILOPSEPARATEPROC glStencilOpSeparate = NULL;
 
 PFNGLGETATTRIBLOCATIONPROC glGetAttribLocation = NULL;
 PFNGLCREATESHADERPROC glCreateShader = NULL;
@@ -811,6 +815,8 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         GET_PROC_ADDRESS(glUniform4fv, "glUniform4fv", PFNGLUNIFORM4FVPROC);
         GET_PROC_ADDRESS(glUniformMatrix4fv, "glUniformMatrix4fv", PFNGLUNIFORMMATRIX4FVPROC);
         GET_PROC_ADDRESS(glUniform1i, "glUniform1i", PFNGLUNIFORM1IPROC);
+        GET_PROC_ADDRESS(glStencilOpSeparate, "glStencilOpSeparate", PFNGLSTENCILOPSEPARATEPROC);
+        GET_PROC_ADDRESS(glStencilFuncSeparate, "glStencilFuncSeparate", PFNGLSTENCILFUNCSEPARATEPROC);
 #if !defined(GL_ES_VERSION_2_0)
         GET_PROC_ADDRESS(glGetStringi,"glGetStringi",PFNGLGETSTRINGIPROC);
         GET_PROC_ADDRESS(glGenVertexArrays, "glGenVertexArrays", PFNGLGENVERTEXARRAYSPROC);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2804,6 +2804,17 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         return func_lut[func];
     }
 
+    static GLenum GetOpenGLFaceTypeFunc(FaceType face_type)
+    {
+        const GLenum face_type_lut[] = {
+            GL_FRONT,
+            GL_BACK,
+            GL_FRONT_AND_BACK,
+        };
+
+        return face_type_lut[face_type];
+    }
+
     static void OpenGLSetDepthFunc(HContext context, CompareFunc func)
     {
         assert(context);
@@ -2832,6 +2843,13 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         CHECK_GL_ERROR
     }
 
+    static void OpenGLSetStencilFuncSeparate(HContext context, FaceType face_type, CompareFunc func, uint32_t ref, uint32_t mask)
+    {
+        assert(context);
+        glStencilFuncSeparate(GetOpenGLFaceTypeFunc(face_type), GetOpenGLCompareFunc(func), ref, mask);
+        CHECK_GL_ERROR
+    }
+
     static void OpenGLSetStencilOp(HContext context, StencilOp sfail, StencilOp dpfail, StencilOp dppass)
     {
         assert(context);
@@ -2850,16 +2868,28 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         CHECK_GL_ERROR;
     }
 
+    static void OpenGLSetStencilOpSeparate(HContext context, FaceType face_type, StencilOp sfail, StencilOp dpfail, StencilOp dppass)
+    {
+        assert(context);
+        const GLenum stencil_op_lut[] = {
+            GL_KEEP,
+            GL_ZERO,
+            GL_REPLACE,
+            GL_INCR,
+            GL_INCR_WRAP,
+            GL_DECR,
+            GL_DECR_WRAP,
+            GL_INVERT,
+        };
+
+        glStencilOpSeparate(GetOpenGLFaceTypeFunc(face_type), stencil_op_lut[sfail], stencil_op_lut[dpfail], stencil_op_lut[dppass]);
+        CHECK_GL_ERROR;
+    }
+
     static void OpenGLSetCullFace(HContext context, FaceType face_type)
     {
         assert(context);
-        const GLenum face_type_lut[] = {
-            GL_FRONT,
-            GL_BACK,
-            GL_FRONT_AND_BACK,
-        };
-
-        glCullFace(face_type_lut[face_type]);
+        glCullFace(GetOpenGLFaceTypeFunc(face_type));
         CHECK_GL_ERROR
     }
 
@@ -2980,7 +3010,9 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         fn_table.m_SetScissor = OpenGLSetScissor;
         fn_table.m_SetStencilMask = OpenGLSetStencilMask;
         fn_table.m_SetStencilFunc = OpenGLSetStencilFunc;
+        fn_table.m_SetStencilFuncSeparate = OpenGLSetStencilFuncSeparate;
         fn_table.m_SetStencilOp = OpenGLSetStencilOp;
+        fn_table.m_SetStencilOpSeparate = OpenGLSetStencilOpSeparate;
         fn_table.m_SetCullFace = OpenGLSetCullFace;
         fn_table.m_SetPolygonOffset = OpenGLSetPolygonOffset;
         fn_table.m_NewRenderTarget = OpenGLNewRenderTarget;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2629,12 +2629,24 @@ bail:
         context->m_PipelineState.m_StencilCompareMask = (uint8_t) mask;
     }
 
+    static void VulkanSetStencilFuncSeparate(HContext context, FaceType face_type, CompareFunc func, uint32_t ref, uint32_t mask)
+    {
+        // TODO: Make room in pipeline handle for separate stencil states
+        VulkanSetStencilFunc(context, func, ref, mask);
+    }
+
     static void VulkanSetStencilOp(HContext context, StencilOp sfail, StencilOp dpfail, StencilOp dppass)
     {
         assert(context);
         context->m_PipelineState.m_StencilOpFail      = sfail;
         context->m_PipelineState.m_StencilOpDepthFail = dpfail;
         context->m_PipelineState.m_StencilOpPass      = dppass;
+    }
+
+    static void VulkanSetStencilOpSeparate(HContext context, FaceType face_type, StencilOp sfail, StencilOp dpfail, StencilOp dppass)
+    {
+        // TODO: Make room in pipeline handle for separate stencil states
+        VulkanSetStencilOp(context, sfail, dpfail, dppass);
     }
 
     static void VulkanSetCullFace(HContext context, FaceType face_type)
@@ -3411,7 +3423,9 @@ bail:
         fn_table.m_SetScissor = VulkanSetScissor;
         fn_table.m_SetStencilMask = VulkanSetStencilMask;
         fn_table.m_SetStencilFunc = VulkanSetStencilFunc;
+        fn_table.m_SetStencilFuncSeparate = VulkanSetStencilFuncSeparate;
         fn_table.m_SetStencilOp = VulkanSetStencilOp;
+        fn_table.m_SetStencilOpSeparate = VulkanSetStencilOpSeparate;
         fn_table.m_SetCullFace = VulkanSetCullFace;
         fn_table.m_SetPolygonOffset = VulkanSetPolygonOffset;
         fn_table.m_NewRenderTarget = VulkanNewRenderTarget;

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -115,16 +115,29 @@ namespace dmRender
         StencilTestParams();
         void Init();
 
-        dmGraphics::CompareFunc m_Func;
-        dmGraphics::StencilOp m_OpSFail;
-        dmGraphics::StencilOp m_OpDPFail;
-        dmGraphics::StencilOp m_OpDPPass;
+        struct
+        {
+            dmGraphics::CompareFunc m_Func;
+            dmGraphics::StencilOp   m_OpSFail;
+            dmGraphics::StencilOp   m_OpDPFail;
+            dmGraphics::StencilOp   m_OpDPPass;
+        } m_Front;
+
+        struct
+        {
+            dmGraphics::CompareFunc m_Func;
+            dmGraphics::StencilOp   m_OpSFail;
+            dmGraphics::StencilOp   m_OpDPFail;
+            dmGraphics::StencilOp   m_OpDPPass;
+        } m_Back;
+
         uint8_t m_Ref;
         uint8_t m_RefMask;
         uint8_t m_BufferMask;
         uint8_t m_ColorBufferMask : 4;
         uint8_t m_ClearBuffer : 1;
-        uint8_t : 3;
+        uint8_t m_SeparateFaceStates : 1;
+        uint8_t : 2;
     };
 
 

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -38,15 +38,20 @@ namespace dmRender
     }
 
     void StencilTestParams::Init() {
-        m_Func = dmGraphics::COMPARE_FUNC_ALWAYS;
-        m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
-        m_OpDPFail = dmGraphics::STENCIL_OP_KEEP;
-        m_OpDPPass = dmGraphics::STENCIL_OP_KEEP;
+        m_Front.m_Func = dmGraphics::COMPARE_FUNC_ALWAYS;
+        m_Front.m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
+        m_Front.m_OpDPFail = dmGraphics::STENCIL_OP_KEEP;
+        m_Front.m_OpDPPass = dmGraphics::STENCIL_OP_KEEP;
+        m_Back.m_Func = dmGraphics::COMPARE_FUNC_ALWAYS;
+        m_Back.m_OpSFail = dmGraphics::STENCIL_OP_KEEP;
+        m_Back.m_OpDPFail = dmGraphics::STENCIL_OP_KEEP;
+        m_Back.m_OpDPPass = dmGraphics::STENCIL_OP_KEEP;
         m_Ref = 0;
         m_RefMask = 0xff;
         m_BufferMask = 0xff;
         m_ColorBufferMask = 0xf;
         m_ClearBuffer = 0;
+        m_SeparateFaceStates = 0;
     }
 
     Constant::Constant() {}
@@ -335,8 +340,19 @@ namespace dmRender
         }
         dmGraphics::SetColorMask(graphics_context, stp.m_ColorBufferMask & (1<<3), stp.m_ColorBufferMask & (1<<2), stp.m_ColorBufferMask & (1<<1), stp.m_ColorBufferMask & (1<<0));
         dmGraphics::SetStencilMask(graphics_context, stp.m_BufferMask);
-        dmGraphics::SetStencilFunc(graphics_context, stp.m_Func, stp.m_Ref, stp.m_RefMask);
-        dmGraphics::SetStencilOp(graphics_context, stp.m_OpSFail, stp.m_OpDPFail, stp.m_OpDPPass);
+
+        if (stp.m_SeparateFaceStates)
+        {
+            dmGraphics::SetStencilFuncSeparate(graphics_context, dmGraphics::FACE_TYPE_FRONT, stp.m_Front.m_Func, stp.m_Ref, stp.m_RefMask);
+            dmGraphics::SetStencilFuncSeparate(graphics_context, dmGraphics::FACE_TYPE_BACK, stp.m_Back.m_Func, stp.m_Ref, stp.m_RefMask);
+            dmGraphics::SetStencilOpSeparate(graphics_context, dmGraphics::FACE_TYPE_FRONT, stp.m_Front.m_OpSFail, stp.m_Front.m_OpDPFail, stp.m_Front.m_OpDPPass);
+            dmGraphics::SetStencilOpSeparate(graphics_context, dmGraphics::FACE_TYPE_BACK, stp.m_Back.m_OpSFail, stp.m_Back.m_OpDPFail, stp.m_Back.m_OpDPPass);
+        }
+        else
+        {
+            dmGraphics::SetStencilFunc(graphics_context, stp.m_Front.m_Func, stp.m_Ref, stp.m_RefMask);
+            dmGraphics::SetStencilOp(graphics_context, stp.m_Front.m_OpSFail, stp.m_Front.m_OpDPFail, stp.m_Front.m_OpDPPass);
+        }
     }
 
     void ApplyRenderObjectConstants(HRenderContext render_context, HMaterial material, const RenderObject* ro)


### PR DESCRIPTION
This PR adds functionality to se a separate stencil state both for front and back triangles in the SDK.