### PR TITLE
[DEFEDIT] Fix slowdown when editing atlas animation properties (second attempt)

### DIFF
--- a/editor/.idea/inspectionProfiles/Project_Default.xml
+++ b/editor/.idea/inspectionProfiles/Project_Default.xml
@@ -1,8 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="ClUnusedImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClUnusedLocalSymbol" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClUnusedRequire" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClUnresolvedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -17,13 +17,16 @@
             [editor.changes-view :as changes-view]
             [editor.console :as console]
             [editor.curve-view :as curve-view]
+            [editor.defold-project :as project]
             [editor.outline-view :as outline-view]
             [editor.prefs :as prefs]
             [editor.properties-view :as properties-view]
-            [internal.graph :as ig]
+            [internal.graph.types :as gt]
+            [internal.node :as in]
             [internal.system :as is]
             [internal.util :as util])
   (:import [clojure.lang MapEntry]
+           [internal.graph.types Arc]
            [java.beans BeanInfo Introspector MethodDescriptor PropertyDescriptor]
            [java.lang.reflect Modifier]
            [javafx.stage Window]))
@@ -54,6 +57,9 @@
 (defn active-view []
   (some-> (app-view)
           (g/node-value :active-view)))
+
+(defn resource-node [path-or-resource]
+  (project/get-resource-node (project) path-or-resource))
 
 (defn selection []
   (->> (g/node-value (project) :selected-node-ids-by-resource-node)
@@ -229,92 +235,123 @@
                          (class-symbol (.getReturnType m))]))))))
         (.getMethodDescriptors (object-bean-info instance))))
 
+(defn direct-internal-successors [basis node-id label]
+  (let [node-type (g/node-type* basis node-id)
+        output-label->output-desc (in/declared-outputs node-type)]
+    (keep (fn [[output-label output-desc]]
+            (when (and (not= label output-label)
+                       (contains? (:dependencies output-desc) label))
+              (pair node-id output-label)))
+          output-label->output-desc)))
+
+(defn direct-override-successors [basis node-id label]
+  (let [graph-id (g/node-id->graph-id node-id)
+        graph (get-in basis [:graphs graph-id])]
+    (map (fn [override-node-id]
+           (pair override-node-id label))
+         (get-in graph [:node->overrides node-id]))))
+
+(defn direct-successors* [direct-connected-successors-fn basis node-id-and-label-pairs]
+  (into #{}
+        (mapcat (fn [[node-id label]]
+                  (concat
+                    (direct-internal-successors basis node-id label)
+                    (direct-override-successors basis node-id label)
+                    (direct-connected-successors-fn node-id label))))
+        node-id-and-label-pairs))
+
+(defn recursive-successors* [direct-connected-successors-fn basis node-id-and-label-pairs]
+  (let [direct-successors (direct-successors* direct-connected-successors-fn basis node-id-and-label-pairs)]
+    (if (empty? direct-successors)
+      direct-successors
+      (into direct-successors
+            (recursive-successors* direct-connected-successors-fn basis direct-successors)))))
+
+(defn direct-connected-successors-by-label [basis node-id]
+  (util/group-into {} []
+                   (fn key-fn [^Arc arc]
+                     (.source-label arc))
+                   (fn value-fn [^Arc arc]
+                     (pair (.target-id arc)
+                           (.target-label arc)))
+                   (gt/arcs-by-source basis node-id)))
+
+(defn make-direct-connected-successors-fn [basis]
+  (let [direct-connected-successors-by-label-fn (memoize (partial direct-connected-successors-by-label basis))]
+    (fn direct-connected-successors [node-id label]
+      (-> node-id direct-connected-successors-by-label-fn label))))
+
 (defn successor-tree
   "Returns a tree of all downstream inputs and outputs affected by a change to
-  the specified node id and label. The result is a map of target node id to
-  affected labels, recursively."
+  the specified node id and label. The result is a map of target node keys to
+  affected labels, recursively. The node-key-fn takes a basis and a node-id,
+  and should return the key to use for the node in the resulting map. If not
+  supplied, the node keys will be a pair of the node-type-key and the node-id."
   ([node-id label]
-   (let [basis (ig/update-successors (g/now) {node-id #{label}})]
-     (successor-tree basis node-id label)))
+   (successor-tree (g/now) node-id label))
   ([basis node-id label]
-   (let [graph-id (g/node-id->graph-id node-id)
-         successors-by-node-id (get-in basis [:graphs graph-id :successors])]
-     (into (sorted-map)
-           (map (fn [[successor-node-id successor-labels]]
-                  (pair successor-node-id
-                        (into (sorted-map)
-                              (keep (fn [successor-label]
-                                      (when-not (and (= node-id successor-node-id)
-                                                     (= label successor-label))
-                                        (pair successor-label
-                                              (not-empty (successor-tree basis successor-node-id successor-label))))))
-                              successor-labels))))
-           (get-in successors-by-node-id [node-id label])))))
+   (let [direct-connected-successors-fn (make-direct-connected-successors-fn basis)]
+     (util/group-into
+       (sorted-map)
+       (sorted-map)
+       (fn key-fn [[successor-node-id]]
+         (pair (node-type-key basis successor-node-id)
+               successor-node-id))
+       (fn value-fn [[successor-node-id successor-label]]
+         (pair successor-label
+               (not-empty
+                 (successor-tree basis successor-node-id successor-label))))
+       (direct-successors* direct-connected-successors-fn basis [(pair node-id label)])))))
+
+(defn- successor-types-impl [successors-fn basis node-id-and-label-pairs]
+  (let [direct-connected-successors-fn (make-direct-connected-successors-fn basis)]
+    (into (sorted-map)
+          (map (fn [[node-type-key successor-labels]]
+                 (pair node-type-key
+                       (into (sorted-map)
+                             (frequencies successor-labels)))))
+          (util/group-into {} []
+                           (comp (partial node-type-key basis) first)
+                           second
+                           (successors-fn direct-connected-successors-fn basis node-id-and-label-pairs)))))
+
+(defn successor-types*
+  "Like successor-types, but you can query multiple inputs at once by providing
+  a sequence of [node-id label] pairs."
+  ([node-id-and-label-pairs]
+   (successor-types* (g/now) node-id-and-label-pairs))
+  ([basis node-id-and-label-pairs]
+   (successor-types-impl recursive-successors* basis node-id-and-label-pairs)))
 
 (defn successor-types
   "Returns a map of all downstream inputs and outputs affected by a change to
   the specified node id and label, recursively. The result is a flat map of
-  target node types to the set of affected labels in that node type."
+  target node types to a map of the affected labels in that node type. The
+  number associated with each affected label is how many upstream labels
+  invalidate that label in the current search space."
   ([node-id label]
-   (let [basis (ig/update-successors (g/now) {node-id #{label}})]
-     (successor-types basis node-id label)))
+   (successor-types (g/now) node-id label))
   ([basis node-id label]
-   (letfn [(select [[node-id node-successors]]
-             (mapcat (fn [[label next-successors]]
-                       (cons (pair node-id label)
-                             (mapcat select next-successors)))
-                     node-successors))]
-     (util/group-into (sorted-map)
-                      (sorted-set)
-                      (comp (partial node-type-key basis) key)
-                      val
-                      (mapcat select
-                              (successor-tree basis node-id label))))))
+   (successor-types* basis [(pair node-id label)])))
 
-(defn successor-types*
-  "Like successor-types, but you can query multiple inputs at once using a map."
-  ([label-seqs-by-node-id]
-   (let [label-sets-by-node-id (util/map-vals set label-seqs-by-node-id)
-         basis (ig/update-successors (g/now) label-sets-by-node-id)]
-     (successor-types* basis label-sets-by-node-id)))
-  ([basis label-seqs-by-node-id]
-   (reduce (partial merge-with into)
-           (sorted-map)
-           (for [[node-id labels] label-seqs-by-node-id
-                 label labels]
-             (successor-types basis node-id label)))))
+(defn direct-successor-types*
+  "Like direct-successor-types, but you can query multiple inputs at once by
+  providing a sequence of [node-id label] pairs."
+  ([node-id-and-label-pairs]
+   (direct-successor-types* (g/now) node-id-and-label-pairs))
+  ([basis node-id-and-label-pairs]
+   (successor-types-impl direct-successors* basis node-id-and-label-pairs)))
 
 (defn direct-successor-types
   "Returns a map of all downstream inputs and outputs immediately affected by a
   change to the specified node id and label. The result is a flat map of target
-  node types to the set of affected labels in that node type."
+  node types to a map of the affected labels in that node type. The number
+  associated with each affected label is how many upstream labels invalidate
+  that label in the current search space."
   ([node-id label]
-   (let [basis (ig/update-successors (g/now) {node-id #{label}})]
-     (direct-successor-types basis node-id label)))
+   (direct-successor-types (g/now) node-id label))
   ([basis node-id label]
-   (util/group-into (sorted-map)
-                    (sorted-set)
-                    (comp (partial node-type-key basis) key)
-                    val
-                    (mapcat (fn [[node-id node-successors]]
-                              (map (fn [[label]]
-                                     (pair node-id label))
-                                   node-successors))
-                            (successor-tree basis node-id label)))))
-
-(defn direct-successor-types*
-  "Like direct-successor-types, but you can query multiple inputs at once using
-  a map."
-  ([label-seqs-by-node-id]
-   (let [label-sets-by-node-id (util/map-vals set label-seqs-by-node-id)
-         basis (ig/update-successors (g/now) label-sets-by-node-id)]
-     (direct-successor-types* basis label-sets-by-node-id)))
-  ([basis label-seqs-by-node-id]
-   (reduce (partial merge-with into)
-           (sorted-map)
-           (for [[node-id labels] label-seqs-by-node-id
-                 label labels]
-             (direct-successor-types basis node-id label)))))
+   (direct-successor-types* basis [(pair node-id label)])))
 
 (defn ordered-occurrences
   "Returns a sorted list of [occurrence-count entry]. The list is sorted by

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -539,9 +539,12 @@
   [animations layout-data]
   (let [incomplete-ddf-texture-set (:texture-set layout-data)
         incomplete-ddf-animations (:animations incomplete-ddf-texture-set)
+        animation-present-in-ddf? (comp not-empty :images)
+        animations-in-ddf (filter animation-present-in-ddf?
+                                  animations)
         complete-ddf-animations (map complete-ddf-animation
                                      incomplete-ddf-animations
-                                     animations)
+                                     animations-in-ddf)
         complete-ddf-texture-set (assoc incomplete-ddf-texture-set
                                    :animations complete-ddf-animations)]
     (assoc layout-data

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -52,6 +52,7 @@
            [com.jogamp.opengl GL GL2]
            [editor.types Animation Image AABB]
            [java.awt.image BufferedImage]
+           [java.util List]
            [javax.vecmath Point3d]))
 
 (set! *warn-on-reflection* true)
@@ -149,9 +150,9 @@
       (str/split #"\.(?=[^\.]+$)")
       first))
 
-(defn image->animation [image id]
+(defn make-animation [id images]
   (types/map->Animation {:id              id
-                         :images          [image]
+                         :images          images
                          :fps             30
                          :flip-horizontal false
                          :flip-vertical   false
@@ -215,8 +216,9 @@
 
   (output atlas-image Image (g/fnk [image-resource maybe-image-size sprite-trim-mode]
                               (Image. (resource/proj-path image-resource) nil (:width maybe-image-size) (:height maybe-image-size) sprite-trim-mode)))
+  (output atlas-images [Image] (g/fnk [atlas-image] [atlas-image]))
   (output animation Animation (g/fnk [atlas-image id]
-                                (image->animation atlas-image id)))
+                                (make-animation id [atlas-image])))
   (output node-outline outline/OutlineData :cached (g/fnk [_node-id build-errors id maybe-image-resource order]
                                                      (let [label (or id "<No Image>")]
                                                        (cond-> {:node-id _node-id
@@ -253,7 +255,7 @@
   (concat
     (g/connect image-node :_node-id         atlas-node :nodes)
     (g/connect image-node :animation        atlas-node :animations)
-    (g/connect image-node :atlas-image      atlas-node :atlas-images)
+    (g/connect image-node :atlas-images     atlas-node :animation-images)
     (g/connect image-node :build-errors     atlas-node :child-build-errors)
     (g/connect image-node :ddf-message      atlas-node :img-ddf)
     (g/connect image-node :id               atlas-node :animation-ids)
@@ -282,6 +284,7 @@
   (concat
     (g/connect animation-node :_node-id         atlas-node     :nodes)
     (g/connect animation-node :animation        atlas-node     :animations)
+    (g/connect animation-node :atlas-images     atlas-node     :animation-images)
     (g/connect animation-node :build-errors     atlas-node     :child-build-errors)
     (g/connect animation-node :ddf-message      atlas-node     :anim-ddf)
     (g/connect animation-node :id               atlas-node     :animation-ids)
@@ -338,6 +341,8 @@
   (output child->order g/Any :cached (g/fnk [nodes] (zipmap nodes (range))))
 
   (input atlas-images Image :array)
+  (output atlas-images [Image] (gu/passthrough atlas-images))
+
   (input img-ddf g/Any :array)
   (input child-scenes g/Any :array)
   (input child-build-errors g/Any :array)
@@ -392,6 +397,14 @@
 
 (defn- validate-extrude-borders [node-id extrude-borders]
   (validation/prop-error :fatal node-id :extrude-borders validation/prop-negative? extrude-borders "Extrude Borders"))
+
+(defn- validate-layout-properties [node-id margin inner-padding extrude-borders]
+  (when-some [errors (->> [(validate-margin node-id margin)
+                           (validate-inner-padding node-id inner-padding)
+                           (validate-extrude-borders node-id extrude-borders)]
+                          (filter some?)
+                          (not-empty))]
+    (g/error-aggregate errors)))
 
 (g/defnk produce-build-targets [_node-id resource texture-set packed-image-generator texture-profile build-settings build-errors]
   (g/precluding-errors build-errors
@@ -473,7 +486,7 @@
 (defn- call-generator [generator]
   ((:f generator) (:args generator)))
 
-(defn- generate-packed-image [{:keys [_node-id image-resources texture-set-data-generator]}]
+(defn- generate-packed-image [{:keys [_node-id image-resources layout-data-generator]}]
   (let [buffered-images (mapv #(resource-io/with-error-translation % _node-id nil
                                  (image-util/read-image %))
                               image-resources)
@@ -481,7 +494,58 @@
     (if (seq errors)
       (g/error-aggregate errors)
       (let [id->image (zipmap (map resource/proj-path image-resources) buffered-images)]
-        (texture-set-gen/layout-images (:layout (call-generator texture-set-data-generator)) id->image)))))
+        (texture-set-gen/layout-images (:layout (call-generator layout-data-generator)) id->image)))))
+
+(g/defnk produce-layout-data-generator
+  [_node-id animation-images all-atlas-images extrude-borders inner-padding margin resource :as args]
+  ;; The TextureSetGenerator.calculateLayout() method inherited from Bob also
+  ;; compiles a TextureSetProto$TextureSet including the animation data in
+  ;; addition to generating the layout. This means that modifying a property on
+  ;; an animation will unnecessarily invalidate the layout, which in turn
+  ;; invalidates the packed image texture. For the editor, we're only interested
+  ;; in the layout-related properties of the produced TextureSetResult. To break
+  ;; the dependency on animation properties, we supply a list of fake animations
+  ;; to the TextureSetGenerator.calculateLayout() method that only includes data
+  ;; that can affect the layout.
+  (or (validate-layout-properties _node-id margin inner-padding extrude-borders)
+      (let [fake-animations (map make-animation
+                                 (repeat "")
+                                 animation-images)
+            augmented-args (-> args
+                               (dissoc :animation-images)
+                               (assoc :animations fake-animations
+                                      :workspace (resource/workspace resource)))]
+        {:f generate-texture-set-data
+         :args augmented-args})))
+
+(defn- complete-ddf-animation [ddf-animation {:keys [flip-horizontal flip-vertical fps id playback] :as _animation}]
+  (assert (boolean? flip-horizontal))
+  (assert (boolean? flip-vertical))
+  (assert (integer? fps))
+  (assert (string? id))
+  (assert (protobuf/val->pb-enum Tile$Playback playback))
+  (assoc ddf-animation
+    :flip-horizontal (if flip-horizontal 1 0)
+    :flip-vertical (if flip-vertical 1 0)
+    :fps (int fps)
+    :id id
+    :playback playback))
+
+(g/defnk produce-texture-set-data
+  ;; The TextureSetResult we generated in produce-layout-data-generator does not
+  ;; contain the animation metadata since it was produced from fake animations.
+  ;; In order to produce a valid TextureSetResult, we complete the protobuf
+  ;; animations inside the embedded TextureSet with our animation properties.
+  [animations layout-data]
+  (let [incomplete-ddf-texture-set (:texture-set layout-data)
+        incomplete-ddf-animations (:animations incomplete-ddf-texture-set)
+        complete-ddf-animations (map complete-ddf-animation
+                                     incomplete-ddf-animations
+                                     animations)
+        complete-ddf-texture-set (assoc incomplete-ddf-texture-set
+                                   :animations complete-ddf-animations)]
+    (assoc layout-data
+      :texture-set complete-ddf-texture-set)))
 
 (g/defnk produce-anim-data
   [texture-set uv-transforms]
@@ -518,9 +582,9 @@
 
   (input build-settings g/Any)
   (input texture-profiles g/Any)
-  (input atlas-images g/Any :array)
   (input animations Animation :array)
   (input animation-ids g/Str :array)
+  (input animation-images [Image] :array)
   (input img-ddf g/Any :array)
   (input anim-ddf g/Any :array)
   (input child-scenes g/Any :array)
@@ -530,28 +594,18 @@
   (output texture-profile g/Any (g/fnk [texture-profiles resource]
                                   (tex-gen/match-texture-profile texture-profiles (resource/proj-path resource))))
 
-  (output all-atlas-images           [Image]             :cached (g/fnk [animations]
-                                                                   (into [] (comp (mapcat :images) (distinct)) animations)))
+  (output all-atlas-images [Image] :cached (g/fnk [animation-images]
+                                             (vec (distinct (flatten animation-images)))))
 
-  (output texture-set-data-generator g/Any (g/fnk [_node-id animations all-atlas-images extrude-borders inner-padding margin resource :as args]
-                                                  (or (when-let [errors (->> [[margin "Margin"]
-                                                                              [inner-padding "Inner Padding"]
-                                                                              [extrude-borders "Extrude Borders"]]
-                                                                             (keep (fn [[v name]]
-                                                                                     (validation/prop-error :fatal _node-id :layout-result validation/prop-negative? v name)))
-                                                                             not-empty)]
-                                                        (g/error-aggregate errors))
-                                                      {:f    generate-texture-set-data
-                                                       :args (assoc args
-                                                               :workspace (resource/workspace resource))})))
-
-  (output texture-set-data g/Any               :cached (g/fnk [texture-set-data-generator] (call-generator texture-set-data-generator)))
-  (output layout-size      g/Any               (g/fnk [texture-set-data] (:size texture-set-data)))
+  (output layout-data-generator g/Any          produce-layout-data-generator)
+  (output texture-set-data g/Any               :cached produce-texture-set-data)
+  (output layout-data      g/Any               :cached (g/fnk [layout-data-generator] (call-generator layout-data-generator)))
+  (output layout-size      g/Any               (g/fnk [layout-data] (:size layout-data)))
   (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
-  (output uv-transforms    g/Any               (g/fnk [texture-set-data] (:uv-transforms texture-set-data)))
-  (output layout-rects     g/Any               (g/fnk [texture-set-data] (:rects texture-set-data)))
+  (output uv-transforms    g/Any               (g/fnk [layout-data] (:uv-transforms layout-data)))
+  (output layout-rects     g/Any               (g/fnk [layout-data] (:rects layout-data)))
 
-  (output packed-image-generator g/Any (g/fnk [_node-id extrude-borders image-resources inner-padding margin texture-set-data-generator]
+  (output packed-image-generator g/Any (g/fnk [_node-id extrude-borders image-resources inner-padding margin layout-data-generator]
                                          (let [flat-image-resources (filterv some? (flatten image-resources))
                                                image-sha1s (map (fn [resource]
                                                                   (resource-io/with-error-translation resource _node-id nil
@@ -570,7 +624,7 @@
                                                 :sha1 packed-image-sha1
                                                 :args {:_node-id _node-id
                                                        :image-resources flat-image-resources
-                                                       :texture-set-data-generator texture-set-data-generator}})))))
+                                                       :layout-data-generator layout-data-generator}})))))
 
   (output packed-image     BufferedImage       :cached (g/fnk [packed-image-generator] (call-generator packed-image-generator)))
 
@@ -791,8 +845,8 @@
   (active? [selection] (move-active? selection))
   (enabled? [selection] (let [node-id (selection->image selection)
                               parent (core/scope node-id)
-                              children (vec (g/node-value parent :nodes))
-                              node-child-index (.indexOf ^java.util.List children node-id)]
+                              ^List children (vec (g/node-value parent :nodes))
+                              node-child-index (.indexOf children node-id)]
                           (pos? node-child-index)))
   (run [selection] (move-node! (selection->image selection) -1)))
 
@@ -800,7 +854,7 @@
   (active? [selection] (move-active? selection))
   (enabled? [selection] (let [node-id (selection->image selection)
                               parent (core/scope node-id)
-                              children (vec (g/node-value parent :nodes))
-                              node-child-index (.indexOf ^java.util.List children node-id)]
+                              ^List children (vec (g/node-value parent :nodes))
+                              node-child-index (.indexOf children node-id)]
                           (< node-child-index (dec (.size children)))))
   (run [selection] (move-node! (selection->image selection) 1)))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -26,7 +26,7 @@
            [com.dynamo.render.proto Render$Resize]
            [java.io BufferedReader File InputStream IOException]
            [java.net HttpURLConnection InetSocketAddress Socket URI]
-           [java.util.zip ZipFile]))
+           [java.util.zip ZipEntry ZipFile]))
 
 (set! *warn-on-reflection* true)
 
@@ -208,13 +208,13 @@
       (fs/set-executable! engine-file)
       engine-file)))
 
-(defn- zip-entries! [zipfile]
+(defn- zip-entries! [^ZipFile zipfile]
   (enumeration-seq (.entries zipfile)))
 
 (defn- unpack-build-zip!
   [^File engine-archive dir]
   (with-open [zip-file (ZipFile. engine-archive)]
-    (doseq [entry (zip-entries! zip-file)]
+    (doseq [^ZipEntry entry (zip-entries! zip-file)]
       (let [savePath (str dir File/separatorChar (.getName entry))
             saveFile (File. savePath)]
         (if (.isDirectory entry)
@@ -222,10 +222,9 @@
             (.mkdirs saveFile))
           (let [parentDir (File. (.substring savePath 0 (.lastIndexOf savePath (int File/separatorChar))))
                 stream (.getInputStream zip-file entry)]
-            (if-not (.exists parentDir) (.mkdirs parentDir))
-            (clojure.java.io/copy stream saveFile)))
-      ))))
-
+            (when-not (.exists parentDir)
+              (.mkdirs parentDir))
+            (io/copy stream saveFile)))))))
 
 (def ^:private dmengine-dependencies
   {"x86_64-win32" #{"OpenAL32.dll" "wrap_oal.dll"}

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2992,7 +2992,7 @@
                               parent (core/scope selected-node-id)
                               node-child-index (g/node-value selected-node-id :child-index)
                               child-indices (g/node-value parent :child-indices)]
-                          (< node-child-index (dec (.size child-indices)))))
+                          (< node-child-index (dec (count child-indices)))))
   (run [selection] (let [selected (g/override-root (handler/selection->node-id selection))]
                      (move-child-node! selected 1))))
 

--- a/editor/src/clj/prof.clj
+++ b/editor/src/clj/prof.clj
@@ -24,10 +24,10 @@
   (future
     (try
       (.browse (Desktop/getDesktop) uri)
-      nil
       (catch Throwable error
         (println (str "Failed to open URI " uri))
-        (println (.getMessage error))))))
+        (println (.getMessage error)))))
+  nil)
 
 (defn list-event-types
   "Print all event types that can be sampled by the profiler. Available options:

--- a/editor/test/integration/atlas_test.clj
+++ b/editor/test/integration/atlas_test.clj
@@ -13,12 +13,6 @@
 (ns integration.atlas-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [editor.collection :as collection]
-            [editor.factory :as factory]
-            [editor.handler :as handler]
-            [editor.defold-project :as project]
-            [editor.types :as types]
-            [editor.properties :as properties]
             [integration.test-util :as test-util]))
 
 (deftest valid-fps
@@ -34,3 +28,13 @@
     (let [node-id (test-util/resource-node project "/graphics/img_not_found.atlas")
           img (:node-id (test-util/outline node-id [0]))]
       (is (g/error? (g/node-value img :animation))))))
+
+(deftest empty-anim
+  (test-util/with-loaded-project
+    (let [node-id (test-util/resource-node project "/graphics/empty_anim.atlas")
+          ddf-texture-set (g/node-value node-id :texture-set)
+          animation-ids-in-ddf (mapv :id (:animations ddf-texture-set))]
+      (is (= ["ball_anim"
+              "block_anim"
+              "pow_anim"]
+             animation-ids-in-ddf)))))

--- a/editor/test/resources/test_project/graphics/empty_anim.atlas
+++ b/editor/test/resources/test_project/graphics/empty_anim.atlas
@@ -1,0 +1,43 @@
+animations {
+  id: "ball_anim"
+  images {
+    image: "/graphics/ball.png"
+    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
+  }
+  playback: PLAYBACK_LOOP_FORWARD
+  fps: 60
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
+  id: "empty_anim"
+  playback: PLAYBACK_LOOP_FORWARD
+  fps: 60
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
+  id: "block_anim"
+  images {
+    image: "/graphics/block.png"
+    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
+  }
+  playback: PLAYBACK_LOOP_FORWARD
+  fps: 60
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+animations {
+  id: "pow_anim"
+  images {
+    image: "/graphics/pow.png"
+    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
+  }
+  playback: PLAYBACK_LOOP_FORWARD
+  fps: 60
+  flip_horizontal: 0
+  flip_vertical: 0
+}
+margin: 0
+extrude_borders: 2
+inner_padding: 0


### PR DESCRIPTION
Second attempt at #5898, including a fix for the issue reported here:
https://forum.defold.com/t/defold-1-2-184-has-been-released/68738/3

Since #5898 was reverted, this re-applies the changes from it. You might want to review commits 
bb13b3a and 95f6f0e for the fix and added test case, respectively.

The issue was that the `TextureSetGenerator.calculateLayout()` method would not include animations that have no images associated with them in the returned `TextureSetResult`. This caused a mismatch when we tried to assign the corresponding animation ids in `atlas/produce-texture-set-data`. The editor code has been updated to take into account that these empty animations will not be present in the returned `TextureSetResult`.