### PR TITLE
Only copy Android native libs for the bundled architectures

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -571,10 +571,11 @@ public class AndroidBundler implements IBundler {
                     // - x86_64
                     // - include
                     // we only copy files from the two architectures we support
-                    for (String architecture : platformToLibMap.values()) {
-                        File architectureDir = new File(jniDir, architecture);
+                    for (Platform platformArchitecture : getArchitectures(project)) {
+                        String architectureLibName = platformToLibMap.get(platformArchitecture);
+                        File architectureDir = new File(jniDir, architectureLibName);
                         if (architectureDir.exists()) {
-                            File dest = new File(libDir, architecture);
+                            File dest = new File(libDir, architectureLibName);
                             log("Copying shared library dir " + architectureDir + " to " + dest);
                             FileUtils.copyDirectory(architectureDir, dest);
                         }


### PR DESCRIPTION
The Android bundler always copies native libraries from dependencies for all supported architectures (32 and 64b bit) even if the bundle is created for a single architecture. To reduce the size of the generated APK the Android bundler will now only copy library files for the architecture(s) for which the bundle is created.

Fixes #6642 
