### PR TITLE
Add override for onNewIntent

### DIFF
--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -292,6 +292,12 @@ public class DefoldActivity extends NativeActivity {
         return super.dispatchKeyEvent(event);
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+    }
+
     /** show virtual keyboard
      * Implemented here to ensure that calls from native code are delayed and run on the UI thread.
      */


### PR DESCRIPTION
Some SDKs (for example AppsFlyer) save data in intent ( in case with Appsflyer it's deep links data). To be able to get this data app should be in `singleTop` mode or manually override `onNewIntent` and set intent.

But changing activity mode to `singleTop` is a bit risky and maybe a reason for regression when working with native extensions.