### PR TITLE
Add option to skip verification of resource archives

### DIFF
--- a/README_SETUP_MACOS.md
+++ b/README_SETUP_MACOS.md
@@ -25,10 +25,12 @@ Verify that Java is installed and working:
 ### Required Software - Python 2
 
 You need a 64 bit Python 2 version (x86_64) to build the engine and tools. The latest tested on all platforms is Python 2.7.16.
-Big Sur comes with both Python 2.7.16 and pip installed.
-On Big Sur Python is a universal binary (x86_64 + arm64), and there's no guarantuee which version it will pick. Using the x86_64 version is a requirement for our tools to work (we load shared libraries, which we build for x86_64).
 
-For older versions of macOS you may need to install using [Brew](https://brew.sh/):
+* Big Sur comes with both Python 2.7.16 and pip installed. On Big Sur Python is a universal binary (x86_64 + arm64), and there's no guarantuee which version it will pick. Using the x86_64 version is a requirement for our tools to work (we load shared libraries, which we build for x86_64).
+
+* The latest version of Monterey (12.3.1) does not come with Python 2 installed. Install via https://www.python.org/downloads/release/python-2716/.
+
+* For older versions of macOS you may need to install using [Brew](https://brew.sh/):
 
 ```sh
 > brew install python2

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
@@ -238,13 +238,32 @@ namespace dmLiveUpdate
     {
         DM_LUA_STACK_CHECK(L, 0);
 
+        int top = lua_gettop(L);
+
         const char* path = luaL_checkstring(L, 1);
 
         StoreArchiveCallbackData* cb = new StoreArchiveCallbackData;
         cb->m_Callback = dmScript::CreateCallback(L, 2);
         cb->m_Path = strdup(path);
 
-        dmLiveUpdate::Result res = dmLiveUpdate::StoreArchiveAsync(path, Callback_StoreArchive, cb);
+        bool verify_archive = true;
+        if (top > 2 && !lua_isnil(L, 3)) {
+            luaL_checktype(L, 3, LUA_TTABLE);
+            lua_pushvalue(L, 3);
+            lua_pushnil(L);
+            while (lua_next(L, -2)) {
+                const char* attr = lua_tostring(L, -2);
+                if (strcmp(attr, "verify") == 0)
+                {
+                    verify_archive = lua_toboolean(L, -1);
+                    dmLogError("Resource_StoreArchive %d", verify_archive);;
+                }
+                lua_pop(L, 1);
+            }
+            lua_pop(L, 1);
+        }
+
+        dmLiveUpdate::Result res = dmLiveUpdate::StoreArchiveAsync(path, Callback_StoreArchive, cb, verify_archive);
 
         if (dmLiveUpdate::RESULT_OK != res)
         {

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
@@ -256,7 +256,6 @@ namespace dmLiveUpdate
                 if (strcmp(attr, "verify") == 0)
                 {
                     verify_archive = lua_toboolean(L, -1);
-                    dmLogError("Resource_StoreArchive %d", verify_archive);;
                 }
                 lua_pop(L, 1);
             }

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
@@ -153,8 +153,11 @@ namespace dmLiveUpdate
 
     /*# register and store a live update zip file
      *
-     * Stores a zip file and uses it for live update content.
-     * The path is renamed and stored in the (internal) live update location
+     * Stores a zip file and uses it for live update content. The contents of the
+     * zip file will be verified against the manifest to ensure file integrity.
+     * It is possible to opt out of the resource verification using an option passed
+     * to this function.
+     * The path is renamed and stored in the (internal) live update location.
      *
      * @name resource.store_archive
      * @param path [type:string] the path to the original file on disc
@@ -169,7 +172,7 @@ namespace dmLiveUpdate
      *
      * @param [options] [type:table] optional table with extra parameters. Supported entries:
      *
-     * - [type:boolean] `validate`: if archive should be validated as well as stored (defaults to true)
+     * - [type:boolean] `verify`: if archive should be verified as well as stored (defaults to true)
      *
      * @examples
      *

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
@@ -167,6 +167,10 @@ namespace dmLiveUpdate
      * `status`
      * : [type:constant] the status of the store operation (See resource.store_manifest)
      *
+     * @param [options] [type:table] optional table with extra parameters. Supported entries:
+     *
+     * - [type:boolean] `validate`: if archive should be validated as well as stored (defaults to true)
+     *
      * @examples
      *
      * How to download an archive with HTTP and store it on device.

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.h
@@ -157,7 +157,7 @@ namespace dmLiveUpdate
      * zip file will be verified against the manifest to ensure file integrity.
      * It is possible to opt out of the resource verification using an option passed
      * to this function.
-     * The path is renamed and stored in the (internal) live update location.
+     * The path is stored in the (internal) live update location.
      *
      * @name resource.store_archive
      * @param path [type:string] the path to the original file on disc

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -314,7 +314,7 @@ namespace dmLiveUpdate
         return res == true ? RESULT_OK : RESULT_INVALID_RESOURCE;
     }
 
-    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data)
+    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool verify_archive)
     {
         struct stat file_stat;
         bool exists = stat(path, &file_stat) == 0;
@@ -328,6 +328,7 @@ namespace dmLiveUpdate
         request.m_Callback = callback;
         request.m_Path = path;
         request.m_IsArchive = 1;
+        request.m_VerifyArchive = verify_archive;
         request.m_Manifest = dmResource::GetManifest(g_LiveUpdate.m_ResourceFactory);
         bool res = AddAsyncResourceRequest(request);
         return res == true ? RESULT_OK : RESULT_INVALID_RESOURCE;

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -314,7 +314,7 @@ namespace dmLiveUpdate
         return res == true ? RESULT_OK : RESULT_INVALID_RESOURCE;
     }
 
-    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool verify_archive)
+    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, bool verify_archive)
     {
         struct stat file_stat;
         bool exists = stat(path, &file_stat) == 0;

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -73,7 +73,7 @@ namespace dmLiveUpdate
 
     /*# Registers an archive (.zip) on disc
      */
-    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool validate_archive);
+    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool verify_archive);
 
     Result StoreManifest(dmResource::Manifest* manifest);
 

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -73,7 +73,7 @@ namespace dmLiveUpdate
 
     /*# Registers an archive (.zip) on disc
      */
-    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data);
+    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool validate_archive);
 
     Result StoreManifest(dmResource::Manifest* manifest);
 

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -73,7 +73,7 @@ namespace dmLiveUpdate
 
     /*# Registers an archive (.zip) on disc
      */
-    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool verify_archive);
+    Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, bool verify_archive);
 
     Result StoreManifest(dmResource::Manifest* manifest);
 

--- a/engine/liveupdate/src/liveupdate_async.cpp
+++ b/engine/liveupdate/src/liveupdate_async.cpp
@@ -53,7 +53,7 @@ namespace dmLiveUpdate
         if (request.m_IsArchive)
         {
             // Stores/stages a zip archive for loading after next reboot
-            res = dmLiveUpdate::StoreZipArchive(request.m_Path);
+            res = dmLiveUpdate::StoreZipArchive(request.m_Path, request.m_VerifyArchive);
             m_JobCompleteData.m_Manifest = 0;
         }
         else if (request.m_Resource.m_Header != 0x0)

--- a/engine/liveupdate/src/liveupdate_null.cpp
+++ b/engine/liveupdate/src/liveupdate_null.cpp
@@ -63,7 +63,7 @@ Result StoreResourceAsync(dmResource::Manifest* manifest, const char* expected_d
    return dmLiveUpdate::RESULT_INVALID_RESOURCE;
 }
 
-Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool verify_archive)
+Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, bool verify_archive)
 {
    return dmLiveUpdate::RESULT_INVALID_RESOURCE;
 }

--- a/engine/liveupdate/src/liveupdate_null.cpp
+++ b/engine/liveupdate/src/liveupdate_null.cpp
@@ -63,7 +63,7 @@ Result StoreResourceAsync(dmResource::Manifest* manifest, const char* expected_d
    return dmLiveUpdate::RESULT_INVALID_RESOURCE;
 }
 
-Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data)
+Result StoreArchiveAsync(const char* path, void (*callback)(bool, void*), void* callback_data, const bool verify_archive)
 {
    return dmLiveUpdate::RESULT_INVALID_RESOURCE;
 }

--- a/engine/liveupdate/src/liveupdate_private.h
+++ b/engine/liveupdate/src/liveupdate_private.h
@@ -51,6 +51,7 @@ namespace dmLiveUpdate
         const char*                 m_Path;
         void*                       m_CallbackData;
         uint8_t                     m_IsArchive:1;
+        uint8_t                     m_VerifyArchive:1;
         void (*m_Callback)(bool,void*);
     };
 
@@ -100,7 +101,7 @@ namespace dmLiveUpdate
 
     // zip archive implementation
     // Verifies and stores a zip archive
-    Result StoreZipArchive(const char* path);
+    Result StoreZipArchive(const char* path, const bool validate_archive);
     dmResourceArchive::Result LULoadManifest_Zip(const char* archive_name, const char* app_path, const char* app_support_path, const dmResource::Manifest* previous, dmResource::Manifest** out);
     dmResourceArchive::Result LULoadArchive_Zip(const dmResource::Manifest* manifest, const char* archive_name, const char* app_path, const char* app_support_path, dmResourceArchive::HArchiveIndexContainer previous, dmResourceArchive::HArchiveIndexContainer* out);
     dmResourceArchive::Result LUUnloadArchive_Zip(dmResourceArchive::HArchiveIndexContainer archive);

--- a/engine/liveupdate/src/liveupdate_private.h
+++ b/engine/liveupdate/src/liveupdate_private.h
@@ -101,7 +101,7 @@ namespace dmLiveUpdate
 
     // zip archive implementation
     // Verifies and stores a zip archive
-    Result StoreZipArchive(const char* path, const bool validate_archive);
+    Result StoreZipArchive(const char* path, const bool verify_archive);
     dmResourceArchive::Result LULoadManifest_Zip(const char* archive_name, const char* app_path, const char* app_support_path, const dmResource::Manifest* previous, dmResource::Manifest** out);
     dmResourceArchive::Result LULoadArchive_Zip(const dmResource::Manifest* manifest, const char* archive_name, const char* app_path, const char* app_support_path, dmResourceArchive::HArchiveIndexContainer previous, dmResourceArchive::HArchiveIndexContainer* out);
     dmResourceArchive::Result LUUnloadArchive_Zip(dmResourceArchive::HArchiveIndexContainer archive);

--- a/engine/liveupdate/src/liveupdate_private.h
+++ b/engine/liveupdate/src/liveupdate_private.h
@@ -101,7 +101,7 @@ namespace dmLiveUpdate
 
     // zip archive implementation
     // Verifies and stores a zip archive
-    Result StoreZipArchive(const char* path, const bool verify_archive);
+    Result StoreZipArchive(const char* path, bool verify_archive);
     dmResourceArchive::Result LULoadManifest_Zip(const char* archive_name, const char* app_path, const char* app_support_path, const dmResource::Manifest* previous, dmResource::Manifest** out);
     dmResourceArchive::Result LULoadArchive_Zip(const dmResource::Manifest* manifest, const char* archive_name, const char* app_path, const char* app_support_path, dmResourceArchive::HArchiveIndexContainer previous, dmResourceArchive::HArchiveIndexContainer* out);
     dmResourceArchive::Result LUUnloadArchive_Zip(dmResourceArchive::HArchiveIndexContainer archive);

--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -180,7 +180,7 @@ namespace dmLiveUpdate
     }
 
     // Store the path to the file into the liveupdate.ref.tmp
-    Result StoreZipArchive(const char* path, const bool verify_archive)
+    Result StoreZipArchive(const char* path, bool verify_archive)
     {
         char application_support_path[DMPATH_MAX_PATH];
 

--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -180,14 +180,17 @@ namespace dmLiveUpdate
     }
 
     // Store the path to the file into the liveupdate.ref.tmp
-    Result StoreZipArchive(const char* path)
+    Result StoreZipArchive(const char* path, const bool validate_archive)
     {
         char application_support_path[DMPATH_MAX_PATH];
 
-        Result result = VerifyZipArchive(path, application_support_path, sizeof(application_support_path));
-        if (RESULT_OK != result)
+        if (validate_archive)
         {
-            return result;
+            Result result = VerifyZipArchive(path, application_support_path, sizeof(application_support_path));
+            if (RESULT_OK != result)
+            {
+                return result;
+            }
         }
 
         // Store zip file ref in "<support path>/liveupdate.ref.tmp"

--- a/engine/liveupdate/src/liveupdate_zip_archive.cpp
+++ b/engine/liveupdate/src/liveupdate_zip_archive.cpp
@@ -180,11 +180,11 @@ namespace dmLiveUpdate
     }
 
     // Store the path to the file into the liveupdate.ref.tmp
-    Result StoreZipArchive(const char* path, const bool validate_archive)
+    Result StoreZipArchive(const char* path, const bool verify_archive)
     {
         char application_support_path[DMPATH_MAX_PATH];
 
-        if (validate_archive)
+        if (verify_archive)
         {
             Result result = VerifyZipArchive(path, application_support_path, sizeof(application_support_path));
             if (RESULT_OK != result)

--- a/engine/liveupdate/src/test/test_liveupdate_async.cpp
+++ b/engine/liveupdate/src/test/test_liveupdate_async.cpp
@@ -57,7 +57,7 @@ struct StoreResourceCallbackData
 
 namespace dmLiveUpdate
 {
-    dmLiveUpdate::Result StoreZipArchive(const char* path, const bool verify_archive)
+    dmLiveUpdate::Result StoreZipArchive(const char* path, bool verify_archive)
     {
         return dmLiveUpdate::RESULT_OK;
     }

--- a/engine/liveupdate/src/test/test_liveupdate_async.cpp
+++ b/engine/liveupdate/src/test/test_liveupdate_async.cpp
@@ -57,7 +57,7 @@ struct StoreResourceCallbackData
 
 namespace dmLiveUpdate
 {
-    dmLiveUpdate::Result StoreZipArchive(const char* path)
+    dmLiveUpdate::Result StoreZipArchive(const char* path, const bool verify_archive)
     {
         return dmLiveUpdate::RESULT_OK;
     }


### PR DESCRIPTION
A call to `resource.store_archive` will trigger a verification process of the files in the archive. If the archive is large, contains many files and/or the target is a low end phone then the verification process can take way too long. This pull request allows developers to pass an arguments to skip verification:

```
local options = {}
options.verify = false
resource.store_archive(path, cb, options)
```

Fixes #6534 