### PR TITLE
Improve first opening time of game.project

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -13,7 +13,11 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.app-view
-  (:require [clojure.java.io :as io]
+  (:require [cljfx.fx.hyperlink :as fx.hyperlink]
+            [cljfx.fx.text :as fx.text]
+            [cljfx.fx.text-flow :as fx.text-flow]
+            [cljfx.fx.v-box :as fx.v-box]
+            [clojure.java.io :as io]
             [clojure.edn :as edn]
             [clojure.string :as string]
             [dynamo.graph :as g]
@@ -739,7 +743,7 @@
         (dialogs/make-info-dialog
           {:title "Launch Failed"
            :icon :icon/triangle-error
-           :header {:fx/type :v-box
+           :header {:fx/type fx.v-box/lifecycle
                     :children [{:fx/type fxui/label
                                 :variant :header
                                 :text (format "Launching %s failed"
@@ -1577,7 +1581,7 @@ If you do not specifically require different script states, consider changing th
          (dialogs/make-info-dialog
           {:title "Couldn't load custom keymap config"
            :icon :icon/triangle-error
-           :header {:fx/type :v-box
+           :header {:fx/type fx.v-box/lifecycle
                     :children [{:fx/type fxui/label
                                 :text (str "The keymap from " path " couldn't be opened.")}]}
            :content (.getMessage e)})
@@ -1799,9 +1803,9 @@ If you do not specifically require different script states, consider changing th
               :size :default
               :icon :icon/git
               :header "This project does not use Version Control"
-              :content {:fx/type :text-flow
+              :content {:fx/type fx.text-flow/lifecycle
                         :style-class "dialog-content-padding"
-                        :children [{:fx/type :text
+                        :children [{:fx/type fx.text/lifecycle
                                     :text (str "A project under Version Control "
                                                "keeps a history of changes and "
                                                "enables you to collaborate with "
@@ -1809,11 +1813,11 @@ If you do not specifically require different script states, consider changing th
                                                "server.\n\nYou can read about "
                                                "how to configure Version Control "
                                                "in the ")}
-                                   {:fx/type :hyperlink
+                                   {:fx/type fx.hyperlink/lifecycle
                                     :text "Defold Manual"
                                     :on-action (fn [_]
                                                  (ui/open-url "https://www.defold.com/manuals/version-control/"))}
-                                   {:fx/type :text
+                                   {:fx/type fx.text/lifecycle
                                     :text "."}]}})))))
 
 (handler/defhandler :save-all :global

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.boot-open-project
-  (:require [clojure.string :as string]
+  (:require [cljfx.fx.v-box :as fx.v-box]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
             [editor.asset-browser :as asset-browser]
@@ -330,7 +331,7 @@
             (if-not (dialogs/make-confirmation-dialog
                       {:title "Resume Sync?"
                        :size :large
-                       :header {:fx/type :v-box
+                       :header {:fx/type fx.v-box/lifecycle
                                 :children [{:fx/type fxui/label
                                             :variant :header
                                             :text "The editor was shut down while synchronizing with the server"}

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.bundle-dialog
-  (:require [clojure.java.io :as io]
+  (:require [cljfx.fx.v-box :as fx.v-box]
+            [clojure.java.io :as io]
             [clojure.set :as set]
             [editor.bundle :as bundle]
             [editor.dialogs :as dialogs]
@@ -62,7 +63,7 @@
         {:title "Overwrite Existing Directory?"
          :owner owner-window
          :icon :icon/circle-question
-         :header {:fx/type :v-box
+         :header {:fx/type fx.v-box/lifecycle
                   :children [{:fx/type fxui/label
                               :variant :header
                               :text "A directory already exists"}

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -17,6 +17,27 @@
             [cljfx.ext.list-view :as fx.ext.list-view]
             [cljfx.ext.table-view :as fx.ext.table-view]
             [cljfx.fx.anchor-pane :as fx.anchor-pane]
+            [cljfx.fx.button :as fx.button]
+            [cljfx.fx.check-box :as fx.check-box]
+            [cljfx.fx.column-constraints :as fx.column-constraints]
+            [cljfx.fx.combo-box :as fx.combo-box]
+            [cljfx.fx.context-menu :as fx.context-menu]
+            [cljfx.fx.grid-pane :as fx.grid-pane]
+            [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.image-view :as fx.image-view]
+            [cljfx.fx.label :as fx.label]
+            [cljfx.fx.list-view :as fx.list-view]
+            [cljfx.fx.menu-button :as fx.menu-button]
+            [cljfx.fx.menu-item :as fx.menu-item]
+            [cljfx.fx.scroll-pane :as fx.scroll-pane]
+            [cljfx.fx.separator :as fx.separator]
+            [cljfx.fx.stack-pane :as fx.stack-pane]
+            [cljfx.fx.table-column :as fx.table-column]
+            [cljfx.fx.table-view :as fx.table-view]
+            [cljfx.fx.text-field :as fx.text-field]
+            [cljfx.fx.text-formatter :as fx.text-formatter]
+            [cljfx.fx.tooltip :as fx.tooltip]
+            [cljfx.fx.v-box :as fx.v-box]
             [clojure.set :as set]
             [clojure.string :as string]
             [dynamo.graph :as g]
@@ -121,7 +142,7 @@
             :else (recur (inc i))))))))
 
 (defn- text-field [props]
-  (assoc props :fx/type :text-field
+  (assoc props :fx/type fx.text-field/lifecycle
                :style-class ["text-field" "cljfx-form-text-field"]))
 
 (defn- add-image-fit-size [{:keys [fit-size] :as props}]
@@ -132,14 +153,14 @@
 (defn- add-image [props]
   (cond-> (-> props
               (dissoc :image)
-              (assoc :graphic {:fx/type :image-view
+              (assoc :graphic {:fx/type fx.image-view/lifecycle
                                :image (icons/get-image (:image props))}))
 
           (contains? props :fit-size)
           add-image-fit-size))
 
 (defn- icon-button [props]
-  (cond-> (assoc props :fx/type :button
+  (cond-> (assoc props :fx/type fx.button/lifecycle
                        :style-class ["button" "cljfx-form-icon-button"])
 
           (contains? props :image)
@@ -157,7 +178,7 @@
   :type)
 
 (defmethod form-input-view :default [{:keys [value type] :as field}]
-  {:fx/type :label
+  {:fx/type fx.label/lifecycle
    :wrap-text true
    :text (str type " " (if (nil? value) "***NIL***" value) " " field)})
 
@@ -206,7 +227,7 @@
 
 (defmethod form-input-view :string [{:keys [value on-value-changed]}]
   {:fx/type text-field
-   :text-formatter {:fx/type :text-formatter
+   :text-formatter {:fx/type fx.text-formatter/lifecycle
                     :value-converter :default
                     :value value
                     :on-value-changed on-value-changed}})
@@ -219,7 +240,7 @@
 ;; region boolean input
 
 (defmethod form-input-view :boolean [{:keys [value on-value-changed]}]
-  {:fx/type :check-box
+  {:fx/type fx.check-box/lifecycle
    :style-class ["check-box" "cljfx-form-check-box"]
    :selected value
    :on-selected-changed on-value-changed})
@@ -232,7 +253,7 @@
   {:fx/type text-field
    :alignment :center-right
    :max-width 80
-   :text-formatter {:fx/type :text-formatter
+   :text-formatter {:fx/type fx.text-formatter/lifecycle
                     :value-converter int-converter
                     :value (int value)
                     :on-value-changed on-value-changed}})
@@ -248,7 +269,7 @@
   {:fx/type text-field
    :alignment :center-right
    :max-width 80
-   :text-formatter {:fx/type :text-formatter
+   :text-formatter {:fx/type fx.text-formatter/lifecycle
                     :value-converter number-converter
                     :value value
                     :on-value-changed on-value-changed}})
@@ -266,7 +287,7 @@
 
 (defmethod form-input-view :url [{:keys [value on-value-changed]}]
   {:fx/type text-field
-   :text-formatter {:fx/type :text-formatter
+   :text-formatter {:fx/type fx.text-formatter/lifecycle
                     :value-converter uri-string-converter
                     :value value
                     :on-value-changed {:event-type :skip-malformed-urls
@@ -284,16 +305,16 @@
 
 (defmethod form-input-view :vec4 [{:keys [value on-value-changed]}]
   (let [labels ["X" "Y" "Z" "W"]]
-    {:fx/type :h-box
+    {:fx/type fx.h-box/lifecycle
      :padding {:left 5}
      :spacing 5
      :children (into []
                      (map-indexed
                        (fn [i n]
-                         {:fx/type :h-box
+                         {:fx/type fx.h-box/lifecycle
                           :alignment :center
                           :spacing 5
-                          :children [{:fx/type :label
+                          :children [{:fx/type fx.label/lifecycle
                                       :min-width :use-pref-size
                                       :text (get labels i)}
                                      {:fx/type form-input-view
@@ -353,7 +374,7 @@
                                         :or {to-string str}}]
   (let [value->label (into {} options)
         label->value (set/map-invert value->label)]
-    {:fx/type :combo-box
+    {:fx/type fx.combo-box/lifecycle
      :style-class ["combo-box" "combo-box-base" "cljfx-form-combo-box"]
      :value value
      :on-value-changed on-value-changed
@@ -511,7 +532,7 @@
         remove-event {:event-type :remove-list-selection
                       :on-removed on-removed
                       :state-path state-path}]
-    {:fx/type :v-box
+    {:fx/type fx.v-box/lifecycle
      :spacing 4
      :children [{:fx/type fx/ext-let-refs
                  :refs (when edit
@@ -532,7 +553,7 @@
                                   :on-selected-indices-changed {:event-type :list-select
                                                                 :state-path state-path}}
                           :desc
-                          {:fx/type :list-view
+                          {:fx/type fx.list-view/lifecycle
                            :style-class ["list-view" "cljfx-form-list-view"]
                            :items (into [] (map-indexed vector) value)
                            :editable true
@@ -546,16 +567,16 @@
                                            (* cell-height
                                               (max (count value) 1)))
                            :fixed-cell-size cell-height
-                           :context-menu {:fx/type :context-menu
-                                          :items [{:fx/type :menu-item
+                           :context-menu {:fx/type fx.context-menu/lifecycle
+                                          :items [{:fx/type fx.menu-item/lifecycle
                                                    :text "Add"
                                                    :disable disable-add
                                                    :on-action add-event}
-                                                  {:fx/type :menu-item
+                                                  {:fx/type fx.menu-item/lifecycle
                                                    :text "Remove"
                                                    :disable disable-remove
                                                    :on-action remove-event}]}}}}}}
-                {:fx/type :h-box
+                {:fx/type fx.h-box/lifecycle
                  :spacing 4
                  :children [{:fx/type icon-button
                              :disable disable-add
@@ -620,11 +641,11 @@
                                               on-value-changed
                                               filter
                                               resource-string-converter]}]
-  {:fx/type :h-box
+  {:fx/type fx.h-box/lifecycle
    :spacing 4
    :children [{:fx/type text-field
                :h-box/hgrow :always
-               :text-formatter {:fx/type :text-formatter
+               :text-formatter {:fx/type fx.text-formatter/lifecycle
                                 :value-converter resource-string-converter
                                 :value value
                                 :on-value-changed on-value-changed}}
@@ -659,11 +680,11 @@
     {:dispatch (assoc on-value-changed :fx/event (.getAbsolutePath file))}))
 
 (defmethod form-input-view :file [{:keys [on-value-changed value filter title]}]
-  {:fx/type :h-box
+  {:fx/type fx.h-box/lifecycle
    :spacing 4
    :children [{:fx/type text-field
                :h-box/hgrow :always
-               :text-formatter {:fx/type :text-formatter
+               :text-formatter {:fx/type fx.text-formatter/lifecycle
                                 :value-converter :default
                                 :value value
                                 :on-value-changed on-value-changed}}
@@ -683,11 +704,11 @@
     {:dispatch (assoc on-value-changed :fx/event file)}))
 
 (defmethod form-input-view :directory [{:keys [on-value-changed value title]}]
-  {:fx/type :h-box
+  {:fx/type fx.h-box/lifecycle
    :spacing 4
    :children [{:fx/type text-field
                :h-box/hgrow :always
-               :text-formatter {:fx/type :text-formatter
+               :text-formatter {:fx/type fx.text-formatter/lifecycle
                                 :value-converter :default
                                 :value value
                                 :on-value-changed on-value-changed}}
@@ -831,7 +852,7 @@
                      {:keys [state state-path value on-value-changed]
                       :or {value []}}]
   (let [{:keys [edit]} state]
-    {:fx/type :table-column
+    {:fx/type fx.table-column/lifecycle
      :reorderable false
      :sortable false
      :min-width (cond
@@ -886,9 +907,9 @@
                    edited-value (or (:value edit)
                                     (get-in value (into [i] path)))]
                {[::edit i path] (edited-table-cell-view edited-column field edited-value)}))
-     :desc {:fx/type :v-box
+     :desc {:fx/type fx.v-box/lifecycle
             :spacing 4
-            :children [{:fx/type :stack-pane
+            :children [{:fx/type fx.stack-pane/lifecycle
                         :style-class "cljfx-table-view-wrapper"
                         :children
                         [{:fx/type fxui/ext-with-advance-events
@@ -897,7 +918,7 @@
                                          :selected-indices (vec selected-indices)
                                          :on-selected-indices-changed {:event-type :table-select
                                                                        :state-path state-path}}
-                                 :desc {:fx/type :table-view
+                                 :desc {:fx/type fx.table-view/lifecycle
                                         :style-class ["table-view" "cljfx-table-view"]
                                         :editable true
                                         :fixed-cell-size line-height
@@ -909,16 +930,16 @@
                                         :columns (mapv #(table-column % field)
                                                        columns)
                                         :items (into [] (map-indexed vector) value)
-                                        :context-menu {:fx/type :context-menu
-                                                       :items [{:fx/type :menu-item
+                                        :context-menu {:fx/type fx.context-menu/lifecycle
+                                                       :items [{:fx/type fx.menu-item/lifecycle
                                                                 :text "Add"
                                                                 :disable disable-add
                                                                 :on-action on-added}
-                                                               {:fx/type :menu-item
+                                                               {:fx/type fx.menu-item/lifecycle
                                                                 :text "Remove"
                                                                 :disable disable-remove
                                                                 :on-action on-removed}]}}}}]}
-                       {:fx/type :h-box
+                       {:fx/type fx.h-box/lifecycle
                         :spacing 4
                         :children [{:fx/type icon-button
                                     :disable disable-add
@@ -997,7 +1018,7 @@
         key-path (:path panel-key)
         selected-index (-> state :key :selected-indices peek)
         fn-setter (:set field)]
-    {:fx/type :v-box
+    {:fx/type fx.v-box/lifecycle
      :spacing 4
      :children
      [(cond-> {:fx/type list-input
@@ -1023,7 +1044,7 @@
 
               (contains? state :key)
               (assoc :state (:key state)))
-      {:fx/type :v-box
+      {:fx/type fx.v-box/lifecycle
        :spacing 6
        :children
        (if (some? selected-index)
@@ -1036,13 +1057,13 @@
                            field-value (get-in value field-path ::no-value)
                            field-state-path (conj state-path :val selected-index (:path field))
                            field-state (get-in state [:val selected-index (:path field)] ::no-value)]
-                       {:fx/type :v-box
+                       {:fx/type fx.v-box/lifecycle
                         :spacing 4
                         :children
-                        [{:fx/type :h-box
+                        [{:fx/type fx.h-box/lifecycle
                           :spacing 4
                           :pref-height line-height
-                          :children (cond-> [{:fx/type :label
+                          :children (cond-> [{:fx/type fx.label/lifecycle
                                               :h-box/margin {:top 5}
                                               :text (:label field)}]
                                             (and (form/optional-field? field)
@@ -1087,7 +1108,7 @@
     (cond-> []
             :always
             (conj (cond->
-                    {:fx/type :label
+                    {:fx/type fx.label/lifecycle
                      :grid-pane/row row
                      :grid-pane/column 0
                      :grid-pane/valignment :top
@@ -1097,7 +1118,7 @@
                      :alignment :top-left
                      :text label}
                     (not-empty help)
-                    (assoc :tooltip {:fx/type :tooltip
+                    (assoc :tooltip {:fx/type fx.tooltip/lifecycle
                                      :text help})))
 
             (and (form/optional-field? field)
@@ -1114,7 +1135,7 @@
                                :path path}})
 
             :always
-            (conj {:fx/type :v-box
+            (conj {:fx/type fx.v-box/lifecycle
                    :style-class (case (:severity error)
                                   :fatal ["cljfx-form-error"]
                                   :warning ["cljfx-form-warning"]
@@ -1143,31 +1164,31 @@
   (string/replace title " " "-"))
 
 (defn- section-view [{:keys [title help fields values ui-state resource-string-converter visible]}]
-  {:fx/type :v-box
+  {:fx/type fx.v-box/lifecycle
    :id (section-id title)
    :visible visible
    :managed visible
    :children (cond-> []
 
                      :always
-                     (conj {:fx/type :label
+                     (conj {:fx/type fx.label/lifecycle
                             :style-class ["label" "cljfx-form-title"]
                             :text title})
 
                      help
-                     (conj {:fx/type :label
+                     (conj {:fx/type fx.label/lifecycle
                             :text help})
 
                      :always
-                     (conj {:fx/type :grid-pane
+                     (conj {:fx/type fx.grid-pane/lifecycle
                             :style-class "cljfx-form-fields"
-                            :column-constraints [{:fx/type :column-constraints
+                            :column-constraints [{:fx/type fx.column-constraints/lifecycle
                                                   :min-width 150
                                                   :max-width 150}
-                                                 {:fx/type :column-constraints
+                                                 {:fx/type fx.column-constraints/lifecycle
                                                   :min-width line-height
                                                   :max-width line-height}
-                                                 {:fx/type :column-constraints
+                                                 {:fx/type fx.column-constraints/lifecycle
                                                   :hgrow :always
                                                   :min-width 200
                                                   :max-width 400}]
@@ -1243,7 +1264,7 @@
     {:set-ui-state (assoc ui-state :filter-term "")}))
 
 (defn- filter-text-field [{:keys [text]}]
-  {:fx/type :text-field
+  {:fx/type fx.text-field/lifecycle
    :id "filter-text-field"
    :style-class ["text-field" "filter-text-field"]
    :prompt-text "Filter"
@@ -1266,7 +1287,7 @@
                visible (:visible section)]
            (if (empty? acc)
              [(conj acc section-view) visible]
-             [(into acc [{:fx/type :separator
+             [(into acc [{:fx/type fx.separator/lifecycle
                           :style-class "cljfx-form-separator"
                           :visible (and seen-visible visible)
                           :managed (and seen-visible visible)}
@@ -1288,14 +1309,14 @@
                                  (- content-height viewport-height))))))
 
 (defn- jump-to-button [{:keys [visible-titles]}]
-  {:fx/type :menu-button
+  {:fx/type fx.menu-button/lifecycle
    :text "Jump to..."
    :style-class "jump-to-menu-button"
    :disable (empty? visible-titles)
    :items (->> visible-titles
                (sort #(.compareToIgnoreCase ^String %1 %2))
                (mapv (fn [title]
-                       {:fx/type :menu-item
+                       {:fx/type fx.menu-item/lifecycle
                         :on-action {:event-type :jump-to
                                     :section (section-id title)}
                         :text title})))})
@@ -1321,7 +1342,7 @@
             :value parent}
      :props {:children (cond-> []
                                (:navigation form-data true)
-                               (conj {:fx/type :h-box
+                               (conj {:fx/type fx.h-box/lifecycle
                                       :style-class "cljfx-form-floating-area"
                                       :anchor-pane/top 24
                                       :anchor-pane/right 24
@@ -1338,11 +1359,11 @@
                                       :anchor-pane/bottom 0
                                       :anchor-pane/left 0
                                       :on-created #(ui/context! % :form {:root parent} nil)
-                                      :desc {:fx/type :scroll-pane
+                                      :desc {:fx/type fx.scroll-pane/lifecycle
                                              :id "scroll-pane"
                                              :view-order 1
                                              :fit-to-width true
-                                             :content {:fx/type :v-box
+                                             :content {:fx/type fx.v-box/lifecycle
                                                        :style-class "cljfx-form"
                                                        :children section-views}}}))}}))
 

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -14,6 +14,14 @@
 
 (ns editor.dialogs
   (:require [cljfx.api :as fx]
+            [cljfx.fx.group :as fx.group]
+            [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.image-view :as fx.image-view]
+            [cljfx.fx.label :as fx.label]
+            [cljfx.fx.progress-bar :as fx.progress-bar]
+            [cljfx.fx.region :as fx.region]
+            [cljfx.fx.scene :as fx.scene]
+            [cljfx.fx.v-box :as fx.v-box]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [dynamo.graph :as g]
@@ -69,28 +77,28 @@
   (-> props
       (dissoc :size :header :content :footer)
       (assoc :fx/type fxui/dialog-stage
-             :scene {:fx/type :scene
+             :scene {:fx/type fx.scene/lifecycle
                      :stylesheets ["dialogs.css"]
-                     :root {:fx/type :v-box
+                     :root {:fx/type fx.v-box/lifecycle
                             :style-class ["dialog-body" (case size
                                                           :small "dialog-body-small"
                                                           :default "dialog-body-default"
                                                           :large "dialog-body-large")]
                             :children (if (some? content)
-                                        [{:fx/type :v-box
+                                        [{:fx/type fx.v-box/lifecycle
                                           :style-class "dialog-with-content-header"
                                           :children [header]}
-                                         {:fx/type :v-box
+                                         {:fx/type fx.v-box/lifecycle
                                           :style-class "dialog-content"
                                           :children [content]}
-                                         {:fx/type :v-box
+                                         {:fx/type fx.v-box/lifecycle
                                           :style-class "dialog-with-content-footer"
                                           :children [footer]}]
-                                        [{:fx/type :v-box
+                                        [{:fx/type fx.v-box/lifecycle
                                           :style-class "dialog-without-content-header"
                                           :children [header]}
-                                         {:fx/type :region :style-class "dialog-no-content"}
-                                         {:fx/type :v-box
+                                         {:fx/type fx.region/lifecycle :style-class "dialog-no-content"}
+                                         {:fx/type fx.v-box/lifecycle
                                           :style-class "dialog-without-content-footer"
                                           :children [footer]}])}})))
 
@@ -103,7 +111,7 @@
 
 (defn- dialog-buttons [props]
   (-> props
-      (assoc :fx/type :h-box)
+      (assoc :fx/type fx.h-box/lifecycle)
       (fxui/provide-defaults :alignment :center-right)
       (fxui/add-style-classes "spacing-smaller")))
 
@@ -131,7 +139,7 @@
                           (let [header-desc (confirmation-dialog-header->fx-desc header)]
                             (if (= icon ::no-icon)
                               header-desc
-                              {:fx/type :h-box
+                              {:fx/type fx.h-box/lifecycle
                                :style-class "spacing-smaller"
                                :alignment :center-left
                                :children [(if (keyword? icon)
@@ -215,7 +223,7 @@
      :on-close-request {:event-type :cancel}
      :title "Set Custom Resolution"
      :size :small
-     :header {:fx/type :v-box
+     :header {:fx/type fx.v-box/lifecycle
               :children [{:fx/type fxui/label
                           :variant :header
                           :text "Set custom game resolution"}
@@ -265,7 +273,7 @@
                  {:title "Update Failed"
                   :owner owner
                   :icon :icon/triangle-error
-                  :header {:fx/type :v-box
+                  :header {:fx/type fx.v-box/lifecycle
                            :children [{:fx/type fxui/label
                                        :variant :header
                                        :text "An error occurred during update installation"}
@@ -286,7 +294,7 @@
      :icon :icon/circle-info
      :size :large
      :owner owner
-     :header {:fx/type :v-box
+     :header {:fx/type fx.v-box/lifecycle
               :children [{:fx/type fxui/label
                           :variant :header
                           :text "Update is ready, but there is even newer version available"}
@@ -305,7 +313,7 @@
     {:title "Platform not supported"
      :icon :icon/circle-sad
      :owner owner
-     :header {:fx/type :v-box
+     :header {:fx/type fx.v-box/lifecycle
               :children [{:fx/type fxui/label
                           :variant :header
                           :text "Updates are no longer provided for this platform"}
@@ -345,7 +353,7 @@
    :showing (fxui/dialog-showing? props)
    :on-close-request {:result false}
    :title "Error"
-   :header {:fx/type :h-box
+   :header {:fx/type fx.h-box/lifecycle
             :style-class "spacing-smaller"
             :alignment :center-left
             :children [{:fx/type fxui/icon
@@ -355,7 +363,7 @@
                         :text "An error occurred"}]}
    :content {:fx/type info-dialog-text-area
              :text (messages ex-map)}
-   :footer {:fx/type :v-box
+   :footer {:fx/type fx.v-box/lifecycle
             :style-class "spacing-smaller"
             :children [{:fx/type fxui/label
                         :text "You can help us fix this problem by reporting it and providing more information about what you were doing when it happened."}
@@ -388,23 +396,23 @@
   {:fx/type dialog-stage
    :showing (fxui/dialog-showing? props)
    :on-close-request (fn [_] (Platform/exit))
-   :header {:fx/type :h-box
+   :header {:fx/type fx.h-box/lifecycle
             :style-class "spacing-default"
             :alignment :center-left
-            :children [{:fx/type :group
-                        :children [{:fx/type :image-view
+            :children [{:fx/type fx.group/lifecycle
+                        :children [{:fx/type fx.image-view/lifecycle
                                     :scale-x 0.25
                                     :scale-y 0.25
                                     :image "logo.png"}]}
                        {:fx/type fxui/label
                         :variant :header
                         :text "Loading project"}]}
-   :content {:fx/type :v-box
+   :content {:fx/type fx.v-box/lifecycle
              :style-class ["dialog-content-padding" "spacing-smaller"]
              :children [{:fx/type fxui/label
                          :wrap-text false
                          :text (:message progress)}
-                        {:fx/type :progress-bar
+                        {:fx/type fx.progress-bar/lifecycle
                          :max-width Double/MAX_VALUE
                          :progress (progress/fraction progress)}]}
    :footer {:fx/type dialog-buttons
@@ -807,13 +815,13 @@
               :text (str "Rename " initial-name)}
      :content {:fx/type fxui/two-col-input-grid-pane
                :style-class "dialog-content-padding"
-               :children [{:fx/type :label
+               :children [{:fx/type fx.label/lifecycle
                            :text label}
                           {:fx/type fxui/text-field
                            :text name
                            :variant (if invalid :error :default)
                            :on-text-changed {:event-type :set-name}}
-                          {:fx/type :label
+                          {:fx/type fx.label/lifecycle
                            :text "Preview"}
                           {:fx/type fxui/text-field
                            :editable false
@@ -886,7 +894,7 @@
                            :on-text-changed {:event-type :set-file-name}}
                           {:fx/type fxui/label
                            :text "Location"}
-                          {:fx/type :h-box
+                          {:fx/type fx.h-box/lifecycle
                            :spacing 4
                            :children [{:fx/type fxui/text-field
                                        :h-box/hgrow :always

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -17,7 +17,15 @@
   (:require [cljfx.api :as fx]
             [cljfx.coerce :as fx.coerce]
             [cljfx.component :as fx.component]
+            [cljfx.fx.button :as fx.button]
+            [cljfx.fx.column-constraints :as fx.column-constraints]
+            [cljfx.fx.grid-pane :as fx.grid-pane]
+            [cljfx.fx.label :as fx.label]
             [cljfx.fx.list-cell :as fx.list-cell]
+            [cljfx.fx.stage :as fx.stage]
+            [cljfx.fx.svg-path :as fx.svg-path]
+            [cljfx.fx.text-area :as fx.text-area]
+            [cljfx.fx.text-field :as fx.text-field]
             [cljfx.lifecycle :as fx.lifecycle]
             [cljfx.mutator :as fx.mutator]
             [cljfx.prop :as fx.prop]
@@ -261,7 +269,7 @@
   "Generic `:stage` that mirrors behavior of `editor.ui/make-stage`"
   [props]
   (assoc props
-    :fx/type :stage
+    :fx/type fx.stage/lifecycle
     :on-focused-changed ui/focus-change-listener
     :icons (if (eutil/is-mac-os?) [] [ui/application-icon-image])))
 
@@ -305,7 +313,7 @@
     :or {variant :label}
     :as props}]
   (-> props
-      (assoc :fx/type :label)
+      (assoc :fx/type fx.label/lifecycle)
       (dissoc :variant)
       (provide-defaults :wrap-text true)
       (add-style-classes (case variant
@@ -322,7 +330,7 @@
     :or {variant :secondary}
     :as props}]
   (-> props
-      (assoc :fx/type :button)
+      (assoc :fx/type fx.button/lifecycle)
       (dissoc :variant)
       (add-style-classes "button" (case variant
                                     :primary "button-primary"
@@ -335,9 +343,9 @@
   columns, useful for multiple label + input fields"
   [props]
   (-> props
-      (assoc :fx/type :grid-pane
-             :column-constraints [{:fx/type :column-constraints}
-                                  {:fx/type :column-constraints
+      (assoc :fx/type fx.grid-pane/lifecycle
+             :column-constraints [{:fx/type fx.column-constraints/lifecycle}
+                                  {:fx/type fx.column-constraints/lifecycle
                                    :hgrow :always}])
       (add-style-classes "input-grid-pane")
       (update :children (fn [children]
@@ -364,7 +372,7 @@
     :or {variant :default}
     :as props}]
   (-> props
-      (assoc :fx/type :text-field)
+      (assoc :fx/type fx.text-field/lifecycle)
       (dissoc :variant)
       (add-style-classes "text-field" (case variant
                                         :default "text-field-default"
@@ -380,7 +388,7 @@
     :or {variant :default}
     :as props}]
   (-> props
-      (assoc :fx/type :text-area)
+      (assoc :fx/type fx.text-area/lifecycle)
       (dissoc :variant)
       (add-style-classes "text-area" (case variant
                                        :default "text-area-default"
@@ -394,7 +402,7 @@
   - `:type` (required) - icon type, see :icon/* keywords"
   [{:keys [type] :as props}]
   (-> props
-      (assoc :fx/type :svg-path
+      (assoc :fx/type fx.svg-path/lifecycle
              :content (case type
                         :icon/android "M28.5,11c-0.6,0-1.1,0.2-1.5,0.5v0c0-3.4-1.8-6.3-4.4-8l1.1-2.2c0.1-0.2,0-0.5-0.2-0.7c-0.2-0.1-0.5,0-0.7,0.2L21.7,3c-1.3-0.6-2.7-1-4.2-1s-2.9,0.4-4.2,1l-1.1-2.1c-0.1-0.2-0.4-0.3-0.7-0.2c-0.2,0.1-0.3,0.4-0.2,0.7l1.1,2.2C9.8,5.2,8,8.1,8,11.5v0C7.6,11.2,7.1,11,6.5,11C5.1,11,4,12.1,4,13.5v8C4,22.9,5.1,24,6.5,24c0.6,0,1.1-0.2,1.5-0.5v1c0,1.4,1.1,2.5,2.5,2.5H11v4.5c0,1.4,1.1,2.5,2.5,2.5s2.5-1.1,2.5-2.5V27h3v4.6c0,1.3,1.1,2.4,2.4,2.4h0.3c1.3,0,2.4-1.1,2.4-2.4V27h0.5c1.4,0,2.5-1.1,2.5-2.5v-1c0.4,0.3,0.9,0.5,1.5,0.5c1.4,0,2.5-1.1,2.5-2.5v-8C31,12.1,29.9,11,28.5,11zM17.5,3c4.5,0,8.2,3.5,8.5,8H9C9.3,6.5,13,3,17.5,3zM6.5,23C5.7,23,5,22.3,5,21.5v-8C5,12.7,5.7,12,6.5,12S8,12.7,8,13.5v8C8,22.3,7.3,23,6.5,23zM26,24.5c0,0.8-0.7,1.5-1.5,1.5H23v5.6c0,0.8-0.6,1.4-1.4,1.4h-0.3c-0.8,0-1.4-0.6-1.4-1.4V26h-5v5.5c0,0.8-0.7,1.5-1.5,1.5S12,32.3,12,31.5V26h-1.5C9.7,26,9,25.3,9,24.5v-3v-8V12h17v1.5v8V24.5zM30,21.5c0,0.8-0.7,1.5-1.5,1.5S27,22.3,27,21.5v-8c0-0.8,0.7-1.5,1.5-1.5s1.5,0.7,1.5,1.5V21.5zM12.5,7.3c0-0.5,0.4-0.8,0.8-0.8c0.5,0,0.9,0.4,0.9,0.8s-0.4,0.9-0.9,0.9C12.9,8.2,12.5,7.8,12.5,7.3zM20.8,7.3c0-0.5,0.4-0.8,0.9-0.8c0.5,0,0.8,0.4,0.8,0.8s-0.4,0.9-0.8,0.9C21.2,8.2,20.8,7.8,20.8,7.3z"
                         :icon/apple "M16.5,8.6l0.4,0c0.1,0,0.2,0,0.4,0c1.4,0,2.6-0.5,3.8-1.5c1.6-1.3,2.5-3,2.9-5C24,1.6,24,1.1,24,0.5l0-0.5h-0.5c-0.1,0-0.4,0-0.5,0.1c-1.1,0.2-2.2,0.6-3.1,1.2c-1.8,1.2-2.9,2.9-3.4,5c-0.1,0.6-0.2,1.2-0.1,1.9L16.5,8.6zM17.4,6.5c0.4-1.9,1.4-3.4,3-4.4c0.8-0.5,1.6-0.9,2.6-1c0,0.3,0,0.6-0.1,0.9c-0.3,1.8-1.1,3.3-2.5,4.4c-1,0.8-2,1.2-3.1,1.2C17.3,7.2,17.4,6.9,17.4,6.5zM30.6,24.3c-2.6-1.3-4-3.2-4.2-5.8c-0.2-2.6,0.9-4.6,3.3-6.3l0.3-0.3l-0.2-0.4c0-0.1-0.1-0.1-0.1-0.2c-0.8-1-1.8-1.8-2.9-2.4c-1.6-0.8-3.2-1-4.9-0.8c-1.2,0.2-2.3,0.6-3.4,1.1c-1,0.4-1.7,0.4-2.4,0.1c-0.6-0.3-1.2-0.5-1.8-0.7c-0.7-0.3-1.5-0.5-2.3-0.5c-2.7,0-4.9,1-6.7,3.2c-1.2,1.5-2,3.3-2.2,5.5c-0.3,2.5,0.1,5.1,1,8c0.6,1.7,1.3,3.2,2.2,4.6c0.8,1.2,1.7,2.6,3,3.6c0.9,0.7,1.8,1.1,2.7,1.1c0.1,0,0.2,0,0.4,0c0.7-0.1,1.5-0.3,2.4-0.7c1.8-0.8,3.4-0.8,5.1-0.1l0.2,0.1c0.3,0.1,0.7,0.3,1,0.4c1.5,0.5,2.8,0.4,4-0.3c0.7-0.4,1.3-1,1.9-1.7c0.8-1,1.9-2.5,2.7-4.1c0.3-0.6,0.5-1.2,0.8-1.8l0.5-1.2L30.6,24.3zM29.6,25.4c-0.2,0.6-0.5,1.2-0.8,1.7c-0.7,1.5-1.7,2.9-2.5,3.9c-0.5,0.7-1.1,1.2-1.7,1.5c-0.9,0.5-1.9,0.6-3.2,0.2c-0.3-0.1-0.6-0.2-0.9-0.4l-0.2-0.1c-1.9-0.8-3.9-0.8-5.9,0.1c-0.8,0.4-1.5,0.6-2.1,0.6c-0.8,0.1-1.6-0.2-2.4-0.9c-1.2-1-2-2.3-2.8-3.4c-0.8-1.3-1.5-2.7-2.1-4.3c-0.9-2.7-1.2-5.1-1-7.5c0.2-2,0.9-3.6,2-5c1.5-1.9,3.5-2.8,5.8-2.8c0,0,0,0,0.1,0c0.7,0,1.4,0.2,2,0.4c0.6,0.2,1.2,0.4,1.8,0.7c1.3,0.5,2.4,0.2,3.3-0.1c1.1-0.4,2-0.8,3.1-1c1.5-0.2,2.9,0,4.4,0.7c0.9,0.4,1.7,1,2.4,1.9c-2.4,1.8-3.5,4.2-3.3,6.9c0.2,2.8,1.6,5,4.3,6.4L29.6,25.4z"

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -13,7 +13,10 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.welcome
-  (:require [clojure.edn :as edn]
+  (:require [cljfx.fx.hyperlink :as fx.hyperlink]
+            [cljfx.fx.text :as fx.text]
+            [cljfx.fx.text-flow :as fx.text-flow]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.string :as string]
@@ -663,20 +666,20 @@
                                             {:title "SSL Connection Error"
                                              :icon :icon/triangle-error
                                              :header "Could not establish an SSL connection"
-                                             :content {:fx/type :text-flow
+                                             :content {:fx/type fx.text-flow/lifecycle
                                                        :style-class "dialog-content-padding"
-                                                       :children [{:fx/type :text
+                                                       :children [{:fx/type fx.text/lifecycle
                                                                    :text (str "Common causes are:\n"
                                                                               "\u00A0\u00A0\u2022\u00A0 Antivirus software configured to scan encrypted connections\n"
                                                                               "\u00A0\u00A0\u2022\u00A0 Expired or misconfigured server certificate\n"
                                                                               "\u00A0\u00A0\u2022\u00A0 Untrusted server certificate\n"
                                                                               "\n"
                                                                               "The following FAQ may apply: ")}
-                                                                  {:fx/type :hyperlink
+                                                                  {:fx/type fx.hyperlink/lifecycle
                                                                    :text "PKIX path building failed"
                                                                    :on-action (fn [_]
                                                                                 (ui/open-url "https://github.com/defold/editor2-issues/blob/master/faq/pkixpathbuilding.md"))}
-                                                                  {:fx/type :text
+                                                                  {:fx/type fx.text/lifecycle
                                                                    :text (str "\n\n" (string/replace (.getMessage error) ": " ":\n\u00A0\u00A0"))}]}})
 
                                           :else


### PR DESCRIPTION
This changeset replaces indirect use of cljfx lifecycles (that resulted in lazy loading of namespaces and classes on first form open) with direct use lifecycles — this moves ns/class loading from form open time to editor open time.

Related to #6740