### PR TITLE
Fixed: New field `enabled` for properties iterator.

### DIFF
--- a/engine/gameobject/proto/gameobject/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject/gameobject_ddf.proto
@@ -336,6 +336,7 @@ message Enable
  * - Sprite
  * - Tile Grid
  * - Model
+ * - Mesh
  *
  * @message
  * @name disable

--- a/engine/gameobject/proto/gameobject/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject/gameobject_ddf.proto
@@ -305,6 +305,7 @@ message SetParent
  * - Sprite
  * - Tile Grid
  * - Model
+ * - Mesh
  *
  * @message
  * @name enable

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -1692,5 +1692,44 @@ namespace dmGameSystem
         }
         return true;
     }
+
+    static bool CompCollisionIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
+    {
+        CollisionWorld* world = (CollisionWorld*)pit->m_Node->m_ComponentWorld;
+        CollisionComponent* component = world->m_Components[pit->m_Node->m_Component];
+
+        uint64_t index = pit->m_Next++;
+
+        uint32_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                if (world->m_3D) 
+                {
+                    pit->m_Property.m_Value.m_Bool = dmPhysics::IsEnabled3D(component->m_Object3D);
+                }
+                else
+                {
+                    pit->m_Property.m_Value.m_Bool = dmPhysics::IsEnabled2D(component->m_Object2D);
+                }
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
+        return false;
+    }
+
+    void CompCollisionIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node)
+    {
+        assert(node->m_Type == dmGameObject::SCENE_NODE_TYPE_COMPONENT);
+        assert(node->m_ComponentType != 0);
+        pit->m_Node = node;
+        pit->m_Next = 0;
+        pit->m_FnIterateNext = CompCollisionIterPropertiesGetNext;
+    }
     
 }

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -1696,7 +1696,7 @@ namespace dmGameSystem
     static bool CompCollisionIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
     {
         CollisionWorld* world = (CollisionWorld*)pit->m_Node->m_ComponentWorld;
-        CollisionComponent* component = world->m_Components[pit->m_Node->m_Component];
+        CollisionComponent* component = (CollisionComponent*)pit->m_Node->m_Component;
 
         uint64_t index = pit->m_Next++;
 

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.h
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.h
@@ -48,6 +48,8 @@ namespace dmGameSystem
 
     dmGameObject::PropertyResult CompCollisionObjectSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
 
+    void CompCollisionIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
+
     uint16_t CompCollisionGetGroupBitIndex(void* world, uint64_t group_hash);
 
     // For script_physics.cpp

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2412,6 +2412,21 @@ namespace dmGameSystem
         }
         index -= num_world_properties;
 
+
+        uint64_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                pit->m_Property.m_Value.m_Bool = dmGui::IsNodeEnabled(component->m_Scene, node, false);
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
+
         if (type == dmGui::NODE_TYPE_TEXT)
         {
             uint64_t num_text_properties = 1;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2412,8 +2412,7 @@ namespace dmGameSystem
         }
         index -= num_world_properties;
 
-
-        uint64_t num_bool_properties = 1;
+        uint32_t num_bool_properties = 1;
         if (index < num_bool_properties)
         {
             if (index == 0)

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -711,6 +711,19 @@ namespace dmGameSystem
         }
         index -= num_world_properties;
 
+        uint32_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                pit->m_Property.m_Value.m_Bool = component->m_Enabled;
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
         return false;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -1006,4 +1006,36 @@ namespace dmGameSystem
         }
     }
 
+    static bool CompMeshIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
+    {
+        MeshWorld* world = (MeshWorld*)pit->m_Node->m_ComponentWorld;
+        MeshComponent* component = world->m_Components.Get(pit->m_Node->m_Component);
+
+        uint64_t index = pit->m_Next++;
+
+        uint32_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                pit->m_Property.m_Value.m_Bool = component->m_Enabled;
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
+        return false;
+    }
+
+    void CompMeshIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node)
+    {
+        assert(node->m_Type == dmGameObject::SCENE_NODE_TYPE_COMPONENT);
+        assert(node->m_ComponentType != 0);
+        pit->m_Node = node;
+        pit->m_Next = 0;
+        pit->m_FnIterateNext = CompMeshIterPropertiesGetNext;
+    }
+
 }

--- a/engine/gamesys/src/gamesys/components/comp_mesh.h
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.h
@@ -38,6 +38,8 @@ namespace dmGameSystem
     dmGameObject::PropertyResult CompMeshGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value);
 
     dmGameObject::PropertyResult CompMeshSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
+
+    void CompMeshIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
 }
 
 #endif // DM_GAMESYS_COMP_MESH_H

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -1071,4 +1071,36 @@ namespace dmGameSystem
     {
         return world->m_Components.Get(user_data);;
     }
+
+    static bool CompModelIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
+    {
+        ModelWorld* world = (ModelWorld*)pit->m_Node->m_ComponentWorld;
+        ModelComponent* component = world->m_Components.Get(pit->m_Node->m_Component);
+
+        uint64_t index = pit->m_Next++;
+
+        uint32_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                pit->m_Property.m_Value.m_Bool = component->m_Enabled;
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
+        return false;
+    }
+
+    void CompModelIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node)
+    {
+        assert(node->m_Type == dmGameObject::SCENE_NODE_TYPE_COMPONENT);
+        assert(node->m_ComponentType != 0);
+        pit->m_Node = node;
+        pit->m_Next = 0;
+        pit->m_FnIterateNext = CompModelIterPropertiesGetNext;
+    }
 }

--- a/engine/gamesys/src/gamesys/components/comp_model.h
+++ b/engine/gamesys/src/gamesys/components/comp_model.h
@@ -43,6 +43,8 @@ namespace dmGameSystem
 
     dmGameObject::PropertyResult CompModelSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
 
+    void CompModelIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
+
     // Used in the script_model.cpp
     struct ModelComponent;
     struct ModelWorld;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1262,6 +1262,19 @@ namespace dmGameSystem
         }
         index -= num_world_properties;
 
+            uint32_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                pit->m_Property.m_Value.m_Bool = component->m_Enabled;
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
         return false;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1262,7 +1262,7 @@ namespace dmGameSystem
         }
         index -= num_world_properties;
 
-            uint32_t num_bool_properties = 1;
+        uint32_t num_bool_properties = 1;
         if (index < num_bool_properties)
         {
             if (index == 0)

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -973,7 +973,7 @@ namespace dmGameSystem
     static bool CompTileGridIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
     {
         TileGridWorld* world = (TileGridWorld*)pit->m_Node->m_ComponentWorld;
-        TileGridComponent* component = world->m_Components[pit->m_Node->m_Component];
+        TileGridComponent* component = (TileGridComponent*)pit->m_Node->m_Component;
 
         uint64_t index = pit->m_Next++;
 

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -969,4 +969,37 @@ namespace dmGameSystem
         }
         return SetMaterialConstant(GetMaterial(component), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompTileGridSetConstantCallback, component);
     }
+
+    static bool CompTileGridIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
+    {
+        TileGridWorld* world = (TileGridWorld*)pit->m_Node->m_ComponentWorld;
+        TileGridComponent* component = world->m_Components[pit->m_Node->m_Component];
+
+        uint64_t index = pit->m_Next++;
+
+        uint32_t num_bool_properties = 1;
+        if (index < num_bool_properties)
+        {
+            if (index == 0)
+            {
+                pit->m_Property.m_Type = dmGameObject::SCENE_NODE_PROPERTY_TYPE_BOOLEAN;
+                pit->m_Property.m_Value.m_Bool = component->m_Enabled;
+                pit->m_Property.m_NameHash = dmHashString64("enabled");
+            }
+            return true;
+        }
+        index -= num_bool_properties;
+
+        return false;
+    }
+
+    void CompTileGridIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node)
+    {
+        assert(node->m_Type == dmGameObject::SCENE_NODE_TYPE_COMPONENT);
+        assert(node->m_ComponentType != 0);
+        pit->m_Node = node;
+        pit->m_Next = 0;
+        pit->m_FnIterateNext = CompTileGridIterPropertiesGetNext;
+    }
+
 }

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.h
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.h
@@ -42,6 +42,8 @@ namespace dmGameSystem
 
     dmGameObject::PropertyResult CompTileGridSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
 
+    void CompTileGridIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
+
     // Script support
     struct TileGridComponent;
 

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -213,7 +213,7 @@ namespace dmGameSystem
                 &CompCollisionObjectCreate, &CompCollisionObjectDestroy, 0, &CompCollisionObjectFinal, &CompCollisionObjectAddToUpdate, 0,
                 &CompCollisionObjectUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0,
                 &CompCollisionObjectOnReload, CompCollisionObjectGetProperty, CompCollisionObjectSetProperty,
-                0, 0,
+                0, CompCollisionIterProperties,
                 1);
 
         REGISTER_COMPONENT_TYPE("camerac", 500, render_context,

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -237,7 +237,7 @@ namespace dmGameSystem
                 CompModelCreate, CompModelDestroy, 0, 0, CompModelAddToUpdate, 0,
                 CompModelUpdate, CompModelRender, 0, CompModelOnMessage, 0,
                 0, CompModelGetProperty, CompModelSetProperty,
-                0, 0,
+                0, CompModelIterProperties,
                 0);
 
         REGISTER_COMPONENT_TYPE("meshc", 725, mesh_context,
@@ -245,7 +245,7 @@ namespace dmGameSystem
                 CompMeshCreate, CompMeshDestroy, 0, 0, CompMeshAddToUpdate, 0,
                 CompMeshUpdate, CompMeshRender, 0, CompMeshOnMessage, 0,
                 0, CompMeshGetProperty, CompMeshSetProperty,
-                0, 0,
+                0, CompMeshIterProperties,
                 0);
 
         REGISTER_COMPONENT_TYPE("emitterc", 750, 0x0,

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -301,7 +301,7 @@ namespace dmGameSystem
                 CompTileGridCreate, CompTileGridDestroy, 0, 0, CompTileGridAddToUpdate, 0,
                 CompTileGridUpdate, CompTileGridRender, 0, CompTileGridOnMessage, 0,
                 CompTileGridOnReload, CompTileGridGetProperty, CompTileGridSetProperty,
-                0, 0,
+                0, CompTileGridIterProperties,
                 1);
 
         REGISTER_COMPONENT_TYPE("labelc", 1400, label_context,


### PR DESCRIPTION
Adds new field `enabled` in properties iterator for Gui nodes and components that support `enable`/`disable` messages. This functionality used in [extension-poco](https://github.com/defold/extension-poco) for tests automation.

Fix https://github.com/defold/extension-poco/issues/4 