### PR TITLE
Fix issue with force using of landscape mode in iOS games on macOS with M1

### DIFF
--- a/engine/glfw/lib/ios/app/AppDelegate.m
+++ b/engine/glfw/lib/ios/app/AppDelegate.m
@@ -43,20 +43,6 @@ char**              g_Argv = 0;
 
 @synthesize window;
 
-- (void)forceDeviceOrientation;
-{
-    // Running iOS8, if we don't force a change in the device orientation then
-    // the framebuffer will not be created with the correct orientation.
-    UIDevice *device = [UIDevice currentDevice];
-    UIDeviceOrientation desired = UIDeviceOrientationLandscapeRight;
-    if (_glfwWin.portrait) {
-        desired = UIDeviceOrientationPortrait;
-    } else if (UIDeviceOrientationLandscapeLeft == device.orientation) {
-        desired = UIDeviceOrientationLandscapeLeft;
-    }
-    [device setValue: [NSNumber numberWithInteger: desired] forKey:@"orientation"];
-}
-
 - (void)reinit:(UIApplication *)application
 {
     g_IsReboot = 1;
@@ -78,8 +64,6 @@ char**              g_Argv = 0;
         _glfwWin.height = tmp;
     }
 
-    [self forceDeviceOrientation];
-
     // We then rebuild the GL view back within the application's event loop.
     dispatch_async(dispatch_get_main_queue(), ^{
         ViewController *controller = (ViewController *)window.rootViewController;
@@ -92,7 +76,6 @@ char**              g_Argv = 0;
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [self forceDeviceOrientation];
 
     // NOTE: On iPhone4 the "resolution" is 480x320 and not 960x640
     // Points vs pixels (and scale factors). I'm not sure that this correct though

--- a/engine/glfw/lib/ios/app/AppDelegate.m
+++ b/engine/glfw/lib/ios/app/AppDelegate.m
@@ -80,12 +80,6 @@ char**              g_Argv = 0;
 
     [self forceDeviceOrientation];
 
-    float version = [[UIDevice currentDevice].systemVersion floatValue];
-    if (8.0 <= version && 8.1 > version) {
-        // These suspect versions of iOS will crash if we proceed to recreate the GL view.
-        return;
-    }
-
     // We then rebuild the GL view back within the application's event loop.
     dispatch_async(dispatch_get_main_queue(), ^{
         ViewController *controller = (ViewController *)window.rootViewController;

--- a/engine/glfw/lib/ios/app/EAGLView.m
+++ b/engine/glfw/lib/ios/app/EAGLView.m
@@ -14,18 +14,6 @@
 
 // OpenGL view
 
-/*
- * Launching your Application in Landscape
- * https://developer.apple.com/library/ios/#technotes/tn2244/_index.html
- *
- * This is something we might want to add support for soon. The following is required:
- *   - Flip width/height when creating the window (in applicationDidFinishLaunching)
- *   - return (interfaceOrientation == UIInterfaceOrientationLandscapeRight);
- *     from shouldAutorotateToInterfaceOrientation
- *
- *   See TN2244 for more information
- */
-
 #include "EAGLView.h"
 #import "TextUtil.h"
 #import "AppDelegate.h"

--- a/engine/glfw/lib/ios/app/ViewController.m
+++ b/engine/glfw/lib/ios/app/ViewController.m
@@ -35,23 +35,6 @@ static int g_view_type = GLFW_NO_API;
 - (void)createView:(BOOL)recreate
 {
     CGRect bounds = self.view.bounds;
-    float version = [[UIDevice currentDevice].systemVersion floatValue];
-    if (8.0 <= version && version < 8.1) {
-        CGSize size = [self getIntendedViewSize];
-        CGRect parent_bounds = self.view.bounds;
-        parent_bounds.size = size;
-
-        if ([self shouldUpdateViewFrame]) {
-            CGPoint origin = [self getIntendedFrameOrigin: size];
-
-            CGRect parent_frame = self.view.frame;
-            parent_frame.origin = origin;
-            parent_frame.size = size;
-
-            self.view.frame = parent_frame;
-        }
-        bounds = parent_bounds;
-    }
     cachedViewSize = bounds.size;
 
     if (g_view_type == GLFW_NO_API)
@@ -87,29 +70,6 @@ static int g_view_type = GLFW_NO_API;
     {
         // According to Apple glFinish() should be called here (Comment moved from AppDelegate applicationWillResignActive)
         glFinish();
-    }
-}
-
-- (void)updateViewFramesWorkaround
-{
-    float version = [[UIDevice currentDevice].systemVersion floatValue];
-    if (8.0 <= version && version < 8.1) {
-        CGRect parent_frame = self.view.frame;
-        CGRect parent_bounds = self.view.bounds;
-
-        CGSize size = [self getIntendedViewSize];
-
-        parent_bounds.size = size;
-
-        if ([self shouldUpdateViewFrame]) {
-            CGPoint origin = [self getIntendedFrameOrigin: size];
-            parent_frame.origin = origin;
-            parent_frame.size = size;
-
-            self.view.frame = parent_frame;
-        }
-
-        baseView.frame = parent_bounds;
     }
 }
 
@@ -242,7 +202,6 @@ static int g_view_type = GLFW_NO_API;
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    [self updateViewFramesWorkaround];
 }
 
 - (void)accelerometer:(UIAccelerometer *)accelerometer didAccelerate:(UIAcceleration *)acceleration

--- a/engine/glfw/lib/ios/app/ViewController.m
+++ b/engine/glfw/lib/ios/app/ViewController.m
@@ -167,42 +167,7 @@ static int g_view_type = GLFW_NO_API;
     [super viewDidUnload];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
-{
-    // NOTE: For iOS < 6
-    if (_glfwWin.portrait)
-    {
-        return   interfaceOrientation == UIInterfaceOrientationPortrait
-              || interfaceOrientation == UIInterfaceOrientationPortraitUpsideDown;
-    }
-    else
-    {
-        return   interfaceOrientation == UIInterfaceOrientationLandscapeRight
-              || interfaceOrientation == UIInterfaceOrientationLandscapeLeft;
-    }
-}
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
-{
-}
-
--(BOOL)shouldAutorotate{
-    // NOTE: Only for iOS6
-    return YES;
-}
-
--(UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    // NOTE: Only for iOS6
-    return UIInterfaceOrientationMaskLandscape | UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
-}
-
 #pragma mark UIContentContainer
-
-// Introduced in iOS8.0
-- (void)viewWillTransitionToSize:(CGSize)size
-       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
-{
-}
 
 - (void)accelerometer:(UIAccelerometer *)accelerometer didAccelerate:(UIAcceleration *)acceleration
 {


### PR DESCRIPTION
Fixed issue when iOS game installed on M1 Mac forces to use landscape mode even if game made in portrait mode.

Fix https://github.com/defold/defold/issues/5727