### PR TITLE
Fix crash in some cases when count of labels more than `label.max_count`

### DIFF
--- a/engine/engine/src/test/issue-6597/issue-6597.collection
+++ b/engine/engine/src/test/issue-6597/issue-6597.collection
@@ -1,0 +1,55 @@
+name: "default"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"spawner\"\n"
+  "  component: \"/issue-6597/spawner.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  "embedded_components {\n"
+  "  id: \"collectionfactory\"\n"
+  "  type: \"collectionfactory\"\n"
+  "  data: \"prototype: \\\"/issue-6597/spawnee.collection\\\"\\n"
+  "load_dynamically: false\\n"
+  "\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/engine/engine/src/test/issue-6597/spawnee.collection
+++ b/engine/engine/src/test/issue-6597/spawnee.collection
@@ -1,0 +1,61 @@
+name: "default"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  children: "go1"
+  data: "embedded_components {\n"
+  "  id: \"factory\"\n"
+  "  type: \"factory\"\n"
+  "  data: \"prototype: \\\"/issue-6597/spawnee.go\\\"\\n"
+  "load_dynamically: false\\n"
+  "\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}
+embedded_instances {
+  id: "go1"
+  data: ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/engine/engine/src/test/issue-6597/spawner.script
+++ b/engine/engine/src/test/issue-6597/spawner.script
@@ -1,0 +1,24 @@
+-- Copyright 2020-2022 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local count = 6
+
+function init(self, params)
+	for i = 1, count do
+		collectionfactory.create("#collectionfactory")
+	end
+	timer.delay(0, false, function()
+		msg.post("@system:", "exit", { code = 0 })
+	end)
+end

--- a/engine/engine/src/test/test_engine.cpp
+++ b/engine/engine/src/test/test_engine.cpp
@@ -374,6 +374,12 @@ TEST_F(EngineTest, ISSUE_4775)
     ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
 }
 
+TEST_F(EngineTest, ISSUE_6597)
+{
+    const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/issue-6597/issue-6597.collectionc", "--config=dmengine.unload_builtins=0", "--config=factory.max_count=2", CONTENT_ROOT "/game.projectc"};
+    ASSERT_EQ(0, Launch(DM_ARRAY_SIZE(argv), (char**)argv, 0, 0, 0));
+}
+
 TEST_F(EngineTest, ModelComponent)
 {
     const char* argv[] = {"test_engine", "--config=bootstrap.main_collection=/model/main.collectionc", "--config=dmengine.unload_builtins=0", CONTENT_ROOT "/game.projectc"};

--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -1141,9 +1141,106 @@ namespace dmGameObject
         return instance;
     }
 
-    static void Unlink(Collection* collection, Instance* instance);
-    static void ReparentChildNodes(Collection* collection, Instance* instance);
-    static void MoveAllUp(Collection* collection, Instance* instance);
+    static void Unlink(Collection* collection, Instance* instance)
+    {
+        // Unlink "me" from parent
+        if (instance->m_Parent != INVALID_INSTANCE_INDEX)
+        {
+            assert(instance->m_Depth > 0);
+            Instance* parent = collection->m_Instances[instance->m_Parent];
+            uint32_t index = parent->m_FirstChildIndex;
+            Instance* prev_child = 0;
+            while (index != INVALID_INSTANCE_INDEX)
+            {
+                Instance* child = collection->m_Instances[index];
+                if (child == instance)
+                {
+                    if (prev_child)
+                        prev_child->m_SiblingIndex = child->m_SiblingIndex;
+                    else
+                        parent->m_FirstChildIndex = child->m_SiblingIndex;
+
+                    break;
+                }
+
+                prev_child = child;
+                index = collection->m_Instances[index]->m_SiblingIndex;
+            }
+            instance->m_SiblingIndex = INVALID_INSTANCE_INDEX;
+            instance->m_Parent = INVALID_INSTANCE_INDEX;
+        }
+    }
+
+    static void MoveUp(Collection* collection, Instance* instance)
+    {
+        /*
+         * Move instance up in hierarchy
+         */
+
+        assert(instance->m_Depth > 0);
+        EraseSwapLevelIndex(collection, instance);
+        instance->m_Depth--;
+        InsertInstanceInLevelIndex(collection, instance);
+    }
+
+    static void MoveAllUp(Collection* collection, Instance* instance)
+    {
+        /*
+         * Move all children up in hierarchy
+         */
+
+        uint32_t index = instance->m_FirstChildIndex;
+        while (index != INVALID_INSTANCE_INDEX)
+        {
+            Instance* child = collection->m_Instances[index];
+            // NOTE: This assertion is only valid if we processes the tree depth first
+            // The order of MoveAllUp and MoveUp below is imperative
+            // NOTE: This assert is not possible when moving more than a single step. TODO: ?
+            //assert(child->m_Depth == instance->m_Depth + 1);
+            MoveAllUp(collection, child);
+            MoveUp(collection, child);
+            index = collection->m_Instances[index]->m_SiblingIndex;
+        }
+    }
+
+    static void ReparentChildNodes(Collection* collection, HInstance instance)
+    {
+        // Reparent child nodes
+        uint32_t index = instance->m_FirstChildIndex;
+        while (index != INVALID_INSTANCE_INDEX)
+        {
+            Instance* child = collection->m_Instances[index];
+            assert(child->m_Parent == instance->m_Index);
+            child->m_Parent = instance->m_Parent;
+            index = collection->m_Instances[index]->m_SiblingIndex;
+        }
+
+        // Add child nodes to parent
+        if (instance->m_Parent != INVALID_INSTANCE_INDEX)
+        {
+            Instance* parent = collection->m_Instances[instance->m_Parent];
+            uint32_t index = parent->m_FirstChildIndex;
+            Instance* child = 0;
+            while (index != INVALID_INSTANCE_INDEX)
+            {
+                child = collection->m_Instances[index];
+                index = collection->m_Instances[index]->m_SiblingIndex;
+            }
+
+            // Child is last child if present
+            if (child)
+            {
+                assert(child->m_SiblingIndex == INVALID_INSTANCE_INDEX);
+                child->m_SiblingIndex = instance->m_FirstChildIndex;
+            }
+            else
+            {
+                assert(parent->m_FirstChildIndex == INVALID_INSTANCE_INDEX);
+                parent->m_FirstChildIndex = instance->m_FirstChildIndex;
+            }
+        }
+    }
+
 
     // Returns if successful or not
     static bool CollectionSpawnFromDescInternal(Collection* collection, dmGameObjectDDF::CollectionDesc* collection_desc, InstancePropertyBuffers *property_buffers, InstanceIdMap *id_mapping, dmTransform::Transform const &transform)
@@ -1485,68 +1582,6 @@ namespace dmGameObject
         return instance;
     }
 
-    static void Unlink(Collection* collection, Instance* instance)
-    {
-        // Unlink "me" from parent
-        if (instance->m_Parent != INVALID_INSTANCE_INDEX)
-        {
-            assert(instance->m_Depth > 0);
-            Instance* parent = collection->m_Instances[instance->m_Parent];
-            uint32_t index = parent->m_FirstChildIndex;
-            Instance* prev_child = 0;
-            while (index != INVALID_INSTANCE_INDEX)
-            {
-                Instance* child = collection->m_Instances[index];
-                if (child == instance)
-                {
-                    if (prev_child)
-                        prev_child->m_SiblingIndex = child->m_SiblingIndex;
-                    else
-                        parent->m_FirstChildIndex = child->m_SiblingIndex;
-
-                    break;
-                }
-
-                prev_child = child;
-                index = collection->m_Instances[index]->m_SiblingIndex;
-            }
-            instance->m_SiblingIndex = INVALID_INSTANCE_INDEX;
-            instance->m_Parent = INVALID_INSTANCE_INDEX;
-        }
-    }
-
-    static void MoveUp(Collection* collection, Instance* instance)
-    {
-        /*
-         * Move instance up in hierarchy
-         */
-
-        assert(instance->m_Depth > 0);
-        EraseSwapLevelIndex(collection, instance);
-        instance->m_Depth--;
-        InsertInstanceInLevelIndex(collection, instance);
-    }
-
-    static void MoveAllUp(Collection* collection, Instance* instance)
-    {
-        /*
-         * Move all children up in hierarchy
-         */
-
-        uint32_t index = instance->m_FirstChildIndex;
-        while (index != INVALID_INSTANCE_INDEX)
-        {
-            Instance* child = collection->m_Instances[index];
-            // NOTE: This assertion is only valid if we processes the tree depth first
-            // The order of MoveAllUp and MoveUp below is imperative
-            // NOTE: This assert is not possible when moving more than a single step. TODO: ?
-            //assert(child->m_Depth == instance->m_Depth + 1);
-            MoveAllUp(collection, child);
-            MoveUp(collection, child);
-            index = collection->m_Instances[index]->m_SiblingIndex;
-        }
-    }
-
     static void MoveDown(Collection* collection, Instance* instance)
     {
         /*
@@ -1837,44 +1872,6 @@ namespace dmGameObject
         }
         instance->m_NextToAdd = INVALID_INSTANCE_INDEX;
         instance->m_ToBeAdded = 0;
-    }
-
-    static void ReparentChildNodes(Collection* collection, HInstance instance)
-    {
-        // Reparent child nodes
-        uint32_t index = instance->m_FirstChildIndex;
-        while (index != INVALID_INSTANCE_INDEX)
-        {
-            Instance* child = collection->m_Instances[index];
-            assert(child->m_Parent == instance->m_Index);
-            child->m_Parent = instance->m_Parent;
-            index = collection->m_Instances[index]->m_SiblingIndex;
-        }
-
-        // Add child nodes to parent
-        if (instance->m_Parent != INVALID_INSTANCE_INDEX)
-        {
-            Instance* parent = collection->m_Instances[instance->m_Parent];
-            uint32_t index = parent->m_FirstChildIndex;
-            Instance* child = 0;
-            while (index != INVALID_INSTANCE_INDEX)
-            {
-                child = collection->m_Instances[index];
-                index = collection->m_Instances[index]->m_SiblingIndex;
-            }
-
-            // Child is last child if present
-            if (child)
-            {
-                assert(child->m_SiblingIndex == INVALID_INSTANCE_INDEX);
-                child->m_SiblingIndex = instance->m_FirstChildIndex;
-            }
-            else
-            {
-                assert(parent->m_FirstChildIndex == INVALID_INSTANCE_INDEX);
-                parent->m_FirstChildIndex = instance->m_FirstChildIndex;
-            }
-        }
     }
 
     static void DoDeleteInstance(Collection* collection, HInstance instance)


### PR DESCRIPTION
Fixes crash that reproduces with the following conditions:
- objects spawned by a collection factory;
- objects has a parent-child hierarchy;
- the parent object has a component that can't be spawned because of max components limit.
 
Fix https://github.com/defold/defold/issues/6597