### PR TITLE
fix: target only x86_64 until official m1 support

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -387,7 +387,7 @@ def default_flags(self):
             self.env.append_value(f, '-mmacosx-version-min=%s' % MIN_OSX_SDK_VERSION)
 
             self.env.append_value(f, ['-isysroot', sys_root, '-nostdinc++', '-isystem', '%s/usr/include/c++/v1' % sys_root])
-            if 'linux' in self.env['BUILD_PLATFORM']:
+            if self.env['BUILD_PLATFORM'] in ('linux', 'darwin'):
                 self.env.append_value(f, ['-target', 'x86_64-apple-darwin19'])
 
         self.env.append_value('LINKFLAGS', ['-stdlib=libc++', '-isysroot', sys_root, '-mmacosx-version-min=%s' % MIN_OSX_SDK_VERSION, '-framework', 'Carbon','-flto'])


### PR DESCRIPTION
How To Build ON an M1 mac targeting x86_64

- Install openjdk11
brew install adoptopenjdk11

- Set JAVA_HOME
export JAVA_HOME=$(/usr/libexec/java_home -v11)

- Switch to x86_64 shell
env /usr/bin/arch -x86_64 /bin/zsh

- Build
https://github.com/defold/defold/blob/dev/README_SETUP_MACOS.md