### PR TITLE
Issue-5591 Add API hooks for logging

### DIFF
--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -31,576 +31,581 @@
 #include <android/log.h>
 #endif
 
-const char* LOG_OUTPUT_TRUNCATED_MESSAGE = "...\n[Output truncated]\n";
-const int DM_LOG_MAX_LOG_FILE_SIZE = 1024 * 1024 * 32;
-
-struct dmLogConnection
+namespace dmLog
 {
-    dmLogConnection()
+
+    const char* LOG_OUTPUT_TRUNCATED_MESSAGE = "...\n[Output truncated]\n";
+    const int MAX_LOG_FILE_SIZE = 1024 * 1024 * 32;
+
+    struct dmLogConnection
     {
-        m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
-    }
+        dmLogConnection()
+        {
+            m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
+        }
 
-    dmSocket::Socket m_Socket;
-};
+        dmSocket::Socket m_Socket;
+    };
 
-static const uint32_t DLIB_MAX_LOG_CONNECTIONS = 16;
+    static const uint32_t DLIB_MAX_LOG_CONNECTIONS = 16;
 
-struct dmLogServer
-{
-    dmLogServer(dmSocket::Socket server_socket, uint16_t port,
-                 dmMessage::HSocket message_socket)
+    struct dmLogServer
     {
-        m_Connections.SetCapacity(DLIB_MAX_LOG_CONNECTIONS);
-        m_ServerSocket = server_socket;
-        m_Port = port;
-        m_MessgeSocket = message_socket;
-        m_Thread = 0;
-    }
+        dmLogServer(dmSocket::Socket server_socket, uint16_t port,
+                     dmMessage::HSocket message_socket)
+        {
+            m_Connections.SetCapacity(DLIB_MAX_LOG_CONNECTIONS);
+            m_ServerSocket = server_socket;
+            m_Port = port;
+            m_MessgeSocket = message_socket;
+            m_Thread = 0;
+        }
 
-    dmArray<dmLogConnection> m_Connections;
-    dmSocket::Socket         m_ServerSocket;
-    uint16_t                 m_Port;
-    dmMessage::HSocket       m_MessgeSocket;
-    dmThread::Thread         m_Thread;
-};
+        dmArray<dmLogConnection> m_Connections;
+        dmSocket::Socket         m_ServerSocket;
+        uint16_t                 m_Port;
+        dmMessage::HSocket       m_MessgeSocket;
+        dmThread::Thread         m_Thread;
+    };
 
-static dmLogServer* g_dmLogServer = 0;
-static dmLogSeverity g_LogLevel = DM_LOG_SEVERITY_USER_DEBUG;
-static int g_TotalBytesLogged = 0;
-static FILE* g_LogFile = 0;
-static dmCustomLogCallback g_CustomLogCallback = 0;
-static void* g_CustomLogCallbackUserData = 0;
+    static dmLogServer* g_dmLogServer = 0;
+    static Severity g_LogLevel = SEVERITY_USER_DEBUG;
+    static int g_TotalBytesLogged = 0;
+    static FILE* g_LogFile = 0;
+    static CustomLogCallback g_CustomLogCallback = 0;
+    static void* g_CustomLogCallbackUserData = 0;
 
-// create and bind the server socket, will reuse old port if supplied handle valid
-static void dmLogInitSocket( dmSocket::Socket& server_socket )
-{
-    if (!dLib::IsDebugMode() || !dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP))
+    // create and bind the server socket, will reuse old port if supplied handle valid
+    static void dmLogInitSocket( dmSocket::Socket& server_socket )
+    {
+        if (!dLib::IsDebugMode() || !dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP))
+            return;
+
+        dmSocket::Result r;
+        dmSocket::Address address;
+        uint16_t port = 0;
+        char error_msg[1024] = { 0 };
+
+        // If the env variable DM_LOG_PORT is set we will try to use
+        // that as port for the log server instead of a dynamic one.
+        const char* env_log_port = getenv("DM_LOG_PORT");
+        if (env_log_port != 0x0)
+        {
+            long t_port = strtol(env_log_port, 0, 10);
+            if (t_port > 0 && t_port < UINT16_MAX)
+            {
+                port = t_port;
+            }
+        }
+
+        if (server_socket != dmSocket::INVALID_SOCKET_HANDLE)
+        {
+            r = dmSocket::GetName(server_socket, &address, &port); // need to reuse the port
+            if (r != dmSocket::RESULT_OK)
+            {
+                snprintf(error_msg, sizeof(error_msg), "Unable to retrieve socket information (%d): %s", r, dmSocket::ResultToString(r));
+                goto bail;
+            }
+
+            r = dmSocket::Delete(server_socket);
+            server_socket = dmSocket::INVALID_SOCKET_HANDLE;
+            if (r != dmSocket::RESULT_OK)
+            {
+                snprintf(error_msg, sizeof(error_msg), "Unable to delete old log socket (%d): %s", r, dmSocket::ResultToString(r));
+                goto bail;
+            }
+        }
+        else
+        {
+            r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV4, &address);
+            if (r != dmSocket::RESULT_OK)
+            {
+                snprintf(error_msg, sizeof(error_msg), "Unable to get listening address for log socket (%d): %s", r, dmSocket::ResultToString(r));
+                goto bail;
+            }
+        }
+
+        r = dmSocket::New(address.m_family, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &server_socket);
+        if (r != dmSocket::RESULT_OK)
+        {
+            snprintf(error_msg, sizeof(error_msg), "Unable to create log socket (%d): %s", r, dmSocket::ResultToString(r));
+            goto bail;
+        }
+
+        dmSocket::SetReuseAddress(server_socket, true);
+        r = dmSocket::Bind(server_socket, address, port);
+        if (r != dmSocket::RESULT_OK)
+        {
+            snprintf(error_msg, sizeof(error_msg), "Unable to bind to log socket (%d): %s", r, dmSocket::ResultToString(r));
+            goto bail;
+        }
+
+        r = dmSocket::Listen(server_socket, 32);
+        if (r != dmSocket::RESULT_OK)
+        {
+            snprintf(error_msg, sizeof(error_msg), "Unable to listen on log socket (%d): %s", r, dmSocket::ResultToString(r));
+            goto bail;
+        }
+
         return;
 
-    dmSocket::Result r;
-    dmSocket::Address address;
-    uint16_t port = 0;
-    char error_msg[1024] = { 0 };
+    bail:
+        fprintf(stderr, "ERROR:DLIB: %s\n", error_msg);
+        if (server_socket != dmSocket::INVALID_SOCKET_HANDLE)
+            dmSocket::Delete(server_socket);
 
-    // If the env variable DM_LOG_PORT is set we will try to use
-    // that as port for the log server instead of a dynamic one.
-    const char* env_log_port = getenv("DM_LOG_PORT");
-    if (env_log_port != 0x0)
-    {
-        long t_port = strtol(env_log_port, 0, 10);
-        if (t_port > 0 && t_port < UINT16_MAX)
-        {
-            port = t_port;
-        }
-    }
-
-    if (server_socket != dmSocket::INVALID_SOCKET_HANDLE)
-    {
-        r = dmSocket::GetName(server_socket, &address, &port); // need to reuse the port
-        if (r != dmSocket::RESULT_OK)
-        {
-            snprintf(error_msg, sizeof(error_msg), "Unable to retrieve socket information (%d): %s", r, dmSocket::ResultToString(r));
-            goto bail;
-        }
-
-        r = dmSocket::Delete(server_socket);
         server_socket = dmSocket::INVALID_SOCKET_HANDLE;
-        if (r != dmSocket::RESULT_OK)
+    }
+
+    static dmSocket::Result SendAll(dmSocket::Socket socket, const char* buffer, int length)
+    {
+        int total_sent_bytes = 0;
+        int sent_bytes = 0;
+
+        while (total_sent_bytes < length)
         {
-            snprintf(error_msg, sizeof(error_msg), "Unable to delete old log socket (%d): %s", r, dmSocket::ResultToString(r));
-            goto bail;
-        }
-    }
-    else
-    {
-        r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV4, &address);
-        if (r != dmSocket::RESULT_OK)
-        {
-            snprintf(error_msg, sizeof(error_msg), "Unable to get listening address for log socket (%d): %s", r, dmSocket::ResultToString(r));
-            goto bail;
-        }
-    }
+            dmSocket::Result r = dmSocket::Send(socket, buffer + total_sent_bytes, length - total_sent_bytes, &sent_bytes);
+            if (r == dmSocket::RESULT_TRY_AGAIN)
+                continue;
 
-    r = dmSocket::New(address.m_family, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &server_socket);
-    if (r != dmSocket::RESULT_OK)
-    {
-        snprintf(error_msg, sizeof(error_msg), "Unable to create log socket (%d): %s", r, dmSocket::ResultToString(r));
-        goto bail;
-    }
-
-    dmSocket::SetReuseAddress(server_socket, true);
-    r = dmSocket::Bind(server_socket, address, port);
-    if (r != dmSocket::RESULT_OK)
-    {
-        snprintf(error_msg, sizeof(error_msg), "Unable to bind to log socket (%d): %s", r, dmSocket::ResultToString(r));
-        goto bail;
-    }
-
-    r = dmSocket::Listen(server_socket, 32);
-    if (r != dmSocket::RESULT_OK)
-    {
-        snprintf(error_msg, sizeof(error_msg), "Unable to listen on log socket (%d): %s", r, dmSocket::ResultToString(r));
-        goto bail;
-    }
-
-    return;
-
-bail:
-    fprintf(stderr, "ERROR:DLIB: %s\n", error_msg);
-    if (server_socket != dmSocket::INVALID_SOCKET_HANDLE)
-        dmSocket::Delete(server_socket);
-
-    server_socket = dmSocket::INVALID_SOCKET_HANDLE;
-}
-
-static dmSocket::Result SendAll(dmSocket::Socket socket, const char* buffer, int length)
-{
-    int total_sent_bytes = 0;
-    int sent_bytes = 0;
-
-    while (total_sent_bytes < length)
-    {
-        dmSocket::Result r = dmSocket::Send(socket, buffer + total_sent_bytes, length - total_sent_bytes, &sent_bytes);
-        if (r == dmSocket::RESULT_TRY_AGAIN)
-            continue;
-
-        if (r != dmSocket::RESULT_OK)
-        {
-            return r;
-        }
-
-        total_sent_bytes += sent_bytes;
-    }
-
-    return dmSocket::RESULT_OK;
-}
-
-static void dmLogUpdateNetwork()
-{
-    dmLogServer* self = g_dmLogServer;
-
-    dmSocket::Selector selector;
-    dmSocket::SelectorSet(&selector, dmSocket::SELECTOR_KIND_READ, self->m_ServerSocket);
-    dmSocket::Result r = dmSocket::Select(&selector, 0);
-    if (r == dmSocket::RESULT_OK)
-    {
-        // Check for new connections
-        if (dmSocket::SelectorIsSet(&selector, dmSocket::SELECTOR_KIND_READ, self->m_ServerSocket))
-        {
-            dmSocket::Address address;
-            dmSocket::Socket client_socket;
-            r = dmSocket::Accept(self->m_ServerSocket, &address, &client_socket);
-            if (r == dmSocket::RESULT_OK)
+            if (r != dmSocket::RESULT_OK)
             {
-                if (self->m_Connections.Full())
+                return r;
+            }
+
+            total_sent_bytes += sent_bytes;
+        }
+
+        return dmSocket::RESULT_OK;
+    }
+
+    static void dmLogUpdateNetwork()
+    {
+        dmLogServer* self = g_dmLogServer;
+
+        dmSocket::Selector selector;
+        dmSocket::SelectorSet(&selector, dmSocket::SELECTOR_KIND_READ, self->m_ServerSocket);
+        dmSocket::Result r = dmSocket::Select(&selector, 0);
+        if (r == dmSocket::RESULT_OK)
+        {
+            // Check for new connections
+            if (dmSocket::SelectorIsSet(&selector, dmSocket::SELECTOR_KIND_READ, self->m_ServerSocket))
+            {
+                dmSocket::Address address;
+                dmSocket::Socket client_socket;
+                r = dmSocket::Accept(self->m_ServerSocket, &address, &client_socket);
+                if (r == dmSocket::RESULT_OK)
                 {
-                    dmLogError("Too many log connections opened");
-                    const char* resp = "1 Too many log connections opened\n";
-                    SendAll(client_socket, resp, strlen(resp));
-                    dmSocket::Shutdown(client_socket, dmSocket::SHUTDOWNTYPE_READWRITE);
-                    dmSocket::Delete(client_socket);
+                    if (self->m_Connections.Full())
+                    {
+                        dmLogError("Too many log connections opened");
+                        const char* resp = "1 Too many log connections opened\n";
+                        SendAll(client_socket, resp, strlen(resp));
+                        dmSocket::Shutdown(client_socket, dmSocket::SHUTDOWNTYPE_READWRITE);
+                        dmSocket::Delete(client_socket);
+                    }
+                    else
+                    {
+                        const char* resp = "0 OK\n";
+                        SendAll(client_socket, resp, strlen(resp));
+                        dmSocket::SetNoDelay(client_socket, true);
+                        dmLogConnection connection;
+                        memset(&connection, 0, sizeof(connection));
+                        connection.m_Socket = client_socket;
+                        self->m_Connections.Push(connection);
+                    }
+                }
+                else if (r == dmSocket::RESULT_BADF || r == dmSocket::RESULT_CONNABORTED)
+                {
+                    // reinitalize log socket
+                    dmLogInitSocket(g_dmLogServer->m_ServerSocket);
+                }
+            }
+        }
+    }
+
+    static void dmLogDispatch(dmMessage::Message *message, void* user_ptr)
+    {
+        dmLogServer* self = g_dmLogServer;
+
+        bool* run = (bool*) user_ptr;
+        LogMessage* log_message = (LogMessage*) &message->m_Data[0];
+        if (log_message->m_Type == LogMessage::SHUTDOWN)
+        {
+            *run = false;
+            return;
+        }
+        int msg_len = (int) strlen(log_message->m_Message);
+
+        // NOTE: Keep i as signed! See --i below after EraseSwap
+        int n = (int) self->m_Connections.Size();
+        for (int i = 0; i < n; ++i)
+        {
+            dmLogConnection* c = &self->m_Connections[i];
+            dmSocket::Result r;
+            int sent_bytes;
+            int total_sent = 0;
+            do
+            {
+                r = dmSocket::Send(c->m_Socket, log_message->m_Message + total_sent, msg_len - total_sent, &sent_bytes);
+                if (r == dmSocket::RESULT_OK)
+                {
+                    total_sent += sent_bytes;
+                }
+                else if (r == dmSocket::RESULT_TRY_AGAIN)
+                {
+                    // Ok
                 }
                 else
                 {
-                    const char* resp = "0 OK\n";
-                    SendAll(client_socket, resp, strlen(resp));
-                    dmSocket::SetNoDelay(client_socket, true);
-                    dmLogConnection connection;
-                    memset(&connection, 0, sizeof(connection));
-                    connection.m_Socket = client_socket;
-                    self->m_Connections.Push(connection);
+                    dmSocket::Shutdown(c->m_Socket, dmSocket::SHUTDOWNTYPE_READWRITE);
+                    dmSocket::Delete(c->m_Socket);
+                    c->m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
+                    self->m_Connections.EraseSwap(i);
+                    --n;
+                    --i;
+                    break;
                 }
-            }
-            else if (r == dmSocket::RESULT_BADF || r == dmSocket::RESULT_CONNABORTED)
-            {
-                // reinitalize log socket
-                dmLogInitSocket(g_dmLogServer->m_ServerSocket);
-            }
+            } while (total_sent < msg_len);
         }
     }
-}
 
-static void dmLogDispatch(dmMessage::Message *message, void* user_ptr)
-{
-    dmLogServer* self = g_dmLogServer;
-
-    bool* run = (bool*) user_ptr;
-    dmLogMessage* log_message = (dmLogMessage*) &message->m_Data[0];
-    if (log_message->m_Type == dmLogMessage::SHUTDOWN)
+    static void dmLogThread(void* args)
     {
-        *run = false;
-        return;
-    }
-    int msg_len = (int) strlen(log_message->m_Message);
+        dmLogServer* self = g_dmLogServer;
 
-    // NOTE: Keep i as signed! See --i below after EraseSwap
-    int n = (int) self->m_Connections.Size();
-    for (int i = 0; i < n; ++i)
-    {
-        dmLogConnection* c = &self->m_Connections[i];
-        dmSocket::Result r;
-        int sent_bytes;
-        int total_sent = 0;
-        do
+        volatile bool run = true;
+        while (run)
         {
-            r = dmSocket::Send(c->m_Socket, log_message->m_Message + total_sent, msg_len - total_sent, &sent_bytes);
-            if (r == dmSocket::RESULT_OK)
-            {
-                total_sent += sent_bytes;
-            }
-            else if (r == dmSocket::RESULT_TRY_AGAIN)
-            {
-                // Ok
-            }
-            else
-            {
-                dmSocket::Shutdown(c->m_Socket, dmSocket::SHUTDOWNTYPE_READWRITE);
-                dmSocket::Delete(c->m_Socket);
-                c->m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
-                self->m_Connections.EraseSwap(i);
-                --n;
-                --i;
-                break;
-            }
-        } while (total_sent < msg_len);
+            // NOTE: We have support for blocking dispatch in dmMessage
+            // but we have to wait for both new messages and on sockets.
+            // Currently no support for that and hence the sleep here
+            dmTime::Sleep(1000 * 30);
+            dmLogUpdateNetwork();
+            dmMessage::Dispatch(self->m_MessgeSocket, dmLogDispatch, (void*) &run);
+        }
     }
-}
 
-static void dmLogThread(void* args)
-{
-    dmLogServer* self = g_dmLogServer;
-
-    volatile bool run = true;
-    while (run)
+    void LogInitialize(const LogParams* params)
     {
-        // NOTE: We have support for blocking dispatch in dmMessage
-        // but we have to wait for both new messages and on sockets.
-        // Currently no support for that and hence the sleep here
-        dmTime::Sleep(1000 * 30);
-        dmLogUpdateNetwork();
-        dmMessage::Dispatch(self->m_MessgeSocket, dmLogDispatch, (void*) &run);
-    }
-}
+        g_TotalBytesLogged = 0;
 
-void dmLogInitialize(const dmLogParams* params)
-{
-    g_TotalBytesLogged = 0;
+        if (!dLib::IsDebugMode() || !dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP))
+            return;
 
-    if (!dLib::IsDebugMode() || !dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP))
-        return;
-
-    if (g_dmLogServer)
-    {
-        fprintf(stderr, "ERROR:DLIB: dmLog already initialized\n");
-        return;
-    }
-
-    dmSocket::Socket server_socket = dmSocket::INVALID_SOCKET_HANDLE;
-    dmSocket::Address address;
-    uint16_t port;
-    dmLogInitSocket(server_socket);
-    if (server_socket == dmSocket::INVALID_SOCKET_HANDLE)
-    {
-        return;
-    }
-    dmSocket::GetName(server_socket, &address, &port);
-
-    dmMessage::HSocket message_socket = 0;
-    dmMessage::Result mr;
-    dmThread::Thread thread = 0;
-
-    mr = dmMessage::NewSocket("@log", &message_socket);
-    if (mr != dmMessage::RESULT_OK)
-    {
-        fprintf(stderr, "ERROR:DLIB: Unable to create @log message socket\n");
-        if (message_socket != 0)
-            dmMessage::DeleteSocket(message_socket);
-        dmSocket::Delete(server_socket);
-        return;
-    }
-
-    g_dmLogServer = new dmLogServer(server_socket, port, message_socket);
-    thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
-    g_dmLogServer->m_Thread = thread;
-
-    /*
-     * This message is parsed by editor 2 - don't remove or change without
-     * corresponding changes in engine.clj
-     */
-    dmLogInfo("Log server started on port %u", (unsigned int) port);
-}
-
-static void CloseLogFile()
-{
-    if (g_LogFile) {
-        fclose(g_LogFile);
-        g_LogFile = 0;
-    }
-}
-
-void dmLogFinalize()
-{
-    if (!g_dmLogServer)
-    {
-        CloseLogFile();
-        return;
-    }
-    dmLogServer* self = g_dmLogServer;
-
-    dmLogMessage msg;
-    msg.m_Type = dmLogMessage::SHUTDOWN;
-    dmMessage::URL receiver;
-    receiver.m_Socket = self->m_MessgeSocket;
-    receiver.m_Path = 0;
-    receiver.m_Fragment = 0;
-    dmMessage::Post(0, &receiver, 0, 0, 0, &msg, sizeof(msg), 0);
-    dmThread::Join(self->m_Thread);
-
-    uint32_t n = self->m_Connections.Size();
-    for (uint32_t i = 0; i < n; ++i)
-    {
-        dmLogConnection* c = &self->m_Connections[i];
-        dmSocket::Shutdown(c->m_Socket, dmSocket::SHUTDOWNTYPE_READWRITE);
-        dmSocket::Delete(c->m_Socket);
-        c->m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
-    }
-
-    if (self->m_ServerSocket != dmSocket::INVALID_SOCKET_HANDLE)
-    {
-        dmSocket::Delete(self->m_ServerSocket);
-        self->m_ServerSocket = dmSocket::INVALID_SOCKET_HANDLE;
-    }
-
-    if (self->m_MessgeSocket != 0)
-    {
-        dmMessage::DeleteSocket(self->m_MessgeSocket);
-    }
-
-    delete self;
-    g_dmLogServer = 0;
-    CloseLogFile();
-}
-
-uint16_t dmLogGetPort()
-{
-    if (!g_dmLogServer)
-        return 0;
-
-    return g_dmLogServer->m_Port;
-}
-
-void dmLogSetlevel(dmLogSeverity severity)
-{
-    g_LogLevel = severity;
-}
-
-#ifdef ANDROID
-static android_LogPriority ToAndroidPriority(dmLogSeverity severity)
-{
-    switch (severity)
-    {
-        case DM_LOG_SEVERITY_DEBUG:
-            return ANDROID_LOG_DEBUG;
-
-        case DM_LOG_SEVERITY_USER_DEBUG:
-            return ANDROID_LOG_DEBUG;
-
-        case DM_LOG_SEVERITY_INFO:
-            return ANDROID_LOG_INFO;
-
-        case DM_LOG_SEVERITY_WARNING:
-            return ANDROID_LOG_WARN;
-
-        case DM_LOG_SEVERITY_ERROR:
-            return ANDROID_LOG_ERROR;
-
-        case DM_LOG_SEVERITY_FATAL:
-            return ANDROID_LOG_FATAL;
-
-        default:
-            return ANDROID_LOG_ERROR;
-    }
-}
-#endif
-
-#define MAX_LISTENERS (32)
-static dmLogListener g_dmLog_Listeners[MAX_LISTENERS];
-static int g_dmLog_ListenersCount = 0;
-static bool g_isSendingLogs = false;
-
-void dmLogRegisterListener(dmLogListener listener)
-{
-    if (g_dmLog_ListenersCount >= MAX_LISTENERS) {
-        dmLogWarning("Max dmLog listeners reached (%d)", MAX_LISTENERS);
-    } else {
-        g_dmLog_Listeners[g_dmLog_ListenersCount++] = listener;
-    }
-}
-
-void dmLogUnregisterListener(dmLogListener listener)
-{
-    for (int i = 0; i < g_dmLog_ListenersCount; ++i)
-    {
-        if (g_dmLog_Listeners[i] == listener)
+        if (g_dmLogServer)
         {
-            g_dmLog_Listeners[i] = g_dmLog_Listeners[g_dmLog_ListenersCount - 1];
-            g_dmLog_ListenersCount--;
+            fprintf(stderr, "ERROR:DLIB: dmLog already initialized\n");
             return;
         }
-    }
-    dmLogWarning("dmLog listener not found");
-}
 
-#undef MAX_LISTENERS
-
-void dmLogInternal(dmLogSeverity severity, const char* domain, const char* format, ...)
-{
-    bool is_debug_mode = dLib::IsDebugMode();
-
-    if (!is_debug_mode && g_dmLog_ListenersCount == 0)
-    {
-        return;
-    }
-
-    if (severity < g_LogLevel)
-    {
-        return;
-    }
-
-    va_list lst;
-    va_start(lst, format);
-
-    const char* severity_str = 0;
-    switch (severity)
-    {
-        case DM_LOG_SEVERITY_DEBUG:
-            severity_str = "DEBUG";
-            break;
-        case DM_LOG_SEVERITY_USER_DEBUG:
-            severity_str = "DEBUG";
-            break;
-        case DM_LOG_SEVERITY_INFO:
-            severity_str = "INFO";
-            break;
-        case DM_LOG_SEVERITY_WARNING:
-            severity_str = "WARNING";
-            break;
-        case DM_LOG_SEVERITY_ERROR:
-            severity_str = "ERROR";
-            break;
-        case DM_LOG_SEVERITY_FATAL:
-            severity_str = "FATAL";
-            break;
-        default:
-            assert(0);
-            break;
-    }
-
-    char tmp_buf[sizeof(dmLogMessage) + DM_LOG_MAX_STRING_SIZE];
-    dmLogMessage* msg = (dmLogMessage*) &tmp_buf[0];
-    char* str_buf = &tmp_buf[sizeof(dmLogMessage)];
-
-    int n = 0;
-    n += dmSnPrintf(str_buf + n, DM_LOG_MAX_STRING_SIZE - n, "%s:%s: ", severity_str, domain);
-    if (n < DM_LOG_MAX_STRING_SIZE)
-    {
-        n += vsnprintf(str_buf + n, DM_LOG_MAX_STRING_SIZE - n, format, lst);
-    }
-
-    if (n < DM_LOG_MAX_STRING_SIZE)
-    {
-        n += dmSnPrintf(str_buf + n, DM_LOG_MAX_STRING_SIZE - n, "\n");
-    }
-
-    if (n >= DM_LOG_MAX_STRING_SIZE)
-    {
-        strcpy(&str_buf[DM_LOG_MAX_STRING_SIZE - (strlen(LOG_OUTPUT_TRUNCATED_MESSAGE) + 1)], LOG_OUTPUT_TRUNCATED_MESSAGE);
-    }
-
-    str_buf[DM_LOG_MAX_STRING_SIZE-1] = '\0';
-    int actual_n = dmMath::Min(n, (int)(DM_LOG_MAX_STRING_SIZE-1));
-
-    g_TotalBytesLogged += actual_n;
-
-    va_end(lst);
-
-    if (!g_isSendingLogs)
-    {
-        g_isSendingLogs = true;
-        for (int i = g_dmLog_ListenersCount - 1; i >= 0 ; --i)
+        dmSocket::Socket server_socket = dmSocket::INVALID_SOCKET_HANDLE;
+        dmSocket::Address address;
+        uint16_t port;
+        dmLogInitSocket(server_socket);
+        if (server_socket == dmSocket::INVALID_SOCKET_HANDLE)
         {
-            g_dmLog_Listeners[i](severity, domain, str_buf);
+            return;
         }
-        g_isSendingLogs = false;
+        dmSocket::GetName(server_socket, &address, &port);
+
+        dmMessage::HSocket message_socket = 0;
+        dmMessage::Result mr;
+        dmThread::Thread thread = 0;
+
+        mr = dmMessage::NewSocket("@log", &message_socket);
+        if (mr != dmMessage::RESULT_OK)
+        {
+            fprintf(stderr, "ERROR:DLIB: Unable to create @log message socket\n");
+            if (message_socket != 0)
+                dmMessage::DeleteSocket(message_socket);
+            dmSocket::Delete(server_socket);
+            return;
+        }
+
+        g_dmLogServer = new dmLogServer(server_socket, port, message_socket);
+        thread = dmThread::New(dmLogThread, 0x80000, 0, "log");
+        g_dmLogServer->m_Thread = thread;
+
+        /*
+         * This message is parsed by editor 2 - don't remove or change without
+         * corresponding changes in engine.clj
+         */
+        dmLogInfo("Log server started on port %u", (unsigned int) port);
     }
 
-    if (!is_debug_mode)
+    static void CloseLogFile()
     {
-        return;
+        if (g_LogFile) {
+            fclose(g_LogFile);
+            g_LogFile = 0;
+        }
     }
 
-    if (g_CustomLogCallback != 0x0)
+    void LogFinalize()
     {
-        g_CustomLogCallback(g_CustomLogCallbackUserData, str_buf);
-        return;
-    }
+        if (!g_dmLogServer)
+        {
+            CloseLogFile();
+            return;
+        }
+        dmLogServer* self = g_dmLogServer;
 
-#ifdef ANDROID
-    __android_log_print(ToAndroidPriority(severity), "defold", "%s", str_buf);
-
-// iOS
-#elif defined(__MACH__) && (defined(__arm__) || defined(__arm64__))
-    __ios_log_print(severity, str_buf);
-#endif
-
-#ifdef __EMSCRIPTEN__
-    //Emscripten maps stderr to console.error and stdout to console.log.
-    if (severity == DM_LOG_SEVERITY_ERROR || severity == DM_LOG_SEVERITY_FATAL){
-        fwrite(str_buf, 1, actual_n, stderr);
-    } else {
-        fwrite(str_buf, 1, actual_n, stdout);
-    }
-#elif !defined(ANDROID)
-    fwrite(str_buf, 1, actual_n, stderr);
-#endif
-
-    if(!dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP))
-        return;
-
-    if (g_LogFile && g_TotalBytesLogged < DM_LOG_MAX_LOG_FILE_SIZE) {
-        fwrite(str_buf, 1, actual_n, g_LogFile);
-        fflush(g_LogFile);
-    }
-
-    dmLogServer* self = g_dmLogServer;
-    if (self)
-    {
-        msg->m_Type = dmLogMessage::MESSAGE;
+        LogMessage msg;
+        msg.m_Type = LogMessage::SHUTDOWN;
         dmMessage::URL receiver;
         receiver.m_Socket = self->m_MessgeSocket;
         receiver.m_Path = 0;
         receiver.m_Fragment = 0;
-        dmMessage::Post(0, &receiver, 0, 0, 0, msg, dmMath::Min(sizeof(dmLogMessage) + actual_n + 1, sizeof(tmp_buf)), 0);
-    }
-}
+        dmMessage::Post(0, &receiver, 0, 0, 0, &msg, sizeof(msg), 0);
+        dmThread::Join(self->m_Thread);
 
-void dmSetLogFile(const char* path)
-{
-    if (g_LogFile) {
-        fclose(g_LogFile);
-        g_LogFile = 0;
-    }
-    g_LogFile = fopen(path, "wb");
-    if (g_LogFile) {
-        dmLogInfo("Writing log to: %s", path);
-    } else {
-        dmLogFatal("Failed to open log-file '%s'", path);
-    }
-}
+        uint32_t n = self->m_Connections.Size();
+        for (uint32_t i = 0; i < n; ++i)
+        {
+            dmLogConnection* c = &self->m_Connections[i];
+            dmSocket::Shutdown(c->m_Socket, dmSocket::SHUTDOWNTYPE_READWRITE);
+            dmSocket::Delete(c->m_Socket);
+            c->m_Socket = dmSocket::INVALID_SOCKET_HANDLE;
+        }
 
-void dmSetCustomLogCallback(dmCustomLogCallback callback, void* user_data)
-{
-    g_CustomLogCallback = callback;
-    g_CustomLogCallbackUserData = user_data;
-}
+        if (self->m_ServerSocket != dmSocket::INVALID_SOCKET_HANDLE)
+        {
+            dmSocket::Delete(self->m_ServerSocket);
+            self->m_ServerSocket = dmSocket::INVALID_SOCKET_HANDLE;
+        }
+
+        if (self->m_MessgeSocket != 0)
+        {
+            dmMessage::DeleteSocket(self->m_MessgeSocket);
+        }
+
+        delete self;
+        g_dmLogServer = 0;
+        CloseLogFile();
+    }
+
+    uint16_t GetPort()
+    {
+        if (!g_dmLogServer)
+            return 0;
+
+        return g_dmLogServer->m_Port;
+    }
+
+    void Setlevel(Severity severity)
+    {
+        g_LogLevel = severity;
+    }
+
+    #ifdef ANDROID
+    static android_LogPriority ToAndroidPriority(Severity severity)
+    {
+        switch (severity)
+        {
+            case SEVERITY_DEBUG:
+                return ANDROID_LOG_DEBUG;
+
+            case SEVERITY_USER_DEBUG:
+                return ANDROID_LOG_DEBUG;
+
+            case SEVERITY_INFO:
+                return ANDROID_LOG_INFO;
+
+            case SEVERITY_WARNING:
+                return ANDROID_LOG_WARN;
+
+            case SEVERITY_ERROR:
+                return ANDROID_LOG_ERROR;
+
+            case SEVERITY_FATAL:
+                return ANDROID_LOG_FATAL;
+
+            default:
+                return ANDROID_LOG_ERROR;
+        }
+    }
+    #endif
+
+    #define MAX_LISTENERS (32)
+    static LogListener g_dmLog_Listeners[MAX_LISTENERS];
+    static int g_dmLog_ListenersCount = 0;
+    static bool g_isSendingLogs = false;
+
+    void RegisterLogListener(LogListener listener)
+    {
+        if (g_dmLog_ListenersCount >= MAX_LISTENERS) {
+            dmLogWarning("Max dmLog listeners reached (%d)", MAX_LISTENERS);
+        } else {
+            g_dmLog_Listeners[g_dmLog_ListenersCount++] = listener;
+        }
+    }
+
+    void UnregisterLogListener(LogListener listener)
+    {
+        for (int i = 0; i < g_dmLog_ListenersCount; ++i)
+        {
+            if (g_dmLog_Listeners[i] == listener)
+            {
+                g_dmLog_Listeners[i] = g_dmLog_Listeners[g_dmLog_ListenersCount - 1];
+                g_dmLog_ListenersCount--;
+                return;
+            }
+        }
+        dmLogWarning("dmLog listener not found");
+    }
+
+    #undef MAX_LISTENERS
+
+    void LogInternal(Severity severity, const char* domain, const char* format, ...)
+    {
+        bool is_debug_mode = dLib::IsDebugMode();
+
+        if (!is_debug_mode && g_dmLog_ListenersCount == 0)
+        {
+            return;
+        }
+
+        if (severity < g_LogLevel)
+        {
+            return;
+        }
+
+        va_list lst;
+        va_start(lst, format);
+
+        const char* severity_str = 0;
+        switch (severity)
+        {
+            case SEVERITY_DEBUG:
+                severity_str = "DEBUG";
+                break;
+            case SEVERITY_USER_DEBUG:
+                severity_str = "DEBUG";
+                break;
+            case SEVERITY_INFO:
+                severity_str = "INFO";
+                break;
+            case SEVERITY_WARNING:
+                severity_str = "WARNING";
+                break;
+            case SEVERITY_ERROR:
+                severity_str = "ERROR";
+                break;
+            case SEVERITY_FATAL:
+                severity_str = "FATAL";
+                break;
+            default:
+                assert(0);
+                break;
+        }
+
+        char tmp_buf[sizeof(LogMessage) + MAX_STRING_SIZE];
+        LogMessage* msg = (LogMessage*) &tmp_buf[0];
+        char* str_buf = &tmp_buf[sizeof(LogMessage)];
+
+        int n = 0;
+        n += dmSnPrintf(str_buf + n, MAX_STRING_SIZE - n, "%s:%s: ", severity_str, domain);
+        if (n < MAX_STRING_SIZE)
+        {
+            n += vsnprintf(str_buf + n, MAX_STRING_SIZE - n, format, lst);
+        }
+
+        if (n < MAX_STRING_SIZE)
+        {
+            n += dmSnPrintf(str_buf + n, MAX_STRING_SIZE - n, "\n");
+        }
+
+        if (n >= MAX_STRING_SIZE)
+        {
+            strcpy(&str_buf[MAX_STRING_SIZE - (strlen(LOG_OUTPUT_TRUNCATED_MESSAGE) + 1)], LOG_OUTPUT_TRUNCATED_MESSAGE);
+        }
+
+        str_buf[MAX_STRING_SIZE-1] = '\0';
+        int actual_n = dmMath::Min(n, (int)(MAX_STRING_SIZE-1));
+
+        g_TotalBytesLogged += actual_n;
+
+        va_end(lst);
+
+        if (!g_isSendingLogs)
+        {
+            g_isSendingLogs = true;
+            for (int i = g_dmLog_ListenersCount - 1; i >= 0 ; --i)
+            {
+                g_dmLog_Listeners[i](severity, domain, str_buf);
+            }
+            g_isSendingLogs = false;
+        }
+
+        if (!is_debug_mode)
+        {
+            return;
+        }
+
+        if (g_CustomLogCallback != 0x0)
+        {
+            g_CustomLogCallback(g_CustomLogCallbackUserData, str_buf);
+            return;
+        }
+
+    #ifdef ANDROID
+        __android_log_print(ToAndroidPriority(severity), "defold", "%s", str_buf);
+
+    // iOS
+    #elif defined(__MACH__) && (defined(__arm__) || defined(__arm64__))
+        __ios_log_print(severity, str_buf);
+    #endif
+
+    #ifdef __EMSCRIPTEN__
+        //Emscripten maps stderr to console.error and stdout to console.log.
+        if (severity == SEVERITY_ERROR || severity == SEVERITY_FATAL){
+            fwrite(str_buf, 1, actual_n, stderr);
+        } else {
+            fwrite(str_buf, 1, actual_n, stdout);
+        }
+    #elif !defined(ANDROID)
+        fwrite(str_buf, 1, actual_n, stderr);
+    #endif
+
+        if(!dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP))
+            return;
+
+        if (g_LogFile && g_TotalBytesLogged < MAX_LOG_FILE_SIZE) {
+            fwrite(str_buf, 1, actual_n, g_LogFile);
+            fflush(g_LogFile);
+        }
+
+        dmLogServer* self = g_dmLogServer;
+        if (self)
+        {
+            msg->m_Type = LogMessage::MESSAGE;
+            dmMessage::URL receiver;
+            receiver.m_Socket = self->m_MessgeSocket;
+            receiver.m_Path = 0;
+            receiver.m_Fragment = 0;
+            dmMessage::Post(0, &receiver, 0, 0, 0, msg, dmMath::Min(sizeof(LogMessage) + actual_n + 1, sizeof(tmp_buf)), 0);
+        }
+    }
+
+    void SetLogFile(const char* path)
+    {
+        if (g_LogFile) {
+            fclose(g_LogFile);
+            g_LogFile = 0;
+        }
+        g_LogFile = fopen(path, "wb");
+        if (g_LogFile) {
+            dmLogInfo("Writing log to: %s", path);
+        } else {
+            dmLogFatal("Failed to open log-file '%s'", path);
+        }
+    }
+
+    void SetCustomLogCallback(CustomLogCallback callback, void* user_data)
+    {
+        g_CustomLogCallback = callback;
+        g_CustomLogCallbackUserData = user_data;
+    }
+
+} //namespace dmLog

--- a/engine/dlib/src/dlib/log.h
+++ b/engine/dlib/src/dlib/log.h
@@ -16,102 +16,107 @@
 #include <dmsdk/dlib/log.h>
 #include <dlib/message.h>
 
-/**
- * @file
- * Logging functions. If DLIB_LOG_DOMAIN is defined the value of the defined is printed
- * after severity. Otherwise DEFAULT will be printed.
- *
- * Network protocol:
- * When connected a message with the following syntax is sent to the client
- * code <space> msg\n
- * eg 0 OK\n
- *
- * code > 0 indicates an error and the connections is closed by remote peer
- *
- * After connection is established log messages are streamed over the socket.
- * No other messages with semantic meaning is sent.
- */
-
-struct dmLogMessage
+namespace dmLog
 {
-    enum Type
+
+    /**
+     * @file
+     * Logging functions. If DLIB_LOG_DOMAIN is defined the value of the defined is printed
+     * after severity. Otherwise DEFAULT will be printed.
+     *
+     * Network protocol:
+     * When connected a message with the following syntax is sent to the client
+     * code <space> msg\n
+     * eg 0 OK\n
+     *
+     * code > 0 indicates an error and the connections is closed by remote peer
+     *
+     * After connection is established log messages are streamed over the socket.
+     * No other messages with semantic meaning is sent.
+     */
+
+    struct LogMessage
     {
-        MESSAGE = 0,
-        SHUTDOWN = 1,
+        enum Type
+        {
+            MESSAGE = 0,
+            SHUTDOWN = 1,
+        };
+
+        uint8_t m_Type;
+        char    m_Message[0];
     };
 
-    uint8_t m_Type;
-    char    m_Message[0];
-};
-
-const uint32_t DM_LOG_MAX_STRING_SIZE = dmMessage::DM_MESSAGE_MAX_DATA_SIZE - sizeof(dmLogMessage);
-struct dmLogParams
-{
-    dmLogParams()
+    const uint32_t MAX_STRING_SIZE = dmMessage::DM_MESSAGE_MAX_DATA_SIZE - sizeof(LogMessage);
+    struct LogParams
     {
-    }
-};
+        LogParams()
+        {
+        }
+    };
 
-/**
- * Initialize logging system. Running this function is only required in order to start the log-server.
- * The function will never fail even if the log-server can't be started. Any errors will be reported to stderr though
- * @param params log parameters
- */
-void dmLogInitialize(const dmLogParams* params);
-
-
-/**
- * Finalize logging system
- */
-void dmLogFinalize();
-
-/**
- * Get log server port
- * @return server port. 0 if the server isn't started.
- */
-uint16_t dmLogGetPort();
+    /**
+     * Initialize logging system. Running this function is only required in order to start the log-server.
+     * The function will never fail even if the log-server can't be started. Any errors will be reported to stderr though
+     * @param params log parameters
+     */
+    void LogInitialize(const LogParams* params);
 
 
-/**
- * Set log level
- * @param severity Log severity
- */
-void dmLogSetlevel(dmLogSeverity severity);
+    /**
+     * Finalize logging system
+     */
+    void LogFinalize();
 
-/**
- * Set log file. The file will be created and truncated.
- * Subsequent invocations to this function will close previous opened file.
- * If the file can't be created a message will be logged to the "console"
- * @param path log path
- */
-void dmSetLogFile(const char* path);
+    /**
+     * Get log server port
+     * @return server port. 0 if the server isn't started.
+     */
+    uint16_t GetPort();
 
-/**
- * Callback declaration for dmSetCustomLogCallback
- */
-typedef void (*dmCustomLogCallback)(void* user_data, const char* s);
 
-/**
- * Sets a custom callback for log output, if this function is set output
- * will only be sent to this callback.
- * Useful for testing purposes to validate logging output from a test
- * Calling dmSetCustomLogCallback with (0x0, 0x0) will restore normal operation
- * @param callback the callback to call with output, once per logging call
- * @param user_data user data pointer that is provided as context in the callback
- */
-void dmSetCustomLogCallback(dmCustomLogCallback callback, void* user_data);
+    /**
+     * Set log level
+     * @param severity Log severity
+     */
+    void Setlevel(Severity severity);
 
-/**
- * iOS specific print function that wraps NSLog to be able to
- * output logging to the device/XCode log.
- *
- * Declared here to be accessible from log.cpp, defined in log_ios.mm
- * since it needs to be compiled as Objective-C.
- *
- * @param severity Log severity
- * @param str_buf String buffer to print
- */
-void __ios_log_print(dmLogSeverity severity, const char* str_buf);
+    /**
+     * Set log file. The file will be created and truncated.
+     * Subsequent invocations to this function will close previous opened file.
+     * If the file can't be created a message will be logged to the "console"
+     * @param path log path
+     */
+    void SetLogFile(const char* path);
 
+    /**
+     * Callback declaration for SetCustomLogCallback
+     */
+    typedef void (*CustomLogCallback)(void* user_data, const char* s);
+
+    /**
+     * Sets a custom callback for log output, if this function is set output
+     * will only be sent to this callback.
+     * Useful for testing purposes to validate logging output from a test
+     * Calling SetCustomLogCallback with (0x0, 0x0) will restore normal operation
+     * @param callback the callback to call with output, once per logging call
+     * @param user_data user data pointer that is provided as context in the callback
+     */
+    void SetCustomLogCallback(CustomLogCallback callback, void* user_data);
+
+    /**
+     * iOS specific print function that wraps NSLog to be able to
+     * output logging to the device/XCode log.
+     *
+     * Declared here to be accessible from log.cpp, defined in log_ios.mm
+     * since it needs to be compiled as Objective-C.
+     *
+     * @param severity Log severity
+     * @param str_buf String buffer to print
+     */
+    void __ios_log_print(Severity severity, const char* str_buf);
+
+    
+} //namespace dmLog
 
 #endif // DM_LOG_H

--- a/engine/dlib/src/dlib/log.h
+++ b/engine/dlib/src/dlib/log.h
@@ -19,104 +19,104 @@
 namespace dmLog
 {
 
-    /**
-     * @file
-     * Logging functions. If DLIB_LOG_DOMAIN is defined the value of the defined is printed
-     * after severity. Otherwise DEFAULT will be printed.
-     *
-     * Network protocol:
-     * When connected a message with the following syntax is sent to the client
-     * code <space> msg\n
-     * eg 0 OK\n
-     *
-     * code > 0 indicates an error and the connections is closed by remote peer
-     *
-     * After connection is established log messages are streamed over the socket.
-     * No other messages with semantic meaning is sent.
-     */
+/**
+ * @file
+ * Logging functions. If DLIB_LOG_DOMAIN is defined the value of the defined is printed
+ * after severity. Otherwise DEFAULT will be printed.
+ *
+ * Network protocol:
+ * When connected a message with the following syntax is sent to the client
+ * code <space> msg\n
+ * eg 0 OK\n
+ *
+ * code > 0 indicates an error and the connections is closed by remote peer
+ *
+ * After connection is established log messages are streamed over the socket.
+ * No other messages with semantic meaning is sent.
+ */
 
-    struct LogMessage
+struct LogMessage
+{
+    enum Type
     {
-        enum Type
-        {
-            MESSAGE = 0,
-            SHUTDOWN = 1,
-        };
-
-        uint8_t m_Type;
-        char    m_Message[0];
+        MESSAGE = 0,
+        SHUTDOWN = 1,
     };
 
-    const uint32_t MAX_STRING_SIZE = dmMessage::DM_MESSAGE_MAX_DATA_SIZE - sizeof(LogMessage);
-    struct LogParams
+    uint8_t m_Type;
+    char    m_Message[0];
+};
+
+const uint32_t MAX_STRING_SIZE = dmMessage::DM_MESSAGE_MAX_DATA_SIZE - sizeof(LogMessage);
+struct LogParams
+{
+    LogParams()
     {
-        LogParams()
-        {
-        }
-    };
+    }
+};
 
-    /**
-     * Initialize logging system. Running this function is only required in order to start the log-server.
-     * The function will never fail even if the log-server can't be started. Any errors will be reported to stderr though
-     * @param params log parameters
-     */
-    void LogInitialize(const LogParams* params);
+/**
+ * Initialize logging system. Running this function is only required in order to start the log-server.
+ * The function will never fail even if the log-server can't be started. Any errors will be reported to stderr though
+ * @param params log parameters
+ */
+void LogInitialize(const LogParams* params);
 
 
-    /**
-     * Finalize logging system
-     */
-    void LogFinalize();
+/**
+ * Finalize logging system
+ */
+void LogFinalize();
 
-    /**
-     * Get log server port
-     * @return server port. 0 if the server isn't started.
-     */
-    uint16_t GetPort();
+/**
+ * Get log server port
+ * @return server port. 0 if the server isn't started.
+ */
+uint16_t GetPort();
 
 
-    /**
-     * Set log level
-     * @param severity Log severity
-     */
-    void Setlevel(Severity severity);
+/**
+ * Set log level
+ * @param severity Log severity
+ */
+void Setlevel(Severity severity);
 
-    /**
-     * Set log file. The file will be created and truncated.
-     * Subsequent invocations to this function will close previous opened file.
-     * If the file can't be created a message will be logged to the "console"
-     * @param path log path
-     */
-    void SetLogFile(const char* path);
+/**
+ * Set log file. The file will be created and truncated.
+ * Subsequent invocations to this function will close previous opened file.
+ * If the file can't be created a message will be logged to the "console"
+ * @param path log path
+ */
+void SetLogFile(const char* path);
 
-    /**
-     * Callback declaration for SetCustomLogCallback
-     */
-    typedef void (*CustomLogCallback)(void* user_data, const char* s);
+/**
+ * Callback declaration for SetCustomLogCallback
+ */
+typedef void (*CustomLogCallback)(void* user_data, const char* s);
 
-    /**
-     * Sets a custom callback for log output, if this function is set output
-     * will only be sent to this callback.
-     * Useful for testing purposes to validate logging output from a test
-     * Calling SetCustomLogCallback with (0x0, 0x0) will restore normal operation
-     * @param callback the callback to call with output, once per logging call
-     * @param user_data user data pointer that is provided as context in the callback
-     */
-    void SetCustomLogCallback(CustomLogCallback callback, void* user_data);
+/**
+ * Sets a custom callback for log output, if this function is set output
+ * will only be sent to this callback.
+ * Useful for testing purposes to validate logging output from a test
+ * Calling SetCustomLogCallback with (0x0, 0x0) will restore normal operation
+ * @param callback the callback to call with output, once per logging call
+ * @param user_data user data pointer that is provided as context in the callback
+ */
+void SetCustomLogCallback(CustomLogCallback callback, void* user_data);
 
-    /**
-     * iOS specific print function that wraps NSLog to be able to
-     * output logging to the device/XCode log.
-     *
-     * Declared here to be accessible from log.cpp, defined in log_ios.mm
-     * since it needs to be compiled as Objective-C.
-     *
-     * @param severity Log severity
-     * @param str_buf String buffer to print
-     */
-    void __ios_log_print(Severity severity, const char* str_buf);
+/**
+ * iOS specific print function that wraps NSLog to be able to
+ * output logging to the device/XCode log.
+ *
+ * Declared here to be accessible from log.cpp, defined in log_ios.mm
+ * since it needs to be compiled as Objective-C.
+ *
+ * @param severity Log severity
+ * @param str_buf String buffer to print
+ */
+void __ios_log_print(Severity severity, const char* str_buf);
 
-    
+
 } //namespace dmLog
 
 #endif // DM_LOG_H

--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -17,8 +17,9 @@
 namespace dmLog
 {
 
-    void __ios_log_print(dmLog::Severity severity, const char* str_buf)
-    {
-        NSLog(@"%@", @(str_buf));
-    }
+void __ios_log_print(dmLog::Severity severity, const char* str_buf)
+{
+    NSLog(@"%@", @(str_buf));
+}
+
 } //namespace dmLog

--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -14,7 +14,11 @@
 
 #import <Foundation/Foundation.h>
 
-void __ios_log_print(dmLog::Severity severity, const char* str_buf)
+namespace dmLog
 {
-    NSLog(@"%@", @(str_buf));
-}
+
+    void __ios_log_print(dmLog::Severity severity, const char* str_buf)
+    {
+        NSLog(@"%@", @(str_buf));
+    }
+} //namespace dmLog

--- a/engine/dlib/src/dlib/log_ios.mm
+++ b/engine/dlib/src/dlib/log_ios.mm
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-void __ios_log_print(dmLogSeverity severity, const char* str_buf)
+void __ios_log_print(dmLog::Severity severity, const char* str_buf)
 {
     NSLog(@"%@", @(str_buf));
 }

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -345,7 +345,6 @@ namespace dmProfile
     {
         if (!g_IsInitialized)
         {
-            dmLogOnceError("dmProfile is not initialized");
             return g_ActiveProfile;
         }
 

--- a/engine/dlib/src/dlib/profile.cpp
+++ b/engine/dlib/src/dlib/profile.cpp
@@ -345,7 +345,7 @@ namespace dmProfile
     {
         if (!g_IsInitialized)
         {
-            dmLogError("dmProfile is not initialized");
+            dmLogOnceError("dmProfile is not initialized");
             return g_ActiveProfile;
         }
 

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -222,7 +222,7 @@ void dmLogInternal(dmLogSeverity severity, const char* domain, const char* forma
 /*# dmLogListener callback typedef
  *
  * dmLog listener function type. Provides all logs from dmLog* functions and print/pprint Lua functions.
- * Used with RegisterLogListener() and UnregisterLogListener()
+ * Used with dmLogRegisterListener() and dmLogUnregisterListener()
  *
  * @typedef
  * @name dmLogListener
@@ -236,19 +236,28 @@ typedef void (*dmLogListener)(dmLogSeverity severity, const char* domain, char* 
  *
  * Registers a dmLog listener.
  *
- * @name RegisterLogListener
+ * @name dmLogRegisterListener
  * @param listener [type:dmLogListener] 
  */
-void RegisterLogListener(dmLogListener listener);
+void dmLogRegisterListener(dmLogListener listener);
 
 /*# unregister dmLog listener.
  *
  * Unregisters a dmLog listener.
  *
- * @name UnregisterLogListener
+ * @name dmLogUnregisterListener
  * @param [type:dmLogListener] listener
  */
-void UnregisterLogListener(dmLogListener listener);
+void dmLogUnregisterListener(dmLogListener listener);
+
+/*# set log system severity level.
+ *
+ * set log system severity level.
+ *
+ * @name dmLogSetlevel
+ * @param [type:dmLogSeverity] severity
+ */
+void dmLogSetlevel(dmLogSeverity severity);
 
 #endif
 

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -211,6 +211,37 @@ void dmLogInternal(dmLogSeverity severity, const char* domain, const char* forma
 #define dmLogOnceFatal(format, args... ) dmLogOnceCritical(dmLogFatal, format, ## args )
 #endif
 
+/*# dmLogListener callback typedef
+ *
+ * dmLog listener function type. Provides all logs from dmLog* functions and print/pprint Lua functions.
+ * Used with RegisterLogListener() and UnregisterLogListener()
+ *
+ * @typedef
+ * @name dmLogListener
+ * @param severity [type:dmLogSeverity]
+ * @param domain [type:const char*]
+ * @param formatted_string [type:char*]
+ */
+typedef void (*dmLogListener)(dmLogSeverity severity, const char* domain, const char* format, ...);
+
+/*# register dmLog listener.
+ *
+ * Registers a dmLog listener.
+ *
+ * @name RegisterLogListener
+ * @param listener [type:dmLogListener] 
+ */
+void RegisterLogListener(dmLogListener listener);
+
+/*# unregister dmLog listener.
+ *
+ * Unregisters a dmLog listener.
+ *
+ * @name UnregisterLogListener
+ * @param [type:dmLogListener] listener
+ */
+void UnregisterLogListener(dmLogListener listener);
+
 #endif
 
 #endif // DMSDK_LOG_H

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -231,9 +231,9 @@ namespace dmLog
      * @name dmLog:LogListener
      * @param severity [type:dmLog::Severity]
      * @param domain [type:const char*]
-     * @param formatted_string [type:char*]
+     * @param formatted_string [type:const char*] null terminated string
      */
-    typedef void (*LogListener)(Severity severity, const char* domain, char* formatted_string);
+    typedef void (*LogListener)(Severity severity, const char* domain, const char* formatted_string);
 
     /*# register dmLog listener.
      *

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -15,250 +15,255 @@
 
 #include <stdint.h>
 
-/*# logging functions
- *
- * Logging functions.
- * @note Log functions will be omitted (NOP) for release builds
- * @note Prefer these functions over `printf` since these can print to the platform specific logs
- *
- * @document
- * @name Log
- * @namespace dmLog
- * @path engine/dlib/src/dmsdk/dlib/log.h
-*/
-
-/*# macro for debug category logging
- *
- * If DLIB_LOG_DOMAIN is defined the value of the defined is printed after severity.
- * Otherwise DEFAULT will be printed.
- *
- * @note Extensions do not need to set this since they get their own logging domain automatically
- *
- * @macro
- * @name DLIB_LOG_DOMAIN
- * @examples
- *
- * ```cpp
- * #define DLIB_LOG_DOMAIN "MyOwnDomain"
- * #include <dmsdk/dlib/log.h>
- * ```
- */
-
-/*# log with "debug" severity
- *
- * Debug messages are temporary log instances used when debugging a certain behavior
- * Use dmLogOnceDebug for one-shot logging
- *
- * @name dmLogDebug
- * @param format [type:const char*] Format string
- * @param args [type:...] Format string args (variable arg list)
- * @return [type:void]
- */
-
-/*# log with "user" severity
- *
- * Debug messages are temporary log instances used when debugging a certain behavior
- * Use dmLogOnceUserDebug for one-shot logging
- *
- * @name dmLogUserDebug
- * @param format [type:const char*] Format string
- * @param args [type:...] Format string args (variable arg list)
- * @return [type:void]
- */
-
-/*# log with "info" severity
- *
- * Info messages are used to inform the developers of relevant information
- * Use dmLogOnceInfo for one-shot logging
- *
- * @name dmLogInfo
- * @param format [type:const char*] Format string
- * @param args [type:...] Format string args (variable arg list)
- * @return [type:void]
- */
-
-/*# log with "warning" severity
- *
- * Warning messages are used to inform the developers about potential problems which can cause errors.
- * Use dmLogOnceWarning for one-shot logging
- *
- * @name dmLogWarning
- * @param format [type:const char*] Format string
- * @param args [type:...] Format string args (variable arg list)
- * @return [type:void]
- */
-
-/*#log with "error" severity
- *
- * Error messages are used in cases where an recoverable error has occurred.
- * Use dmLogOnceError for one-shot logging
- *
- * @name dmLogError
- * @param format [type:const char*] Format string
- * @param args [type:...] Format string args (variable arg list)
- * @return [type:void]
- */
-
-/*# log with "fatal" severity
- *
- * Fatal messages are used in cases where an unrecoverable error has occurred.
- * Use dmLogOnceFatal for one-shot logging
- *
- * @name dmLogFatal
- * @param format [type:const char*] Format string
- * @param args [type:...] Format string args (variable arg list)
- * @return [type:void]
- */
-
-/*# Log severity
- *
- * Log severity
- *
- * @enum
- * @name dmLogSeverity
- * @member DM_LOG_SEVERITY_DEBUG
- * @member DM_LOG_SEVERITY_USER_DEBUG
- * @member DM_LOG_SEVERITY_INFO
- * @member DM_LOG_SEVERITY_WARNING
- * @member DM_LOG_SEVERITY_ERROR
- * @member DM_LOG_SEVERITY_FATAL
- */
-enum dmLogSeverity
+namespace dmLog
 {
-    DM_LOG_SEVERITY_DEBUG       = 0,//!< DM_LOG_SEVERITY_DEBUG
-    DM_LOG_SEVERITY_USER_DEBUG  = 1,//!< DM_LOG_SEVERITY_USER_DEBUG
-    DM_LOG_SEVERITY_INFO        = 2,//!< DM_LOG_SEVERITY_INFO
-    DM_LOG_SEVERITY_WARNING     = 3,//!< DM_LOG_SEVERITY_WARNING
-    DM_LOG_SEVERITY_ERROR       = 4,//!< DM_LOG_SEVERITY_ERROR
-    DM_LOG_SEVERITY_FATAL       = 5,//!< DM_LOG_SEVERITY_FATAL
-};
 
-#if defined(NDEBUG)
+    /*# logging functions
+     *
+     * Logging functions.
+     * @note Log functions will be omitted (NOP) for release builds
+     * @note Prefer these functions over `printf` since these can print to the platform specific logs
+     *
+     * @document
+     * @name Log
+     * @namespace dmLog
+     * @path engine/dlib/src/dmsdk/dlib/log.h
+    */
 
-#define dmLogDebug(format, ... ) do {} while(0);
-#define dmLogUserDebug(format, ... ) do {} while(0);
-#define dmLogInfo(format, args...) do {} while(0);
-#define dmLogWarning(format, args...) do {} while(0);
-#define dmLogError(format, args...) do {} while(0);
-#define dmLogFatal(format, args...) do {} while(0);
+    /*# macro for debug category logging
+     *
+     * If DLIB_LOG_DOMAIN is defined the value of the defined is printed after severity.
+     * Otherwise DEFAULT will be printed.
+     *
+     * @note Extensions do not need to set this since they get their own logging domain automatically
+     *
+     * @macro
+     * @name DLIB_LOG_DOMAIN
+     * @examples
+     *
+     * ```cpp
+     * #define DLIB_LOG_DOMAIN "MyOwnDomain"
+     * #include <dmsdk/dlib/log.h>
+     * ```
+     */
 
-#define dmLogOnceDebug(format, args... ) do {} while(0);
-#define dmLogOnceUserDebug(format, args... ) do {} while(0);
-#define dmLogOnceInfo(format, args... ) do {} while(0);
-#define dmLogOnceWarning(format, args... ) do {} while(0);
-#define dmLogOnceError(format, args... ) do {} while(0);
-#define dmLogOnceFatal(format, args... ) do {} while(0);
+    /*# log with "debug" severity
+     *
+     * Debug messages are temporary log instances used when debugging a certain behavior
+     * Use dmLogOnceDebug for one-shot logging
+     *
+     * @name dmLogDebug
+     * @param format [type:const char*] Format string
+     * @param args [type:...] Format string args (variable arg list)
+     * @return [type:void]
+     */
 
-#else
+    /*# log with "user" severity
+     *
+     * Debug messages are temporary log instances used when debugging a certain behavior
+     * Use dmLogOnceUserDebug for one-shot logging
+     *
+     * @name dmLogUserDebug
+     * @param format [type:const char*] Format string
+     * @param args [type:...] Format string args (variable arg list)
+     * @return [type:void]
+     */
 
-#ifndef DLIB_LOG_DOMAIN
-#define DLIB_LOG_DOMAIN "DEFAULT"
-#ifdef __GNUC__
-#warning "DLIB_LOG_DOMAIN is not defined"
-#endif
-#endif
+    /*# log with "info" severity
+     *
+     * Info messages are used to inform the developers of relevant information
+     * Use dmLogOnceInfo for one-shot logging
+     *
+     * @name dmLogInfo
+     * @param format [type:const char*] Format string
+     * @param args [type:...] Format string args (variable arg list)
+     * @return [type:void]
+     */
 
-#ifdef __GNUC__
-void dmLogInternal(dmLogSeverity severity, const char* domain, const char* format, ...)
-    __attribute__ ((format (printf, 3, 4)));
-#else
-void dmLogInternal(dmLogSeverity severity, const char* domain, const char* format, ...);
-#endif
+    /*# log with "warning" severity
+     *
+     * Warning messages are used to inform the developers about potential problems which can cause errors.
+     * Use dmLogOnceWarning for one-shot logging
+     *
+     * @name dmLogWarning
+     * @param format [type:const char*] Format string
+     * @param args [type:...] Format string args (variable arg list)
+     * @return [type:void]
+     */
 
-#ifdef _MSC_VER
-#define dmLogDebug(format, ... ) dmLogInternal(DM_LOG_SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-#define dmLogUserDebug(format, ... ) dmLogInternal(DM_LOG_SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-#define dmLogInfo(format, ... ) dmLogInternal(DM_LOG_SEVERITY_INFO, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-#define dmLogWarning(format, ... ) dmLogInternal(DM_LOG_SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-#define dmLogError(format, ... ) dmLogInternal(DM_LOG_SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-#define dmLogFatal(format, ... ) dmLogInternal(DM_LOG_SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-#else
-#define dmLogDebug(format, args...) dmLogInternal(DM_LOG_SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
-#define dmLogUserDebug(format, args...) dmLogInternal(DM_LOG_SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
-#define dmLogInfo(format, args...) dmLogInternal(DM_LOG_SEVERITY_INFO, DLIB_LOG_DOMAIN, format, ## args);
-#define dmLogWarning(format, args...) dmLogInternal(DM_LOG_SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, ## args);
-#define dmLogError(format, args...) dmLogInternal(DM_LOG_SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, ## args);
-#define dmLogFatal(format, args...) dmLogInternal(DM_LOG_SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, ## args);
-#endif
+    /*#log with "error" severity
+     *
+     * Error messages are used in cases where an recoverable error has occurred.
+     * Use dmLogOnceError for one-shot logging
+     *
+     * @name dmLogError
+     * @param format [type:const char*] Format string
+     * @param args [type:...] Format string args (variable arg list)
+     * @return [type:void]
+     */
 
-#define dmLogOnceIdentifier __dmLogOnce
-#define __DM_LOG_PASTE(x, y) x ## y
-#define DM_LOG_PASTE(x, y) __DM_LOG_PASTE(x, y)
+    /*# log with "fatal" severity
+     *
+     * Fatal messages are used in cases where an unrecoverable error has occurred.
+     * Use dmLogOnceFatal for one-shot logging
+     *
+     * @name dmLogFatal
+     * @param format [type:const char*] Format string
+     * @param args [type:...] Format string args (variable arg list)
+     * @return [type:void]
+     */
 
-#ifdef _MSC_VER
-#define dmLogOnceInternal(method, format, ... )                     \
-    {                                                               \
-        static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
-        if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
-        {                                                           \
-            DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
-            method(format, __VA_ARGS__ );                           \
-        }                                                           \
-    }
-#define dmLogOnceDebug(format, ... ) dmLogOnceInternal(dmLogDebug, format, __VA_ARGS__ )
-#define dmLogOnceUserDebug(format, ... ) dmLogOnceInternal(dmLogUserDebug, format, __VA_ARGS__ )
-#define dmLogOnceInfo(format, ... ) dmLogOnceInternal(dmLogInfo, format, __VA_ARGS__ )
-#define dmLogOnceWarning(format, ... ) dmLogOnceInternal(dmLogWarning, format, __VA_ARGS__ )
-#define dmLogOnceError(format, ... ) dmLogOnceInternal(dmLogError, format, __VA_ARGS__ )
-#define dmLogOnceFatal(format, ... ) dmLogOnceCritical(dmLogFatal, format, __VA_ARGS__ )
-#else
-#define dmLogOnceInternal(method, format, args... )                 \
-    {                                                               \
-        static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
-        if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
-        {                                                           \
-            DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
-            method(format, ## args );                               \
-        }                                                           \
-    }
-#define dmLogOnceDebug(format, args... ) dmLogOnceInternal(dmLogDebug, format, ## args )
-#define dmLogOnceUserDebug(format, args... ) dmLogOnceInternal(dmLogUserDebug, format, ## args )
-#define dmLogOnceInfo(format, args... ) dmLogOnceInternal(dmLogInfo, format, ## args )
-#define dmLogOnceWarning(format, args... ) dmLogOnceInternal(dmLogWarning, format, ## args )
-#define dmLogOnceError(format, args... ) dmLogOnceInternal(dmLogError, format, ## args )
-#define dmLogOnceFatal(format, args... ) dmLogOnceCritical(dmLogFatal, format, ## args )
-#endif
+    /*# Log severity
+     *
+     * Log severity
+     *
+     * @enum
+     * @name dmLog::Severity
+     * @member dmLog::SEVERITY_DEBUG
+     * @member dmLog::SEVERITY_USER_DEBUG
+     * @member dmLog::SEVERITY_INFO
+     * @member dmLog::SEVERITY_WARNING
+     * @member dmLog::SEVERITY_ERROR
+     * @member dmLog::SEVERITY_FATAL
+     */
+    enum Severity
+    {
+        SEVERITY_DEBUG       = 0,//!< dmLog::SEVERITY_DEBUG
+        SEVERITY_USER_DEBUG  = 1,//!< dmLog::SEVERITY_USER_DEBUG
+        SEVERITY_INFO        = 2,//!< dmLog::SEVERITY_INFO
+        SEVERITY_WARNING     = 3,//!< dmLog::SEVERITY_WARNING
+        SEVERITY_ERROR       = 4,//!< dmLog::SEVERITY_ERROR
+        SEVERITY_FATAL       = 5,//!< dmLog::SEVERITY_FATAL
+    };
 
-/*# dmLogListener callback typedef
- *
- * dmLog listener function type. Provides all logs from dmLog* functions and print/pprint Lua functions.
- * Used with dmLogRegisterListener() and dmLogUnregisterListener()
- *
- * @typedef
- * @name dmLogListener
- * @param severity [type:dmLogSeverity]
- * @param domain [type:const char*]
- * @param formatted_string [type:char*]
- */
-typedef void (*dmLogListener)(dmLogSeverity severity, const char* domain, char* formatted_string);
+    #if defined(NDEBUG)
 
-/*# register dmLog listener.
- *
- * Registers a dmLog listener.
- *
- * @name dmLogRegisterListener
- * @param listener [type:dmLogListener] 
- */
-void dmLogRegisterListener(dmLogListener listener);
+    #define dmLogDebug(format, ... ) do {} while(0);
+    #define dmLogUserDebug(format, ... ) do {} while(0);
+    #define dmLogInfo(format, args...) do {} while(0);
+    #define dmLogWarning(format, args...) do {} while(0);
+    #define dmLogError(format, args...) do {} while(0);
+    #define dmLogFatal(format, args...) do {} while(0);
 
-/*# unregister dmLog listener.
- *
- * Unregisters a dmLog listener.
- *
- * @name dmLogUnregisterListener
- * @param [type:dmLogListener] listener
- */
-void dmLogUnregisterListener(dmLogListener listener);
+    #define dmLogOnceDebug(format, args... ) do {} while(0);
+    #define dmLogOnceUserDebug(format, args... ) do {} while(0);
+    #define dmLogOnceInfo(format, args... ) do {} while(0);
+    #define dmLogOnceWarning(format, args... ) do {} while(0);
+    #define dmLogOnceError(format, args... ) do {} while(0);
+    #define dmLogOnceFatal(format, args... ) do {} while(0);
 
-/*# set log system severity level.
- *
- * set log system severity level.
- *
- * @name dmLogSetlevel
- * @param [type:dmLogSeverity] severity
- */
-void dmLogSetlevel(dmLogSeverity severity);
+    #else
 
-#endif
+    #ifndef DLIB_LOG_DOMAIN
+    #define DLIB_LOG_DOMAIN "DEFAULT"
+    #ifdef __GNUC__
+    #warning "DLIB_LOG_DOMAIN is not defined"
+    #endif
+    #endif
+
+    #ifdef __GNUC__
+    void LogInternal(Severity severity, const char* domain, const char* format, ...)
+        __attribute__ ((format (printf, 3, 4)));
+    #else
+    void LogInternal(Severity severity, const char* domain, const char* format, ...);
+    #endif
+
+    #ifdef _MSC_VER
+    #define dmLogDebug(format, ... ) LogInternal(dmLog::SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+    #define dmLogUserDebug(format, ... ) LogInternal(dmLog::SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+    #define dmLogInfo(format, ... ) LogInternal(dmLog::SEVERITY_INFO, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+    #define dmLogWarning(format, ... ) LogInternal(dmLog::SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+    #define dmLogError(format, ... ) LogInternal(dmLog::SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+    #define dmLogFatal(format, ... ) LogInternal(dmLog::SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+    #else
+    #define dmLogDebug(format, args...) LogInternal(dmLog::SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
+    #define dmLogUserDebug(format, args...) LogInternal(dmLog::SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
+    #define dmLogInfo(format, args...) LogInternal(dmLog::SEVERITY_INFO, DLIB_LOG_DOMAIN, format, ## args);
+    #define dmLogWarning(format, args...) LogInternal(dmLog::SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, ## args);
+    #define dmLogError(format, args...) LogInternal(dmLog::SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, ## args);
+    #define dmLogFatal(format, args...) LogInternal(dmLog::SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, ## args);
+    #endif
+
+    #define dmLogOnceIdentifier __dmLogOnce
+    #define __DM_LOG_PASTE(x, y) x ## y
+    #define DM_LOG_PASTE(x, y) __DM_LOG_PASTE(x, y)
+
+    #ifdef _MSC_VER
+    #define dmLogOnceInternal(method, format, ... )                     \
+        {                                                               \
+            static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
+            if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
+            {                                                           \
+                DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
+                method(format, __VA_ARGS__ );                           \
+            }                                                           \
+        }
+    #define dmLogOnceDebug(format, ... ) dmLogOnceInternal(dmLogDebug, format, __VA_ARGS__ )
+    #define dmLogOnceUserDebug(format, ... ) dmLogOnceInternal(dmLogUserDebug, format, __VA_ARGS__ )
+    #define dmLogOnceInfo(format, ... ) dmLogOnceInternal(dmLogInfo, format, __VA_ARGS__ )
+    #define dmLogOnceWarning(format, ... ) dmLogOnceInternal(dmLogWarning, format, __VA_ARGS__ )
+    #define dmLogOnceError(format, ... ) dmLogOnceInternal(dmLogError, format, __VA_ARGS__ )
+    #define dmLogOnceFatal(format, ... ) dmLogOnceInternal(dmLogFatal, format, __VA_ARGS__ )
+    #else
+    #define dmLogOnceInternal(method, format, args... )                 \
+        {                                                               \
+            static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
+            if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
+            {                                                           \
+                DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
+                method(format, ## args );                               \
+            }                                                           \
+        }
+    #define dmLogOnceDebug(format, args... ) dmLogOnceInternal(dmLogDebug, format, ## args )
+    #define dmLogOnceUserDebug(format, args... ) dmLogOnceInternal(dmLogUserDebug, format, ## args )
+    #define dmLogOnceInfo(format, args... ) dmLogOnceInternal(dmLogInfo, format, ## args )
+    #define dmLogOnceWarning(format, args... ) dmLogOnceInternal(dmLogWarning, format, ## args )
+    #define dmLogOnceError(format, args... ) dmLogOnceInternal(dmLogError, format, ## args )
+    #define dmLogOnceFatal(format, args... ) dmLogOnceInternal(dmLogFatal, format, ## args )
+    #endif
+
+    /*# dmLog:LogListener callback typedef
+     *
+     * dmLog listener function type. Provides all logs from dmLog* functions and print/pprint Lua functions.
+     * Used with dmLogRegisterListener() and dmLogUnregisterListener()
+     *
+     * @typedef
+     * @name dmLog:LogListener
+     * @param severity [type:dmLog::Severity]
+     * @param domain [type:const char*]
+     * @param formatted_string [type:char*]
+     */
+    typedef void (*LogListener)(Severity severity, const char* domain, char* formatted_string);
+
+    /*# register dmLog listener.
+     *
+     * Registers a dmLog listener.
+     * This listener recieve logs even in release bundle.
+     *
+     * @name dmLog::RegisterLogListener
+     * @param listener [type:dmLog::LogListener] 
+     */
+    void RegisterLogListener(LogListener listener);
+
+    /*# unregister dmLog listener.
+     *
+     * Unregisters a dmLog listener.
+     *
+     * @name dmLog::UnregisterLogListener
+     * @param [type:dmLog::LogListener] listener
+     */
+    void UnregisterLogListener(LogListener listener);
+
+    /*# set log system severity level.
+     *
+     * set log system severity level.
+     *
+     * @name dmLog::Setlevel
+     * @param [type:dmLog::Severity] severity
+     */
+    void Setlevel(Severity severity);
+
+    #endif
+} //namespace dmLog
 
 #endif // DMSDK_LOG_H

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -18,252 +18,252 @@
 namespace dmLog
 {
 
-    /*# logging functions
-     *
-     * Logging functions.
-     * @note Log functions will be omitted (NOP) for release builds
-     * @note Prefer these functions over `printf` since these can print to the platform specific logs
-     *
-     * @document
-     * @name Log
-     * @namespace dmLog
-     * @path engine/dlib/src/dmsdk/dlib/log.h
-    */
+/*# logging functions
+ *
+ * Logging functions.
+ * @note Log functions will be omitted (NOP) for release builds
+ * @note Prefer these functions over `printf` since these can print to the platform specific logs
+ *
+ * @document
+ * @name Log
+ * @namespace dmLog
+ * @path engine/dlib/src/dmsdk/dlib/log.h
+*/
 
-    /*# macro for debug category logging
-     *
-     * If DLIB_LOG_DOMAIN is defined the value of the defined is printed after severity.
-     * Otherwise DEFAULT will be printed.
-     *
-     * @note Extensions do not need to set this since they get their own logging domain automatically
-     *
-     * @macro
-     * @name DLIB_LOG_DOMAIN
-     * @examples
-     *
-     * ```cpp
-     * #define DLIB_LOG_DOMAIN "MyOwnDomain"
-     * #include <dmsdk/dlib/log.h>
-     * ```
-     */
+/*# macro for debug category logging
+ *
+ * If DLIB_LOG_DOMAIN is defined the value of the defined is printed after severity.
+ * Otherwise DEFAULT will be printed.
+ *
+ * @note Extensions do not need to set this since they get their own logging domain automatically
+ *
+ * @macro
+ * @name DLIB_LOG_DOMAIN
+ * @examples
+ *
+ * ```cpp
+ * #define DLIB_LOG_DOMAIN "MyOwnDomain"
+ * #include <dmsdk/dlib/log.h>
+ * ```
+ */
 
-    /*# log with "debug" severity
-     *
-     * Debug messages are temporary log instances used when debugging a certain behavior
-     * Use dmLogOnceDebug for one-shot logging
-     *
-     * @name dmLogDebug
-     * @param format [type:const char*] Format string
-     * @param args [type:...] Format string args (variable arg list)
-     * @return [type:void]
-     */
+/*# log with "debug" severity
+ *
+ * Debug messages are temporary log instances used when debugging a certain behavior
+ * Use dmLogOnceDebug for one-shot logging
+ *
+ * @name dmLogDebug
+ * @param format [type:const char*] Format string
+ * @param args [type:...] Format string args (variable arg list)
+ * @return [type:void]
+ */
 
-    /*# log with "user" severity
-     *
-     * Debug messages are temporary log instances used when debugging a certain behavior
-     * Use dmLogOnceUserDebug for one-shot logging
-     *
-     * @name dmLogUserDebug
-     * @param format [type:const char*] Format string
-     * @param args [type:...] Format string args (variable arg list)
-     * @return [type:void]
-     */
+/*# log with "user" severity
+ *
+ * Debug messages are temporary log instances used when debugging a certain behavior
+ * Use dmLogOnceUserDebug for one-shot logging
+ *
+ * @name dmLogUserDebug
+ * @param format [type:const char*] Format string
+ * @param args [type:...] Format string args (variable arg list)
+ * @return [type:void]
+ */
 
-    /*# log with "info" severity
-     *
-     * Info messages are used to inform the developers of relevant information
-     * Use dmLogOnceInfo for one-shot logging
-     *
-     * @name dmLogInfo
-     * @param format [type:const char*] Format string
-     * @param args [type:...] Format string args (variable arg list)
-     * @return [type:void]
-     */
+/*# log with "info" severity
+ *
+ * Info messages are used to inform the developers of relevant information
+ * Use dmLogOnceInfo for one-shot logging
+ *
+ * @name dmLogInfo
+ * @param format [type:const char*] Format string
+ * @param args [type:...] Format string args (variable arg list)
+ * @return [type:void]
+ */
 
-    /*# log with "warning" severity
-     *
-     * Warning messages are used to inform the developers about potential problems which can cause errors.
-     * Use dmLogOnceWarning for one-shot logging
-     *
-     * @name dmLogWarning
-     * @param format [type:const char*] Format string
-     * @param args [type:...] Format string args (variable arg list)
-     * @return [type:void]
-     */
+/*# log with "warning" severity
+ *
+ * Warning messages are used to inform the developers about potential problems which can cause errors.
+ * Use dmLogOnceWarning for one-shot logging
+ *
+ * @name dmLogWarning
+ * @param format [type:const char*] Format string
+ * @param args [type:...] Format string args (variable arg list)
+ * @return [type:void]
+ */
 
-    /*#log with "error" severity
-     *
-     * Error messages are used in cases where an recoverable error has occurred.
-     * Use dmLogOnceError for one-shot logging
-     *
-     * @name dmLogError
-     * @param format [type:const char*] Format string
-     * @param args [type:...] Format string args (variable arg list)
-     * @return [type:void]
-     */
+/*#log with "error" severity
+ *
+ * Error messages are used in cases where an recoverable error has occurred.
+ * Use dmLogOnceError for one-shot logging
+ *
+ * @name dmLogError
+ * @param format [type:const char*] Format string
+ * @param args [type:...] Format string args (variable arg list)
+ * @return [type:void]
+ */
 
-    /*# log with "fatal" severity
-     *
-     * Fatal messages are used in cases where an unrecoverable error has occurred.
-     * Use dmLogOnceFatal for one-shot logging
-     *
-     * @name dmLogFatal
-     * @param format [type:const char*] Format string
-     * @param args [type:...] Format string args (variable arg list)
-     * @return [type:void]
-     */
+/*# log with "fatal" severity
+ *
+ * Fatal messages are used in cases where an unrecoverable error has occurred.
+ * Use dmLogOnceFatal for one-shot logging
+ *
+ * @name dmLogFatal
+ * @param format [type:const char*] Format string
+ * @param args [type:...] Format string args (variable arg list)
+ * @return [type:void]
+ */
 
-    /*# Log severity
-     *
-     * Log severity
-     *
-     * @enum
-     * @name dmLog::Severity
-     * @member dmLog::SEVERITY_DEBUG
-     * @member dmLog::SEVERITY_USER_DEBUG
-     * @member dmLog::SEVERITY_INFO
-     * @member dmLog::SEVERITY_WARNING
-     * @member dmLog::SEVERITY_ERROR
-     * @member dmLog::SEVERITY_FATAL
-     */
-    enum Severity
-    {
-        SEVERITY_DEBUG       = 0,//!< dmLog::SEVERITY_DEBUG
-        SEVERITY_USER_DEBUG  = 1,//!< dmLog::SEVERITY_USER_DEBUG
-        SEVERITY_INFO        = 2,//!< dmLog::SEVERITY_INFO
-        SEVERITY_WARNING     = 3,//!< dmLog::SEVERITY_WARNING
-        SEVERITY_ERROR       = 4,//!< dmLog::SEVERITY_ERROR
-        SEVERITY_FATAL       = 5,//!< dmLog::SEVERITY_FATAL
-    };
+/*# Log severity
+ *
+ * Log severity
+ *
+ * @enum
+ * @name dmLog::Severity
+ * @member dmLog::LOG_SEVERITY_DEBUG
+ * @member dmLog::LOG_SEVERITY_USER_DEBUG
+ * @member dmLog::LOG_SEVERITY_INFO
+ * @member dmLog::LOG_SEVERITY_WARNING
+ * @member dmLog::LOG_SEVERITY_ERROR
+ * @member dmLog::LOG_SEVERITY_FATAL
+ */
+enum Severity
+{
+    LOG_SEVERITY_DEBUG       = 0,//!< dmLog::LOG_SEVERITY_DEBUG
+    LOG_SEVERITY_USER_DEBUG  = 1,//!< dmLog::LOG_SEVERITY_USER_DEBUG
+    LOG_SEVERITY_INFO        = 2,//!< dmLog::LOG_SEVERITY_INFO
+    LOG_SEVERITY_WARNING     = 3,//!< dmLog::LOG_SEVERITY_WARNING
+    LOG_SEVERITY_ERROR       = 4,//!< dmLog::LOG_SEVERITY_ERROR
+    LOG_SEVERITY_FATAL       = 5,//!< dmLog::LOG_SEVERITY_FATAL
+};
 
-    #if defined(NDEBUG)
+#if defined(NDEBUG)
 
-    #define dmLogDebug(format, ... ) do {} while(0);
-    #define dmLogUserDebug(format, ... ) do {} while(0);
-    #define dmLogInfo(format, args...) do {} while(0);
-    #define dmLogWarning(format, args...) do {} while(0);
-    #define dmLogError(format, args...) do {} while(0);
-    #define dmLogFatal(format, args...) do {} while(0);
+#define dmLogDebug(format, ... ) do {} while(0);
+#define dmLogUserDebug(format, ... ) do {} while(0);
+#define dmLogInfo(format, args...) do {} while(0);
+#define dmLogWarning(format, args...) do {} while(0);
+#define dmLogError(format, args...) do {} while(0);
+#define dmLogFatal(format, args...) do {} while(0);
 
-    #define dmLogOnceDebug(format, args... ) do {} while(0);
-    #define dmLogOnceUserDebug(format, args... ) do {} while(0);
-    #define dmLogOnceInfo(format, args... ) do {} while(0);
-    #define dmLogOnceWarning(format, args... ) do {} while(0);
-    #define dmLogOnceError(format, args... ) do {} while(0);
-    #define dmLogOnceFatal(format, args... ) do {} while(0);
+#define dmLogOnceDebug(format, args... ) do {} while(0);
+#define dmLogOnceUserDebug(format, args... ) do {} while(0);
+#define dmLogOnceInfo(format, args... ) do {} while(0);
+#define dmLogOnceWarning(format, args... ) do {} while(0);
+#define dmLogOnceError(format, args... ) do {} while(0);
+#define dmLogOnceFatal(format, args... ) do {} while(0);
 
-    #else
+#else
 
-    #ifndef DLIB_LOG_DOMAIN
-    #define DLIB_LOG_DOMAIN "DEFAULT"
-    #ifdef __GNUC__
-    #warning "DLIB_LOG_DOMAIN is not defined"
-    #endif
-    #endif
+#ifndef DLIB_LOG_DOMAIN
+#define DLIB_LOG_DOMAIN "DEFAULT"
+#ifdef __GNUC__
+#warning "DLIB_LOG_DOMAIN is not defined"
+#endif
+#endif
 
-    #ifdef __GNUC__
-    void LogInternal(Severity severity, const char* domain, const char* format, ...)
-        __attribute__ ((format (printf, 3, 4)));
-    #else
-    void LogInternal(Severity severity, const char* domain, const char* format, ...);
-    #endif
+#ifdef __GNUC__
+void LogInternal(Severity severity, const char* domain, const char* format, ...)
+    __attribute__ ((format (printf, 3, 4)));
+#else
+void LogInternal(Severity severity, const char* domain, const char* format, ...);
+#endif
 
-    #ifdef _MSC_VER
-    #define dmLogDebug(format, ... ) LogInternal(dmLog::SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-    #define dmLogUserDebug(format, ... ) LogInternal(dmLog::SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-    #define dmLogInfo(format, ... ) LogInternal(dmLog::SEVERITY_INFO, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-    #define dmLogWarning(format, ... ) LogInternal(dmLog::SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-    #define dmLogError(format, ... ) LogInternal(dmLog::SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-    #define dmLogFatal(format, ... ) LogInternal(dmLog::SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
-    #else
-    #define dmLogDebug(format, args...) LogInternal(dmLog::SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
-    #define dmLogUserDebug(format, args...) LogInternal(dmLog::SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
-    #define dmLogInfo(format, args...) LogInternal(dmLog::SEVERITY_INFO, DLIB_LOG_DOMAIN, format, ## args);
-    #define dmLogWarning(format, args...) LogInternal(dmLog::SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, ## args);
-    #define dmLogError(format, args...) LogInternal(dmLog::SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, ## args);
-    #define dmLogFatal(format, args...) LogInternal(dmLog::SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, ## args);
-    #endif
+#ifdef _MSC_VER
+#define dmLogDebug(format, ... ) LogInternal(dmLog::LOG_SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+#define dmLogUserDebug(format, ... ) LogInternal(dmLog::LOG_SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+#define dmLogInfo(format, ... ) LogInternal(dmLog::LOG_SEVERITY_INFO, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+#define dmLogWarning(format, ... ) LogInternal(dmLog::LOG_SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+#define dmLogError(format, ... ) LogInternal(dmLog::LOG_SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+#define dmLogFatal(format, ... ) LogInternal(dmLog::LOG_SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, __VA_ARGS__ );
+#else
+#define dmLogDebug(format, args...) LogInternal(dmLog::LOG_SEVERITY_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
+#define dmLogUserDebug(format, args...) LogInternal(dmLog::LOG_SEVERITY_USER_DEBUG, DLIB_LOG_DOMAIN, format, ## args);
+#define dmLogInfo(format, args...) LogInternal(dmLog::LOG_SEVERITY_INFO, DLIB_LOG_DOMAIN, format, ## args);
+#define dmLogWarning(format, args...) LogInternal(dmLog::LOG_SEVERITY_WARNING, DLIB_LOG_DOMAIN, format, ## args);
+#define dmLogError(format, args...) LogInternal(dmLog::LOG_SEVERITY_ERROR, DLIB_LOG_DOMAIN, format, ## args);
+#define dmLogFatal(format, args...) LogInternal(dmLog::LOG_SEVERITY_FATAL, DLIB_LOG_DOMAIN, format, ## args);
+#endif
 
-    #define dmLogOnceIdentifier __dmLogOnce
-    #define __DM_LOG_PASTE(x, y) x ## y
-    #define DM_LOG_PASTE(x, y) __DM_LOG_PASTE(x, y)
+#define dmLogOnceIdentifier __dmLogOnce
+#define __DM_LOG_PASTE(x, y) x ## y
+#define DM_LOG_PASTE(x, y) __DM_LOG_PASTE(x, y)
 
-    #ifdef _MSC_VER
-    #define dmLogOnceInternal(method, format, ... )                     \
-        {                                                               \
-            static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
-            if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
-            {                                                           \
-                DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
-                method(format, __VA_ARGS__ );                           \
-            }                                                           \
-        }
-    #define dmLogOnceDebug(format, ... ) dmLogOnceInternal(dmLogDebug, format, __VA_ARGS__ )
-    #define dmLogOnceUserDebug(format, ... ) dmLogOnceInternal(dmLogUserDebug, format, __VA_ARGS__ )
-    #define dmLogOnceInfo(format, ... ) dmLogOnceInternal(dmLogInfo, format, __VA_ARGS__ )
-    #define dmLogOnceWarning(format, ... ) dmLogOnceInternal(dmLogWarning, format, __VA_ARGS__ )
-    #define dmLogOnceError(format, ... ) dmLogOnceInternal(dmLogError, format, __VA_ARGS__ )
-    #define dmLogOnceFatal(format, ... ) dmLogOnceInternal(dmLogFatal, format, __VA_ARGS__ )
-    #else
-    #define dmLogOnceInternal(method, format, args... )                 \
-        {                                                               \
-            static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
-            if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
-            {                                                           \
-                DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
-                method(format, ## args );                               \
-            }                                                           \
-        }
-    #define dmLogOnceDebug(format, args... ) dmLogOnceInternal(dmLogDebug, format, ## args )
-    #define dmLogOnceUserDebug(format, args... ) dmLogOnceInternal(dmLogUserDebug, format, ## args )
-    #define dmLogOnceInfo(format, args... ) dmLogOnceInternal(dmLogInfo, format, ## args )
-    #define dmLogOnceWarning(format, args... ) dmLogOnceInternal(dmLogWarning, format, ## args )
-    #define dmLogOnceError(format, args... ) dmLogOnceInternal(dmLogError, format, ## args )
-    #define dmLogOnceFatal(format, args... ) dmLogOnceInternal(dmLogFatal, format, ## args )
-    #endif
+#ifdef _MSC_VER
+#define dmLogOnceInternal(method, format, ... )                     \
+    {                                                               \
+        static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
+        if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
+        {                                                           \
+            DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
+            method(format, __VA_ARGS__ );                           \
+        }                                                           \
+    }
+#define dmLogOnceDebug(format, ... ) dmLogOnceInternal(dmLogDebug, format, __VA_ARGS__ )
+#define dmLogOnceUserDebug(format, ... ) dmLogOnceInternal(dmLogUserDebug, format, __VA_ARGS__ )
+#define dmLogOnceInfo(format, ... ) dmLogOnceInternal(dmLogInfo, format, __VA_ARGS__ )
+#define dmLogOnceWarning(format, ... ) dmLogOnceInternal(dmLogWarning, format, __VA_ARGS__ )
+#define dmLogOnceError(format, ... ) dmLogOnceInternal(dmLogError, format, __VA_ARGS__ )
+#define dmLogOnceFatal(format, ... ) dmLogOnceInternal(dmLogFatal, format, __VA_ARGS__ )
+#else
+#define dmLogOnceInternal(method, format, args... )                 \
+    {                                                               \
+        static int DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 0; \
+        if (DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) == 0)       \
+        {                                                           \
+            DM_LOG_PASTE(dmLogOnceIdentifier, __LINE__) = 1;        \
+            method(format, ## args );                               \
+        }                                                           \
+    }
+#define dmLogOnceDebug(format, args... ) dmLogOnceInternal(dmLogDebug, format, ## args )
+#define dmLogOnceUserDebug(format, args... ) dmLogOnceInternal(dmLogUserDebug, format, ## args )
+#define dmLogOnceInfo(format, args... ) dmLogOnceInternal(dmLogInfo, format, ## args )
+#define dmLogOnceWarning(format, args... ) dmLogOnceInternal(dmLogWarning, format, ## args )
+#define dmLogOnceError(format, args... ) dmLogOnceInternal(dmLogError, format, ## args )
+#define dmLogOnceFatal(format, args... ) dmLogOnceInternal(dmLogFatal, format, ## args )
+#endif
 
-    /*# dmLog:LogListener callback typedef
-     *
-     * dmLog listener function type. Provides all logs from dmLog* functions and print/pprint Lua functions.
-     * Used with dmLogRegisterListener() and dmLogUnregisterListener()
-     *
-     * @typedef
-     * @name dmLog:LogListener
-     * @param severity [type:dmLog::Severity]
-     * @param domain [type:const char*]
-     * @param formatted_string [type:const char*] null terminated string
-     */
-    typedef void (*LogListener)(Severity severity, const char* domain, const char* formatted_string);
+/*# dmLog:LogListener callback typedef
+ *
+ * dmLog listener function type. Provides all logs from dmLog* functions and print/pprint Lua functions.
+ * Used with dmLogRegisterListener() and dmLogUnregisterListener()
+ *
+ * @typedef
+ * @name dmLog:LogListener
+ * @param severity [type:dmLog::Severity]
+ * @param domain [type:const char*]
+ * @param formatted_string [type:const char*] null terminated string
+ */
+typedef void (*LogListener)(Severity severity, const char* domain, const char* formatted_string);
 
-    /*# register dmLog listener.
-     *
-     * Registers a dmLog listener.
-     * This listener recieve logs even in release bundle.
-     *
-     * @name dmLog::RegisterLogListener
-     * @param listener [type:dmLog::LogListener] 
-     */
-    void RegisterLogListener(LogListener listener);
+/*# register dmLog listener.
+ *
+ * Registers a dmLog listener.
+ * This listener recieve logs even in release bundle.
+ *
+ * @name dmLog::RegisterLogListener
+ * @param listener [type:dmLog::LogListener] 
+ */
+void RegisterLogListener(LogListener listener);
 
-    /*# unregister dmLog listener.
-     *
-     * Unregisters a dmLog listener.
-     *
-     * @name dmLog::UnregisterLogListener
-     * @param [type:dmLog::LogListener] listener
-     */
-    void UnregisterLogListener(LogListener listener);
+/*# unregister dmLog listener.
+ *
+ * Unregisters a dmLog listener.
+ *
+ * @name dmLog::UnregisterLogListener
+ * @param [type:dmLog::LogListener] listener
+ */
+void UnregisterLogListener(LogListener listener);
 
-    /*# set log system severity level.
-     *
-     * set log system severity level.
-     *
-     * @name dmLog::Setlevel
-     * @param [type:dmLog::Severity] severity
-     */
-    void Setlevel(Severity severity);
+/*# set log system severity level.
+ *
+ * set log system severity level.
+ *
+ * @name dmLog::Setlevel
+ * @param [type:dmLog::Severity] severity
+ */
+void Setlevel(Severity severity);
 
-    #endif
+#endif
 } //namespace dmLog
 
 #endif // DMSDK_LOG_H

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -110,10 +110,18 @@
  * @return [type:void]
  */
 
-/** Log severity
+/*# Log severity
+ *
  * Log severity
+ *
  * @enum
  * @name dmLogSeverity
+ * @member DM_LOG_SEVERITY_DEBUG
+ * @member DM_LOG_SEVERITY_USER_DEBUG
+ * @member DM_LOG_SEVERITY_INFO
+ * @member DM_LOG_SEVERITY_WARNING
+ * @member DM_LOG_SEVERITY_ERROR
+ * @member DM_LOG_SEVERITY_FATAL
  */
 enum dmLogSeverity
 {

--- a/engine/dlib/src/dmsdk/dlib/log.h
+++ b/engine/dlib/src/dmsdk/dlib/log.h
@@ -230,7 +230,7 @@ void dmLogInternal(dmLogSeverity severity, const char* domain, const char* forma
  * @param domain [type:const char*]
  * @param formatted_string [type:char*]
  */
-typedef void (*dmLogListener)(dmLogSeverity severity, const char* domain, const char* format, ...);
+typedef void (*dmLogListener)(dmLogSeverity severity, const char* domain, char* formatted_string);
 
 /*# register dmLog listener.
  *

--- a/engine/dlib/src/test/test_connection_pool.cpp
+++ b/engine/dlib/src/test/test_connection_pool.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    dmLogSetlevel(DM_LOG_SEVERITY_INFO);
+    dmLog::Setlevel(dmLog::SEVERITY_INFO);
     dmSocket::Initialize();
     dmSSLSocket::Initialize();
     jc_test_init(&argc, argv);

--- a/engine/dlib/src/test/test_connection_pool.cpp
+++ b/engine/dlib/src/test/test_connection_pool.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    dmLog::Setlevel(dmLog::SEVERITY_INFO);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_INFO);
     dmSocket::Initialize();
     dmSSLSocket::Initialize();
     jc_test_init(&argc, argv);

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -1156,7 +1156,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    dmLogSetlevel(DM_LOG_SEVERITY_INFO);
+    dmLog::Setlevel(dmLog::SEVERITY_INFO);
     dmSocket::Initialize();
     dmSSLSocket::Initialize();
     jc_test_init(&argc, argv);

--- a/engine/dlib/src/test/test_httpclient.cpp
+++ b/engine/dlib/src/test/test_httpclient.cpp
@@ -1156,7 +1156,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    dmLog::Setlevel(dmLog::SEVERITY_INFO);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_INFO);
     dmSocket::Initialize();
     dmSSLSocket::Initialize();
     jc_test_init(&argc, argv);

--- a/engine/dlib/src/test/test_log.cpp
+++ b/engine/dlib/src/test/test_log.cpp
@@ -29,9 +29,9 @@
 
 TEST(dmLog, Init)
 {
-    dmLogParams params;
-    dmLogInitialize(&params);
-    dmLogFinalize();
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
+    dmLog::LogFinalize();
 }
 
 static void LogThread(void* arg)
@@ -55,9 +55,9 @@ static void LogThread(void* arg)
 TEST(dmLog, Client)
 {
     char buf[256];
-    dmLogParams params;
-    dmLogInitialize(&params);
-    uint16_t port = dmLogGetPort();
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
+    uint16_t port = dmLog::GetPort();
     ASSERT_GT(port, 0);
     dmSnPrintf(buf, sizeof(buf), "python src/test/test_log.py %d", port);
 #ifdef _WIN32
@@ -87,7 +87,7 @@ TEST(dmLog, Client)
     pclose(f);
 #endif
     dmThread::Join(log_thread);
-    dmLogFinalize();
+    dmLog::LogFinalize();
 }
 #endif
 
@@ -103,11 +103,11 @@ TEST(dmLog, LogFile)
     dmSys::GetLogPath(path, sizeof(path));
     dmStrlCat(path, "log.txt", sizeof(path));
 
-    dmLogParams params;
-    dmLogInitialize(&params);
-    dmSetLogFile(path);
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
+    dmLog::SetLogFile(path);
     dmLogInfo("TESTING_LOG");
-    dmLogFinalize();
+    dmLog::LogFinalize();
 
     char tmp[1024];
     FILE* f = fopen(path, "rb");
@@ -131,7 +131,7 @@ static void TestLogCaptureCallback(void* user_data, const char* log)
 TEST(dmLog, TestCapture)
 {
     dmArray<char> log_output;
-    dmSetCustomLogCallback(TestLogCaptureCallback, &log_output);
+    dmLog::SetCustomLogCallback(TestLogCaptureCallback, &log_output);
     dmLogDebug("This is a debug message");
     dmLogInfo("This is a info message");
     dmLogWarning("This is a warning message");
@@ -148,7 +148,7 @@ TEST(dmLog, TestCapture)
 
     ASSERT_STREQ(ExpectedOutput,
                 log_output.Begin());
-    dmSetCustomLogCallback(0x0, 0x0);
+    dmLog::SetCustomLogCallback(0x0, 0x0);
 }
 
 int main(int argc, char **argv)

--- a/engine/dlib/src/test/test_ssdp.cpp
+++ b/engine/dlib/src/test/test_ssdp.cpp
@@ -443,7 +443,7 @@ TEST_F(dmSSDPTest, JavaClient)
 int main(int argc, char **argv)
 {
     srand(time(NULL));
-    dmLogSetlevel(DM_LOG_SEVERITY_DEBUG);
+    dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
     dmSocket::Initialize();
     jc_test_init(&argc, argv);
     int ret = jc_test_run_all();

--- a/engine/dlib/src/test/test_ssdp.cpp
+++ b/engine/dlib/src/test/test_ssdp.cpp
@@ -443,7 +443,7 @@ TEST_F(dmSSDPTest, JavaClient)
 int main(int argc, char **argv)
 {
     srand(time(NULL));
-    dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_DEBUG);
     dmSocket::Initialize();
     jc_test_init(&argc, argv);
     int ret = jc_test_run_all();

--- a/engine/dlib/src/test/test_ssdp_internals.cpp
+++ b/engine/dlib/src/test/test_ssdp_internals.cpp
@@ -417,7 +417,7 @@ TEST_F(dmSSDPInternalTest, ClientServer_MatchingInterfaces)
 int main(int argc, char **argv)
 {
     srand(time(NULL));
-    dmLogSetlevel(DM_LOG_SEVERITY_DEBUG);
+    dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
     jc_test_init(&argc, argv);
     return jc_test_run_all();
 }

--- a/engine/dlib/src/test/test_ssdp_internals.cpp
+++ b/engine/dlib/src/test/test_ssdp_internals.cpp
@@ -417,7 +417,7 @@ TEST_F(dmSSDPInternalTest, ClientServer_MatchingInterfaces)
 int main(int argc, char **argv)
 {
     srand(time(NULL));
-    dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_DEBUG);
     jc_test_init(&argc, argv);
     return jc_test_run_all();
 }

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -648,7 +648,7 @@ namespace dmEngine
             else if (strncmp(verbose_long, arg, sizeof(verbose_long)-1) == 0 ||
                      strncmp(verbose_short, arg, sizeof(verbose_short)-1) == 0)
             {
-                dmLogSetlevel(DM_LOG_SEVERITY_DEBUG);
+                dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
             }
         }
 
@@ -696,7 +696,7 @@ namespace dmEngine
                 const char* path = dmConfigFile::GetString(engine->m_Config, "project.log_dir", sys_path);
                 char full[DMPATH_MAX_PATH];
                 dmPath::Concat(path, "log.txt", full, sizeof(full));
-                dmSetLogFile(full);
+                dmLog::SetLogFile(full);
             } else {
                 dmLogFatal("Unable to get log-file path");
             }
@@ -1926,8 +1926,8 @@ void dmEngineInitialize()
     dmSSLSocket::Initialize();
     dmMemProfile::Initialize();
     dmProfile::Initialize(256, 1024 * 16, 128);
-    dmLogParams params;
-    dmLogInitialize(&params);
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
 
     if (dLib::FeaturesSupported(DM_FEATURE_BIT_SOCKET_SERVER_TCP | DM_FEATURE_BIT_SOCKET_SERVER_UDP))
     {
@@ -1943,7 +1943,7 @@ void dmEngineFinalize()
         dmEngineService::Delete(dmEngine::g_EngineService);
     }
     dmGraphics::Finalize();
-    dmLogFinalize();
+    dmLog::LogFinalize();
     dmProfile::Finalize();
     dmMemProfile::Finalize();
     dmSSLSocket::Finalize();

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -648,7 +648,7 @@ namespace dmEngine
             else if (strncmp(verbose_long, arg, sizeof(verbose_long)-1) == 0 ||
                      strncmp(verbose_short, arg, sizeof(verbose_short)-1) == 0)
             {
-                dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
+                dmLog::Setlevel(dmLog::LOG_SEVERITY_DEBUG);
             }
         }
 

--- a/engine/engine/src/engine_service.cpp
+++ b/engine/engine/src/engine_service.cpp
@@ -360,7 +360,7 @@ namespace dmEngineService
             dmSocket::Address address;
             dmWebServer::GetName(web_server, &address, &m_Port);
             dmSnPrintf(m_PortText, sizeof(m_PortText), "%d", (int) m_Port);
-            dmSnPrintf(m_LogPortText, sizeof(m_LogPortText), "%d", (int) dmLogGetPort());
+            dmSnPrintf(m_LogPortText, sizeof(m_LogPortText), "%d", (int) dmLog::GetPort());
 
             // The redirect server
             params.m_Port = 8002;

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
@@ -333,7 +333,7 @@ TEST_F(CollectionTest, PostCollection)
 
 TEST_F(CollectionTest, CollectionFail)
 {
-    dmLogSetlevel(DM_LOG_SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
     for (int i = 0; i < 20; ++i)
     {
         // NOTE: Coll is local and not collection in CollectionTest
@@ -349,12 +349,12 @@ TEST_F(CollectionTest, CollectionFail)
         ASSERT_NE(dmResource::RESULT_OK, r);
         dmGameObject::PostUpdate(m_Register);
     }
-    dmLogSetlevel(DM_LOG_SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
 }
 
 TEST_F(CollectionTest, CollectionComponentFail)
 {
-    dmLogSetlevel(DM_LOG_SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
     for (int i = 0; i < 4; ++i)
     {
         // NOTE: Coll is local and not collection in CollectionTest
@@ -369,7 +369,7 @@ TEST_F(CollectionTest, CollectionComponentFail)
         ASSERT_NE(dmResource::RESULT_OK, r);
         dmGameObject::PostUpdate(m_Register);
     }
-    dmLogSetlevel(DM_LOG_SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
 }
 
 TEST_F(CollectionTest, CollectionInCollection)
@@ -437,7 +437,7 @@ TEST_F(CollectionTest, CollectionInCollection)
 
 TEST_F(CollectionTest, CollectionInCollectionChildFail)
 {
-    dmLogSetlevel(DM_LOG_SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
     for (int i = 0; i < 20; ++i)
     {
         // NOTE: Coll is local and not collection in CollectionTest
@@ -449,7 +449,7 @@ TEST_F(CollectionTest, CollectionInCollectionChildFail)
             r = PreloaderGet(m_Factory, "root2.collection", (void**) &coll);
         ASSERT_NE(dmResource::RESULT_OK, r);
     }
-    dmLogSetlevel(DM_LOG_SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
 }
 
 TEST_F(CollectionTest, DefaultValues)

--- a/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
+++ b/engine/gameobject/src/gameobject/test/collection/test_gameobject_collection.cpp
@@ -333,7 +333,7 @@ TEST_F(CollectionTest, PostCollection)
 
 TEST_F(CollectionTest, CollectionFail)
 {
-    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_FATAL);
     for (int i = 0; i < 20; ++i)
     {
         // NOTE: Coll is local and not collection in CollectionTest
@@ -349,12 +349,12 @@ TEST_F(CollectionTest, CollectionFail)
         ASSERT_NE(dmResource::RESULT_OK, r);
         dmGameObject::PostUpdate(m_Register);
     }
-    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_WARNING);
 }
 
 TEST_F(CollectionTest, CollectionComponentFail)
 {
-    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_FATAL);
     for (int i = 0; i < 4; ++i)
     {
         // NOTE: Coll is local and not collection in CollectionTest
@@ -369,7 +369,7 @@ TEST_F(CollectionTest, CollectionComponentFail)
         ASSERT_NE(dmResource::RESULT_OK, r);
         dmGameObject::PostUpdate(m_Register);
     }
-    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_WARNING);
 }
 
 TEST_F(CollectionTest, CollectionInCollection)
@@ -437,7 +437,7 @@ TEST_F(CollectionTest, CollectionInCollection)
 
 TEST_F(CollectionTest, CollectionInCollectionChildFail)
 {
-    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_FATAL);
     for (int i = 0; i < 20; ++i)
     {
         // NOTE: Coll is local and not collection in CollectionTest
@@ -449,7 +449,7 @@ TEST_F(CollectionTest, CollectionInCollectionChildFail)
             r = PreloaderGet(m_Factory, "root2.collection", (void**) &coll);
         ASSERT_NE(dmResource::RESULT_OK, r);
     }
-    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_WARNING);
 }
 
 TEST_F(CollectionTest, DefaultValues)

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -176,10 +176,10 @@ TEST_F(ScriptTest, TestFailingScript02)
     // Test init failure
 
     // Avoid logging expected errors. Better solution?
-    dmLogSetlevel(DM_LOG_SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
     dmGameObject::New(m_Collection, "/go2.goc");
     bool result = dmGameObject::Init(m_Collection);
-    dmLogSetlevel(DM_LOG_SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
     EXPECT_FALSE(result);
     result = dmGameObject::Final(m_Collection);
     EXPECT_FALSE(result);
@@ -194,9 +194,9 @@ TEST_F(ScriptTest, TestFailingScript03)
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 
     // Avoid logging expected errors. Better solution?
-    dmLogSetlevel(DM_LOG_SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
     ASSERT_FALSE(dmGameObject::Update(m_Collection, &m_UpdateContext));
-    dmLogSetlevel(DM_LOG_SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
     dmGameObject::Delete(m_Collection, go, false);
 }
 

--- a/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/test/script/test_gameobject_script.cpp
@@ -176,10 +176,10 @@ TEST_F(ScriptTest, TestFailingScript02)
     // Test init failure
 
     // Avoid logging expected errors. Better solution?
-    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_FATAL);
     dmGameObject::New(m_Collection, "/go2.goc");
     bool result = dmGameObject::Init(m_Collection);
-    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_WARNING);
     EXPECT_FALSE(result);
     result = dmGameObject::Final(m_Collection);
     EXPECT_FALSE(result);
@@ -194,9 +194,9 @@ TEST_F(ScriptTest, TestFailingScript03)
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
 
     // Avoid logging expected errors. Better solution?
-    dmLog::Setlevel(dmLog::SEVERITY_FATAL);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_FATAL);
     ASSERT_FALSE(dmGameObject::Update(m_Collection, &m_UpdateContext));
-    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_WARNING);
     dmGameObject::Delete(m_Collection, go, false);
 }
 

--- a/engine/graphics/src/test/test_app_vulkan.cpp
+++ b/engine/graphics/src/test/test_app_vulkan.cpp
@@ -96,8 +96,8 @@ struct AppCtx
 
 static void AppCreate(void* _ctx)
 {
-    dmLogParams params;
-    dmLogInitialize(&params);
+    dmLog::LogParams params;
+    dmLog::LogInitialize(&params);
 
     AppCtx* ctx = (AppCtx*)_ctx;
     ctx->m_Created++;

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -122,9 +122,9 @@ TEST_F(dmGraphicsTest, CloseOpenWindow)
     params.m_Height = HEIGHT;
     params.m_Fullscreen = false;
     params.m_PrintDeviceInfo = true;
-    dmLogSetlevel(DM_LOG_SEVERITY_INFO);
+    dmLog::Setlevel(dmLog::SEVERITY_INFO);
     ASSERT_EQ(dmGraphics::WINDOW_RESULT_OK, dmGraphics::OpenWindow(m_Context, &params));
-    dmLogSetlevel(DM_LOG_SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
 }
 
 TEST_F(dmGraphicsTest, TestWindowState)

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -122,9 +122,9 @@ TEST_F(dmGraphicsTest, CloseOpenWindow)
     params.m_Height = HEIGHT;
     params.m_Fullscreen = false;
     params.m_PrintDeviceInfo = true;
-    dmLog::Setlevel(dmLog::SEVERITY_INFO);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_INFO);
     ASSERT_EQ(dmGraphics::WINDOW_RESULT_OK, dmGraphics::OpenWindow(m_Context, &params));
-    dmLog::Setlevel(dmLog::SEVERITY_WARNING);
+    dmLog::Setlevel(dmLog::LOG_SEVERITY_WARNING);
 }
 
 TEST_F(dmGraphicsTest, TestWindowState)

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -368,7 +368,7 @@ namespace dmScript
     {
         int n = lua_gettop(L);
         lua_getglobal(L, "tostring");
-        char buffer[DM_LOG_MAX_STRING_SIZE];
+        char buffer[dmLog::MAX_STRING_SIZE];
         buffer[0] = 0;
         for (int i = 1; i <= n; ++i)
         {
@@ -553,7 +553,7 @@ namespace dmScript
         DM_LUA_STACK_CHECK(L, 0);
         int n = lua_gettop(L);
 
-        char buf[DM_LOG_MAX_STRING_SIZE];
+        char buf[dmLog::MAX_STRING_SIZE];
         dmPPrint::Printer printer(buf, sizeof(buf));
         dmHashTable<uintptr_t, bool> printed_tables;
         for (int s = 1; s <= n; ++s)

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -41,7 +41,7 @@ class ScriptTest : public jc_test_base_class
 protected:
     virtual void SetUp()
     {
-        dmSetCustomLogCallback(LogCallback, this);
+        dmLog::SetCustomLogCallback(LogCallback, this);
         m_Context = dmScript::NewContext(0x0, 0, true);
         dmScript::Initialize(m_Context);
         L = dmScript::GetLuaState(m_Context);
@@ -51,7 +51,7 @@ protected:
     {
         dmScript::Finalize(m_Context);
         dmScript::DeleteContext(m_Context);
-        dmSetCustomLogCallback(0x0, 0x0);
+        dmLog::SetCustomLogCallback(0x0, 0x0);
     }
 
     const char* RemoveTableAddresses(char* str)

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -191,7 +191,7 @@ int Launch(int argc, char **argv) {
     }
 
     if (dmConfigFile::GetInt(config, "launcher.debug", 0)) {
-        dmLogSetlevel(DM_LOG_SEVERITY_DEBUG);
+        dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
     }
 
     ReplaceContext context;

--- a/engine/tools/src/launcher/launcher.cpp
+++ b/engine/tools/src/launcher/launcher.cpp
@@ -191,7 +191,7 @@ int Launch(int argc, char **argv) {
     }
 
     if (dmConfigFile::GetInt(config, "launcher.debug", 0)) {
-        dmLog::Setlevel(dmLog::SEVERITY_DEBUG);
+        dmLog::Setlevel(dmLog::LOG_SEVERITY_DEBUG);
     }
 
     ReplaceContext context;


### PR DESCRIPTION
fix https://github.com/defold/defold/issues/5591

This example works even in release:

```
#include <iostream>

static void dmLogListener(dmLog::Severity severity, const char* domain, const char* formatted_string)
{
    std::cout << "~~~ " <<severity<<" -- --- "<< formatted_string;
}

static  dmExtension::Result Initialize(dmExtension::Params* params)
{
    dmLog::RegisterLogListener(dmLogListener);
    dmLogInfo("Some log");
    dmLog::UnregisterLogListener(dmLogListener);
    return dmExtension::RESULT_OK;
}
```