### PR TITLE
Fix opening of OpenGL window in compat mode

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -737,9 +737,19 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
             if (is_desktop) {
                 dmLogWarning("Trying OpenGL 3.1 compat mode");
 
-                // Try a second time, this time without core profile, and lower the minor version
-                glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 1); // We currently cannot go lower since we support shader model 140
-                glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
+                // Try a second time, this time without core profile, and lower the minor version.
+                // And GLFW clears hints, so we have to set them again.
+                if (params->m_HighDPI) {
+                    glfwOpenWindowHint(GLFW_WINDOW_HIGH_DPI, 1);
+                }
+                glfwOpenWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+                glfwOpenWindowHint(GLFW_FSAA_SAMPLES, params->m_Samples);
+
+                // We currently cannot go lower since we support shader model 140
+                glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
+                glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 1);
+
+                glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 
                 if (!glfwOpenWindow(params->m_Width, params->m_Height, 8, 8, 8, 8, 32, 8, mode))
                 {


### PR DESCRIPTION
This PR fixes the issue with OpenGL 3.1 graphics cards like Intel HD, HD 2000/3000 etc.

Comments:
- GLFW [clears window hints](https://github.com/defold/defold/blob/f89acfb9d7a60eaefa540af05dbb37cfa4148226/engine/glfw/lib/window.c#L530), i.e. we should set all of them again.
- We shouldn't set the value of GLFW_OPENGL_PROFILE, because [it requires OpenGL >=3.2](https://github.com/defold/defold/blob/f89acfb9d7a60eaefa540af05dbb37cfa4148226/engine/glfw/lib/window.c#L516).

Now, the engine runs well on [the integrated GPU of Celeron G530](https://www.techpowerup.com/gpu-specs/intel-sandy-bridge-gt1.g579):
![opengl 3 1 compat mode](https://user-images.githubusercontent.com/193258/148591696-149818e6-e196-434c-a60e-a6745ad3cc7e.png)

