### PR TITLE
Added raw gamepad input to gui scripts

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -405,7 +405,12 @@ namespace dmGameObject
         float m_ScreenDX;
         /// Cursor dy since last frame, in screen space
         float m_ScreenDY;
-        float m_AccX, m_AccY, m_AccZ;
+        /// Accelerometer x value (if present)
+        float m_AccX;
+        /// Accelerometer y value (if present)
+        float m_AccY;
+        /// Accelerometer z value (if present)
+        float m_AccZ;
         /// Touch data
         dmHID::Touch m_Touch[dmHID::MAX_TOUCH_COUNT];
         /// Number of m_Touch

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2204,6 +2204,8 @@ namespace dmGameSystem
             gui_input_action.m_IsGamepad = params.m_InputAction->m_IsGamepad;
             gui_input_action.m_GamepadDisconnected = params.m_InputAction->m_GamepadDisconnected;
             gui_input_action.m_GamepadConnected = params.m_InputAction->m_GamepadConnected;
+            gui_input_action.m_GamepadPacket = params.m_InputAction->m_GamepadPacket;
+            gui_input_action.m_HasGamepadPacket = params.m_InputAction->m_HasGamepadPacket;
             gui_input_action.m_AccX = params.m_InputAction->m_AccX;
             gui_input_action.m_AccY = params.m_InputAction->m_AccY;
             gui_input_action.m_AccZ = params.m_InputAction->m_AccZ;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1831,6 +1831,48 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
                         lua_setfield(L, -2, "gamepad_name");
                     }
 
+                    if (ia->m_HasGamepadPacket)
+                    {
+                        dmHID::GamepadPacket gamepadPacket = ia->m_GamepadPacket;
+                        lua_pushliteral(L, "gamepad_axis");
+                        lua_createtable(L, dmHID::MAX_GAMEPAD_AXIS_COUNT, 0);
+                        for (int i = 0; i < dmHID::MAX_GAMEPAD_AXIS_COUNT; ++i)
+                        {
+                            lua_pushinteger(L, (lua_Integer) (i+1));
+                            lua_pushnumber(L, gamepadPacket.m_Axis[i]);
+                            lua_settable(L, -3);
+                        }
+                        lua_settable(L, -3);
+
+                        lua_pushliteral(L, "gamepad_buttons");
+                        lua_createtable(L, dmHID::MAX_GAMEPAD_AXIS_COUNT, 0);
+                        for (int i = 0; i < dmHID::MAX_GAMEPAD_AXIS_COUNT; ++i)
+                        {
+                            lua_pushinteger(L, (lua_Integer) (i+1));
+                            lua_pushnumber(L, dmHID::GetGamepadButton(&gamepadPacket, i));
+                            lua_settable(L, -3);
+                        }
+                        lua_settable(L, -3);
+
+                        lua_pushliteral(L, "gamepad_hats");
+                        lua_createtable(L, dmHID::MAX_GAMEPAD_HAT_COUNT, 0);
+                        for (int i = 0; i < dmHID::MAX_GAMEPAD_HAT_COUNT; ++i)
+                        {
+                            lua_pushinteger(L, (lua_Integer) (i+1));
+                            uint8_t hat_value;
+                            if (dmHID::GetGamepadHat(&gamepadPacket, i, &hat_value))
+                            {
+                                lua_pushnumber(L, hat_value);
+                            }
+                            else
+                            {
+                                lua_pushnumber(L, 0);
+                            }
+                            lua_settable(L, -3);
+                        }
+                        lua_settable(L, -3);
+                    }
+
                     if (ia->m_ActionId != 0)
                     {
                         lua_pushstring(L, "value");

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -368,20 +368,26 @@ namespace dmGui
         char     m_Text[dmHID::MAX_CHAR_COUNT];
         uint32_t m_TextCount;
         uint32_t m_GamepadIndex;
-        uint16_t m_IsGamepad : 1;
-        uint16_t m_GamepadDisconnected : 1;
-        uint16_t m_GamepadConnected : 1;
-        uint16_t m_HasText : 1;
+        dmHID::GamepadPacket m_GamepadPacket;
+
+        uint8_t  m_IsGamepad : 1;
+        uint8_t  m_GamepadDisconnected : 1;
+        uint8_t  m_GamepadConnected : 1;
+        uint8_t  m_HasGamepadPacket : 1;
+        /// If input has a text payload (can be true even if text count is 0)
+        uint8_t  m_HasText : 1;
         /// If the input was 0 last update
-        uint16_t m_Pressed : 1;
+        uint8_t  m_Pressed : 1;
         /// If the input turned from above 0 to 0 this update
-        uint16_t m_Released : 1;
+        uint8_t  m_Released : 1;
         /// If the input was held enough for the value to be repeated this update
-        uint16_t m_Repeated : 1;
-        /// If the position fields (m_X, m_Y, m_DX, m_DY) are set and valid to read
-        uint16_t m_PositionSet : 1;
-        /// If the acceleration fields (m_AccX, m_AccY, m_AccZ) are set and valid to read
-        uint16_t m_AccelerationSet : 1;
+        uint8_t  m_Repeated : 1;
+        /// If the position fields (m_X, m_Y, m_DX, m_DY) were set and valid to read
+        uint8_t  m_PositionSet : 1;
+        /// If the accelerometer fields (m_AccX, m_AccY, m_AccZ) were set and valid to read
+        uint8_t  m_AccelerationSet : 1;
+        /// If the input action was consumed in an event dispatch
+        uint8_t  m_Consumed : 1;
     };
 
     struct RenderEntry {


### PR DESCRIPTION
Raw gamepad events were previously only sent to script components. This fix adds raw gamepad input events to gui scripts as well.
 
Fixes #6945 