### PR TITLE
Editor resource types can refer to icons in the project

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -38,7 +38,7 @@
             [editor.graph-util :as gu]
             [editor.handler :as handler]
             [editor.hot-reload :as hot-reload]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.keymap :as keymap]
             [editor.live-update-settings :as live-update-settings]
             [editor.lua :as lua]
@@ -1517,7 +1517,7 @@ If you do not specifically require different script states, consider changing th
     (.add tabs tab)
     (g/transact
       (select app-view resource-node [resource-node]))
-    (.setGraphic tab (jfx/get-image-view (or (:icon resource-type) "icons/64/Icons_29-AT-Unknown.png") 16))
+    (.setGraphic tab (icons/get-image-view (or (:icon resource-type) "icons/64/Icons_29-AT-Unknown.png") 16))
     (.addAll (.getStyleClass tab) ^Collection (resource/style-classes resource))
     (ui/register-tab-toolbar tab "#toolbar" :toolbar)
     (let [close-handler (.getOnClosed tab)]

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -18,7 +18,7 @@
             [editor.fs :as fs]
             [editor.fxui :as fxui]
             [editor.handler :as handler]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.ui :as ui]
             [editor.prefs :as prefs]
             [editor.resource :as resource]
@@ -621,7 +621,7 @@
         db (.startDragAndDrop ^Node (.getSource e) (into-array TransferMode [mode]))
         content (ClipboardContent.)]
     (when (= 1 (count resources))
-      (.setDragView db (jfx/get-image (workspace/resource-icon (first resources)) 16)
+      (.setDragView db (icons/get-image (workspace/resource-icon (first resources)) 16)
                     0 16))
     (.putFiles content files)
     (.setContent db content)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -32,6 +32,7 @@
             [editor.graph-view :as graph-view]
             [editor.hot-reload :as hot-reload]
             [editor.html-view :as html-view]
+            [editor.icons :as icons]
             [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.properties-view :as properties-view]
@@ -401,6 +402,7 @@
         extensions (extensions/make *project-graph*)
         project (project/open-project! *project-graph* extensions workspace game-project-res render-progress!)]
     (ui/run-now
+      (icons/initialize! workspace)
       (load-stage workspace project prefs updater newly-created?)
       (when-let [missing-dependencies (not-empty (workspace/missing-dependencies workspace))]
         (show-missing-dependencies-alert! missing-dependencies)))

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -15,7 +15,7 @@
             [dynamo.graph :as g]
             [editor.code.data :refer [CursorRange->line-number]]
             [editor.handler :as handler]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.outline :as outline]
             [editor.resource :as resource]
             [editor.ui :as ui]
@@ -194,7 +194,7 @@
                 :info #{"severity-info"}
                 :warning #{"severity-warning"}
                 #{"severity-error"})
-        image (jfx/get-image-view icon 16)
+        image (icons/get-image-view icon 16)
         text (Text. message)]
     {:graphic (HBox. (ui/node-array [image text]))
      :style style}))

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -23,7 +23,7 @@
             [editor.field-expression :as field-expression]
             [editor.form :as form]
             [editor.fxui :as fxui]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.handler :as handler]
             [editor.resource :as resource]
             [editor.settings :as settings]
@@ -131,7 +131,7 @@
   (cond-> (-> props
               (dissoc :image)
               (assoc :graphic {:fx/type :image-view
-                               :image (jfx/get-image (:image props))}))
+                               :image (icons/get-image (:image props))}))
 
           (contains? props :fit-size)
           add-image-fit-size))

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -23,7 +23,7 @@
             [editor.fxui :as fxui]
             [editor.github :as github]
             [editor.handler :as handler]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
@@ -626,7 +626,7 @@
           (fuzzy-text/runs (count text) matching-indices))))
 
 (defn- make-matched-list-item-graphic [icon text matching-indices]
-  (let [icon-view (jfx/get-image-view icon 16)
+  (let [icon-view (icons/get-image-view icon 16)
         text-view (TextFlow. (into-array Text (matched-text-runs text matching-indices)))]
     (doto (HBox. (ui/node-array [icon-view text-view]))
       (.setAlignment Pos/CENTER_LEFT)

--- a/editor/src/clj/editor/icons.clj
+++ b/editor/src/clj/editor/icons.clj
@@ -1,0 +1,63 @@
+(ns editor.icons
+  (:require [clojure.java.io :as io]
+            [editor.workspace :as workspace]
+            [service.log :as log]
+            [util.thread-util :as thread-util])
+  (:import [java.net URL]
+           [javafx.scene.image Image ImageView]))
+
+(defonce cached-icons-atom (atom {}))
+(defonce workspace-atom (atom nil))
+
+(defn initialize! [workspace]
+  (assert (integer? workspace))
+  (reset! workspace-atom workspace))
+
+(defn- load-bundled-image
+  ^Image [^URL bundled-resource-url ^Double size]
+  (if (some? size)
+    (Image. (str bundled-resource-url) size size true true)
+    (Image. (str bundled-resource-url))))
+
+(defn- load-workspace-image
+  ^Image [resource ^Double size]
+  (try
+    (with-open [input-stream (io/input-stream resource)]
+      (if (some? size)
+        (Image. input-stream size size true true)
+        (Image. input-stream)))
+    (catch Exception exception
+      (let [msg (str "Failed to load icon `" name "` from workspace.\n")]
+        (log/error :msg msg :exception exception)
+        nil))))
+
+(defn- load-icon-image
+  ^Image [^String name ^Double size]
+  (if-some [bundled-resource-url (io/resource name)]
+    (load-bundled-image bundled-resource-url size)
+    (when-some [workspace @workspace-atom]
+      (when-some [resource (workspace/find-resource workspace name)]
+        (load-workspace-image resource size)))))
+
+(defn get-image
+  (^Image [name]
+   (get-image name nil))
+  (^Image [name ^Double size]
+   (let [icon-key [name size]]
+     (if-some [cached-entry (find @cached-icons-atom icon-key)]
+       (val cached-entry)
+       (first
+         (thread-util/swap-rest!
+           cached-icons-atom
+           (fn [cached-icons]
+             (let [icon-image (load-icon-image (str name) size)
+                   updated-cached-icons (assoc cached-icons icon-key icon-image)]
+               [updated-cached-icons icon-image]))))))))
+
+(defn get-image-view
+  (^ImageView [name]
+   (ImageView. (get-image name)))
+  (^ImageView [name ^Double size]
+   (doto (ImageView. (get-image name))
+     (.setFitWidth size)
+     (.setFitHeight size))))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -15,7 +15,7 @@
             [editor.app-view :as app-view]
             [editor.error-reporting :as error-reporting]
             [editor.handler :as handler]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.outline :as outline]
             [editor.resource :as resource]
             [editor.types :as types]
@@ -378,7 +378,7 @@
             data (outline/copy item-iterators)]
         (when-let [icon (and (= 1 (count item-iterators))
                              (:icon (outline/value (first item-iterators))))]
-          (.setDragView db (jfx/get-image icon 16) 0 16))
+          (.setDragView db (icons/get-image icon 16) 0 16))
         (.setContent db {(data-format-fn) data})
         (.consume e)))))
 
@@ -471,7 +471,7 @@
                                            (or outline-reference? outline-show-link?))
                            label (if show-link? (format "%s - %s" label (resource/resource->proj-path link)) label)]
                        (proxy-super setText label)
-                       (proxy-super setGraphic (jfx/get-image-view icon 16))
+                       (proxy-super setGraphic (icons/get-image-view icon 16))
                        (if parent-reference?
                          (ui/add-style! this "parent-reference")
                          (ui/remove-style! this "parent-reference"))

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -16,7 +16,7 @@
             [editor.code.data :as data]
             [editor.core :as core]
             [editor.defold-project-search :as project-search]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.prefs :as prefs]
             [editor.resource :as resource]
             [editor.ui :as ui]
@@ -96,7 +96,7 @@
   [{:keys [resource] :as _item}]
   (-> resource
       workspace/resource-icon
-      (jfx/get-image-view 16)))
+      (icons/get-image-view 16)))
 
 (defn- make-matched-item-row-indicator
   ^Label [{:keys [^long row] :as _item}]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -18,7 +18,7 @@
             [dynamo.graph :as g]
             [editor.error-reporting :as error-reporting]
             [editor.handler :as handler]
-            [editor.jfx :as jfx]
+            [editor.icons :as icons]
             [editor.progress :as progress]
             [editor.math :as math]
             [editor.util :as eutil]
@@ -803,7 +803,7 @@
                 (do
                   (proxy-super setText (:text render-data))
                   (when-let [icon (:icon render-data)]
-                    (proxy-super setGraphic (jfx/get-image-view icon 16)))))))
+                    (proxy-super setGraphic (icons/get-image-view icon 16)))))))
           (proxy-super setTooltip (:tooltip render-data)))))))
 
 (defn- make-list-cell-factory [render-fn]
@@ -838,7 +838,7 @@
                            (proxy-super setGraphic (when-let [icon (:icon render-data)]
                                                      (if (= :empty icon)
                                                        (ImageView.)
-                                                       (jfx/get-image-view icon (:icon-size render-data 16)))))))
+                                                       (icons/get-image-view icon (:icon-size render-data 16)))))))
                        (proxy-super setTooltip (:tooltip render-data))
                        (proxy-super setOnDragOver (:over-handler render-data))
                        (proxy-super setOnDragDropped (:dropped-handler render-data))
@@ -1203,7 +1203,7 @@
       (when on-open
         (.setOnShowing menu (event-handler e (on-open))))
       (when icon
-        (.setGraphic menu (wrap-menu-image (jfx/get-image-view icon 16))))
+        (.setGraphic menu (wrap-menu-image (icons/get-image-view icon 16))))
       (when style-classes
         (assert (set? style-classes))
         (doto (.getStyleClass menu)
@@ -1239,7 +1239,7 @@
     (when (some? key-combo)
       (.setAccelerator menu-item key-combo))
     (when icon
-      (.setGraphic menu-item (wrap-menu-image (jfx/get-image-view icon 16))))
+      (.setGraphic menu-item (wrap-menu-image (icons/get-image-view icon 16))))
     (when style-classes
       (assert (set? style-classes))
       (doto (.getStyleClass menu-item)
@@ -1675,7 +1675,7 @@
                                                                                   (when new
                                                                                     (let [command-contexts (contexts scene)]
                                                                                       (execute-command command-contexts (:command new) (:user-data new))))))
-                                                   (.add (.getChildren hbox) (jfx/get-image-view (:icon menu-item) 16))
+                                                   (.add (.getChildren hbox) (icons/get-image-view (:icon menu-item) 16))
                                                    (.add (.getChildren hbox) cb)
                                                    hbox)
                                                  (let [button (ToggleButton. (or (handler/label handler-ctx) (:label menu-item)))
@@ -1690,7 +1690,7 @@
                                                      (.setGraphic button (graphic-fn))
 
                                                      icon
-                                                     (.setGraphic button (jfx/get-image-view icon 16)))
+                                                     (.setGraphic button (icons/get-image-view icon 16)))
                                                    (when command
                                                      (on-action! button (fn [event]
                                                                           (execute-command (contexts scene) command user-data))))


### PR DESCRIPTION
Fixes #5994.

### Technical changes
The editor is now able to load icon images from the project resources. Previously all icons needed to be embedded in the editor `.jar` file.