### PR TITLE
Make sure `game.arcd` isn't compressed in `apk`/`aab`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -36,10 +36,12 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
 
@@ -228,6 +230,27 @@ public class BundlerTest {
         }
     }
 
+    
+    private void verifyArchive() throws IOException
+    {
+        String projectName = "unnamed";
+        File outputDirFile = getOutputDirFile(outputDir, projectName);
+        assertTrue(outputDirFile.exists());
+        switch (platform)
+        {
+            case Arm64Android:
+            case Armv7Android:
+            {
+                File outputApk = new File(outputDirFile, projectName + ".apk");
+                assertTrue(outputApk.exists());
+                ZipFile apkZip = new ZipFile(outputApk.getAbsolutePath());
+                ZipEntry zipEntry = apkZip.getEntry("assets/game.arcd");
+                assertFalse(zipEntry == null);
+                assertEquals(zipEntry.getMethod(), ZipEntry.STORED);
+            }
+        }
+    }
+
     private List<String> getZipFiles(File zipFile) throws IOException {
         List<String> files = new ArrayList<String>();
         InputStream inputStream = new FileInputStream(zipFile);
@@ -388,6 +411,7 @@ public class BundlerTest {
         createDefaultFiles(contentRoot);
         createFile(contentRoot, "test.icns", "test_icon");
         build();
+        verifyArchive();
     }
 
     private String createFile(String root, String name, String content) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -248,6 +248,7 @@ public class BundlerTest {
                 assertFalse(zipEntry == null);
                 assertEquals(zipEntry.getMethod(), ZipEntry.STORED);
             }
+            break;
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -606,8 +606,13 @@ public class AndroidBundler implements IBundler {
         log("Creating Android Application Bundle");
         try {
             File bundletool = new File(Bob.getLibExecPath("bundletool-all.jar"));
-
             File baseAab = new File(outDir, getProjectTitle(project) + ".aab");
+
+            File aabDir = new File(outDir, "aab");
+            File baseConfig = new File(aabDir, "BundleConfig.json");
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(baseConfig))) {
+                writer.write("{\"compression\":{\"uncompressedGlob\": [\"assets/game.arcd\"]}}");
+            }
 
             List<String> args = new ArrayList<String>();
             args.add(getJavaBinFile("java")); args.add("-jar");
@@ -615,6 +620,7 @@ public class AndroidBundler implements IBundler {
             args.add("build-bundle");
             args.add("--modules"); args.add(baseZip.getAbsolutePath());
             args.add("--output"); args.add(baseAab.getAbsolutePath());
+            args.add("--config"); args.add(baseConfig.getAbsolutePath());
 
             Result res = exec(args);
             if (res.ret != 0) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/ZipUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/ZipUtil.java
@@ -61,7 +61,7 @@ public class ZipUtil {
 		boolean isAsset = filePath.startsWith("assets");
 		if (isAsset) {
 			// Set up an uncompressed file, unfortunately need to calculate crc32 and other data for this to work.
-			// https://blogs.oracle.com/CoreJavaTechTips/entry/creating_zip_and_jar_files
+			// https://www.infoworld.com/article/2071337/creating-zip-and-jar-files.html
 			crc = new CRC32();
 			zipMethod = ZipEntry.STORED;
 			ze.setCompressedSize(fileSize);


### PR DESCRIPTION
Keep the main resource archive `game.arcd` in the Android bundle uncompressed to prevent unnecessary memory allocations in runtime.

Fix https://github.com/defold/defold/issues/6766