### PR TITLE
Make sure particle fx duration doesn't go below 0

### DIFF
--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -186,7 +186,7 @@ namespace dmParticle
         emitter->m_OriginalSeed = original_seed;
 
         uint32_t seed = original_seed;
-        emitter->m_Duration = emitter_ddf->m_Duration + dmMath::Rand11(&seed) * emitter_ddf->m_DurationSpread;
+        emitter->m_Duration = dmMath::Max(0.0f, emitter_ddf->m_Duration + dmMath::Rand11(&seed) * emitter_ddf->m_DurationSpread);
         emitter->m_StartDelay = emitter_ddf->m_StartDelay + dmMath::Rand11(&seed) * emitter_ddf->m_StartDelaySpread;
         emitter->m_SpawnRateSpread = dmMath::Rand11(&seed) * ((dmParticleDDF::Emitter::Property&)emitter_ddf->m_Properties[EMITTER_KEY_SPAWN_RATE]).m_Spread;
     }


### PR DESCRIPTION
The duration of a particle emitter can be configured to go below 0 if using a spread value larger than the duration. If this happens while previewing a particle fx animation in the editor the whole editor will freeze. Using a negative duration at runtime should also not be allowed. This fix will prevent the duration from becoming negative.

Fixes #6368 