### PR TITLE
Update editor JOGL version to 2.4.0-rc

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -109,16 +109,16 @@
                      [org.openjfx/javafx-swing "18" :classifier "mac"]
                      [org.openjfx/javafx-swing "18" :classifier "win"]
 
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-linux-amd64"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-macosx-universal"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-windows-amd64"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-windows-i586"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-linux-amd64"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-macosx-universal"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-windows-amd64"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-windows-i586"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-linux-amd64"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-macosx-universal"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-windows-amd64"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-windows-i586"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-linux-amd64"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-macosx-universal"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-windows-amd64"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-windows-i586"]
 
                      [org.snakeyaml/snakeyaml-engine "1.0"]]
 
@@ -182,10 +182,12 @@
 
   :uberjar-exclusions [#"^natives/"]
 
-  :profiles          {:test    {:injections [(defonce force-toolkit-init
-                                               (javafx.application.Platform/startup
-                                                 (fn []
-                                                   (com.jogamp.opengl.GLProfile/initSingleton))))]
+  :profiles          {:test    {:injections [(defonce initialize-test-prerequisites
+                                               (do
+                                                 (com.defold.libs.ResourceUnpacker/unpackResources)
+                                                 (javafx.application.Platform/startup
+                                                   (fn []
+                                                     (com.jogamp.opengl.GLProfile/initSingleton)))))]
                                 :resource-paths ["test/resources"]}
                       :preflight {:dependencies [[jonase/kibit "0.1.6" :exclusions [org.clojure/clojure]]
                                                  [cljfmt-mg "0.6.4" :exclusions [org.clojure/clojure]]]}

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -99,8 +99,8 @@
   ;; this the first time the method is called. It is safe to call from any
   ;; thead, but will block until the unpacking thread has completed.
   ;;
-  ;; Having this call here mainly benefits the tests and repl-interactions, as
-  ;; the editor will also explicitly call unpackResources at startup.
+  ;; Having this call here mainly benefits repl-interactions, as the editor and
+  ;; tests will explicitly call unpackResources at startup.
   (ResourceUnpacker/unpackResources)
   (System/getProperty "defold.unpack.path"))
 

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -109,8 +109,8 @@
 
 (defn jogl-native-dep?
   [[artifact version & {:keys [classifier]}]]
-  (and (#{'org.jogamp.gluegen/gluegen-rt
-          'org.jogamp.jogl/jogl-all} artifact)
+  (and (#{'com.metsci.ext.org.jogamp.gluegen/gluegen-rt
+          'com.metsci.ext.org.jogamp.jogl/jogl-all} artifact)
        classifier))
 
 (defn extract-jogl-native-dep


### PR DESCRIPTION
Updating to JOGL `2.4.0-rc` fixes editor test failures introduced by the JDK update in #6635.

I've run the editor tests with these changes in a PR onto `editor-dev` #6641, so presumably this should solve the failing tests on `dev`.