### PR TITLE
Create WebGL 1.0 context on iOS < 15.2 (issue when game hangs on start in HTML5 bundle on iOS 15.0 -15.1).

### DIFF
--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -659,6 +659,7 @@ var LibraryGLFW = {
       stencil: (GLFW.params[0x0002000A] > 0) // GLFW_STENCIL_BITS
     };
 
+    // iOS < 15.2 has issues with WebGl 2.0 contexts. It's created without issues but doesn't work.
     var iOSVersion = false;
     try {
       iOSVersion = parseFloat(('' + (/CPU.*OS ([0-9_]{1,5})|(CPU like).*AppleWebKit.*Mobile/i.exec(navigator.userAgent) || [0,''])[1]) .replace('undefined', '3_2').replace('_', '.').replace('_', '')) || false;
@@ -668,7 +669,6 @@ var LibraryGLFW = {
     {
       contextAttributes.majorVersion = 1;
     }
-    
 
     // Browser.createContext: https://github.com/emscripten-core/emscripten/blob/master/src/library_browser.js#L312
     Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -659,6 +659,17 @@ var LibraryGLFW = {
       stencil: (GLFW.params[0x0002000A] > 0) // GLFW_STENCIL_BITS
     };
 
+    var iOSVersion = false;
+    try {
+      iOSVersion = parseFloat(('' + (/CPU.*OS ([0-9_]{1,5})|(CPU like).*AppleWebKit.*Mobile/i.exec(navigator.userAgent) || [0,''])[1]) .replace('undefined', '3_2').replace('_', '.').replace('_', '')) || false;
+    } catch (e) {}
+
+    if (iOSVersion && iOSVersion < 15.2)
+    {
+      contextAttributes.majorVersion = 1;
+    }
+    
+
     // Browser.createContext: https://github.com/emscripten-core/emscripten/blob/master/src/library_browser.js#L312
     Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
     if (Module.ctx == null) {


### PR DESCRIPTION
WebGL 2.0 used by defold starting iOS 15. 
However it seems like it's crashes from time to time on iOS 15.0.x and  doesn't work at all on iOS 15.1.x (black screen on initialization)

But iOS 15.2 works just fine.

So, in this PR I'm check-in iOS version and if it's lower than 15.2 the engine creates WebGL 1.0 context.