### PR TITLE
Testing use of "UNIVERSAL" instead of "universal"

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -711,7 +711,7 @@ public class AndroidBundler implements IBundler {
             args.add(getJavaBinFile("java")); args.add("-jar");
             args.add(bundletool.getAbsolutePath());
             args.add("build-apks");
-            args.add("--mode"); args.add("universal");
+            args.add("--mode"); args.add("UNIVERSAL");
             args.add("--bundle"); args.add(aabPath);
             args.add("--output"); args.add(apksPath);
             args.add("--ks"); args.add(keystore);


### PR DESCRIPTION
This change is confirmed to work for the affected user. The reason is that Java String.toUpperCase() interacts with the user locale and results in the wrong uppercase value here:

https://github.com/google/bundletool/blob/0.14.0/src/main/java/com/android/tools/build/bundletool/flags/Flag.java#L218

This snippet of code confirms this:

```java
import java.util.Locale;

public class ToLocaleTest {
    public static void main(String[] args) throws Exception {
        Locale.setDefault(new Locale("tr"));
        String lowerCaseStr = "universal";
    	String upperCaseStr = lowerCaseStr.toUpperCase();
    	System.out.println("Lower case is '" + lowerCaseStr + "' and upper case is '" + upperCaseStr + "'");
    }
}
```

Results in `Lower case is 'universal' and upper case is 'UNİVERSAL'` (note the İ in the uppercase result).
