### PR TITLE
Set layout node names from display profiles

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2106,16 +2106,27 @@
                   (when select-fn
                     (select-fn [node]))))))
 
+(defn- unused-display-profiles [gui-scene-node-id]
+  (g/with-auto-evaluation-context ec
+    (let [layouts (->> (g/node-value gui-scene-node-id :layout-msgs ec)
+                       (map :name)
+                       set)]
+      (->> (g/node-value gui-scene-node-id :display-profiles ec)
+           (map :name)
+           (remove layouts)))))
+
 (g/defnode LayoutsNode
   (inherits outline/OutlineNode)
   (input names g/Str :array)
+  (input scene g/NodeID)
   (output name-counts NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
   (output node-outline outline/OutlineData :cached (gen-outline-fnk "Layouts" "Layouts" 4 false []))
   (output add-handler-info g/Any
-          (g/fnk [_node-id]
-                 [_node-id "Layout" layout-icon add-layout-handler {}])))
+          (g/fnk [_node-id scene]
+            (mapv #(vector _node-id % layout-icon add-layout-handler {:display-profile %})
+                  (unused-display-profiles scene)))))
 
 ;; //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2296,6 +2307,11 @@
 (defn- get-ids [outline]
   (map :label (tree-seq (constantly true) :children outline)))
 
+(defn- one-or-many-handler-infos-to-vec [one-or-many-handler-infos]
+  (if (g/node-id? (first one-or-many-handler-infos))
+    [one-or-many-handler-infos]
+    one-or-many-handler-infos))
+
 (g/defnode GuiSceneNode
   (inherits resource-node/ResourceNode)
 
@@ -2349,6 +2365,8 @@
   (input textures-node g/NodeID) ; for tests
   (input particlefx-resources-node g/NodeID) ; for tests
   (input handler-infos g/Any :array)
+  (output handler-infos g/Any (g/fnk [handler-infos]
+                                (into [] (mapcat one-or-many-handler-infos-to-vec) handler-infos)))
   (input dep-build-targets g/Any :array)
   (input project-settings g/Any)
   (input default-tex-params g/Any)
@@ -2468,7 +2486,7 @@
 (defn- tx-node-id [tx-entry]
   (get-in tx-entry [:node :_node-id]))
 
-(defn- attach-resource 
+(defn- attach-resource
   ([self resources-node resource-node]
    (attach-resource self resources-node resource-node false))
   ([self resources-node resource-node internal?]
@@ -2541,14 +2559,12 @@
                        [])
         handler-options (when (empty? node-options)
                           (when (g/has-output? (g/node-type* node) :add-handler-info)
-                            (let [[parent menu-label menu-icon add-fn opts] (g/node-value node :add-handler-info)
-                                  parent (if (= node scene) parent node)]
-                              (make-add-handler scene parent menu-label menu-icon add-fn opts))))]
-      (filter some? (conj node-options handler-options))))
-
-(defn- unused-display-profiles [scene]
-  (let [layouts (set (map :name (g/node-value scene :layout-msgs)))]
-    (filter (complement layouts) (map :name (g/node-value scene :display-profiles)))))
+                            (->> (g/node-value node :add-handler-info)
+                                 one-or-many-handler-infos-to-vec
+                                 (map (fn [[parent menu-label menu-icon add-fn opts]]
+                                        (let [parent (if (= node scene) parent node)]
+                                          (make-add-handler scene parent menu-label menu-icon add-fn opts)))))))]
+      (filter some? (into node-options handler-options))))
 
 (defn- add-layout-options [node user-data]
   (let [scene (node->gui-scene node)
@@ -2756,7 +2772,7 @@
                                         (assoc :child-index child-index)
                                         (select-keys (g/declared-property-labels node-type))
                                         (cond->
-                                         (= :type-template (:type node-desc))
+                                          (= :type-template (:type node-desc))
                                           (assoc :template {:resource (workspace/resolve-resource resource (:template node-desc))
                                                             :overrides (get template-data (:id node-desc) {})})))
 
@@ -2771,6 +2787,7 @@
       (g/make-nodes graph-id [layouts-node LayoutsNode]
                     (g/connect layouts-node :_node-id self :layouts-node) ; for the tests :/
                     (g/connect layouts-node :_node-id self :nodes)
+                    (g/connect self :_node-id layouts-node :scene)
                     (g/connect layouts-node :build-errors self :build-errors)
                     (g/connect layouts-node :node-outline self :child-outlines)
                     (g/connect layouts-node :add-handler-info self :handler-infos)
@@ -2784,7 +2801,7 @@
                         (g/make-nodes graph-id [layout [LayoutNode (dissoc layout-desc :nodes)]]
                                       (attach-layout self layouts-node layout)
                                       (g/set-property layout :nodes (:nodes layout-desc)))))))
-    custom-data)))
+     custom-data)))
 
 (defn- color-alpha [node-desc color-field alpha-field]
   ;; The alpha field replaced the fourth component of color,
@@ -2953,25 +2970,25 @@
                                       :custom-type 0
                                       :icon box-icon}
                                      {:node-type :type-pie
-                                     :node-cls PieNode
-                                     :display-name "Pie"
-                                     :custom-type 0
-                                     :icon pie-icon}
+                                      :node-cls PieNode
+                                      :display-name "Pie"
+                                      :custom-type 0
+                                      :icon pie-icon}
                                      {:node-type :type-text
-                                     :node-cls TextNode
-                                     :display-name "Text"
-                                     :custom-type 0
-                                     :icon text-icon}
+                                      :node-cls TextNode
+                                      :display-name "Text"
+                                      :custom-type 0
+                                      :icon text-icon}
                                      {:node-type :type-template
-                                     :node-cls TemplateNode
-                                     :display-name "Template"
-                                     :custom-type 0
-                                     :icon template-icon}
+                                      :node-cls TemplateNode
+                                      :display-name "Template"
+                                      :custom-type 0
+                                      :icon template-icon}
                                      {:node-type :type-particlefx
-                                     :node-cls ParticleFXNode
-                                     :display-name "ParticleFX"
-                                     :custom-type 0
-                                     :icon particlefx/particle-fx-icon}])
+                                      :node-cls ParticleFXNode
+                                      :display-name "ParticleFX"
+                                      :custom-type 0
+                                      :icon particlefx/particle-fx-icon}])
 
 (def ^:private custom-node-type-infos (atom []))
 


### PR DESCRIPTION
This fixes a crash which happens when adding a layout to a gui scene.

Fixes #6475 

Note: the previous implementation of the `add-handler-info` label
returned a single tuple with information about a single context menu
option. Gui's LayoutsNode has many add options — one for every not yet
defined display profile. I cannot change it to always return
a collection of tuples, because this is label is also used in spine
extension, and since we can't force our users to update, such a change
will break existing users. So I decided to allow both a single tuple and
a collection of tuples to preserve compatibility.

Note: there is a `handler-infos` input label that collects all handler
info tuples from GuiSceneNode's children. Due to a data type change of
`add-handler-info` I also added a `handler-infos` output that ensures
that it's a flat vector of info tuples. My concern is: `:handler-infos`
are completely unused. Should we remove them altogether?