### PR TITLE
Do not create animations for box nodes with one frame flipbook animations during gui scene creation

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -301,6 +301,10 @@ namespace dmGameSystem
                         dmLogError("The texture animation '%s' in texture '%s' could not be set for '%s', result: %d.", texture_anim_name, texture_str, node_desc->m_Id != 0x0 ? node_desc->m_Id : "unnamed", gui_result);
                         result = false;
                     }
+                    if (dmGui::GetNodeAnimationFrameCount(scene, n) == 1)
+                    {
+                        dmGui::CancelNodeFlipbookAnim(scene, n);
+                    }
                 }
             }
         }

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -301,6 +301,11 @@ namespace dmGameSystem
                         dmLogError("The texture animation '%s' in texture '%s' could not be set for '%s', result: %d.", texture_anim_name, texture_str, node_desc->m_Id != 0x0 ? node_desc->m_Id : "unnamed", gui_result);
                         result = false;
                     }
+                    // Fix for https://github.com/defold/defold/issues/6384
+                    // If the animation is a single frame there's no point in actually playing the
+                    // animation. Instead we can immediately cancel the animation and the node will
+                    // still have the correct image.
+                    // By doing this we'll not take up an animation slot (there's a max animation cap).
                     if (dmGui::GetNodeAnimationFrameCount(scene, n) == 1)
                     {
                         dmGui::CancelNodeFlipbookAnim(scene, n);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -927,6 +927,17 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         return GetNodeAnimationFrameInternal(GetNode(scene, node));
     }
 
+    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node)
+    {
+        TextureSetAnimDesc* anim_desc = GetNodeTextureSet(scene, node);
+        if (anim_desc == 0)
+        {
+            return -1;
+        }
+        return anim_desc->m_State.m_End - anim_desc->m_State.m_Start;
+    }
+
+
     static inline const float* GetNodeFlipbookAnimUVInternal(InternalNode* in)
     {
         int32_t anim_frame = GetNodeAnimationFrameInternal(in);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -884,6 +884,7 @@ namespace dmGui
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node);
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical);
     int32_t GetNodeAnimationFrame(HScene scene, HNode node);
+    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node);
     TextureSetAnimDesc* GetNodeTextureSet(HScene scene, HNode node);
 
     void* GetNodeFont(HScene scene, HNode node);

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -288,6 +288,10 @@ namespace dmGui
         return 0;
     }
 
+    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node)
+    {
+        return 0;
+    }
 
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node)
     {


### PR DESCRIPTION
When a GUI scene is created each textured box node with an implicit one frame flipbook animation will generate an internal animation reference. This is a problem in complex GUI scenes where these animations take up animation slots towards the max animation count (currently 1024). This is not necessarily a problem but if there are a lot of these nodes and they are disabled in the `init()` function of an attached `gui_script` it means that the animations will not complete until the node is enabled.

This fix adds a check on scene creation for all textured box nodes with one frame animation and completes these animations immediately.

Fixes #6384 