### PR TITLE
Issue-3799 New adjust mode "None" for GUI node

### DIFF
--- a/engine/gamesys/proto/gamesys/gui_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gui_ddf.proto
@@ -78,6 +78,7 @@ message NodeDesc
         ADJUST_MODE_FIT = 0 [(displayName) = "Fit"];
         ADJUST_MODE_ZOOM = 1 [(displayName) = "Zoom"];
         ADJUST_MODE_STRETCH = 2 [(displayName) = "Stretch"];
+        ADJUST_MODE_NONE = 3 [(displayName) = "None"];
     };
 
     // NOTE: Enum values must correspond to the enum values in dmGui

--- a/engine/gui/src/dmsdk/gui/gui.h
+++ b/engine/gui/src/dmsdk/gui/gui.h
@@ -313,12 +313,14 @@ namespace dmGui
      * @member ADJUST_MODE_FIT     //!< 0
      * @member ADJUST_MODE_ZOOM    //!< 1
      * @member ADJUST_MODE_STRETCH //!< 2
+     * @member ADJUST_MODE_NONE    //!< 3
      */
     enum AdjustMode
     {
         ADJUST_MODE_FIT     = 0,
         ADJUST_MODE_ZOOM    = 1,
         ADJUST_MODE_STRETCH = 2,
+        ADJUST_MODE_NONE    = 3,
     };
 
     /*#

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2589,6 +2589,11 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
             parent_adjust_scale.setX(uniform);
             parent_adjust_scale.setY(uniform);
         }
+        else if (adjust_mode == dmGui::ADJUST_MODE_NONE)
+        {
+            parent_adjust_scale.setX(1.0f);
+            parent_adjust_scale.setY(1.0f);
+        }
         parent_adjust_scale.setZ(1.0f);
         parent_adjust_scale.setW(1.0f);
         return parent_adjust_scale;

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -2860,6 +2860,17 @@ TEST_F(dmGuiTest, CalculateNodeTransform)
     ASSERT_EQ( Vector4(4, 4, 1, 1), nn1->m_Node.m_LocalAdjustScale );
     ASSERT_EQ( Vector4(4, 4, 1, 1), nn2->m_Node.m_LocalAdjustScale );
     ASSERT_EQ( Vector4(4, 4, 1, 1), nn3->m_Node.m_LocalAdjustScale );
+
+    //
+    dmGui::SetNodeAdjustMode(m_Scene, n1, dmGui::ADJUST_MODE_NONE);
+    dmGui::SetNodeAdjustMode(m_Scene, n2, dmGui::ADJUST_MODE_NONE);
+    dmGui::SetNodeAdjustMode(m_Scene, n3, dmGui::ADJUST_MODE_NONE);
+
+    dmGui::CalculateNodeTransform(m_Scene, nn3, dmGui::CalculateNodeTransformFlags(dmGui::CALCULATE_NODE_BOUNDARY | dmGui::CALCULATE_NODE_INCLUDE_SIZE | dmGui::CALCULATE_NODE_RESET_PIVOT), transform);
+
+    ASSERT_EQ( Vector4(1, 1, 1, 1), nn1->m_Node.m_LocalAdjustScale );
+    ASSERT_EQ( Vector4(1, 1, 1, 1), nn2->m_Node.m_LocalAdjustScale );
+    ASSERT_EQ( Vector4(1, 1, 1, 1), nn3->m_Node.m_LocalAdjustScale );
 }
 
 TEST_F(dmGuiTest, CalculateNodeTransformCached)


### PR DESCRIPTION
Added new adjust mode "None" for GUI nodes.
This mode makes a node **scale** behave the same way as it behaves when Adjust Reference for the gui component set to Disabled. 

Fix https://github.com/defold/defold/issues/3799