### PR TITLE
resource.set_texture improvements

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -110,11 +110,9 @@ namespace dmGameSystem
         dmResource::Result result = dmResource::RESULT_FORMAT_ERROR;
         for (uint32_t i = 0; i < image_desc->m_DDFImage->m_Alternatives.m_Count; ++i)
         {
-            dmGraphics::TextureImage::Image* image = &image_desc->m_DDFImage->m_Alternatives[i];
-
-
+            dmGraphics::TextureImage::Image* image    = &image_desc->m_DDFImage->m_Alternatives[i];
             dmGraphics::TextureFormat original_format = TextureImageToTextureFormat(image->m_Format);
-            dmGraphics::TextureFormat output_format = original_format;
+            dmGraphics::TextureFormat output_format   = original_format;
 
             uint32_t num_mips = image->m_MipMapOffset.m_Count;
             if (dmGraphics::IsFormatTranscoded(image->m_CompressionType))
@@ -214,7 +212,8 @@ namespace dmGameSystem
             }
 
             // If we requested to upload a specific mipmap, upload only that level
-            // It is expect that we only have offsets for that level in the image desc as well
+            // It is expected that we only have offsets for that level in the image desc as well
+            // -> See script_resource.cpp::SetTexture
             if (params.m_MipMap != SPECIFIC_MIPMAP_DONT_CARE)
             {
                 if (image_desc->m_DecompressedData[0] == 0)

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -356,9 +356,12 @@ namespace dmGameSystem
     dmResource::Result ResTextureRecreate(const dmResource::ResourceRecreateParams& params)
     {
         ResTextureReCreateParams* recreate_params = (ResTextureReCreateParams*)params.m_Message;
-
-        dmGraphics::TextureImage* texture_image = (dmGraphics::TextureImage*) recreate_params->m_TextureImage; //params.m_Message;
-        if( !texture_image )
+        dmGraphics::TextureImage* texture_image = 0x0;
+        if (recreate_params)
+        {
+            texture_image = (dmGraphics::TextureImage*) recreate_params->m_TextureImage;
+        }
+        if(!texture_image)
         {
             dmDDF::Result e = dmDDF::LoadMessage<dmGraphics::TextureImage>(params.m_Buffer, params.m_BufferSize, (&texture_image));
             if ( e != dmDDF::RESULT_OK )
@@ -373,9 +376,12 @@ namespace dmGameSystem
         // Note that the image desc for performance reasons keeps references to the DDF image, meaning they're invalid after the DDF message has been free'd!
         ImageDesc* image_desc = CreateImage(params.m_Filename, (dmGraphics::HContext) params.m_Context, texture_image);
 
-        image_desc->m_RegionUpdateX = recreate_params->m_X;
-        image_desc->m_RegionUpdateY = recreate_params->m_Y;
-        image_desc->m_MipMap        = recreate_params->m_MipMap;
+        if (recreate_params)
+        {
+            image_desc->m_RegionUpdateX = recreate_params->m_X;
+            image_desc->m_RegionUpdateY = recreate_params->m_Y;
+            image_desc->m_MipMap        = recreate_params->m_MipMap;
+        }
 
         // Set up the new texture (version), wait for it to finish before issuing new requests
         SynchronizeTexture(texture, true);

--- a/engine/gamesys/src/gamesys/resources/res_texture.h
+++ b/engine/gamesys/src/gamesys/resources/res_texture.h
@@ -20,13 +20,20 @@
 
 namespace dmGameSystem
 {
-    struct ResTextureReCreateParams
+    struct ResTextureUploadParams
     {
-        void*    m_TextureImage;
         uint16_t m_X;
         uint16_t m_Y;
-        uint8_t  m_MipMap    : 7;
-        uint8_t  m_SubUpdate : 1;
+        uint8_t  m_MipMap               : 5;
+        uint8_t  m_UploadSpecificMipmap : 1;
+        uint8_t  m_SubUpdate            : 1;
+        uint8_t                         : 1;
+    };
+
+    struct ResTextureReCreateParams
+    {
+        void*                  m_TextureImage;
+        ResTextureUploadParams m_UploadParams;
     };
 
     dmResource::Result ResTexturePreload(const dmResource::ResourcePreloadParams& params);

--- a/engine/gamesys/src/gamesys/resources/res_texture.h
+++ b/engine/gamesys/src/gamesys/resources/res_texture.h
@@ -20,6 +20,14 @@
 
 namespace dmGameSystem
 {
+    struct ResTextureReCreateParams
+    {
+        void*    m_TextureImage;
+        uint16_t m_X;
+        uint16_t m_Y;
+        uint8_t  m_MipMap;
+    };
+
     dmResource::Result ResTexturePreload(const dmResource::ResourcePreloadParams& params);
 
     dmResource::Result ResTextureCreate(const dmResource::ResourceCreateParams& params);

--- a/engine/gamesys/src/gamesys/resources/res_texture.h
+++ b/engine/gamesys/src/gamesys/resources/res_texture.h
@@ -25,7 +25,8 @@ namespace dmGameSystem
         void*    m_TextureImage;
         uint16_t m_X;
         uint16_t m_Y;
-        uint8_t  m_MipMap;
+        uint8_t  m_MipMap    : 7;
+        uint8_t  m_SubUpdate : 1;
     };
 
     dmResource::Result ResTexturePreload(const dmResource::ResourcePreloadParams& params);

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -473,6 +473,7 @@ static int GraphicsTextureTypeToImageType(int texturetype)
  * : [type:number] The texture type. Supported values:
  *
  * - `resource.TEXTURE_TYPE_2D`
+ * - `resource.TEXTURE_TYPE_CUBE_MAP`
  *
  * `width`
  * : [type:number] The width of the texture (in pixels)
@@ -487,9 +488,18 @@ static int GraphicsTextureTypeToImageType(int texturetype)
  * - `resource.TEXTURE_FORMAT_RGB`
  * - `resource.TEXTURE_FORMAT_RGBA`
  *
+ * `x`
+ * : [type:number] optional x offset of the texture (in pixels)
+ *
+ * `y`
+ * : [type:number] optional y offset of the texture (in pixels)
+ *
+ * `mipmap`
+ * : [type:number] optional mipmap to upload the data to
+ *
  * @param buffer [type:buffer] The buffer of precreated pixel data
  *
- * [icon:attention] Currently, only 1 mipmap is generated.
+ * [icon:attention] To update a cube map texture you need to pass in six times the amount of data via the buffer, since a cube map has six sides!
  *
  * @examples
  * How to set all pixels of an atlas
@@ -509,9 +519,36 @@ static int GraphicsTextureTypeToImageType(int texturetype)
  *           self.stream[index + 2] = 0x10
  *       end
  *   end
-
+ *
  *   local resource_path = go.get("#sprite", "texture0")
  *   local header = { width=self.width, height=self.height, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGB, num_mip_maps=1 }
+ *   resource.set_texture( resource_path, header, self.buffer )
+ * end
+ * ```
+ *
+ * @examples
+ * How to update a specific region of an atlas by using the x,y values. Assumes the already set atlas is a 128x128 texture.
+ *
+ * ```lua
+ * function init(self)
+ *   self.x = 16
+ *   self.y = 16
+ *   self.height = 128 - self.x * 2
+ *   self.width = 128 - self.y * 2
+ *   self.buffer = buffer.create(self.width * self.height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+ *   self.stream = buffer.get_stream(self.buffer, hash("rgb"))
+ *
+ *   for y=1,self.height do
+ *       for x=1,self.width do
+ *           local index = (y-1) * self.width * 3 + (x-1) * 3 + 1
+ *           self.stream[index + 0] = 0xff
+ *           self.stream[index + 1] = 0x80
+ *           self.stream[index + 2] = 0x10
+ *       end
+ *   end
+ *
+ *   local resource_path = go.get("#sprite", "texture0")
+ *   local header = { width=self.width, height=self.height, x=self.x, y=self.y, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGB, num_mip_maps=1 }
  *   resource.set_texture( resource_path, header, self.buffer )
  * end
  * ```
@@ -922,6 +959,12 @@ static const luaL_reg Module_methods[] =
 /*# 2D texture type
  *
  * @name resource.TEXTURE_TYPE_2D
+ * @variable
+ */
+
+/*# Cube map texture type
+ *
+ * @name resource.TEXTURE_TYPE_CUBE_MAP
  * @variable
  */
 

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -521,8 +521,8 @@ static int GraphicsTextureTypeToImageType(int texturetype)
  *   end
  *
  *   local resource_path = go.get("#sprite", "texture0")
- *   local header = { width=self.width, height=self.height, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGB, num_mip_maps=1 }
- *   resource.set_texture( resource_path, header, self.buffer )
+ *   local args = { width=self.width, height=self.height, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGB, num_mip_maps=1 }
+ *   resource.set_texture( resource_path, args, self.buffer )
  * end
  * ```
  *
@@ -548,8 +548,8 @@ static int GraphicsTextureTypeToImageType(int texturetype)
  *   end
  *
  *   local resource_path = go.get("#sprite", "texture0")
- *   local header = { width=self.width, height=self.height, x=self.x, y=self.y, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGB, num_mip_maps=1 }
- *   resource.set_texture( resource_path, header, self.buffer )
+ *   local args = { width=self.width, height=self.height, x=self.x, y=self.y, type=resource.TEXTURE_TYPE_2D, format=resource.TEXTURE_FORMAT_RGB, num_mip_maps=1 }
+ *   resource.set_texture( resource_path, args, self.buffer )
  * end
  * ```
  */
@@ -607,10 +607,13 @@ static int SetTexture(lua_State* L)
 
     ResTextureReCreateParams recreate_params;
     recreate_params.m_TextureImage = &texture_image;
-    recreate_params.m_X            = x;
-    recreate_params.m_Y            = y;
-    recreate_params.m_MipMap       = mipmap;
-    recreate_params.m_SubUpdate    = sub_update;
+
+    ResTextureUploadParams& upload_params = recreate_params.m_UploadParams;
+    upload_params.m_X                     = x;
+    upload_params.m_Y                     = y;
+    upload_params.m_MipMap                = mipmap;
+    upload_params.m_SubUpdate             = sub_update;
+    upload_params.m_UploadSpecificMipmap  = 1;
 
     dmResource::Result r = dmResource::SetResource(g_ResourceModule.m_Factory, path_hash, (void*) &recreate_params);
 

--- a/engine/gamesys/src/gamesys/test/resource/set_texture.go
+++ b/engine/gamesys/src/gamesys/test/resource/set_texture.go
@@ -1,0 +1,9 @@
+components {
+  id: "set_texture_go"
+  component: "/resource/set_texture.script"
+}
+
+components {
+  id: "sprite"
+  component: "/resource/sprite.sprite"
+}

--- a/engine/gamesys/src/gamesys/test/resource/set_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/set_texture.script
@@ -16,7 +16,7 @@ function init(self)
 	self.update_counter = 0
 end
 
--- tile_set of sprite is 84 x 67
+-- oridinal dimensions of the sprite is 84 x 67, but it gets downsized to 64 x 64
 local function test_success_simple(self)
 	local x             = 16
 	local y             = 16

--- a/engine/gamesys/src/gamesys/test/resource/set_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/set_texture.script
@@ -1,0 +1,97 @@
+-- Copyright 2020-2022 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function init(self)
+	self.update_counter = 0
+end
+
+-- tile_set of sprite is 84 x 67
+local function test_success_simple(self)
+	local x             = 16
+	local y             = 16
+	local height        = 32
+	local width         = 32
+	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+	local resource_path = go.get("#sprite", "texture0")
+	local header = {
+		width        = width,
+		height       = height,
+		type         = resource.TEXTURE_TYPE_2D,
+		format       = resource.TEXTURE_FORMAT_RGB,
+		x            = x,
+		y            = y,
+	}
+	resource.set_texture(resource_path, header, buf)
+end
+
+local function test_success_resize(self)
+	local height        = 256
+	local width         = 256
+	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+	local resource_path = go.get("#sprite", "texture0")
+	local header = {
+		width        = width,
+		height       = height,
+		type         = resource.TEXTURE_TYPE_2D,
+		format       = resource.TEXTURE_FORMAT_RGB,
+	}
+	resource.set_texture(resource_path, header, buf)
+end
+
+local function test_fail_out_of_bounds(self)
+	local x             = 256
+	local y             = 256
+	local height        = 32
+	local width         = 32
+	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+	local resource_path = go.get("#sprite", "texture0")
+	local header = {
+		width        = width,
+		height       = height,
+		type         = resource.TEXTURE_TYPE_2D,
+		format       = resource.TEXTURE_FORMAT_RGB,
+		x            = x,
+		y            = y,
+	}
+	resource.set_texture(resource_path, header, buf)
+end
+
+local function test_fail_wrong_mipmap(self)
+	local height        = 1
+	local width         = 1
+	local buf           = buffer.create(width * height, { {name=hash("rgb"), type=buffer.VALUE_TYPE_UINT8, count=3} } )
+	local resource_path = go.get("#sprite", "texture0")
+	local header = {
+		width        = width,
+		height       = height,
+		type         = resource.TEXTURE_TYPE_2D,
+		format       = resource.TEXTURE_FORMAT_RGB,
+		mipmap       = 128,
+	}
+	resource.set_texture(resource_path, header, buf)
+end
+
+function update(self, dt)
+	if self.update_counter == 0 then
+		test_success_simple(self)
+	elseif self.update_counter == 1 then
+		test_success_resize(self)
+	elseif self.update_counter == 2 then
+		test_fail_out_of_bounds(self)
+	elseif self.update_counter == 2 then
+		test_fail_wrong_mipmap(self)
+	end
+
+	self.update_counter = self.update_counter + 1
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -193,6 +193,63 @@ TEST_F(ResourceTest, TestReloadTextureSet)
     dmResource::Release(m_Factory, (void**) resource);
 }
 
+TEST_F(ResourceTest, TestSetTextureFromScript)
+{
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory    = m_Factory;
+    scriptlibcontext.m_Register   = m_Register;
+    scriptlibcontext.m_LuaState   = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    // Spawn the game object with the script we want to call
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/resource/set_texture.goc", dmHashString64("/set_texture"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    dmGameSystem::TextureSetResource* texture_set_res = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/tile/valid.t.texturesetc", (void**) &texture_set_res));
+
+    dmGraphics::HTexture backing_texture = texture_set_res->m_Texture;
+    ASSERT_EQ(dmGraphics::GetTextureWidth(backing_texture), 64);
+    ASSERT_EQ(dmGraphics::GetTextureHeight(backing_texture), 64);
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Test 1: Update a sub-region of the texture
+    //      -> set_texture.script::test_success_simple
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Test 2: Update the entire texture, should be 256x256 after the call
+    //      -> set_texture.script::test_success_resize
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_EQ(dmGraphics::GetTextureWidth(backing_texture), 256);
+    ASSERT_EQ(dmGraphics::GetTextureHeight(backing_texture), 256);
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Test 3: Try doing a region update, but outside the texture boundaries, which should fail 
+    //      -> set_texture.script::test_fail_out_of_bounds
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    ASSERT_FALSE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Test 4: Try updating the texture with a mipmap that's outside of the allowed range
+    //      -> set_texture.script::test_fail_wrong_mipmap
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    ASSERT_FALSE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    // cleanup
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 TEST_P(ResourceFailTest, Test)
 {
     const ResourceFailParams& p = GetParam();

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -25,6 +25,7 @@
 DM_PROPERTY_GROUP(rmtp_Graphics, "Graphics");
 DM_PROPERTY_U32(rmtp_DrawCalls, 0, FrameReset, "# vertices", &rmtp_Graphics);
 
+#include <dlib/math.h> // Max/Min
 #include <dlib/log.h>
 #include <dlib/dstrings.h>
 
@@ -304,6 +305,21 @@ namespace dmGraphics
             default:
                 return false;
         }
+    }
+
+    uint16_t GetMipmapSize(uint16_t size_0, uint8_t mipmap)
+    {
+        for (uint32_t i = 0; i < mipmap; ++i)
+        {
+            size_0 /= 2;
+        }
+        return size_0;
+    }
+
+    uint8_t GetMipmapCount(uint16_t width, uint16_t height)
+    {
+        uint16_t dim = dmMath::Max(width, height);
+        return (uint8_t) floor(log2f(dim)) + 1;
     }
 
     PipelineState GetDefaultPipelineState()

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -25,7 +25,6 @@
 DM_PROPERTY_GROUP(rmtp_Graphics, "Graphics");
 DM_PROPERTY_U32(rmtp_DrawCalls, 0, FrameReset, "# vertices", &rmtp_Graphics);
 
-#include <dlib/math.h> // Max/Min
 #include <dlib/log.h>
 #include <dlib/dstrings.h>
 
@@ -316,10 +315,9 @@ namespace dmGraphics
         return size_0;
     }
 
-    uint8_t GetMipmapCount(uint16_t width, uint16_t height)
+    uint8_t GetMipmapCount(uint16_t size)
     {
-        uint16_t dim = dmMath::Max(width, height);
-        return (uint8_t) floor(log2f(dim)) + 1;
+        return (uint8_t) floor(log2f(size)) + 1;
     }
 
     PipelineState GetDefaultPipelineState()

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -610,7 +610,7 @@ namespace dmGraphics
     void DisableTexture(HContext context, uint32_t unit, HTexture texture);
     uint32_t GetMaxTextureSize(HContext context);
     uint16_t GetMipmapSize(uint16_t size_0, uint8_t mipmap);
-    uint8_t GetMipmapCount(uint16_t width, uint16_t height);
+    uint8_t GetMipmapCount(uint16_t size);
 
     /**
      * Get status of texture.

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -609,6 +609,8 @@ namespace dmGraphics
     void EnableTexture(HContext context, uint32_t unit, HTexture texture);
     void DisableTexture(HContext context, uint32_t unit, HTexture texture);
     uint32_t GetMaxTextureSize(HContext context);
+    uint16_t GetMipmapSize(uint16_t size_0, uint8_t mipmap);
+    uint8_t GetMipmapCount(uint16_t width, uint16_t height);
 
     /**
      * Get status of texture.

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1116,6 +1116,13 @@ namespace dmGraphics
         if (params.m_Data != 0x0)
             memcpy(texture->m_Data, params.m_Data, params.m_DataSize);
         texture->m_MipMapCount = dmMath::Max(texture->m_MipMapCount, (uint16_t)(params.m_MipMap+1));
+
+        // The width/height of the texture can change from this function as well
+        if (!params.m_SubUpdate && params.m_MipMap == 0)
+        {
+            texture->m_Width  = params.m_Width;
+            texture->m_Height = params.m_Height;
+        }
     }
 
     // Not used?

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3285,7 +3285,16 @@ bail:
             if (texture->m_Format != vk_format || texture->m_Width != params.m_Width || texture->m_Height != params.m_Height)
             {
                 DestroyResourceDeferred(g_VulkanContext->m_MainResourcesToDestroy[g_VulkanContext->m_SwapChain->m_ImageIndex], texture);
-                texture->m_Format = vk_format;
+                texture->m_Format      = vk_format;
+                texture->m_Width       = params.m_Width;
+                texture->m_Height      = params.m_Height;
+
+                // If the texture has requested mipmaps and we need to recreate the texture, make sure to allocate enough mipmaps
+                // JG: Might want to go back to this part and recreate if mipmap count has changed from when the texture was originally created
+                if (texture->m_MipMapCount > 1)
+                {
+                    texture->m_MipMapCount = (uint16_t) GetMipmapCount(texture->m_Width, texture->m_Height);
+                }
             }
         }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3293,7 +3293,7 @@ bail:
                 // JG: Might want to go back to this part and recreate if mipmap count has changed from when the texture was originally created
                 if (texture->m_MipMapCount > 1)
                 {
-                    texture->m_MipMapCount = (uint16_t) GetMipmapCount(texture->m_Width, texture->m_Height);
+                    texture->m_MipMapCount = (uint16_t) GetMipmapCount(dmMath::Max(texture->m_Width, texture->m_Height));
                 }
             }
         }


### PR DESCRIPTION
Added new functionality to the resource.set_texture function - you can now update a specific region of the texture as well as update only a specific mipmap with new data. This is done by setting the new "table" argument values:

```
local header = {
	width = ...,
	height = ...,
	type = ...,
	format = ...,
	x = number, -- New field
	y = number, -- New field
	mipmap = number, -- New field
}
```

Fixes #7123 

## PR checklist (remove before merging)

* [x] Prepared the PR for release notes
	* [x] Proper description of feature or fix (see example x?)
	* [x] Added a #fixes ### if it fixes an issue
	* [x] Assigned issue to a project
* [x] Added documentation for public API changes
* [x] Is this a new feature?
	* [x] Added engine and/or editor unit tests
	* [ ] ~~Added or updated manual entry~~
