### PR TITLE
Added Info.plist merge marker declaration

### DIFF
--- a/engine/engine/content/builtins/manifests/ios/Info.plist
+++ b/engine/engine/content/builtins/manifests/ios/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd" [ <!ATTLIST key merge (keep) #IMPLIED> ]>
 <plist version="1.0">
 <dict>
         <key>BuildMachineOSBuild</key>


### PR DESCRIPTION
This was added on the extender recently (https://github.com/defold/extender/issues/205) and to help developers get started the merge marker definition should be included in the default Info.plist for iOS.