### PR TITLE
Issue-6660: Selectable graphics adapter

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -66,7 +66,7 @@ if 'waf_dynamo_private' not in sys.modules:
 
 def platform_supports_feature(platform, feature, data):
     if feature == 'vulkan':
-        return platform not in ['js-web', 'wasm-web', 'x86_64-ios', 'win32', 'x86_64-win32', 'x86_64-linux']
+        return platform not in ['js-web', 'wasm-web', 'x86_64-ios', 'x86_64-linux']
     return waf_dynamo_private.supports_feature(platform, feature, data)
 
 def platform_setup_tools(ctx, build_util):

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2049,12 +2049,15 @@ dmEngine::HEngine dmEngineCreate(int argc, char *argv[])
 {
     dmGraphics::AdapterType adapter_type_from_args;
     bool graphics_initialized = false;
+    bool graphics_adapter_requested_by_args = false;
 
     // If user has passed in the arugment --graphics-adapter=x, we try to
     // initialize the graphics with that adapter. If that doesn't work,
     // e.g if the adapter 'x' isn't available, we fallback to the regular
     // priority based selection of graphics adapter
-    if (GetGraphicsAdapterTypeFromArgs(argc, argv, &adapter_type_from_args))
+    graphics_adapter_requested_by_args = GetGraphicsAdapterTypeFromArgs(argc, argv, &adapter_type_from_args);
+
+    if (graphics_adapter_requested_by_args)
     {
         graphics_initialized = dmGraphics::InitializeByAdapterType(adapter_type_from_args);
     }
@@ -2079,6 +2082,16 @@ dmEngine::HEngine dmEngineCreate(int argc, char *argv[])
         Delete(engine);
         return 0;
     }
+
+
+    dmGraphics::AdapterType adapter_type_engine = dmGraphics::GetAdapterType(engine->m_GraphicsContext);
+    if (graphics_adapter_requested_by_args && adapter_type_from_args != adapter_type_engine)
+    {
+        dmLogWarning("Requested graphics adapater '%s' is not supported, currently selected: '%s'",
+            dmGraphics::GraphicsAdapterTypeToStr(adapter_type_from_args),
+            dmGraphics::GraphicsAdapterTypeToStr(adapter_type_engine));
+    }
+
     return engine;
 }
 

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2042,11 +2042,8 @@ dmEngine::HEngine dmEngineCreate(int argc, char *argv[])
 
     if (!dmGraphics::Initialize(arg_adapter_type))
     {
-        dmLogError("Could not initialize graphics. No graphics adapter was found.");
         return 0;
     }
-
-    dmLogInfo("Initialised graphics device '%s'", dmGraphics::GetGraphicsAdapterTypeLiteral(dmGraphics::GetAdapterType()));
 
     dmEngine::HEngine engine = dmEngine::New(dmEngine::g_EngineService);
     bool initialized = dmEngine::Init(engine, argc, argv);

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2017,11 +2017,56 @@ void dmEngineFinalize()
     dmSocket::Finalize();
 }
 
+bool GetGraphicsAdapterTypeFromArgs(int argc, char *argv[], dmGraphics::AdapterType* adapter_type_out)
+{
+    const char arg_adapter_type[] = "--graphics-adapter=";
+    for (int i = 0; i < argc; ++i)
+    {
+        const char* arg = argv[i];
+        if (strncmp(arg_adapter_type, arg, sizeof(arg_adapter_type)-1) == 0)
+        {
+            const char* eq = strchr(arg, '=');
+            if (strncmp("opengl", eq+1, sizeof("opengl")-1) == 0) {
+                *adapter_type_out = dmGraphics::ADAPTER_TYPE_OPENGL;
+                return true;
+            } else if (strncmp("vulkan", eq+1, sizeof("vulkan")-1) == 0) {
+                *adapter_type_out = dmGraphics::ADAPTER_TYPE_VULKAN;
+                return true;
+            } else if (strncmp("null", eq+1, sizeof("null")-1) == 0) {
+                *adapter_type_out = dmGraphics::ADAPTER_TYPE_NULL;
+                return true;
+            } else {
+                dmLogWarning("Invalid value used for %s%s.", arg_adapter_type, eq);
+            }
+        }
+    }
+
+    return false;
+}
+
+
 dmEngine::HEngine dmEngineCreate(int argc, char *argv[])
 {
-    if (!dmGraphics::Initialize())
+    dmGraphics::AdapterType adapter_type_from_args;
+    bool graphics_initialized = false;
+
+    // If user has passed in the arugment --graphics-adapter=x, we try to
+    // initialize the graphics with that adapter. If that doesn't work,
+    // e.g if the adapter 'x' isn't available, we fallback to the regular
+    // priority based selection of graphics adapter
+    if (GetGraphicsAdapterTypeFromArgs(argc, argv, &adapter_type_from_args))
     {
-        dmLogError("Could not initialize graphics.");
+        graphics_initialized = dmGraphics::InitializeByAdapterType(adapter_type_from_args);
+    }
+
+    if (!graphics_initialized)
+    {
+        graphics_initialized = dmGraphics::Initialize();
+    }
+
+    if (!graphics_initialized)
+    {
+        dmLogError("Could not initialize graphics. No graphics adapter was found.");
         return 0;
     }
 

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2073,6 +2073,14 @@ dmEngine::HEngine dmEngineCreate(int argc, char *argv[])
         return 0;
     }
 
+    dmGraphics::AdapterType adapter_type_engine = dmGraphics::GetAdapterType();
+    if (graphics_adapter_requested_by_args && adapter_type_from_args != adapter_type_engine)
+    {
+        dmLogWarning("Requested graphics adapater '%s' is not supported, currently selected: '%s'",
+            dmGraphics::GraphicsAdapterTypeToStr(adapter_type_from_args),
+            dmGraphics::GraphicsAdapterTypeToStr(adapter_type_engine));
+    }
+
     dmEngine::HEngine engine = dmEngine::New(dmEngine::g_EngineService);
     bool initialized = dmEngine::Init(engine, argc, argv);
 
@@ -2081,15 +2089,6 @@ dmEngine::HEngine dmEngineCreate(int argc, char *argv[])
         // Leave cleaning up of engine service to the finalize call
         Delete(engine);
         return 0;
-    }
-
-
-    dmGraphics::AdapterType adapter_type_engine = dmGraphics::GetAdapterType(engine->m_GraphicsContext);
-    if (graphics_adapter_requested_by_args && adapter_type_from_args != adapter_type_engine)
-    {
-        dmLogWarning("Requested graphics adapater '%s' is not supported, currently selected: '%s'",
-            dmGraphics::GraphicsAdapterTypeToStr(adapter_type_from_args),
-            dmGraphics::GraphicsAdapterTypeToStr(adapter_type_engine));
     }
 
     return engine;

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -61,12 +61,17 @@ def build(bld):
         additional_libs.append('TREMOLO')
 
     graphics_lib = 'GRAPHICS DMGLFW'
-    graphics_lib_symbols = 'GraphicsAdapterOpenGL'
-    if bld.env['PLATFORM'] in ('arm64-nx64',) or Options.options.with_vulkan:
-        graphics_lib = 'GRAPHICS_VULKAN DMGLFW VULKAN'
-        graphics_lib_symbols = 'GraphicsAdapterVulkan'
+    graphics_lib_symbols = ['GraphicsAdapterOpenGL']
 
-    exported_symbols.append(graphics_lib_symbols)
+    if Options.options.with_vulkan:
+        graphics_lib += ' GRAPHICS_VULKAN VULKAN'
+        graphics_lib_symbols.append('GraphicsAdapterVulkan')
+
+    if bld.env['PLATFORM'] in ('arm64-nx64',):
+        graphics_lib = 'GRAPHICS_VULKAN DMGLFW VULKAN'
+        graphics_lib_symbols = ['GraphicsAdapterVulkan']
+
+    exported_symbols += graphics_lib_symbols
 
     mobile_service_symbols = ['IACExt', 'IAPExt', 'PushExt', 'WebViewExt']
     if bld.env['PLATFORM'] in ('arm64-darwin', 'x86_64-ios'):

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -57,16 +57,6 @@ namespace dmGraphics
 
                 next = next->m_Next;
             }
-
-            if (!selected)
-            {
-                return false;
-            }
-
-            g_functions = selected->m_RegisterCb();
-            g_adapter   = selected;
-
-            return true;
         }
         else
         {
@@ -74,15 +64,22 @@ namespace dmGraphics
             {
                 if (next->m_AdapterType == by_type && next->m_IsSupportedCb())
                 {
-                    g_functions = next->m_RegisterCb();
-                    g_adapter   = next;
-                    return true;
+                    selected = next;
+                    break;
                 }
                 next = next->m_Next;
             }
         }
 
-        return false;
+        if (!selected)
+        {
+            return false;
+        }
+
+        g_functions = selected->m_RegisterCb();
+        g_adapter   = selected;
+
+        return true;
     }
 
     WindowParams::WindowParams()

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -331,7 +331,7 @@ namespace dmGraphics
         return SelectGraphicsAdapterByPriorityOrType(false, adapter_type) && g_functions.m_Initialize();
     }
 
-    AdapterType GetAdapterType(HContext context)
+    AdapterType GetAdapterType()
     {
         return g_adapter->m_AdapterType;
     }

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include <dlib/log.h>
 #include <dlib/dstrings.h>
 
 namespace dmGraphics
@@ -103,6 +104,18 @@ namespace dmGraphics
         g_functions = selected->m_RegisterCb();
         g_adapter   = selected;
         return true;
+    }
+
+    static const char* GetGraphicsAdapterTypeLiteral(AdapterType adapter_type)
+    {
+        switch(adapter_type)
+        {
+            case ADAPTER_TYPE_NULL:   return "null";
+            case ADAPTER_TYPE_OPENGL: return "opengl";
+            case ADAPTER_TYPE_VULKAN: return "vulkan";
+            default: break;
+        }
+        return "<unknown adapter type>";
     }
 
     WindowParams::WindowParams()
@@ -365,9 +378,16 @@ namespace dmGraphics
 
         if (result)
         {
-            return g_functions.m_Initialize();
+            result = g_functions.m_Initialize();
         }
 
+        if (result)
+        {
+            dmLogInfo("Initialised graphics device '%s'", GetGraphicsAdapterTypeLiteral(g_adapter->m_AdapterType));
+            return true;
+        }
+
+        dmLogError("Could not initialize graphics. No graphics adapter was found.");
         return false;
     }
 

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -663,20 +663,18 @@ namespace dmGraphics
             return ~0u;
     }
 
-    #define DM_GRAPHICS_ADAPTER_TYPE_TO_STR(x) case x: return #x
     static inline const char* GraphicsAdapterTypeToStr(AdapterType adapter_type)
     {
         switch(adapter_type)
         {
-            DM_GRAPHICS_ADAPTER_TYPE_TO_STR(ADAPTER_TYPE_NULL);
-            DM_GRAPHICS_ADAPTER_TYPE_TO_STR(ADAPTER_TYPE_OPENGL);
-            DM_GRAPHICS_ADAPTER_TYPE_TO_STR(ADAPTER_TYPE_VULKAN);
+            case ADAPTER_TYPE_NULL:   return "NULL";
+            case ADAPTER_TYPE_OPENGL: return "OpenGL";
+            case ADAPTER_TYPE_VULKAN: return "Vulkan";
             default: break;
         }
 
         return "UNKNOWN_ADAPTER_TYPE";
     }
-    #undef DM_VK_RESULT_TO_STRING_CASE
 }
 
 #endif // DM_GRAPHICS_H

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -350,6 +350,13 @@ namespace dmGraphics
     bool InitializeByAdapterType(AdapterType adapter_type);
 
     /**
+     * Get the currently selected adapter type. Must be called after graphics has initialized.
+     * @params context Graphics context handle
+     * @return AdapterType from the selcted adapter
+     */
+    AdapterType GetAdapterType();
+
+    /**
      * Finalize graphics system
      */
     void Finalize();
@@ -358,13 +365,6 @@ namespace dmGraphics
      * Starts the app that needs to control the update loop (iOS only)
      */
     void AppBootstrap(int argc, char** argv, void* init_ctx, EngineInit init_fn, EngineExit exit_fn, EngineCreate create_fn, EngineDestroy destroy_fn, EngineUpdate update_fn, EngineGetResult result_fn);
-
-    /**
-     * Get the currently selected adapter type. Must be called after graphics has initialized.
-     * @params context Graphics context handle
-     * @return AdapterType from the selcted adapter
-     */
-    AdapterType GetAdapterType(HContext context);
 
     /**
      * Get the window refresh rate
@@ -667,9 +667,9 @@ namespace dmGraphics
     {
         switch(adapter_type)
         {
-            case ADAPTER_TYPE_NULL:   return "NULL";
-            case ADAPTER_TYPE_OPENGL: return "OpenGL";
-            case ADAPTER_TYPE_VULKAN: return "Vulkan";
+            case ADAPTER_TYPE_NULL:   return "null";
+            case ADAPTER_TYPE_OPENGL: return "opengl";
+            case ADAPTER_TYPE_VULKAN: return "vulkan";
             default: break;
         }
 

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -347,13 +347,6 @@ namespace dmGraphics
     bool Initialize(const char* adapter_type_str = 0);
 
     /**
-     * Get the currently selected adapter type. Must be called after graphics has initialized.
-     * @params context Graphics context handle
-     * @return AdapterType from the selcted adapter
-     */
-    AdapterType GetAdapterType();
-
-    /**
      * Finalize graphics system
      */
     void Finalize();
@@ -657,18 +650,6 @@ namespace dmGraphics
             case BUFFER_TYPE_STENCIL_BIT: return 2;
         }
         return ~0u;
-    }
-
-    static inline const char* GetGraphicsAdapterTypeLiteral(AdapterType adapter_type)
-    {
-        switch(adapter_type)
-        {
-            case ADAPTER_TYPE_NULL:   return "null";
-            case ADAPTER_TYPE_OPENGL: return "opengl";
-            case ADAPTER_TYPE_VULKAN: return "vulkan";
-            default: break;
-        }
-        return "<unknown adapter type>";
     }
 }
 

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -360,6 +360,13 @@ namespace dmGraphics
     void AppBootstrap(int argc, char** argv, void* init_ctx, EngineInit init_fn, EngineExit exit_fn, EngineCreate create_fn, EngineDestroy destroy_fn, EngineUpdate update_fn, EngineGetResult result_fn);
 
     /**
+     * Get the currently selected adapter type. Must be called after graphics has initialized.
+     * @params context Graphics context handle
+     * @return AdapterType from the selcted adapter
+     */
+    AdapterType GetAdapterType(HContext context);
+
+    /**
      * Get the window refresh rate
      * @params context Graphics context handle
      * @return The window refresh rate, 0 if refresh rate could not be read.
@@ -655,6 +662,21 @@ namespace dmGraphics
         else
             return ~0u;
     }
+
+    #define DM_GRAPHICS_ADAPTER_TYPE_TO_STR(x) case x: return #x
+    static inline const char* GraphicsAdapterTypeToStr(AdapterType adapter_type)
+    {
+        switch(adapter_type)
+        {
+            DM_GRAPHICS_ADAPTER_TYPE_TO_STR(ADAPTER_TYPE_NULL);
+            DM_GRAPHICS_ADAPTER_TYPE_TO_STR(ADAPTER_TYPE_OPENGL);
+            DM_GRAPHICS_ADAPTER_TYPE_TO_STR(ADAPTER_TYPE_VULKAN);
+            default: break;
+        }
+
+        return "UNKNOWN_ADAPTER_TYPE";
+    }
+    #undef DM_VK_RESULT_TO_STRING_CASE
 }
 
 #endif // DM_GRAPHICS_H

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -640,8 +640,8 @@ namespace dmGraphics
     {
         switch(buffer_type)
         {
-            case BUFFER_TYPE_COLOR_BIT:   return "BUFFER_TYPE_COLOR_BIT"; 
-            case BUFFER_TYPE_DEPTH_BIT:   return "BUFFER_TYPE_DEPTH_BIT"; 
+            case BUFFER_TYPE_COLOR_BIT:   return "BUFFER_TYPE_COLOR_BIT";
+            case BUFFER_TYPE_DEPTH_BIT:   return "BUFFER_TYPE_DEPTH_BIT";
             case BUFFER_TYPE_STENCIL_BIT: return "BUFFER_TYPE_STENCIL_BIT";
             default:break;
         }
@@ -652,7 +652,7 @@ namespace dmGraphics
     {
         switch(buffer_type)
         {
-            case BUFFER_TYPE_COLOR_BIT:   return 0; 
+            case BUFFER_TYPE_COLOR_BIT:   return 0;
             case BUFFER_TYPE_DEPTH_BIT:   return 1;
             case BUFFER_TYPE_STENCIL_BIT: return 2;
         }

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -341,13 +341,10 @@ namespace dmGraphics
 
     /**
      * Initialize graphics system
+     * @params adapter_type_str String identifier for which adapter to use (vulkan/opengl/null)
+     * @return True if a graphics backend could be created, false otherwise.
      */
-    bool Initialize();
-
-    /**
-     * Initialize graphics system by a specific adapter type
-     */
-    bool InitializeByAdapterType(AdapterType adapter_type);
+    bool Initialize(const char* adapter_type_str = 0);
 
     /**
      * Get the currently selected adapter type. Must be called after graphics has initialized.
@@ -641,29 +638,28 @@ namespace dmGraphics
 
     const char* GetBufferTypeLiteral(BufferType buffer_type)
     {
-        if (buffer_type == BUFFER_TYPE_COLOR_BIT)
-            return "BUFFER_TYPE_COLOR_BIT";
-        else if (buffer_type == BUFFER_TYPE_DEPTH_BIT)
-            return "BUFFER_TYPE_DEPTH_BIT";
-        else if (buffer_type == BUFFER_TYPE_STENCIL_BIT)
-            return "BUFFER_TYPE_STENCIL_BIT";
-        else
-            return "<unknown buffer type>";
+        switch(buffer_type)
+        {
+            case BUFFER_TYPE_COLOR_BIT:   return "BUFFER_TYPE_COLOR_BIT"; 
+            case BUFFER_TYPE_DEPTH_BIT:   return "BUFFER_TYPE_DEPTH_BIT"; 
+            case BUFFER_TYPE_STENCIL_BIT: return "BUFFER_TYPE_STENCIL_BIT";
+            default:break;
+        }
+        return "<unknown buffer type>";
     }
 
     uint32_t GetBufferTypeIndex(BufferType buffer_type)
     {
-        if (buffer_type == BUFFER_TYPE_COLOR_BIT)
-            return 0;
-        else if (buffer_type == BUFFER_TYPE_DEPTH_BIT)
-            return 1;
-        else if (buffer_type == BUFFER_TYPE_STENCIL_BIT)
-            return 2;
-        else
-            return ~0u;
+        switch(buffer_type)
+        {
+            case BUFFER_TYPE_COLOR_BIT:   return 0; 
+            case BUFFER_TYPE_DEPTH_BIT:   return 1;
+            case BUFFER_TYPE_STENCIL_BIT: return 2;
+        }
+        return ~0u;
     }
 
-    static inline const char* GraphicsAdapterTypeToStr(AdapterType adapter_type)
+    static inline const char* GetGraphicsAdapterTypeLiteral(AdapterType adapter_type)
     {
         switch(adapter_type)
         {
@@ -672,8 +668,7 @@ namespace dmGraphics
             case ADAPTER_TYPE_VULKAN: return "vulkan";
             default: break;
         }
-
-        return "UNKNOWN_ADAPTER_TYPE";
+        return "<unknown adapter type>";
     }
 }
 

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -64,6 +64,13 @@ namespace dmGraphics
     static const HVertexProgram INVALID_VERTEX_PROGRAM_HANDLE = ~0u;
     static const HFragmentProgram INVALID_FRAGMENT_PROGRAM_HANDLE = ~0u;
 
+    enum AdapterType
+    {
+        ADAPTER_TYPE_NULL,
+        ADAPTER_TYPE_OPENGL,
+        ADAPTER_TYPE_VULKAN,
+    };
+
 
     // buffer clear types, each value is guaranteed to be separate bits
     enum BufferType
@@ -336,6 +343,11 @@ namespace dmGraphics
      * Initialize graphics system
      */
     bool Initialize();
+
+    /**
+     * Initialize graphics system by a specific adapter type
+     */
+    bool InitializeByAdapterType(AdapterType adapter_type);
 
     /**
      * Finalize graphics system

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -27,9 +27,13 @@ namespace dmGraphics
 
     struct GraphicsAdapter
     {
+        GraphicsAdapter(AdapterType adapter_type)
+        : m_AdapterType(adapter_type) {}
+
         struct GraphicsAdapter*            m_Next;
         GraphicsAdapterRegisterFunctionsCb m_RegisterCb;
         GraphicsAdapterIsSupportedCb       m_IsSupportedCb;
+        AdapterType                        m_AdapterType;
         int8_t                             m_Priority;
     };
 

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -54,7 +54,7 @@ namespace dmGraphics
     static GraphicsAdapterFunctionTable NullRegisterFunctionTable();
     static bool                         NullIsSupported();
     static const int8_t    g_null_adapter_priority = 2;
-    static GraphicsAdapter g_null_adapter;
+    static GraphicsAdapter g_null_adapter(ADAPTER_TYPE_NULL);
 
     DM_REGISTER_GRAPHICS_ADAPTER(GraphicsAdapterNull, &g_null_adapter, NullIsSupported, NullRegisterFunctionTable, g_null_adapter_priority);
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -472,11 +472,6 @@ static void LogFrameBufferError(GLenum status)
         return GL_FALSE;
     }
 
-    static bool OpenGLIsSupported()
-    {
-        return Initialize();
-    }
-
     static HContext OpenGLNewContext(const ContextParams& params)
     {
         if (g_Context == 0x0)
@@ -510,6 +505,11 @@ static void LogFrameBufferError(GLenum status)
     {
         // NOTE: We do glfwInit as glfw doesn't cleanup menus properly on OSX.
         return (glfwInit() == GL_TRUE);
+    }
+
+    static bool OpenGLIsSupported()
+    {
+        return OpenGLInitialize();
     }
 
     static void OpenGLFinalize()

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -329,7 +329,7 @@ static void LogFrameBufferError(GLenum status)
     static GraphicsAdapterFunctionTable OpenGLRegisterFunctionTable();
     static bool                         OpenGLIsSupported();
     static int8_t          g_null_adapter_priority = 1;
-    static GraphicsAdapter g_opengl_adapter;
+    static GraphicsAdapter g_opengl_adapter(ADAPTER_TYPE_OPENGL);
 
     DM_REGISTER_GRAPHICS_ADAPTER(GraphicsAdapterOpenGL, &g_opengl_adapter, OpenGLIsSupported, OpenGLRegisterFunctionTable, g_null_adapter_priority);
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -31,7 +31,7 @@ namespace dmGraphics
     static GraphicsAdapterFunctionTable VulkanRegisterFunctionTable();
     static bool                         VulkanIsSupported();
     static const int8_t    g_vulkan_adapter_priority = 0;
-    static GraphicsAdapter g_vulkan_adapter;
+    static GraphicsAdapter g_vulkan_adapter(ADAPTER_TYPE_VULKAN);
 
     DM_REGISTER_GRAPHICS_ADAPTER(GraphicsAdapterVulkan, &g_vulkan_adapter, VulkanIsSupported, VulkanRegisterFunctionTable, g_vulkan_adapter_priority);
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -92,7 +92,7 @@ namespace dmGraphics
 
         return "UNKNOWN_ERROR";
     }
-    #undef DM_VK_RESULT_TO_STRING_CASE
+    #undef DM_VK_RESULT_TO_STR_CASE
 
     #define DM_TEXTURE_FORMAT_TO_STR_CASE(x) case TEXTURE_FORMAT_##x: return #x;
     static const char* TextureFormatToString(TextureFormat format)
@@ -146,15 +146,6 @@ namespace dmGraphics
         m_RenderDocSupport        = params.m_RenderDocSupport;
 
         DM_STATIC_ASSERT(sizeof(m_TextureFormatSupport)*4 >= TEXTURE_FORMAT_COUNT, Invalid_Struct_Size );
-    }
-
-    Context::~Context()
-    {
-        if (m_Instance != VK_NULL_HANDLE)
-        {
-            vkDestroyInstance(m_Instance, 0);
-            m_Instance = VK_NULL_HANDLE;
-        }
     }
 
     static inline uint32_t GetNextRenderTargetId()
@@ -1081,6 +1072,12 @@ bail:
     {
         if (context != 0x0)
         {
+            if (context->m_Instance != VK_NULL_HANDLE)
+            {
+                vkDestroyInstance(context->m_Instance, 0);
+                context->m_Instance = VK_NULL_HANDLE;
+            }
+
             delete context;
             g_VulkanContext = 0x0;
         }

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -146,9 +146,6 @@ namespace dmGraphics
         vkEnumeratePhysicalDevices(vkInstance, &vk_device_count, vk_device_list);
         assert(vk_device_count == deviceListSize);
 
-        const uint8_t vk_max_extension_count = 128;
-        VkExtensionProperties vk_device_extensions[vk_max_extension_count];
-
         for (uint32_t i=0; i < vk_device_count; ++i)
         {
             VkPhysicalDevice vk_device = vk_device_list[i];
@@ -164,18 +161,15 @@ namespace dmGraphics
 
             vkEnumerateDeviceExtensionProperties(vk_device, 0, &vk_device_extension_count, 0);
 
-            // Note: If this is triggered, we need a higher limit for the max extension count
-            //       or simply allocate the exact memory dynamically to hold the extensions data..
-            assert(vk_device_extension_count < vk_max_extension_count);
+            VkExtensionProperties* vk_device_extensions = new VkExtensionProperties[vk_device_extension_count];
 
             if (vkEnumerateDeviceExtensionProperties(vk_device, 0, &vk_device_extension_count, vk_device_extensions) == VK_SUCCESS)
             {
-                device_list[i].m_DeviceExtensions = new VkExtensionProperties[vk_device_extension_count];
-
-                for (uint8_t j = 0; j < vk_device_extension_count; ++j)
-                {
-                    device_list[i].m_DeviceExtensions[j] = vk_device_extensions[j];
-                }
+                device_list[i].m_DeviceExtensions = vk_device_extensions;
+            }
+            else if (vk_device_extensions != 0x0)
+            {
+                delete[] vk_device_extensions;
             }
 
             device_list[i].m_Device               = vk_device;

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -375,7 +375,6 @@ namespace dmGraphics
     struct Context
     {
         Context(const ContextParams& params, const VkInstance vk_instance);
-        ~Context();
 
         Texture*                        m_TextureUnits[DM_MAX_TEXTURE_UNITS];
         PipelineCache                   m_PipelineCache;


### PR DESCRIPTION
This PR adds:
* Link vulkan libraries together with opengl when building with --with-vulkan (this only applies to local builds and not CI)
* Add argument '--graphics-adapter=xxx' to dmengine to select a specific graphics adapter