### PR TITLE
Ignore URL query parameters when serving files from the editor

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -360,9 +360,10 @@
       {:code 302
        :headers {"Location" (str html5-url-prefix "/index.html")}}
 
-      (let [served-file   (try-resolve-html5-file project url)
+      (let [url-without-query-params  (get (string/split url #"\?") 0)
+            served-file   (try-resolve-html5-file project url-without-query-params)
             extra-headers {"Content-Type" (html5-mime-types
-                                            (FilenameUtils/getExtension (clojure.string/lower-case url))
+                                            (FilenameUtils/getExtension (clojure.string/lower-case url-without-query-params))
                                             "application/octet-stream")}]
         (cond
           ;; The requested URL is a directory or located outside build-html5-output-path.

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -360,7 +360,7 @@
       {:code 302
        :headers {"Location" (str html5-url-prefix "/index.html")}}
 
-      (let [url-without-query-params  (get (string/split url #"\?") 0)
+      (let [url-without-query-params  (.getPath (java.net.URL. (str "http://" url)))
             served-file   (try-resolve-html5-file project url-without-query-params)
             extra-headers {"Content-Type" (html5-mime-types
                                             (FilenameUtils/getExtension (clojure.string/lower-case url-without-query-params))


### PR DESCRIPTION
The webserver in the editor which serves files to a local HTML5 build did not handle URLs containing query parameters. This change removes any query parameters from an URL before looking up a file to serve as response to a GET request.

Fixes #6940 