### PR TITLE
Prevent the editor from reloading external changes during build

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -106,7 +106,8 @@
 
 (defn- handle-application-focused! [workspace changes-view]
   (app-view/clear-build-launch-progress!)
-  (when (and (not (sync/sync-dialog-open?))
+  (when (and (not (app-view/build-in-progress?))
+             (not (sync/sync-dialog-open?))
              (disk-availability/available?))
     (async-reload! workspace changes-view)))
 


### PR DESCRIPTION
### User-facing changes
* The editor will no longer detect external changes made to the project while a build is in progress. This change was made to cover situations where pre-build hooks make changes to the project files. Previously, these changes could be reloaded while the project was in an incomplete state if the user tabbed out of the editor application at an inopportune time.