### PR TITLE
Move render-mode to graph

### DIFF
--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -248,7 +248,6 @@
                               :aabbs :picking-color
                               :picking-color :picking-rect
                               :picking-rect :normal})
-(def render-mode-atom (atom :normal))
 (def last-picking-rect (atom nil))
 (def render-mode-passes {:normal pass/render-passes
                          :aabbs pass/render-passes
@@ -269,9 +268,8 @@
           (map #(assoc % :render-fn render-aabb)))
         renderables))
 
-(defn render! [^GLContext context renderables updatable-states viewport pass->render-args]
+(defn render! [^GLContext context render-mode renderables updatable-states viewport pass->render-args]
   (let [^GL2 gl (.getGL context)
-        render-mode @render-mode-atom
         batch-key (render-mode-batch-key render-mode)]
     (gl/gl-clear gl 0.0 0.0 0.0 1)
     (.glColor4f gl 1.0 1.0 1.0 1.0)
@@ -787,6 +785,7 @@
   (property viewport Region (default (g/constantly (types/->Region 0 0 0 0))))
   (property active-updatable-ids g/Any)
   (property play-mode g/Keyword)
+  (property render-mode g/Keyword)
   (property drawable GLAutoDrawable)
   (property picking-drawable GLAutoDrawable)
   (property async-copy-state g/Any)
@@ -1129,6 +1128,7 @@
 (defn update-image-view! [^ImageView image-view ^GLAutoDrawable drawable async-copy-state-atom evaluation-context]
   (when-let [view-id (ui/user-data image-view ::view-id)]
     (let [action-queue (g/node-value view-id :input-action-queue evaluation-context)
+          render-mode (g/node-value view-id :render-mode evaluation-context)
           tool-user-data (g/node-value view-id :selected-tool-renderables evaluation-context) ; TODO: for what actions do we need selected tool renderables?
           play-mode (g/node-value view-id :play-mode evaluation-context)
           active-updatables (g/node-value view-id :active-updatables evaluation-context)
@@ -1161,7 +1161,7 @@
             (let [renderables (g/node-value view-id :all-renderables evaluation-context)
                   viewport (g/node-value view-id :viewport evaluation-context)
                   pass->render-args (g/node-value view-id :pass->render-args evaluation-context)]
-              (render! gl-context renderables new-updatable-states viewport pass->render-args)
+              (render! gl-context render-mode renderables new-updatable-states viewport pass->render-args)
               (ui/user-data! image-view ::last-renderables-invalidate-counter renderables-invalidate-counter)
               (ui/user-data! image-view ::last-frame-version frame-version)
               (scene-cache/prune-context! gl)
@@ -1312,12 +1312,13 @@
                                           (let [key-event ^KeyEvent event]
                                             (when (and (.isShortcutDown key-event)
                                                        (= "t" (.getText key-event)))
-                                              (swap! render-mode-atom render-mode-transitions)
-                                              (g/invalidate-outputs! [[view-id :all-renderables]]))))))
+                                              (g/update-property! view-id :render-mode render-mode-transitions))))))
     scene-view-pane))
 
 (defn- make-scene-view [scene-graph ^Parent parent opts]
-  (let [view-id (g/make-node! scene-graph SceneView :updatable-states {})
+  (let [view-id (g/make-node! scene-graph SceneView
+                              :updatable-states {}
+                              :render-mode :normal)
         scene-view-pane (make-scene-view-pane view-id opts)]
     (ui/children! parent [scene-view-pane])
     (ui/with-controls scene-view-pane [scene-view-info-label]
@@ -1327,7 +1328,7 @@
 (g/defnk produce-frame [all-renderables ^Region viewport pass->render-args ^GLAutoDrawable drawable]
   (when drawable
     (gl/with-drawable-as-current drawable
-      (render! gl-context all-renderables nil viewport pass->render-args)
+      (render! gl-context :normal all-renderables nil viewport pass->render-args)
       (let [[w h] (vp-dims viewport)
             buf-image (read-to-buffered-image w h)]
         (scene-cache/prune-context! gl)


### PR DESCRIPTION
This commit is related to #5447: we want to move away from using
explicit cache invalidation so we can eventualy change caching
implementation.

Note: changing render-mode is a dev-time only feature