### PR TITLE
Fix issue when bundling for iOS without any native extensions

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 import java.io.OutputStream;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -219,6 +220,15 @@ public class IOSBundler implements IBundler {
 
     }
 
+    private void copyManifestFile(BundleHelper helper, Platform platform, File destDir) throws IOException, CompileExceptionError {
+        File manifestFile = helper.copyOrWriteManifestFile(platform, destDir);
+        String manifest = FileUtils.readFileToString(manifestFile, StandardCharsets.UTF_8);
+        // remove attribute definition (https://github.com/defold/defold/pull/6914)
+        // it is automatically removed if the manifest was merged
+        manifest = manifest.replace("[ <!ATTLIST key merge (keep) #IMPLIED> ]", "");
+        FileUtils.write(manifestFile, manifest);
+    }
+
     @Override
     public void bundleApplication(Project project, Platform platform, File bundleDir, ICanceled canceled) throws IOException, CompileExceptionError {
         logger.log(Level.INFO, "Entering IOSBundler.bundleApplication()");
@@ -366,8 +376,7 @@ public class IOSBundler implements IBundler {
         }
 
         BundleHelper helper = new BundleHelper(project, Platform.Arm64Ios, bundleDir, variant);
-
-        helper.copyOrWriteManifestFile(architectures.get(0), appDir);
+        copyManifestFile(helper, architectures.get(0), appDir);
         helper.copyIosIcons();
 
         BundleHelper.throwIfCanceled(canceled);


### PR DESCRIPTION
A recent improvement to the Info.plist merge process for native extensions had the unfortunate side-effect that builds without any native extensions failed to install due to strict checks of the Info.plist. This fix solves this issue by removing the merge attribute definition from the Inof.plist file if it still exists when bundling (which it does if bundling without native extensions).

Fixes #7025 