### PR TITLE
Consider `XDG_DATA_HOME` in `GetApplicationSupportPath` when platform is Linux

### DIFF
--- a/engine/dlib/src/dlib/sys.cpp
+++ b/engine/dlib/src/dlib/sys.cpp
@@ -449,7 +449,7 @@ namespace dmSys
 
     Result GetApplicationSupportPath(const char* application_name, char* path, uint32_t path_len)
     {
-        const char* dirs[] = {"HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
+        const char* dirs[] = {"XDG_DATA_HOME", "HOME", "TMPDIR", "TMP", "TEMP"}; // Added common temp directories since server instances usually don't have a HOME set
         size_t count = sizeof(dirs)/sizeof(dirs[0]);
         const char* home = 0;
         for (size_t i = 0; i < count; ++i)


### PR DESCRIPTION
The [XDG Base Directory specification](https://wiki.archlinux.org/title/XDG_Base_Directory) seems to be a widely accepted way of organizing support files on Linux. Storing support files under `$XDG_DATA_HOME` (if defined) would be preferable to writing directly under `$HOME`.