### PR TITLE
Fix build exception when local cache is enabled but no remote cache is set up

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCache.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCache.java
@@ -166,6 +166,6 @@ public class ResourceCache {
 			return false;
 		}
 		File f = fileFromKey(key);
-		return f.exists() || http.exists(urlFromFile(f));
+		return f.exists() || (remoteCacheUrl != null && http.exists(urlFromFile(f)));
 	}
 }


### PR DESCRIPTION
If try to build project with 190 version and enable only local cache we get build exception.

**Steps to reproduce**
1. Clone git@github.com:defold/defold-examples.git
2. Download bob.jar for 190 version
3. Run command `java -jar ./bob.jar --with-symbols --archive --platform armv7-darwin --architectures arm64-darwin --resource-cache-local $(pwd)/build-cache distclean build bundle`

**Result**
Got following exception
```
Building...java.net.MalformedURLException: no protocol: null/4bd3b916445e1f1d7479f0e2f06dd8847aa37ff2
	at java.base/java.net.URL.<init>(URL.java:674)
	at java.base/java.net.URL.<init>(URL.java:569)
	at java.base/java.net.URL.<init>(URL.java:516)
	at com.dynamo.bob.cache.ResourceCache.urlFromFile(ResourceCache.java:54)
	at com.dynamo.bob.cache.ResourceCache.contains(ResourceCache.java:169)
	at com.dynamo.bob.Project.runTasks(Project.java:1319)
	at com.dynamo.bob.Project.doBuild(Project.java:1135)
	at com.dynamo.bob.Project.build(Project.java:584)
	at com.dynamo.bob.Bob.mainInternal(Bob.java:708)
	at com.dynamo.bob.Bob.main(Bob.java:757)
```