### PR TITLE
Limit CI push trigger to release-channel branches to avoid duplicate builds

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -3,12 +3,16 @@ name: CI - Editor Only
 on:
   push:
     branches:
-      - 'DEFEDIT-*'
       - 'editor-dev'
   pull_request:
     branches:
       - 'DEFEDIT-*'
       - 'editor-dev'
+  pull_request_target:
+    branches:
+       - 'DEFEDIT-*'
+       - 'editor-dev'
+    types: [labeled]
 
 env:
   S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -2,24 +2,24 @@ name: CI - Main
 
 on:
   push:
-     branches:
-       - '*'
-       - '!skip-ci-*'
-       - '!DEFEDIT-*'
-       - '!editor-dev'
+    branches:
+      - 'hotfix-*'
+      - 'dev'
+      - 'beta'
+      - 'master'
   pull_request:
-     branches:
+    branches:
        - '*'
        - '!skip-ci-*'
        - '!DEFEDIT-*'
        - '!editor-dev'
   pull_request_target:
-     branches:
+    branches:
        - '*'
        - '!skip-ci-*'
        - '!DEFEDIT-*'
        - '!editor-dev'
-     types: [labeled]
+    types: [labeled]
   repository_dispatch: {}
 
 env:

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       !contains(github.event.head_commit.message, 'skip-ci') &&
-      (github.event_name != 'pull_request'        || (github.event_name == 'pull_request'        && github.event.pull_request.head.repo.full_name == github.repository)) &&
+      (github.event_name != 'pull_request'        || (github.event_name == 'pull_request'        && github.event.pull_request.head.repo.full_name == github.repository)) &&
       (github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ok to test')))
     steps: [
       {

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -380,6 +380,10 @@ def get_branch():
 
     return branch
 
+def get_target_branch():
+    # The name of the base (or target) branch. Only set for pull request events.
+    return os.environ.get('GITHUB_BASE_REF', '')
+
 def is_workflow_enabled_in_repo():
     if not is_repo_private():
         return True # all workflows are enabled by default
@@ -465,7 +469,7 @@ def main(argv):
         release_channel = "editor-alpha"
         make_release = True
         engine_artifacts = args.engine_artifacts
-    elif branch and branch.startswith("DEFEDIT-"):
+    elif branch and (branch.startswith("DEFEDIT-") or get_target_branch() == "editor-dev"):
         engine_channel = None
         editor_channel = "editor-dev"
         make_release = False


### PR DESCRIPTION
Fixes #7066

### Technical changes
* The `push` CI rule will now only trigger as a result of committing to `master`, `beta`, `dev`, `editor-dev`, or a `hotfix-`-prefixed branch. The `pull_request` rule will still trigger as a result of committing to a branch that is associated with a pull request.