### PR TITLE
Cancel all property animations on a game object in a single call

### DIFF
--- a/engine/gameobject/src/gameobject/comp_anim.cpp
+++ b/engine/gameobject/src/gameobject/comp_anim.cpp
@@ -126,7 +126,7 @@ namespace dmGameObject
             while (index != INVALID_INDEX)
             {
                 Animation* anim = &world->m_Animations[world->m_AnimMap[index]];
-                if (anim->m_ComponentId == component_id && anim->m_PropertyId == property_id)
+                if (anim->m_ComponentId == component_id && (property_id == 0 || anim->m_PropertyId == property_id))
                 {
                     StopAnimation(anim, false);
                 }
@@ -605,6 +605,14 @@ namespace dmGameObject
     {
         if (instance == 0)
             return PROPERTY_RESULT_INVALID_INSTANCE;
+
+        AnimWorld* world = GetWorld(collection);
+        uint16_t* head_ptr = world->m_InstanceToIndex.Get((uintptr_t)instance);
+        if (property_id == 0)
+        {
+            StopAnimations(world, head_ptr, component_id, 0);
+            return PROPERTY_RESULT_OK;
+        }
         PropertyDesc prop_desc;
         PropertyOptions property_opt;
         property_opt.m_Index = 0;
@@ -618,8 +626,6 @@ namespace dmGameObject
         {
             return PROPERTY_RESULT_UNSUPPORTED_TYPE;
         }
-        AnimWorld* world = GetWorld(collection);
-        uint16_t* head_ptr = world->m_InstanceToIndex.Get((uintptr_t)instance);
         StopAnimations(world, head_ptr, component_id, property_id);
         if (element_count > 1)
         {

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1732,21 +1732,33 @@ namespace dmGameObject
         return 0;
     }
 
-    /*# cancels all animations of the named property of the specified game object or component
+    /*# cancels all or specified property animations of the game object or component
      *
-     * By calling this function, all stored animations of the given property will be canceled.
+     * By calling this function, all or specified stored property animations of the game object or component will be canceled.
      *
      * See the <a href="/manuals/properties">properties guide</a> for which properties can be animated and the <a href="/manuals/animation">animation guide</a> for how to animate them.
      *
      * @name go.cancel_animations
-     * @param url [type:string|hash|url] url of the game object or component having the property
-     * @param property [type:string|hash] id of the property to cancel
+     * @param url [type:string|hash|url] url of the game object or component
+     * @param [property] [type:string|hash] optional id of the property to cancel
      * @examples
      *
      * Cancel the animation of the position of a game object:
      *
      * ```lua
      * go.cancel_animations(go.get_id(), "position")
+     * ```
+     * 
+     * Cancel all property animations of the current game object:
+     * 
+     * ```lua
+     * go.cancel_animations(".")
+     * ```
+     * 
+     * Cancel all property animations of the sprite component of the current game object:
+     * 
+     * ```lua
+     * go.cancel_animations("#sprite")
      * ```
      */
     int Script_CancelAnimations(lua_State* L)
@@ -1766,13 +1778,16 @@ namespace dmGameObject
             luaL_error(L, "go.animate can only animate instances within the same collection.");
         }
         dmhash_t property_id = 0;
-        if (lua_isstring(L, 2))
+        if (top >= 2 && !lua_isnil(L, 2))
         {
-            property_id = dmHashString64(lua_tostring(L, 2));
-        }
-        else
-        {
-            property_id = dmScript::CheckHash(L, 2);
+            if (lua_isstring(L, 2))
+            {
+                property_id = dmHashString64(lua_tostring(L, 2));
+            }
+            else
+            {
+                property_id = dmScript::CheckHash(L, 2);
+            }
         }
         dmGameObject::HInstance target_instance = dmGameObject::GetInstanceFromIdentifier(collection, target.m_Path);
         if (target_instance == 0)

--- a/engine/gameobject/src/gameobject/test/anim/cancel_all.go_pb
+++ b/engine/gameobject/src/gameobject/test/anim/cancel_all.go_pb
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/cancel_all.scriptc"
+}

--- a/engine/gameobject/src/gameobject/test/anim/cancel_all.script
+++ b/engine/gameobject/src/gameobject/test/anim/cancel_all.script
@@ -1,0 +1,43 @@
+-- Copyright 2020-2022 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+go.property("test_value_1", vmath.vector3())
+go.property("test_value_2", 0)
+
+local epsilon = 0.000001
+
+local function callback(self, url, property_id)
+    go.cancel_animations(url)
+end
+
+function init(self)
+    go.cancel_animations("#", nil)
+    go.animate("#", "test_value_1.x", go.PLAYBACK_ONCE_FORWARD, 2, go.EASING_LINEAR, 2)
+    go.animate("#", "test_value_1.y", go.PLAYBACK_ONCE_FORWARD, 1, go.EASING_LINEAR, 1, 0, callback)
+    go.animate("#", "test_value_2", go.PLAYBACK_ONCE_FORWARD, 8, go.EASING_LINEAR, 2)
+    self.timer = 0
+    self.frame = 0
+    self.counter = 0
+end
+
+function update(self, dt)
+    assert(math.abs(self.timer - self.test_value_1.x) < epsilon)
+    assert(math.abs(self.timer - self.test_value_1.y) < epsilon)
+    assert(math.abs(self.test_value_2 - self.counter) < epsilon)
+    if self.frame < 4 then
+        self.timer = self.timer + dt
+        self.counter = self.counter + 1
+    end
+    self.frame = self.frame + 1
+end

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -238,6 +238,32 @@ TEST_F(AnimTest, Cancel)
     dmGameObject::Delete(m_Collection, go, false);
 }
 
+TEST_F(AnimTest, CancelAll)
+{
+    dmGameObject::HInstance go = dmGameObject::New(m_Collection, "/dummy.goc");
+
+    m_UpdateContext.m_DT = 0.25f;
+    dmhash_t id1 = hash("position");
+    dmhash_t id2 = hash("scale");
+    dmGameObject::PropertyVar var1(Vectormath::Aos::Vector3(10.f, 0.f, 0.f));
+    dmGameObject::PropertyVar var2(2.f);
+    float duration = 1.0f;
+    float delay = 0.f;
+
+    Animate(m_Collection, go, 0, id1, dmGameObject::PLAYBACK_ONCE_FORWARD, var1, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
+    Animate(m_Collection, go, 0, id2, dmGameObject::PLAYBACK_ONCE_FORWARD, var2, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, 0));
+
+    dmGameObject::Update(m_Collection, &m_UpdateContext);
+    ASSERT_EQ(0.0f, X(go));
+    ASSERT_EQ(1.0f, dmGameObject::GetUniformScale(go));
+
+    ASSERT_EQ(0u, this->m_FinishCount);
+    ASSERT_EQ(2u, this->m_CancelCount);
+
+    dmGameObject::Delete(m_Collection, go, false);
+}
+
 TEST_F(AnimTest, AnimateEuler)
 {
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, "/dummy.goc");

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -100,20 +100,6 @@ static float X(dmGameObject::HInstance instance)
     return dmGameObject::GetPosition(instance).getX();
 }
 
-static float ScaleX(dmGameObject::HInstance instance)
-{
-    return dmGameObject::GetScale(instance).getX();
-}
-
-static float EulerZ(dmGameObject::HInstance instance)
-{
-    dmGameObject::PropertyDesc out_value;
-    dmGameObject::PropertyOptions property_opt;
-    property_opt.m_Index = 0;
-    dmGameObject::GetProperty(instance, 0, dmHashString64("euler.z"), property_opt, out_value);
-    return (float)out_value.m_Variant.m_Number;
-}
-
 static dmhash_t hash(const char* s)
 {
     return dmHashString64(s);
@@ -235,28 +221,19 @@ TEST_F(AnimTest, Cancel)
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, "/dummy.goc");
 
     m_UpdateContext.m_DT = 0.25f;
-    dmhash_t id1 = hash("position");
-    dmhash_t id2 = hash("scale");
-    dmhash_t id3 = hash("euler.z");
-    dmGameObject::PropertyVar var1(Vectormath::Aos::Vector3(10.f, 0.f, 0.f));
-    dmGameObject::PropertyVar var2(Vectormath::Aos::Vector3(2.0f));
-    dmGameObject::PropertyVar var3(360.0f);
+    dmhash_t id = hash("position");
+    dmGameObject::PropertyVar var(Vectormath::Aos::Vector3(10.f, 0.f, 0.f));
     float duration = 1.0f;
     float delay = 0.f;
 
-    Animate(m_Collection, go, 0, id1, dmGameObject::PLAYBACK_ONCE_FORWARD, var1, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
-    Animate(m_Collection, go, 0, id2, dmGameObject::PLAYBACK_ONCE_FORWARD, var2, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
-    Animate(m_Collection, go, 0, id3, dmGameObject::PLAYBACK_ONCE_FORWARD, var3, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
-    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, id1));
-    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, 0));
+    Animate(m_Collection, go, 0, id, dmGameObject::PLAYBACK_ONCE_FORWARD, var, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, id));
 
     dmGameObject::Update(m_Collection, &m_UpdateContext);
     ASSERT_EQ(0.0f, X(go));
-    ASSERT_EQ(1.0f, ScaleX(go));
-    ASSERT_EQ(0.0f, EulerZ(go));
 
     ASSERT_EQ(0u, this->m_FinishCount);
-    ASSERT_EQ(3u, this->m_CancelCount);
+    ASSERT_EQ(1u, this->m_CancelCount);
 
     dmGameObject::Delete(m_Collection, go, false);
 }

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -583,6 +583,18 @@ TEST_F(AnimTest, ScriptedCancel)
     }
 }
 
+TEST_F(AnimTest, ScriptedCancelAll)
+{
+    m_UpdateContext.m_DT = 0.25f;
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/cancel_all.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    for (uint32_t i = 0; i < 10; ++i)
+    {
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    }
+}
+
 TEST_F(AnimTest, ScriptedAnimBadURL)
 {
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/anim_bad_url.goc", hash("test"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));

--- a/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
+++ b/engine/gameobject/src/gameobject/test/anim/test_gameobject_anim.cpp
@@ -100,6 +100,20 @@ static float X(dmGameObject::HInstance instance)
     return dmGameObject::GetPosition(instance).getX();
 }
 
+static float ScaleX(dmGameObject::HInstance instance)
+{
+    return dmGameObject::GetScale(instance).getX();
+}
+
+static float EulerZ(dmGameObject::HInstance instance)
+{
+    dmGameObject::PropertyDesc out_value;
+    dmGameObject::PropertyOptions property_opt;
+    property_opt.m_Index = 0;
+    dmGameObject::GetProperty(instance, 0, dmHashString64("euler.z"), property_opt, out_value);
+    return (float)out_value.m_Variant.m_Number;
+}
+
 static dmhash_t hash(const char* s)
 {
     return dmHashString64(s);
@@ -221,19 +235,28 @@ TEST_F(AnimTest, Cancel)
     dmGameObject::HInstance go = dmGameObject::New(m_Collection, "/dummy.goc");
 
     m_UpdateContext.m_DT = 0.25f;
-    dmhash_t id = hash("position");
-    dmGameObject::PropertyVar var(Vectormath::Aos::Vector3(10.f, 0.f, 0.f));
+    dmhash_t id1 = hash("position");
+    dmhash_t id2 = hash("scale");
+    dmhash_t id3 = hash("euler.z");
+    dmGameObject::PropertyVar var1(Vectormath::Aos::Vector3(10.f, 0.f, 0.f));
+    dmGameObject::PropertyVar var2(Vectormath::Aos::Vector3(2.0f));
+    dmGameObject::PropertyVar var3(360.0f);
     float duration = 1.0f;
     float delay = 0.f;
 
-    Animate(m_Collection, go, 0, id, dmGameObject::PLAYBACK_ONCE_FORWARD, var, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
-    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, id));
+    Animate(m_Collection, go, 0, id1, dmGameObject::PLAYBACK_ONCE_FORWARD, var1, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
+    Animate(m_Collection, go, 0, id2, dmGameObject::PLAYBACK_ONCE_FORWARD, var2, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
+    Animate(m_Collection, go, 0, id3, dmGameObject::PLAYBACK_ONCE_FORWARD, var3, dmEasing::Curve(dmEasing::TYPE_LINEAR), duration, delay, AnimationStopped, this, 0x0);
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, id1));
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, CancelAnimations(m_Collection, go, 0, 0));
 
     dmGameObject::Update(m_Collection, &m_UpdateContext);
     ASSERT_EQ(0.0f, X(go));
+    ASSERT_EQ(1.0f, ScaleX(go));
+    ASSERT_EQ(0.0f, EulerZ(go));
 
     ASSERT_EQ(0u, this->m_FinishCount);
-    ASSERT_EQ(1u, this->m_CancelCount);
+    ASSERT_EQ(3u, this->m_CancelCount);
 
     dmGameObject::Delete(m_Collection, go, false);
 }


### PR DESCRIPTION
It is now possible to cancel all property animations on a game object by calling `go.cancel_animations(url)` without providing a property as the second argument.

Fixes #6492