### PR TITLE
Issue-3718 Camera properties are available via `go.get()/set()` and `go.animate()`

### DIFF
--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -89,3 +89,58 @@ message AcquireCameraFocus {}
  * ```
  */
 message ReleaseCameraFocus {}
+
+/*# [type:float] camera fov
+ *
+ * Vertical field of view of the camera.
+ * The type of the property is float.
+ *
+ * @name fov
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local fov = go.get("#camera", "fov")
+ *   go.set("#sprite", "fov", fov + 0.1)
+ *   go.animate("#camera", "fov", go.PLAYBACK_ONCE_PINGPONG, 1.2, go.EASING_LINEAR, 1)
+ * end
+ * ```
+ */
+
+ /*# [type:float] camera near_z
+ *
+ * Camera frustum near plane.
+ * The type of the property is float.
+ *
+ * @name near_z
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local near_z = go.get("#camera", "near_z")
+ *   go.set("#sprite", "near_z", 10)
+ * end
+ * ```
+ */
+
+/*# [type:float] camera far_z
+ *
+ * Camera frustum far plane.
+ * The type of the property is float.
+ *
+ * @name far_z
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local far_z = go.get("#camera", "far_z")
+ *   go.set("#sprite", "far_z", 10)
+ * end
+ * ```
+ */

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -52,11 +52,9 @@ namespace dmGameSystem
         dmArray<CameraComponent*> m_FocusStack;
     };
 
-    static const dmhash_t CAMERA_PROP_ASPECT_RATIO= dmHashString64("aspect_ratio");
     static const dmhash_t CAMERA_PROP_FOV = dmHashString64("fov");
     static const dmhash_t CAMERA_PROP_NEAR_Z = dmHashString64("near_z");
     static const dmhash_t CAMERA_PROP_FAR_Z = dmHashString64("far_z");
-    static const dmhash_t CAMERA_PROP_AUTO_ASPECT_RATIO= dmHashString64("auto_aspect_ratio");
 
     dmGameObject::CreateResult CompCameraNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -278,12 +276,7 @@ namespace dmGameSystem
         CameraComponent* component = (CameraComponent*)*params.m_UserData;
         dmhash_t get_property = params.m_PropertyId;
 
-        if (CAMERA_PROP_ASPECT_RATIO == get_property)
-        {
-            out_value.m_Variant = dmGameObject::PropertyVar(component->m_AspectRatio);
-            return dmGameObject::PROPERTY_RESULT_OK;
-        }
-        else if (CAMERA_PROP_FOV == get_property)
+        if (CAMERA_PROP_FOV == get_property)
         {
             out_value.m_Variant = dmGameObject::PropertyVar(component->m_Fov);
             return dmGameObject::PROPERTY_RESULT_OK;
@@ -298,11 +291,6 @@ namespace dmGameSystem
             out_value.m_Variant = dmGameObject::PropertyVar(component->m_FarZ);
             return dmGameObject::PROPERTY_RESULT_OK;
         }
-        else if (CAMERA_PROP_AUTO_ASPECT_RATIO == get_property)
-        {
-            out_value.m_Variant = dmGameObject::PropertyVar(component->m_AutoAspectRatio == 1);
-            return dmGameObject::PROPERTY_RESULT_OK;
-        }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 
@@ -310,12 +298,8 @@ namespace dmGameSystem
     {
         CameraComponent* component = (CameraComponent*)*params.m_UserData;
         dmhash_t set_property = params.m_PropertyId;
-        if (CAMERA_PROP_ASPECT_RATIO == set_property)
-        {
-            component->m_AspectRatio = params.m_Value.m_Number;
-            return dmGameObject::PROPERTY_RESULT_OK;
-        }
-        else if (CAMERA_PROP_FOV == set_property)
+        
+        if (CAMERA_PROP_FOV == set_property)
         {
             component->m_Fov = params.m_Value.m_Number;
             return dmGameObject::PROPERTY_RESULT_OK;
@@ -328,11 +312,6 @@ namespace dmGameSystem
         else if (CAMERA_PROP_FAR_Z == set_property)
         {
             component->m_FarZ = params.m_Value.m_Number;
-            return dmGameObject::PROPERTY_RESULT_OK;
-        }
-        else if (CAMERA_PROP_AUTO_ASPECT_RATIO == set_property)
-        {
-            component->m_AutoAspectRatio = params.m_Value.m_Bool;
             return dmGameObject::PROPERTY_RESULT_OK;
         }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -310,12 +310,6 @@ namespace dmGameSystem
     {
         CameraComponent* component = (CameraComponent*)*params.m_UserData;
         dmhash_t set_property = params.m_PropertyId;
-
-        if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER)
-        {
-            return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
-        }
-
         if (CAMERA_PROP_ASPECT_RATIO == set_property)
         {
             component->m_AspectRatio = params.m_Value.m_Number;

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -265,4 +265,36 @@ namespace dmGameSystem
         camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
         camera->m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
     }
+
+    dmGameObject::PropertyResult CompCameraGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value)
+    {
+        SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
+        SpriteComponent* component = &sprite_world->m_Components.Get(*params.m_UserData);
+        dmhash_t get_property = params.m_PropertyId;
+
+        if (IsReferencingProperty(SPRITE_PROP_SCALE, get_property))
+        {
+            return GetProperty(out_value, get_property, component->m_Scale, SPRITE_PROP_SCALE);
+        }
+        else if (IsReferencingProperty(SPRITE_PROP_SIZE, get_property))
+        {
+            return GetProperty(out_value, get_property, component->m_Size, SPRITE_PROP_SIZE);
+        }
+    }
+
+    dmGameObject::PropertyResult CompCameraSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
+    {
+        SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
+        SpriteComponent* component = &sprite_world->m_Components.Get(*params.m_UserData);
+        dmhash_t set_property = params.m_PropertyId;
+
+        if (IsReferencingProperty(SPRITE_PROP_SCALE, set_property))
+        {
+            return SetProperty(set_property, params.m_Value, component->m_Scale, SPRITE_PROP_SCALE);
+        }
+        else if (IsReferencingProperty(SPRITE_PROP_SIZE, set_property))
+        {
+            return SetProperty(set_property, params.m_Value, component->m_Size, SPRITE_PROP_SIZE);
+        }
+    }
 }

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -22,6 +22,7 @@
 #include "../resources/res_camera.h"
 #include <gamesys/gamesys_ddf.h>
 #include "../gamesys_private.h"
+#include "comp_private.h"
 
 namespace dmGameSystem
 {
@@ -50,6 +51,12 @@ namespace dmGameSystem
         dmArray<CameraComponent> m_Cameras;
         dmArray<CameraComponent*> m_FocusStack;
     };
+
+    static const dmhash_t CAMERA_PROP_ASPECT_RATIO= dmHashString64("aspect_ratio");
+    static const dmhash_t CAMERA_PROP_FOV = dmHashString64("fov");
+    static const dmhash_t CAMERA_PROP_NEAR_Z = dmHashString64("near_z");
+    static const dmhash_t CAMERA_PROP_FAR_Z = dmHashString64("far_z");
+    static const dmhash_t CAMERA_PROP_AUTO_ASPECT_RATIO= dmHashString64("auto_aspect_ratio");
 
     dmGameObject::CreateResult CompCameraNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -268,33 +275,72 @@ namespace dmGameSystem
 
     dmGameObject::PropertyResult CompCameraGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value)
     {
-        SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
-        SpriteComponent* component = &sprite_world->m_Components.Get(*params.m_UserData);
+        CameraComponent* component = (CameraComponent*)*params.m_UserData;
         dmhash_t get_property = params.m_PropertyId;
 
-        if (IsReferencingProperty(SPRITE_PROP_SCALE, get_property))
+        if (CAMERA_PROP_ASPECT_RATIO == get_property)
         {
-            return GetProperty(out_value, get_property, component->m_Scale, SPRITE_PROP_SCALE);
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_AspectRatio);
+            return dmGameObject::PROPERTY_RESULT_OK;
         }
-        else if (IsReferencingProperty(SPRITE_PROP_SIZE, get_property))
+        else if (CAMERA_PROP_FOV == get_property)
         {
-            return GetProperty(out_value, get_property, component->m_Size, SPRITE_PROP_SIZE);
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_Fov);
+            return dmGameObject::PROPERTY_RESULT_OK;
         }
+        else if (CAMERA_PROP_NEAR_Z == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_NearZ);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_FAR_Z == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_FarZ);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_AUTO_ASPECT_RATIO == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_AutoAspectRatio == 1);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 
     dmGameObject::PropertyResult CompCameraSetProperty(const dmGameObject::ComponentSetPropertyParams& params)
     {
-        SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
-        SpriteComponent* component = &sprite_world->m_Components.Get(*params.m_UserData);
+        CameraComponent* component = (CameraComponent*)*params.m_UserData;
         dmhash_t set_property = params.m_PropertyId;
 
-        if (IsReferencingProperty(SPRITE_PROP_SCALE, set_property))
+        if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER)
         {
-            return SetProperty(set_property, params.m_Value, component->m_Scale, SPRITE_PROP_SCALE);
+            return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
         }
-        else if (IsReferencingProperty(SPRITE_PROP_SIZE, set_property))
+
+        if (CAMERA_PROP_ASPECT_RATIO == set_property)
         {
-            return SetProperty(set_property, params.m_Value, component->m_Size, SPRITE_PROP_SIZE);
+            component->m_AspectRatio = params.m_Value.m_Number;
+            return dmGameObject::PROPERTY_RESULT_OK;
         }
+        else if (CAMERA_PROP_FOV == set_property)
+        {
+            component->m_Fov = params.m_Value.m_Number;
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_NEAR_Z == set_property)
+        {
+            component->m_NearZ = params.m_Value.m_Number;
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_FAR_Z == set_property)
+        {
+            component->m_FarZ = params.m_Value.m_Number;
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_AUTO_ASPECT_RATIO == set_property)
+        {
+            component->m_AutoAspectRatio = params.m_Value.m_Bool;
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 }

--- a/engine/gamesys/src/gamesys/components/comp_camera.h
+++ b/engine/gamesys/src/gamesys/components/comp_camera.h
@@ -31,6 +31,10 @@ namespace dmGameSystem
 
     dmGameObject::UpdateResult CompCameraOnMessage(const dmGameObject::ComponentOnMessageParams& params);
 
+    dmGameObject::PropertyResult CompCameraGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value);
+
+    dmGameObject::PropertyResult CompCameraSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
+
     void CompCameraOnReload(const dmGameObject::ComponentOnReloadParams& params);
 }
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2165,7 +2165,7 @@ namespace dmGameSystem
     static dmGameObject::PropertyResult CompGuiGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value) {
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
         dmhash_t set_property = params.m_PropertyId;
-        if (set_property== PROP_MATERIAL) {
+        if (set_property == PROP_MATERIAL) {
             return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetMaterial(gui_component, gui_component->m_Resource), out_value);
         }
         else if (set_property == PROP_FONTS) {

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -220,7 +220,7 @@ namespace dmGameSystem
                 &CompCameraNewWorld, &CompCameraDeleteWorld,
                 &CompCameraCreate, &CompCameraDestroy, 0, 0, &CompCameraAddToUpdate, 0,
                 &CompCameraUpdate, 0, 0, &CompCameraOnMessage, 0,
-                &CompCameraOnReload, 0, 0,
+                &CompCameraOnReload, CompCameraGetProperty, CompCameraSetProperty,
                 0, 0,
                 1);
 


### PR DESCRIPTION
fix https://github.com/defold/defold/issues/3718