### PR TITLE
Improved error handling when using multiple tilemap collision objects in a single game object

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -1120,7 +1120,12 @@ namespace dmGameSystem
             flags.m_FlipHorizontal = ddf->m_FlipHorizontal;
             flags.m_FlipVertical = ddf->m_FlipVertical;
             flags.m_Rotate90 = ddf->m_Rotate90;
-            dmPhysics::SetGridShapeHull(component->m_Object2D, ddf->m_Shape, row, column, hull, flags);
+            bool success = dmPhysics::SetGridShapeHull(component->m_Object2D, ddf->m_Shape, row, column, hull, flags);
+            if (!success)
+            {
+                dmLogError("SetGridShapeHull: unable to set hull %d for shape %d", hull, ddf->m_Shape);
+                return dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
+            }
             uint16_t child = column + tile_grid_resource->m_ColumnCount * row;
             uint16_t group = 0;
             uint16_t mask = 0;

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -511,15 +511,17 @@ namespace dmPhysics
      * @param row row
      * @param column column
      * @param hull hull index. Use GRIDSHAPE_EMPTY_CELL to clear the cell.
+     * @return true if successful
      */
-    void SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags);
+    bool SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags);
 
     /**
      * Enable or disable a grid shape (layer)
      * @param shape_index index of the collision shape
      * @param enable true if the layer should be enabled
+     * @return true if successful
      */
-    void SetGridShapeEnable(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t enable);
+    bool SetGridShapeEnable(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t enable);
 
     /**
      * Set group and mask for collision object

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -657,15 +657,24 @@ namespace dmPhysics
         return fixture;
     }
 
+    static inline b2GridShape* GetGridShape(b2Body* body, uint32_t index)
+    {
+        b2Fixture* fixture = GetFixture(body, index);
+        if (fixture == 0 || fixture->GetShape()->GetType() != b2Shape::e_grid)
+        {
+            return 0;
+        }
+        return (b2GridShape*) fixture->GetShape();
+    }
+
     bool SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
     {
         b2Body* body = (b2Body*) collision_object;
-        b2Fixture* fixture = GetFixture(body, shape_index);
-        if (fixture == 0)
+        b2GridShape* grid_shape = GetGridShape(body, shape_index);
+        if (grid_shape == 0)
         {
             return false;
         }
-        b2GridShape* grid_shape = (b2GridShape*) fixture->GetShape();
         b2GridShape::CellFlags f;
         f.m_FlipHorizontal = flags.m_FlipHorizontal;
         f.m_FlipVertical = flags.m_FlipVertical;

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -691,7 +691,11 @@ namespace dmPhysics
         {
             return false;
         }
-        b2GridShape* grid_shape = (b2GridShape*) fixture->GetShape();
+        b2GridShape* grid_shape = GetGridShape(body, shape_index);
+        if (grid_shape == 0)
+        {
+            return false;
+        }
         grid_shape->m_enabled = enable;
 
         if (!enable)

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -654,32 +654,34 @@ namespace dmPhysics
         {
             fixture = fixture->GetNext();
         }
-        assert(fixture != 0x0);
         return fixture;
     }
 
-    static inline b2GridShape* GetGridShape(b2Body* body, uint32_t index)
-    {
-        b2Fixture* fixture = GetFixture(body, index);
-        assert(fixture->GetShape()->GetType() == b2Shape::e_grid);
-        return (b2GridShape*) fixture->GetShape();
-    }
-
-    void SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
+    bool SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
     {
         b2Body* body = (b2Body*) collision_object;
-        b2GridShape* grid_shape = GetGridShape(body, shape_index);
+        b2Fixture* fixture = GetFixture(body, shape_index);
+        if (fixture == 0)
+        {
+            return false;
+        }
+        b2GridShape* grid_shape = (b2GridShape*) fixture->GetShape();
         b2GridShape::CellFlags f;
         f.m_FlipHorizontal = flags.m_FlipHorizontal;
         f.m_FlipVertical = flags.m_FlipVertical;
         f.m_Rotate90 = flags.m_Rotate90;
         grid_shape->SetCellHull(body, row, column, hull, f);
+        return true;
     }
 
-    void SetGridShapeEnable(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t enable)
+    bool SetGridShapeEnable(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t enable)
     {
         b2Body* body = (b2Body*) collision_object;
         b2Fixture* fixture = GetFixture(body, shape_index);
+        if (fixture == 0)
+        {
+            return false;
+        }
         b2GridShape* grid_shape = (b2GridShape*) fixture->GetShape();
         grid_shape->m_enabled = enable;
 
@@ -687,6 +689,7 @@ namespace dmPhysics
         {
             body->PurgeContacts(fixture);
         }
+        return true;
     }
 
     void SetCollisionObjectFilter(HCollisionObject2D collision_shape,

--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -92,12 +92,14 @@ namespace dmPhysics
     {
     }
 
-    void SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
+    bool SetGridShapeHull(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t row, uint32_t column, uint32_t hull, HullFlags flags)
     {
+        return false;
     }
 
-    void SetGridShapeEnable(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t enable)
+    bool SetGridShapeEnable(HCollisionObject2D collision_object, uint32_t shape_index, uint32_t enable)
     {
+        return false;
     }
 
     void SetCollisionObjectFilter(HCollisionObject2D collision_object,

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -203,6 +203,41 @@ TYPED_TEST(PhysicsTest, UseBullet)
 }
 
 
+TYPED_TEST(PhysicsTest, SetGridShapeHull)
+{
+    int32_t rows = 1;
+    int32_t columns = 2;
+    int32_t cell_width = 16;
+    int32_t cell_height = 16;
+
+    VisualObject vo_a;
+    vo_a.m_Position = Point3(0, 0, 0);
+    dmPhysics::CollisionObjectData data;
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_STATIC;
+    data.m_Mass = 0.0f;
+    data.m_UserData = &vo_a;
+    data.m_Group = 0xffff;
+    data.m_Mask = 0xffff;
+
+    const float hull_vertices[] = {-0.5f, -0.5f,
+                                    0.5f, -0.5f,
+                                    0.5f,  0.5f,
+                                   -0.5f,  0.5f};
+
+    const dmPhysics::HullDesc hulls[] = { {0, 4}, {0, 4} };
+    dmPhysics::HHullSet2D hull_set = dmPhysics::NewHullSet2D(TestFixture::m_Context, hull_vertices, 4, hulls, 2);
+    dmPhysics::HCollisionShape2D grid_shape = dmPhysics::NewGridShape2D(TestFixture::m_Context, hull_set, Point3(0,0,0), cell_width, cell_height, rows, columns);
+    typename TypeParam::CollisionObjectType grid_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &grid_shape, 1u);
+
+    ASSERT_TRUE(dmPhysics::SetGridShapeHull(grid_co, 0, 0, 0, 0, EMPTY_FLAGS));
+    ASSERT_FALSE(dmPhysics::SetGridShapeHull(grid_co, 1, 0, 0, 0, EMPTY_FLAGS));
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, grid_co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(grid_shape);
+    dmPhysics::DeleteHullSet2D(hull_set);
+}
+
+
 TYPED_TEST(PhysicsTest, GridShapePolygon)
 {
     int32_t rows = 4;


### PR DESCRIPTION
When using `tilemap.set_tile()` we currently broadcast a message to all collision components on the same game object that a tile was changed. This is potentially problematic if there are multiple collision components referencing different tilemaps as their shapes because all collision components will react to the message and update, regardless if they used the same tilemap shape or not. What's worse is if the tilemaps have different number of layers it will in fact result in a crash.

This kind of very loose coupling between tilemaps and collision components is unfortunate and does only really work well in a scenario where you have ONE tilemap and ONE collision component using the tilemap as its shape. Solving this design flaw is not covered by this fix which only adds improved error handling to avoid a crash.

Fixes #6386 