### PR TITLE
Added frustum culling to default render script

### DIFF
--- a/engine/engine/content/builtins/render/default.render_script
+++ b/engine/engine/content/builtins/render/default.render_script
@@ -73,6 +73,9 @@ function update(self)
     render.set_stencil_mask(0xff)
     render.clear({[render.BUFFER_COLOR_BIT] = self.clear_color, [render.BUFFER_DEPTH_BIT] = 1, [render.BUFFER_STENCIL_BIT] = 0})
 
+    local proj = get_projection(self)
+    local frustum = proj * self.view
+
     render.set_viewport(0, 0, render.get_window_width(), render.get_window_height())
     render.set_view(self.view)
 
@@ -83,20 +86,24 @@ function update(self)
     render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
     render.disable_state(render.STATE_CULL_FACE)
 
-    render.set_projection(get_projection(self))
+    render.set_projection(proj)
 
-    render.draw(self.tile_pred)
-    render.draw(self.particle_pred)
+    render.draw(self.tile_pred, {frustum = frustum})
+    render.draw(self.particle_pred, {frustum = frustum})
     render.draw_debug3d()
 
     -- render GUI
     --
-    render.set_view(vmath.matrix4())
-    render.set_projection(vmath.matrix4_orthographic(0, render.get_window_width(), 0, render.get_window_height(), -1, 1))
+    local view_gui = vmath.matrix4()
+    local proj_gui = vmath.matrix4_orthographic(0, render.get_window_width(), 0, render.get_window_height(), -1, 1)
+    local frustum_gui = proj_gui * view_gui
+
+    render.set_view(view_gui)
+    render.set_projection(proj_gui)
 
     render.enable_state(render.STATE_STENCIL_TEST)
-    render.draw(self.gui_pred)
-    render.draw(self.text_pred)
+    render.draw(self.gui_pred, {frustum = frustum_gui})
+    render.draw(self.text_pred, {frustum = frustum_gui})
     render.disable_state(render.STATE_STENCIL_TEST)
 end
 


### PR DESCRIPTION
In this initial version of the feature, it’s only used for sprites. Expected benefits are reduced vertex buffer sizes (saving GPU bandwidth), and reduced number of draw calls (depending on projects).

Frustum culling is enabled by default in the [default.render_script](https://github.com/defold/defold/blob/dev/engine/engine/content/builtins/render/default.render_script#L77). If you have a custom render script, you need to create a frustum matrix, and pass it into your render.draw() calls.