### PR TITLE
Fix issue with long bytecode delta calculation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaBuilderTest.java
@@ -220,4 +220,53 @@ public class LuaBuilderTest extends AbstractProtoBuilderTest {
         assertTrue(luaSource.getBytecode64().size() == 0);
         assertTrue(luaSource.getDelta().size() > 0);
     }
+
+    @Test
+    public void testLuaBytecodeDeltaCalculation() throws Exception {
+        LuaBuilder builder = new LuaBuilder() {};
+
+        // create some mock bytecode
+        byte[] b32 = new byte[258];
+        byte[] b64 = new byte[258];
+        // byte 0 is the same
+        b32[0] = 5;
+        b64[0] = 5;
+        // bytes 1 to 256 are diffing
+        for (int i=1; i <= 256; i++) {
+            b32[i] = 99;
+            b64[i] = 66;
+        }
+        // byte 257 is the same
+        b32[257] = 11;
+        b64[257] = 11;
+
+        // construct the delta
+        byte[] delta = builder.constructBytecodeDelta(b64, b32);
+
+        // each diff consists of index (1-4 bytes), count (1 byte), bytes (count bytes)
+        // this means that each diff contains a maximum of 255 bytes
+
+        // the bytecode in this test is larger than 256 bytes byte but less than
+        // 65536 bytes which means that the index will use two bytes
+
+        // first diff is on byte 1-255
+        // index - diff is on the 2nd byte (0x0001)
+        assertTrue(delta[0] == 0x01);
+        assertTrue(delta[1] == 0x00);
+        // count - diff consists of 255 values
+        assertTrue((delta[2] & 0xff) == 255);
+        // byte - diffing bytes
+        for (int i = 1; i <= 255; i++) {
+            assertTrue(delta[2 + i] == 99);
+        }
+
+        // second diff is on byte 256
+        // index - diff is on the 256th byte (0x0100)
+        assertTrue(delta[258] == 0x00);
+        assertTrue(delta[259] == 0x01);
+        // count - diff consists of 1 value
+        assertTrue((delta[260] & 0xff) == 1);
+        // byte - the last diffing byte
+        assertTrue(delta[261] == 99);
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -289,6 +289,79 @@ public abstract class LuaBuilder extends Builder<Void> {
         return constructBytecode(task, source, inputFile, outputFile, options, env);
     }
 
+    public byte[] constructBytecodeDelta(byte[] bytecode64, byte[] bytecode32) throws CompileExceptionError
+    {
+        // expect same length on 32 and 64 bit bytecode if storing a delta
+        if (bytecode32.length != bytecode64.length) {
+            throw new CompileExceptionError("Byte code length mismatch");
+        }
+
+       /**
+         * Calculate the difference/delta between the 64-bit and 32-bit
+         * bytecode.
+         * The delta is stored together with the 64-bit bytecode and when
+         * the 32-bit bytecode is needed the delta is applied to the 64-bit
+         * bytecode to transform it to the equivalent 32-bit version.
+         * 
+         * The delta is stored in the following format:
+         * 
+         * * index - The index where to apply the next change. 1-4 bytes.
+         *           The size depends on the size of the entire bytecode:
+         *           1 byte - Size less than 2^8
+         *           2 bytes - Size less than 2^16
+         *           3 bytes - Size less than 2^24
+         *           4 bytes - Size more than or equal to 2^24
+         * * count - The number of consecutive bytes to alter. 1 byte (ie max 255 changes)
+         * * bytes - The 32-bit bytecode values to apply to the 64-bit bytecode starting
+         *           at the index.
+         */
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int i = 0;
+        while(i < bytecode32.length) {
+            // find sequences of consecutive bytes that differ
+            // max 255 at a time
+            int count = 0;
+            while(count < 255 && (i + count) < bytecode32.length) {
+                if (bytecode32[i + count] == bytecode64[i + count]) {
+                    break;
+                }
+                count++;
+            }
+
+            // found a sequence of bytes
+            // write index, count and bytes
+            if (count > 0) {
+                if (count == 256) {
+                    Bob.verbose("\n\nLuaBuilder count %d\n\n", count);
+                }
+
+                // write index of diff
+                bos.write(i);
+                if (bytecode32.length >= (1 << 8)) {
+                    bos.write((i & 0xFF00) >> 8);
+                }
+                if (bytecode32.length >= (1 << 16)) {
+                    bos.write((i & 0xFF0000) >> 16);
+                }
+                if (bytecode32.length >= (1 << 24)) {
+                    bos.write((i & 0xFF000000) >> 24);
+                }
+
+                bos.write(count);
+
+                // write consecutive bytes that differ
+                bos.write(bytecode32, i, count);
+                i += count;
+            }
+            else {
+                i += 1;
+            }
+        }
+
+        byte[] delta = bos.toByteArray();
+        return delta;
+    }
+
     @Override
     public void build(Task<Void> task) throws CompileExceptionError, IOException {
 
@@ -381,75 +454,11 @@ public abstract class LuaBuilder extends Builder<Void> {
                 srcBuilder.setBytecode64(ByteString.copyFrom(bytecode64));
             }
             else {
-                // expect same length on 32 and 64 bit bytecode if storing a delta
-                if (bytecode32.length != bytecode64.length) {
-                    throw new CompileExceptionError(task.input(0), 0, "Byte code length mismatch");
-                }
+                byte[] delta = constructBytecodeDelta(bytecode32, bytecode64);
+                srcBuilder.setDelta(ByteString.copyFrom(delta));
 
                 Bob.verbose("Writing 64-bit bytecode with 32-bit delta for %s", task.input(0).getPath());
                 srcBuilder.setBytecode(ByteString.copyFrom(bytecode64));
-
-                /**
-                 * Calculate the difference/delta between the 64-bit and 32-bit
-                 * bytecode.
-                 * The delta is stored together with the 64-bit bytecode and when
-                 * the 32-bit bytecode is needed the delta is applied to the 64-bit
-                 * bytecode to transform it to the equivalent 32-bit version.
-                 * 
-                 * The delta is stored in the following format:
-                 * 
-                 * * index - The index where to apply the next change. 1-4 bytes.
-                 *           The size depends on the size of the entire bytecode:
-                 *           1 byte - Size less than 2^8
-                 *           2 bytes - Size less than 2^16
-                 *           3 bytes - Size less than 2^24
-                 *           4 bytes - Size more than or equal to 2^24
-                 * * count - The number of consecutive bytes to alter. 1 byte (ie max 255 changes)
-                 * * bytes - The 32-bit bytecode values to apply to the 64-bit bytecode starting
-                 *           at the index.
-                 */
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                int i = 0;
-                while(i < bytecode32.length) {
-                    // find sequences of consecutive bytes that differ
-                    // max 255 at a time
-                    int count = 0;
-                    while(count < 255 && (i + count) < bytecode32.length) {
-                        if (bytecode32[i + count] == bytecode64[i + count]) {
-                            break;
-                        }
-                        count++;
-                    }
-
-                    // found a sequence of bytes
-                    // write index, count and bytes
-                    if (count > 0) {
-
-                        // write index of diff
-                        bos.write(i);
-                        if (bytecode32.length >= (1 << 8)) {
-                            bos.write((i & 0xFF00) >> 8);
-                        }
-                        if (bytecode32.length >= (1 << 16)) {
-                            bos.write((i & 0xFF0000) >> 16);
-                        }
-                        if (bytecode32.length >= (1 << 24)) {
-                            bos.write((i & 0xFF000000) >> 24);
-                        }
-
-                        bos.write(count);
-
-                        // write consecutive bytes that differ
-                        bos.write(bytecode32, i, count);
-                        i += count;
-                    }
-                    else {
-                        i += 1;
-                    }
-                }
-
-                byte[] delta = bos.toByteArray();
-                srcBuilder.setDelta(ByteString.copyFrom(delta));
             }
         }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -414,7 +414,7 @@ public abstract class LuaBuilder extends Builder<Void> {
                     // find sequences of consecutive bytes that differ
                     // max 255 at a time
                     int count = 0;
-                    while(count < 256 && (i + count) < bytecode32.length) {
+                    while(count < 255 && (i + count) < bytecode32.length) {
                         if (bytecode32[i + count] == bytecode64[i + count]) {
                             break;
                         }


### PR DESCRIPTION
If the bytecode delta was 256 bytes or longer the count wrapped around and was written as 0.
