### PR TITLE
Issue-6883 Fix rare crash in profiler

### DIFF
--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1820,7 +1820,7 @@ namespace dmScript
     // to calculate the length of the input string or output string
     static char* ConcatString(char* w_ptr, const char* w_ptr_end, const char* str)
     {
-        while ((w_ptr != w_ptr_end) && *str)
+        while ((w_ptr != w_ptr_end) && str && *str)
         {
             *w_ptr++ = *str++;
         }
@@ -1850,7 +1850,10 @@ namespace dmScript
             LuaFunctionInfo fi;
             if (dmScript::GetLuaFunctionRefInfo(L, optional_callback_index, &fi))
             {
-                function_source = fi.m_FileName;
+                if (fi.m_FileName)
+                {
+                    function_source = fi.m_FileName;
+                }
                 if (fi.m_OptionalName)
                 {
                     w_ptr = ConcatString(w_ptr, w_ptr_end, fi.m_OptionalName);


### PR DESCRIPTION
Make sure that profiler doesn't crash if Lua doesn't provide information about function source.

Fix https://github.com/defold/defold/issues/6883