### PR TITLE
Issue-6611 Make it possible to build LiveUpdate archive without `clean` command

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -126,7 +126,6 @@ public class Project {
     private String buildDirectory = "build";
     private Map<String, String> options = new HashMap<String, String>();
     private List<URL> libUrls = new ArrayList<URL>();
-    private final List<String> excludedCollectionProxies = new ArrayList<String>();
     private List<String> propertyFiles = new ArrayList<String>();
 
     private BobProjectProperties projectProperties;
@@ -1855,11 +1854,11 @@ run:
     }
 
     public void excludeCollectionProxy(String path) {
-        this.excludedCollectionProxies.add(path);
+        state.addExcludedCollectionProxy(path);
     }
 
     public final List<String> getExcludedCollectionProxies() {
-        return this.excludedCollectionProxies;
+        return state.getExcludedCollectionProxies();
     }
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/State.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/State.java
@@ -34,8 +34,9 @@ import com.dynamo.bob.fs.IResource;
  */
 public class State implements Serializable {
 
-    private static final long serialVersionUID = -275410118302470803L;
+    private static final long serialVersionUID = -275410118302470802L;
     private Map<String, byte[]> signatures = new HashMap<String, byte[]>();
+    private final List<String> excludedCollectionProxies = new ArrayList<String>();
 
     /**
      * Get signature for path
@@ -61,6 +62,7 @@ public class State implements Serializable {
      */
     public void removeSignature(String path) {
         signatures.remove(path);
+        excludedCollectionProxies.remove(path);
     }
 
     /**
@@ -69,6 +71,22 @@ public class State implements Serializable {
      */
     public List<String> getPaths() {
         return new ArrayList<>(signatures.keySet());
+    }
+
+    /**
+     * Add excluded collection proxy
+     * @param path path to the collection proxy
+     */
+    public void addExcludedCollectionProxy(String path) {
+        excludedCollectionProxies.add(path);
+    }
+
+    /**
+     * Get all excluded collection proxies
+     * @return list of all excluded collection proxies
+     */
+    public List<String> getExcludedCollectionProxies() {
+        return excludedCollectionProxies;
     }
 
     /**

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -57,6 +57,7 @@ import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.util.BobProjectProperties;
+import com.dynamo.bob.util.TimeProfiler;
 import com.dynamo.graphics.proto.Graphics.PlatformProfile;
 import com.dynamo.graphics.proto.Graphics.TextureProfile;
 import com.dynamo.graphics.proto.Graphics.TextureProfiles;
@@ -193,6 +194,7 @@ public class GameProjectBuilder extends Builder<Void> {
     }
 
     private void createArchive(Collection<String> resources, RandomAccessFile archiveIndex, RandomAccessFile archiveData, ManifestBuilder manifestBuilder, List<String> excludedResources, Path resourcePackDirectory) throws IOException, CompileExceptionError {
+        TimeProfiler.start("createArchive");
         Bob.verbose("GameProjectBuilder.createArchive\n");
         long tstart = System.currentTimeMillis();
 
@@ -220,6 +222,9 @@ public class GameProjectBuilder extends Builder<Void> {
             archiveBuilder.add(s, compress, encrypt);
         }
 
+        TimeProfiler.addData("resources", resources.size());
+        TimeProfiler.addData("excludedResources", excludedResources.size());
+
         archiveBuilder.write(archiveIndex, archiveData, resourcePackDirectory, excludedResources);
         manifestBuilder.setArchiveIdentifier(archiveBuilder.getArchiveIndexHash());
         archiveIndex.close();
@@ -234,6 +239,7 @@ public class GameProjectBuilder extends Builder<Void> {
 
         long tend = System.currentTimeMillis();
         Bob.verbose("GameProjectBuilder.createArchive took %f\n", (tend-tstart)/1000.0);
+        TimeProfiler.stop();
     }
 
     private static void findResources(Project project, Message node, Collection<String> resources) throws CompileExceptionError {
@@ -532,8 +538,11 @@ public class GameProjectBuilder extends Builder<Void> {
                 HashSet<String> resources = findResources(project, rootNode);
 
                 List<String> excludedResources = new ArrayList<String>();
-                for (String excludedResource : project.getExcludedCollectionProxies()) {
-                    excludedResources.add(excludedResource);
+                boolean shouldPublish = project.option("liveupdate", "false").equals("true");
+                if (shouldPublish) {
+                    for (String excludedResource : project.getExcludedCollectionProxies()) {
+                        excludedResources.add(excludedResource);
+                    }
                 }
 
                 ManifestBuilder manifestBuilder = this.prepareManifestBuilder(rootNode, excludedResources);


### PR DESCRIPTION
Fix issue when `bob.jar` doesn't have enough information to be able to re-create LiveUpdate archive without running `clean` command.

Fix https://github.com/defold/defold/issues/6611