### PR TITLE
Redesign game.project form

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -78,7 +78,7 @@
 
                      [org.luaj/luaj-jse "3.0.1"]
 
-                     [cljfx "1.7.19"]
+                     [cljfx "1.7.20"]
 
                      [org.openjfx/javafx-base "18"]
                      [org.openjfx/javafx-base "18" :classifier "linux"]

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -702,7 +702,7 @@
    :label "Info.plist",
    :default "/builtins/manifests/osx/Info.plist",
    :path ["osx" "infoplist"]}
-   {:type :string,
+  {:type :string,
    :help "default language and region (CFBundleDevelopmentRegion)",
    :default "en",
    :path ["osx" "default_language"]}
@@ -785,7 +785,7 @@
    :help "scale mode for canvas, by default 'Downscale Fit'",
    :default "downscale_fit",
    :path ["html5" "scale_mode"]
-   :options [["downscale_fit" "Downscale Fit"] ["fit" "Fit"] ["stretch" "Stretch"] ["no_scale" "No Scale" ]]}
+   :options [["downscale_fit" "Downscale Fit"] ["fit" "Fit"] ["stretch" "Stretch"] ["no_scale" "No Scale"]]}
   {:type :string,
    :help "the application id as issued by Facebook",
    :default "",
@@ -817,43 +817,79 @@
    :help "max number of concurrent (visible) tiles in a collection",
    :default 2048,
    :path ["tilemap" "max_tile_count"]}]
-
+ :group-order ["Main" "Platforms" "Components" "Runtime" "Distribution"]
+ :default-category "project"
  :categories
- {"sound" {:help "Sound related settings"},
+ {"sound" {:help "Sound related settings"
+           :group "Components"},
   "html5" {:help "HTML5 related settings"
-           :title "HTML5"},
-  "resource" {:help "Resource loading and management related settings"},
-  "factory" {:help "GameObject factory related settings"},
-  "graphics" {:help "Graphics related settings"},
-  "engine" {:help "Runtime settings for the engine"},
-  "bootstrap" {:help "Initial settings for the engine"},
-  "label" {:help "Label related settings"},
-  "collection" {:help "Collection related settings"},
-  "project" {:help "General project settings"},
-  "collectionfactory" {:title "Collection Factory"}
-  "collection_proxy" {:help "Collection proxy related settings"}
-  "physics" {:help "Physics settings"},
+           :title "HTML5"
+           :group "Platforms"},
+  "resource" {:help "Resource loading and management related settings"
+              :group "Runtime"},
+  "factory" {:help "GameObject factory related settings"
+             :group "Components"},
+  "graphics" {:help "Graphics related settings"
+              :group "Runtime"},
+  "engine" {:help "Runtime settings for the engine"
+            :group "Runtime"},
+  "bootstrap" {:help "Initial settings for the engine"
+               :group "Main"},
+  "label" {:help "Label related settings"
+           :group "Components"},
+  "collection" {:help "Collection related settings"
+                :group "Components"},
+  "project" {:help "General project settings"
+             :group "Main"},
+  "collectionfactory" {:title "Collection Factory"
+                       :group "Components"}
+  "collection_proxy" {:help "Collection proxy related settings"
+                      :group "Components"}
+  "physics" {:help "Physics settings"
+             :group "Runtime"},
   "osx" {:help "Mac OSX related settings"
-         :title "OSX"},
-  "network" {:help "Network related settings"},
-  "script" {:help "Script system settings"},
-  "shader" {:help "Shader related settings"}
+         :title "OSX"
+         :group "Platforms"},
+  "network" {:help "Network related settings"
+             :group "Runtime"},
+  "script" {:help "Script system settings"
+            :group "Components"},
+  "shader" {:help "Shader related settings"
+            :group "Runtime"}
   "gui" {:help "GUI related settings"
-         :title "GUI"},
-  "sprite" {:help "Sprite related settings"},
-  "tilemap", {:help "Tilemap related settings"},
-  "facebook" {:help "Facebook related settings"},
-  "windows" {:help "Windows related settings"},
-  "input" {:help "Input related settings"},
-  "library" {:help "Settings for when this project is used as a library by another project"},
-  "display" {:help "Resolution and other display related settings"},
+         :title "GUI"
+         :group "Components"},
+  "sprite" {:help "Sprite related settings"
+            :group "Components"},
+  "tilemap" {:help "Tilemap related settings"
+             :group "Components"},
+  "facebook" {:help "Facebook related settings"
+              :group "Runtime"},
+  "windows" {:help "Windows related settings"
+             :group "Platforms"},
+  "input" {:help "Input related settings"
+           :group "Runtime"},
+  "library" {:help "Settings for when this project is used as a library by another project"
+             :group "Distribution"},
+  "display" {:help "Resolution and other display related settings"
+             :group "Runtime"},
   "ios" {:help "iOS related settings"
-         :title "iOS"},
+         :title "iOS"
+         :group "Platforms"},
   "iap" {:help "In App Purchase related settings"
-         :title "IAP"},
+         :title "IAP"
+         :group "Runtime"},
+  "mesh" {:group "Components"}
+  "model" {:group "Components"}
+  "render" {:group "Runtime"}
   "particle_fx" {:help "Particle FX related settings"
-                 :title "Particle FX"},
-  "android" {:help "Android related settings"},
-  "liveupdate" {:help "Liveupdate settings"},
-  "native_extension" {:help "Settings for native extensions"},
-  "profiler" {:help "Settings related to the runtime profiler"}}}
+                 :title "Particle FX"
+                 :group "Components"},
+  "android" {:help "Android related settings"
+             :group "Platforms"},
+  "liveupdate" {:help "Liveupdate settings"
+                :group "Distribution"},
+  "native_extension" {:help "Settings for native extensions"
+                      :group "Distribution"},
+  "profiler" {:help "Settings related to the runtime profiler"
+              :group "Runtime"}}}

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -27,7 +27,6 @@
             [cljfx.fx.image-view :as fx.image-view]
             [cljfx.fx.label :as fx.label]
             [cljfx.fx.list-view :as fx.list-view]
-            [cljfx.fx.menu-button :as fx.menu-button]
             [cljfx.fx.menu-item :as fx.menu-item]
             [cljfx.fx.scroll-pane :as fx.scroll-pane]
             [cljfx.fx.separator :as fx.separator]
@@ -38,6 +37,9 @@
             [cljfx.fx.text-formatter :as fx.text-formatter]
             [cljfx.fx.tooltip :as fx.tooltip]
             [cljfx.fx.v-box :as fx.v-box]
+            [cljfx.lifecycle :as fx.lifecycle]
+            [cljfx.mutator :as fx.mutator]
+            [cljfx.prop :as fx.prop]
             [clojure.set :as set]
             [clojure.string :as string]
             [dynamo.graph :as g]
@@ -53,7 +55,8 @@
             [editor.ui :as ui]
             [editor.url :as url]
             [editor.view :as view]
-            [editor.workspace :as workspace])
+            [editor.workspace :as workspace]
+            [internal.util :as util])
   (:import [javafx.event Event]
            [javafx.scene Node]
            [javafx.scene.control Cell ComboBox ListView$EditEvent ScrollPane TableColumn$CellEditEvent TableView ListView]
@@ -1160,12 +1163,8 @@
                                       (not= ::no-value state)
                                       (assoc :state state))]}))))
 
-(defn- section-id [title]
-  (string/replace title " " "-"))
-
 (defn- section-view [{:keys [title help fields values ui-state resource-string-converter visible]}]
   {:fx/type fx.v-box/lifecycle
-   :id (section-id title)
    :visible visible
    :managed visible
    :children (cond-> []
@@ -1263,14 +1262,42 @@
   (when (= KeyCode/ESCAPE (.getCode event))
     {:set-ui-state (assoc ui-state :filter-term "")}))
 
-(defn- filter-text-field [{:keys [text]}]
-  {:fx/type fx.text-field/lifecycle
-   :id "filter-text-field"
-   :style-class ["text-field" "filter-text-field"]
-   :prompt-text "Filter"
-   :text text
-   :on-key-pressed {:event-type :filter-key-pressed}
-   :on-text-changed {:event-type :filter-text-changed}})
+(defmethod handle-event :navigate-sections [{:keys [fx/event ui-state sections selected-section-title]}]
+  (when (instance? KeyEvent event)
+    (let [^KeyEvent event event]
+      (when (= KeyEvent/KEY_PRESSED (.getEventType event))
+        (condp = (.getCode event)
+          KeyCode/DOWN
+          (do (.consume event)
+              (when-let [next-section (->> sections
+                                           (drop-while #(not= % selected-section-title))
+                                           second)]
+                {:set-ui-state (assoc ui-state :selected-section-title next-section)}))
+
+          KeyCode/UP
+          (do (.consume event)
+              (when-let [prev-section (->> sections
+                                           (take-while #(not= % selected-section-title))
+                                           last)]
+                {:set-ui-state (assoc ui-state :selected-section-title prev-section)}))
+
+          nil)))))
+
+(defn- filter-text-field [{:keys [text sections selected-section-title]}]
+  (wrap-focus-text-field
+    {:fx/type fx.text-field/lifecycle
+     :id "filter-text-field"
+     :min-height :use-pref-size
+     :pref-height 10
+     :max-height :use-pref-size
+     :style-class ["text-field" "filter-text-field"]
+     :prompt-text "Filter"
+     :text text
+     :event-filter {:event-type :navigate-sections
+                    :sections sections
+                    :selected-section-title selected-section-title}
+     :on-key-pressed {:event-type :filter-key-pressed}
+     :on-text-changed {:event-type :filter-text-changed}}))
 
 ;; endregion
 
@@ -1298,74 +1325,128 @@
 
 ;; region jump-to
 
-(defmethod handle-event :jump-to [{:keys [section ^Node parent]}]
-  (let [^ScrollPane scroll-pane (.lookup parent "#scroll-pane")
-        ^Node node (.lookup parent (str "#" section))
-        content-height (-> scroll-pane .getContent .getBoundsInLocal .getHeight)
-        viewport-height (-> scroll-pane .getViewportBounds .getHeight)]
-    (when (> content-height viewport-height)
-      (.setVvalue scroll-pane (/ (- (.getMinY (.getBoundsInParent node))
-                                    24)                     ;; form padding
-                                 (- content-height viewport-height))))))
+(defmethod handle-event :jump-to [{:keys [section ui-state]}]
+  {:set-ui-state (assoc ui-state :selected-section-title section)})
 
-(defn- jump-to-button [{:keys [visible-titles]}]
-  {:fx/type fx.menu-button/lifecycle
-   :text "Jump to..."
-   :style-class "jump-to-menu-button"
-   :disable (empty? visible-titles)
-   :items (->> visible-titles
-               (sort #(.compareToIgnoreCase ^String %1 %2))
-               (mapv (fn [title]
-                       {:fx/type fx.menu-item/lifecycle
-                        :on-action {:event-type :jump-to
-                                    :section (section-id title)}
-                        :text title})))})
+(defn- form-sections [{:keys [groups sections selected-section-title]}]
+  {:fx/type fx/ext-let-refs
+   :refs (into {}
+               (comp
+                 (mapcat val)
+                 (map (juxt identity
+                            (fn [title]
+                              {:fx/type fx.label/lifecycle
+                               :pseudo-classes (if (= title selected-section-title) #{:active} #{})
+                               :max-width ##Inf
+                               :style-class "cljfx-form-section-button"
+                               :on-mouse-clicked {:event-type :jump-to :section title}
+                               :text title}))))
+               groups)
+   :desc {:fx/type fxui/ext-ensure-scroll-pane-child-visible
+          :child-desc {:fx/type fx/ext-get-ref :ref selected-section-title}
+          :scroll-pane-desc {:fx/type fx.scroll-pane/lifecycle
+                             :event-filter {:event-type :navigate-sections
+                                            :sections sections
+                                            :selected-section-title selected-section-title}
+                             :style-class "cljfx-form-contents-scroll-pane"
+                             :hbar-policy :never
+                             :fit-to-width true
+                             :fit-to-height true
+                             :content {:fx/type fx.v-box/lifecycle
+                                       :fill-width true
+                                       :spacing 16
+                                       :children (mapv (fn [[group titles]]
+                                                         {:fx/type fx.v-box/lifecycle
+                                                          :fill-width true
+                                                          :children (into [{:fx/type fx.label/lifecycle
+                                                                            :style-class "cljfx-form-section-header"
+                                                                            :text group}]
+                                                                          (map
+                                                                            (fn [title]
+                                                                              {:fx/type fx/ext-get-ref :ref title}))
+                                                                          titles)})
+                                                       groups)}}}})
 
 ;; endregion
 
 (defn- form-view [{:keys [parent form-data ui-state resource-string-converter]}]
-  (let [{:keys [sections values]} form-data
+  (let [{:keys [sections values group-order default-section-name]} form-data
         filter-term (:filter-term ui-state)
-        sections-with-visibility (mapv #(set-section-visibility % values filter-term)
-                                       sections)
-        visible-titles (into []
-                             (comp
-                               (filter :visible)
-                               (map :title))
-                             sections-with-visibility)
-        section-views (make-section-views sections-with-visibility
-                                          values
-                                          ui-state
-                                          resource-string-converter)]
+        sections-with-visibility (mapv #(set-section-visibility % values filter-term) sections)
+        navigation (:navigation form-data true)]
     {:fx/type with-anchor-pane-props
      :desc {:fx/type fxui/ext-value
             :value parent}
-     :props {:children (cond-> []
-                               (:navigation form-data true)
-                               (conj {:fx/type fx.h-box/lifecycle
-                                      :style-class "cljfx-form-floating-area"
-                                      :anchor-pane/top 24
-                                      :anchor-pane/right 24
-                                      :view-order 0
-                                      :children [{:fx/type filter-text-field
-                                                  :text filter-term}
-                                                 {:fx/type jump-to-button
-                                                  :visible-titles visible-titles}]})
+     :props {:children [(if navigation
+                          (let [visible-sections (filterv :visible sections-with-visibility)
+                                groups (->> visible-sections
+                                            (util/group-into
+                                              {}
+                                              (sorted-set-by #(.compareToIgnoreCase ^String %1 %2))
+                                              :group
+                                              :title)
+                                            (sort-by #(group-order (key %) ##Inf)))
+                                visible-titles (into #{} (map :title) visible-sections)
+                                selected-section-title (or (-> ui-state :selected-section-title (or default-section-name) visible-titles)
+                                                           (some-> groups first val first visible-titles))]
+                            {:fx/type :h-box
+                             :anchor-pane/top 0
+                             :anchor-pane/right 0
+                             :anchor-pane/bottom 0
+                             :anchor-pane/left 0
+                             :children [{:fx/type fx.v-box/lifecycle
+                                         :min-width 160
+                                         :pref-width 160
+                                         :style-class "cljfx-form-contents"
+                                         :view-order 0
+                                         :children [{:fx/type filter-text-field
+                                                     :v-box/margin 12
+                                                     :text filter-term
+                                                     :sections (mapcat val groups)
+                                                     :selected-section-title selected-section-title}
+                                                    {:fx/type form-sections
+                                                     :sections (mapcat val groups)
+                                                     :selected-section-title selected-section-title
+                                                     :groups groups}]}
+                                        {:fx/type fx/ext-let-refs
+                                         :h-box/hgrow :always
+                                         :refs (into {}
+                                                     (map (juxt :title
+                                                                #(assoc % :fx/type section-view
+                                                                          :values values
+                                                                          :ui-state ui-state
+                                                                          :resource-string-converter resource-string-converter)))
+                                                     sections-with-visibility)
+                                         :desc {:fx/type fx/ext-on-instance-lifecycle
+                                                :on-created #(ui/context! % :form {:root parent} nil)
+                                                :desc {:fx/type fx.scroll-pane/lifecycle
+                                                       :id "scroll-pane"
+                                                       :view-order 1
+                                                       :fit-to-width true
+                                                       :content {:fx/type fx.v-box/lifecycle
+                                                                 :style-class "cljfx-form"
+                                                                 :children (if selected-section-title
+                                                                             [{:fx/type fx/ext-get-ref
+                                                                               :ref selected-section-title}]
+                                                                             [])}}}}]})
 
-                               :always
-                               (conj {:fx/type fx/ext-on-instance-lifecycle
-                                      :anchor-pane/top 0
-                                      :anchor-pane/right 0
-                                      :anchor-pane/bottom 0
-                                      :anchor-pane/left 0
-                                      :on-created #(ui/context! % :form {:root parent} nil)
-                                      :desc {:fx/type fx.scroll-pane/lifecycle
-                                             :id "scroll-pane"
-                                             :view-order 1
-                                             :fit-to-width true
-                                             :content {:fx/type fx.v-box/lifecycle
-                                                       :style-class "cljfx-form"
-                                                       :children section-views}}}))}}))
+                          {:fx/type fx/ext-on-instance-lifecycle
+                           :anchor-pane/top 0
+                           :anchor-pane/right 0
+                           :anchor-pane/bottom 0
+                           :anchor-pane/left 0
+                           :on-created #(ui/context! % :form {:root parent} nil)
+                           :desc {:fx/type fx.scroll-pane/lifecycle
+                                  :id "scroll-pane"
+                                  :view-order 1
+                                  :fit-to-width true
+                                  :content {:fx/type fx.v-box/lifecycle
+                                            :style-class "cljfx-form"
+                                            :children (make-section-views
+                                                        sections-with-visibility
+                                                        values
+                                                        ui-state
+                                                        resource-string-converter)}}})]}}))
 
 (defn- wrap-force-refresh [f view-id]
   (fn [event]
@@ -1430,6 +1511,7 @@
         repaint-timer (ui/->timer 30 "refresh-form-view"
                                   (fn [_timer _elapsed]
                                     (g/node-value view-id :form-view)))]
+    (g/node-value view-id :form-view)
     (ui/timer-start! repaint-timer)
     (ui/timer-stop-on-closed! tab repaint-timer)
     view-id))

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -38,7 +38,7 @@
            [javafx.scene Node]
            [javafx.beans.property ReadOnlyProperty]
            [javafx.beans.value ChangeListener]
-           [javafx.scene.control TextInputControl ListView]
+           [javafx.scene.control TextInputControl ListView ScrollPane]
            [javafx.util Callback]))
 
 (set! *warn-on-reflection* true)
@@ -94,6 +94,49 @@
     (delete [_ component opts]
       (binding [fx.lifecycle/*in-progress?* false]
         (fx.lifecycle/delete fx.lifecycle/dynamic component opts)))))
+
+(def ^:private ext-ensure-scroll-pane-child-visible-impl
+  (fx/make-ext-with-props
+    {:ensure-visible
+     (fx.prop/make
+       (fx.mutator/setter
+         (fn [^ScrollPane pane ^Node child]
+           (when child
+             (let [content-height (-> pane .getContent .getBoundsInLocal .getHeight)
+                   viewport-bounds (.getViewportBounds pane)
+                   viewport-height (.getHeight viewport-bounds)
+                   viewport-bottom (- (.getHeight viewport-bounds) (.getMinY viewport-bounds))
+                   child-bounds (-> pane .getContent (.sceneToLocal (.localToScene child (.getBoundsInLocal child))))]
+               (when (< viewport-height content-height)
+                 (cond
+                   ;; when child view is below viewport, scroll down
+                   (< viewport-bottom (.getMaxY child-bounds))
+                   (.setVvalue pane (/ (- (.getMaxY child-bounds) (.getHeight viewport-bounds))
+                                       (- content-height viewport-height)))
+                   ;; when child view is above viewport, scroll down
+                   (< (.getMinY child-bounds) (- (.getMinY viewport-bounds)))
+                   (.setVvalue pane (/ (.getMinY child-bounds)
+                                       (- content-height viewport-height)))))))))
+       fx.lifecycle/dynamic)}))
+
+(defn ext-ensure-scroll-pane-child-visible
+  "Extension lifecycle that ensures ScrollPane's child node is visible
+
+  This extension will perform scroll whenever the child node is changed
+
+  Expected props:
+
+    :scroll-pane-desc    cljfx description (required) that resolves to
+                         a ScrollPane instance
+    :child-desc          cljfx description (optional) that resolves to a Node
+                         that is also present in the ScrollPane's content. This
+                         can be achieved using fx/ext-let-refs + fx/ext-get-ref"
+  [{:keys [scroll-pane-desc child-desc]}]
+  {:fx/type ext-ensure-scroll-pane-child-visible-impl
+   :props (if (some? child-desc)
+            {:ensure-visible child-desc}
+            {})
+   :desc scroll-pane-desc})
 
 (defn make-event-filter-prop
   "Creates a prop-config that will add event filter for specified `event-type`

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -98,11 +98,15 @@
     (= :comma-separated-list (:type setting))
     (assoc :type :list :element {:type :string :default (or (first (:default setting)) "item")})))
 
+(defn- section-title [category-name category-info]
+  (or (:title category-info)
+      (->> (string/split category-name #"(_|\s+)")
+           (mapv string/capitalize)
+           (string/join " "))))
+
 (defn- make-form-section [category-name category-info settings]
-  {:title (or (:title category-info)
-              (->> (string/split category-name #"(_|\s+)")
-                   (mapv string/capitalize)
-                   (string/join " ")))
+  {:title (section-title category-name category-info)
+   :group (:group category-info "Other")
    :help (:help category-info)
    :fields (mapv make-form-field settings)})
 
@@ -111,8 +115,18 @@
         categories (distinct (mapv settings-core/presentation-category meta-settings))
         category->settings (group-by settings-core/presentation-category meta-settings)
         sections (mapv #(make-form-section % (get-in meta-info [:categories %]) (category->settings %)) categories)
-        values (make-form-values-map settings)]
-    {:form-ops form-ops :sections sections :values values :meta-settings meta-settings}))
+        values (make-form-values-map settings)
+        group-order (into {}
+                          (map-indexed (fn [i v]
+                                         [v i]))
+                          (:group-order meta-info))]
+    {:form-ops form-ops
+     :sections sections
+     :values values
+     :meta-settings meta-settings
+     :group-order group-order
+     :default-section-name (when-let [category-name (:default-category meta-info)]
+                             (section-title category-name (get-in meta-info [:categories category-name])))}))
 
 (defn get-setting-error [setting-value meta-setting label]
   (cond

--- a/editor/styling/stylesheets/components/_cljfx-form.css
+++ b/editor/styling/stylesheets/components/_cljfx-form.css
@@ -109,54 +109,55 @@
   }
 }
 
-@mixin floating-input() {
-  -fx-border-color: -df-component-light;
-  -fx-border-radius: 2px;
-  -fx-background-radius: 3px;
-  -fx-pref-width: 120px;
-  -fx-background-position: right 6px center;
-  -fx-background-repeat: no-repeat;
-  -fx-padding: 4px 22px 4px 8px;
-}
-
-.cljfx-form-floating-area {
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.2), 8, 0, 0, 4);
-  -fx-background-color: -df-component-darker;
-  -fx-background-radius: 6px;
-  -fx-padding: 12px;
-  -fx-spacing: 8px;
+.cljfx-form-contents {
+  -fx-background-color: derive(-df-background-light, 5%);
 
   .filter-text-field {
-    @include floating-input();
-    -fx-background-color: rgba(0, 0, 0, 0.1);
+    -fx-border-color: -df-component-light;
+    -fx-border-radius: 2px;
+    -fx-background-radius: 3px;
+    -fx-pref-width: 120px;
+    -fx-background-position: right 6px center;
+    -fx-background-repeat: no-repeat;
+    -fx-padding: 4px 22px 4px 8px;
+    -fx-background-color: -df-background-light;
     -fx-background-image: url("icons/32/Icons_M_09_search.png");
     -fx-background-size: 15px;
     -fx-cursor: text;
     &:focused {
       -fx-padding: 4px 22px 3px 8px;
-      -fx-background-color: -df-component-dark;
+      -fx-background-color: -df-background;
       -fx-border-color: -df-component-light -df-component-light -df-defold-orange -df-component-light;
     }
   }
-
-  .jump-to-menu-button {
-    @include floating-input();
-    -fx-focus-traversable: false;
-    -fx-background-color: rgba(0, 0, 0, 0.1);
-    -fx-background-image: url("icons/32/Icons_S_05_arrowdown.png");
-
-    &:hover {
-      -fx-background-color: -df-component-light;
-    }
-    &:disabled {
-      .label {
-        -fx-opacity: 1;
+  & .scroll-bar {
+    -fx-background-color: derive(-df-background-light, 5%);
+  }
+}
+.cljfx-form-contents {
+  -fx-padding: 1px;
+  &-scroll-pane {
+    & > .viewport {-fx-background-color: transparent !important;}
+  }
+}
+.cljfx-form-section {
+  &-header {
+    -fx-padding: 2px 12px;
+    -fx-font-size: 90%;
+    -fx-text-fill: derive(-df-text, -20%);
+  }
+  &-button {
+    -fx-padding: 2px 12px;
+    -fx-text-fill: -df-text;
+    &:active {
+      -fx-text-fill: -df-text-selected;
+      -fx-background-color: -df-component;
+      &:hover {
+        -fx-background-color: -df-component;
       }
-      -fx-opacity: 0.4;
     }
-    .label {
-      -fx-alignment: center-left;
+    &:hover {
+      -fx-background-color: -df-component-dark;
     }
-
   }
 }


### PR DESCRIPTION
This changeset alters the UI of forms that requested navigation (currently only game.project form) in a following way:
- the form shows sections UI organized in groups;
- the form shows at most one section at a time.

Fixes #6740