### PR TITLE
Revert bytecode generation for HTML5 builds

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -16,6 +16,7 @@ package com.dynamo.bob.pipeline;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -101,13 +101,33 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         Project p = GetProject();
         p.setOption("use-lua-source", "true");
 
-        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        final String path = "/test.script";
+        final String scriptSource = "function foo() print('foo') end";
+        LuaModule luaModule = (LuaModule)build(path, scriptSource).get(0);
         LuaSource luaSource = luaModule.getSource();
         assertTrue(luaSource.getScript() != null);
         assertTrue(luaSource.getScript().size() > 0);
         assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
+        p.getOutputFlags("build/" + path+ "c").contains(Project.OutputFlags.UNCOMPRESSED);
+    }
+
+    @Test
+    public void testUseCompressedLuaSource() throws Exception {
+        Project p = GetProject();
+        p.setOption("use-compressed-lua-source", "true");
+
+        final String path = "/test.script";
+        final String scriptSource = "function foo() print('foo') end";
+        LuaModule luaModule = (LuaModule)build(path, scriptSource).get(0);
+        LuaSource luaSource = luaModule.getSource();
+        assertTrue(luaSource.getScript() != null);
+        assertTrue(luaSource.getScript().size() > 0);
+        assertTrue(luaSource.getBytecode().size() == 0);
+        assertTrue(luaSource.getBytecode64().size() == 0);
+        assertTrue(luaSource.getDelta().size() == 0);
+        p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.ENCRYPTED);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -110,13 +110,13 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
-        p.getOutputFlags("build/" + path+ "c").contains(Project.OutputFlags.UNCOMPRESSED);
+        p.getOutputFlags("build/" + path+ "c").contains(Project.OutputFlags.ENCRYPTED);
     }
 
     @Test
-    public void testUseCompressedLuaSource() throws Exception {
+    public void testUseUncompressedLuaSource() throws Exception {
         Project p = GetProject();
-        p.setOption("use-compressed-lua-source", "true");
+        p.setOption("use-lua-source", "true");
 
         final String path = "/test.script";
         final String scriptSource = "function foo() print('foo') end";
@@ -127,7 +127,7 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
-        p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.ENCRYPTED);
+        p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED);
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -111,7 +111,7 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
-        assertTrue(p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED));
+        assertTrue(p.getOutputFlags("build" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED));
     }
 
     @Test
@@ -128,8 +128,8 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
-        assertTrue(p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.ENCRYPTED));
-        assertFalse(p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED));
+        assertTrue(p.getOutputFlags("build" + path + "c").contains(Project.OutputFlags.ENCRYPTED));
+        assertFalse(p.getOutputFlags("build" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED));
     }
 
     // Leaving these tests in case we decide to reintroduce bytecode generation for Lua 5.1.5

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -110,34 +110,54 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
-        p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED);
+        assertTrue(p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED));
     }
 
     @Test
-    public void testVanillaLuaBytecode() throws Exception {
+    public void testCompressedLuaSourceForHTML5() throws Exception {
         Project p = GetProject();
         p.setOption("platform", "js-web");
 
-        StringBuilder src = new StringBuilder();
-        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+        final String path = "/test.script";
+        final String scriptSource = "function foo() print('foo') end";
+        LuaModule luaModule = (LuaModule)build(path, scriptSource).get(0);
         LuaSource luaSource = luaModule.getSource();
-        assertTrue(luaSource.getScript().size() == 0);
-        assertTrue(luaSource.getBytecode().size() > 0);
+        assertTrue(luaSource.getScript() != null);
+        assertTrue(luaSource.getScript().size() > 0);
+        assertTrue(luaSource.getBytecode().size() == 0);
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() == 0);
+        assertTrue(p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.ENCRYPTED));
+        assertFalse(p.getOutputFlags("build/" + path + "c").contains(Project.OutputFlags.UNCOMPRESSED));
     }
 
-    @Test
-    public void testVanillaLuaBytecodeChunkname() throws Exception {
-        Project p = GetProject();
-        p.setOption("platform", "js-web");
+    // Leaving these tests in case we decide to reintroduce bytecode generation for Lua 5.1.5
+    //
+    // @Test
+    // public void testVanillaLuaBytecode() throws Exception {
+    //     Project p = GetProject();
+    //     p.setOption("platform", "js-web");
 
-        StringBuilder src = new StringBuilder();
-        LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
-        LuaSource luaSource = luaModule.getSource();
-        String chunkname = luaSource.getBytecode().substring(12+4, 12+4+12).toStringUtf8();
-        assertEquals("@test.script", chunkname);
-    }
+    //     StringBuilder src = new StringBuilder();
+    //     LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+    //     LuaSource luaSource = luaModule.getSource();
+    //     assertTrue(luaSource.getScript().size() == 0);
+    //     assertTrue(luaSource.getBytecode().size() > 0);
+    //     assertTrue(luaSource.getBytecode64().size() == 0);
+    //     assertTrue(luaSource.getDelta().size() == 0);
+    // }
+
+    // @Test
+    // public void testVanillaLuaBytecodeChunkname() throws Exception {
+    //     Project p = GetProject();
+    //     p.setOption("platform", "js-web");
+
+    //     StringBuilder src = new StringBuilder();
+    //     LuaModule luaModule = (LuaModule)build("/test.script", "function foo() print('foo') end").get(0);
+    //     LuaSource luaSource = luaModule.getSource();
+    //     String chunkname = luaSource.getBytecode().substring(12+4, 12+4+12).toStringUtf8();
+    //     assertEquals("@test.script", chunkname);
+    // }
 
     @Test
     public void testLuaJITBytecode64WithoutDelta() throws Exception {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -97,26 +97,9 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
     }
 
     @Test
-    public void testUseLuaSource() throws Exception {
-        Project p = GetProject();
-        p.setOption("use-lua-source", "true");
-
-        final String path = "/test.script";
-        final String scriptSource = "function foo() print('foo') end";
-        LuaModule luaModule = (LuaModule)build(path, scriptSource).get(0);
-        LuaSource luaSource = luaModule.getSource();
-        assertTrue(luaSource.getScript() != null);
-        assertTrue(luaSource.getScript().size() > 0);
-        assertTrue(luaSource.getBytecode().size() == 0);
-        assertTrue(luaSource.getBytecode64().size() == 0);
-        assertTrue(luaSource.getDelta().size() == 0);
-        p.getOutputFlags("build/" + path+ "c").contains(Project.OutputFlags.ENCRYPTED);
-    }
-
-    @Test
     public void testUseUncompressedLuaSource() throws Exception {
         Project p = GetProject();
-        p.setOption("use-lua-source", "true");
+        p.setOption("use-uncompressed-lua-source", "true");
 
         final String path = "/test.script";
         final String scriptSource = "function foo() print('foo') end";

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -465,7 +465,6 @@ public class Bob {
         addOption(options, null, "binary-output", true, "Location where built engine binary will be placed. Default is \"<build-output>/<platform>/\"", true);
 
         addOption(options, null, "use-vanilla-lua", false, "DEPRECATED! Use --use-uncompressed-lua-source instead.", true);
-        addOption(options, null, "use-lua-source", false, "Use compressed and encrypted Lua source code instead of byte code", true);
         addOption(options, null, "use-uncompressed-lua-source", false, "Use uncompressed and unencrypted Lua source code instead of byte code", true);
         addOption(options, null, "archive-resource-padding", true, "The alignment of the resources in the game archive. Default is 4", true);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -464,8 +464,9 @@ public class Bob {
         addOption(options, null, "defoldsdk", true, "What version of the defold sdk (sha1) to use", true);
         addOption(options, null, "binary-output", true, "Location where built engine binary will be placed. Default is \"<build-output>/<platform>/\"", true);
 
-        addOption(options, null, "use-vanilla-lua", false, "DEPRECATED! Use --use-lua-source instead.", true);
+        addOption(options, null, "use-vanilla-lua", false, "DEPRECATED! Use --use-lua-source or --use-compressed-lua-source instead.", true);
         addOption(options, null, "use-lua-source", false, "Use uncompressed and unencrypted Lua source code instead of byte code", true);
+        addOption(options, null, "use-compressed-lua-source", false, "Use compressed and encrypted Lua source code instead of byte code", true);
         addOption(options, null, "archive-resource-padding", true, "The alignment of the resources in the game archive. Default is 4", true);
 
         addOption(options, "l", "liveupdate", true, "Yes if liveupdate content should be published", true);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -464,9 +464,9 @@ public class Bob {
         addOption(options, null, "defoldsdk", true, "What version of the defold sdk (sha1) to use", true);
         addOption(options, null, "binary-output", true, "Location where built engine binary will be placed. Default is \"<build-output>/<platform>/\"", true);
 
-        addOption(options, null, "use-vanilla-lua", false, "DEPRECATED! Use --use-lua-source or --use-compressed-lua-source instead.", true);
-        addOption(options, null, "use-lua-source", false, "Use uncompressed and unencrypted Lua source code instead of byte code", true);
-        addOption(options, null, "use-compressed-lua-source", false, "Use compressed and encrypted Lua source code instead of byte code", true);
+        addOption(options, null, "use-vanilla-lua", false, "DEPRECATED! Use --use-uncompressed-lua-source instead.", true);
+        addOption(options, null, "use-lua-source", false, "Use compressed and encrypted Lua source code instead of byte code", true);
+        addOption(options, null, "use-uncompressed-lua-source", false, "Use uncompressed and unencrypted Lua source code instead of byte code", true);
         addOption(options, null, "archive-resource-padding", true, "The alignment of the resources in the game archive. Default is 4", true);
 
         addOption(options, "l", "liveupdate", true, "Yes if liveupdate content should be published", true);
@@ -659,8 +659,8 @@ public class Bob {
         }
 
         if (cmd.hasOption("use-vanilla-lua")) {
-            System.out.println("--use-vanilla-lua option is deprecated. Use --use-lua-source instead.");
-            project.setOption("use-lua-source", "true");
+            System.out.println("--use-vanilla-lua option is deprecated. Use --use-uncompressed-lua-source instead.");
+            project.setOption("use-uncompressed-lua-source", "true");
         }
 
         Option[] options = cmd.getOptions();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1485,6 +1485,10 @@ run:
         return outputs;
     }
 
+    public EnumSet<OutputFlags> getOutputFlags(String resourcePath) {
+        return outputs.get(resourcePath);
+    }
+
     /**
      * Add output flag to resource
      * @param resourcePath output resource absolute path

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -313,15 +313,15 @@ public abstract class LuaBuilder extends Builder<Void> {
             }
         }
 
-        boolean use_lua_source = this.project.option("use-lua-source", "false").equals("true");
-        
+        boolean useLuaSource = this.project.option("use-lua-source", "false").equals("true");
+        boolean useCompressedLuaSource = this.project.option("use-compressed-lua-source", "false").equals("true");
         // set compression and encryption flags
         // if the use-lua-source flag is set the project will use uncompressed plain text Lua script files
         // if the use-lua-source flag is NOT set the project will use encrypted and possibly also compressed bytecode
         for(IResource res : task.getOutputs()) {
             String path = res.getAbsPath();
             if(path.endsWith("luac") || path.endsWith("scriptc") || path.endsWith("gui_scriptc") || path.endsWith("render_scriptc")) {
-                if (use_lua_source) {
+                if (useLuaSource) {
                     project.addOutputFlags(path, Project.OutputFlags.UNCOMPRESSED);
                 }
                 else {
@@ -333,7 +333,7 @@ public abstract class LuaBuilder extends Builder<Void> {
         LuaSource.Builder srcBuilder = LuaSource.newBuilder();
         srcBuilder.setFilename(task.input(0).getPath());
 
-        if (use_lua_source) {
+        if (useLuaSource || useCompressedLuaSource) {
             srcBuilder.setScript(ByteString.copyFrom(script.getBytes()));
         } else if (needsVanillaLua32.contains(project.getPlatform())) {
             byte[] bytecode = constructLuaBytecode(task, "luac-32", script);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -314,14 +314,14 @@ public abstract class LuaBuilder extends Builder<Void> {
         }
 
         boolean useLuaSource = this.project.option("use-lua-source", "false").equals("true");
-        boolean useCompressedLuaSource = this.project.option("use-compressed-lua-source", "false").equals("true");
+        boolean useUncompressedLuaSource = this.project.option("use-uncompressed-lua-source", "false").equals("true");
         // set compression and encryption flags
-        // if the use-lua-source flag is set the project will use uncompressed plain text Lua script files
-        // if the use-lua-source flag is NOT set the project will use encrypted and possibly also compressed bytecode
+        // if the use-uncompressed-lua-source flag is set the project will use uncompressed plain text Lua script files
+        // if the use-uncompressed-lua-source flag is NOT set the project will use encrypted and possibly also compressed bytecode
         for(IResource res : task.getOutputs()) {
             String path = res.getAbsPath();
             if(path.endsWith("luac") || path.endsWith("scriptc") || path.endsWith("gui_scriptc") || path.endsWith("render_scriptc")) {
-                if (useLuaSource) {
+                if (useUncompressedLuaSource) {
                     project.addOutputFlags(path, Project.OutputFlags.UNCOMPRESSED);
                 }
                 else {
@@ -333,7 +333,7 @@ public abstract class LuaBuilder extends Builder<Void> {
         LuaSource.Builder srcBuilder = LuaSource.newBuilder();
         srcBuilder.setFilename(task.input(0).getPath());
 
-        if (useLuaSource || useCompressedLuaSource) {
+        if (useLuaSource || useUncompressedLuaSource) {
             srcBuilder.setScript(ByteString.copyFrom(script.getBytes()));
         } else if (needsVanillaLua32.contains(project.getPlatform())) {
             byte[] bytecode = constructLuaBytecode(task, "luac-32", script);


### PR DESCRIPTION
The Lua bytecode generation for platforms using Lua 5.1.5 (ie HTML5) which was introduced in Defold 1.3.5 has been removed. Tests have shown that the generated bytecode becomes larger than source code, even when compressed (this is not the case for LuaJIT bytecode). This increase in size is unacceptable for web games.

In addition to this the command line flag `--use-lua-source` which was introduced in 1.3.5 has been replaced with `--use-uncompressed-lua-source` flag to clearly signify that the included Lua source code is not only in source code format but also that it is not compressed. The deprecated `--use-vanilla-lua` option maps to `--use-uncompressed-lua-source`.

Fixes #6891 