### PR TITLE
DEFEDIT Fix freeze at project load time when an editor script requires another Lua module

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -351,11 +351,20 @@ def smoke_test():
     call('python scripts/build.py distclean install_ext smoke_test')
 
 
-# https://stackoverflow.com/a/55276236/1266551
+
 def get_branch():
-    branch = call("git rev-parse --abbrev-ref HEAD").strip()
-    if branch == "HEAD":
-        branch = call("git rev-parse HEAD")
+    # The name of the head branch. Only set for pull request events.
+    branch = os.environ.get('GITHUB_HEAD_REF', '')
+    if branch is '':
+        # The branch or tag name that triggered the workflow run.
+        branch = os.environ.get('GITHUB_REF_NAME', '')
+
+    if branch is '':
+        # https://stackoverflow.com/a/55276236/1266551
+        branch = call("git rev-parse --abbrev-ref HEAD").strip()
+        if branch == "HEAD":
+            branch = call("git rev-parse HEAD")
+
     return branch
 
 def is_workflow_enabled_in_repo():

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -740,7 +740,11 @@
     file-path))
 
 (defn- find-resource [project path]
-  (g/with-auto-evaluation-context evaluation-context
+  ;; Use a throwaway evaluation-context, since this may be called from within a
+  ;; g/user-data-swap! update function, in which case a cache update will force
+  ;; a retry, sending us into an infinite loop.
+  ;; TODO: Consider not using g/user-data-swap! in the reload! function below.
+  (let [evaluation-context (g/make-evaluation-context {:basis (g/now)})]
     (some-> (project/get-resource-node project path evaluation-context)
             (g/node-value :lines evaluation-context)
             (data/lines-input-stream))))


### PR DESCRIPTION
### User-facing changes
* Fix for the project load dialog freezing at "ready" if the project contains an `editor_script` that uses the Lua `require` function to import another Lua module.