### PR TITLE
Better error handling if a project contains Clojure files

### DIFF
--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -273,10 +273,12 @@ ordinary paths."
 
 (defn- load-plugin! [workspace resource]
   ; TODO Handle Exceptions!
-  (log/info :msg (str "Loading plugin" (resource/path resource)))
-  (let [plugin-fn (load-string (slurp resource))]
-    (plugin-fn workspace))
-  (log/info :msg (str "Loaded plugin" (resource/path resource))))
+  (log/info :msg (str "Loading plugin " (resource/path resource)))
+  (if-let [plugin-fn (load-string (slurp resource))]
+    (do
+      (plugin-fn workspace)
+      (log/info :msg (str "Loaded plugin " (resource/path resource))))
+    (log/info :msg (str "Unable to load plugin " (resource/path resource)))))
 
 (defn- load-editor-plugins! [workspace added]
   (let [added-resources (set (map resource/proj-path added))


### PR DESCRIPTION
Our Clojure plugin system expect Clojure files to return a function to call when the plugin is loaded. Previously the editor crashed if a Clojure file didn't return a function. With this fix the editor will handle this and log that it failed to load the plugin.

Fixes #6374 