### PR TITLE
Add "-keypass" parameter to allow a different key password

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -427,8 +427,9 @@ public class Bob {
         addOption(options, "pk", "private-key", true, "DEPRECATED! Private key (Android)", false);
 
         addOption(options, "ks", "keystore", true, "Deployment keystore used to sign APKs (Android)", false);
-        addOption(options, "ksp", "keystore-pass", true, "Pasword of the deployment keystore (Android)", false);
+        addOption(options, "ksp", "keystore-pass", true, "Password of the deployment keystore (Android)", false);
         addOption(options, "ksa", "keystore-alias", true, "The alias of the signing key+cert you want to use (Android)", false);
+        addOption(options, "kp", "key-pass", true, "Password of the deployment key if different from the keystore password (Android)", false);
 
         addOption(options, "d", "debug", false, "Use debug version of dmengine (when bundling). Deprecated, use --variant instead", false);
         addOption(options, null, "variant", true, "Specify debug, release or headless version of dmengine (when bundling)", false);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -203,6 +203,25 @@ public class AndroidBundler implements IBundler {
         }
         return alias;
     }
+	
+	/**
+     * Get key password. This loads the key password file and returns
+     * the password stored in the file.
+     */
+    private static String getKeyPassword(Project project) throws IOException, CompileExceptionError {
+        return readFile(getKeyPasswordFile(project)).trim();
+    }
+	
+	/**
+     * Get key password file. Uses the keystore password file if none specified
+     */
+    private static String getKeyPasswordFile(Project project) throws IOException, CompileExceptionError {
+        String keyPassword = project.option("key-pass", "");
+        if (keyPassword.length() == 0) {
+            return getKeystorePasswordFile(project);
+        }
+        return keyPassword;
+    }
 
     private static String getProjectTitle(Project project) {
         BobProjectProperties projectProperties = project.getProjectProperties();
@@ -617,11 +636,13 @@ public class AndroidBundler implements IBundler {
         String keystore = getKeystore(project);
         String keystorePassword = getKeystorePassword(project);
         String keystoreAlias = getKeystoreAlias(project);
+		String keyPassword = getKeyPassword(project);
 
         Result r = exec(getJavaBinFile("jarsigner"),
             "-verbose",
             "-keystore", keystore,
             "-storepass", keystorePassword,
+			"-keypass", keyPassword,
             signFile.getAbsolutePath(),
             keystoreAlias);
         if (r.ret != 0) {
@@ -728,6 +749,7 @@ public class AndroidBundler implements IBundler {
         String keystore = getKeystore(project);
         String keystorePasswordFile = getKeystorePasswordFile(project);
         String keystoreAlias = getKeystoreAlias(project);
+		String keyPasswordFile = getKeyPasswordFile(project);
 
         try {
             File bundletool = new File(Bob.getLibExecPath("bundletool-all.jar"));
@@ -746,6 +768,7 @@ public class AndroidBundler implements IBundler {
             args.add("--ks"); args.add(keystore);
             args.add("--ks-pass"); args.add("file:" + keystorePasswordFile);
             args.add("--ks-key-alias"); args.add(keystoreAlias);
+			args.add("--key-pass"); args.add("file:" + keyPasswordFile);
 
             Result res = exec(args);
             if (res.ret != 0) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -203,16 +203,16 @@ public class AndroidBundler implements IBundler {
         }
         return alias;
     }
-	
-	/**
+    
+    /**
      * Get key password. This loads the key password file and returns
      * the password stored in the file.
      */
     private static String getKeyPassword(Project project) throws IOException, CompileExceptionError {
         return readFile(getKeyPasswordFile(project)).trim();
     }
-	
-	/**
+    
+    /**
      * Get key password file. Uses the keystore password file if none specified
      */
     private static String getKeyPasswordFile(Project project) throws IOException, CompileExceptionError {
@@ -636,13 +636,13 @@ public class AndroidBundler implements IBundler {
         String keystore = getKeystore(project);
         String keystorePassword = getKeystorePassword(project);
         String keystoreAlias = getKeystoreAlias(project);
-		String keyPassword = getKeyPassword(project);
+        String keyPassword = getKeyPassword(project);
 
         Result r = exec(getJavaBinFile("jarsigner"),
             "-verbose",
             "-keystore", keystore,
             "-storepass", keystorePassword,
-			"-keypass", keyPassword,
+            "-keypass", keyPassword,
             signFile.getAbsolutePath(),
             keystoreAlias);
         if (r.ret != 0) {
@@ -749,7 +749,7 @@ public class AndroidBundler implements IBundler {
         String keystore = getKeystore(project);
         String keystorePasswordFile = getKeystorePasswordFile(project);
         String keystoreAlias = getKeystoreAlias(project);
-		String keyPasswordFile = getKeyPasswordFile(project);
+        String keyPasswordFile = getKeyPasswordFile(project);
 
         try {
             File bundletool = new File(Bob.getLibExecPath("bundletool-all.jar"));
@@ -768,7 +768,7 @@ public class AndroidBundler implements IBundler {
             args.add("--ks"); args.add(keystore);
             args.add("--ks-pass"); args.add("file:" + keystorePasswordFile);
             args.add("--ks-key-alias"); args.add(keystoreAlias);
-			args.add("--key-pass"); args.add("file:" + keyPasswordFile);
+            args.add("--key-pass"); args.add("file:" + keyPasswordFile);
 
             Result res = exec(args);
             if (res.ret != 0) {

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -235,20 +235,23 @@
   {:architecture-32bit? "armv7-android"
    :architecture-64bit? "arm64-android"})
 
-(defn- android-bundle-bob-args [{:keys [^File keystore ^File keystore-pass bundle-format] :as bundle-options}]
+(defn- android-bundle-bob-args [{:keys [^File keystore ^File keystore-pass ^File key-pass bundle-format] :as bundle-options}]
   (let [bob-architectures
         (for [[option-key bob-architecture] android-architecture-option->bob-architecture-string
               :when (bundle-options option-key)]
           bob-architecture)
         bob-args {"architectures" (string/join "," bob-architectures)}]
     (assert (or (and (nil? keystore)
-                     (nil? keystore-pass))
+                     (nil? keystore-pass)
+                     (nil? key-pass))
                 (and (.isFile keystore)
-                     (.isFile keystore-pass))))
+                     (.isFile keystore-pass)
+                     (or (nil? key-pass) (.isFile key-pass)))))
     (cond-> bob-args
             bundle-format (assoc "bundle-format" bundle-format)
             keystore (assoc "keystore" (.getAbsolutePath keystore))
-            keystore-pass (assoc "keystore-pass" (.getAbsolutePath keystore-pass)))))
+            keystore-pass (assoc "keystore-pass" (.getAbsolutePath keystore-pass))
+            key-pass (assoc "key-pass" (.getAbsolutePath key-pass)))))
 
 (def ^:private ios-architecture-option->bob-architecture-string
   {:architecture-64bit? "arm64-darwin"

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -532,7 +532,7 @@ class Configuration(object):
             installed_packages.update(target_package_paths)
 
         print("Installing python wheels")
-        run.env_command(self._form_env(), ['python', './packages/get-pip.py', 'pip==19.3.1'])
+        run.env_command(self._form_env(), ['python', './packages/get-pip.py', 'pip==20.3.4'])
         run.env_command(self._form_env(), ['python', '-m', 'pip', '-q', '-q', 'install', '-t', join(self.ext, 'lib', 'python'), 'requests', 'pyaml'])
         for whl in glob(join(self.defold_root, 'packages', '*.whl')):
             self._log('Installing %s' % basename(whl))


### PR DESCRIPTION
This permits a key password to be passed to Bob for signing Android builds, in addition to the keystore password.

```
java -jar bob.jar --key-pass=mykeypass.txt --platform=armv7-android bundle
```

Fixes #5630 