### PR TITLE
Added Android ASAN repack script

### DIFF
--- a/scripts/mobile/README.md
+++ b/scripts/mobile/README.md
@@ -1,0 +1,6 @@
+# Repack scripts
+
+The repack scripts exist in order for the engine developers to quickly replace the engine
+in a package
+
+[ANDROID](./README_ANDROID.md)

--- a/scripts/mobile/README_ANDROID.md
+++ b/scripts/mobile/README_ANDROID.md
@@ -1,0 +1,38 @@
+# Repack scripts - Android
+
+## ASan
+
+The script `android-repack-asan.sh` doesn't actually replace the executable in the package.
+What it does it detect if the executable is dependent on the `libclang_rt.asan-*-android.so` library.
+If so, it will copy the file to the correct library path in the package.
+
+Also, it will then copy the `android-wrap.asan.sh` as the `wrap.sh` in the package.
+
+In order to run this package via the `wrap.sh`, you will need to have set the project to "debuggable".
+In game.project, set the property `android.debuggable` to `1`.
+
+Note: The wrap.sh support was added in Android O (API 27).
+
+[Documentation - wrap.sh](https://developer.android.com/ndk/guides/wrap-script#creating_the_wrap_shell_script)
+[Documentation - Asan](https://developer.android.com/ndk/guides/asan)
+
+UBSan is currently not supported by Android.
+
+### C++ and ASAN
+
+You need to set some compiler+linker flags. We suggest you add a `game.appmanifest` file, and set that in the `game.project` setting `native_extension.app_manifest`:
+
+```
+platforms:
+    armv7-android:
+        context:
+            defines: ['SANITIZE_ADDRESS']
+            flags: ['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope']
+            linkFlags: ['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope']
+
+    arm64-android:
+        context:
+            defines: ['SANITIZE_ADDRESS']
+            flags: ['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope']
+            linkFlags: ['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope']
+```

--- a/scripts/mobile/android-repack-asan.sh
+++ b/scripts/mobile/android-repack-asan.sh
@@ -69,20 +69,12 @@ ZIPALIGN="${DEFOLD_HOME}/com.dynamo.cr/com.dynamo.cr.bob/libexec/x86_64-darwin/z
 APKSIGNER="${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}/apksigner"
 GDBSERVER=${ANDROID_NDK_ROOT}/prebuilt/android-arm/gdbserver/gdbserver
 
-ENGINE_LIB="${DYNAMO_HOME}/bin/armv7-android/libdmengine.so"
-ENGINE_64_LIB="${DYNAMO_HOME}/bin/arm64-android/libdmengine.so"
-ENGINE_DEX="${DYNAMO_HOME}/share/java/classes.dex"
-
 [ $(which "${ZIP}") ] || terminate "'${ZIP}' is not installed"
 [ $(which "${UNZIP}") ] || terminate "'${UNZIP}' is not installed"
 [ $(which "${ZIPALIGN}") ] || terminate "'${ZIPALIGN}' is not installed"
 [ $(which "${APKSIGNER}") ] || terminate "'${APKSIGNER}' is not installed"
 
-[ -f "${ENGINE_LIB}" ] || echo "Engine does not exist: ${ENGINE_LIB}"
-[ -f "${ENGINE_64_LIB}" ] || echo "Engine does not exist: ${ENGINE_64_LIB}"
 [ -f "${SOURCE}" ] || terminate "Source does not exist: ${SOURCE}"
-[ -f "${ENGINE_DEX}" ] || terminate "Engine does not exist: ${ENGINE_DEX}"
-
 [ -f "${KEYSTORE}" ] || terminate "Keystore does not exist: ${KEYSTORE}"
 [ -f "${KEYSTORE_PASS}" ] || terminate "Keystore password file does not exist: ${KEYSTORE_PASS}"
 
@@ -103,36 +95,54 @@ REPACKZIP_ALIGNED="${ROOT}/repack.aligned.zip"
 APPLICATION="$(basename "${SOURCE}" ".apk")"
 TARGET="$(cd "$(dirname "${SOURCE}")"; pwd)/${APPLICATION}.repack"
 
+ASAN_PATH_32=$(find ${ANDROID_NDK_ROOT} -iname "libclang_rt.asan-arm-android.so")
+ASAN_PATH_64=$(find ${ANDROID_NDK_ROOT} -iname "libclang_rt.asan-aarch64-android.so")
+
+WRAP_ASAN=${SCRIPT_PATH}/android-wrap-asan.sh
+
 "${UNZIP}" -q "${SOURCE}" -d "${BUILD}"
 (
     cd "${BUILD}"
 
     EXENAME=
+    LIBPATH_32=
     if [ -d "lib/armeabi-v7a" ]; then
         EXENAME=`(cd lib/armeabi-v7a && ls lib*.so)`
+        LIBPATH_32=lib/armeabi-v7a/${EXENAME}
     fi
 
     EXENAME_64=
+    LIBPATH_64=
     if [ -d "lib/arm64-v8a" ]; then
         EXENAME_64=`(cd lib/arm64-v8a && ls lib*.so)`
+        LIBPATH_64=lib/arm64-v8a/${EXENAME_64}
     fi
 
     rm -rf "META-INF"
-    if [ -e "${ENGINE_LIB}" ]; then
-        if [ "$EXENAME" != "" ]; then
-            cp -v "${ENGINE_LIB}" "lib/armeabi-v7a/${EXENAME}"
+
+    if [ -e "${LIBPATH_32}" ]; then
+        ASAN_DEPENDENCY_32=$(aarch64-linux-android-objdump -p ${LIBPATH_32} | grep NEEDED | grep libclang_rt.asan | awk '{print $2;}')
+        if [ "$ASAN_DEPENDENCY_32" != "" ]; then
+            echo "Found ASAN:" ${ASAN_DEPENDENCY_32}
+            cp -v ${ASAN_PATH_32} "lib/armeabi-v7a/"
         fi
+        echo "Copying wrapper script"
+        cp -v ${WRAP_ASAN} "lib/armeabi-v7a/wrap.sh"
     fi
-    if [ -e "${ENGINE_64_LIB}" ]; then
-        if [ "$EXENAME_64" != "" ]; then
-            cp -v "${ENGINE_64_LIB}" "lib/arm64-v8a/${EXENAME_64}"
+    if [ -e "${LIBPATH_64}" ]; then
+        ASAN_DEPENDENCY_64=$(aarch64-linux-android-objdump -p ${LIBPATH_64} | grep NEEDED | grep libclang_rt.asan | awk '{print $2;}')
+        if [ "$ASAN_DEPENDENCY_64" != "" ]; then
+            echo "Found ASAN:" ${ASAN_DEPENDENCY_64}
+            cp -v ${ASAN_PATH_64} "lib/arm64-v8a/"
         fi
+        echo "Copying wrapper script"
+        cp -v ${WRAP_ASAN} "lib/arm64-v8a/wrap.sh"
     fi
-    cp -v "${ENGINE_DEX}" "classes.dex"
 
     if [ -e "$GDBSERVER" ]; then
         cp -v "${ANDROID_NDK_ROOT}/prebuilt/android-arm/gdbserver/gdbserver" ./lib/armeabi-v7a/gdbserver
     fi
+
 
     ${ZIP} -qr "${REPACKZIP}" "." -x "resources.arsc"
     # Targeting R+ (version 30 and above) requires the resources.arsc of installed

--- a/scripts/mobile/android-wrap-asan.sh
+++ b/scripts/mobile/android-wrap-asan.sh
@@ -1,0 +1,34 @@
+#!/system/bin/sh
+echo -----------------------------------------------------------------------
+echo DEFOLD ANDROID WRAP SCRIPT
+echo -----------------------------------------------------------------------
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Reference
+# https://www.nrbtech.io/blog/2022/3/22/using-address-sanitizer-asan-to-debug-c-memory-issues-in-android-applications
+# https://developer.android.com/ndk/guides/wrap-script
+# https://github.com/android/ndk/issues/1297#issuecomment-651070101 (android:extractNativeLibs="true")
+
+cmd=$1
+shift
+
+os_version=$(getprop ro.build.version.sdk)
+#os_version=27
+
+echo "MAWE OS VERSION: ${os_version}"
+
+if [ "$os_version" -eq "27" ]; then
+  cmd="$cmd -Xrunjdwp:transport=dt_android_adb,suspend=n,server=y -Xcompiler-option --debuggable $@"
+elif [ "$os_version" -eq "28" ]; then
+  cmd="$cmd -XjdwpProvider:adbconnection -XjdwpOptions:suspend=n,server=y -Xcompiler-option --debuggable $@"
+else
+  cmd="$cmd -XjdwpProvider:adbconnection -XjdwpOptions:suspend=n,server=y $@"
+fi
+
+ASAN_LIB=$(ls "$HERE"/libclang_rt.asan-*-android.so)
+export LD_PRELOAD=${ASAN_LIB}
+export ASAN_OPTIONS=log_to_syslog=false,allow_user_segv_handler=1,fast_unwind_on_malloc=1
+
+exec $cmd
+

--- a/scripts/mobile/android-wrap-asan.sh
+++ b/scripts/mobile/android-wrap-asan.sh
@@ -14,9 +14,6 @@ cmd=$1
 shift
 
 os_version=$(getprop ro.build.version.sdk)
-#os_version=27
-
-echo "MAWE OS VERSION: ${os_version}"
 
 if [ "$os_version" -eq "27" ]; then
   cmd="$cmd -Xrunjdwp:transport=dt_android_adb,suspend=n,server=y -Xcompiler-option --debuggable $@"


### PR DESCRIPTION
Added an easy-to-use .apk repack script for users that have built their custom engine with ASAN.
The script copies the correct shared library from a local install of the Android NDK in DYNAMO_HOME.