### PR TITLE
Issue 6602: Fix for looping out of bounds when generating render batches

### DIFF
--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -325,11 +325,12 @@ namespace dmRender
         T prev = m_Iterator;
         while (m_Iterator < m_EntriesEnd)
         {
-            if (!m_TestEqFn(prev, ++m_Iterator))
+            T next = ++m_Iterator;
+            if ((next >= m_EntriesEnd) || !m_TestEqFn(prev, next))
             {
                 break;
             }
-            prev = m_Iterator;
+            prev = next;
         }
 
         return m_BatchStart < m_EntriesEnd;

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -1026,6 +1026,34 @@ dmHashEnableReverseHash(true);
     dmRender::DeleteNamedConstantBuffer(buffer);
 }
 
+static bool BatchEntryTestEq(int* a, int* b)
+{
+    return *a == *b;
+}
+
+TEST(Render, BatchIterator)
+{
+    int array1[] = {1, 1, 1, 2, 2, 5, 5, 5, 5};
+    dmRender::BatchIterator<int*> iterator1(DM_ARRAY_SIZE(array1), array1, BatchEntryTestEq);
+
+    ASSERT_TRUE(iterator1.Next());
+    ASSERT_EQ(3U, iterator1.Length());
+    ASSERT_EQ(array1+0, iterator1.Begin());
+    ASSERT_EQ(1U, *iterator1.Begin());
+
+    ASSERT_TRUE(iterator1.Next());
+    ASSERT_EQ(2U, iterator1.Length());
+    ASSERT_EQ(array1+3, iterator1.Begin());
+    ASSERT_EQ(2U, *iterator1.Begin());
+
+    ASSERT_TRUE(iterator1.Next());
+    ASSERT_EQ(4U, iterator1.Length());
+    ASSERT_EQ(array1+5, iterator1.Begin());
+    ASSERT_EQ(5U, *iterator1.Begin());
+
+    ASSERT_FALSE(iterator1.Next());
+}
+
 int main(int argc, char **argv)
 {
     jc_test_init(&argc, argv);

--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -244,7 +244,8 @@ namespace dmScript
             float wrapped_count = ((-timer->m_Remaining) / timer->m_Delay) + 1.f;
             float offset_to_next_trigger  = floor(wrapped_count) * timer->m_Delay;
             timer->m_Remaining += offset_to_next_trigger;
-            assert(timer->m_Remaining >= 0.f);
+            if (timer->m_Remaining < 0) // If the delay is very small, the floating point precision might produce issues
+                timer->m_Remaining = timer->m_Delay; // reset the timer
         }
 
         timer_world->m_InUpdate = 0;


### PR DESCRIPTION
Fixes a crash when generating render batches.

Fixes #6602 