### PR TITLE
Bail early if manifest file failed to load from zip archive

### DIFF
--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -278,6 +278,7 @@ namespace dmLiveUpdate
         {
             dmLogError("Could not read entry name '%s' from archive", LIVEUPDATE_ARCHIVE_MANIFEST_FILENAME);
             dmZip::Close(zip);
+            return dmResourceArchive::RESULT_NOT_FOUND;
         }
 
         dmResourceArchive::Result result = dmResourceArchive::LoadManifestFromBuffer(manifest_data, manifest_len, out);

--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -81,6 +81,7 @@ namespace dmLiveUpdate
         {
             dmLogError("Could not read entry name '%s' from archive", LIVEUPDATE_ARCHIVE_MANIFEST_FILENAME);
             dmZip::Close(zip);
+            return RESULT_INVALID_RESOURCE;
         }
 
         dmResource::Manifest* manifest = new dmResource::Manifest();

--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -282,6 +282,11 @@ namespace dmLiveUpdate
 
         dmResourceArchive::Result result = dmResourceArchive::LoadManifestFromBuffer(manifest_data, manifest_len, out);
         dmMemory::AlignedFree(manifest_data);
+        if (dmResourceArchive::RESULT_OK != result)
+        {
+            dmLogError("Could not load manifest: %d", result);
+            return result;
+        }
 
         // Verify
         dmLiveUpdate::Result lu_result = dmLiveUpdate::VerifyManifest(*out);

--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -274,10 +274,10 @@ namespace dmLiveUpdate
 
         uint32_t manifest_len = 0;
         uint8_t* manifest_data = GetZipResource(zip, LIVEUPDATE_ARCHIVE_MANIFEST_FILENAME, &manifest_len);
+        dmZip::Close(zip);
         if (!manifest_data)
         {
             dmLogError("Could not read entry name '%s' from archive", LIVEUPDATE_ARCHIVE_MANIFEST_FILENAME);
-            dmZip::Close(zip);
             return dmResourceArchive::RESULT_NOT_FOUND;
         }
 


### PR DESCRIPTION
Instead of crashing you now get an error when the engine fails to load the manifest from the zip archive: 

`ERROR:LIVEUPDATE: Could not load manifest: -2`

Fixes #6018 

Question: should we delete the zip archive?