### PR TITLE
Fix move-up/move-down action availability

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2906,8 +2906,10 @@
   (active? [selection] (or (selection->gui-node selection)
                            (selection->layer-node selection)))
   (enabled? [selection] (let [selected-node-id (g/override-root (handler/selection->node-id selection))
-                              node-child-index (g/node-value selected-node-id :child-index)]
-                          (pos? node-child-index)))
+                              parent (core/scope selected-node-id)
+                              node-child-index (g/node-value selected-node-id :child-index)
+                              first-index (transduce (map second) min Long/MAX_VALUE (g/node-value parent :child-indices))]
+                          (< first-index node-child-index)))
   (run [selection] (let [selected (g/override-root (handler/selection->node-id selection))]
                      (move-child-node! selected -1))))
 
@@ -2917,8 +2919,8 @@
   (enabled? [selection] (let [selected-node-id (g/override-root (handler/selection->node-id selection))
                               parent (core/scope selected-node-id)
                               node-child-index (g/node-value selected-node-id :child-index)
-                              child-indices (g/node-value parent :child-indices)]
-                          (< node-child-index (dec (count child-indices)))))
+                              last-index (transduce (map second) max 0 (g/node-value parent :child-indices))]
+                          (< node-child-index last-index)))
   (run [selection] (let [selected (g/override-root (handler/selection->node-id selection))]
                      (move-child-node! selected 1))))
 


### PR DESCRIPTION
The problem with existing availability implementation was the assumption
that `:child-indices` of a parent are consequtive and start with 0. It
turns out `:child-indices` are neither. For nested gui nodes, child
indices don't start with 0, so it's possible to have indices in the
following shape:
```clj
[[72057594037928031 4]
 [72057594037928032 5]]
```
Also, after adding new box nodes, it's possible for indices to be
non-consequtive, e.g.:
```clj
[[72057594037928029 2]
 [72057594037928030 3]
 [72057594037928033 6]]
```
The solution is to find min/max index and compare it with selected
node's index.

Fixes #5811