### PR TITLE
Issue-6764 Make it possible to avoid filling `device_ident` value

### DIFF
--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -680,6 +680,10 @@ namespace dmSys
 #endif
     }
 
+    void GetSecureInfo(SystemInfo* info)
+    {
+    }
+
 #elif defined(__ANDROID__)
 
     void GetSystemInfo(SystemInfo* info)
@@ -742,7 +746,16 @@ namespace dmSys
             dmStrlCpy(info->m_SystemVersion, release, sizeof(info->m_SystemVersion));
             env->ReleaseStringUTFChars(releaseObj, release);
         }
+    }
 
+    void GetSecureInfo(SystemInfo* info)
+    {
+        dmAndroid::ThreadAttacher thread;
+        JNIEnv* env = thread.GetEnv();
+        if (!env)
+        {
+            return;
+        }
         jclass activity_class = env->FindClass("android/app/NativeActivity");
         jmethodID get_content_resolver_method = env->GetMethodID(activity_class, "getContentResolver", "()Landroid/content/ContentResolver;");
         jobject content_resolver = env->CallObjectMethod(thread.GetActivity()->clazz, get_content_resolver_method);
@@ -788,6 +801,10 @@ namespace dmSys
         }
         FillLanguageTerritory(lang, info);
         FillTimeZone(info);
+    }
+
+    void GetSecureInfo(SystemInfo* info)
+    {
     }
 #endif
 

--- a/engine/dlib/src/dlib/sys.h
+++ b/engine/dlib/src/dlib/sys.h
@@ -269,6 +269,12 @@ namespace dmSys
     void GetSystemInfo(SystemInfo* info);
 
     /**
+     * Get information which may be secure on some platforms
+     * @param info input data
+     */
+    void GetSecureInfo(SystemInfo* info);
+
+    /**
      * Get engine information
      * @param info input data
      */

--- a/engine/dlib/src/dlib/sys_cocoa.mm
+++ b/engine/dlib/src/dlib/sys_cocoa.mm
@@ -197,10 +197,15 @@ namespace dmSys
 
         FillLanguageTerritory(lang, info);
         FillTimeZone(info);
-        dmStrlCpy(info->m_DeviceIdentifier, [[d.identifierForVendor UUIDString] UTF8String], sizeof(info->m_DeviceIdentifier));
 
         NSString *device_language = [[NSLocale preferredLanguages]objectAtIndex:0];
         dmStrlCpy(info->m_DeviceLanguage, [device_language UTF8String], sizeof(info->m_DeviceLanguage));
+    }
+
+    void GetSecureInfo(SystemInfo* info)
+    {
+        UIDevice* d = [UIDevice currentDevice];
+        dmStrlCpy(info->m_DeviceIdentifier, [[d.identifierForVendor UUIDString] UTF8String], sizeof(info->m_DeviceIdentifier));
     }
 
     bool GetApplicationInfo(const char* id, ApplicationInfo* info)
@@ -258,6 +263,10 @@ namespace dmSys
 
         FillLanguageTerritory(lang, info);
         FillTimeZone(info);
+    }
+
+    void GetSecureInfo(SystemInfo* info)
+    {
     }
 
     bool GetApplicationInfo(const char* id, ApplicationInfo* info)

--- a/engine/dlib/src/test/test_sys.cpp
+++ b/engine/dlib/src/test/test_sys.cpp
@@ -140,6 +140,7 @@ TEST(dmSys, GetSystemInfo)
 {
     dmSys::SystemInfo info;
     dmSys::GetSystemInfo(&info);
+    dmSys::GetSecureInfo(&info);
 
     dmLogInfo("DeviceModel: '%s'", info.m_DeviceModel);
     dmLogInfo("SystemName: '%s'", info.m_SystemName);

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -495,7 +495,8 @@ union SaveLoadBuffer
      *
      * Returns a table with system information.
      * @name sys.get_sys_info
-     * @param ignore_secure_values [type:boolean] this flag ignores values might be secured by OS e.g. `device_ident`
+     * @param options [type:table] (optional) options table
+     * - ignore_secure [type:boolean] this flag ignores values might be secured by OS e.g. `device_ident`
      * @return sys_info [type:table] table with system information in the following fields:
      *
      * `device_model`
@@ -553,8 +554,14 @@ union SaveLoadBuffer
 
         if ( top >= 1)
         {
-            luaL_checktype(L, 1, LUA_TBOOLEAN);
-            ignore_secure_values = lua_toboolean(L, 1);
+            luaL_checktype(L, 1, LUA_TTABLE);
+            lua_pushvalue(L, 1);
+
+            lua_getfield(L, -1, "ignore_secure");
+            ignore_secure_values = lua_isnil(L, -1) ? false : lua_toboolean(L, -1);
+            lua_pop(L, 1);
+
+            lua_pop(L, 1);
         }
 
         if (!ignore_secure_values)

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -495,6 +495,7 @@ union SaveLoadBuffer
      *
      * Returns a table with system information.
      * @name sys.get_sys_info
+     * @param ignore_secure_values [type:boolean] this flag ignores values might be secured by OS e.g. `device_ident`
      * @return sys_info [type:table] table with system information in the following fields:
      *
      * `device_model`
@@ -525,7 +526,7 @@ union SaveLoadBuffer
      * : [type:number] The current offset from GMT (Greenwich Mean Time), in minutes.
      *
      * `device_ident`
-     * : [type:string] [icon:ios] "identifierForVendor" on iOS. [icon:android] "android_id" on Android. On Android, you need to add `READ_PHONE_STATE` permission to be able to get this data. We don't use this permission in Defold.
+     * : [type:string] This value secured by OS. [icon:ios] "identifierForVendor" on iOS. [icon:android] "android_id" on Android. On Android, you need to add `READ_PHONE_STATE` permission to be able to get this data. We don't use this permission in Defold.
      *
      * `user_agent`
      * : [type:string] [icon:html5] The HTTP user agent, i.e. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8"
@@ -541,12 +542,25 @@ union SaveLoadBuffer
      * end
      * ```
      */
-    int Sys_GetSysInfo(lua_State* L)
+    static int Sys_GetSysInfo(lua_State* L)
     {
         int top = lua_gettop(L);
 
         dmSys::SystemInfo info;
         dmSys::GetSystemInfo(&info);
+
+        bool ignore_secure_values = false;
+
+        if ( top >= 1)
+        {
+            luaL_checktype(L, 1, LUA_TBOOLEAN);
+            ignore_secure_values = lua_toboolean(L, 1);
+        }
+
+        if (!ignore_secure_values)
+        {
+            dmSys::GetSecureInfo(&info);
+        } 
 
         lua_newtable(L);
         lua_pushliteral(L, "device_model");

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -702,7 +702,7 @@ union SaveLoadBuffer
     }
 
     // Android version 6 Marshmallow (API level 23) and up does not support getting hw adr programmatically (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
-    bool IsAndroidMarshmallowOrAbove()
+    static bool IsAndroidMarshmallowOrAbove()
     {
         #ifdef ANDROID
             const long android_marshmallow_api_level = 23;

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -704,22 +704,11 @@ union SaveLoadBuffer
     // Android version 6 Marshmallow (API level 23) and up does not support getting hw adr programmatically (https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).
     bool IsAndroidMarshmallowOrAbove()
     {
-        const long android_marshmallow_api_level = 23;
-        bool is_android = false;
-        bool marshmallow_or_higher = false;
-        long api_level_android = 0;
-
-        dmSys::SystemInfo info;
-        dmSys::GetSystemInfo(&info);
-
-        is_android = strcmp("Android", info.m_SystemName) == 0;
-        if (is_android)
-        {
-            api_level_android = strtol(info.m_ApiVersion, 0, 10);
-            marshmallow_or_higher = (api_level_android >= android_marshmallow_api_level);
-        }
-
-        return is_android && marshmallow_or_higher;
+        #ifdef ANDROID
+            const long android_marshmallow_api_level = 23;
+            return android_get_device_api_level() >= android_marshmallow_api_level;
+        #endif
+        return false;
     }
 
     /*# enumerate network interfaces


### PR DESCRIPTION
Fixed issue when `GetSystemInfo()` (the method used internally and for `sys.get_sys_info()`) by default requests `device_ident `. On Android this is `android_id` - a value secured by OS. If an application requests this then Data Safety Section needs to be filled even if app doesn't use internet connection and any IDs at all.
If you don't need `device_ident` value just call `sys.get_sys_info()` function with `{ignore_secure = true}` parameter: `sys.get_sys_info({ignore_secure  = true})` 

Fix https://github.com/defold/defold/issues/6764 