### PR TITLE
Metadata mechanism for buffer (#6455)

### DIFF
--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -19,7 +19,7 @@
 #include <dlib/log.h>
 #include <dlib/memory.h>
 #include <dlib/math.h>
-#include <dmsdk/dlib/vmath.h> // for Point3
+#include <dmsdk/dlib/vmath.h>
 #include <dlib/array.h>
 
 #include <string.h>
@@ -667,7 +667,7 @@ namespace dmBuffer
         }
 
         *count = item->m_ValueCount;
-        *type = (ValueType)item->m_ValueType; // assumes item->m_ValueType is properly initialized when setting the metadata
+        *type = (ValueType)item->m_ValueType;
         *data = item->m_Data;
 
         return RESULT_OK;
@@ -696,11 +696,10 @@ namespace dmBuffer
             if (metadata_items.Full()) {
                 metadata_items.OffsetCapacity(2);
             }
-            // assume OffsetCapacity(2) worked
             item = (Buffer::MetaData*) malloc(sizeof(Buffer::MetaData));
             item->m_Name = name_hash;
-            item->m_ValueCount = count; // no restriction in max number of values
-            item->m_ValueType = type; // no validation, all ValueTypes do
+            item->m_ValueCount = count;
+            item->m_ValueType = type;
             item->m_Data = malloc(values_block_size);
             memcpy(item->m_Data, data, values_block_size);
             metadata_items.Push(item);

--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -169,9 +169,7 @@ namespace dmBuffer
 
         for (uint32_t i=0; i<buffer->m_MetaDataArray.Size(); i++) {
             Buffer::MetaData* metadata = buffer->m_MetaDataArray[i];
-            if (metadata->m_Data) {
-                free(metadata->m_Data);
-            }
+            free(metadata->m_Data);
             free(metadata);
         }
         buffer->m_MetaDataArray.SetSize(0);

--- a/engine/dlib/src/dlib/buffer.cpp
+++ b/engine/dlib/src/dlib/buffer.cpp
@@ -13,11 +13,15 @@
 // specific language governing permissions and limitations under the License.
 
 
+#include "array.h"
+#include "hash.h"
 #include <dmsdk/dlib/buffer.h>
 
 #include <dlib/log.h>
 #include <dlib/memory.h>
 #include <dlib/math.h>
+#include <dmsdk/dlib/vmath.h> // for Point3
+#include <dlib/array.h>
 
 #include <string.h>
 #include <assert.h>
@@ -49,6 +53,14 @@ namespace dmBuffer
             uint8_t     m_ValueCount;
         };
 
+        struct MetaData
+        {
+            dmhash_t    m_Name;
+            uint8_t     m_ValueType;
+            uint8_t     m_ValueCount;
+            void*       m_Data;
+        };
+
         void*    m_Data;            // All stream data, including guard bytes after each stream and 16 byte aligned.
         Stream*  m_Streams;
         uint32_t m_Stride;          // The struct size (in bytes)
@@ -56,6 +68,8 @@ namespace dmBuffer
         uint16_t m_Version;
         uint16_t m_ContentVersion;  // A running number, which user can use to signal content changes
         uint8_t  m_NumStreams;
+        dmArray<MetaData*> m_MetaDataArray;
+
     };
 
     struct BufferContext
@@ -151,6 +165,18 @@ namespace dmBuffer
         return version << 16 | index;
     }
 
+    static void FreeMetadata(Buffer* buffer) {
+
+        for (uint32_t i=0; i<buffer->m_MetaDataArray.Size(); i++) {
+            Buffer::MetaData* metadata = buffer->m_MetaDataArray[i];
+            if (metadata->m_Data) {
+                free(metadata->m_Data);
+            }
+            free(metadata);
+        }
+        buffer->m_MetaDataArray.SetSize(0);
+    }
+
     static void FreeBuffer(BufferContext* ctx, HBuffer hbuffer)
     {
         uint16_t version = hbuffer >> 16;
@@ -160,6 +186,8 @@ namespace dmBuffer
             dmLogError("Stale buffer handle when freeing buffer");
             return;
         }
+        FreeMetadata(b);
+
         ctx->m_Buffers[hbuffer & 0xffff] = 0;
         dmMemory::AlignedFree(b);
     }
@@ -614,6 +642,119 @@ namespace dmBuffer
             return RESULT_BUFFER_INVALID;
         }
         buffer->m_ContentVersion++;
+        return RESULT_OK;
+    }
+
+    // Returns a pointer to the metadata item or 0 if not found.  Assumes buffer is valid.
+    Buffer::MetaData* FindMetaDataItem(Buffer* buffer, dmhash_t name_hash) {
+        dmArray<Buffer::MetaData*>& arr = buffer->m_MetaDataArray;
+        for (uint32_t  i=0; i<arr.Size(); i++) {
+            if (arr[i]->m_Name == name_hash) {
+                return arr[i];
+            }
+        }
+        return 0; // nothing found
+    }
+
+
+    Result GetMetaData(HBuffer hbuffer, dmhash_t name_hash, void** data, uint32_t* count, ValueType* type) {
+        Buffer* buffer = GetBuffer(g_BufferContext, hbuffer);
+        if (!buffer) {
+            return RESULT_BUFFER_INVALID;
+        }
+
+        Buffer::MetaData* item = FindMetaDataItem(buffer, name_hash);
+        if (!item) {
+            return RESULT_METADATA_NOT_EXIST;
+        }
+
+        *count = item->m_ValueCount;
+        *type = (ValueType)item->m_ValueType; // assumes value tpe is sanitized when setting the metadata
+        *data = item->m_Data;
+
+        return RESULT_OK;
+    }
+
+    Result SetMetaData(HBuffer hbuffer, dmhash_t name_hash, const void* data, uint32_t count, ValueType type) {
+        Buffer* buffer = GetBuffer(g_BufferContext, hbuffer);
+        if (!buffer) {
+            return RESULT_BUFFER_INVALID;
+        }
+        if (count == 0) {
+            return RESULT_METADATA_INVALID;
+        }
+
+        Buffer::MetaData* item = FindMetaDataItem(buffer, name_hash);
+        uint32_t values_block_size = GetSizeForValueType(type)*count; // do this once
+        if (item) {
+            // make sure the type and value count is right
+            if (item->m_ValueCount != count || item->m_ValueType != type) {
+                return RESULT_METADATA_INVALID; // TODO use a proper error status hsere
+            }
+            memcpy(item->m_Data, data, values_block_size);
+        } else {
+            dmArray<Buffer::MetaData*>& metadata_items = buffer->m_MetaDataArray;
+            if (metadata_items.Remaining() <= 0) {
+                metadata_items.OffsetCapacity(2); // TODO - shall we set an upper limit to the number of meta data entries ?
+            }
+            if (metadata_items.Remaining() > 0) {
+                item = (Buffer::MetaData*) malloc(sizeof(Buffer::MetaData));
+                item->m_Name = name_hash;
+                item->m_ValueCount = count; // no restriction in max number of values
+                item->m_ValueType = type; // no validation, all ValueTypes do
+                item->m_Data = malloc(values_block_size);
+                memcpy(item->m_Data, data, values_block_size);
+                metadata_items.Push(item);
+            } else {
+                return RESULT_ALLOCATION_ERROR;
+            }
+        }
+
+        return RESULT_OK;
+    }
+
+    Result SetBounds(HBuffer hbuffer, const dmVMath::Point3& min, const dmVMath::Point3& max) {
+        Buffer* buffer = GetBuffer(g_BufferContext, hbuffer);
+        if (!buffer) {
+            return RESULT_BUFFER_INVALID;
+        }
+
+        Result r = SetMetaData(hbuffer, dmHashString64("min_aabb"), &min, 3, VALUE_TYPE_FLOAT32);
+        if (r != RESULT_OK) {
+            return r;
+        }
+        r = SetMetaData(hbuffer, dmHashString64("max_aabb"), &max, 3, VALUE_TYPE_FLOAT32);
+        if (r != RESULT_OK) {
+            return r;
+        }
+
+        return RESULT_OK;
+    }
+
+    Result GetBounds(HBuffer hbuffer, dmVMath::Point3& min, dmVMath::Point3& max) {
+        Buffer* buffer = GetBuffer(g_BufferContext, hbuffer);
+        if (!buffer) {
+            return RESULT_BUFFER_INVALID;
+        }
+
+        float* floats_p;
+        uint32_t value_count;
+        ValueType value_type;
+
+        Result r = GetMetaData(hbuffer, dmHashString64("min_aabb"), (void**) &floats_p, &value_count, &value_type);
+        if (r != RESULT_OK) {
+            return r;
+        }
+        assert(value_count == 3 && "metadata 'min_aabb' should have 3 values");
+        assert(value_type == VALUE_TYPE_FLOAT32 && "metadata 'min_aabb' should be floats");
+        min = dmVMath::Point3(floats_p[0], floats_p[1], floats_p[2]);
+
+        r = GetMetaData(hbuffer, dmHashString64("max_aabb"), (void**) &floats_p, &value_count, &value_type);
+        if (r != RESULT_OK) {
+            return r;
+        }
+        max = dmVMath::Point3(floats_p[0], floats_p[1], floats_p[2]);
+
         return RESULT_OK;
     }
 }

--- a/engine/dlib/src/dlib/buffer.h
+++ b/engine/dlib/src/dlib/buffer.h
@@ -74,10 +74,6 @@ Result GetStreamOffset(HBuffer buffer, uint32_t index, uint32_t* offset);
 
 Result CalcStructSize(uint32_t num_streams, const StreamDeclaration* streams, uint32_t* size, uint32_t* offsets);
 
-Result SetMetaData(HBuffer hbuffer, dmhash_t name_hash, const void* data, uint32_t count, ValueType type);
-
-Result GetMetaData(HBuffer hbuffer, dmhash_t name_hash, void** data, uint32_t* count, ValueType* type);
-
 }
 
 #endif

--- a/engine/dlib/src/dlib/buffer.h
+++ b/engine/dlib/src/dlib/buffer.h
@@ -74,6 +74,10 @@ Result GetStreamOffset(HBuffer buffer, uint32_t index, uint32_t* offset);
 
 Result CalcStructSize(uint32_t num_streams, const StreamDeclaration* streams, uint32_t* size, uint32_t* offsets);
 
+Result SetMetaData(HBuffer hbuffer, dmhash_t name_hash, const void* data, uint32_t count, ValueType type);
+
+Result GetMetaData(HBuffer hbuffer, dmhash_t name_hash, void** data, uint32_t* count, ValueType* type);
+
 }
 
 #endif

--- a/engine/dlib/src/dmsdk/dlib/buffer.h
+++ b/engine/dlib/src/dmsdk/dlib/buffer.h
@@ -399,9 +399,34 @@ namespace dmBuffer
      */
     Result UpdateContentVersion(HBuffer hbuffer);
 
-    Result SetBounds(HBuffer hbuffer, const dmVMath::Point3& min, const dmVMath::Point3& max);
+    /*# set a metadata entry
+     *
+     * Create or update a new metadata entry with a number of values of a specific type.
+     * It will allocate space to store these values.
+     *
+     * @name dmBuffer::SetMetaData
+     * @param hbuffer [type:dmBuffer::HBuffer] A buffer handle
+     * @param name_hash [type:dmhash_t] The entry name as a hash
+     * @param data [type:void*] A pointer to an array of the values
+     * @param count [type:uint32_t] Number of values in the array
+     * @param type [type:dmBuffer::ValueType] The type of the values
+     * @return result [type:dmBuffer::Result] RESULT_OK if the metadata entry was successfully stored
+     */
+    Result SetMetaData(HBuffer hbuffer, dmhash_t name_hash, const void* data, uint32_t count, ValueType type);
 
-    Result GetBounds(HBuffer hbuffer, dmVMath::Point3& min, dmVMath::Point3& max);
+    /*# retrieve a metadata entry
+     *
+     * Retrieve metadata entry information
+     *
+     * @name dmBuffer::GetMetaData
+     * @param hbuffer [type:dmBuffer::HBuffer] A buffer handle
+     * @param name_hash [type:dmhash_t] The entry name as a hash
+     * @param data [type:void**] Gets the internal address of metadata values
+     * @param count [type:uint32_t] Gets the number of metadata values stored
+     * @param type [type:dmBuffer::ValueType] Gets the type of values of the metadata
+     */
+    Result GetMetaData(HBuffer hbuffer, dmhash_t name_hash, void** data, uint32_t* count, ValueType* type);
+
 }
 
 #endif // DMSDK_BUFFER_H

--- a/engine/dlib/src/dmsdk/dlib/buffer.h
+++ b/engine/dlib/src/dmsdk/dlib/buffer.h
@@ -19,7 +19,6 @@
 
 #include "hash.h"
 #include "align.h"
-#include <dmsdk/dlib/vmath.h>  // for Point3
 
 namespace dmBuffer
 {

--- a/engine/dlib/src/dmsdk/dlib/buffer.h
+++ b/engine/dlib/src/dmsdk/dlib/buffer.h
@@ -19,6 +19,7 @@
 
 #include "hash.h"
 #include "align.h"
+#include <dmsdk/dlib/vmath.h>  // for Point3
 
 namespace dmBuffer
 {
@@ -105,6 +106,8 @@ namespace dmBuffer
         RESULT_STREAM_TYPE_MISMATCH,
         RESULT_STREAM_COUNT_MISMATCH,
         RESULT_STREAM_MISMATCH,
+        RESULT_METADATA_INVALID,
+        RESULT_METADATA_NOT_EXIST,
     };
 
     /*# StreamDeclaration struct
@@ -395,6 +398,10 @@ namespace dmBuffer
      * @return result [type:dmBuffer::Result] Returns BUFFER_OK if all went ok
      */
     Result UpdateContentVersion(HBuffer hbuffer);
+
+    Result SetBounds(HBuffer hbuffer, const dmVMath::Point3& min, const dmVMath::Point3& max);
+
+    Result GetBounds(HBuffer hbuffer, dmVMath::Point3& min, dmVMath::Point3& max);
 }
 
 #endif // DMSDK_BUFFER_H

--- a/engine/dlib/src/test/test_buffer.cpp
+++ b/engine/dlib/src/test/test_buffer.cpp
@@ -33,6 +33,27 @@ class BufferTest : public jc_test_base_class
     }
 };
 
+class MetaDataTest : public jc_test_base_class
+{
+public:
+    dmBuffer::HBuffer buffer;
+protected:
+    virtual void SetUp() {
+        dmBuffer::NewContext();
+
+        dmBuffer::StreamDeclaration streams_decl[] = {
+            {dmHashString64("position"), dmBuffer::VALUE_TYPE_UINT8, 3},
+            {dmHashString64("texcoord"), dmBuffer::VALUE_TYPE_UINT8, 1}
+        };
+        dmBuffer::Create(4, streams_decl, 2, &buffer);
+    }
+
+    virtual void TearDown() {
+        dmBuffer::Destroy(buffer);
+        dmBuffer::DeleteContext();
+    }
+};
+
 class GetDataTest : public jc_test_base_class
 {
 public:
@@ -217,41 +238,67 @@ TEST_F(BufferTest, ValidateBuffer)
     dmBuffer::Destroy(buffer);
 }
 
-TEST_F(BufferTest, MetaData)
+TEST_F(MetaDataTest, WrongParams)
 {
-    dmBuffer::HBuffer buffer = 0x0;
-    dmBuffer::StreamDeclaration streams_decl[] = {
-        {dmHashString64("position"), dmBuffer::VALUE_TYPE_UINT8, 3},
-        {dmHashString64("texcoord"), dmBuffer::VALUE_TYPE_UINT8, 1}
-    };
-    dmBuffer::Result r = dmBuffer::Create(4, streams_decl, 2, &buffer);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-
     float min_aabb[] = {-1.0f, -2.0f, -3.0f};
-    float max_aabb[] = {1.0f, 2.0f, 3.0f};
 
     // zero buffer
-    r = dmBuffer::SetMetaData(0, dmHashString64("min_AABB"), min_aabb, 3, dmBuffer::VALUE_TYPE_FLOAT32);
+    dmBuffer::Result r = dmBuffer::SetMetaData(0, dmHashString64("min_AABB"), min_aabb, 3, dmBuffer::VALUE_TYPE_FLOAT32);
     ASSERT_EQ(dmBuffer::RESULT_BUFFER_INVALID, r);
 
     // count == 0
     r = dmBuffer::SetMetaData(buffer, dmHashString64("min_AABB"), min_aabb, 0, dmBuffer::VALUE_TYPE_FLOAT32);
     ASSERT_EQ(dmBuffer::RESULT_METADATA_INVALID, r);
 
+}
+
+template <typename T>
+void verifyMetadataByType(dmBuffer::HBuffer buffer, const char* name, T value1, T value2, T value3, dmBuffer::ValueType value_type) {
+    T values[3] = {value1, value2, value3};
+    T* verify_data;
+    uint32_t verify_count;
+    dmBuffer::ValueType verify_type;
+
+    // generic set & get
+    dmBuffer::Result r = dmBuffer::SetMetaData(buffer, dmHashString64(name), values, 3, value_type);
+    ASSERT_EQ(dmBuffer::RESULT_OK, r);
+    r = dmBuffer::GetMetaData(buffer, dmHashString64(name), (void**)&verify_data, &verify_count, &verify_type);
+    ASSERT_EQ(dmBuffer::RESULT_OK, r);
+    ASSERT_EQ(value1, verify_data[0]);
+    ASSERT_EQ(value2, verify_data[1]);
+    ASSERT_EQ(value3, verify_data[2]);
+    ASSERT_EQ(3, verify_count);
+    ASSERT_EQ(value_type, verify_type);
+}
+
+TEST_F(MetaDataTest, DifferentDataTypes)
+{
+    verifyMetadataByType<float>(buffer, "float32_values", 1.0f, 2.0f, 3.0f, dmBuffer::VALUE_TYPE_FLOAT32);
+
+    verifyMetadataByType<uint8_t>(buffer, "uint8_values", 1, 2, 3, dmBuffer::VALUE_TYPE_UINT8);
+    verifyMetadataByType<uint16_t>(buffer, "uint16_values", 257, 258, 259, dmBuffer::VALUE_TYPE_UINT16);
+    verifyMetadataByType<uint32_t>(buffer, "uint32_values", 65537, 65538, 65539, dmBuffer::VALUE_TYPE_UINT32);
+    verifyMetadataByType<uint64_t>(buffer, "uint64_values", 1, 2, 3, dmBuffer::VALUE_TYPE_UINT64);
+
+    verifyMetadataByType<int8_t>(buffer, "int8_values", -1, -2, -3, dmBuffer::VALUE_TYPE_INT8);
+    verifyMetadataByType<int16_t>(buffer, "int16_values", -257, -258, -259, dmBuffer::VALUE_TYPE_INT16);
+    verifyMetadataByType<int32_t>(buffer, "int32_values", -65537, -65538, -65539, dmBuffer::VALUE_TYPE_INT32);
+    verifyMetadataByType<int64_t>(buffer, "int64_values", -1, -2, -3, dmBuffer::VALUE_TYPE_INT64);
+}
+
+TEST_F(MetaDataTest, MultipleItems)
+{
+    float min_aabb[] = {-1.0f, -2.0f, -3.0f};
+    float max_aabb[] = {1.0f, 2.0f, 3.0f};
     float* verify_data;
     uint32_t verify_count;
     dmBuffer::ValueType verify_type;
 
-    // set & get
-    r = dmBuffer::SetMetaData(buffer, dmHashString64("min_AABB"), min_aabb, 3, dmBuffer::VALUE_TYPE_FLOAT32);
+    // set first
+    dmBuffer::Result r = dmBuffer::SetMetaData(buffer, dmHashString64("min_AABB"), min_aabb, 3, dmBuffer::VALUE_TYPE_FLOAT32);
     ASSERT_EQ(dmBuffer::RESULT_OK, r);
-    r = dmBuffer::GetMetaData(buffer, dmHashString64("min_AABB"), (void**)&verify_data, &verify_count, &verify_type);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-    ASSERT_EQ(-1.0f, verify_data[0]);
-    ASSERT_EQ(-2.0f, verify_data[1]);
-    ASSERT_EQ(-3.0f, verify_data[2]);
 
-    // second item
+    // set second and verify
     r = dmBuffer::SetMetaData(buffer, dmHashString64("max_AABB"), max_aabb, 3, dmBuffer::VALUE_TYPE_FLOAT32);
     ASSERT_EQ(dmBuffer::RESULT_OK, r);
     r = dmBuffer::GetMetaData(buffer, dmHashString64("max_AABB"), (void**)&verify_data, &verify_count, &verify_type);
@@ -259,6 +306,19 @@ TEST_F(BufferTest, MetaData)
     ASSERT_EQ(1.0f, verify_data[0]);
     ASSERT_EQ(2.0f, verify_data[1]);
     ASSERT_EQ(3.0f, verify_data[2]);
+}
+
+TEST_F(MetaDataTest, Update)
+{
+    float min_aabb[] = {-1.0f, -2.0f, -3.0f};
+    float max_aabb[] = {1.0f, 2.0f, 3.0f};
+    float* verify_data;
+    uint32_t verify_count;
+    dmBuffer::ValueType verify_type;
+
+    // set
+    dmBuffer::Result r = dmBuffer::SetMetaData(buffer, dmHashString64("min_AABB"), min_aabb, 3, dmBuffer::VALUE_TYPE_FLOAT32);
+    ASSERT_EQ(dmBuffer::RESULT_OK, r);
 
     // update
     float min_aabb2[] = {-10.0f, -20.0f, -30.0f};
@@ -277,63 +337,6 @@ TEST_F(BufferTest, MetaData)
     // update with wrong type
     r = dmBuffer::SetMetaData(buffer, dmHashString64("min_AABB"), min_aabb2, 3, dmBuffer::VALUE_TYPE_UINT32);
     ASSERT_EQ(dmBuffer::RESULT_METADATA_INVALID, r);
-
-    dmBuffer::Destroy(buffer);
-    buffer = 0;
-}
-
-TEST_F(BufferTest, BoundsMetadata)
-{
-    dmBuffer::HBuffer buffer = 0x0;
-    dmBuffer::StreamDeclaration streams_decl[] = {
-        {dmHashString64("position"), dmBuffer::VALUE_TYPE_UINT8, 3},
-        {dmHashString64("texcoord"), dmBuffer::VALUE_TYPE_UINT8, 1}
-    };
-    dmBuffer::Result r = dmBuffer::Create(4, streams_decl, 2, &buffer);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-
-    dmVMath::Point3 min_point( -1.0, -2.0, -3.0);
-    dmVMath::Point3 max_point( 1.0, 2.0, 3.0);
-
-    // set & get bounds
-    r = dmBuffer::SetBounds(buffer, min_point, max_point);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-
-    dmVMath::Point3 min_point2;
-    dmVMath::Point3 max_point2;
-    r = dmBuffer::GetBounds(buffer, min_point2, max_point2);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-
-    ASSERT_TRUE(min_point.getX() == min_point2.getX() &&
-                min_point.getY() == min_point2.getY() &&
-                min_point.getZ() == min_point2.getZ()
-                );
-    ASSERT_TRUE(max_point.getX() == max_point2.getX() &&
-                max_point.getY() == max_point2.getY() &&
-                max_point.getZ() == max_point2.getZ()
-                );
-
-    // update bounds
-    min_point = dmVMath::Point3(-2.0, -4.0, -6.0);
-    max_point = dmVMath::Point3(2.0, 4.0, 6.0);
-
-    r = dmBuffer::SetBounds(buffer, min_point, max_point);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-
-    r = dmBuffer::GetBounds(buffer, min_point2, max_point2);
-    ASSERT_EQ(dmBuffer::RESULT_OK, r);
-
-    ASSERT_TRUE(min_point.getX() == min_point2.getX() &&
-                min_point.getY() == min_point2.getY() &&
-                min_point.getZ() == min_point2.getZ()
-                );
-    ASSERT_TRUE(max_point.getX() == max_point2.getX() &&
-                max_point.getY() == max_point2.getY() &&
-                max_point.getZ() == max_point2.getZ()
-                );
-
-    dmBuffer::Destroy(buffer);
-    buffer = 0;
 }
 
 


### PR DESCRIPTION
Adds generic metadata mechanism to dmBuffer::Buffer 

* Get/SetMetadata() type of interface 
* Higher level Get/SetBounds() functions have also been added

part of #6455 