### PR TITLE
Use original filename in chunk names

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -19,10 +19,12 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.dynamo.bob.Project;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.test.util.PropertiesTestUtil;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.lua.proto.Lua.LuaModule;
+import com.dynamo.script.proto.Lua.LuaSource;
 import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarations;
 import com.dynamo.properties.proto.PropertiesProto.PropertyDeclarationEntry;
 
@@ -92,5 +94,78 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         } catch (CompileExceptionError e) {
             assertEquals(2, e.getLineNumber());
         }
+    }
+
+    @Test
+    public void testUseLuaSource() throws Exception {
+        Project p = GetProject();
+        p.setOption("use-lua-source", "true");
+
+        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        LuaSource luaSource = luaModule.getSource();
+        assertTrue(luaSource.getScript() != null);
+        assertTrue(luaSource.getScript().size() > 0);
+        assertTrue(luaSource.getBytecode().size() == 0);
+        assertTrue(luaSource.getBytecode64().size() == 0);
+        assertTrue(luaSource.getDelta().size() == 0);
+    }
+
+    @Test
+    public void testVanillaLuaBytecode() throws Exception {
+        Project p = GetProject();
+        p.setOption("platform", "js-web");
+
+        StringBuilder src = new StringBuilder();
+        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        LuaSource luaSource = luaModule.getSource();
+        assertTrue(luaSource.getScript().size() == 0);
+        assertTrue(luaSource.getBytecode().size() > 0);
+        assertTrue(luaSource.getBytecode64().size() == 0);
+        assertTrue(luaSource.getDelta().size() == 0);
+    }
+
+    @Test
+    public void testLuaJITBytecode64WithoutDelta() throws Exception {
+        Project p = GetProject();
+        p.setOption("platform", "armv7-android");
+        p.setOption("architectures", "arm64-android");
+
+        StringBuilder src = new StringBuilder();
+        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        LuaSource luaSource = luaModule.getSource();
+        assertTrue(luaSource.getScript().size() == 0);
+        assertTrue(luaSource.getBytecode().size() > 0);
+        assertTrue(luaSource.getBytecode64().size() == 0);
+        assertTrue(luaSource.getDelta().size() == 0);
+    }
+
+    @Test
+    public void testLuaJITBytecode32WithoutDelta() throws Exception {
+        Project p = GetProject();
+        p.setOption("platform", "armv7-android");
+        p.setOption("architectures", "armv7-android");
+
+        StringBuilder src = new StringBuilder();
+        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        LuaSource luaSource = luaModule.getSource();
+        assertTrue(luaSource.getScript().size() == 0);
+        assertTrue(luaSource.getBytecode().size() > 0);
+        assertTrue(luaSource.getBytecode64().size() == 0);
+        assertTrue(luaSource.getDelta().size() == 0);
+    }
+
+    @Test
+    public void testLuaJITBytecode64WithDelta() throws Exception {
+        Project p = GetProject();
+        p.setOption("platform", "armv7-android");
+        p.setOption("architectures", "armv7-android,arm64-android");
+
+        StringBuilder src = new StringBuilder();
+        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        LuaSource luaSource = luaModule.getSource();
+        assertTrue(luaSource.getScript().size() == 0);
+        assertTrue(luaSource.getBytecode().size() > 0);
+        assertTrue(luaSource.getBytecode64().size() == 0);
+        assertTrue(luaSource.getDelta().size() > 0);
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -125,6 +125,18 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
     }
 
     @Test
+    public void testVanillaLuaBytecodeChunkname() throws Exception {
+        Project p = GetProject();
+        p.setOption("platform", "js-web");
+
+        StringBuilder src = new StringBuilder();
+        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        LuaSource luaSource = luaModule.getSource();
+        String chunkname = luaSource.getBytecode().substring(12+4, 12+4+12).toStringUtf8();
+        assertEquals("@test.script", chunkname);
+    }
+
+    @Test
     public void testLuaJITBytecode64WithoutDelta() throws Exception {
         Project p = GetProject();
         p.setOption("platform", "armv7-android");


### PR DESCRIPTION
Starting in Defold 1.3.5 we compile HTML5 standard Lua 5.1.5 code to bytecode. This had the unfortunate side effect that the filenames used in the bytecode were the temporary filenames and not the original names. This fix solves this and uses the original filename as the chunkname in the bytecode.

Fixes #6837 