### PR TITLE
Fix editor exception during build if a referenced collection overrides a resource script property

### DIFF
--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -746,6 +746,25 @@
 
     go-props-with-fused-build-resources))
 
+(defn- source-resource-go-prop [property-desc]
+  (if (not= :property-type-hash (:type property-desc))
+    property-desc
+    (let [build-resource (:clj-value property-desc)]
+      (if (not (workspace/build-resource? build-resource))
+        property-desc
+        (let [source-resource (:resource build-resource)
+              source-proj-path (resource/proj-path source-resource)]
+          (assoc property-desc
+            :clj-value source-resource
+            :value source-proj-path))))))
+
+(defn source-resource-go-props
+  "Given a sequence of go-props, return an equal-length sequence of go-props
+  where all build resources have been replaced by their respective source
+  resources."
+  [go-props-with-build-resources]
+  (mapv source-resource-go-prop go-props-with-build-resources))
+
 (defn try-get-go-prop-proj-path
   "Returns a non-empty string of the assigned proj-path, or nil if no
   resource was assigned or the go-prop is not a resource property."

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -1540,7 +1540,13 @@
           make-resource-node! (partial tu/make-resource-node! project)
           edit-property! (fn [node-id proj-path] (edit-property! node-id :__atlas (tu/resource workspace proj-path)))
           assigned-property? (fn [node-id proj-path] (atlas-resource-property? (get (properties node-id) :__atlas) (tu/resource workspace proj-path)))
-          overridden-property? (fn [node-id] (overridden? node-id "atlas"))]
+          overridden-property? (fn [node-id] (overridden? node-id "atlas"))
+          build-target-source-path (comp resource/proj-path :resource :resource)
+          built-source-paths (fn [resource-node]
+                               (into #{}
+                                     (keep build-target-source-path)
+                                     (pipeline/flatten-build-targets
+                                       (g/node-value resource-node :build-targets))))]
       (with-open [_ (tu/make-directory-deleter (workspace/project-path workspace))]
         (make-atlas! "/from-props-script.atlas")
         (make-atlas! "/from-props-game-object.atlas")
@@ -1572,7 +1578,13 @@
             (is (assigned-property? ov-ov-props-script-component "/from-props-game-object.atlas"))
             (is (overridden-property? props-script-component))
             (is (not (overridden-property? ov-props-script-component)))
-            (is (not (overridden-property? ov-ov-props-script-component))))
+            (is (not (overridden-property? ov-ov-props-script-component)))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-props-game-object.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection))))
 
           (with-open [_ (tu/make-graph-reverter project-graph)]
             (edit-property! ov-props-script-component            "/from-props-collection.atlas")
@@ -1581,7 +1593,13 @@
             (is (assigned-property? ov-ov-props-script-component "/from-props-collection.atlas"))
             (is (not (overridden-property? props-script-component)))
             (is (overridden-property? ov-props-script-component))
-            (is (not (overridden-property? ov-ov-props-script-component))))
+            (is (not (overridden-property? ov-ov-props-script-component)))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-props-collection.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection))))
 
           (with-open [_ (tu/make-graph-reverter project-graph)]
             (edit-property! ov-ov-props-script-component         "/from-sub-props-collection.atlas")
@@ -1590,7 +1608,13 @@
             (is (assigned-property? ov-ov-props-script-component "/from-sub-props-collection.atlas"))
             (is (not (overridden-property? props-script-component)))
             (is (not (overridden-property? ov-props-script-component)))
-            (is (overridden-property? ov-ov-props-script-component)))
+            (is (overridden-property? ov-ov-props-script-component))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-sub-props-collection.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection))))
 
           (with-open [_ (tu/make-graph-reverter project-graph)]
             (edit-property! props-script-component               "/from-props-game-object.atlas")
@@ -1600,7 +1624,14 @@
             (is (assigned-property? ov-ov-props-script-component "/from-props-collection.atlas"))
             (is (overridden-property? props-script-component))
             (is (overridden-property? ov-props-script-component))
-            (is (not (overridden-property? ov-ov-props-script-component))))
+            (is (not (overridden-property? ov-ov-props-script-component)))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-props-collection.atlas"
+                     "/from-props-game-object.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection))))
 
           (with-open [_ (tu/make-graph-reverter project-graph)]
             (edit-property! props-script-component               "/from-props-game-object.atlas")
@@ -1610,7 +1641,14 @@
             (is (assigned-property? ov-ov-props-script-component "/from-sub-props-collection.atlas"))
             (is (overridden-property? props-script-component))
             (is (not (overridden-property? ov-props-script-component)))
-            (is (overridden-property? ov-ov-props-script-component)))
+            (is (overridden-property? ov-ov-props-script-component))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-sub-props-collection.atlas"
+                     "/from-props-game-object.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection))))
 
           (with-open [_ (tu/make-graph-reverter project-graph)]
             (edit-property! ov-props-script-component            "/from-props-collection.atlas")
@@ -1620,7 +1658,14 @@
             (is (assigned-property? ov-ov-props-script-component "/from-sub-props-collection.atlas"))
             (is (not (overridden-property? props-script-component)))
             (is (overridden-property? ov-props-script-component))
-            (is (overridden-property? ov-ov-props-script-component)))
+            (is (overridden-property? ov-ov-props-script-component))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-sub-props-collection.atlas"
+                     "/from-props-collection.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection))))
 
           (with-open [_ (tu/make-graph-reverter project-graph)]
             (edit-property! props-script-component               "/from-props-game-object.atlas")
@@ -1631,7 +1676,15 @@
             (is (assigned-property? ov-ov-props-script-component "/from-sub-props-collection.atlas"))
             (is (overridden-property? props-script-component))
             (is (overridden-property? ov-props-script-component))
-            (is (overridden-property? ov-ov-props-script-component))))))))
+            (is (overridden-property? ov-ov-props-script-component))
+            (is (= #{"/sub-props.collection"
+                     "/props.go"
+                     "/props.script"
+                     "/from-sub-props-collection.atlas"
+                     "/from-props-collection.atlas"
+                     "/from-props-game-object.atlas"
+                     "/from-props-script.atlas"}
+                   (built-source-paths sub-props-collection)))))))))
 
 (deftest overrides-remain-after-script-edit-test
   (with-clean-system


### PR DESCRIPTION
Fixed an editor exception during build if a referenced collection overrides a resource script property.

Fixes #7048