### PR TITLE
Read `game.properties` and `ext.properties` as metadata for `game.project`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
@@ -56,8 +56,9 @@ public class BundleHelperTest {
 
     void testValue(String p, String c, String k, Object expected) throws IOException, ParseException {
         BobProjectProperties properties = new BobProjectProperties();
+        properties.loadDefaultMetaFile();
         properties.load(new ByteArrayInputStream(p.getBytes()));
-        Map<String, Map<String, Object>> map = BundleHelper.createPropertiesMap(properties);
+        Map<String, Map<String, Object>> map = properties.createTypedMap(new BobProjectProperties.PropertyType[]{BobProjectProperties.PropertyType.BOOL});
 
         Object actual = map.get(c).get(k);
         assertEquals(expected, actual);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundleHelperTest.java
@@ -37,7 +37,6 @@ import com.dynamo.bob.bundle.BundleHelper.ResourceInfo;
 import com.dynamo.bob.fs.ClassLoaderMountPoint;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.ExtenderUtil;
-import com.dynamo.bob.util.BobProjectProperties;
 
 public class BundleHelperTest {
 
@@ -52,24 +51,6 @@ public class BundleHelperTest {
     @After
     public void tearDown() throws Exception {
         this.mp.unmount();
-    }
-
-    void testValue(String p, String c, String k, Object expected) throws IOException, ParseException {
-        BobProjectProperties properties = new BobProjectProperties();
-        properties.loadDefaultMetaFile();
-        properties.load(new ByteArrayInputStream(p.getBytes()));
-        Map<String, Map<String, Object>> map = properties.createTypedMap(new BobProjectProperties.PropertyType[]{BobProjectProperties.PropertyType.BOOL});
-
-        Object actual = map.get(c).get(k);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testProperties() throws IOException, ParseException {
-        testValue("[project]\nwrite_log=0", "project", "write_log", false);
-        testValue("[project]\nwrite_log=1", "project", "write_log", true);
-        testValue("", "project", "write_log", false);
-        testValue("", "project", "title", "unnamed");
     }
 
     // Thx, Java

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -58,15 +58,23 @@ public class BobProjectPropertiesTest {
     }
 
     @Test
-    public void testProperties() throws IOException, ParseException {
-        testValue("", "project", "title", "unnamed");
-    }
-
-    @Test
     public void testTypedProperties() throws IOException, ParseException {
         testValue("[project]\nwrite_log=0", "project", "write_log", false);
         testValue("[project]\nwrite_log=1", "project", "write_log", true);
         testValue("", "project", "write_log", false);
+        testValue("", "project", "title", "unnamed");
+    }
+
+    @Test
+    public void testProperties() throws IOException, ParseException {
+        BobProjectProperties properties = createProperties();
+
+        assertEquals(false, properties.getBooleanValue("html5", "doesn't_exist", false));
+        assertEquals(new Integer(834), properties.getIntValue("html5", "doesn't_exist", 834));
+
+        assertEquals(false, properties.getBooleanValue("display", "fullscreen"));
+        assertEquals(true, properties.getBooleanValue("sound", "use_thread"));
+        assertEquals(new Integer(960), properties.getIntValue("display", "width"));
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -1,0 +1,88 @@
+// Copyright 2020-2022 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+// 
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
+import com.dynamo.bob.util.BobProjectProperties;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BobProjectPropertiesTest {
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    BobProjectProperties createProperties() throws IOException, ParseException {
+        BobProjectProperties properties = new BobProjectProperties();
+        properties.loadDefaultMetaFile();
+        return properties;
+    }
+
+    void load(BobProjectProperties properties, String load) throws IOException, ParseException {
+        properties.load(new ByteArrayInputStream(load.getBytes()));
+    }
+
+    void testValue(String p, String c, String k, Object expected) throws IOException, ParseException {
+        BobProjectProperties properties = createProperties();
+        load(properties, p);
+        Map<String, Map<String, Object>> map = properties.createTypedMap(new BobProjectProperties.PropertyType[]{BobProjectProperties.PropertyType.BOOL});
+
+        Object actual = map.get(c).get(k);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testProperties() throws IOException, ParseException {
+        testValue("", "project", "title", "unnamed");
+    }
+
+    @Test
+    public void testTypedProperties() throws IOException, ParseException {
+        testValue("[project]\nwrite_log=0", "project", "write_log", false);
+        testValue("[project]\nwrite_log=1", "project", "write_log", true);
+        testValue("", "project", "write_log", false);
+    }
+
+    @Test
+    public void testPropertiesOverride() throws IOException, ParseException {
+        BobProjectProperties properties = createProperties();
+        String main = "[project]\ntitle = Title one\ncustom_string_list#0 = http://test.com/test.zip\ncustom_string_list#2 = http://test.com/test2.zip\ncustom_string_list#1 = http://test.com/test1.zip\n";
+        String override = "[project]\ntitle = Title two\ncustom_string_list=http://test.com/new.zip,http://test.com/new1.zip";
+        load(properties, main);
+        load(properties, override);
+
+        assertEquals("Title two", properties.getStringValue("project", "title"));
+        assertEquals("http://test.com/new.zip,http://test.com/new1.zip", properties.getStringValue("project", "custom_string_list"));
+
+        String[] array = properties.getStringArrayValue("project", "custom_string_list");
+        assertEquals(2, array.length);
+        assertEquals("http://test.com/new.zip", array[0]);
+        assertEquals("http://test.com/new1.zip", array[1]);
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
@@ -466,17 +466,4 @@ public class JBobTest {
         assertThat(result.size(), is(1));
         assertTrue(result.get(0).isOk());
     }
-
-    @Test
-    public void testUrlParsing() throws Exception {
-        List<URL> urls = LibraryUtil.parseLibraryUrls(" http://localhost ,http://localhost,,");
-        assertThat(urls.size(), is(2));
-        assertTrue(urls.get(0).toString().equals("http://localhost"));
-        assertTrue(urls.get(1).toString().equals("http://localhost"));
-    }
-
-    @Test(expected=LibraryException.class)
-    public void testUrlParsingInvalid() throws Exception {
-        LibraryUtil.parseLibraryUrls(" http://localhost ,http://localhost,,httpinvalid");
-    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -191,6 +191,9 @@ public class ProjectBuildTest {
 
     @Test
     public void testStringArray() throws IOException, ConfigurationException, CompileExceptionError, MultipleCompileException, ParseException {
+       /* This test helps to make sure that any array of strings that uses # for indices may be parsed,
+        * build into a comma separated string and then be parsed again in the same order.
+        */
         projectName = "String Array";
         createDefaultFiles();
         createFile(contentRoot, "game.project", "[project]\ntitle = " + projectName +

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -202,6 +202,20 @@ public class ProjectBuildTest {
         checkProjectSettingArray(outputProps, "project", "custom_string_list", new String[]{"http://test.com/test.zip", "http://test.com/test1.zip", "http://test.com/test2.zip"});
     }
 
+    @Test
+    public void testGameProjectMetaProperties() throws IOException, ConfigurationException, CompileExceptionError, MultipleCompileException, ParseException {
+        projectName = "String Array";
+        createDefaultFiles();
+        createFile(contentRoot, "game.project", "[project]\ntitle = " + projectName +
+            "\ncustom_property = just content");
+        createFile(contentRoot, BobProjectProperties.PROPERTIES_PROJECT_FILE, "[project]\ncustom_property.private = 1\n");
+        build();
+        BobProjectProperties outputProps = new BobProjectProperties();
+        outputProps.load(new FileInputStream(new File(contentRoot + "/build/game.projectc")));
+
+        checkProjectSetting(outputProps, "project", "custom_property", null);
+    }
+
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
         file.deleteOnExit();

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -189,6 +189,19 @@ public class ProjectBuildTest {
         checkProjectSettingArray(outputProps, "custom", "list2", new String[]{"a", "b", "c"});
     }
 
+    @Test
+    public void testStringArray() throws IOException, ConfigurationException, CompileExceptionError, MultipleCompileException, ParseException {
+        projectName = "String Array";
+        createDefaultFiles();
+        createFile(contentRoot, "game.project", "[project]\ntitle = " + projectName +
+            "\ncustom_string_list#0 = http://test.com/test.zip\ncustom_string_list#2 = http://test.com/test2.zip\ncustom_string_list#1 = http://test.com/test1.zip\n");
+        build();
+        BobProjectProperties outputProps = new BobProjectProperties();
+        outputProps.load(new FileInputStream(new File(contentRoot + "/build/game.projectc")));
+
+        checkProjectSettingArray(outputProps, "project", "custom_string_list", new String[]{"http://test.com/test.zip", "http://test.com/test1.zip", "http://test.com/test2.zip"});
+    }
+
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
         file.deleteOnExit();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -541,9 +541,12 @@ public class Bob {
 
     private static void setupProject(Project project, boolean resolveLibraries, String sourceDirectory) throws IOException, LibraryException, CompileExceptionError {
         BobProjectProperties projectProperties = project.getProjectProperties();
-        String dependencies = projectProperties.getStringValue("project", "dependencies", "");
+        String[] dependencies = projectProperties.getStringArrayValue("project", "dependencies");
+        List<URL> libUrls = new ArrayList<>();
+        for (String val : dependencies) {
+            libUrls.add(new URL(val));
+        }
 
-        List<URL> libUrls = LibraryUtil.parseLibraryUrls(dependencies);
         project.setLibUrls(libUrls);
         if (resolveLibraries) {
             TimeProfiler.start("Resolve libs");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -549,17 +549,17 @@ public class Project {
 
     // Loads the properties from a game project settings file
     // Also adds any properties specified with the "--settings" flag
-    public static BobProjectProperties loadProperties(IResource resource, List<String> settingsFiles) throws IOException {
-        if (!resource.exists()) {
-            throw new IOException(String.format("Project file not found: %s", resource.getAbsPath()));
+    public static BobProjectProperties loadProperties(IResource projectFile, List<String> settingsFiles) throws IOException {
+        if (!projectFile.exists()) {
+            throw new IOException(String.format("Project file not found: %s", projectFile.getAbsPath()));
         }
 
         BobProjectProperties properties = new BobProjectProperties();
         try {
             properties.loadDefaults();
-            Project.loadPropertyFile(properties, resource.getAbsPath());
+            Project.loadPropertyFile(properties, projectFile.getAbsPath());
         } catch(ParseException e) {
-            throw new IOException("Could not parse: " + resource.getAbsPath());
+            throw new IOException("Could not parse: " + projectFile.getAbsPath());
         }
 
         for (String filepath : settingsFiles) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -534,7 +534,7 @@ public class Project {
         projectProperties = new BobProjectProperties();
     }
 
-    public static void loadPropertyFile(BobProjectProperties properties, String filepath) throws IOException {
+    private static void loadPropertyFile(BobProjectProperties properties, String filepath) throws IOException {
         Path pathHandle = Paths.get(filepath);
         if (!Files.exists(pathHandle) || !pathHandle.toFile().isFile())
             throw new IOException(filepath + " is not a file");
@@ -556,7 +556,7 @@ public class Project {
 
         BobProjectProperties properties = new BobProjectProperties();
         try {
-            properties.loadDefaults();
+            properties.loadDefaultMetaFile();
             Project.loadPropertyFile(properties, projectFile.getAbsPath());
         } catch(ParseException e) {
             throw new IOException("Could not parse: " + projectFile.getAbsPath());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -534,14 +534,14 @@ public class Project {
         projectProperties = new BobProjectProperties();
     }
 
-    private static void loadPropertyFile(BobProjectProperties properties, String filepath) throws IOException {
+    private static void loadPropertyFile(BobProjectProperties properties, String filepath, Boolean isMeta) throws IOException {
         Path pathHandle = Paths.get(filepath);
         if (!Files.exists(pathHandle) || !pathHandle.toFile().isFile())
             throw new IOException(filepath + " is not a file");
         byte[] data = Files.readAllBytes(pathHandle);
         ByteArrayInputStream is = new ByteArrayInputStream(data);
         try {
-            properties.load(is);
+            properties.load(is, isMeta);
         } catch(ParseException e) {
             throw new IOException("Could not parse: " + filepath);
         }
@@ -549,21 +549,38 @@ public class Project {
 
     // Loads the properties from a game project settings file
     // Also adds any properties specified with the "--settings" flag
-    public static BobProjectProperties loadProperties(IResource projectFile, List<String> settingsFiles) throws IOException {
+    public static BobProjectProperties loadProperties(Project project, IResource projectFile, List<String> settingsFiles) throws IOException {
         if (!projectFile.exists()) {
             throw new IOException(String.format("Project file not found: %s", projectFile.getAbsPath()));
         }
 
         BobProjectProperties properties = new BobProjectProperties();
         try {
+            // load meta.properties embeded in bob.jar
             properties.loadDefaultMetaFile();
-            Project.loadPropertyFile(properties, projectFile.getAbsPath());
+            // load property files from extensions
+            List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);
+            if (!extensionFolders.isEmpty()) {
+                for (String extension : extensionFolders) {
+                    IResource resource = project.getResource(extension + "/" + BobProjectProperties.PROPERTIES_EXTENSION_FILE);
+                    if (resource.exists()) {
+                        loadPropertyFile(properties, resource.getAbsPath(), true);
+                    }
+                }
+            }
+            // load property file from the project
+            IResource gameProjectProperties = projectFile.getResource(BobProjectProperties.PROPERTIES_PROJECT_FILE);
+            if (gameProjectProperties.exists()) {
+               loadPropertyFile(properties, gameProjectProperties.getAbsPath(), true);
+            }
+            // load game.project file
+            Project.loadPropertyFile(properties, projectFile.getAbsPath(), false);
         } catch(ParseException e) {
             throw new IOException("Could not parse: " + projectFile.getAbsPath());
         }
-
+        // load settings file specified in `--settings` for bob.jar
         for (String filepath : settingsFiles) {
-            Project.loadPropertyFile(properties, filepath);
+            Project.loadPropertyFile(properties, filepath, false);
         }
 
         return properties;
@@ -572,7 +589,7 @@ public class Project {
     public void loadProjectFile() throws IOException {
         IResource gameProject = getGameProjectResource();
         if (gameProject.exists()) {
-            projectProperties = Project.loadProperties(gameProject, this.getPropertyFiles());
+            projectProperties = Project.loadProperties(this, gameProject, this.getPropertyFiles());
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
@@ -78,10 +78,6 @@ public class LinuxBundler implements IBundler {
         FileUtils.deleteDirectory(appDir);
         appDir.mkdirs();
 
-        // In order to make a transition period, while phasing out 32 bit Darwin/Linux support completely, we will only support 64 bit for extensions
-        final List<String> extensionFolders = ExtenderUtil.getExtensionFolders(project);
-        final boolean hasExtensions = !extensionFolders.isEmpty();
-
         BundleHelper.throwIfCanceled(canceled);
 
         bundleApplicationForPlatform(platform, project, appDir, exeName);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -1,29 +1,40 @@
 [project]
 help = General project settings
+
 title.type = string
 title.help = the title of the application
 title.default = unnamed
+
 version.type = string
 version.help = application version
 version.default = 1.0
+
 write_log.type = bool
 write_log.help = Write log file to disk
 write_log.default = 0
+
 compress_archive.type = bool
 compress_archive.help = Compress archive (not for Android)
 compress_archive.default = 1
-dependencies.type = string
+
+dependencies.type = string_array
 dependencies.help = projects required by this projectx
+dependencies.private = 1
+
 publisher.type = string
 publisher.help = The publisher name
 publisher.default = unnamed
+
 developer.type = string
 developer.help = The developer name
 developer.default = unnamed
+
 custom_resources.help = A comma separated list of resources that will be included in the project. If directories are specified, all files and directories in that directory are recursively included
 custom_resources.type = string
+
 bundle_exclude_resources.help = A comma separated list of resources that should not be included in the bundle
 bundle_exclude_resources.type = string
+
 bundle_resources.type = string
 bundle_resources.help = A directory containing resource files and folders that should be copied as-is into the resulting package when bundling
 
@@ -606,7 +617,7 @@ auto_finish_transactions.default = 1
 
 [network]
 help = Network related settings
-http_timeout.type = float
+http_timeout.type = number
 http_timeout.help = http timeout in seconds. zero to disable timeout
 http_timeout.default = 0
 ssl_certificates.type = resource

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -501,8 +501,7 @@ public class GameProjectBuilder extends Builder<Void> {
     // Used to transform an input game.project properties map to a game.projectc representation.
     // Can be used for doing build time properties conversion.
     static public void transformGameProjectFile(BobProjectProperties properties) throws IOException {
-        // Remove project dependencies list for security.
-        properties.remove("project", "dependencies");
+        properties.removePrivateFields();
 
         // Map deprecated 'variable_dt' to new settings resulting in same runtime behavior
         Boolean variableDt = properties.getBooleanValue("display", "variable_dt");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -526,7 +526,7 @@ public class GameProjectBuilder extends Builder<Void> {
 
         IResource input = task.input(0);
 
-        BobProjectProperties properties = Project.loadProperties(input, project.getPropertyFiles());
+        BobProjectProperties properties = Project.loadProperties(project, input, project.getPropertyFiles());
 
         try {
             if (project.option("archive", "false").equals("true")) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -337,9 +337,9 @@ public class BobProjectProperties {
     public String getStringValue(String category, String key, String defaultValue) {
         ProjectProperty val = getValue(category, key);
         if (val != null) {
-            String value = val.getValue();
-            if (value != null) {
-                return value;
+            String result = val.getValue();
+            if (result != null) {
+                return result;
             }
         }
         return defaultValue;
@@ -368,7 +368,10 @@ public class BobProjectProperties {
     public Boolean getBooleanValue(String category, String key, Boolean defaultValue) {
         ProjectProperty val = getValue(category, key);
         if (val != null) {
-            return (Boolean)val.getTypedValue(BobProjectProperties.PropertyType.BOOL);
+            Boolean result = (Boolean)val.getTypedValue(BobProjectProperties.PropertyType.BOOL);
+            if (result != null) {
+                return result;
+            }
         }
         return defaultValue;
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -69,6 +69,7 @@ public class BobProjectProperties {
         private String defaultValue;
         PropertyType type;
         private Boolean isPrivate;
+
         private Map<Integer, String> valuesArray;
 
         public ProjectProperty() {
@@ -144,6 +145,10 @@ public class BobProjectProperties {
                     Object v = f.get(prop);
                     if ((v != null) && (t.isEnum() || t.equals(String.class) || t.equals(Boolean.class))) {
                         f.set(this, v);
+                        if (f.getName() == "value") {
+                            // it's important to reset old parsed values from value Array in value overwritten
+                            valuesArray = null;
+                        }
                     }
                 }
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -45,6 +45,9 @@ import com.dynamo.bob.Bob;
  */
 public class BobProjectProperties {
 
+    public final static String PROPERTIES_PROJECT_FILE = "game.properties";
+    public final static String PROPERTIES_EXTENSION_FILE = "ext.properties";
+
     public enum PropertyType {
         BOOL("bool"),
         STRING("string"),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -417,10 +417,24 @@ public class BobProjectProperties {
      * @param key category key
      * @return return true if default value;
      */
-    public boolean isDefault(String category, String key) {
+    public Boolean isDefault(String category, String key) {
         Map<String, ProjectProperty> group = this.properties.get(category);
         if (group != null && group.containsKey(key)) {
             return group.get(key).isDefault();
+        }
+        return false;
+    }
+
+    /**
+     * Check if value is private
+     * @param category property category
+     * @param key category key
+     * @return return true if private value;
+     */
+    public Boolean isPrivate(String category, String key) {
+        Map<String, ProjectProperty> group = this.properties.get(category);
+        if (group != null && group.containsKey(key)) {
+            return group.get(key).isPrivate();
         }
         return false;
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -25,34 +25,280 @@ import java.text.ParseException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.lang.reflect.Field;
+import java.lang.IllegalArgumentException;
+import java.lang.IllegalAccessException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.io.IOUtils;
 import com.dynamo.bob.Bob;
 
 /**
  * .ini-file-link parser abstraction
- * @note Copy-paste of ProjectProperties in order to avoid adding bob as a dependency to most plugins
- * @author chmu
  *
  */
 public class BobProjectProperties {
-    private Map<String, Map<String, String>> properties;
 
-    // A way to store what properties are the defaults
-    // and also not overridden by the properties member.
-    private Map<String, Map<String, String>> defaults;
+    public enum PropertyType {
+        BOOL("bool"),
+        STRING("string"),
+        NUMBER("number"),
+        INTEGER("integer"),
+        STRING_ARRAY("string_array"),
+        RESOURCE("resource");
+
+        private String type;
+
+        PropertyType(String propType) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return this.type;
+        }
+    }
+
+    private class ProjectProperty {
+        private String value;
+        private String defaultValue;
+        PropertyType type;
+        private Boolean isPrivate;
+        private Map<Integer, String> valuesArray;
+
+        public ProjectProperty() {
+        }
+
+        public void setAttribute(String key, String value) {
+            if (key == null || key.isEmpty() || value == null) {
+                return;
+            }
+            switch(key) {
+                case "value":
+                    this.value = value;
+                    break;
+                case "type":
+                    this.type = PropertyType.valueOf(value.toUpperCase());
+                    break;
+                case "default":
+                    this.defaultValue = value;
+                    break;
+                case "help":
+                    // no need in bob
+                    break;
+                case "private":
+                    this.isPrivate = value.equals("1");
+                    break;
+            }
+        }
+
+        public Object getTypedValue(PropertyType type) {
+            try {
+                String val = getValue();
+                Object result = null;
+                if (val == null) {
+                    return null;
+                }
+                switch(type) {
+                    case STRING:
+                    case RESOURCE:
+                        result = val;
+                        break;
+                    case INTEGER:
+                        result = Integer.parseInt(val);
+                        break;
+                    case NUMBER:
+                        result = Float.parseFloat(val);
+                        break;
+                    case BOOL:
+                        result = val.equals("1");
+                        break;
+                    case STRING_ARRAY:
+                        if (this.valuesArray == null) {
+                            parseValueAsValuesArray();
+                        }
+                        result = this.valuesArray;
+                        break;
+                }
+                return result;
+
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to get typed value for property", e);
+            }
+        }
+
+        public Object getTypedValue() {
+            return getTypedValue(this.type);
+        }
+
+        public void overrideBy(ProjectProperty prop) {
+            try {
+                Field[] fields = ProjectProperty.class.getDeclaredFields();
+                for(Field f : fields) {
+                    Class t = f.getType();
+                    Object v = f.get(prop);
+                    if ((v != null) && (t.isEnum() || t.equals(String.class) || t.equals(Boolean.class))) {
+                        f.set(this, v);
+                    }
+                }
+            }
+            catch (IllegalArgumentException e) {
+                throw new RuntimeException("Can't override field ", e);
+            }
+            catch (IllegalAccessException e) {
+                throw new RuntimeException("Can't access field ", e);
+            }
+        }
+
+        public String getValue() {
+            return this.value != null ? this.value : this.defaultValue;
+        }
+        
+        public PropertyType getType() {
+            return this.type;
+        }
+
+        public void addArrayValue(String index, String value) {
+            if (this.valuesArray == null) {
+                this.valuesArray = new TreeMap<Integer, String>();
+            }
+            if (index == null || index.isEmpty() || value == null) {
+                return;
+            }
+            try {
+                int indexNum = Integer.parseInt(index);
+                this.valuesArray.put(indexNum, value);
+                this.value = this.valuesArray.values().stream().collect(Collectors.joining(","));
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Can't add element from array property", e);
+            }
+
+        }
+
+        public boolean isDefault() {
+            return this.value == null && this.defaultValue != null;
+        }
+
+        public Boolean isPrivate() {
+            return this.isPrivate == null ? false : this.isPrivate;
+        }
+
+        // parse string as comma separater list of strings
+        private void parseValueAsValuesArray() {
+            String[] values = this.value.trim().split(",");
+            Map<Integer, String> outValues = new TreeMap<Integer, String>();
+            int counter = 0;
+            for (String v : values) {
+                v = v.trim();
+                if (v.length() > 0) {
+                    outValues.put(counter, v);
+                    counter++;
+                }
+            }
+            this.valuesArray = outValues;
+        }
+
+    }
+
+    private Map<String, Map<String, ProjectProperty>> properties;
 
     /**
      * Constructor with initially empty
      */
     public BobProjectProperties() {
-        this.properties = new LinkedHashMap<String, Map<String, String>>();
-        this.defaults = new LinkedHashMap<String, Map<String, String>>();
+        this.properties = new LinkedHashMap<String, Map<String, ProjectProperty>>();
+    }
+
+    public Map<String, Map<String, Object>> createTypedMap(PropertyType[] types) {
+        Map<String, Map<String, Object>> result = new HashMap<String, Map<String, Object>>();
+        for (String categoryName : properties.keySet()) {
+            Map<String, Object> resultCategory = new HashMap<String, Object>();
+            result.put(categoryName, resultCategory);
+            Map<String, ProjectProperty> category = properties.get(categoryName);
+            for (String key : category.keySet()) {
+                ProjectProperty prop = category.get(key);
+                if (ArrayUtils.contains(types, prop.getType())) {
+                    resultCategory.put(key, prop.getTypedValue());
+                }
+                else {
+                    resultCategory.put(key, prop.getValue());
+                }
+                
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Load properties in-place from {@link InputStream}
+     * @param in {@link InputStream} to load from
+     * @throws IOException
+     * @throws ParseException
+     */
+    public void load(InputStream in) throws IOException, ParseException {
+        try {
+            Map<String, Map<String, ProjectProperty>> props = doLoad(in);
+            // merge into properties
+            BobProjectProperties.mergeProperties(properties, props);
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+    }
+
+    /**
+     * Load default properties from the internal meta.properties file
+     * @throws IOException
+     * @throws ParseException
+     */
+    public void loadDefaultMetaFile()  throws IOException, ParseException {
+        InputStream is = Bob.class.getResourceAsStream("meta.properties");
+        try {
+            load(is);
+        } catch (ParseException e) {
+            throw new RuntimeException("Failed to parse meta.properties", e);
+        } finally {
+            IOUtils.closeQuietly(is);
+        }
+    }
+
+    /**
+     * Get property as an array of strings based on a comma separated value, with default value
+     * @param category property category
+     * @param key category key
+     * @param defaultValue
+     * @return property value as an array of strings. defaultValue if not set
+     */
+    public String[] getStringArrayValue(String category, String key, String[] defaultValue) {
+        Map<String, ProjectProperty> group = this.properties.get(category);
+        if (group != null) {
+            ProjectProperty val = group.get(key);
+            if (val != null) {
+                if (val.valuesArray == null) {
+                    if (val.value == null) {
+                        return defaultValue;
+                    }
+                    val.parseValueAsValuesArray();
+                }
+                return val.valuesArray.values().toArray(new String[val.valuesArray.size()]);
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Get property as an array of strings based on a comma separated value
+     * @param category property category
+     * @param key category key
+     * @return property value as an array of strings. defaultValue if not set
+     */
+    public String[] getStringArrayValue(String category, String key) {
+        return getStringArrayValue(category, key, new String[0]);
     }
 
     /**
@@ -73,84 +319,11 @@ public class BobProjectProperties {
      * @return property value. defaultValue if not set
      */
     public String getStringValue(String category, String key, String defaultValue) {
-        Map<String, String> group = this.properties.get(category);
-        if (group != null) {
-            String val = group.get(key);
-            if (val != null) {
-                return val;
-            }
-        }
-        return defaultValue;
-    }
-
-    /**
-     * Get property as an array of strings based on a comma separated value, with default value
-     * @param category property category
-     * @param key category key
-     * @param defaultValue
-     * @return property value as an array of strings. defaultValue if not set
-     */
-    public String[] getStringArrayValue(String category, String key, String[] defaultValue) {
-        Map<String, String> group = this.properties.get(category);
-        if (group != null) {
-            String val = group.get(key);
-            if (val != null) {
-                String[] values = val.trim().split(",");
-                ArrayList<String> outValues = new ArrayList<String>();
-                for (String v : values) {
-                    v = v.trim();
-                    if (v.length() > 0) {
-                        outValues.add(v);
-                    }
-                }
-                return outValues.toArray(new String[outValues.size()]);
-            }
-        }
-        return defaultValue;
-    }
-
-    /**
-     * Get property as an array of strings based on a comma separated value
-     * @param category property category
-     * @param key category key
-     * @return property value as an array of strings. null if not set
-     */
-    public String[] getStringArrayValue(String category, String key) {
-        return getStringArrayValue(category, key, null);
-    }
-
-    /**
-     * Get property as integer
-     * @param category property category
-     * @param key category key
-     * @return property value as integer. null if not set or on number format errors
-     */
-    public Integer getIntValue(String category, String key) {
-        String value = getStringValue(category, key);
-        try {
-            return new Integer(value);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    /**
-     * Get property as integer with default value
-     * @param category property category
-     * @param key category key
-     * @param defaultValue
-     * @return property value as integer. defaultValue if not set or on number format errors
-     */
-    public Integer getIntValue(String category, String key, Integer defaultValue) {
-        Map<String, String> group = this.properties.get(category);
-        if (group != null) {
-            String val = group.get(key);
-            if (val != null) {
-                try {
-                    return new Integer(val);
-                } catch (NumberFormatException e) {
-                    return defaultValue;
-                }
+        ProjectProperty val = getValue(category, key);
+        if (val != null) {
+            String value = val.getValue();
+            if (value != null) {
+                return value;
             }
         }
         return defaultValue;
@@ -163,9 +336,9 @@ public class BobProjectProperties {
      * @return property value as boolean. null if not set.
      */
     public Boolean getBooleanValue(String category, String key) {
-        String value = getStringValue(category, key);
-        if (value != null) {
-            return value.equals("1");
+        ProjectProperty val = getValue(category, key);
+        if (val != null) {
+            return (Boolean)val.getTypedValue(BobProjectProperties.PropertyType.BOOL);
         }
         return null;
     }
@@ -177,11 +350,57 @@ public class BobProjectProperties {
      * @return property value as boolean. defaultValue if not set
      */
     public Boolean getBooleanValue(String category, String key, Boolean defaultValue) {
-        String value = getStringValue(category, key);
-        if (value != null) {
-            return value.equals("1");
+        ProjectProperty val = getValue(category, key);
+        if (val != null) {
+            return (Boolean)val.getTypedValue(BobProjectProperties.PropertyType.BOOL);
         }
         return defaultValue;
+    }
+
+    /**
+     * Get property as integer
+     * @param category property category
+     * @param key category key
+     * @return property value as integer. null if not set or on number format errors
+     */
+    public Integer getIntValue(String category, String key) {
+        ProjectProperty val = getValue(category, key);
+        if (val != null) {
+            return (Integer)val.getTypedValue(BobProjectProperties.PropertyType.INTEGER);
+        }
+        return null;
+    }
+
+    /**
+     * Get property as integer with default value
+     * @param category property category
+     * @param key category key
+     * @param defaultValue
+     * @return property value as integer. defaultValue if not set or on number format errors
+     */
+    public Integer getIntValue(String category, String key, Integer defaultValue) {
+       ProjectProperty val = getValue(category, key);
+        if (val != null) {
+            Integer result = (Integer)val.getTypedValue(BobProjectProperties.PropertyType.INTEGER);
+            if (result != null) {
+                return result;
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Check if the user didn't set this value
+     * @param category property category
+     * @param key category key
+     * @return return true if default value;
+     */
+    public boolean isDefault(String category, String key) {
+        Map<String, ProjectProperty> group = this.properties.get(category);
+        if (group != null && group.containsKey(key)) {
+            return group.get(key).isDefault();
+        }
+        return false;
     }
 
     /**
@@ -191,18 +410,20 @@ public class BobProjectProperties {
      * @param value value. if value is null the key/value-pair is effectively removed
      */
     public void putStringValue(String category, String key, String value) {
-        Map<String, String> group = this.properties.get(category);
+        Map<String, ProjectProperty> group = this.properties.get(category);
         if (group == null) {
             if (value == null) {
                 // Category doesn't exists and the value is null
                 // Just return
                 return;
             }
-            group = new LinkedHashMap<String, String>();
+            group = new LinkedHashMap<String, ProjectProperty>();
             this.properties.put(category, group);
         }
         if (value != null) {
-            group.put(key, value);
+            ProjectProperty prop = new ProjectProperty();
+            prop.setAttribute("value", value);
+            group.put(key, prop);
         } else {
             group.remove(key);
         }
@@ -229,88 +450,49 @@ public class BobProjectProperties {
     }
 
     /**
-     * Remove a property
-     * @param category property category
-     * @param key category key
+     * Remove all private fields
      */
-    public void remove(String category, String key) {
-        putStringValue(category, key, null);
-    }
-
-    // Helper class to pass tuple of Key+Value
-    // via doLoad and a KeyValueFilter class.
-    static private class StringKeyValue {
-        public String key;
-        public String value;
-        StringKeyValue(String key, String value) {
-            this.key = key;
-            this.value = value;
+    public void removePrivateFields() {
+        for (String categoryName : properties.keySet()) {
+            Map<String, ProjectProperty> category = properties.get(categoryName);
+            category.entrySet().removeIf(entry -> entry.getValue().isPrivate());
         }
     }
 
-    // Helper interface to create a filter for doLoad
-    // Used when loading default properties to filter
-    // out entries that has valid default values.
-    @FunctionalInterface
-    private interface KeyValueFilter {
-        public boolean filter(StringKeyValue entry);
-    }
-
-    static private Map<String, String> copyMap(Map<String, String> map) {
-        Map<String, String> dst = new LinkedHashMap<String, String>();
-        for (String key : map.keySet()) {
-            dst.put(key, map.get(key));
-        }
-        return dst;
-    }
-
-    static private Map<String, Map<String, String>> copyProperties(Map<String, Map<String, String>> src) {
-        Map<String, Map<String, String>> dst = new LinkedHashMap<String, Map<String, String>>();
-        for (String category : src.keySet()) {
-            Map<String, String> propGroup = src.get(category);
-            dst.put(category, copyMap(propGroup));
-        }
-        return dst;
-    }
-
-    static private void mergeMultilineKey(Map<String, Map<String, String>> properties, String group, String keyToMerge) {
-        Map<String, String> propGroup = properties.get(group);
-        if (propGroup == null) {
-            return;
-        }
-        // TreeMap implements SortedMap which give us values sorted by key
-        // find all matching keys and add them based on their indices, ie foo.0,
-        // foo.1, foo.123 etc
-        // a key without an index in the key name is treated as having index 0
-        Map<Integer, String> values = new TreeMap<Integer, String>();
-        for(String key : propGroup.keySet().stream().collect(Collectors.toList())) {
-            if (key.startsWith(keyToMerge)) {
-                int index = 0;
-                int keyIndex = key.indexOf("#");
-                if (keyIndex != -1) {
-                    try {
-                        index = Integer.parseInt(key.substring(keyIndex + 1).trim());
-                    }
-                    catch(Exception e) {
-                        continue;
-                    }
-                }
-                String value = propGroup.get(key);
-                values.put(index, value);
-                propGroup.remove(key);
+    private ProjectProperty getValue(String category, String key) {
+        Map<String, ProjectProperty> group = this.properties.get(category);
+        if (group != null) {
+            ProjectProperty val = group.get(key);
+            if (val != null) {
+                return val;
             }
         }
-        if (!values.isEmpty()) {
-            // merge the individual values back to a single long comma separated list in memory
-            String mergedValues = values.values().stream().collect(Collectors.joining(","));
-            propGroup.put(keyToMerge, mergedValues);
+        return null;
+    }
+
+    // Merge properties from b to a
+    private static void mergeProperties(Map<String, Map<String, ProjectProperty>> a, Map<String, Map<String, ProjectProperty>> b) {
+        for (String category : b.keySet()) {
+            if (!a.containsKey(category)) {
+                a.put(category, new LinkedHashMap<String, ProjectProperty>());
+            }
+            Map<String, ProjectProperty> propGroupA = a.get(category);
+            Map<String, ProjectProperty> propGroupB = b.get(category);
+            for (String key : propGroupB.keySet()) {
+                if (!propGroupA.containsKey(key)) {
+                    propGroupA.put(key, propGroupB.get(key));
+                }
+                else {
+                    propGroupA.get(key).overrideBy(propGroupB.get(key));
+                }
+            }
         }
     }
 
-    static private Map<String, Map<String, String>> doLoad(InputStream in, KeyValueFilter passFunc) throws IOException, ParseException {
-        Map<String, Map<String, String>> properties = new LinkedHashMap<String, Map<String, String>>();
+    private Map<String, Map<String, ProjectProperty>> doLoad(InputStream in) throws IOException, ParseException {
+        Map<String, Map<String, ProjectProperty>> properties = new LinkedHashMap<String, Map<String, ProjectProperty>>();
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-        Map<String, String> propGroup = null;
+        Map<String, ProjectProperty> propGroup = null;
         int cursor = 0;
         String line = reader.readLine();
         while (line != null) {
@@ -322,7 +504,7 @@ public class BobProjectProperties {
                 String category = line.substring(1, line.length() - 1);
                 propGroup = properties.get(category);
                 if (propGroup == null) {
-                    propGroup = new LinkedHashMap<String, String>();
+                    propGroup = new LinkedHashMap<String, ProjectProperty>();
                     properties.put(category, propGroup);
                 }
             } else if (line.length() > 0) {
@@ -333,15 +515,37 @@ public class BobProjectProperties {
                 boolean valid = true;
                 if (sep != -1) {
                     try {
-                        String key = line.substring(0, sep).trim();
+                        String fullKey = line.substring(0, sep).trim();
                         String value = line.substring(sep + 1).trim();
-                        if (passFunc != null) {
-                            StringKeyValue keyVal = new StringKeyValue(key, value);
-                            if (passFunc.filter(keyVal)) {
-                                propGroup.put(keyVal.key, value);
+                        if(fullKey.contains(".")) {
+                            String[] keyAndAttr = fullKey.split("\\.");
+                            String key = keyAndAttr[0];
+                            ProjectProperty prop = propGroup.get(key);
+                            if (prop == null) {
+                                prop = new ProjectProperty();
                             }
-                        } else {
-                            propGroup.put(key, value);
+                            prop.setAttribute(keyAndAttr[1], value);
+                            propGroup.put(key, prop);
+                        }
+                        else if (fullKey.contains("#")) {
+                            String[] keyAndIndex = fullKey.split("#");
+                            String key = keyAndIndex[0];
+                            ProjectProperty prop = propGroup.get(key);
+                            if (prop == null) {
+                                prop = new ProjectProperty();
+                            }
+                            prop.addArrayValue(keyAndIndex[1], value);
+                            propGroup.put(key, prop);
+                        }
+                        else
+                        {
+                            String key = fullKey;
+                            ProjectProperty prop = propGroup.get(key);
+                            if (prop == null) {
+                                prop = new ProjectProperty();
+                            }
+                            prop.setAttribute("value", value);
+                            propGroup.put(key, prop); 
                         }
                     } catch (IndexOutOfBoundsException e) {
                         valid = false;
@@ -360,110 +564,25 @@ public class BobProjectProperties {
     }
 
     /**
-     * Load default properties from the internal meta.properties file
-     * @throws IOException
-     * @throws ParseException
-     */
-    public void loadDefaults() throws IOException, ParseException {
-        KeyValueFilter filterDefaults = new KeyValueFilter(){
-           @Override
-           public boolean filter(StringKeyValue entry) {
-                // Only keep entries where key ends with ".default"
-                if (entry.key.endsWith(".default") && !entry.value.isEmpty()) {
-
-                    // Modify key to remove ".default" part
-                    entry.key = entry.key.substring(0, entry.key.length() - ".default".length());
-                    return true;
-                }
-
-                return false;
-            }
-        };
-
-        InputStream is = Bob.class.getResourceAsStream("meta.properties");
-        try {
-            defaults = doLoad(is, filterDefaults);
-            properties = copyProperties(defaults);
-        } catch (ParseException e) {
-            throw new RuntimeException("Failed to parse meta.properties", e);
-        } finally {
-            IOUtils.closeQuietly(is);
-        }
-    }
-
-    public void removeProperty(String category, String key) throws RuntimeException {
-        Map<String, String> propGroup = properties.get(category);
-        if (propGroup != null) {
-            propGroup.remove(key);
-            return;
-        }
-        throw new RuntimeException(String.format("No such property %s.%s", category, key));
-    }
-
-    // remove any properties in b from a
-    private static void removeProperties(Map<String, Map<String, String>> a, Map<String, Map<String, String>> b) {
-        for (String category : b.keySet()) {
-            if (!a.containsKey(category)) {
-                continue;
-            }
-            Map<String, String> propGroupA = a.get(category);
-            Map<String, String> propGroupB = b.get(category);
-            for (String key : propGroupB.keySet()) {
-                if (propGroupA.containsKey(key)) {
-                    propGroupA.remove(key);
-                }
-            }
-        }
-    }
-
-    // Merge properties from b to a
-    private static void mergeProperties(Map<String, Map<String, String>> a, Map<String, Map<String, String>> b) {
-        for (String category : b.keySet()) {
-            if (!a.containsKey(category)) {
-                a.put(category, new LinkedHashMap<String, String>());
-            }
-            Map<String, String> propGroupA = a.get(category);
-            Map<String, String> propGroupB = b.get(category);
-            for (String key : propGroupB.keySet()) {
-                propGroupA.put(key, propGroupB.get(key));
-            }
-        }
-    }
-
-    // returns true if the user didn't set this value
-    public boolean isDefault(String category, String key) {
-        return defaults.containsKey(category) && defaults.get(category).containsKey(key);
-    }
-
-    public boolean containsProperty(String category, String key) {
-        return properties.containsKey(category) && properties.get(category).containsKey(key);
-    }
-
-    /**
-     * Load properties in-place from {@link InputStream}
-     * @param in {@link InputStream} to load from
-     * @throws IOException
-     * @throws ParseException
-     */
-    public void load(InputStream in) throws IOException, ParseException {
-        try {
-            Map<String, Map<String, String>> props = doLoad(in, null);
-            mergeMultilineKey(props, "project", "dependencies");
-            // remove any properties in props from defaults
-            removeProperties(defaults, props);
-            // merge into properties
-            mergeProperties(properties, props);
-        } finally {
-            IOUtils.closeQuietly(in);
-        }
-    }
-
-    /**
      * Get all category names
      * @return {@link Collection} of cateory names
      */
     public Collection<String> getCategoryNames() {
         return properties.keySet();
+    }
+
+    /**
+     * Get all keys for given category
+     * @param category category to get keys for
+     * @return collection of keys
+     */
+    public Collection<String> getKeys(String category) {
+        Map<String, ProjectProperty> group = this.properties.get(category);
+        if (group != null) {
+            return group.keySet();
+        } else {
+            return Collections.emptySet();
+        }
     }
 
     /**
@@ -475,8 +594,11 @@ public class BobProjectProperties {
             pw.format("[%s]%n", category);
 
             for (String key : getKeys(category)) {
-                String value = getStringValue(category, key);
-                pw.format("%s = %s%n", key, value);
+                ProjectProperty prop = getValue(category, key);
+                String value = prop.getValue();
+                if (value != null) {
+                    pw.format("%s = %s%n", key, value);
+                }
             }
             pw.println();
         }
@@ -503,20 +625,6 @@ public class BobProjectProperties {
         PrintWriter pw = new PrintWriter(sw);
         save(pw);
         return sw.toString();
-    }
-
-    /**
-     * Get all keys for given category
-     * @param category category to get keys for
-     * @return collection of keys
-     */
-    public Collection<String> getKeys(String category) {
-        Map<String, String> group = this.properties.get(category);
-        if (group != null) {
-            return group.keySet();
-        } else {
-            return Collections.emptySet();
-        }
     }
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/LibraryUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/LibraryUtil.java
@@ -169,26 +169,4 @@ public class LibraryUtil {
         }
         return includeDirs;
     }
-
-    /**
-     * Parse a comma separated string of URLs.
-     * @param urls
-     * @return a list of the parsed URLs
-     */
-    public static List<URL> parseLibraryUrls(String urls) throws LibraryException {
-        List<URL> result = new ArrayList<URL>();
-        String[] libUrls = urls.split("[,\\s]");
-        for (String urlStr : libUrls) {
-            urlStr = urlStr.trim();
-            if (!urlStr.isEmpty()) {
-                try {
-                    URL url = new URL(urlStr);
-                    result.add(url);
-                } catch (MalformedURLException e) {
-                    throw new LibraryException(String.format("The library URL %s is not valid", urlStr), e);
-                }
-            }
-        }
-        return result;
-    }
 }


### PR DESCRIPTION
From now on it's possible to create metadata for the `game.project` file in the project itself and in an extension.

The project file should have the name `game.properties` in the root folder (near `game.project` file) for an extension it's `ext.properties` next to `ext.manifest`.

This file has `ini` format where attributes may be specified after dots:
```
[my_category]
my_property.private = 1
...
```
The default meta file that is always applied and available [here](https://github.com/defold/defold/blob/dev/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties)

Currently available are the following attributes:
```
// `type` - used for the value string parsing (only in bob.jar for now)
my_property.type = string // one of the follwoing values: bool, string, number, integer, string_array, resource

// `help` - used as help tip in the editor (not used for now)
my_property.help = string

// `default` - value used as default if user didn't set value manually (only in bob.jar for now)
my_property.default = string

// `private` - private value used during the bundle process but will be removed from the bundle itself
my_property.private = 1 // boolean value 1 or 0

``` 

At the moment meta properties are used only in `bob.jar` when bundling an app, but later will be parsed by the editor and represented in the `game.project` viewer. 