### PR TITLE
Added `physics.max_collision_object_count` field in `game.project`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -110,6 +110,10 @@ type.type = string
 type.help = which type of physics to use, 2D (default) or 3D
 type.default = 2D
 
+max_collision_object_count.type = integer
+max_collision_object_count.help = max number of sprites, 128 by default
+max_collision_object_count.default = 128
+
 use_fixed_timestep.type = bool
 use_fixed_timestep.help = If the physics should use fixed time steps. See engine.fixed_update_frequency
 use_fixed_timestep.default = 0

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -155,6 +155,10 @@
    :label "Clear Color Alpha"
    :default 0,
    :path ["render" "clear_color_alpha"]}
+  {:type :integer,
+   :help "max number of collision objects, 128 by default",
+   :default 128,
+   :path ["physics" "max_count"]}
   {:type :string,
    :help "which type of physics to use, 2D (default) or 3D",
    :default "2D",

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -158,7 +158,7 @@
   {:type :integer,
    :help "max number of collision objects, 128 by default",
    :default 128,
-   :path ["physics" "max_count"]}
+   :path ["physics" "max_collision_object_count"]}
   {:type :string,
    :help "which type of physics to use, 2D (default) or 3D",
    :default "2D",

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1069,6 +1069,7 @@ namespace dmEngine
             engine->m_PhysicsContext.m_3D = false;
             engine->m_PhysicsContext.m_Context2D = dmPhysics::NewContext2D(physics_params);
         }
+        engine->m_PhysicsContext.m_MaxCollisionObjectCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_MAX_COLLISION_OBJECTS_KEY, 128);
         engine->m_PhysicsContext.m_MaxCollisionCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_MAX_COLLISIONS_KEY, 64);
         engine->m_PhysicsContext.m_MaxContactPointCount = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_MAX_CONTACTS_KEY, 128);
         engine->m_PhysicsContext.m_UseFixedTimestep = dmConfigFile::GetInt(engine->m_Config, dmGameSystem::PHYSICS_USE_FIXED_TIMESTEP, 1) ? 1 : 0;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -42,7 +42,7 @@ namespace dmGameSystem
     using namespace dmVMath;
 
     /// Config key to use for tweaking maximum number of collision objects
-    const char* PHYSICS_MAX_COLLISION_OBJECTS_KEY   = "physics.max_count";
+    const char* PHYSICS_MAX_COLLISION_OBJECTS_KEY   = "physics.max_collision_object_count";
     /// Config key to use for tweaking maximum number of collisions reported
     const char* PHYSICS_MAX_COLLISIONS_KEY          = "physics.max_collisions";
     /// Config key to use for tweaking maximum number of contacts reported
@@ -866,7 +866,7 @@ namespace dmGameSystem
         }
         if (world->m_Components.Full())
         {
-            dmLogError("Collision Object could not be created since the buffer is full (%d). See 'physics.max_count' in game.project", world->m_Components.Capacity());
+            dmLogError("Collision Object could not be created since the buffer is full (%d). See 'physics.max_collision_object_count' in game.project", world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         CollisionComponent* component = (CollisionComponent*)*params.m_UserData;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -41,14 +41,16 @@ namespace dmGameSystem
 {
     using namespace dmVMath;
 
+    /// Config key to use for tweaking maximum number of collision objects
+    const char* PHYSICS_MAX_COLLISION_OBJECTS_KEY   = "physics.max_count";
     /// Config key to use for tweaking maximum number of collisions reported
-    const char* PHYSICS_MAX_COLLISIONS_KEY      = "physics.max_collisions";
+    const char* PHYSICS_MAX_COLLISIONS_KEY          = "physics.max_collisions";
     /// Config key to use for tweaking maximum number of contacts reported
-    const char* PHYSICS_MAX_CONTACTS_KEY        = "physics.max_contacts";
+    const char* PHYSICS_MAX_CONTACTS_KEY            = "physics.max_contacts";
     /// Config key for using fixed frame rate for the physics worlds
-    const char* PHYSICS_USE_FIXED_TIMESTEP      = "physics.use_fixed_timestep";
+    const char* PHYSICS_USE_FIXED_TIMESTEP          = "physics.use_fixed_timestep";
     /// Config key for using max updates during a single step
-    const char* PHYSICS_MAX_FIXED_TIMESTEPS     = "physics.max_fixed_timesteps";
+    const char* PHYSICS_MAX_FIXED_TIMESTEPS         = "physics.max_fixed_timesteps";
 
     static const dmhash_t PROP_LINEAR_DAMPING = dmHashString64("linear_damping");
     static const dmhash_t PROP_ANGULAR_DAMPING = dmHashString64("angular_damping");
@@ -181,9 +183,11 @@ namespace dmGameSystem
             return dmGameObject::CREATE_RESULT_OK;
         }
         PhysicsContext* physics_context = (PhysicsContext*)params.m_Context;
+        uint32_t comp_count = dmMath::Min(params.m_MaxComponentInstances, physics_context->m_MaxCollisionObjectCount);
         dmPhysics::NewWorldParams world_params;
         world_params.m_GetWorldTransformCallback = GetWorldTransform;
         world_params.m_SetWorldTransformCallback = SetWorldTransform;
+        world_params.m_MaxCollisionObjectsCount = comp_count;
 
         dmPhysics::HWorld2D world2D;
         dmPhysics::HWorld3D world3D;
@@ -219,11 +223,6 @@ namespace dmGameSystem
         world->m_ComponentTypeIndex = params.m_ComponentIndex;
         world->m_3D = physics_context->m_3D;
         world->m_FirstUpdate = 1;
-        uint32_t comp_count = params.m_MaxComponentInstances;
-        if (comp_count == 0xFFFFFFFF)
-        {
-            comp_count = 32;
-        }
         world->m_Components.SetCapacity(comp_count);
         *params.m_World = world;
         return dmGameObject::CREATE_RESULT_OK;
@@ -865,6 +864,11 @@ namespace dmGameSystem
         {
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
+        if (world->m_Components.Full())
+        {
+            dmLogError("Collision Object could not be created since the buffer is full (%d). See 'physics.max_count' in game.project", world->m_Components.Capacity());
+            return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
+        }
         CollisionComponent* component = (CollisionComponent*)*params.m_UserData;
         assert(!component->m_AddedToUpdate);
 
@@ -875,8 +879,6 @@ namespace dmGameSystem
         }
         component->m_AddedToUpdate = true;
 
-        if (world->m_Components.Full())
-            world->m_Components.OffsetCapacity(32);
         world->m_Components.Push(component);
         return dmGameObject::CREATE_RESULT_OK;
     }

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -35,6 +35,8 @@ namespace dmMessage { struct URL; }
 
 namespace dmGameSystem
 {
+    /// Config key to use for tweaking maximum number of collision objects
+    extern const char* PHYSICS_MAX_COLLISION_OBJECTS_KEY;
     /// Config key to use for tweaking maximum number of collisions reported
     extern const char* PHYSICS_MAX_COLLISIONS_KEY;
     /// Config key to use for tweaking maximum number of contacts reported
@@ -80,6 +82,7 @@ namespace dmGameSystem
             dmPhysics::HContext2D m_Context2D;
         };
         uint32_t    m_MaxCollisionCount;
+        uint32_t    m_MaxCollisionObjectCount;
         uint32_t    m_MaxContactPointCount;
         bool        m_Debug;
         bool        m_3D;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -42,6 +42,7 @@ struct Params
 
 struct ProjectOptions {
   uint32_t m_MaxCollisionCount;
+  uint32_t m_MaxCollisionObjectCount;
   uint32_t m_MaxContactPointCount;
   bool m_3D;
   float m_Scale;
@@ -72,6 +73,7 @@ public:
     GamesysTest() {
         // Default configuration values for the engine. Subclass GamesysTest and ovewrite in constructor.
         this->m_projectOptions.m_MaxCollisionCount = 0;
+        this->m_projectOptions.m_MaxCollisionObjectCount = 0;
         this->m_projectOptions.m_MaxContactPointCount = 0;
         this->m_projectOptions.m_3D = false;
         this->m_projectOptions.m_Scale = 1.0f;
@@ -146,6 +148,7 @@ public:
       // override configuration values specified in GamesysTest()
       m_projectOptions.m_MaxCollisionCount = 32;
       m_projectOptions.m_MaxContactPointCount = 64;
+      m_projectOptions.m_MaxCollisionObjectCount = 512;
       m_projectOptions.m_3D = true;
     }
 };
@@ -425,6 +428,7 @@ void GamesysTest<T>::SetUp()
     memset(&m_PhysicsContext, 0, sizeof(m_PhysicsContext));
     m_PhysicsContext.m_MaxCollisionCount = this->m_projectOptions.m_MaxCollisionCount;
     m_PhysicsContext.m_MaxContactPointCount = this->m_projectOptions.m_MaxContactPointCount;
+    m_PhysicsContext.m_MaxCollisionObjectCount = this->m_projectOptions.m_MaxCollisionObjectCount;
     m_PhysicsContext.m_3D = this->m_projectOptions.m_3D;
     if (m_PhysicsContext.m_3D) {
         m_PhysicsContext.m_Context3D = dmPhysics::NewContext3D(dmPhysics::NewContextParams());
@@ -474,6 +478,7 @@ void GamesysTest<T>::SetUp()
 
     m_PhysicsContext.m_MaxCollisionCount = 64;
     m_PhysicsContext.m_MaxContactPointCount = 128;
+    m_PhysicsContext.m_MaxCollisionObjectCount = 512;
 
     dmResource::Result r = dmGameSystem::RegisterResourceTypes(m_Factory, m_RenderContext, m_InputContext, &m_PhysicsContext);
     ASSERT_EQ(dmResource::RESULT_OK, r);

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -305,6 +305,8 @@ namespace dmPhysics
         GetWorldTransformCallback m_GetWorldTransformCallback;
         /// param set_world_transform Callback for copying the transform from the collision object to the corresponding user data
         SetWorldTransformCallback m_SetWorldTransformCallback;
+        /// max number of collision objects
+        uint32_t m_MaxCollisionObjectsCount;
     };
 
     /**

--- a/engine/physics/src/physics/physics_3d.cpp
+++ b/engine/physics/src/physics/physics_3d.cpp
@@ -143,8 +143,7 @@ namespace dmPhysics
         ToBt(params.m_WorldMin, world_aabb_min, context->m_Scale);
         btVector3 world_aabb_max;
         ToBt(params.m_WorldMax, world_aabb_max, context->m_Scale);
-        int maxProxies = 1024;
-        m_OverlappingPairCache = new btAxisSweep3(world_aabb_min,world_aabb_max,maxProxies);
+        m_OverlappingPairCache = new btAxisSweep3(world_aabb_min,world_aabb_max, params.m_MaxCollisionObjectsCount);
 
         m_Solver = new btSequentialImpulseConstraintSolver;
 

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -57,6 +57,7 @@ protected:
         dmPhysics::NewWorldParams world_params;
         world_params.m_GetWorldTransformCallback = GetWorldTransform;
         world_params.m_SetWorldTransformCallback = SetWorldTransform;
+        world_params.m_MaxCollisionObjectsCount = 1024;
         m_World = (*m_Test.m_NewWorldFunc)(m_Context, world_params);
         m_CollisionCount = 0;
         m_ContactPointCount = 0;


### PR DESCRIPTION
Added `physics.max_collision_object_count` field in `game.project` to set maximum count of collision objects per physics world. This prevents a crash which would happen in earlier versions when using more than 1024 collision objects in a physics world.

__IMPORTANT__: This is a breaking change. The default value for `physics.max_collision_object_count` is 128. Make sure you adjust the value to suit the needs of your project.

Fixes https://github.com/defold/defold/issues/7070

