### PR TITLE
Use only one channel for DF-fonts without shadow blur (smaller font size)

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -453,9 +453,9 @@ public class Fontc {
             channelCount = 4;
         } else if (fontDesc.getOutputFormat() == FontTextureFormat.TYPE_DISTANCE_FIELD &&
                    inputFormat == InputFontFormat.FORMAT_TRUETYPE) {
-            // If font has shadow, we'll need 3 channels. Not all platforms universally support
+            // If font has shadow and blur, we'll need 3 channels. Not all platforms universally support
             // texture formats with only 2 channels (such as LUMINANCE_ALPHA)
-            if (fontDesc.getShadowAlpha() > 0.0f) {
+            if (fontDesc.getShadowBlur() > 0.0f && fontDesc.getShadowAlpha() > 0.0f) {
                 channelCount = 3;
             }
             else {


### PR DESCRIPTION

[df-font-size.zip](https://github.com/defold/defold/files/7876951/df-font-size.zip)
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/2209596/149660550-6b9d7f27-44f2-47fe-aeeb-ace46cf10f9b.png">
