### PR TITLE
Track in profiler if thread was attached to JVM and wasn't detached

### DIFF
--- a/engine/dlib/src/dlib/android.cpp
+++ b/engine/dlib/src/dlib/android.cpp
@@ -27,7 +27,6 @@ ThreadAttacher::ThreadAttacher()
 , m_Env(NULL)
 , m_IsAttached(false)
 {
-    JNIEnv* env = 0;
     if (m_Activity->vm->GetEnv((void **)&m_Env, JNI_VERSION_1_6) != JNI_OK)
     {
         m_Activity->vm->AttachCurrentThread(&m_Env, 0);

--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -28,6 +28,10 @@
 
 #include <algorithm> // std::sort
 
+DM_PROPERTY_GROUP(rmtp_Profiler, "Profiler");
+DM_PROPERTY_U32(rmtp_CpuUsage, 0, FrameReset, "%% Cpu Usage", &rmtp_Profiler);
+DM_PROPERTY_U32(rmtp_Memory, 0, FrameReset, "Memory usage in kb", &rmtp_Profiler);
+
 namespace dmProfiler
 {
 
@@ -40,10 +44,6 @@ namespace dmProfiler
  * @name Profiler
  * @namespace profiler
  */
-
-DM_PROPERTY_GROUP(rmtp_Profiler, "Profiler");
-DM_PROPERTY_U32(rmtp_CpuUsage, 0, FrameReset, "%% Cpu Usage", &rmtp_Profiler);
-DM_PROPERTY_U32(rmtp_Memory, 0, FrameReset, "Memory usage in kb", &rmtp_Profiler);
 
 static uint32_t g_ProfilerPort = 0; // 0 means use the default port of the current library
 static bool g_TrackCpuUsage = false;
@@ -694,6 +694,8 @@ static dmExtension::Result UpdateProfiler(dmExtension::Params* params)
         DM_PROPERTY_SET_U32(rmtp_CpuUsage, dmProfilerExt::GetCpuUsage()*100.0);
         DM_PROPERTY_SET_U32(rmtp_Memory, dmProfilerExt::GetMemoryUsage() / 1024u);
     }
+
+    dmProfilerExt::UpdatePlatformProfiler();
 
     return dmExtension::RESULT_OK;
 }

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -44,5 +44,5 @@ void dmProfilerExt::UpdatePlatformProfiler()
 {
     // Shows if thread was attached to JVM and wasn't detached
     JNIEnv* env = 0;
-    DM_PROPERTY_SET_BOOL(rmtp_AttachedToJVM, g_AndroidApp->activity->vm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK);
+    DM_PROPERTY_SET_BOOL(rmtp_AttachedToJVM, g_AndroidApp->activity->vm->GetEnv((void **)&env, JNI_VERSION_1_6) == JNI_OK);
 }

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -25,7 +25,7 @@ extern struct android_app* __attribute__((weak)) g_AndroidApp;
 
 void dmProfilerExt::SampleCpuUsage()
 {
-    // Should be implementd using JNI for Android 8+
+    // Should be implemented using JNI for Android 8+
     // see https://github.com/defold/defold/issues/3385
     dmProfilerExt::SampleProcCpuUsage();
 }

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -12,25 +12,37 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#include <dlib/profile.h>
+#include <dmsdk/dlib/android.h>
+
 #include "profiler_private.h"
 #include "profiler_proc_utils.h"
 
+DM_PROPERTY_EXTERN(rmtp_Profiler);
+DM_PROPERTY_BOOL(rmtp_AttachedToJVM, false, FrameReset, "Thread attached to JVM", &rmtp_Profiler);
+
+extern struct android_app* __attribute__((weak)) g_AndroidApp;
+
 void dmProfilerExt::SampleCpuUsage()
 {
-    dmProfilerExt:SampleProcCpuUsage();
+    // Should be implementd using JNI for Android 8+
+    // see https://github.com/defold/defold/issues/3385
+    dmProfilerExt::SampleProcCpuUsage();
 }
 
 uint64_t dmProfilerExt::GetMemoryUsage()
 {
-    return GetProcMemoryUsage();
+    return dmProfilerExt::GetProcMemoryUsage();
 }
 
 double dmProfilerExt::GetCpuUsage()
 {
-    return GetProcCpuUsage();
+    return dmProfilerExt::GetProcCpuUsage();
 }
 
 void dmProfilerExt::UpdatePlatformProfiler()
 {
-    // nop
+    // Shows if thread was attached and wasn't detached
+    JNIEnv* env = 0;
+    DM_PROPERTY_SET_BOOL(rmtp_AttachedToJVM, g_AndroidApp->activity->vm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK);
 }

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -42,7 +42,7 @@ double dmProfilerExt::GetCpuUsage()
 
 void dmProfilerExt::UpdatePlatformProfiler()
 {
-    // Shows if thread was attached and wasn't detached
+    // Shows if thread was attached to JVM and wasn't detached
     JNIEnv* env = 0;
     DM_PROPERTY_SET_BOOL(rmtp_AttachedToJVM, g_AndroidApp->activity->vm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK);
 }

--- a/engine/profiler/src/profiler_cocoa.mm
+++ b/engine/profiler/src/profiler_cocoa.mm
@@ -70,3 +70,8 @@ double dmProfilerExt::GetCpuUsage()
 
     return double(total_cpu) / double(TH_USAGE_SCALE);
 }
+
+void dmProfilerExt::UpdatePlatformProfiler()
+{
+    // nop
+}

--- a/engine/profiler/src/profiler_null.cpp
+++ b/engine/profiler/src/profiler_null.cpp
@@ -36,4 +36,9 @@ extern "C" void ProfilerExt()
     // nop
 }
 
+void PlatformUpdate()
+{
+    // nop
+}
+
 } // dmProfiler

--- a/engine/profiler/src/profiler_private.h
+++ b/engine/profiler/src/profiler_private.h
@@ -34,6 +34,11 @@ namespace dmProfilerExt {
      * Get current CPU usage for process, as reported by OS.
      */
     double GetCpuUsage();
+
+    /**
+     * Call update in platforms implementations to collect platform specific data.
+     */
+    void UpdatePlatformProfiler();
 }
 
 #endif // #ifndef DM_PROFILER_PRIVATE_H

--- a/engine/profiler/src/profiler_proc_utils.cpp
+++ b/engine/profiler/src/profiler_proc_utils.cpp
@@ -1,0 +1,129 @@
+// Copyright 2020-2022 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+// 
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <dlib/time.h>
+#include <unistd.h>
+
+#include "profiler_proc_utils.h"
+
+// Inspired by this post: http://stackoverflow.com/questions/1420426/how-to-calculate-the-cpu-usage-of-a-process-by-pid-in-linux-from-c
+static uint64_t _sample_cpu_last_t = 0;
+static long int _sample_cpu_last_tot = 0;
+static long int _sample_cpu_last_proc = 0;
+static double _sample_cpu_usage = 0.0;
+static bool _sample_cpu_enabled = true;
+
+static long int ParseTotalCPUUsage()
+{
+    FILE* fp = NULL;
+    if ((fp = fopen("/proc/stat", "r")) == NULL) {
+        dmLogError("Could not open /proc/stat");
+        // If we can't read /proc/stat we might not have permission
+        // which is the case on Android 8+. For now we disable the
+        // CPU usage alltogether to avoid spamming the log with errors.
+        // There is a new issue for actually solving this and getting
+        // the data from another source: DEF-3497
+        _sample_cpu_enabled = false;
+        return 0;
+    }
+
+    // Find cpu line and first jiffies entry
+    long int jiffies = 0;
+    if (fscanf(fp, "cpu %ld", &jiffies) != 1) {
+        dmLogError("Could not parse CPU information.");
+        fclose(fp);
+        return 0;
+    }
+
+    // Sum rest of entries
+    long int part = 0;
+    while (fscanf(fp, "%ld", &part) == 1) {
+        jiffies += part;
+    }
+    fclose(fp);
+    return jiffies;
+}
+
+static long int ParseProcStat()
+{
+    FILE* fp = NULL;
+    if ((fp = fopen("/proc/self/stat", "r")) == NULL) {
+        dmLogError("Could not open /proc/self/stat");
+        return 0;
+    }
+
+    long int utime = 0;
+    long int stime = 0;
+    if (fscanf(fp, "%*d %*s %*s %*d %*d %*d %*d %*d %*d %*d %*d %*d %*d %ld %ld", &utime, &stime) != 2) {
+        dmLogError("Could not parse process CPU information.");
+        fclose(fp);
+        return 0;
+    }
+    fclose(fp);
+
+    return utime + stime;
+}
+
+void dmProfilerExt::SampleProcCpuUsage()
+{
+    if (!_sample_cpu_enabled) {
+        return;
+    }
+
+    uint64_t time = dmTime::GetTime();
+    if (_sample_cpu_last_t == 0) {
+        _sample_cpu_last_t = time;
+        return;
+    }
+    if ((time - _sample_cpu_last_t) * 0.000001 > SAMPLE_CPU_INTERVAL) {
+        long int cur_tot = ParseTotalCPUUsage();
+        long int cur_proc = ParseProcStat();
+
+        double tot_delta = (double)cur_tot - (double)_sample_cpu_last_tot;
+        if (tot_delta > 0) {
+            _sample_cpu_usage = ((double)cur_proc - (double)_sample_cpu_last_proc) / tot_delta;
+        }
+
+        _sample_cpu_last_tot = cur_tot;
+        _sample_cpu_last_proc = cur_proc;
+        _sample_cpu_last_t = time;
+    }
+}
+
+uint64_t dmProfilerExt::GetProcMemoryUsage()
+{
+    long rss = 0;
+    long vmu = 0;
+    FILE* fp = NULL;
+    if ((fp = fopen( "/proc/self/statm", "r" )) == NULL) {
+        dmLogError("Could not open /proc/self/statm");
+        return 0;
+    }
+
+    if (fscanf(fp, "%ld %ld", &vmu, &rss) != 2)
+    {
+        dmLogError("Could not parse memory information.");
+        fclose(fp);
+        return 0;
+    }
+    fclose(fp);
+
+    long page_size = sysconf( _SC_PAGESIZE);
+    return rss * page_size;
+}
+
+double dmProfilerExt::GetProcCpuUsage()
+{
+    return _sample_cpu_usage;
+}

--- a/engine/profiler/src/profiler_proc_utils.cpp
+++ b/engine/profiler/src/profiler_proc_utils.cpp
@@ -15,6 +15,7 @@
 #include <dlib/time.h>
 #include <unistd.h>
 
+#include "profiler_private.h"
 #include "profiler_proc_utils.h"
 
 // Inspired by this post: http://stackoverflow.com/questions/1420426/how-to-calculate-the-cpu-usage-of-a-process-by-pid-in-linux-from-c

--- a/engine/profiler/src/profiler_proc_utils.h
+++ b/engine/profiler/src/profiler_proc_utils.h
@@ -17,8 +17,6 @@
 
 #include <script/script.h>
 
-#define SAMPLE_CPU_INTERVAL 0.25
-
 namespace dmProfilerExt {
     /**
      * Call to sample CPU usage from proc in intevals.

--- a/engine/profiler/src/profiler_proc_utils.h
+++ b/engine/profiler/src/profiler_proc_utils.h
@@ -12,25 +12,28 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#include "profiler_private.h"
-#include "profiler_proc_utils.h"
+#ifndef DM_PROFILER_PROC_PRIVATE_H
+#define DM_PROFILER_PROC_PRIVATE_H
 
-void dmProfilerExt::SampleCpuUsage()
-{
-    dmProfilerExt:SampleProcCpuUsage();
+#include <script/script.h>
+
+#define SAMPLE_CPU_INTERVAL 0.25
+
+namespace dmProfilerExt {
+    /**
+     * Call to sample CPU usage from proc in intevals.
+     */
+    void SampleProcCpuUsage();
+
+    /**
+     * Get current memory usage in bytes from proc (resident/working set) for the process, as reported by OS.
+     */
+    uint64_t GetProcMemoryUsage();
+
+    /**
+     * Get current CPU usage for process from proc, as reported by OS.
+     */
+    double GetProcCpuUsage();
 }
 
-uint64_t dmProfilerExt::GetMemoryUsage()
-{
-    return GetProcMemoryUsage();
-}
-
-double dmProfilerExt::GetCpuUsage()
-{
-    return GetProcCpuUsage();
-}
-
-void dmProfilerExt::UpdatePlatformProfiler()
-{
-    // nop
-}
+#endif // #ifndef DM_PROFILER_PROC_PRIVATE_H

--- a/engine/profiler/src/profiler_unsupported.cpp
+++ b/engine/profiler/src/profiler_unsupported.cpp
@@ -28,3 +28,8 @@ double dmProfilerExt::GetCpuUsage()
 {
     return 0.0;
 }
+
+void dmProfilerExt::UpdatePlatformProfiler()
+{
+    // nop
+}

--- a/engine/profiler/src/profiler_win32.cpp
+++ b/engine/profiler/src/profiler_win32.cpp
@@ -97,3 +97,8 @@ double dmProfilerExt::GetCpuUsage()
 {
     return _sample_cpu_usage;
 }
+
+void dmProfilerExt::UpdatePlatformProfiler()
+{
+    // nop
+}

--- a/engine/profiler/src/wscript
+++ b/engine/profiler/src/wscript
@@ -13,8 +13,13 @@ def build(bld):
 
     if 'macos' in bld.env.PLATFORM:
         source += ' profiler_cocoa.mm'
-    elif 'android' in bld.env.PLATFORM or 'linux' in bld.env.PLATFORM:
+    elif 'android' in bld.env.PLATFORM:
+        source += ' profiler_android.cpp'
+        source += ' profiler_proc_utils.cpp'
+    elif 'linux' in bld.env.PLATFORM:
         source += ' profiler_linux.cpp'
+        source += ' profiler_proc_utils.cpp'
+        profiler_proc_utils.cpp
     elif 'win32' in bld.env.PLATFORM:
         source += ' profiler_win32.cpp'
     else:

--- a/engine/profiler/src/wscript
+++ b/engine/profiler/src/wscript
@@ -19,7 +19,6 @@ def build(bld):
     elif 'linux' in bld.env.PLATFORM:
         source += ' profiler_linux.cpp'
         source += ' profiler_proc_utils.cpp'
-        profiler_proc_utils.cpp
     elif 'win32' in bld.env.PLATFORM:
         source += ' profiler_win32.cpp'
     else:


### PR DESCRIPTION
It detects only cases when thread attached and wasn't detached between frames. 
Not sure how useful it is since we detach thread every from in our input system.