### PR TITLE
Issue-6506 Add ability to bundle Android in both formats `apk` and `aab` at the same time

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -399,7 +399,7 @@ public class Bob {
 
         addOption(options, "p", "platform", true, "Platform (when bundling)", true);
         addOption(options, "bo", "bundle-output", true, "Bundle output directory", false);
-        addOption(options, "bf", "bundle-format", true, "Format of the created bundle (Android: 'apk' and 'aab')", false);
+        addOption(options, "bf", "bundle-format", true, "Which formats to create the application bundle in. Comma separated list. (Android: 'apk' and 'aab')", false);
 
         addOption(options, "mp", "mobileprovisioning", true, "mobileprovisioning profile (iOS)", false);
         addOption(options, null, "identity", true, "Sign identity (iOS)", false);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -672,6 +672,7 @@ public class AndroidBundler implements IBundler {
         BundleHelper.throwIfCanceled(canceled);
 
         FileUtils.deleteDirectory(new File(outDir, "aab"));
+        FileUtils.deleteDirectory(new File(outDir, "res"));
     }
 
     private static File createAAB(Project project, File outDir, BundleHelper helper, ICanceled canceled) throws IOException, CompileExceptionError {
@@ -805,15 +806,17 @@ public class AndroidBundler implements IBundler {
 
 
         String bundleFormat = project.option("bundle-format", "apk");
-        if (bundleFormat.equals("aab")) {
-            createAAB(project, outDir, helper, canceled);
-        }
-        else if (bundleFormat.equals("apk")) {
-            File aab = createAAB(project, outDir, helper, canceled);
+        File aab = createAAB(project, outDir, helper, canceled);
+
+        if (bundleFormat.contains("apk")) {
             File apk = createAPK(aab, project, outDir, canceled);
+        }
+
+        if (!bundleFormat.contains("aab")) {
             aab.delete();
         }
-        else {
+
+        if (!bundleFormat.contains("aab") && !bundleFormat.contains("apk")) {
             throw new CompileExceptionError("Unknown bundle format: " + bundleFormat);
         }
     }

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -390,7 +390,7 @@
       (ui/children! [(labeled! "Keystore" keystore-file-field)
                      (labeled! "Keystore Password" keystore-pass-file-field)
                      (labeled! "Architectures" architecture-controls)
-                     (labeled! "Bundle Format" (doto (make-choice-box refresh! [["APK" "apk"] ["AAB" "aab"]])
+                     (labeled! "Bundle Format" (doto (make-choice-box refresh! [["APK" "apk"] ["AAB" "aab"] ["APK+AAB", "apk,aab"]])
                                                 (.setId "bundle-format-choice-box")))]))))
 
 (defn- load-android-prefs! [prefs view]


### PR DESCRIPTION
Added new ability to create both `AAB` and `APK` bundle at the same time. It makes it simpler to prepare bundle for release (`AAB`) and final tests (`APK`) without running bundle process twice. To create both an APK and an AAB specify both bundle formats in a comma separated list:

```
java -jar bob-jar --bundle-format=apk,aab
```

Fix https://github.com/defold/defold/issues/6506