### PR TITLE
Create release notes from GitHub data 

### DIFF
--- a/scripts/releasenotes_github.py
+++ b/scripts/releasenotes_github.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright 2020-2022 The Defold Foundation
+# Copyright 2014-2020 King
+# Copyright 2009-2014 Ragnar Svensson, Christian Murray
+# Licensed under the Defold License version 1.0 (the "License"); you may not use
+# this file except in compliance with the License.
+# 
+# You may obtain a copy of the License, together with FAQs at
+# https://www.defold.com/license
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# add build_tools folder to the import search path
+import sys, os, io
+from os.path import join, dirname, basename, relpath, expanduser, normpath, abspath
+sys.path.append(os.path.join(normpath(join(dirname(abspath(__file__)), '..')), "build_tools"))
+
+import optparse
+import github
+import json
+
+
+owner = "defold"
+repo = "defold"
+token = None
+
+def pprint(d):
+    print(json.dumps(d, indent=4, sort_keys=True))
+
+
+def get_project(name):
+    response = github.get("repos/%s/%s/projects" % (owner, repo), token)
+    for project in response:
+        if project["name"] == name:
+            return project
+
+
+def get_cards_in_column(project, column_name):
+    columns = github.get(project["columns_url"], token)
+    for column in columns:
+        if column["name"] == column_name:
+            return github.get(column["cards_url"], token)
+
+
+def get_issue_labels(issue):
+    labels = []
+    for label in issue["labels"]:
+        labels.append(label["name"])
+    return labels
+
+
+def get_issue_timeline(issue, reverse = True):
+    timeline = github.get(issue["timeline_url"], token)
+    if reverse:
+        timeline.reverse()
+    return timeline
+
+
+def get_closing_pull_request(issue):
+    if "pull_request" in issue:
+        return issue
+    timeline = get_issue_timeline(issue)
+    for t in timeline:
+        if t["event"] in [ "connected", "cross-referenced"]:
+            if not "source" in t:
+                continue
+            issue = t["source"]["issue"]
+            if not "pull_request" in issue:
+                continue
+            if "merged_at" in issue["pull_request"]:
+                return issue
+
+
+def issue_to_markdown(issue, hide_details = True):
+    prefix = "FIX"
+    if "bug" in issue["labels"]:
+        prefix = "BUG"
+    elif "feature request" in issue["labels"]:
+        prefix = "NEW"
+
+    md = ("__%s__: %s ([#%s](%s))\n" % (prefix, issue["title"], issue["number"], issue["url"]))
+    if hide_details: md += ("[details=\"Details\"]\n")
+    md += ("%s\n" % issue["body"])
+    if hide_details: md += ("\n---\n[/details]\n")
+    md += ("\n")
+    return md
+
+
+
+def generate(version):
+    print("Generating release notes for %s" % version)
+    project = get_project(version)
+    if not project:
+        print("Unable to find GitHub project for version %s" % version)
+        return None
+
+    output = []
+    for card in get_cards_in_column(project, "Done"):
+        content_url = card.get("content_url")
+        # do not process cards that doesn't reference an issue
+        if not content_url and "issue" not in content_url:
+            output.append({
+                "title": "Note",
+                "body": card["note"],
+                "url": None,
+                "labels": []
+            })
+            continue
+
+        # get the issue associated with the card
+        issue = github.get(content_url, token)
+        print("Processing issue %s" % issue["html_url"])
+
+        # only include issues that are closed
+        # since we're getting issues from the "Done" column there really should be only closed issues..
+        if issue["state"] != "closed":
+            print("  Error: Issue is in the Done column but is not closed.")
+            continue
+
+        # get the pr that closed the issue
+        pr = get_closing_pull_request(issue)
+        if pr:
+            output.append({
+                "title": pr["title"],
+                "body": pr["body"],
+                "number": issue["number"],
+                "url": issue["html_url"],
+                "labels": get_issue_labels(issue)
+            })
+        else:
+            print("  Issue is not associated with a pull request.")
+            output.append({
+                "title": issue["title"],
+                "body": issue["body"],
+                "number": issue["number"],
+                "url": issue["html_url"],
+                "labels": get_issue_labels(issue)
+            })
+
+
+    cards = []
+    engine = []
+    editor = []
+    for o in output:
+        if o["url"] is None:
+            cards.append(o)
+        elif "editor" in o["labels"]:
+            editor.append(o)
+        else:
+            engine.append(o)
+
+
+    content = ("# Defold %s\n" % version)
+    for card in cards:
+        content += ("%s\n" % card["body"])
+    content += ("## Engine\n")
+    for issue in engine:
+        content += issue_to_markdown(issue)
+    content += ("## Editor\n")
+    for issue in editor:
+        content += issue_to_markdown(issue)
+
+    with io.open("releasenotes-forum-%s.md" % version, "wb") as f:
+        f.write(content.encode('utf-8'))
+
+
+if __name__ == '__main__':
+    usage = '''usage: %prog [options] command(s)
+
+Commands:
+generate - Generate release notes
+'''
+    parser = optparse.OptionParser(usage)
+
+    parser.add_option('--version', dest='version',
+                      default = None,
+                      help = 'Version to genereate release notes for')
+
+    parser.add_option('--token', dest='token',
+                      default = None,
+                      help = 'GitHub API topken')
+
+
+    options, args = parser.parse_args()
+
+    if not args:
+        parser.print_help()
+        exit(1)
+
+    if not options.token:
+        print("No token specified")
+        parser.print_help()
+        exit(1)
+
+    if not options.version:
+        print("No version specified")
+        parser.print_help()
+        exit(1)
+
+    token = options.token
+    for cmd in args:
+        if cmd == "generate":
+            generate(options.version)
+
+
+    print('Done')

--- a/scripts/releasenotes_github.py
+++ b/scripts/releasenotes_github.py
@@ -86,7 +86,7 @@ def get_issue_type(issue):
 
 
 def issue_to_markdown(issue, hide_details = True):
-    md = ("__%s__: %s ([#%s](%s))\n" % (issue["type"], issue["title"], issue["number"], issue["url"]))
+    md = ("__%s__: __%s__ ([#%s](%s))\n" % (issue["type"], issue["title"], issue["number"], issue["url"]))
     if hide_details: md += ("[details=\"Details\"]\n")
     md += ("%s\n" % issue["body"])
     if hide_details: md += ("\n---\n[/details]\n")


### PR DESCRIPTION
This script creates release notes from a project on GitHub. The script fetches the project and iterates over all cards in the Done column.

For each card it generates a release notes entry:

* For a card without an associated issue it uses the card note
* For a card with an associated issue it uses the issue and the closing pull request (if any)
* For a card with an associated pull request it uses the pull request data only

In order for this script to be really useful we need to make sure that all issues we fix that we want in the release notes are assigned to a Project on GitHub.