### PR TITLE
Created liveupdate Lua module

### DIFF
--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -50,7 +50,7 @@ def build(bld):
                              'ResourceTypeAnim', 'ResourceTypeAnimationSet', 'ResourceTypeGui', 'ResourceTypeGuiScript']
     component_type_symbols = ['ComponentTypeAnim', 'ComponentTypeScript', 'ComponentTypeGui']
 
-    exported_symbols = ['DefaultSoundDevice', 'AudioDecoderWav', 'CrashExt', 'ProfilerExt']
+    exported_symbols = ['DefaultSoundDevice', 'AudioDecoderWav', 'CrashExt', 'ProfilerExt', 'LiveUpdateExt']
 
     # Add stb_vorbis and/or tremolo depending on platform
     #if 'web' in bld.env['PLATFORM'] or 'win32' in bld.env['PLATFORM']:
@@ -170,7 +170,7 @@ def build(bld):
     obj = bld.new_task_gen(
         features = 'cc cxx cprogram apk web extract_symbols',
         uselib = 'RECORD_NULL GAMEOBJECT DDF LIVEUPDATE GAMESYS RESOURCE PHYSICS RENDER PLATFORM_SOCKET SCRIPT LUA EXTENSION HID_NULL INPUT PARTICLE RIG GUI CRASH DLIB SOUND_NULL CRASH'.split() + graphics_lib.split() + profile_lib + additional_libs,
-        exported_symbols = ['ProfilerExt', 'GraphicsAdapterNull'] + resource_type_symbols + component_type_symbols,
+        exported_symbols = ['ProfilerExt', 'LiveUpdateExt', 'GraphicsAdapterNull'] + resource_type_symbols + component_type_symbols,
         uselib_local = 'engine engine_service',
         web_libs = web_libs,
         includes = '../build ../proto . ..',

--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -49,6 +49,11 @@ namespace dmGameSystem
 
     const char* COLLECTION_PROXY_MAX_COUNT_KEY = "collection_proxy.max_count";
 
+    static const dmhash_t COLLECTION_PROXY_LOAD_HASH = dmHashString64("load");
+    static const dmhash_t COLLECTION_PROXY_ASYNC_LOAD_HASH = dmHashString64("async_load");
+    static const dmhash_t COLLECTION_PROXY_UNLOAD_HASH = dmHashString64("unload");
+    static const dmhash_t COLLECTION_PROXY_INIT_HASH = dmHashString64("init");
+
     struct CollectionProxyComponent
     {
         dmMessage::URL                  m_Unloader;
@@ -390,7 +395,7 @@ namespace dmGameSystem
         CollectionProxyComponent* proxy = (CollectionProxyComponent*) *params.m_UserData;
         CollectionProxyContext* context = (CollectionProxyContext*)params.m_Context;
 
-        if (params.m_Message->m_Id == dmHashString64("load") || params.m_Message->m_Id == dmHashString64("async_load"))
+        if (params.m_Message->m_Id == COLLECTION_PROXY_LOAD_HASH || params.m_Message->m_Id == COLLECTION_PROXY_ASYNC_LOAD_HASH)
         {
             if (proxy->m_Collection == 0)
             {
@@ -404,7 +409,7 @@ namespace dmGameSystem
                 proxy->m_LoadSender = params.m_Message->m_Sender;
                 proxy->m_LoadReceiver = params.m_Message->m_Receiver;
 
-                if (params.m_Message->m_Id == dmHashString64("async_load"))
+                if (params.m_Message->m_Id == COLLECTION_PROXY_ASYNC_LOAD_HASH)
                 {
                     proxy->m_Preloader = dmResource::NewPreloader(context->m_Factory, proxy->m_Resource->m_DDF->m_Collection);
                 }
@@ -423,7 +428,7 @@ namespace dmGameSystem
                 LogMessageError(params.m_Message, "The collection %s could not be loaded since it was already.", proxy->m_Resource->m_DDF->m_Collection);
             }
         }
-        else if (params.m_Message->m_Id == dmHashString64("unload"))
+        else if (params.m_Message->m_Id == COLLECTION_PROXY_UNLOAD_HASH)
         {
             if (proxy->m_Preloader != 0)
             {
@@ -445,7 +450,7 @@ namespace dmGameSystem
                 LogMessageError(params.m_Message, "The collection %s could not be unloaded since it was never loaded.", proxy->m_Resource->m_DDF->m_Collection);
             }
         }
-        else if (params.m_Message->m_Id == dmHashString64("init"))
+        else if (params.m_Message->m_Id == COLLECTION_PROXY_INIT_HASH)
         {
             if (proxy->m_Collection != 0)
             {

--- a/engine/gamesys/src/gamesys/scripts/script_collectionproxy.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collectionproxy.cpp
@@ -24,9 +24,6 @@
 
 namespace dmGameSystem
 {
-    static const char* COLLECTION_PROXY_EXT = "spinemodelc";
-    static const dmhash_t COLLECTION_PROXY_EXT_HASH = dmHashString64(COLLECTION_PROXY_EXT);
-
     static dmhash_t GetCollectionProxyUrlHash(lua_State* L, int index)
     {
         dmMessage::URL sender;

--- a/engine/gamesys/src/gamesys/scripts/script_collectionproxy.h
+++ b/engine/gamesys/src/gamesys/scripts/script_collectionproxy.h
@@ -26,55 +26,6 @@ namespace dmGameSystem
 
     void ScriptCollectionProxyRegister(const struct ScriptLibContext& context);
     void ScriptCollectionProxyFinalize(const struct ScriptLibContext& context);
-
-    /*# return an indexed table of missing resources for a collection proxy
-     *
-     * return an indexed table of missing resources for a collection proxy. Each
-     * entry is a hexadecimal string that represents the data of the specific
-     * resource. This representation corresponds with the filename for each
-     * individual resource that is exported when you bundle an application with
-     * LiveUpdate functionality. It should be considered good practise to always
-     * check whether or not there are any missing resources in a collection proxy
-     * before attempting to load the collection proxy.
-     *
-     * @namespace collectionproxy
-     * @name collectionproxy.missing_resources
-     * @param collectionproxy [type:url] the collectionproxy to check for missing
-     * resources.
-     * @return resources [type:table] the missing resources
-     *
-     * @examples
-     *
-     * ```lua
-     * function init(self)
-     *     self.manifest = resource.get_current_manifest()
-     * end
-     *
-     * local function callback(self, id, response)
-     *     local expected = self.resources[id]
-     *     if response ~= nil and response.status == 200 then
-     *         print("Successfully downloaded resource: " .. expected)
-     *         resource.store_resource(response.response)
-     *     else
-     *         print("Failed to download resource: " .. expected)
-     *         -- error handling
-     *     end
-     * end
-     *
-     * local function download_resources(self, cproxy)
-     *     self.resources = {}
-     *     local resources = collectionproxy.missing_resources(cproxy)
-     *     for _, v in ipairs(resources) do
-     *         print("Downloading resource: " .. v)
-     *
-     *         local uri = "http://example.defold.com/" .. v
-     *         local id = http.request(uri, "GET", callback)
-     *         self.resources[id] = v
-     *     end
-     * end
-     * ```
-     */
-    int CollectionProxy_MissingResources(lua_State* L);
 };
 
 #endif // H_SCRIPT_COLLECTIONPROXY

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -893,6 +893,19 @@ static int GetTextMetrics(lua_State* L)
     return 1;
 }
 
+#define DEPRECATE_LU_FUNCTION(LUA_NAME, CPP_NAME) \
+    static int Deprecated_ ## CPP_NAME(lua_State* L) \
+    { \
+        dmLogOnceWarning("Function `resource.%s` is deprecated. Please use `liveupdate.%s` instead.", LUA_NAME, LUA_NAME); \
+        return dmLiveUpdate:: CPP_NAME (L); \
+    }
+
+DEPRECATE_LU_FUNCTION("get_current_manifest", Resource_GetCurrentManifest);
+DEPRECATE_LU_FUNCTION("is_using_liveupdate_data", Resource_IsUsingLiveUpdateData);
+DEPRECATE_LU_FUNCTION("store_resource", Resource_StoreResource);
+DEPRECATE_LU_FUNCTION("store_manifest", Resource_StoreManifest);
+DEPRECATE_LU_FUNCTION("store_archive", Resource_StoreArchive);
+
 static const luaL_reg Module_methods[] =
 {
     {"set", Set},
@@ -904,11 +917,11 @@ static const luaL_reg Module_methods[] =
     {"get_text_metrics", GetTextMetrics},
 
     // LiveUpdate functionality in resource namespace
-    {"get_current_manifest", dmLiveUpdate::Resource_GetCurrentManifest},
-    {"is_using_liveupdate_data", dmLiveUpdate::Resource_IsUsingLiveUpdateData},
-    {"store_resource", dmLiveUpdate::Resource_StoreResource},
-    {"store_manifest", dmLiveUpdate::Resource_StoreManifest},
-    {"store_archive", dmLiveUpdate::Resource_StoreArchive},
+    {"get_current_manifest", Deprecated_Resource_GetCurrentManifest},
+    {"is_using_liveupdate_data", Deprecated_Resource_IsUsingLiveUpdateData},
+    {"store_resource", Deprecated_Resource_StoreResource},
+    {"store_manifest", Deprecated_Resource_StoreManifest},
+    {"store_archive", Deprecated_Resource_StoreArchive},
 
     {0, 0}
 };

--- a/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource_liveupdate.cpp
@@ -17,6 +17,7 @@
 
 #include <script/script.h>
 #include <dlib/log.h>
+#include <extension/extension.h>
 
 namespace dmLiveUpdate
 {
@@ -273,4 +274,36 @@ namespace dmLiveUpdate
         return 0;
     }
 
+    static const luaL_reg Module_methods[] =
+    {
+        {"get_current_manifest", dmLiveUpdate::Resource_GetCurrentManifest},
+        {"is_using_liveupdate_data", dmLiveUpdate::Resource_IsUsingLiveUpdateData},
+        {"store_resource", dmLiveUpdate::Resource_StoreResource}, // Stores a single resource
+        {"store_manifest", dmLiveUpdate::Resource_StoreManifest}, // Store a .dmanifest file
+        {"store_archive", dmLiveUpdate::Resource_StoreArchive},   // Store a .zip archive
+
+        {0, 0}
+    };
+
+    static void LuaInit(lua_State* L)
+    {
+        int top = lua_gettop(L);
+        luaL_register(L, "liveupdate", Module_methods);
+
+        lua_pop(L, 1);
+        assert(top == lua_gettop(L));
+    }
+
+    static dmExtension::Result InitializeLiveUpdate(dmExtension::Params* params)
+    {
+        LuaInit(params->m_L);
+        return dmExtension::RESULT_OK;
+    }
+
+    static dmExtension::Result FinalizeLiveUpdate(dmExtension::Params* params)
+    {
+        return dmExtension::RESULT_OK;
+    }
 };
+
+DM_DECLARE_EXTENSION(LiveUpdateExt, "LiveUpdate", 0, 0, dmLiveUpdate::InitializeLiveUpdate, 0, 0, dmLiveUpdate::FinalizeLiveUpdate)

--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -104,44 +104,70 @@ namespace dmLiveUpdate
      ** LiveUpdate utility functions
      ********************************************************************** **/
 
-    uint32_t GetMissingResources(const dmhash_t urlHash, char*** buffer)
+    struct GetResourceHashContext
+    {
+        uint32_t            m_HexDigestLength;
+        void*               m_Context;
+        FGetResourceHashHex m_Callback;
+        dmArray<dmhash_t>   m_Unique;
+        char*               m_ScratchBuffer;
+    };
+
+    static inline bool ContainsResource(dmArray<dmhash_t>& entries, dmhash_t entry)
+    {
+        uint32_t size = entries.Size();
+        for (uint32_t i = 0; i < size; ++i)
+        {
+            if (entries[i] == entry)
+                return true;
+        }
+        return false;
+    }
+
+    static void GetResourceHashCallback(void* context, const uint8_t* resource_hash, uint32_t length)
+    {
+        GetResourceHashContext* ctx = (GetResourceHashContext*)context;
+
+        dmhash_t short_hash = dmHashBuffer64(resource_hash, length);
+        bool contains = ContainsResource(ctx->m_Unique, short_hash);
+        if (contains)
+            return;
+
+        ctx->m_Unique.Push(short_hash);
+
+        dmResource::BytesToHexString(resource_hash, length, ctx->m_ScratchBuffer, ctx->m_HexDigestLength);
+
+        ctx->m_Callback(ctx->m_Context, (const char*)ctx->m_ScratchBuffer, ctx->m_HexDigestLength-1);
+    }
+
+    static void GetResources(const dmhash_t url_hash, bool only_missing, FGetResourceHashHex callback, void* context)
     {
         dmResource::Manifest* manifest = dmResource::GetManifest(g_LiveUpdate.m_ResourceFactory);
+        if (manifest == 0)
+            return;
 
-        uint32_t resourceCount = MissingResources(manifest, urlHash, NULL, 0); // First, get the number of dependants
-        uint32_t uniqueCount = 0;
-        if (resourceCount > 0)
-        {
-            uint8_t** resources = (uint8_t**) malloc(resourceCount * sizeof(uint8_t*));
-            *buffer = (char**) malloc(resourceCount * sizeof(char**));
-            resourceCount = MissingResources(manifest, urlHash, resources, resourceCount);
+        GetResourceHashContext ctx;
+        ctx.m_Context = context;
+        ctx.m_Callback = callback;
 
-            dmLiveUpdateDDF::HashAlgorithm algorithm = manifest->m_DDFData->m_Header.m_ResourceHashAlgorithm;
-            uint32_t hexDigestLength = HexDigestLength(algorithm) + 1;
-            bool isUnique;
-            char* scratch = (char*) alloca(hexDigestLength * sizeof(char*));
-            for (uint32_t i = 0; i < resourceCount; ++i)
-            {
-                isUnique = true;
-                dmResource::BytesToHexString(resources[i], dmResource::HashLength(algorithm), scratch, hexDigestLength);
-                for (uint32_t j = 0; j < uniqueCount; ++j) // only return unique hashes even if there are multiple resource instances in the collectionproxy
-                {
-                    if (memcmp((*buffer)[j], scratch, hexDigestLength) == 0)
-                    {
-                        isUnique = false;
-                        break;
-                    }
-                }
-                if (isUnique)
-                {
-                    (*buffer)[uniqueCount] = (char*) malloc(hexDigestLength * sizeof(char*));
-                    memcpy((*buffer)[uniqueCount], scratch, hexDigestLength);
-                    ++uniqueCount;
-                }
-            }
-            free(resources);
-        }
-        return uniqueCount;
+        dmLiveUpdateDDF::HashAlgorithm algorithm = manifest->m_DDFData->m_Header.m_ResourceHashAlgorithm;
+        ctx.m_HexDigestLength = HexDigestLength(algorithm) + 1;
+        ctx.m_ScratchBuffer = (char*) alloca(ctx.m_HexDigestLength * sizeof(char*));
+
+        uint32_t resource_count = GetNumDependants(manifest, url_hash);
+        ctx.m_Unique.SetCapacity(resource_count);
+
+        GetResourceHashes(manifest, url_hash, only_missing, GetResourceHashCallback, &ctx);
+    }
+
+    void GetResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
+    {
+        GetResources(url_hash, false, callback, context);
+    }
+
+    void GetMissingResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
+    {
+        GetResources(url_hash, true, callback, context);
     }
 
     Result VerifyResource(const dmResource::Manifest* manifest, const char* expected, uint32_t expected_length, const char* data, uint32_t data_length)

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -58,7 +58,11 @@ namespace dmLiveUpdate
 
     void RegisterArchiveLoaders();
 
-    uint32_t GetMissingResources(const dmhash_t urlHash, char*** buffer);
+
+    typedef void (*FGetResourceHashHex)(void* context, const char* hash, uint32_t length);
+
+    void GetResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context);
+    void GetMissingResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context);
 
     /*
      * Verifies the manifest cryptographic signature and that the manifest supports the current running dmengine version.

--- a/engine/liveupdate/src/liveupdate_null.cpp
+++ b/engine/liveupdate/src/liveupdate_null.cpp
@@ -38,9 +38,12 @@ void RegisterArchiveLoaders()
 {
 }
 
-uint32_t GetMissingResources(const dmhash_t urlHash, char*** buffer)
+void GetResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
 {
-    return 0;
+}
+
+void GetMissingResources(const dmhash_t url_hash, FGetResourceHashHex callback, void* context)
+{
 }
 
 Result VerifyManifest(const dmResource::Manifest* manifest)

--- a/engine/liveupdate/src/liveupdate_private.h
+++ b/engine/liveupdate/src/liveupdate_private.h
@@ -72,7 +72,10 @@ namespace dmLiveUpdate
 
     HResourceEntry FindResourceEntry(const HManifestFile manifest, const dmhash_t urlHash);
 
-    uint32_t MissingResources(dmResource::Manifest* manifest, const dmhash_t urlHash, uint8_t* entries[], uint32_t entries_size);
+    uint32_t GetNumDependants(dmResource::Manifest* manifest, const dmhash_t urlHash);
+
+    typedef void (*FGetResourceHash)(void* context, const uint8_t* hash, uint32_t length);
+    void GetResourceHashes(dmResource::Manifest* manifest, const dmhash_t urlHash, bool only_missing, FGetResourceHash callback, void* context);
 
     void CreateResourceHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const char* buf, size_t buflen, uint8_t* digest);
     void CreateManifestHash(dmLiveUpdateDDF::HashAlgorithm algorithm, const uint8_t* buf, size_t buflen, uint8_t* digest);

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -132,8 +132,6 @@ struct SResourceFactory
     // Resource manifest
     Manifest*                                    m_Manifest;
     void*                                        m_ArchiveMountInfo;
-
-    uint8_t                                      m_UseLiveUpdate : 1;
 };
 
 SResourceType* FindResourceType(SResourceFactory* factory, const char* extension)
@@ -457,7 +455,6 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
     SResourceFactory* factory = new SResourceFactory;
     memset(factory, 0, sizeof(*factory));
     factory->m_Socket = socket;
-    factory->m_UseLiveUpdate = params->m_Flags & RESOURCE_FACTORY_FLAGS_LIVE_UPDATE ? 1 : 0;
 
     dmURI::Result uri_result = dmURI::Parse(uri, &factory->m_UriParts);
     if (uri_result != dmURI::RESULT_OK)

--- a/share/extender/build.yml
+++ b/share/extender/build.yml
@@ -1,13 +1,16 @@
 context:
     includes: ['{{dynamo_home}}/include', '{{dynamo_home}}/sdk/include', '{{dynamo_home}}/ext/include']
-    symbols: ["DefaultSoundDevice", "AudioDecoderWav", "CrashExt", "AudioDecoderStbVorbis", "WebViewExt", "IAPExt", "IACExt", "PushExt", "FacebookExt", "ProfilerExt", "GraphicsAdapterOpenGL",
+    symbols: ["DefaultSoundDevice", "AudioDecoderWav", "CrashExt", "AudioDecoderStbVorbis", "WebViewExt", "IAPExt", "IACExt", "PushExt", "FacebookExt", "ProfilerExt", "GraphicsAdapterOpenGL","LiveUpdateExt",
                 "ResourceTypeGameObject", "ResourceTypeCollection", "ResourceTypeScript", "ResourceTypeLua", "ResourceTypeAnim", "ResourceTypeAnimationSet", "ResourceTypeGui", "ResourceTypeGuiScript",
                 "ComponentTypeScript", "ComponentTypeAnim", "ComponentTypeGui"]
     allowedLibs: ["engine","engine_release","webviewext","profile","profile_null","remotery","remotery_null","profilerext","profilerext_null","crashext","crashext_null","facebookext","iapext","pushext","iacext","record","record_null","gameobject","ddf","resource","gamesys","graphics","graphics_null","graphics_transcoder_null","graphics_transcoder_basisu","basis_transcoder","physics_2d","physics_3d","physics_null","BulletDynamics","BulletCollision","LinearMath","Box2D","render","script","luajit-5.1","extension","hid","hid_null","input","particle","rig","dlib","dmglfw","gui","crashext","sound","sound_null","tremolo","vpx","liveupdate",
                   "libengine.lib","libengine_release.lib","libwebviewext.lib","libprofile.lib","libprofile_null.lib","libremotery.lib","libremotery_null.lib","libprofilerext.lib","libprofilerext_null.lib","libcrashext","libcrashext_null","libfacebookext.lib","libiapext.lib","libpushext.lib","libiacext.lib","librecord.lib","librecord_null.lib","libgameobject.lib","libddf.lib","libresource.lib","libgamesys.lib","libgraphics.lib","libgraphics_null.lib","libgraphics_transcoder_null.lib","libgraphics_transcoder_basisu.lib","libbasis_transcoder.lib","libphysics_2d.lib","libphysics_3d.lib","libphysics_null.lib","libBulletDynamics.lib","libBulletCollision.lib","libLinearMath.lib","libBox2D.lib","librender.lib",
                   "libscript.lib","libluajit.lib-5.1","libextension.lib","libhid.lib","libhid_null.lib","libinput.lib","libparticle.lib","librig.lib","libdlib.lib","libdmglfw.lib","libgui.lib","libcrashext.lib","libsound.lib","libsound_null.lib","libtremolo.lib","libvpx.lib","libliveupdate.lib",
                   "engine_service","engine_service_null","libengine_service.lib","libengine_service_null.lib"]
-    allowedSymbols: ["DefaultSoundDevice", "NullSoundDevice", "AudioDecoderWav", "CrashExt", "AudioDecoderStbVorbis", "WebViewExt", "IAPExt", "IACExt", "PushExt", "FacebookExt", "ProfilerExt", "GraphicsAdapterOpenGL", "GraphicsAdapterVulkan", "GraphicsAdapterNull"]
+    allowedSymbols: ["DefaultSoundDevice", "NullSoundDevice", "AudioDecoderWav", "CrashExt", "AudioDecoderStbVorbis",
+                    "WebViewExt", "IAPExt", "IACExt", "PushExt", "FacebookExt",
+                    "ProfilerExt", "GraphicsAdapterOpenGL", "GraphicsAdapterVulkan", "GraphicsAdapterNull",
+                    "LiveUpdateExt"]
     defines: ['DLIB_LOG_DOMAIN="{{extension_name_upper}}"']
 
 main: |


### PR DESCRIPTION
We've moved some liveupdate specific functions from the `resources.` Lua module, to the `liveupdate.*` module.
We've also deprecated the usage of the old functions in the resources module.

Part of the #3207 epic ticket