### PR TITLE
Issue 6319 floating point render target

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1032,6 +1032,19 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
             context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA_ASTC_4x4;
         }
 
+        // Check if we're using a recent enough OpenGL version
+        if (context->m_IsGles3Version)
+        {
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGB16F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGB32F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA16F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA32F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_R16F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RG16F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_R32F;
+            context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RG32F;
+        }
+
         // GL_NUM_COMPRESSED_TEXTURE_FORMATS is deprecated in newer OpenGL Versions
         GLint iNumCompressedFormats = 0;
         glGetIntegerv(GL_NUM_COMPRESSED_TEXTURE_FORMATS, &iNumCompressedFormats);

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -148,6 +148,15 @@ namespace dmGraphics
         m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RGB;
         m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RGBA;
 
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RGB16F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RGB32F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RGBA16F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RGBA32F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_R16F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RG16F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_R32F;
+        m_TextureFormatSupport   |= 1 << TEXTURE_FORMAT_RG32F;
+
 #if defined(__MACH__) && !(defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR))
         // Apparently these aren't supported on macOS/Metal
 #else
@@ -2833,7 +2842,7 @@ bail:
 
             VkFormat vk_color_format;
 
-            // Promote format to RGBA if RBG, since it's not supported
+            // Promote format to RGBA if RGB, since it's not supported
             if (color_buffer_params.m_Format == TEXTURE_FORMAT_RGB)
             {
                 vk_color_format              = VK_FORMAT_R8G8B8A8_UNORM;

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -226,6 +226,11 @@ namespace dmGraphics
         return VK_FORMAT_UNDEFINED;
     }
 
+    void GetFormatProperties(VkPhysicalDevice vk_physical_device, VkFormat vk_format, VkFormatProperties* properties)
+    {
+        vkGetPhysicalDeviceFormatProperties(vk_physical_device, vk_format, properties);
+    }
+
     VkSampleCountFlagBits GetClosestSampleCountFlag(PhysicalDevice* physicalDevice, uint32_t bufferFlagBits, uint8_t sampleCount)
     {
         VkSampleCountFlags vk_sample_count = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -509,6 +509,7 @@ namespace dmGraphics
     QueueFamily    GetQueueFamily(PhysicalDevice* device, const VkSurfaceKHR surface);
     const VkFormat GetSupportedTilingFormat(VkPhysicalDevice vk_physical_device, const VkFormat* vk_format_candidates,
         uint32_t vk_num_format_candidates, VkImageTiling vk_tiling_type, VkFormatFeatureFlags vk_format_flags);
+    void           GetFormatProperties(VkPhysicalDevice vk_physical_device, VkFormat vk_format, VkFormatProperties* properties);
     VkSampleCountFlagBits GetClosestSampleCountFlag(PhysicalDevice* physicalDevice, uint32_t bufferFlagBits, uint8_t sampleCount);
     // Misc functions
     VkResult TransitionImageLayout(VkDevice vk_device, VkCommandPool vk_command_pool, VkQueue vk_graphics_queue, VkImage vk_image,

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -113,7 +113,7 @@ namespace dmRender
         context->m_ViewProj = context->m_Projection * context->m_View;
 
         context->m_ScriptContext = params.m_ScriptContext;
-        InitializeRenderScriptContext(context->m_RenderScriptContext, params.m_ScriptContext, params.m_CommandBufferSize);
+        InitializeRenderScriptContext(context->m_RenderScriptContext, graphics_context, params.m_ScriptContext, params.m_CommandBufferSize);
         context->m_ScriptWorld = dmScript::NewScriptWorld(context->m_ScriptContext);
 
         context->m_DebugRenderer.m_RenderContext = 0;

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -36,9 +36,9 @@ namespace dmRender
      * Rendering functions, messages and constants. The "render" namespace is
      * accessible only from render scripts.
      *
-     * The rendering API is built on top of OpenGL ES 2.0, is a subset of the
+     * The rendering API was originally built on top of OpenGL ES 2.0, and it uses a subset of the
      * OpenGL computer graphics rendering API for rendering 2D and 3D computer
-     * graphics. OpenGL ES 2.0 is supported on all our target platforms.
+     * graphics. Our current target is OpenGLES 3.0 with fallbacks to 2.0 on some platforms.
      *
      * [icon:attention] It is possible to create materials and write shaders that
      * require features not in OpenGL ES 2.0, but those will not work cross platform.
@@ -535,22 +535,50 @@ namespace dmRender
      */
 
     /*#
-     * @name render.FORMAT_RGB_DXT1
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_RGB16F
      * @variable
      */
 
     /*#
-     * @name render.FORMAT_RGBA_DXT1
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_RGB32F
      * @variable
      */
 
     /*#
-     * @name render.FORMAT_RGBA_DXT3
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_RGBA16F
      * @variable
      */
 
     /*#
-     * @name render.FORMAT_RGBA_DXT5
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_RGBA32F
+     * @variable
+     */
+
+    /*#
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_R16F
+     * @variable
+     */
+
+    /*#
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_RG16F
+     * @variable
+     */
+
+    /*#
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_R32F
+     * @variable
+     */
+
+    /*#
+     * May be nil if the format isn't supported
+     * @name render.FORMAT_RG32F
      * @variable
      */
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2533,7 +2533,6 @@ namespace dmRender
         lua_setfield(L, -2, "FORMAT_"#name);
 
         REGISTER_FORMAT_CONSTANT(LUMINANCE);
-        REGISTER_FORMAT_CONSTANT(RGB);
         REGISTER_FORMAT_CONSTANT(RGBA);
         REGISTER_FORMAT_CONSTANT(DEPTH);
         REGISTER_FORMAT_CONSTANT(STENCIL);
@@ -2547,6 +2546,7 @@ namespace dmRender
         }
 
         // These depend on driver support
+        REGISTER_FORMAT_CONSTANT(RGB);
         REGISTER_FORMAT_CONSTANT(RGB16F);
         REGISTER_FORMAT_CONSTANT(RGB32F);
         REGISTER_FORMAT_CONSTANT(RGBA16F);

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -604,7 +604,7 @@ namespace dmRender
      *
      * Key          | Values
      * ------------ | ----------------------------
-     * `format`     |  `render.FORMAT_LUMINANCE`<br/>`render.FORMAT_RGB`<br/>`render.FORMAT_RGBA`<br/> `render.FORMAT_RGB_DXT1`<br/>`render.FORMAT_RGBA_DXT1`<br/>`render.FORMAT_RGBA_DXT3`<br/> `render.FORMAT_RGBA_DXT5`<br/>`render.FORMAT_DEPTH`<br/>`render.FORMAT_STENCIL`<br/>
+     * `format`     |  `render.FORMAT_LUMINANCE`<br/>`render.FORMAT_RGB`<br/>`render.FORMAT_RGBA`<br/>`render.FORMAT_DEPTH`<br/>`render.FORMAT_STENCIL`<br/>`render.FORMAT_RGBA32F`<br/>`render.FORMAT_RGBA16F`<br/>
      * `width`      | number
      * `height`     | number
      * `min_filter` | `render.FILTER_LINEAR`<br/>`render.FILTER_NEAREST`
@@ -2467,7 +2467,7 @@ namespace dmRender
         {0, 0}
     };
 
-    void InitializeRenderScriptContext(RenderScriptContext& context, dmScript::HContext script_context, uint32_t command_buffer_size)
+    void InitializeRenderScriptContext(RenderScriptContext& context, dmGraphics::HContext graphics_context, dmScript::HContext script_context, uint32_t command_buffer_size)
     {
         context.m_CommandBufferSize = command_buffer_size;
 
@@ -2510,20 +2510,23 @@ namespace dmRender
         REGISTER_FORMAT_CONSTANT(DEPTH);
         REGISTER_FORMAT_CONSTANT(STENCIL);
 
-        /*
-         * We don't expose floating point texture for now,
-         * until we have taken an official stand how to expose
-         * rendering capabilities. See DEF-2886
-         *
+#undef REGISTER_FORMAT_CONSTANT
 
+#define REGISTER_FORMAT_CONSTANT(name)\
+        if (dmGraphics::IsTextureFormatSupported(graphics_context, dmGraphics::TEXTURE_FORMAT_##name)) { \
+            lua_pushnumber(L, (lua_Number) dmGraphics::TEXTURE_FORMAT_##name); \
+            lua_setfield(L, -2, "FORMAT_"#name); \
+        }
+
+        // These depend on driver support
         REGISTER_FORMAT_CONSTANT(RGB16F);
         REGISTER_FORMAT_CONSTANT(RGB32F);
         REGISTER_FORMAT_CONSTANT(RGBA16F);
         REGISTER_FORMAT_CONSTANT(RGBA32F);
-        REGISTER_FORMAT_CONSTANT(LUMINANCE16F);
-        REGISTER_FORMAT_CONSTANT(LUMINANCE32F);
-
-        */
+        REGISTER_FORMAT_CONSTANT(R16F);
+        REGISTER_FORMAT_CONSTANT(RG16F);
+        REGISTER_FORMAT_CONSTANT(R32F);
+        REGISTER_FORMAT_CONSTANT(RG32F);
 
 #undef REGISTER_FORMAT_CONSTANT
 

--- a/engine/render/src/render/render_script.h
+++ b/engine/render/src/render/render_script.h
@@ -19,6 +19,7 @@
 #include <dlib/hashtable.h>
 #include <dlib/message.h>
 
+#include <graphics/graphics.h>
 #include <script/script.h>
 
 #include "render.h"
@@ -59,7 +60,7 @@ namespace dmRender
         int                         m_ContextTableReference;
     };
 
-    void InitializeRenderScriptContext(RenderScriptContext& context, dmScript::HContext script_context, uint32_t command_buffer_size);
+    void InitializeRenderScriptContext(RenderScriptContext& context, dmGraphics::HContext graphics_context, dmScript::HContext script_context, uint32_t command_buffer_size);
     void FinalizeRenderScriptContext(RenderScriptContext& context, dmScript::HContext script_context);
 }
 


### PR DESCRIPTION
The following constants are set if supported on the device and are otherwise nil if not supported:

* render.FORMAT_RGB16F
* render.FORMAT_RGB32F
* render.FORMAT_RGBA16F
* render.FORMAT_RGBA32F
* render.FORMAT_R16F
* render.FORMAT_RG16F
* render.FORMAT_R32F
* render.FORMAT_RG32F 

Fixes #6319 