### PR TITLE
Issue-6551 `gui.get_flipbook()` returns empty string for a box node created in the editor

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -301,15 +301,6 @@ namespace dmGameSystem
                         dmLogError("The texture animation '%s' in texture '%s' could not be set for '%s', result: %d.", texture_anim_name, texture_str, node_desc->m_Id != 0x0 ? node_desc->m_Id : "unnamed", gui_result);
                         result = false;
                     }
-                    // Fix for https://github.com/defold/defold/issues/6384
-                    // If the animation is a single frame there's no point in actually playing the
-                    // animation. Instead we can immediately cancel the animation and the node will
-                    // still have the correct image.
-                    // By doing this we'll not take up an animation slot (there's a max animation cap).
-                    if (dmGui::GetNodeAnimationFrameCount(scene, n) == 1)
-                    {
-                        dmGui::CancelNodeFlipbookAnim(scene, n);
-                    }
                 }
             }
         }

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -301,6 +301,15 @@ namespace dmGameSystem
                         dmLogError("The texture animation '%s' in texture '%s' could not be set for '%s', result: %d.", texture_anim_name, texture_str, node_desc->m_Id != 0x0 ? node_desc->m_Id : "unnamed", gui_result);
                         result = false;
                     }
+                    // Fix for https://github.com/defold/defold/issues/6384
+                    // If the animation is a single frame there's no point in actually playing the
+                    // animation. Instead we can immediately cancel the animation and the node will
+                    // still have the correct image.
+                    // By doing this we'll not take up an animation slot (there's a max animation cap).
+                    if (dmGui::GetNodeAnimationFrameCount(scene, n) == 1)
+                    {
+                        dmGui::CancelNodeFlipbookAnim(scene, n);
+                    }
                 }
             }
         }

--- a/engine/gamesys/src/gamesys/test/gui/gui_flipbook_anim.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/gui_flipbook_anim.gui_script
@@ -20,6 +20,18 @@ end
 
 function init( self )
     self.node = gui.get_node("box")
+    
+    local flipbook = gui.get_flipbook(self.node)
+    assert(flipbook == hash("anim"))
+    
+    gui.play_flipbook(self.node, "anim_once")
+    flipbook = gui.get_flipbook(self.node)
+    assert(flipbook == hash("anim_once"))
+
+    gui.cancel_flipbook(self.node)
+    flipbook = gui.get_flipbook(self.node)
+    assert(flipbook == hash("anim_once"))
+
     gui.play_flipbook(self.node, "anim_once", callback)
 end
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -465,7 +465,7 @@ namespace dmGui
             {
                 if (node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
                 {
-                    CancelNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
+                    ClearNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
                 }
 
                 node.m_Texture     = 0;
@@ -484,7 +484,7 @@ namespace dmGui
             Node& node = nodes[i].m_Node;
             if (node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
             {
-                CancelNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
+                ClearNodeFlipbookAnim(scene, GetNodeHandle(&nodes[i]));
             }
             node.m_Texture = 0;
             node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
@@ -2868,7 +2868,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     {
         InternalNode* n = GetNode(scene, node);
         if (n->m_Node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
-            CancelNodeFlipbookAnim(scene, node);
+            ClearNodeFlipbookAnim(scene, node);
         if (TextureInfo* texture_info = scene->m_Textures.Get(texture_id)) {
             n->m_Node.m_TextureHash = texture_id;
             n->m_Node.m_Texture = texture_info->m_TextureSource;
@@ -3754,6 +3754,12 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         InternalNode* n = GetNode(scene, node);
         CancelAnimationComponent(scene, node, &n->m_Node.m_FlipbookAnimPosition);
         n->m_Node.m_Animated = false;
+    }
+
+    void ClearNodeFlipbookAnim(HScene scene, HNode node)
+    {
+        CancelNodeFlipbookAnim(scene, node);
+        n->m_Node.m_FlipbookAnimHash = 0x0;
     }
 
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical)

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -3730,7 +3730,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         }
         n->m_Node.m_FlipbookAnimHash = anim;
 
-        if(n->m_Node.m_TextureSetAnimDesc.m_State.m_Playback == PLAYBACK_NONE || GetNodeAnimationFrameCount(scene, node) == 1)
+        if(n->m_Node.m_TextureSetAnimDesc.m_State.m_Playback == PLAYBACK_NONE)
         {
             n->m_Node.m_Animated = false;
             CancelAnimationComponent(scene, node, &n->m_Node.m_FlipbookAnimPosition);

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -3759,6 +3759,7 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     void ClearNodeFlipbookAnim(HScene scene, HNode node)
     {
         CancelNodeFlipbookAnim(scene, node);
+        InternalNode* n = GetNode(scene, node);
         n->m_Node.m_FlipbookAnimHash = 0x0;
     }
 

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -884,7 +884,6 @@ namespace dmGui
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node);
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical);
     int32_t GetNodeAnimationFrame(HScene scene, HNode node);
-    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node);
     TextureSetAnimDesc* GetNodeTextureSet(HScene scene, HNode node);
 
     void* GetNodeFont(HScene scene, HNode node);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -880,6 +880,7 @@ namespace dmGui
     float GetNodeFlipbookPlaybackRate(HScene scene, HNode node);
     void SetNodeFlipbookPlaybackRate(HScene scene, HNode node, float playback_rate);
     void CancelNodeFlipbookAnim(HScene scene, HNode node);
+    void ClearNodeFlipbookAnim(HScene scene, HNode node);
     dmhash_t GetNodeFlipbookAnimId(HScene scene, HNode node);
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node);
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -885,6 +885,7 @@ namespace dmGui
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node);
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical);
     int32_t GetNodeAnimationFrame(HScene scene, HNode node);
+    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node);
     TextureSetAnimDesc* GetNodeTextureSet(HScene scene, HNode node);
 
     void* GetNodeFont(HScene scene, HNode node);

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -288,11 +288,6 @@ namespace dmGui
         return 0;
     }
 
-    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node)
-    {
-        return 0;
-    }
-
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node)
     {
         return 0;

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -287,6 +287,11 @@ namespace dmGui
     {
         return 0;
     }
+    
+    int32_t GetNodeAnimationFrameCount(HScene scene, HNode node)
+    {
+        return 0;
+    }
 
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node)
     {

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -849,6 +849,10 @@ namespace dmGui
     {
     }
 
+    void ClearNodeFlipbookAnim(HScene scene, HNode node)
+    {
+    }
+
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical)
     {
     }

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -153,6 +153,7 @@ namespace dmGui
         TextureSetAnimDesc m_TextureSetAnimDesc;
         uint64_t    m_FlipbookAnimHash;
         float       m_FlipbookAnimPosition;
+        bool        m_Animated;
 
         uint64_t    m_FontHash;
         void*       m_Font;

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -833,7 +833,7 @@ TEST_F(dmGuiTest, ScriptFlipbookAnim)
                     "    gui.cancel_flipbook(n)\n"
                     "    id2 = gui.get_flipbook(n)\n"
                     "    gui.play_flipbook(n, id, flipbook_complete)\n"
-                    "    assert(id ~= id2)\n"
+                    "    assert(id == id2)\n"
                     "end\n"
                     "\n"
                     "function update(self, dt)\n"

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -515,6 +515,11 @@ TEST_F(dmGuiTest, FlipbookAnim)
     dmGui::CancelNodeFlipbookAnim(m_Scene, node);
 
     fb_id = dmGui::GetNodeFlipbookAnimId(m_Scene, node);
+    ASSERT_EQ(dmHashString64("ta1"), fb_id);
+
+    dmGui::ClearNodeFlipbookAnim(m_Scene, node);
+
+    fb_id = dmGui::GetNodeFlipbookAnimId(m_Scene, node);
     ASSERT_EQ(0U, fb_id);
 
     r = dmGui::PlayNodeFlipbookAnim(m_Scene, node, "ta1", 0.0f, 1.0f, 0x0);


### PR DESCRIPTION
Fix bug when `gui.get_flipbook()` returns empty string for a box node created in the editor or after `gui.cancel_flipbook()`.

Fix https://github.com/defold/defold/issues/6551