### PR TITLE
Added support for ABGR in texc, in order to skip a java data copy loop

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
@@ -60,23 +60,24 @@ public class TexcLibrary {
         public static int L8                = 0;
         public static int R8G8B8            = 1;
         public static int R8G8B8A8          = 2;
-        public static int RGB_PVRTC_2BPPV1  = 3;
-        public static int RGB_PVRTC_4BPPV1  = 4;
-        public static int RGBA_PVRTC_2BPPV1 = 5;
-        public static int RGBA_PVRTC_4BPPV1 = 6;
-        public static int RGB_ETC1          = 7;
-        public static int R5G6B5            = 8;
-        public static int R4G4B4A4          = 9;
-        public static int L8A8              = 10;
+        public static int B8G8R8A8          = 3;
+        public static int RGB_PVRTC_2BPPV1  = 4;
+        public static int RGB_PVRTC_4BPPV1  = 5;
+        public static int RGBA_PVRTC_2BPPV1 = 6;
+        public static int RGBA_PVRTC_4BPPV1 = 7;
+        public static int RGB_ETC1          = 8;
+        public static int R5G6B5            = 9;
+        public static int R4G4B4A4          = 10;
+        public static int L8A8              = 11;
 
-        public static int RGBA_ETC2         = 11;
-        public static int RGBA_ASTC_4x4     = 12;
+        public static int RGBA_ETC2         = 12;
+        public static int RGBA_ASTC_4x4     = 13;
 
-        public static int RGB_BC1           = 13;
-        public static int RGBA_BC3          = 14;
-        public static int R_BC4             = 15;
-        public static int RG_BC5            = 16;
-        public static int RGBA_BC7          = 17;
+        public static int RGB_BC1           = 14;
+        public static int RGBA_BC3          = 15;
+        public static int R_BC4             = 16;
+        public static int RG_BC5            = 17;
+        public static int RGBA_BC7          = 18;
     }
 
     public interface ColorSpace {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/TexcLibrary.java
@@ -60,7 +60,7 @@ public class TexcLibrary {
         public static int L8                = 0;
         public static int R8G8B8            = 1;
         public static int R8G8B8A8          = 2;
-        public static int B8G8R8A8          = 3;
+        public static int A8B8G8R8          = 3;
         public static int RGB_PVRTC_2BPPV1  = 4;
         public static int RGB_PVRTC_4BPPV1  = 5;
         public static int RGBA_PVRTC_2BPPV1 = 6;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -278,6 +278,7 @@ public class TextureGenerator {
 
         Pointer texture = TexcLibrary.TEXC_Create(width, height, PixelFormat.R8G8B8A8, ColorSpace.SRGB, texcCompressionType, buffer);
         Pointer texture = TexcLibrary.TEXC_Create(width, height, PixelFormat.B8G8R8A8, ColorSpace.SRGB, texcCompressionType, buffer_input);
+        Pointer texture = TexcLibrary.TEXC_Create(width, height, PixelFormat.A8B8G8R8, ColorSpace.SRGB, texcCompressionType, buffer_input);
         if (texture == null) {
             throw new TextureGeneratorException("Failed to create texture");
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -220,20 +220,6 @@ public class TextureGenerator {
 
     private static TextureImage.Image generateFromColorAndFormat(BufferedImage image, ColorModel colorModel, TextureFormat textureFormat, TextureFormatAlternative.CompressionLevel compressionLevel, TextureImage.CompressionType compressionType, boolean generateMipMaps, int maxTextureSize, boolean compress, boolean premulAlpha, EnumSet<FlipAxis> flipAxis) throws TextureGeneratorException, IOException {
 
-        long startTime = System.currentTimeMillis();
-
-
-        long time_readbuffer = 0;
-        long time_create = 0;
-        long time_premulalpha = 0;
-        long time_genmipMaps = 0;
-        long time_flip = 0;
-        long time_resize = 0;
-        long time_encode = 0;
-        long time_getdata = 0;
-        long time_getmipMaps = 0;
-
-
         int width = image.getWidth();
         int height = image.getHeight();
         int componentCount = colorModel.getNumComponents();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -385,7 +385,6 @@ public class TextureGenerator {
                     break;
             }
 
-            raw.setData(ByteString.copyFrom(buffer));
             raw.setData(ByteString.copyFrom(buffer_output));
             raw.setFormat(textureFormat);
             raw.setCompressionType(compressionType);
@@ -396,7 +395,6 @@ public class TextureGenerator {
         } finally {
             TexcLibrary.TEXC_Destroy(texture);
         }
-
     }
 
     // For convenience, some methods without the flipAxis and/or compress argument.

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -276,8 +276,6 @@ public class TextureGenerator {
             throw new TextureGeneratorException("Invalid texture format.");
         }
 
-        Pointer texture = TexcLibrary.TEXC_Create(width, height, PixelFormat.R8G8B8A8, ColorSpace.SRGB, texcCompressionType, buffer);
-        Pointer texture = TexcLibrary.TEXC_Create(width, height, PixelFormat.B8G8R8A8, ColorSpace.SRGB, texcCompressionType, buffer_input);
         Pointer texture = TexcLibrary.TEXC_Create(width, height, PixelFormat.A8B8G8R8, ColorSpace.SRGB, texcCompressionType, buffer_input);
         if (texture == null) {
             throw new TextureGeneratorException("Failed to create texture");

--- a/engine/texc/src/texc.h
+++ b/engine/texc/src/texc.h
@@ -29,6 +29,7 @@ namespace dmTexc
         PF_L8,
         PF_R8G8B8,
         PF_R8G8B8A8,
+        PF_A8B8G8R8,
         PF_RGB_PVRTC_2BPPV1,
         PF_RGB_PVRTC_4BPPV1,
         PF_RGBA_PVRTC_2BPPV1,

--- a/engine/texc/src/texc_private.cpp
+++ b/engine/texc/src/texc_private.cpp
@@ -177,6 +177,22 @@ namespace dmTexc
         }
     }
 
+    void ABGR8888ToRGBA8888(const uint8_t* data, const uint32_t width, const uint32_t height, uint8_t* color_rgba)
+    {
+        for(uint32_t i = 0; i < width*height; ++i)
+        {
+            uint8_t a = *(data++);
+            uint8_t b = *(data++);
+            uint8_t g = *(data++);
+            uint8_t r = *(data++);
+
+            *(color_rgba++) = r;
+            *(color_rgba++) = g;
+            *(color_rgba++) = b;
+            *(color_rgba++) = a;
+        }
+    }
+
     void RGBA8888ToRGB888(const uint8_t* data, const uint32_t width, const uint32_t height, uint8_t* color_rgb)
     {
         for(uint32_t i = 0; i < width*height; ++i)
@@ -236,6 +252,7 @@ namespace dmTexc
         switch(pf)
         {
         case PF_R8G8B8A8:
+        case PF_A8B8G8R8:
         case PF_RGBA_PVRTC_2BPPV1:
         case PF_RGBA_PVRTC_4BPPV1:
         case PF_R4G4B4A4:
@@ -265,6 +282,7 @@ namespace dmTexc
         switch(pf)
         {
         case PF_R8G8B8A8:   return 4;
+        case PF_A8B8G8R8:   return 4;
         case PF_R8G8B8:     return 3;
         case PF_R4G4B4A4:   return 2;
         case PF_L8A8:       return 2;
@@ -292,6 +310,7 @@ namespace dmTexc
         case PF_R8G8B8:     RGB888ToRGBA8888(input, width, height, out); break;
         case PF_R5G6B5:     RGB565ToRGBA8888((uint16_t*)input, width, height, out); break;
         case PF_R4G4B4A4:   RGBA4444ToRGBA8888((uint16_t*)input, width, height, out); break;
+        case PF_A8B8G8R8:   ABGR8888ToRGBA8888(input, width, height, out); break;
         case PF_R8G8B8A8:   memcpy(out, input, width*height*4); break;
         default:
             dmLogError("Format not yet supported: %d", pf);


### PR DESCRIPTION
Saves ~20-25% in the case of the spineboy atlas. (~100-125ms for the copy step)