### PR TITLE
Changed default value for wasm streaming in html5 builds

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -113,7 +113,7 @@ var EngineLoader = {
     asmjs_from: 0,
     asmjs_to: 50,
 
-    stream_wasm: true,
+    stream_wasm: false,
 
     loadAndInstantiateWasmAsync: function(src, fromProgress, toProgress, callback) {
         FileLoader.load(src, "arraybuffer", EngineLoader.wasm_size,

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -554,6 +554,14 @@ archive_location_suffix.type = string
 archive_location_suffix.help = string to suffix bundled archive file path with
 archive_location_suffix.default =
 
+engine_arguments.type = string
+engine_arguments.help = comma separated list of engine arguments
+engine_arguments.default = 
+
+wasm_streaming.type = bool
+wasm_streaming.help = set to true to enable streaming of the wasm file (faster and uses less memory, but requires MIME type 'application/wasm')
+wasm_streaming.default = 0
+
 show_fullscreen_button.type = bool
 show_fullscreen_button.help = set to true if you want to have the fullscreen button
 show_fullscreen_button.default = 1

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -753,7 +753,11 @@
    :help "comma separated list of engine arguments",
    :default "",
    :path ["html5" "engine_arguments"]}
-   {:type :boolean,
+  {:type :boolean,
+   :help "set to true to enable streaming of the wasm file (faster and uses less memory, but requires MIME type 'application/wasm')",
+   :default false
+   :path ["html5" "wasm_streaming"]}
+  {:type :boolean,
    :help "set to true if you want to have the fullscreen button",
    :default true
    :path ["html5" "show_fullscreen_button"]}

--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -204,6 +204,7 @@
 	</script>
 
 	<script id='engine-start' type='text/javascript'>
+		EngineLoader.stream_wasm = "{{html5.wasm_streaming}}" === "true";
 		EngineLoader.load("canvas", "{{exe-name}}");
 	</script>
 </body>


### PR DESCRIPTION
The option to stream the .wasm file in HTML5 builds was introduced and made the default option in Defold 1.2.130. This option will load faster and use less memory, but it requirers the server to respond with content type "application/wasm" for it to work. This change makes the wasm streaming option an opt-in instead of the default for HTML5 build. It is now possible to enable wasm streaming via the `html5.wasm_streaming` game.project option.

Fixes #6466 