### PR TITLE
Make active-tab a propery instead of output

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -229,6 +229,7 @@
   (property scene Scene)
   (property editor-tabs-split SplitPane)
   (property active-tab-pane TabPane)
+  (property active-tab Tab)
   (property tool-tab-pane TabPane)
   (property auto-pulls g/Any)
   (property active-tool g/Keyword)
@@ -250,7 +251,6 @@
 
   (output open-views g/Any :cached (g/fnk [open-views] (into {} open-views)))
   (output open-dirty-views g/Any :cached (g/fnk [open-dirty-views] (into #{} (keep #(when (second %) (first %))) open-dirty-views)))
-  (output active-tab Tab (g/fnk [^TabPane active-tab-pane] (some-> active-tab-pane ui/selected-tab)))
   (output hidden-renderable-tags types/RenderableTags (gu/passthrough hidden-renderable-tags))
   (output hidden-node-outline-key-paths types/NodeOutlineKeyPaths (gu/passthrough hidden-node-outline-key-paths))
   (output active-outline g/Any (gu/passthrough active-outline))
@@ -328,14 +328,14 @@
       (g/connect source-node source-label target-node target-label)
       [])))
 
-(defn- on-selected-tab-changed! [app-view app-scene resource-node view-type]
+(defn- on-selected-tab-changed! [app-view app-scene tab resource-node view-type]
   (g/transact
     (concat
       (replace-connection resource-node :node-outline app-view :active-outline)
       (if (= :scene view-type)
         (replace-connection resource-node :scene app-view :active-scene)
-        (disconnect-sources app-view :active-scene))))
-  (g/invalidate-outputs! [[app-view :active-tab]])
+        (disconnect-sources app-view :active-scene))
+      (g/set-property app-view :active-tab tab)))
   (ui/user-data! app-scene ::ui/refresh-requested? true))
 
 (handler/defhandler :move-tool :workbench
@@ -1537,7 +1537,7 @@ If you do not specifically require different script states, consider changing th
       (.addListener
         (reify ChangeListener
           (changed [_this _observable _old-val new-val]
-            (on-selected-tab-changed! app-view app-scene (tab->resource-node new-val) (tab->view-type new-val))))))
+            (on-selected-tab-changed! app-view app-scene new-val (tab->resource-node new-val) (tab->view-type new-val))))))
   (-> tab-pane
       (.getTabs)
       (.addListener
@@ -1564,7 +1564,7 @@ If you do not specifically require different script states, consider changing th
         (ui/add-style! old-editor-tab-pane "inactive")
         (ui/remove-style! new-editor-tab-pane "inactive")
         (g/set-property! app-view :active-tab-pane new-editor-tab-pane)
-        (on-selected-tab-changed! app-view app-scene resource-node view-type)))))
+        (on-selected-tab-changed! app-view app-scene selected-tab resource-node view-type)))))
 
 (defn open-custom-keymap
   [path]

--- a/editor/src/reveal/editor/reveal.clj
+++ b/editor/src/reveal/editor/reveal.clj
@@ -3,7 +3,9 @@
             [dynamo.graph :as g]
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
-            [vlaaad.reveal :as r]))
+            [vlaaad.reveal :as r]
+            [internal.system :as is])
+  (:import [clojure.lang IRef]))
 
 (defn- node-value-or-err [ec node-id label]
   (try
@@ -46,6 +48,7 @@
         targets (g/targets-of basis node-id label)]
     (cond->
       {:value (or e v)
+       :annotation {::node-id+label [node-id label]}
        :render (r/horizontal
                  (r/stream label)
                  r/separator
@@ -81,6 +84,29 @@
            :branch? :children
            :render #(:render % (:value %))
            :valuate :value
+           :annotate :annotation
            :children #((:children %))
            :root (root-tree-node ec x)})))))
 
+(defn- de-duplicating-observable [ref f]
+  (reify IRef
+    (deref [_] (f @ref))
+    (addWatch [this key callback]
+      (add-watch ref [this key] (fn [_ _ old new]
+                                  (let [old (f old)
+                                        new (f new)]
+                                    (when-not (= old new)
+                                      (callback key this old new))))))
+    (removeWatch [this key]
+      (remove-watch ref [this key]))))
+
+(defn watch-all [node-id label]
+  {:fx/type r/ref-watch-all-view
+   :ref (de-duplicating-observable
+          g/*the-system*
+          (fn [sys]
+            (g/node-value node-id label (is/default-evaluation-context sys))))})
+
+(r/defaction ::defold:watch [_ {::keys [node-id+label]}]
+  (when node-id+label
+    #(apply watch-all node-id+label)))


### PR DESCRIPTION
This is related to #5447 — not relying on output invalidation will allow
us to change caching implementation