### PR TITLE
Fix bug on iOS when profiler doesn't show CPU and Memory usage

### DIFF
--- a/engine/profiler/src/wscript
+++ b/engine/profiler/src/wscript
@@ -11,7 +11,7 @@ def build(bld):
     source = 'profiler.cpp profile_render.cpp'
     source_null = 'profiler_null.cpp'
 
-    if 'macos' in bld.env.PLATFORM:
+    if 'macos' in bld.env.PLATFORM or 'ios' in bld.env.PLATFORM:
         source += ' profiler_cocoa.mm'
     elif 'android' in bld.env.PLATFORM:
         source += ' profiler_android.cpp'


### PR DESCRIPTION
Fix a regression bug introduced in 1.3.7 when profiler doesn't show CPU and Memory usage on iOS.

Fix https://github.com/defold/defold/issues/7113