### PR TITLE
Issue-6336 Ignore focus lost/gain events for detection if app is in background (Android)

### DIFF
--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -194,7 +194,7 @@ void computeIconifiedState()
     // Iconified unless opened, resumed (not paused)
 
     // A good detailed overview over the recommended app flow is found here:
-    //   https://developer.nvidia.com/fixing-common-android-lifecycle-issues-games
+    // https://developer.download.nvidia.com/assets/mobile/docs/android_lifecycle_app_note.pdf
     _glfwWin.iconified = !(g_AppResumed && g_AppFocused && _glfwWinAndroid.surface != EGL_NO_SURFACE);
 
     LOGV("iconified: %s    (resume: %s, focus: %s, surface: %s)",

--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -66,7 +66,6 @@ struct InputEvent g_AppInputEvents[MAX_APP_INPUT_EVENTS];
 int g_NumAppInputEvents = 0;
 pthread_t g_MainThread = 0;
 bool g_AppResumed = false;
-bool g_AppFocused = false;
 
 static void initThreads( void )
 {
@@ -195,12 +194,11 @@ void computeIconifiedState()
 
     // A good detailed overview over the recommended app flow is found here:
     // https://developer.download.nvidia.com/assets/mobile/docs/android_lifecycle_app_note.pdf
-    _glfwWin.iconified = !(g_AppResumed && g_AppFocused && _glfwWinAndroid.surface != EGL_NO_SURFACE);
+    _glfwWin.iconified = !(g_AppResumed && _glfwWinAndroid.surface != EGL_NO_SURFACE);
 
-    LOGV("iconified: %s    (resume: %s, focus: %s, surface: %s)",
+    LOGV("iconified: %s    (resume: %s, surface: %s)",
         _glfwWin.iconified?"YES":"no",
         g_AppResumed?"YES":"no",
-        g_AppFocused?"YES":"no",
         (_glfwWinAndroid.surface != EGL_NO_SURFACE )?"YES":"no");
 }
 
@@ -261,15 +259,11 @@ void _glfwAndroidHandleCommand(struct android_app* app, int32_t cmd) {
         computeIconifiedState();
         break;
     case APP_CMD_GAINED_FOCUS:
-        g_AppFocused = true;
-        computeIconifiedState();
         break;
     case APP_CMD_LOST_FOCUS:
         if (g_KeyboardActive) {
             _glfwShowKeyboard(0, 0, 0);
         }
-        g_AppFocused = false;
-        computeIconifiedState();
         break;
     case APP_CMD_START:
         break;


### PR DESCRIPTION
Fixes issue when showing any activity in foreground paused the game loop on Android. It might be any activity: ADS, webview, alarm indication, a status icon popup, etc.

If the game loop paused work extensions can't receive messages from the native side which is important for communication Lua<->C++<->Java.

Fix https://github.com/defold/defold/issues/6336
Fix https://github.com/defold/extension-webview/issues/26