### PR TITLE
Updated Readme for linux engine and editor setup. 

### DIFF
--- a/README_SETUP_LINUX.md
+++ b/README_SETUP_LINUX.md
@@ -105,6 +105,12 @@ Configure `ccache` by running ([source](https://ccache.samba.org/manual.html))
 > /usr/local/bin/ccache --max-size=5G
 ```
 
+Or just:
+
+```sh
+> ccache --max-size=5G
+```
+
 Install snapd package manager:
 
 ```sh

--- a/README_SETUP_LINUX.md
+++ b/README_SETUP_LINUX.md
@@ -6,10 +6,14 @@
 
 ### Required Software - Java JDK 11
 
-Download and install the latest JDK 11 release from either of these locations:
+Download and install the latest JDK 11 (11.0.15 or later) release from either of these locations:
 
 * [Adoptium/Temurin](https://github.com/adoptium/temurin11-binaries/releases) - The Adoptium Working Group promotes and supports high-quality runtimes and associated technology for use across the Java ecosystem
 * [Microsoft OpenJDK builds](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11) - The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source and available for free for anyone to deploy anywhere
+* or from apt-get:
+```
+> sudo apt-get install openjdk-11-jdk
+```
 
 When Java is installed you may also add need to add java to your PATH and export JAVA_HOME:
 
@@ -100,12 +104,6 @@ Quick and easy install:
 ```
 
 Configure `ccache` by running ([source](https://ccache.samba.org/manual.html))
-
-```sh
-> /usr/local/bin/ccache --max-size=5G
-```
-
-Or just:
 
 ```sh
 > ccache --max-size=5G

--- a/editor/README_BUILD.md
+++ b/editor/README_BUILD.md
@@ -59,6 +59,7 @@ cd editor
 
 # Build and run
 lein init
+lein run
 ```
 
 

--- a/editor/README_SETUP_LINUX.md
+++ b/editor/README_SETUP_LINUX.md
@@ -4,11 +4,11 @@
 
 ### Required Software - Java JDK 11
 
-Download and install the latest JDK 11 release from either of these locations:
+Download and install the latest JDK 11 (11.0.15 or later) release from either of these locations:
 
 * [Adoptium/Temurin](https://github.com/adoptium/temurin11-binaries/releases) - The Adoptium Working Group promotes and supports high-quality runtimes and associated technology for use across the Java ecosystem
 * [Microsoft OpenJDK builds](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11) - The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source and available for free for anyone to deploy anywhere
-* or with:
+* or from apt-get:
 ```
 > sudo apt-get install openjdk-11-jdk
 ```

--- a/editor/README_SETUP_LINUX.md
+++ b/editor/README_SETUP_LINUX.md
@@ -8,6 +8,10 @@ Download and install the latest JDK 11 release from either of these locations:
 
 * [Adoptium/Temurin](https://github.com/adoptium/temurin11-binaries/releases) - The Adoptium Working Group promotes and supports high-quality runtimes and associated technology for use across the Java ecosystem
 * [Microsoft OpenJDK builds](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11) - The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source and available for free for anyone to deploy anywhere
+* or with:
+```
+> sudo apt-get install openjdk-11-jdk
+```
 
 When Java is installed you may also add need to add java to your PATH and export JAVA_HOME:
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -668,7 +668,7 @@ namespace dmRender
      *
      * function update(self, dt)
      *     -- enable target so all drawing is done to it
-     *     render.enable_render_target(self.my_render_target)
+     *     render.set_render_target(self.my_render_target)
      *
      *     -- draw a predicate to the render target
      *     render.draw(self.my_pred)
@@ -1077,13 +1077,13 @@ namespace dmRender
      * ```lua
      * function update(self, dt)
      *     -- enable target so all drawing is done to it
-     *     render.enable_render_target(self.my_render_target)
+     *     render.set_render_target(self.my_render_target)
      *
      *     -- draw a predicate to the render target
      *     render.draw(self.my_pred)
      *
      *     -- disable target
-     *     render.disable_render_target(self.my_render_target)
+     *     render.set_render_target(render.RENDER_TARGET_DEFAULT)
      *
      *     render.enable_texture(0, self.my_render_target, render.BUFFER_COLOR_BIT)
      *     -- draw a predicate with the render target available as texture 0 in the predicate


### PR DESCRIPTION
After setting up Defold on local Ubuntu 20.04 machine, I thought I could add some useful additions to the manuals:

Added option to install openjdk11 for Editor prerequisite.
For me `ccache --max-size=5G` was working and I think it's more universal than with a path provided (for me it was not there)?
It looks like `lein init` does not run the Editor, so I added a command `lein run` to the proper manual.