### PR TITLE
Speed up building of script files

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -94,6 +94,9 @@ public class Bob {
                     // For now we just issue a warning that we don't fully clean up.
                     System.out.println("Warning: Failed to clean up temp directory '" + tmpDirFile.getAbsolutePath() + "'");
                 }
+                finally {
+                    luaInitialized = false;
+                }
             }
         }));
       }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -64,6 +64,7 @@ public class Bob {
 
     private static boolean verbose = false;
     private static File rootFolder = null;
+    private static boolean luaInitialized = false;
 
     public Bob() {
     }
@@ -124,9 +125,13 @@ public class Bob {
     }
 
     public static void initLua() {
+        if (luaInitialized) {
+            return;
+        }
         init();
         try {
             extract(Bob.class.getResource("/lib/luajit-share.zip"), new File(rootFolder, "share"));
+            luaInitialized = true;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The LuaBuilder unpacks the `lib/luajit-share.zip` archive for each script file that gets built. This is obviously a waste of time, especially in a large project with many script files.