### PR TITLE
Fix issue when backspace holding doesn't work on iOS

### DIFF
--- a/engine/glfw/lib/ios/app/BaseView.h
+++ b/engine/glfw/lib/ios/app/BaseView.h
@@ -27,6 +27,7 @@
     BOOL secureTextEntry;
     id <UITextInputDelegate> inputDelegate;
     NSMutableString *markedText;
+    NSString *fakeText;
 }
 
 - (void)swapBuffers;


### PR DESCRIPTION
This fix makes it possible to remove multiple symbols if a user holds `backspace` button instead of a single tap - a single character removing.

Fix https://github.com/defold/defold/issues/6613