### PR TITLE
Add possibility to add extra keys should be taken into account for cache key

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Task.java
@@ -36,6 +36,7 @@ public class Task<T> {
     private String name;
     private List<IResource> inputs = new ArrayList<IResource>();
     private List<IResource> outputs = new ArrayList<IResource>();
+    private List<String> extraCacheKeys = new ArrayList<String>();
     private Task<?> productOf;
 
     public T data;
@@ -80,6 +81,11 @@ public class Task<T> {
                 throw new IllegalArgumentException(String.format("Resource '%s' is not an output resource", output));
             }
             task.outputs.add(output);
+            return this;
+        }
+
+        public TaskBuilder<T> addExtraCacheKey(String key) {
+            task.extraCacheKeys.add(key);
             return this;
         }
 
@@ -163,6 +169,23 @@ public class Task<T> {
         }
     }
 
+    /**
+     * Update a message digest with a list of extra cache parameters.
+     * @param, digest The digest to update with the resources
+     * @param keys A list of keys to add
+     */
+    private void updateDigestWithExtraCacheKeys(MessageDigest digest, List<String> keys) throws IOException {
+        if (keys.size() == 0)
+        {
+            return;
+        }
+        List<String> sortedKeys = new ArrayList<String>(keys);
+        Collections.sort(sortedKeys);
+        for (String r : sortedKeys) {
+            digest.update(r.getBytes());
+        }
+    }
+
     public MessageDigest calculateSignatureDigest() throws IOException {
         // TODO: Checksum of builder-class byte-code. Seems to be rather difficult though..
         MessageDigest digest;
@@ -173,6 +196,7 @@ public class Task<T> {
         }
 
         updateDigestWithResources(digest, inputs);
+        updateDigestWithExtraCacheKeys(digest, extraCacheKeys);
 
         builder.signature(digest);
         return digest;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaBuilder.java
@@ -118,6 +118,8 @@ public abstract class LuaBuilder extends Builder<Void> {
                 .addOutput(input.changeExt(params.outExt()));
 
         LuaScanner scanner = getLuaScanner(input);
+        long finalLuaHash = MurmurHash.hash64(scanner.getParsedLua());
+        taskBuilder.addExtraCacheKey(Long.toString(finalLuaHash));
 
         List<LuaScanner.Property> properties = scanner.getProperties();
         for (LuaScanner.Property property : properties) {


### PR DESCRIPTION
Now builders have a possibility to add custom keys, which should be taken into account when cache key calculates.

LuaBuilder uses it for adding hash out of lua source after plugins processing as a part of the cache key.