### PR TITLE
Fix atlas image deduplication

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -606,7 +606,10 @@
                                   (tex-gen/match-texture-profile texture-profiles (resource/proj-path resource))))
 
   (output all-atlas-images [Image] :cached (g/fnk [animation-images]
-                                             (vec (distinct (flatten animation-images)))))
+                                             (into []
+                                                   (util/distinct-by
+                                                     #(dissoc % :digest-ignored/error-node-id))
+                                                   (flatten animation-images))))
 
   (output layout-data-generator g/Any          produce-layout-data-generator)
   (output texture-set-data g/Any               :cached produce-texture-set-data)

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -217,8 +217,9 @@
   (input animation-updatable g/Any)
 
   (output atlas-image Image (g/fnk [_node-id image-resource maybe-image-size sprite-trim-mode]
-                              (assoc (Image. image-resource nil (:width maybe-image-size) (:height maybe-image-size) sprite-trim-mode)
-                                :digest-ignored/error-node-id _node-id)))
+                              (with-meta
+                                (Image. image-resource nil (:width maybe-image-size) (:height maybe-image-size) sprite-trim-mode)
+                                {:error-node-id _node-id})))
   (output atlas-images [Image] (g/fnk [atlas-image] [atlas-image]))
   (output animation Animation (g/fnk [atlas-image id]
                                 (make-animation id [atlas-image])))
@@ -606,10 +607,7 @@
                                   (tex-gen/match-texture-profile texture-profiles (resource/proj-path resource))))
 
   (output all-atlas-images [Image] :cached (g/fnk [animation-images]
-                                             (into []
-                                                   (util/distinct-by
-                                                     #(dissoc % :digest-ignored/error-node-id))
-                                                   (flatten animation-images))))
+                                             (into [] (distinct) (flatten animation-images))))
 
   (output layout-data-generator g/Any          produce-layout-data-generator)
   (output texture-set-data g/Any               :cached produce-texture-set-data)

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -100,7 +100,7 @@
 
 (defn- make-image-sprite-geometry
   ^TextureSetProto$SpriteGeometry [^Image image]
-  (let [error-node-id (:digest-ignored/error-node-id image)
+  (let [error-node-id (:error-node-id (meta image))
         resource (.path image)
         sprite-trim-mode (.sprite-trim-mode image)]
     (assert (g/node-id? error-node-id))

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -190,8 +190,6 @@
    width    :- Int32
    height   :- Int32
    sprite-trim-mode :- sprite-trim-modes]
-  {(s/optional-key :digest-ignored/error-node-id) Long}
-
   ImageHolder
   (contents [this] contents))
 

--- a/editor/src/clj/util/digestable.clj
+++ b/editor/src/clj/util/digestable.clj
@@ -32,10 +32,6 @@
   (or (instance? Named value)
       (string? value)))
 
-(defn- ignored-key? [value]
-  (and (instance? Named value)
-       (= "digest-ignored" (namespace value))))
-
 (defn- node-id-key? [value]
   (and (named? value)
        (string/ends-with? (name value) "node-id")))
@@ -85,12 +81,11 @@
     (digest-tagged! tag-sym (resource/resource-hash resource) writer)))
 
 (defn- digest-map-entry! [[key value] ^Writer writer]
-  (when-not (ignored-key? key)
-    (digest! key writer)
-    (digest-raw! " " writer)
-    (if (node-id-entry? key value)
-      (digest-tagged! 'Node (node-id-data-representation value) writer)
-      (digest! value writer))))
+  (digest! key writer)
+  (digest-raw! " " writer)
+  (if (node-id-entry? key value)
+    (digest-tagged! 'Node (node-id-data-representation value) writer)
+    (digest! value writer)))
 
 (defn- digest-map! [coll writer]
   (let [sorted-sequence (if (sorted? coll) coll (sort-by key coll))]


### PR DESCRIPTION
Atlases with duplicate images in different animations will no longer have the images duplicated in the atlas image.

Fixes #7096
