### PR TITLE
Option to use chunked transfer encoding for HTTPS post data larger than 16kb

### DIFF
--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -185,6 +185,7 @@ namespace dmHttpClient
         bool                m_Secure;
         uint16_t            m_Port;
         uint16_t            m_IgnoreCache:1;
+        uint16_t            m_ChunkedTransfer:1;
         int*                m_CancelFlag;
 
         // Used both for reading header and content. NOTE: Extra byte for null-termination
@@ -292,6 +293,9 @@ namespace dmHttpClient
                 break;
             case OPTION_REQUEST_IGNORE_CACHE:
                 client->m_IgnoreCache = value != 0 ? 1 : 0;
+                break;
+            case OPTION_REQUEST_CHUNKED_TRANSFER:
+                client->m_ChunkedTransfer = value != 0 ? 1 : 0;
                 break;
             default:
                 return RESULT_INVAL_ERROR;
@@ -575,6 +579,11 @@ if (sock_res != dmSocket::RESULT_OK)\
             if (client->m_Secure && send_content_length > MAX_HTTPS_POST_CHUNK_SIZE)
             {
                 chunked = 1;
+            }
+            // disable chunked transfer encoding if explicitly disabled by the user
+            if (chunked == 1 && client->m_ChunkedTransfer == 0)
+            {
+                chunked = 0;
             }
 
             // If we want to send more that this, we need to send it chunked

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -581,7 +581,7 @@ if (sock_res != dmSocket::RESULT_OK)\
                 chunked = 1;
             }
             // disable chunked transfer encoding if explicitly disabled by the user
-            if (chunked == 1 && client->m_ChunkedTransfer == 0)
+            if (client->m_ChunkedTransfer == 0)
             {
                 chunked = 0;
             }

--- a/engine/dlib/src/dlib/http_client.h
+++ b/engine/dlib/src/dlib/http_client.h
@@ -107,6 +107,8 @@ namespace dmHttpClient
         OPTION_REQUEST_TIMEOUT,
         /// Don't use the http cache
         OPTION_REQUEST_IGNORE_CACHE,
+        /// Use chunked transfer encoding for POST/PUT if request data is larger than 16k
+        OPTION_REQUEST_CHUNKED_TRANSFER,
     };
 
     /**

--- a/engine/script/src/http_service.cpp
+++ b/engine/script/src/http_service.cpp
@@ -241,6 +241,7 @@ namespace dmHttpService
             worker->m_Request = request;
             dmHttpClient::SetOptionInt(worker->m_Client, dmHttpClient::OPTION_REQUEST_TIMEOUT, request->m_Timeout);
             dmHttpClient::SetOptionInt(worker->m_Client, dmHttpClient::OPTION_REQUEST_IGNORE_CACHE, request->m_IgnoreCache);
+            dmHttpClient::SetOptionInt(worker->m_Client, dmHttpClient::OPTION_REQUEST_CHUNKED_TRANSFER, request->m_ChunkedTransfer);
 
             dmHttpClient::Result r = dmHttpClient::Request(worker->m_Client, request->m_Method, url.m_Path);
             if (r == dmHttpClient::RESULT_OK || r == dmHttpClient::RESULT_NOT_200_OK) {

--- a/engine/script/src/script/http_ddf.proto
+++ b/engine/script/src/script/http_ddf.proto
@@ -31,6 +31,9 @@ message HttpRequest
     // Explicitly ignore the http cache.
     // It's for 304 requests where we just want to confirm the 304 (e.g. for liveupdate).
     optional bool   ignore_cache   = 9;
+
+    // Use chunked transfer encoding
+    optional bool   chunked_transfer   = 10 [default=true];
 }
 
 message HttpResponse

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -86,6 +86,7 @@ namespace dmScript
      * - [type:number] `timeout`: timeout in seconds
      * - [type:string] `path`: path on disc where to download the file. Only overwrites the path if status is 200
      * - [type:boolean] `ignore_cache`: don't return cached data if we get a 304
+     * - [type:boolean] `chunked_transfer`: use chunked transfer encoding for https requests larger than 16kb. Defaults to true.
      *
      *
      * @examples

--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -184,6 +184,7 @@ namespace dmScript
             uint64_t timeout = g_Timeout;
             const char* path = 0;
             bool ignore_cache = false;
+            bool chunked_transfer = true;
             if (top > 5 && !lua_isnil(L, 6)) {
                 luaL_checktype(L, 6, LUA_TTABLE);
                 lua_pushvalue(L, 6);
@@ -201,6 +202,10 @@ namespace dmScript
                     else if (strcmp(attr, "ignore_cache") == 0)
                     {
                         ignore_cache = lua_toboolean(L, -1);
+                    }
+                    else if (strcmp(attr, "chunked_transfer") == 0)
+                    {
+                        chunked_transfer = lua_toboolean(L, -1);
                     }
 
                     lua_pop(L, 1);
@@ -224,6 +229,7 @@ namespace dmScript
             request->m_Timeout = timeout;
             request->m_Path = path;
             request->m_IgnoreCache = ignore_cache;
+            request->m_ChunkedTransfer = chunked_transfer;
 
             uint32_t post_len = sizeof(dmHttpDDF::HttpRequest) + method_len + 1 + url_len + 1;
             dmMessage::URL receiver;


### PR DESCRIPTION
When using HTTP POST requests to send large amounts of data to a server over https it may be required to use a Chunked Transfer-Encoding header since some web servers have a max TLS record size of 16kb. The default behaviour in Defold is to use chunked transfer encoding for all https requests with post data larger than 16kb. This is however problematic since some servers do not support chunked transfer encoding. To solve this we have now added a new option to the `http.request()` option table to toggle use of chunked transfer encoding:

```
local options = {
    chunked_transfer = false -- disable chunked transfer encoding
}
http.request(url, method, callback, headers, post_data, options)
```

Fixes #6448 