### PR TITLE
Speed up performance around transact

### DIFF
--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -14,12 +14,12 @@
 
 (ns internal.graph
   (:require [clojure.core.reducers :as r]
-            [clojure.set :as set]
             [internal.graph.types :as gt]
             [internal.node :as in]
             [internal.util :as util]
             [util.coll :refer [pair]])
   (:import [clojure.lang IPersistentSet]
+           [java.util ArrayDeque HashSet]
            [internal.graph.types Arc]))
 
 ;; A brief braindump on Overrides.
@@ -813,50 +813,40 @@
                result')
         (persistent! result')))))
 
-(defn- set-or-union [s1 s2]
-  (if s1
-    (into s1 s2)
-    s2))
-
-(def ^:private merge-with-union (let [red-f (fn [m [k v]] (update m k set-or-union v))]
-                                  (completing (fn [m1 m2] (reduce red-f m1 m2)))))
-
-(defn- basis-dependencies [basis outputs-by-node-ids]
-  (let [graph-id->node-successor-map (into {} (map (fn [[graph-id graph]] [graph-id (:successors graph)])) (:graphs basis))
-        node-id->successor-map (fn [node-id]
-                                 (some-> node-id
-                                         gt/node-id->graph-id
-                                         graph-id->node-successor-map
-                                         (get node-id)))]
-    (loop [;; 'todo' is the running stack (actually a map) of entries to traverse
-           ;; it's expensive to iterate a map, so start by turning it into a seq
-           todo (seq outputs-by-node-ids)
-           ;; collect next batch of entries in a map, to coalesce common node ids
-           next-todo {}
-           ;; final transitive closure of entries found, as a map
-           result {}]
-      (if-let [[node-id outputs] (first todo)]
-        (let [seen? (get result node-id)]
-          ;; termination condition is when we have seen *every* output already
-          (if (and seen? (every? seen? outputs))
-            ;; completely remove the node-id from todo as we have seen *every* output
-            (recur (next todo) next-todo result)
-            ;; does the node-id have any successors at all?
-            (if-let [label->succ (node-id->successor-map node-id)]
-              ;; ignore the outputs we have already seen
-              (let [outputs (if seen? (set/difference outputs seen?) outputs)
-                    ;; Add every successor to the stack for later processing
-                    next-todo (transduce (map label->succ) merge-with-union next-todo outputs)
-                    ;; And include the unseen output labels to the result
-                    result (update result node-id set-or-union outputs)]
-                (recur (next todo) next-todo result))
-              ;; There were no successors, recur without that node-id
-              (recur (next todo) next-todo result))))
-        ;; check if there is a next batch of entries to process
-        (if-let [todo (seq next-todo)]
-          (recur todo {} result)
-          result)))))
-
+(defn- basis-dependencies [basis node-id+outputs]
+  (let [graph-id->node-successor-map
+        (persistent!
+          (reduce-kv
+            (fn [acc graph-id graph]
+              (assoc! acc graph-id (:successors graph)))
+            (transient {})
+            (:graphs basis)))
+        node-id+output->successors (fn [node-id+output]
+                                     (let [node-id (node-id+output 0)
+                                           output (node-id+output 1)]
+                                       (-> node-id
+                                           gt/node-id->graph-id
+                                           graph-id->node-successor-map
+                                           (get node-id)
+                                           (get output))))
+        deque (ArrayDeque.)
+        result (HashSet.)]
+    (reduce (fn [_ node-id+output]
+              (.push deque node-id+output))
+            nil
+            node-id+outputs)
+    (loop []
+      (when-some [node-id+output (.pollLast deque)]
+        (when-not (.contains result node-id+output)
+          (when-some [successors (node-id+output->successors node-id+output)]
+            (reduce
+              (fn [_ successor-node-id+output]
+                (.push deque successor-node-id+output))
+              nil
+              successors)
+            (.add result node-id+output)))
+        (recur)))
+    result))
 
 (defrecord MultigraphBasis [graphs]
   gt/IBasis
@@ -1158,20 +1148,21 @@
                                                                                                            (fn [basis node-id label]
                                                                                                              (gt/arcs-by-source basis node-id label)))]
                                                                                       (reduce (fn [new-node-successors label]
-                                                                                                (let [single-label #{label}
-                                                                                                      dep-labels (get deps-by-label label)
+                                                                                                (let [dep-labels (get deps-by-label label)
                                                                                                       ;; The internal dependent outputs
-                                                                                                      deps (cond-> (transient {})
-                                                                                                                   (and dep-labels (> (count dep-labels) 0))
-                                                                                                                   (assoc! node-id dep-labels))
+                                                                                                      deps (cond-> (transient [])
+                                                                                                                   (and dep-labels (pos? (count dep-labels)))
+                                                                                                                   (as-> $ (reduce #(conj! %1 [node-id %2]) $ dep-labels)))
                                                                                                       ;; The closest overrides
-                                                                                                      deps (transduce (map #(pair % single-label)) conj! deps overrides)
+                                                                                                      deps (transduce (map #(pair % label)) conj! deps overrides)
                                                                                                       ;; The connected nodes and their outputs
-                                                                                                      deps (transduce (keep (fn [^Arc arc]
-                                                                                                                              (let [target-id (.target-id arc)
-                                                                                                                                    target-label (.target-label arc)]
-                                                                                                                                (when-let [dep-labels (get (input-deps basis target-id) target-label)]
-                                                                                                                                  [target-id dep-labels]))))
+                                                                                                      deps (transduce (comp
+                                                                                                                        (keep (fn [^Arc arc]
+                                                                                                                                (let [target-id (.target-id arc)
+                                                                                                                                      target-label (.target-label arc)]
+                                                                                                                                  (when-let [dep-labels (get (input-deps basis target-id) target-label)]
+                                                                                                                                    (mapv #(vector target-id %) dep-labels)))))
+                                                                                                                        cat)
                                                                                                                       conj!
                                                                                                                       deps
                                                                                                                       (arcs-by-source basis node-id label))]

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -19,8 +19,8 @@
             [internal.util :as util]
             [util.coll :refer [pair]])
   (:import [clojure.lang IPersistentSet]
-           [java.util ArrayDeque HashSet]
-           [internal.graph.types Arc]))
+           [internal.graph.types Arc]
+           [java.util ArrayDeque HashSet]))
 
 ;; A brief braindump on Overrides.
 ;;
@@ -1152,17 +1152,16 @@
                                                                                                       ;; The internal dependent outputs
                                                                                                       deps (cond-> (transient [])
                                                                                                                    (and dep-labels (pos? (count dep-labels)))
-                                                                                                                   (as-> $ (reduce #(conj! %1 [node-id %2]) $ dep-labels)))
+                                                                                                                   (as-> $ (reduce #(conj! %1 (pair node-id %2)) $ dep-labels)))
                                                                                                       ;; The closest overrides
                                                                                                       deps (transduce (map #(pair % label)) conj! deps overrides)
                                                                                                       ;; The connected nodes and their outputs
-                                                                                                      deps (transduce (comp
-                                                                                                                        (keep (fn [^Arc arc]
-                                                                                                                                (let [target-id (.target-id arc)
-                                                                                                                                      target-label (.target-label arc)]
-                                                                                                                                  (when-let [dep-labels (get (input-deps basis target-id) target-label)]
-                                                                                                                                    (mapv #(vector target-id %) dep-labels)))))
-                                                                                                                        cat)
+                                                                                                      deps (transduce (mapcat
+                                                                                                                        (fn [^Arc arc]
+                                                                                                                          (let [target-id (.target-id arc)
+                                                                                                                                target-label (.target-label arc)]
+                                                                                                                            (when-let [dep-labels (get (input-deps basis target-id) target-label)]
+                                                                                                                              (mapv #(pair target-id %) dep-labels)))))
                                                                                                                       conj!
                                                                                                                       deps
                                                                                                                       (arcs-by-source basis node-id label))]

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -105,7 +105,12 @@
 
 (defn- bump-invalidate-counters
   [invalidate-map entries]
-  (reduce (fn [m entry] (update m entry (fnil unchecked-inc 0))) invalidate-map entries))
+  (persistent!
+    (reduce
+      (fn [m entry]
+        (assoc! m entry (unchecked-inc (m entry 0))))
+      (transient invalidate-map)
+      entries)))
 
 (defn invalidate-outputs
   "Invalidate the given outputs and _everything_ that could be
@@ -114,14 +119,7 @@
   [system outputs]
   ;; 'dependencies' takes a map, where outputs is a vec of node-id+label pairs
   (let [basis (basis system)
-        cache-entries (->> outputs
-                           ;; vec -> map, [[node-id label]] -> {node-id #{labels}}
-                           (reduce (fn [m [node-id label]]
-                                     (update m node-id (fn [label-set label] (if label-set (conj label-set label) #{label})) label))
-                                   {})
-                           (gt/dependencies basis)
-                           ;; map -> vec
-                           (into [] (mapcat (fn [[node-id labels]] (mapv #(vector node-id %) labels)))))]
+        cache-entries (gt/dependencies basis outputs)]
     (-> system
         (update :cache c/cache-invalidate cache-entries)
         (update :invalidate-counters bump-invalidate-counters cache-entries))))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -169,7 +169,7 @@
     (assoc ctx
       :nodes-affected
       (into nodes-affected
-            (map #(vector node-id %))
+            (map #(pair node-id %))
             dirty-deps))))
 
 (defn- mark-output-activated
@@ -178,7 +178,7 @@
   (let [nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (conj nodes-affected [node-id output-label]))))
+      (conj nodes-affected (pair node-id output-label)))))
 
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
@@ -187,7 +187,7 @@
     (assoc ctx
       :nodes-affected
       (into nodes-affected
-            (map #(vector node-id %))
+            (map #(pair node-id %))
             output-labels))))
 
 (defn- mark-all-outputs-activated
@@ -201,7 +201,7 @@
     (assoc ctx
       :nodes-affected
       (into nodes-affected
-            (map #(vector node-id %))
+            (map #(pair node-id %))
             output-labels))))
 
 (defn- next-node-id [ctx graph-id]
@@ -787,7 +787,7 @@
 
 (defn- mark-nodes-modified
   [{:keys [nodes-affected] :as ctx}]
-  (assoc ctx :nodes-modified (into #{} (map #(% 0)) nodes-affected)))
+  (assoc ctx :nodes-modified (into #{} (map key) nodes-affected)))
 
 (defn- map-vals-bargs
   [m f]

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -168,10 +168,9 @@
         nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        (into (nodes-affected node-id #{})
-              dirty-deps)))))
+      (into nodes-affected
+            (map #(vector node-id %))
+            dirty-deps))))
 
 (defn- mark-output-activated
   [ctx node-id output-label]
@@ -179,11 +178,7 @@
   (let [nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        (if-some [existing-affected (nodes-affected node-id)]
-          (conj existing-affected output-label)
-          #{output-label})))))
+      (conj nodes-affected [node-id output-label]))))
 
 (defn- mark-outputs-activated
   [ctx node-id output-labels]
@@ -191,10 +186,9 @@
   (let [nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        (into (nodes-affected node-id #{})
-              output-labels)))))
+      (into nodes-affected
+            (map #(vector node-id %))
+            output-labels))))
 
 (defn- mark-all-outputs-activated
   [ctx node-id]
@@ -206,9 +200,9 @@
         nodes-affected (:nodes-affected ctx)]
     (assoc ctx
       :nodes-affected
-      (assoc nodes-affected
-        node-id
-        output-labels))))
+      (into nodes-affected
+            (map #(vector node-id %))
+            output-labels))))
 
 (defn- next-node-id [ctx graph-id]
   (is/next-node-id* (:node-id-generators ctx) graph-id))
@@ -793,7 +787,7 @@
 
 (defn- mark-nodes-modified
   [{:keys [nodes-affected] :as ctx}]
-  (assoc ctx :nodes-modified (set (keys nodes-affected))))
+  (assoc ctx :nodes-modified (into #{} (map #(% 0)) nodes-affected)))
 
 (defn- map-vals-bargs
   [m f]
@@ -820,7 +814,7 @@
 (defn new-transaction-context
   [basis node-id-generators override-id-generator metrics-collector]
   {:basis basis
-   :nodes-affected {}
+   :nodes-affected #{}
    :nodes-added []
    :nodes-modified #{}
    :nodes-deleted {}
@@ -855,11 +849,7 @@
   ;; afterwards, it will have the transitive closure of all [node-id output] pairs
   ;; reachable from the original collection.
   (du/measuring (:metrics ctx) :trace-dependencies
-    (let [outputs-modified (->> (:nodes-affected ctx)
-                                (gt/dependencies (:basis ctx))
-                                (into []
-                                      (mapcat (fn [[nid ls]]
-                                                (mapv #(vector nid %) ls)))))]
+    (let [outputs-modified (gt/dependencies (:basis ctx) (:nodes-affected ctx))]
       (assoc ctx :outputs-modified outputs-modified))))
 
 (defn transact*

--- a/editor/test/dynamo/integration/override_test.clj
+++ b/editor/test/dynamo/integration/override_test.clj
@@ -865,9 +865,9 @@
           mains (mapv first all)
           subs (mapv second all)]
       (testing "value fnk"
-        (is (every? (deps [[main-0 :a-property]]) (outs mains :virt-property))))
+        (is (every? (set (deps [[main-0 :a-property]])) (outs mains :virt-property))))
       (testing "output"
-        (is (every? (deps [[main-0 :a-property]]) (outs mains :cached-output))))
+        (is (every? (set (deps [[main-0 :a-property]])) (outs mains :cached-output))))
       (testing "connections"
         (is (every? conn? (for [[m s] all]
                             [s :_node-id m :sub-nodes])))
@@ -883,9 +883,9 @@
                                          (g/connect src :a-property tgt :in-value)
                                          (g/override src)))]
       (testing "regular dep"
-        (is (every? (deps [[src :a-property]]) [[tgt :out-value]])))
+        (is (every? (set (deps [[src :a-property]])) [[tgt :out-value]])))
       (testing "no override deps"
-        (is (not-any? (deps [[src-1 :a-property]]) [[tgt :out-value]])))
+        (is (not-any? (set (deps [[src-1 :a-property]])) [[tgt :out-value]])))
       (testing "connections"
         (is (conn? [src :a-property tgt :in-value]))
         (is (no-conn? [src-1 :a-property tgt :in-value])))))
@@ -895,7 +895,7 @@
                                          (g/connect src :a-property tgt :in-value)
                                          (g/override tgt)))]
       (testing "regular dep"
-        (is (every? (deps [[src :a-property]]) [[tgt :out-value] [tgt-1 :out-value]])))
+        (is (every? (set (deps [[src :a-property]])) [[tgt :out-value] [tgt-1 :out-value]])))
       (testing "connections"
         (is (conn? [src :a-property tgt :in-value]))
         (is (conn? [src :a-property tgt-1 :in-value])))))

--- a/editor/test/internal/dependency_test.clj
+++ b/editor/test/internal/dependency_test.clj
@@ -22,7 +22,7 @@
 
 (defn- dependencies
   [& pairs]
-  (ts/graph-dependencies (g/now) (partition 2 pairs)))
+  (ts/graph-dependencies (g/now) (map vec (partition 2 pairs))))
 
 (g/defnode SingleOutput
   (output out-from-inline g/Str (g/fnk [] "out-from-inline")))

--- a/editor/test/internal/system_test.clj
+++ b/editor/test/internal/system_test.clj
@@ -444,7 +444,10 @@
 
         (is (= 2 (count (ts/undo-stack project-graph))))        
 
-        (is (= {p-source #{:_declared-properties :source-label :_properties}} (successors p-source :source-label)))
+        (is (= #{[p-source :_declared-properties]
+                 [p-source :source-label]
+                 [p-source :_properties]}
+               (set (successors p-source :source-label))))
         (is (= nil (sarcs p-source :source-label)))
         (is (= nil (tarcs v-sink :target-label)))
 
@@ -454,7 +457,11 @@
 
         (is (= 3 (count (ts/undo-stack project-graph))))
 
-        (is (= {p-source #{:_declared-properties :source-label :_properties} v-sink #{:loud}} (successors p-source :source-label)))
+        (is (= #{[p-source :_declared-properties]
+                 [p-source :source-label]
+                 [p-source :_properties]
+                 [v-sink :loud]}
+               (set (successors p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (sarcs p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (tarcs v-sink :target-label))))
 
@@ -465,7 +472,11 @@
         (is (= 2 (count (ts/undo-stack project-graph))))
 
         ;; check hydrated after undo, v-sink :loud used to be missing from successors
-        (is (= {p-source #{:_declared-properties :source-label :_properties} v-sink #{:loud}} (successors p-source :source-label)))
+        (is (= #{[p-source :_declared-properties]
+                 [p-source :source-label]
+                 [p-source :_properties]
+                 [v-sink :loud]}
+               (set (successors p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (sarcs p-source :source-label))))
         (is (= [[p-source :source-label v-sink :target-label]] (g/arcs->tuples (tarcs v-sink :target-label))))
 

--- a/editor/test/support/test_support.clj
+++ b/editor/test/support/test_support.clj
@@ -76,9 +76,4 @@
   ([tgts]
    (graph-dependencies (g/now) tgts))
   ([basis tgts]
-   (->> tgts
-        (reduce (fn [m [nid l]]
-                  (update m nid (fn [s l] (if s (conj s l) #{l})) l))
-                {})
-        (g/dependencies basis)
-        (into #{} (mapcat (fn [[nid ls]] (mapv #(vector nid %) ls)))))))
+   (g/dependencies basis tgts)))


### PR DESCRIPTION
This changeset improves transact performance by:
- using in-place mutation while computing the result;
- reducing the amount of allocations when calculating the deps by using vectors instead of sets;
- using node-id+output coll instead of map of node-id to output set as in and out data structures: this reduces the amount of data transformations and will allow us to move to a more performant Endpoint data structure in the future;
- using transients when bumping invalidation counters.

Related to #5447