### PR TITLE
Fix for editor rendering of models with local vertex space and local scaling matrices

### DIFF
--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -286,7 +286,7 @@
       (update :indices (fn [bytes] (bytes-to-indices bytes (:indices-format mesh))))))
 
 (defn- get-and-update-meshes [model]
-  (let [transform (:local model) ; {:rotation [0.0 0.0 0.0 1.0], :translation [0.0 0.0 0.0], :scale [1.0 1.0 1.0]}
+  (let [transform (:local model)
         local-translation (Vector3d. (get (:translation transform) 0) (get (:translation transform) 1) (get (:translation transform) 2))
         local-rotation (Quat4d. (get (:rotation transform) 0) (get (:rotation transform) 1) (get (:rotation transform) 2) (get (:rotation transform) 3))
         local-scale (Vector3d. (get (:scale transform) 0) (get (:scale transform) 1) (get (:scale transform) 2))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -195,10 +195,10 @@
                     meshes (:meshes user-data)
                     mesh (first meshes)
                     local-transform (:transform mesh) ; Each mesh uses the local matrix of the model it belongs to
-                    world-transform world-matrix
+                    world-transform (:world-transform renderable)
                     world-matrix (doto (Matrix4d. world-transform) (.mul local-transform))]
               mesh meshes
-              :let [vb (request-vb! gl node-id mesh world-transform vertex-space scratch)
+              :let [vb (request-vb! gl node-id mesh world-matrix vertex-space scratch)
                     vertex-binding (vtx/use-with [node-id ::mesh] vb shader)]]
           (gl/with-gl-bindings gl render-args [vertex-binding]
             (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -287,9 +287,9 @@
 
 (defn- get-and-update-meshes [model]
   (let [transform (:local model)
-        local-translation (Vector3d. (get (:translation transform) 0) (get (:translation transform) 1) (get (:translation transform) 2))
-        local-rotation (Quat4d. (get (:rotation transform) 0) (get (:rotation transform) 1) (get (:rotation transform) 2) (get (:rotation transform) 3))
-        local-scale (Vector3d. (get (:scale transform) 0) (get (:scale transform) 1) (get (:scale transform) 2))
+        local-translation (doto (Vector3d.) (math/clj->vecmath (:translation transform)))
+        local-rotation (doto (Quat4d.) (math/clj->vecmath (:rotation transform)))
+        local-scale (doto (Vector3d.) (math/clj->vecmath (:scale transform)))
         ^Matrix4d local-matrix (math/->mat4-non-uniform local-translation local-rotation local-scale)
 
         meshes (:meshes model)


### PR DESCRIPTION
Here we render the ship with both world + local space.
[gltf_test.zip](https://github.com/defold/defold/files/9763464/gltf_test.zip)

<img width="901" alt="Screenshot 2022-10-12 at 10 54 31" src="https://user-images.githubusercontent.com/1349334/195303615-e2f1151a-c826-4c4e-8138-2c5e7cb7b137.png">
