### PR TITLE
Correctly scale convex collision shapes in nested factory created game objects

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1273,7 +1273,6 @@ namespace dmGameObject
             if (!GetParent(new_instances[i]))
             {
                 new_instances[i]->m_Transform = dmTransform::Mul(transform, new_instances[i]->m_Transform);
-                dmLogInfo("CollectionSpawnFromDescInternal new_instances scale x: %f y: %f z: %f", new_instances[i]->m_Transform.GetScale().getX(), new_instances[i]->m_Transform.GetScale().getY(), new_instances[i]->m_Transform.GetScale().getZ());
             }
 
             // world transforms need to be up to date in time for the script init calls

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1255,21 +1255,6 @@ namespace dmGameObject
             }
         }
 
-        if (success)
-        {
-            // Update the transform for all parent-less objects
-            for (uint32_t i=0;i!=new_instances.Size();i++)
-            {
-                if (!GetParent(new_instances[i]))
-                {
-                    new_instances[i]->m_Transform = dmTransform::Mul(transform, new_instances[i]->m_Transform);
-                }
-
-                // world transforms need to be up to date in time for the script init calls
-                collection->m_WorldTransforms[new_instances[i]->m_Index] = dmTransform::ToMatrix4(new_instances[i]->m_Transform);
-            }
-        }
-
         // Exit point 1: Before components are created.
         if (!success)
         {
@@ -1280,6 +1265,19 @@ namespace dmGameObject
             }
             id_mapping->Clear();
             return false;
+        }
+
+        // Update the transform for all parent-less objects
+        for (uint32_t i=0;i!=new_instances.Size();i++)
+        {
+            if (!GetParent(new_instances[i]))
+            {
+                new_instances[i]->m_Transform = dmTransform::Mul(transform, new_instances[i]->m_Transform);
+                dmLogInfo("CollectionSpawnFromDescInternal new_instances scale x: %f y: %f z: %f", new_instances[i]->m_Transform.GetScale().getX(), new_instances[i]->m_Transform.GetScale().getY(), new_instances[i]->m_Transform.GetScale().getZ());
+            }
+
+            // world transforms need to be up to date in time for the script init calls
+            collection->m_WorldTransforms[new_instances[i]->m_Index] = dmTransform::ToMatrix4(new_instances[i]->m_Transform);
         }
 
         // Create components and set properties

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -386,7 +386,7 @@ namespace dmPhysics
             else if (fix->GetShape()->GetType() == b2Shape::e_polygon) {
                 b2PolygonShape* pshape = (b2PolygonShape*)shape;
                 float s = object_scale / shape->m_creationScale;
-                for( int i = 0; i < 4; ++i)
+                for( int i = 0; i < b2_maxPolygonVertices; ++i)
                 {
                     b2Vec2 p = pshape->m_verticesOriginal[i];
                     pshape->m_vertices[i].Set(p.x * s, p.y * s);


### PR DESCRIPTION
Child game objects containing convex collision shapes were not correctly scaled when created using a collection factory. Previously only the first four vertices of the shape were scaled. This works for a box shape but obviously not for a more complex shape.

Fixes #6373