### PR TITLE
Issue-6354 Use Application Support folder for game logs if `./log.txt` is unavailable

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -51,6 +51,7 @@ import com.dynamo.bob.Task.TaskBuilder;
 import com.dynamo.bob.archive.ArchiveBuilder;
 import com.dynamo.bob.archive.EngineVersion;
 import com.dynamo.bob.archive.ManifestBuilder;
+import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.graphics.proto.Graphics.PlatformProfile;
@@ -502,6 +503,11 @@ public class GameProjectBuilder extends Builder<Void> {
             properties.putBooleanValue("display", "vsync", false);
             properties.putIntValue("display", "update_frequency", 0);
         }
+
+        // Convert project title to a string which may be used as a folder name and save in project.title_as_file_name
+        String title = properties.getStringValue("project", "title", "Unnamed");
+        String fileNameTitle = BundleHelper.projectNameToBinaryName(title);
+        properties.putStringValue("project", "title_as_file_name", fileNameTitle);
     }
 
     @Override

--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -588,7 +588,7 @@ void LogInternal(Severity severity, const char* domain, const char* format, ...)
     }
 }
 
-void SetLogFile(const char* path)
+bool SetLogFile(const char* path)
 {
     if (g_LogFile) {
         fclose(g_LogFile);
@@ -599,7 +599,9 @@ void SetLogFile(const char* path)
         dmLogInfo("Writing log to: %s", path);
     } else {
         dmLogFatal("Failed to open log-file '%s'", path);
+        return false;
     }
+    return true;
 }
 
 void SetCustomLogCallback(CustomLogCallback callback, void* user_data)

--- a/engine/dlib/src/dlib/log.h
+++ b/engine/dlib/src/dlib/log.h
@@ -86,8 +86,9 @@ void Setlevel(Severity severity);
  * Subsequent invocations to this function will close previous opened file.
  * If the file can't be created a message will be logged to the "console"
  * @param path log path
+ * @return true if file successfully created.
  */
-void SetLogFile(const char* path);
+bool SetLogFile(const char* path);
 
 /**
  * Callback declaration for SetCustomLogCallback

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -693,28 +693,34 @@ namespace dmEngine
         int write_log = dmConfigFile::GetInt(engine->m_Config, "project.write_log", 0);
         if (write_log) {
             uint32_t count = 0;
-            char* log_paths[2];
+            char* log_paths[3];
+
+            const char* LOG_FILE_NAME = "log.txt";
+
+            const char* log_dir = dmConfigFile::GetString(engine->m_Config, "project.log_dir", NULL);
+            char log_config_path[DMPATH_MAX_PATH];
+            if (log_dir != NULL)
+            {
+                dmPath::Concat(log_dir, LOG_FILE_NAME, log_config_path, sizeof(log_config_path));
+                log_paths[count] = log_config_path;
+                count++;
+            }
+
             char sys_path[DMPATH_MAX_PATH];
             char main_log_path[DMPATH_MAX_PATH];
             if (dmSys::GetLogPath(sys_path, sizeof(sys_path)) == dmSys::RESULT_OK)
             {
-                const char* main_dir = dmConfigFile::GetString(engine->m_Config, "project.log_dir", sys_path);
-                dmPath::Concat(main_dir, "log.txt", main_log_path, sizeof(main_log_path));
+                dmPath::Concat(sys_path, LOG_FILE_NAME, main_log_path, sizeof(main_log_path));
                 log_paths[count] = main_log_path;
                 count++;
             }
-            else
-            {
-                dmLogFatal("Unable to get log-file path");
-            }
-
 
             char application_support_path[DMPATH_MAX_PATH];
             char application_support_log_path[DMPATH_MAX_PATH];
-            const char* logs_dir = dmConfigFile::GetString(engine->m_Config, "project.title_as_file_name", "DefoldLogs");
+            const char* logs_dir = dmConfigFile::GetString(engine->m_Config, "project.title_as_file_name", "defoldlogs");
             if (dmSys::GetApplicationSavePath(logs_dir, application_support_path, sizeof(application_support_path)) == dmSys::RESULT_OK)
             {
-                dmPath::Concat(application_support_path, "log.txt", application_support_log_path, sizeof(application_support_log_path));
+                dmPath::Concat(application_support_path, LOG_FILE_NAME, application_support_log_path, sizeof(application_support_log_path));
                 log_paths[count] = application_support_log_path;
                 count++;
             }

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -692,14 +692,38 @@ namespace dmEngine
 
         int write_log = dmConfigFile::GetInt(engine->m_Config, "project.write_log", 0);
         if (write_log) {
+            uint32_t count = 0;
+            char* log_paths[2];
             char sys_path[DMPATH_MAX_PATH];
-            if (dmSys::GetLogPath(sys_path, sizeof(sys_path)) == dmSys::RESULT_OK) {
-                const char* path = dmConfigFile::GetString(engine->m_Config, "project.log_dir", sys_path);
-                char full[DMPATH_MAX_PATH];
-                dmPath::Concat(path, "log.txt", full, sizeof(full));
-                dmLog::SetLogFile(full);
-            } else {
+            char main_log_path[DMPATH_MAX_PATH];
+            if (dmSys::GetLogPath(sys_path, sizeof(sys_path)) == dmSys::RESULT_OK)
+            {
+                const char* main_dir = dmConfigFile::GetString(engine->m_Config, "project.log_dir", sys_path);
+                dmPath::Concat(main_dir, "log.txt", main_log_path, sizeof(main_log_path));
+                log_paths[count] = main_log_path;
+                count++;
+            }
+            else
+            {
                 dmLogFatal("Unable to get log-file path");
+            }
+
+
+            char application_support_path[DMPATH_MAX_PATH];
+            char application_support_log_path[DMPATH_MAX_PATH];
+            const char* logs_dir = dmConfigFile::GetString(engine->m_Config, "project.title_as_file_name", "DefoldLogs");
+            if (dmSys::GetApplicationSavePath(logs_dir, application_support_path, sizeof(application_support_path)) == dmSys::RESULT_OK)
+            {
+                dmPath::Concat(application_support_path, "log.txt", application_support_log_path, sizeof(application_support_log_path));
+                log_paths[count] = application_support_log_path;
+                count++;
+            }
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                if (dmLog::SetLogFile(log_paths[i]))
+                {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes path to the `log.txt` file for macOS bundle where the creation of the file in `app` is impossible.

If `project.wrile_log` checkbox is ON in `game.project`, engine writes logs in `log.txt` file.
The path to the file depends on the platform (see [manual](https://defold.com/manuals/debugging-game-and-system-logs/?q=log.txt#reading-the-game-log-from-the-log-file)).

From now on macOS the file path will be `/Users/user_name/Library/Application Support/projectname/log.txt`

Fixes https://github.com/defold/defold/issues/6354