### PR TITLE
Label alpha not always working properly in html5

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -417,10 +417,10 @@ public class Fontc {
             fontMapBuilder.setSdfSpread(sdf_spread);
             fontMapBuilder.setSdfOutline(outline_edge);
             fontMapBuilder.setSdfShadow(shadow_edge);
-            fontMapBuilder.setAlpha(this.fontDesc.getAlpha());
-            fontMapBuilder.setOutlineAlpha(this.fontDesc.getOutlineAlpha());
-            fontMapBuilder.setShadowAlpha(this.fontDesc.getShadowAlpha());
         }
+        fontMapBuilder.setAlpha(this.fontDesc.getAlpha());
+        fontMapBuilder.setOutlineAlpha(this.fontDesc.getOutlineAlpha());
+        fontMapBuilder.setShadowAlpha(this.fontDesc.getShadowAlpha());
 
         // Load external image resource for BMFont files
         BufferedImage imageBMFont = null;

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -493,7 +493,10 @@
      :cache-cell-height (:height cache-cell-wh)
      :cache-cell-max-ascent (+ cache-cell-max-ascent padding)
      :glyph-channels channel-count
-     :glyph-data (ByteString/copyFrom glyph-data-bank)}))
+     :glyph-data (ByteString/copyFrom glyph-data-bank)
+     :alpha (:alpha font-desc)
+     :outline-alpha (:outline-alpha font-desc)
+     :shadow-alpha (:shadow-alpha font-desc)}))
 
 (defn- calculate-ttf-distance-field-edge-limit [^double width ^double spread ^double edge]
   (let [sdf-limit-value (- (/ width spread))]

--- a/scripts/macos/macos-repack.sh
+++ b/scripts/macos/macos-repack.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright 2020-2022 The Defold Foundation
+# Copyright 2014-2020 King
+# Copyright 2009-2014 Ragnar Svensson, Christian Murray
+# Licensed under the Defold License version 1.0 (the "License"); you may not use
+# this file except in compliance with the License.
+# 
+# You may obtain a copy of the License, together with FAQs at
+# https://www.defold.com/license
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+set -eu
+
+SCRIPT_NAME="$(basename "${0}")"
+SCRIPT_PATH="$(cd "$(dirname "${0}")"; pwd)"
+
+
+# ----------------------------------------------------------------------------
+# Script functions
+# ----------------------------------------------------------------------------
+function terminate() {
+    echo "TERM - ${1:-}" && exit ${2:-1}
+}
+
+function terminate_usage() {
+    echo "Usage: ${SCRIPT_NAME} <app>"
+    echo "  app   - filepath to the app"
+    exit 1
+}
+
+function terminate_trap() {
+    trap - SIGHUP SIGINT SIGTERM
+    [ ! -z "${ROOT:-}" ] && rm -rf "${ROOT}"
+    terminate "An unexpected error occurred."
+}
+
+
+# ----------------------------------------------------------------------------
+# Script environment
+# ----------------------------------------------------------------------------
+[ ! -z "${DYNAMO_HOME:-}" ] || terminate "DYNAMO_HOME is not set"
+
+APP="${1:-}" && [ ! -z "${APP}" ] || terminate_usage
+
+[ -d "${APP}" ] || terminate "App does not exist: ${APP}"
+
+
+# ----------------------------------------------------------------------------
+# Script
+# ----------------------------------------------------------------------------
+trap 'terminate_trap' SIGHUP SIGINT SIGTERM EXIT
+
+APP_DIR="$(dirname "$APP")"
+EXEPATH=${APP}/Contents/MacOS/
+PROJECTNAME=$(cd ${EXEPATH} && ls)
+REPACK_APP=${APP_DIR}/${PROJECTNAME}.repack.app
+REPACK_EXEPATH=${REPACK_APP}/Contents/MacOS/
+
+cp -vr ${APP} ${REPACK_APP}
+cp -v ${DYNAMO_HOME}/bin/x86_64-darwin/dmengine ${REPACK_EXEPATH}/${PROJECTNAME}
+
+
+# ----------------------------------------------------------------------------
+# Script teardown
+# ----------------------------------------------------------------------------
+trap - SIGHUP SIGINT SIGTERM EXIT
+echo "Wrote ${REPACK_APP}"
+exit 0


### PR DESCRIPTION
In HTML5 builds if a font is created with outline and shadow alpha set to 0 it still renders the outline behind the font if the font face itself is (semi-)transparent. The problem was caused by a difference in texture format between different platforms (GL_LUMINANCE vs GL_RED) and how these are sampled in the shader, (L,L,L,1) vs (R,0,0,1). This, combined with the fact that if the font was a bitmap ttf font, the face, outline and shadow alpha weren't copied to the compiled font, was the cause of the problem.

Fixes #5835
Fixes #5428 