### PR TITLE
Improve build progress reporting

### DIFF
--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -20,6 +20,7 @@
             [editor.icons :as icons]
             [editor.outline :as outline]
             [editor.resource :as resource]
+            [editor.resource-io :as resource-io]
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [util.coll :refer [pair]])
@@ -85,7 +86,9 @@
 (defn- missing-resource-node? [evaluation-context node-id]
   (and (g/node-instance? (:basis evaluation-context) resource/ResourceNode node-id)
        (some? (g/node-value node-id :resource evaluation-context))
-       (some? (g/node-value node-id :_output-jammers evaluation-context))))
+       (if-some [output-jammers (g/node-value node-id :_output-jammers evaluation-context)]
+         (resource-io/file-not-found-error? (first (vals output-jammers)))
+         false)))
 
 (defn- error-item [evaluation-context root-cause]
   (let [{:keys [message severity]} (first root-cause)

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -174,11 +174,10 @@
         true)
 
     exception
-    (if (engine-build-errors/handle-build-error! render-error! project evaluation-context exception)
-      true
-      (throw exception))))
+    (do (engine-build-errors/handle-build-error! render-error! project evaluation-context exception)
+        true)))
 
-(defn async-bob-build! [render-reload-progress! render-save-progress! render-build-progress! task-cancelled? render-build-error! bob-commands bob-args project changes-view callback!]
+(defn async-bob-build! [render-reload-progress! render-save-progress! render-build-progress! show-build-log-stream! task-cancelled? render-build-error! bob-commands bob-args project changes-view callback!]
   (disk-availability/push-busy!)
   (future
     (try
@@ -223,7 +222,7 @@
                              (let [evaluation-context (g/make-evaluation-context)]
                                (future
                                  (try
-                                   (let [result (bob/bob-build! project evaluation-context bob-commands bob-args render-build-progress! task-cancelled?)]
+                                   (let [result (bob/bob-build! project evaluation-context bob-commands bob-args render-build-progress! show-build-log-stream! task-cancelled?)]
                                      (extensions/execute-hook!
                                        project
                                        :on-bundle-finished

--- a/editor/src/clj/editor/resource_io.clj
+++ b/editor/src/clj/editor/resource_io.clj
@@ -21,6 +21,9 @@
 (defn file-not-found-error [node-id label severity resource]
   (g/->error node-id label severity nil (format "The file '%s' could not be found." (resource/proj-path resource)) {:type :file-not-found :resource resource}))
 
+(defn file-not-found-error? [error]
+  (= :file-not-found (-> error :user-data :type)))
+
 (defn invalid-content-error [node-id label severity resource]
   (g/->error node-id label severity nil (format "The file '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content :resource resource}))
 

--- a/editor/test/integration/spine_extension_test.clj
+++ b/editor/test/integration/spine_extension_test.clj
@@ -88,8 +88,7 @@
                         (let [error-tree (build-errors-view/build-resource-tree error-value)
                               error-item-of-parent-resource (first (:children error-tree))
                               error-item-of-faulty-node (first (:children error-item-of-parent-resource))]
-                          (is (= :unknown-parent
-                                 (:type error-item-of-parent-resource)))
+                          (is (= :resource (:type error-item-of-parent-resource)))
                           (is (= (str "The file '" error-resource-path "' could not be loaded.")
                                  (:message error-item-of-faulty-node)))))]
                 (is (invalid-content-error? "/main/main.collection" (test-util/build-error! main-collection)))


### PR DESCRIPTION
User-facing changes:
1. All build engine errors are now shown in the Build Errors view. Previously, some exceptions that occurred during engine build process were silently ignored.
2. Files with invalid content are properly displayed in the Build Errors view. Previously, invalid files were displayed as "Unknown source" instead of a file path.
3. Verbose bob log is now shown when bundling in the console view.

Fixes #6408