### PR TITLE
Don't scroll to selection unless it changed

### DIFF
--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -95,7 +95,7 @@
                                                         (when expanded (.setExpanded item expanded))
                                                         (or selected expanded))) items)))
 
-(defn- sync-selection [^TreeView tree-view selection old-tree-view-indices]
+(defn- sync-selection [^TreeView tree-view selection old-selected-ids]
   (let [root (.getRoot tree-view)
         selection-model (.getSelectionModel tree-view)]
     (.clearSelection selection-model)
@@ -107,7 +107,7 @@
               selected-indices (filter #(selected-ids (item->node-id (.getTreeItem tree-view %))) (range count))]
           (when (not (empty? selected-indices))
             (ui/select-indices! tree-view selected-indices))
-          (when-not (= old-tree-view-indices selected-indices)
+          (when-not (= old-selected-ids selected-ids)
             (when-some [first-item (first (.getSelectedItems selection-model))]
               (ui/scroll-to-item! tree-view first-item))))))))
 
@@ -154,28 +154,30 @@
     new-root))
 
 (defn- update-tree-view-selection!
-  [^TreeView tree-view selection old-tree-view-indices]
+  [^TreeView tree-view selection old-selected-ids]
   (binding [*programmatic-selection* true]
-    (sync-selection tree-view selection old-tree-view-indices)
+    (sync-selection tree-view selection old-selected-ids)
     tree-view))
 
 (defn- update-tree-view-root!
-  [^TreeView tree-view ^TreeItem root selection old-tree-view-indices]
+  [^TreeView tree-view ^TreeItem root selection old-selected-ids]
   (binding [*programmatic-selection* true]
     (when (not (identical? (.getRoot tree-view) root))
       (when root
         (.setExpanded root true)
         (.setRoot tree-view root)))
-    (sync-selection tree-view selection old-tree-view-indices)
+    (sync-selection tree-view selection old-selected-ids)
     tree-view))
 
 (g/defnk update-tree-view [^TreeView raw-tree-view ^TreeItem root selection]
-  (let [tree-view-indices (vec (.getSelectedIndices (.getSelectionModel raw-tree-view)))]
+  (let [tree-view-ids (into #{}
+                            (map item->node-id)
+                            (.getSelectedItems (.getSelectionModel raw-tree-view)))]
     (if (identical? (.getRoot raw-tree-view) root)
       (if (= (set selection) (set (map :node-id (ui/selection raw-tree-view))))
         raw-tree-view
-        (update-tree-view-selection! raw-tree-view selection tree-view-indices))
-      (update-tree-view-root! raw-tree-view root selection tree-view-indices))))
+        (update-tree-view-selection! raw-tree-view selection tree-view-ids))
+      (update-tree-view-root! raw-tree-view root selection tree-view-ids))))
 
 (defn- item->value [^TreeItem item]
   (.getValue item))

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -95,7 +95,7 @@
                                                         (when expanded (.setExpanded item expanded))
                                                         (or selected expanded))) items)))
 
-(defn- sync-selection [^TreeView tree-view selection]
+(defn- sync-selection [^TreeView tree-view selection old-tree-view-indices]
   (let [root (.getRoot tree-view)
         selection-model (.getSelectionModel tree-view)]
     (.clearSelection selection-model)
@@ -107,8 +107,9 @@
               selected-indices (filter #(selected-ids (item->node-id (.getTreeItem tree-view %))) (range count))]
           (when (not (empty? selected-indices))
             (ui/select-indices! tree-view selected-indices))
-          (when-some [first-item (first (.getSelectedItems selection-model))]
-            (ui/scroll-to-item! tree-view first-item)))))))
+          (when-not (= old-tree-view-indices selected-indices)
+            (when-some [first-item (first (.getSelectedItems selection-model))]
+              (ui/scroll-to-item! tree-view first-item))))))))
 
 (defn- decorate
   ([hidden-node-outline-key-paths root]
@@ -153,27 +154,28 @@
     new-root))
 
 (defn- update-tree-view-selection!
-  [^TreeView tree-view selection]
+  [^TreeView tree-view selection old-tree-view-indices]
   (binding [*programmatic-selection* true]
-    (sync-selection tree-view selection)
+    (sync-selection tree-view selection old-tree-view-indices)
     tree-view))
 
 (defn- update-tree-view-root!
-  [^TreeView tree-view ^TreeItem root selection]
+  [^TreeView tree-view ^TreeItem root selection old-tree-view-indices]
   (binding [*programmatic-selection* true]
     (when (not (identical? (.getRoot tree-view) root))
       (when root
         (.setExpanded root true)
         (.setRoot tree-view root)))
-    (sync-selection tree-view selection)
+    (sync-selection tree-view selection old-tree-view-indices)
     tree-view))
 
 (g/defnk update-tree-view [^TreeView raw-tree-view ^TreeItem root selection]
-  (if (identical? (.getRoot raw-tree-view) root)
-    (if (= (set selection) (set (map :node-id (ui/selection raw-tree-view))))
-      raw-tree-view
-      (update-tree-view-selection! raw-tree-view selection))
-    (update-tree-view-root! raw-tree-view root selection)))
+  (let [tree-view-indices (vec (.getSelectedIndices (.getSelectionModel raw-tree-view)))]
+    (if (identical? (.getRoot raw-tree-view) root)
+      (if (= (set selection) (set (map :node-id (ui/selection raw-tree-view))))
+        raw-tree-view
+        (update-tree-view-selection! raw-tree-view selection tree-view-indices))
+      (update-tree-view-root! raw-tree-view root selection tree-view-indices))))
 
 (defn- item->value [^TreeItem item]
   (.getValue item))


### PR DESCRIPTION
We scroll on every selection sync. This was initially implemented to scroll to item in the outline when selection in the scene is changed. Current behavior has a downside: when a property of a selected item is changed, it forces the scroll to happen, which is very annoying. This changeset skips tree view scrolling if the selection didn't change.

Fixes #6558