### PR TITLE
Use label as tooltip text for unknown settings

### DIFF
--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -77,15 +77,9 @@
 (defn- make-form-values-map [settings]
   (settings-core/make-settings-map settings))
 
-(defn- label [key]
-  (-> key
-      name
-      camel/->Camel_Snake_Case_String
-      (string/replace "_" " ")))
-
 (defn- make-form-field [setting]
   (cond-> (assoc setting
-                 :label (or (:label setting) (label (second (:path setting))))
+                 :label (or (:label setting) (settings-core/label (second (:path setting))))
                  :optional true
                  :hidden? (:hidden? setting false))
 
@@ -100,9 +94,7 @@
 
 (defn- section-title [category-name category-info]
   (or (:title category-info)
-      (->> (string/split category-name #"(_|\s+)")
-           (mapv string/capitalize)
-           (string/join " "))))
+      (settings-core/label category-name)))
 
 (defn- make-form-section [category-name category-info settings]
   {:title (section-title category-name category-info)

--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -161,10 +161,23 @@
   (-> (add-type-defaults (edn/read reader))
       (add-to-from-string)))
 
+(defn label [key]
+  (->> (s/split (name key) #"(_|\s+)")
+       (mapv s/capitalize)
+       (s/join " ")))
+
 (defn- make-meta-settings-for-unknown [meta-settings settings]
-  (let [known-settings (set (map :path meta-settings))
-        unknown-settings (remove known-settings (map :path settings))]
-    (map (fn [setting-path] {:path setting-path :type :string :help "unknown setting" :unknown-setting? true}) unknown-settings)))
+  (let [known-settings (into #{} (map :path) meta-settings)]
+    (into []
+          (comp
+            (map :path)
+            (remove known-settings)
+            (map (fn [setting-path]
+                   {:path setting-path
+                    :type :string
+                    :help (label (last setting-path))
+                    :unknown-setting? true})))
+          settings)))
 
 (defn add-meta-info-for-unknown-settings [meta-info settings]
   (update meta-info :settings #(concat % (make-meta-settings-for-unknown % settings))))


### PR DESCRIPTION
This allows viewing the full name of a setting in a tooltip when it does not fit in its place.

Fixes #6786