### PR TITLE
Issue-6093 Do not throw `Unable to play animation` error, when changing texture for sprite

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1173,14 +1173,22 @@ namespace dmGameSystem
             // Since the animation referred to the old texture, we need to update it
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
-                // Try to maintain offset and rate
-                PlayAnimation(component, component->m_CurrentAnimation, GetCursor(component), component->m_PlaybackRate);
-
                 TextureSetResource* texture_set = GetTextureSet(component, component->m_Resource);
+                uint32_t* anim_id = texture_set->m_AnimationIds.Get(component->m_CurrentAnimation);
+                if (anim_id)
+                {
+                    PlayAnimation(component, component->m_CurrentAnimation, GetCursor(component), component->m_PlaybackRate);
+                }
+                else
+                {
+                    component->m_Playing = 0;
+                    component->m_CurrentAnimation = 0x0;
+                    component->m_CurrentAnimationFrame = 0;
+                }
                 sprite_world->m_ReallocBuffers |= (sprite_world->m_UseGeometries == 0 && texture_set->m_TextureSet->m_UseGeometries != 0) ? 1 : 0;
                 sprite_world->m_UseGeometries |= texture_set->m_TextureSet->m_UseGeometries;
+                return res;
             }
-            return res;
         }
         return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component);
     }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1187,8 +1187,8 @@ namespace dmGameSystem
                 }
                 sprite_world->m_ReallocBuffers |= (sprite_world->m_UseGeometries == 0 && texture_set->m_TextureSet->m_UseGeometries != 0) ? 1 : 0;
                 sprite_world->m_UseGeometries |= texture_set->m_TextureSet->m_UseGeometries;
-                return res;
             }
+            return res;
         }
         return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component);
     }


### PR DESCRIPTION

This Draft PR is made instead of design doc because it's easier to implement and show idea and throw it if it doesn't work.

-----

Possible fix for https://github.com/defold/defold/issues/6093

### Issue
When dev changes atlas for sprite component, but new atlas doesn't have an animation with the same name, the engine throws error:

>ERROR:GAMESYS: Unable to play animation 'i_log' from texture '/main/generated/atlases/items_containers1.texturec' since it could not be found.


```
go.property("atlas", resource.atlas("/new.atlas"))

function init(self)
    go.set("#sprite", "image", self.atlas)
end
```

### Solution

Not sure if it makes sense to complicate `go.set()` and add а possibility to set both texture and animation in one call (we don't use tables for `gi.set()` for now).
Instead, I just avoid error throwing and keep responsibility for animation changing to a dev. If he changes texture he should think about changing animation as well (in a separate `play_flipbook` call)

----
