### PR TITLE
Added particle initial stretch values to emitter template

### DIFF
--- a/editor/resources/templates/template.emitter
+++ b/editor/resources/templates/template.emitter
@@ -98,3 +98,16 @@ particle_properties {
   key: PARTICLE_KEY_ROTATION
   points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0 }
 }
+particle_properties {
+  key: PARTICLE_KEY_STRETCH_FACTOR_X
+  points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0 }
+}
+particle_properties {
+  key: PARTICLE_KEY_STRETCH_FACTOR_Y
+  points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0 }
+}
+particle_properties {
+  key: PARTICLE_KEY_ANGULAR_VELOCITY
+  points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0 }
+}
+


### PR DESCRIPTION
This fix adds missing values to the particle emitter template used by the editor when adding an emitter to a particlefx.

Fixes #6224 