### PR TITLE
Force 3D physics body activation to wake it up

### DIFF
--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -1017,7 +1017,7 @@ namespace dmPhysics
     void Wakeup3D(HCollisionObject3D collision_object)
     {
         btCollisionObject* co = GetCollisionObject(collision_object);
-        co->activate();
+        co->activate(true);
     }
 
     void SetLockedRotation3D(HCollisionObject3D collision_object, bool locked_rotation) {


### PR DESCRIPTION
This fixes an issue where `physics.wakeup(url)` didn't wake up dynamic 3D physics bodies.

Fixes https://github.com/defold/defold/issues/6576