### PR TITLE
Fix typo in logging and documentation

### DIFF
--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -596,7 +596,7 @@ namespace dmGraphics
     bool IsFormatTranscoded(dmGraphics::TextureImage::CompressionType format);
 
     /** checks if the texture format is compressed
-     * @name IsFormatTranscoded
+     * @name Transcode
      * @param path The path of the texture
      * @param image The input image
      * @param format The desired output format

--- a/engine/graphics/src/transcoder/graphics_transcoder_basisu.cpp
+++ b/engine/graphics/src/transcoder/graphics_transcoder_basisu.cpp
@@ -152,7 +152,7 @@ namespace dmGraphics
         }
 
 #if defined(TEX_TRANSCODE_DEBUG)
-        dmLogInfo("Transcoding: %p from %d to %d (%s -> %s)", path, format, transcoder_format, ToString(format), ToString(transcoder_format));
+        dmLogInfo("Transcoding: %s from %d to %d (%s -> %s)", path, format, transcoder_format, ToString(format), ToString(transcoder_format));
 #endif
 
         tr.start_transcoding(ptr, size);


### PR DESCRIPTION
Show texture path instead of pointer 
for example
`Transcoding: /main/GUI/atlases/16bit/gui_travel_cards.texturec from 5 to 16 (TEXTURE_FORMAT_RGBA_16BPP -> cTFRGBA4444)`
instead of 

`Transcoding: 0x70e3cf7b7b from 5 to 16 (TEXTURE_FORMAT_RGBA_16BPP -> cTFRGBA4444)`