### PR TITLE
Catch all exceptions while reading custom keymap

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -35,7 +35,7 @@ jobs:
       { name: 'Checkout', uses: actions/checkout@v2 },
       { name: 'Fetch tags', run: 'git fetch --depth=1 origin +refs/tags/*:refs/tags/*' },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install Leiningen', uses: DeLaGuardo/setup-clojure@master, with: { lein: 2.8.3 } },
       {
         name: 'Build editor',
@@ -59,7 +59,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         run: 'ci/ci.sh download-editor --platform=${{ matrix.platform }}'
@@ -91,7 +91,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2 },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         shell: bash,

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install' },
       {
         name: 'Build engine',
@@ -41,7 +41,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2 },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install' },
       {
         name: 'Build engine',

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -64,7 +64,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', shell: bash, run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -92,7 +92,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Build engine',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_engine != true)),
@@ -115,7 +115,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -139,7 +139,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -163,7 +163,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -187,7 +187,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -211,7 +211,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', shell: bash, run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -236,7 +236,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', shell: bash, run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -260,7 +260,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Build bob',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_bob != true)),
@@ -302,7 +302,7 @@ jobs:
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Fetch tags', run: 'git fetch --depth=1 origin +refs/tags/*:refs/tags/*' },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install Leiningen', uses: DeLaGuardo/setup-clojure@master, with: { lein: 2.8.3 } },
       {
         name: 'Build editor',
@@ -334,7 +334,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_sign != true)),
@@ -378,7 +378,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         shell: bash,

--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -13,7 +13,7 @@ time =
 channel =
 archive_domain =
 [launcher]
-jdk = ${bootstrap.resourcespath}/packages/jdk11.0.1-p1
+jdk = ${bootstrap.resourcespath}/packages/jdk-11.0.15+10
 java = ${launcher.jdk}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Main

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -182,7 +182,10 @@
 
   :uberjar-exclusions [#"^natives/"]
 
-  :profiles          {:test    {:injections [(defonce force-toolkit-init (javafx.application.Platform/startup (fn [])))]
+  :profiles          {:test    {:injections [(defonce force-toolkit-init
+                                               (javafx.application.Platform/startup
+                                                 (fn []
+                                                   (com.jogamp.opengl.GLProfile/initSingleton))))]
                                 :resource-paths ["test/resources"]}
                       :preflight {:dependencies [[jonase/kibit "0.1.6" :exclusions [org.clojure/clojure]]
                                                  [cljfmt-mg "0.6.4" :exclusions [org.clojure/clojure]]]}

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -109,16 +109,16 @@
                      [org.openjfx/javafx-swing "18" :classifier "mac"]
                      [org.openjfx/javafx-swing "18" :classifier "win"]
 
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-linux-amd64"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-macosx-universal"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-windows-amd64"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-windows-i586"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-linux-amd64"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-macosx-universal"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-windows-amd64"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-windows-i586"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-linux-amd64"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-macosx-universal"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-windows-amd64"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-windows-i586"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-linux-amd64"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-macosx-universal"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-windows-amd64"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-windows-i586"]
 
                      [org.snakeyaml/snakeyaml-engine "1.0"]]
 
@@ -182,10 +182,12 @@
 
   :uberjar-exclusions [#"^natives/"]
 
-  :profiles          {:test    {:injections [(defonce force-toolkit-init
-                                               (javafx.application.Platform/startup
-                                                 (fn []
-                                                   (com.jogamp.opengl.GLProfile/initSingleton))))]
+  :profiles          {:test    {:injections [(defonce initialize-test-prerequisites
+                                               (do
+                                                 (com.defold.libs.ResourceUnpacker/unpackResources)
+                                                 (javafx.application.Platform/startup
+                                                   (fn []
+                                                     (com.jogamp.opengl.GLProfile/initSingleton)))))]
                                 :resource-paths ["test/resources"]}
                       :preflight {:dependencies [[jonase/kibit "0.1.6" :exclusions [org.clojure/clojure]]
                                                  [cljfmt-mg "0.6.4" :exclusions [org.clojure/clojure]]]}

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -29,6 +29,7 @@ import ConfigParser
 import datetime
 import imp
 import fnmatch
+import urllib
 
 # TODO: collect common functions in a more suitable reusable module
 try:
@@ -51,17 +52,15 @@ CDN_PACKAGES_URL=os.environ.get("DM_PACKAGES_URL", None)
 # - /editor/bundle-resources/config at "launcher.jdk" key
 # - /scripts/build.py smoke_test, `java` variable
 # - /editor/src/clj/editor/updater.clj, `protected-dirs` let binding
-java_version = '11.0.1'
-java_version_patch = 'p1'
-
+java_version = '11.0.15+10'
 
 platform_to_java = {'x86_64-linux': 'linux-x64',
-                    'x86_64-darwin': 'osx-x64',
+                    'x86_64-darwin': 'macos-x64',
                     'x86_64-win32': 'windows-x64'}
 
 python_platform_to_java = {'linux2': 'linux-x64',
                            'win32': 'windows-x64',
-                           'darwin': 'osx-x64'}
+                           'darwin': 'macos-x64'}
 
 def log(msg):
     print(msg)
@@ -72,19 +71,37 @@ def mkdirs(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
-def extract(file, path, is_mac):
-    print('Extracting %s to %s' % (file, path))
-
+def extract_tar(file, path, is_mac):
     if is_mac:
-        # We use the system tar command for macOSX because tar (and
+        # We use the system tar command for macOS because tar (and
         # others) on macOS has special handling of ._ files that
         # contain additional HFS+ attributes. See for example:
         # http://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x
         exec_command(['tar', '-C', path, '-xzf', file])
     else:
-        tf = tarfile.TarFile.open(file, 'r:gz')
-        tf.extractall(path)
-        tf.close()
+        with tarfile.TarFile.open(file, 'r:gz') as tf:
+            tf.extractall(path)
+
+def extract_zip(file, path, is_mac):
+    if is_mac:
+        # We use the system unzip command for macOS because zip (and
+        # others) on macOS has special handling of ._ files that
+        # contain additional HFS+ attributes. See for example:
+        # http://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x
+        exec_command(['unzip', file, '-d', path])
+    else:
+        with zipfile.ZipFile(file, 'r') as zf:
+            zf.extractall(path)
+
+def extract(file, path, is_mac):
+    print('Extracting %s to %s' % (file, path))
+
+    if fnmatch.fnmatch(file, "*.tar.gz-*"):
+        extract_tar(file, path, is_mac)
+    elif fnmatch.fnmatch(file, "*.zip-*"):
+        extract_zip(file, path, is_mac)
+    else:
+        assert False, "Don't know how to extract " + file
 
 modules = {}
 
@@ -243,28 +260,34 @@ def launcher_path(options, platform, exe_suffix):
     else:
         return path.join(os.environ['DYNAMO_HOME'], "bin", platform, "launcher%s" % exe_suffix)
 
-
 def full_jdk_url(jdk_platform):
-    return '%s/openjdk-%s_%s_bin.tar.gz' % (CDN_PACKAGES_URL, java_version, jdk_platform)
+    version = urllib.quote(java_version)
+    platform = urllib.quote(jdk_platform)
+    extension = "zip" if jdk_platform.startswith("windows") else "tar.gz"
+    return '%s/microsoft-jdk-%s-%s.%s' % (CDN_PACKAGES_URL, version, platform, extension)
 
+def full_build_jdk_url():
+    return full_jdk_url(python_platform_to_java[sys.platform])
 
 def download_build_jdk():
     print('Downloading build jdk')
-    rmtree('build/jdk')
-    is_mac = sys.platform == 'darwin'
-    jdk_url = full_jdk_url(python_platform_to_java[sys.platform])
+    jdk_url = full_build_jdk_url()
     jdk = download(jdk_url)
     if not jdk:
         print('Failed to download build jdk %s' % jdk_url)
         sys.exit(5)
+    return jdk
+
+def extract_build_jdk(build_jdk):
+    print('Extracting build jdk')
+    rmtree('build/jdk')
     mkdirs('build/jdk')
-    extract(jdk, 'build/jdk', is_mac)
+    is_mac = sys.platform == 'darwin'
+    extract(build_jdk, 'build/jdk', is_mac)
     if is_mac:
-        return 'build/jdk/jdk-%s.jdk/Contents/Home' % java_version
+        return 'build/jdk/jdk-%s/Contents/Home' % java_version
     else:
         return 'build/jdk/jdk-%s' % java_version
-
-
 
 def check_reflections(java_cmd_env):
     reflection_prefix = 'Reflection warning, ' # final space important
@@ -287,7 +310,8 @@ def check_reflections(java_cmd_env):
 
 def build(options):
     build_jdk = download_build_jdk()
-    java_cmd_env = 'JAVA_CMD=%s/bin/java' % build_jdk
+    extracted_build_jdk = extract_build_jdk(build_jdk)
+    java_cmd_env = 'JAVA_CMD=%s/bin/java' % extracted_build_jdk
 
     print('Building editor')
 
@@ -365,6 +389,7 @@ def remove_platform_files_from_archive(platform, jar):
 def create_bundle(options):
     jar_file = 'target/defold-editor-2.0.0-SNAPSHOT-standalone.jar'
     build_jdk = download_build_jdk()
+    extracted_build_jdk = extract_build_jdk(build_jdk)
 
     mkdirs('target/editor')
     for platform in options.target_platform:
@@ -372,10 +397,13 @@ def create_bundle(options):
         rmtree('tmp')
 
         jdk_url = full_jdk_url(platform_to_java[platform])
-        jdk = download(jdk_url)
-        if not jdk:
-            print('Failed to download %s' % jdk_url)
-            sys.exit(5)
+        if jdk_url == full_build_jdk_url():
+            jdk = build_jdk
+        else:
+            jdk = download(jdk_url)
+            if not jdk:
+                print('Failed to download %s' % jdk_url)
+                sys.exit(5)
 
         tmp_dir = "tmp"
 
@@ -437,13 +465,13 @@ def create_bundle(options):
         extract(jdk, tmp_dir, is_mac)
 
         if is_mac:
-            platform_jdk = '%s/jdk-%s.jdk/Contents/Home' % (tmp_dir, java_version)
+            platform_jdk = '%s/jdk-%s/Contents/Home' % (tmp_dir, java_version)
         else:
             platform_jdk = '%s/jdk-%s' % (tmp_dir, java_version)
 
         # use jlink to generate a custom Java runtime to bundle with the editor
-        packages_jdk = '%s/jdk%s-%s' % (packages_dir, java_version, java_version_patch)
-        exec_command(['%s/bin/jlink' % build_jdk,
+        packages_jdk = '%s/jdk-%s' % (packages_dir, java_version)
+        exec_command(['%s/bin/jlink' % extracted_build_jdk,
                       '@jlink-options',
                       '--module-path=%s/jmods' % platform_jdk,
                       '--output=%s' % packages_jdk])
@@ -485,7 +513,7 @@ def sign(options):
         if 'darwin' in platform:
             # we need to sign the binaries in Resources folder manually as codesign of
             # the *.app will not process files in Resources
-            jdk_dir = "jdk%s-%s" % (java_version, java_version_patch)
+            jdk_dir = "jdk-%s" % (java_version)
             jdk_path = os.path.join(sign_dir, "Defold.app", "Contents", "Resources", "packages", jdk_dir)
             for exe in find_files(os.path.join(jdk_path, "bin"), "*"):
                 sign_files('darwin', options, exe)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1572,13 +1572,13 @@ If you do not specifically require different script states, consider changing th
             (some-> path
                     slurp
                     edn/read-string))
-       (catch IOException e
+       (catch Exception e
          (dialogs/make-info-dialog
           {:title "Couldn't load custom keymap config"
            :icon :icon/triangle-error
            :header {:fx/type :v-box
                     :children [{:fx/type fxui/label
-                                :text (str "The keymap path " path " couldn't be opened.")}]}
+                                :text (str "The keymap from " path " couldn't be opened.")}]}
            :content (.getMessage e)})
          (log/error :exception e)
          nil)))

--- a/editor/src/clj/editor/collada_scene.clj
+++ b/editor/src/clj/editor/collada_scene.clj
@@ -346,7 +346,7 @@
                     :select-batch-key _node-id
                     :user-data {:meshes meshes
                                 :shader shader-pos-nrm-tex
-                                :textures {"texture" texture/white-pixel}
+                                :textures {"texture" @texture/white-pixel}
                                 :scratch-arrays (gen-scratch-arrays meshes)}
                     :passes [pass/opaque pass/opaque-selection]}
        :children [{:node-id _node-id

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -260,9 +260,15 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
   (let [unit (+ unit-index GL2/GL_TEXTURE0)]
     (->TextureLifecycle request-id ::texture unit params (->texture-data width height data-format nil false))))
 
-(def white-pixel (image-texture ::white (-> (image-util/blank-image 1 1) (image-util/flood 1.0 1.0 1.0)) (assoc default-image-texture-params
-                                                                                                                :min-filter GL2/GL_NEAREST
-                                                                                                                :mag-filter GL2/GL_NEAREST)))
+(defonce white-pixel
+  (delay
+    (image-texture
+      ::white
+      (-> (image-util/blank-image 1 1)
+          (image-util/flood 1.0 1.0 1.0))
+      (assoc default-image-texture-params
+        :min-filter GL2/GL_NEAREST
+        :mag-filter GL2/GL_NEAREST))))
 
 (defn tex-sub-image [^GL2 gl ^TextureLifecycle texture data x y w h data-format]
   (let [tex (->texture texture gl)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -226,7 +226,7 @@
 (defn render-tris [^GL2 gl render-args renderables rcount]
   (let [user-data (get-in renderables [0 :user-data])
         clipping-state (:clipping-state user-data)
-        gpu-texture (or (get user-data :gpu-texture) texture/white-pixel)
+        gpu-texture (or (get user-data :gpu-texture) @texture/white-pixel)
         material-shader (get user-data :material-shader)
         blend-mode (get user-data :blend-mode)
         vb (gen-vb gl renderables)
@@ -2672,7 +2672,7 @@
       (g/make-nodes graph-id [textures-node TexturesNode
                               no-texture [InternalTextureNode
                                           :name ""
-                                          :gpu-texture texture/white-pixel]]
+                                          :gpu-texture @texture/white-pixel]]
                     (g/connect textures-node :_node-id self :textures-node) ; for the tests :/
                     (g/connect textures-node :_node-id self :nodes)
                     (g/connect textures-node :build-errors self :build-errors)

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -132,7 +132,7 @@
 (defn render-tris [^GL2 gl render-args renderables rcount]
   (let [renderable (first renderables)
         user-data (:user-data renderable)
-        gpu-texture (or (get user-data :gpu-texture) texture/white-pixel)
+        gpu-texture (or (get user-data :gpu-texture) @texture/white-pixel)
         vb (gen-vb gl renderables)
         vcount (count vb)]
     (when (> vcount 0)

--- a/editor/src/clj/editor/rulers.clj
+++ b/editor/src/clj/editor/rulers.clj
@@ -48,7 +48,7 @@
 (defonce ^:private img-dims [(.getWidth numbers-image) (.getHeight numbers-image)])
 (defonce ^:private img-dims-recip (mapv #(/ 1 %) img-dims))
 (defonce ^:private numbers-texture-params (merge texture/default-image-texture-params {:min-filter gl/nearest :mag-filter gl/nearest}))
-(defonce ^:private numbers-texture (texture/image-texture ::number-texture numbers-image numbers-texture-params))
+(defonce ^:private numbers-texture (delay (texture/image-texture ::number-texture numbers-image numbers-texture-params)))
 
 (def ^:private max-ticks 100)
 (def ^:private max-label-chars 15)
@@ -150,7 +150,7 @@
           :let [user-data (:user-data renderable)
                 {:keys [vb tri-count line-count]} user-data]]
     (let [vertex-binding (vtx/use-with ::vertex-buffer vb tex-shader)]
-      (gl/with-gl-bindings gl render-args [tex-shader vertex-binding numbers-texture]
+      (gl/with-gl-bindings gl render-args [tex-shader vertex-binding @numbers-texture]
         (shader/set-uniform tex-shader gl "texture_sampler" 0)
         (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 tri-count)
         (gl/gl-draw-arrays gl GL/GL_LINES tri-count line-count)))))

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -99,8 +99,8 @@
   ;; this the first time the method is called. It is safe to call from any
   ;; thead, but will block until the unpacking thread has completed.
   ;;
-  ;; Having this call here mainly benefits the tests and repl-interactions, as
-  ;; the editor will also explicitly call unpackResources at startup.
+  ;; Having this call here mainly benefits repl-interactions, as the editor and
+  ;; tests will explicitly call unpackResources at startup.
   (ResourceUnpacker/unpackResources)
   (System/getProperty "defold.unpack.path"))
 

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -333,7 +333,7 @@
                           (or "")
                           io/file
                           .getCanonicalFile)
-        protected-dirs [(io/file resources-dir "packages" "jdk11.0.1-p1")]
+        protected-dirs [(io/file resources-dir "packages" "jdk-11.0.15+10")]
         install-dir (.getCanonicalFile
                       (if-let [path (system/defold-resourcespath)]
                         (case os

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -109,8 +109,8 @@
 
 (defn jogl-native-dep?
   [[artifact version & {:keys [classifier]}]]
-  (and (#{'org.jogamp.gluegen/gluegen-rt
-          'org.jogamp.jogl/jogl-all} artifact)
+  (and (#{'com.metsci.ext.org.jogamp.gluegen/gluegen-rt
+          'com.metsci.ext.org.jogamp.jogl/jogl-all} artifact)
        classifier))
 
 (defn extract-jogl-native-dep

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1748,7 +1748,7 @@ class Configuration(object):
         config = ConfigParser()
         config.read(info['config'])
         overrides = {'bootstrap.resourcespath': info['resources_path']}
-        jdk = 'jdk11.0.1-p1'
+        jdk = 'jdk-11.0.15+10'
         host2 = get_host_platform2()
         if 'win32' in host2:
             java = join('Defold', 'packages', jdk, 'bin', 'java.exe')


### PR DESCRIPTION
If a custom keymap contains invalid edn, a runtime exception is thrown. We should catch these exceptions so editor continues to work.

Fixes #6652