### PR TITLE
DEFEDIT-7041 Generalize settings-file lists

### DIFF
--- a/editor/resources/live-update-meta.edn
+++ b/editor/resources/live-update-meta.edn
@@ -43,7 +43,9 @@
    :help "List of supported engine versions",
    :default ["0.0.0"],
    :presentation-category "Manifest"
-   :path ["liveupdate" "supported-versions"]}]
+   :path ["liveupdate" "supported-versions"]
+   :element {:type :string
+             :default "0.0.0"}}]
  :categories
  {"liveupdate" {:title "Live Update"}
   "Amazon" {}

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -23,10 +23,12 @@
    :help "compress archive (not for Android)",
    :default true,
    :path ["project" "compress_archive"]}
-  {:type :library-list,
+  {:type :list,
    :help
    "a comma separated list of URL:s to projects required by this project",
-   :path ["project" "dependencies"]}
+   :path ["project" "dependencies"]
+   :element {:type :url
+             :default "https://url.to/library"}}
   {:type :string,
    :help
    "a comma separated list of resources that will be included in the project. If directories are specified, all files and directories in that directory are recursively included",

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -55,7 +55,8 @@
             [editor.view :as view]
             [editor.workspace :as workspace]
             [internal.util :as util])
-  (:import [javafx.event Event]
+  (:import [java.io File]
+           [javafx.event Event]
            [javafx.scene Node]
            [javafx.scene.control Cell ComboBox ListView$EditEvent TableColumn$CellEditEvent TableView ListView]
            [javafx.scene.input KeyCode KeyEvent]
@@ -423,30 +424,66 @@
   {:set-ui-state (update-in ui-state state-path dissoc :edit)
    :dispatch (assoc on-edited :fx/event {:index index :item event})})
 
-(defmethod handle-event :add-list-element [{:keys [value
+(defn- absolute-or-maybe-proj-path
+  ^String [^File file workspace in-project]
+  (if in-project
+    (workspace/as-proj-path workspace file)
+    (.getAbsolutePath file)))
+
+(defn query-added-list-elements-or-dialog-type [element ^Event event workspace project]
+  (case (:type element)
+    :directory
+    (when-some [selected-directory (dialogs/make-directory-dialog
+                                     (or (:title element) "Select Directory")
+                                     (workspace/project-path workspace)
+                                     (fxui/event->window event))]
+      (or (some-> selected-directory
+                  (absolute-or-maybe-proj-path workspace (:in-project element))
+                  (vector))
+          :directory-not-in-project))
+
+    :file
+    (when-some [selected-file (dialogs/make-file-dialog
+                                (or (:title element) "Select File")
+                                (:filter element)
+                                nil
+                                (fxui/event->window event))]
+      (or (some-> selected-file
+                  (absolute-or-maybe-proj-path workspace (:in-project element))
+                  (vector))
+          :file-not-in-project))
+
+    :resource
+    (resource-dialog/make
+      workspace project
+      {:ext (:filter element)
+       :selection :multiple})
+
+    ;; default
+    [(form/field-default element)]))
+
+(defmethod handle-event :add-list-element [{:keys [element
+                                                   fx/event
                                                    on-added
+                                                   project
                                                    state-path
                                                    ui-state
-                                                   element]}]
-  [[:dispatch (assoc on-added :fx/event [element])]
-   [:set-ui-state (assoc-in ui-state (conj state-path :selected-indices) [(count value)])]])
+                                                   value
+                                                   workspace]}]
+  (let [added-list-elements-or-dialog-type
+        (query-added-list-elements-or-dialog-type element event workspace project)]
+    (cond
+      (keyword? added-list-elements-or-dialog-type)
+      (let [dialog-type added-list-elements-or-dialog-type]
+        {:show-dialog dialog-type})
 
-(defmethod handle-event :add-list-resource [{:keys [workspace
-                                                    project
-                                                    filter
-                                                    value
-                                                    on-added
-                                                    state-path
-                                                    ui-state]}]
-  (let [resources (resource-dialog/make workspace project {:ext filter
-                                                           :selection :multiple})]
-    (when-not (empty? resources)
-      (let [value-count (count value)
-            added-count (count resources)
-            indices (vec (range value-count
-                                (+ value-count added-count)))]
-        [[:dispatch (assoc on-added :fx/event resources)]
-         [:set-ui-state (assoc-in ui-state (conj state-path :selected-indices) indices)]]))))
+      (seq added-list-elements-or-dialog-type)
+      (let [added-list-elements added-list-elements-or-dialog-type
+            old-element-count (count value)
+            new-element-count (+ old-element-count (count added-list-elements))
+            added-indices (vec (range old-element-count new-element-count))]
+        [[:dispatch (assoc on-added :fx/event added-list-elements)]
+         [:set-ui-state (assoc-in ui-state (conj state-path :selected-indices) added-indices)]]))))
 
 (defmethod handle-event :remove-list-selection [{:keys [on-removed state-path ui-state]}]
   (let [indices-path (conj state-path :selected-indices)]
@@ -523,17 +560,11 @@
   (let [{:keys [selected-indices edit]} state
         disable-add (not (form/has-default? element))
         disable-remove (empty? selected-indices)
-        add-event (if (= :resource (:type element))
-                    {:event-type :add-list-resource
-                     :value value
-                     :on-added on-added
-                     :state-path state-path
-                     :filter (:filter element)}
-                    {:event-type :add-list-element
-                     :value value
-                     :on-added on-added
-                     :state-path state-path
-                     :element (form/field-default element)})
+        add-event {:event-type :add-list-element
+                   :value value
+                   :on-added on-added
+                   :state-path state-path
+                   :element element}
         remove-event {:event-type :remove-list-selection
                       :on-removed on-removed
                       :state-path state-path}]
@@ -677,14 +708,18 @@
 (defmethod handle-event :on-file-selected [{:keys [on-value-changed
                                                    filter
                                                    ^Event fx/event
-                                                   title]}]
-  (when-let [file (dialogs/make-file-dialog (or title "Select File")
-                                            filter
-                                            nil
-                                            (.getWindow (.getScene ^Node (.getSource event))))]
-    {:dispatch (assoc on-value-changed :fx/event (.getAbsolutePath file))}))
+                                                   title
+                                                   in-project
+                                                   workspace]}]
+  (when-some [file (dialogs/make-file-dialog (or title "Select File")
+                                             filter
+                                             nil
+                                             (fxui/event->window event))]
+    (if-some [path (absolute-or-maybe-proj-path file workspace in-project)]
+      {:dispatch (assoc on-value-changed :fx/event path)}
+      {:show-dialog :file-not-in-project})))
 
-(defmethod form-input-view :file [{:keys [on-value-changed value filter title]}]
+(defmethod form-input-view :file [{:keys [on-value-changed value filter title in-project]}]
   {:fx/type fx.h-box/lifecycle
    :spacing 4
    :children [{:fx/type text-field
@@ -698,17 +733,20 @@
                :on-action {:event-type :on-file-selected
                            :on-value-changed on-value-changed
                            :filter filter
+                           :in-project in-project
                            :title title}}]})
 
 ;; endregion
 
 ;; region directory input
 
-(defmethod handle-event :on-directory-selected [{:keys [on-value-changed title]}]
-  (when-let [file (ui/choose-directory (or title "Select Directory") nil)]
-    {:dispatch (assoc on-value-changed :fx/event file)}))
+(defmethod handle-event :on-directory-selected [{:keys [on-value-changed title fx/event in-project workspace]}]
+  (when-some [file (dialogs/make-directory-dialog (or title "Select Directory") nil (fxui/event->window event))]
+    (if-some [path (absolute-or-maybe-proj-path file workspace in-project)]
+      {:dispatch (assoc on-value-changed :fx/event path)}
+      {:show-dialog :directory-not-in-project})))
 
-(defmethod form-input-view :directory [{:keys [on-value-changed value title]}]
+(defmethod form-input-view :directory [{:keys [on-value-changed value title in-project]}]
   {:fx/type fx.h-box/lifecycle
    :spacing 4
    :children [{:fx/type text-field
@@ -721,6 +759,7 @@
                :text "\u2026"
                :on-action {:event-type :on-directory-selected
                            :on-value-changed on-value-changed
+                           :in-project in-project
                            :title title}}]})
 
 ;; endregion
@@ -1486,7 +1525,20 @@
                                      (instance? ListView x)
                                      (.edit ^ListView x -1)))
                     :open-resource (fn [[node value] _]
-                                     (ui/run-command node :open {:resources [value]}))})
+                                     (ui/run-command node :open {:resources [value]}))
+                    :show-dialog (fn [dialog-type _]
+                                   (case dialog-type
+                                     :directory-not-in-project
+                                     (dialogs/make-info-dialog
+                                       {:title "Invalid Directory"
+                                        :icon :icon/triangle-error
+                                        :header "The directory must reside within the project."})
+
+                                     :file-not-in-project
+                                     (dialogs/make-info-dialog
+                                       {:title "Invalid File"
+                                        :icon :icon/triangle-error
+                                        :header "The file must reside within the project."})))})
                  (wrap-force-refresh view-id))}
 
       :middleware (comp

--- a/editor/src/clj/editor/form.clj
+++ b/editor/src/clj/editor/form.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.form
-  (:require [editor.util :as util]))
+  (:require [editor.util :as util])
+  (:import [java.net URI]))
 
 (set! *warn-on-reflection* true)
 
@@ -30,6 +31,9 @@
   {:table []
    :string ""
    :resource nil
+   :file ""
+   :directory ""
+   :url (URI. "https://example.com")
    :boolean false
    :integer 0
    :number 0.0

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.fs
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string])
   (:import [java.util UUID]
            [java.io File FileNotFoundException IOException RandomAccessFile]
            [java.nio.channels OverlappingFileLockException]
@@ -102,11 +103,6 @@
       (.isDirectory directory)
       (catch Exception _
         false))))
-
-(defn below-directory?
-  "Returns true if the file system entry is located below the directory."
-  [^File entry ^File directory]
-  (-> entry .toPath .toAbsolutePath (.startsWith (-> directory .toPath .toAbsolutePath))))
 
 (defn empty-directory?
   "Returns true if the argument refers to an existing empty directory."
@@ -290,6 +286,19 @@
         upper-file (io/file (io/file fs-temp-dir "CASETEST"))]
     (touch-file! lower-file)
     (not (same-path? (.toPath lower-file) (.toPath upper-file)))))
+
+(defn- comparable-path
+  ^String [entry]
+  (cond-> (-> entry io/as-file .toPath .normalize .toAbsolutePath .toString)
+          (not case-sensitive?) .toLowerCase))
+
+(defn below-directory?
+  "Returns true if the file system entry is located below the directory."
+  [^File entry ^File directory]
+  (let [entry-path (comparable-path entry)
+        directory-path (comparable-path directory)]
+    (and (= \/ (get entry-path (count directory-path)))
+         (string/starts-with? entry-path directory-path))))
 
 (declare copy-directory!)
 

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -103,6 +103,11 @@
       (catch Exception _
         false))))
 
+(defn below-directory?
+  "Returns true if the file system entry is located below the directory."
+  [^File entry ^File directory]
+  (-> entry .toPath .toAbsolutePath (.startsWith (-> directory .toPath .toAbsolutePath))))
+
 (defn empty-directory?
   "Returns true if the argument refers to an existing empty directory."
   [^File directory]

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -37,13 +37,19 @@
            [java.util Collection]
            [javafx.application Platform]
            [javafx.collections ObservableList]
+           [javafx.event Event]
            [javafx.scene Node]
            [javafx.beans.property ReadOnlyProperty]
            [javafx.beans.value ChangeListener]
            [javafx.scene.control TextInputControl ListView ScrollPane]
+           [javafx.stage Window]
            [javafx.util Callback]))
 
 (set! *warn-on-reflection* true)
+
+(defn event->window
+  ^Window [^Event event]
+  (.getWindow (.getScene ^Node (.getSource event))))
 
 (def ext-value
   "Extension lifecycle that returns value on `:value` key"

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -64,7 +64,7 @@
                                          (assoc setting :value (settings-core/render-raw-setting-value meta-setting value)))))))
                        (let [transformed-settings-map (transform-settings! settings-map)]
                          (sort-by first transformed-settings-map)))
-        ^String user-data-content (settings-core/settings->str settings)]
+        user-data-content (settings-core/settings->str settings meta-settings :comma-separated-list)]
     {:resource resource :content (.getBytes user-data-content)}))
 
 (defn- resource-content [resource]
@@ -252,5 +252,6 @@
     :label "Project"
     :node-type GameProjectNode
     :load-fn load-game-project
+    :meta-settings (:settings gpcore/basic-meta-info)
     :icon game-project-icon
     :view-types [:cljfx-form-view :text]))

--- a/editor/src/clj/editor/game_project_core.clj
+++ b/editor/src/clj/editor/game_project_core.clj
@@ -22,7 +22,9 @@
                                        settings-core/pushback-reader)]
                        (settings-core/load-meta-info r)))
 
+(def meta-settings (:settings basic-meta-info))
+
 (defn default-settings []
-  (-> (:settings basic-meta-info)
+  (-> meta-settings
       settings-core/make-default-settings
       settings-core/make-settings-map))

--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -13,17 +13,17 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.library
-  (:require [editor.progress :as progress]
-            [editor.settings-core :as settings-core]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [editor.fs :as fs]
-            [clojure.java.io :as io]
-            [clojure.string :as str])
+            [editor.progress :as progress]
+            [editor.settings-core :as settings-core])
   (:import [java.io File InputStream]
+           [java.net HttpURLConnection URI]
            [java.util Base64]
            [java.util.zip ZipInputStream]
-           [java.net URI HttpURLConnection]
-           [org.apache.commons.io FilenameUtils]
-           [org.apache.commons.codec.digest DigestUtils]))
+           [org.apache.commons.codec.digest DigestUtils]
+           [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 

--- a/editor/src/clj/editor/live_update_settings.clj
+++ b/editor/src/clj/editor/live_update_settings.clj
@@ -101,6 +101,7 @@
     :label "Live Update Settings"
     :node-type LiveUpdateSettingsNode
     :load-fn load-live-update-settings
+    :meta-settings (:settings basic-meta-info)
     :icon live-update-icon
     :view-types [:cljfx-form-view :text]))
 

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -172,7 +172,8 @@
                :write-fn (partial protobuf/map->str ddf-type))]
     (apply workspace/register-resource-type workspace (mapcat identity args))))
 
-(defn register-settings-resource-type [workspace & {:keys [ext node-type load-fn icon view-types tags tag-opts label] :as args}]
+(defn register-settings-resource-type [workspace & {:keys [ext node-type load-fn meta-settings icon view-types tags tag-opts label] :as args}]
+  {:pre [(seqable? meta-settings)]}
   (let [read-fn (fn [resource]
                   (with-open [setting-reader (io/reader resource)]
                     (settings-core/parse-settings setting-reader)))
@@ -182,5 +183,6 @@
                           (let [source-value (read-fn resource)]
                             (load-fn project self resource source-value)))
                :read-fn read-fn
-               :write-fn (comp settings-core/settings->str settings-core/settings-with-value))]
+               :write-fn (comp #(settings-core/settings->str % meta-settings :multi-line-list)
+                               settings-core/settings-with-value))]
     (apply workspace/register-resource-type workspace (mapcat identity args))))

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -84,11 +84,8 @@
     (contains? setting :options)
     (assoc :type :choicebox)
 
-    (= :library-list (:type setting))
-    (assoc :type :list :element {:type :url :default "https://url.to/library"})
-
     (= :comma-separated-list (:type setting))
-    (assoc :type :list :element {:type :string :default (or (first (:default setting)) "item")})))
+    (assoc :type :list)))
 
 (defn- section-title [category-name category-info]
   (or (:title category-info)
@@ -249,4 +246,5 @@
     :icon icon
     :node-type SimpleSettingsResourceNode
     :load-fn (partial load-simple-settings-resource-node meta-info)
+    :meta-settings (:settings meta-info)
     :view-types [:cljfx-form-view :text]))

--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -142,7 +142,7 @@
   (when raw
     (let [element-meta-setting (get meta-setting :element default-list-element-meta-setting)]
       (into []
-            (map #(parse-setting-value element-meta-setting %))
+            (keep #(parse-setting-value element-meta-setting %))
             (text-util/parse-comma-separated-string raw)))))
 
 (defmethod parse-setting-value :list [meta-setting raw]

--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -16,6 +16,7 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as s]
+            [editor.url :as url]
             [util.text-util :as text-util])
   (:import [java.io BufferedReader PushbackReader Reader StringReader]))
 
@@ -71,20 +72,33 @@
   (when-let [[_ new-category] (re-find #"^\s*\[([^\]]*)\]" line)]
     (assoc parse-state :current-category new-category)))
 
-(defn- parse-setting-line [{:keys [current-category settings] :as parse-state} line]
-  (when-let [[_ key val] (seq (map s/trim (re-find #"([^=]+)=(.*)" line)))]
-    (let [cleaned-path (first (seq (non-blank (s/split key #"\#"))))]
+(defn- parse-setting-line [parse-state line]
+  (when-let [[_ key value] (seq (map s/trim (re-find #"([^=]+)=(.*)" line)))]
+    (let [[cleaned-path index-string] (non-blank (s/split key #"\#"))]
       (when-let [setting-path (seq (non-blank (s/split cleaned-path #"\.")))]
-        (let [full-path (into [current-category] setting-path)]
-          (if-let [existing-value (get-setting settings full-path)]
-            (update parse-state :settings set-setting full-path (str existing-value "," val))
-            (update parse-state :settings conj {:path full-path :value val})))))))
+        (let [full-path (into [(:current-category parse-state)] setting-path)]
+          ;; For non-list values, the value will be a string.
+          ;; For list values, we build up a vector of strings that we then join
+          ;; into comma-separated strings in the parse-state->settings function.
+          (if (nil? index-string)
+            (update parse-state :settings conj {:path full-path :value value})
+            (update parse-state :settings (fn [settings]
+                                            (let [entries (or (get-setting settings full-path) [])]
+                                              (set-setting settings full-path (conj entries value)))))))))))
 
 (defn- parse-error [line]
   (throw (Exception. (format "Invalid setting line: %s" line))))
 
-(defn- parse-state->settings [{:keys [settings]}]
-  settings)
+(defn- parse-state->settings [parse-state]
+  ;; After parsing, list values will be vectors of strings.
+  ;; Join them into comma-separated string values.
+  (into []
+        (map (fn [setting]
+               (update setting :value (fn [value]
+                                        (if (vector? value)
+                                          (text-util/join-comma-separated-string value)
+                                          value)))))
+        (:settings parse-state)))
 
 (defn parse-settings [reader]
   (parse-state->settings (reduce
@@ -95,7 +109,7 @@
                           (empty-parse-state)
                           (read-setting-lines reader))))
 
-(defmulti parse-setting-value (fn [type ^String raw] type))
+(defmulti parse-setting-value (fn [meta-setting ^String raw] (:type meta-setting)))
 
 (defmethod parse-setting-value :string [_ raw]
   raw)
@@ -119,18 +133,29 @@
 (defmethod parse-setting-value :directory [_ raw]
   raw)
 
-(defmethod parse-setting-value :comma-separated-list [_ raw]
+(defmethod parse-setting-value :url [_ raw]
+  (some-> raw url/try-parse))
+
+(def ^:private default-list-element-meta-setting {:type :string})
+
+(defn- parse-list-setting-value [meta-setting raw]
   (when raw
-    (into [] (text-util/parse-comma-separated-string raw))))
+    (let [element-meta-setting (get meta-setting :element default-list-element-meta-setting)]
+      (into []
+            (map #(parse-setting-value element-meta-setting %))
+            (text-util/parse-comma-separated-string raw)))))
+
+(defmethod parse-setting-value :list [meta-setting raw]
+  (parse-list-setting-value meta-setting raw))
+
+(defmethod parse-setting-value :comma-separated-list [meta-setting raw]
+  (parse-list-setting-value meta-setting raw))
 
 (def ^:private type-defaults
   {:string ""
    :boolean false
    :integer 0
-   :number 0.0
-   :resource nil
-   :file nil
-   :directory nil})
+   :number 0.0})
 
 (defn- add-type-defaults [meta-info]
   (update-in meta-info [:settings]
@@ -143,10 +168,9 @@
              (fn [settings]
                (map (fn [meta-setting]
                       (if (contains? meta-setting :options)
-                        (let [type (:type meta-setting)]
-                          (assoc meta-setting
-                                 :from-string #(parse-setting-value type %)
-                                 :to-string #(render-raw-setting-value meta-setting %)))
+                        (assoc meta-setting
+                          :from-string #(parse-setting-value meta-setting %)
+                          :to-string #(render-raw-setting-value meta-setting %))
                         meta-setting))
                     settings))))
 
@@ -199,10 +223,10 @@
     value))
 
 (defn- sanitize-setting [meta-settings-map {:keys [path] :as setting}]
-  (when-let [{:keys [type] :as meta-setting} (meta-settings-map path)]
+  (when-some [meta-setting (meta-settings-map path)]
     (update setting :value
             #(do (->> %
-                     (parse-setting-value type)
+                     (parse-setting-value meta-setting)
                      (sanitize-value meta-setting))))))
 
 (defn sanitize-settings [meta-settings settings]
@@ -210,7 +234,8 @@
 
 (defn make-default-settings [meta-settings]
   (mapv (fn [meta-setting]
-         {:path (:path meta-setting) :value (:default meta-setting)})
+          {:path (:path meta-setting)
+           :value (:default meta-setting)})
        meta-settings))
 
 (def setting-category (comp first :path))
@@ -232,30 +257,46 @@
 (defn- category->str [category settings]
   (s/join "\n" (cons (str "[" category "]") (map setting->str settings))))
 
-(defn split-multi-line-setting [category key settings]
-  (let [path [category key]]
-    (if-let [comma-separated-setting (not-empty (get-setting settings path))]
-      (let [comma-separated-setting-parts (non-blank (s/split comma-separated-setting #","))
-            comma-separated-setting-count (count comma-separated-setting-parts)
-            cleaned-settings (remove-setting settings path)]
-        (reduce
-          (fn [settings i]
-            (set-setting settings [category (str key "#" i)] (nth comma-separated-setting-parts i)))
+(defn- split-multi-line-setting-at-path [settings setting-path]
+  (let [comma-separated-setting (get-setting settings setting-path)]
+    (if (empty? comma-separated-setting)
+      settings
+      (let [list-element-strings (text-util/parse-comma-separated-string comma-separated-setting)
+            cleaned-settings (remove-setting settings setting-path)
+            [category key] setting-path]
+        (reduce-kv
+          (fn [settings index list-element-string]
+            (set-setting settings [category (str key "#" index)] list-element-string))
           cleaned-settings
-          (range 0 comma-separated-setting-count)))
-      settings)))
+          list-element-strings)))))
 
-(defn settings->str [settings]
-  (let [split-settings (split-multi-line-setting "project" "dependencies" (vec settings))
+(defn- split-multi-line-settings [settings meta-settings]
+  (transduce (keep (fn [meta-setting]
+                     (when (= :list (:type meta-setting))
+                       (:path meta-setting))))
+             (completing split-multi-line-setting-at-path)
+             settings
+             meta-settings))
+
+(defn settings->str
+  ^String [settings meta-settings list-format]
+  (let [split-settings (case list-format
+                         :comma-separated-list settings
+                         :multi-line-list (split-multi-line-settings (vec settings) meta-settings))
         cat-order (category-order split-settings)
         cat-grouped-settings (category-grouped-settings split-settings)]
 
     ;; Here we interleave categories with \n\n rather than join to make sure the file also ends with
     ;; two consecutive newlines. This is purely to avoid whitespace diffs when loading a project
     ;; created in the old editor and saving.
-    (s/join (interleave (map #(category->str % (cat-grouped-settings %)) cat-order) (repeat "\n\n")))))
+    (s/join (interleave (map #(category->str % (cat-grouped-settings %))
+                             cat-order)
+                        (repeat "\n\n")))))
 
 (defmulti render-raw-setting-value (fn [meta-setting value] (:type meta-setting)))
+
+(defmethod render-raw-setting-value :default [_ value]
+  (str value))
 
 (defmethod render-raw-setting-value :boolean [_ value]
   (if value "1" "0"))
@@ -266,11 +307,33 @@
     (str value "c")
     value))
 
-(defmethod render-raw-setting-value :default [_ value]
-  (str value))
+(defmulti quoted-list-element-setting? (fn [meta-setting] (:type meta-setting)))
 
-(defmethod render-raw-setting-value :comma-separated-list [_ value]
-  (when (seq value) (text-util/join-comma-separated-string value)))
+(defmethod quoted-list-element-setting? :default [_] false)
+
+(defmethod quoted-list-element-setting? :string [_] true)
+
+(defmethod quoted-list-element-setting? :resource [_] true)
+
+(defmethod quoted-list-element-setting? :file [_] true)
+
+(defmethod quoted-list-element-setting? :directory [_] true)
+
+(defmethod quoted-list-element-setting? :url [_] true)
+
+(defn- render-raw-list-setting-value [meta-setting value]
+  (when (seq value)
+    (let [element-meta-setting (get meta-setting :element default-list-element-meta-setting)
+          string-values (map #(render-raw-setting-value element-meta-setting %) value)]
+      (if (quoted-list-element-setting? element-meta-setting)
+        (text-util/join-comma-separated-string string-values)
+        (s/join ", " string-values)))))
+
+(defmethod render-raw-setting-value :list [meta-setting value]
+  (render-raw-list-setting-value meta-setting value))
+
+(defmethod render-raw-setting-value :comma-separated-list [meta-setting value]
+  (render-raw-list-setting-value meta-setting value))
 
 (defn make-settings-map [settings]
   (into {} (map (juxt :path :value) settings)))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -206,27 +206,6 @@
            (.initOwner stage owner)))
      stage)))
 
-(defn ^File choose-file [{:keys [^String title ^String directory filters ^Window owner-window] :or {title "Choose File"}}]
-  (let [chooser (doto (FileChooser.)
-                  (.setTitle title))]
-    (when-let [initial-directory (some-> directory (File.))]
-      (when (.isDirectory initial-directory)
-        (.setInitialDirectory chooser initial-directory)))
-    (doseq [{:keys [^String description exts]} filters]
-      (let [ext-array (into-array exts)]
-        (.add (.getExtensionFilters chooser) (FileChooser$ExtensionFilter. description ^"[Ljava.lang.String;" ext-array))))
-    (.showOpenDialog chooser owner-window)))
-
-(defn choose-directory
-  ([title ^File initial-dir] (choose-directory title initial-dir @*main-stage*))
-  ([title ^File initial-dir parent]
-   (let [chooser (DirectoryChooser.)]
-     (when initial-dir
-       (.setInitialDirectory chooser initial-dir))
-     (.setTitle chooser title)
-     (let [file (.showDialog chooser parent)]
-       (when file (.getAbsolutePath file))))))
-
 (defn collect-controls [^Parent root keys]
   (let [controls (zipmap (map keyword keys) (map #(.lookup root (str "#" %)) keys))
         missing (->> controls

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -63,6 +63,13 @@ ordinary paths."
   (^File [workspace path]
    (io/file (project-path workspace) (str (skip-first-char plugins-dir) (skip-first-char path)))))
 
+(defn as-proj-path
+  ^String [workspace file-or-path]
+  (let [file (io/as-file file-or-path)
+        project-directory (project-path workspace)]
+    (when (fs/below-directory? file project-directory)
+      (resource/file->proj-path project-directory file))))
+
 (defrecord BuildResource [resource prefix]
   resource/Resource
   (children [this] nil)

--- a/editor/test/editor/fs_test.clj
+++ b/editor/test/editor/fs_test.clj
@@ -666,3 +666,12 @@
         (is (= ["destination.txt"] (test-util/file-tree dir)))
         (is (= src-contents (slurp tgt)))))))
 
+(deftest below-directory-test
+  (test-util/with-temp-dir! project-dir
+    (is (true? (fs/below-directory? (io/file project-dir "file.txt") project-dir)))
+    (is (true? (fs/below-directory? (io/file project-dir "subdirectory") project-dir)))
+    (is (true? (fs/below-directory? (io/file project-dir "subdirectory" "file.txt") project-dir)))
+    (is (true? (fs/below-directory? (io/file project-dir "subdirectory" "file.txt") (io/file project-dir "subdirectory"))))
+    (is (true? (fs/below-directory? (io/file project-dir "subdirectory" ".." "subdirectory" "file.txt") (io/file project-dir "subdirectory"))))
+    (is (false? (fs/below-directory? (io/file project-dir "file.txt") (io/file project-dir "subdirectory"))))
+    (is (false? (fs/below-directory? (io/file project-dir "subdirectory" "file.txt") (io/file project-dir "subdirectory" ".."))))))

--- a/editor/test/editor/fs_test.clj
+++ b/editor/test/editor/fs_test.clj
@@ -672,6 +672,12 @@
     (is (true? (fs/below-directory? (io/file project-dir "subdirectory") project-dir)))
     (is (true? (fs/below-directory? (io/file project-dir "subdirectory" "file.txt") project-dir)))
     (is (true? (fs/below-directory? (io/file project-dir "subdirectory" "file.txt") (io/file project-dir "subdirectory"))))
-    (is (true? (fs/below-directory? (io/file project-dir "subdirectory" ".." "subdirectory" "file.txt") (io/file project-dir "subdirectory"))))
+    (is (true? (fs/below-directory? (io/file project-dir "otherdirectory" ".." "subdirectory" "file.txt") (io/file project-dir "subdirectory"))))
+    (is (false? (fs/below-directory? (io/file project-dir ".." "subdirectory" "file.txt") (io/file project-dir "subdirectory"))))
     (is (false? (fs/below-directory? (io/file project-dir "file.txt") (io/file project-dir "subdirectory"))))
-    (is (false? (fs/below-directory? (io/file project-dir "subdirectory" "file.txt") (io/file project-dir "subdirectory" ".."))))))
+    (is (false? (fs/below-directory? (io/file project-dir "subdirectory") (io/file project-dir "subdir"))))
+    (is (false? (fs/below-directory? project-dir project-dir)))
+
+    (if fs/case-sensitive?
+      (is (false? (fs/below-directory? (io/file project-dir "SUBDIRECTORY" "file.txt") (io/file project-dir "subdirectory"))))
+      (is (true? (fs/below-directory? (io/file project-dir "SUBDIRECTORY" "file.txt") (io/file project-dir "subdirectory")))))))

--- a/editor/test/integration/library_test.clj
+++ b/editor/test/integration/library_test.clj
@@ -19,6 +19,7 @@
             [editor.editor-extensions :as extensions]
             [editor.defold-project :as project]
             [editor.game-project :as game-project]
+            [editor.game-project-core :as game-project-core]
             [editor.gui :as gui]
             [editor.library :as library]
             [editor.progress :as progress]
@@ -119,10 +120,11 @@
 (defn- write-deps! [game-project deps]
   (let [settings (with-open [game-project-reader (io/reader game-project)]
                    (settings-core/parse-settings game-project-reader))]
-    (spit-until-new-mtime game-project (-> settings
-                                         (settings-core/set-setting ["project" "dependencies"] deps)
-                                         settings-core/settings-with-value
-                                         settings-core/settings->str))))
+    (spit-until-new-mtime game-project
+                          (-> settings
+                              (settings-core/set-setting ["project" "dependencies"] deps)
+                              (settings-core/settings-with-value)
+                              (settings-core/settings->str game-project-core/meta-settings :multi-line-list)))))
 
 (deftest open-project
   (with-clean-system

--- a/editor/test/integration/library_test.clj
+++ b/editor/test/integration/library_test.clj
@@ -42,21 +42,23 @@
          project (test-util/setup-project! workspace)]
      [workspace project])))
 
-(def ^:private uri-string "file:/scriptlib file:/imagelib1 file:/imagelib2 file:/bogus")
+(def ^:private uri-string "file:/scriptlib, file:/imagelib1, file:/imagelib2, file:/bogus")
 (def ^:private uris (library/parse-library-uris uri-string))
 
 (deftest uri-parsing
   (testing "sane uris"
     (is (= uris [(URI. "file:/scriptlib") (URI. "file:/imagelib1") (URI. "file:/imagelib2") (URI. "file:/bogus")]))
-    (is (= (library/parse-library-uris "file:/scriptlib,file:/imagelib1,file:/imagelib2,file:/bogus")
-           [(URI. "file:/scriptlib") (URI. "file:/imagelib1") (URI. "file:/imagelib2") (URI. "file:/bogus")])))
+    (is (= uris (library/parse-library-uris "file:/scriptlib,file:/imagelib1,file:/imagelib2,file:/bogus"))))
+  (testing "quoted values"
+    (is (= uris (library/parse-library-uris "\"file:/scriptlib\",\"file:/imagelib1\",\"file:/imagelib2\",\"file:/bogus\"")))
+    (is (= uris (library/parse-library-uris "\"file:/scriptlib\", \"file:/imagelib1\", \"file:/imagelib2\", \"file:/bogus\""))))
   (testing "various spacing and commas allowed"
-    (is (= uris (library/parse-library-uris "   file:/scriptlib   file:/imagelib1\tfile:/imagelib2  file:/bogus\t")))
-    (is (= uris (library/parse-library-uris " ,, file:/scriptlib ,  ,,  file:/imagelib1\tfile:/imagelib2 ,,,,  file:/bogus\t,")))
-    (is (= uris (library/parse-library-uris "\tfile:/scriptlib\tfile:/imagelib1\tfile:/imagelib2\tfile:/bogus   ")))
-    (is (= uris (library/parse-library-uris "\r\nfile:/scriptlib\nfile:/imagelib1\rfile:/imagelib2\tfile:/bogus "))))
+    (is (= uris (library/parse-library-uris "   file:/scriptlib,   file:/imagelib1\t,file:/imagelib2,  file:/bogus\t")))
+    (is (= uris (library/parse-library-uris " ,, file:/scriptlib ,  ,,  file:/imagelib1,\tfile:/imagelib2 ,,,,  file:/bogus\t,")))
+    (is (= uris (library/parse-library-uris "\tfile:/scriptlib,\tfile:/imagelib1,\tfile:/imagelib2,\tfile:/bogus   ")))
+    (is (= uris (library/parse-library-uris "\r\nfile:/scriptlib,\nfile:/imagelib1,\rfile:/imagelib2,\tfile:/bogus "))))
   (testing "ignore non-uris"
-    (is (= uris (library/parse-library-uris "this file:/scriptlib sure file:/imagelib1 aint file:/imagelib2 no file:/bogus uri")))))
+    (is (= uris (library/parse-library-uris "this, file:/scriptlib, sure, file:/imagelib1, aint, file:/imagelib2, no, file:/bogus, uri")))))
 
 (deftest initial-state
   (with-clean-system

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -81,7 +81,7 @@
 ;; │   └── props.script
 ;; └── test.particlefx
 
-(def ^:private lib-uris (library/parse-library-uris "file:/scriptlib file:/imagelib1 file:/imagelib2"))
+(def ^:private lib-uris (library/parse-library-uris "file:/scriptlib, file:/imagelib1, file:/imagelib2"))
 
 (def ^:private scriptlib-uri (first lib-uris)) ; /scripts/main.script
 (def ^:private imagelib1-uri (second lib-uris)) ; /images/{pow,paddle}.png

--- a/editor/test/integration/resource_watch_test.clj
+++ b/editor/test/integration/resource_watch_test.clj
@@ -30,7 +30,7 @@
 
 (def ^:dynamic *project-path* "test/resources/lib_resource_project")
 
-(def ^:private lib-uris (library/parse-library-uris "file:/scriptlib file:/imagelib1 file:/imagelib2 file:/bogus"))
+(def ^:private lib-uris (library/parse-library-uris "file:/scriptlib, file:/imagelib1, file:/imagelib2, file:/bogus"))
 
 (def ^:private scriptlib-uri (first lib-uris))
 (def ^:private imagelib1-uri (nth lib-uris 1))


### PR DESCRIPTION
Fixes #7041

### Technical changes
* Replaced the `:type :library-list` setting type with a general `:type :list, :element {:type :url}`-style declaration. We now also support lists of all the singular types such as `:file`, `:directory`, `:string`, etc.
* Added `:in-project true` property to `:directory` and `:file` setting types. This will only allow adding files or directories that are located below the current project.
* Removed `ui/choose-file` and `ui/choose-directory` functions that were duplicating functionality from the `dialogs` module. These calls now use `dialog/make-file-dialog` and `dialog/make-directory-dialog` instead.
* `settings-core/settings->str` now requires the `meta-settings` as an argument in order to determine how lists should be written to the output (multi-line or comma-separated).
* You must now specify `:meta-settings` when calling `resource-node/register-settings-resource-type`.
* The `settings-core/parse-setting-value` `defmethod` now takes the full `meta-setting` as its first argument, not just its `:type`.