### PR TITLE
Fix Lua breakpoints not hitting unless bytecode is embedded

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -468,7 +468,7 @@
                     Lua$LuaModule
                     {:source {:script (ByteString/copyFromUtf8
                                         (slurp (data/lines-reader cleaned-lines)))
-                              :filename (resource/proj-path (:resource resource))}
+                              :filename (luajit/luajit-path-to-chunk-name (resource/proj-path (:resource resource)))}
                      :modules modules
                      :resources (mapv lua/lua-module->build-path modules)
                      :properties (properties/go-props->decls go-props true)

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -42,7 +42,7 @@
       (.printStackTrace e)
       {})))
 
-(def ^:private docs (string/split "base bit buffer builtins camera collectionfactory collectionproxy coroutine crash debug facebook factory go gui html5 http iac iap image io json label math model msg os package particlefx physics profiler push render resource socket sound spine sprite string sys table tilemap timer vmath webview window zlib" #" "))
+(def ^:private docs (string/split "base bit buffer builtins camera collectionfactory collectionproxy coroutine crash debug facebook factory go gui html5 http iac iap image io json label math model msg os package particlefx physics profiler push render resource socket sound sprite string sys table tilemap timer vmath webview window zlib" #" "))
 
 (defn- sdoc-path [doc]
   (format "doc/%s_doc.sdoc" doc))

--- a/engine/engine/content/builtins/scripts/mobdebug.lua
+++ b/engine/engine/content/builtins/scripts/mobdebug.lua
@@ -330,7 +330,7 @@ local function stack(start)
     if not source then break end
 
     local src = source.source
-    if src:find("@") == 1 then
+    if src:find("[@=]") == 1 then
       src = src:sub(2):gsub("\\", "/")
       if src:find("%./") == 1 then src = src:sub(3) end
     end
@@ -633,8 +633,8 @@ local function debug_hook(event, line)
       -- Unfortunately, there is no reliable/quick way to figure out
       -- what is the filename and what is the source code.
       -- If the name doesn't start with `@`, assume it's a file name if it's all on one line.
-      if find(file, "^@") or not find(file, "[\r\n]") then
-        file = gsub(gsub(file, "^@", ""), "\\", "/")
+      if find(file, "^[@=]") or not find(file, "[\r\n]") then
+        file = gsub(gsub(file, "^[@=]", ""), "\\", "/")
         -- normalize paths that may include up-dir or same-dir references
         -- if the path starts from the up-dir or reference,
         -- prepend `basedir` to generate absolute path to keep breakpoints working.


### PR DESCRIPTION
Fixes #6885

### User-facing changes
* Fixed Lua debugger breakpoints not suspending execution when running from the editor or bundling with the `--use-lua-source` flag.

### Technical changes
* Re-applied the patches to `mobdebug` from `DEF-971 - Mobdebug path handling`.
* Corrected the `filename` field in `LuaSource` binaries built from the editor so it matches Bob build output.
* Fixed an exception logged by the editor at startup caused by missing Spine documentation.