### PR TITLE
Map unknown gamepads and read raw gamepad packets

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1322,6 +1322,8 @@ bail:
         input_action.m_GamepadIndex = action->m_GamepadIndex;
         input_action.m_GamepadDisconnected = action->m_GamepadDisconnected;
         input_action.m_GamepadConnected = action->m_GamepadConnected;
+        input_action.m_GamepadPacket = action->m_GamepadPacket;
+        input_action.m_HasGamepadPacket = action->m_HasGamepadPacket;
 
         input_buffer->Push(input_action);
     }

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -362,6 +362,8 @@ namespace dmGameObject
         uint8_t  m_IsGamepad : 1;
         uint8_t  m_GamepadDisconnected : 1;
         uint8_t  m_GamepadConnected : 1;
+        dmHID::GamepadPacket m_GamepadPacket;
+        uint32_t m_HasGamepadPacket;
         /// If input has a text payload (can be true even if text count is 0)
         uint8_t  m_HasText : 1;
         /// If the input was 0 last update
@@ -904,4 +906,3 @@ namespace dmGameObject
 }
 
 #endif // DMSDK_GAMEOBJECT_H
-

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -359,11 +359,12 @@ namespace dmGameObject
         char     m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t m_TextCount;
         uint32_t m_GamepadIndex;
+        dmHID::GamepadPacket m_GamepadPacket;
+
         uint8_t  m_IsGamepad : 1;
         uint8_t  m_GamepadDisconnected : 1;
         uint8_t  m_GamepadConnected : 1;
-        dmHID::GamepadPacket m_GamepadPacket;
-        uint32_t m_HasGamepadPacket;
+        uint32_t m_HasGamepadPacket : 1;
         /// If input has a text payload (can be true even if text count is 0)
         uint8_t  m_HasText : 1;
         /// If the input was 0 last update

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -379,6 +379,48 @@ namespace dmGameObject
                 lua_setfield(L, action_table, "gamepad_name");
             }
 
+            if (params.m_InputAction->m_HasGamepadPacket)
+            {
+                dmHID::GamepadPacket gamepadPacket = params.m_InputAction->m_GamepadPacket;
+                lua_pushliteral(L, "gamepad_axis");
+                lua_createtable(L, dmHID::MAX_GAMEPAD_AXIS_COUNT, 0);
+                for (int i = 0; i < dmHID::MAX_GAMEPAD_AXIS_COUNT; ++i)
+                {
+                    lua_pushinteger(L, (lua_Integer) (i+1));
+                    lua_pushnumber(L, gamepadPacket.m_Axis[i]);
+                    lua_settable(L, -3);
+                }
+                lua_settable(L, -3);
+
+                lua_pushliteral(L, "gamepad_buttons");
+                lua_createtable(L, dmHID::MAX_GAMEPAD_AXIS_COUNT, 0);
+                for (int i = 0; i < dmHID::MAX_GAMEPAD_AXIS_COUNT; ++i)
+                {
+                    lua_pushinteger(L, (lua_Integer) (i+1));
+                    lua_pushnumber(L, dmHID::GetGamepadButton(&gamepadPacket, i));
+                    lua_settable(L, -3);
+                }
+                lua_settable(L, -3);
+
+                lua_pushliteral(L, "gamepad_hats");
+                lua_createtable(L, dmHID::MAX_GAMEPAD_HAT_COUNT, 0);
+                for (int i = 0; i < dmHID::MAX_GAMEPAD_HAT_COUNT; ++i)
+                {
+                    lua_pushinteger(L, (lua_Integer) (i+1));
+                    uint8_t hat_value;
+                    if (dmHID::GetGamepadHat(&gamepadPacket, i, hat_value))
+                    {
+                        lua_pushnumber(L, hat_value);
+                    }
+                    else
+                    {
+                        lua_pushnumber(L, 0);
+                    }
+                    lua_settable(L, -3);
+                }
+                lua_settable(L, -3);
+            }
+
             if (params.m_InputAction->m_ActionId != 0)
             {
                 lua_pushliteral(L, "value");

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -408,7 +408,7 @@ namespace dmGameObject
                 {
                     lua_pushinteger(L, (lua_Integer) (i+1));
                     uint8_t hat_value;
-                    if (dmHID::GetGamepadHat(&gamepadPacket, i, hat_value))
+                    if (dmHID::GetGamepadHat(&gamepadPacket, i, &hat_value))
                     {
                         lua_pushnumber(L, hat_value);
                     }

--- a/engine/gameobject/src/gameobject/test/wscript
+++ b/engine/gameobject/src/gameobject/test/wscript
@@ -357,7 +357,7 @@ def build(bld):
         test_task_gen = bld.new_task_gen(features = 'cxx cprogram test',
                                          includes = '../../../src . .. ../../../proto',
                                          exported_symbols = exported_symbols,
-                                         uselib = 'TESTMAIN RESOURCE DDF PLATFORM_SOCKET PLATFORM_THREAD SCRIPT LUA EXTENSION DLIB RIG CARES',
+                                         uselib = 'TESTMAIN RESOURCE DDF PLATFORM_SOCKET PLATFORM_THREAD SCRIPT LUA EXTENSION DLIB RIG HID',
                                          uselib_local = 'gameobject',
                                          web_libs = ['library_sys.js', 'library_script.js'],
                                          proto_gen_py = True,

--- a/engine/gameobject/wscript
+++ b/engine/gameobject/wscript
@@ -31,6 +31,7 @@ def configure(conf):
     conf.env['STATICLIB_RESOURCE'] = 'resource'
     conf.env['STATICLIB_SCRIPT'] = 'script'
     conf.env['STATICLIB_EXTENSION'] = 'extension'
+    conf.env['STATICLIB_HID'] = 'hid_null'
 
     conf.env.append_unique('CCDEFINES', 'DLIB_LOG_DOMAIN="GAMEOBJECT"')
     conf.env.append_unique('CXXDEFINES', 'DLIB_LOG_DOMAIN="GAMEOBJECT"')

--- a/engine/hid/src/dmsdk/hid/hid.h
+++ b/engine/hid/src/dmsdk/hid/hid.h
@@ -639,6 +639,32 @@ namespace dmHID
      */
     void AddKeyboardChar(HContext context, int chr);
 
+    /**
+     * Obtain a gamepad packet reflecting the current input state of the gamepad in a  HID context.
+     *
+     * @param gamepad gamepad handle
+     * @param out_packet Gamepad packet out argument
+     * @return If the packet was successfully updated or not.
+     */
+    bool GetGamepadPacket(HGamepad gamepad, GamepadPacket* out_packet);
+
+    /**
+     * Convenience function to retrieve the state of a gamepad button from a gamepad packet.
+     * @param packet Gamepad packet
+     * @param button The requested button
+     * @return If the button was pressed or not
+     */
+    bool GetGamepadButton(GamepadPacket* packet, uint32_t button);
+
+    /**
+     * Convenience function to retrieve the state of a gamepad hat from a gamepad packet.
+     * @param packet Gamepad packet
+     * @param hat The requested hat index
+     * @param hat_value Reference to where the hat value should be written
+     * @return If the hat has data or not
+     */
+    bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t& hat_value);
+
 }
 
 #endif // DMSDK_HID_H

--- a/engine/hid/src/dmsdk/hid/hid.h
+++ b/engine/hid/src/dmsdk/hid/hid.h
@@ -644,7 +644,7 @@ namespace dmHID
      *
      * @param gamepad gamepad handle
      * @param out_packet Gamepad packet out argument
-     * @return If the packet was successfully updated or not.
+     * @return True if the packet was successfully updated.
      */
     bool GetGamepadPacket(HGamepad gamepad, GamepadPacket* out_packet);
 
@@ -652,7 +652,7 @@ namespace dmHID
      * Convenience function to retrieve the state of a gamepad button from a gamepad packet.
      * @param packet Gamepad packet
      * @param button The requested button
-     * @return If the button was pressed or not
+     * @return True if the button is currently pressed down.
      */
     bool GetGamepadButton(GamepadPacket* packet, uint32_t button);
 
@@ -660,8 +660,8 @@ namespace dmHID
      * Convenience function to retrieve the state of a gamepad hat from a gamepad packet.
      * @param packet Gamepad packet
      * @param hat The requested hat index
-     * @param hat_value Reference to where the hat value should be written
-     * @return If the hat has data or not
+     * @param out_hat_value Hat value out argument
+     * @return True if the hat has data.
      */
     bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t* out_hat_value);
 

--- a/engine/hid/src/dmsdk/hid/hid.h
+++ b/engine/hid/src/dmsdk/hid/hid.h
@@ -663,7 +663,7 @@ namespace dmHID
      * @param hat_value Reference to where the hat value should be written
      * @return If the hat has data or not
      */
-    bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t& hat_value);
+    bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t* out_hat_value);
 
 }
 

--- a/engine/hid/src/hid.cpp
+++ b/engine/hid/src/hid.cpp
@@ -332,11 +332,11 @@ namespace dmHID
         }
     }
 
-    bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t& hat_value)
+    bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t* out_hat_value)
     {
         if (packet != 0x0)
         {
-            hat_value = packet->m_Hat[hat];
+            *out_hat_value = packet->m_Hat[hat];
             return true;
         } else {
             return false;

--- a/engine/hid/src/hid.h
+++ b/engine/hid/src/hid.h
@@ -235,15 +235,6 @@ namespace dmHID
     bool GetMarkedTextPacket(HContext context, MarkedTextPacket* out_packet);
 
     /**
-     * Obtain a gamepad packet reflecting the current input state of the gamepad in a  HID context.
-     *
-     * @param gamepad gamepad handle
-     * @param out_packet Gamepad packet out argument
-     * @return If the packet was successfully updated or not.
-     */
-    bool GetGamepadPacket(HGamepad gamepad, GamepadPacket* out_packet);
-
-    /**
      * Obtain a touch device packet reflecting the current input state of a HID context.
      *
      * @param context context from which to retrieve the packet
@@ -299,23 +290,6 @@ namespace dmHID
      * @param context context
      */
     void ResetKeyboard(HContext context);
-
-    /**
-     * Convenience function to retrieve the state of a gamepad button from a gamepad packet.
-     * @param packet Gamepad packet
-     * @param button The requested button
-     * @return If the button was pressed or not
-     */
-    bool GetGamepadButton(GamepadPacket* packet, uint32_t button);
-
-    /**
-     * Convenience function to retrieve the state of a gamepad hat from a gamepad packet.
-     * @param packet Gamepad packet
-     * @param hat The requested hat index
-     * @param hat_value Reference to where the hat value should be written
-     * @return If the hat has data or not
-     */
-    bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t& hat_value);
 
     /**
      * Convenience function to retrieve the position of a specific touch.

--- a/engine/hid/src/test/test_app_hid.cpp
+++ b/engine/hid/src/test/test_app_hid.cpp
@@ -175,8 +175,6 @@ static UpdateResult EngineUpdate(void* _engine)
             LOG("%s", pressed ? "*" : "_");
         }
 
-        //bool GetGamepadHat(GamepadPacket* packet, uint32_t hat, uint8_t& hat_value);
-
         LOG("AXIS: ");
 
         uint32_t numaxis = dmHID::GetGamepadAxisCount(pad);

--- a/engine/input/proto/input/input_ddf.proto
+++ b/engine/input/proto/input/input_ddf.proto
@@ -183,7 +183,8 @@ enum Gamepad
     GAMEPAD_GUIDE = 24;
     GAMEPAD_CONNECTED = 25;
     GAMEPAD_DISCONNECTED = 26;
-    MAX_GAMEPAD_COUNT = 27;
+    GAMEPAD_RAW = 27;
+    MAX_GAMEPAD_COUNT = 28;
 }
 
 enum GamepadType

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -988,7 +988,7 @@ namespace dmInput
         case dmInputDDF::GAMEPAD_TYPE_HAT:
             {
                 uint8_t t = 0;
-                bool s = dmHID::GetGamepadHat(packet, input.m_Index, t);
+                bool s = dmHID::GetGamepadHat(packet, input.m_Index, &t);
                 if (s && (t & input.m_HatMask)) {
                     v = 1.0f;
                 }

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -130,6 +130,11 @@ namespace dmInput
             return 0x0;
         } else {
             GamepadConfig* config = GetGamepadConfigFromDeviceName(binding, dmHashString32(device_name));
+            if (config == 0x0)
+            {
+                dmLogWarning("No gamepad map found for gamepad %d (%s). Ignored.", gamepad_index, device_name);
+                return 0x0;
+            }
             if (config->m_DeviceId == UNKNOWN_GAMEPAD_CONFIG_ID)
             {
                 dmLogWarning("No gamepad map found for gamepad %d (%s).", gamepad_index, device_name);

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -137,7 +137,7 @@ namespace dmInput
             }
             if (config->m_DeviceId == UNKNOWN_GAMEPAD_CONFIG_ID)
             {
-                dmLogWarning("No gamepad map found for gamepad %d (%s).", gamepad_index, device_name);
+                dmLogWarning("No gamepad map found for gamepad %d (%s). The raw gamepad map will be used.", gamepad_index, device_name);
             }
             GamepadBinding* gamepad_binding = new GamepadBinding();
             memset(gamepad_binding, 0, sizeof(*gamepad_binding));

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -26,6 +26,8 @@
 
 namespace dmInput
 {
+    const uint32_t UNKNOWN_GAMEPAD_CONFIG_ID = dmHashString32("UNKNOWN_GAMEPAD_CONFIG_ID");
+
     dmHID::Key KEY_MAP[dmInputDDF::MAX_KEY_COUNT];
     dmHID::MouseButton MOUSE_BUTTON_MAP[dmInputDDF::MAX_KEY_COUNT];
 
@@ -98,6 +100,16 @@ namespace dmInput
         }
     }
 
+    static GamepadConfig* GetGamepadConfigFromDeviceName(HBinding binding, const uint32_t device_hash)
+    {
+        GamepadConfig* config = binding->m_Context->m_GamepadMaps.Get(device_hash);
+        if (config == 0x0)
+        {
+            config = binding->m_Context->m_GamepadMaps.Get(UNKNOWN_GAMEPAD_CONFIG_ID);
+        }
+        return config;
+    }
+
     static GamepadBinding* NewGamepadBinding(HBinding binding, uint32_t gamepad_index)
     {
         dmHID::HGamepad gamepad = dmHID::GetGamepad(binding->m_Context->m_HidContext, gamepad_index);
@@ -117,13 +129,11 @@ namespace dmInput
              */
             return 0x0;
         } else {
-            GamepadConfig* config = binding->m_Context->m_GamepadMaps.Get(dmHashString32(device_name));
-            if (config == 0x0)
+            GamepadConfig* config = GetGamepadConfigFromDeviceName(binding, dmHashString32(device_name));
+            if (config->m_DeviceId == UNKNOWN_GAMEPAD_CONFIG_ID)
             {
-                dmLogWarning("No gamepad map found for gamepad %d (%s), it will not be used.", gamepad_index, device_name);
-                return 0x0;
+                dmLogWarning("No gamepad map found for gamepad %d (%s).", gamepad_index, device_name);
             }
-
             GamepadBinding* gamepad_binding = new GamepadBinding();
             memset(gamepad_binding, 0, sizeof(*gamepad_binding));
             gamepad_binding->m_Gamepad = gamepad;
@@ -359,11 +369,27 @@ namespace dmInput
                 count++;
             }
         }
+
+        context->m_GamepadMaps.SetCapacity(dmMath::Max(1, (count + 1) / 3), count + 1);
+
+        // Add a gamepad config that will be used when an unidentified gamepad
+        // is connected. This will allow developers to at least read raw button,
+        // axis and hat data and do their own mappings.
+        GamepadConfig unknownGamepadConfig;
+        unknownGamepadConfig.m_DeadZone = 0.0;
+        unknownGamepadConfig.m_DeviceId = UNKNOWN_GAMEPAD_CONFIG_ID;
+        memset(unknownGamepadConfig.m_Inputs, 0, sizeof(unknownGamepadConfig.m_Inputs));
+        for (uint32_t j = 0; j < (sizeof(unknownGamepadConfig.m_Inputs) / sizeof(struct GamepadInput)); ++j)
+        {
+            unknownGamepadConfig.m_Inputs[j].m_Index = (uint16_t)~0;
+        }
+        context->m_GamepadMaps.Put(UNKNOWN_GAMEPAD_CONFIG_ID, unknownGamepadConfig);
+
         if (count == 0)
         {
             return;
         }
-        context->m_GamepadMaps.SetCapacity(dmMath::Max(1, count/3), count);
+
         for (uint32_t i = 0; i < ddf->m_Driver.m_Count; ++i)
         {
             const dmInputDDF::GamepadMap& gamepad_map = ddf->m_Driver[i];
@@ -374,6 +400,7 @@ namespace dmInput
                 {
                     GamepadConfig config;
                     config.m_DeadZone = gamepad_map.m_DeadZone;
+                    config.m_DeviceId = device_id;
                     memset(config.m_Inputs, 0, sizeof(config.m_Inputs));
                     for (uint32_t j = 0; j < (sizeof(config.m_Inputs) / sizeof(struct GamepadInput)); ++j)
                     {
@@ -431,6 +458,7 @@ namespace dmInput
         action->m_HasText = 0;
         action->m_GamepadDisconnected = 0;
         action->m_GamepadConnected = 0;
+        action->m_HasGamepadPacket = 0;
     }
 
     struct UpdateContext
@@ -649,7 +677,7 @@ namespace dmInput
                     dmHID::GamepadPacket* packet = &gamepad_binding->m_Packet;
 
                     dmHID::GamepadPacket* prev_packet = &gamepad_binding->m_PreviousPacket;
-                    GamepadConfig* config = binding->m_Context->m_GamepadMaps.Get(gamepad_binding->m_DeviceId);
+                    GamepadConfig* config = GetGamepadConfigFromDeviceName(binding, gamepad_binding->m_DeviceId);
                     if (config != 0x0)
                     {
                         dmHID::GetGamepadPacket(gamepad, packet);
@@ -702,7 +730,18 @@ namespace dmInput
                                         action->m_TextCount = dmStrlCpy(action->m_Text, device_name, sizeof(action->m_Text));
                                     }
                                 }
-                            } else {
+                            }
+                            else if (trigger.m_Input == dmInputDDF::GAMEPAD_RAW)
+                            {
+                                Action* action = gamepad_binding->m_Actions.Get(trigger.m_ActionId);
+                                if (action != 0x0)
+                                {
+                                    action->m_GamepadPacket = gamepad_binding->m_Packet;
+                                    action->m_HasGamepadPacket = 1;
+                                }
+                            }
+                            else
+                            {
                                 if (input.m_Index != (uint16_t)~0)
                                 {
                                     float v = ApplyGamepadModifiers(packet, input);

--- a/engine/input/src/input.h
+++ b/engine/input/src/input.h
@@ -43,6 +43,8 @@ namespace dmInput
         uint32_t m_IsGamepad : 1;
         uint32_t m_GamepadDisconnected : 1;
         uint32_t m_GamepadConnected : 1;
+        dmHID::GamepadPacket m_GamepadPacket;
+        uint32_t m_HasGamepadPacket;
         uint32_t m_Pressed : 1;
         uint32_t m_Released : 1;
         uint32_t m_Repeated : 1;

--- a/engine/input/src/input.h
+++ b/engine/input/src/input.h
@@ -40,18 +40,19 @@ namespace dmInput
         uint32_t     m_TextCount;
         uint32_t     m_HasText;
         uint32_t m_GamepadIndex;
+        dmHID::GamepadPacket m_GamepadPacket;
+
         uint32_t m_IsGamepad : 1;
         uint32_t m_GamepadDisconnected : 1;
         uint32_t m_GamepadConnected : 1;
-        dmHID::GamepadPacket m_GamepadPacket;
-        uint32_t m_HasGamepadPacket;
+        uint32_t m_HasGamepadPacket : 1;
         uint32_t m_Pressed : 1;
         uint32_t m_Released : 1;
         uint32_t m_Repeated : 1;
         uint32_t m_PositionSet : 1;
         uint32_t m_AccelerationSet : 1;
         uint32_t m_Dirty : 1; // it's dirty and should report its value
-        uint32_t :23;
+        uint32_t :22;
     };
 
     typedef struct Context* HContext;

--- a/engine/input/src/input_private.h
+++ b/engine/input/src/input_private.h
@@ -128,6 +128,7 @@ namespace dmInput
 
     struct GamepadConfig
     {
+        uint32_t m_DeviceId;
         float m_DeadZone;
         GamepadInput m_Inputs[dmInputDDF::MAX_GAMEPAD_COUNT];
     };


### PR DESCRIPTION
* Added mapping of unknown gamepads to a default unknown gamepad
* Added a new GAMEPAD_RAW trigger to read raw gamepad data (buttons, hats and axis)

Fixes #5895 