### PR TITLE
Re-enable editor tests for dev branch

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -472,7 +472,6 @@ def main(argv):
         engine_channel = "dev"
         editor_channel = "dev"
         make_release = False
-        skip_editor_tests = True
         engine_artifacts = args.engine_artifacts or "archived"
 
     print("Using branch={} engine_channel={} editor_channel={} engine_artifacts={}".format(branch, engine_channel, editor_channel, engine_artifacts))


### PR DESCRIPTION
This re-enables editor tests for pull requests that target the `dev` branch. We've had a few instances of where failing editor tests have not been caught before reaching `dev`. This can happen when changes are made to the editor code, but also if a significant change is made to a `protobuf` file without also making the corresponding change to the editor.