### PR TITLE
Patch reported system name for iPads running OS version 15+

### DIFF
--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -774,7 +774,7 @@ namespace dmSys
         PGETUSERDEFAULTLOCALENAME GetUserDefaultLocaleName = (PGETUSERDEFAULTLOCALENAME)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetUserDefaultLocaleName");
         dmStrlCpy(info->m_DeviceModel, "", sizeof(info->m_DeviceModel));
         dmStrlCpy(info->m_SystemName, "Windows", sizeof(info->m_SystemName));
-        OSVERSIONINFOA version_info;
+        OSVERSIONINFOEXA version_info;
         version_info.dwOSVersionInfoSize = sizeof(version_info);
         GetVersionExA(&version_info);
 

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -776,7 +776,7 @@ namespace dmSys
         dmStrlCpy(info->m_SystemName, "Windows", sizeof(info->m_SystemName));
         OSVERSIONINFOEXA version_info;
         version_info.dwOSVersionInfoSize = sizeof(version_info);
-        GetVersionExA(&version_info);
+        GetVersionExA((LPOSVERSIONINFOEXA*)&version_info);
 
         // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa#remarks
         if (version_info.wProductType == VER_NT_WORKSTATION)

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -654,8 +654,9 @@ namespace dmSys
 #if defined(__EMSCRIPTEN__)
         dmStrlCpy(info->m_SystemName, "HTML5", sizeof(info->m_SystemName));
 #else
-        dmStrlCpy(info->m_SystemName, uts.sysname, sizeof(info->m_SystemName));
+        dmStrlCpy(info->m_SystemName, "Linux", sizeof(info->m_SystemName));
 #endif
+        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
         dmStrlCpy(info->m_SystemVersion, uts.release, sizeof(info->m_SystemVersion));
         info->m_DeviceModel[0] = '\0';
 
@@ -683,7 +684,11 @@ namespace dmSys
     void GetSystemInfo(SystemInfo* info)
     {
         memset(info, 0, sizeof(*info));
+        struct utsname uts;
+        uname(&uts);
+
         dmStrlCpy(info->m_SystemName, "Android", sizeof(info->m_SystemName));
+        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
 
         dmAndroid::ThreadAttacher thread;
         JNIEnv* env = thread.GetEnv();
@@ -772,6 +777,16 @@ namespace dmSys
         OSVERSIONINFOA version_info;
         version_info.dwOSVersionInfoSize = sizeof(version_info);
         GetVersionExA(&version_info);
+
+        // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa#remarks
+        if (version_info.wProductType == VER_NT_WORKSTATION)
+        {
+            dmStrlCpy(info->m_OperatingSystemName, "Windows", sizeof(info->m_OperatingSystemName));
+        }
+        else
+        {
+            dmStrlCpy(info->m_OperatingSystemName, "Windows Server", sizeof(info->m_OperatingSystemName));
+        }
 
         const int max_len = 256;
         char lang[max_len];

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -683,9 +683,6 @@ namespace dmSys
     void GetSystemInfo(SystemInfo* info)
     {
         memset(info, 0, sizeof(*info));
-        struct utsname uts;
-        uname(&uts);
-
         dmStrlCpy(info->m_SystemName, "Android", sizeof(info->m_SystemName));
 
         dmAndroid::ThreadAttacher thread;
@@ -772,9 +769,9 @@ namespace dmSys
         PGETUSERDEFAULTLOCALENAME GetUserDefaultLocaleName = (PGETUSERDEFAULTLOCALENAME)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetUserDefaultLocaleName");
         dmStrlCpy(info->m_DeviceModel, "", sizeof(info->m_DeviceModel));
         dmStrlCpy(info->m_SystemName, "Windows", sizeof(info->m_SystemName));
-        OSVERSIONINFOEXA version_info;
+        OSVERSIONINFOA version_info;
         version_info.dwOSVersionInfoSize = sizeof(version_info);
-        GetVersionExA((LPOSVERSIONINFOA)&version_info);
+        GetVersionExA(&version_info);
 
         const int max_len = 256;
         char lang[max_len];

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -656,7 +656,6 @@ namespace dmSys
 #else
         dmStrlCpy(info->m_SystemName, "Linux", sizeof(info->m_SystemName));
 #endif
-        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
         dmStrlCpy(info->m_SystemVersion, uts.release, sizeof(info->m_SystemVersion));
         info->m_DeviceModel[0] = '\0';
 
@@ -688,7 +687,6 @@ namespace dmSys
         uname(&uts);
 
         dmStrlCpy(info->m_SystemName, "Android", sizeof(info->m_SystemName));
-        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
 
         dmAndroid::ThreadAttacher thread;
         JNIEnv* env = thread.GetEnv();
@@ -777,16 +775,6 @@ namespace dmSys
         OSVERSIONINFOEXA version_info;
         version_info.dwOSVersionInfoSize = sizeof(version_info);
         GetVersionExA((LPOSVERSIONINFOA)&version_info);
-
-        // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa#remarks
-        if (version_info.wProductType == VER_NT_WORKSTATION)
-        {
-            dmStrlCpy(info->m_OperatingSystemName, "Windows", sizeof(info->m_OperatingSystemName));
-        }
-        else
-        {
-            dmStrlCpy(info->m_OperatingSystemName, "Windows Server", sizeof(info->m_OperatingSystemName));
-        }
 
         const int max_len = 256;
         char lang[max_len];

--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -776,7 +776,7 @@ namespace dmSys
         dmStrlCpy(info->m_SystemName, "Windows", sizeof(info->m_SystemName));
         OSVERSIONINFOEXA version_info;
         version_info.dwOSVersionInfoSize = sizeof(version_info);
-        GetVersionExA((LPOSVERSIONINFOEXA*)&version_info);
+        GetVersionExA((LPOSVERSIONINFOA)&version_info);
 
         // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa#remarks
         if (version_info.wProductType == VER_NT_WORKSTATION)

--- a/engine/dlib/src/dlib/sys.h
+++ b/engine/dlib/src/dlib/sys.h
@@ -90,8 +90,10 @@ namespace dmSys
         char m_DeviceModel[32];
         /// Device manufacturer if available
         char m_Manufacturer[32];
-        /// System name, i.e. OS name, e.g. "Darwin", "iPhone OS", "Linux", etc
+        /// System name, hardcoded per platform e.g. "Darwin", "iPhone OS", "Linux", etc
         char m_SystemName[32];
+        /// OS name, as reported by the system, e.g. "Darwin", "iPadOS", "iPhone OS", "Linux", "Windows", "Windows Server" etc
+        char m_OperatingSystemName[32];
         /// System version, e.g. 12.0.1
         char m_SystemVersion[32];
         /// Api version, e.g. 23 for android, 9.1 for iOS, empty for platforms with no concept of an api or sdk

--- a/engine/dlib/src/dlib/sys.h
+++ b/engine/dlib/src/dlib/sys.h
@@ -92,8 +92,6 @@ namespace dmSys
         char m_Manufacturer[32];
         /// System name, hardcoded per platform e.g. "Darwin", "iPhone OS", "Linux", etc
         char m_SystemName[32];
-        /// OS name, as reported by the system, e.g. "Darwin", "iPadOS", "iPhone OS", "Linux", "Windows", "Windows Server" etc
-        char m_OperatingSystemName[32];
         /// System version, e.g. 12.0.1
         char m_SystemVersion[32];
         /// Api version, e.g. 23 for android, 9.1 for iOS, empty for platforms with no concept of an api or sdk

--- a/engine/dlib/src/dlib/sys_cocoa.mm
+++ b/engine/dlib/src/dlib/sys_cocoa.mm
@@ -31,21 +31,6 @@
 
 namespace dmSys
 {
-    static inline void PatchSystemName(char *system_name, uint32_t buffer_size)
-    {
-        // iPads with iOS version 15+ have started reporting iPadOS
-        if (dmStrCaseCmp(system_name, "iPadOS")==0)
-        {
-            dmStrlCpy(system_name, "iPhone OS", buffer_size);
-        }
-        // Apple have in iOS 9.1 beta changed from "iPhone OS" to "iOS" as part of their rebranding sceme.
-        // In case this beta reached a public release, we patch "iOS" to "iPhone OS" as system name to guarantee continuity on existing products.
-        else if(dmStrCaseCmp(system_name, "iOS")==0)
-        {
-            dmStrlCpy(system_name, "iPhone OS", buffer_size);
-        }
-    }
-
     Result GetApplicationPath(char* path_out, uint32_t path_len)
     {
     	assert(path_len > 0);
@@ -198,8 +183,8 @@ namespace dmSys
 
         dmStrlCpy(info->m_Manufacturer, "Apple", sizeof(info->m_Manufacturer));
         dmStrlCpy(info->m_DeviceModel, uts.machine, sizeof(info->m_DeviceModel));
-        dmStrlCpy(info->m_SystemName, [d.systemName UTF8String], sizeof(info->m_SystemName));
-        PatchSystemName(info->m_SystemName, sizeof(info->m_SystemName));
+        dmStrlCpy(info->m_SystemName, "iPhone OS", sizeof(info->m_SystemName));
+        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
         dmStrlCpy(info->m_SystemVersion, [d.systemVersion UTF8String], sizeof(info->m_SystemVersion));
         dmStrlCpy(info->m_ApiVersion, [d.systemVersion UTF8String], sizeof(info->m_ApiVersion));
 
@@ -249,9 +234,9 @@ namespace dmSys
         struct utsname uts;
         uname(&uts);
 
-        dmStrlCpy(info->m_SystemName, uts.sysname, sizeof(info->m_SystemName));
-        PatchSystemName(info->m_SystemName, sizeof(info->m_SystemName));
+        dmStrlCpy(info->m_SystemName, "Darwin", sizeof(info->m_SystemName));
         dmStrlCpy(info->m_SystemVersion, uts.release, sizeof(info->m_SystemVersion));
+        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
         info->m_DeviceModel[0] = '\0';
 
         const char* default_lang = "en_US";

--- a/engine/dlib/src/dlib/sys_cocoa.mm
+++ b/engine/dlib/src/dlib/sys_cocoa.mm
@@ -184,7 +184,6 @@ namespace dmSys
         dmStrlCpy(info->m_Manufacturer, "Apple", sizeof(info->m_Manufacturer));
         dmStrlCpy(info->m_DeviceModel, uts.machine, sizeof(info->m_DeviceModel));
         dmStrlCpy(info->m_SystemName, "iPhone OS", sizeof(info->m_SystemName));
-        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
         dmStrlCpy(info->m_SystemVersion, [d.systemVersion UTF8String], sizeof(info->m_SystemVersion));
         dmStrlCpy(info->m_ApiVersion, [d.systemVersion UTF8String], sizeof(info->m_ApiVersion));
 
@@ -236,7 +235,6 @@ namespace dmSys
 
         dmStrlCpy(info->m_SystemName, "Darwin", sizeof(info->m_SystemName));
         dmStrlCpy(info->m_SystemVersion, uts.release, sizeof(info->m_SystemVersion));
-        dmStrlCpy(info->m_OperatingSystemName, uts.sysname, sizeof(info->m_OperatingSystemName));
         info->m_DeviceModel[0] = '\0';
 
         const char* default_lang = "en_US";

--- a/engine/dlib/src/dlib/sys_cocoa.mm
+++ b/engine/dlib/src/dlib/sys_cocoa.mm
@@ -1,10 +1,10 @@
 // Copyright 2020 The Defold Foundation
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -33,9 +33,14 @@ namespace dmSys
 {
     static inline void PatchSystemName(char *system_name, uint32_t buffer_size)
     {
+        // iPads with iOS version 15+ have started reporting iPadOS
+        if (dmStrCaseCmp(system_name, "iPadOS")==0)
+        {
+            dmStrlCpy(system_name, "iPhone OS", buffer_size);
+        }
         // Apple have in iOS 9.1 beta changed from "iPhone OS" to "iOS" as part of their rebranding sceme.
         // In case this beta reached a public release, we patch "iOS" to "iPhone OS" as system name to guarantee continuity on existing products.
-        if(dmStrCaseCmp(system_name, "iOS")==0)
+        else if(dmStrCaseCmp(system_name, "iOS")==0)
         {
             dmStrlCpy(system_name, "iPhone OS", buffer_size);
         }
@@ -57,7 +62,7 @@ namespace dmSys
     	}
     	return RESULT_OK;
     }
-    
+
     Result GetApplicationSavePath(const char* application_name, char* path, uint32_t path_len)
     {
         return GetApplicationSupportPath(application_name, path, path_len);

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -141,6 +141,7 @@ TEST(dmSys, GetSystemInfo)
 
     dmLogInfo("DeviceModel: '%s'", info.m_DeviceModel);
     dmLogInfo("SystemName: '%s'", info.m_SystemName);
+    dmLogInfo("OperatingSystemName: '%s'", info.m_OperatingSystemName);
     dmLogInfo("SystemVersion: '%s'", info.m_SystemVersion);
     dmLogInfo("SystemApiVersion: '%s'", info.m_ApiVersion);
     dmLogInfo("Language: '%s'", info.m_Language);

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -141,7 +141,6 @@ TEST(dmSys, GetSystemInfo)
 
     dmLogInfo("DeviceModel: '%s'", info.m_DeviceModel);
     dmLogInfo("SystemName: '%s'", info.m_SystemName);
-    dmLogInfo("OperatingSystemName: '%s'", info.m_OperatingSystemName);
     dmLogInfo("SystemVersion: '%s'", info.m_SystemVersion);
     dmLogInfo("SystemApiVersion: '%s'", info.m_ApiVersion);
     dmLogInfo("Language: '%s'", info.m_Language);

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -502,7 +502,10 @@ union SaveLoadBuffer
      * : [type:string] [icon:ios][icon:android] Only available on iOS and Android.
      *
      * `system_name`
-     * : [type:string] The system OS name: "Darwin", "Linux", "Windows", "HTML5", "Android" or "iPhone OS"
+     * : [type:string] The system name: "Darwin", "Linux", "Windows", "HTML5", "Android" or "iPhone OS"
+     *
+     * `os_name`
+     * : [type:string] The system OS name: "Windows", "Windows Server", "HTML5", "Android", "iPadOS", "iPhone OS" etc
      *
      * `system_version`
      * : [type:string] The system OS version.
@@ -555,6 +558,9 @@ union SaveLoadBuffer
         lua_rawset(L, -3);
         lua_pushliteral(L, "system_name");
         lua_pushstring(L, info.m_SystemName);
+        lua_rawset(L, -3);
+        lua_pushliteral(L, "os_name");
+        lua_pushstring(L, info.m_OperatingSystemName);
         lua_rawset(L, -3);
         lua_pushliteral(L, "system_version");
         lua_pushstring(L, info.m_SystemVersion);
@@ -1174,7 +1180,7 @@ union SaveLoadBuffer
      */
 
     static int Sys_Deserialize(lua_State* L)
-    {   
+    {
         DM_LUA_STACK_CHECK(L, 1);
         size_t bytes_lenght;
         const char* bytes = luaL_checklstring(L, 1, &bytes_lenght);

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -505,7 +505,7 @@ union SaveLoadBuffer
      * : [type:string] The system name: "Darwin", "Linux", "Windows", "HTML5", "Android" or "iPhone OS"
      *
      * `os_name`
-     * : [type:string] The system OS name: "Windows", "Windows Server", "HTML5", "Android", "iPadOS", "iPhone OS" etc
+     * : [type:string] The system OS name: "Windows", "Windows Server", "Emscripten", "Android", "iPadOS", "iPhone OS" etc
      *
      * `system_version`
      * : [type:string] The system OS version.

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -504,9 +504,6 @@ union SaveLoadBuffer
      * `system_name`
      * : [type:string] The system name: "Darwin", "Linux", "Windows", "HTML5", "Android" or "iPhone OS"
      *
-     * `os_name`
-     * : [type:string] The system OS name: "Windows", "Windows Server", "Emscripten", "Android", "iPadOS", "iPhone OS" etc
-     *
      * `system_version`
      * : [type:string] The system OS version.
      *
@@ -558,9 +555,6 @@ union SaveLoadBuffer
         lua_rawset(L, -3);
         lua_pushliteral(L, "system_name");
         lua_pushstring(L, info.m_SystemName);
-        lua_rawset(L, -3);
-        lua_pushliteral(L, "os_name");
-        lua_pushstring(L, info.m_OperatingSystemName);
         lua_rawset(L, -3);
         lua_pushliteral(L, "system_version");
         lua_pushstring(L, info.m_SystemVersion);

--- a/scripts/mobile/android-repack.sh
+++ b/scripts/mobile/android-repack.sh
@@ -135,7 +135,10 @@ TARGET="$(cd "$(dirname "${SOURCE}")"; pwd)/${APPLICATION}.repack"
     # Todo: Detect ASAN dependency
     # ".../lib/arm64/libSoundTest.so": dlopen failed: library "libclang_rt.asan-aarch64-android.so" not found
 
-    ${ZIP} -qr "${REPACKZIP}" "."
+    ${ZIP} -qr "${REPACKZIP}" "." -x "resources.arsc"
+    # Targeting R+ (version 30 and above) requires the resources.arsc of installed
+    # APKs to be stored uncompressed and aligned on a 4-byte boundary
+    ${ZIP} -q -Z store "${REPACKZIP}" "resources.arsc"
 )
 
 "${ZIPALIGN}" -v 4 "${REPACKZIP}" "${REPACKZIP_ALIGNED}" > /dev/null 2>&1


### PR DESCRIPTION
iPads with OS version 15+ are reporting a system name of "iPadOS" instead of "iPhone OS". This risks breaking a lot of user code that expects all Apple devices (phones and tablets) to report the same system name. This fix patches the reported `system_name` in `sys.get_sys_info()` such that it reports `iPhone OS` also on iPads.

Fixes #6343 