### PR TITLE
Improved progress bar when streaming the wasm file on engine startup

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -102,16 +102,8 @@ var FileLoader = {
 
 var EngineLoader = {
     wasm_size: 2000000,
-    wasm_from: 0,
-    wasm_to: 40,
-
     wasmjs_size: 250000,
-    wasmjs_from: 40,
-    wasmjs_to: 50,
-
     asmjs_size: 4000000,
-    asmjs_from: 0,
-    asmjs_to: 50,
 
     stream_wasm: false,
 
@@ -133,9 +125,32 @@ var EngineLoader = {
             });
     },
 
-    streamAndInstantiateWasmAsync: function(src, fromProgress, toProgress, callback) {
+    setupWasmStreamAsync: async function(src, fromProgress, toProgress) {
+        // https://stackoverflow.com/a/69179454
+        var fetchFn = fetch;
+        if (typeof TransformStream === "function" && ReadableStream.prototype.pipeThrough) {
+            async function fetchWithProgress(path) {
+                const response = await fetch(path);
+                // May be incorrect if compressed
+                const contentLength = response.headers.get("Content-Length");
+                const total = parseInt(contentLength, 10);
+
+                let bytesLoaded = 0;
+                const ts = new TransformStream({
+                    transform (chunk, controller) {
+                        bytesLoaded += chunk.byteLength;
+                        Progress.calculateProgress(fromProgress, toProgress, bytesLoaded, total);
+                        controller.enqueue(chunk)
+                    }
+                });
+
+                return new Response(response.body.pipeThrough(ts), response);
+            }
+            fetchFn = fetchWithProgress;
+        }
+
         Module.instantiateWasm = function(imports, successCallback) {
-            WebAssembly.instantiateStreaming(fetch(src), imports).then(function(output) {
+            WebAssembly.instantiateStreaming(fetchFn(src), imports).then(function(output) {
                 Progress.calculateProgress(fromProgress, toProgress, 1, 1);
                 successCallback(output.instance);
             }).catch(function(e) {
@@ -144,22 +159,28 @@ var EngineLoader = {
             });
             return {}; // Compiling asynchronously, no exports.
         }
-        callback();
     },
 
     // instantiate the .wasm file either by streaming it or first loading and then instantiate it
     // https://github.com/emscripten-core/emscripten/blob/master/tests/manual_wasm_instantiate.html#L170
-    loadWasmAsync: function(src, fromProgress, toProgress, callback) {
+    loadWasmAsync: function(exeName) {
         if (EngineLoader.stream_wasm && (typeof WebAssembly.instantiateStreaming === "function")) {
-            EngineLoader.streamAndInstantiateWasmAsync(src, fromProgress, toProgress, callback);
+            EngineLoader.setupWasmStreamAsync(exeName + ".wasm", 10, 50);
+            EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, 0, 10);
         }
         else {
-            EngineLoader.loadAndInstantiateWasmAsync(src, fromProgress, toProgress, callback);
+            EngineLoader.loadAndInstantiateWasmAsync(exeName + ".wasm", 0, 40, function() {
+                EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, 40, 50);
+            });
         }
     },
 
+    loadAsmJsAsync: function(exeName) {
+        EngineLoader.loadAndRunScriptAsync(exeName + '_asmjs.js', EngineLoader.asmjs_size, 0, 50);
+    },
+
     // load and start engine script (asm.js or wasm.js)
-    loadScriptAsync: function(src, estimatedSize, fromProgress, toProgress) {
+    loadAndRunScriptAsync: function(src, estimatedSize, fromProgress, toProgress) {
         FileLoader.load(src, "text", estimatedSize,
             function(loaded, total) { Progress.calculateProgress(fromProgress, toProgress, loaded, total); },
             function(error) { throw error; },
@@ -171,16 +192,12 @@ var EngineLoader = {
     },
 
     // load engine (asm.js or wasm.js + wasm)
-    // engine load progress goes from 1-50% for ams.js
-    // engine load progress goes from 0-40% for .wasm and 40-50% for wasm.js
     load: function(appCanvasId, exeName) {
         Progress.addProgress(Module.setupCanvas(appCanvasId));
         if (Module['isWASMSupported']) {
-            EngineLoader.loadWasmAsync(exeName + ".wasm", EngineLoader.wasm_from, EngineLoader.wasm_to, function(wasm) {
-                EngineLoader.loadScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, EngineLoader.wasmjs_from, EngineLoader.wasmjs_to);
-            });
+            EngineLoader.loadWasmAsync(exeName);
         } else {
-            EngineLoader.loadScriptAsync(exeName + '_asmjs.js', EngineLoader.asmjs_size, EngineLoader.asmjs_from, EngineLoader.asmjs_to);
+            EngineLoader.loadAsmJsAsync(exeName);
         }
     }
 }


### PR DESCRIPTION
This improves the accuracy of the HTML5 progress bar when streaming the .wasm file on engine startup (using the Wasm Streaming option in game.project).

Fixes #6563 