### PR TITLE
Added collectionproxy.get_resources()

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -49,6 +49,11 @@ namespace dmGameSystem
 
     const char* COLLECTION_PROXY_MAX_COUNT_KEY = "collection_proxy.max_count";
 
+    static const dmhash_t COLLECTION_PROXY_LOAD_HASH = dmHashString64("load");
+    static const dmhash_t COLLECTION_PROXY_ASYNC_LOAD_HASH = dmHashString64("async_load");
+    static const dmhash_t COLLECTION_PROXY_UNLOAD_HASH = dmHashString64("unload");
+    static const dmhash_t COLLECTION_PROXY_INIT_HASH = dmHashString64("init");
+
     struct CollectionProxyComponent
     {
         dmMessage::URL                  m_Unloader;
@@ -390,7 +395,7 @@ namespace dmGameSystem
         CollectionProxyComponent* proxy = (CollectionProxyComponent*) *params.m_UserData;
         CollectionProxyContext* context = (CollectionProxyContext*)params.m_Context;
 
-        if (params.m_Message->m_Id == dmHashString64("load") || params.m_Message->m_Id == dmHashString64("async_load"))
+        if (params.m_Message->m_Id == COLLECTION_PROXY_LOAD_HASH || params.m_Message->m_Id == COLLECTION_PROXY_ASYNC_LOAD_HASH)
         {
             if (proxy->m_Collection == 0)
             {
@@ -404,7 +409,7 @@ namespace dmGameSystem
                 proxy->m_LoadSender = params.m_Message->m_Sender;
                 proxy->m_LoadReceiver = params.m_Message->m_Receiver;
 
-                if (params.m_Message->m_Id == dmHashString64("async_load"))
+                if (params.m_Message->m_Id == COLLECTION_PROXY_ASYNC_LOAD_HASH)
                 {
                     proxy->m_Preloader = dmResource::NewPreloader(context->m_Factory, proxy->m_Resource->m_DDF->m_Collection);
                 }
@@ -423,7 +428,7 @@ namespace dmGameSystem
                 LogMessageError(params.m_Message, "The collection %s could not be loaded since it was already.", proxy->m_Resource->m_DDF->m_Collection);
             }
         }
-        else if (params.m_Message->m_Id == dmHashString64("unload"))
+        else if (params.m_Message->m_Id == COLLECTION_PROXY_UNLOAD_HASH)
         {
             if (proxy->m_Preloader != 0)
             {
@@ -445,7 +450,7 @@ namespace dmGameSystem
                 LogMessageError(params.m_Message, "The collection %s could not be unloaded since it was never loaded.", proxy->m_Resource->m_DDF->m_Collection);
             }
         }
-        else if (params.m_Message->m_Id == dmHashString64("init"))
+        else if (params.m_Message->m_Id == COLLECTION_PROXY_INIT_HASH)
         {
             if (proxy->m_Collection != 0)
             {

--- a/engine/gamesys/src/gamesys/scripts/script_collectionproxy.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collectionproxy.cpp
@@ -24,9 +24,6 @@
 
 namespace dmGameSystem
 {
-    static const char* COLLECTION_PROXY_EXT = "spinemodelc";
-    static const dmhash_t COLLECTION_PROXY_EXT_HASH = dmHashString64(COLLECTION_PROXY_EXT);
-
     static dmhash_t GetCollectionProxyUrlHash(lua_State* L, int index)
     {
         dmMessage::URL sender;

--- a/engine/gamesys/src/gamesys/scripts/script_collectionproxy.h
+++ b/engine/gamesys/src/gamesys/scripts/script_collectionproxy.h
@@ -26,55 +26,6 @@ namespace dmGameSystem
 
     void ScriptCollectionProxyRegister(const struct ScriptLibContext& context);
     void ScriptCollectionProxyFinalize(const struct ScriptLibContext& context);
-
-    /*# return an indexed table of missing resources for a collection proxy
-     *
-     * return an indexed table of missing resources for a collection proxy. Each
-     * entry is a hexadecimal string that represents the data of the specific
-     * resource. This representation corresponds with the filename for each
-     * individual resource that is exported when you bundle an application with
-     * LiveUpdate functionality. It should be considered good practise to always
-     * check whether or not there are any missing resources in a collection proxy
-     * before attempting to load the collection proxy.
-     *
-     * @namespace collectionproxy
-     * @name collectionproxy.missing_resources
-     * @param collectionproxy [type:url] the collectionproxy to check for missing
-     * resources.
-     * @return resources [type:table] the missing resources
-     *
-     * @examples
-     *
-     * ```lua
-     * function init(self)
-     *     self.manifest = resource.get_current_manifest()
-     * end
-     *
-     * local function callback(self, id, response)
-     *     local expected = self.resources[id]
-     *     if response ~= nil and response.status == 200 then
-     *         print("Successfully downloaded resource: " .. expected)
-     *         resource.store_resource(response.response)
-     *     else
-     *         print("Failed to download resource: " .. expected)
-     *         -- error handling
-     *     end
-     * end
-     *
-     * local function download_resources(self, cproxy)
-     *     self.resources = {}
-     *     local resources = collectionproxy.missing_resources(cproxy)
-     *     for _, v in ipairs(resources) do
-     *         print("Downloading resource: " .. v)
-     *
-     *         local uri = "http://example.defold.com/" .. v
-     *         local id = http.request(uri, "GET", callback)
-     *         self.resources[id] = v
-     *     end
-     * end
-     * ```
-     */
-    int CollectionProxy_MissingResources(lua_State* L);
 };
 
 #endif // H_SCRIPT_COLLECTIONPROXY

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -104,44 +104,70 @@ namespace dmLiveUpdate
      ** LiveUpdate utility functions
      ********************************************************************** **/
 
-    uint32_t GetMissingResources(const dmhash_t urlHash, char*** buffer)
+    struct GetResourceHashContext
+    {
+        uint32_t            m_HexDigestLength;
+        void*               m_Context;
+        FGetResourceHashHex m_Callback;
+        dmArray<dmhash_t>   m_Unique;
+        char*               m_ScratchBuffer;
+    };
+
+    static inline bool ContainsResource(dmArray<dmhash_t>& entries, dmhash_t entry)
+    {
+        uint32_t size = entries.Size();
+        for (uint32_t i = 0; i < size; ++i)
+        {
+            if (entries[i] == entry)
+                return true;
+        }
+        return false;
+    }
+
+    static void GetResourceHashCallback(void* context, const uint8_t* resource_hash, uint32_t length)
+    {
+        GetResourceHashContext* ctx = (GetResourceHashContext*)context;
+
+        dmhash_t short_hash = dmHashBuffer64(resource_hash, length);
+        bool contains = ContainsResource(ctx->m_Unique, short_hash);
+        if (contains)
+            return;
+
+        ctx->m_Unique.Push(short_hash);
+
+        dmResource::BytesToHexString(resource_hash, length, ctx->m_ScratchBuffer, ctx->m_HexDigestLength);
+
+        ctx->m_Callback(ctx->m_Context, (const char*)ctx->m_ScratchBuffer, ctx->m_HexDigestLength-1);
+    }
+
+    static void GetResources(const dmhash_t url_hash, bool only_missing, FGetResourceHashHex callback, void* context)
     {
         dmResource::Manifest* manifest = dmResource::GetManifest(g_LiveUpdate.m_ResourceFactory);
+        if (manifest == 0)
+            return;
 
-        uint32_t resourceCount = MissingResources(manifest, urlHash, NULL, 0); // First, get the number of dependants
-        uint32_t uniqueCount = 0;
-        if (resourceCount > 0)
-        {
-            uint8_t** resources = (uint8_t**) malloc(resourceCount * sizeof(uint8_t*));
-            *buffer = (char**) malloc(resourceCount * sizeof(char**));
-            resourceCount = MissingResources(manifest, urlHash, resources, resourceCount);
+        GetResourceHashContext ctx;
+        ctx.m_Context = context;
+        ctx.m_Callback = callback;
 
-            dmLiveUpdateDDF::HashAlgorithm algorithm = manifest->m_DDFData->m_Header.m_ResourceHashAlgorithm;
-            uint32_t hexDigestLength = HexDigestLength(algorithm) + 1;
-            bool isUnique;
-            char* scratch = (char*) alloca(hexDigestLength * sizeof(char*));
-            for (uint32_t i = 0; i < resourceCount; ++i)
-            {
-                isUnique = true;
-                dmResource::BytesToHexString(resources[i], dmResource::HashLength(algorithm), scratch, hexDigestLength);
-                for (uint32_t j = 0; j < uniqueCount; ++j) // only return unique hashes even if there are multiple resource instances in the collectionproxy
-                {
-                    if (memcmp((*buffer)[j], scratch, hexDigestLength) == 0)
-                    {
-                        isUnique = false;
-                        break;
-                    }
-                }
-                if (isUnique)
-                {
-                    (*buffer)[uniqueCount] = (char*) malloc(hexDigestLength * sizeof(char*));
-                    memcpy((*buffer)[uniqueCount], scratch, hexDigestLength);
-                    ++uniqueCount;
-                }
-            }
-            free(resources);
-        }
-        return uniqueCount;
+        dmLiveUpdateDDF::HashAlgorithm algorithm = manifest->m_DDFData->m_Header.m_ResourceHashAlgorithm;
+        ctx.m_HexDigestLength = HexDigestLength(algorithm) + 1;
+        ctx.m_ScratchBuffer = (char*) alloca(ctx.m_HexDigestLength * sizeof(char*));
+
+        uint32_t resource_count = GetNumDependants(manifest, url_hash);
+        ctx.m_Unique.SetCapacity(resource_count);
+
+        GetResourceHashes(manifest, url_hash, only_missing, GetResourceHashCallback, &ctx);
+    }
+
+    void GetResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
+    {
+        GetResources(url_hash, false, callback, context);
+    }
+
+    void GetMissingResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
+    {
+        GetResources(url_hash, true, callback, context);
     }
 
     Result VerifyResource(const dmResource::Manifest* manifest, const char* expected, uint32_t expected_length, const char* data, uint32_t data_length)

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -58,7 +58,11 @@ namespace dmLiveUpdate
 
     void RegisterArchiveLoaders();
 
-    uint32_t GetMissingResources(const dmhash_t urlHash, char*** buffer);
+
+    typedef void (*FGetResourceHashHex)(void* context, const char* hash, uint32_t length);
+
+    void GetResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context);
+    void GetMissingResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context);
 
     /*
      * Verifies the manifest cryptographic signature and that the manifest supports the current running dmengine version.

--- a/engine/liveupdate/src/liveupdate_null.cpp
+++ b/engine/liveupdate/src/liveupdate_null.cpp
@@ -38,9 +38,12 @@ void RegisterArchiveLoaders()
 {
 }
 
-uint32_t GetMissingResources(const dmhash_t urlHash, char*** buffer)
+void GetResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
 {
-    return 0;
+}
+
+void GetMissingResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
+{
 }
 
 Result VerifyManifest(const dmResource::Manifest* manifest)

--- a/engine/liveupdate/src/liveupdate_private.h
+++ b/engine/liveupdate/src/liveupdate_private.h
@@ -72,7 +72,10 @@ namespace dmLiveUpdate
 
     HResourceEntry FindResourceEntry(const HManifestFile manifest, const dmhash_t urlHash);
 
-    uint32_t MissingResources(dmResource::Manifest* manifest, const dmhash_t urlHash, uint8_t* entries[], uint32_t entries_size);
+    uint32_t GetNumDependants(dmResource::Manifest* manifest, const dmhash_t urlHash);
+
+    typedef void (*FGetResourceHash)(void* context, const uint8_t* hash, uint32_t length);
+    void GetResourceHashes(dmResource::Manifest* manifest, const dmhash_t urlHash, bool only_missing, FGetResourceHash callback, void* context);
 
     void CreateResourceHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const char* buf, size_t buflen, uint8_t* digest);
     void CreateManifestHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const uint8_t* buf, size_t buflen, uint8_t* digest);


### PR DESCRIPTION
Returns a list of all the resources that the collection proxy is dependent on:

```
   local resources = collectionproxy.get_resources(proxy_url)
   for _, v in ipairs(resources) do
       print("Resource: " .. v)
    end
```

This functionality will later be used for removing old live update content from disk.

Part of #3207

Design here:
https://docs.google.com/document/d/16d5CqHT71piqTcgwBc9z7RaOiraVBDzep6HBozrJ5L8/edit#