### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
+++ b/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
@@ -13,6 +13,7 @@
         {{#has-icons?}}
         android:icon="@drawable/icon"
         {{/has-icons?}}
+        tools:replace="android:label"
         android:label="{{project.title}}" android:hasCode="true"
         android:name="android.support.multidex.MultiDexApplication"
         android:debuggable="{{android.debuggable}}">


### PR DESCRIPTION
tryed to add applovin ironsource adapter  (https://github.com/SalavatR/defold-maxsdk/blob/fd6903cdcefd9e14f685c0b54dc13fa69ce81dcf/def_applovin_maxsdk/manifests/android/build.gradle#L22)

Build fails with error:
**Android Manifest merger failed: Attribute application@label value=(@string/app_name)**