### PR TITLE
Use "push" instead of "pull_request" CI triggers

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -3,9 +3,6 @@ name: CI - Editor Only
 on:
   push:
     branches:
-      - 'editor-dev'
-  pull_request:
-    branches:
       - 'DEFEDIT-*'
       - 'editor-dev'
   pull_request_target:

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -2,23 +2,15 @@ name: CI - Main
 
 on:
   push:
-    branches:
-      - 'hotfix-*'
-      - 'dev'
-      - 'beta'
-      - 'master'
-  pull_request:
-    branches:
-       - '*'
-       - '!skip-ci-*'
-       - '!DEFEDIT-*'
-       - '!editor-dev'
+    branches-ignore:
+       - 'skip-ci-*'
+       - 'DEFEDIT-*'
+       - 'editor-dev'
   pull_request_target:
-    branches:
-       - '*'
-       - '!skip-ci-*'
-       - '!DEFEDIT-*'
-       - '!editor-dev'
+    branches-ignore:
+       - 'skip-ci-*'
+       - 'DEFEDIT-*'
+       - 'editor-dev'
     types: [labeled]
   repository_dispatch: {}
 
@@ -44,7 +36,7 @@ jobs:
 # ---- PRE-CHECK
 # ---- * Do not proceed if commit message contains "skip-ci"
 # ---- * If workflow is started from a "pull_request" event only proceed if coming from the Defold org
-# ---- * If workflow is started from a "pull_equest_target" event only proceed if it has the label "ok to test"
+# ---- * If workflow is started from a "pull_request_target" event only proceed if it has the label "ok to test"
   pre-check:
     runs-on: ubuntu-20.04
     if: |

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -13,8 +13,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-
-
 import sys
 import subprocess
 import platform
@@ -382,7 +380,7 @@ def get_branch():
 
     return branch
 
-def get_target_branch():
+def get_pull_request_target_branch():
     # The name of the base (or target) branch. Only set for pull request events.
     return os.environ.get('GITHUB_BASE_REF', '')
 
@@ -472,7 +470,7 @@ def main(argv):
         release_channel = "editor-alpha"
         make_release = True
         engine_artifacts = args.engine_artifacts
-    elif branch and (branch.startswith("DEFEDIT-") or get_target_branch() == "editor-dev"):
+    elif branch and (branch.startswith("DEFEDIT-") or get_pull_request_target_branch() == "editor-dev"):
         engine_channel = None
         editor_channel = "editor-dev"
         make_release = False


### PR DESCRIPTION
Use "push" instead of "pull_request" CI triggers. This change ensures in-progress branches that are in an unmergable state will still build on CI.