### PR TITLE
Report defignored files as non-existent

### DIFF
--- a/editor/src/clj/editor/code/text_file.clj
+++ b/editor/src/clj/editor/code/text_file.clj
@@ -60,6 +60,9 @@
     :icon "icons/32/Icons_11-Script-general.png"}
    {:ext "appmanifest"
     :label "App Manifest"
+    :icon "icons/32/Icons_11-Script-general.png"}
+   {:ext "defignore"
+    :label "Defignore"
     :icon "icons/32/Icons_11-Script-general.png"}])
 
 (g/defnode TextNode

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -96,10 +96,10 @@
   (openable? [this] (resource/openable? resource))
 
   io/IOFactory
-  (io/make-input-stream  [this opts] (io/input-stream resource))
-  (io/make-reader        [this opts] (io/reader resource))
-  (io/make-output-stream [this opts] (io/output-stream resource))
-  (io/make-writer        [this opts] (io/writer resource)))
+  (make-input-stream  [this opts] (io/input-stream resource))
+  (make-reader        [this opts] (io/reader resource))
+  (make-output-stream [this opts] (io/output-stream resource))
+  (make-writer        [this opts] (io/writer resource)))
 
 (defn- make-custom-build-target [node-id resource]
   (bt/with-content-hash

--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -96,26 +96,9 @@
 
 (def reserved-proj-paths #{"/builtins" "/build" "/.internal" "/.git"})
 
-(def ^:private ignored-proj-paths-atom (atom nil))
-
-(defn- ignored-proj-paths [^File root]
-  (assert (and (some? root)
-               (.isDirectory root)))
-  (swap! ignored-proj-paths-atom
-         (fn [ignored-proj-paths]
-           (if (some? ignored-proj-paths)
-             ignored-proj-paths
-             (let [defignore-file (io/file root ".defignore")]
-               (if (.isFile defignore-file)
-                 (set (str/split-lines (slurp defignore-file)))
-                 #{}))))))
-
-(defn ignored-proj-path? [^File root path]
-  (contains? (ignored-proj-paths root) path))
-
 (defn reserved-proj-path? [^File root path]
   (or (reserved-proj-paths path)
-      (ignored-proj-path? root path)))
+      (resource/ignored-project-path? root path)))
 
 (defn- file-resource-filter [^File root ^File f]
   (not (or (let [file-name (.getName f)]

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -79,13 +79,13 @@ ordinary paths."
   (openable? [this] false)
 
   io/IOFactory
-  (io/make-input-stream  [this opts] (io/make-input-stream (File. (resource/abs-path this)) opts))
-  (io/make-reader        [this opts] (io/make-reader (io/make-input-stream this opts) opts))
-  (io/make-output-stream [this opts] (let [file (File. (resource/abs-path this))] (io/make-output-stream file opts)))
-  (io/make-writer        [this opts] (io/make-writer (io/make-output-stream this opts) opts))
+  (make-input-stream  [this opts] (io/make-input-stream (File. (resource/abs-path this)) opts))
+  (make-reader        [this opts] (io/make-reader (io/make-input-stream this opts) opts))
+  (make-output-stream [this opts] (let [file (File. (resource/abs-path this))] (io/make-output-stream file opts)))
+  (make-writer        [this opts] (io/make-writer (io/make-output-stream this opts) opts))
 
   io/Coercions
-  (io/as-file [this] (File. (resource/abs-path this))))
+  (as-file [this] (File. (resource/abs-path this))))
 
 (def build-resource? (partial instance? BuildResource))
 

--- a/editor/src/reveal/editor/reveal.clj
+++ b/editor/src/reveal/editor/reveal.clj
@@ -7,6 +7,7 @@
             [internal.graph.types :as gt]
             [internal.system :as is])
   (:import [clojure.lang IRef]
+           [editor.resource FileResource ZipResource]
            [internal.graph.types Endpoint]))
 
 (defn- node-value-or-err [ec node-id label]
@@ -120,3 +121,15 @@
     r/separator
     (r/stream (gt/endpoint-label endpoint))
     (r/raw-string "]" {:fill :object})))
+
+(r/defstream FileResource [resource]
+  (r/horizontal
+    (r/raw-string "#resource/file" {:fill :object})
+    r/separator
+    (r/stream (resource/proj-path resource))))
+
+(r/defstream ZipResource [resource]
+  (r/horizontal
+    (r/raw-string "#resource/zip" {:fill :object})
+    r/separator
+    (r/stream (resource/proj-path resource))))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -177,10 +177,10 @@
   (openable? [this] (= :file source-type))
 
   io/IOFactory
-  (io/make-input-stream  [this opts] (io/make-input-stream content opts))
-  (io/make-reader        [this opts] (io/make-reader (io/make-input-stream this opts) opts))
-  (io/make-output-stream [this opts] (assert false "writing to not supported"))
-  (io/make-writer        [this opts] (assert false "writing to not supported")))
+  (make-input-stream  [this opts] (io/make-input-stream content opts))
+  (make-reader        [this opts] (io/make-reader (io/make-input-stream this opts) opts))
+  (make-output-stream [this opts] (assert false "writing to not supported"))
+  (make-writer        [this opts] (assert false "writing to not supported")))
 
 (defn make-fake-file-resource
   ([workspace root file content]


### PR DESCRIPTION
Additionally, this changeset makes the editor sync resources after save if `.defignore` file was modified.

Fixes #6400