### PR TITLE
Migrate Google Analytics to Measurement Protocol v4

### DIFF
--- a/editor/src/clj/editor/analytics.clj
+++ b/editor/src/clj/editor/analytics.clj
@@ -124,7 +124,7 @@
   (let [config @config-atom
         cid (get config :cid)
         payload { :client_id cid :events batch }
-        payload-json (json/write-str payload)]
+        ^String payload-json (json/write-str payload)]
     (.getBytes payload-json StandardCharsets/UTF_8)))
 
 (defn- get-response-code!

--- a/editor/src/clj/editor/analytics.clj
+++ b/editor/src/clj/editor/analytics.clj
@@ -41,6 +41,7 @@
 (defonce ^:private payload-content-type "application/json")
 (defonce ^:private shutdown-timeout 1000)
 (defonce ^:private worker-atom (atom nil))
+(defonce ^:private session-id (rand))
 
 ;; -----------------------------------------------------------------------------
 ;; Validation
@@ -270,16 +271,25 @@
 (defn track-event!
   ([^String category ^String action]
    (append-event! {:name "select_content"
-                   :params {:content_type (str category "-" action)}}))
+                   :params {:content_type (str category "-" action)
+                            :engagement_time_msec "100"
+                            :session_id session-id}}))
   ([^String category ^String action ^String label]
    (append-event! {:name "select_content"
-                   :params {:content_type (str category "-" action) :item_id label}})))
+                   :params {:content_type (str category "-" action)
+                            :item_id label
+                            :engagement_time_msec "100"
+                            :session_id session-id}})))
 
 (defn track-exception! [^Throwable exception]
   (append-event! {:name "exception"
-                  :params {:name (.getSimpleName (class exception)) }}))
+                  :params {:name (.getSimpleName (class exception)) 
+                  	        :engagement_time_msec "100"
+                           :session_id session-id}}))
 
 (defn track-screen! [^String screen-name]
     (append-event! {:name "page_view"
-                    :params {:page_location screen-name}}))
+                    :params {:page_location screen-name
+                    	        :engagement_time_msec "100"
+                             :session_id session-id}}))
 

--- a/editor/src/clj/editor/analytics.clj
+++ b/editor/src/clj/editor/analytics.clj
@@ -284,12 +284,12 @@
 (defn track-exception! [^Throwable exception]
   (append-event! {:name "exception"
                   :params {:name (.getSimpleName (class exception)) 
-                  	        :engagement_time_msec "100"
+                           :engagement_time_msec "100"
                            :session_id session-id}}))
 
 (defn track-screen! [^String screen-name]
     (append-event! {:name "page_view"
                     :params {:page_location screen-name
-                    	        :engagement_time_msec "100"
+                             :engagement_time_msec "100"
                              :session_id session-id}}))
 

--- a/editor/src/clj/editor/analytics.clj
+++ b/editor/src/clj/editor/analytics.clj
@@ -33,14 +33,13 @@
 ;; Set this to true to see the events that get sent when testing.
 (defonce ^:private log-events? false)
 
-(defonce ^:private batch-size 16)
+(defonce ^:private batch-size 25)
 (defonce ^:private cid-regex #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 (defonce ^:private config-atom (atom nil))
 (defonce ^:private event-queue-atom (atom PersistentQueue/EMPTY))
 (defonce ^:private max-failed-send-attempts 5)
-(defonce ^:private payload-content-type "application/x-www-form-urlencoded; charset=UTF-8")
+(defonce ^:private payload-content-type "application/json")
 (defonce ^:private shutdown-timeout 1000)
-(defonce ^:private uid-regex #"[0-9A-F]{16}")
 (defonce ^:private worker-atom (atom nil))
 
 ;; -----------------------------------------------------------------------------
@@ -51,8 +50,7 @@
   (and (string? value)
        (try
          (let [url (URL. value)]
-           (and (nil? (.getQuery url))
-                (nil? (.getRef url))
+           (and (nil? (.getRef url))
                 (let [protocol (.getProtocol url)]
                   (or (= "http" protocol)
                       (= "https" protocol)))))
@@ -63,26 +61,11 @@
   (and (string? value)
        (.matches (re-matcher cid-regex value))))
 
-(defn- valid-uid? [value]
-  (and (string? value)
-       (.matches (re-matcher uid-regex value))))
-
 (defn- valid-config? [config]
   (and (map? config)
-       (= #{:cid :uid} (set (keys config)))
-       (let [{:keys [cid uid]} config]
-         (and (valid-cid? cid)
-              (or (nil? uid)
-                  (valid-uid? uid))))))
-
-(def ^:private valid-event?
-  (every-pred map?
-              (comp nil? :cd1) ; Custom Dimension 1 is reserved for the uid.
-              (comp (every-pred string? not-empty) :t)
-              (partial every?
-                       (every-pred (comp keyword? key)
-                                   (comp string? val)
-                                   (comp not-empty val)))))
+       (= #{:cid} (set (keys config)))
+       (let [{:keys [cid]} config]
+         (valid-cid? cid))))
 
 ;; -----------------------------------------------------------------------------
 ;; Configuration
@@ -90,19 +73,15 @@
 
 (defn- make-config []
   {:post [(valid-config? %)]}
-  {:cid (str (UUID/randomUUID))
-   :uid nil})
+  {:cid (str (UUID/randomUUID))})
 
 (defn- config-file
   ^File []
   (.toFile (.resolve (Editor/getSupportPath) ".defold-analytics")))
 
-(defn- write-config-to-file! [{:keys [cid uid]} ^File config-file]
-  {:pre [(valid-cid? cid)
-         (or (nil? uid) (valid-uid? uid))]}
-  (let [json (if (some? uid)
-               {"cid" cid "uid" uid}
-               {"cid" cid})]
+(defn- write-config-to-file! [{:keys [cid]} ^File config-file]
+  {:pre [(valid-cid? cid)]}
+  (let [json {"cid" cid}]
     (with-open [writer (io/writer config-file)]
       (json/write json writer))))
 
@@ -115,10 +94,10 @@
 
 (defn- read-config-from-file! [^File config-file]
   (with-open [reader (io/reader config-file)]
-    (let [{cid "cid" uid "uid"} (json/read reader)]
-      {:cid cid :uid uid})))
+    (let [{cid "cid"} (json/read reader)]
+      {:cid cid})))
 
-(defn- read-config! [invalidate-uid?]
+(defn- read-config! []
   {:post [(valid-config? %)]}
   (let [config-file (config-file)
         config-from-file (try
@@ -129,47 +108,23 @@
                              nil))
         config (if-not (valid-config? config-from-file)
                  (make-config)
-                 (cond-> config-from-file
-                         (and invalidate-uid?
-                              (contains? config-from-file :uid))
-                         (assoc :uid nil)))]
+                 config-from-file)]
     (when (not= config-from-file config)
       (write-config! config))
     config))
 
 ;; -----------------------------------------------------------------------------
 ;; Internals
+;; https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag
 ;; -----------------------------------------------------------------------------
-
-;; Entries sent to Google Analytics must be both UTF-8 and URL Encoded.
-;; See the "URL Encoding Values" section here for details:
-;; https://developers.google.com/analytics/devguides/collection/protocol/v1/reference
-(def encode-string (partial url/encode url/x-www-form-urlencoded-safe-character? false StandardCharsets/UTF_8))
-
-(defn- encode-key-value-pair
-  ^String [[k v]]
-  (str (encode-string (name k)) "=" (encode-string v)))
-
-(defn- event->line
-  ^String [event {:keys [cid uid] :as _config}]
-  {:pre [(valid-event? event)
-         (valid-cid? cid)
-         (or (nil? uid) (valid-uid? uid))]}
-  (let [tid (str "tid=" (get-in connection-properties [:google-analytics :tid]))
-        common-pairs (if (some? uid) ; NOTE: The uid is also supplied as Custom Dimension 1.
-                       ["v=1" tid (str "cid=" cid) (str "uid=" uid) (str "cd1=" uid)]
-                       ["v=1" tid (str "cid=" cid)])
-        pairs (into common-pairs
-                    (map encode-key-value-pair)
-                    event)]
-    (string/join "&" pairs)))
 
 (defn- batch->payload
   ^bytes [batch]
-  {:pre [(vector? batch)
-         (not-empty batch)]}
-  (let [text (string/join "\n" batch)]
-    (.getBytes text StandardCharsets/UTF_8)))
+  (let [config @config-atom
+        cid (get config :cid)
+        payload { :client_id cid :events batch }
+        payload-json (json/write-str payload)]
+    (.getBytes payload-json StandardCharsets/UTF_8)))
 
 (defn- get-response-code!
   "Wrapper rebound to verify response from dev server in tests."
@@ -183,7 +138,6 @@
     (doto connection
       (.setRequestMethod "POST")
       (.setDoOutput true)
-      (.setFixedLengthStreamingMode (count payload))
       (.setRequestProperty "Content-Type" content-type)
       (.connect))
     (with-open [output-stream (.getOutputStream connection)]
@@ -193,13 +147,16 @@
 (defn- ok-response-code? [^long response-code]
   (<= 200 response-code 299))
 
-(defn- send-payload! [analytics-url ^bytes payload]
+(defn- send-payload! [analytics-url ^bytes payload-json]
   (try
-    (let [response-code (get-response-code! (post! analytics-url payload-content-type payload))]
+    (let [connection (post! analytics-url payload-content-type payload-json)
+          response-message (.getResponseMessage connection)
+          response-code (get-response-code! connection)
+          response-body (slurp (.getInputStream connection))]
       (if (ok-response-code? response-code)
         true
         (do
-          (log/warn :msg (str "Analytics server sent non-OK response code " response-code))
+          (log/warn :msg (str "Analytics server sent non-OK response code " response-code " " response-message " " response-body))
           false)))
     (catch Exception error
       (log/warn :msg "An exception was thrown when sending analytics data" :exception error)
@@ -279,19 +236,18 @@
 
 (defn- append-event! [event]
   (when-some [config @config-atom]
-    (let [line (event->line event config)]
-      (when (enabled?)
-        (swap! event-queue-atom conj line))
-      (when log-events?
-        (log/info :msg line)))))
+    (when (enabled?)
+      (swap! event-queue-atom conj event))
+    (when log-events?
+      (log/info :msg event))))
 
 ;; -----------------------------------------------------------------------------
 ;; Public interface
 ;; -----------------------------------------------------------------------------
 
-(defn start! [^String analytics-url send-interval invalidate-uid?]
+(defn start! [^String analytics-url send-interval]
   {:pre [(valid-analytics-url? analytics-url)]}
-  (reset! config-atom (read-config! invalidate-uid?))
+  (reset! config-atom (read-config!))
   (when (some? (sys/defold-version))
     (swap! worker-atom
            (fn [started-worker]
@@ -311,37 +267,19 @@
 (defn enabled? []
   (some? @worker-atom))
 
-(defn set-uid! [^String uid]
-  {:pre [(or (nil? uid) (valid-uid? uid))]}
-  (swap! config-atom
-         (fn [config]
-           (let [config (or config (read-config! false))
-                 updated-config (assoc config :uid uid)]
-             (when (not= config updated-config)
-               (write-config! updated-config))
-             updated-config))))
-
 (defn track-event!
   ([^String category ^String action]
-   (append-event! {:t "event"
-                   :ec category
-                   :ea action}))
+   (append-event! {:name "select_content"
+                   :params {:content_type (str category "-" action)}}))
   ([^String category ^String action ^String label]
-   (append-event! {:t "event"
-                   :ec category
-                   :ea action
-                   :el label})))
+   (append-event! {:name "select_content"
+                   :params {:content_type (str category "-" action) :item_id label}})))
 
 (defn track-exception! [^Throwable exception]
-  (append-event! {:t "exception"
-                  :exd (.getSimpleName (class exception))}))
+  (append-event! {:name "exception"
+                  :params {:name (.getSimpleName (class exception)) }}))
 
 (defn track-screen! [^String screen-name]
-  (if-some [version (sys/defold-version)]
-    (append-event! {:t "screenview"
-                    :an "defold"
-                    :av version
-                    :cd screen-name})
-    (append-event! {:t "screenview"
-                    :an "defold"
-                    :cd screen-name})))
+    (append-event! {:name "page_view"
+                    :params {:page_location screen-name}}))
+

--- a/editor/src/clj/editor/boot.clj
+++ b/editor/src/clj/editor/boot.clj
@@ -126,11 +126,11 @@
                 (prefs/load-prefs prefs-path)
                 (prefs/make-prefs "defold"))
         updater (updater/start!)
-        analytics-url "https://www.google-analytics.com/batch"
+        analytics-url (get connection-properties :analytics-url)
         analytics-send-interval 300]
     (when (some? updater)
       (updater/delete-backup-files! updater))
-    (analytics/start! analytics-url analytics-send-interval true)
+    (analytics/start! analytics-url analytics-send-interval)
     (Shutdown/addShutdownAction analytics/shutdown!)
     (try
       (let [game-project-path (get-in opts [:arguments 0])]

--- a/editor/src/clj/editor/connection_properties.clj
+++ b/editor/src/clj/editor/connection_properties.clj
@@ -18,8 +18,9 @@
   {:sentry {:project-id "97739"
             :key "9e25fea9bc334227b588829dd60265c1"
             :secret "f694ef98d47d42cf8bb67ef18a4e9cdb"}
-   :google-analytics {:tid "UA-83690-7"}
    :git-issues {:url "https://github.com/defold/defold"}
+   :analytics-url "https://www.google-analytics.com/mp/collect?api_secret=TiZ0CR6kTQ6I5SxJvH2Veg&measurement_id=G-WPGB4YL1FQ"
+   :analytics-validation-url "https://www.google-analytics.com/debug/mp/collect?api_secret=TiZ0CR6kTQ6I5SxJvH2Veg&measurement_id=G-WPGB4YL1FQ"
    :native-extensions {:build-server-url "https://build.defold.com"}
    :updater {:download-url-template "https://%s/archive/%s/%s/editor2/Defold-%s.zip"
              :update-url-template "https://%s/editor2/channels/%s/update-v4.json"}})

--- a/editor/test/editor/analytics_test.clj
+++ b/editor/test/editor/analytics_test.clj
@@ -18,6 +18,7 @@
             [clojure.string :as string]
             [clojure.test :refer :all]
             [editor.analytics :as analytics]
+            [editor.connection-properties :refer [connection-properties]]
             [editor.fs :as fs]
             [editor.system :as sys]
             [integration.test-util :as test-util]
@@ -28,9 +29,8 @@
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:private validation-server-url "https://www.google-analytics.com/debug/collect")
+(defonce ^:private validation-server-url (get connection-properties :analytics-validation-url))
 (defonce ^:private mock-cid "7f208496-5029-4d4b-b530-e3c089980548")
-(defonce ^:private mock-uid "63AD229B66CB4EFB")
 (defonce ^:private send-interval 300)
 (defonce ^:private shutdown-timeout 4000)
 (defonce ^:private temp-config-file (fs/create-temp-file! "defold-analytics"))
@@ -53,148 +53,35 @@
 (deftest with-config-test
   (with-config! {:cid mock-cid}
     (is (fs/existing-file? temp-config-file))
-    (is (= {:cid mock-cid :uid nil} (get-config!))))
-
-  (with-config! {:cid mock-cid :uid mock-uid}
-    (is (fs/existing-file? temp-config-file))
-    (is (= {:cid mock-cid :uid mock-uid} (get-config!))))
+    (is (= {:cid mock-cid} (get-config!))))
 
   (with-config! nil
     (is (not (fs/existing-file? temp-config-file)))
     (is (thrown? FileNotFoundException (get-config!)))))
 
-(defn- get-response-code-and-append-hit-parsing-results! [hit-parsing-results-atom ^HttpURLConnection connection]
-  ;; See https://developers.google.com/analytics/devguides/collection/protocol/v1/validating-hits
+(defn- get-response-code-and-append-validation-messages! [validation-messages-atom ^HttpURLConnection connection]
+  ;; See https://developers.google.com/analytics/devguides/collection/protocol/ga4/validating-events?client_type=gtag
   ;; for a description of the validation-result JSON data format.
   (let [validation-result (with-open [stream (.getInputStream connection)
                                       reader (io/reader stream)]
                             (json/read reader))]
-    (swap! hit-parsing-results-atom into (get validation-result "hitParsingResult"))
+    (swap! validation-messages-atom into (get validation-result "validationMessages"))
     (.getResponseCode connection)))
 
-(deftest not-signed-in-events-test
+(deftest events-test
   ;; NOTE: This test posts to Google validation servers.
-  (let [hit-parsing-results (let [hit-parsing-results-atom (atom [])]
-                              (with-redefs [analytics/get-response-code! (partial get-response-code-and-append-hit-parsing-results! hit-parsing-results-atom)
+  (let [validation-messages (let [validation-messages-atom (atom [])]
+                              (with-redefs [analytics/get-response-code! (partial get-response-code-and-append-validation-messages! validation-messages-atom)
                                             sys/defold-version (constantly "0.1.234")]
                                 (with-config! {:cid mock-cid}
-                                  (analytics/start! validation-server-url send-interval false)
+                                  (analytics/start! validation-server-url send-interval)
                                   (analytics/track-event! "test-category" "test-action")
                                   (analytics/track-event! "test-category" "test-action" "test-label")
                                   (analytics/track-exception! (NullPointerException.))
                                   (analytics/track-screen! "test-screen-name")
                                   (analytics/shutdown! shutdown-timeout)
-                                  @hit-parsing-results-atom)))]
-    (is (= 4 (count hit-parsing-results)))
-    (is (every? #(true? (get % "valid")) hit-parsing-results))
-    (is (= ["/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&t=event&ec=test-category&ea=test-action"
-            "/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&t=event&ec=test-category&ea=test-action&el=test-label"
-            "/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&t=exception&exd=NullPointerException"
-            "/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&t=screenview&an=defold&av=0.1.234&cd=test-screen-name"]
-           (mapv #(get % "hit") hit-parsing-results)))))
-
-(deftest signed-in-events-test
-  ;; NOTE: This test posts to Google validation servers.
-  (let [hit-parsing-results (let [hit-parsing-results-atom (atom [])]
-                              (with-redefs [analytics/get-response-code! (partial get-response-code-and-append-hit-parsing-results! hit-parsing-results-atom)
-                                            sys/defold-version (constantly "0.1.234")]
-                                (with-config! {:cid mock-cid :uid mock-uid}
-                                  (analytics/start! validation-server-url send-interval false)
-                                  (analytics/track-event! "test-category" "test-action")
-                                  (analytics/track-event! "test-category" "test-action" "test-label")
-                                  (analytics/track-exception! (NullPointerException.))
-                                  (analytics/track-screen! "test-screen-name")
-                                  (analytics/shutdown! shutdown-timeout)
-                                  @hit-parsing-results-atom)))]
-    (is (= 4 (count hit-parsing-results)))
-    (is (every? #(true? (get % "valid")) hit-parsing-results))
-    (is (= ["/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&uid=63AD229B66CB4EFB&cd1=63AD229B66CB4EFB&t=event&ec=test-category&ea=test-action"
-            "/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&uid=63AD229B66CB4EFB&cd1=63AD229B66CB4EFB&t=event&ec=test-category&ea=test-action&el=test-label"
-            "/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&uid=63AD229B66CB4EFB&cd1=63AD229B66CB4EFB&t=exception&exd=NullPointerException"
-            "/debug/collect?v=1&tid=UA-83690-7&cid=7f208496-5029-4d4b-b530-e3c089980548&uid=63AD229B66CB4EFB&cd1=63AD229B66CB4EFB&t=screenview&an=defold&av=0.1.234&cd=test-screen-name"]
-           (mapv #(get % "hit") hit-parsing-results)))))
-
-(defn- payload->lines [^bytes payload]
-  (let [text (String. payload StandardCharsets/UTF_8)]
-    (string/split-lines text)))
-
-(defn- get-event-hits!
-  ([hits-atom event-action]
-   (get-event-hits! hits-atom event-action false))
-  ([hits-atom event-action invalidate-uid?]
-   (reset! hits-atom [])
-   (with-redefs [analytics/get-response-code! (constantly 200)
-                 analytics/post! (fn [_ _ payload] (swap! hits-atom into (payload->lines payload)))
-                 sys/defold-version (constantly "0.1.234")]
-     (analytics/start! "https://not-used" send-interval invalidate-uid?)
-     (analytics/track-event! "test-category" event-action)
-     (analytics/shutdown! shutdown-timeout)
-     @hits-atom)))
-
-(deftest encoding-test
-  (let [get-hits! (partial get-event-hits! (atom nil))]
-    (with-config! {:cid mock-cid}
-      ;; This is from the "URL Encoding Values" section in the Measurement Protocol reference:
-      ;; https://developers.google.com/analytics/devguides/collection/protocol/v1/reference
-      (is (= [(str "v=1&tid=UA-83690-7&cid=" mock-cid "&t=event&ec=test-category&ea=%2Fmy%20page%20%E2%82%AC")]
-             (get-hits! "/my page €"))))))
-
-(deftest config-effects-test
-  (let [get-hits! (partial get-event-hits! (atom nil) "test-action")]
-
-    (testing "No config file."
-      (with-config! nil
-        (let [hits (get-hits! false)
-              config (get-config!)]
-          (is (valid-cid? (:cid config)))
-          (is (nil? (:uid config)))
-          (is (= [(str "v=1&tid=UA-83690-7&cid=" (:cid config) "&t=event&ec=test-category&ea=test-action")]
-                 hits)))))
-
-    (testing "Corrupt config file."
-      (with-redefs [analytics/config-file (constantly temp-config-file)]
-        (spit temp-config-file "asdf")
-        (let [hits (log/without-logging (get-hits! false))
-              config (get-config!)]
-          (is (valid-cid? (:cid config)))
-          (is (nil? (:uid config)))
-          (is (= [(str "v=1&tid=UA-83690-7&cid=" (:cid config) "&t=event&ec=test-category&ea=test-action")]
-                 hits)))))
-
-    (testing "Old-format config file with cid, but without uid."
-      (with-config! {:cid mock-cid}
-        (is (= [(str "v=1&tid=UA-83690-7&cid=" mock-cid "&t=event&ec=test-category&ea=test-action")]
-               (get-hits! false)))))
-
-    (testing "Config file with cid and uid."
-      (with-config! {:cid mock-cid :uid mock-uid}
-        (is (= [(str "v=1&tid=UA-83690-7&cid=" mock-cid "&uid=" mock-uid "&cd1=" mock-uid "&t=event&ec=test-category&ea=test-action")]
-               (get-hits! false)))
-        (is (= {:cid mock-cid :uid mock-uid}
-               (get-config!)))))
-
-    (testing "Config file with cid and uid, invalidate uid."
-      (with-config! {:cid mock-cid :uid mock-uid}
-        (is (= [(str "v=1&tid=UA-83690-7&cid=" mock-cid "&t=event&ec=test-category&ea=test-action")]
-               (get-hits! true)))
-        (is (= {:cid mock-cid :uid nil}
-               (get-config!)))))
-
-    (testing "Sign in"
-      (with-config! {:cid mock-cid}
-        (analytics/set-uid! mock-uid)
-        (is (= [(str "v=1&tid=UA-83690-7&cid=" mock-cid "&uid=" mock-uid "&cd1=" mock-uid "&t=event&ec=test-category&ea=test-action")]
-               (get-hits! false)))
-        (is (= {:cid mock-cid :uid mock-uid}
-               (get-config!)))))
-
-    (testing "Sign out"
-      (with-config! {:cid mock-cid :uid mock-uid}
-        (analytics/set-uid! nil)
-        (is (= [(str "v=1&tid=UA-83690-7&cid=" mock-cid "&t=event&ec=test-category&ea=test-action")]
-               (get-hits! false)))
-        (is (= {:cid mock-cid :uid nil}
-               (get-config!)))))))
+                                  @validation-messages-atom)))]
+    (is (= 0 (count validation-messages)))))
 
 (deftest send-error-test
   (with-redefs [sys/defold-version (constantly "0.1.234")]
@@ -204,7 +91,7 @@
         (with-redefs [analytics/get-response-code! (constantly 404)
                       analytics/post! post-call-logger]
           (log/without-logging
-            (analytics/start! "https://not-used" 10 false)
+            (analytics/start! "https://not-used" 10)
             (analytics/track-event! "test-category" "test-action")
             (Thread/sleep 1000))
 
@@ -217,7 +104,7 @@
         (with-redefs [analytics/get-response-code! (constantly 200)
                       analytics/post! post-call-logger]
           (log/without-logging
-            (analytics/start! "https://not-used" 10 false)
+            (analytics/start! "https://not-used" 10)
             (analytics/track-event! "test-category" "test-action")
             (Thread/sleep 1000))
 


### PR DESCRIPTION
The anonymised analytics in the editor used an old version of Google Analytics. This change updates to the new GA Measurement Protocol.

Fixes #7051 
