### PR TITLE
Better handling of Android configuration changes

### DIFF
--- a/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
+++ b/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
         <activity android:name="com.dynamo.android.DefoldActivity"
                 android:label="{{project.title}}"
-                android:configChanges="orientation|screenSize|keyboardHidden"
+                android:configChanges="fontScale|keyboard|keyboardHidden|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
                 android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
                 android:screenOrientation="{{orientation-support}}"
                 android:launchMode="singleTask">


### PR DESCRIPTION
Some device configurations can change during runtime (such as screen orientation, keyboard availability, global font size, etc). When such a change occurs, Android restarts the running game Activity. This behavior may be a reason for immediate app closing that looks like a crash and sometimes the reason for ANRs.

This fix adds all possible configuration changes into the lists configuration changes that the activity will handle itself (`android:configChanges` in `AndroidManifest.xml`)

`AndroidManifest.xml` has changed. Make sure you have these changes in your custom `AndroidManifest.xml` if you use one.

Fixes https://github.com/defold/defold/issues/6174 and https://github.com/defold/defold/issues/3163