### PR TITLE
Add serialization nested depth limit to the debugger

### DIFF
--- a/editor/src/clj/editor/debugging/mobdebug.clj
+++ b/editor/src/clj/editor/debugging/mobdebug.clj
@@ -141,8 +141,9 @@
     (count (get refs value))))
 
 (defn- lua-ref->identity-string [ref structure-refs]
-  (let [lua-table (get structure-refs ref)]
-    (format "<%s>" (:string (meta lua-table)))))
+  (if-let [lua-table (get structure-refs ref)]
+    (format "<%s>" (:string (meta lua-table)))
+    (str "..." (:address ref))))
 
 (defn lua-value->identity-string
   "Returns string representing identity of a lua value. Does not show internal

--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -111,14 +111,15 @@ local function encode_as_primitive(val)
   return encoder(val)
 end
 
-local function collect_refs(val, refs)
+local function collect_refs(depth, val, refs)
   local t = type(val)
   if t == "table" then
-    if not refs[val] then
+    if depth < 100 and not refs[val] then
       refs[val] = val
+      local next_depth = depth + 1
       for k, v in pairs(val) do
-        collect_refs(k, refs)
-        collect_refs(v, refs)
+        collect_refs(next_depth, k, refs)
+        collect_refs(next_depth, v, refs)
       end
     end
   end
@@ -147,7 +148,7 @@ end
 
 local function encode_structure(val)
   local refs = {}
-  local encoded_refs = encode_refs(collect_refs(val, refs))
+  local encoded_refs = encode_refs(collect_refs(0, val, refs))
   return "#lua/structure{:value " .. encode_as_primitive(val) .. " :refs " .. encoded_refs .. "}"
 end
 


### PR DESCRIPTION
User-facing changes: debugger table serialization now has a nesting limit of 100 depth levels. Deeper tables will not be serialized and instead will be shown as e.g. `...0x0119a21230`. This also prevents stack overflow exceptions on breakpoints if very deeply nested structures (without circular references) are used.

Fixes #7088