### PR TITLE
Remove partially cached HTTP response on timeout

### DIFF
--- a/engine/dlib/src/dlib/http_cache.cpp
+++ b/engine/dlib/src/dlib/http_cache.cpp
@@ -549,6 +549,11 @@ namespace dmHttpCache
         return RESULT_OK;
     }
 
+    void SetError(HCache cache, HCacheCreator cache_creator)
+    {
+        cache_creator->m_Error = 1;
+    }
+
     Result End(HCache cache, HCacheCreator cache_creator)
     {
         dmMutex::ScopedLock lock(cache->m_Mutex);
@@ -565,6 +570,7 @@ namespace dmHttpCache
 
         if (cache_creator->m_Error)
         {
+            dmSys::Unlink(cache_creator->m_Filename);
             FreeCacheCreator(cache, cache_creator);
             cache->m_CacheTable.Erase(uri_hash);
             return RESULT_IO_ERROR;

--- a/engine/dlib/src/dlib/http_cache.h
+++ b/engine/dlib/src/dlib/http_cache.h
@@ -146,6 +146,13 @@ namespace dmHttpCache
     Result Add(HCache cache, HCacheCreator cache_creator, const void* content, uint32_t content_len);
 
     /**
+     * Set cache entry as erroneous
+     * @param cache cache
+     * @param cache_creator cache creator handle
+     */
+    void SetError(HCache cache, HCacheCreator cache_creator);
+
+    /**
      * End cache entry creation
      * @param cache cache
      * @param cache_creator cache creator handle

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -967,6 +967,10 @@ bail:
 
             if (response.m_CacheCreator)
             {
+                if (r != RESULT_OK)
+                {
+                    dmHttpCache::SetError(client->m_HttpCache, response.m_CacheCreator);
+                }
                 dmHttpCache::End(client->m_HttpCache, response.m_CacheCreator);
                 response.m_CacheCreator = 0;
             }

--- a/engine/dlib/src/test/test_httpcache.cpp
+++ b/engine/dlib/src/test/test_httpcache.cpp
@@ -155,6 +155,37 @@ TEST_F(dmHttpCacheTest, Simple)
     ASSERT_EQ(dmHttpCache::RESULT_OK, r);
 }
 
+TEST_F(dmHttpCacheTest, SetError)
+{
+    dmHttpCache::HCache cache;
+    dmHttpCache::NewParams params;
+    params.m_Path = "tmp/cache";
+    dmHttpCache::Result r = dmHttpCache::Open(&params, &cache);
+    ASSERT_EQ(dmHttpCache::RESULT_OK, r);
+
+    // Start cache entry creation
+    dmHttpCache::HCacheCreator cache_creator;
+    r = dmHttpCache::Begin(cache, "uri", "etag", 0, &cache_creator);
+    ASSERT_EQ(dmHttpCache::RESULT_OK, r);
+    r = dmHttpCache::Add(cache, cache_creator, "data", strlen("data"));
+    ASSERT_EQ(dmHttpCache::RESULT_OK, r);
+    // Raise an error
+    dmHttpCache::SetError(cache, cache_creator);
+    // Finish cache entry creation, which due to the error will not generate
+    // a cache entry
+    r = dmHttpCache::End(cache, cache_creator);
+    ASSERT_EQ(dmHttpCache::RESULT_IO_ERROR, r);
+
+    // Check that there is no stored etag
+    char tag_buffer[16];
+    r = dmHttpCache::GetETag(cache, "uri", tag_buffer, sizeof(tag_buffer));
+    ASSERT_EQ(dmHttpCache::RESULT_NO_ENTRY, r);
+
+    // Free
+    r = dmHttpCache::Close(cache);
+    ASSERT_EQ(dmHttpCache::RESULT_OK, r);
+}
+
 TEST_F(dmHttpCacheTest, MaxAge)
 {
     dmHttpCache::HCache cache;


### PR DESCRIPTION
This fixes an issue where a network request is interrupted due to a network error or timeout still left a partial response stored in the HTTP cache. Subsequent requests for the same resource would in such a case return the partial and most likely corrupted response stored in the cache. The cache will now remove any partial response on error.

Fixes #7034 