### PR TITLE
Issue-6551 Fix issue when `gui.get_flipbook()` returns empty string for a node created in the editor

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -306,9 +306,11 @@ namespace dmGameSystem
                     // animation. Instead we can immediately cancel the animation and the node will
                     // still have the correct image.
                     // By doing this we'll not take up an animation slot (there's a max animation cap).
+                    // Even though we cancel animation we still need flipbook hash:
+                    // https://github.com/defold/defold/issues/6551
                     if (dmGui::GetNodeAnimationFrameCount(scene, n) == 1)
                     {
-                        dmGui::CancelNodeFlipbookAnim(scene, n);
+                        dmGui::CancelNodeFlipbookAnim(scene, n, true);
                     }
                 }
             }

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -308,6 +308,9 @@ namespace dmGameSystem
                     // By doing this we'll not take up an animation slot (there's a max animation cap).
                     // Even though we cancel animation we still need flipbook hash:
                     // https://github.com/defold/defold/issues/6551
+                    // We can't move this logic into dmGui::PlayNodeFlipbookAnim()
+                    // because if we do so we will never play all the one-frame animations which is a breaking 
+                    // change. In this case, we cancel one-frame animation ONLY when we initially setup node.
                     if (dmGui::GetNodeAnimationFrameCount(scene, n) == 1)
                     {
                         dmGui::CancelNodeFlipbookAnim(scene, n, true);

--- a/engine/gamesys/src/gamesys/test/gui/gui_flipbook_anim.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/gui_flipbook_anim.gui_script
@@ -20,6 +20,10 @@ end
 
 function init( self )
     self.node = gui.get_node("box")
+    
+    local flipbook = gui.get_flipbook(self.node)
+    assert(flipbook == hash("anim"))
+
     gui.play_flipbook(self.node, "anim_once", callback)
 end
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -3744,11 +3744,18 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         return PlayNodeFlipbookAnim(scene, node, dmHashString64(anim), offset, playback_rate, anim_complete_callback, callback_userdata1, callback_userdata2);
     }
 
-    void CancelNodeFlipbookAnim(HScene scene, HNode node)
+    void CancelNodeFlipbookAnim(HScene scene, HNode node, bool keep_anim_hash)
     {
         InternalNode* n = GetNode(scene, node);
         CancelAnimationComponent(scene, node, &n->m_Node.m_FlipbookAnimPosition);
+        if (keep_anim_hash)
+            return;
         n->m_Node.m_FlipbookAnimHash = 0;
+    }
+
+    void CancelNodeFlipbookAnim(HScene scene, HNode node)
+    {
+        CancelNodeFlipbookAnim(scene, node, false);
     }
 
     void GetNodeFlipbookAnimUVFlip(HScene scene, HNode node, bool& flip_horizontal, bool& flip_vertical)

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -879,6 +879,7 @@ namespace dmGui
     void SetNodeFlipbookCursor(HScene scene, HNode node, float cursor);
     float GetNodeFlipbookPlaybackRate(HScene scene, HNode node);
     void SetNodeFlipbookPlaybackRate(HScene scene, HNode node, float playback_rate);
+    void CancelNodeFlipbookAnim(HScene scene, HNode node, bool keep_anim_hash);
     void CancelNodeFlipbookAnim(HScene scene, HNode node);
     dmhash_t GetNodeFlipbookAnimId(HScene scene, HNode node);
     const float* GetNodeFlipbookAnimUV(HScene scene, HNode node);

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -849,6 +849,10 @@ namespace dmGui
     {
         return RESULT_OK;
     }
+    
+    void CancelNodeFlipbookAnim(HScene scene, HNode node, bool keep_anim_hash)
+    {
+    }
 
     void CancelNodeFlipbookAnim(HScene scene, HNode node)
     {


### PR DESCRIPTION
Fix issue when `gui.get_flipbook()` returns empty string for a box node created in the editor.

Fix https://github.com/defold/defold/issues/6551