### PR TITLE
Show .defignore in the editor

### DIFF
--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -118,7 +118,9 @@
       (ignored-proj-path? root path)))
 
 (defn- file-resource-filter [^File root ^File f]
-  (not (or (= (.charAt (.getName f) 0) \.)
+  (not (or (let [file-name (.getName f)]
+             (and (str/starts-with? file-name ".")
+                  (not= file-name ".defignore")))
            (reserved-proj-path? root (resource/file->proj-path root f)))))
 
 (defn- make-file-tree


### PR DESCRIPTION
This changeset makes the editor show .defignore file (both in Assets and Changed Files views) even though its name starts with dot.

Fixes #6428
Fixes #6429