### PR TITLE
[DEFEDIT] Fix slowdown when editing atlas animation properties

### DIFF
--- a/editor/.idea/inspectionProfiles/Project_Default.xml
+++ b/editor/.idea/inspectionProfiles/Project_Default.xml
@@ -1,8 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="ClUnusedImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClUnusedLocalSymbol" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClUnusedRequire" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClUnresolvedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -17,10 +17,13 @@
             [editor.changes-view :as changes-view]
             [editor.console :as console]
             [editor.curve-view :as curve-view]
+            [editor.defold-project :as project]
             [editor.outline-view :as outline-view]
             [editor.prefs :as prefs]
             [editor.properties-view :as properties-view]
             [internal.graph :as ig]
+            [internal.graph.types :as gt]
+            [internal.node :as in]
             [internal.system :as is]
             [internal.util :as util])
   (:import [clojure.lang MapEntry]
@@ -54,6 +57,9 @@
 (defn active-view []
   (some-> (app-view)
           (g/node-value :active-view)))
+
+(defn resource-node [path-or-resource]
+  (project/get-resource-node (project) path-or-resource))
 
 (defn selection []
   (->> (g/node-value (project) :selected-node-ids-by-resource-node)
@@ -229,92 +235,125 @@
                          (class-symbol (.getReturnType m))]))))))
         (.getMethodDescriptors (object-bean-info instance))))
 
+(defn direct-internal-successors [basis node-id label]
+  (let [node-type (g/node-type* basis node-id)
+        output-label->output-desc (in/declared-outputs node-type)]
+    (keep (fn [[output-label output-desc]]
+            (when (and (not= label output-label)
+                       (contains? (:dependencies output-desc) label))
+              (pair node-id output-label)))
+          output-label->output-desc)))
+
+(defn direct-override-successors [basis node-id label]
+  (let [graph-id (g/node-id->graph-id node-id)
+        graph (get-in basis [:graphs graph-id])]
+    (map (fn [override-node-id]
+           (pair override-node-id label))
+         (get-in graph [:node->overrides node-id]))))
+
+(defn direct-connected-successors [basis node-id label]
+  (map (fn [arc]
+         (pair (:target-id arc)
+               (:target-label arc)))
+       (gt/arcs-by-source basis node-id label)))
+
+(defn direct-successors [basis node-id label]
+  (sequence
+    (mapcat (fn call-successors-fn [successors-fn]
+              (successors-fn basis node-id label)))
+    [direct-internal-successors
+     direct-override-successors
+     direct-connected-successors]))
+
+(defn direct-successors* [basis node-id-and-label-pairs]
+  (sequence
+    (comp (mapcat (fn [[node-id label]]
+                    (direct-successors basis node-id label)))
+          (distinct))
+    node-id-and-label-pairs))
+
+(defn recursive-successors* [basis node-id-and-label-pairs]
+  (sequence
+    (comp (mapcat (fn [[node-id label]]
+                    (let [direct-successors (direct-successors basis node-id label)]
+                      (concat
+                        direct-successors
+                        (recursive-successors* basis direct-successors)))))
+          (distinct))
+    node-id-and-label-pairs))
+
+(defn recursive-successors [basis node-id label]
+  (recursive-successors* basis [(pair node-id label)]))
+
 (defn successor-tree
   "Returns a tree of all downstream inputs and outputs affected by a change to
-  the specified node id and label. The result is a map of target node id to
-  affected labels, recursively."
+  the specified node id and label. The result is a map of target node keys to
+  affected labels, recursively. The node-key-fn takes a basis and a node-id,
+  and should return the key to use for the node in the resulting map. If not
+  supplied, the node keys will be a pair of the node-type-key and the node-id."
   ([node-id label]
-   (let [basis (ig/update-successors (g/now) {node-id #{label}})]
-     (successor-tree basis node-id label)))
+   (successor-tree (g/now) node-id label))
   ([basis node-id label]
-   (let [graph-id (g/node-id->graph-id node-id)
-         successors-by-node-id (get-in basis [:graphs graph-id :successors])]
-     (into (sorted-map)
-           (map (fn [[successor-node-id successor-labels]]
-                  (pair successor-node-id
-                        (into (sorted-map)
-                              (keep (fn [successor-label]
-                                      (when-not (and (= node-id successor-node-id)
-                                                     (= label successor-label))
-                                        (pair successor-label
-                                              (not-empty (successor-tree basis successor-node-id successor-label))))))
-                              successor-labels))))
-           (get-in successors-by-node-id [node-id label])))))
+   (util/group-into
+     (sorted-map)
+     (sorted-map)
+     (fn key-fn [[successor-node-id]]
+       (pair (node-type-key basis successor-node-id)
+             successor-node-id))
+     (fn value-fn [[successor-node-id successor-label]]
+       (pair successor-label
+             (not-empty
+               (successor-tree basis successor-node-id successor-label))))
+     (direct-successors basis node-id label))))
+
+(defn- successor-types-impl [successors-fn basis node-id-and-label-pairs]
+  (into (sorted-map)
+        (map (fn [[node-type-key successor-labels]]
+               (pair node-type-key
+                     (into (sorted-map)
+                           (frequencies successor-labels)))))
+        (util/group-into {} []
+                         (comp (partial node-type-key basis) first)
+                         second
+                         (successors-fn basis node-id-and-label-pairs))))
+
+(defn successor-types*
+  "Like successor-types, but you can query multiple inputs at once by providing
+  a sequence of [node-id label] pairs."
+  ([node-id-and-label-pairs]
+   (successor-types* (g/now) node-id-and-label-pairs))
+  ([basis node-id-and-label-pairs]
+   (successor-types-impl recursive-successors* basis node-id-and-label-pairs)))
 
 (defn successor-types
   "Returns a map of all downstream inputs and outputs affected by a change to
   the specified node id and label, recursively. The result is a flat map of
-  target node types to the set of affected labels in that node type."
+  target node types to a map of the affected labels in that node type. The
+  number associated with each affected label is how many upstream labels
+  invalidate that label in the current search space."
   ([node-id label]
-   (let [basis (ig/update-successors (g/now) {node-id #{label}})]
-     (successor-types basis node-id label)))
+   (successor-types (g/now) node-id label))
   ([basis node-id label]
-   (letfn [(select [[node-id node-successors]]
-             (mapcat (fn [[label next-successors]]
-                       (cons (pair node-id label)
-                             (mapcat select next-successors)))
-                     node-successors))]
-     (util/group-into (sorted-map)
-                      (sorted-set)
-                      (comp (partial node-type-key basis) key)
-                      val
-                      (mapcat select
-                              (successor-tree basis node-id label))))))
+   (successor-types* basis [(pair node-id label)])))
 
-(defn successor-types*
-  "Like successor-types, but you can query multiple inputs at once using a map."
-  ([label-seqs-by-node-id]
-   (let [label-sets-by-node-id (util/map-vals set label-seqs-by-node-id)
-         basis (ig/update-successors (g/now) label-sets-by-node-id)]
-     (successor-types* basis label-sets-by-node-id)))
-  ([basis label-seqs-by-node-id]
-   (reduce (partial merge-with into)
-           (sorted-map)
-           (for [[node-id labels] label-seqs-by-node-id
-                 label labels]
-             (successor-types basis node-id label)))))
+(defn direct-successor-types*
+  "Like direct-successor-types, but you can query multiple inputs at once by
+  providing a sequence of [node-id label] pairs."
+  ([node-id-and-label-pairs]
+   (direct-successor-types* (g/now) node-id-and-label-pairs))
+  ([basis node-id-and-label-pairs]
+   (successor-types-impl direct-successors* basis node-id-and-label-pairs)))
 
 (defn direct-successor-types
   "Returns a map of all downstream inputs and outputs immediately affected by a
   change to the specified node id and label. The result is a flat map of target
-  node types to the set of affected labels in that node type."
+  node types to a map of the affected labels in that node type. The number
+  associated with each affected label is how many upstream labels invalidate
+  that label in the current search space."
   ([node-id label]
-   (let [basis (ig/update-successors (g/now) {node-id #{label}})]
-     (direct-successor-types basis node-id label)))
+   (direct-successor-types (g/now) node-id label))
   ([basis node-id label]
-   (util/group-into (sorted-map)
-                    (sorted-set)
-                    (comp (partial node-type-key basis) key)
-                    val
-                    (mapcat (fn [[node-id node-successors]]
-                              (map (fn [[label]]
-                                     (pair node-id label))
-                                   node-successors))
-                            (successor-tree basis node-id label)))))
-
-(defn direct-successor-types*
-  "Like direct-successor-types, but you can query multiple inputs at once using
-  a map."
-  ([label-seqs-by-node-id]
-   (let [label-sets-by-node-id (util/map-vals set label-seqs-by-node-id)
-         basis (ig/update-successors (g/now) label-sets-by-node-id)]
-     (direct-successor-types* basis label-sets-by-node-id)))
-  ([basis label-seqs-by-node-id]
-   (reduce (partial merge-with into)
-           (sorted-map)
-           (for [[node-id labels] label-seqs-by-node-id
-                 label labels]
-             (direct-successor-types basis node-id label)))))
+   (direct-successor-types* basis [(pair node-id label)])))
 
 (defn ordered-occurrences
   "Returns a sorted list of [occurrence-count entry]. The list is sorted by

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -404,14 +404,6 @@
                            (validate-extrude-borders node-id extrude-borders)]
                           (filter some?)
                           (not-empty))]
-    (g/error-aggregate errors))
-
-  (when-let [errors (->> [[margin "Margin"]
-                          [inner-padding "Inner Padding"]
-                          [extrude-borders "Extrude Borders"]]
-                         (keep (fn [[v name]]
-                                 (validation/prop-error :fatal node-id :layout-result validation/prop-negative? v name)))
-                         not-empty)]
     (g/error-aggregate errors)))
 
 (g/defnk produce-build-targets [_node-id resource texture-set packed-image-generator texture-profile build-settings build-errors]

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -52,6 +52,7 @@
            [com.jogamp.opengl GL GL2]
            [editor.types Animation Image AABB]
            [java.awt.image BufferedImage]
+           [java.util List]
            [javax.vecmath Point3d]))
 
 (set! *warn-on-reflection* true)
@@ -791,8 +792,8 @@
   (active? [selection] (move-active? selection))
   (enabled? [selection] (let [node-id (selection->image selection)
                               parent (core/scope node-id)
-                              children (vec (g/node-value parent :nodes))
-                              node-child-index (.indexOf ^java.util.List children node-id)]
+                              ^List children (vec (g/node-value parent :nodes))
+                              node-child-index (.indexOf children node-id)]
                           (pos? node-child-index)))
   (run [selection] (move-node! (selection->image selection) -1)))
 
@@ -800,7 +801,7 @@
   (active? [selection] (move-active? selection))
   (enabled? [selection] (let [node-id (selection->image selection)
                               parent (core/scope node-id)
-                              children (vec (g/node-value parent :nodes))
-                              node-child-index (.indexOf ^java.util.List children node-id)]
+                              ^List children (vec (g/node-value parent :nodes))
+                              node-child-index (.indexOf children node-id)]
                           (< node-child-index (dec (.size children)))))
   (run [selection] (move-node! (selection->image selection) 1)))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -26,7 +26,7 @@
            [com.dynamo.render.proto Render$Resize]
            [java.io BufferedReader File InputStream IOException]
            [java.net HttpURLConnection InetSocketAddress Socket URI]
-           [java.util.zip ZipFile]))
+           [java.util.zip ZipEntry ZipFile]))
 
 (set! *warn-on-reflection* true)
 
@@ -208,13 +208,13 @@
       (fs/set-executable! engine-file)
       engine-file)))
 
-(defn- zip-entries! [zipfile]
+(defn- zip-entries! [^ZipFile zipfile]
   (enumeration-seq (.entries zipfile)))
 
 (defn- unpack-build-zip!
   [^File engine-archive dir]
   (with-open [zip-file (ZipFile. engine-archive)]
-    (doseq [entry (zip-entries! zip-file)]
+    (doseq [^ZipEntry entry (zip-entries! zip-file)]
       (let [savePath (str dir File/separatorChar (.getName entry))
             saveFile (File. savePath)]
         (if (.isDirectory entry)
@@ -222,10 +222,9 @@
             (.mkdirs saveFile))
           (let [parentDir (File. (.substring savePath 0 (.lastIndexOf savePath (int File/separatorChar))))
                 stream (.getInputStream zip-file entry)]
-            (if-not (.exists parentDir) (.mkdirs parentDir))
-            (clojure.java.io/copy stream saveFile)))
-      ))))
-
+            (when-not (.exists parentDir)
+              (.mkdirs parentDir))
+            (io/copy stream saveFile)))))))
 
 (def ^:private dmengine-dependencies
   {"x86_64-win32" #{"OpenAL32.dll" "wrap_oal.dll"}

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2992,7 +2992,7 @@
                               parent (core/scope selected-node-id)
                               node-child-index (g/node-value selected-node-id :child-index)
                               child-indices (g/node-value parent :child-indices)]
-                          (< node-child-index (dec (.size child-indices)))))
+                          (< node-child-index (dec (count child-indices)))))
   (run [selection] (let [selected (g/override-root (handler/selection->node-id selection))]
                      (move-child-node! selected 1))))
 

--- a/editor/src/clj/prof.clj
+++ b/editor/src/clj/prof.clj
@@ -24,10 +24,10 @@
   (future
     (try
       (.browse (Desktop/getDesktop) uri)
-      nil
       (catch Throwable error
         (println (str "Failed to open URI " uri))
-        (println (.getMessage error))))))
+        (println (.getMessage error)))))
+  nil)
 
 (defn list-event-types
   "Print all event types that can be sampled by the profiler. Available options:


### PR DESCRIPTION
Partially fixes #5755.

### User-facing changes
Editing properties on an animation inside an atlas would invalidate the atlas layout, despite the fact that the animation properties cannot affect the layout of the atlas.

### Technical changes
* Refactored connections between `AltasNode`, `AtlasImage`, and `AtalsAnimationNode` to break dependencies between animation properties and the generated layout.
* Re-wrote successor query functions in `dev.clj` to more accurately report graph dependencies.