### PR TITLE
Center view on camera

### DIFF
--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -23,6 +23,7 @@ message CameraDesc
     required float  near_z              = 3;
     required float  far_z               = 4;
     optional uint32 auto_aspect_ratio   = 5 [default = 0];
+    optional uint32 center              = 6 [default = 0];
 }
 
 /*# sets camera properties

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -38,6 +38,8 @@ message CameraDesc
  * @param fov [type:number] field of view of the lens, measured as the angle in radians between the right and left edge
  * @param near_z [type:number] position of the near clipping plane (distance from camera along relative z)
  * @param far_z [type:number] position of the far clipping plane (distance from camera along relative z)
+ * @param orthographic_projection [type:bool] set to use an orthographic projection
+ * @param orthographic_zoom [type:number] zoom level when the camera is using an orthographic projection
  * @examples
  *
  * In the examples, it is assumed that the instance of the script has a camera-component with id "camera".
@@ -48,10 +50,12 @@ message CameraDesc
  */
 message SetCamera
 {
-    required float          aspect_ratio    = 1;
-    required float          fov             = 2;
-    required float          near_z          = 3;
-    required float          far_z           = 4;
+    required float  aspect_ratio            = 1;
+    required float  fov                     = 2;
+    required float  near_z                  = 3;
+    required float  far_z                   = 4;
+    optional uint32 orthographic_projection = 5 [default = 0];
+    optional float  orthographic_zoom       = 6 [default = 1.0];
 }
 
 /*# makes the receiving camera become the active camera
@@ -106,7 +110,7 @@ message ReleaseCameraFocus {}
  * ```lua
  * function init(self)
  *   local fov = go.get("#camera", "fov")
- *   go.set("#sprite", "fov", fov + 0.1)
+ *   go.set("#camera", "fov", fov + 0.1)
  *   go.animate("#camera", "fov", go.PLAYBACK_ONCE_PINGPONG, 1.2, go.EASING_LINEAR, 1)
  * end
  * ```
@@ -125,7 +129,7 @@ message ReleaseCameraFocus {}
  * ```lua
  * function init(self)
  *   local near_z = go.get("#camera", "near_z")
- *   go.set("#sprite", "near_z", 10)
+ *   go.set("#camera", "near_z", 10)
  * end
  * ```
  */
@@ -143,7 +147,26 @@ message ReleaseCameraFocus {}
  * ```lua
  * function init(self)
  *   local far_z = go.get("#camera", "far_z")
- *   go.set("#sprite", "far_z", 10)
+ *   go.set("#camera", "far_z", 10)
+ * end
+ * ```
+ */
+
+/*# [type:float] camera orthographic_zoom
+ *
+ * Zoom level when using an orthographic projection.
+ * The type of the property is float.
+ *
+ * @name orthographic_zoom
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local orthographic_zoom = go.get("#camera", "orthographic_zoom")
+ *   go.set("#camera", "orthographic_zoom", 2.0)
+ *   go.animate("#camera", "orthographic_zoom", go.PLAYBACK_ONCE_PINGPONG, 0.5, go.EASING_INOUTQUAD, 2)
  * end
  * ```
  */

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -18,12 +18,13 @@ option java_outer_classname = "Camera";
 
 message CameraDesc
 {
-    required float  aspect_ratio        = 1;
-    required float  fov                 = 2;
-    required float  near_z              = 3;
-    required float  far_z               = 4;
-    optional uint32 auto_aspect_ratio   = 5 [default = 0];
-    optional uint32 center              = 6 [default = 0];
+    required float  aspect_ratio            = 1;
+    required float  fov                     = 2;
+    required float  near_z                  = 3;
+    required float  far_z                   = 4;
+    optional uint32 auto_aspect_ratio       = 5 [default = 0];
+    optional uint32 orthographic_projection = 6 [default = 0];
+    optional float  orthographic_zoom       = 7 [default = 1.0];
 }
 
 /*# sets camera properties

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -50,6 +50,7 @@ namespace dmGameSystem
         float m_FarZ;
         uint32_t m_AutoAspectRatio : 1;
         uint32_t m_AddedToUpdate : 1;
+        uint32_t m_Center : 1;
         uint16_t m_ComponentIndex;
     };
 
@@ -94,6 +95,7 @@ namespace dmGameSystem
             camera.m_NearZ = cam_resource->m_DDF->m_NearZ;
             camera.m_FarZ = cam_resource->m_DDF->m_FarZ;
             camera.m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
+            camera.m_Center = cam_resource->m_DDF->m_Center != 0;
             camera.m_AddedToUpdate = 0;
             camera.m_ComponentIndex = params.m_ComponentIndex;
             w->m_Cameras.Push(camera);
@@ -168,8 +170,19 @@ namespace dmGameSystem
             dmVMath::Matrix4 projection = Matrix4::perspective(camera->m_Fov, aspect_ratio, camera->m_NearZ, camera->m_FarZ);
 
             dmVMath::Point3 pos = dmGameObject::GetWorldPosition(camera->m_Instance);
+            if (camera->m_Center)
+            {
+                uint32_t width = dmGraphics::GetWindowWidth(dmRender::GetGraphicsContext(render_context));
+                uint32_t height = dmGraphics::GetWindowHeight(dmRender::GetGraphicsContext(render_context));
+                float display_scale = dmGraphics::GetDisplayScaleFactor(dmRender::GetGraphicsContext(render_context));
+                float half_width = (float)width / display_scale / 2.0f;
+                float half_height = (float)height / display_scale / 2.0f;
+                pos = pos - dmVMath::Vector3(half_width, half_height, 0.0f);
+            }
+
             dmVMath::Quat rot = dmGameObject::GetWorldRotation(camera->m_Instance);
             Point3 look_at = pos + Vectormath::Aos::rotate(rot, dmVMath::Vector3(0.0f, 0.0f, -1.0f));
+
             Vector3 up = Vectormath::Aos::rotate(rot, dmVMath::Vector3(0.0f, 1.0f, 0.0f));
             dmVMath::Matrix4 view = Matrix4::lookAt(pos, look_at, up);
 

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -302,7 +302,8 @@ namespace dmGameSystem
         camera->m_NearZ = cam_resource->m_DDF->m_NearZ;
         camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
         camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
-        camera->m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection;
+        camera->m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
+        camera->m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera->m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -193,7 +193,6 @@ namespace dmGameSystem
 
             dmVMath::Quat rot = dmGameObject::GetWorldRotation(camera->m_Instance);
             Point3 look_at = pos + Vectormath::Aos::rotate(rot, dmVMath::Vector3(0.0f, 0.0f, -1.0f));
-
             Vector3 up = Vectormath::Aos::rotate(rot, dmVMath::Vector3(0.0f, 1.0f, 0.0f));
             dmVMath::Matrix4 view = Matrix4::lookAt(pos, look_at, up);
 

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -301,7 +301,6 @@ namespace dmGameSystem
         camera->m_Fov = cam_resource->m_DDF->m_Fov;
         camera->m_NearZ = cam_resource->m_DDF->m_NearZ;
         camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
-        camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
         camera->m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera->m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera->m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -48,9 +48,10 @@ namespace dmGameSystem
         float m_Fov;
         float m_NearZ;
         float m_FarZ;
+        float m_OrthographicZoom;
         uint32_t m_AutoAspectRatio : 1;
         uint32_t m_AddedToUpdate : 1;
-        uint32_t m_Center : 1;
+        uint32_t m_OrthographicProjection : 1;
         uint16_t m_ComponentIndex;
     };
 
@@ -63,6 +64,7 @@ namespace dmGameSystem
     static const dmhash_t CAMERA_PROP_FOV = dmHashString64("fov");
     static const dmhash_t CAMERA_PROP_NEAR_Z = dmHashString64("near_z");
     static const dmhash_t CAMERA_PROP_FAR_Z = dmHashString64("far_z");
+    static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_ZOOM = dmHashString64("orthographic_zoom");
 
     dmGameObject::CreateResult CompCameraNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -95,7 +97,8 @@ namespace dmGameSystem
             camera.m_NearZ = cam_resource->m_DDF->m_NearZ;
             camera.m_FarZ = cam_resource->m_DDF->m_FarZ;
             camera.m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
-            camera.m_Center = cam_resource->m_DDF->m_Center != 0;
+            camera.m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection != 0;
+            camera.m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
             camera.m_AddedToUpdate = 0;
             camera.m_ComponentIndex = params.m_ComponentIndex;
             w->m_Cameras.Push(camera);
@@ -159,25 +162,33 @@ namespace dmGameSystem
         if (camera != 0x0 && camera->m_AddedToUpdate)
         {
             dmRender::RenderContext* render_context = (dmRender::RenderContext*)params.m_Context;
+            float width = (float)dmGraphics::GetWindowWidth(dmRender::GetGraphicsContext(render_context));
+            float height = (float)dmGraphics::GetWindowHeight(dmRender::GetGraphicsContext(render_context));
 
             float aspect_ratio = camera->m_AspectRatio;
             if (camera->m_AutoAspectRatio)
             {
-                float width = (float)dmGraphics::GetWindowWidth(dmRender::GetGraphicsContext(render_context));
-                float height = (float)dmGraphics::GetWindowHeight(dmRender::GetGraphicsContext(render_context));
                 aspect_ratio = width / height;
             }
-            dmVMath::Matrix4 projection = Matrix4::perspective(camera->m_Fov, aspect_ratio, camera->m_NearZ, camera->m_FarZ);
 
             dmVMath::Point3 pos = dmGameObject::GetWorldPosition(camera->m_Instance);
-            if (camera->m_Center)
+            dmVMath::Matrix4 projection;
+            if (camera->m_OrthographicProjection)
             {
-                uint32_t width = dmGraphics::GetWindowWidth(dmRender::GetGraphicsContext(render_context));
-                uint32_t height = dmGraphics::GetWindowHeight(dmRender::GetGraphicsContext(render_context));
                 float display_scale = dmGraphics::GetDisplayScaleFactor(dmRender::GetGraphicsContext(render_context));
-                float half_width = (float)width / display_scale / 2.0f;
-                float half_height = (float)height / display_scale / 2.0f;
-                pos = pos - dmVMath::Vector3(half_width, half_height, 0.0f);
+                float zoom = camera->m_OrthographicZoom;
+                float zoomed_width = width / display_scale / zoom;
+                float zoomed_height = height / display_scale / zoom;
+
+                float left = -zoomed_width / 2;
+                float right = zoomed_width / 2;
+                float bottom = -zoomed_height / 2;
+                float top = zoomed_height / 2;
+                projection = Matrix4::orthographic(left, right, bottom, top, camera->m_NearZ, camera->m_FarZ);
+            }
+            else
+            {
+                projection = Matrix4::perspective(camera->m_Fov, aspect_ratio, camera->m_NearZ, camera->m_FarZ);
             }
 
             dmVMath::Quat rot = dmGameObject::GetWorldRotation(camera->m_Instance);
@@ -289,7 +300,9 @@ namespace dmGameSystem
         camera->m_Fov = cam_resource->m_DDF->m_Fov;
         camera->m_NearZ = cam_resource->m_DDF->m_NearZ;
         camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
-        camera->m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
+        camera->m_FarZ = cam_resource->m_DDF->m_FarZ;
+        camera->m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection;
+        camera->m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
     }
 
     dmGameObject::PropertyResult CompCameraGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value)
@@ -310,6 +323,11 @@ namespace dmGameSystem
         else if (CAMERA_PROP_FAR_Z == get_property)
         {
             out_value.m_Variant = dmGameObject::PropertyVar(component->m_FarZ);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_ORTHOGRAPHIC_ZOOM == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_OrthographicZoom);
             return dmGameObject::PROPERTY_RESULT_OK;
         }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
@@ -333,6 +351,11 @@ namespace dmGameSystem
         else if (CAMERA_PROP_FAR_Z == set_property)
         {
             component->m_FarZ = params.m_Value.m_Number;
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_ORTHOGRAPHIC_ZOOM == set_property)
+        {
+            component->m_OrthographicZoom = params.m_Value.m_Number;
             return dmGameObject::PROPERTY_RESULT_OK;
         }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -241,6 +241,8 @@ namespace dmGameSystem
             camera->m_Fov = ddf->m_Fov;
             camera->m_NearZ = ddf->m_NearZ;
             camera->m_FarZ = ddf->m_FarZ;
+            camera->m_OrthographicProjection = ddf->m_OrthographicProjection;
+            camera->m_OrthographicZoom = ddf->m_OrthographicZoom;
         }
         else if ((dmDDF::Descriptor*)params.m_Message->m_Descriptor == dmGamesysDDF::AcquireCameraFocus::m_DDFDescriptor)
         {

--- a/engine/glfw/include/GL/glfw.h
+++ b/engine/glfw/include/GL/glfw.h
@@ -569,6 +569,7 @@ GLFWAPI void glfwRegisterUIApplicationDelegate(void* delegate);
 GLFWAPI void glfwUnregisterUIApplicationDelegate(void* delegate);
 GLFWAPI void glfwSetViewType(int view_type);
 GLFWAPI void glfwSetWindowBackgroundColor(unsigned int color);
+GLFWAPI float glfwGetDisplayScaleFactor();
 
 // Defold extensions (Android)
 #if defined(ANDROID)

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -1071,6 +1071,10 @@ var LibraryGLFW = {
   },
 
   glfwSetWindowBackgroundColor: function() {
+  },
+
+  glfwGetDisplayScaleFactor: function() {
+    return 1;
   }
 };
 

--- a/engine/glfw/lib/android/android_window.c
+++ b/engine/glfw/lib/android/android_window.c
@@ -683,6 +683,11 @@ void _glfwPlatformSetWindowBackgroundColor(unsigned int color)
 {
 }
 
+float _glfwPlatformGetDisplayScaleFactor()
+{
+    return 1.0f;
+}
+
 #define MAX_ACTIVITY_LISTENERS (32)
 static glfwactivityresultfun g_Listeners[MAX_ACTIVITY_LISTENERS];
 static int g_ListenersCount = 0;

--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -1186,3 +1186,13 @@ void _glfwPlatformSetWindowBackgroundColor(unsigned int color)
     float b = ((color >> 16) & 0xff) / 255.0f;
     [_glfwWin.window setBackgroundColor: [NSColor colorWithDeviceRed:r green:g blue:b alpha:1.0f]];
 }
+
+float _glfwPlatformGetDisplayScaleFactor()
+{
+    CGDirectDisplayID currentDisplayID = [[[[_glfwWin.window screen] deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
+    CGDisplayModeRef mode = CGDisplayCopyDisplayMode(currentDisplayID);
+    float scaling_factor = (float)CGDisplayModeGetPixelWidth(mode) / (float)CGDisplayModeGetWidth(mode);
+    CGDisplayModeRelease(mode);
+    return scaling_factor;
+}
+

--- a/engine/glfw/lib/internal.h
+++ b/engine/glfw/lib/internal.h
@@ -245,6 +245,7 @@ void _glfwPlatformUnacquireAuxContextVulkan(void* context);
 void _glfwPlatformUnacquireAuxContextOpenGL(void* context);
 void _glfwPlatformSetViewType(int view_type);
 void _glfwPlatformSetWindowBackgroundColor(unsigned int color);
+float _glfwPlatformGetDisplayScaleFactor();
 
 //========================================================================
 // Prototypes for platform independent internal functions

--- a/engine/glfw/lib/ios/app/ViewController.m
+++ b/engine/glfw/lib/ios/app/ViewController.m
@@ -197,6 +197,11 @@ void _glfwPlatformSetWindowBackgroundColor(unsigned int color)
     viewController.view.backgroundColor = [[UIColor alloc]initWithRed:r green:g blue:b alpha:a];
 }
 
+float _glfwPlatformGetDisplayScaleFactor()
+{
+    return 1.0f;
+}
+
 void* _glfwPlatformAcquireAuxContext()
 {
     if (_glfwWin.clientAPI == GLFW_NO_API)

--- a/engine/glfw/lib/win32/win32_window.c
+++ b/engine/glfw/lib/win32/win32_window.c
@@ -2045,3 +2045,9 @@ void _glfwPlatformSetWindowBackgroundColor(unsigned int color)
     HBRUSH brush = CreateSolidBrush(RGB(r, g, b));
     SetClassLongPtr(_glfwWin.classAtom, GCLP_HBRBACKGROUND, (LONG_PTR)brush);
 }
+
+float _glfwPlatformGetDisplayScaleFactor()
+{
+    return 1.0f;
+}
+

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -1141,3 +1141,11 @@ GLFWAPI void glfwSetWindowBackgroundColor(unsigned int color)
 {
     _glfwPlatformSetWindowBackgroundColor(color);
 }
+
+//========================================================================
+// Get display scale factor
+//========================================================================
+GLFWAPI float glfwGetDisplayScaleFactor()
+{
+    return _glfwPlatformGetDisplayScaleFactor();
+}

--- a/engine/glfw/lib/x11/x11_window.c
+++ b/engine/glfw/lib/x11/x11_window.c
@@ -2077,3 +2077,9 @@ void _glfwPlatformSetWindowBackgroundColor(unsigned int color)
     attributes.background_pixel = xc.pixel;
     XChangeWindowAttributes(_glfwLibrary.display, _glfwWin.window, CWBackPixel, &attributes);
 }
+
+float _glfwPlatformGetDisplayScaleFactor()
+{
+    return 1.0f;
+}
+

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -444,6 +444,10 @@ namespace dmGraphics
     {
         return g_functions.m_GetWindowHeight(context);
     }
+    float GetDisplayScaleFactor(HContext context)
+    {
+        return g_functions.m_GetDisplayScaleFactor(context);
+    }
     void SetWindowSize(HContext context, uint32_t width, uint32_t height)
     {
         g_functions.m_SetWindowSize(context, width, height);

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -453,6 +453,13 @@ namespace dmGraphics
     void ResizeWindow(HContext context, uint32_t width, uint32_t height);
 
     /**
+     * Get the scale factor of the display.
+     * The display scale factor is usally 1.0 but will for instance be 2.0 on a macOS Retina display.
+     * @return Scale factor
+     */
+    float GetDisplayScaleFactor(HContext context);
+
+    /**
      * Return the default texture filtering modes.
      * @param context Graphics context handle
      * @param out_min_filter Out parameter to write the default min filtering mode to

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -68,6 +68,7 @@ namespace dmGraphics
     typedef uint32_t (*GetHeightFn)(HContext context);
     typedef uint32_t (*GetWindowWidthFn)(HContext context);
     typedef uint32_t (*GetWindowHeightFn)(HContext context);
+    typedef float (*GetDisplayScaleFactorFn)(HContext context);
     typedef void (*SetWindowSizeFn)(HContext context, uint32_t width, uint32_t height);
     typedef void (*ResizeWindowFn)(HContext context, uint32_t width, uint32_t height);
     typedef void (*GetDefaultTextureFiltersFn)(HContext context, TextureFilter& out_min_filter, TextureFilter& out_mag_filter);
@@ -178,6 +179,7 @@ namespace dmGraphics
         GetHeightFn m_GetHeight;
         GetWindowWidthFn m_GetWindowWidth;
         GetWindowHeightFn m_GetWindowHeight;
+        GetDisplayScaleFactorFn m_GetDisplayScaleFactor;
         SetWindowSizeFn m_SetWindowSize;
         ResizeWindowFn m_ResizeWindow;
         GetDefaultTextureFiltersFn m_GetDefaultTextureFilters;

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -211,6 +211,11 @@ namespace dmGraphics
         return context->m_WindowWidth;
     }
 
+    static float NullGetDisplayScaleFactor(HContext context)
+    {
+        return 1.0f;
+    }
+
     static uint32_t NullGetWindowHeight(HContext context)
     {
         return context->m_WindowHeight;
@@ -1302,6 +1307,7 @@ namespace dmGraphics
         fn_table.m_GetHeight = NullGetHeight;
         fn_table.m_GetWindowWidth = NullGetWindowWidth;
         fn_table.m_GetWindowHeight = NullGetWindowHeight;
+        fn_table.m_GetDisplayScaleFactor = NullGetDisplayScaleFactor;
         fn_table.m_SetWindowSize = NullSetWindowSize;
         fn_table.m_ResizeWindow = NullResizeWindow;
         fn_table.m_GetDefaultTextureFilters = NullGetDefaultTextureFilters;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1252,6 +1252,12 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         return context->m_WindowWidth;
     }
 
+    static float OpenGLGetDisplayScaleFactor(HContext context)
+    {
+        assert(context);
+        return glfwGetDisplayScaleFactor();
+    }
+
     static uint32_t OpenGLGetWindowHeight(HContext context)
     {
         assert(context);
@@ -3100,6 +3106,7 @@ static uintptr_t GetExtProcAddress(const char* name, const char* extension_name,
         fn_table.m_GetHeight = OpenGLGetHeight;
         fn_table.m_GetWindowWidth = OpenGLGetWindowWidth;
         fn_table.m_GetWindowHeight = OpenGLGetWindowHeight;
+        fn_table.m_GetDisplayScaleFactor = OpenGLGetDisplayScaleFactor;
         fn_table.m_SetWindowSize = OpenGLSetWindowSize;
         fn_table.m_ResizeWindow = OpenGLResizeWindow;
         fn_table.m_GetDefaultTextureFilters = OpenGLGetDefaultTextureFilters;

--- a/engine/graphics/src/vulkan/graphics_native.cpp
+++ b/engine/graphics/src/vulkan/graphics_native.cpp
@@ -304,6 +304,11 @@ namespace dmGraphics
         return context->m_WindowHeight;
     }
 
+    float VulkanGetDisplayScaleFactor(HContext context)
+    {
+        return glfwGetDisplayScaleFactor();
+    }
+
     void VulkanGetNativeWindowSize(uint32_t* width, uint32_t* height)
     {
         int w, h;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3469,6 +3469,7 @@ bail:
         fn_table.m_GetHeight = VulkanGetHeight;
         fn_table.m_GetWindowWidth = VulkanGetWindowWidth;
         fn_table.m_GetWindowHeight = VulkanGetWindowHeight;
+        fn_table.m_GetDisplayScaleFactor = VulkanGetDisplayScaleFactor;
         fn_table.m_SetWindowSize = VulkanSetWindowSize;
         fn_table.m_ResizeWindow = VulkanResizeWindow;
         fn_table.m_GetDefaultTextureFilters = VulkanGetDefaultTextureFilters;

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -568,6 +568,7 @@ namespace dmGraphics
     uint32_t VulkanGetHeight(HContext context);
     uint32_t VulkanGetWindowWidth(HContext context);
     uint32_t VulkanGetWindowHeight(HContext context);
+    float VulkanGetDisplayScaleFactor(HContext context);
     uint32_t VulkanGetWindowRefreshRate(HContext context);
     void VulkanSetWindowSize(HContext context, uint32_t width, uint32_t height);
     void VulkanResizeWindow(HContext context, uint32_t width, uint32_t height);


### PR DESCRIPTION
Added an option on the camera component to toggle from the default perspective projection to an orthographic projection. When a camera component is in orthographic projection mode it will automatically center on the position of the game object the camera belongs to.

A new `orthographic_zoom` property has also been added to the camera component to change the zoom level when using the orthographic projection. This can be used either as a fixed zoom or from a script to set a variable zoom level based on window dimensions.

These changes are compatible with the existing default render script. To use both the view and projection from the camera the developer must send a `use_camera_projection` message to the render script. The camera and render documentation need to be changed to reflect these changes.

Fixes #6828 