### PR TITLE
Fixed issue when using fixed update function and time scale 0

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2518,7 +2518,7 @@ namespace dmGameObject
             }
         }
 
-        if (update_context->m_FixedUpdateFrequency != 0)
+        if (update_context->m_FixedUpdateFrequency != 0 && update_context->m_TimeScale > 0.001f)
         {
             if (collection->m_FirstUpdate)
             {


### PR DESCRIPTION
This is a fix for a recently introduced issue when using a fixed update and the timestep of a collection proxy was set to 0.

Fixes #6566 