### PR TITLE
Use `--verify-graphics-calls=false` by default for HTML5

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -575,7 +575,7 @@ archive_location_suffix.default =
 
 engine_arguments.type = string
 engine_arguments.help = comma separated list of engine arguments
-engine_arguments.default = 
+engine_arguments.default = --verify-graphics-calls=false
 
 wasm_streaming.type = bool
 wasm_streaming.help = set to true to enable streaming of the wasm file (faster and uses less memory, but requires MIME type 'application/wasm')

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -771,7 +771,7 @@
    :path ["html5" "archive_location_suffix"]}
   {:type :string,
    :help "comma separated list of engine arguments",
-   :default "",
+   :default "--verify-graphics-calls=false",
    :path ["html5" "engine_arguments"]}
   {:type :boolean,
    :help "set to true to enable streaming of the wasm file (faster and uses less memory, but requires MIME type 'application/wasm')",


### PR DESCRIPTION
Verifying of the graphics calls in html5 build maybe useful for debug reason, but it's may be very slow on some browsers. This fix makes `--verify-graphics-calls=false` the option by default to make build faster even in debug. But if you have any graphics related issues in your buld while testing, remove this argument or change it to `--verify-graphics-calls=true` to have more information what's going on.