### PR TITLE
Sign App Extensions when bundling for iOS

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -514,11 +514,33 @@ public class IOSBundler implements IBundler {
 
                     Process process = processBuilder.start();
                     logProcess(process);
-
                 }
             } else {
                 System.out.printf("No ./Framework folder to sign\n");
             }
+
+            // Sign any .appex files in the PlugIns folder
+            File pluginsDir = new File(appDir, "PlugIns");
+            if (pluginsDir.exists()) {
+                logger.log(Level.INFO, "Signing ./PlugIns folder");
+                for (File file : pluginsDir.listFiles()) {
+
+                    BundleHelper.throwIfCanceled(canceled);
+
+                    if (!file.getName().endsWith(".appex")) {
+                        continue;
+                    }
+
+                    ProcessBuilder processBuilder = new ProcessBuilder("codesign", "-f", "-s", identity, file.getAbsolutePath());
+                    processBuilder.environment().put("CODESIGN_ALLOCATE", Bob.getExe(Platform.getHostPlatform(), "codesign_allocate"));
+
+                    Process process = processBuilder.start();
+                    logProcess(process);
+                }
+            } else {
+                System.out.printf("No ./PlugIns folder to sign\n");
+            }
+
 
             BundleHelper.throwIfCanceled(canceled);
             ProcessBuilder processBuilder = new ProcessBuilder("codesign",


### PR DESCRIPTION
An App Extension lets you extend custom functionality and content beyond your app and make it available to users while they’re interacting with other apps or the system. Examples are app specific stickers in iMessage or extensions to the sharing dialog.

App Extensions must be included in the PlugIns folder and they must be signed. It is easy to include extensions in a `PlugIns` folder by adding the `PlugIns` folder as a [bundle resource](https://defold.com/manuals/project-settings/#bundle-resources) to be included in the application bundle.

This change automatically signs any files in `PlugIns` with the `.appex` file extension when the application is bundled.

Fixes #6488 