### PR TITLE
Prevent the editor from reloading external changes during build

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -17,7 +17,6 @@
             [dynamo.graph :as g]
             [editor.build :as build]
             [editor.build-errors-view :as build-errors-view]
-            [editor.bundle :as bundle]
             [editor.bundle-dialog :as bundle-dialog]
             [editor.changes-view :as changes-view]
             [editor.code.data :refer [CursorRange->line-number]]
@@ -60,7 +59,6 @@
             [editor.types :as types]
             [editor.ui :as ui]
             [editor.url :as url]
-            [editor.util :as util]
             [editor.view :as view]
             [editor.workspace :as workspace]
             [internal.util :refer [first-where]]
@@ -679,7 +677,10 @@
       (report-build-launch-progress! "Reboot failed")
       (throw e))))
 
-(def ^:private build-in-progress? (atom false))
+(def ^:private build-in-progress-atom (atom false))
+
+(defn build-in-progress? []
+  @build-in-progress-atom)
 
 (defn- on-launched-hook! [project process url]
   (let [hook-options {:exception-policy :ignore :opts {:url url}}]
@@ -810,12 +811,12 @@
                   (try
                     (ui-thread-fn return-value)
                     (catch Throwable error
-                      (reset! build-in-progress? false)
+                      (reset! build-in-progress-atom false)
                       (render-build-progress! progress/done)
                       (cancel-engine-build!)
                       (throw error)))))
               (catch Throwable error
-                (reset! build-in-progress? false)
+                (reset! build-in-progress-atom false)
                 (render-build-progress! progress/done)
                 (cancel-engine-build!)
                 (error-reporting/report-exception! error))))
@@ -823,7 +824,7 @@
 
         finish-with-result!
         (fn finish-with-result! [project-build-results engine build-engine-exception]
-          (reset! build-in-progress? false)
+          (reset! build-in-progress-atom false)
           (render-build-progress! progress/done)
           (cancel-engine-build!)
           (when (some? result-fn)
@@ -923,8 +924,8 @@
     ;; thread, then process the results on the ui thread, and potentially
     ;; trigger subsequent phases which will again get off the ui thread as
     ;; soon as they can.
-    (assert (not @build-in-progress?))
-    (reset! build-in-progress? true)
+    (assert (not @build-in-progress-atom))
+    (reset! build-in-progress-atom true)
     (phase-1-run-pre-build-hook!)))
 
 (defn- handle-build-results! [workspace render-build-error! build-results]
@@ -957,7 +958,7 @@
                           (engine-build-errors/handle-build-error! render-build-error! project evaluation-context build-engine-exception))))))))
 
 (handler/defhandler :build :global
-  (enabled? [] (not @build-in-progress?))
+  (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view debug-view main-stage tool-tab-pane]
     (debug-view/detach! debug-view)
     (build-handler project workspace prefs web-server build-errors-view main-stage tool-tab-pane)))
@@ -1007,7 +1008,7 @@ If you do not specifically require different script states, consider changing th
   ;; there is a single menu item whose label changes in various states.
   (active? [debug-view evaluation-context]
            (not (debug-view/debugging? debug-view evaluation-context)))
-  (enabled? [] (not @build-in-progress?))
+  (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view console-view debug-view main-stage tool-tab-pane]
     (when (debugging-supported? project)
       (let [main-scene (.getScene ^Stage main-stage)
@@ -1018,7 +1019,7 @@ If you do not specifically require different script states, consider changing th
           (run-with-debugger! workspace project prefs debug-view render-build-error! web-server))))))
 
 (handler/defhandler :rebuild :global
-  (enabled? [] (not @build-in-progress?))
+  (enabled? [] (not (build-in-progress?)))
   (run [project workspace prefs web-server build-errors-view debug-view main-stage tool-tab-pane]
     (debug-view/detach! debug-view)
     (workspace/clear-build-cache! workspace)
@@ -1067,7 +1068,7 @@ If you do not specifically require different script states, consider changing th
   (when-some [target (targets/selected-target prefs)]
     (and (targets/controllable-target? target)
          (not (debug-view/suspended? debug-view evaluation-context))
-         (not @build-in-progress?))))
+         (not (build-in-progress?)))))
 
 (defn- hot-reload! [project prefs build-errors-view main-stage tool-tab-pane]
   (let [main-scene (.getScene ^Stage main-stage)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -103,7 +103,8 @@
 
 (defn- handle-application-focused! [workspace changes-view]
   (app-view/clear-build-launch-progress!)
-  (when (and (not (sync/sync-dialog-open?))
+  (when (and (not (app-view/build-in-progress?))
+             (not (sync/sync-dialog-open?))
              (disk-availability/available?))
     (async-reload! workspace changes-view)))
 


### PR DESCRIPTION
Cherry-pick #6711 into `hotfix-192`.

---

### User-facing changes
* The editor will no longer detect external changes made to the project while a build is in progress. This change was made to cover situations where pre-build hooks make changes to the project files. Previously, these changes could be reloaded while the project was in an incomplete state if the user tabbed out of the editor application at an inopportune time.