### PR TITLE
Extended logs for release version

### DIFF
--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -84,7 +84,7 @@ static bool dmLogAvailable()
 static bool dmSystemLogsEnabled()
 {
     bool available = dLib::IsDebugMode();
-#if DM_SYSTEM_LOG_ENABLED
+#if DM_LOG_ENABLED
     available = true;
 #endif
     return available;


### PR DESCRIPTION
Hi! Sometimes we need logs in release version

I did it blindly because I can't build the engine

If I understood correctly, it will be enough to declare one of the options in the .appmanifest file
MIN_LEVEL_SEVERITY_DEBUG || MIN_LEVEL_SEVERITY_USER_DEBUG || MIN_LEVEL_SEVERITY_INFO || MIN_LEVEL_SEVERITY_WARNING || MIN_LEVEL_SEVERITY_ERROR || MIN_LEVEL_SEVERITY_FATAL 

like this

    common:
        context:
            defines: ["MIN_LEVEL_SEVERITY_ERROR"]