### PR TITLE
update type extractor regex to match first ], not last

### DIFF
--- a/engine/docs/src/script_doc.py
+++ b/engine/docs/src/script_doc.py
@@ -316,7 +316,7 @@ def _parse_comment(text):
 
 def extract_type_from_docstr(s):
     # try to extract the type information
-    m = re.search(r'^\s*(?:\s*\[type:\s*(.*)\])+\s*([\w\W]*)', s)
+    m = re.search(r'^\s*(?:\s*\[type:\s*([^\]]*)\])+\s*([\w\W]*)', s)
     if m and m.group(1):
         type_list = m.group(1).split("|")
         if len(type_list) == 1:


### PR DESCRIPTION
Alters the documentation regex to match the first ']', not the last one.


Fixes #7108 

Please note that I do not have the toolchain set up currently to build the project and ensure there are no side-effects to these changes. The changes should only affect the API reference, but I can't test these changes myself yet.