### PR TITLE
Read editor update info from update-v4.json

### DIFF
--- a/editor/src/clj/editor/connection_properties.clj
+++ b/editor/src/clj/editor/connection_properties.clj
@@ -16,10 +16,10 @@
 
 (def ^:const connection-properties
   {:sentry {:project-id "97739"
-            :key        "9e25fea9bc334227b588829dd60265c1"
-            :secret     "f694ef98d47d42cf8bb67ef18a4e9cdb"}
+            :key "9e25fea9bc334227b588829dd60265c1"
+            :secret "f694ef98d47d42cf8bb67ef18a4e9cdb"}
    :google-analytics {:tid "UA-83690-7"}
    :git-issues {:url "https://github.com/defold/defold"}
    :native-extensions {:build-server-url "https://build.defold.com"}
    :updater {:download-url-template "https://%s/archive/%s/%s/editor2/Defold-%s.zip"
-             :update-url-template "https://%s/editor2/channels/%s/update-v3.json"}})
+             :update-url-template "https://%s/editor2/channels/%s/update-v4.json"}})

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -292,9 +292,10 @@ ordinary paths."
       (do
         (plugin-fn workspace)
         (log/info :msg (str "Loaded plugin " (resource/path resource))))
-      (log/info :msg (str "Unable to load plugin " (resource/path resource))))
+      (log/error :msg (str "Unable to load plugin " (resource/path resource))))
     (catch Exception e
-      (log/error :msg (str "Exception while loading plugin: " (.getMessage e)))
+      (log/error :msg (str "Exception while loading plugin: " (.getMessage e))
+                 :exception e)
       (ui/run-later
         (dialogs/make-info-dialog
           {:title "Unable to Load Plugin"

--- a/editor/test/editor/updater_test.clj
+++ b/editor/test/editor/updater_test.clj
@@ -46,14 +46,14 @@
 
                 updater/update-url
                 (fn [archive-domain channel]
-                  (format "http://localhost:%s/editor2/channels/%s/update-v3.json"
+                  (format "http://localhost:%s/editor2/channels/%s/update-v4.json"
                           test-port channel))]
     (f)))
 
 (use-fixtures :once error-log-level-fixture test-urls-fixture)
 
 (defn make-handler-resources [channel sha1]
-  {(format "/editor2/channels/%s/update-v3.json" channel)
+  {(format "/editor2/channels/%s/update-v4.json" channel)
    (response/response (json/write-str {:sha1 sha1}))
 
    (format "/archive/%s/%s/editor2/Defold-%s.zip" sha1 channel (.getPair (Platform/getHostPlatform)))


### PR DESCRIPTION
We recently changed part of the URL:s we upload the macOS version of the editor from `darwin` to `macos`. In order to ensure older versions of the editor read from the updated URL, we need to make sure everyone updates to a version of the editor that uses the new URL. We achieve this by making a break in the update timeline. Older editors will first update to the latest version available in the `update-v3.json` era. This version includes the `darwin` to `macos` rename and changes the URL we use to check for new versions to look at `update-v4.json`, which we'll be using henceforth. This saves us from having to add `darwin` to `macos` redirects for every new release of the editor in case an old client has not updated their editor in a while.

After we merge this PR, we should:
* Add one final `darwin` to `macos` redirect to the merged SHA of this PR.
* Merge #6987 