### PR TITLE
Fix flipping and some scaling issues in 2D physics when allow dynamic transforms is enabled (issue 5917).

### DIFF
--- a/engine/physics/src/box2d/Box2D/Collision/Shapes/b2CircleShape.h
+++ b/engine/physics/src/box2d/Box2D/Collision/Shapes/b2CircleShape.h
@@ -60,6 +60,9 @@ public:
 
 	/// Position
 	b2Vec2 m_p;
+
+	// Defold modifications
+	b2Vec2 m_creationP; // DEFOLD: Store the position used at creation time
 };
 
 inline b2CircleShape::b2CircleShape()


### PR DESCRIPTION
This PR fixes issue #5917. I found that circle shapes were not properly positioned, and polygons didn't use original vertices during flipping.

Test project:
[physics_scale_test2.zip](https://github.com/defold/defold/files/6830950/physics_scale_test2.zip)


Unfortunately, this PR doesn't fix issue #5891.