### PR TITLE
Tests for the gui.cancel_animation function incorrectly return a correct test result

### DIFF
--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -792,7 +792,7 @@ TEST_F(dmGuiScriptTest, TestCancelAnimation)
         params.m_UserData = this;
         //params.m_RigContext = m_RigContext;
         dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
-    	dmGui::SetSceneResolution(scene, 1, 1);
+        dmGui::SetSceneResolution(scene, 1, 1);
         dmGui::SetSceneScript(scene, script);
 
         // Set position
@@ -860,7 +860,7 @@ TEST_F(dmGuiScriptTest, TestCancelAnimationComponent)
         params.m_UserData = this;
         //params.m_RigContext = m_RigContext;
         dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
-    	dmGui::SetSceneResolution(scene, 1, 1);
+        dmGui::SetSceneResolution(scene, 1, 1);
         dmGui::SetSceneScript(scene, script);
 
         // Set position

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -792,6 +792,7 @@ TEST_F(dmGuiScriptTest, TestCancelAnimation)
         params.m_UserData = this;
         //params.m_RigContext = m_RigContext;
         dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    	dmGui::SetSceneResolution(scene, 1, 1);
         dmGui::SetSceneScript(scene, script);
 
         // Set position
@@ -859,6 +860,7 @@ TEST_F(dmGuiScriptTest, TestCancelAnimationComponent)
         params.m_UserData = this;
         //params.m_RigContext = m_RigContext;
         dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    	dmGui::SetSceneResolution(scene, 1, 1);
         dmGui::SetSceneScript(scene, script);
 
         // Set position


### PR DESCRIPTION
In tests for gui.cancel_animation function, the transformation matrix contains invalid values (nan).

The following two functions are affected in the "engine/gui/src/test/test_gui_script.cpp" file:
- TestCancelAnimation
- TestCancelAnimationComponent

In both test functions, the SetSceneResolution function call is missing after Scene is created. As a result, after the RenderScene function is executed, the passed transformation matrix contains invalid values. Because of this, the test functions incorrectly returns a correct test result.