### PR TITLE
Make sure to copy asset folders as well when creating the Android bundle

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -515,7 +515,12 @@ public class AndroidBundler implements IBundler {
             for(File asset : getExtenderAssets(project)) {
                 File dest = new File(assetsDir, asset.getName());
                 log("Copying asset " + asset + " to " + dest);
-                FileUtils.copyFile(asset, dest);
+                if (asset.isDirectory()) {
+                    FileUtils.copyDirectory(asset, dest);
+                }
+                else {
+                    FileUtils.copyFile(asset, dest);
+                }
                 BundleHelper.throwIfCanceled(canceled);
             }
 


### PR DESCRIPTION
Some Android dependencies ship additional folders in the `assets` directory. In the case of Helpshift (`com.helpshift:helpshift-sdkx:10.1.0`) there is an `assets/helpshift/` folder containing additional files. The build pipeline incorrectly assumed that everything in `assets` was files. This fix checks each entry in `assets` and in the case of a folder it copies the folder and everything in it to the bundle.

Fixes #6487 