### PR TITLE
Fix issue with sys.save() for certain combinations of data

### DIFF
--- a/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
+++ b/engine/gameobject/src/gameobject/test/factory/test_gameobject_factory.cpp
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include <dlib/hash.h>
+#include <dlib/align.h>
 #include <dlib/log.h>
 
 #include "../gameobject.h"
@@ -216,7 +217,7 @@ TEST_F(FactoryTest, FactoryProperties)
     lua_pushliteral(L, "bool");
     lua_pushboolean(L, 1);
     lua_rawset(L, -3);
-    char buffer[256];
+    char DM_ALIGNED(16) buffer[256];
     uint32_t buffer_size = dmScript::CheckTable(L, buffer, 256, -1);
     lua_pop(L, 1);
 
@@ -238,7 +239,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailUnsupportedType)
     lua_pushliteral(L, "number");
     lua_pushliteral(L, "fail");
     lua_rawset(L, -3);
-    char buffer[256];
+    char DM_ALIGNED(16) buffer[256];
     uint32_t buffer_size = dmScript::CheckTable(L, buffer, 256, -1);
     lua_pop(L, 1);
 
@@ -255,7 +256,7 @@ TEST_F(FactoryTest, FactoryPropertiesFailTypeMismatch)
     lua_pushliteral(L, "number");
     dmScript::PushHash(L, (dmhash_t)0);
     lua_rawset(L, -3);
-    char buffer[256];
+    char DM_ALIGNED(16) buffer[256];
     uint32_t buffer_size = dmScript::CheckTable(L, buffer, 256, -1);
     lua_pop(L, 1);
 

--- a/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/test/props/test_gameobject_props.cpp
@@ -16,6 +16,7 @@
 #include <jc_test/jc_test.h>
 
 #include <dlib/dstrings.h>
+#include <dlib/align.h>
 #include <dlib/hash.h>
 #include <dlib/message.h>
 #include <resource/resource.h>
@@ -246,7 +247,7 @@ TEST_F(PropsTest, PropsSpawn)
     lua_pushliteral(L, "quat");
     dmScript::PushQuat(L, Quat(1, 2, 3, 4));
     lua_rawset(L, -3);
-    uint8_t buffer[1024];
+    uint8_t DM_ALIGNED(16) buffer[1024];
     uint32_t buffer_size = 1024;
     uint32_t size_used = dmScript::CheckTable(L, (char*)buffer, buffer_size, -1);
     lua_pop(L, 1);

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -18,6 +18,7 @@
 #define JC_TEST_IMPLEMENTATION
 #include <jc_test/jc_test.h>
 #include <dlib/dstrings.h>
+#include <dlib/align.h>
 #include <dlib/hash.h>
 #include <dlib/math.h>
 #include <dlib/message.h>
@@ -2127,7 +2128,7 @@ TEST_F(dmGuiTest, PostMessageToGuiLuaTable)
     r = dmGui::SetScript(m_Script, LuaSourceFromStr(s));
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
-    char buffer[256 + sizeof(dmMessage::Message)];
+    char DM_ALIGNED(16) buffer[256 + sizeof(dmMessage::Message)];
     dmMessage::Message* message = (dmMessage::Message*)buffer;
     message->m_Sender = dmMessage::URL();
     message->m_Receiver = dmMessage::URL();
@@ -2397,7 +2398,7 @@ TEST_F(dmGuiTest, Bug352)
     r = dmGui::SetScript(m_Script, LuaSourceFromStr((const char*)BUG352_LUA, BUG352_LUA_SIZE));
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
-    char buffer[256 + sizeof(dmMessage::Message)];
+    char DM_ALIGNED(16) buffer[256 + sizeof(dmMessage::Message)];
     dmMessage::Message* message = (dmMessage::Message*)buffer;
     message->m_Sender = dmMessage::URL();
     message->m_Receiver = dmMessage::URL();

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -258,7 +258,7 @@ namespace dmScript
      * Supported types: LUA_TBOOLEAN, LUA_TNUMBER, LUA_TSTRING, Point3, Vector3, Vector4 and Quat
      * Keys must be strings
      * @param L Lua state
-     * @param buffer Buffer that will be written to
+     * @param buffer Buffer that will be written to (must be DM_ALIGNED(16))
      * @param buffer_size Buffer size
      * @param index Index of the table
      * @return Number of bytes used in buffer

--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -500,7 +500,7 @@ namespace dmScript
             message_id = CheckHash(L, 2);
         }
 
-        DM_ALIGNED(16) char data[MAX_MESSAGE_DATA_SIZE];
+        char DM_ALIGNED(16) data[MAX_MESSAGE_DATA_SIZE];
         uint32_t data_size = 0;
 
 

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -35,6 +35,8 @@
 #include <dlib/log.h>
 #include <dlib/socket.h>
 #include <dlib/path.h>
+#include <dlib/align.h>
+#include <dlib/memory.h>
 #include <resource/resource.h>
 #include "script.h"
 #include "script/sys_ddf.h"
@@ -57,7 +59,7 @@ union SaveLoadBuffer
 {
     uint32_t m_alignment; // This alignment is required for js-web
     char m_buffer[MAX_BUFFER_SIZE]; // Resides in .bss
-} g_saveload;
+} DM_ALIGNED(16) g_saveload;
 
 #define LIB_NAME "sys"
 
@@ -75,7 +77,9 @@ union SaveLoadBuffer
     {
         if (required_size > MAX_BUFFER_SIZE)
         {
-            return (char*)malloc(required_size);
+            char* buffer = 0;
+            dmMemory::Result r = dmMemory::AlignedMalloc((void**)&buffer, 16, required_size);
+            return buffer;
         }
         else
         {
@@ -87,7 +91,7 @@ union SaveLoadBuffer
     {
         if (buffer != g_saveload.m_buffer)
         {
-            free(buffer);
+            dmMemory::AlignedFree(buffer);
         }
     }
 

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -299,7 +299,7 @@ namespace dmScript
         return total_size;
     }
 
-    uint32_t DoCheckTableSize(lua_State* L, int index)
+    uint32_t DoCheckTableSize(lua_State* L, int index, int total_size)
     {
         int top = lua_gettop(L);
         (void)top;
@@ -342,8 +342,10 @@ namespace dmScript
 
                 case LUA_TNUMBER:
                 {
-                    int align = ((size + sizeof(float) - 1) & ~(sizeof(float) - 1)) - size;
-                    size += align;
+                    int offset = total_size + size;
+                    int aligned_offset = (offset + sizeof(float)-1) & ~(sizeof(float)-1);
+                    int align_size = aligned_offset - offset;
+                    size += align_size;
                     size += sizeof(lua_Number);
                 }
                 break;
@@ -359,8 +361,11 @@ namespace dmScript
                     // subtype
                     size += 1;
 
-                    int align = ((size + sizeof(float) - 1) & ~(sizeof(float) - 1)) - size;
-                    size += align;
+                    int offset = total_size + size;
+                    int aligned_offset = (offset + sizeof(float)-1) & ~(sizeof(float)-1);
+                    int align_size = aligned_offset - offset;
+                    size += align_size;
+
 
                     if (IsVector3(L, -1))
                     {
@@ -395,7 +400,7 @@ namespace dmScript
 
                 case LUA_TTABLE:
                 {
-                    size += DoCheckTableSize(L, -1);
+                    size += DoCheckTableSize(L, -1, total_size + size);
                 }
                 break;
 
@@ -412,7 +417,8 @@ namespace dmScript
 
     uint32_t CheckTableSize(lua_State* L, int index)
     {
-        return sizeof(TableHeader) + DoCheckTableSize(L, index);
+        uint32_t size = sizeof(TableHeader) + DoCheckTableSize(L, index, 0);
+        return size;
     }
 
     uint32_t DoCheckTable(lua_State* L, const TableHeader& header, const char* original_buffer, char* buffer, uint32_t buffer_size, int index)
@@ -670,6 +676,7 @@ namespace dmScript
 
     uint32_t CheckTable(lua_State* L, char* buffer, uint32_t buffer_size, int index)
     {
+        assert((intptr_t)buffer % 16 == 0);
         if (buffer_size > sizeof(TableHeader)) {
             char* original_buffer = buffer;
 

--- a/engine/script/src/script_table.cpp
+++ b/engine/script/src/script_table.cpp
@@ -299,7 +299,7 @@ namespace dmScript
         return total_size;
     }
 
-    uint32_t DoCheckTableSize(lua_State* L, int index, int total_size)
+    uint32_t DoCheckTableSize(lua_State* L, int index, int parent_offset)
     {
         int top = lua_gettop(L);
         (void)top;
@@ -342,7 +342,7 @@ namespace dmScript
 
                 case LUA_TNUMBER:
                 {
-                    int offset = total_size + size;
+                    int offset = parent_offset + size;
                     int aligned_offset = (offset + sizeof(float)-1) & ~(sizeof(float)-1);
                     int align_size = aligned_offset - offset;
                     size += align_size;
@@ -361,7 +361,7 @@ namespace dmScript
                     // subtype
                     size += 1;
 
-                    int offset = total_size + size;
+                    int offset = parent_offset + size;
                     int aligned_offset = (offset + sizeof(float)-1) & ~(sizeof(float)-1);
                     int align_size = aligned_offset - offset;
                     size += align_size;
@@ -400,7 +400,7 @@ namespace dmScript
 
                 case LUA_TTABLE:
                 {
-                    size += DoCheckTableSize(L, -1, total_size + size);
+                    size += DoCheckTableSize(L, -1, parent_offset + size);
                 }
                 break;
 

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -436,6 +436,46 @@ TEST_F(LuaTableTest, case1308)
     lua_pop(L, 1);
 }
 
+TEST_F(LuaTableTest, NestedTableSizeCheck)
+{
+    /**
+     * This table structure was guaranteed to crash on frist version of #6676
+     * Fix in https://github.com/defold/defold/pull/6991
+     * 
+     * {
+     *   foo = 1234,
+     *   b = {
+     *       a = 1234,
+     *   }
+     * }
+     *
+     */
+    // create outer table
+    lua_newtable(L);
+
+    // foo = 1234
+    lua_pushnumber(L, 1234);
+    lua_setfield(L, -2, "foo");
+
+    // create inner table "b"
+    lua_newtable(L);
+
+    // a = 1234
+    lua_pushnumber(L, 1234);
+    lua_setfield(L, -2, "a");
+
+    // b = {}
+    lua_setfield(L, -2, "b");
+
+    uint32_t calculated_table_size = dmScript::CheckTableSize(L, -1);
+    uint32_t actual_table_size = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+
+    lua_pop(L, 1);
+
+    ASSERT_EQ(calculated_table_size, actual_table_size);
+}
+
+
 // TODO!!
 // TEST_F(LuaTableTest, ReadTruncatedFile)
 // {

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -68,7 +68,7 @@ static bool RunString(lua_State* L, const char* script)
 
 class LuaTableTest* g_LuaTableTest = 0;
 
-class LuaTableTest : public jc_test_base_class
+DM_ALIGNED(16) class LuaTableTest : public jc_test_base_class
 {
 protected:
     virtual void SetUp()

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -100,7 +100,7 @@ protected:
 TEST_F(LuaTableTest, EmptyTable)
 {
     lua_newtable(L);
-    char buf[8 + 4];
+    DM_ALIGNED(16) char buf[8 + 4];
     uint32_t buffer_used = dmScript::CheckTable(L, buf, sizeof(buf), -1);
     // 4 bytes for count
     ASSERT_EQ(12U, buffer_used);

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -100,7 +100,7 @@ protected:
 TEST_F(LuaTableTest, EmptyTable)
 {
     lua_newtable(L);
-    DM_ALIGNED(16) char buf[8 + 4];
+    char DM_ALIGNED(16) buf[8 + 4];
     uint32_t buffer_used = dmScript::CheckTable(L, buf, sizeof(buf), -1);
     // 4 bytes for count
     ASSERT_EQ(12U, buffer_used);
@@ -260,7 +260,7 @@ const uint32_t IOOB_BUFFER_SIZE = 8 + 2 + 2 + (sizeof(char) + sizeof(char) + 5 *
 
 int ProduceIndexOutOfBounds(lua_State *L)
 {
-    char DM_ALIGNED(16) char buf[IOOB_BUFFER_SIZE];
+    char DM_ALIGNED(16) buf[IOOB_BUFFER_SIZE];
     lua_newtable(L);
     // invalid key
     lua_pushnumber(L, 0xffffffffLL+1);

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -260,7 +260,7 @@ const uint32_t IOOB_BUFFER_SIZE = 8 + 2 + 2 + (sizeof(char) + sizeof(char) + 5 *
 
 int ProduceIndexOutOfBounds(lua_State *L)
 {
-    char buf[IOOB_BUFFER_SIZE];
+    char DM_ALIGNED(16) char buf[IOOB_BUFFER_SIZE];
     lua_newtable(L);
     // invalid key
     lua_pushnumber(L, 0xffffffffLL+1);

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -944,7 +944,7 @@ TEST_F(LuaTableTest, Stress)
             }
 
             // Add eight to ensure there is room for the header too.
-            char* buf = new char[8 + buf_size + 4]; // add 4 extra at end for GUARD BYTES
+            char* DM_ALIGNED(16) buf = new char[8 + buf_size + 4]; // add 4 extra at end for GUARD BYTES
             buf[8 + buf_size + 0] = 0xBA;
             buf[8 + buf_size + 1] = 0xAD;
             buf[8 + buf_size + 2] = 0xF0;

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -68,7 +68,10 @@ static bool RunString(lua_State* L, const char* script)
 
 class LuaTableTest* g_LuaTableTest = 0;
 
-DM_ALIGNED(16) class LuaTableTest : public jc_test_base_class
+char DM_ALIGNED(16) g_Buf[256];
+
+
+class LuaTableTest : public jc_test_base_class
 {
 protected:
     virtual void SetUp()
@@ -88,8 +91,6 @@ protected:
         g_LuaTableTest = 0;
 
     }
-
-    char DM_ALIGNED(16) m_Buf[256];
 
     int top;
     dmScript::HContext m_Context;
@@ -226,11 +227,11 @@ TEST_F(LuaTableTest, TestSerializeLargeNumbers)
         lua_settable(L, -3);
     }
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_Number found[count] = { 0 };
 
@@ -326,11 +327,11 @@ TEST_F(LuaTableTest, Table01)
     lua_pushinteger(L, 456);
     lua_setfield(L, -2, "b");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "a");
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
@@ -351,7 +352,7 @@ TEST_F(LuaTableTest, Table01)
     lua_pushinteger(L, 456);
     lua_setfield(L, -2, "b");
 
-    int result = PCallCheckTable(L, m_Buf, buffer_used-1, -1, true);
+    int result = PCallCheckTable(L, g_Buf, buffer_used-1, -1, true);
 
     ASSERT_NE(result, 0);
 
@@ -368,11 +369,11 @@ TEST_F(LuaTableTest, Table02)
     lua_pushstring(L, "kalle");
     lua_setfield(L, -2, "foo2");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "foo");
     ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
@@ -394,7 +395,7 @@ TEST_F(LuaTableTest, Table02)
     lua_pushstring(L, "kalle");
     lua_setfield(L, -2, "foo2");
 
-    int result = PCallCheckTable(L, m_Buf, buffer_used-1, -1, true);
+    int result = PCallCheckTable(L, g_Buf, buffer_used-1, -1, true);
 
     ASSERT_NE(result, 0);
 
@@ -414,11 +415,11 @@ TEST_F(LuaTableTest, case1308)
 
     lua_setfield(L, -2, "t");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "a");
     ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
@@ -468,7 +469,7 @@ TEST_F(LuaTableTest, NestedTableSizeCheck)
     lua_setfield(L, -2, "b");
 
     uint32_t calculated_table_size = dmScript::CheckTableSize(L, -1);
-    uint32_t actual_table_size = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t actual_table_size = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
 
     lua_pop(L, 1);
 
@@ -564,11 +565,11 @@ TEST_F(LuaTableTest, TSTRING) // binary strings (def2821)
     lua_pushlstring(L, (const char*)binary_string2, 8);
     lua_setfield(L, -2, "key3");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "key1");
     ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
@@ -600,11 +601,11 @@ TEST_F(LuaTableTest, Vector3)
     dmScript::PushVector3(L, dmVMath::Vector3(1,2,3));
     lua_setfield(L, -2, "v");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "v");
     dmVMath::Vector3* v1 = dmScript::ToVector3(L, -1);
@@ -628,11 +629,11 @@ TEST_F(LuaTableTest, Vector4)
     dmScript::PushVector4(L, dmVMath::Vector4(1,2,3,4));
     lua_setfield(L, -2, "v");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "v");
     dmVMath::Vector4* v1 = dmScript::ToVector4(L, -1);
@@ -658,11 +659,11 @@ TEST_F(LuaTableTest, Quat)
     dmScript::PushQuat(L, dmVMath::Quat(1,2,3,4));
     lua_setfield(L, -2, "v");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "v");
     dmVMath::Quat* v1 = dmScript::ToQuat(L, -1);
@@ -692,11 +693,11 @@ TEST_F(LuaTableTest, Matrix4)
     dmScript::PushMatrix4(L, m);
     lua_setfield(L, -2, "v");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "v");
     dmVMath::Matrix4* m1 = dmScript::ToMatrix4(L, -1);
@@ -723,11 +724,11 @@ TEST_F(LuaTableTest, Hash)
     dmScript::PushHash(L, hash);
     lua_setfield(L, -2, "h");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "h");
     ASSERT_TRUE(dmScript::IsHash(L, -1));
@@ -753,11 +754,11 @@ TEST_F(LuaTableTest, URL)
     dmScript::PushURL(L, url);
     lua_setfield(L, -2, "url");
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_getfield(L, -1, "url");
     ASSERT_TRUE(dmScript::IsURL(L, -1));
@@ -793,11 +794,11 @@ TEST_F(LuaTableTest, MixedKeys)
     lua_pushnumber(L, 5);
     lua_settable(L, -3);
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
-    dmScript::PushTable(L, m_Buf, sizeof(m_Buf));
+    dmScript::PushTable(L, g_Buf, sizeof(g_Buf));
 
     lua_pushnumber(L, 1);
     lua_gettable(L, -2);
@@ -860,16 +861,16 @@ TEST_F(LuaTableTest, CorruptedTables)
 
     // Make sure we write to the buffer so that Valgrind doesn't complain
     // at the lua_pushlstring below.
-    memset(m_Buf, 0, sizeof(m_Buf));
+    memset(g_Buf, 0, sizeof(g_Buf));
 
-    uint32_t buffer_used = dmScript::CheckTable(L, m_Buf, sizeof(m_Buf), -1);
+    uint32_t buffer_used = dmScript::CheckTable(L, g_Buf, sizeof(g_Buf), -1);
     (void) buffer_used;
     lua_pop(L, 1);
 
     for (uint32_t i = buffer_used-1; i > 0; --i)
     {
         lua_pushcfunction(L, ParseTruncatedTable);
-        lua_pushlstring(L, m_Buf, sizeof(m_Buf));
+        lua_pushlstring(L, g_Buf, sizeof(g_Buf));
         lua_pushnumber(L, i);
         int res = lua_pcall(L, 2, 0, 0x0);
         ASSERT_EQ(LUA_ERRRUN, res);

--- a/engine/script/src/test/test_script_table.cpp
+++ b/engine/script/src/test/test_script_table.cpp
@@ -16,6 +16,7 @@
 #include <dlib/dstrings.h>
 #include <dlib/log.h>
 #include <dlib/align.h>
+#include <dlib/memory.h>
 #include <dlib/math.h>
 #define JC_TEST_IMPLEMENTATION
 #include <jc_test/jc_test.h>
@@ -944,7 +945,8 @@ TEST_F(LuaTableTest, Stress)
             }
 
             // Add eight to ensure there is room for the header too.
-            char* DM_ALIGNED(16) buf = new char[8 + buf_size + 4]; // add 4 extra at end for GUARD BYTES
+            char* buf;
+            dmMemory::AlignedMalloc((void**)&buf, 16, 8 + buf_size + 4); // add 4 extra at end for GUARD BYTES
             buf[8 + buf_size + 0] = 0xBA;
             buf[8 + buf_size + 1] = 0xAD;
             buf[8 + buf_size + 2] = 0xF0;
@@ -977,7 +979,7 @@ TEST_F(LuaTableTest, Stress)
             ASSERT_EQ(d, rd);
 
             lua_pop(L, 1);
-            delete[] buf;
+            dmMemory::AlignedFree(buf);
         }
     }
 }


### PR DESCRIPTION
There was an issue in the way the buffer alignment was calculated when checking table size for a table containing nested tables with numbers or userdata.

Fixes #6676 