### PR TITLE
Removed support for 32-bit iPhoneOS (armv7-darwin)

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -110,7 +110,7 @@ jobs:
     needs: [pre-check]
     strategy:
       matrix:
-        platform: [armv7-darwin, arm64-darwin, x86_64-ios]
+        platform: [arm64-darwin, x86_64-ios]
     runs-on: ubuntu-18.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },

--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -31,7 +31,6 @@ The following platforms are supported:
 * `win32`
 * `x86_64-win32`
 * `x86_64-ios`
-* `armv7-darwin`
 * `arm64-darwin`
 * `armv7-android`
 * `arm64-android`

--- a/build_tools/BuildUtility.py
+++ b/build_tools/BuildUtility.py
@@ -22,7 +22,6 @@ class BuildUtility:
                             {'platform': 'win32', 'os': 'win', 'arch': 'x86'},
                             {'platform': 'x86_64-win32', 'os': 'win', 'arch': 'x86_64'},
                             {'platform': 'x86_64-ios', 'os': 'ios', 'arch': 'x86_64'},
-                            {'platform': 'armv7-darwin', 'os': 'ios', 'arch': 'armv7'},
                             {'platform': 'arm64-darwin', 'os': 'ios', 'arch': 'arm64'},
                             {'platform': 'armv7-android', 'os': 'android', 'arch': 'armv7'},
                             {'platform': 'arm64-android', 'os': 'android', 'arch': 'arm64'},

--- a/build_tools/sdk.py
+++ b/build_tools/sdk.py
@@ -49,8 +49,6 @@ defold_info = defaultdict(defaultdict)
 defold_info['xcode']['version'] = VERSION_XCODE
 defold_info['xcode']['pattern'] = PACKAGES_XCODE_TOOLCHAIN
 defold_info['xcode-clang']['version'] = VERSION_XCODE_CLANG
-defold_info['armv7-darwin']['version'] = VERSION_IPHONEOS
-defold_info['armv7-darwin']['pattern'] = PACKAGES_IOS_SDK
 defold_info['arm64-darwin']['version'] = VERSION_IPHONEOS
 defold_info['arm64-darwin']['pattern'] = PACKAGES_IOS_SDK
 defold_info['x86_64-ios']['version'] = VERSION_IPHONESIMULATOR
@@ -65,7 +63,7 @@ defold_info['x86_64-darwin']['pattern'] = PACKAGES_MACOS_SDK
 def _convert_darwin_platform(platform):
     if platform in ('x86_64-darwin',):
         return 'macosx'
-    if platform in ('armv7-darwin','arm64-darwin'):
+    if platform in ('arm64-darwin',):
         return 'iphoneos'
     if platform in ('x86_64-ios',):
         return 'iphonesimulator'
@@ -134,7 +132,7 @@ def _get_defold_path(sdkfolder, platform):
 def check_defold_sdk(sdkfolder, platform):
     folders = []
 
-    if platform in ('x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if platform in ('x86_64-darwin', 'arm64-darwin', 'x86_64-ios'):
         folders.append(_get_defold_path(sdkfolder, 'xcode'))
         folders.append(_get_defold_path(sdkfolder, platform))
 
@@ -154,7 +152,7 @@ def check_defold_sdk(sdkfolder, platform):
 
 
 def check_local_sdk(platform):
-    if platform in ('x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if platform in ('x86_64-darwin', 'arm64-darwin', 'x86_64-ios'):
         xcode_version = get_local_darwin_toolchain_version()
         if not xcode_version:
             return False
@@ -163,7 +161,7 @@ def check_local_sdk(platform):
 
 def _get_defold_sdk_info(sdkfolder, platform):
     info = {}
-    if platform in ('x86_64-darwin','x86_64-ios','armv7-darwin','arm64-darwin'):
+    if platform in ('x86_64-darwin','x86_64-ios','arm64-darwin'):
         info['xcode'] = {}
         info['xcode']['version'] = VERSION_XCODE
         info['xcode']['path'] = _get_defold_path(sdkfolder, 'xcode')
@@ -176,7 +174,7 @@ def _get_defold_sdk_info(sdkfolder, platform):
 
 def _get_local_sdk_info(platform):
     info = {}
-    if platform in ('x86_64-darwin','x86_64-ios','armv7-darwin','arm64-darwin'):
+    if platform in ('x86_64-darwin','x86_64-ios','arm64-darwin'):
         info['xcode'] = {}
         info['xcode']['version'] = get_local_darwin_toolchain_version()
         info['xcode']['path'] = get_local_darwin_toolchain_path()
@@ -206,7 +204,7 @@ def get_sdk_info(sdkfolder, platform):
     return None
 
 def get_toolchain_root(sdkinfo, platform):
-    if platform in ('x86_64-darwin','x86_64-ios','armv7-darwin','arm64-darwin'):
+    if platform in ('x86_64-darwin','x86_64-ios','arm64-darwin'):
         return sdkinfo['xcode']['path']
     return None
 

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -52,7 +52,7 @@ if 'waf_dynamo_private' not in sys.modules:
 
 def platform_supports_feature(platform, feature, data):
     if feature == 'vulkan':
-        return platform not in ['js-web', 'wasm-web', 'armv7-darwin', 'x86_64-ios', 'win32', 'x86_64-win32', 'x86_64-linux']
+        return platform not in ['js-web', 'wasm-web', 'x86_64-ios', 'win32', 'x86_64-win32', 'x86_64-linux']
     return waf_dynamo_private.supports_feature(platform, feature, data)
 
 def platform_setup_tools(ctx, build_util):
@@ -827,7 +827,7 @@ Task.task_type_from_func('app_bundle',
 
 def _strip_executable(bld, platform, target_arch, path):
     """ Strips the debug symbols from an executable """
-    if platform not in ['x86_64-linux','x86_64-darwin','armv7-darwin','arm64-darwin','armv7-android','arm64-android']:
+    if platform not in ['x86_64-linux','x86_64-darwin','arm64-darwin','armv7-android','arm64-android']:
         return 0 # return ok, path is still unstripped
 
     strip = "strip"
@@ -1418,7 +1418,7 @@ def detect(conf):
 
     sdkinfo = sdk.get_sdk_info(SDK_ROOT, build_util.get_target_platform())
 
-    if 'linux' in build_platform and build_util.get_target_platform() in ('x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if 'linux' in build_platform and build_util.get_target_platform() in ('x86_64-darwin', 'arm64-darwin', 'x86_64-ios'):
         conf.env['TESTS_UNSUPPORTED'] = True
         print "Tests disabled (%s cannot run on %s)" % (build_util.get_target_platform(), build_platform)
 
@@ -1426,7 +1426,7 @@ def detect(conf):
         print "Codesign disabled", Options.options.skip_codesign
 
     # Vulkan support
-    if Options.options.with_vulkan and build_util.get_target_platform() in ('armv7-darwin','x86_64-ios','js-web','wasm-web'):
+    if Options.options.with_vulkan and build_util.get_target_platform() in ('x86_64-ios','js-web','wasm-web'):
         conf.fatal('Vulkan is unsupported on %s' % build_util.get_target_platform())
 
     if 'win32' in platform:
@@ -1592,7 +1592,7 @@ def detect(conf):
     conf.env.BINDIR = Utils.subst_vars('${PREFIX}/bin/%s' % build_util.get_target_platform(), conf.env)
     conf.env.LIBDIR = Utils.subst_vars('${PREFIX}/lib/%s' % build_util.get_target_platform(), conf.env)
 
-    if platform in ('x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if platform in ('x86_64-darwin', 'arm64-darwin', 'x86_64-ios'):
         conf.check_tool('waf_objectivec')
 
         # Unknown argument: -Bstatic, -Bdynamic
@@ -1638,7 +1638,7 @@ def detect(conf):
 
     if platform in ('x86_64-darwin',):
         conf.env['FRAMEWORK_OPENAL'] = ['OpenAL']
-    elif platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    elif platform in ('arm64-darwin', 'x86_64-ios'):
         conf.env['FRAMEWORK_OPENAL'] = ['OpenAL', 'AudioToolbox']
     elif platform in ('armv7-android', 'arm64-android'):
         conf.env['LIB_OPENAL'] = ['OpenSLES']
@@ -1675,7 +1675,7 @@ def detect(conf):
         conf.env['STATICLIB_VULKAN'] = vulkan_validation and 'vulkan' or 'MoltenVK'
         conf.env['FRAMEWORK_VULKAN'] = ['Metal', 'IOSurface', 'QuartzCore']
         conf.env['FRAMEWORK_DMGLFW'] = ['QuartzCore']
-    elif platform in ('armv7-darwin','arm64-darwin','x86_64-ios'):
+    elif platform in ('arm64-darwin','x86_64-ios'):
         conf.env['STATICLIB_VULKAN'] = 'MoltenVK'
         conf.env['FRAMEWORK_VULKAN'] = 'Metal'
         conf.env['FRAMEWORK_DMGLFW'] = ['QuartzCore', 'OpenGLES', 'CoreVideo', 'CoreGraphics']
@@ -1713,7 +1713,7 @@ def set_options(opt):
     opt.tool_options('compiler_cc')
     opt.tool_options('compiler_cxx')
 
-    opt.add_option('--platform', default='', dest='platform', help='target platform, eg armv7-darwin')
+    opt.add_option('--platform', default='', dest='platform', help='target platform, eg arm64-darwin')
     opt.add_option('--skip-tests', action='store_true', default=False, dest='skip_tests', help='skip running unit tests')
     opt.add_option('--skip-build-tests', action='store_true', default=False, dest='skip_build_tests', help='skip building unit tests')
     opt.add_option('--skip-codesign', action="store_true", default=False, dest='skip_codesign', help='skip code signing')

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -109,7 +109,6 @@ public class BundlerTest {
 
             // Can only do this on OSX machines currently
             if (Platform.getHostPlatform() == Platform.X86_64Darwin) {
-                data.add(new Platform[]{Platform.Armv7Darwin});
                 data.add(new Platform[]{Platform.Arm64Darwin});
                 data.add(new Platform[]{Platform.X86_64Ios});
             }
@@ -122,7 +121,6 @@ public class BundlerTest {
         switch (platform)
         {
             case X86_64Darwin:
-            case Armv7Darwin:
             case Arm64Darwin:
             case X86_64Ios:
                     folderName = projectName + ".app";
@@ -134,7 +132,6 @@ public class BundlerTest {
     private String getBundleAppFolder(String projectName) {
         switch (platform)
         {
-            case Armv7Darwin:
             case Arm64Darwin:
             case X86_64Ios:
                 return String.format("Payload/%s.app/", projectName);
@@ -190,7 +187,6 @@ public class BundlerTest {
                 assertTrue(wasmFile.exists());
             }
             break;
-            case Armv7Darwin:
             case Arm64Darwin:
             case X86_64Ios:
             {
@@ -261,7 +257,7 @@ public class BundlerTest {
             assertTrue(zip.exists());
             files = getZipFiles(zip);
         }
-        else if (platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios)
+        else if (platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios)
         {
             File zip = new File(outputDirFile.getParentFile(), projectName + ".ipa");
             assertTrue(zip.exists());
@@ -404,8 +400,8 @@ public class BundlerTest {
         if (platform == Platform.Armv7Android || platform == Platform.Arm64Android) {
             buildPlatform = Platform.Armv7Android;
         }
-        else if (platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
-            buildPlatform = Platform.Armv7Darwin;
+        else if (platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
+            buildPlatform = Platform.Arm64Darwin;
         }
 
         project.setOption("platform", buildPlatform.getPair());
@@ -569,7 +565,6 @@ public class BundlerTest {
                     expectedFiles.add("META-INF/BNDLTOOL.RSA");
                 }
                 break;
-            case Armv7Darwin:
             case Arm64Darwin:
             case X86_64Ios:
                 expectedFiles.add("Payload/unnamed.app/unnamed");

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
@@ -302,7 +302,6 @@ public class BundleResourcesTest {
         expected.put(Platform.X86Win32, new String[] { "win32.txt", "x86-win32.txt" });
         expected.put(Platform.X86_64Win32, new String[] { "win32.txt", "x86_64-win32.txt" });
         expected.put(Platform.Armv7Android, new String[] { "android.txt" });
-        expected.put(Platform.Armv7Darwin, new String[] { "ios.txt", "armv7-ios.txt" });
         expected.put(Platform.Arm64Darwin, new String[] { "ios.txt", "arm64-ios.txt" });
         expected.put(Platform.JsWeb, new String[] { "web.txt" });
 
@@ -358,7 +357,7 @@ public class BundleResourcesTest {
 
         Map<String, String> appmanifestOptions = new HashMap<String,String>();
         appmanifestOptions.put("baseVariant", "release");
-        resources = ExtenderUtil.getExtensionSources(project, Platform.Armv7Darwin, appmanifestOptions);
+        resources = ExtenderUtil.getExtensionSources(project, Platform.Arm64Darwin, appmanifestOptions);
         assertEquals(6, resources.size());
 
         assertTrue(findInResourceList(resources, "extension1/ext.manifest") != null);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/PlatformTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/PlatformTest.java
@@ -30,7 +30,6 @@ public class PlatformTest {
         assertTrue(Platform.matchPlatformAgainstOS("x86_64-win32",   PlatformProfile.OS.OS_ID_WINDOWS));
         assertTrue(Platform.matchPlatformAgainstOS("x86_64-darwin",  PlatformProfile.OS.OS_ID_OSX));
         assertTrue(Platform.matchPlatformAgainstOS("x86_64-linux",   PlatformProfile.OS.OS_ID_LINUX));
-        assertTrue(Platform.matchPlatformAgainstOS("armv7-darwin",   PlatformProfile.OS.OS_ID_IOS));
         assertTrue(Platform.matchPlatformAgainstOS("arm64-darwin",   PlatformProfile.OS.OS_ID_IOS));
         assertTrue(Platform.matchPlatformAgainstOS("armv7-android",  PlatformProfile.OS.OS_ID_ANDROID));
         assertTrue(Platform.matchPlatformAgainstOS("js-web",         PlatformProfile.OS.OS_ID_WEB));
@@ -38,7 +37,6 @@ public class PlatformTest {
 
         assertTrue(Platform.matchPlatformAgainstOS("x86_64-linux",   PlatformProfile.OS.OS_ID_GENERIC));
 
-        assertFalse(Platform.matchPlatformAgainstOS("armv7-darwin",  PlatformProfile.OS.OS_ID_WINDOWS));
         assertFalse(Platform.matchPlatformAgainstOS("arm64-darwin",  PlatformProfile.OS.OS_ID_OSX));
         assertFalse(Platform.matchPlatformAgainstOS("armv7-android", PlatformProfile.OS.OS_ID_IOS));
         assertFalse(Platform.matchPlatformAgainstOS("js-web",        PlatformProfile.OS.OS_ID_ANDROID));

--- a/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
+++ b/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
@@ -24,7 +24,6 @@ mkdir -p libexec/x86_64-linux
 mkdir -p libexec/x86_64-darwin
 mkdir -p libexec/x86-win32
 mkdir -p libexec/x86_64-win32
-mkdir -p libexec/armv7-darwin
 mkdir -p libexec/arm64-darwin
 mkdir -p libexec/x86_64-ios
 mkdir -p libexec/armv7-android
@@ -94,8 +93,6 @@ copy win32/dmengine_headless.exe x86-win32/dmengine_headless.exe
 copy x86_64-win32/dmengine.exe x86_64-win32/dmengine.exe
 copy x86_64-win32/dmengine_release.exe x86_64-win32/dmengine_release.exe
 copy x86_64-win32/dmengine_headless.exe x86_64-win32/dmengine_headless.exe
-copy armv7-darwin/stripped/dmengine armv7-darwin/dmengine
-copy armv7-darwin/stripped/dmengine_release armv7-darwin/dmengine_release
 copy arm64-darwin/stripped/dmengine arm64-darwin/dmengine
 copy arm64-darwin/stripped/dmengine_release arm64-darwin/dmengine_release
 copy x86_64-ios/stripped/dmengine x86_64-ios/dmengine

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Platform.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Platform.java
@@ -26,7 +26,6 @@ public enum Platform {
     X86_64Win32("x86_64", "win32", new String[] {".exe"}, "", "", ".dll", new String[] {"win32", "x86_64-win32"}, PlatformArchitectures.Windows64, "x86_64-win32"),
     X86Linux("x86", "linux", new String[] {""}, "", "lib", ".so", new String[] {"linux", "x86-linux"}, PlatformArchitectures.Linux, "x86-linux"),
     X86_64Linux("x86_64", "linux", new String[] {""}, "", "lib", ".so", new String[] {"linux", "x86_64-linux"}, PlatformArchitectures.Linux, "x86_64-linux"),
-    Armv7Darwin("armv7", "darwin", new String[] {""}, "", "lib", ".so", new String[] {"ios", "armv7-ios"}, PlatformArchitectures.iOS, "armv7-ios"),
     Arm64Darwin("arm64", "darwin", new String[] {""}, "", "lib", ".so", new String[] {"ios", "arm64-ios"}, PlatformArchitectures.iOS, "arm64-ios"),
     X86_64Ios("x86_64", "ios", new String[] {""}, "", "lib", ".so", new String[] {"ios", "x86_64-ios"}, PlatformArchitectures.iOS, "x86_64-ios"),
     Armv7Android("armv7", "android", new String[] {".so"}, "lib", "lib", ".so", new String[] {"android", "armv7-android"}, PlatformArchitectures.Android, "armv7-android"),
@@ -41,7 +40,7 @@ public enum Platform {
         platformPatterns.put(PlatformProfile.OS.OS_ID_WINDOWS, "^x86(_64)?-win32$");
         platformPatterns.put(PlatformProfile.OS.OS_ID_OSX,     "^x86(_64)?-darwin$");
         platformPatterns.put(PlatformProfile.OS.OS_ID_LINUX,   "^x86(_64)?-linux$");
-        platformPatterns.put(PlatformProfile.OS.OS_ID_IOS,     "^(armv7-darwin)|(arm64-darwin)|(x86_64-ios)$");
+        platformPatterns.put(PlatformProfile.OS.OS_ID_IOS,     "^(arm64-darwin)|(x86_64-ios)$");
         platformPatterns.put(PlatformProfile.OS.OS_ID_ANDROID, "^arm((v7)|(64))-android$");
         platformPatterns.put(PlatformProfile.OS.OS_ID_WEB,     "^((js)|(wasm))-web$");
         platformPatterns.put(PlatformProfile.OS.OS_ID_SWITCH,  "^(arm64-nx64)$");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/PlatformArchitectures.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/PlatformArchitectures.java
@@ -17,7 +17,7 @@ public enum PlatformArchitectures {
     Windows32(new String[] {"x86-win32"}, new String[] {"x86-win32"}),
     Windows64(new String[] {"x86_64-win32"}, new String[] {"x86_64-win32"}),
     Linux(new String[] {"x86_64-linux"}, new String[] {"x86_64-linux"}),
-    iOS(new String[] {"arm64-darwin", "armv7-darwin", "x86_64-ios"}, new String[] {"arm64-darwin", "armv7-darwin"}),
+    iOS(new String[] {"arm64-darwin", "x86_64-ios"}, new String[] {"arm64-darwin"}),
     Android(new String[] {"arm64-android", "armv7-android"}, new String[] {"armv7-android","arm64-android"}),
     Web(new String[] {"js-web", "wasm-web"}, new String[] {"js-web", "wasm-web"}),
     NX64(new String[] {"arm64-nx64"}, new String[] {"arm64-nx64"});

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -940,7 +940,6 @@ public class Project {
         for(String platform : platforms) {
             String symbolsFilename = null;
             switch(platform) {
-                case "armv7-darwin":
                 case "arm64-darwin":
                 case "x86_64-darwin":
                     symbolsFilename = String.format("dmengine%s.dSYM.zip", variantSuffix);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -706,7 +706,7 @@ public class Project {
         bundlers.put(Platform.X86Win32, Win32Bundler.class);
         bundlers.put(Platform.X86_64Win32, Win64Bundler.class);
         bundlers.put(Platform.Armv7Android, AndroidBundler.class);
-        bundlers.put(Platform.Armv7Darwin, IOSBundler.class);
+        bundlers.put(Platform.Arm64Darwin, IOSBundler.class);
         bundlers.put(Platform.X86_64Ios, IOSBundler.class);
         bundlers.put(Platform.JsWeb, HTML5Bundler.class);
     }
@@ -778,7 +778,7 @@ public class Project {
         Platform p = getPlatform();
         PlatformArchitectures platformArchs = p.getArchitectures();
         String[] platformStrings;
-        if (p == Platform.Armv7Darwin || p == Platform.Arm64Darwin || p == Platform.JsWeb || p == Platform.WasmWeb || p == Platform.Armv7Android || p == Platform.Arm64Android)
+        if (p == Platform.Arm64Darwin || p == Platform.JsWeb || p == Platform.WasmWeb || p == Platform.Armv7Android || p == Platform.Arm64Android)
         {
             // Here we'll get a list of all associated architectures (armv7, arm64) and build them at the same time
             platformStrings = platformArchs.getArchitectures();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -112,7 +112,7 @@ public class BundleHelper {
         this.title = this.projectProperties.getStringValue("project", "title", "Unnamed");
 
         String appDirSuffix = "";
-        if (platform == Platform.X86_64Darwin || platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin) {
+        if (platform == Platform.X86_64Darwin || platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
             appDirSuffix = ".app";
         }
 
@@ -250,7 +250,7 @@ public class BundleHelper {
     }
 
     private String getManifestName(Platform platform) {
-        if (platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin) {
+        if (platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
             return BundleHelper.MANIFEST_NAME_IOS;
         } else if (platform == Platform.X86_64Darwin) {
             return BundleHelper.MANIFEST_NAME_OSX;
@@ -280,7 +280,7 @@ public class BundleHelper {
 
         IResource mainManifest;
         Map<String, Object> properties = new HashMap<>();
-        if (platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
+        if (platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
             mainManifest = getResource("ios", "infoplist");
             properties = createIOSManifestProperties(exeName);
         } else if (platform == Platform.X86_64Darwin) {
@@ -324,7 +324,7 @@ public class BundleHelper {
     }
 
     public File getAppManifestFile(Platform platform, File appDir) {
-        if (platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios  ) {
+        if (platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
             return new File(appDir, "Info.plist");
         } else if (platform == Platform.X86_64Darwin) {
             return new File(appDir, "Contents/Info.plist");
@@ -337,7 +337,7 @@ public class BundleHelper {
     }
 
     public static String getMainManifestName(Platform platform) {
-        if (platform == Platform.Armv7Darwin || platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
+        if (platform == Platform.Arm64Darwin || platform == Platform.X86_64Ios) {
             return MANIFEST_NAME_IOS;
         } else if (platform == Platform.X86_64Darwin) {
             return MANIFEST_NAME_OSX;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -146,13 +146,12 @@ public class IOSBundler implements IBundler {
     }
 
     @Override
-    public void bundleApplication(Project project, File bundleDir, ICanceled canceled)
-            throws IOException, CompileExceptionError {
+    public void bundleApplication(Project project, File bundleDir, ICanceled canceled) throws IOException, CompileExceptionError {
         logger.log(Level.INFO, "Entering IOSBundler.bundleApplication()");
 
         BundleHelper.throwIfCanceled(canceled);
 
-        final Platform platform = Platform.Armv7Darwin;
+        final Platform platform = Platform.Arm64Darwin;
         final List<Platform> architectures = Platform.getArchitecturesFromString(project.option("architectures", ""), platform);
 
         Map<String, IResource> bundleResources = ExtenderUtil.collectBundleResources(project, architectures);
@@ -293,7 +292,7 @@ public class IOSBundler implements IBundler {
             logger.log(Level.WARNING, "ios.icons_asset is not set");
         }
 
-        BundleHelper helper = new BundleHelper(project, Platform.Armv7Darwin, bundleDir, variant);
+        BundleHelper helper = new BundleHelper(project, Platform.Arm64Darwin, bundleDir, variant);
 
         helper.copyOrWriteManifestFile(architectures.get(0), appDir);
         helper.copyIosIcons();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -541,7 +541,6 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
                 }
                 break;
 
-                case Armv7Darwin:
                 case Arm64Darwin:
                 case X86_64Ios:
                 {

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -510,8 +510,7 @@
                                                             (fromString [label]
                                                               (if (= no-identity-label label) nil label)))))
         architecture-controls (doto (VBox.)
-                                (ui/children! [(make-labeled-check-box "32-bit (armv7)" "architecture-32bit-check-box" true refresh!)
-                                               (make-labeled-check-box "64-bit (arm64)" "architecture-64bit-check-box" true refresh!)
+                                (ui/children! [(make-labeled-check-box "64-bit (arm64)" "architecture-64bit-check-box" true refresh!)
                                                (make-labeled-check-box "Simulator (x86_64)" "architecture-simulator-check-box" false refresh!)]))]
     (ui/on-action! code-signing-identity-choice-box refresh!)
     (doto (VBox.)
@@ -526,7 +525,7 @@
 (defn- load-ios-prefs! [prefs view code-signing-identity-names]
   ;; This falls back on settings from the Sign iOS Application dialog if available,
   ;; but we will write to our own keys in the preference for these.
-  (ui/with-controls view [sign-app-check-box code-signing-identity-choice-box provisioning-profile-text-field architecture-32bit-check-box architecture-64bit-check-box architecture-simulator-check-box]
+  (ui/with-controls view [sign-app-check-box code-signing-identity-choice-box provisioning-profile-text-field architecture-64bit-check-box architecture-simulator-check-box]
     (ui/value! sign-app-check-box (prefs/get-prefs prefs "bundle-ios-sign-app?" true))
     (ui/value! code-signing-identity-choice-box (or ((set code-signing-identity-names)
                                                      (or (get-string-pref prefs "bundle-ios-code-signing-identity")
@@ -534,30 +533,27 @@
                                                     (first code-signing-identity-names)))
     (ui/value! provisioning-profile-text-field (or (get-string-pref prefs "bundle-ios-provisioning-profile")
                                                    (get-string-pref prefs "last-provisioning-profile")))
-    (ui/value! architecture-32bit-check-box (prefs/get-prefs prefs "bundle-ios-architecture-32bit?" true))
     (ui/value! architecture-64bit-check-box (prefs/get-prefs prefs "bundle-ios-architecture-64bit?" true))
     (ui/value! architecture-simulator-check-box (prefs/get-prefs prefs "bundle-ios-architecture-simulator?" false))))
 
 (defn- save-ios-prefs! [prefs view]
-  (ui/with-controls view [sign-app-check-box code-signing-identity-choice-box provisioning-profile-text-field architecture-32bit-check-box architecture-64bit-check-box architecture-simulator-check-box]
+  (ui/with-controls view [sign-app-check-box code-signing-identity-choice-box provisioning-profile-text-field architecture-64bit-check-box architecture-simulator-check-box]
     (prefs/set-prefs prefs "bundle-ios-sign-app?" (ui/value sign-app-check-box))
     (set-string-pref! prefs "bundle-ios-code-signing-identity" (ui/value code-signing-identity-choice-box))
     (set-string-pref! prefs "bundle-ios-provisioning-profile" (ui/value provisioning-profile-text-field))
-    (prefs/set-prefs prefs "bundle-ios-architecture-32bit?" (ui/value architecture-32bit-check-box))
     (prefs/set-prefs prefs "bundle-ios-architecture-64bit?" (ui/value architecture-64bit-check-box))
     (prefs/set-prefs prefs "bundle-ios-architecture-simulator?" (ui/value architecture-simulator-check-box))))
 
 (defn- get-ios-options [view]
-  (ui/with-controls view [sign-app-check-box code-signing-identity-choice-box provisioning-profile-text-field architecture-32bit-check-box architecture-64bit-check-box architecture-simulator-check-box]
-    {:architecture-32bit? (ui/value architecture-32bit-check-box)
-     :architecture-64bit? (ui/value architecture-64bit-check-box)
+  (ui/with-controls view [sign-app-check-box code-signing-identity-choice-box provisioning-profile-text-field architecture-64bit-check-box architecture-simulator-check-box]
+    {:architecture-64bit? (ui/value architecture-64bit-check-box)
      :architecture-simulator? (ui/value architecture-simulator-check-box)
      :code-signing-identity (ui/value code-signing-identity-choice-box)
      :provisioning-profile (get-file provisioning-profile-text-field)
      :sign-app? (ui/value sign-app-check-box)}))
 
-(defn- set-ios-options! [view {:keys [architecture-32bit? architecture-64bit? architecture-simulator? code-signing-identity provisioning-profile sign-app?] :as _options} issues code-signing-identity-names]
-  (ui/with-controls view [architecture-32bit-check-box architecture-64bit-check-box architecture-simulator-check-box code-signing-identity-choice-box ok-button provisioning-profile-text-field sign-app-check-box]
+(defn- set-ios-options! [view {:keys [architecture-64bit? architecture-simulator? code-signing-identity provisioning-profile sign-app?] :as _options} issues code-signing-identity-names]
+  (ui/with-controls view [architecture-64bit-check-box architecture-simulator-check-box code-signing-identity-choice-box ok-button provisioning-profile-text-field sign-app-check-box]
     (ui/value! sign-app-check-box sign-app?)
     (doto code-signing-identity-choice-box
       (set-choice! (into [nil] code-signing-identity-names) code-signing-identity)
@@ -567,9 +563,6 @@
       (set-file! provisioning-profile)
       (set-field-status! (:provisioning-profile issues))
       (ui/disable! (not sign-app?)))
-    (doto architecture-32bit-check-box
-      (ui/value! architecture-32bit?)
-      (set-field-status! (:architecture issues)))
     (doto architecture-64bit-check-box
       (ui/value! architecture-64bit?)
       (set-field-status! (:architecture issues)))
@@ -581,7 +574,7 @@
                                    (and (some? code-signing-identity)
                                         (fs/existing-file? provisioning-profile)))))))
 
-(defn- get-ios-issues [{:keys [architecture-32bit? architecture-64bit? architecture-simulator? code-signing-identity provisioning-profile sign-app?] :as _options} code-signing-identity-names]
+(defn- get-ios-issues [{:keys [architecture-64bit? architecture-simulator? code-signing-identity provisioning-profile sign-app?] :as _options} code-signing-identity-names]
   {:general (when (and sign-app? (empty? code-signing-identity-names))
               [:fatal "No code signing identities found on this computer."])
    :code-signing-identity (when (and sign-app? (nil? code-signing-identity))
@@ -596,7 +589,7 @@
 
                              (not (existing-file-of-type? "mobileprovision" provisioning-profile))
                              [:fatal "Invalid provisioning profile."]))
-   :architecture (when-not (or architecture-32bit? architecture-64bit? architecture-simulator?)
+   :architecture (when-not (or architecture-64bit? architecture-simulator?)
                    [:fatal "At least one architecture must be selected."])})
 
 (deftype IOSBundleOptionsPresenter [workspace view variant-choices compression-choices]
@@ -613,7 +606,7 @@
     (save-generic-prefs! prefs view)
     (save-ios-prefs! prefs view))
   (get-options [_this]
-    (merge {:platform "armv7-darwin"}
+    (merge {:platform "arm64-darwin"}
            (get-generic-options view)
            (get-ios-options view)))
   (set-options! [_this options]

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -156,7 +156,6 @@
                                   [Platform/Arm64Darwin
                                    Platform/Arm64Android
                                    Platform/Armv7Android
-                                   Platform/Armv7Darwin
                                    Platform/JsWeb
                                    Platform/X86Win32
                                    Platform/X86_64Darwin

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -102,8 +102,6 @@
 (def ^:private extender-platforms
   {(.getPair Platform/X86_64Darwin) {:platform      "x86_64-osx"
                                      :library-paths #{"osx" "x86_64-osx"}}
-   (.getPair Platform/Armv7Darwin)  {:platform      "armv7-ios"
-                                     :library-paths #{"ios" "armv7-ios"}}
    (.getPair Platform/Arm64Darwin)  {:platform      "arm64-ios"
                                      :library-paths #{"ios" "arm64-ios"}}
    (.getPair Platform/Armv7Android) {:platform      "armv7-android"

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -287,7 +287,6 @@
 (defn- get-ne-platform [platform]
   (case platform
     "arm64-darwin"  "arm64-ios"
-    "armv7-darwin"  "armv7-ios"
     "x86_64-darwin" "x86_64-osx"
     platform))
 

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -249,8 +249,7 @@
             keystore-pass (assoc "keystore-pass" (.getAbsolutePath keystore-pass)))))
 
 (def ^:private ios-architecture-option->bob-architecture-string
-  {:architecture-32bit? "armv7-darwin"
-   :architecture-64bit? "arm64-darwin"
+  {:architecture-64bit? "arm64-darwin"
    :architecture-simulator? "x86_64-ios"})
 
 (defn- ios-bundle-bob-args [{:keys [code-signing-identity ^File provisioning-profile sign-app?] :as bundle-options}]

--- a/editor/src/java/com/defold/editor/Platform.java
+++ b/editor/src/java/com/defold/editor/Platform.java
@@ -18,7 +18,6 @@ public enum Platform {
     X86Win32("x86", "win32", ".exe", "", "", ".dll"),
     X86_64Win32("x86_64", "win32", ".exe", "", "", ".dll"),
     X86_64Linux("x86_64", "linux", "", "", "lib", ".so"),
-    Armv7Darwin("armv7", "darwin", "", "", "lib", ".so"),
     Arm64Darwin("arm64", "darwin", "", "", "lib", ".so"),
     Armv7Android("armv7", "android", ".so", "lib", "lib", ".so"),
     Arm64Android("arm64", "android", ".so", "lib", "lib", ".so"),

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -31,9 +31,6 @@
                     "lib" ["particle_shared.dll"]}
    "x86_64-linux"  {"bin" ["dmengine"]
                     "lib" ["libparticle_shared.so"]}
-   ;; The iOS version is needed for the "Sign iOS app" in the macOS editor
-   "armv7-darwin"  {"bin" ["dmengine"]
-                    "lib" []}
    "arm64-darwin"  {"bin" ["dmengine"]
                     "lib" []}})
 

--- a/engine/dlib/src/test/wscript
+++ b/engine/dlib/src/test/wscript
@@ -78,7 +78,7 @@ def build(bld):
     bld.env["JAVACFLAGS"] = '-g -source 1.7 -target 1.7'.split()
 
     extra_defines = []
-    if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
         extra_defines = ['DM_NO_SYSTEM_FUNCTION'] # Needed because we wish to build the tests for all platforms, but not all platforms have the system() function
 
     skip_run = False

--- a/engine/engine/src/test/wscript
+++ b/engine/engine/src/test/wscript
@@ -7,7 +7,7 @@ import waf_gamesys
 
 def build(bld):
     defines = ['_XBOX'] #NOTE: _XBOX to get static lib and avoid dllimport/dllexport stuff
-    if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
         defines = ['DM_NO_SYSTEM_FUNCTION'] # Needed because we wish to build the tests for all platforms, but not all platforms have the system() function
 
     additional_libs = []

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -69,7 +69,7 @@ def build(bld):
     exported_symbols.append(graphics_lib_symbols)
 
     mobile_service_symbols = ['IACExt', 'IAPExt', 'PushExt', 'WebViewExt']
-    if bld.env['PLATFORM'] in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env['PLATFORM'] in ('arm64-darwin', 'x86_64-ios'):
         exported_symbols.extend(mobile_service_symbols)
         exported_symbols.append('FacebookExt')
 
@@ -155,7 +155,7 @@ def build(bld):
         additional_libs += ['UNWIND']
 
     graphics_lib = 'GRAPHICS_NULL'
-    if bld.env['PLATFORM'] in ('arm64-android','armv7-android', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env['PLATFORM'] in ('arm64-android','armv7-android', 'arm64-darwin', 'x86_64-ios'):
         graphics_lib = 'GRAPHICS_NULL DMGLFW' # g_AndroidApp is currently in glfw. UIApplicationMain is currently in glfw
 
     obj = bld.new_task_gen(

--- a/engine/extension/src/wscript
+++ b/engine/extension/src/wscript
@@ -12,7 +12,7 @@ def build(bld):
     dmsdk_add_files(bld, '${PREFIX}/sdk/include/dmsdk', 'dmsdk')
 
     source = ['extension.cpp']
-    if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
         source += ['extension_ios.cpp']
     if re.match('arm.*?android', bld.env.PLATFORM):
         source += ['extension_android.cpp']

--- a/engine/gamesys/src/gamesys/wscript
+++ b/engine/gamesys/src/gamesys/wscript
@@ -16,7 +16,7 @@ def build(bld):
 
     resource.find_sources_in_dirs(['.', 'resources', 'components', 'scripts', '../../proto/gamesys'])
 
-    if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
         resource.source += ['scripts/window/script_window_ios.mm']
     elif re.match('.*?android', bld.env.PLATFORM):
         resource.source += ['scripts/window/script_window_android.cpp']

--- a/engine/gamesys/wscript
+++ b/engine/gamesys/wscript
@@ -30,7 +30,7 @@ def configure(conf):
 
     if platform == "darwin" or platform == "x86_64-darwin":
         conf.env.append_value('LINKFLAGS', ['-framework', 'Cocoa', '-framework', 'OpenGL', '-framework', 'OpenAL', '-framework', 'AGL', '-framework', 'IOKit', '-framework', 'Carbon', '-framework', 'CoreVideo', '-framework', 'QuartzCore'])
-    elif platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    elif platform in ('arm64-darwin', 'x86_64-ios'):
         pass
     elif re.match('arm.*?android', platform):
         conf.env.append_value('LINKFLAGS', ['-lEGL', '-lGLESv1_CM', '-lGLESv2', '-landroid'])

--- a/engine/glfw/examples/wscript_build
+++ b/engine/glfw/examples/wscript_build
@@ -13,7 +13,7 @@ if 'win32' in platform:
 
 
 samples = 'boing gears heightmap listmodes mipmaps mtbench mthello particles pong3d splitview triangle wave'
-if platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios', 'armv7-android'):
+if platform in ('arm64-darwin', 'x86_64-ios', 'armv7-android'):
     # Other examples are not compatible with OpenGLES
     samples = 'simple_gles2'
 elif 'web' in platform:

--- a/engine/glfw/lib/wscript_build
+++ b/engine/glfw/lib/wscript_build
@@ -11,7 +11,7 @@ darwin_vulkan_mobile  = False
 if platform == 'darwin' or platform == 'x86_64-darwin':
     dmglfw.find_sources_in_dirs('. cocoa')
     dmglfw.includes = '. cocoa'
-elif platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+elif platform in ('arm64-darwin', 'x86_64-ios'):
     dmglfw.find_sources_in_dirs('. ios ios/app')
     dmglfw.includes = '. ios'
     darwin_vulkan_mobile = True

--- a/engine/glfw/wscript
+++ b/engine/glfw/wscript
@@ -36,7 +36,7 @@ def configure(conf):
         conf.env.append_value('LINKFLAGS', ['-framework', 'Cocoa', '-framework', 'IOKit', '-framework', 'CoreVideo'])
         if not Options.options.with_vulkan:
             conf.env.append_value('LINKFLAGS', ['-framework', 'OpenGL', '-framework', 'AGL'])
-    elif platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    elif platform in ('arm64-darwin', 'x86_64-ios'):
         conf.env.append_value('LINKFLAGS', ['-framework', 'UIKit', '-framework', 'QuartzCore', '-framework', 'CoreGraphics'])
         if not Options.options.with_vulkan:
             conf.env.append_value('LINKFLAGS', ['-framework', 'OpenGLES'])

--- a/engine/graphics/src/test/wscript
+++ b/engine/graphics/src/test/wscript
@@ -13,7 +13,7 @@ def build(bld):
                          target = name)
 
     print "MAWE", platform_supports_feature(bld.env.PLATFORM, 'vulkan', {}), bld.env.PLATFORM 
-    if platform_supports_feature(bld.env.PLATFORM, 'vulkan', {}) and not bld.env.PLATFORM in ('x86_64-linux','armv7-darwin','x86_64-ios'):
+    if platform_supports_feature(bld.env.PLATFORM, 'vulkan', {}) and not bld.env.PLATFORM in ('x86_64-linux','x86_64-ios'):
 
         extra_libs = []
         if bld.env.PLATFORM in ('armv7-android', 'arm64-android'):

--- a/engine/graphics/wscript
+++ b/engine/graphics/wscript
@@ -43,7 +43,7 @@ def configure(conf):
 
     if platform == "darwin" or platform == 'x86_64-darwin':
         conf.env.append_value('LINKFLAGS', ['-framework', 'Carbon', '-framework', 'OpenGL', '-framework', 'AGL', '-framework', 'IOKit', '-framework', 'CoreVideo'])
-    elif platform == "armv7-darwin" or platform == "x86_64-ios":
+    elif platform == "x86_64-ios":
         pass
     elif platform == "linux" or platform == "x86_64-linux":
         conf.env.append_value('LINKFLAGS', ['-lXext', '-lX11', '-lXi', '-lGL', '-lGLU', '-lpthread'])

--- a/engine/lua/src/lua/wscript_build
+++ b/engine/lua/src/lua/wscript_build
@@ -3,7 +3,7 @@ import os, re
 
 EXTRA_DEFINES = []
 
-if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
     # Note: LUA_NO_SYSTEM is our own invention, mimicking the LJ_NO_SYSTEM
     EXTRA_DEFINES = ['LUA_NO_SYSTEM']
 

--- a/engine/record/src/test/wscript
+++ b/engine/record/src/test/wscript
@@ -10,7 +10,7 @@ def build(bld):
         record = 'record_null'
 
     extra_defines = []
-    if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
         extra_defines = ['DM_NO_SYSTEM_FUNCTION'] # Needed because we wish to build the tests for all platforms, but not all platforms have the system() function
 
     test_record = bld.new_task_gen(features='cxx cprogram test',

--- a/engine/render/wscript
+++ b/engine/render/wscript
@@ -38,8 +38,6 @@ def configure(conf):
 
     if platform == "darwin":
         conf.env.append_value('LINKFLAGS', ['-framework', 'Cocoa', '-framework', 'OpenGL', '-framework', 'OpenAL', '-framework', 'AGL', '-framework', 'IOKit', '-framework', 'Carbon', '-framework', 'CoreVideo'])
-    elif platform == "armv7-darwin":
-        pass
     elif platform == "linux":
         conf.env.append_value('LINKFLAGS', ['-lglut', '-lXext', '-lX11', '-lXi', '-lGL', '-lGLU', '-lpthread'])
     elif "win32" in platform:

--- a/engine/resource/src/wscript
+++ b/engine/resource/src/wscript
@@ -21,7 +21,7 @@ def build(bld):
 
     if bld.env.PLATFORM in ('armv7-android','arm64-android'):
         resource.source.append('mount/mount_android.cpp');
-    elif bld.env.PLATFORM in ('x86_64-linux','x86_64-darwin','armv7-darwin','arm64-darwin','x86_64-ios'):
+    elif bld.env.PLATFORM in ('x86_64-linux','x86_64-darwin','arm64-darwin','x86_64-ios'):
         resource.source.append('mount/mount_mmap.cpp');
     else:
         resource.source.append('mount/mount_generic.cpp');

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -20,7 +20,7 @@ def build(bld):
 
     if 'android' in bld.env.PLATFORM:
         source += ['sound_android.cpp']
-    elif bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+    elif bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios'):
         source += ['sound_ios.mm']
     else:
         source += ['sound_generic.cpp']

--- a/engine/tools/wscript
+++ b/engine/tools/wscript
@@ -32,7 +32,7 @@ def configure(conf):
 
     if platform == "darwin" or platform == "x86_64-darwin":
         conf.env.append_value('LINKFLAGS', ['-framework', 'Cocoa', '-framework', 'OpenGL', '-framework', 'AGL', '-framework', 'IOKit', '-framework', 'Carbon', '-framework', 'CoreVideo', '-framework', 'QuartzCore'])
-    elif platform == "armv7-darwin" or platform == 'x86_64-ios':
+    elif platform == 'x86_64-ios':
         pass
     elif platform == "linux" or platform == "x86_64-linux":
         conf.env['LIB_X'] = ['Xext', 'X11', 'Xi', 'GL', 'GLU']

--- a/engine/webview/src/wscript
+++ b/engine/webview/src/wscript
@@ -8,7 +8,7 @@ def configure(conf):
 def build(bld):
     source = ['webview_null.cpp']
 
-    if bld.env.PLATFORM in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios', 'armv7-android'):
+    if bld.env.PLATFORM in ('arm64-darwin', 'x86_64-ios', 'armv7-android'):
         source = ['webview_mobile.cpp']
 
     webview = bld.new_task_gen(features = 'cxx cstaticlib',

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -35,7 +35,7 @@ from ConfigParser import ConfigParser
 BASE_PLATFORMS = [  'x86_64-linux',
                     'x86_64-darwin',
                     'win32', 'x86_64-win32',
-                    'x86_64-ios', 'armv7-darwin', 'arm64-darwin',
+                    'x86_64-ios', 'arm64-darwin',
                     'armv7-android', 'arm64-android',
                     'js-web', 'wasm-web']
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -83,7 +83,6 @@ def get_target_platforms():
 PACKAGES_ALL="protobuf-2.3.0 waf-1.5.9 junit-4.6 protobuf-java-2.3.0 openal-1.1 maven-3.0.1 ant-1.9.3 vecmath vpx-1.7.0 luajit-2.1.0-beta3 tremolo-0.0.8 defold-robot-0.7.0 bullet-2.77 libunwind-395b27b68c5453222378bc5fe4dab4c6db89816a jctest-0.8 vulkan-1.1.108".split()
 PACKAGES_HOST="protobuf-2.3.0 cg-3.1 vpx-1.7.0 luajit-2.1.0-beta3 tremolo-0.0.8".split()
 PACKAGES_IOS_X86_64="protobuf-2.3.0 luajit-2.1.0-beta3 tremolo-0.0.8 bullet-2.77".split()
-PACKAGES_IOS="protobuf-2.3.0 luajit-2.1.0-beta3 tremolo-0.0.8 bullet-2.77".split()
 PACKAGES_IOS_64="protobuf-2.3.0 luajit-2.1.0-beta3 tremolo-0.0.8 bullet-2.77 MoltenVK-1.0.41".split()
 PACKAGES_DARWIN="protobuf-2.3.0 vpx-1.7.0".split()
 PACKAGES_DARWIN_64="protobuf-2.3.0 luajit-2.1.0-beta3 vpx-1.7.0 tremolo-0.0.8 sassc-5472db213ec223a67482df2226622be372921847 bullet-2.77 spirv-cross-2018-08-07 glslc-v2018.0 MoltenVK-1.0.41".split()
@@ -475,7 +474,6 @@ class Configuration(object):
             'x86_64-linux':   PACKAGES_LINUX_64,
             'darwin':         PACKAGES_DARWIN, # ?? Still used by bob-light?
             'x86_64-darwin':  PACKAGES_DARWIN_64,
-            'armv7-darwin':   PACKAGES_IOS,
             'arm64-darwin':   PACKAGES_IOS_64,
             'x86_64-ios':     PACKAGES_IOS_X86_64,
             'armv7-android':  PACKAGES_ANDROID,
@@ -582,7 +580,7 @@ class Configuration(object):
         self.sdk_info = sdk.get_sdk_info(sdkfolder, target_platform)
 
         # We currently only support a subset of platforms using this mechanic
-        if platform in ('x86_64-darwin','x86_64-ios','armv7-darwin','arm64-darwin'):
+        if platform in ('x86_64-darwin','x86_64-ios','arm64-darwin'):
             if not self.sdk_info:
                 print("Couldn't find any sdks")
                 print("We recommend you follow the packaging steps found here: %s" % "https://github.com/defold/defold/blob/dev/scripts/package/README.md#packaging-the-sdks")
@@ -595,12 +593,12 @@ class Configuration(object):
         sdkfolder = join(self.ext, 'SDKs')
 
         target_platform = self.target_platform
-        if target_platform in ('x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+        if target_platform in ('x86_64-darwin', 'arm64-darwin', 'x86_64-ios'):
             # macOS SDK
             download_sdk(self,'%s/%s.tar.gz' % (self.package_path, sdk.PACKAGES_MACOS_SDK), join(sdkfolder, sdk.PACKAGES_MACOS_SDK))
             download_sdk(self,'%s/%s.darwin.tar.gz' % (self.package_path, sdk.PACKAGES_XCODE_TOOLCHAIN), join(sdkfolder, sdk.PACKAGES_XCODE_TOOLCHAIN))
 
-        if target_platform in ('armv7-darwin', 'arm64-darwin', 'x86_64-ios'):
+        if target_platform in ('arm64-darwin', 'x86_64-ios'):
             # iOS SDK
             download_sdk(self,'%s/%s.tar.gz' % (self.package_path, sdk.PACKAGES_IOS_SDK), join(sdkfolder, sdk.PACKAGES_IOS_SDK))
             download_sdk(self,'%s/%s.tar.gz' % (self.package_path, sdk.PACKAGES_IOS_SIMULATOR_SDK), join(sdkfolder, sdk.PACKAGES_IOS_SIMULATOR_SDK))
@@ -626,7 +624,7 @@ class Configuration(object):
         if 'linux' in self.host2:
             download_sdk(self, '%s/%s.tar.xz' % (self.package_path, PACKAGES_LINUX_TOOLCHAIN), join(sdkfolder, 'linux', PACKAGES_LINUX_CLANG), format='J')
 
-        if target_platform in ('x86_64-darwin', 'armv7-darwin', 'arm64-darwin', 'x86_64-ios') and 'linux' in self.host2:
+        if target_platform in ('x86_64-darwin', 'arm64-darwin', 'x86_64-ios') and 'linux' in self.host2:
             if not os.path.exists(join(sdkfolder, 'linux', PACKAGES_LINUX_CLANG, 'cctools')):
                 download_sdk(self, '%s/%s.tar.gz' % (self.package_path, PACKAGES_CCTOOLS_PORT), join(sdkfolder, 'linux', PACKAGES_LINUX_CLANG), force_extract=True)
 
@@ -899,7 +897,7 @@ class Configuration(object):
 
     def _strip_engine(self, path):
         """ Strips the debug symbols from an executable """
-        if self.target_platform not in ['x86_64-linux','x86_64-darwin','armv7-darwin','arm64-darwin','x86_64-ios','armv7-android','arm64-android']:
+        if self.target_platform not in ['x86_64-linux','x86_64-darwin','arm64-darwin','x86_64-ios','armv7-android','arm64-android']:
             return False
 
         sdkfolder = join(self.ext, 'SDKs')
@@ -917,7 +915,7 @@ class Configuration(object):
             ANDROID_HOST = 'linux' if sys.platform == 'linux2' else 'darwin'
             strip = "%s/toolchains/%s-%s/prebuilt/%s-x86_64/bin/%s-strip" % (ANDROID_NDK_ROOT, ANDROID_PLATFORM, ANDROID_GCC_VERSION, ANDROID_HOST, ANDROID_PLATFORM)
 
-        if self.target_platform in ('x86_64-darwin','armv7-darwin','arm64-darwin','x86_64-ios') and 'linux2' == sys.platform:
+        if self.target_platform in ('x86_64-darwin','arm64-darwin','x86_64-ios') and 'linux2' == sys.platform:
             strip = os.path.join(sdkfolder, 'linux', PACKAGES_LINUX_CLANG, 'bin', 'x86_64-apple-darwin19-strip')
 
         run.shell_command("%s %s" % (strip, path))
@@ -1179,7 +1177,7 @@ class Configuration(object):
         for type, plfs in {'android-bundling': [['armv7-android', 'armv7-android'], ['arm64-android', 'arm64-android']],
                            'win32-bundling': [['win32', 'x86-win32'], ['x86_64-win32', 'x86_64-win32']],
                            'js-bundling': [['js-web', 'js-web'], ['wasm-web', 'wasm-web']],
-                           'ios-bundling': [['armv7-darwin', 'armv7-darwin'], ['arm64-darwin', 'arm64-darwin'], ['x86_64-ios', 'x86_64-ios']],
+                           'ios-bundling': [['arm64-darwin', 'arm64-darwin'], ['x86_64-ios', 'x86_64-ios']],
                            'osx-bundling': [['x86_64-darwin', 'x86_64-darwin']],
                            'linux-bundling': [['x86_64-linux', 'x86_64-linux']],
                            'switch-bundling': [['arm64-nx64', 'arm64-nx64']]}.iteritems():

--- a/scripts/mobile/ios-repack.sh
+++ b/scripts/mobile/ios-repack.sh
@@ -29,7 +29,7 @@ function terminate() {
 
 function terminate_usage() {
     echo "Usage: ${SCRIPT_NAME} <platform> <identity> <profile> <source>"
-    echo "  platform - 'armv7-darwin' or 'arm64-darwin'"
+    echo "  platform - 'arm64-darwin'"
     echo "  identity - name of the iPhone developer identity"
     echo "  profile  - absolute filepath to the provisioning profile"
     echo "  source   - absolute filepath to the source ipa to repack"
@@ -55,7 +55,7 @@ PLATFORM="${1:-}" && [ ! -z "${PLATFORM}" ] || terminate_usage
 IDENTITY="${2:-}" && [ ! -z "${IDENTITY}" ] || terminate_usage
 PROFILE="${3:-}" && [ ! -z "${PROFILE}" ] || terminate_usage
 SOURCE="${4:-}" && [ ! -z "${SOURCE}" ] || terminate_usage
-[[ "armv7-darwin arm64-darwin" =~ "${PLATFORM}" ]] || terminate_usage
+[[ "arm64-darwin" =~ "${PLATFORM}" ]] || terminate_usage
 
 SOURCE="$(cd "$(dirname "${SOURCE}")"; pwd)/$(basename "${SOURCE}")"
 PROFILE="$(cd "$(dirname "${PROFILE}")"; pwd)/$(basename "${PROFILE}")"

--- a/scripts/resources/downloads.html
+++ b/scripts/resources/downloads.html
@@ -109,7 +109,6 @@
                 var platformToIcon = {}
                 platformToIcon['armv7-android'] = icon_android;
                 platformToIcon['arm64-android'] = icon_android;
-                platformToIcon['armv7-darwin']  = icon_ios;
                 platformToIcon['arm64-darwin']  = icon_ios;
                 platformToIcon['x86_64-ios']    = icon_ios;
                 platformToIcon['js-web']        = icon_html5;

--- a/scripts/update-editor-binaries.sh
+++ b/scripts/update-editor-binaries.sh
@@ -58,12 +58,12 @@ function copy_file() {
 # Resources
 # ----------------------------------------------------------------------------
 SOURCES=(
-    "x86_64-linux"  "x86_64-darwin" "win32"  "armv7-darwin" "arm64-darwin"
+    "x86_64-linux"  "x86_64-darwin" "win32"  "arm64-darwin"
     "armv7-android" "arm64-android" "js-web" "x86_64-win32"
 )
 
 TARGETS=(
-    "x86_64-linux"  "x86_64-darwin" "x86-win32" "armv7-darwin" "arm64-darwin"
+    "x86_64-linux"  "x86_64-darwin" "x86-win32" "arm64-darwin"
     "armv7-android" "arm64-android" "js-web"    "x86_64-win32"
 )
 

--- a/share/ext/build.sh
+++ b/share/ext/build.sh
@@ -20,7 +20,6 @@ function usage() {
     echo " * x86_64-darwin"
     echo " * linux"
     echo " * x86_64-linux"
-    echo " * armv7-darwin"
     echo " * arm64-darwin"
     echo " * x86_64-ios"
     echo " * armv7-android"

--- a/share/ext/common.sh
+++ b/share/ext/common.sh
@@ -241,27 +241,7 @@ function cmi() {
     export PLATFORM=$1
 
     case $1 in
-        armv7-darwin)
-            [ ! -e "${IOS_SDK_ROOT}" ] && echo "No SDK found at ${IOS_SDK_ROOT}" && exit 1
-            # NOTE: We set this PATH in order to use libtool from iOS SDK
-            # Otherwise we get the following error "malformed object (unknown load command 1)"
-            export PATH=$DARWIN_TOOLCHAIN_ROOT/usr/bin:$PATH
-            export CPPFLAGS="-arch armv7 -isysroot ${IOS_SDK_ROOT}"
-            export CXXFLAGS="${CXXFLAGS} -miphoneos-version-min=${IOS_MIN_SDK_VERSION} -stdlib=libc++ -arch armv7 -isysroot ${IOS_SDK_ROOT}"
-            export CFLAGS="${CPPFLAGS} -miphoneos-version-min=${IOS_MIN_SDK_VERSION} -stdlib=libc++"
-            # NOTE: We use the gcc-compiler as preprocessor. The preprocessor seems to only work with x86-arch.
-            # Wrong include-directories and defines are selected.
-            export CPP="$DARWIN_TOOLCHAIN_ROOT/usr/bin/clang -E"
-            export CC=$DARWIN_TOOLCHAIN_ROOT/usr/bin/clang
-            export CXX=$DARWIN_TOOLCHAIN_ROOT/usr/bin/clang++
-            export AR=$DARWIN_TOOLCHAIN_ROOT/usr/bin/ar
-            export RANLIB=$DARWIN_TOOLCHAIN_ROOT/usr/bin/ranlib
-            cmi_cross $1 arm-darwin
-            ;;
-
         arm64-darwin)
-            # Essentially the same environment vars as armv7-darwin but with "-arch arm64".
-
             [ ! -e "${IOS_SDK_ROOT}" ] && echo "No SDK found at ${IOS_SDK_ROOT}" && exit 1
             # NOTE: We set this PATH in order to use libtool from iOS SDK
             # Otherwise we get the following error "malformed object (unknown load command 1)"

--- a/share/ext/luajit/README.md
+++ b/share/ext/luajit/README.md
@@ -5,21 +5,9 @@
 `luajit-32` for MacOS cannot currently be built with latest LuaJIT.
 We therefore use the prebuilt version
 
-
-## `armv7-darwin`
-
-(note, the next time we upgrade, we probably aren't supporting this architecture anymore)
-
-To build a version for `armv7-android`, we neede 32 bit executable support on the host. In order to do that, we installed a Mac OS 10.14 VM in Parallels Desktop.
-
-IN the common.sh script I set:
-
-DARWIN_TOOLCHAIN_ROOT=${SCRIPTDIR}/luajit/sdk/XcodeDefault.xctoolchain
-
-
 ## `armv7-android`
 
-In order to build this platform more easily (see the above note on `armv7-darwin` it's easier to use a docker container.
+In order to build this platform more easily it's easier to use a docker container.
 
     $ ./scripts/docker/build.sh
     $ ./scripts/docker/run.sh

--- a/share/ext/luajit/build_luajit.sh
+++ b/share/ext/luajit/build_luajit.sh
@@ -30,18 +30,6 @@ function luajit_configure() {
 	COMMON_FLAGS_64="-DLUAJIT_DISABLE_JIT -DLUAJIT_NUMMODE=LJ_NUMMODE_DUAL "
 
 	case $CONF_TARGET in
-		armv7-darwin)
-			TAR_SKIP_BIN=1
-			XFLAGS="$COMMON_FLAGS_32"
-			export CROSS=""
-			export PATH=$DARWIN_TOOLCHAIN_ROOT/usr/bin:$PATH
-			export HOST_CC="$DARWIN_TOOLCHAIN_ROOT/usr/bin/clang"
-			export HOST_CFLAGS="$XFLAGS -m32 -isysroot $OSX_SDK_ROOT -I."
-			export HOST_ALDFLAGS="-m32 -isysroot $OSX_SDK_ROOT"
-			export TARGET_FLAGS="$CFLAGS"
-			export XCFLAGS="-DLUAJIT_TARGET=LUAJIT_ARCH_ARM"
-			export SKIPLUAJIT=true
-			;;
 		arm64-darwin)
 			TAR_SKIP_BIN=1
 			XFLAGS="$COMMON_FLAGS_64"
@@ -137,9 +125,6 @@ function cmi_patch() {
 export CONF_TARGET=$1
 
 case $1 in
-	armv7-darwin)
-		export TARGET_SYS=iOS
-		;;
 	arm64-darwin)
 		export TARGET_SYS=iOS
 		;;

--- a/share/ext/tremolo/build_tremolo.sh
+++ b/share/ext/tremolo/build_tremolo.sh
@@ -52,10 +52,6 @@ case $1 in
         EXTRA_FLAGS="-mmacosx-version-min=10.7"
         ;;
 
-    armv7-darwin)
-        EXTRA_FLAGS="-miphoneos-version-min=6.0"
-        ;;
-
     arm64-darwin)
         EXTRA_FLAGS="-miphoneos-version-min=6.0"
         ;;

--- a/share/extender/build.yml
+++ b/share/extender/build.yml
@@ -198,46 +198,7 @@ platforms:
     manifestName:     'Info.plist'
     manifestMergeCmd: 'java -jar {{env.MANIFEST_MERGE_TOOL}} --platform {{platform}} --main {{mainManifest}} {{#libraries}} --lib {{.}} {{/libraries}} --out {{target}}'
 
-  armv7-ios:
-    env:
-        PLATFORMSDK_DIR:        "{{env.PLATFORMSDK_DIR}}"
-        MANIFEST_MERGE_TOOL:    "{{env.MANIFEST_MERGE_TOOL}}"
-        XCODE_VERSION:          "{{env.XCODE_13_VERSION}}"
-        XCODE_CLANG_VERSION:    "{{env.XCODE_13_CLANG_VERSION}}"
-        SWIFT_VERSION:          "{{env.SWIFT_5_5_VERSION}}"
-        IOS_VERSION:            "{{env.IOS_15_VERSION}}"
-        LD_LIBRARY_PATH:        "{{env.LIB_TAPI_1_6_PATH}}:{{env.LD_LIBRARY_PATH}}"
-        SYSROOT:                "{{env.PLATFORMSDK_DIR}}/iPhoneOS{{env.IOS_15_VERSION}}.sdk"
-    context:
-        frameworks: ["OpenGLES", "OpenAL", "QuartzCore", "CoreGraphics", "AudioToolbox", "SystemConfiguration", "CoreVideo", "UIKit", "Security", "AVFAudio"]
-        weakFrameworks: ["Foundation"]
-        engineLibs: ["engine", "engine_service", "mbedtls", "zip", "webviewext", "profilerext", "facebookext", "iapext", "pushext", "iacext", "record_null", "gameobject", "ddf", "resource", "gamesys", "graphics", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "LinearMath", "Box2D", "render", "script", "luajit-5.1", "extension", "hid", "input", "particle", "rig", "dlib", "dmglfw", "gui", "crashext", "sound", "tremolo", "liveupdate", "resolv"]
-        libPaths:   ["{{dynamo_home}}/lib/armv7-darwin", "{{dynamo_home}}/ext/lib/armv7-darwin", "{{env.SYSROOT}}/usr/lib", "{{env.SYSROOT}}/usr/lib/swift", "{{env.PLATFORMSDK_DIR}}/XcodeDefault{{env.XCODE_VERSION}}.xctoolchain/usr/lib/swift-{{env.SWIFT_VERSION}}/iphoneos", "{{env.PLATFORMSDK_DIR}}/XcodeDefault{{env.XCODE_VERSION}}.xctoolchain/usr/lib/swift/iphoneos", "{{env.PLATFORMSDK_DIR}}/XcodeDefault{{env.XCODE_VERSION}}.xctoolchain/usr/lib/clang/{{env.XCODE_CLANG_VERSION}}/lib/darwin"]
-        defines:    ["DM_PLATFORM_IOS", "LUA_BYTECODE_ENABLE_32"]
-        systemIncludes:    ["{{env.SYSROOT}}/usr/include/c++/v1"]
-        flags:      ["-fno-exceptions", "-fvisibility=hidden"]
-        linkFlags:  ['-fobjc-link-runtime', '-dead_strip', '-Wl,-U,_objc_loadClassref']
-        libs:       ['clang_rt.ios']
-        dynamicLibs: []
-        symbols:    ["AudioDecoderTremolo"]
-
-    exePrefix: ''
-    exeExt: ''
-    shlibRe: 'lib(.+).dylib'
-    stlibRe: 'lib(.+).a'
-    sourceRe: '(?i).*(\.cpp|\.c|\.cc|\.cxx|\.c\+\+|.mm|.m)'
-    writeLibPattern: 'lib%s.a'
-    writeExePattern: 'dmengine'
-    symbolsPattern: '.*dSYM'
-    zipContentPattern: 'dmengine'
-    allowedLibs:    ["(\\w[\\w\\.+-]+)"]
-    allowedFlags: ["-ObjC","-ObjC\\+\\+","-Wa,{{comma_separated_arg}}","-W{{warning}}","-Wno-{{warning}}","-ansi","--ansi","-std-default={{arg}}","-stdlib=(libstdc\\+\\+|libc\\+\\+)","-w","-std=(c89|c99|c\\+\\+98|c\\+\\+0x|c\\+\\+11|c\\+\\+14|c\\+\\+17)","-Wp,{{comma_separated_arg}}","--extra-warnings","--warn-{{warning}}","--warn-={{warning}}","-f(no-)?objc-arc(-exceptions)?","-ferror-limit={{number}}","-O([0-4]?|fast|s|z)","-Wl,[-_a-zA-Z0-9,/@]+","-fno-rtti","-f\\w[\\w-=]+"]
-    compileCmd: 'clang++ -c -arch armv7 -target arm-apple-darwin19 -m32 -g -O2 -stdlib=libc++ -miphoneos-version-min=8.0 -isysroot {{env.SYSROOT}} -nostdinc++ {{#systemIncludes}}-isystem {{{.}}} {{/systemIncludes}} {{#defines}}-D{{{.}}} {{/defines}} {{#flags}}{{{.}}} {{/flags}} {{#ext.includes}}-I{{{.}}} {{/ext.includes}} {{#ext.frameworkPaths}}-F{{{.}}} {{/ext.frameworkPaths}} {{#includes}}-I{{{.}}} {{/includes}} {{#platformIncludes}}-I{{.}} {{/platformIncludes}} {{src}} -o{{tgt}}'
-    linkCmd: 'clang++ -arch armv7 -target arm-apple-darwin19 -m32 -g -O2 -stdlib=libc++ -miphoneos-version-min=8.0 -isysroot {{env.SYSROOT}} -o {{tgt}} {{#linkFlags}}{{{.}}} {{/linkFlags}} {{#ext.libPaths}}-L{{{.}}} {{/ext.libPaths}} {{#libs}}-l{{{.}}} {{/libs}} {{#ext.libs}}-l{{{.}}} {{/ext.libs}} {{#ext.dynamicLibs}}-l{{{.}}} {{/ext.dynamicLibs}} {{#dynamicLibs}}-l{{{.}}} {{/dynamicLibs}} {{#ext.frameworkPaths}}-F{{{.}}} {{/ext.frameworkPaths}} {{#ext.frameworks}}-framework {{{.}}} {{/ext.frameworks}} {{#frameworks}}-framework {{{.}}} {{/frameworks}} {{#weakFrameworks}}-weak_framework {{{.}}} {{/weakFrameworks}} {{#libPaths}}-L{{{.}}} {{/libPaths}} {{#engineLibs}}-l{{{.}}} {{/engineLibs}} {{#src}}{{{.}}} {{/src}}'
-    libCmd: 'ar rcs {{tgt}} {{#objs}}{{{.}}} {{/objs}}'
-    symbolCmd: 'dsymutil -o {{src}}.dSYM {{src}}'
-    manifestName:     'Info.plist'
-    manifestMergeCmd: 'java -jar {{env.MANIFEST_MERGE_TOOL}} --platform {{platform}} --main {{mainManifest}} {{#libraries}} --lib {{.}} {{/libraries}} --out {{target}}'
+  # armv7-ios removed in Defold 1.2.193
 
   x86_64-ios:
     env:

--- a/share/extender/variants/headless.appmanifest
+++ b/share/extender/variants/headless.appmanifest
@@ -61,13 +61,6 @@ platforms:
             symbols: ["NullSoundDevice"]
             libs: ["record_null","sound_null","graphics_null","hid_null"]
 
-    armv7-ios:
-        context:
-            excludeLibs: ["record","vpx","sound","tremolo","graphics","hid"]
-            excludeSymbols: ["DefaultSoundDevice","AudioDecoderWav","AudioDecoderStbVorbis","AudioDecoderTremolo","GraphicsAdapterOpenGL","GraphicsAdapterVulkan"]
-            symbols: ["NullSoundDevice"]
-            libs: ["record_null","sound_null","graphics_null","hid_null"]
-
     arm64-ios:
         context:
             excludeLibs: ["record","vpx","sound","tremolo","graphics","hid"]

--- a/share/extender/variants/release.appmanifest
+++ b/share/extender/variants/release.appmanifest
@@ -46,11 +46,6 @@ platforms:
             excludeLibs: ["engine", "engine_service", "profilerext"]
             libs: ["engine_release", "engine_service_null", "profilerext_null"]
 
-    armv7-ios:
-        context:
-            excludeLibs: ["engine", "engine_service", "profilerext"]
-            libs: ["engine_release", "engine_service_null", "profilerext_null"]
-
     arm64-ios:
         context:
             excludeLibs: ["engine", "engine_service", "profilerext"]


### PR DESCRIPTION
Defold doesn't support armv7 platform on iOS anymore.
`info.plist` in builtins/manifests/ios` has changed (`UIRequiredDeviceCapabilities`) make sure you have these changes in your custom `info.plist` if you use one.

If your game is already released with `armv7` then you have to change `MinimumOSVersion` to `11.0` in your `info.plist` to be able to update it on AppStore.

The platform sent to bob is now "--platform=arm64-darwin".
The bundle output folder from Editor is now `arm64-darwin`.

Fixes https://github.com/defold/defold/issues/6369