### PR TITLE
Fix for updating 3D physics too fast in fixed time step mode

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -163,6 +163,10 @@ velocity_threshold.type = number
 velocity_threshold.help = minimum velocity that will result in ellastic collisions
 velocity_threshold.default = 1
 
+max_fixed_timesteps.type = integer
+max_fixed_timesteps.help = max number of steps in the simulation when using fixed timestep
+max_fixed_timesteps.default = 2
+
 [bootstrap]
 help = Initial settings for the engine
 main_collection.type = resource

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -235,7 +235,11 @@
    :help
    "minimum velocity that will result in ellastic collisions",
    :default 1.0,
-   :path ["physics" "velocity_threshold"]},   
+   :path ["physics" "velocity_threshold"]},
+  {:type :integer,
+   :help "max number of steps in the simulation when using fixed timestep (3D only)",
+   :default 2,
+   :path ["physics" "max_fixed_timesteps"]},
   {:type :string,
    :help
    "which filtering to use for min filtering, linear (default) or nearest",
@@ -817,6 +821,7 @@
   "resource" {:help "Resource loading and management related settings"},
   "factory" {:help "GameObject factory related settings"},
   "graphics" {:help "Graphics related settings"},
+  "engine" {:help "Runtime settings for the engine"},
   "bootstrap" {:help "Initial settings for the engine"},
   "label" {:help "Label related settings"},
   "collection" {:help "Collection related settings"},

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1067,6 +1067,7 @@ namespace dmEngine
         engine->m_PhysicsContext.m_MaxCollisionCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_MAX_COLLISIONS_KEY, 64);
         engine->m_PhysicsContext.m_MaxContactPointCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_MAX_CONTACTS_KEY, 128);
         engine->m_PhysicsContext.m_UseFixedTimestep = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_USE_FIXED_TIMESTEP, 1) ? 1 : 0;
+        engine->m_PhysicsContext.m_MaxFixedTimesteps = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_MAX_FIXED_TIMESTEPS, 2);
         // TODO: Should move inside the ifdef release? Is this usable without the debug callbacks?
         engine->m_PhysicsContext.m_Debug = (bool) dmConfigFile::GetInt(engine->m_Config, "physics.debug", 0);
 

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2503,7 +2503,7 @@ namespace dmGameObject
             const float fixed_frequency = update_context->m_FixedUpdateFrequency;
             // If the proxy is slowed down, we want e.g. the physics to be slowed down as well
             const float fixed_dt = (1.0f / (float)fixed_frequency) * update_context->m_TimeScale;
-            float num_fixed_steps = (uint32_t)(time / fixed_dt);
+            uint32_t num_fixed_steps = (uint32_t)(time / fixed_dt);
             // Store the remainder for the next frame
             collection->m_FixedAccumTime = time - (num_fixed_steps * fixed_dt);
 

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -43,6 +43,8 @@ namespace dmGameSystem
     const char* PHYSICS_MAX_CONTACTS_KEY        = "physics.max_contacts";
     /// Config key for using fixed frame rate for the physics worlds
     const char* PHYSICS_USE_FIXED_TIMESTEP      = "physics.use_fixed_timestep";
+    /// Config key for using max updates during a single step
+    const char* PHYSICS_MAX_FIXED_TIMESTEPS     = "physics.max_fixed_timesteps";
 
     static const dmhash_t PROP_LINEAR_DAMPING = dmHashString64("linear_damping");
     static const dmhash_t PROP_ANGULAR_DAMPING = dmHashString64("angular_damping");
@@ -1013,6 +1015,7 @@ namespace dmGameSystem
         step_world_context.m_RayCastCallback = RayCastCallback;
         step_world_context.m_RayCastUserData = world;
         step_world_context.m_FixedTimeStep = physics_context->m_UseFixedTimestep;
+        step_world_context.m_MaxFixedTimeSteps = physics_context->m_MaxFixedTimesteps;
 
         step_world_context.m_DT = params.m_UpdateContext->m_DT;
 

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -41,6 +41,8 @@ namespace dmGameSystem
     extern const char* PHYSICS_MAX_CONTACTS_KEY;
     /// Config key to use for tweaking the physics frame rate
     extern const char* PHYSICS_USE_FIXED_TIMESTEP;
+    /// Config key for using max updates during a single step
+    extern const char* PHYSICS_MAX_FIXED_TIMESTEPS;
     /// Config key to use for tweaking maximum number of collection proxies
     extern const char* COLLECTION_PROXY_MAX_COUNT_KEY;
     /// Config key to use for tweaking maximum number of factories
@@ -77,11 +79,12 @@ namespace dmGameSystem
             dmPhysics::HContext3D m_Context3D;
             dmPhysics::HContext2D m_Context2D;
         };
-        uint32_t m_MaxCollisionCount;
-        uint32_t m_MaxContactPointCount;
-        bool m_Debug;
-        bool m_3D;
-        bool m_UseFixedTimestep;
+        uint32_t    m_MaxCollisionCount;
+        uint32_t    m_MaxContactPointCount;
+        bool        m_Debug;
+        bool        m_3D;
+        bool        m_UseFixedTimestep;
+        uint32_t    m_MaxFixedTimesteps;
     };
 
     struct ParticleFXContext

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -349,6 +349,7 @@ namespace dmPhysics
         /// Time step
         float                   m_DT;
         bool                    m_FixedTimeStep;
+        uint32_t                m_MaxFixedTimeSteps;
         /// Collision callback function
         CollisionCallback       m_CollisionCallback;
         /// Collision callback user data

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -360,8 +360,6 @@ namespace dmPhysics
 
     void StepWorld3D(HWorld3D world, const StepWorldContext& step_context)
     {
-        float dt = step_context.m_DT;
-        float fixed_timestep = step_context.m_FixedTimeStep ? dt : 1.0f/60.0f;
         HContext3D context = world->m_Context;
         float scale = context->m_Scale;
         // Epsilon defining what transforms are considered noise and not
@@ -425,11 +423,12 @@ namespace dmPhysics
         {
             DM_PROFILE(Physics, "StepSimulation");
 
-            // We want to make sure that if necessary, we at least cover two (potential) updates
-            // in order to not truncate the time (it would make the simulation go slower)
-            int maxSteps = 2;
+            // Default behavior for Bullet3D is to use fixed timesteps with max_steps=1 and fixed_timestep=1.0f/60.0f
+            float dt = step_context.m_DT;
+            float fixed_timestep = step_context.m_FixedTimeStep ? dt : 1.0f/60.0f;
+            int max_steps = step_context.m_MaxFixedTimeSteps;
 
-            world->m_DynamicsWorld->stepSimulation(dt, maxSteps, fixed_timestep);
+            world->m_DynamicsWorld->stepSimulation(dt, max_steps, fixed_timestep);
         }
 
         // Handle ray cast requests

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -361,7 +361,7 @@ namespace dmPhysics
     void StepWorld3D(HWorld3D world, const StepWorldContext& step_context)
     {
         float dt = step_context.m_DT;
-        bool fixed_time_step = step_context.m_FixedTimeStep;
+        float fixed_timestep = step_context.m_FixedTimeStep ? dt : 1.0f/60.0f;
         HContext3D context = world->m_Context;
         float scale = context->m_Scale;
         // Epsilon defining what transforms are considered noise and not
@@ -424,9 +424,12 @@ namespace dmPhysics
 
         {
             DM_PROFILE(Physics, "StepSimulation");
-            // Step simulation
-            // TODO: Max substeps = 1 for now...
-            world->m_DynamicsWorld->stepSimulation(dt, fixed_time_step ? 0 : 1);
+
+            // We want to make sure that if necessary, we at least cover two (potential) updates
+            // in order to not truncate the time (it would make the simulation go slower)
+            int maxSteps = 2;
+
+            world->m_DynamicsWorld->stepSimulation(dt, maxSteps, fixed_timestep);
         }
 
         // Handle ray cast requests

--- a/engine/physics/src/physics/test/test_physics.cpp
+++ b/engine/physics/src/physics/test/test_physics.cpp
@@ -826,9 +826,25 @@ TYPED_TEST(PhysicsTest, SetVelocity)
     ang_vel = (*TestFixture::m_Test.m_GetAngularVelocityFunc)(TestFixture::m_Context, box_co);
     ASSERT_EQ(4.0f, lengthSqr(ang_vel));
 
+    ///////////////////////////////////////////////////////////////////////
+    // For the 3D physics engine to reset the local time
+    float old_dt = TestFixture::m_StepWorldContext.m_DT;
+    bool use_fixed_time_step = TestFixture::m_StepWorldContext.m_FixedTimeStep;
+    uint32_t max_fixed_timesteps = TestFixture::m_StepWorldContext.m_MaxFixedTimeSteps;
+    TestFixture::m_StepWorldContext.m_DT = 0;
+    TestFixture::m_StepWorldContext.m_FixedTimeStep = 0;
+    TestFixture::m_StepWorldContext.m_MaxFixedTimeSteps = 0;
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+
+    TestFixture::m_StepWorldContext.m_DT = old_dt;
+    TestFixture::m_StepWorldContext.m_MaxFixedTimeSteps = max_fixed_timesteps;
+    TestFixture::m_StepWorldContext.m_FixedTimeStep = use_fixed_time_step;
+    ///////////////////////////////////////////////////////////////////////
+
     (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
 
     lin_vel = (*TestFixture::m_Test.m_GetLinearVelocityFunc)(TestFixture::m_Context, box_co);
+
     ASSERT_NEAR(1.0f, lengthSqr(lin_vel), 0.05f);
     ang_vel = (*TestFixture::m_Test.m_GetAngularVelocityFunc)(TestFixture::m_Context, box_co);
     ASSERT_NEAR(4.0f, lengthSqr(ang_vel), 0.05f);
@@ -1289,6 +1305,22 @@ TYPED_TEST(PhysicsTest, FilteredRayCasting)
 TYPED_TEST(PhysicsTest, GravityChange)
 {
     float box_half_ext = 0.5f;
+
+    ///////////////////////////////////////////////////////////////////////
+    // For the 3D physics engine to reset the local time
+    float old_dt = TestFixture::m_StepWorldContext.m_DT;
+    bool use_fixed_time_step = TestFixture::m_StepWorldContext.m_FixedTimeStep;
+    uint32_t max_fixed_timesteps = TestFixture::m_StepWorldContext.m_MaxFixedTimeSteps;
+    TestFixture::m_StepWorldContext.m_DT = 0;
+    TestFixture::m_StepWorldContext.m_FixedTimeStep = 0;
+    TestFixture::m_StepWorldContext.m_MaxFixedTimeSteps = 0;
+    (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+
+    TestFixture::m_StepWorldContext.m_DT = old_dt;
+    TestFixture::m_StepWorldContext.m_MaxFixedTimeSteps = max_fixed_timesteps;
+    TestFixture::m_StepWorldContext.m_FixedTimeStep = use_fixed_time_step;
+    ///////////////////////////////////////////////////////////////////////
+
 
     // Verify that we get the defualt gravity.
     Vector3 gravity = (*TestFixture::m_Test.m_GetGravityFunc)(TestFixture::m_World);

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -65,6 +65,7 @@ protected:
         m_StepWorldContext.m_CollisionUserData = &m_CollisionCount;
         m_StepWorldContext.m_ContactPointCallback = ContactPointCallback;
         m_StepWorldContext.m_ContactPointUserData = &m_ContactPointCount;
+        m_StepWorldContext.m_MaxFixedTimeSteps = 2;
     }
 
     virtual void TearDown()


### PR DESCRIPTION
The changes in Defold 1.3.1 to decouple physics updates from the engine loop and the support for variable and high refresh rate screens introduced a problem with 3D physics and the new `fixed_update()` life-cycle function where physics was updated too often. This fix solves this issue and introduces consistent behavior in 2D and 3D physics with fixed updates.