### PR TITLE
Add some project references into copy payload

### DIFF
--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -187,7 +187,7 @@
           workbench            (.lookup root "#workbench")
           scene-visibility     (scene-visibility/make-scene-visibility-node! *view-graph*)
           app-view             (app-view/make-app-view *view-graph* project stage menu-bar editor-tabs-split tool-tabs prefs)
-          outline-view         (outline-view/make-outline-view *view-graph* *project-graph* outline app-view)
+          outline-view         (outline-view/make-outline-view *view-graph* project outline app-view)
           properties-view      (properties-view/make-properties-view workspace project app-view *view-graph* (.lookup root "#properties"))
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs)
           web-server           (-> (http-server/->server 0 {engine-profiler/url-prefix engine-profiler/handler

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -133,13 +133,19 @@
                    (some? (resource/path (g/node-value src-node :resource (g/make-evaluation-context {:basis basis :cache c/null-cache})))))))))
 
 (defn copy
-  ([src-item-iterators]
-    (copy src-item-iterators default-copy-traverse))
-  ([src-item-iterators traverse?]
-    (let [root-ids (mapv #(:node-id (value %)) src-item-iterators)
-          fragment (-> (g/copy root-ids {:traverse? traverse?})
-                       (add-attachments root-ids))]
-      (serialize fragment))))
+  ([project src-item-iterators]
+   (copy project src-item-iterators default-copy-traverse))
+  ([project src-item-iterators traverse?]
+   (let [root-ids (mapv #(:node-id (value %)) src-item-iterators)
+         fragment (-> (g/copy root-ids {:traverse? traverse?
+                                        :external-refs {project :project}
+                                        :external-labels {project #{:collision-group-nodes
+                                                                    :collision-groups-data
+                                                                    :default-tex-params
+                                                                    :settings}}})
+                      (add-attachments root-ids))]
+
+     (serialize fragment))))
 
 (defn- read-only? [item-it]
   (:read-only (value item-it) false))
@@ -169,25 +175,25 @@
        true))))
 
 (defn cut!
-  ([src-item-iterators]
-    (cut! src-item-iterators []))
-  ([src-item-iterators extra-tx-data]
-    (let [data     (copy src-item-iterators)
-          root-ids (mapv #(:node-id (value %)) src-item-iterators)]
-      (g/transact
-        (concat
-          (g/operation-label "Cut")
-          (for [id root-ids]
-            (g/delete-node (g/override-root id)))
-          extra-tx-data))
-      data)))
+  ([project src-item-iterators]
+   (cut! project src-item-iterators []))
+  ([project src-item-iterators extra-tx-data]
+   (let [data (copy project src-item-iterators)
+         root-ids (mapv #(:node-id (value %)) src-item-iterators)]
+     (g/transact
+       (concat
+         (g/operation-label "Cut")
+         (for [id root-ids]
+           (g/delete-node (g/override-root id)))
+         extra-tx-data))
+     data)))
 
 (defn- deserialize
   [text]
   (g/read-graph text (core/read-handlers)))
 
-(defn- paste [graph fragment]
-  (g/paste graph fragment {}))
+(defn- paste [project fragment]
+  (g/paste (g/node-id->graph-id project) fragment {:external-refs {:project project}}))
 
 (defn- nodes-by-id
   [paste-data]
@@ -245,27 +251,27 @@
           (g/operation-sequence op-seq)
           (select-fn (mapv :_node-id root-nodes)))))))
 
-(defn- paste-target [graph item-iterator data]
-  (let [paste-data (paste graph (deserialize data))
+(defn- paste-target [project item-iterator data]
+  (let [paste-data (paste project (deserialize data))
         root-nodes (root-nodes paste-data)]
     (find-target-item item-iterator root-nodes)))
 
-(defn paste! [graph item-iterator data select-fn]
+(defn paste! [project item-iterator data select-fn]
   (let [fragment (deserialize data)
-        paste-data (paste graph fragment)
+        paste-data (paste project fragment)
         root-nodes (root-nodes paste-data)]
     (when-let [[item reqs] (find-target-item item-iterator root-nodes)]
       (do-paste! "Paste" (gensym) paste-data (:attachments fragment) item reqs select-fn))))
 
-(defn paste? [graph item-iterator data]
+(defn paste? [project item-iterator data]
   (try
-    (some? (paste-target graph item-iterator data))
+    (some? (paste-target project item-iterator data))
     (catch Exception e
       (log/warn :exception e)
       ; TODO - ignore
       false)))
 
-(defn drag? [graph item-iterators]
+(defn drag? [item-iterators]
   (delete? item-iterators))
 
 (defn- descendant? [src-item item-iterator]
@@ -275,7 +281,7 @@
       (recur src-item (parent item-iterator)))
     false))
 
-(defn drop? [graph src-item-iterators item-iterator data]
+(defn drop? [project src-item-iterators item-iterator data]
   (and
     ; src is not descendant of target
     (not
@@ -283,15 +289,15 @@
                                  (descendant? (value it) item-iterator)))
               false src-item-iterators))
     ; pasting is allowed
-    (when-let [[tgt _] (paste-target graph item-iterator data)]
+    (when-let [[tgt _] (paste-target project item-iterator data)]
       (not (reduce (fn [parent? it]
                      (let [parent-item (value (parent it))]
                        (or parent? (= parent-item tgt) (= (:alt-outline parent-item) tgt)))) false src-item-iterators)))))
 
-(defn drop! [graph src-item-iterators item-iterator data select-fn]
-  (when (drop? graph src-item-iterators item-iterator data)
+(defn drop! [project src-item-iterators item-iterator data select-fn]
+  (when (drop? project src-item-iterators item-iterator data)
     (let [fragment (deserialize data)
-          paste-data (paste graph fragment)
+          paste-data (paste project fragment)
           root-nodes (root-nodes paste-data)]
       (when-let [[item reqs] (find-target-item item-iterator root-nodes)]
         (let [op-seq (gensym)]

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -324,10 +324,10 @@
 (handler/defhandler :copy :workbench
   (active? [selection] (handler/selection->node-ids selection))
   (enabled? [selection] (< 0 (count selection)))
-  (run [outline-view]
+  (run [outline-view project]
        (let [root-its (root-iterators outline-view)
              cb (Clipboard/getSystemClipboard)
-             data (outline/copy root-its)]
+             data (outline/copy project root-its)]
          (set-paste-parent! root-its)
          (.setContent cb {(data-format-fn) data}))))
 
@@ -345,12 +345,12 @@
                   data-format (data-format-fn)]
               (and target-item-it
                    (.hasContent cb data-format)
-                   (outline/paste? (g/node-id->graph-id project) target-item-it (.getContent cb data-format)))))
+                   (outline/paste? project target-item-it (.getContent cb data-format)))))
   (run [project outline-view app-view]
     (let [target-item-it (paste-target-it (root-iterators outline-view))
           cb (Clipboard/getSystemClipboard)
           data-format (data-format-fn)]
-      (outline/paste! (g/node-id->graph-id project) target-item-it (.getContent cb data-format) (partial app-view/select app-view))
+      (outline/paste! project target-item-it (.getContent cb data-format) (partial app-view/select app-view))
       (set-paste-parent! (root-iterators outline-view)))))
 
 (handler/defhandler :cut :workbench
@@ -359,13 +359,13 @@
             (let [item-iterators (root-iterators outline-view evaluation-context)]
               (and (< 0 (count item-iterators))
                    (outline/cut? item-iterators))))
-  (run [app-view selection-provider outline-view]
+  (run [app-view selection-provider outline-view project]
        (let [item-iterators (root-iterators outline-view)
              cb (Clipboard/getSystemClipboard)
              data-format (data-format-fn)
              next (-> (handler/succeeding-selection selection-provider)
                     handler/selection->node-ids)]
-         (.setContent cb {data-format (outline/cut! item-iterators (if next (app-view/select app-view next)))}))))
+         (.setContent cb {data-format (outline/cut! project item-iterators (if next (app-view/select app-view next)))}))))
 
 (defn- dump-mouse-event [^MouseEvent e]
   (prn "src" (.getSource e))
@@ -377,11 +377,11 @@
   (prn "ges-src" (.getGestureSource e))
   (prn "ges-tgt" (.getGestureTarget e)))
 
-(defn- drag-detected [proj-graph outline-view ^MouseEvent e]
+(defn- drag-detected [project outline-view ^MouseEvent e]
   (let [item-iterators (root-iterators outline-view)]
-    (when (outline/drag? proj-graph item-iterators)
+    (when (outline/drag? item-iterators)
       (let [db (.startDragAndDrop ^Node (.getSource e) (into-array TransferMode TransferMode/COPY_OR_MOVE))
-            data (outline/copy item-iterators)]
+            data (outline/copy project item-iterators)]
         (when-let [icon (and (= 1 (count item-iterators))
                              (:icon (outline/value (first item-iterators))))]
           (.setDragView db (icons/get-image icon 16) 0 16))
@@ -394,7 +394,7 @@
       node
       (target (.getParent node)))))
 
-(defn- drag-over [proj-graph outline-view ^DragEvent e]
+(defn- drag-over [project outline-view ^DragEvent e]
   (if (not (instance? TreeCell (.getTarget e)))
     (when-let [parent (.getParent ^Node (.getTarget e))]
       (Event/fireEvent parent (.copyFor e (.getSource e) parent)))
@@ -414,7 +414,7 @@
           (let [item-iterators (if (ui/drag-internal? e)
                                  (root-iterators outline-view)
                                  [])]
-            (when (outline/drop? proj-graph item-iterators (->iterator (.getTreeItem cell))
+            (when (outline/drop? project item-iterators (->iterator (.getTreeItem cell))
                                  (.getContent db (data-format-fn)))
               (let [modes (if (ui/drag-internal? e)
                             [TransferMode/MOVE]
@@ -422,18 +422,18 @@
                 (.acceptTransferModes e (into-array TransferMode modes)))
               (.consume e))))))))
 
-(defn- drag-dropped [proj-graph app-view outline-view ^DragEvent e]
+(defn- drag-dropped [project app-view outline-view ^DragEvent e]
   (let [^TreeCell cell (target (.getTarget e))
         db (.getDragboard e)]
     (let [item-iterators (if (ui/drag-internal? e)
                            (root-iterators outline-view)
                            [])]
-      (when (outline/drop! proj-graph item-iterators (->iterator (.getTreeItem cell))
+      (when (outline/drop! project item-iterators (->iterator (.getTreeItem cell))
                            (.getContent db (data-format-fn)) (partial app-view/select app-view))
         (.setDropCompleted e true)
         (.consume e)))))
 
-(defn- drag-entered [proj-graph outline-view ^DragEvent e]
+(defn- drag-entered [project outline-view ^DragEvent e]
   (let [^TreeCell cell (target (.getTarget e))
         db (.getDragboard e)]
     (when (and cell
@@ -442,7 +442,7 @@
       (let [item-iterators (if (ui/drag-internal? e)
                              (root-iterators outline-view)
                              [])]
-        (when (outline/drop? proj-graph item-iterators (->iterator (.getTreeItem cell))
+        (when (outline/drop? project item-iterators (->iterator (.getTreeItem cell))
                              (.getContent db (data-format-fn)))
           (ui/add-style! cell "drop-target")))
 
@@ -519,15 +519,15 @@
       ;; TODO - handle selection order
       (app-view/select! app-view selection))))
 
-(defn- setup-tree-view [proj-graph ^TreeView tree-view outline-view app-view]
-  (let [drag-entered-handler (ui/event-handler e (drag-entered proj-graph outline-view e))
+(defn- setup-tree-view [project ^TreeView tree-view outline-view app-view]
+  (let [drag-entered-handler (ui/event-handler e (drag-entered project outline-view e))
         drag-exited-handler (ui/event-handler e (drag-exited e))]
     (doto tree-view
       (ui/customize-tree-view! {:double-click-expand? true})
       (.. getSelectionModel (setSelectionMode SelectionMode/MULTIPLE))
-      (.setOnDragDetected (ui/event-handler e (drag-detected proj-graph outline-view e)))
-      (.setOnDragOver (ui/event-handler e (drag-over proj-graph outline-view e)))
-      (.setOnDragDropped (ui/event-handler e (error-reporting/catch-all! (drag-dropped proj-graph app-view outline-view e))))
+      (.setOnDragDetected (ui/event-handler e (drag-detected project outline-view e)))
+      (.setOnDragOver (ui/event-handler e (drag-over project outline-view e)))
+      (.setOnDragDropped (ui/event-handler e (error-reporting/catch-all! (drag-dropped project app-view outline-view e))))
       (.setCellFactory (reify Callback (call ^TreeCell [this view] (make-tree-cell view drag-entered-handler drag-exited-handler))))
       (ui/observe-selection #(propagate-selection %2 app-view))
       (ui/bind-double-click! :open)
@@ -535,7 +535,7 @@
       (ui/context! :outline {} (SelectionProvider. outline-view) {} {java.lang.Long :node-id
                                                                      resource/Resource :link}))))
 
-(defn make-outline-view [view-graph proj-graph tree-view app-view]
+(defn make-outline-view [view-graph project tree-view app-view]
   (let [outline-view (first (g/tx-nodes-added (g/transact (g/make-node view-graph OutlineView :raw-tree-view tree-view))))]
-    (setup-tree-view proj-graph tree-view outline-view app-view)
+    (setup-tree-view project tree-view outline-view app-view)
     outline-view))

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -367,8 +367,8 @@
         arcs))
 
 (defn arc-endpoints-p [p ^Arc arc]
-  (and (p (.source-id arc))
-       (p (.target-id arc))))
+  (and (p (.source-id arc) (.source-label arc))
+       (p (.target-id arc) (.target-label arc))))
 
 (defn empty-graph
   []

--- a/editor/test/integration/outline_test.clj
+++ b/editor/test/integration/outline_test.clj
@@ -17,7 +17,6 @@
             [dynamo.graph :as g]
             [editor.app-view :as app-view]
             [editor.collection :as collection]
-            [editor.defold-project :as project]
             [editor.game-object :as game-object]
             [editor.outline :as outline]
             [integration.test-util :as test-util]
@@ -26,13 +25,13 @@
 
 (defn- outline
   ([node]
-    (outline node []))
+   (outline node []))
   ([node path]
-    (loop [outline (g/node-value node :node-outline)
-           path path]
-      (if-let [segment (first path)]
-        (recur (get (vec (:children outline)) segment) (rest path))
-        outline))))
+   (loop [outline (g/node-value node :node-outline)
+          path path]
+     (if-let [segment (first path)]
+       (recur (get (vec (:children outline)) segment) (rest path))
+       outline))))
 
 (def ^:private ^:dynamic *clipboard* nil)
 (def ^:private ^:dynamic *dragboard* nil)
@@ -54,53 +53,53 @@
   (when (delete? node path)
     (g/delete-node! (g/override-root (:node-id (outline node path))))))
 
-(defn- copy! [node path]
-  (let [data (outline/copy [(->iterator node path)])]
+(defn- copy! [project node path]
+  (let [data (outline/copy project [(->iterator node path)])]
     (alter-var-root #'*clipboard* (constantly data))))
 
 (defn- cut? [node & paths]
   (outline/cut? (mapv #(->iterator node %) paths)))
 
-(defn- cut! [node & paths]
-  (let [data (outline/cut! (mapv #(->iterator node %) paths))]
+(defn- cut! [project node & paths]
+  (let [data (outline/cut! project (mapv #(->iterator node %) paths))]
     (alter-var-root #'*clipboard* (constantly data))))
 
 (defn- paste!
   ([project app-view node]
-    (paste! project app-view node []))
+   (paste! project app-view node []))
   ([project app-view node path]
-    (let [it (->iterator node path)]
-      (assert (outline/paste? (project/graph project) it *clipboard*))
-      (outline/paste! (project/graph project) it *clipboard* (partial app-view/select app-view)))))
+   (let [it (->iterator node path)]
+     (assert (outline/paste? project it *clipboard*))
+     (outline/paste! project it *clipboard* (partial app-view/select app-view)))))
 
 (defn- copy-paste! [project app-view node path]
-  (copy! node path)
+  (copy! project node path)
   (paste! project app-view node (butlast path)))
 
 (defn- drag? [node path]
-  (outline/drag? (g/node-id->graph-id node) [(->iterator node path)]))
+  (outline/drag? [(->iterator node path)]))
 
-(defn- drag! [node path]
+(defn- drag! [project node path]
   (let [src-item-iterators [(->iterator node path)]
-        data (outline/copy src-item-iterators)]
+        data (outline/copy project src-item-iterators)]
     (alter-var-root #'*dragboard* (constantly data))
     (alter-var-root #'*drag-source-iterators* (constantly src-item-iterators))))
 
 (defn- drop!
   ([project app-view node]
-    (drop! project app-view node []))
+   (drop! project app-view node []))
   ([project app-view node path]
-    (outline/drop! (project/graph project) *drag-source-iterators* (->iterator node path) *dragboard* (partial app-view/select app-view))))
+   (outline/drop! project *drag-source-iterators* (->iterator node path) *dragboard* (partial app-view/select app-view))))
 
 (defn- drop?
   ([project node]
-    (drop? project node []))
+   (drop? project node []))
   ([project node path]
-    (outline/drop? (project/graph project) *drag-source-iterators* (->iterator node path) *dragboard*)))
+   (outline/drop? project *drag-source-iterators* (->iterator node path) *dragboard*)))
 
 (defn- child-count
   ([node]
-    (child-count node []))
+   (child-count node []))
   ([node path]
    (count (:children (outline node path)))))
 
@@ -126,7 +125,7 @@
     (let [root (test-util/resource-node project "/collection/embedded_embedded_sounds.collection")]
       ; 2 go instance
       (is (= 2 (child-count root)))
-      (copy! root [0])
+      (copy! project root [0])
       (paste! project app-view root)
       ; 3 go instances
       (is (= 3 (child-count root))))))
@@ -136,7 +135,7 @@
     (let [root (test-util/resource-node project "/collection/embedded_embedded_sounds.collection")]
       ; 1 comp instance
       (is (= 1 (child-count root [0])))
-      (copy! root [0 0])
+      (copy! project root [0 0])
       (paste! project app-view root [0])
       ; 2 comp instances
       (is (= 2 (child-count root [0]))))))
@@ -146,12 +145,12 @@
     (let [root (test-util/resource-node project "/logic/atlas_sprite.go")]
       ; 1 comp instance
       (is (= 1 (child-count root)))
-      (copy! root [0])
+      (copy! project root [0])
       (paste! project app-view root)
       ; 2 comp instances
       (is (= 2 (child-count root)))
       (is (contains? (outline root [1]) :icon))
-      (cut! root [0])
+      (cut! project root [0])
       ; 1 comp instances
       (is (= 1 (child-count root))))))
 
@@ -174,7 +173,7 @@
       (is (= 1 (child-count root)))
       ; 1 sprite comp
       (is (= 1 (child-count root [0])))
-      (copy! root [0]) ;; copy go-instance
+      (copy! project root [0]) ;; copy go-instance
       (paste! project app-view root) ;; paste into root
       ; 2 go instances
       (is (= 2 (child-count root)))
@@ -185,7 +184,7 @@
       (is (= 2 (child-count root [0])))
       ; go instance can be cut
       (is (cut? root [0 0]))
-      (cut! root [0 0])
+      (cut! project root [0 0])
       ; 1 sprite
       (is (= 1 (child-count root [0]))))))
 
@@ -199,7 +198,7 @@
           tgt-root (test-util/resource-node project "/collection/test.collection")]
       ; 0 go instance
       (is (= 0 (child-count tgt-root)))
-      (copy! src-root [0]) ;; copy go-instance from source
+      (copy! project src-root [0]) ;; copy go-instance from source
       (paste! project app-view tgt-root) ;; paste into target root
       ; 1 go instance
       (is (= 1 (child-count tgt-root))))))
@@ -216,20 +215,20 @@
       (is (= 1 (child-count root)))
       ; 2 go instances
       (is (= 2 (child-count root [0])))
-      (copy! root [0])
+      (copy! project root [0])
       (paste! project app-view root)
       (is (= 2 (child-count root)))
       ; 2 go instances in referenced collection
       (is (= 2 (child-count root [0])))
       (is (= 2 (child-count root [1])))
-      (cut! root [0 0])
+      (cut! project root [0 0])
       ; 1 go instance remains in referenced collection
       (is (= 1 (child-count root [0])))
       (is (= 1 (child-count root [1])))
       (paste! project app-view root)
       ; 2 collection instances + 1 go instances
       (is (= 3 (child-count root)))
-      (cut! root [2])
+      (cut! project root [2])
       (paste! project app-view root [0])
       ; 2 collection instances
       (is (= 2 (child-count root)))
@@ -242,20 +241,20 @@
     (let [root (test-util/resource-node project "/logic/atlas_sprite.collection")]
       (is (= 1 (child-count root)))
       (let [first-id (get (outline root [0]) :label)]
-        (drag! root [0])
+        (drag! project root [0])
         (is (not (drop? project root)))
         (is (not (drop? project root [0])))
         (copy-paste! project app-view root [0])
         (is (= 2 (child-count root)))
         (let [second-id (get (outline root [1]) :label)]
           (is (not= first-id second-id))
-          (drag! root [1])
+          (drag! project root [1])
           (is (drop? project root [0]))
           (drop! project app-view root [0])
           (is (= 1 (child-count root)))
           (is (= 2 (child-count root [0])))
           (is (= second-id (get (outline root [0 0]) :label)))
-          (drag! root [0 0])
+          (drag! project root [0 0])
           (drop! project app-view root)
           (is (= 2 (child-count root)))
           (is (= second-id (get (outline root [1]) :label))))))))
@@ -264,7 +263,7 @@
   (test-util/with-loaded-project
     (let [root (test-util/resource-node project "/logic/atlas_sprite.collection")]
       (copy-paste! project app-view root [0])
-      (drag! root [0])
+      (drag! project root [0])
       (drop! project app-view root [1]))))
 
 (deftest read-only-items
@@ -280,12 +279,12 @@
     (let [root (test-util/resource-node project "/logic/main.gui")]
       (let [first-id (get (outline root [0 1]) :label)
             next-id (get (outline root [0 2]) :label)]
-        (drag! root [0 1])
+        (drag! project root [0 1])
         (drop! project app-view root [0 0])
         (let [second-id (get (outline root [0 0 0]) :label)]
           (is (= first-id second-id))
           (is (= next-id (get (outline root [0 1]) :label)))
-          (drag! root [0 0 0])
+          (drag! project root [0 0 0])
           (drop! project app-view root [0])
           (is (= second-id (get (outline root [0 5]) :label))))))))
 
@@ -356,7 +355,7 @@
       (is (not (nil? (outline root (conj tmpl-path 0)))))
       (let [sub-id (:node-id (outline root (conj tmpl-path 0)))]
         (g/transact (g/set-property sub-id :position new-pos)))
-      (drag! root tmpl-path)
+      (drag! project root tmpl-path)
       (drop! project app-view root [0 0])
       (let [tmpl-path [0 0 1]]
         (is (= -100.0 (get-in (prop root tmpl-path :template) [:overrides "sub_box" :position 0])))
@@ -447,7 +446,7 @@
       ; + primary (emitter)
       ; + secondary (emitter)
       (is (= 4 (child-count root)))
-      (copy! root [2])
+      (copy! project root [2])
       (paste! project app-view root)
       (is (= 5 (child-count root)))
       (is (some? (g/node-value (:node-id (outline root [3])) :scene))))))
@@ -466,7 +465,7 @@
 
       ;; Copy "props_embedded" game_object.
       (is (= "props_embedded" (:label (outline root [0 0 1]))))
-      (let [{:keys [arcs attachments nodes]} (#'outline/deserialize (copy! root [0 0 1]))
+      (let [{:keys [arcs attachments nodes]} (#'outline/deserialize (copy! project root [0 0 1]))
             serial-id->node-type (into {} (map (juxt :serial-id :node-type)) nodes)]
 
         (is (= {0 collection/EmbeddedGOInstanceNode
@@ -510,7 +509,7 @@
       (is (= "props_embedded" (:label (outline root [0 0 1]))))
       (is (= 1 (child-count root)))
       (is (= 2 (child-count root [0 0])))
-      (drag! root [0 0 1])
+      (drag! project root [0 0 1])
       (drop! project app-view root)
       (is (= 2 (child-count root)))
       (is (= 1 (child-count root [0 0])))
@@ -534,7 +533,7 @@
       (is (= "props" (:label (outline root [0 0 0]))))
       (is (= 2 (child-count root)))
       (is (= 1 (child-count root [0 0 0])))
-      (drag! root [1])
+      (drag! project root [1])
       (drop! project app-view root [0 0 0])
       (is (= 1 (child-count root)))
       (is (= 2 (child-count root [0 0 0])))
@@ -567,7 +566,7 @@
       ;; Cut "props_embedded" game_object and paste it below "sub_props".
       (is (= "props_embedded" (:label (outline root [0 0 1]))))
       (is (= 2 (child-count root [0 0])))
-      (cut! root [0 0 1])
+      (cut! project root [0 0 1])
       (is (= 1 (child-count root [0 0])))
 
       (is (= "sub_props" (:label (outline root [0]))))
@@ -593,7 +592,7 @@
       ;; Cut "props" game_object and paste it below the root collection.
       (is (= "props" (:label (outline root [0 0 0]))))
       (is (= 1 (child-count root [0 0])))
-      (cut! root [0 0 0])
+      (cut! project root [0 0 0])
       (is (= 0 (child-count root [0 0])))
 
       (is (= "Collection" (:label (outline root))))
@@ -632,7 +631,7 @@
       ;; Cut "scene/pie" and paste it below "scene/sub_scene/sub_box".
       (is (= "scene/pie" (:label (outline root [0 0 0 0]))))
       (is (= 1 (child-count root [0 0 0])))
-      (cut! root [0 0 0 0])
+      (cut! project root [0 0 0 0])
       (is (= 0 (child-count root [0 0 0])))
 
       (is (= "scene/sub_scene/sub_box" (:label (outline root [0 0 1 0]))))
@@ -661,7 +660,7 @@
       ;; Cut "scene/sub_scene/sub_box" and paste it below "Nodes" in the root gui.
       (is (= "scene/sub_scene" (:label (outline root [0 0 1]))))
       (is (= 1 (child-count root [0 0 1])))
-      (cut! root [0 0 1 0])
+      (cut! project root [0 0 1 0])
       (is (= 0 (child-count root [0 0 1])))
 
       (is (= "Nodes" (:label (outline root [0]))))
@@ -702,7 +701,7 @@
       (is (= 2 (child-count root)))
       (testing "Cut `left_child` and `right`"
         (is (true? (cut? root [0 0] [1])))
-        (cut! root [0 0] [1])
+        (cut! project root [0 0] [1])
         (is (= 0 (child-count root [0])))
         (is (= 1 (child-count root))))
       (testing "Paste `left_child` and `right` below `root`"
@@ -745,7 +744,7 @@
                ; + collisionobject1
                (is (= 1 (child-count root [0])))
                (is (= 0 (child-count root [1])))
-               (drag! root [0 0])
+               (drag! project root [0 0])
                (drop! project app-view root [1])
                ; Game Object
                ; + collisionobject
@@ -774,7 +773,7 @@
                ;   + Box (shape)
                ;   + Capsule (shape)
                ; + sprite
-               (drag! root [0 0])
+               (drag! project root [0 0])
                ;; Not possible to drag to the second collisionobject1 since they are references to the same file
                (is (not (drop? project root [1])))))))
 


### PR DESCRIPTION
This commit extends copy/paste functionality with support for including references to external nodes in copy payload. To do that, `copy` must provide a map from node id to its reference keyword (e.g. `:project`), and then `paste` must provide an inversed map from reference keywords to node ids. This allows copy-pasting collision objects' connections to the project node.

User-facing changes: collision objects are correctly copy-pasted in projects with 3D physics.

Fixes #5049