### PR TITLE
Issue-6816 Fix issue when engine can't play more than 32 sounds simultaneously 

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1112,6 +1112,7 @@ namespace dmEngine
         engine->m_TilemapContext.m_MaxTileCount     = dmConfigFile::GetInt(engine->m_Config, "tilemap.max_tile_count", 2048);
 
         engine->m_SoundContext.m_MaxComponentCount  = dmConfigFile::GetInt(engine->m_Config, "sound.max_component_count", 32);
+        engine->m_SoundContext.m_MaxSoundInstances  = dmConfigFile::GetInt(engine->m_Config, "sound.max_sound_instances", 256);
 
         engine->m_CollectionProxyContext.m_Factory = engine->m_Factory;
         engine->m_CollectionProxyContext.m_MaxCollectionProxyCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::COLLECTION_PROXY_MAX_COUNT_KEY, 8);

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -74,11 +74,11 @@ namespace dmGameSystem
 
         SoundWorld* world = new SoundWorld();
         uint32_t comp_count = dmMath::Min(params.m_MaxComponentInstances, sound_context->m_MaxComponentCount);
-        const uint32_t MAX_INSTANCE_COUNT = 32;
-        world->m_Entries.SetCapacity(MAX_INSTANCE_COUNT);
-        world->m_Entries.SetSize(MAX_INSTANCE_COUNT);
-        world->m_EntryIndices.SetCapacity(MAX_INSTANCE_COUNT);
-        memset(&world->m_Entries.Front(), 0, MAX_INSTANCE_COUNT * sizeof(PlayEntry));
+        const uint32_t max_instances = sound_context->m_MaxSoundInstances;
+        world->m_Entries.SetCapacity(max_instances);
+        world->m_Entries.SetSize(max_instances);
+        world->m_EntryIndices.SetCapacity(max_instances);
+        memset(&world->m_Entries.Front(), 0, max_instances * sizeof(PlayEntry));
 
         world->m_Components.SetCapacity(comp_count);
 
@@ -408,7 +408,7 @@ namespace dmGameSystem
             }
             else
             {
-                LogMessageError(params.m_Message, "A sound could not be played since the sound buffer is full (%d).", world->m_EntryIndices.Capacity());
+                LogMessageError(params.m_Message, "A sound could not be played since all sounds instances are used (%d). Increase the project setting 'sound.max_sound_instances'", world->m_EntryIndices.Capacity());
             }
         }
         else if (params.m_Message->m_Descriptor == (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor)

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -138,6 +138,7 @@ namespace dmGameSystem
             memset(this, 0, sizeof(*this));
         }
         uint32_t                    m_MaxComponentCount;
+        uint32_t                    m_MaxSoundInstances;
     };
 
     struct MeshContext

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -470,6 +470,7 @@ void GamesysTest<T>::SetUp()
     dmBuffer::NewContext(); // ???
 
     m_SoundContext.m_MaxComponentCount = 32;
+    m_SoundContext.m_MaxSoundInstances = 256;
 
     m_PhysicsContext.m_MaxCollisionCount = 64;
     m_PhysicsContext.m_MaxContactPointCount = 128;


### PR DESCRIPTION
Use `sound.max_sound_instances` as maximum count of simultaneously played sounds.

Fix https://github.com/defold/defold/issues/6816