### PR TITLE
Show options when there are multiple candidates for a partial console path

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1511,7 +1511,7 @@
 (defn handle-mouse-released! [view-node ^MouseEvent event]
   (.consume event)
   (when-some [{:keys [on-click!] :as hovered-region} (:region (get-property view-node :hovered-element))]
-    (on-click! hovered-region))
+    (on-click! hovered-region event))
   (refresh-mouse-cursor! view-node event)
   (set-properties! view-node :selection
                    (data/mouse-released (get-property view-node :lines)

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -23,6 +23,7 @@
             [editor.handler :as handler]
             [editor.resource :as resource]
             [editor.ui :as ui]
+            [editor.util :as util]
             [editor.workspace :as workspace])
   (:import [clojure.lang PersistentQueue]
            [editor.code.data Cursor CursorRange LayoutInfo Rect]
@@ -30,7 +31,7 @@
            [javafx.beans.property SimpleStringProperty]
            [javafx.scene Parent Scene]
            [javafx.scene.canvas Canvas GraphicsContext]
-           [javafx.scene.control Button Tab TabPane TextField]
+           [javafx.scene.control Button Tab TextField]
            [javafx.scene.input Clipboard KeyCode KeyEvent MouseEvent ScrollEvent]
            [javafx.scene.layout GridPane Pane]
            [javafx.scene.paint Color]
@@ -355,39 +356,42 @@
 (def ^:private ^:const line-sub-regions-pattern-partial #"([^\s<>:]+):(\d+)")
 (def ^:private ^:const sub-region-strip-ellipsis-prefix-pattern #"^(?>\.{3})?(.*)")
 
+(def ^:private non-empty-string? (comp string? not-empty))
+
 (defn- make-resource-reference-region
-  ([row start-col end-col resource-proj-path on-click!]
-   (assert (string? (not-empty resource-proj-path)))
-   (assert (ifn? on-click!))
+  ([row start-col end-col resource-proj-path-candidates on-click!]
+   {:pre [(vector? resource-proj-path-candidates)
+          (not-empty resource-proj-path-candidates)
+          (every? non-empty-string? resource-proj-path-candidates)
+          (ifn? on-click!)]}
    (assoc (data/->CursorRange (data/->Cursor row start-col)
                               (data/->Cursor row end-col))
      :type :resource-reference
-     :proj-path resource-proj-path
+     :proj-path-candidates resource-proj-path-candidates
      :on-click! on-click!))
-  ([row start-col end-col resource-proj-path resource-row on-click!]
-   (assert (integer? resource-row))
-   (assert (not (neg? ^long resource-row)))
-   (assoc (make-resource-reference-region row start-col end-col resource-proj-path on-click!)
+  ([row start-col end-col resource-proj-path-candidates resource-row on-click!]
+   {:pre [(integer? resource-row)
+          (not (neg? ^long resource-row))]}
+   (assoc (make-resource-reference-region row start-col end-col resource-proj-path-candidates on-click!)
      :row resource-row)))
 
 (defn- strip-ellipsis-prefix [partial-path]
   (second (re-matches sub-region-strip-ellipsis-prefix-pattern partial-path)))
 
-(defn- find-project-resource-from-potential-match
-  [resource-map partial-path]
+(defn- find-project-resource-paths-from-potential-match [resource-map partial-path]
   (if (contains? resource-map partial-path)
-    partial-path ;; Already a valid path
-    (let [partial-path (strip-ellipsis-prefix partial-path)
-          partial-matches (filter #(string/ends-with? % partial-path) (keys resource-map))]
-      (when (= 1 (bounded-count 2 partial-matches))
-        (first partial-matches)))))
+    [partial-path] ; An exact match.
+    (let [partial-path-without-ellipsis-prefix (strip-ellipsis-prefix partial-path)]
+      (vec (sort util/natural-order
+                 (filter #(string/ends-with? % partial-path-without-ellipsis-prefix)
+                         (keys resource-map)))))))
 
 (defn- make-line-sub-regions [resource-map on-region-click! row line]
   (into []
         (comp
           (mapcat #(re-match-result-seq % line))
           (keep (fn [^MatchResult result]
-                  (when-let [resource-proj-path (find-project-resource-from-potential-match resource-map (.group result 1))]
+                  (when-some [resource-proj-path-candidates (not-empty (find-project-resource-paths-from-potential-match resource-map (.group result 1)))]
                     (let [resource-row (some-> (.group result 2) Long/parseUnsignedLong)
                           start-col (.start result)
                           end-col (if (string/ends-with? (.group result) ":")
@@ -395,8 +399,8 @@
                                     (.end result))]
                       (if (or (nil? resource-row)
                               (neg? (dec (long resource-row))))
-                        (make-resource-reference-region row start-col end-col resource-proj-path on-region-click!)
-                        (make-resource-reference-region row start-col end-col resource-proj-path (dec (long resource-row)) on-region-click!))))))
+                        (make-resource-reference-region row start-col end-col resource-proj-path-candidates on-region-click!)
+                        (make-resource-reference-region row start-col end-col resource-proj-path-candidates (dec (long resource-row)) on-region-click!))))))
           (distinct))
         [line-sub-regions-pattern line-sub-regions-pattern-partial]))
 
@@ -503,6 +507,12 @@
        ["editor.selection.background.inactive" (.interpolate selection-background-color background-color 0.25)]
        ["editor.selection.occurrence.outline" (Color/valueOf "#A2B0BE")]])))
 
+(defn- openable-resource? [value]
+  (and (resource/openable-resource? value)
+       (resource/exists? value)))
+
+(def ^:private resource->menu-item (comp ui/string->menu-item resource/proj-path))
+
 (defn make-console! [graph workspace ^Tab console-tab ^GridPane console-grid-pane open-resource-fn]
   (let [^Pane canvas-pane (.lookup console-grid-pane "#console-canvas-pane")
         canvas (Canvas. (.getWidth canvas-pane) (.getHeight canvas-pane))
@@ -518,14 +528,21 @@
                                              :line-height-factor 1.2
                                              :resize-reference :bottom))
         tool-bar (setup-tool-bar! (.lookup console-grid-pane "#console-tool-bar") view-node)
-        on-region-click! (fn on-region-click! [region]
+        on-region-click! (fn on-region-click! [region ^MouseEvent event]
                            (when (= :resource-reference (:type region))
-                             (let [resource (workspace/find-resource workspace (:proj-path region))]
-                               (when (and (resource/openable-resource? resource)
-                                          (resource/exists? resource))
-                                 (let [opts (when-some [row (:row region)]
-                                              {:cursor-range (data/Cursor->CursorRange (data/->Cursor row 0))})]
-                                   (open-resource-fn resource opts))))))
+                             (let [open-resource! (fn open-resource! [resource]
+                                                    (when (openable-resource? resource)
+                                                      (let [opts (when-some [row (:row region)]
+                                                                   {:cursor-range (data/Cursor->CursorRange (data/->Cursor row 0))})]
+                                                        (open-resource-fn resource opts))))
+                                   resource-candidates (into []
+                                                             (comp (keep (partial workspace/find-resource workspace))
+                                                                   (filter openable-resource?))
+                                                             (:proj-path-candidates region))]
+                               (case (count resource-candidates)
+                                 0 nil
+                                 1 (open-resource! (first resource-candidates))
+                                 (ui/show-simple-context-menu-at-mouse! resource->menu-item open-resource! resource-candidates event)))))
         repainter (ui/->timer "repaint-console-view" (fn [_ elapsed-time]
                                                        (when (and (.isSelected console-tab) (not (ui/ui-disabled?)))
                                                          (repaint-console-view! view-node workspace on-region-click! elapsed-time))))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -29,34 +29,33 @@
             [service.log :as log]
             [service.smoke-log :as slog]
             [util.profiler :as profiler])
-  (:import
-   [com.defold.control LongField]
-   [com.defold.control ListCell]
-   [com.defold.control TreeCell]
-   [com.sun.javafx.application PlatformImpl]
-   [com.sun.javafx.event DirectEvent]
-   [java.awt Desktop Desktop$Action]
-   [java.io File IOException]
-   [java.net URI]
-   [java.util Collection]
-   [javafx.animation AnimationTimer Timeline KeyFrame KeyValue]
-   [javafx.application Platform]
-   [javafx.beans InvalidationListener]
-   [javafx.beans.value ChangeListener ObservableValue]
-   [javafx.collections FXCollections ListChangeListener ObservableList]
-   [javafx.css Styleable]
-   [javafx.event ActionEvent Event EventDispatcher EventHandler EventTarget]
-   [javafx.fxml FXMLLoader]
-   [javafx.geometry Orientation]
-   [javafx.scene Group Node Parent Scene]
-   [javafx.scene.control ButtonBase Cell CheckBox CheckMenuItem ChoiceBox ColorPicker ComboBox ComboBoxBase ContextMenu Control Label Labeled ListView Menu MenuBar MenuItem MultipleSelectionModel ProgressBar SelectionMode SelectionModel Separator SeparatorMenuItem Tab TableView TabPane TextField TextInputControl Toggle ToggleButton Tooltip TreeItem TreeTableView TreeView]
-   [javafx.scene.input Clipboard ContextMenuEvent DragEvent KeyCode KeyCombination KeyEvent MouseButton MouseEvent]
-   [javafx.scene.image Image ImageView]
-   [javafx.scene.layout AnchorPane Pane HBox]
-   [javafx.scene.shape SVGPath]
-   [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter]
-   [javafx.stage Stage Modality Window PopupWindow StageStyle]
-   [javafx.util Callback Duration StringConverter]))
+  (:import [com.defold.control ListCell]
+           [com.defold.control LongField]
+           [com.defold.control TreeCell]
+           [com.sun.javafx.application PlatformImpl]
+           [com.sun.javafx.event DirectEvent]
+           [java.awt Desktop Desktop$Action]
+           [java.io File IOException]
+           [java.net URI]
+           [java.util Collection]
+           [javafx.animation AnimationTimer KeyFrame KeyValue Timeline]
+           [javafx.application Platform]
+           [javafx.beans InvalidationListener]
+           [javafx.beans.value ChangeListener ObservableValue]
+           [javafx.collections FXCollections ListChangeListener ObservableList]
+           [javafx.css Styleable]
+           [javafx.event ActionEvent Event EventDispatcher EventHandler EventTarget]
+           [javafx.fxml FXMLLoader]
+           [javafx.geometry Orientation Point2D]
+           [javafx.scene Group Node Parent Scene]
+           [javafx.scene.control ButtonBase Cell CheckBox CheckMenuItem ChoiceBox ColorPicker ComboBox ComboBoxBase ContextMenu Control Label Labeled ListView Menu MenuBar MenuItem MultipleSelectionModel ProgressBar SelectionMode SelectionModel Separator SeparatorMenuItem Tab TableView TabPane TextField TextInputControl Toggle ToggleButton Tooltip TreeItem TreeTableView TreeView]
+           [javafx.scene.image Image ImageView]
+           [javafx.scene.input Clipboard ContextMenuEvent DragEvent KeyCode KeyCombination KeyEvent MouseButton MouseEvent]
+           [javafx.scene.layout AnchorPane HBox Pane]
+           [javafx.scene.shape SVGPath]
+           [javafx.stage DirectoryChooser FileChooser FileChooser$ExtensionFilter]
+           [javafx.stage Stage Modality PopupWindow StageStyle Window]
+           [javafx.util Callback Duration StringConverter]))
 
 (set! *warn-on-reflection* true)
 
@@ -102,6 +101,9 @@
 (defprotocol Text
   (text ^String [this])
   (text! [this ^String val]))
+
+(defprotocol HasAction
+  (on-action! [this fn]))
 
 (defprotocol HasValue
   (value [this])
@@ -657,6 +659,8 @@
   (editable! [this val] (.setDisable this (not val))))
 
 (extend-type MenuItem
+  HasAction
+  (on-action! [this fn] (.setOnAction this (event-handler e (fn e))))
   HasUserData
   (user-data [this key] (get (.getUserData this) key))
   (user-data! [this key val] (.setUserData this (assoc (or (.getUserData this) {}) key val))))
@@ -670,9 +674,6 @@
   (text! [this val]
     (when (not= (.getText this) val)
       (.setText this val))))
-
-(defprotocol HasAction
-  (on-action! [this fn]))
 
 (defprotocol HasChildren
   (children! [this c])
@@ -2173,3 +2174,35 @@ command."
      (doto (SVGPath.)
        (add-style! "bottom")
        (.setContent (make-path-data col row [[0,6 1,5 1,7 2,6 3,7 4,6 5,7 5,5 6,6 5,7 4,8 5,9 4,10 3,9 2,10 1,9 2,8] [3,5 2,4 3,3 4,4]])))]))
+
+(defn string->menu-item
+  ^MenuItem [^String str]
+  (doto (MenuItem.)
+    (.setText str)))
+
+(defn show-simple-context-menu!
+  [menu-item-fn item-action-fn items ^Node anchor-node ^Point2D offset]
+  (let [handle-action! (fn [^Event event]
+                         (let [menu-item (.getTarget event)
+                               item (user-data menu-item ::item)]
+                           (item-action-fn item)))
+        menu-items (map (fn [item]
+                          (doto (menu-item-fn item)
+                            (user-data! ::item item)
+                            (on-action! handle-action!)))
+                        items)
+        context-menu (doto (make-context-menu menu-items)
+                       (on-closed! (fn [_]
+                                     (item-action-fn nil))))
+        hide-event-handler (event-handler event (.hide context-menu))]
+    (.addEventFilter anchor-node MouseEvent/MOUSE_PRESSED hide-event-handler)
+    (on-closed! context-menu (fn [_]
+                               (.removeEventFilter anchor-node MouseEvent/MOUSE_PRESSED hide-event-handler)
+                               (item-action-fn nil)))
+    (.show context-menu anchor-node (.getX offset) (.getY offset))))
+
+(defn show-simple-context-menu-at-mouse!
+  [menu-item-fn item-action-fn items ^MouseEvent mouse-event]
+  (let [anchor-node (.getTarget mouse-event)
+        offset (Point2D. (.getScreenX mouse-event) (.getScreenY mouse-event))]
+    (show-simple-context-menu! menu-item-fn item-action-fn items anchor-node offset)))

--- a/editor/test/editor/console_test.clj
+++ b/editor/test/editor/console_test.clj
@@ -63,14 +63,14 @@
 
     "ERROR:SCRIPT: e_name_is_quite_long_how_will_you_deal_with_that_huh.script:2: attempt to call field 'balooba' (a nil value)" ["e_name_is_quite_long_how_will_you_deal_with_that_huh.script" "2"]))
 
-(defn- on-region-click! [_region]
+(defn- on-region-click! [_region _event]
   nil)
 
 (defn- resource-reference-region
   ([row col text resource-proj-path]
-   (#'console/make-resource-reference-region row col (+ col (count text)) resource-proj-path on-region-click!))
+   (#'console/make-resource-reference-region row col (+ col (count text)) [resource-proj-path] on-region-click!))
   ([row col text resource-proj-path resource-row]
-   (#'console/make-resource-reference-region row col (+ col (count text)) resource-proj-path resource-row on-region-click!)))
+   (#'console/make-resource-reference-region row col (+ col (count text)) [resource-proj-path] resource-row on-region-click!)))
 
 (defn- whole-line-region [type row text]
   (#'console/make-whole-line-region type row text))


### PR DESCRIPTION
### User-facing changes
* When multiple project resources match a partial file path in the Console, we now present a choice of resources to open.

### Technical changes
* The `on-click!` callback for a `code.view` region is now called with an additional `MouseEvent` argument.