### PR TITLE
Update copyright year to 2022

### DIFF
--- a/editor/bundle-resources/Info.plist
+++ b/editor/bundle-resources/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Defold</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Defold, Copyright Defold Foundation. 2009-2021. All rights reserved.</string>
+	<string>Defold, Copyright Defold Foundation. 2009-2022. All rights reserved.</string>
 	<key>CFBundleIconFile</key>
 	<string>logo.icns</string>
 	<key>CFBundleIdentifier</key>

--- a/editor/resources/splash.fxml
+++ b/editor/resources/splash.fxml
@@ -26,7 +26,7 @@
             <Button id="error-button" text="Exit" visible="false" />
             <TextFlow id="startup-tip" maxWidth="500.0"/>
             <Label id="version" text="No Version" visible="false" wrapText="true" />
-            <Label id="copyright" text="2009–2021 Defold Foundation. All rights reserved." wrapText="true" />
+            <Label id="copyright" text="2009-2022 Defold Foundation. All rights reserved." wrapText="true" />
           </VBox>
        </AnchorPane>
        <AnchorPane id="footer" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">


### PR DESCRIPTION
The three files where the project displays copyright info are:
- `editor/bundle-resources/Info.plist`: "Defold, Copyright Defold Foundation. 2009-2022. All rights reserved." _(updated in this PR)_
- `editor/resources/splash.fxml`: "2009-2022 Defold Foundation. All rights reserved." _(updated in this PR)_
- `editor/resources/about.fxml`: "Copyright © 2009-2022" _(had already been updated by @britzl in https://github.com/defold/defold/commit/c281f9bace)_

I think the fact that each file uses a different string format contributes to people forgetting to update all three, but that may be out of scope for this PR.