### PR TITLE
Made dmObjectPool into a class, with new access function GetRawObjects()

### DIFF
--- a/engine/dlib/src/dmsdk/dlib/object_pool.h
+++ b/engine/dlib/src/dmsdk/dlib/object_pool.h
@@ -39,10 +39,9 @@
  * @name dmObjectPool
  */
 template <typename T>
-struct dmObjectPool
+class dmObjectPool
 {
-    // all fields are private
-    dmArray<T>        m_Objects; // All objects [0..Size()]
+private:
 
     struct Entry
     {
@@ -50,10 +49,12 @@ struct dmObjectPool
         uint32_t m_Next;
     };
 
+    dmArray<T>          m_Objects; // All objects [0..Size()]
     dmArray<Entry>      m_Entries;
-    uint32_t            m_FirstFree;
     dmArray<uint32_t>   m_ToLogical;
+    uint32_t            m_FirstFree;
 
+public:
 
     /*#
      * Constructor
@@ -165,6 +166,17 @@ struct dmObjectPool
         // Put in free list
         e->m_Next = m_FirstFree;
         m_FirstFree = e - m_Entries.Begin();
+    }
+
+    /*#
+     * Get the array of currently active objects
+     * @note The order of objects in this array may change if Alloc() or Free() has been called
+     * @name GetRawObjects
+     * @return object [type: dmArray<T>&] a reference to the array of objects
+     */
+    dmArray<T>& GetRawObjects()
+    {
+        return m_Objects;
     }
 
     /*#

--- a/engine/dlib/src/test/test_objectpool.cpp
+++ b/engine/dlib/src/test/test_objectpool.cpp
@@ -47,7 +47,7 @@ TEST(dmObjectPool, Test)
     uint32_t sum = 0;
     uint32_t sum2 = 0;
     for (uint32_t i = 0; i < n; i++) {
-        sum += pool.m_Objects[i].m_Value;
+        sum += pool.GetRawObjects()[i].m_Value;
     }
     for (std::map<uint32_t, uint32_t>::iterator i = mapping.begin(); i != mapping.end(); ++i) {
         sum2 += pool.Get(i->first).m_Value;
@@ -64,7 +64,7 @@ TEST(dmObjectPool, Test)
 
     sum = 0;
     for (uint32_t i = 0; i < n - 2; i++) {
-        sum += pool.m_Objects[i].m_Value;
+        sum += pool.GetRawObjects()[i].m_Value;
     }
 
     sum2 = 0;
@@ -85,7 +85,7 @@ TEST(dmObjectPool, Test)
 
     sum = 0;
     for (uint32_t i = 0; i < n; i++) {
-        sum += pool.m_Objects[i].m_Value;
+        sum += pool.GetRawObjects()[i].m_Value;
     }
     sum2 = 0;
     for (std::map<uint32_t, uint32_t>::iterator i = mapping.begin(); i != mapping.end(); ++i) {
@@ -108,7 +108,7 @@ TEST(dmObjectPool, Test)
 
     sum = 0;
     for (uint32_t i = 0; i < n + 2; i++) {
-        sum += pool.m_Objects[i].m_Value;
+        sum += pool.GetRawObjects()[i].m_Value;
     }
     sum2 = 0;
     for (std::map<uint32_t, uint32_t>::iterator i = mapping.begin(); i != mapping.end(); ++i) {

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -100,7 +100,7 @@ namespace dmGameSystem
         LabelWorld* world = new LabelWorld();
         uint32_t comp_count = dmMath::Min(params.m_MaxComponentInstances, label_context->m_MaxLabelCount);
         world->m_Components.SetCapacity(comp_count);
-        memset(world->m_Components.m_Objects.Begin(), 0, sizeof(LabelComponent) * comp_count);
+        memset(world->m_Components.GetRawObjects().Begin(), 0, sizeof(LabelComponent) * comp_count);
 
         *params.m_World = world;
         return dmGameObject::CREATE_RESULT_OK;
@@ -110,8 +110,9 @@ namespace dmGameSystem
     {
         LabelWorld* world = (LabelWorld*)params.m_World;
 
-        LabelComponent* components = world->m_Components.m_Objects.Begin();
-        for (uint32_t i = 0; i < world->m_Components.m_Objects.Size(); ++i )
+        dmArray<LabelComponent>& components = world->m_Components.GetRawObjects();
+        uint32_t n = components.Size();
+        for (uint32_t i = 0; i < n; ++i )
         {
             LabelComponent& component = components[i];
             if (component.m_UserAllocatedText)
@@ -287,7 +288,7 @@ namespace dmGameSystem
     {
         DM_PROFILE("UpdateTransforms");
 
-        dmArray<LabelComponent>& components = world->m_Components.m_Objects;
+        dmArray<LabelComponent>& components = world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
         for (uint32_t i = 0; i < n; ++i)
         {
@@ -433,7 +434,7 @@ namespace dmGameSystem
         LabelWorld* world = (LabelWorld*)params.m_World;
         dmRender::HRenderContext render_context = label_context->m_RenderContext;
 
-        dmArray<LabelComponent>& components = world->m_Components.m_Objects;
+        dmArray<LabelComponent>& components = world->m_Components.GetRawObjects();
         uint32_t component_count = components.Size();
 
         DM_PROPERTY_ADD_U32(rmtp_Label, component_count);

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -385,7 +385,7 @@ namespace dmGameSystem
     {
         DM_PROFILE("UpdateTransforms");
 
-        dmArray<MeshComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<MeshComponent*>& components = world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
         for (uint32_t i = 0; i < n; ++i)
         {
@@ -422,7 +422,7 @@ namespace dmGameSystem
 
         MeshWorld* world = (MeshWorld*)params.m_World;
 
-        dmArray<MeshComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<MeshComponent*>& components = world->m_Components.GetRawObjects();
         const uint32_t count = components.Size();
 
         for (uint32_t i = 0; i < count; ++i)
@@ -770,7 +770,7 @@ namespace dmGameSystem
 
         UpdateTransforms(world);
 
-        dmArray<MeshComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<MeshComponent*>& components = world->m_Components.GetRawObjects();
         const uint32_t count = components.Size();
 
         // Prepare list submit
@@ -975,7 +975,7 @@ namespace dmGameSystem
     static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams& params)
     {
         MeshWorld* world = (MeshWorld*) params.m_UserData;
-        dmArray<MeshComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<MeshComponent*>& components = world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
         for (uint32_t i = 0; i < n; ++i)
         {

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -697,7 +697,7 @@ namespace dmGameSystem
     {
         DM_PROFILE(__FUNCTION__);
 
-        dmArray<ModelComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<ModelComponent*>& components = world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
         uint32_t num_render_items = 0;
         for (uint32_t i = 0; i < n; ++i)
@@ -744,7 +744,7 @@ namespace dmGameSystem
 
         dmRig::Result rig_res = dmRig::Update(world->m_RigContext, params.m_UpdateContext->m_DT);
 
-        dmArray<ModelComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<ModelComponent*>& components = world->m_Components.GetRawObjects();
         const uint32_t count = components.Size();
 
         for (uint32_t i = 0; i < count; ++i)
@@ -824,7 +824,7 @@ namespace dmGameSystem
 
         UpdateTransforms(world); // TODO: Why can't we move this to the CompModelUpdate()?
 
-        dmArray<ModelComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<ModelComponent*>& components = world->m_Components.GetRawObjects();
 
         uint32_t num_components = components.Size();
         uint32_t mesh_count = 0;
@@ -1111,7 +1111,7 @@ namespace dmGameSystem
     static void ResourceReloadedCallback(const dmResource::ResourceReloadedParams& params)
     {
         ModelWorld* world = (ModelWorld*) params.m_UserData;
-        dmArray<ModelComponent*>& components = world->m_Components.m_Objects;
+        const dmArray<ModelComponent*>& components = world->m_Components.GetRawObjects();
         uint32_t n = components.Size();
         for (uint32_t i = 0; i < n; ++i)
         {

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -986,7 +986,6 @@ namespace dmGameSystem
 
     static bool CompTileGridIterPropertiesGetNext(dmGameObject::SceneNodePropertyIterator* pit)
     {
-        TileGridWorld* world = (TileGridWorld*)pit->m_Node->m_ComponentWorld;
         TileGridComponent* component = (TileGridComponent*)pit->m_Node->m_Component;
 
         uint64_t index = pit->m_Next++;

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -436,7 +436,7 @@ namespace dmRig
     {
         DM_PROFILE("RigAnimate");
 
-        const dmArray<RigInstance*>& instances = context->m_Instances.m_Objects;
+        const dmArray<RigInstance*>& instances = context->m_Instances.GetRawObjects();
         uint32_t n = instances.Size();
         for (uint32_t i = 0; i < n; ++i)
         {
@@ -557,7 +557,7 @@ namespace dmRig
 
     static Result PostUpdate(HRigContext context)
     {
-        const dmArray<RigInstance*>& instances = context->m_Instances.m_Objects;
+        const dmArray<RigInstance*>& instances = context->m_Instances.GetRawObjects();
         uint32_t count = instances.Size();
         bool updated_pose = false;
         for (uint32_t i = 0; i < count; ++i)


### PR DESCRIPTION
The previous interface was allowing users to directly access a private member `m_Objects`. This access has now been restricted to be done solely through the `dmObjectPool::GetRawObjects()`. The hope is that this will convey the volatility when using this array directly.