### PR TITLE
Issue 3692: Uniform arrays editor fixes

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -340,10 +340,11 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
 
                 SPIRVReflector.Resource firstUniform = ubo.uniforms.get(0);
                 SPIRVReflector.Resource uniform = new SPIRVReflector.Resource();
-                uniform.name    = firstUniform.name;
-                uniform.type    = firstUniform.type;
-                uniform.binding = ubo.binding;
-                uniform.set     = ubo.set;
+                uniform.name         = firstUniform.name;
+                uniform.type         = firstUniform.type;
+                uniform.elementCount = firstUniform.elementCount;
+                uniform.binding      = ubo.binding;
+                uniform.set          = ubo.set;
                 bindingEntry.add(uniform);
 
                 ShaderDesc.ShaderDataType type = stringTypeToShaderType(uniform.type);
@@ -475,6 +476,7 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
             ShaderDesc.ResourceBinding.Builder resourceBindingBuilder = ShaderDesc.ResourceBinding.newBuilder();
             resourceBindingBuilder.setName(res.name);
             resourceBindingBuilder.setType(stringTypeToShaderType(res.type));
+            resourceBindingBuilder.setElementCount(res.elementCount);
             resourceBindingBuilder.setSet(res.set);
             resourceBindingBuilder.setBinding(res.binding);
             builder.addUniforms(resourceBindingBuilder);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import com.dynamo.bob.CompileExceptionError;
@@ -38,6 +39,7 @@ public class ShaderUtil {
         {
             public String name;
             public String type;
+            public int    elementCount;
             public int    binding;
             public int    set;
         }
@@ -72,15 +74,21 @@ public class ShaderUtil {
                 JsonNode membersNode = typeNode.get("members");
 
                 for (Iterator<JsonNode> membersNodeIt = membersNode.getElements(); membersNodeIt.hasNext();) {
-                    JsonNode uniformNode   = membersNodeIt.next();
-                    String uniformNodeName = uniformNode.get("name").asText();
-                    String uniformNodeType = uniformNode.get("type").asText();
+                    JsonNode uniformNode = membersNodeIt.next();
+                    Resource res         = new Resource();
+                    res.name             = uniformNode.get("name").asText();
+                    res.type             = uniformNode.get("type").asText();
+                    res.elementCount     = 1;
+                    res.binding          = 0;
+                    res.set              = 0;
 
-                    Resource res = new Resource();
-                    res.name     = uniformNode.get("name").asText();
-                    res.type     = uniformNode.get("type").asText();
-                    res.binding  = 0;
-                    res.set      = 0;
+                    JsonNode arrayNode = uniformNode.get("array");
+                    if (arrayNode != null && arrayNode.isArray())
+                    {
+                        ArrayNode array = (ArrayNode) arrayNode;
+                        res.elementCount = arrayNode.get(0).asInt();
+                    }
+
                     ubo.uniforms.add(res);
                 }
 
@@ -101,11 +109,12 @@ public class ShaderUtil {
 
             for (Iterator<JsonNode> iter = texturesNode.getElements(); iter.hasNext();) {
                 JsonNode textureNode = iter.next();
-                Resource res = new Resource();
-                res.name     = textureNode.get("name").asText();
-                res.type     = textureNode.get("type").asText();
-                res.binding  = textureNode.get("binding").asInt();
-                res.set      = textureNode.get("set").asInt();
+                Resource res     = new Resource();
+                res.name         = textureNode.get("name").asText();
+                res.type         = textureNode.get("type").asText();
+                res.binding      = textureNode.get("binding").asInt();
+                res.set          = textureNode.get("set").asInt();
+                res.elementCount = 1;
                 textures.add(res);
             }
 

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -443,7 +443,7 @@
       (let [{:keys [user-data]} renderable
             {:keys [vbuf gpu-texture]} user-data
             vertex-binding (vtx/use-with ::atlas-binding vbuf atlas-shader)]
-        (gl/with-gl-bindings gl render-args [gpu-texture atlas-shader vertex-binding]
+        (gl/with-gl-bindings gl render-args [atlas-shader vertex-binding gpu-texture]
           (shader/set-uniform atlas-shader gl "texture_sampler" 0)
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 6))))))
 

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -127,6 +127,7 @@
 (defn- shader-resource->map [^ShaderUtil$SPIRVReflector$Resource shader-resource]
   {:name (.name shader-resource)
    :type (shader-type-from-str (.type shader-resource))
+   :element-count (.elementCount shader-resource)
    :set (.set shader-resource)
    :binding (.binding shader-resource)})
 

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -81,7 +81,7 @@
 
 (defn render-cubemap
   [^GL2 gl render-args camera gpu-texture vertex-binding]
-  (gl/with-gl-bindings gl render-args [gpu-texture cubemap-shader vertex-binding]
+  (gl/with-gl-bindings gl render-args [cubemap-shader vertex-binding gpu-texture]
     (shader/set-uniform cubemap-shader gl "world" geom/Identity4d)
     (shader/set-uniform cubemap-shader gl "cameraPosition" (types/position camera))
     (shader/set-uniform cubemap-shader gl "envMap" 0)

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -398,7 +398,7 @@
                   shader (:shader emitter-sim-data)
                   vtx-binding (vtx/use-with context vbuf shader)
                   blend-mode (convert-blend-mode (:blend-mode render-data))]
-              (gl/with-gl-bindings gl render-args [gpu-texture shader vtx-binding]
+              (gl/with-gl-bindings gl render-args [shader vtx-binding gpu-texture]
                 (gl/set-blend-mode gl blend-mode)
                 (gl/gl-draw-arrays gl GL/GL_TRIANGLES (:v-index render-data) (:v-count render-data))
                 (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))))))))

--- a/editor/src/clj/editor/rulers.clj
+++ b/editor/src/clj/editor/rulers.clj
@@ -148,7 +148,7 @@
           :let [user-data (:user-data renderable)
                 {:keys [vb tri-count line-count]} user-data]]
     (let [vertex-binding (vtx/use-with ::vertex-buffer vb tex-shader)]
-      (gl/with-gl-bindings gl render-args [numbers-texture tex-shader vertex-binding]
+      (gl/with-gl-bindings gl render-args [tex-shader vertex-binding numbers-texture]
         (shader/set-uniform tex-shader gl "texture_sampler" 0)
         (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 tri-count)
         (gl/gl-draw-arrays gl GL/GL_LINES tri-count line-count)))))

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -170,14 +170,14 @@
       (let [shader (:shader user-data)
             vertex-binding (vtx/use-with ::sprite-trans (gen-vertex-buffer renderables count) shader)
             blend-mode (:blend-mode user-data)]
-        (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
+        (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
           (gl/set-blend-mode gl blend-mode)
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* count 6))
           (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)))
 
       pass/selection
       (let [vertex-binding (vtx/use-with ::sprite-selection (gen-vertex-buffer renderables count) id-shader)]
-        (gl/with-gl-bindings gl (assoc render-args :id (scene-picking/renderable-picking-id-uniform (first renderables))) [gpu-texture id-shader vertex-binding]
+        (gl/with-gl-bindings gl (assoc render-args :id (scene-picking/renderable-picking-id-uniform (first renderables))) [id-shader vertex-binding gpu-texture]
           (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (* count 6)))))))
 
 (defn- render-sprite-outlines [^GL2 gl render-args renderables count]

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -208,6 +208,6 @@
                 (.glVertex3d gl x1 y1 0)
                 (.glVertex3d gl x1 y0 0)
                 (.glEnd gl)
-                (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
+                (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
                   (shader/set-uniform shader gl "texture_sampler" 0)
                   (gl/gl-draw-arrays gl GL2/GL_TRIANGLES 0 (* n 6)))))))))))

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -188,7 +188,7 @@
                 ;; until the scene has been flattened.
                 render-args (assoc render-args :view-proj (:world-view-proj render-args))
                 vertex-binding (vtx/use-with node-id vbuf shader)]
-            (gl/with-gl-bindings gl render-args [gpu-texture shader vertex-binding]
+            (gl/with-gl-bindings gl render-args [shader vertex-binding gpu-texture]
               (gl/set-blend-mode gl blend-mode)
               ;; TODO: can't use selected because we also need to know when nothing is selected
               #_(if selected
@@ -202,7 +202,7 @@
             {:keys [node-id vbuf gpu-texture]} user-data]
         (when vbuf
           (let [vertex-binding (vtx/use-with node-id vbuf tile-map-id-shader)]
-            (gl/with-gl-bindings gl (assoc render-args :id (scene-picking/renderable-picking-id-uniform (first renderables))) [gpu-texture tile-map-id-shader vertex-binding]
+            (gl/with-gl-bindings gl (assoc render-args :id (scene-picking/renderable-picking-id-uniform (first renderables))) [tile-map-id-shader vertex-binding gpu-texture]
               (gl/gl-push-matrix gl
                 (gl/gl-mult-matrix-4d gl world-transform)
                 (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf))))))))))
@@ -624,7 +624,7 @@
     (.glMatrixMode gl GL2/GL_MODELVIEW)
     (gl/gl-push-matrix gl
       (gl/gl-mult-matrix-4d gl brush-transform)
-      (gl/with-gl-bindings gl render-args [gpu-texture tex-shader vb]
+      (gl/with-gl-bindings gl render-args [tex-shader vb gpu-texture]
         (shader/set-uniform tex-shader gl "texture_sampler" 0)
         (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf))))))
 
@@ -751,7 +751,7 @@
   (let [vbuf (gen-palette-tiles-vbuf tile-source-attributes texture-set-data)
         vb (vtx/use-with ::palette-tiles vbuf tex-shader)
         gpu-texture (texture/set-params gpu-texture tile-source/texture-params)]
-    (gl/with-gl-bindings gl render-args [gpu-texture tex-shader vb]
+    (gl/with-gl-bindings gl render-args [tex-shader vb gpu-texture]
       (shader/set-uniform tex-shader gl "texture_sampler" 0)
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))
 

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -359,7 +359,7 @@
   (let [vbuf (gen-tiles-vbuf tile-source-attributes uv-transforms scale-factor)
         vb (vtx/use-with node-id vbuf tile-shader)
         gpu-texture (texture/set-params gpu-texture texture-params)]
-    (gl/with-gl-bindings gl render-args [gpu-texture tile-shader vb]
+    (gl/with-gl-bindings gl render-args [tile-shader vb gpu-texture]
       (shader/set-uniform tile-shader gl "texture_sampler" 0)
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))
 

--- a/engine/engine/src/test/script_props/test_script_props.collection
+++ b/engine/engine/src/test/script_props/test_script_props.collection
@@ -11,3 +11,8 @@ instances {
     }
   }
 }
+instances {
+  id: "uniform_property"
+  prototype: "/script_props/uniform_property.go"
+}
+

--- a/engine/engine/src/test/script_props/uniform_property.fp
+++ b/engine/engine/src/test/script_props/uniform_property.fp
@@ -1,0 +1,7 @@
+varying mediump vec2 var_texcoord0;
+uniform lowp vec4 uniform_array[16];
+
+void main()
+{
+    gl_FragColor = uniform_array[15];
+}

--- a/engine/engine/src/test/script_props/uniform_property.go
+++ b/engine/engine/src/test/script_props/uniform_property.go
@@ -1,0 +1,14 @@
+components {
+  id: "script"
+  component: "/script_props/uniform_property.script"
+}
+embedded_components {
+  id: "sprite"
+  type: "sprite"
+  data: "tile_set: \"/builtins/graphics/particle_blob.tilesource\"\n"
+  "default_animation: \"anim\"\n"
+  "material: \"/script_props/uniform_property.material\"\n"
+  "blend_mode: BLEND_MODE_ALPHA\n"
+  ""
+}
+

--- a/engine/engine/src/test/script_props/uniform_property.material
+++ b/engine/engine/src/test/script_props/uniform_property.material
@@ -1,0 +1,21 @@
+name: "sprite"
+tags: "tile"
+vertex_program: "/builtins/materials/sprite.vp"
+fragment_program: "/script_props/uniform_property.fp"
+vertex_space: VERTEX_SPACE_WORLD
+fragment_constants {
+  name: "uniform_array"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  value {
+    x: 0.0
+    y: 1.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/engine/src/test/script_props/uniform_property.script
+++ b/engine/engine/src/test/script_props/uniform_property.script
@@ -1,0 +1,47 @@
+go.property("vec4", vmath.vector4(4, 5, 6, 7))
+
+local function assert_exit(assert_that, error_string)
+    if not assert_that then
+        if error_string then
+            print(error_string)
+        end
+        msg.post("@system:", "exit", { code = 1 })
+        assert(assert_that)
+    end
+end
+
+local function assert_vec4(v_test,v_correct)
+    local v = v_test.x == v_correct.x and
+        v_test.y == v_correct.y and
+        v_test.z == v_correct.z and
+        v_test.w == v_correct.w
+    local e = v and nil or tostring(v_test) .. " and " .. tostring(v_correct) .. " are not the same!"
+    assert_exit(v, e)
+end
+
+local function assert_error(func)
+    local r, err = pcall(func)
+    assert_exit(not r, err)
+end
+
+function init(self, config)
+    -- Get First Array value, specified in the material
+    assert_vec4(go.get("#sprite", "uniform_array", { index = 1 }), vmath.vector4(1,0,0,1))
+
+    -- Get second array value, specified in the material
+    assert_vec4(go.get("#sprite", "uniform_array", { index = 2 }), vmath.vector4(0,1,0,1))
+
+    -- Test index out of bounds
+    assert_error(function() go.get("#sprite", "uniform_array", { index = 0 }) end)
+    assert_error(function() go.get("#sprite", "uniform_array", { index = 17 }) end)
+    assert_error(function() go.get("#sprite", "uniform_array", { index = -1 }) end)
+
+    -- Test setting a value and then getting it
+    local v_to_set = vmath.vector4(0, 0, 1, 1)
+    go.set("#sprite", "uniform_array", v_to_set, { index = 16 })
+    local v_from_prop = go.get("#sprite", "uniform_array", { index = 16 })
+    assert_vec4(v_from_prop, v_to_set)
+
+    msg.post("main:/main#script", "done")
+end
+

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -397,6 +397,8 @@ namespace dmGameObject
         dmhash_t m_PropertyId;
         /// User data storage pointer
         uintptr_t* m_UserData;
+        /// Options for getting the property
+        PropertyOptions m_Options;
     };
 
     /*#
@@ -421,6 +423,8 @@ namespace dmGameObject
         uintptr_t* m_UserData;
         /// New value of the property
         PropertyVar m_Value;
+        /// Options for setting the property
+        PropertyOptions m_Options;
     };
 
     /*#

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -241,6 +241,19 @@ namespace dmGameObject
         UPDATE_RESULT_UNKNOWN_ERROR = -1000,
     };
 
+    /*# Property Options
+     *
+     * A table of options for getting and setting properties.
+     *
+     * @struct
+     * @name PropertyOptions
+     * @member m_Index [type:int32_t] The index of the property to set, only applicable if property is array.
+     */
+    struct PropertyOptions
+    {
+        int32_t m_Index;
+    };
+
     /*# property variant
      * Property variant that holds the data for a variable
      *
@@ -300,6 +313,8 @@ namespace dmGameObject
      * @member m_Variant [type: PropertyVar] Variant holding the value
      * @member m_ValuePtr [type: float*] Pointer to the value, only set for mutable values. The actual data type is described by the variant.
      * @member m_ReadOnly [type: bool] Determines whether we are permitted to write to this property.
+     * @member m_ArraySize [type: uint8_t] The number of elements the property holds (if array).
+     * @member m_IsArray [type: uint8_t] Indicates if this property is an array or not.
      */
     struct PropertyDesc
     {
@@ -308,6 +323,8 @@ namespace dmGameObject
         PropertyVar m_Variant;
         float* m_ValuePtr;
         bool m_ReadOnly;
+        uint8_t m_ArraySize : 7;
+        uint8_t m_IsArray   : 1;
     };
 
     /*#

--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -203,7 +203,9 @@ namespace dmGameObject
                     else
                     {
                         PropertyDesc desc;
-                        GetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, desc);
+                        PropertyOptions property_opt;
+                        property_opt.m_Index = 0;
+                        GetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, desc);
                         anim.m_From = (float)desc.m_Variant.m_Number;
                     }
                 }
@@ -308,7 +310,9 @@ namespace dmGameObject
                 }
                 else
                 {
-                    SetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, PropertyVar(v));
+                    PropertyOptions property_opt;
+                    property_opt.m_Index = 0;
+                    SetProperty(anim.m_Instance, anim.m_ComponentId, anim.m_PropertyId, property_opt, PropertyVar(v));
                 }
             }
             if (completed)
@@ -533,7 +537,9 @@ namespace dmGameObject
         if (instance == 0)
             return PROPERTY_RESULT_INVALID_INSTANCE;
         PropertyDesc prop_desc;
-        PropertyResult prop_result = GetProperty(instance, component_id, property_id, prop_desc);
+        PropertyOptions property_opt;
+        property_opt.m_Index = 0;
+        PropertyResult prop_result = GetProperty(instance, component_id, property_id, property_opt, prop_desc);
         if (prop_result != PROPERTY_RESULT_OK)
         {
             return prop_result;
@@ -598,7 +604,9 @@ namespace dmGameObject
         if (instance == 0)
             return PROPERTY_RESULT_INVALID_INSTANCE;
         PropertyDesc prop_desc;
-        PropertyResult prop_result = GetProperty(instance, component_id, property_id, prop_desc);
+        PropertyOptions property_opt;
+        property_opt.m_Index = 0;
+        PropertyResult prop_result = GetProperty(instance, component_id, property_id, property_opt, prop_desc);
         if (prop_result != PROPERTY_RESULT_OK)
         {
             return prop_result;

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -3015,10 +3015,15 @@ namespace dmGameObject
         instance->m_Transform.SetRotation(dmVMath::EulerToQuat(instance->m_EulerRotation));
     }
 
-    PropertyResult GetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyDesc& out_value)
+    PropertyResult GetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyOptions options, PropertyDesc& out_value)
     {
         if (instance == 0)
             return PROPERTY_RESULT_INVALID_INSTANCE;
+
+        // Default array size to 0, it should not be used as an array by default
+        out_value.m_ArraySize = 0;
+        out_value.m_IsArray = 0;
+
         if (component_id == 0)
         {
             out_value.m_ValuePtr = 0x0;
@@ -3174,6 +3179,7 @@ namespace dmGameObject
                     p.m_World = instance->m_Collection->m_ComponentWorlds[component.m_TypeIndex];
                     p.m_Instance = instance;
                     p.m_PropertyId = property_id;
+                    p.m_Options = options;
                     p.m_UserData = user_data;
                     PropertyDesc prop_desc;
                     PropertyResult result = type->m_GetPropertyFunction(p, prop_desc);
@@ -3195,7 +3201,7 @@ namespace dmGameObject
         }
     }
 
-    PropertyResult SetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, const PropertyVar& value)
+    PropertyResult SetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyOptions options, const PropertyVar& value)
     {
         if (instance == 0)
             return PROPERTY_RESULT_INVALID_INSTANCE;
@@ -3376,6 +3382,7 @@ namespace dmGameObject
                     p.m_PropertyId = property_id;
                     p.m_UserData = user_data;
                     p.m_Value = value;
+                    p.m_Options = options;
                     return type->m_SetPropertyFunction(p);
                 }
                 else

--- a/engine/gameobject/src/gameobject/gameobject.h
+++ b/engine/gameobject/src/gameobject/gameobject.h
@@ -342,7 +342,10 @@ namespace dmGameObject
      * @param out_value Description of the retrieved property value
      * @return PROPERTY_RESULT_OK if the out-parameters were written
      */
-    PropertyResult GetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyDesc& out_value);
+    PropertyResult GetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyOptions options, PropertyDesc& out_value);
+
+
+    uint32_t GetPropertyArrayLength(HInstance instance, dmhash_t component_id, dmhash_t property_id);
 
     /**
      * Sets the value of a property.
@@ -355,7 +358,7 @@ namespace dmGameObject
      * @param userdata2 User specified data
      * @return PROPERTY_RESULT_OK if the value could be set
      */
-    PropertyResult SetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, const PropertyVar& value);
+    PropertyResult SetProperty(HInstance instance, dmhash_t component_id, dmhash_t property_id, PropertyOptions options, const PropertyVar& value);
 
     typedef void (*AnimationStopped)(dmGameObject::HInstance instance, dmhash_t component_id, dmhash_t property_id,
                                         bool finished, void* userdata1, void* userdata2);

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -557,13 +557,49 @@ namespace dmGameObject
         dmGameObject::HInstance target_instance = dmGameObject::GetInstanceFromIdentifier(dmGameObject::GetCollection(instance), target.m_Path);
         if (target_instance == 0)
             return luaL_error(L, "Could not find any instance with id '%s'.", dmHashReverseSafe64(target.m_Path));
+        dmGameObject::PropertyOptions property_options;
+        property_options.m_Index = 0;
+        bool index_requested = false;
+
+        // Options table
+        if (lua_gettop(L) > 2)
+        {
+            luaL_checktype(L, 3, LUA_TTABLE);
+            lua_pushvalue(L, 3);
+
+            lua_getfield(L, -1, "index");
+            if (!lua_isnumber(L, -1))
+            {
+                return luaL_error(L, "Invalid number passed as index argument in options table.");
+            }
+
+            property_options.m_Index = luaL_checkinteger(L, -1) - 1;
+
+            if (property_options.m_Index < 0)
+            {
+                return luaL_error(L, "Trying to get property value from '%s' with a negative index.", dmHashReverseSafe64(property_id));
+            }
+
+            lua_pop(L, 1);
+
+            lua_pop(L, 1);
+
+            index_requested = true;
+        }
         dmGameObject::PropertyDesc property_desc;
-        dmGameObject::PropertyResult result = dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_desc);
+        dmGameObject::PropertyResult result = dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_options, property_desc);
         switch (result)
         {
         case dmGameObject::PROPERTY_RESULT_OK:
-            dmGameObject::LuaPushVar(L, property_desc.m_Variant);
-            return 1;
+            {
+                if (index_requested && !property_desc.m_IsArray)
+                {
+                    return luaL_error(L, "Options table contains index, but property '%s' is not an array.", dmHashReverseSafe64(property_id));
+                }
+
+                dmGameObject::LuaPushVar(L, property_desc.m_Variant);
+                return 1;
+            }
         case dmGameObject::PROPERTY_RESULT_NOT_FOUND:
             {
                 const char* path = dmHashReverseSafe64(target.m_Path);
@@ -578,7 +614,7 @@ namespace dmGameObject
                 }
             }
         case dmGameObject::PROPERTY_RESULT_COMP_NOT_FOUND:
-            return luaL_error(L, "could not find component '%s' when resolving '%s'", dmHashReverseSafe64(target.m_Fragment), lua_tostring(L, 1));
+            return luaL_error(L, "Could not find component '%s' when resolving '%s'", dmHashReverseSafe64(target.m_Fragment), lua_tostring(L, 1));
         default:
             // Should never happen, programmer error
             return luaL_error(L, "go.get failed with error code %d", result);
@@ -654,9 +690,31 @@ namespace dmGameObject
         if (target_instance == 0)
             return luaL_error(L, "could not find any instance with id '%s'.", dmHashReverseSafe64(target.m_Path));
         dmGameObject::PropertyResult result = dmGameObject::LuaToVar(L, 3, property_var);
+
+        dmGameObject::PropertyOptions property_options;
+        property_options.m_Index = 0;
+
+        // Options table
+        if (lua_gettop(L) > 3)
+        {
+            luaL_checktype(L, 4, LUA_TTABLE);
+            lua_pushvalue(L, 4);
+
+            lua_getfield(L, -1, "index");
+            if (!lua_isnumber(L, -1))
+            {
+                return luaL_error(L, "Invalid number passed as index argument in options table.");
+            }
+            // TODO: Check if property is an array and throw error if it isn't
+            property_options.m_Index = luaL_checkinteger(L, -1) - 1;
+            lua_pop(L, 1);
+
+            lua_pop(L, 1);
+        }
+
         if (result == PROPERTY_RESULT_OK)
         {
-            result = dmGameObject::SetProperty(target_instance, target.m_Fragment, property_id, property_var);
+            result = dmGameObject::SetProperty(target_instance, target.m_Fragment, property_id, property_options, property_var);
         }
         switch (result)
         {
@@ -681,7 +739,7 @@ namespace dmGameObject
         case PROPERTY_RESULT_TYPE_MISMATCH:
             {
                 dmGameObject::PropertyDesc property_desc;
-                dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_desc);
+                dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_options, property_desc);
                 return luaL_error(L, "the property '%s' of '%s' must be a %s", dmHashReverseSafe64(property_id), lua_tostring(L, 1), GetPropertyTypeName(property_desc.m_Variant.m_Type));
             }
         case dmGameObject::PROPERTY_RESULT_COMP_NOT_FOUND:
@@ -1549,6 +1607,10 @@ namespace dmGameObject
         dmGameObject::HInstance target_instance = dmGameObject::GetInstanceFromIdentifier(collection, target.m_Path);
         if (target_instance == 0)
             return luaL_error(L, "Could not find any instance with id '%s'.", dmHashReverseSafe64(target.m_Path));
+
+        dmGameObject::PropertyOptions opt;
+        opt.m_Index = 0;
+
         dmGameObject::PropertyResult res = dmGameObject::CancelAnimations(collection, target_instance, target.m_Fragment, property_id);
 
         switch (res)
@@ -1568,7 +1630,7 @@ namespace dmGameObject
         case PROPERTY_RESULT_TYPE_MISMATCH:
             {
                 dmGameObject::PropertyDesc property_desc;
-                dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, property_desc);
+                dmGameObject::GetProperty(target_instance, target.m_Fragment, property_id, opt, property_desc);
                 return luaL_error(L, "The property '%s' must be of a numerical type", dmHashReverseSafe64(property_id));
             }
         case dmGameObject::PROPERTY_RESULT_COMP_NOT_FOUND:

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -297,17 +297,21 @@ static dmhash_t hash(const char* s)
 #define ASSERT_GET_PROP_NUM(go, prop, v0, epsilon)\
     {\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v0, desc.m_Variant.m_Number, epsilon);\
     }\
 
 #define ASSERT_SET_PROP_NUM(go, prop, v0, epsilon)\
     {\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
         dmGameObject::PropertyVar var(v0);\
-        dmGameObject::SetProperty(go, 0, hash(prop), var);\
+        dmGameObject::SetProperty(go, 0, hash(prop), opt, var);\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_NEAR(v0, desc.m_Variant.m_Number, epsilon);\
     }\
 
@@ -315,24 +319,30 @@ static dmhash_t hash(const char* s)
     {\
         dmGameObject::SetScale(go, v0);\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v0, *desc.m_ValuePtr, epsilon);\
     }\
 
 #define ASSERT_SET_PROP_V1(go, prop, v0, epsilon)\
     {\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
         dmGameObject::PropertyVar var(v0);\
-        dmGameObject::SetProperty(go, 0, hash(prop), var);\
+        dmGameObject::SetProperty(go, 0, hash(prop), opt, var);\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_NEAR(v0, *desc.m_ValuePtr, epsilon);\
     }\
 
 #define ASSERT_GET_PROP_V3(go, prop, v, epsilon)\
     {\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_VECTOR3, desc.m_Variant.m_Type);\
         ASSERT_EQ(hash(prop ".x"), desc.m_ElementIds[0]);\
         ASSERT_EQ(hash(prop ".y"), desc.m_ElementIds[1]);\
@@ -340,17 +350,17 @@ static dmhash_t hash(const char* s)
         ASSERT_NEAR(v.getX(), desc.m_ValuePtr[0], epsilon);\
         ASSERT_NEAR(v.getY(), desc.m_ValuePtr[1], epsilon);\
         ASSERT_NEAR(v.getZ(), desc.m_ValuePtr[2], epsilon);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".x"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".x"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getX(), desc.m_ValuePtr[0], epsilon);\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".y"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".y"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getY(), desc.m_ValuePtr[0], epsilon);\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".z"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".z"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getZ(), desc.m_ValuePtr[0], epsilon);\
     }
@@ -358,9 +368,11 @@ static dmhash_t hash(const char* s)
 #define ASSERT_SET_PROP_V3(go, prop, v, epsilon)\
     {\
         dmGameObject::PropertyVar var(v);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, hash(prop), var));\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, hash(prop), opt, var));\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_NEAR(v.getX(), desc.m_ValuePtr[0], epsilon);\
         ASSERT_NEAR(v.getY(), desc.m_ValuePtr[1], epsilon);\
         ASSERT_NEAR(v.getZ(), desc.m_ValuePtr[2], epsilon);\
@@ -368,29 +380,31 @@ static dmhash_t hash(const char* s)
         float v0 = v.getX() + 1.0f;\
         dmhash_t id = hash(prop ".x");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
 \
         v0 = v.getY() + 1.0f;\
         id = hash(prop ".y");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
 \
         v0 = v.getZ() + 1.0f;\
         id = hash(prop ".z");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
     }
 
 #define ASSERT_GET_PROP_V4(go, prop, v, epsilon)\
     {\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_TRUE(dmGameObject::PROPERTY_TYPE_VECTOR4 == desc.m_Variant.m_Type || dmGameObject::PROPERTY_TYPE_QUAT == desc.m_Variant.m_Type);\
         ASSERT_EQ(hash(prop ".x"), desc.m_ElementIds[0]);\
         ASSERT_EQ(hash(prop ".y"), desc.m_ElementIds[1]);\
@@ -400,21 +414,21 @@ static dmhash_t hash(const char* s)
         ASSERT_NEAR(v.getY(), desc.m_ValuePtr[1], epsilon);\
         ASSERT_NEAR(v.getZ(), desc.m_ValuePtr[2], epsilon);\
         ASSERT_NEAR(v.getW(), desc.m_ValuePtr[3], epsilon);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".x"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".x"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getX(), desc.m_ValuePtr[0], epsilon);\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".y"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".y"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getY(), desc.m_ValuePtr[0], epsilon);\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".z"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".z"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getZ(), desc.m_ValuePtr[0], epsilon);\
 \
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".w"), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop ".w"), opt, desc));\
         ASSERT_EQ(dmGameObject::PROPERTY_TYPE_NUMBER, desc.m_Variant.m_Type);\
         ASSERT_NEAR(v.getW(), desc.m_ValuePtr[0], epsilon);\
 }
@@ -422,9 +436,11 @@ static dmhash_t hash(const char* s)
 #define ASSERT_SET_PROP_V4(go, prop, v, epsilon)\
     {\
         dmGameObject::PropertyVar var(v);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, hash(prop), var));\
+        dmGameObject::PropertyOptions opt;\
+        opt.m_Index = 0;\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, hash(prop), opt, var));\
         dmGameObject::PropertyDesc desc;\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, hash(prop), opt, desc));\
         ASSERT_NEAR(v.getX(), desc.m_ValuePtr[0], epsilon);\
         ASSERT_NEAR(v.getY(), desc.m_ValuePtr[1], epsilon);\
         ASSERT_NEAR(v.getZ(), desc.m_ValuePtr[2], epsilon);\
@@ -433,29 +449,29 @@ static dmhash_t hash(const char* s)
         float v0 = v.getX() + 1.0f;\
         dmhash_t id = hash(prop ".x");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
 \
         v0 = v.getY() + 1.0f;\
         id = hash(prop ".y");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
 \
         v0 = v.getZ() + 1.0f;\
         id = hash(prop ".z");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
 \
         v0 = v.getW() + 1.0f;\
         id = hash(prop ".w");\
         var = dmGameObject::PropertyVar(v0);\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, var));\
-        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, desc));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, 0, id, opt, var));\
+        ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(go, 0, id, opt, desc));\
         ASSERT_NEAR(v0, desc.m_ValuePtr[0], epsilon);\
     }
 

--- a/engine/gamesys/proto/gamesys/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gamesys_ddf.proto
@@ -140,6 +140,7 @@ message SetConstant
 {
     required uint64         name_hash   = 1;
     required dmMath.Vector4 value       = 2 [(field_align)=true];
+    optional int32          index       = 3 [default=0];
 }
 
 /* Function wrapper documented in gamesys_script.cpp */

--- a/engine/gamesys/src/dmsdk/gamesys/render_constants.h
+++ b/engine/gamesys/src/dmsdk/gamesys/render_constants.h
@@ -94,10 +94,11 @@ namespace dmGameSystem
      * @param constants [type: dmGameSystem::HComponentRenderConstants] the constants
      * @param material [type: dmRender::HMaterial] the material
      * @param name_hash [type: dmhash_t] the hashed name of the constant
+     * @param value_index [type: uint32_t] index of the constant value to set, if the constant is an array
      * @param element_index [type: uint32_t*] pointer to the index of the element (in range [0,3]). May be 0
      * @param var [type: const dmGameObject::PropertyVar&] the constant value
      */
-    void SetRenderConstant(HComponentRenderConstants constants, dmRender::HMaterial material, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var);
+    void SetRenderConstant(HComponentRenderConstants constants, dmRender::HMaterial material, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var);
 
     /*#
      * Removes a render constant from the container
@@ -146,32 +147,34 @@ namespace dmGameSystem
      * @name GetMaterialConstant
      * @param material [type: dmRender::HMaterial] the material
      * @param name_hash [type: dmhash_t] the name of the property
+     * @param value_index [type: int32_t] the index of the constant value to get, if it is an array
      * @param out_desc [type: dmGameObject::PropertyDesc&] the property descriptor
      * @param use_value_ptr [type: bool] should the property pointer be used (m_ValuePtr)
      * @param callback [type: CompGetConstantCallback] callback to resolve property
      * @param callback_user_data [type: void*] callback user data
      * @return result [type: dmGameObject::PropertyResult] the result
      */
-    dmGameObject::PropertyResult GetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, dmGameObject::PropertyDesc& out_desc, bool use_value_ptr, CompGetConstantCallback callback, void* callback_user_data);
+    dmGameObject::PropertyResult GetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, int32_t value_index, dmGameObject::PropertyDesc& out_desc, bool use_value_ptr, CompGetConstantCallback callback, void* callback_user_data);
 
     /*#
      * Used in SetMaterialConstant to set a render constant's value
      * @typedef
      * @name CompSetConstantCallback
      */
-    typedef void (*CompSetConstantCallback)(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var);
+    typedef void (*CompSetConstantCallback)(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var);
 
     /**
      * Helper function to set material constants of components that use them: sprite, label, tile maps, spine and models
      * @name SetMaterialConstant
      * @param material [type: dmRender::HMaterial] the material
      * @param name_hash [type: dmhash_t] the name of the property
+     * @param value_index [type: uint32_t] index of the constant value to set, if the material constant is an array
      * @param var [type: dmGameObject::PropertyVar] the property
      * @param callback [type: CompGetConstantCallback] the callback used to set the property
      * @param callback_user_data [type: void*] callback user data
      * @return result [type: dmGameObject::PropertyResult] the result
      */
-    dmGameObject::PropertyResult SetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, CompSetConstantCallback callback, void* callback_user_data);
+    dmGameObject::PropertyResult SetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, int32_t value_index, CompSetConstantCallback callback, void* callback_user_data);
 
 }
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -983,7 +983,7 @@ namespace dmGameSystem
         for (uint32_t i = 0; i < first_emitter_render_data->m_RenderConstantsSize; ++i)
         {
             dmParticle::RenderConstant* c = &first_emitter_render_data->m_RenderConstants[i];
-            dmRender::EnableRenderObjectConstant(&ro, c->m_NameHash, c->m_Value);
+            dmRender::EnableRenderObjectConstant(&ro, c->m_NameHash, &c->m_Value, 1);
         }
 
         ApplyStencilClipping(gui_context, stencil_scopes[0], ro);

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -470,13 +470,13 @@ namespace dmGameSystem
         return component->m_RenderConstants && dmGameSystem::GetRenderConstant(component->m_RenderConstants, name_hash, out_constant);
     }
 
-    static void CompLabelSetConstantCallback(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var)
+    static void CompLabelSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var)
     {
         LabelComponent* component = (LabelComponent*)user_data;
         if (!component->m_RenderConstants)
             component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
 
-        SetRenderConstant(component->m_RenderConstants, GetMaterial(component, component->m_Resource), name_hash, element_index, var);
+        SetRenderConstant(component->m_RenderConstants, GetMaterial(component, component->m_Resource), name_hash, value_index, element_index, var);
         component->m_ReHash = 1;
     }
 
@@ -576,7 +576,7 @@ namespace dmGameSystem
         {
             return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetFontMap(component, component->m_Resource), out_value);
         }
-        return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, out_value, false, CompLabelGetConstantCallback, component);
+        return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, params.m_Options.m_Index, out_value, false, CompLabelGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompLabelSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -617,6 +617,6 @@ namespace dmGameSystem
             component->m_ReHash |= res == dmGameObject::PROPERTY_RESULT_OK;
             return res;
         }
-        return SetMaterialConstant(GetMaterial(component, component->m_Resource), set_property, params.m_Value, CompLabelSetConstantCallback, component);
+        return SetMaterialConstant(GetMaterial(component, component->m_Resource), set_property, params.m_Value, params.m_Options.m_Index, CompLabelSetConstantCallback, component);
     }
 }

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -812,12 +812,12 @@ namespace dmGameSystem
         return component->m_RenderConstants && dmGameSystem::GetRenderConstant(component->m_RenderConstants, name_hash, out_constant);
     }
 
-    static void CompMeshSetConstantCallback(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var)
+    static void CompMeshSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var)
     {
         MeshComponent* component = (MeshComponent*)user_data;
         if (!component->m_RenderConstants)
             component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
-        dmGameSystem::SetRenderConstant(component->m_RenderConstants, component->m_Resource->m_Material, name_hash, element_index, var);
+        dmGameSystem::SetRenderConstant(component->m_RenderConstants, component->m_Resource->m_Material, name_hash, value_index, element_index, var);
         component->m_ReHash = 1;
     }
 
@@ -839,7 +839,7 @@ namespace dmGameSystem
             {
                 dmGameSystemDDF::SetConstant* ddf = (dmGameSystemDDF::SetConstant*)params.m_Message->m_Data;
                 dmGameObject::PropertyResult result = dmGameSystem::SetMaterialConstant(component->m_Resource->m_Material, ddf->m_NameHash,
-                        dmGameObject::PropertyVar(ddf->m_Value), CompMeshSetConstantCallback, component);
+                        dmGameObject::PropertyVar(ddf->m_Value), ddf->m_Index, CompMeshSetConstantCallback, component);
                 if (result == dmGameObject::PROPERTY_RESULT_NOT_FOUND)
                 {
                     dmMessage::URL& receiver = params.m_Message->m_Receiver;
@@ -892,7 +892,7 @@ namespace dmGameSystem
             }
         }
 
-        return GetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, out_value, true, CompMeshGetConstantCallback, component);
+        return GetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Options.m_Index, out_value, true, CompMeshGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompMeshSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -970,7 +970,7 @@ namespace dmGameSystem
             }
         }
 
-        dmGameObject::PropertyResult res = SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, CompMeshSetConstantCallback, component);
+        dmGameObject::PropertyResult res = SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompMeshSetConstantCallback, component);
         component->m_ReHash |= res == dmGameObject::PROPERTY_RESULT_OK;
 
         return res;

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -758,12 +758,12 @@ namespace dmGameSystem
         return GetRenderConstant(component->m_RenderConstants, name_hash, out_constant);
     }
 
-    static void CompModelSetConstantCallback(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var)
+    static void CompModelSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var)
     {
         ModelComponent* component = (ModelComponent*)user_data;
         if (!component->m_RenderConstants)
             component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
-        SetRenderConstant(component->m_RenderConstants, GetMaterial(component, component->m_Resource), name_hash, element_index, var);
+        SetRenderConstant(component->m_RenderConstants, GetMaterial(component, component->m_Resource), name_hash, value_index, element_index, var);
         component->m_ReHash = 1;
     }
 
@@ -800,7 +800,7 @@ namespace dmGameSystem
             {
                 dmGameSystemDDF::SetConstant* ddf = (dmGameSystemDDF::SetConstant*)params.m_Message->m_Data;
                 dmGameObject::PropertyResult result = dmGameSystem::SetMaterialConstant(GetMaterial(component, component->m_Resource), ddf->m_NameHash,
-                        dmGameObject::PropertyVar(ddf->m_Value), CompModelSetConstantCallback, component);
+                        dmGameObject::PropertyVar(ddf->m_Value), ddf->m_Index, CompModelSetConstantCallback, component);
                 if (result == dmGameObject::PROPERTY_RESULT_NOT_FOUND)
                 {
                     dmMessage::URL& receiver = params.m_Message->m_Receiver;
@@ -925,7 +925,7 @@ namespace dmGameSystem
                 return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetTexture(component, component->m_Resource, i), out_value);
             }
         }
-        return GetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, out_value, true, CompModelGetConstantCallback, component);
+        return GetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Options.m_Index, out_value, true, CompModelGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompModelSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -986,7 +986,7 @@ namespace dmGameSystem
                 return res;
             }
         }
-        return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, CompModelSetConstantCallback, component);
+        return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompModelSetConstantCallback, component);
     }
 
     static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams& params)

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -503,7 +503,7 @@ namespace dmGameSystem
         for (uint32_t i = 0; i < constant_count; ++i)
         {
             dmParticle::RenderConstant* c = &constants[i];
-            dmRender::EnableRenderObjectConstant(ro, c->m_NameHash, c->m_Value);
+            dmRender::EnableRenderObjectConstant(ro, c->m_NameHash, &c->m_Value, 1);
         }
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -967,12 +967,12 @@ namespace dmGameSystem
         return GetRenderConstant(component->m_RenderConstants, name_hash, out_constant);
     }
 
-    static void CompSpriteSetConstantCallback(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var)
+    static void CompSpriteSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var)
     {
         SpriteComponent* component = (SpriteComponent*)user_data;
         if (!component->m_RenderConstants)
             component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
-        SetRenderConstant(component->m_RenderConstants, GetMaterial(component, component->m_Resource), name_hash, element_index, var);
+        SetRenderConstant(component->m_RenderConstants, GetMaterial(component, component->m_Resource), name_hash, value_index, element_index, var);
         component->m_ReHash = 1;
     }
 
@@ -1054,7 +1054,7 @@ namespace dmGameSystem
             {
                 dmGameSystemDDF::SetConstant* ddf = (dmGameSystemDDF::SetConstant*)params.m_Message->m_Data;
                 dmGameObject::PropertyResult result = dmGameSystem::SetMaterialConstant(GetMaterial(component, component->m_Resource), ddf->m_NameHash,
-                        dmGameObject::PropertyVar(ddf->m_Value), CompSpriteSetConstantCallback, component);
+                        dmGameObject::PropertyVar(ddf->m_Value), ddf->m_Index, CompSpriteSetConstantCallback, component);
                 if (result == dmGameObject::PROPERTY_RESULT_NOT_FOUND)
                 {
                     dmMessage::URL& receiver = params.m_Message->m_Receiver;
@@ -1127,7 +1127,7 @@ namespace dmGameSystem
         {
             return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetTextureSet(component, component->m_Resource)->m_Texture, out_value);
         }
-        return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, out_value, false, CompSpriteGetConstantCallback, component);
+        return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, params.m_Options.m_Index, out_value, false, CompSpriteGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompSpriteSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -1182,7 +1182,7 @@ namespace dmGameSystem
             }
             return res;
         }
-        return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, CompSpriteSetConstantCallback, component);
+        return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component);
     }
 
     static bool CompSpriteIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -810,7 +810,7 @@ namespace dmGameSystem
         return ~0u;
     }
 
-    static void CompTileGridSetConstantCallback(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var);
+    static void CompTileGridSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var);
 
     dmGameObject::UpdateResult CompTileGridOnMessage(const dmGameObject::ComponentOnMessageParams& params)
     {
@@ -882,7 +882,7 @@ namespace dmGameSystem
             dmGameSystemDDF::SetConstantTileMap* ddf = (dmGameSystemDDF::SetConstantTileMap*)params.m_Message->m_Data;
             if (!component->m_RenderConstants)
                 component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
-            SetRenderConstant(component->m_RenderConstants, GetMaterial(component), ddf->m_NameHash, 0, ddf->m_Value);
+            SetRenderConstant(component->m_RenderConstants, GetMaterial(component), ddf->m_NameHash, 0, 0, ddf->m_Value);
             ReHash(component);
         }
         else if (params.m_Message->m_Id == dmGameSystemDDF::ResetConstantTileMap::m_DDFDescriptor->m_NameHash)
@@ -921,12 +921,12 @@ namespace dmGameSystem
         return GetRenderConstant(component->m_RenderConstants, name_hash, out_constant);
     }
 
-    static void CompTileGridSetConstantCallback(void* user_data, dmhash_t name_hash, uint32_t* element_index, const dmGameObject::PropertyVar& var)
+    static void CompTileGridSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var)
     {
         TileGridComponent* component = (TileGridComponent*)user_data;
         if (!component->m_RenderConstants)
             component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
-        SetRenderConstant(component->m_RenderConstants, GetMaterial(component), name_hash, element_index, var);
+        SetRenderConstant(component->m_RenderConstants, GetMaterial(component), name_hash, value_index, element_index, var);
         ReHash(component);
     }
 
@@ -941,7 +941,7 @@ namespace dmGameSystem
         {
             return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetTextureSet(component), out_value);
         }
-        return GetMaterialConstant(GetMaterial(component), params.m_PropertyId, out_value, true, CompTileGridGetConstantCallback, component);
+        return GetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Options.m_Index, out_value, true, CompTileGridGetConstantCallback, component);
     }
 
     dmGameObject::PropertyResult CompTileGridSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
@@ -955,6 +955,6 @@ namespace dmGameSystem
         {
             return SetResourceProperty(dmGameObject::GetFactory(params.m_Instance), params.m_Value, TEXTURE_SET_EXT_HASH, (void**)&component->m_TextureSet);
         }
-        return SetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Value, CompTileGridSetConstantCallback, component);
+        return SetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompTileGridSetConstantCallback, component);
     }
 }

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -59,18 +59,23 @@ namespace dmGameSystem
 
     }
 
-    dmGameObject::PropertyResult GetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, dmGameObject::PropertyDesc& out_desc, bool use_value_ptr, CompGetConstantCallback callback, void* callback_user_data)
+    dmGameObject::PropertyResult GetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, int32_t value_index, dmGameObject::PropertyDesc& out_desc, bool use_value_ptr, CompGetConstantCallback callback, void* callback_user_data)
     {
         dmhash_t constant_id = 0;
         dmhash_t* element_ids = 0x0;
         uint32_t element_index = ~0u;
-        bool result = dmRender::GetMaterialProgramConstantInfo(material, name_hash, &constant_id, &element_ids, &element_index);
+        uint16_t constant_array_size = 0;
+        bool result = dmRender::GetMaterialProgramConstantInfo(material, name_hash, &constant_id, &element_ids, &element_index, &constant_array_size);
         if (result)
         {
             Vector4* value = 0x0;
             dmRender::Constant* comp_constant = 0x0;
             if (callback(callback_user_data, constant_id, &comp_constant))
-                value = &comp_constant->m_Value;
+                value = &comp_constant->m_ValuePtr[value_index];
+
+            out_desc.m_ArraySize = constant_array_size;
+            out_desc.m_IsArray   = constant_array_size > 1;
+
             if (constant_id == name_hash)
             {
                 if (element_ids != 0x0)
@@ -90,7 +95,7 @@ namespace dmGameSystem
                 {
                     dmRender::Constant c;
                     dmRender::GetMaterialProgramConstant(material, constant_id, c);
-                    out_desc.m_Variant = dmGameObject::PropertyVar(c.m_Value);
+                    out_desc.m_Variant = dmGameObject::PropertyVar(c.m_ValuePtr[value_index]);
                 }
             }
             else
@@ -120,12 +125,13 @@ namespace dmGameSystem
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 
-    dmGameObject::PropertyResult SetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, CompSetConstantCallback callback, void* callback_user_data)
+    dmGameObject::PropertyResult SetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, int32_t value_index, CompSetConstantCallback callback, void* callback_user_data)
     {
         dmhash_t constant_id = 0;
         dmhash_t* element_ids = 0x0;
         uint32_t element_index = ~0u;
-        bool result = dmRender::GetMaterialProgramConstantInfo(material, name_hash, &constant_id, &element_ids, &element_index);
+        uint16_t num_components = 0;
+        bool result = dmRender::GetMaterialProgramConstantInfo(material, name_hash, &constant_id, &element_ids, &element_index, &num_components);
         if (result)
         {
             int32_t location = dmRender::GetMaterialConstantLocation(material, constant_id);
@@ -137,7 +143,7 @@ namespace dmGameSystem
                     {
                         return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
                     }
-                    callback(callback_user_data, constant_id, 0x0, var);
+                    callback(callback_user_data, constant_id, value_index, 0x0, var);
                 }
                 else
                 {
@@ -145,7 +151,7 @@ namespace dmGameSystem
                     {
                         return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
                     }
-                    callback(callback_user_data, constant_id, &element_index, var);
+                    callback(callback_user_data, constant_id, value_index, &element_index, var);
                 }
                 return dmGameObject::PROPERTY_RESULT_OK;
             }

--- a/engine/gamesys/src/gamesys/resources/res_material.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_material.cpp
@@ -143,7 +143,8 @@ namespace dmGameSystem
             const char* name = fragment_constant[i].m_Name;
             dmhash_t name_hash = dmHashString64(name);
             dmRender::SetMaterialProgramConstantType(material, name_hash, fragment_constant[i].m_Type);
-            dmRender::SetMaterialProgramConstant(material, name_hash, fragment_constant[i].m_Value);
+            dmRender::SetMaterialProgramConstant(material, name_hash,
+                (Vectormath::Aos::Vector4*) fragment_constant[i].m_Value.m_Data, fragment_constant[i].m_Value.m_Count);
         }
         // do the same for vertex constants
         for (uint32_t i = 0; i < vertex_count; i++)
@@ -151,7 +152,8 @@ namespace dmGameSystem
             const char* name = vertex_constant[i].m_Name;
             dmhash_t name_hash = dmHashString64(name);
             dmRender::SetMaterialProgramConstantType(material, name_hash, vertex_constant[i].m_Type);
-            dmRender::SetMaterialProgramConstant(material, name_hash, vertex_constant[i].m_Value);
+            dmRender::SetMaterialProgramConstant(material, name_hash,
+                (Vectormath::Aos::Vector4*) vertex_constant[i].m_Value.m_Data, vertex_constant[i].m_Value.m_Count);
         }
 
 

--- a/engine/gamesys/src/gamesys/scripts/script_model.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_model.cpp
@@ -475,6 +475,7 @@ namespace dmGameSystem
         dmGameSystemDDF::SetConstant msg;
         msg.m_NameHash = name_hash;
         msg.m_Value = *value;
+        msg.m_Index = 0; // TODO: Pass a real index here?
 
         dmMessage::URL receiver;
         dmMessage::URL sender;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -422,7 +422,9 @@ static void DeleteInstance(dmGameObject::HCollection collection, dmGameObject::H
 
 static void GetResourceProperty(dmGameObject::HInstance instance, dmhash_t comp_name, dmhash_t prop_name, dmhash_t* out_val) {
     dmGameObject::PropertyDesc desc;
-    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(instance, comp_name, prop_name, desc));
+    dmGameObject::PropertyOptions opt;
+    opt.m_Index = 0;
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::GetProperty(instance, comp_name, prop_name, opt, desc));
     dmGameObject::PropertyType type = desc.m_Variant.m_Type;
     ASSERT_TRUE(dmGameObject::PROPERTY_TYPE_HASH == type);
     *out_val = desc.m_Variant.m_Hash;
@@ -430,7 +432,9 @@ static void GetResourceProperty(dmGameObject::HInstance instance, dmhash_t comp_
 
 static dmGameObject::PropertyResult SetResourceProperty(dmGameObject::HInstance instance, dmhash_t comp_name, dmhash_t prop_name, dmhash_t in_val) {
     dmGameObject::PropertyVar prop_var(in_val);
-    return dmGameObject::SetProperty(instance, comp_name, prop_name, prop_var);
+    dmGameObject::PropertyOptions opt;
+    opt.m_Index = 0;
+    return dmGameObject::SetProperty(instance, comp_name, prop_name, opt, prop_var);
 }
 
 TEST_F(SoundTest, UpdateSoundResource)
@@ -721,7 +725,9 @@ TEST_F(ParticleFxTest, PlayAnim)
 static float GetFloatProperty(dmGameObject::HInstance go, dmhash_t component_id, dmhash_t property_id)
 {
     dmGameObject::PropertyDesc property_desc;
-    dmGameObject::GetProperty(go, component_id, property_id, property_desc);
+    dmGameObject::PropertyOptions property_opt;
+    property_opt.m_Index = 0;
+    dmGameObject::GetProperty(go, component_id, property_id, property_opt, property_desc);
     return property_desc.m_Variant.m_Number;
 }
 
@@ -2945,7 +2951,7 @@ TEST_F(RenderConstantsTest, SetGetConstant)
     ASSERT_EQ(0, constant);
 
     dmGameObject::PropertyVar var1(dmVMath::Vector4(1,2,3,4));
-    dmGameSystem::SetRenderConstant(constants, material, name_hash1, 0, var1); // stores the previous value
+    dmGameSystem::SetRenderConstant(constants, material, name_hash1, 0, 0, var1); // stores the previous value
 
     result = dmGameSystem::GetRenderConstant(constants, name_hash1, &constant);
     ASSERT_TRUE(result);
@@ -2954,7 +2960,7 @@ TEST_F(RenderConstantsTest, SetGetConstant)
 
     // Issue in 1.2.183: We reallocated the array, thus invalidating the previous pointer
     dmGameObject::PropertyVar var2(dmVMath::Vector4(5,6,7,8));
-    dmGameSystem::SetRenderConstant(constants, material, name_hash2, 0, var2);
+    dmGameSystem::SetRenderConstant(constants, material, name_hash2, 0, 0, var2);
     // Make sure it's still valid and doesn't trigger an ASAN issue
     ASSERT_EQ(name_hash1, constant->m_NameHash);
 

--- a/engine/graphics/proto/graphics/graphics_ddf.proto
+++ b/engine/graphics/proto/graphics/graphics_ddf.proto
@@ -181,10 +181,11 @@ message ShaderDesc
 
     message ResourceBinding
     {
-        required string         name    = 1;
-        required ShaderDataType type    = 2;
-        optional uint32         set     = 3 [default=0];
-        optional uint32         binding = 4 [default=0];
+        required string         name          = 1;
+        required ShaderDataType type          = 2;
+        optional uint32         element_count = 3 [default=1];
+        optional uint32         set           = 4 [default=0];
+        optional uint32         binding       = 5 [default=0];
     }
 
     message Shader

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -520,9 +520,9 @@ namespace dmGraphics
     {
         return g_functions.m_ReloadProgram(context, program, vert_program, frag_program);
     }
-    uint32_t GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type)
+    uint32_t GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size)
     {
-        return g_functions.m_GetUniformName(prog, index, buffer, buffer_size, type);
+        return g_functions.m_GetUniformName(prog, index, buffer, buffer_size, type, size);
     }
     uint32_t GetUniformCount(HProgram prog)
     {
@@ -532,9 +532,9 @@ namespace dmGraphics
     {
         return g_functions.m_GetUniformLocation(prog, name);
     }
-    void SetConstantV4(HContext context, const Vectormath::Aos::Vector4* data, int base_register)
+    void SetConstantV4(HContext context, const Vectormath::Aos::Vector4* data, int count, int base_register)
     {
-        g_functions.m_SetConstantV4(context, data, base_register);
+        g_functions.m_SetConstantV4(context, data, count, base_register);
     }
     void SetConstantM4(HContext context, const Vectormath::Aos::Vector4* data, int base_register)
     {

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -511,11 +511,11 @@ namespace dmGraphics
     void DisableProgram(HContext context);
     bool ReloadProgram(HContext context, HProgram program, HVertexProgram vert_program, HFragmentProgram frag_program);
 
-    uint32_t GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type);
+    uint32_t GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
     uint32_t GetUniformCount(HProgram prog);
     int32_t  GetUniformLocation(HProgram prog, const char* name);
 
-    void SetConstantV4(HContext context, const Vectormath::Aos::Vector4* data, int base_register);
+    void SetConstantV4(HContext context, const Vectormath::Aos::Vector4* data, int count, int base_register);
     void SetConstantM4(HContext context, const Vectormath::Aos::Vector4* data, int base_register);
     void SetSampler(HContext context, int32_t location, int32_t unit);
 

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -105,10 +105,10 @@ namespace dmGraphics
     typedef void (*EnableProgramFn)(HContext context, HProgram program);
     typedef void (*DisableProgramFn)(HContext context);
     typedef bool (*ReloadProgramFn)(HContext context, HProgram program, HVertexProgram vert_program, HFragmentProgram frag_program);
-    typedef uint32_t (*GetUniformNameFn)(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type);
+    typedef uint32_t (*GetUniformNameFn)(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
     typedef uint32_t (*GetUniformCountFn)(HProgram prog);
     typedef int32_t (* GetUniformLocationFn)(HProgram prog, const char* name);
-    typedef void (*SetConstantV4Fn)(HContext context, const Vectormath::Aos::Vector4* data, int base_register);
+    typedef void (*SetConstantV4Fn)(HContext context, const Vectormath::Aos::Vector4* data, int count, int base_register);
     typedef void (*SetConstantM4Fn)(HContext context, const Vectormath::Aos::Vector4* data, int base_register);
     typedef void (*SetSamplerFn)(HContext context, int32_t location, int32_t unit);
     typedef void (*SetViewportFn)(HContext context, int32_t x, int32_t y, int32_t width, int32_t height);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -808,7 +808,7 @@ namespace dmGraphics
         return ((Program*)prog)->m_Uniforms.Size();
     }
 
-    static uint32_t NullGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type)
+    static uint32_t NullGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size)
     {
         Program* program = (Program*)prog;
         assert(index < program->m_Uniforms.Size());
@@ -816,6 +816,7 @@ namespace dmGraphics
         *buffer = '\0';
         dmStrlCat(buffer, uniform.m_Name, buffer_size);
         *type = uniform.m_Type;
+        *size = 1; // TODO
         return (uint32_t)strlen(buffer);
     }
 
@@ -847,7 +848,7 @@ namespace dmGraphics
         return context->m_ProgramRegisters[base_register];
     }
 
-    static void NullSetConstantV4(HContext context, const Vector4* data, int base_register)
+    static void NullSetConstantV4(HContext context, const Vector4* data, int count, int base_register)
     {
         assert(context);
         assert(context->m_Program != 0x0);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1863,13 +1863,14 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         return count;
     }
 
-    static uint32_t OpenGLGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type)
+    static uint32_t OpenGLGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size)
     {
         GLint uniform_size;
         GLenum uniform_type;
         GLsizei uniform_name_length;
         glGetActiveUniform(prog, index, buffer_size, &uniform_name_length, &uniform_size, &uniform_type, buffer);
         *type = GetGraphicsType(uniform_type);
+        *size = uniform_size;
         CHECK_GL_ERROR;
         return (uint32_t)uniform_name_length;
     }
@@ -1893,11 +1894,11 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         CHECK_GL_ERROR;
     }
 
-    static void OpenGLSetConstantV4(HContext context, const Vector4* data, int base_register)
+    static void OpenGLSetConstantV4(HContext context, const Vector4* data, int count, int base_register)
     {
         assert(context);
 
-        glUniform4fv(base_register,  1, (const GLfloat*) data);
+        glUniform4fv(base_register, count, (const GLfloat*) data);
         CHECK_GL_ERROR;
     }
 

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -381,22 +381,23 @@ TEST_F(dmGraphicsTest, TestProgram)
     ASSERT_EQ(3, dmGraphics::GetUniformLocation(program, "tint"));
     char buffer[64];
     dmGraphics::Type type;
-    dmGraphics::GetUniformName(program, 0, buffer, 64, &type);
+    int32_t size;
+    dmGraphics::GetUniformName(program, 0, buffer, 64, &type, &size);
     ASSERT_STREQ("view_proj", buffer);
     ASSERT_EQ(dmGraphics::TYPE_FLOAT_MAT4, type);
-    dmGraphics::GetUniformName(program, 1, buffer, 64, &type);
+    dmGraphics::GetUniformName(program, 1, buffer, 64, &type, &size);
     ASSERT_STREQ("world", buffer);
     ASSERT_EQ(dmGraphics::TYPE_FLOAT_MAT4, type);
-    dmGraphics::GetUniformName(program, 2, buffer, 64, &type);
+    dmGraphics::GetUniformName(program, 2, buffer, 64, &type, &size);
     ASSERT_STREQ("texture_sampler", buffer);
     ASSERT_EQ(dmGraphics::TYPE_SAMPLER_2D, type);
-    dmGraphics::GetUniformName(program, 3, buffer, 64, &type);
+    dmGraphics::GetUniformName(program, 3, buffer, 64, &type, &size);
     ASSERT_STREQ("tint", buffer);
     ASSERT_EQ(dmGraphics::TYPE_FLOAT_VEC4, type);
 
     dmGraphics::EnableProgram(m_Context, program);
     Vector4 constant(1.0f, 2.0f, 3.0f, 4.0f);
-    dmGraphics::SetConstantV4(m_Context, &constant, 0);
+    dmGraphics::SetConstantV4(m_Context, &constant, 1, 0);
     Vector4 matrix[4] = {   Vector4(1.0f, 2.0f, 3.0f, 4.0f),
                             Vector4(5.0f, 6.0f, 7.0f, 8.0f),
                             Vector4(9.0f, 10.0f, 11.0f, 12.0f),

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1726,7 +1726,7 @@ bail:
             else
             {
                 dynamic_offsets[res.m_UniformDataIndex] = (uint32_t) scratch_buffer->m_MappedDataCursor;
-                const uint32_t uniform_size_nonalign    = GetShaderTypeSize(res.m_Type);
+                const uint32_t uniform_size_nonalign    = GetShaderTypeSize(res.m_Type) * res.m_ElementCount;
                 const uint32_t uniform_size             = DM_ALIGN(uniform_size_nonalign, dynamic_alignment);
 
                 // Copy client data to aligned host memory
@@ -2005,6 +2005,7 @@ bail:
                 res.m_Binding              = ddf->m_Uniforms[i].m_Binding;
                 res.m_Set                  = ddf->m_Uniforms[i].m_Set;
                 res.m_Type                 = ddf->m_Uniforms[i].m_Type;
+                res.m_ElementCount         = ddf->m_Uniforms[i].m_ElementCount;
                 res.m_Name                 = strdup(ddf->m_Uniforms[i].m_Name);
                 res.m_NameHash             = 0;
 
@@ -2020,7 +2021,7 @@ bail:
                 else
                 {
                     res.m_UniformDataIndex     = uniform_buffer_count;
-                    uniform_data_size_aligned += DM_ALIGN(GetShaderTypeSize(res.m_Type), dynamicAlignment);
+                    uniform_data_size_aligned += DM_ALIGN(GetShaderTypeSize(res.m_Type) * res.m_ElementCount, dynamicAlignment);
                     uniform_buffer_count++;
                 }
             }
@@ -2094,7 +2095,7 @@ bail:
             {
                 assert(num_uniform_buffers < byte_offset_list_size);
                 byte_offset_list_out[res.m_UniformDataIndex] = byte_offset;
-                byte_offset                                 += GetShaderTypeSize(res.m_Type);
+                byte_offset                                 += GetShaderTypeSize(res.m_Type) * res.m_ElementCount;
                 vk_descriptor_type                           = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
                 num_uniform_buffers++;
             }
@@ -2361,7 +2362,7 @@ bail:
         return (Type) 0xffffffff;
     }
 
-    static uint32_t VulkanGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type)
+    static uint32_t VulkanGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size)
     {
         assert(prog);
         Program* program_ptr = (Program*) prog;
@@ -2380,6 +2381,7 @@ bail:
 
         ShaderResourceBinding* res = &module->m_Uniforms[index];
         *type = shaderDataTypeToGraphicsType(res->m_Type);
+        *size = res->m_ElementCount;
 
         return (uint32_t)dmStrlCpy(buffer, res->m_Name, buffer_size);
     }
@@ -2433,7 +2435,7 @@ bail:
         return -1;
     }
 
-    static void VulkanSetConstantV4(HContext context, const Vectormath::Aos::Vector4* data, int base_register)
+    static void VulkanSetConstantV4(HContext context, const Vectormath::Aos::Vector4* data, int count, int base_register)
     {
         assert(context->m_CurrentProgram);
         assert(base_register >= 0);
@@ -2450,7 +2452,7 @@ bail:
             assert(!IsUniformTextureSampler(res));
             uint32_t offset_index      = res.m_UniformDataIndex;
             uint32_t offset            = program_ptr->m_UniformDataOffsets[offset_index];
-            memcpy(&program_ptr->m_UniformData[offset], data, sizeof(Vectormath::Aos::Vector4));
+            memcpy(&program_ptr->m_UniformData[offset], data, sizeof(Vectormath::Aos::Vector4) * count);
         }
 
         if (index_fs != UNIFORM_LOCATION_MAX)
@@ -2461,7 +2463,7 @@ bail:
             // Fragment uniforms are packed behind vertex uniforms hence the extra offset here
             uint32_t offset_index = program_ptr->m_VertexModule->m_UniformBufferCount + res.m_UniformDataIndex;
             uint32_t offset       = program_ptr->m_UniformDataOffsets[offset_index];
-            memcpy(&program_ptr->m_UniformData[offset], data, sizeof(Vectormath::Aos::Vector4));
+            memcpy(&program_ptr->m_UniformData[offset], data, sizeof(Vectormath::Aos::Vector4) * count);
         }
     }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -264,6 +264,7 @@ namespace dmGraphics
         char*                      m_Name;
         uint64_t                   m_NameHash;
         ShaderDesc::ShaderDataType m_Type;
+        uint16_t                   m_ElementCount;
         uint16_t                   m_Set;
         uint16_t                   m_Binding;
         union

--- a/engine/render/proto/render/material_ddf.proto
+++ b/engine/render/proto/render/material_ddf.proto
@@ -25,7 +25,7 @@ message MaterialDesc
     {
         required string name = 1;
         required ConstantType type = 2;
-        optional dmMath.Vector4 value = 3;
+        repeated dmMath.Vector4 value = 3;
     }
 
     enum VertexSpace

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -86,12 +86,12 @@ namespace dmRender
      */
     struct Constant
     {
-        dmVMath::Vector4                        m_Value;
+        dmVMath::Vector4*                       m_ValuePtr;
         dmhash_t                                m_NameHash;
         dmRenderDDF::MaterialDesc::ConstantType m_Type;
         int32_t                                 m_Location;
+        uint16_t                                m_ArraySize;
 
-    // Private
         Constant();
         Constant(dmhash_t name_hash, int32_t location);
     };
@@ -158,6 +158,7 @@ namespace dmRender
      * @struct
      * @name RenderObject
      * @member m_Constants [type: dmRender::Constant[]] the shader constants
+     * @member m_ConstantsData [type: dmVMath::Vector4[]] the data memory block for the constant values
      * @member m_WorldTransform [type: dmVMath::Matrix4] the world transform (usually identity for batched objects)
      * @member m_TextureTransform [type: dmVMath::Matrix4] the texture transform
      * @member m_VertexBuffer [type: dmGraphics::HVertexBuffer] the vertex buffer
@@ -184,6 +185,7 @@ namespace dmRender
         static const uint32_t MAX_TEXTURE_COUNT = 8;
         static const uint32_t MAX_CONSTANT_COUNT = 16;
         Constant                        m_Constants[MAX_CONSTANT_COUNT];
+        dmVMath::Vector4                m_ConstantsData[MAX_CONSTANT_COUNT];
         dmVMath::Matrix4                m_WorldTransform;
         dmVMath::Matrix4                m_TextureTransform;
         dmGraphics::HVertexBuffer       m_VertexBuffer;
@@ -349,9 +351,10 @@ namespace dmRender
      * @name EnableRenderObjectConstant
      * @param ro [type: dmRender::RenderObject*] the render object
      * @param name_hash [type: dmhash_t] the name of the material constant
-     * @param value [type: dmVMath::Vector4] the constant
+     * @param values [type: dmVMath::Vector4*] the constant values
+     * @param num_values [type: uint32_t] length of value array
      */
-    void EnableRenderObjectConstant(RenderObject* ro, dmhash_t name_hash, const Vectormath::Aos::Vector4& value);
+    void EnableRenderObjectConstant(RenderObject* ro, dmhash_t name_hash, const Vectormath::Aos::Vector4* values, uint32_t num_values);
 
     /*#
      * Disables a previously set render constant on a render object

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -1015,14 +1015,14 @@ namespace dmRender
         ro->m_SetStencilTest = first_te.m_StencilTestParamsSet;
 
         Vector4 texture_size_recip(im_recip, ih_recip, cache_cell_width_ratio, cache_cell_height_ratio);
-        EnableRenderObjectConstant(ro, g_TextureSizeRecipHash, texture_size_recip);
+        EnableRenderObjectConstant(ro, g_TextureSizeRecipHash, &texture_size_recip, 1);
 
         const dmRender::Constant* constants = first_te.m_RenderConstants;
         uint32_t size = first_te.m_NumRenderConstants;
         for (uint32_t i = 0; i < size; ++i)
         {
             const dmRender::Constant& c = constants[i];
-            dmRender::EnableRenderObjectConstant(ro, c.m_NameHash, c.m_Value);
+            dmRender::EnableRenderObjectConstant(ro, c.m_NameHash, c.m_ValuePtr, c.m_ArraySize);
         }
 
         for (uint32_t *i = begin;i != end; ++i)

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -37,17 +37,20 @@ namespace dmRender
         const uint32_t buffer_size = 128;
         char buffer[buffer_size];
         dmGraphics::Type type;
+        int32_t size = 0;
 
+        uint32_t constants_data_size = 0;
         uint32_t constants_count = 0;
         uint32_t samplers_count = 0;
         for (uint32_t i = 0; i < total_constants_count; ++i)
         {
             type = (dmGraphics::Type) -1;
-            dmGraphics::GetUniformName(m->m_Program, i, buffer, buffer_size, &type);
+            dmGraphics::GetUniformName(m->m_Program, i, buffer, buffer_size, &type, &size);
 
             if (type == dmGraphics::TYPE_FLOAT_VEC4 || type == dmGraphics::TYPE_FLOAT_MAT4)
             {
                 constants_count++;
+                constants_data_size += sizeof(Vector4) * size;
             }
             else if (type == dmGraphics::TYPE_SAMPLER_2D || type == dmGraphics::TYPE_SAMPLER_CUBE)
             {
@@ -65,6 +68,12 @@ namespace dmRender
             m->m_Constants.SetCapacity(constants_count);
         }
 
+        if (constants_count > 0)
+        {
+            m->m_ConstantData = (Vector4*) malloc(constants_data_size);
+            memset(m->m_ConstantData, 0, constants_data_size);
+        }
+
         if (samplers_count > 0)
         {
             m->m_Samplers.SetCapacity(samplers_count);
@@ -74,9 +83,10 @@ namespace dmRender
             }
         }
 
+        dmVMath::Vector4* constant_data_ptr = m->m_ConstantData;
         for (uint32_t i = 0; i < total_constants_count; ++i)
         {
-            uint32_t name_str_length = dmGraphics::GetUniformName(m->m_Program, i, buffer, buffer_size, &type);
+            uint32_t name_str_length = dmGraphics::GetUniformName(m->m_Program, i, buffer, buffer_size, &type, &size);
             int32_t location         = dmGraphics::GetUniformLocation(m->m_Program, buffer);
 
             // DEF-2971-hotfix
@@ -91,13 +101,31 @@ namespace dmRender
             }
 
             assert(name_str_length > 0);
+
+            // For uniform arrays, OpenGL returns the name as "uniform[0]",
+            // but we want to identify it as the base name instead.
+            for (int j = 0; j < name_str_length; ++j)
+            {
+                if (buffer[j] == '[')
+                {
+                    buffer[j] = 0;
+                    break;
+                }
+            }
+
             dmhash_t name_hash = dmHashString64(buffer);
 
             if (type == dmGraphics::TYPE_FLOAT_VEC4 || type == dmGraphics::TYPE_FLOAT_MAT4)
             {
                 m->m_NameHashToLocation.Put(name_hash, location);
+                Constant render_constant(name_hash, location);
+                render_constant.m_ArraySize = size;
+                render_constant.m_ValuePtr  = constant_data_ptr;
+                constant_data_ptr          += size;
+
                 MaterialConstant constant;
-                constant.m_Constant = Constant(name_hash, location);
+                constant.m_Constant = render_constant;
+
                 if (type == dmGraphics::TYPE_FLOAT_VEC4)
                 {
                     size_t original_size = strlen(buffer);
@@ -136,6 +164,10 @@ namespace dmRender
     {
         dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
         dmGraphics::DeleteProgram(graphics_context, material->m_Program);
+
+        if (material->m_ConstantData)
+            free(material->m_ConstantData);
+
         delete material;
     }
 
@@ -153,7 +185,7 @@ namespace dmRender
             {
                 case dmRenderDDF::MaterialDesc::CONSTANT_TYPE_USER:
                 {
-                    dmGraphics::SetConstantV4(graphics_context, &constant.m_Value, location);
+                    dmGraphics::SetConstantV4(graphics_context, constant.m_ValuePtr, constant.m_ArraySize, location);
                     break;
                 }
                 case dmRenderDDF::MaterialDesc::CONSTANT_TYPE_VIEWPROJ:
@@ -318,7 +350,7 @@ namespace dmRender
         return false;
     }
 
-    bool GetMaterialProgramConstantInfo(HMaterial material, dmhash_t name_hash, dmhash_t* out_constant_id, dmhash_t* out_element_ids[4], uint32_t* out_element_index)
+    bool GetMaterialProgramConstantInfo(HMaterial material, dmhash_t name_hash, dmhash_t* out_constant_id, dmhash_t* out_element_ids[4], uint32_t* out_element_index, uint16_t* out_array_size)
     {
         dmArray<MaterialConstant>& constants = material->m_Constants;
         uint32_t n = constants.Size();
@@ -330,6 +362,7 @@ namespace dmRender
             {
                 *out_element_ids = c.m_ElementIds;
                 *out_constant_id = c.m_Constant.m_NameHash;
+                *out_array_size  = c.m_Constant.m_ArraySize;
                 return true;
             }
             for (uint32_t elem_i = 0; elem_i < 4; ++elem_i)
@@ -337,7 +370,8 @@ namespace dmRender
                 if (c.m_ElementIds[elem_i] == name_hash)
                 {
                     *out_element_index = elem_i;
-                    *out_constant_id = c.m_Constant.m_NameHash;
+                    *out_constant_id   = c.m_Constant.m_NameHash;
+                    *out_array_size    = c.m_Constant.m_ArraySize;
                     return true;
                 }
             }
@@ -354,23 +388,23 @@ namespace dmRender
             MaterialConstant& c = constants[i];
             if (c.m_Constant.m_NameHash == name_hash)
             {
-                out_value = c.m_Constant.m_Value.getElem(element_index);
+                out_value = c.m_Constant.m_ValuePtr[0].getElem(element_index);
                 return true;
             }
         }
         return false;
     }
 
-    void SetMaterialProgramConstant(HMaterial material, dmhash_t name_hash, Vector4 value)
+    void SetMaterialProgramConstant(HMaterial material, dmhash_t name_hash, Vector4* values, uint32_t count)
     {
         dmArray<MaterialConstant>& constants = material->m_Constants;
         uint32_t n = constants.Size();
         for (uint32_t i = 0; i < n; ++i)
         {
             MaterialConstant& c = constants[i];
-            if (c.m_Constant.m_NameHash == name_hash)
+            if (c.m_Constant.m_NameHash == name_hash && count <= c.m_Constant.m_ArraySize)
             {
-                c.m_Constant.m_Value = value;
+                memcpy(c.m_Constant.m_ValuePtr, values, sizeof(c.m_Constant.m_ValuePtr[0]) * count);
             }
         }
     }

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -56,7 +56,7 @@ namespace dmRender
 
     Constant::Constant() {}
     Constant::Constant(dmhash_t name_hash, int32_t location)
-        : m_Value(Vectormath::Aos::Vector4(0))
+        : m_ValuePtr(0)
         , m_NameHash(name_hash)
         , m_Type(dmRenderDDF::MaterialDesc::CONSTANT_TYPE_USER)
         , m_Location(location)
@@ -365,7 +365,7 @@ namespace dmRender
                 const Constant* c = &ro->m_Constants[i];
                 if (c->m_Location != -1)
                 {
-                    dmGraphics::SetConstantV4(graphics_context, &c->m_Value, c->m_Location);
+                    dmGraphics::SetConstantV4(graphics_context, c->m_ValuePtr, 1, c->m_Location);
                 }
             }
             return;
@@ -378,7 +378,7 @@ namespace dmRender
                 int32_t* location = material->m_NameHashToLocation.Get(ro->m_Constants[i].m_NameHash);
                 if (location)
                 {
-                    dmGraphics::SetConstantV4(graphics_context, &c->m_Value, *location);
+                    dmGraphics::SetConstantV4(graphics_context, c->m_ValuePtr, 1, *location);
                 }
             }
         }
@@ -737,7 +737,7 @@ namespace dmRender
         return DrawRenderList(context, &context->m_DebugRenderer.m_2dPredicate, 0);
     }
 
-    void EnableRenderObjectConstant(RenderObject* ro, dmhash_t name_hash, const Vector4& value)
+    void EnableRenderObjectConstant(RenderObject* ro, dmhash_t name_hash, const Vector4* values, uint32_t num_values)
     {
         assert(ro);
         HMaterial material = ro->m_Material;
@@ -750,18 +750,36 @@ namespace dmRender
             return;
         }
 
+        Constant material_constant;
+        GetMaterialProgramConstant(material, name_hash, material_constant);
+
+        Vector4* value_ptr     = ro->m_ConstantsData;
+        Vector4* value_ptr_end = value_ptr + RenderObject::MAX_CONSTANT_COUNT;
+
         for (uint32_t i = 0; i < RenderObject::MAX_CONSTANT_COUNT; ++i)
         {
             Constant* c = &ro->m_Constants[i];
+
+            if ((value_ptr + num_values) > value_ptr_end)
+            {
+                dmLogError("Out of per object constant slots, max %d, when setting constant '%s' '", RenderObject::MAX_CONSTANT_COUNT, dmHashReverseSafe64(name_hash));
+                return;
+            }
+
             if (c->m_Location == -1 || c->m_NameHash == name_hash)
             {
                 // New or current slot found
-                c->m_Value = value;
+                c->m_ValuePtr  = value_ptr;
+                c->m_ArraySize = material_constant.m_ArraySize;
+                memcpy(c->m_ValuePtr, values, sizeof(values[0]) * num_values);
+
                 c->m_NameHash = name_hash;
-                c->m_Type = dmRenderDDF::MaterialDesc::CONSTANT_TYPE_USER;
+                c->m_Type     = dmRenderDDF::MaterialDesc::CONSTANT_TYPE_USER;
                 c->m_Location = location;
                 return;
             }
+
+            value_ptr += c->m_ArraySize;
         }
 
         dmLogError("Out of per object constant slots, max %d, when setting constant '%s' '", RenderObject::MAX_CONSTANT_COUNT, dmHashReverseSafe64(name_hash));
@@ -863,7 +881,7 @@ namespace dmRender
         int32_t* location = context->m_Material->m_NameHashToLocation.Get(*name_hash);
         if (location)
         {
-            dmGraphics::SetConstantV4(context->m_GraphicsContext, value, *location);
+            dmGraphics::SetConstantV4(context->m_GraphicsContext, value, 1, *location);
         }
     }
 

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -74,8 +74,8 @@ namespace dmRender
 
     struct MaterialConstant
     {
-        Constant m_Constant;
-        dmhash_t m_ElementIds[4];
+        Constant  m_Constant;
+        dmhash_t  m_ElementIds[4];
     };
 
     struct RenderContextParams
@@ -207,7 +207,7 @@ namespace dmRender
      * @param out_element_index Set if the hash matched an element
      * @return True if a constant or element was found
      */
-    bool                            GetMaterialProgramConstantInfo(HMaterial material, dmhash_t name_hash, dmhash_t* out_constant_id, dmhash_t* out_element_ids[4], uint32_t* out_element_index);
+    bool                            GetMaterialProgramConstantInfo(HMaterial material, dmhash_t name_hash, dmhash_t* out_constant_id, dmhash_t* out_element_ids[4], uint32_t* out_element_index, uint16_t* out_num_components);
 
     /** Retrieve the value of a constant element
      * @param material Material containing the constant
@@ -217,7 +217,7 @@ namespace dmRender
      * @return True if the value was retrieved
      */
     bool                            GetMaterialProgramConstantElement(HMaterial material, dmhash_t name_hash, uint32_t element_index, float& out_value);
-    void                            SetMaterialProgramConstant(HMaterial material, dmhash_t name_hash, Vectormath::Aos::Vector4 constant);
+    void                            SetMaterialProgramConstant(HMaterial material, dmhash_t name_hash, Vectormath::Aos::Vector4* constant, uint32_t count);
     int32_t                         GetMaterialConstantLocation(HMaterial material, dmhash_t name_hash);
     void                            SetMaterialSampler(HMaterial material, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter);
     HRenderContext                  GetMaterialRenderContext(HMaterial material);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -60,12 +60,12 @@ namespace dmRender
 
     struct Material
     {
-
         Material()
         : m_RenderContext(0)
         , m_Program(0)
         , m_VertexProgram(0)
         , m_FragmentProgram(0)
+        , m_ConstantData(0)
         , m_UserData1(0)
         , m_UserData2(0)
         , m_VertexSpace(dmRenderDDF::MaterialDesc::VERTEX_SPACE_LOCAL)
@@ -79,6 +79,7 @@ namespace dmRender
         dmHashTable64<int32_t>                  m_NameHashToLocation;
         dmArray<MaterialConstant>               m_Constants;
         dmArray<Sampler>                        m_Samplers;
+        dmVMath::Vector4*                       m_ConstantData;
         uint32_t                                m_TagListKey;      // the key to use with GetMaterialTagList()
         uint64_t                                m_UserData1;
         uint64_t                                m_UserData2;

--- a/engine/render/src/test/test_material.cpp
+++ b/engine/render/src/test/test_material.cpp
@@ -85,7 +85,8 @@ TEST(dmMaterialTest, TestMaterialConstants)
     // renderobject default setup
     dmRender::RenderObject ro;
     ro.m_Material = material;
-    dmRender::EnableRenderObjectConstant(&ro, dmHashString64("tint"), Vector4(1.0f, 0.0f, 0.0f, 0.0f));
+    Vector4 test_v(1.0f, 0.0f, 0.0f, 0.0f);
+    dmRender::EnableRenderObjectConstant(&ro, dmHashString64("tint"), &test_v, 1);
 
     // test setting constant
     dmGraphics::HProgram program = dmRender::GetMaterialProgram(material);
@@ -135,7 +136,8 @@ TEST(dmMaterialTest, TestMaterialConstantsOverride)
     // renderobject default setup
     dmRender::RenderObject ro;
     ro.m_Material = material;
-    dmRender::EnableRenderObjectConstant(&ro, dmHashString64("tint"), Vector4(1.0f, 0.0f, 0.0f, 0.0f));
+    Vector4 test_v(1.0f, 0.0f, 0.0f, 0.0f);
+    dmRender::EnableRenderObjectConstant(&ro, dmHashString64("tint"), &test_v, 1);
 
     // using the null graphics device, constant locations are assumed to be in declaration order.
     // test setting constant, no override material
@@ -150,7 +152,8 @@ TEST(dmMaterialTest, TestMaterialConstantsOverride)
     ASSERT_EQ(0.0f, v.getW());
 
     // test setting constant, override material
-    dmRender::EnableRenderObjectConstant(&ro, dmHashString64("tint"), Vector4(2.0f, 1.0f, 1.0f, 1.0f));
+    test_v = Vector4(2.0f, 1.0f, 1.0f, 1.0f);
+    dmRender::EnableRenderObjectConstant(&ro, dmHashString64("tint"), &test_v, 1);
     ASSERT_EQ(0,  ro.m_Constants[0].m_Location);
     ASSERT_EQ(-1, ro.m_Constants[1].m_Location);
     ASSERT_EQ(-1, ro.m_Constants[2].m_Location);


### PR DESCRIPTION
Note: Re-introduces reverted changes from #5992.

This fixes issues related to the uniform array material file format change. It does not allow for editing uniform arrays in the editor, but it will produce correct binaries for the runtime.

It also ensures shaders are bound before textures in the editor. This fixes issues where certain objects would not be rendered in the editor viewport because of uniform validation code added in #4515.