### PR TITLE
Remove _basis from output arguments

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -88,7 +88,8 @@
 (defn node-type
   "Return the node-type given a node. Uses the current basis if not provided."
   [node]
-  (gt/node-type node))
+  (when node
+    (gt/node-type node)))
 
 (defn node-override? [node]
   (some? (gt/original node)))

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -88,10 +88,13 @@
 (defn node-type
   "Return the node-type given a node. Uses the current basis if not provided."
   ([node]
-    (node-type (now) node))
+   (node-type (now) node))
   ([basis node]
-    (when node
-      (gt/node-type node basis))))
+   (when node
+     (gt/node-type node basis))))
+
+(defn node-override? [node]
+  (some? (gt/original node)))
 
 (defn cache "The system cache of node values"
   []
@@ -174,9 +177,9 @@
 (defn is-modified?
   "Returns a boolean if a node, or node and output, was modified as a result of a transaction given a tx-result."
   ([transaction node-id]
-    (boolean (contains? (:outputs-modified transaction) node-id)))
+   (boolean (contains? (:outputs-modified transaction) node-id)))
   ([transaction node-id output]
-    (boolean (get-in transaction [:outputs-modified node-id output]))))
+   (boolean (get-in transaction [:outputs-modified node-id output]))))
 
 (defn is-added?
   "Returns a boolean if a node was added as a result of a transaction given a tx-result and node."
@@ -555,10 +558,10 @@
 
 (defn disconnect-sources
   ([target-id target-label]
-    (disconnect-sources (now) target-id target-label))
+   (disconnect-sources (now) target-id target-label))
   ([basis target-id target-label]
    (assert target-id)
-    (it/disconnect-sources basis target-id target-label)))
+   (it/disconnect-sources basis target-id target-label)))
 
 (defn set-property
   "Creates the transaction step to assign a value to a node's property (or properties) value(s).  It will take effect when the transaction
@@ -939,19 +942,19 @@
   "Returns true if the node is a member of a given type, including
    supertypes."
   ([type node]
-    (node-instance*? (now) type node))
+   (node-instance*? (now) type node))
   ([basis type node]
-    (if-let [nt (and type (node-type basis node))]
-      (isa? (:key @nt) (:key @type))
-      false)))
+   (if-let [nt (and type (node-type basis node))]
+     (isa? (:key @nt) (:key @type))
+     false)))
 
 (defn node-instance?
   "Returns true if the node is a member of a given type, including
    supertypes."
   ([type node-id]
-    (node-instance? (now) type node-id))
+   (node-instance? (now) type node-id))
   ([basis type node-id]
-    (node-instance*? basis type (gt/node-by-id-at basis node-id))))
+   (node-instance*? basis type (gt/node-by-id-at basis node-id))))
 
 ;; ---------------------------------------------------------------------------
 ;; Support for serialization, copy & paste, and drag & drop
@@ -1070,7 +1073,7 @@
   ([root-ids opts]
    (copy (now) root-ids opts))
   ([basis root-ids {:keys [traverse? serializer] :or {traverse? (clojure.core/constantly false) serializer default-node-serializer} :as opts}]
-    (s/validate opts-schema opts)
+   (s/validate opts-schema opts)
    (let [arcs-by-source (partial deep-arcs-by-source basis)
          arcs-by-target (partial gt/arcs-by-target basis)
          serializer     #(assoc (serializer basis (gt/node-by-id-at basis %2)) :serial-id %1)
@@ -1166,9 +1169,9 @@
 
 (defn override-original
   ([node-id]
-    (override-original (now) node-id))
+   (override-original (now) node-id))
   ([basis node-id]
-    (ig/override-original basis node-id)))
+   (ig/override-original basis node-id)))
 
 (defn override-root
   ([node-id]
@@ -1180,9 +1183,9 @@
 
 (defn override?
   ([node-id]
-    (override? (now) node-id))
+   (override? (now) node-id))
   ([basis node-id]
-    (not (nil? (override-original basis node-id)))))
+   (not (nil? (override-original basis node-id)))))
 
 (defn override-id
   ([node-id]
@@ -1191,12 +1194,15 @@
    (when-some [node (node-by-id basis node-id)]
      (:override-id node))))
 
+(defn node-property-overridden? [node property]
+  (gt/property-overridden? node property))
+
 (defn property-overridden?
   ([node-id property]
    (property-overridden? (now) node-id property))
   ([basis node-id property]
    (if-let [node (node-by-id basis node-id)]
-     (gt/property-overridden? node property)
+     (node-property-overridden? node property)
      false)))
 
 (defn property-value-origin?

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -83,15 +83,12 @@
    (node-type* (now) node-id))
   ([basis node-id]
    (when-let [n (gt/node-by-id-at basis node-id)]
-     (gt/node-type n basis))))
+     (gt/node-type n))))
 
 (defn node-type
   "Return the node-type given a node. Uses the current basis if not provided."
-  ([node]
-   (node-type (now) node))
-  ([basis node]
-   (when node
-     (gt/node-type node basis))))
+  [node]
+  (gt/node-type node))
 
 (defn node-override? [node]
   (some? (gt/original node)))
@@ -941,12 +938,10 @@
 (defn node-instance*?
   "Returns true if the node is a member of a given type, including
    supertypes."
-  ([type node]
-   (node-instance*? (now) type node))
-  ([basis type node]
-   (if-let [nt (and type (node-type basis node))]
-     (isa? (:key @nt) (:key @type))
-     false)))
+  [type node]
+  (if-let [nt (and type (node-type node))]
+    (isa? (:key @nt) (:key @type))
+    false))
 
 (defn node-instance?
   "Returns true if the node is a member of a given type, including
@@ -954,7 +949,7 @@
   ([type node-id]
    (node-instance? (now) type node-id))
   ([basis type node-id]
-   (node-instance*? basis type (gt/node-by-id-at basis node-id))))
+   (node-instance*? type (gt/node-by-id-at basis node-id))))
 
 ;; ---------------------------------------------------------------------------
 ;; Support for serialization, copy & paste, and drag & drop
@@ -1005,13 +1000,12 @@
   [basis pred root-ids]
   (ig/pre-traverse basis root-ids (partial predecessors (every-arc-pred in-same-graph? pred))))
 
-(defn default-node-serializer
-  [basis node]
+(defn default-node-serializer [node]
   (let [node-id                (gt/node-id node)
         all-node-properties    (into {} (map (fn [[key value]] [key (:value value)])
                                              (:properties (node-value node-id :_declared-properties))))
         properties-without-fns (util/filterm (comp not fn? val) all-node-properties)]
-    {:node-type  (node-type basis node)
+    {:node-type  (node-type node)
      :properties properties-without-fns}))
 
 (def opts-schema {(s/optional-key :traverse?) Runnable
@@ -1076,7 +1070,7 @@
    (s/validate opts-schema opts)
    (let [arcs-by-source (partial deep-arcs-by-source basis)
          arcs-by-target (partial gt/arcs-by-target basis)
-         serializer     #(assoc (serializer basis (gt/node-by-id-at basis %2)) :serial-id %1)
+         serializer     #(assoc (serializer (gt/node-by-id-at basis %2)) :serial-id %1)
          original-ids   (input-traverse basis traverse? root-ids)
          replacements   (zipmap original-ids (map-indexed serializer original-ids))
          serial-ids     (into {}

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -264,6 +264,10 @@
                                            :view-type (ui/user-data active-tab ::view-type)})))
 
   (output active-resource-node g/NodeID :cached (g/fnk [active-view open-views] (:resource-node (get open-views active-view))))
+  (output active-resource-node+type g/Any :cached
+          (g/fnk [active-view open-views]
+            (when-let [{:keys [resource-node resource-node-type]} (get open-views active-view)]
+              [resource-node resource-node-type])))
   (output active-resource resource/Resource :cached (g/fnk [active-view open-views] (:resource (get open-views active-view))))
   (output open-resource-nodes g/Any :cached (g/fnk [open-views] (->> open-views vals (map :resource-node))))
   (output selected-node-ids g/Any (g/fnk [selected-node-ids-by-resource-node active-resource-node]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -303,7 +303,7 @@
           (g/connect app-view :selected-node-ids outline-view :selection)
           (g/connect app-view :hidden-node-outline-key-paths outline-view :hidden-node-outline-key-paths)
           (g/connect app-view :active-resource asset-browser :active-resource)
-          (g/connect app-view :active-resource-node scene-visibility :active-resource-node)
+          (g/connect app-view :active-resource-node+type scene-visibility :active-resource-node+type)
           (g/connect app-view :active-scene scene-visibility :active-scene)
           (g/connect outline-view :tree-selection scene-visibility :outline-selection)
           (g/connect scene-visibility :hidden-renderable-tags app-view :hidden-renderable-tags)

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -216,15 +216,15 @@
   (when (= resource/Resource (:type edit-type))
     (resource-assignment-error node-id prop-kw prop-name value (:ext edit-type))))
 
-(g/defnk produce-script-property-entries [_basis _node-id deleted? name resource-kind type value]
+(g/defnk produce-script-property-entries [_this _node-id deleted? name resource-kind type value]
   (when-not deleted?
     (let [prop-kw (properties/user-name->key name)
           prop-type (script-property-type->property-type type)
           edit-type (script-property-edit-type prop-type resource-kind)
           error (validate-value-against-edit-type _node-id :value name value edit-type)
           go-prop-type (script-property-type->go-prop-type type)
-          overridden? (g/property-overridden? _basis _node-id :value)
-          read-only? (nil? (g/override-original _basis _node-id))
+          overridden? (g/node-property-overridden? _this :value)
+          read-only? (not (g/node-override? _this))
           visible? (not deleted?)]
       ;; NOTE: :assoc-original-value? here tells the node internals that it
       ;; needs to assoc in the :original-value from the overridden node when

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -767,8 +767,8 @@
           (map (partial cursor-range-draw-info :range (color-lookup color-scheme "editor.selection.occurrence.outline") nil)
                (data/visible-occurrences-of-selected-word lines cursor-ranges minimap-layout nil)))))))
 
-(g/defnk produce-execution-markers [lines debugger-execution-locations node-id+resource]
-  (when-some [path (some-> node-id+resource second resource/proj-path)]
+(g/defnk produce-execution-markers [lines debugger-execution-locations node-id+type+resource]
+  (when-some [path (some-> node-id+type+resource (get 2) resource/proj-path)]
     (into []
           (comp (filter #(= path (:file %)))
                 (map (fn [{:keys [^long line type]}]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -480,8 +480,8 @@
 (g/deftype ^:private NodeIndex [(s/one s/Int "node-id") (s/one s/Int "index")])
 (g/deftype ^:private NameIndex [(s/one s/Str "name") (s/one s/Int "index")])
 
-(g/defnk override-node? [_basis _node-id] (g/override? _basis _node-id))
-(g/defnk not-override-node? [_basis _node-id] (not (g/override? _basis _node-id)))
+(g/defnk override-node? [_this] (g/node-override? _this))
+(g/defnk not-override-node? [_this] (not (g/node-override? _this)))
 
 (defn- validate-contains [severity fmt prop-kw node-id coll key]
   (validation/prop-error severity node-id

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -80,7 +80,7 @@
   (output dirty? g/Bool (g/fnk [cleaned-save-value source-value editable?]
                           (and editable? (some? cleaned-save-value) (not= cleaned-save-value source-value))))
   (output node-id+resource g/Any :unjammable (g/fnk [_node-id resource] [_node-id resource]))
-  (output valid-node-id+type+resource g/Any (g/fnk [_node-id _type resource] [_node-id _type resource])) ; Jammed when defective.
+  (output valid-node-id+type+resource g/Any (g/fnk [_node-id _this resource] [_node-id (g/node-type _this) resource])) ; Jammed when defective.
   (output own-build-errors g/Any (g/constantly nil))
   (output build-targets g/Any (g/constantly []))
   (output node-outline outline/OutlineData :cached

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -80,7 +80,7 @@
   (output dirty? g/Bool (g/fnk [cleaned-save-value source-value editable?]
                           (and editable? (some? cleaned-save-value) (not= cleaned-save-value source-value))))
   (output node-id+resource g/Any :unjammable (g/fnk [_node-id resource] [_node-id resource]))
-  (output valid-node-id+resource g/Any (g/fnk [_node-id resource] [_node-id resource])) ; Jammed when defective.
+  (output valid-node-id+type+resource g/Any (g/fnk [_node-id _type resource] [_node-id _type resource])) ; Jammed when defective.
   (output own-build-errors g/Any (g/constantly nil))
   (output build-targets g/Any (g/constantly []))
   (output node-outline outline/OutlineData :cached
@@ -109,7 +109,7 @@
                                      (DigestUtils/sha256Hex ^String content))))))
 
 (defn defective? [resource-node]
-  (let [value (g/node-value resource-node :valid-node-id+resource)]
+  (let [value (g/node-value resource-node :valid-node-id+type+resource)]
     (and (g/error? value)
          (g/error-fatal? value))))
 

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -117,15 +117,16 @@
   (property visibility-filters-enabled? g/Bool (default true))
   (property filtered-renderable-tags types/RenderableTags (default #{:dev-visibility-bounds}))
 
-  (input active-resource-node g/NodeID)
+  (input active-resource-node+type g/Any)
   (input active-scene g/Any :substitute nil)
   (input outline-selection g/Any :substitute nil)
   (input scene-hide-history-datas SceneHideHistoryData :array)
 
-  (output active-scene-resource-node g/NodeID (g/fnk [_basis active-resource-node]
-                                                (when (some? active-resource-node)
-                                                  (when (g/has-output? (g/node-type* _basis active-resource-node) :scene)
-                                                    active-resource-node))))
+  (output active-scene-resource-node g/NodeID (g/fnk [active-resource-node+type]
+                                                (when (some? active-resource-node+type)
+                                                  (let [[node type] active-resource-node+type]
+                                                    (when (g/has-output? type :scene)
+                                                      node)))))
 
   (output hidden-outline-name-paths-by-scene-resource-node OutlineNamePathsByNodeID :cached (g/fnk [scene-hide-history-datas]
                                                                                               (into {}

--- a/editor/src/clj/editor/view.clj
+++ b/editor/src/clj/editor/view.clj
@@ -17,11 +17,12 @@
 
 (g/defnode WorkbenchView
   (input resource-node g/NodeID)
-  (input node-id+resource g/Any :substitute nil)
+  (input node-id+type+resource g/Any :substitute nil)
   (input dirty? g/Bool :substitute false)
-  (output view-data g/Any (g/fnk [_node-id node-id+resource]
-                            [_node-id (when-let [[node-id resource] node-id+resource]
+  (output view-data g/Any (g/fnk [_node-id node-id+type+resource]
+                            [_node-id (when-let [[node-id type resource] node-id+type+resource]
                                         {:resource-node node-id
+                                         :resource-node-type type
                                          :resource resource})]))
   ;; we cache view-dirty? to avoid recomputing dirty? on the resource
   ;; node for every open tab whenever one resource changes
@@ -30,5 +31,5 @@
 (defn connect-resource-node [view resource-node]
   (concat
     (g/connect resource-node :_node-id view :resource-node)
-    (g/connect resource-node :valid-node-id+resource view :node-id+resource)
+    (g/connect resource-node :valid-node-id+type+resource view :node-id+type+resource)
     (g/connect resource-node :dirty? view :dirty?)))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -628,9 +628,7 @@
   [basis node-id]
   (when-some [node (gt/node-by-id-at basis node-id)]
     (let [override-id (gt/override-id node)]
-      (loop [inputs (some-> node
-                            (gt/node-type basis)
-                            in/cascade-deletes)
+      (loop [inputs (some-> node gt/node-type in/cascade-deletes)
              result (vec (get-overrides basis node-id))]
         (if-some [input (first inputs)]
           (let [explicit (map first (explicit-sources basis node-id input))
@@ -975,7 +973,7 @@
           target-graph-id (gt/node-id->graph-id target-id)
           target-graph (get graphs target-graph-id)
           target-node (node-id->node target-graph target-id)
-          target-node-type (gt/node-type target-node this)]
+          target-node-type (gt/node-type target-node)]
       (assert (<= (:_volatility source-graph 0) (:_volatility target-graph 0)))
       (assert (in/has-input? target-node-type target-label) (str "No label " target-label " exists on node " target-node))
       (if (= source-graph-id target-graph-id)
@@ -1111,9 +1109,7 @@
      :outputs-to-refresh outputs-to-refresh}))
 
 (defn- input-deps [basis node-id]
-  (some-> (gt/node-by-id-at basis node-id)
-          (gt/node-type basis)
-          in/input-dependencies))
+  (some-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies))
 
 (defn- update-graph-successors
   "The purpose of this fn is to build a data structure that reflects which set of node-id + outputs that can be reached from the incoming changes (map of node-id + outputs)
@@ -1139,7 +1135,7 @@
                                                        ([] [{} []])
                                                        ([[new-acc remove-acc] [node-id labels old-node-successors]]
                                                         (let [new-node-successors (if-some [node (gt/node-by-id-at basis node-id)]
-                                                                                    (let [node-type (gt/node-type node basis)
+                                                                                    (let [node-type (gt/node-type node)
                                                                                           deps-by-label (or (in/input-dependencies node-type) {})
                                                                                           node-and-overrides (tree-seq (constantly true) node-id->overrides node-id)
                                                                                           override-filter-fn (complement (into #{} override-id-xf node-and-overrides))

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -30,7 +30,7 @@
 
 (defprotocol Node
   (node-id               [this]                          "Return an ID that can be used to get this node (or a future value of it).")
-  (node-type             [this basis]                    "Return the node type that created this node.")
+  (node-type             [this]                          "Return the node type that created this node.")
   (get-property          [this basis property]           "Return the value of the named property")
   (set-property          [this basis property value]     "Set the named property")
   (overridden-properties [this]                          "Return a map of property name to override value")

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -33,7 +33,7 @@
   (node-type             [this basis]                    "Return the node type that created this node.")
   (get-property          [this basis property]           "Return the value of the named property")
   (set-property          [this basis property value]     "Set the named property")
-  (overridden-properties [this basis]                    "Return a map of property name to override value")
+  (overridden-properties [this]                          "Return a map of property name to override value")
   (property-overridden?  [this property]))
 
 (defprotocol OverrideNode

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -260,7 +260,7 @@
   (node-id [this]
     (:_node-id this))
 
-  (node-type [_ _]
+  (node-type [_]
     node-type)
 
   (get-property [this basis property]
@@ -428,8 +428,7 @@
 
 (defn node-property-value* [node label evaluation-context]
   (validate-evaluation-context evaluation-context)
-  (let [basis (:basis evaluation-context)
-        node-type (gt/node-type node basis)]
+  (let [node-type (gt/node-type node)]
     (when-let [behavior (property-behavior node-type label)]
       ((:fn behavior) node label evaluation-context))))
 
@@ -593,7 +592,7 @@
 
 (defn- all-available-arguments
   [description]
-  (set/union #{:_this :_type}
+  (set/union #{:_this}
              (util/key-set (:input description))
              (util/key-set (:property description))
              (util/key-set (:output description))))
@@ -1207,8 +1206,7 @@
 
 (defn- call-with-error-checked-fnky-arguments-form
   [description label node-sym node-id-sym evaluation-context-sym arguments runtime-fnk-expr & [supplied-arguments]]
-  (let [base-args {:_node-id `(gt/node-id ~node-sym)
-                   :_type `(gt/node-type ~node-sym (:basis ~evaluation-context-sym))}
+  (let [base-args {:_node-id `(gt/node-id ~node-sym)}
         arglist (without arguments (keys supplied-arguments))
         argument-forms (zipmap arglist (map #(get base-args % (if (= label %)
                                                                 `(gt/get-property ~node-sym (:basis ~evaluation-context-sym) ~label)
@@ -1243,9 +1241,6 @@
   (cond
     (= :_this argument)
     node-sym
-
-    (= :_type argument)
-    `(gt/node-type ~node-sym (:basis ~evaluation-context-sym))
 
     (and (= output argument)
          (desc-has-property? description argument)
@@ -1317,7 +1312,7 @@
 (defn- node-type-name [node-id evaluation-context]
   (let [basis (:basis evaluation-context)
         node (gt/node-by-id-at basis node-id)]
-    (type-name (gt/node-type node basis))))
+    (type-name (gt/node-type node))))
 
 (defn mark-in-production [node-id label evaluation-context]
   (assert (not (contains? (:in-production evaluation-context) [node-id label]))
@@ -1370,9 +1365,7 @@
 (defn- gather-arguments-form [description label node-sym node-id-sym evaluation-context-sym arguments-sym schema-sym forms]
   (let [arg-names (get-in description [:output label :arguments])
         argument-forms (zipmap arg-names (map #(fnk-argument-form description label % node-sym node-id-sym evaluation-context-sym) arg-names))
-        argument-forms (assoc argument-forms
-                         :_node-id node-id-sym
-                         :_type `(gt/node-type ~node-sym (:basis ~evaluation-context-sym)))]
+        argument-forms (assoc argument-forms :_node-id node-id-sym)]
     (list `let
           [arguments-sym argument-forms]
           forms)))
@@ -1514,7 +1507,7 @@
           display-order-sym 'display-order]
       `(fn [~node-sym ~label-sym ~evaluation-context-sym]
          (let [~node-id-sym (gt/node-id ~node-sym)
-               ~display-order-sym (property-display-order (gt/node-type ~node-sym (:basis ~evaluation-context-sym)))
+               ~display-order-sym (property-display-order (gt/node-type ~node-sym))
                ~value-map-sym ~(apply merge {}
                                       (for [[p _] (remove (comp intrinsic-properties key) props)]
                                         {p (property-value-exprs description p node-sym node-id-sym evaluation-context-sym (get props p))}))]
@@ -1541,10 +1534,10 @@
 ;;; ----------------------------------------
 ;;; Overrides
 
-(defrecord OverrideNode [override-id node-id original-id properties]
+(defrecord OverrideNode [override-id node-id node-type original-id properties]
   gt/Node
   (node-id [this] node-id)
-  (node-type [this basis] (gt/node-type (gt/node-by-id-at basis original-id) basis))
+  (node-type [this] node-type)
   (get-property [this basis property]
     (get properties property (gt/get-property (gt/node-by-id-at basis original-id) basis property)))
   (set-property [this basis property value]
@@ -1556,19 +1549,18 @@
 
   gt/Evaluation
   (produce-value [this output evaluation-context]
-    (let [basis (:basis evaluation-context)
-          type (gt/node-type this basis)]
+    (let [basis (:basis evaluation-context)]
       (cond
         (= :_node-id output)
         node-id
 
         (or (= :_declared-properties output)
             (= :_properties output))
-        (let [beh (behavior type output)
+        (let [beh (behavior node-type output)
               props ((:fn beh) this output evaluation-context)
               original (gt/node-by-id-at basis original-id)
               orig-props (:properties (gt/produce-value original output evaluation-context))
-              declared? (partial contains? (all-properties type))]
+              declared? (partial contains? (all-properties node-type))]
           (when-not (:dry-run evaluation-context)
             (let [;; Values for undeclared properties must be manually propagated from the original.
                   props-with-inherited-override-values
@@ -1616,13 +1608,13 @@
                              orig-props)]
               (assoc props :properties props-with-overrides-and-original-values))))
 
-        (or (has-output? type output)
-            (has-input? type output))
-        (let [beh (behavior type output)]
+        (or (has-output? node-type output)
+            (has-input? node-type output))
+        (let [beh (behavior node-type output)]
           ((:fn beh) this output evaluation-context))
 
         true
-        (if (contains? (all-properties type) output)
+        (if (contains? (all-properties node-type) output)
           (get properties output)
           (when-some [node (gt/node-by-id-at basis original-id)]
             (gt/produce-value node output evaluation-context))))))
@@ -1633,5 +1625,5 @@
   (original [this] original-id)
   (set-original [this original-id] (assoc this :original-id original-id)))
 
-(defn make-override-node [override-id node-id original-id properties]
-  (->OverrideNode override-id node-id original-id properties))
+(defn make-override-node [override-id node-id node-type original-id properties]
+  (->OverrideNode override-id node-id node-type original-id properties))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -159,7 +159,7 @@
   [ctx node-id input-label]
   (if-let [nodes-affected (get-in ctx [:nodes-affected node-id] #{})]
     (let [basis (:basis ctx)
-          dirty-deps (-> (gt/node-by-id-at basis node-id) (gt/node-type basis) in/input-dependencies (get input-label))]
+          dirty-deps (-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies (get input-label))]
       (update ctx :nodes-affected assoc node-id (reduce conj nodes-affected dirty-deps)))
     ctx))
 
@@ -179,7 +179,7 @@
   [ctx node-id]
   (let [basis (:basis ctx)
         all-labels (-> (gt/node-by-id-at basis node-id)
-                       (gt/node-type basis)
+                       gt/node-type
                        in/output-labels)]
     (update ctx :nodes-affected assoc node-id (set all-labels))))
 
@@ -221,10 +221,9 @@
   (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-source (:basis ctx) source-id source-label)))
 
 (defn- disconnect-stale [ctx node-id old-node new-node labels-fn disconnect-fn]
-  (let [basis (:basis ctx)
-        stale-labels (set/difference
-                       (-> old-node (gt/node-type basis) labels-fn)
-                       (-> new-node (gt/node-type basis) labels-fn))]
+  (let [stale-labels (set/difference
+                       (-> old-node gt/node-type labels-fn)
+                       (-> new-node gt/node-type labels-fn))]
     (loop [ctx ctx
            labels stale-labels]
       (if-let [label (first labels)]
@@ -308,7 +307,13 @@
         graph-id (gt/node-id->graph-id root-id)
         node-ids (ig/pre-traverse basis [root-id] traverse-fn)
         override-id (next-override-id ctx graph-id)
-        override-nodes (mapv #(in/make-override-node override-id (next-node-id ctx graph-id) % (properties-by-node-id %)) node-ids)
+        override-nodes (mapv #(in/make-override-node
+                                override-id
+                                (next-node-id ctx graph-id)
+                                (gt/node-type (gt/node-by-id-at basis %))
+                                %
+                                (properties-by-node-id %))
+                             node-ids)
         override-node-ids (map gt/node-id override-nodes)
         original-node-id->override-node-id (zipmap node-ids override-node-ids)
         new-override-nodes-tx-data (map new-node override-nodes)
@@ -339,7 +344,12 @@
                 ctx
                 (let [graph-id (gt/node-id->graph-id node-id)
                       new-override-node-id (next-node-id ctx graph-id)
-                      new-override-node (in/make-override-node override-id new-override-node-id node-id {})]
+                      new-override-node (in/make-override-node
+                                          override-id
+                                          new-override-node-id
+                                          (gt/node-type (gt/node-by-id-at basis node-id))
+                                          node-id
+                                          {})]
                   (-> ctx
                       (ctx-add-node new-override-node)
                       (ctx-override-node node-id new-override-node-id))))))
@@ -429,8 +439,7 @@
 
 (defn- invoke-setter
   [ctx node-id node property old-value new-value override-node? dynamic?]
-  (let [basis (:basis ctx)
-        node-type (gt/node-type node basis)
+  (let [node-type (gt/node-type node)
         value-type (some-> (in/property-type node-type property) deref in/schema s/maybe)]
     (if-let [validation-error (and in/*check-schemas* value-type (s/check value-type new-value))]
       (do
@@ -458,7 +467,7 @@
   (let [node-id (gt/node-id node)
         override-node? (some? (gt/original node))]
     (loop [ctx ctx
-           props (seq (in/declared-property-labels (gt/node-type node (:basis ctx))))]
+           props (seq (in/declared-property-labels (gt/node-type node)))]
       (if-let [prop (first props)]
         (let [ctx (if-let [v (get node prop)]
                     (invoke-setter ctx node-id node prop nil v override-node? false)
@@ -489,14 +498,14 @@
             old-value (in/node-property-value* node property (in/custom-evaluation-context {:basis basis}))
             new-value (apply fn old-value args)
             override-node? (some? (gt/original node))
-            dynamic? (not (contains? (some-> (gt/node-type node basis) in/all-properties) property))]
+            dynamic? (not (contains? (some-> (gt/node-type node) in/all-properties) property))]
         (invoke-setter ctx node-id node property old-value new-value override-node? dynamic?))
       ctx)))
 
 (defn- ctx-set-property-to-nil [ctx node-id node property]
   (let [basis (:basis ctx)
         old-value (gt/get-property node basis property)
-        node-type (gt/node-type node basis)]
+        node-type (gt/node-type node)]
     (if-let [setter-fn (in/property-setter node-type property)]
       (apply-tx ctx (call-setter-fn ctx property setter-fn basis node-id old-value nil))
       ctx)))
@@ -504,7 +513,7 @@
 (defmethod perform :clear-property [ctx {:keys [node-id property]}]
   (let [basis (:basis ctx)]
     (if-let [node (gt/node-by-id-at basis node-id)] ; nil if node was deleted in this transaction
-      (let [dynamic? (not (contains? (some-> (gt/node-type node basis) in/all-properties) property))]
+      (let [dynamic? (not (contains? (some-> (gt/node-type node) in/all-properties) property))]
         (-> ctx
             (mark-outputs-activated node-id (cond-> (if dynamic? [property :_properties] [property])
                                               (and (gt/original node) (gt/property-overridden? node property)) (conj :_overridden-properties)))
@@ -517,22 +526,21 @@
   ctx)
 
 (defn- ctx-disconnect-single [ctx target target-id target-label]
-  (if (= :one (in/input-cardinality (gt/node-type target (:basis ctx)) target-label))
+  (if (= :one (in/input-cardinality (gt/node-type target) target-label))
     (disconnect-inputs ctx target-id target-label)
     ctx))
 
 (defn- ctx-add-overrides [ctx source-id source source-label target target-label]
-  (let [basis (:basis ctx)
-        target-id (gt/node-id target)]
-    (if ((in/cascade-deletes (gt/node-type target basis)) target-label)
+  (let [target-id (gt/node-id target)]
+    (if ((in/cascade-deletes (gt/node-type target)) target-label)
       (populate-overrides ctx target-id)
       ctx)))
 
 (defn- assert-type-compatible
-  [basis source-id source-node source-label target-id target-node target-label]
-  (let [output-nodetype (gt/node-type source-node basis)
+  [source-id source-node source-label target-id target-node target-label]
+  (let [output-nodetype (gt/node-type source-node)
         output-valtype (in/output-type output-nodetype source-label)
-        input-nodetype (gt/node-type target-node basis)
+        input-nodetype (gt/node-type target-node)
         input-valtype (in/input-type input-nodetype target-label)]
     (assert output-valtype
             (format "Attempting to connect %s (a %s) %s to %s (a %s) %s, but %s does not have an output or property named %s"
@@ -554,7 +562,7 @@
   (if-let [source (gt/node-by-id-at (:basis ctx) source-id)] ; nil if source node was deleted in this transaction
     (if-let [target (gt/node-by-id-at (:basis ctx) target-id)] ; nil if target node was deleted in this transaction
       (do
-        (assert-type-compatible (:basis ctx) source-id source source-label target-id target target-label)
+        (assert-type-compatible source-id source source-label target-id target target-label)
         (-> ctx
                                         ; If the input has :one cardinality, disconnect existing connections first
             (ctx-disconnect-single target target-id target-label)
@@ -572,7 +580,7 @@
 (defn- ctx-remove-overrides [ctx source-id source-label target-id target-label]
   (let [basis (:basis ctx)
         target (gt/node-by-id-at basis target-id)]
-    (if (contains? (in/cascade-deletes (gt/node-type target basis)) target-label)
+    (if (contains? (in/cascade-deletes (gt/node-type target)) target-label)
       (let [source-override-nodes (map (partial gt/node-by-id-at basis) (ig/get-overrides basis source-id))]
         (loop [target-override-node-ids (ig/get-overrides basis target-id)
                ctx ctx]

--- a/editor/test/dynamo/integration/override_test.clj
+++ b/editor/test/dynamo/integration/override_test.clj
@@ -37,7 +37,7 @@
   (property virt-property g/Str
             (value (g/fnk [a-property] a-property)))
   (property dyn-property g/Str
-            (dynamic override? (g/fnk [_node-id _basis] (some? (g/override-original _basis _node-id)))))
+            (dynamic override? (g/fnk [_this] (g/node-override? _this))))
   (input sub-nodes g/NodeID :array :cascade-delete)
   (output sub-nodes [g/NodeID] (g/fnk [sub-nodes] sub-nodes))
   (output cached-output g/Str :cached (g/fnk [a-property] a-property))

--- a/editor/test/integration/subselection_test.clj
+++ b/editor/test/integration/subselection_test.clj
@@ -48,21 +48,21 @@
 (defrecord Mesh [vertices]
   types/GeomCloud
   (types/geom-aabbs [this ids] (->> (iv/iv-filter-ids vertices ids)
-                                (iv/iv-mapv (fn [[id v]] [id [v v]]))
-                                (into {})))
+                                    (iv/iv-mapv (fn [[id v]] [id [v v]]))
+                                    (into {})))
   (types/geom-insert [this positions] (update this :vertices iv/iv-into positions))
   (types/geom-delete [this ids] (update this :vertices iv/iv-remove-ids ids))
   (types/geom-update [this ids f] (let [ids (set ids)]
-                             (assoc this :vertices (iv/iv-mapv (fn [entry]
-                                                                 (let [[id v] entry]
-                                                                   (if (ids id) [id (f v)] entry))) vertices))))
+                                    (assoc this :vertices (iv/iv-mapv (fn [entry]
+                                                                        (let [[id v] entry]
+                                                                          (if (ids id) [id (f v)] entry))) vertices))))
   (types/geom-transform [this ids transform]
     (let [p (Point3d.)]
       (types/geom-update this ids (fn [v]
-                             (let [[x y] v]
-                               (.set p x y 0.0)
-                               (.transform transform p)
-                               [(.getX p) (.getY p) 0.0]))))))
+                                    (let [[x y] v]
+                                      (.set p x y 0.0)
+                                      (.transform transform p)
+                                      [(.getX p) (.getY p) 0.0]))))))
 
 (defn ->mesh [vertices]
   (Mesh. (iv/iv-vec vertices)))
@@ -133,8 +133,8 @@
 
 (g/defnode MoveManip
   (input selection g/Any)
-  (output position g/Any (g/fnk [selection _basis]
-                                (let [evaluation-context (g/make-evaluation-context {:basis _basis})
+  (output position g/Any (g/fnk [selection]
+                                (let [evaluation-context (g/make-evaluation-context)
                                       positions (->> (for [[nid props] selection
                                                            [k ids] props]
                                                        (map (fn [[id aabb]] [id (centroid aabb)]) (-> (g/node-value nid k evaluation-context)

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -232,7 +232,7 @@
         (g/transact
           (concat
             (g/connect node-id :_node-id view :resource-node)
-            (g/connect node-id :valid-node-id+resource view :node-id+resource)
+            (g/connect node-id :valid-node-id+type+resource view :node-id+type+resource)
             (g/connect view :view-data app-view :open-views)
             (g/set-property app-view :active-view view)))
         (app-view/select! app-view [node-id])

--- a/editor/test/internal/copy_paste_test.clj
+++ b/editor/test/internal/copy_paste_test.clj
@@ -215,10 +215,10 @@
         (g/connect node3 :produces-value node2 :consumes-value)
         (g/connect node4 :produces-value node3 :discards-value)])
       [node3 (g/copy [node1] {:traverse? (comp stop-at-stoppers)
-                              :serializer (fn [basis node]
+                              :serializer (fn [node]
                                             (if (g/node-instance? StopperNode (g/node-id node))
                                               (serialize-stopper node)
-                                              (g/default-node-serializer basis node)))})]))
+                                              (g/default-node-serializer node)))})]))
 
 (deftest serialization-uses-predicates
   (ts/with-clean-system

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -828,8 +828,8 @@
       :_declared-properties)))
 
 #_(deftest overriding-outputs-dont-automatically-inherit-dependencies-of-corresponding-property
-  ;; TODO: This test fails. The error it suggests does not cause any serious problems - at worst, some output gets unnecessarily invalidated.
-  (is (not (affected-by? :overridden :input-three))))
+    ;; TODO: This test fails. The error it suggests does not cause any serious problems - at worst, some output gets unnecessarily invalidated.
+    (is (not (affected-by? :overridden :input-three))))
 
 (g/defnode CustomPropertiesOutput
   (output _properties g/Properties :cached
@@ -899,13 +899,13 @@
 (g/defnk produce-all [test :as all]
   all)
 
-(g/defnk produce-all-intrinsics [test _node-id _basis :as all]
+(g/defnk produce-all-intrinsics [test _node-id _this _type :as all]
   all)
 
 (g/defnode AsAllNode
   (property test g/Str (default "test"))
   (output inline g/Any (g/fnk [test :as all] all))
-  (output inline-intrinsics g/Any (g/fnk [test _node-id _basis :as all] all))
+  (output inline-intrinsics g/Any (g/fnk [test _node-id _this _type :as all] all))
   (output defnk g/Any produce-all)
   (output defnk-intrinsics g/Any produce-all-intrinsics))
 
@@ -913,6 +913,6 @@
   (with-clean-system
     (let [[n] (tx-nodes (g/make-node world AsAllNode))]
       (is (= {:test "test"} (g/node-value n :inline)))
-      (is (= #{:test :_node-id :_basis} (set (keys (g/node-value n :inline-intrinsics)))))
+      (is (= #{:test :_node-id :_this :_type} (set (keys (g/node-value n :inline-intrinsics)))))
       (is (= {:test "test"} (g/node-value n :defnk)))
-      (is (= #{:test :_node-id :_basis} (set (keys (g/node-value n :defnk-intrinsics))))))))
+      (is (= #{:test :_node-id :_this :_type} (set (keys (g/node-value n :defnk-intrinsics))))))))

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -899,13 +899,13 @@
 (g/defnk produce-all [test :as all]
   all)
 
-(g/defnk produce-all-intrinsics [test _node-id _this _type :as all]
+(g/defnk produce-all-intrinsics [test _node-id _this :as all]
   all)
 
 (g/defnode AsAllNode
   (property test g/Str (default "test"))
   (output inline g/Any (g/fnk [test :as all] all))
-  (output inline-intrinsics g/Any (g/fnk [test _node-id _this _type :as all] all))
+  (output inline-intrinsics g/Any (g/fnk [test _node-id _this :as all] all))
   (output defnk g/Any produce-all)
   (output defnk-intrinsics g/Any produce-all-intrinsics))
 
@@ -913,6 +913,6 @@
   (with-clean-system
     (let [[n] (tx-nodes (g/make-node world AsAllNode))]
       (is (= {:test "test"} (g/node-value n :inline)))
-      (is (= #{:test :_node-id :_this :_type} (set (keys (g/node-value n :inline-intrinsics)))))
+      (is (= #{:test :_node-id :_this} (set (keys (g/node-value n :inline-intrinsics)))))
       (is (= {:test "test"} (g/node-value n :defnk)))
-      (is (= #{:test :_node-id :_this :_type} (set (keys (g/node-value n :defnk-intrinsics))))))))
+      (is (= #{:test :_node-id :_this} (set (keys (g/node-value n :defnk-intrinsics))))))))


### PR DESCRIPTION
This commit is related to #5447. It removes basis from node output fnk's
arguments, which is a prerequisite for a different caching strategy that
will eventually solve the issue.