### PR TITLE
Cherry-pick JDK 11.0.15+10 & JOGL 2.4.0-rc onto editor-dev

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -35,7 +35,7 @@ jobs:
       { name: 'Checkout', uses: actions/checkout@v2 },
       { name: 'Fetch tags', run: 'git fetch --depth=1 origin +refs/tags/*:refs/tags/*' },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install Leiningen', uses: DeLaGuardo/setup-clojure@master, with: { lein: 2.8.3 } },
       {
         name: 'Build editor',
@@ -59,7 +59,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         run: 'ci/ci.sh download-editor --platform=${{ matrix.platform }}'
@@ -91,7 +91,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2 },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         shell: bash,

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install' },
       {
         name: 'Build engine',
@@ -41,7 +41,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2 },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install' },
       {
         name: 'Build engine',

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -64,7 +64,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', shell: bash, run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -92,7 +92,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Build engine',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_engine != true)),
@@ -115,7 +115,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -139,7 +139,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -163,7 +163,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -187,7 +187,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -211,7 +211,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', shell: bash, run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -236,7 +236,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install dependencies', shell: bash, run: 'ci/ci.sh install --platform=${{ matrix.platform }}' },
       {
         name: 'Build engine',
@@ -260,7 +260,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Build bob',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_bob != true)),
@@ -302,7 +302,7 @@ jobs:
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Fetch tags', run: 'git fetch --depth=1 origin +refs/tags/*:refs/tags/*' },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       { name: 'Install Leiningen', uses: DeLaGuardo/setup-clojure@master, with: { lein: 2.8.3 } },
       {
         name: 'Build editor',
@@ -334,7 +334,7 @@ jobs:
         name: 'Install Python',
         run: python --version
       },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_sign != true)),
@@ -378,7 +378,7 @@ jobs:
     steps: [
       { name: 'Checkout', uses: actions/checkout@v2, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v2, with: { python-version: 2.x, architecture: x64 } },
-      { name: 'Install Java', uses: actions/setup-java@v1, with: { java-version: '11.0.2' } },
+      { name: 'Install Java', uses: actions/setup-java@v3, with: { java-version: '11.0.13', distribution: 'microsoft'} },
       {
         name: 'Download editor',
         shell: bash,

--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -12,6 +12,7 @@
           <entry key="clojure.core/defmulti" value="-1" />
           <entry key="dynamo.graph/make-nodes" value="-1" />
           <entry key="dynamo.graph/precluding-errors" value="-1" />
+          <entry key="dynamo.graph/transact" value="-1" />
           <entry key="dynamo.graph/with-auto-evaluation-context" value="-1" />
           <entry key="dynamo.graph/with-auto-or-fake-evaluation-context" value="-1" />
           <entry key="dynamo.graph/with-system" value="-1" />
@@ -48,6 +49,8 @@
           <entry key="integration.test-util/with-prop" value="-1" />
           <entry key="integration.test-util/with-temp-dir!" value="-1" />
           <entry key="org.httpkit.server/with-channel" value="-1" />
+          <entry key="util.debug-util/measuring" value="-1" />
+          <entry key="util.debug-util/metrics-time" value="-1" />
           <entry key="util.profiler/profile" value="-1" />
           <entry key="vlaaad.reveal/defaction" value="-1" />
         </map>

--- a/editor/bundle-resources/config
+++ b/editor/bundle-resources/config
@@ -13,7 +13,7 @@ time =
 channel =
 archive_domain =
 [launcher]
-jdk = ${bootstrap.resourcespath}/packages/jdk11.0.1-p1
+jdk = ${bootstrap.resourcespath}/packages/jdk-11.0.15+10
 java = ${launcher.jdk}/bin/java
 jar = ${bootstrap.resourcespath}/packages/defold-${build.editor_sha1}.jar
 main = com.defold.editor.Main

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -208,6 +208,7 @@
                       :reveal {:source-paths ["src/reveal"]
                                :injections [(require 'editor.reveal)]
                                :dependencies [[vlaaad/reveal "1.3.273"]]}
+                      :metrics {:jvm-opts ["-Ddefold.metrics=true"]}
                       :dev     {:dependencies      [[com.clojure-goes-fast/clj-async-profiler "0.5.1"]
                                                     [com.clojure-goes-fast/clj-memory-meter "0.1.2"]
                                                     [criterium "0.4.3"]

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -182,7 +182,10 @@
 
   :uberjar-exclusions [#"^natives/"]
 
-  :profiles          {:test    {:injections [(defonce force-toolkit-init (javafx.application.Platform/startup (fn [])))]
+  :profiles          {:test    {:injections [(defonce force-toolkit-init
+                                               (javafx.application.Platform/startup
+                                                 (fn []
+                                                   (com.jogamp.opengl.GLProfile/initSingleton))))]
                                 :resource-paths ["test/resources"]}
                       :preflight {:dependencies [[jonase/kibit "0.1.6" :exclusions [org.clojure/clojure]]
                                                  [cljfmt-mg "0.6.4" :exclusions [org.clojure/clojure]]]}

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -109,16 +109,16 @@
                      [org.openjfx/javafx-swing "18" :classifier "mac"]
                      [org.openjfx/javafx-swing "18" :classifier "win"]
 
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-linux-amd64"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-macosx-universal"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-windows-amd64"]
-                     [org.jogamp.gluegen/gluegen-rt               "2.3.2" :classifier "natives-windows-i586"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-linux-amd64"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-macosx-universal"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-windows-amd64"]
-                     [org.jogamp.jogl/jogl-all                    "2.3.2" :classifier "natives-windows-i586"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-linux-amd64"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-macosx-universal"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-windows-amd64"]
+                     [com.metsci.ext.org.jogamp.gluegen/gluegen-rt "2.4.0-rc-20200202" :classifier "natives-windows-i586"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-linux-amd64"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-macosx-universal"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-windows-amd64"]
+                     [com.metsci.ext.org.jogamp.jogl/jogl-all      "2.4.0-rc-20200202" :classifier "natives-windows-i586"]
 
                      [org.snakeyaml/snakeyaml-engine "1.0"]]
 
@@ -182,10 +182,12 @@
 
   :uberjar-exclusions [#"^natives/"]
 
-  :profiles          {:test    {:injections [(defonce force-toolkit-init
-                                               (javafx.application.Platform/startup
-                                                 (fn []
-                                                   (com.jogamp.opengl.GLProfile/initSingleton))))]
+  :profiles          {:test    {:injections [(defonce initialize-test-prerequisites
+                                               (do
+                                                 (com.defold.libs.ResourceUnpacker/unpackResources)
+                                                 (javafx.application.Platform/startup
+                                                   (fn []
+                                                     (com.jogamp.opengl.GLProfile/initSingleton)))))]
                                 :resource-paths ["test/resources"]}
                       :preflight {:dependencies [[jonase/kibit "0.1.6" :exclusions [org.clojure/clojure]]
                                                  [cljfmt-mg "0.6.4" :exclusions [org.clojure/clojure]]]}

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -29,6 +29,7 @@ import ConfigParser
 import datetime
 import imp
 import fnmatch
+import urllib
 
 # TODO: collect common functions in a more suitable reusable module
 try:
@@ -51,17 +52,15 @@ CDN_PACKAGES_URL=os.environ.get("DM_PACKAGES_URL", None)
 # - /editor/bundle-resources/config at "launcher.jdk" key
 # - /scripts/build.py smoke_test, `java` variable
 # - /editor/src/clj/editor/updater.clj, `protected-dirs` let binding
-java_version = '11.0.1'
-java_version_patch = 'p1'
-
+java_version = '11.0.15+10'
 
 platform_to_java = {'x86_64-linux': 'linux-x64',
-                    'x86_64-darwin': 'osx-x64',
+                    'x86_64-darwin': 'macos-x64',
                     'x86_64-win32': 'windows-x64'}
 
 python_platform_to_java = {'linux2': 'linux-x64',
                            'win32': 'windows-x64',
-                           'darwin': 'osx-x64'}
+                           'darwin': 'macos-x64'}
 
 def log(msg):
     print(msg)
@@ -72,19 +71,37 @@ def mkdirs(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
-def extract(file, path, is_mac):
-    print('Extracting %s to %s' % (file, path))
-
+def extract_tar(file, path, is_mac):
     if is_mac:
-        # We use the system tar command for macOSX because tar (and
+        # We use the system tar command for macOS because tar (and
         # others) on macOS has special handling of ._ files that
         # contain additional HFS+ attributes. See for example:
         # http://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x
         exec_command(['tar', '-C', path, '-xzf', file])
     else:
-        tf = tarfile.TarFile.open(file, 'r:gz')
-        tf.extractall(path)
-        tf.close()
+        with tarfile.TarFile.open(file, 'r:gz') as tf:
+            tf.extractall(path)
+
+def extract_zip(file, path, is_mac):
+    if is_mac:
+        # We use the system unzip command for macOS because zip (and
+        # others) on macOS has special handling of ._ files that
+        # contain additional HFS+ attributes. See for example:
+        # http://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x
+        exec_command(['unzip', file, '-d', path])
+    else:
+        with zipfile.ZipFile(file, 'r') as zf:
+            zf.extractall(path)
+
+def extract(file, path, is_mac):
+    print('Extracting %s to %s' % (file, path))
+
+    if fnmatch.fnmatch(file, "*.tar.gz-*"):
+        extract_tar(file, path, is_mac)
+    elif fnmatch.fnmatch(file, "*.zip-*"):
+        extract_zip(file, path, is_mac)
+    else:
+        assert False, "Don't know how to extract " + file
 
 modules = {}
 
@@ -243,28 +260,34 @@ def launcher_path(options, platform, exe_suffix):
     else:
         return path.join(os.environ['DYNAMO_HOME'], "bin", platform, "launcher%s" % exe_suffix)
 
-
 def full_jdk_url(jdk_platform):
-    return '%s/openjdk-%s_%s_bin.tar.gz' % (CDN_PACKAGES_URL, java_version, jdk_platform)
+    version = urllib.quote(java_version)
+    platform = urllib.quote(jdk_platform)
+    extension = "zip" if jdk_platform.startswith("windows") else "tar.gz"
+    return '%s/microsoft-jdk-%s-%s.%s' % (CDN_PACKAGES_URL, version, platform, extension)
 
+def full_build_jdk_url():
+    return full_jdk_url(python_platform_to_java[sys.platform])
 
 def download_build_jdk():
     print('Downloading build jdk')
-    rmtree('build/jdk')
-    is_mac = sys.platform == 'darwin'
-    jdk_url = full_jdk_url(python_platform_to_java[sys.platform])
+    jdk_url = full_build_jdk_url()
     jdk = download(jdk_url)
     if not jdk:
         print('Failed to download build jdk %s' % jdk_url)
         sys.exit(5)
+    return jdk
+
+def extract_build_jdk(build_jdk):
+    print('Extracting build jdk')
+    rmtree('build/jdk')
     mkdirs('build/jdk')
-    extract(jdk, 'build/jdk', is_mac)
+    is_mac = sys.platform == 'darwin'
+    extract(build_jdk, 'build/jdk', is_mac)
     if is_mac:
-        return 'build/jdk/jdk-%s.jdk/Contents/Home' % java_version
+        return 'build/jdk/jdk-%s/Contents/Home' % java_version
     else:
         return 'build/jdk/jdk-%s' % java_version
-
-
 
 def check_reflections(java_cmd_env):
     reflection_prefix = 'Reflection warning, ' # final space important
@@ -287,7 +310,8 @@ def check_reflections(java_cmd_env):
 
 def build(options):
     build_jdk = download_build_jdk()
-    java_cmd_env = 'JAVA_CMD=%s/bin/java' % build_jdk
+    extracted_build_jdk = extract_build_jdk(build_jdk)
+    java_cmd_env = 'JAVA_CMD=%s/bin/java' % extracted_build_jdk
 
     print('Building editor')
 
@@ -365,6 +389,7 @@ def remove_platform_files_from_archive(platform, jar):
 def create_bundle(options):
     jar_file = 'target/defold-editor-2.0.0-SNAPSHOT-standalone.jar'
     build_jdk = download_build_jdk()
+    extracted_build_jdk = extract_build_jdk(build_jdk)
 
     mkdirs('target/editor')
     for platform in options.target_platform:
@@ -372,10 +397,13 @@ def create_bundle(options):
         rmtree('tmp')
 
         jdk_url = full_jdk_url(platform_to_java[platform])
-        jdk = download(jdk_url)
-        if not jdk:
-            print('Failed to download %s' % jdk_url)
-            sys.exit(5)
+        if jdk_url == full_build_jdk_url():
+            jdk = build_jdk
+        else:
+            jdk = download(jdk_url)
+            if not jdk:
+                print('Failed to download %s' % jdk_url)
+                sys.exit(5)
 
         tmp_dir = "tmp"
 
@@ -437,13 +465,13 @@ def create_bundle(options):
         extract(jdk, tmp_dir, is_mac)
 
         if is_mac:
-            platform_jdk = '%s/jdk-%s.jdk/Contents/Home' % (tmp_dir, java_version)
+            platform_jdk = '%s/jdk-%s/Contents/Home' % (tmp_dir, java_version)
         else:
             platform_jdk = '%s/jdk-%s' % (tmp_dir, java_version)
 
         # use jlink to generate a custom Java runtime to bundle with the editor
-        packages_jdk = '%s/jdk%s-%s' % (packages_dir, java_version, java_version_patch)
-        exec_command(['%s/bin/jlink' % build_jdk,
+        packages_jdk = '%s/jdk-%s' % (packages_dir, java_version)
+        exec_command(['%s/bin/jlink' % extracted_build_jdk,
                       '@jlink-options',
                       '--module-path=%s/jmods' % platform_jdk,
                       '--output=%s' % packages_jdk])
@@ -485,7 +513,7 @@ def sign(options):
         if 'darwin' in platform:
             # we need to sign the binaries in Resources folder manually as codesign of
             # the *.app will not process files in Resources
-            jdk_dir = "jdk%s-%s" % (java_version, java_version_patch)
+            jdk_dir = "jdk-%s" % (java_version)
             jdk_path = os.path.join(sign_dir, "Defold.app", "Contents", "Resources", "packages", jdk_dir)
             for exe in find_files(os.path.join(jdk_path, "bin"), "*"):
                 sign_files('darwin', options, exe)

--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -26,17 +26,14 @@
             [internal.graph.types :as gt]
             [internal.node :as in]
             [internal.system :as is]
-            [internal.util :as util])
-  (:import [clojure.lang MapEntry]
-           [internal.graph.types Arc]
+            [internal.util :as util]
+            [util.coll :refer [pair]])
+  (:import [internal.graph.types Arc]
            [java.beans BeanInfo Introspector MethodDescriptor PropertyDescriptor]
            [java.lang.reflect Modifier]
            [javafx.stage Window]))
 
 (set! *warn-on-reflection* true)
-
-(defn- pair [a b]
-  (MapEntry/create a b))
 
 (defn workspace []
   0)

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -948,7 +948,7 @@
   "Returns true if the node is a member of any of the given types, including
    their supertypes."
   [node types]
-  (let [node-type-key (some-> (gt/node-type node) deref :key)]
+  (let [node-type-key (-> node gt/node-type deref :key)]
     (some? (and node-type-key
                 (some (fn [type]
                         (let [type-key (:key @type)]
@@ -1002,12 +1002,12 @@
 
 (defn- every-arc-pred [& preds]
   (fn [basis ^Arc arc]
-    (loop [preds preds]
-      (if-some [pred (first preds)]
-        (if (pred basis arc)
-          (recur (next preds))
-          false)
-        true))))
+    (reduce (fn [_ pred]
+              (if (pred basis arc)
+                true
+                (reduced false)))
+            true
+            preds)))
 
 (defn- predecessors [pred basis node-id]
   (into []

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1572,13 +1572,13 @@ If you do not specifically require different script states, consider changing th
             (some-> path
                     slurp
                     edn/read-string))
-       (catch IOException e
+       (catch Exception e
          (dialogs/make-info-dialog
           {:title "Couldn't load custom keymap config"
            :icon :icon/triangle-error
            :header {:fx/type :v-box
                     :children [{:fx/type fxui/label
-                                :text (str "The keymap path " path " couldn't be opened.")}]}
+                                :text (str "The keymap from " path " couldn't be opened.")}]}
            :content (.getMessage e)})
          (log/error :exception e)
          nil)))

--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -21,8 +21,9 @@
             [editor.outline :as outline]
             [editor.resource :as resource]
             [editor.ui :as ui]
-            [editor.workspace :as workspace])
-  (:import [clojure.lang MapEntry PersistentQueue]
+            [editor.workspace :as workspace]
+            [util.coll :refer [pair]])
+  (:import [clojure.lang PersistentQueue]
            [java.util Collection]
            [javafx.collections ObservableList]
            [javafx.scene.control TreeItem TreeView]
@@ -31,9 +32,6 @@
            [javafx.scene.text Text]))
 
 (set! *warn-on-reflection* true)
-
-(defn- pair [a b]
-  (MapEntry. a b))
 
 (defn- queue [item]
   (conj PersistentQueue/EMPTY item))

--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -16,7 +16,8 @@
   (:require [clojure.set :as set]
             [clojure.string :as string]
             [editor.code.syntax :as syntax]
-            [editor.code.util :as util])
+            [editor.code.util :as util]
+            [util.coll :refer [pair]])
   (:import [java.io IOException Reader Writer InputStream]
            [java.nio CharBuffer]
            [java.util Collections]
@@ -674,7 +675,7 @@
         (map (fn [cursor-range]
                (let [start-row (.row (cursor-range-start cursor-range))
                      end-row (inc (.row (cursor-range-end cursor-range)))]
-                 (util/pair start-row end-row))))))
+                 (pair start-row end-row))))))
 
 (defn cursor-ranges->row-runs [lines cursor-ranges]
   (into [] (cursor-ranges->row-runs-xform lines) cursor-ranges))
@@ -1435,7 +1436,7 @@
         range-inverted? (pos? (compare-cursor-position from to))
         start (assoc (if range-inverted? to from) :order :start)
         end (assoc (if range-inverted? from to) :order :end)]
-    (util/pair start end)))
+    (pair start end)))
 
 (defn- pack-cursor-range
   ^CursorRange [^CursorRange cursor-range ^Cursor start ^Cursor end]
@@ -1789,7 +1790,7 @@
                   (assert (= row (.row ^Cursor (.to line-cursor-range))))
                   (assert (= 1 (count replacement-lines)))
                   (when-not (zero? length-difference)
-                    (util/pair row length-difference)))))
+                    (pair row length-difference)))))
         indentation-splices))
 
 (defn- splice-indentation [lines cursor-ranges regions indentation-splices]
@@ -1934,7 +1935,7 @@
 
 (defn- insert-lines-seqs [indent-level-pattern indent-string grammar lines cursor-ranges regions ^LayoutInfo layout lines-seqs]
   (when-not (empty? lines-seqs)
-    (-> (splice lines regions (map #(util/pair (adjust-cursor-range lines %1) %2) cursor-ranges lines-seqs))
+    (-> (splice lines regions (map #(pair (adjust-cursor-range lines %1) %2) cursor-ranges lines-seqs))
         (fix-indentation-after-splice indent-level-pattern indent-string grammar)
         (update-document-width-after-splice layout)
         (update :cursor-ranges (partial mapv cursor-range-end-range))
@@ -2758,7 +2759,7 @@
     (when-some [counterpart-cursor-range (case search-direction
                                            :prev (find-brace-counterpart brace counterpart lines (.from brace-cursor-range) -1)
                                            :next (find-brace-counterpart brace counterpart lines (.to brace-cursor-range) 1))]
-      (util/pair brace-cursor-range counterpart-cursor-range))))
+      (pair brace-cursor-range counterpart-cursor-range))))
 
 (defn- line-empty? [line line-start]
   (= line-start (count line)))

--- a/editor/src/clj/editor/code/syntax.clj
+++ b/editor/src/clj/editor/code/syntax.clj
@@ -14,7 +14,8 @@
 
 (ns editor.code.syntax
   (:require [clojure.string :as string]
-            [editor.code.util :as util])
+            [editor.code.util :as util]
+            [util.coll :refer [pair]])
   (:import (java.util.regex MatchResult Pattern)))
 
 (set! *warn-on-reflection* true)
@@ -63,7 +64,7 @@
 (defn- append-run! [transient-runs index scope]
   (let [last-coll-index (dec (count transient-runs))
         prev-run-index (first (get transient-runs last-coll-index))
-        run (util/pair index scope)]
+        run (pair index scope)]
     (if (= index prev-run-index)
       (assoc! transient-runs last-coll-index run)
       (conj! transient-runs run))))
@@ -120,10 +121,10 @@
   (let [root-scope (some find-parent-scope contexts)]
     ;; Skip very long lines since these might lock up the regex engine.
     (if (< 1024 (count line))
-      (util/pair contexts [(util/pair 0 root-scope)])
+      (pair contexts [(pair 0 root-scope)])
       (loop [start 0
              contexts contexts
-             runs (transient [(util/pair 0 root-scope)])]
+             runs (transient [(pair 0 root-scope)])]
         (if-some [match (first-match contexts line start)]
           (let [parent-scope (some find-parent-scope (.contexts match))
                 match-result ^MatchResult (.match-result match)]
@@ -133,4 +134,4 @@
                      :match (append-match! runs parent-scope match-result (.pattern match))
                      :begin (append-begin! runs parent-scope match-result (.pattern match))
                      :end (append-end! runs parent-scope match-result (.pattern match)))))
-          (util/pair contexts (persistent! runs)))))))
+          (pair contexts (persistent! runs)))))))

--- a/editor/src/clj/editor/code/util.clj
+++ b/editor/src/clj/editor/code/util.clj
@@ -13,9 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.code.util
-  (:require [clojure.string :as string])
-  (:import [clojure.lang MapEntry]
-           [java.util ArrayList Collections Comparator List]
+  (:import [java.util ArrayList Collections Comparator List]
            [java.util.regex Matcher Pattern]))
 
 (set! *warn-on-reflection* true)
@@ -85,11 +83,6 @@
       (if (pred (nth coll index))
         index
         (recur (dec index))))))
-
-(defn pair
-  "Returns a two-element collection that implements IPersistentVector."
-  [a b]
-  (MapEntry/create a b))
 
 (defn re-matcher-from
   "Returns an instance of java.util.regex.Matcher that starts at an offset."

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -17,7 +17,7 @@
             [dynamo.graph :as g]
             [editor.code.data :as data]
             [editor.code.resource :as r]
-            [editor.code.util :refer [pair split-lines]]
+            [editor.code.util :refer [split-lines]]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
             [editor.keymap :as keymap]
@@ -31,7 +31,8 @@
             [editor.workspace :as workspace]
             [internal.util :as util]
             [schema.core :as s]
-            [service.smoke-log :as slog])
+            [service.smoke-log :as slog]
+            [util.coll :refer [pair]])
   (:import [com.defold.control ListView]
            [com.sun.javafx.font FontResource FontStrike PGFont]
            [com.sun.javafx.geom.transform BaseTransform]

--- a/editor/src/clj/editor/collada_scene.clj
+++ b/editor/src/clj/editor/collada_scene.clj
@@ -346,7 +346,7 @@
                     :select-batch-key _node-id
                     :user-data {:meshes meshes
                                 :shader shader-pos-nrm-tex
-                                :textures {"texture" texture/white-pixel}
+                                :textures {"texture" @texture/white-pixel}
                                 :scratch-arrays (gen-scratch-arrays meshes)}
                     :passes [pass/opaque pass/opaque-selection]}
        :children [{:node-id _node-id

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -35,9 +35,11 @@
             [editor.scene :as scene]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
+            [internal.cache :as c]
             [internal.util :as util]
             [service.log :as log])
   (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc GameObject$PrototypeDesc]
+           [internal.graph.types Arc]
            [java.io StringReader]
            [javax.vecmath Matrix4d Point3d Quat4d Vector3d]))
 
@@ -254,13 +256,8 @@
                               (gen-embed-ddf id child-ids position rotation scale proto-msg))))
 
 (defn- component-resource [comp-id basis]
-  (cond
-    (g/node-instance? basis game-object/ReferencedComponent comp-id)
-    (some-> (g/node-value comp-id :path (g/make-evaluation-context {:basis basis}))
-            :resource)
-
-    (g/node-instance? basis game-object/ComponentNode comp-id)
-    (g/node-value comp-id :source-resource (g/make-evaluation-context {:basis basis}))))
+  (when (g/node-instance? basis game-object/ComponentNode comp-id)
+    (g/node-value comp-id :source-resource (g/make-evaluation-context {:basis basis :cache c/null-cache}))))
 
 (defn- overridable-component? [basis node-id]
   (some-> node-id
@@ -269,11 +266,14 @@
     :tags
     (contains? :overridable-properties)))
 
-(defn- or-go-traverse? [basis [src-id src-label tgt-id tgt-label]]
-  (or
-    (overridable-component? basis src-id)
-    (g/node-instance? basis resource-node/ResourceNode src-id)
-    (g/node-instance? basis script/ScriptPropertyNode src-id)))
+(def ^:private or-go-traverse-fn
+  (g/make-override-traverse-fn
+    (fn or-go-traverse-fn [basis ^Arc arc]
+      (let [source-node-id (.source-id arc)]
+        (or (overridable-component? basis source-node-id)
+            (g/node-instance-of-any? basis source-node-id
+                                     [resource-node/ResourceNode
+                                      script/ScriptPropertyNode]))))))
 
 (defn- path-error [node-id resource]
   (or (validation/prop-error :fatal node-id :path validation/prop-nil? resource "Path")
@@ -308,7 +308,7 @@
                        (when-some [{connect-tx-data :tx-data go-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
                          (concat
                            connect-tx-data
-                           (g/override go-node {:traverse? or-go-traverse?}
+                           (g/override go-node {:traverse-fn or-go-traverse-fn}
                                        (fn [evaluation-context id-mapping]
                                          (let [or-go-node (get id-mapping go-node)
                                                comp-name->refd-comp-node (g/node-value go-node :component-ids evaluation-context)]
@@ -562,12 +562,15 @@
              :outline-reference? true
              :alt-outline source-outline))))
 
-(defn- or-coll-traverse? [basis [src-id src-label tgt-id tgt-label]]
-  (or
-    (overridable-component? basis src-id)
-    (g/node-instance? basis resource-node/ResourceNode src-id)
-    (g/node-instance? basis script/ScriptPropertyNode src-id)
-    (g/node-instance? basis InstanceNode src-id)))
+(def ^:private or-coll-traverse-fn
+  (g/make-override-traverse-fn
+    (fn or-coll-traverse-fn [basis ^Arc arc]
+      (let [source-node-id (.source-id arc)]
+        (or (overridable-component? basis source-node-id)
+            (g/node-instance-of-any? basis source-node-id
+                                     [resource-node/ResourceNode
+                                      script/ScriptPropertyNode
+                                      InstanceNode]))))))
 
 (g/defnode CollectionInstanceNode
   (inherits scene/SceneNode)
@@ -589,7 +592,7 @@
                (when-some [{connect-tx-data :tx-data coll-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
                  (concat
                    connect-tx-data
-                   (g/override coll-node {:traverse? or-coll-traverse?}
+                   (g/override coll-node {:traverse-fn or-coll-traverse-fn}
                                (fn [evaluation-context id-mapping]
                                  (let [or-coll-node (get id-mapping coll-node)
                                        go-name->go-node (comp #(g/node-value % :source-id evaluation-context)

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -449,7 +449,7 @@
 (g/defnk produce-build-targets
   [_node-id resource pb-msg collision-shape dep-build-targets mass type project-physics-type shapes]
   (let [dep-build-targets (flatten dep-build-targets)
-        convex-shape (when (and collision-shape (= "convexshape" (:ext (resource/resource-type collision-shape))))
+        convex-shape (when (and collision-shape (= "convexshape" (resource/type-ext collision-shape)))
                        (get-in (first dep-build-targets) [:user-data :pb]))
         pb-msg (if convex-shape
                  (dissoc pb-msg :collision-shape) ; Convex shape will be merged into :embedded-collision-shape below.

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -16,37 +16,41 @@
   "Define the concept of a project, and its Project node type. This namespace bridges between Eclipse's workbench and
   ordinary paths."
   (:require [clojure.java.io :as io]
-            [clojure.set :as set]
             [dynamo.graph :as g]
             [editor.code.script-intelligence :as si]
             [editor.collision-groups :as collision-groups]
             [editor.core :as core]
             [editor.error-reporting :as error-reporting]
+            [editor.game-project-core :as gpc]
             [editor.gl :as gl]
+            [editor.graph-util :as gu]
             [editor.handler :as handler]
-            [editor.ui :as ui]
             [editor.library :as library]
+            [editor.placeholder-resource :as placeholder-resource]
             [editor.progress :as progress]
             [editor.resource :as resource]
             [editor.resource-io :as resource-io]
             [editor.resource-node :as resource-node]
             [editor.resource-update :as resource-update]
-            [editor.workspace :as workspace]
-            [editor.game-project-core :as gpc]
             [editor.settings-core :as settings-core]
-            [editor.pipeline :as pipeline]
-            [editor.placeholder-resource :as placeholder-resource]
+            [editor.ui :as ui]
             [editor.util :as util]
-            [service.log :as log]
-            [editor.graph-util :as gu]
-            [util.text-util :as text-util]
+            [editor.workspace :as workspace]
+            [internal.cache :as c]
             [schema.core :as s]
+            [service.log :as log]
+            [util.coll :refer [pair]]
+            [util.debug-util :as du]
+            [util.text-util :as text-util]
             [util.thread-util :as thread-util])
   (:import (java.util.concurrent.atomic AtomicLong)))
 
 (set! *warn-on-reflection* true)
 
 (def ^:dynamic *load-cache* nil)
+
+(defonce load-metrics-atom (du/when-metrics (atom nil)))
+(defonce resource-change-metrics-atom (du/when-metrics (atom nil)))
 
 (def ^:private TBreakpoint
   {:resource s/Any
@@ -142,40 +146,64 @@
                   batch
                   load-deps)))))))
 
-(defn load-resource-nodes [project node-ids render-progress! resource-node-dependencies]
+(defn- load-resource-nodes [project node-ids render-progress! resource-node-dependencies resource-metrics]
   (let [evaluation-context (g/make-evaluation-context)
         node-id->resource (into {}
                                 (map (fn [node-id]
                                        [node-id (g/node-value node-id :resource evaluation-context)]))
                                 node-ids)
         old-nodes-by-resource-path (g/node-value project :nodes-by-resource-path evaluation-context)
-        loaded-nodes-by-resource-path (into {} (map (fn [[node-id resource]]
-                                                      [(resource/proj-path resource) node-id]))
+        loaded-nodes-by-resource-path (into {}
+                                            (map (fn [[node-id resource]]
+                                                   [(resource/proj-path resource) node-id]))
                                             node-id->resource)
         nodes-by-resource-path (merge old-nodes-by-resource-path loaded-nodes-by-resource-path)
         loaded-nodes (set node-ids)
-        load-deps (fn [node-id] (node-load-dependencies node-id loaded-nodes nodes-by-resource-path resource-node-dependencies evaluation-context))
+        load-deps (fn [node-id]
+                    (du/measuring resource-metrics (resource/proj-path (g/node-value node-id :resource evaluation-context)) :find-new-reload-dependencies
+                      (node-load-dependencies node-id loaded-nodes nodes-by-resource-path resource-node-dependencies evaluation-context)))
         node-ids (sort-nodes-for-loading loaded-nodes load-deps)
         basis (:basis evaluation-context)
         render-loading-progress! (progress/nest-render-progress render-progress! (progress/make "" 5 0) 4)
         render-processing-progress! (progress/nest-render-progress render-progress! (progress/make "" 5 4))
+        resource-metrics-load-timer (du/when-metrics
+                                      (volatile! 0))
+        start-resource-metrics-load-timer! (du/when-metrics
+                                             (fn []
+                                               (vreset! resource-metrics-load-timer (System/nanoTime))))
+        stop-resource-metrics-load-timer! (du/when-metrics
+                                            (fn [resource-path]
+                                              (let [end-time (System/nanoTime)
+                                                    ^long start-time @resource-metrics-load-timer]
+                                                (du/update-metrics resource-metrics resource-path :process-load-tx-data (- end-time start-time)))))
         load-txs (doall
-                   (for [[node-index node-id] (map-indexed #(clojure.lang.MapEntry/create (inc %1) %2) node-ids)]
-                     (let [resource-path (resource/resource->proj-path (node-id->resource node-id))]
+                   (for [[node-index node-id] (map-indexed #(pair (inc %1) %2) node-ids)]
+                     (let [resource (node-id->resource node-id)
+                           resource-path (resource/resource->proj-path resource)
+                           loading-progress (progress/make (str "Loading " resource-path)
+                                                           (count node-ids)
+                                                           node-index)
+                           processing-progress (progress/make (str "Processing " resource-path)
+                                                              (count node-ids)
+                                                              node-index)]
                        (do
-                         (render-loading-progress! (progress/make (str "Loading " resource-path)
-                                                                  (count node-ids)
-                                                                  node-index))
-                         [(g/callback render-processing-progress! (progress/make (str "Processing " resource-path)
-                                                                                 (count node-ids)
-                                                                                 node-index))
-                          (load-node project node-id (g/node-type* basis node-id) (node-id->resource node-id))]))))]
+                         (render-loading-progress! loading-progress)
+                         (du/if-metrics
+                           [(g/callback render-processing-progress! processing-progress)
+                            (g/callback start-resource-metrics-load-timer!)
+                            (du/measuring resource-metrics resource-path :generate-load-tx-data
+                              (load-node project node-id (g/node-type* basis node-id) resource))
+                            (g/callback stop-resource-metrics-load-timer! resource-path)]
+                           [(g/callback render-processing-progress! processing-progress)
+                            (load-node project node-id (g/node-type* basis node-id) resource)])))))]
     (g/update-cache-from-evaluation-context! evaluation-context)
     load-txs))
 
-(defn- load-nodes! [project node-ids render-progress! resource-node-dependencies]
-  (g/transact (load-resource-nodes project node-ids render-progress! resource-node-dependencies))
-  (render-progress! progress/done))
+(defn- load-nodes! [project node-ids render-progress! resource-node-dependencies resource-metrics transaction-metrics]
+  (let [tx-result (g/transact transaction-metrics
+                    (load-resource-nodes project node-ids render-progress! resource-node-dependencies resource-metrics))]
+    (render-progress! progress/done)
+    tx-result))
 
 (defn connect-if-output [src-type src tgt connections]
   (let [outputs (g/output-labels src-type)]
@@ -226,11 +254,16 @@
   ([project resources]
    (load-project project resources progress/null-render-progress!))
   ([project resources render-progress!]
-   (assert (not (seq (g/node-value project :nodes))) "load-project should only be used when loading an empty project")
+   (assert (empty? (g/node-value project :nodes)) "load-project should only be used when loading an empty project")
    (with-bindings {#'*load-cache* (atom (into #{} (g/node-value project :nodes)))}
-     (let [nodes (make-nodes! project resources)
+     (let [process-metrics (du/make-metrics-collector)
+           resource-metrics (du/make-metrics-collector)
+           transaction-metrics (du/make-metrics-collector)
+           nodes (du/measuring process-metrics :make-new-nodes
+                   (make-nodes! project resources))
            script-intel (script-intelligence project)]
-       (load-nodes! project nodes render-progress! {})
+       (du/measuring process-metrics :load-new-nodes
+         (load-nodes! project nodes render-progress! {} resource-metrics transaction-metrics))
        (when-let [game-project (get-resource-node project "/game.project")]
          (g/transact
            (concat
@@ -238,6 +271,12 @@
              (g/connect game-project :display-profiles-data project :display-profiles)
              (g/connect game-project :texture-profiles-data project :texture-profiles)
              (g/connect game-project :settings-map project :settings))))
+       (du/when-metrics
+         (reset! load-metrics-atom
+                 {:new-nodes-by-path (g/node-value project :nodes-by-resource-path)
+                  :process-metrics @process-metrics
+                  :resource-metrics @resource-metrics
+                  :transaction-metrics @transaction-metrics}))
        project))))
 
 (defn make-embedded-resource [project type data]
@@ -433,27 +472,37 @@
 
 (defn- perform-resource-change-plan [plan project render-progress!]
   (binding [*load-cache* (atom (into #{} (g/node-value project :nodes)))]
-    (let [collected-properties-by-resource
-          (g/with-auto-evaluation-context evaluation-context
-            (into {}
-                  (map (fn [[resource old-node-id]]
-                         [resource
-                          (g/collect-overridden-properties old-node-id evaluation-context)]))
-                  (:transfer-overrides plan)))
+    (let [process-metrics (du/make-metrics-collector)
+          resource-metrics (du/make-metrics-collector)
+          transaction-metrics (du/make-metrics-collector)
+
+          collected-properties-by-resource
+          (du/measuring process-metrics :collect-overridden-properties
+            (g/with-auto-evaluation-context evaluation-context
+              (into {}
+                    (map (fn [[resource old-node-id]]
+                           [resource
+                            (du/measuring resource-metrics (resource/proj-path resource) :collect-overridden-properties
+                              (g/collect-overridden-properties old-node-id evaluation-context))]))
+                    (:transfer-overrides plan))))
 
           old-nodes-by-path (g/node-value project :nodes-by-resource-path)
           rn-dependencies-evaluation-context (g/make-evaluation-context)
           old-resource-node-dependencies (memoize
                                            (fn [node-id]
-                                             (let [deps (g/node-value node-id :reload-dependencies rn-dependencies-evaluation-context)]
+                                             (let [deps (du/measuring resource-metrics (resource/proj-path (g/node-value node-id :resource rn-dependencies-evaluation-context)) :find-old-reload-dependencies
+                                                          (g/node-value node-id :reload-dependencies rn-dependencies-evaluation-context))]
                                                (when-not (g/error? deps)
                                                  deps))))
           resource->old-node (comp old-nodes-by-path resource/proj-path)
-          new-nodes (make-nodes! project (:new plan))
-          resource-path->new-node (into {} (map (fn [resource-node]
-                                                  (let [resource (g/node-value resource-node :resource)]
-                                                    [(resource/proj-path resource) resource-node]))
-                                                new-nodes))
+          new-nodes (du/measuring process-metrics :make-new-nodes
+                      (make-nodes! project (:new plan)))
+          resource-path->new-node (g/with-auto-evaluation-context evaluation-context
+                                    (into {}
+                                          (map (fn [resource-node]
+                                                 (let [resource (g/node-value resource-node :resource evaluation-context)]
+                                                   [(resource/proj-path resource) resource-node])))
+                                          new-nodes))
           resource->new-node (comp resource-path->new-node resource/proj-path)
           ;; when transferring overrides and arcs, the target is either a newly created or already (still!)
           ;; existing node.
@@ -464,83 +513,132 @@
       ;; The new target nodes do not need to be loaded. When loading the new targets,
       ;; corresponding override-nodes for the incoming connections will be created in the
       ;; overrides.
-      (let [transfers (into {}
-                            (map (juxt second (comp resource->node first)))
-                            (:transfer-overrides plan))]
-        (g/transact
-          (g/transfer-overrides transfers)))
+      (du/measuring process-metrics :transfer-overrides
+        (g/transact transaction-metrics
+          (du/if-metrics
+            ;; Doing metrics - Submit separate transaction steps for each resource.
+            (for [[resource old-node-id] (:transfer-overrides plan)]
+              (g/transfer-overrides {old-node-id (resource->node resource)}))
+
+            ;; Not doing metrics - submit as a single transaction step.
+            (g/transfer-overrides
+              (into {}
+                    (map (fn [[resource old-node-id]]
+                           [old-node-id (resource->node resource)]))
+                    (:transfer-overrides plan))))))
 
       ;; must delete old versions of resource nodes before loading to avoid
       ;; load functions finding these when doing lookups of dependencies...
-      (g/transact
-        (for [node (:delete plan)]
-          (g/delete-node node)))
+      (du/measuring process-metrics :delete-old-nodes
+        (g/transact transaction-metrics
+          (for [node (:delete plan)]
+            (g/delete-node node))))
 
-      (load-nodes! project new-nodes render-progress! old-resource-node-dependencies)
+      (du/measuring process-metrics :load-new-nodes
+        (load-nodes! project new-nodes render-progress! old-resource-node-dependencies resource-metrics transaction-metrics))
 
-      (g/update-cache-from-evaluation-context! rn-dependencies-evaluation-context)
+      (du/measuring process-metrics :update-cache
+        (g/update-cache-from-evaluation-context! rn-dependencies-evaluation-context))
 
-      (g/transact
-        (for [[source-resource output-arcs] (:transfer-outgoing-arcs plan)]
-          (let [source-node (resource->node source-resource)
-                existing-arcs (set (gu/explicit-outputs source-node))]
-            (for [[source-label [target-node target-label]] (remove existing-arcs output-arcs)]
-              ;; if (g/node-by-id target-node), the target of the outgoing arc
-              ;; has not been deleted above - implying it has not been replaced by a
-              ;; new version.
-              ;; Otherwise, the target-node has probably been replaced by another version
-              ;; (reloaded) and that should have reestablished any incoming arcs to it already
-              (if (g/node-by-id target-node)
-                (g/connect source-node source-label target-node target-label)
-                [])))))
+      (du/measuring process-metrics :transfer-outgoing-arcs
+        (g/transact transaction-metrics
+          (for [[source-resource output-arcs] (:transfer-outgoing-arcs plan)]
+            (let [source-node (resource->node source-resource)
+                  existing-arcs (set (gu/explicit-outputs source-node))]
+              (for [[source-label [target-node target-label]] (remove existing-arcs output-arcs)]
+                ;; if (g/node-by-id target-node), the target of the outgoing arc
+                ;; has not been deleted above - implying it has not been replaced by a
+                ;; new version.
+                ;; Otherwise, the target-node has probably been replaced by another version
+                ;; (reloaded) and that should have reestablished any incoming arcs to it already
+                (when (g/node-by-id target-node)
+                  (g/connect source-node source-label target-node target-label)))))))
 
-      (g/transact
-        (for [[resource-node new-resource] (:redirect plan)]
-          (g/set-property resource-node :resource new-resource)))
+      (du/measuring process-metrics :redirect
+        (g/transact transaction-metrics
+          (for [[resource-node new-resource] (:redirect plan)]
+            (g/set-property resource-node :resource new-resource))))
 
-      (g/transact
-        (for [node (:mark-deleted plan)]
-          (let [flaw (resource-io/file-not-found-error node nil :fatal (g/node-value node :resource))]
-            (g/mark-defective node flaw))))
+      (du/measuring process-metrics :mark-deleted
+        (g/transact transaction-metrics
+          (for [node (:mark-deleted plan)]
+            (let [flaw (resource-io/file-not-found-error node nil :fatal (g/node-value node :resource))]
+              (g/mark-defective node flaw)))))
 
-      (let [all-outputs (mapcat (fn [node]
-                                  (map (fn [[output _]] [node output]) (gu/explicit-outputs node)))
-                                (:invalidate-outputs plan))]
-        (g/invalidate-outputs! all-outputs))
+      ;; invalidate outputs.
+      (du/measuring process-metrics :invalidate-outputs
+        (let [basis (g/now)
+              uncached-evaluation-context (du/when-metrics
+                                            (g/make-evaluation-context {:basis basis :cache c/null-cache}))]
+          (du/if-metrics
+            (doseq [node-id (:invalidate-outputs plan)]
+              (du/measuring resource-metrics (resource/proj-path (g/node-value node-id :resource uncached-evaluation-context)) :invalidate-outputs
+                (g/invalidate-outputs! (mapv (fn [[_ src-label]]
+                                               [node-id src-label])
+                                             (g/explicit-outputs basis node-id)))))
+            (g/invalidate-outputs! (into []
+                                         (mapcat (fn [node-id]
+                                                   (map (fn [[_ src-label]]
+                                                          [node-id src-label])
+                                                        (g/explicit-outputs basis node-id))))
+                                         (:invalidate-outputs plan))))))
 
       ;; restore overridden properties.
-      (let [restore-properties-tx-data
-            (g/with-auto-evaluation-context evaluation-context
-              (into []
-                    (mapcat (fn [[resource collected-properties]]
-                              (when-some [new-node-id (resource->new-node resource)]
-                                (g/restore-overridden-properties new-node-id collected-properties evaluation-context))))
-                    collected-properties-by-resource))]
-        (when (seq restore-properties-tx-data)
-          (g/transact
-            restore-properties-tx-data)))
+      (du/measuring process-metrics :restore-overridden-properties
+        (du/if-metrics
+          (g/with-auto-evaluation-context evaluation-context
+            (doseq [[resource collected-properties] collected-properties-by-resource]
+              (when-some [new-node-id (resource->new-node resource)]
+                (du/measuring resource-metrics (resource/proj-path resource) :restore-overridden-properties
+                  (let [restore-properties-tx-data (g/restore-overridden-properties new-node-id collected-properties evaluation-context)]
+                    (when (seq restore-properties-tx-data)
+                      (g/transact transaction-metrics restore-properties-tx-data)))))))
+          (let [restore-properties-tx-data
+                (g/with-auto-evaluation-context evaluation-context
+                  (into []
+                        (mapcat (fn [[resource collected-properties]]
+                                  (when-some [new-node-id (resource->new-node resource)]
+                                    (g/restore-overridden-properties new-node-id collected-properties evaluation-context))))
+                        collected-properties-by-resource))]
+            (when (seq restore-properties-tx-data)
+              (g/transact transaction-metrics
+                restore-properties-tx-data)))))
 
-      (let [old->new (into {} (map (fn [[p n]] [(old-nodes-by-path p) n]) resource-path->new-node))
-            dissoc-deleted (fn [x] (apply dissoc x (:mark-deleted plan)))]
-        (g/transact
-          (concat
-            (let [all-selections (-> (g/node-value project :all-selections)
-                                     (dissoc-deleted)
-                                     (remap-selection old->new (comp vector first)))]
-              (perform-selection project all-selections))
-            (let [all-sub-selections (-> (g/node-value project :all-sub-selections)
-                                         (dissoc-deleted)
-                                         (remap-selection old->new (constantly [])))]
-              (perform-sub-selection project all-sub-selections)))))
+      (du/measuring process-metrics :update-selection
+        (let [old->new (into {}
+                             (map (fn [[p n]]
+                                    [(old-nodes-by-path p) n]))
+                             resource-path->new-node)
+              dissoc-deleted (fn [x] (apply dissoc x (:mark-deleted plan)))]
+          (g/transact transaction-metrics
+            (concat
+              (let [all-selections (-> (g/node-value project :all-selections)
+                                       (dissoc-deleted)
+                                       (remap-selection old->new (comp vector first)))]
+                (perform-selection project all-selections))
+              (let [all-sub-selections (-> (g/node-value project :all-sub-selections)
+                                           (dissoc-deleted)
+                                           (remap-selection old->new (constantly [])))]
+                (perform-sub-selection project all-sub-selections))))))
 
       ;; invalidating outputs is the only change that does not reset the undo history
       (when (some seq (vals (dissoc plan :invalidate-outputs)))
-        (g/reset-undo! (graph project))))))
+        (g/reset-undo! (graph project)))
+
+      (du/when-metrics
+        (reset! resource-change-metrics-atom
+                {:old-nodes-by-path old-nodes-by-path
+                 :new-nodes-by-path resource-path->new-node
+                 :process-metrics @process-metrics
+                 :resource-metrics @resource-metrics
+                 :transaction-metrics @transaction-metrics})))))
 
 (defn- handle-resource-changes [project changes render-progress!]
-  (-> (resource-update/resource-change-plan (g/node-value project :nodes-by-resource-path) changes)
-      ;; for debugging resource loading/reloading issues: (resource-update/print-plan)
-      (perform-resource-change-plan project render-progress!)))
+  (let [nodes-by-resource-path (g/node-value project :nodes-by-resource-path)
+        resource-change-plan (du/metrics-time "Generate resource change plan" (resource-update/resource-change-plan nodes-by-resource-path changes))]
+    ;; For debugging resource loading / reloading issues:
+    ;; (resource-update/print-plan resource-change-plan)
+    (du/metrics-time "Perform resource change plan" (perform-resource-change-plan resource-change-plan project render-progress!))))
 
 (g/defnk produce-collision-groups-data
   [collision-group-nodes]

--- a/editor/src/clj/editor/fuzzy_text.clj
+++ b/editor/src/clj/editor/fuzzy_text.clj
@@ -13,8 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.fuzzy-text
-  (:require [clojure.string :as string])
-  (:import (clojure.lang MapEntry)))
+  (:require [clojure.string :as string]
+            [util.coll :refer [pair]]))
 
 ;; Sublime Text-style fuzzy text matching.
 ;;
@@ -60,9 +60,6 @@
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
-
-(defn- pair [a b]
-  (MapEntry. a b))
 
 (defn- case-insensitive-character-indices
   "Returns a vector of indices where the specified code point exists in the

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -98,9 +98,9 @@
      :label ""}))
 
 (def ^:private identity-transform-properties
-  {:position [0.0 0.0 0.0]
-   :rotation [0.0 0.0 0.0 1.0]
-   :scale [1.0 1.0 1.0]})
+  {:position [(float 0.0) (float 0.0) (float 0.0)]
+   :rotation [(float 0.0) (float 0.0) (float 0.0) (float 1.0)]
+   :scale [(float 1.0) (float 1.0) (float 1.0)]})
 
 (defn- supported-transform-properties [component-resource-type]
   (assert (some? component-resource-type))
@@ -309,7 +309,7 @@
                            (when-some [{connect-tx-data :tx-data comp-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
                              (concat
                                connect-tx-data
-                               (g/override comp-node {:traverse? (constantly true)}
+                               (g/override comp-node {:traverse-fn g/always-override-traverse-fn}
                                            (fn [evaluation-context id-mapping]
                                              (let [or-comp-node (get id-mapping comp-node)
                                                    comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -260,9 +260,15 @@ If supplied, the unit is the offset of GL_TEXTURE0, i.e. 0 => GL_TEXTURE0. The d
   (let [unit (+ unit-index GL2/GL_TEXTURE0)]
     (->TextureLifecycle request-id ::texture unit params (->texture-data width height data-format nil false))))
 
-(def white-pixel (image-texture ::white (-> (image-util/blank-image 1 1) (image-util/flood 1.0 1.0 1.0)) (assoc default-image-texture-params
-                                                                                                                :min-filter GL2/GL_NEAREST
-                                                                                                                :mag-filter GL2/GL_NEAREST)))
+(defonce white-pixel
+  (delay
+    (image-texture
+      ::white
+      (-> (image-util/blank-image 1 1)
+          (image-util/flood 1.0 1.0 1.0))
+      (assoc default-image-texture-params
+        :min-filter GL2/GL_NEAREST
+        :mag-filter GL2/GL_NEAREST))))
 
 (defn tex-sub-image [^GL2 gl ^TextureLifecycle texture data x y w h data-format]
   (let [tex (->texture texture gl)

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -13,9 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.graph-util
-  (:require [dynamo.graph :as g]
-            [internal.graph :as ig]
-            [internal.graph.types :as gt]))
+  (:require [dynamo.graph :as g]))
 
 (set! *warn-on-reflection* true)
 
@@ -25,6 +23,11 @@
 (defn array-subst-remove-errors [arr]
   (vec (remove g/error? arr)))
 
-(defn explicit-outputs [node]
-  ;; don't include arcs from override-original nodes
-  (mapv (fn [[_ src-label tgt-id tgt-label]] [src-label [tgt-id tgt-label]]) (g/explicit-outputs node)))
+(defn explicit-outputs
+  ([node-id]
+   (explicit-outputs (g/now) node-id))
+  ([basis node-id]
+   ;; don't include arcs from override-original nodes
+   (mapv (fn [[_ src-label tgt-id tgt-label]]
+           [src-label [tgt-id tgt-label]])
+         (g/explicit-outputs basis node-id))))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -226,7 +226,7 @@
 (defn render-tris [^GL2 gl render-args renderables rcount]
   (let [user-data (get-in renderables [0 :user-data])
         clipping-state (:clipping-state user-data)
-        gpu-texture (or (get user-data :gpu-texture) texture/white-pixel)
+        gpu-texture (or (get user-data :gpu-texture) @texture/white-pixel)
         material-shader (get user-data :material-shader)
         blend-mode (get user-data :blend-mode)
         vb (gen-vb gl renderables)
@@ -2672,7 +2672,7 @@
       (g/make-nodes graph-id [textures-node TexturesNode
                               no-texture [InternalTextureNode
                                           :name ""
-                                          :gpu-texture texture/white-pixel]]
+                                          :gpu-texture @texture/white-pixel]]
                     (g/connect textures-node :_node-id self :textures-node) ; for the tests :/
                     (g/connect textures-node :_node-id self :nodes)
                     (g/connect textures-node :build-errors self :build-errors)

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -81,6 +81,7 @@
   (input texture-profiles g/Any)
 
   ;; we never modify ImageNode, save-data and source-value can be trivial and not cached
+  (output undecorated-save-data g/Any (g/constantly nil))
   (output save-data g/Any (g/constantly nil))
   (output source-value g/Any (g/constantly nil))
 

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -132,7 +132,7 @@
 (defn render-tris [^GL2 gl render-args renderables rcount]
   (let [renderable (first renderables)
         user-data (:user-data renderable)
-        gpu-texture (or (get user-data :gpu-texture) texture/white-pixel)
+        gpu-texture (or (get user-data :gpu-texture) @texture/white-pixel)
         vb (gen-vb gl renderables)
         vcount (count vb)]
     (when (> vcount 0)

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -95,7 +95,7 @@
                                                         (when expanded (.setExpanded item expanded))
                                                         (or selected expanded))) items)))
 
-(defn- sync-selection [^TreeView tree-view selection old-tree-view-indices]
+(defn- sync-selection [^TreeView tree-view selection old-selected-ids]
   (let [root (.getRoot tree-view)
         selection-model (.getSelectionModel tree-view)]
     (.clearSelection selection-model)
@@ -107,7 +107,7 @@
               selected-indices (filter #(selected-ids (item->node-id (.getTreeItem tree-view %))) (range count))]
           (when (not (empty? selected-indices))
             (ui/select-indices! tree-view selected-indices))
-          (when-not (= old-tree-view-indices selected-indices)
+          (when-not (= old-selected-ids selected-ids)
             (when-some [first-item (first (.getSelectedItems selection-model))]
               (ui/scroll-to-item! tree-view first-item))))))))
 
@@ -154,28 +154,30 @@
     new-root))
 
 (defn- update-tree-view-selection!
-  [^TreeView tree-view selection old-tree-view-indices]
+  [^TreeView tree-view selection old-selected-ids]
   (binding [*programmatic-selection* true]
-    (sync-selection tree-view selection old-tree-view-indices)
+    (sync-selection tree-view selection old-selected-ids)
     tree-view))
 
 (defn- update-tree-view-root!
-  [^TreeView tree-view ^TreeItem root selection old-tree-view-indices]
+  [^TreeView tree-view ^TreeItem root selection old-selected-ids]
   (binding [*programmatic-selection* true]
     (when (not (identical? (.getRoot tree-view) root))
       (when root
         (.setExpanded root true)
         (.setRoot tree-view root)))
-    (sync-selection tree-view selection old-tree-view-indices)
+    (sync-selection tree-view selection old-selected-ids)
     tree-view))
 
 (g/defnk update-tree-view [^TreeView raw-tree-view ^TreeItem root selection]
-  (let [tree-view-indices (vec (.getSelectedIndices (.getSelectionModel raw-tree-view)))]
+  (let [tree-view-ids (into #{}
+                            (map item->node-id)
+                            (.getSelectedItems (.getSelectionModel raw-tree-view)))]
     (if (identical? (.getRoot raw-tree-view) root)
       (if (= (set selection) (set (map :node-id (ui/selection raw-tree-view))))
         raw-tree-view
-        (update-tree-view-selection! raw-tree-view selection tree-view-indices))
-      (update-tree-view-root! raw-tree-view root selection tree-view-indices))))
+        (update-tree-view-selection! raw-tree-view selection tree-view-ids))
+      (update-tree-view-root! raw-tree-view root selection tree-view-ids))))
 
 (defn- item->value [^TreeItem item]
   (.getValue item))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -95,7 +95,7 @@
                                                         (when expanded (.setExpanded item expanded))
                                                         (or selected expanded))) items)))
 
-(defn- sync-selection [^TreeView tree-view selection]
+(defn- sync-selection [^TreeView tree-view selection old-tree-view-indices]
   (let [root (.getRoot tree-view)
         selection-model (.getSelectionModel tree-view)]
     (.clearSelection selection-model)
@@ -107,8 +107,9 @@
               selected-indices (filter #(selected-ids (item->node-id (.getTreeItem tree-view %))) (range count))]
           (when (not (empty? selected-indices))
             (ui/select-indices! tree-view selected-indices))
-          (when-some [first-item (first (.getSelectedItems selection-model))]
-            (ui/scroll-to-item! tree-view first-item)))))))
+          (when-not (= old-tree-view-indices selected-indices)
+            (when-some [first-item (first (.getSelectedItems selection-model))]
+              (ui/scroll-to-item! tree-view first-item))))))))
 
 (defn- decorate
   ([hidden-node-outline-key-paths root]
@@ -153,27 +154,28 @@
     new-root))
 
 (defn- update-tree-view-selection!
-  [^TreeView tree-view selection]
+  [^TreeView tree-view selection old-tree-view-indices]
   (binding [*programmatic-selection* true]
-    (sync-selection tree-view selection)
+    (sync-selection tree-view selection old-tree-view-indices)
     tree-view))
 
 (defn- update-tree-view-root!
-  [^TreeView tree-view ^TreeItem root selection]
+  [^TreeView tree-view ^TreeItem root selection old-tree-view-indices]
   (binding [*programmatic-selection* true]
     (when (not (identical? (.getRoot tree-view) root))
       (when root
         (.setExpanded root true)
         (.setRoot tree-view root)))
-    (sync-selection tree-view selection)
+    (sync-selection tree-view selection old-tree-view-indices)
     tree-view))
 
 (g/defnk update-tree-view [^TreeView raw-tree-view ^TreeItem root selection]
-  (if (identical? (.getRoot raw-tree-view) root)
-    (if (= (set selection) (set (map :node-id (ui/selection raw-tree-view))))
-      raw-tree-view
-      (update-tree-view-selection! raw-tree-view selection))
-    (update-tree-view-root! raw-tree-view root selection)))
+  (let [tree-view-indices (vec (.getSelectedIndices (.getSelectionModel raw-tree-view)))]
+    (if (identical? (.getRoot raw-tree-view) root)
+      (if (= (set selection) (set (map :node-id (ui/selection raw-tree-view))))
+        raw-tree-view
+        (update-tree-view-selection! raw-tree-view selection tree-view-indices))
+      (update-tree-view-root! raw-tree-view root selection tree-view-indices))))
 
 (defn- item->value [^TreeItem item]
   (.getValue item))

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -14,7 +14,8 @@
 
 (ns editor.pipeline.fontc
   (:require [clojure.java.io :as io]
-            [editor.resource :as resource])
+            [editor.resource :as resource]
+            [util.coll :refer [pair]])
   (:import [com.dynamo.bob.font BMFont BMFont$Char DistanceFieldGenerator]
            [com.google.protobuf ByteString]
            [javax.imageio ImageIO]
@@ -125,9 +126,6 @@
 (defn- int->boolean [n]
   (assert (some? n))
   (not= n 0))
-
-(defn- pair [a b]
-  (clojure.lang.MapEntry. a b))
 
 (defn- fnt-semi-glyphs [^BMFont bm-font]
   (let [semi-glyphs (for [index (range (.. bm-font charArray size))]

--- a/editor/src/clj/editor/placeholder_resource.clj
+++ b/editor/src/clj/editor/placeholder_resource.clj
@@ -19,8 +19,8 @@
             [util.text-util :as text-util]
             [editor.workspace :as workspace]))
 
-(g/defnk produce-save-data [_node-id dirty? resource save-value]
-  (cond-> {:dirty? dirty? :node-id _node-id :resource resource :value save-value}
+(g/defnk produce-undecorated-save-data [_node-id resource save-value]
+  (cond-> {:node-id _node-id :resource resource :value save-value}
           (some? save-value) (assoc :content (r/write-fn save-value))))
 
 (g/defnk produce-build-targets [_node-id resource]
@@ -29,7 +29,7 @@
 (g/defnode PlaceholderResourceNode
   (inherits r/CodeEditorResourceNode)
   (output build-targets g/Any produce-build-targets)
-  (output save-data g/Any produce-save-data))
+  (output undecorated-save-data g/Any produce-undecorated-save-data))
 
 (defn load-node [project node-id resource]
   (if (text-util/binary? resource)

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -98,11 +98,11 @@
               :outline-error? (g/error-fatal? own-build-errors)
               :outline-overridden? (not (empty? _overridden-properties))})))
 
-  (output sha256 g/Str :cached (g/fnk [resource save-data]
+  (output sha256 g/Str :cached (g/fnk [resource undecorated-save-data]
                                  ;; Careful! This might throw if resource has been removed
                                  ;; outside the editor. Use from editor.engine.native-extensions seems
                                  ;; to catch any exceptions.
-                                 (let [content (get save-data :content ::no-content)]
+                                 (let [content (get undecorated-save-data :content ::no-content)]
                                    (if (= ::no-content content)
                                      (with-open [s (io/input-stream resource)]
                                        (DigestUtils/sha256Hex ^java.io.InputStream s))
@@ -122,7 +122,8 @@
           ((protobuf/get-fields-fn (protobuf/resource-field-paths ddf-type)) source-value))))
 
 (defn register-ddf-resource-type [workspace & {:keys [ext node-type ddf-type load-fn dependencies-fn sanitize-fn icon view-types tags tag-opts label] :as args}]
-  (let [read-fn (comp (or sanitize-fn identity) (partial protobuf/read-text ddf-type))
+  (let [read-fn (cond->> (partial protobuf/read-text ddf-type)
+                         (some? sanitize-fn) (comp sanitize-fn))
         args (assoc args
                :textual? true
                :load-fn (fn [project self resource]

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -102,6 +102,10 @@
                                  ;; Careful! This might throw if resource has been removed
                                  ;; outside the editor. Use from editor.engine.native-extensions seems
                                  ;; to catch any exceptions.
+                                 ;; Also, be aware that resource-update/keep-existing-node?
+                                 ;; assumes this output will produce a sha256 hex hash string
+                                 ;; from the bytes we'll be writing to disk, so be careful
+                                 ;; if you decide to overload it.
                                  (let [content (get undecorated-save-data :content ::no-content)]
                                    (if (= ::no-content content)
                                      (with-open [s (io/input-stream resource)]

--- a/editor/src/clj/editor/resource_update.clj
+++ b/editor/src/clj/editor/resource_update.clj
@@ -168,8 +168,6 @@
   ;; ZipResource to another - e.g. if you replace a library dependency with another
   ;; one that has the same file - thus, we must update the :resource field of the
   ;; node. Just like a redirect.
-  ;;
-  ;; TODO: Don't we also need to invalidate outputs when we redirect? Not done currently.
   (let [non-moved-changed (remove (comp (some-fn move-source-paths move-target-paths) resource/proj-path) changed)
         {loadable-changed true stateless-changed false} (group-by stateful? non-moved-changed)
         {stateless-swapped true stateless-changed false} (group-by resource-swapped? stateless-changed)]

--- a/editor/src/clj/editor/rulers.clj
+++ b/editor/src/clj/editor/rulers.clj
@@ -48,7 +48,7 @@
 (defonce ^:private img-dims [(.getWidth numbers-image) (.getHeight numbers-image)])
 (defonce ^:private img-dims-recip (mapv #(/ 1 %) img-dims))
 (defonce ^:private numbers-texture-params (merge texture/default-image-texture-params {:min-filter gl/nearest :mag-filter gl/nearest}))
-(defonce ^:private numbers-texture (texture/image-texture ::number-texture numbers-image numbers-texture-params))
+(defonce ^:private numbers-texture (delay (texture/image-texture ::number-texture numbers-image numbers-texture-params)))
 
 (def ^:private max-ticks 100)
 (def ^:private max-label-chars 15)
@@ -150,7 +150,7 @@
           :let [user-data (:user-data renderable)
                 {:keys [vb tri-count line-count]} user-data]]
     (let [vertex-binding (vtx/use-with ::vertex-buffer vb tex-shader)]
-      (gl/with-gl-bindings gl render-args [tex-shader vertex-binding numbers-texture]
+      (gl/with-gl-bindings gl render-args [tex-shader vertex-binding @numbers-texture]
         (shader/set-uniform tex-shader gl "texture_sampler" 0)
         (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 tri-count)
         (gl/gl-draw-arrays gl GL/GL_LINES tri-count line-count)))))

--- a/editor/src/clj/editor/system.clj
+++ b/editor/src/clj/editor/system.clj
@@ -99,8 +99,8 @@
   ;; this the first time the method is called. It is safe to call from any
   ;; thead, but will block until the unpacking thread has completed.
   ;;
-  ;; Having this call here mainly benefits the tests and repl-interactions, as
-  ;; the editor will also explicitly call unpackResources at startup.
+  ;; Having this call here mainly benefits repl-interactions, as the editor and
+  ;; tests will explicitly call unpackResources at startup.
   (ResourceUnpacker/unpackResources)
   (System/getProperty "defold.unpack.path"))
 

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -333,7 +333,7 @@
                           (or "")
                           io/file
                           .getCanonicalFile)
-        protected-dirs [(io/file resources-dir "packages" "jdk11.0.1-p1")]
+        protected-dirs [(io/file resources-dir "packages" "jdk-11.0.15+10")]
         install-dir (.getCanonicalFile
                       (if-let [path (system/defold-resourcespath)]
                         (case os

--- a/editor/src/clj/internal/cache.clj
+++ b/editor/src/clj/internal/cache.clj
@@ -20,7 +20,7 @@
 (def ^:dynamic *cache-debug* nil)
 
 ;; ----------------------------------------
-;; Null cache for testing
+;; Null cache for testing / uncached queries
 ;; ----------------------------------------
 (cc/defcache NullCache [cache]
   cc/CacheProtocol
@@ -32,7 +32,7 @@
   (evict [this key] this)
   (seed [this base] base))
 
-(defn- null-cache [] (NullCache. {}))
+(def null-cache (NullCache. {}))
 
 ;; ----------------------------------------
 ;; Mutators
@@ -68,7 +68,7 @@
     (make-cache default-cache-limit))
   ([limit]
     (if (zero? limit)
-      (null-cache)
+      null-cache
       (cc/lru-cache-factory {} :threshold limit))))
 
 (defn cache-hit

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -14,12 +14,12 @@
 
 (ns internal.graph
   (:require [clojure.core.reducers :as r]
-            [clojure.set :as set]
             [internal.graph.types :as gt]
             [internal.node :as in]
             [internal.util :as util]
             [util.coll :refer [pair]])
   (:import [clojure.lang IPersistentSet]
+           [java.util ArrayDeque HashSet]
            [internal.graph.types Arc]))
 
 ;; A brief braindump on Overrides.
@@ -813,50 +813,40 @@
                result')
         (persistent! result')))))
 
-(defn- set-or-union [s1 s2]
-  (if s1
-    (into s1 s2)
-    s2))
-
-(def ^:private merge-with-union (let [red-f (fn [m [k v]] (update m k set-or-union v))]
-                                  (completing (fn [m1 m2] (reduce red-f m1 m2)))))
-
-(defn- basis-dependencies [basis outputs-by-node-ids]
-  (let [graph-id->node-successor-map (into {} (map (fn [[graph-id graph]] [graph-id (:successors graph)])) (:graphs basis))
-        node-id->successor-map (fn [node-id]
-                                 (some-> node-id
-                                         gt/node-id->graph-id
-                                         graph-id->node-successor-map
-                                         (get node-id)))]
-    (loop [;; 'todo' is the running stack (actually a map) of entries to traverse
-           ;; it's expensive to iterate a map, so start by turning it into a seq
-           todo (seq outputs-by-node-ids)
-           ;; collect next batch of entries in a map, to coalesce common node ids
-           next-todo {}
-           ;; final transitive closure of entries found, as a map
-           result {}]
-      (if-let [[node-id outputs] (first todo)]
-        (let [seen? (get result node-id)]
-          ;; termination condition is when we have seen *every* output already
-          (if (and seen? (every? seen? outputs))
-            ;; completely remove the node-id from todo as we have seen *every* output
-            (recur (next todo) next-todo result)
-            ;; does the node-id have any successors at all?
-            (if-let [label->succ (node-id->successor-map node-id)]
-              ;; ignore the outputs we have already seen
-              (let [outputs (if seen? (set/difference outputs seen?) outputs)
-                    ;; Add every successor to the stack for later processing
-                    next-todo (transduce (map label->succ) merge-with-union next-todo outputs)
-                    ;; And include the unseen output labels to the result
-                    result (update result node-id set-or-union outputs)]
-                (recur (next todo) next-todo result))
-              ;; There were no successors, recur without that node-id
-              (recur (next todo) next-todo result))))
-        ;; check if there is a next batch of entries to process
-        (if-let [todo (seq next-todo)]
-          (recur todo {} result)
-          result)))))
-
+(defn- basis-dependencies [basis node-id+outputs]
+  (let [graph-id->node-successor-map
+        (persistent!
+          (reduce-kv
+            (fn [acc graph-id graph]
+              (assoc! acc graph-id (:successors graph)))
+            (transient {})
+            (:graphs basis)))
+        node-id+output->successors (fn [node-id+output]
+                                     (let [node-id (node-id+output 0)
+                                           output (node-id+output 1)]
+                                       (-> node-id
+                                           gt/node-id->graph-id
+                                           graph-id->node-successor-map
+                                           (get node-id)
+                                           (get output))))
+        deque (ArrayDeque.)
+        result (HashSet.)]
+    (reduce (fn [_ node-id+output]
+              (.push deque node-id+output))
+            nil
+            node-id+outputs)
+    (loop []
+      (when-some [node-id+output (.pollLast deque)]
+        (when-not (.contains result node-id+output)
+          (when-some [successors (node-id+output->successors node-id+output)]
+            (reduce
+              (fn [_ successor-node-id+output]
+                (.push deque successor-node-id+output))
+              nil
+              successors)
+            (.add result node-id+output)))
+        (recur)))
+    result))
 
 (defrecord MultigraphBasis [graphs]
   gt/IBasis
@@ -1158,20 +1148,21 @@
                                                                                                            (fn [basis node-id label]
                                                                                                              (gt/arcs-by-source basis node-id label)))]
                                                                                       (reduce (fn [new-node-successors label]
-                                                                                                (let [single-label #{label}
-                                                                                                      dep-labels (get deps-by-label label)
+                                                                                                (let [dep-labels (get deps-by-label label)
                                                                                                       ;; The internal dependent outputs
-                                                                                                      deps (cond-> (transient {})
-                                                                                                                   (and dep-labels (> (count dep-labels) 0))
-                                                                                                                   (assoc! node-id dep-labels))
+                                                                                                      deps (cond-> (transient [])
+                                                                                                                   (and dep-labels (pos? (count dep-labels)))
+                                                                                                                   (as-> $ (reduce #(conj! %1 [node-id %2]) $ dep-labels)))
                                                                                                       ;; The closest overrides
-                                                                                                      deps (transduce (map #(pair % single-label)) conj! deps overrides)
+                                                                                                      deps (transduce (map #(pair % label)) conj! deps overrides)
                                                                                                       ;; The connected nodes and their outputs
-                                                                                                      deps (transduce (keep (fn [^Arc arc]
-                                                                                                                              (let [target-id (.target-id arc)
-                                                                                                                                    target-label (.target-label arc)]
-                                                                                                                                (when-let [dep-labels (get (input-deps basis target-id) target-label)]
-                                                                                                                                  [target-id dep-labels]))))
+                                                                                                      deps (transduce (comp
+                                                                                                                        (keep (fn [^Arc arc]
+                                                                                                                                (let [target-id (.target-id arc)
+                                                                                                                                      target-label (.target-label arc)]
+                                                                                                                                  (when-let [dep-labels (get (input-deps basis target-id) target-label)]
+                                                                                                                                    (mapv #(vector target-id %) dep-labels)))))
+                                                                                                                        cat)
                                                                                                                       conj!
                                                                                                                       deps
                                                                                                                       (arcs-by-source basis node-id label))]

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -1045,12 +1045,6 @@
   (let [graph-id (gt/override-id->graph-id override-id)]
     (get-in basis [:graphs graph-id :overrides override-id :traverse-fn])))
 
-(defn- arc-source-id [^Arc arc]
-  (.source-id arc))
-
-(defn- arc-source-label [^Arc arc]
-  (.source-label arc))
-
 (defn hydrate-after-undo [basis graph-state]
   ;; NOTE: This was originally written in a simpler way. This longer-form
   ;; implementation is optimized in order to solve performance issues in graphs
@@ -1059,15 +1053,15 @@
         graphs (:graphs basis)
         other-graphs (dissoc graphs graph-id)
         old-sarcs (get graph-state :sarcs)
-        arc-from-graph? #(= graph-id (gt/node-id->graph-id (arc-source-id %)))
+        arc-from-graph? #(= graph-id (gt/node-id->graph-id (.source-id ^Arc %)))
         arc-to-graph? #(= graph-id (gt/node-id->graph-id (.target-id ^Arc %)))
 
         ;; Create a sarcs-like map structure containing just the Arcs that
         ;; connect nodes in our graph to nodes in other graphs. Use the tarcs
         ;; from the other graphs as the source of truth.
         external-sarcs (into {}
-                             (map (juxt key (comp (partial group-by arc-source-label) val)))
-                             (group-by arc-source-id
+                             (map (juxt key (comp (partial group-by gt/source-label) val)))
+                             (group-by gt/source-id
                                        (into #{}
                                              (comp (mapcat :tarcs)
                                                    (mapcat val)

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -13,13 +13,14 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns internal.graph
-  (:require [clojure.set :as set]
-            [clojure.core.reducers :as r]
+  (:require [clojure.core.reducers :as r]
+            [clojure.set :as set]
             [internal.graph.types :as gt]
+            [internal.node :as in]
             [internal.util :as util]
-            [internal.node :as in])
-  (:import [internal.graph.types Arc]
-           [clojure.lang IPersistentSet]))
+            [util.coll :refer [pair]])
+  (:import [clojure.lang IPersistentSet]
+           [internal.graph.types Arc]))
 
 ;; A brief braindump on Overrides.
 ;;
@@ -360,11 +361,14 @@
   `(Arc. ~source-id ~source-label ~target-id ~target-label))
 
 (defn arcs->tuples [arcs]
-  (mapv (fn [^Arc arc] [(.source-id arc) (.source-label arc) (.target-id arc) (.target-label arc)]) arcs))
+  ;; TODO: Get rid of this and expose Arc instances directly.
+  (mapv (fn [^Arc arc]
+          [(.source-id arc) (.source-label arc) (.target-id arc) (.target-label arc)])
+        arcs))
 
-(defn arc-endpoints-p [p arc]
-  (and (p (.source-id ^Arc arc))
-       (p (.target-id ^Arc arc))))
+(defn arc-endpoints-p [p ^Arc arc]
+  (and (p (.source-id arc))
+       (p (.target-id arc))))
 
 (defn empty-graph
   []
@@ -426,7 +430,7 @@
 
 (defn basis-remove-node
   ([basis node-id]
-   (basis-remove-node basis node-id (some-> (get-in basis [:graphs (gt/node-id->graph-id node-id) :nodes node-id]) gt/original)))
+   (basis-remove-node basis node-id (gt/original-node basis node-id) false))
   ([basis node-id original-id]
    (basis-remove-node basis node-id original-id false))
   ([basis node-id original-id original-deleted?]
@@ -521,9 +525,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defn pre-traverse
-  "Traverses a graph depth-first preorder from start, successors being
+  "Traverses a graph depth-first preorder from start, succ being
   a function that returns direct successors for the node. Returns a
-  lazy seq of nodes."
+  vector of node-ids."
   [basis start succ & {:keys [seen] :or {seen #{}}}]
   (loop [stack start
          next []
@@ -531,12 +535,19 @@
          result (transient [])]
     (if-let [nxt (first stack)]
       (if (contains? seen nxt)
-        (recur (rest stack) next seen result)
-        (let [seen (conj seen nxt)]
-          (recur (succ basis nxt) (conj next (rest stack))
-                 seen (conj! result nxt))))
+        (recur (rest stack)
+               next
+               seen
+               result)
+        (recur (succ basis nxt)
+               (conj next (rest stack))
+               (conj seen nxt)
+               (conj! result nxt)))
       (if-let [next-stack (peek next)]
-        (recur next-stack (pop next) seen result)
+        (recur next-stack
+               (pop next)
+               seen
+               result)
         (persistent! result)))))
 
 (defn get-overrides [basis node-id]
@@ -549,8 +560,11 @@
 (defn override-originals [basis node-id]
   (into '() (take-while some? (iterate (partial override-original basis) node-id))))
 
-(defn- override-of [graph node-id override-id]
-  (some #(and (= override-id (gt/override-id (node-id->node graph %))) %) (overrides graph node-id)))
+(defn override-of [graph node-id override-id]
+  (some (fn [override-node-id]
+          (when (= override-id (gt/override-id (node-id->node graph override-node-id)))
+            override-node-id))
+        (overrides graph node-id)))
 
 (defn- node-id->arcs [graph node-id arc-kw]
   (into [] cat (vals (-> graph (get arc-kw) (get node-id)))))
@@ -623,8 +637,8 @@
 
 (defn cascade-delete-sources
   "Successors function for use with pre-traverse that produces all the node ids
-  that will will be deleted along with the original node. Duplicates produced by
-  this function will be discarded by pre-traverse."
+  that will be deleted along with the original node. Duplicates produced by this
+  function will be discarded by pre-traverse."
   [basis node-id]
   (when-some [node (gt/node-by-id-at basis node-id)]
     (let [override-id (gt/override-id node)]
@@ -753,15 +767,16 @@
 (defn- lift-target-arcs [basis target-id target-override-chain arcs]
   (loop [override-chain target-override-chain
          arcs arcs]
-    (if (empty? override-chain)
-      (mapv #(assoc % :target-id target-id) arcs)
-      (recur (rest override-chain)
-             (mapv (fn [^Arc arc]
-                     (let [source (.source-id arc)]
-                       (if-some [source-override-node (override-of (node-id->graph basis source) source (first override-chain))]
-                         (assoc arc :source-id source-override-node)
-                         arc)))
-                   arcs)))))
+    (let [override-id (first override-chain)]
+      (if (nil? override-id)
+        (mapv #(assoc % :target-id target-id) arcs)
+        (recur (rest override-chain)
+               (mapv (fn [^Arc arc]
+                       (let [source-id (.source-id arc)]
+                         (if-some [source-override-node-id (override-of (node-id->graph basis source-id) source-id override-id)]
+                           (assoc arc :source-id source-override-node-id)
+                           arc)))
+                     arcs))))))
 
 (defn- collect-override-chains+explicit-arcs
   "Used by arcs-by-source to find explicit arcs from all original nodes
@@ -798,7 +813,11 @@
                result')
         (persistent! result')))))
 
-(def ^:private set-or-union (fn [s1 s2] (if s1 (set/union s1 s2) s2)))
+(defn- set-or-union [s1 s2]
+  (if s1
+    (into s1 s2)
+    s2))
+
 (def ^:private merge-with-union (let [red-f (fn [m [k v]] (update m k set-or-union v))]
                                   (completing (fn [m1 m2] (reduce red-f m1 m2)))))
 
@@ -827,7 +846,7 @@
               ;; ignore the outputs we have already seen
               (let [outputs (if seen? (set/difference outputs seen?) outputs)
                     ;; Add every successor to the stack for later processing
-                    next-todo (transduce (map #(label->succ %)) merge-with-union next-todo outputs)
+                    next-todo (transduce (map label->succ) merge-with-union next-todo outputs)
                     ;; And include the unseen output labels to the result
                     result (update result node-id set-or-union outputs)]
                 (recur (next todo) next-todo result))
@@ -888,7 +907,7 @@
                                            (let [arcs (graph-explicit-arcs-by-target graph node-id label)
                                                  node (gt/node-by-id-at this node-id)
                                                  original (gt/original node)]
-                                             (if (and (empty? arcs) original)
+                                             (if (and original (empty? arcs))
                                                (recur original (conj chain (gt/override-id node)))
                                                [chain arcs])))]
       (lift-target-arcs this node-id override-chain explicit-arcs)))
@@ -1117,33 +1136,29 @@
      the internal input-dependencies, i.e. outputs consuming the given output
      the closest override-nodes, i.e. override-node-a + output-x, as they can be potential dependents
      all connected nodes, where node-id-a + output-x => [[node-id-b + input-y] ...] => [[node-id-b + output+z] ...]"
-  [old-successors basis graph-id graph changes]
+  [old-successors basis graph changes]
   (let [node-id->overrides (or (:node->overrides graph) (constantly nil))
-        ;; Transducer to collect override-id's
-        override-id-xf (keep #(some->> %
-                                       (node-id->node graph)
-                                       (gt/override-id)))
         changes+old-node-successors (mapv (fn [[node-id labels]]
                                             [node-id labels (old-successors node-id)])
                                           changes)
         [new-successors removed-successor-entries] (r/fold
                                                      (fn combinef
-                                                       ([] [{} []])
+                                                       ([]
+                                                        (pair {} []))
                                                        ([[new-successors-1 removed-successor-entries-1] [new-successors-2 removed-successor-entries-2]]
-                                                        [(merge new-successors-1 new-successors-2) (into removed-successor-entries-1 removed-successor-entries-2)]))
+                                                        (pair (into new-successors-1 new-successors-2) (into removed-successor-entries-1 removed-successor-entries-2))))
                                                      (fn reducef
-                                                       ([] [{} []])
+                                                       ([]
+                                                        (pair {} []))
                                                        ([[new-acc remove-acc] [node-id labels old-node-successors]]
                                                         (let [new-node-successors (if-some [node (gt/node-by-id-at basis node-id)]
                                                                                     (let [node-type (gt/node-type node)
                                                                                           deps-by-label (or (in/input-dependencies node-type) {})
-                                                                                          node-and-overrides (tree-seq (constantly true) node-id->overrides node-id)
-                                                                                          override-filter-fn (complement (into #{} override-id-xf node-and-overrides))
                                                                                           overrides (node-id->overrides node-id)
                                                                                           labels (or labels (in/output-labels node-type))
                                                                                           arcs-by-source (if (> (count labels) 1)
                                                                                                            (let [arcs (gt/arcs-by-source basis node-id)
-                                                                                                                 arcs-by-source-label (group-by #(.source-label ^Arc %) arcs)]
+                                                                                                                 arcs-by-source-label (util/group-into #(.source-label ^Arc %) arcs)]
                                                                                                              (fn [_ _ label]
                                                                                                                (arcs-by-source-label label)))
                                                                                                            (fn [basis node-id label]
@@ -1153,10 +1168,10 @@
                                                                                                       dep-labels (get deps-by-label label)
                                                                                                       ;; The internal dependent outputs
                                                                                                       deps (cond-> (transient {})
-                                                                                                             (and dep-labels (> (count dep-labels) 0))
-                                                                                                             (assoc! node-id dep-labels))
+                                                                                                                   (and dep-labels (> (count dep-labels) 0))
+                                                                                                                   (assoc! node-id dep-labels))
                                                                                                       ;; The closest overrides
-                                                                                                      deps (transduce (map #(vector % single-label)) conj! deps overrides)
+                                                                                                      deps (transduce (map #(pair % single-label)) conj! deps overrides)
                                                                                                       ;; The connected nodes and their outputs
                                                                                                       deps (transduce (keep (fn [^Arc arc]
                                                                                                                               (let [target-id (.target-id arc)
@@ -1171,17 +1186,20 @@
                                                                                               labels))
                                                                                     nil)]
                                                           (if (nil? new-node-successors)
-                                                            [new-acc (conj remove-acc node-id)]
-                                                            [(assoc new-acc node-id new-node-successors) remove-acc]))))
+                                                            (pair new-acc (conj remove-acc node-id))
+                                                            (pair (assoc new-acc node-id new-node-successors) remove-acc)))))
                                                      changes+old-node-successors)]
-    (apply dissoc (merge old-successors new-successors) removed-successor-entries)))
+    (persistent!
+      (reduce dissoc!
+              (transient (into old-successors new-successors))
+              removed-successor-entries))))
 
 (defn update-successors
   [basis changes]
   ;; changes = {node-id #{outputs}}
   (reduce (fn [basis [graph-id changes]]
             (if-let [graph (get (:graphs basis) graph-id)]
-              (update-in basis [:graphs graph-id :successors] update-graph-successors basis graph-id graph changes)
+              (update-in basis [:graphs graph-id :successors] update-graph-successors basis graph changes)
               basis))
           basis
-          (group-by (comp gt/node-id->graph-id first) changes)))
+          (util/group-into (comp gt/node-id->graph-id first) changes)))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -19,8 +19,8 @@
             [internal.util :as util]
             [util.coll :refer [pair]])
   (:import [clojure.lang IPersistentSet]
-           [java.util ArrayDeque HashSet]
-           [internal.graph.types Arc]))
+           [internal.graph.types Arc]
+           [java.util ArrayDeque HashSet]))
 
 ;; A brief braindump on Overrides.
 ;;
@@ -1152,17 +1152,16 @@
                                                                                                       ;; The internal dependent outputs
                                                                                                       deps (cond-> (transient [])
                                                                                                                    (and dep-labels (pos? (count dep-labels)))
-                                                                                                                   (as-> $ (reduce #(conj! %1 [node-id %2]) $ dep-labels)))
+                                                                                                                   (as-> $ (reduce #(conj! %1 (pair node-id %2)) $ dep-labels)))
                                                                                                       ;; The closest overrides
                                                                                                       deps (transduce (map #(pair % label)) conj! deps overrides)
                                                                                                       ;; The connected nodes and their outputs
-                                                                                                      deps (transduce (comp
-                                                                                                                        (keep (fn [^Arc arc]
-                                                                                                                                (let [target-id (.target-id arc)
-                                                                                                                                      target-label (.target-label arc)]
-                                                                                                                                  (when-let [dep-labels (get (input-deps basis target-id) target-label)]
-                                                                                                                                    (mapv #(vector target-id %) dep-labels)))))
-                                                                                                                        cat)
+                                                                                                      deps (transduce (mapcat
+                                                                                                                        (fn [^Arc arc]
+                                                                                                                          (let [target-id (.target-id arc)
+                                                                                                                                target-label (.target-label arc)]
+                                                                                                                            (when-let [dep-labels (get (input-deps basis target-id) target-label)]
+                                                                                                                              (mapv #(pair target-id %) dep-labels)))))
                                                                                                                       conj!
                                                                                                                       deps
                                                                                                                       (arcs-by-source basis node-id label))]

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -15,14 +15,13 @@
 (ns internal.graph.types)
 
 (set! *warn-on-reflection* true)
-(set! *unchecked-math* :warn-on-boxed)
 
-(defrecord Arc [^long source-id source-label ^long target-id target-label])
+(defrecord Arc [source-id source-label target-id target-label])
 
-(defn source-id ^long [^Arc arc] (.source-id arc))
+(defn source-id [^Arc arc] (.source-id arc))
 (defn source-label [^Arc arc] (.source-label arc))
 (defn source [^Arc arc] [(.source-id arc) (.source-label arc)])
-(defn target-id ^long [^Arc arc] (.target-id arc))
+(defn target-id [^Arc arc] (.target-id arc))
 (defn target-label [^Arc arc] (.target-label arc))
 (defn target [^Arc arc] [(.target-id arc) (.target-label arc)])
 

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -12,15 +12,18 @@
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations under the License.
 
-(ns internal.graph.types
-  (:require [internal.util :as util]
-            [schema.core :as s]))
+(ns internal.graph.types)
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
-(defrecord Arc [source-id source-label target-id target-label])
+(defrecord Arc [^long source-id source-label ^long target-id target-label])
 
+(defn source-id ^long [^Arc arc] (.source-id arc))
+(defn source-label [^Arc arc] (.source-label arc))
 (defn source [^Arc arc] [(.source-id arc) (.source-label arc)])
+(defn target-id ^long [^Arc arc] (.target-id arc))
+(defn target-label [^Arc arc] (.target-label arc))
 (defn target [^Arc arc] [(.target-id arc) (.target-label arc)])
 
 (defn node-id? [v] (integer? v))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -105,7 +105,12 @@
 
 (defn- bump-invalidate-counters
   [invalidate-map entries]
-  (reduce (fn [m entry] (update m entry (fnil unchecked-inc 0))) invalidate-map entries))
+  (persistent!
+    (reduce
+      (fn [m entry]
+        (assoc! m entry (unchecked-inc (m entry 0))))
+      (transient invalidate-map)
+      entries)))
 
 (defn invalidate-outputs
   "Invalidate the given outputs and _everything_ that could be
@@ -114,14 +119,7 @@
   [system outputs]
   ;; 'dependencies' takes a map, where outputs is a vec of node-id+label pairs
   (let [basis (basis system)
-        cache-entries (->> outputs
-                           ;; vec -> map, [[node-id label]] -> {node-id #{labels}}
-                           (reduce (fn [m [node-id label]]
-                                     (update m node-id (fn [label-set label] (if label-set (conj label-set label) #{label})) label))
-                                   {})
-                           (gt/dependencies basis)
-                           ;; map -> vec
-                           (into [] (mapcat (fn [[node-id labels]] (mapv #(vector node-id %) labels)))))]
+        cache-entries (gt/dependencies basis outputs)]
     (-> system
         (update :cache c/cache-invalidate cache-entries)
         (update :invalidate-counters bump-invalidate-counters cache-entries))))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -15,13 +15,15 @@
 (ns internal.transaction
   "Internal functions that implement the transactional behavior."
   (:require [clojure.set :as set]
-            [clojure.string :as str]
             [internal.util :as util]
             [internal.graph :as ig]
             [internal.graph.types :as gt]
             [internal.node :as in]
             [internal.system :as is]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [util.coll :refer [pair]]
+            [util.debug-util :as du])
+  (:import [internal.graph.types Arc]))
 
 (set! *warn-on-reflection* true)
 
@@ -157,31 +159,56 @@
 ;; ---------------------------------------------------------------------------
 (defn- mark-input-activated
   [ctx node-id input-label]
-  (if-let [nodes-affected (get-in ctx [:nodes-affected node-id] #{})]
-    (let [basis (:basis ctx)
-          dirty-deps (-> (gt/node-by-id-at basis node-id) gt/node-type in/input-dependencies (get input-label))]
-      (update ctx :nodes-affected assoc node-id (reduce conj nodes-affected dirty-deps)))
-    ctx))
+  ;; This gets called a lot, so we're trying to keep allocations to a minimum.
+  (let [basis (:basis ctx)
+        dirty-deps (-> (gt/node-by-id-at basis node-id)
+                       gt/node-type
+                       in/input-dependencies
+                       (get input-label))
+        nodes-affected (:nodes-affected ctx)]
+    (assoc ctx
+      :nodes-affected
+      (assoc nodes-affected
+        node-id
+        (into (nodes-affected node-id #{})
+              dirty-deps)))))
 
 (defn- mark-output-activated
   [ctx node-id output-label]
-  (if-let [nodes-affected (get-in ctx [:nodes-affected node-id] #{})]
-    (update ctx :nodes-affected assoc node-id (conj nodes-affected output-label))
-    ctx))
+  ;; This gets called a lot, so we're trying to keep allocations to a minimum.
+  (let [nodes-affected (:nodes-affected ctx)]
+    (assoc ctx
+      :nodes-affected
+      (assoc nodes-affected
+        node-id
+        (if-some [existing-affected (nodes-affected node-id)]
+          (conj existing-affected output-label)
+          #{output-label})))))
 
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
-  (if-let [nodes-affected (get-in ctx [:nodes-affected node-id] #{})]
-    (update ctx :nodes-affected assoc node-id (reduce conj nodes-affected output-labels))
-    ctx))
+  ;; This gets called a lot, so we're trying to keep allocations to a minimum.
+  (let [nodes-affected (:nodes-affected ctx)]
+    (assoc ctx
+      :nodes-affected
+      (assoc nodes-affected
+        node-id
+        (into (nodes-affected node-id #{})
+              output-labels)))))
 
 (defn- mark-all-outputs-activated
   [ctx node-id]
+  ;; This gets called a lot, so we're trying to keep allocations to a minimum.
   (let [basis (:basis ctx)
-        all-labels (-> (gt/node-by-id-at basis node-id)
-                       gt/node-type
-                       in/output-labels)]
-    (update ctx :nodes-affected assoc node-id (set all-labels))))
+        output-labels (-> (gt/node-by-id-at basis node-id)
+                          gt/node-type
+                          in/output-labels)
+        nodes-affected (:nodes-affected ctx)]
+    (assoc ctx
+      :nodes-affected
+      (assoc nodes-affected
+        node-id
+        output-labels))))
 
 (defn- next-node-id [ctx graph-id]
   (is/next-node-id* (:node-id-generators ctx) graph-id))
@@ -204,12 +231,12 @@
   such as [[connect]] and [[update-property]]."
   (fn [ctx m] (:type m)))
 
+(defmulti metrics-key :type)
+
 (def ^:private ctx-disconnect)
 
-(defn- ctx-disconnect-arc [ctx arc]
-  (let [[source-id source-label] (gt/source arc)
-        [target-id target-label] (gt/target arc)]
-    (ctx-disconnect ctx source-id source-label target-id target-label)))
+(defn- ctx-disconnect-arc [ctx ^Arc arc]
+  (ctx-disconnect ctx (.source-id arc) (.source-label arc) (.target-id arc) (.target-label arc)))
 
 (defn- disconnect-inputs [ctx target-id target-label]
   (reduce ctx-disconnect-arc ctx (ig/explicit-arcs-by-target (:basis ctx) target-id target-label)))
@@ -245,7 +272,8 @@
       (let [targets (ig/explicit-targets basis node-id)]
         (-> (reduce (fn [ctx [node-id input]]
                       (mark-input-activated ctx node-id input))
-                    ctx targets)
+                    ctx
+                    targets)
             (disconnect-all-inputs node-id)
             (mark-all-outputs-activated node-id)
             (update :basis gt/delete-node node-id)
@@ -265,39 +293,52 @@
   [ctx {:keys [node-id]}]
   (ctx-delete-node ctx node-id))
 
+(defmethod metrics-key :delete-node
+  [{:keys [node-id]}]
+  node-id)
+
 (defmethod perform :new-override
   [ctx {:keys [override-id root-id traverse-fn]}]
   (-> ctx
       (update :basis gt/add-override override-id (ig/make-override root-id traverse-fn))))
 
+(defmethod metrics-key :new-override
+  [{:keys [root-id]}]
+  root-id)
+
 (defn- flag-all-successors-changed [ctx node-ids]
   (let [successors (get ctx :successors-changed)]
     (assoc ctx :successors-changed (reduce (fn [successors node-id]
                                              (assoc successors node-id nil))
-                                           successors node-ids))))
+                                           successors
+                                           node-ids))))
 
 (defn- flag-successors-changed [ctx changes]
   (let [successors (get ctx :successors-changed)]
     (assoc ctx :successors-changed (reduce (fn [successors [node-id label]]
                                              (if-let [node-succ (get successors node-id #{})]
                                                (assoc successors node-id (conj node-succ label))
-                                               successors))
-                                           successors changes))))
+                                               successors)) ; Found nil - all successors already flagged as changed.
+                                           successors
+                                           changes))))
 
 (defn- ctx-override-node [ctx original-node-id override-node-id]
   (assert (= (gt/node-id->graph-id original-node-id) (gt/node-id->graph-id override-node-id))
           "Override nodes must belong to the same graph as the original")
   (let [basis (:basis ctx)
-        original (gt/node-by-id-at basis original-node-id)
         all-originals (ig/override-originals basis original-node-id)]
     (-> ctx
-        (update :basis gt/override-node original-node-id override-node-id)
+        (assoc :basis (gt/override-node basis original-node-id override-node-id))
         (flag-all-successors-changed all-originals)
         (flag-successors-changed (mapcat #(gt/sources basis %) all-originals)))))
 
 (defmethod perform :override-node
   [ctx {:keys [original-node-id override-node-id]}]
   (ctx-override-node ctx original-node-id override-node-id))
+
+(defmethod metrics-key :override-node
+  [{:keys [original-node-id]}]
+  original-node-id)
 
 (declare apply-tx)
 
@@ -330,6 +371,10 @@
       (apply-tx ctx' (init-fn (in/custom-evaluation-context {:basis (:basis ctx')})
                               original-node-id->override-node-id)))))
 
+(defmethod metrics-key :override
+  [{:keys [root-id]}]
+  root-id)
+
 (defn- node-id->override-id [basis node-id]
   (->> node-id
        (gt/node-by-id-at basis)
@@ -340,7 +385,8 @@
 (defn- ctx-make-override-nodes [ctx override-id node-ids]
   (reduce (fn [ctx node-id]
             (let [basis (:basis ctx)]
-              (if (some #(= override-id (node-id->override-id basis %)) (ig/get-overrides basis node-id))
+              (if (some #(= override-id (node-id->override-id basis %))
+                        (ig/get-overrides basis node-id))
                 ctx
                 (let [graph-id (gt/node-id->graph-id node-id)
                       new-override-node-id (next-node-id ctx graph-id)
@@ -353,36 +399,66 @@
                   (-> ctx
                       (ctx-add-node new-override-node)
                       (ctx-override-node node-id new-override-node-id))))))
-          ctx node-ids))
+          ctx
+          node-ids))
 
 (defn- populate-overrides [ctx node-id]
   (let [basis (:basis ctx)
-        override-nodes (ig/get-overrides basis node-id)]
-    (reduce (fn [ctx override-node-id]
-              (let [override-id (node-id->override-id basis override-node-id)
-                    override (ig/override-by-id basis override-id)
-                    traverse-fn (:traverse-fn override)
-                    node-ids (subvec (ig/pre-traverse basis [node-id] traverse-fn) 1)]
-                (reduce populate-overrides
-                        (ctx-make-override-nodes ctx override-id node-ids)
-                        override-nodes)))
-            ctx override-nodes)))
+        override-node-ids (ig/get-overrides basis node-id)
+        override-node-count (count override-node-ids)
+        ctx (loop [override-node-index 0
+                   ctx ctx
+                   prev-traverse-fn nil
+                   prev-traverse-result nil]
+              (if (>= override-node-index override-node-count)
+                ctx
+                (let [^long override-node-id (override-node-ids override-node-index)
+                      override-id (node-id->override-id basis override-node-id)
+                      traverse-fn (:traverse-fn (ig/override-by-id basis override-id))
+                      node-ids (if (identical? prev-traverse-fn traverse-fn)
+                                 prev-traverse-result
+                                 (subvec (ig/pre-traverse basis [node-id] traverse-fn) 1))]
+                  (recur (inc override-node-index)
+                         (ctx-make-override-nodes ctx override-id node-ids)
+                         traverse-fn
+                         node-ids))))]
+    (reduce populate-overrides
+            ctx
+            override-node-ids)))
 
 (defmethod perform :transfer-overrides
   [ctx {:keys [from-id->to-id]}]
+  ;; This method updates the existing override layer to use the to-id as the
+  ;; root of the override layer. It also updates the "first level" (i.e. direct)
+  ;; override nodes that have from-id as their original to instead have to-id as
+  ;; their original. It then deletes every other override node that was produced
+  ;; from the existing override layer and re-runs the populate-overrides
+  ;; function for the updated graph state. This will cause any missing override
+  ;; nodes to be re-created from the structure of to-id.
   (let [basis (:basis ctx)
-        from-id->override-node-ids (into {}
-                                         (map (juxt identity (partial ig/get-overrides basis)))
-                                         (keys from-id->to-id)) ; "first level" override nodes
-        override-node-ids (into #{} cat (vals from-id->override-node-ids))
+        override-node-ids (into #{}
+                                (mapcat (partial ig/get-overrides basis))
+                                (keys from-id->to-id)) ; "first level" override nodes
         retained override-node-ids
-        override-node-id->override-id (into {} (map (fn [override-node-id] [override-node-id (gt/override-id (gt/node-by-id-at basis override-node-id))])) override-node-ids)
-        override-id->override (into {} (map (fn [[_ override-id]] [override-id (ig/override-by-id basis override-id)])) override-node-id->override-id)
+        override-node-id->override-id (into {}
+                                            (map (fn [override-node-id]
+                                                   (pair override-node-id
+                                                         (gt/override-id (gt/node-by-id-at basis override-node-id)))))
+                                            override-node-ids)
+        override-id->override (into {}
+                                    (comp
+                                      (map val)
+                                      (distinct)
+                                      (map (fn [override-id]
+                                             (pair override-id
+                                                   (ig/override-by-id basis override-id)))))
+                                    override-node-id->override-id)
         override-node-id->override (comp override-id->override override-node-id->override-id)
-        overrides-to-fix (into '()
-                               (filter (fn [[_ override]] (contains? from-id->to-id (:root-id override))))
+        overrides-to-fix (into []
+                               (filter (fn [[_ override]]
+                                         (contains? from-id->to-id (:root-id override))))
                                override-id->override)
-        nodes-to-delete (into '()
+        nodes-to-delete (into []
                               (comp
                                 (mapcat (fn [override-node-id]
                                           (let [override (override-node-id->override override-node-id)
@@ -393,6 +469,11 @@
                               override-node-ids)]
     (-> ctx
         (update :basis (fn [basis]
+                         ;; Clear out the original to override node-id mappings
+                         ;; from the graph. Normally entries are removed from
+                         ;; this mapping inside basis-remove-node as nodes are
+                         ;; deleted, but since we're transferring overrides, we
+                         ;; must do it manually here.
                          (reduce (fn [basis from-node-id]
                                    (gt/override-node-clear basis from-node-id))
                                  basis
@@ -402,21 +483,36 @@
                                    (gt/replace-override basis override-id (update override :root-id from-id->to-id)))
                                  basis
                                  overrides-to-fix))) ; re-root overrides that used to have a from node id as root
-        ((partial reduce ctx-delete-node) nodes-to-delete)
+        (as-> ctx
+              (reduce ctx-delete-node ctx nodes-to-delete))
+
         ;; * repoint the first level override nodes to use to-node as original
         ;; * add as override nodes of to-node
-        ((partial reduce (fn [ctx override-node-id]
-                           (let [basis (:basis ctx)
-                                 override-node (gt/node-by-id-at basis override-node-id)
-                                 old-original (gt/original override-node)
-                                 new-original (from-id->to-id old-original)
-                                 [new-basis new-node] (gt/replace-node basis override-node-id (gt/set-original override-node new-original))]
-                             (-> ctx
-                                 (assoc :basis new-basis)
-                                 (mark-all-outputs-activated override-node-id)
-                                 (ctx-override-node new-original override-node-id)))))
-         override-node-ids)
-        ((partial reduce populate-overrides) (vals from-id->to-id)))))
+        (as-> ctx
+              (reduce (fn [ctx override-node-id]
+                        (let [basis (:basis ctx)
+                              override-node (gt/node-by-id-at basis override-node-id)
+                              old-original (gt/original override-node)
+                              new-original (from-id->to-id old-original)
+                              [new-basis] (gt/replace-node basis override-node-id (gt/set-original override-node new-original))]
+                          (-> ctx
+                              (assoc :basis new-basis)
+                              (mark-all-outputs-activated override-node-id)
+                              (ctx-override-node new-original override-node-id))))
+                      ctx
+                      override-node-ids))
+        (as-> ctx
+              (reduce populate-overrides
+                      ctx
+                      (vals from-id->to-id))))))
+
+(defmethod metrics-key :transfer-overrides
+  [{:keys [from-id->to-id]}]
+  ;; When metrics are enabled, this is called for one override node at a time.
+  ;; This is potentially less efficient, but we get valuable context about which
+  ;; specific nodes are costly to transfer overrides for.
+  (when (= 1 (count from-id->to-id))
+    (second (first from-id->to-id))))
 
 (defn- property-default-setter
   [basis node-id node property _ new-value]
@@ -489,6 +585,10 @@
   (when (and *tx-debug* (nil? (gt/node-id node))) (println "NIL NODE ID: " node))
   (ctx-add-node ctx node))
 
+(defmethod metrics-key :create-node
+  [{:keys [node]}]
+  (gt/node-id node))
+
 (defmethod perform :update-property [ctx {:keys [node-id property fn args] :as tx-step}]
   (let [basis (:basis ctx)]
     (when (and *tx-debug* (nil? node-id)) (println "NIL NODE ID: update-property " tx-step))
@@ -501,6 +601,10 @@
             dynamic? (not (contains? (some-> (gt/node-type node) in/all-properties) property))]
         (invoke-setter ctx node-id node property old-value new-value override-node? dynamic?))
       ctx)))
+
+(defmethod metrics-key :update-property
+  [{:keys [node-id property]}]
+  [node-id property])
 
 (defn- ctx-set-property-to-nil [ctx node-id node property]
   (let [basis (:basis ctx)
@@ -521,20 +625,36 @@
             (ctx-set-property-to-nil node-id node property)))
       ctx)))
 
+(defmethod metrics-key :clear-property
+  [{:keys [node-id property]}]
+  [node-id property])
+
 (defmethod perform :callback [ctx {:keys [fn args]}]
   (apply fn args)
   ctx)
+
+(defmethod metrics-key :callback
+  [_]
+  nil)
 
 (defn- ctx-disconnect-single [ctx target target-id target-label]
   (if (= :one (in/input-cardinality (gt/node-type target) target-label))
     (disconnect-inputs ctx target-id target-label)
     ctx))
 
-(defn- ctx-add-overrides [ctx source-id source source-label target target-label]
-  (let [target-id (gt/node-id target)]
-    (if ((in/cascade-deletes (gt/node-type target)) target-label)
-      (populate-overrides ctx target-id)
-      ctx)))
+(defn- flag-override-nodes-affected [ctx target target-label]
+  (let [target-id (gt/node-id target)
+        override-nodes-affected-seen (:override-nodes-affected-seen ctx)]
+    (if (contains? override-nodes-affected-seen target-id)
+      ctx
+      (let [target-node-type (gt/node-type target)
+            target-cascade-deletes (in/cascade-deletes target-node-type)]
+        (if-not (contains? target-cascade-deletes target-label)
+          ctx
+          (let [override-nodes-affected-ordered (:override-nodes-affected-ordered ctx)]
+            (assoc ctx
+              :override-nodes-affected-seen (conj override-nodes-affected-seen target-id)
+              :override-nodes-affected-ordered (conj override-nodes-affected-ordered target-id))))))))
 
 (defn- assert-type-compatible
   [source-id source-node source-label target-id target-node target-label]
@@ -564,18 +684,22 @@
       (do
         (assert-type-compatible source-id source source-label target-id target target-label)
         (-> ctx
-                                        ; If the input has :one cardinality, disconnect existing connections first
+            ;; If the input has :one cardinality, disconnect existing connections first
             (ctx-disconnect-single target target-id target-label)
             (mark-input-activated target-id target-label)
             (update :basis gt/connect source-id source-label target-id target-label)
             (flag-successors-changed [[source-id source-label]])
-            (ctx-add-overrides source-id source source-label target target-label)))
+            (flag-override-nodes-affected target target-label)))
       ctx)
     ctx))
 
 (defmethod perform :connect
   [ctx {:keys [source-id source-label target-id target-label] :as tx-data}]
   (ctx-connect ctx source-id source-label target-id target-label))
+
+(defmethod metrics-key :connect
+  [{:keys [source-id source-label target-id target-label]}]
+  [source-id source-label target-id target-label])
 
 (defn- ctx-remove-overrides [ctx source-id source-label target-id target-label]
   (let [basis (:basis ctx)
@@ -607,25 +731,45 @@
   [ctx {:keys [source-id source-label target-id target-label]}]
   (ctx-disconnect ctx source-id source-label target-id target-label))
 
+(defmethod metrics-key :disconnect
+  [{:keys [source-id source-label target-id target-label]}]
+  [source-id source-label target-id target-label])
+
 (defmethod perform :update-graph-value
   [ctx {:keys [graph-id fn args]}]
   (-> ctx
       (update-in [:basis :graphs graph-id :graph-values] #(apply fn % args))
       (update :graphs-modified conj graph-id)))
 
+(defmethod metrics-key :update-graph-value
+  [{:keys [graph-id]}]
+  graph-id)
+
 (defmethod perform :label
   [ctx {:keys [label]}]
   (assoc ctx :label label))
 
+(defmethod metrics-key :label
+  [_]
+  nil)
+
 (defmethod perform :sequence-label
   [ctx {:keys [label]}]
   (assoc ctx :sequence-label label))
+
+(defmethod metrics-key :sequence-label
+  [_]
+  nil)
 
 (defmethod perform :invalidate
   [ctx {:keys [node-id] :as tx-data}]
   (if (gt/node-by-id-at (:basis ctx) node-id)
     (mark-all-outputs-activated ctx node-id)
     ctx))
+
+(defmethod metrics-key :invalidate
+  [{:keys [node-id]}]
+  node-id)
 
 (defn- apply-tx
   [ctx actions]
@@ -635,14 +779,15 @@
       (if-let [action (first actions)]
         (if (sequential? action)
           (recur (apply-tx ctx action) (next actions))
-          (recur
-            (update
-              (try (perform ctx action)
-                   (catch Exception e
-                     (when *tx-debug*
-                       (println (txerrstr ctx "Transaction failed on " action)))
-                     (throw e)))
-              :completed conj action) (next actions)))
+          (recur (-> (try
+                       (du/measuring (:metrics ctx) (:type action) (metrics-key action)
+                         (perform ctx action))
+                       (catch Exception e
+                         (when *tx-debug*
+                           (println (txerrstr ctx "Transaction failed on " action)))
+                         (throw e)))
+                     (update :completed conj action))
+                 (next actions)))
         (recur ctx (next actions)))
       ctx)))
 
@@ -661,7 +806,9 @@
     label
     (update-in [:basis :graphs] map-vals-bargs #(assoc % :tx-label label))))
 
-(def tx-report-keys [:basis :graphs-modified :nodes-added :nodes-modified :nodes-deleted :outputs-modified :label :sequence-label])
+(def tx-report-keys
+  (cond-> [:basis :graphs-modified :nodes-added :nodes-modified :nodes-deleted :outputs-modified :label :sequence-label]
+          (du/metrics-enabled?) (conj :metrics)))
 
 (defn- finalize-update
   "Makes the transacted graph the new value of the world-state graph."
@@ -671,7 +818,7 @@
              :graphs-modified (into graphs-modified (map gt/node-id->graph-id nodes-modified)))))
 
 (defn new-transaction-context
-  [basis node-id-generators override-id-generator]
+  [basis node-id-generators override-id-generator metrics-collector]
   {:basis basis
    :nodes-affected {}
    :nodes-added []
@@ -679,27 +826,41 @@
    :nodes-deleted {}
    :outputs-modified #{}
    :graphs-modified #{}
+   :override-nodes-affected-seen #{}
+   :override-nodes-affected-ordered []
    :successors-changed {}
    :node-id-generators node-id-generators
    :override-id-generator override-id-generator
    :completed []
    :txid (new-txid)
    :tx-data-context (atom {})
-   :deferred-setters []})
+   :deferred-setters []
+   :metrics metrics-collector})
+
+(defn- update-overrides
+  [{:keys [override-nodes-affected-ordered] :as ctx}]
+  (du/measuring (:metrics ctx) :update-overrides
+    (reduce populate-overrides
+            ctx
+            override-nodes-affected-ordered)))
 
 (defn- update-successors
   [{:keys [successors-changed] :as ctx}]
-  (update ctx :basis ig/update-successors successors-changed))
+  (du/measuring (:metrics ctx) :update-successors
+    (update ctx :basis ig/update-successors successors-changed)))
 
 (defn- trace-dependencies
   [ctx]
   ;; at this point, :outputs-modified contains [node-id output] pairs.
   ;; afterwards, it will have the transitive closure of all [node-id output] pairs
   ;; reachable from the original collection.
-  (let [outputs-modified (->> (:nodes-affected ctx)
-                              (gt/dependencies (:basis ctx))
-                              (into [] (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))]
-    (assoc ctx :outputs-modified outputs-modified)))
+  (du/measuring (:metrics ctx) :trace-dependencies
+    (let [outputs-modified (->> (:nodes-affected ctx)
+                                (gt/dependencies (:basis ctx))
+                                (into []
+                                      (mapcat (fn [[nid ls]]
+                                                (mapv #(vector nid %) ls)))))]
+      (assoc ctx :outputs-modified outputs-modified))))
 
 (defn transact*
   [ctx actions]
@@ -707,6 +868,7 @@
     (println (txerrstr ctx "actions" (seq actions))))
   (-> ctx
       (apply-tx actions)
+      update-overrides
       mark-nodes-modified
       update-successors
       trace-dependencies

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -169,7 +169,7 @@
     (assoc ctx
       :nodes-affected
       (into nodes-affected
-            (map #(vector node-id %))
+            (map #(pair node-id %))
             dirty-deps))))
 
 (defn- mark-output-activated
@@ -178,7 +178,7 @@
   (let [nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (conj nodes-affected [node-id output-label]))))
+      (conj nodes-affected (pair node-id output-label)))))
 
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
@@ -187,7 +187,7 @@
     (assoc ctx
       :nodes-affected
       (into nodes-affected
-            (map #(vector node-id %))
+            (map #(pair node-id %))
             output-labels))))
 
 (defn- mark-all-outputs-activated
@@ -201,7 +201,7 @@
     (assoc ctx
       :nodes-affected
       (into nodes-affected
-            (map #(vector node-id %))
+            (map #(pair node-id %))
             output-labels))))
 
 (defn- next-node-id [ctx graph-id]
@@ -787,7 +787,7 @@
 
 (defn- mark-nodes-modified
   [{:keys [nodes-affected] :as ctx}]
-  (assoc ctx :nodes-modified (into #{} (map #(% 0)) nodes-affected)))
+  (assoc ctx :nodes-modified (into #{} (map key) nodes-affected)))
 
 (defn- map-vals-bargs
   [m f]

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -168,10 +168,9 @@
         nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        (into (nodes-affected node-id #{})
-              dirty-deps)))))
+      (into nodes-affected
+            (map #(vector node-id %))
+            dirty-deps))))
 
 (defn- mark-output-activated
   [ctx node-id output-label]
@@ -179,11 +178,7 @@
   (let [nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        (if-some [existing-affected (nodes-affected node-id)]
-          (conj existing-affected output-label)
-          #{output-label})))))
+      (conj nodes-affected [node-id output-label]))))
 
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
@@ -191,10 +186,9 @@
   (let [nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        (into (nodes-affected node-id #{})
-              output-labels)))))
+      (into nodes-affected
+            (map #(vector node-id %))
+            output-labels))))
 
 (defn- mark-all-outputs-activated
   [ctx node-id]
@@ -206,9 +200,9 @@
         nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        output-labels))))
+      (into nodes-affected
+            (map #(vector node-id %))
+            output-labels))))
 
 (defn- next-node-id [ctx graph-id]
   (is/next-node-id* (:node-id-generators ctx) graph-id))
@@ -793,7 +787,7 @@
 
 (defn- mark-nodes-modified
   [{:keys [nodes-affected] :as ctx}]
-  (assoc ctx :nodes-modified (set (keys nodes-affected))))
+  (assoc ctx :nodes-modified (into #{} (map #(% 0)) nodes-affected)))
 
 (defn- map-vals-bargs
   [m f]
@@ -820,7 +814,7 @@
 (defn new-transaction-context
   [basis node-id-generators override-id-generator metrics-collector]
   {:basis basis
-   :nodes-affected {}
+   :nodes-affected #{}
    :nodes-added []
    :nodes-modified #{}
    :nodes-deleted {}
@@ -855,11 +849,7 @@
   ;; afterwards, it will have the transitive closure of all [node-id output] pairs
   ;; reachable from the original collection.
   (du/measuring (:metrics ctx) :trace-dependencies
-    (let [outputs-modified (->> (:nodes-affected ctx)
-                                (gt/dependencies (:basis ctx))
-                                (into []
-                                      (mapcat (fn [[nid ls]]
-                                                (mapv #(vector nid %) ls)))))]
+    (let [outputs-modified (gt/dependencies (:basis ctx) (:nodes-affected ctx))]
       (assoc ctx :outputs-modified outputs-modified))))
 
 (defn transact*

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -75,7 +75,10 @@
   "Like core.group-by, but you can specify the associative container to group
   into, as well as the empty collection to use for the groups. If the optional
   value-fn is supplied, it will be used to transform each element before adding
-  them to the groups."
+  them to the groups. It can also be a drop-in replacement for group-by that is
+  slightly more efficient since it will make use of transient vectors."
+  ([key-fn coll]
+   (group-into {} [] key-fn nil coll))
   ([groups-container empty-group key-fn coll]
    (group-into groups-container empty-group key-fn nil coll))
   ([groups-container empty-group key-fn value-fn coll]

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -1,0 +1,7 @@
+(ns util.coll
+  (:import [clojure.lang MapEntry]))
+
+(defn pair
+  "Returns a two-element collection that implements IPersistentVector."
+  [a b]
+  (MapEntry. a b))

--- a/editor/src/clj/util/debug_util.clj
+++ b/editor/src/clj/util/debug_util.clj
@@ -18,16 +18,10 @@
   ^double [^long counter]
   (/ (double counter) 6.0E10))
 
-(defn- system-property-set?
-  [system-property-name]
-  (if-some [string-value (System/getProperty system-property-name)]
-    (Boolean/parseBoolean string-value)
-    false))
-
 (defn metrics-enabled?
   "Returns true if we're running with the defold.metrics system property set."
   []
-  (system-property-set? "defold.metrics"))
+  (Boolean/getBoolean "defold.metrics"))
 
 (defmacro if-metrics
   "Evaluate metrics-expr if we're running with the defold.metrics system property set.

--- a/editor/src/clj/util/debug_util.clj
+++ b/editor/src/clj/util/debug_util.clj
@@ -1,0 +1,118 @@
+(ns util.debug-util)
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn counter->ms
+  "Converts a nanosecond counter value into a double in milliseconds."
+  ^double [^long counter]
+  (/ (double counter) 1000000.0))
+
+(defn counter->seconds
+  "Converts a nanosecond counter value into a double in seconds."
+  ^double [^long counter]
+  (/ (double counter) 1000000000.0))
+
+(defn counter->minutes
+  "Converts a nanosecond counter value into a double in minutes."
+  ^double [^long counter]
+  (/ (double counter) 6.0E10))
+
+(defn- system-property-set?
+  [system-property-name]
+  (if-some [string-value (System/getProperty system-property-name)]
+    (Boolean/parseBoolean string-value)
+    false))
+
+(defn metrics-enabled?
+  "Returns true if we're running with the defold.metrics system property set."
+  []
+  (system-property-set? "defold.metrics"))
+
+(defmacro if-metrics
+  "Evaluate metrics-expr if we're running with the defold.metrics system property set.
+  Otherwise, evaluate no-metrics-expr."
+  [metrics-expr no-metrics-expr]
+  (if (metrics-enabled?)
+    metrics-expr
+    no-metrics-expr))
+
+(defmacro when-metrics
+  "Only evaluate body if we're running with the defold.metrics system property set.
+  Returns the value of the last expr in body, or nil if the system property is not set."
+  [& body]
+  (if (metrics-enabled?)
+    (cons 'do body)
+    nil))
+
+(defmacro metrics-time
+  "Evaluates expr. Then prints the supplied label along with the time it took if
+  we're running a metrics version. Regardless, returns the value of expr."
+  ([expr]
+   (metrics-time "Expression" expr))
+  ([label expr]
+   (if-not (metrics-enabled?)
+     expr
+     `(let [start# (System/nanoTime)
+            ret# ~expr
+            end# (System/nanoTime)]
+        (println (str ~label " completed in " (counter->ms (- end# start#)) " ms"))
+        ret#))))
+
+(defmacro make-metrics-collector
+  "Returns a metrics-collector for use with the measuring macro if we're running
+  a metrics version. Otherwise, returns nil."
+  []
+  (when (metrics-enabled?)
+    '(volatile! {})))
+
+(defn- update-task-metrics
+  [metrics task-key ^long counter]
+  (if-some [task-entry (find metrics task-key)]
+    (let [^long task-counter (val task-entry)]
+      (assoc metrics task-key (+ task-counter counter)))
+    (assoc metrics task-key counter)))
+
+(defn- update-subtask-metrics
+  [metrics task-key subtask-key ^long counter]
+  (if-some [task-entry (find metrics task-key)]
+    (let [task-metrics (val task-entry)]
+      (if-some [subtask-entry (find task-metrics subtask-key)]
+        (let [^long subtask-counter (val subtask-entry)]
+          (assoc metrics task-key (assoc task-metrics subtask-key (+ subtask-counter counter))))
+        (assoc metrics task-key (assoc task-metrics subtask-key counter))))
+    (assoc metrics task-key {subtask-key counter})))
+
+(defmacro update-metrics
+  "Adds to the specified counter in the provided metrics-collector."
+  ([metrics-collector task-key counter]
+   (when (metrics-enabled?)
+     `(when ~metrics-collector
+        (vswap! ~metrics-collector #'update-task-metrics ~task-key ~counter)
+        nil)))
+  ([metrics-collector task-key subtask-key counter]
+   (when (metrics-enabled?)
+     `(when ~metrics-collector
+        (vswap! ~metrics-collector #'update-subtask-metrics ~task-key ~subtask-key ~counter)
+        nil))))
+
+(defmacro measuring
+  "Evaluates expr. Then adds the time it took to the specified counter in the
+  provided metrics-collector if we're running a metrics version. Regardless,
+  returns the value of expr."
+  ([metrics-collector task-key expr]
+   (if-not (metrics-enabled?)
+     expr
+     `(let [start# (System/nanoTime)
+            ret# ~expr
+            end# (System/nanoTime)]
+        (update-metrics ~metrics-collector ~task-key (- end# start#))
+        ret#)))
+  ([metrics-collector task-key subtask-key expr]
+   (if-not (metrics-enabled?)
+     expr
+     `(let [start# (System/nanoTime)
+            ret# ~expr
+            end# (System/nanoTime)]
+        (update-metrics ~metrics-collector ~task-key ~subtask-key (- end# start#))
+        ret#))))

--- a/editor/src/clj/util/digestable.clj
+++ b/editor/src/clj/util/digestable.clj
@@ -18,17 +18,15 @@
             [editor.math :as math]
             [editor.resource :as resource]
             [editor.workspace]
+            [util.coll :refer [pair]]
             [util.digest :as digest])
-  (:import [clojure.lang MapEntry Named]
+  (:import [clojure.lang Named]
            [java.io OutputStreamWriter Writer]))
 
 (set! *warn-on-reflection* true)
 
 (defprotocol Digestable
   (digest! [value writer]))
-
-(defn- pair [a b]
-  (MapEntry/create a b))
 
 (defn- named? [value]
   (or (instance? Named value)

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -109,8 +109,8 @@
 
 (defn jogl-native-dep?
   [[artifact version & {:keys [classifier]}]]
-  (and (#{'org.jogamp.gluegen/gluegen-rt
-          'org.jogamp.jogl/jogl-all} artifact)
+  (and (#{'com.metsci.ext.org.jogamp.gluegen/gluegen-rt
+          'com.metsci.ext.org.jogamp.jogl/jogl-all} artifact)
        classifier))
 
 (defn extract-jogl-native-dep

--- a/editor/test/dynamo/integration/override_test.clj
+++ b/editor/test/dynamo/integration/override_test.clj
@@ -865,9 +865,9 @@
           mains (mapv first all)
           subs (mapv second all)]
       (testing "value fnk"
-        (is (every? (deps [[main-0 :a-property]]) (outs mains :virt-property))))
+        (is (every? (set (deps [[main-0 :a-property]])) (outs mains :virt-property))))
       (testing "output"
-        (is (every? (deps [[main-0 :a-property]]) (outs mains :cached-output))))
+        (is (every? (set (deps [[main-0 :a-property]])) (outs mains :cached-output))))
       (testing "connections"
         (is (every? conn? (for [[m s] all]
                             [s :_node-id m :sub-nodes])))
@@ -883,9 +883,9 @@
                                          (g/connect src :a-property tgt :in-value)
                                          (g/override src)))]
       (testing "regular dep"
-        (is (every? (deps [[src :a-property]]) [[tgt :out-value]])))
+        (is (every? (set (deps [[src :a-property]])) [[tgt :out-value]])))
       (testing "no override deps"
-        (is (not-any? (deps [[src-1 :a-property]]) [[tgt :out-value]])))
+        (is (not-any? (set (deps [[src-1 :a-property]])) [[tgt :out-value]])))
       (testing "connections"
         (is (conn? [src :a-property tgt :in-value]))
         (is (no-conn? [src-1 :a-property tgt :in-value])))))
@@ -895,7 +895,7 @@
                                          (g/connect src :a-property tgt :in-value)
                                          (g/override tgt)))]
       (testing "regular dep"
-        (is (every? (deps [[src :a-property]]) [[tgt :out-value] [tgt-1 :out-value]])))
+        (is (every? (set (deps [[src :a-property]])) [[tgt :out-value] [tgt-1 :out-value]])))
       (testing "connections"
         (is (conn? [src :a-property tgt :in-value]))
         (is (conn? [src :a-property tgt-1 :in-value])))))

--- a/editor/test/dynamo/integration/override_test.clj
+++ b/editor/test/dynamo/integration/override_test.clj
@@ -17,15 +17,13 @@
             [clojure.test :refer :all]
             [dynamo.graph :as g]
             [dynamo.integration.override-test-support :as support]
-            [editor.defold-project :as project]
-            [editor.resource :as resource]
             [editor.util :as util]
             [integration.test-util :as test-util]
             [internal.graph.types :as gt]
             [internal.util]
             [schema.core :as s]
             [support.test-support :as ts])
-  (:import  [javax.vecmath Vector3d]))
+  (:import [javax.vecmath Vector3d]))
 
 (g/defnode BaseNode
   (property base-property g/Str))
@@ -49,7 +47,9 @@
                                          (update :display-order conj :c-property)))))
 
 (g/defnode SubNode
-  (property value g/Str))
+  (property value g/Str)
+  (input sub-nodes g/NodeID :array :cascade-delete)
+  (output sub-nodes [g/NodeID] (g/fnk [sub-nodes] sub-nodes)))
 
 (defn- override [node-id]
   (-> (g/override node-id {})
@@ -96,6 +96,63 @@
                     (get-in p [:properties :dyn-property :override?])))]
           (is (false? (f main)))
           (is (true? (f or-main))))))))
+
+(deftest connect
+  (testing "Connecting to original spawns override nodes in direct override layers"
+    (ts/with-clean-system
+      ;; Test with two direct overrides of main.
+      (let [[main] (ts/tx-nodes (g/make-nodes world [main MainNode]
+                                  (g/override main)
+                                  (g/override main)))
+            [new1-sub new2-sub] (ts/tx-nodes (g/make-nodes world [new1-sub SubNode
+                                                                  new2-sub SubNode
+                                                                  new2-sub-sub SubNode]
+                                               (g/connect new2-sub-sub :_node-id new2-sub :sub-nodes)))
+            node-count-before-connection (-> world g/graph :nodes count)]
+        (g/connect! new1-sub :_node-id main :sub-nodes)
+        (is (= (+ node-count-before-connection 2) ; Single node cloned to two override layers.
+               (-> world g/graph :nodes count)))
+        (g/connect! new2-sub :_node-id main :sub-nodes)
+        (is (= (+ node-count-before-connection 2 4) ; Two-node chain cloned to two override layers.
+               (-> world g/graph :nodes count))))))
+  (testing "Connecting to original spawns override nodes in recursive override layers"
+    (ts/with-clean-system
+      ;; Test with one direct override of main, and one override of that override.
+      (let [[main] (ts/tx-nodes (g/make-node world MainNode))
+            [or-main] (ts/tx-nodes (g/override main))
+            [_or2-main] (ts/tx-nodes (g/override or-main))
+            [new1-sub new2-sub] (ts/tx-nodes (g/make-nodes world [new1-sub SubNode
+                                                                  new2-sub SubNode
+                                                                  new2-sub-sub SubNode]
+                                               (g/connect new2-sub-sub :_node-id new2-sub :sub-nodes)))
+            node-count-before-connection (-> world g/graph :nodes count)]
+        (g/connect! new1-sub :_node-id main :sub-nodes)
+        (is (= (+ node-count-before-connection 2) ; Single node cloned to two override layers.
+               (-> world g/graph :nodes count)))
+        (g/connect! new2-sub :_node-id main :sub-nodes)
+        (is (= (+ node-count-before-connection 2 4) ; Two-node chain cloned to two override layers.
+               (-> world g/graph :nodes count))))))
+  (testing "Connecting to override only spawns override nodes in subsequent override layers"
+    (ts/with-clean-system
+      ;; Test with one direct override of main, and one override of that override.
+      (let [[main] (ts/tx-nodes (g/make-node world MainNode))
+            [or-main] (ts/tx-nodes (g/override main))
+            [or2-main] (ts/tx-nodes (g/override or-main))
+            [new1-sub new2-sub new3-sub] (ts/tx-nodes (g/make-nodes world [new1-sub SubNode
+                                                                           new2-sub SubNode
+                                                                           new3-sub SubNode
+                                                                           new3-sub-sub SubNode]
+                                                        (g/connect new3-sub-sub :_node-id new3-sub :sub-nodes)))
+            node-count-before-connection (-> world g/graph :nodes count)]
+        (g/connect! new1-sub :_node-id or2-main :sub-nodes)
+        (is (= node-count-before-connection)
+            (-> world g/graph :nodes count)) ; Connecting to override with no subsequent overrides spawns no nodes.
+        (g/connect! new2-sub :_node-id or-main :sub-nodes)
+        (is (= (+ node-count-before-connection 1) ; Single node cloned to one override layer.
+               (-> world g/graph :nodes count)))
+        (g/connect! new3-sub :_node-id or-main :sub-nodes)
+        (is (= (+ node-count-before-connection 1 2) ; Two-node chain cloned to one override layer.
+               (-> world g/graph :nodes count)))))))
 
 (deftest delete
   (ts/with-clean-system
@@ -229,7 +286,7 @@
       (let [[main cache-node or-main] (ts/tx-nodes (g/make-nodes world [main StringInput
                                                                         cache [DetectCacheInvalidation :invalid-cache (atom 0)]]
                                                      (g/connect cache :cached-value main :value)
-                                                     (g/override main {:traverse? (constantly false)})))]
+                                                     (g/override main {:traverse-fn g/never-override-traverse-fn})))]
         (is (= cache-node (ffirst (g/sources-of main :value))))
         (is (= cache-node (ffirst (g/sources-of or-main :value)))))))
   (testing "existing override"
@@ -869,7 +926,7 @@
     (let [[script] (ts/tx-nodes (g/make-nodes world [script Script]))
           [go comp or-script] (ts/tx-nodes (g/make-nodes world [go GameObject
                                                                 comp Component]
-                                             (g/override script {:traverse? (constantly true)}
+                                             (g/override script {:traverse-fn g/always-override-traverse-fn}
                                                          (fn [evaluation-context id-mapping]
                                                            (let [or-script (id-mapping script)]
                                                              (concat
@@ -877,14 +934,14 @@
                                                                (g/connect or-script :_node-id comp :instance)))))))
           [coll inst or-go] (ts/tx-nodes (g/make-nodes world [coll Collection
                                                               inst GameObjectInstance]
-                                           (g/override go {:traverse? (constantly true)}
+                                           (g/override go {:traverse-fn g/always-override-traverse-fn}
                                                        (fn [evaluation-context id-mapping]
                                                          (let [or-go (id-mapping go)]
                                                            (concat
                                                              (g/connect inst :_node-id coll :instances)
                                                              (g/connect or-go :_node-id inst :source)))))))
           [comp-2 or-script-2] (ts/tx-nodes (g/make-nodes world [comp Component]
-                                              (g/override script {:traverse? (constantly true)}
+                                              (g/override script {:traverse-fn g/always-override-traverse-fn}
                                                           (fn [evaluation-context id-mapping]
                                                             (let [or-script (id-mapping script)]
                                                               (g/connect or-script :_node-id comp :instance))))))
@@ -897,7 +954,7 @@
     (let [[script] (ts/tx-nodes (g/make-nodes world [script Script]))
           [go comp or-script] (ts/tx-nodes (g/make-nodes world [go GameObject
                                                                 comp Component]
-                                             (g/override script {:traverse? (constantly true)}
+                                             (g/override script {:traverse-fn g/always-override-traverse-fn}
                                                          (fn [evaluation-context id-mapping]
                                                            (let [or-script (id-mapping script)]
                                                              (concat
@@ -905,7 +962,7 @@
                                                                (g/connect or-script :_node-id comp :instance)))))))
           [coll inst or-go] (ts/tx-nodes (g/make-nodes world [coll Collection
                                                               inst GameObjectInstance]
-                                           (g/override go {:traverse? (constantly false)}
+                                           (g/override go {:traverse-fn g/never-override-traverse-fn}
                                                        (fn [evaluation-context id-mapping]
                                                          (let [or-go (id-mapping go)]
                                                            (concat
@@ -930,12 +987,12 @@
                                       (ts/tx-nodes (g/make-nodes world [coll Collection
                                                                         go-inst GameObjectInstance]
                                                      (g/connect go-inst :_node-id coll :instances)
-                                                     (g/override go {:traverse? (constantly true)}
+                                                     (g/override go {:traverse-fn g/always-override-traverse-fn}
                                                                  (fn [evaluation-context id-mapping]
                                                                    (let [or-go (id-mapping go)]
                                                                      (g/connect or-go :_node-id go-inst :source)))))))
           [comp or-script] (ts/tx-nodes (g/make-nodes world [comp Component]
-                                          (g/override script {:traverse? (constantly true)}
+                                          (g/override script {:traverse-fn g/always-override-traverse-fn}
                                                       (fn [evaluation-context id-mapping]
                                                         (let [or-script (id-mapping script)]
                                                           (concat
@@ -1007,4 +1064,3 @@
         (let [output-freqs (frequencies (mapcat g/outputs all-nodes))
               input-freqs (frequencies (mapcat g/inputs all-nodes))]
           (is (= output-freqs input-freqs)))))))
-

--- a/editor/test/integration/resource_watch_test.clj
+++ b/editor/test/integration/resource_watch_test.clj
@@ -26,8 +26,7 @@
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [service.log :as log])
-  (:import [java.net URL]
-           [org.apache.commons.io IOUtils]))
+  (:import [org.apache.commons.io IOUtils]))
 
 (def ^:dynamic *project-path* "test/resources/lib_resource_project")
 

--- a/editor/test/integration/scope_test.clj
+++ b/editor/test/integration/scope_test.clj
@@ -46,7 +46,7 @@
           old-node-ids (set (ig/node-ids (g/graph graph-id)))
           old-basis (g/now)
           mem-resource (project/make-embedded-resource project resource-type-name inline-resource)]
-      (#'project/load-nodes! project (#'project/make-nodes! project [mem-resource]) (constantly nil) {})
+      (#'project/load-nodes! project (#'project/make-nodes! project [mem-resource]) (constantly nil) {} nil nil)
       (let [new-resource-node (project/get-resource-node project mem-resource)
             new-count (node-count (g/graph graph-id))]
         (is (> new-count old-count))

--- a/editor/test/internal/copy_paste_test.clj
+++ b/editor/test/internal/copy_paste_test.clj
@@ -18,7 +18,8 @@
             [clojure.test :refer :all]
             [cognitect.transit :as transit]
             [dynamo.graph :as g]
-            [support.test-support :as ts]))
+            [support.test-support :as ts])
+  (:import [internal.graph.types Arc]))
 
 (defn arc-node-references
   [fragment]
@@ -197,8 +198,8 @@
   (input  discards-value g/Str)
   (output produces-value g/Str (g/fnk [a-property] a-property)))
 
-(defn- stop-at-stoppers [basis [src src-label tgt tgt-label]]
-  (not (g/node-instance? StopperNode tgt)))
+(defn- stop-at-stoppers [basis ^Arc arc]
+  (not (g/node-instance? basis StopperNode (.target-id arc))))
 
 (defrecord Standin [original-id])
 
@@ -311,9 +312,9 @@
   (output component-id g/Any (g/fnk [_node-id id] [id _node-id]))
   (output node-outline g/Any (g/fnk [] {})))
 
-(defn- copy-traverse [_basis [_src-node _src-label _tgt-node tgt-label]]
+(defn- copy-traverse [_basis ^Arc arc]
   ;; This is a simplification of the traversal rules from outline/default-copy-traverse.
-  (= :child-outlines tgt-label))
+  (= :child-outlines (.target-label arc)))
 
 (deftest copy-flattens-override-hierarchy
   (ts/with-clean-system

--- a/editor/test/internal/dependency_test.clj
+++ b/editor/test/internal/dependency_test.clj
@@ -22,7 +22,7 @@
 
 (defn- dependencies
   [& pairs]
-  (ts/graph-dependencies (g/now) (partition 2 pairs)))
+  (ts/graph-dependencies (g/now) (map vec (partition 2 pairs))))
 
 (g/defnode SingleOutput
   (output out-from-inline g/Str (g/fnk [] "out-from-inline")))

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -444,7 +444,10 @@
 
         (is (= 2 (count (ts/undo-stack project-graph))))        
 
-        (is (= {p-source #{:_declared-properties :source-label :_properties}} (successors p-source :source-label)))
+        (is (= #{[p-source :_declared-properties]
+                 [p-source :source-label]
+                 [p-source :_properties]}
+               (set (successors p-source :source-label))))
         (is (= nil (sarcs p-source :source-label)))
         (is (= nil (tarcs v-sink :target-label)))
 
@@ -454,7 +457,11 @@
 
         (is (= 3 (count (ts/undo-stack project-graph))))
 
-        (is (= {p-source #{:_declared-properties :source-label :_properties} v-sink #{:loud}} (successors p-source :source-label)))
+        (is (= #{[p-source :_declared-properties]
+                 [p-source :source-label]
+                 [p-source :_properties]
+                 [v-sink :loud]}
+               (set (successors p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (sarcs p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (tarcs v-sink :target-label))))
 
@@ -465,7 +472,11 @@
         (is (= 2 (count (ts/undo-stack project-graph))))
 
         ;; check hydrated after undo, v-sink :loud used to be missing from successors
-        (is (= {p-source #{:_declared-properties :source-label :_properties} v-sink #{:loud}} (successors p-source :source-label)))
+        (is (= #{[p-source :_declared-properties]
+                 [p-source :source-label]
+                 [p-source :_properties]
+                 [v-sink :loud]}
+               (set (successors p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (sarcs p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (tarcs v-sink :target-label))))
 

--- a/editor/test/support/test_support.clj
+++ b/editor/test/support/test_support.clj
@@ -76,9 +76,4 @@
   ([tgts]
    (graph-dependencies (g/now) tgts))
   ([basis tgts]
-   (->> tgts
-        (reduce (fn [m [nid l]]
-                  (update m nid (fn [s l] (if s (conj s l) #{l})) l))
-                {})
-        (g/dependencies basis)
-        (into #{} (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))))
+   (g/dependencies basis tgts)))

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1748,7 +1748,7 @@ class Configuration(object):
         config = ConfigParser()
         config.read(info['config'])
         overrides = {'bootstrap.resourcespath': info['resources_path']}
-        jdk = 'jdk11.0.1-p1'
+        jdk = 'jdk-11.0.15+10'
         host2 = get_host_platform2()
         if 'win32' in host2:
             java = join('Defold', 'packages', jdk, 'bin', 'java.exe')


### PR DESCRIPTION
Update the editor to use bundled JDK 11.0.15+10 and JOGL 2.4.0-rc.

This branch can be used as a starting point for PR:s that should eventually go into `editor-dev` to work around the current SSH issues seen on `editor-dev` until we feel safe to merge the JDK update.