### PR TITLE
[DEFEDIT] Issue 6164: Ensure editor builds can see changes from pre-build hooks

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -213,6 +213,7 @@
                                                     "-Ddefold.log.dir="
                                                     "-Djogl.debug.DebugGL" ; TraceGL is also useful
                                                     "-Djogl.texture.notexrect=true"
+                                                    "-XX:MaxRAMPercentage=75"
                                                     ;"-XX:+UnlockCommercialFeatures"
                                                     ;"-XX:+FlightRecorder"
                                                     "-XX:-OmitStackTraceInFastThrow"

--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -14,8 +14,6 @@
   (:require [clojure.set :as set]
             [dynamo.graph :as g]
             [editor.defold-project :as project]
-            [editor.editor-extensions :as extensions]
-            [editor.engine :as engine]
             [editor.pipeline :as pipeline]
             [editor.progress :as progress]
             [editor.workspace :as workspace]))
@@ -42,33 +40,20 @@
 
 (defn build-project!
   [project node evaluation-context extra-build-targets old-artifact-map render-progress!]
-  (if-let [extension-error (extensions/execute-hook! project :on-build-started {:exception-policy :as-error
-                                                                                :opts {:platform (engine/current-platform)}})]
-    (do
-      (extensions/execute-hook! project :on-build-finished {:exception-policy :ignore
-                                                            :opts {:success false
-                                                                   :platform (engine/current-platform)}})
-      {:error extension-error})
-    (let [steps (atom [])
-          collect-tracer (make-collect-progress-steps-tracer :build-targets steps)
-          _ (g/node-value node :build-targets (assoc evaluation-context :dry-run true :tracer collect-tracer))
-          progress-message-fn (partial compiling-progress-message (set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context)))
-          step-count (count @steps)
-          progress-tracer (project/make-progress-tracer :build-targets step-count progress-message-fn (progress/nest-render-progress render-progress! (progress/make "" 10) 5))
-          evaluation-context-with-progress-trace (assoc evaluation-context :tracer progress-tracer)
-          prewarm-partitions (partition-all (max (quot step-count (+ (available-processors) 2)) 1000) (rseq @steps))
-          _ (batched-pmap (fn [node-id] (g/node-value node-id :build-targets evaluation-context-with-progress-trace)) prewarm-partitions)
-          node-build-targets (g/node-value node :build-targets evaluation-context)
-          build-targets (cond-> node-build-targets
-                                (seq extra-build-targets)
-                                (into extra-build-targets))
-          build-dir (workspace/build-path (project/workspace project))
-          ret (if (g/error? build-targets)
-                {:error build-targets}
-                (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5)))]
-      (extensions/execute-hook! project
-                                :on-build-finished
-                                {:exception-policy :ignore
-                                 :opts {:success (not (:error ret))
-                                        :platform (engine/current-platform)}})
-      ret)))
+  (let [steps (atom [])
+        collect-tracer (make-collect-progress-steps-tracer :build-targets steps)
+        _ (g/node-value node :build-targets (assoc evaluation-context :dry-run true :tracer collect-tracer))
+        progress-message-fn (partial compiling-progress-message (set/map-invert (g/node-value project :nodes-by-resource-path evaluation-context)))
+        step-count (count @steps)
+        progress-tracer (project/make-progress-tracer :build-targets step-count progress-message-fn (progress/nest-render-progress render-progress! (progress/make "" 10) 5))
+        evaluation-context-with-progress-trace (assoc evaluation-context :tracer progress-tracer)
+        prewarm-partitions (partition-all (max (quot step-count (+ (available-processors) 2)) 1000) (rseq @steps))
+        _ (batched-pmap (fn [node-id] (g/node-value node-id :build-targets evaluation-context-with-progress-trace)) prewarm-partitions)
+        node-build-targets (g/node-value node :build-targets evaluation-context)
+        build-targets (cond-> node-build-targets
+                              (seq extra-build-targets)
+                              (into extra-build-targets))
+        build-dir (workspace/build-path (project/workspace project))]
+    (if (g/error? build-targets)
+      {:error build-targets}
+      (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5)))))

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -739,10 +739,11 @@
       (vreset! (:request-sync *execution-context*) true))
     file-path))
 
-(defn- find-resource [project evaluation-context path]
-  (some-> (project/get-resource-node project path evaluation-context)
-          (g/node-value :lines evaluation-context)
-          (data/lines-input-stream)))
+(defn- find-resource [project path]
+  (g/with-auto-evaluation-context evaluation-context
+    (some-> (project/get-resource-node project path evaluation-context)
+            (g/node-value :lines evaluation-context)
+            (data/lines-input-stream))))
 
 (defn- remove-file [^Path project-path ^String file-name]
   (let [file-path (ensure-file-path-in-project-directory project-path file-name)
@@ -766,7 +767,7 @@
                                .toPath
                                .normalize)
               env (luart/make-env
-                    :find-resource #(find-resource project ec %)
+                    :find-resource #(find-resource project %)
                     :open-file #(open-file project-path %1 %2)
                     :out #(display-output! ui %1 %2)
                     :globals {"editor" {"get" do-ext-get

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -15,14 +15,14 @@
             [clojure.string :as string]
             [cognitect.transit :as transit]
             [dynamo.graph :as g]
-            [schema.core :as s]
             [editor.core :as core]
             [editor.fs :as fs]
-            [util.digest :as digest])
-  (:import [java.io ByteArrayOutputStream File IOException]
-           [java.nio.file FileSystem FileSystems]
+            [util.digest :as digest]
+            [schema.core :as s])
+  (:import [java.io File IOException InputStream FilterInputStream]
            [java.net URI]
-           [java.util.zip ZipEntry ZipInputStream]
+           [java.nio.file FileSystem FileSystems]
+           [java.util.zip ZipEntry ZipFile ZipInputStream]
            [org.apache.commons.io FilenameUtils IOUtils]))
 
 (set! *warn-on-reflection* true)
@@ -207,13 +207,23 @@
 (defn make-memory-resource [workspace resource-type data]
   (MemoryResource. workspace (:ext resource-type) data))
 
-(defrecord ZipResource [workspace ^URI zip-uri name path data children]
+(defn- make-zip-resource-input-stream
+  ^InputStream [zip-resource]
+  (let [zip-file (ZipFile. ^File (io/as-file (:zip-uri zip-resource)))
+        zip-entry (.getEntry zip-file (:zip-entry zip-resource))]
+    (proxy [FilterInputStream] [(.getInputStream zip-file zip-entry)]
+      (close []
+        (let [^FilterInputStream this this]
+          (proxy-super close)
+          (.close zip-file))))))
+
+(defrecord ZipResource [workspace ^URI zip-uri name path zip-entry children]
   Resource
   (children [this] children)
   (ext [this] (FilenameUtils/getExtension name))
   (resource-type [this] (get (g/node-value workspace :resource-types) (type-ext this)))
   (source-type [this] (if (zero? (count children)) :file :folder))
-  (exists? [this] (not (nil? data)))
+  (exists? [this] (not (nil? zip-entry)))
   (read-only? [this] true)
   (path [this] path)
   (abs-path [this] nil)
@@ -224,24 +234,21 @@
   (openable? [this] (= :file (source-type this)))
 
   io/IOFactory
-  (io/make-input-stream  [this opts] (io/make-input-stream (:data this) opts))
+  (io/make-input-stream  [this opts] (make-zip-resource-input-stream this))
   (io/make-reader        [this opts] (io/make-reader (io/make-input-stream this opts) opts))
   (io/make-output-stream [this opts] (throw (Exception. "Zip resources are read-only")))
   (io/make-writer        [this opts] (throw (Exception. "Zip resources are read-only")))
 
   io/Coercions
-  (io/as-file [this]
-    (let [zip-url (.toURL zip-uri)]
-      (when (= (.getPath zip-url) (.getFile zip-url))
-        (io/file (.getFile zip-url))))))
+  (io/as-file [this] (io/as-file zip-uri)))
 
 (core/register-record-type! ZipResource)
 
 (core/register-read-handler!
  "zip-resource"
  (transit/read-handler
-  (fn [{:keys [workspace ^String zip-uri name path data children]}]
-    (ZipResource. workspace (URI. zip-uri) name path data children))))
+  (fn [{:keys [workspace ^String zip-uri name path zip-entry children]}]
+    (ZipResource. workspace (URI. zip-uri) name path zip-entry children))))
 
 (core/register-write-handler!
  ZipResource
@@ -252,57 +259,50 @@
      :zip-uri   (.toString ^URI (:zip-uri r))
      :name      (:name r)
      :path      (:path r)
-     :data      (:data r)     
+     :zip-entry (:zip-entry r)
      :children  (:children r)})))
 
 (defmethod print-method ZipResource [zip-resource ^java.io.Writer w]
   (.write w (format "{:ZipResource %s}" (pr-str (proj-path zip-resource)))))
 
-(defn- read-zip-entry [^ZipInputStream zip ^ZipEntry e]
-  (let [os (ByteArrayOutputStream.)
-        buf (byte-array (* 1024 16))]
-    (loop [n (.read zip buf 0 (count buf))]
-     (when (> n 0)
-       (.write os buf 0 n)
-       (recur (.read zip buf 0 (count buf)))))
-    (.toByteArray os)))
-
 (defn- outside-base-path? [base-path ^ZipEntry entry]
   (and (seq base-path) (not (.startsWith (->unix-seps (.getName entry)) (str base-path "/")))))
 
-(defn- path-relative-base [base-path ^ZipEntry entry]
-  (let [entry-name (->unix-seps (.getName entry))]
+(defn- path-relative-base [base-path zip-entry-name]
+  (let [clean-zip-entry-name (->unix-seps zip-entry-name)]
     (if (seq base-path)
-      (.replaceFirst entry-name (str base-path "/") "")
-      entry-name)))
+      (.replaceFirst clean-zip-entry-name (str base-path "/") "")
+      clean-zip-entry-name)))
 
-(defn- load-zip [file-or-url base-path]
-  (when-let [stream (and file-or-url (io/input-stream file-or-url))]
+(defn- load-zip [^File zip-file ^String base-path]
+  (when-let [stream (some-> zip-file io/input-stream)]
     (with-open [zip (ZipInputStream. stream)]
-      (loop [entries []]
-        (let [e (.getNextEntry zip)]
-          (if-not e
-            entries
-            (recur (if (or (.isDirectory e) (outside-base-path? base-path e))
-                     entries
-                     (conj entries {:name (FilenameUtils/getName (.getName e))
-                                    :path (path-relative-base base-path e)
-                                    :buffer (read-zip-entry zip e)
-                                    :crc (.getCrc e)})))))))))
+      (loop [entries (transient [])]
+        (if-some [zip-entry (.getNextEntry zip)]
+          (recur (if (or (.isDirectory zip-entry)
+                         (outside-base-path? base-path zip-entry))
+                   entries
+                   (let [zip-entry-name (.getName zip-entry)]
+                     (conj! entries {:name (FilenameUtils/getName zip-entry-name)
+                                     :path (path-relative-base base-path zip-entry-name)
+                                     :zip-entry zip-entry-name
+                                     :crc (.getCrc zip-entry)}))))
+          (persistent! entries))))))
 
 (defn- ->zip-resources [workspace zip-uri path [key val]]
   (let [path' (if (string/blank? path) key (str path "/" key))]
-    (if (:path val) ; i.e. we've reached an actual entry with name, path, buffer
-      (ZipResource. workspace zip-uri (:name val) (:path val) (:buffer val) nil)
-      (ZipResource. workspace zip-uri key path' nil (mapv (fn [x] (->zip-resources workspace zip-uri path' x)) val)))))
+    (if (:path val) ; i.e. we've reached an actual entry with name, path, zip-entry
+      (ZipResource. workspace zip-uri (:name val) (:path val) (:zip-entry val) nil)
+      (ZipResource. workspace zip-uri key path' nil (mapv #(->zip-resources workspace zip-uri path' %) val)))))
 
 (defn load-zip-resources
-  ([workspace file-or-url]
-   (load-zip-resources workspace file-or-url nil))
-  ([workspace file-or-url base-path]
-   (let [entries (load-zip file-or-url base-path)]
+  ([workspace ^File zip-file]
+   (load-zip-resources workspace zip-file nil))
+  ([workspace ^File zip-file ^String base-path]
+   (let [entries (load-zip zip-file base-path)
+         zip-uri (.toURI zip-file)]
      {:tree (->> (reduce (fn [acc node] (assoc-in acc (string/split (:path node) #"/") node)) {} entries)
-                 (mapv (fn [x] (->zip-resources workspace (.toURI (io/as-url file-or-url)) "" x))))
+                 (mapv (fn [x] (->zip-resources workspace zip-uri "" x))))
       :crc (into {} (map (juxt (fn [e] (str "/" (:path e))) :crc) entries))})))
 
 (g/defnode ResourceNode

--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -85,7 +85,7 @@
         lib-states))
 
 (defn- make-builtins-snapshot [workspace]
-  (let [resources (:tree (resource/load-zip-resources workspace (io/resource "builtins.zip")))
+  (let [resources (some->> "builtins.zip" io/resource io/as-file (resource/load-zip-resources workspace) :tree)
         flat-resources (resource/resource-list-seq resources)]
     {:resources resources
      :status-map (into {} (map (juxt resource/proj-path (constantly {:version :constant :source :builtins})) flat-resources))}))

--- a/editor/styling/stylesheets/components/_scroll-bar.scss
+++ b/editor/styling/stylesheets/components/_scroll-bar.scss
@@ -1,5 +1,5 @@
 .scroll-bar {
-    -fx-background-color: -df-background;
+    -fx-background-color: -df-background-light;
     &:horizontal {
         -fx-background-insets: 0px -1px -1px -1px;
         //-fx-padding: 2px -1px -1px -1px;

--- a/editor/styling/stylesheets/modules/_diff-view.scss
+++ b/editor/styling/stylesheets/modules/_diff-view.scss
@@ -24,7 +24,7 @@
 
   .code-view {
     -fx-pref-width: 300px;
-    -fx-background-color: -df-background-lighter;
+    -fx-background-color: -df-background-light;
   }
 
   .code-view-header {


### PR DESCRIPTION
Fixes #2811
Fixes #6164

### User-facing changes
* Fixed an issue where the project build would not see changes made by pre-build hooks.
* Projects that use native extensions will now build them in parallel with the project content, resulting in slightly faster builds.
* Scroll bars now blend into the panel background like they used to.
* Changes lines in the Diff View are now highlighted again.

### Technical changes
* The project build now obtains an `evalutation-context` for the background threads after any changes made by pre-build hooks have been incorporated into the project.
* We now submit the native extension build job to the server directly after the pre-build hooks have been run, so the engine will be built in parallel with the project content.
* The editor scripts no longer use a stale `evaluation-context` for locating editor script resources.
* `ZipResource` contents are no longer unpacked and kept around as byte arrays in memory.
* Fixed a few stylesheet errors.