### PR TITLE
Add support for setting / getting mouse lock state

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1249,8 +1249,10 @@ namespace dmEngine
             }
         }
 
-        script_lib_context.m_Factory = engine->m_Factory;
-        script_lib_context.m_Register = engine->m_Register;
+        script_lib_context.m_Factory    = engine->m_Factory;
+        script_lib_context.m_Register   = engine->m_Register;
+        script_lib_context.m_HidContext = engine->m_HidContext;
+
         if (engine->m_SharedScriptContext) {
             script_lib_context.m_LuaState = dmScript::GetLuaState(engine->m_SharedScriptContext);
             if (!dmGameSystem::InitializeScriptLibs(script_lib_context))

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -156,9 +156,10 @@ namespace dmGameSystem
     {
         ScriptLibContext();
 
-        lua_State* m_LuaState;
-        dmResource::HFactory m_Factory;
+        lua_State*              m_LuaState;
+        dmResource::HFactory    m_Factory;
         dmGameObject::HRegister m_Register;
+        dmHID::HContext         m_HidContext;
     };
 
 

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -560,14 +560,6 @@ namespace dmGameSystem
         }
     }
 
-    static bool CheckBoolean(lua_State* L, int index)
-    {
-        if ( lua_isboolean( L, index ) )
-            return lua_toboolean( L, index );
-
-        return luaL_error(L, "Argument %d must be a boolean", index);
-    }
-
     static void UnpackConnectJointParams(lua_State* L, dmPhysics::JointType type, int table_index, dmPhysics::ConnectJointParams& params)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -1225,7 +1217,7 @@ namespace dmGameSystem
         void* comp_world = 0x0;
         GetCollisionObject(L, 1, collection, &comp, &comp_world);
         dmhash_t group_id = dmScript::CheckHashOrString(L, 2);
-        bool boolvalue = CheckBoolean(L, 3);
+        bool boolvalue = dmScript::CheckBoolean(L, 3);
 
         if (! dmGameSystem::SetCollisionMaskBit(comp_world, comp, group_id, boolvalue)) {
             return luaL_error(L, "Collision group not registered: %s.", dmHashReverseSafe64(group_id));

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -590,14 +590,6 @@ namespace dmGameSystem
         return 0;
     }
 
-    static bool CheckBoolean(lua_State* L, int index)
-    {
-        if ( lua_isboolean( L, index ) )
-            return lua_toboolean( L, index );
-
-        return luaL_error(L, "Argument %d must be a boolean", index);
-    }
-
     /*# pause a playing a sound(s)
      * Pause all active voices
      *
@@ -623,7 +615,7 @@ namespace dmGameSystem
         dmScript::ResolveURL(L, 1, &receiver, &sender);
 
         dmGameSystemDDF::PauseSound msg;
-        msg.m_Pause = CheckBoolean(L, 2);
+        msg.m_Pause = dmScript::CheckBoolean(L, 2);
 
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PauseSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::PauseSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;

--- a/engine/gamesys/src/gamesys/scripts/script_window.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_window.cpp
@@ -16,6 +16,7 @@
 #include <dlib/log.h>
 #include "../gamesys.h"
 #include <script/script.h>
+#include <hid/hid.h>
 
 #include "script_window.h"
 
@@ -43,6 +44,7 @@ enum WindowEvent
 
 struct WindowInfo
 {
+    dmHID::HContext m_HidContext;
     dmScript::LuaCallbackInfo* m_Callback;
     int m_Width;
     int m_Height;
@@ -168,6 +170,36 @@ static int SetListener(lua_State* L)
     return 0;
 }
 
+/*# set the locking state for current mouse cursor
+ *
+ * Set the locking state for current mouse cursor on a PC platform.
+ *
+ * This function locks or unlocks the mouse cursor to the center point of the window. While the cursor is locked,
+ * mouse position updates will still be sent to the scripts as usual.
+ *
+ * @name window.set_mouse_lock
+ * @param flag [type:boolean] The lock state for the mouse cursor
+ */
+static int SetMouseLock(lua_State* L)
+{
+    int top = lua_gettop(L);
+
+    bool flag = dmScript::CheckBoolean(L, 1);
+
+    // Hiding the cursor is the same thing as locking it currently
+    if (flag)
+    {
+        dmHID::HideMouseCursor(g_Window.m_HidContext);
+    }
+    else
+    {
+        dmHID::ShowMouseCursor(g_Window.m_HidContext);
+    }
+
+    assert(top == lua_gettop(L));
+    return 0;
+}
+
 /*# set the mode for screen dimming
  *
  * [icon:ios] [icon:android] Sets the dimming mode on a mobile device.
@@ -251,12 +283,32 @@ static int GetSize(lua_State* L)
     return 2;
 }
 
+/*# get the cursor lock state
+ *
+ * This returns the current lock state of the mouse cursor
+ *
+ * @name window.get_mouse_lock
+ * @return state [type:boolean] The lock state
+ */
+static int GetMouseLock(lua_State* L)
+{
+    int top = lua_gettop(L);
+    bool cursor_visible = dmHID::GetCursorVisible(g_Window.m_HidContext);
+    // If cursor is visible, it is not locked
+    lua_pushboolean(L, !cursor_visible);
+
+    assert(top + 1 == lua_gettop(L));
+    return 1;
+}
+
 static const luaL_reg Module_methods[] =
 {
-    {"set_listener", SetListener},
-    {"set_dim_mode", SetDimMode},
-    {"get_dim_mode", GetDimMode},
-    {"get_size", GetSize},
+    {"set_listener",   SetListener},
+    {"set_dim_mode",   SetDimMode},
+    {"set_mouse_lock", SetMouseLock},
+    {"get_dim_mode",   GetDimMode},
+    {"get_size",       GetSize},
+    {"get_mouse_lock", GetMouseLock},
     {0, 0}
 };
 
@@ -352,6 +404,8 @@ static void LuaInit(lua_State* L)
 void ScriptWindowRegister(const ScriptLibContext& context)
 {
     LuaInit(context.m_LuaState);
+
+    g_Window.m_HidContext = context.m_HidContext;
 }
 
 void ScriptWindowFinalize(const ScriptLibContext& context)
@@ -359,6 +413,7 @@ void ScriptWindowFinalize(const ScriptLibContext& context)
     if (g_Window.m_Callback)
         dmScript::DestroyCallback(g_Window.m_Callback);
     g_Window.m_Callback = 0;
+    g_Window.m_HidContext = 0;
 }
 
 void ScriptWindowOnWindowFocus(bool focus)

--- a/engine/gamesys/src/gamesys/scripts/script_window.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_window.cpp
@@ -404,7 +404,6 @@ static void LuaInit(lua_State* L)
 void ScriptWindowRegister(const ScriptLibContext& context)
 {
     LuaInit(context.m_LuaState);
-
     g_Window.m_HidContext = context.m_HidContext;
 }
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -867,7 +867,41 @@ TEST_P(CursorTest, Cursor)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
-TEST_F(WindowEventTest, Test)
+TEST_F(WindowTest, MouseLock)
+{
+    dmHID::NewContextParams hid_params = {};
+    dmHID::HContext hid_context = dmHID::NewContext(hid_params);
+    dmHID::Init(hid_context);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory    = m_Factory;
+    scriptlibcontext.m_Register   = m_Register;
+    scriptlibcontext.m_LuaState   = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_HidContext = hid_context;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    // Spawn the game object with the script we want to call
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/window/mouse_lock.goc", dmHashString64("/mouse_lock"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_FALSE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    // cleanup
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+
+    dmHID::DeleteContext(hid_context);
+}
+
+TEST_F(WindowTest, Events)
 {
     dmGameSystem::ScriptLibContext scriptlibcontext;
     scriptlibcontext.m_Factory = m_Factory;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -248,10 +248,10 @@ public:
 };
 
 
-class WindowEventTest : public GamesysTest<const char*>
+class WindowTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~WindowEventTest() {}
+    virtual ~WindowTest() {}
 };
 
 struct DrawCountParams

--- a/engine/gamesys/src/gamesys/test/window/mouse_lock.go
+++ b/engine/gamesys/src/gamesys/test/window/mouse_lock.go
@@ -1,0 +1,4 @@
+components {
+  id: "script"
+  component: "/window/mouse_lock.script"
+}

--- a/engine/gamesys/src/gamesys/test/window/mouse_lock.script
+++ b/engine/gamesys/src/gamesys/test/window/mouse_lock.script
@@ -1,0 +1,33 @@
+-- Copyright 2020-2022 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function init(self)
+	self.update_counter = 0
+end
+
+function update(self, dt)
+	if self.update_counter == 0 then
+		local mouse_lock = window.get_mouse_lock()
+		assert(mouse_lock == false)
+
+		window.set_mouse_lock(true)
+		mouse_lock = window.get_mouse_lock()
+		assert(mouse_lock == true)
+	elseif self.update_counter == 1 then
+		-- not supported
+		window.set_mouse_lock("false")
+	end
+
+	self.update_counter = self.update_counter + 1
+end

--- a/engine/glfw/include/GL/glfw.h
+++ b/engine/glfw/include/GL/glfw.h
@@ -570,6 +570,7 @@ GLFWAPI void glfwUnregisterUIApplicationDelegate(void* delegate);
 GLFWAPI void glfwSetViewType(int view_type);
 GLFWAPI void glfwSetWindowBackgroundColor(unsigned int color);
 GLFWAPI float glfwGetDisplayScaleFactor();
+GLFWAPI int glfwGetMouseLocked();
 
 // Defold extensions (Android)
 #if defined(ANDROID)

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -524,17 +524,9 @@ var LibraryGLFW = {
     },
 
     onPointerLockEventChange: function(event) {
-      var pointerLockElement = document["pointerLockElement"] ||
-                            document["mozPointerLockElement"] ||
-                            document["webkitIsPointerLockElement"] ||
-                            document["msIsPointerLockElement"];
-      GLFW.isPointerLocked = !!pointerLockElement;
-
+      GLFW.isPointerLocked = !!document["pointerLockElement"];
       if (!GLFW.isPointerLocked) {
         document.removeEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
-        document.removeEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
-        document.removeEventListener('webkitpointerlockchange', GLFW.onPointerLockEventChange, true);
-        document.removeEventListener('mspointerlockchange', GLFW.onPointerLockEventChange, true);
       }
     },
 
@@ -547,26 +539,14 @@ var LibraryGLFW = {
       if (!GLFW.isPointerLocked)
       {
         document.addEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
-        document.addEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
-        document.addEventListener('webkitpointerlockchange', GLFW.onPointerLockEventChange, true);
-        document.addEventListener('mspointerlockchange', GLFW.onPointerLockEventChange, true);
-
-        var RPL = element.requestPointerLock ||
-                  element.mozRequestPointerLock ||
-                  element.webkitRequestPointerLock ||
-                  element.msRequestPointerLock ||
-            (function() {});
-          RPL.apply(element, []);
+        var RPL = element.requestPointerLock || (function() {});
+        RPL.apply(element, []);
       }
     },
 
     cancelPointerLock: function() {
-      var EPL = document.exitPointerLock ||
-                document.mozExitPointerLock ||
-                document.webkitExitPointerLock ||
-                document.msExitPointerLock ||
-          (function() {});
-        EPL.apply(document, []);
+      var EPL = document.exitPointerLock || (function() {});
+      EPL.apply(document, []);
     },
     disconnectJoystick: function (joy) {
       _free(GLFW.joys[joy].id);

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -521,11 +521,29 @@ var LibraryGLFW = {
       GLFW.refreshJoysticks(true);
     },
 
+    onPointerLockEventChange: function(event) {
+      GLFW.isPointerLocked = document["pointerLockElement"] ||
+                            document["mozPointerLockElement"] ||
+                            document["webkitIsPointerLockElement"] ||
+                            document["msIsPointerLockElement"];
+      if (!GLFW.isPointerLocked) {
+        document.removeEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
+        document.removeEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
+        document.removeEventListener('webkitpointerlockchange', GLFW.onPointerLockEventChange, true);
+        document.removeEventListener('mspointerlockchange', GLFW.onPointerLockEventChange, true);
+      }
+    },
+
     requestPointerLock: function() {
       element = element || Module["fullScreenContainer"] || Module["canvas"];
       if (!element) {
         return;
       }
+
+      document.addEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
+      document.addEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
+      document.addEventListener('webkitpointerlockchange', GLFW.onPointerLockEventChange, true);
+      document.addEventListener('mspointerlockchange', GLFW.onPointerLockEventChange, true);
 
       var RPL = element.requestPointerLock ||
                 element.mozRequestPointerLock ||
@@ -875,8 +893,7 @@ var LibraryGLFW = {
   },
 
   glfwGetMouseLocked: function() {
-    // If it's not visible, it's locked, hence the negation
-    return !GLFW.params[0x00030001] // GLFW_MOUSE_CURSOR
+    return GLFW.isPointerLocked;
   },
 
   glfwSetKeyCallback: function(cbfun) {

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -53,6 +53,7 @@ var LibraryGLFW = {
     prevNonFSWidth: 0,
     prevNonFSHeight: 0,
     isFullscreen: false,
+    isPointerLocked: false,
     dpi: 1,
     mouseTouchId:null,
 
@@ -520,6 +521,28 @@ var LibraryGLFW = {
       GLFW.refreshJoysticks(true);
     },
 
+    requestPointerLock: function() {
+      element = element || Module["fullScreenContainer"] || Module["canvas"];
+      if (!element) {
+        return;
+      }
+
+      var RPL = element.requestPointerLock ||
+                element.mozRequestPointerLock ||
+                element.webkitRequestPointerLock ||
+                element.msRequestPointerLock ||
+          (function() {});
+        RPL.apply(element, []);
+    },
+
+    cancelPointerLock: function() {
+      var EPL = document.exitPointerLock ||
+                document.mozExitPointerLock ||
+                document.webkitExitPointerLock ||
+                document.msExitPointerLock ||
+          (function() {});
+        EPL.apply(document, []);
+    },
     disconnectJoystick: function (joy) {
       _free(GLFW.joys[joy].id);
       delete GLFW.joys[joy];
@@ -851,6 +874,11 @@ var LibraryGLFW = {
     GLFW.wheelPos = pos;
   },
 
+  glfwGetMouseLocked: function() {
+    // If it's not visible, it's locked, hence the negation
+    return !GLFW.params[0x00030001] // GLFW_MOUSE_CURSOR
+  },
+
   glfwSetKeyCallback: function(cbfun) {
     GLFW.keyFunc = cbfun;
   },
@@ -1016,11 +1044,11 @@ var LibraryGLFW = {
 
   /* Enable/disable functions */
   glfwEnable: function(token) {
-    GLFW.params[token] = false;
+    GLFW.params[token] = true;
   },
 
   glfwDisable: function(token) {
-    GLFW.params[token] = true;
+    GLFW.params[token] = false;
   },
 
   /* Image/texture I/O support */

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -522,10 +522,12 @@ var LibraryGLFW = {
     },
 
     onPointerLockEventChange: function(event) {
-      GLFW.isPointerLocked = document["pointerLockElement"] ||
+      var pointerLockElement = document["pointerLockElement"] ||
                             document["mozPointerLockElement"] ||
                             document["webkitIsPointerLockElement"] ||
                             document["msIsPointerLockElement"];
+      GLFW.isPointerLocked = !!pointerLockElement;
+
       if (!GLFW.isPointerLocked) {
         document.removeEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
         document.removeEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
@@ -534,23 +536,26 @@ var LibraryGLFW = {
       }
     },
 
-    requestPointerLock: function() {
-      element = element || Module["fullScreenContainer"] || Module["canvas"];
+    requestPointerLock: function(element) {
+      element = element || Module["canvas"];
       if (!element) {
         return;
       }
 
-      document.addEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
-      document.addEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
-      document.addEventListener('webkitpointerlockchange', GLFW.onPointerLockEventChange, true);
-      document.addEventListener('mspointerlockchange', GLFW.onPointerLockEventChange, true);
+      if (!GLFW.isPointerLocked)
+      {
+        document.addEventListener('pointerlockchange', GLFW.onPointerLockEventChange, true);
+        document.addEventListener('mozpointerlockchange', GLFW.onPointerLockEventChange, true);
+        document.addEventListener('webkitpointerlockchange', GLFW.onPointerLockEventChange, true);
+        document.addEventListener('mspointerlockchange', GLFW.onPointerLockEventChange, true);
 
-      var RPL = element.requestPointerLock ||
-                element.mozRequestPointerLock ||
-                element.webkitRequestPointerLock ||
-                element.msRequestPointerLock ||
-          (function() {});
-        RPL.apply(element, []);
+        var RPL = element.requestPointerLock ||
+                  element.mozRequestPointerLock ||
+                  element.webkitRequestPointerLock ||
+                  element.msRequestPointerLock ||
+            (function() {});
+          RPL.apply(element, []);
+      }
     },
 
     cancelPointerLock: function() {
@@ -893,7 +898,7 @@ var LibraryGLFW = {
   },
 
   glfwGetMouseLocked: function() {
-    return GLFW.isPointerLocked;
+    return GLFW.isPointerLocked ? 1 : 0;
   },
 
   glfwSetKeyCallback: function(cbfun) {
@@ -1062,10 +1067,19 @@ var LibraryGLFW = {
   /* Enable/disable functions */
   glfwEnable: function(token) {
     GLFW.params[token] = true;
+
+    if (token == 0x00030001) // GLFW_MOUSE_CURSOR)
+    {
+      GLFW.cancelPointerLock();
+    }
   },
 
   glfwDisable: function(token) {
     GLFW.params[token] = false;
+    if (token == 0x00030001) // GLFW_MOUSE_CURSOR)
+    {
+      GLFW.requestPointerLock();
+    }
   },
 
   /* Image/texture I/O support */

--- a/engine/glfw/lib/input.c
+++ b/engine/glfw/lib/input.c
@@ -363,3 +363,11 @@ GLFWAPI int GLFWAPIENTRY glfwSetGamepadCallback(GLFWkeyfun cbfun)
     return 1;
 }
 
+// DEFOLD change
+// Since the locking of the mouse is done internally in glfw,
+// we need to query the current state here
+GLFWAPI int glfwGetMouseLocked()
+{
+    return _glfwWin.mouseLock;
+}
+

--- a/engine/hid/src/glfw/hid_native.cpp
+++ b/engine/hid/src/glfw/hid_native.cpp
@@ -294,6 +294,21 @@ namespace dmHID
         glfwAccelerometerEnable();
     }
 
+    void ShowMouseCursor(HContext context)
+    {
+        glfwEnable(GLFW_MOUSE_CURSOR);
+    }
+
+    void HideMouseCursor(HContext context)
+    {
+        glfwDisable(GLFW_MOUSE_CURSOR);
+    }
+
+    bool GetCursorVisible(HContext context)
+    {
+        return !glfwGetMouseLocked();
+    }
+
     const char* GetKeyName(Key key)
     {
         return KEY_NAMES[key];

--- a/engine/hid/src/hid.h
+++ b/engine/hid/src/hid.h
@@ -294,6 +294,22 @@ namespace dmHID
     void ResetKeyboard(HContext context);
 
     /**
+     * Show mouse cursor if applicable, e.g PC platform
+     */
+    void ShowMouseCursor(HContext context);
+
+    /**
+     * Hide mouse cursor if applicable, e.g PC platform.
+     * This effectively locks the mouse position to the center of the current window.
+     */
+    void HideMouseCursor(HContext context);
+
+    /**
+     * Gets the lock state of the current mouse if applicable, e.g PC platform
+     */
+    bool GetCursorVisible(HContext context);
+
+    /**
      * Convenience function to retrieve the position of a specific touch.
      * Used in unit tests (test_input.cpp)
      *

--- a/engine/hid/src/hid_null.cpp
+++ b/engine/hid/src/hid_null.cpp
@@ -25,8 +25,13 @@ namespace dmHID
     // detect sloppy init/final usage
     dmHashTable<uintptr_t, char*>* g_DummyData = 0x0;
 
+    // Mostly used for tests
+    static uint8_t g_MouseVisible = 0;
+
     bool Init(HContext context)
     {
+        g_MouseVisible = 1;
+
         if (g_DummyData == 0x0)
         {
             g_DummyData = new dmHashTable<uintptr_t, char*>();
@@ -98,14 +103,16 @@ namespace dmHID
 
     void ShowMouseCursor(HContext context)
     {
+        g_MouseVisible = 1;
     }
 
     void HideMouseCursor(HContext context)
     {
+        g_MouseVisible = 0;
     }
 
     bool GetCursorVisible(HContext context)
     {
-        return true;
+        return g_MouseVisible;
     }
 }

--- a/engine/hid/src/hid_null.cpp
+++ b/engine/hid/src/hid_null.cpp
@@ -95,4 +95,17 @@ namespace dmHID
     void EnableAccelerometer()
     {
     }
+
+    void ShowMouseCursor(HContext context)
+    {
+    }
+
+    void HideMouseCursor(HContext context)
+    {
+    }
+
+    bool GetCursorVisible(HContext context)
+    {
+        return true;
+    }
 }

--- a/engine/hid/src/test/test_app_hid.cpp
+++ b/engine/hid/src/test/test_app_hid.cpp
@@ -155,7 +155,6 @@ static UpdateResult EngineUpdate(void* _engine)
 
 
 #define LOG if (packet_changed) printf
-//#define LOG
 
     for (uint32_t i = 0; i < dmHID::MAX_GAMEPAD_COUNT; ++i)
     {

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1931,4 +1931,13 @@ namespace dmScript
         return r;
     }
 
+    bool CheckBoolean(lua_State* L, int index)
+    {
+        if (lua_isboolean(L, index))
+        {
+            return lua_toboolean(L, index);
+        }
+        return luaL_error(L, "Argument %d must be a boolean", index);
+    }
+
 } // dmScript

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1940,7 +1940,7 @@ namespace dmScript
         return luaL_error(L, "Argument %d must be a boolean", index);
     }
 
-    bool PushBoolean(lua_State* L, bool v)
+    void PushBoolean(lua_State* L, bool v)
     {
         lua_pushboolean(L, v);
     }

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -1940,4 +1940,8 @@ namespace dmScript
         return luaL_error(L, "Argument %d must be a boolean", index);
     }
 
+    bool PushBoolean(lua_State* L, bool v)
+    {
+        lua_pushboolean(L, v);
+    }
 } // dmScript

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -264,7 +264,7 @@ namespace dmScript
      * @return Number of bytes used in buffer
      */
     uint32_t CheckTable(lua_State* L, char* buffer, uint32_t buffer_size, int index);
-    
+
     /**
      * Get the size of a table when serialized
      * @param L Lua state
@@ -310,6 +310,14 @@ namespace dmScript
      * @return The FloatVector value
      */
     dmVMath::FloatVector* CheckVector(lua_State* L, int index);
+
+    /**
+     * Check if the value in the supplied index on the lua stack is a boolean.
+     * @param L Lua state
+     * @param index Index of the value
+     * @return The boolean value
+     */
+    bool CheckBoolean(lua_State* L, int index);
 
     /**
      * Check if the value at #index is a URL

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -324,7 +324,7 @@ namespace dmScript
      * @param L Lua state
      * @param v boolean value to push
      */
-    bool PushBoolean(lua_State* L, bool v);
+    void PushBoolean(lua_State* L, bool v);
 
     /**
      * Check if the value at #index is a URL

--- a/engine/script/src/script.h
+++ b/engine/script/src/script.h
@@ -320,6 +320,13 @@ namespace dmScript
     bool CheckBoolean(lua_State* L, int index);
 
     /**
+     * Push a Boolean value onto the supplied lua state, will increase the stack by 1.
+     * @param L Lua state
+     * @param v boolean value to push
+     */
+    bool PushBoolean(lua_State* L, bool v);
+
+    /**
      * Check if the value at #index is a URL
      * @param L Lua state
      * @param index Index of the value

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -1060,6 +1060,61 @@ TEST_F(ScriptTest, InstanceId)
     dmScript::Unref(L, LUA_REGISTRYINDEX, instanceref3);
 }
 
+static bool g_panic_function_called = false;
+static jmp_buf g_env_buffer;
+static int boolean_panic_fn(lua_State *L)
+{
+    g_panic_function_called = true;
+    fprintf(stderr, "PANIC: unprotected error in call to Lua API (%s) (boolean_panic_fn)\n", lua_tostring(L, -1));
+    longjmp(g_env_buffer, 1);
+    return 0;
+}
+
+TEST_F(ScriptTest, LuaBooleanFunctions)
+{
+    DM_LUA_STACK_CHECK(L, 0);
+
+    ///////////////////////////////
+    // Test simple CheckBoolean fn
+    ///////////////////////////////
+    lua_pushboolean(L, true);
+    ASSERT_TRUE(dmScript::CheckBoolean(L, -1));
+    lua_pop(L, 1);
+
+    lua_pushboolean(L, true);
+    ASSERT_TRUE(dmScript::CheckBoolean(L, -1));
+    lua_pop(L, 1);
+
+    /////////////////////////////////////////////
+    // Test checking something that isn't boolean
+    //   this requires us to use a special panic fn
+    //   we need to use longjmp for that since
+    //   lua will automatically exit
+    /////////////////////////////////////////////
+    lua_CFunction current_panic = lua_atpanic(L, boolean_panic_fn);
+
+    int val;
+    val = setjmp(g_env_buffer);
+
+    if (val == 0)
+    {
+        lua_pushnumber(L, 123);
+        dmScript::CheckBoolean(L, -1);
+    }
+
+    ASSERT_TRUE(g_panic_function_called);
+    // lua_pushnumber + error message + error function
+    lua_pop(L, 3);
+
+    lua_atpanic(L, current_panic);
+
+    /////////////////////////////////////
+    // Test PushBoolean with simple value
+    /////////////////////////////////////
+    dmScript::PushBoolean(L, true);
+    ASSERT_TRUE(lua_toboolean(L, -1));
+    lua_pop(L, 1);
+}
 
 int main(int argc, char **argv)
 {

--- a/engine/script/src/test/test_script.cpp
+++ b/engine/script/src/test/test_script.cpp
@@ -1060,6 +1060,21 @@ TEST_F(ScriptTest, InstanceId)
     dmScript::Unref(L, LUA_REGISTRYINDEX, instanceref3);
 }
 
+#if defined(_WIN32)
+    #define USE_PANIC_FN 0
+#else
+    #define USE_PANIC_FN 1
+    static jmp_buf g_env_buffer;
+    static bool g_panic_function_called = false;
+    static int boolean_panic_fn(lua_State *L)
+    {
+        g_panic_function_called = true;
+        fprintf(stderr, "PANIC: unprotected error in call to Lua API (%s) (custom boolean_panic_fn)\n", lua_tostring(L, -1));
+        longjmp(g_env_buffer, 1);
+        return 0;
+    }
+#endif
+
 TEST_F(ScriptTest, LuaBooleanFunctions)
 {
     DM_LUA_STACK_CHECK(L, 0);
@@ -1075,6 +1090,25 @@ TEST_F(ScriptTest, LuaBooleanFunctions)
     ASSERT_TRUE(dmScript::CheckBoolean(L, -1));
     lua_pop(L, 1);
 
+    /////////////////////////////////////////////
+    // Test checking something that isn't boolean
+    /////////////////////////////////////////////
+#if USE_PANIC_FN
+    lua_CFunction current_panic = lua_atpanic(L, boolean_panic_fn);
+
+    // Val will be zero first time the code reaches here,
+    // but the longjmp from the error handler will return 1
+    // after it has been called
+    int val = setjmp(g_env_buffer);
+
+    if (val == 0)
+    {
+        lua_pushnumber(L, 123);
+        dmScript::CheckBoolean(L, -1);
+    }
+    lua_atpanic(L, current_panic);
+    ASSERT_TRUE(g_panic_function_called);
+#else
     bool error_check_occured = false;
     lua_pushnumber(L, 123);
     try
@@ -1086,6 +1120,7 @@ TEST_F(ScriptTest, LuaBooleanFunctions)
         error_check_occured = true;
     }
     ASSERT_TRUE(error_check_occured);
+#endif
     lua_pop(L, 3);
 
     /////////////////////////////////////


### PR DESCRIPTION
Added mouse locking functionality on desktop and web platforms. This is done by using two new API functions:

```
-- set the mouse locking state
window.set_mouse_lock(true|false)
-- get the currently set mouse locking state
local mouse_lock = window.get_mouse_lock()
```

Note that for web platforms, you cannot request mouse lock outside of "user interactions", so to get that to work you can use the `html5.set_interaction_listener(callback)` function to request the mouse lock for web platforms.

Fixes #6992 