### PR TITLE
Updated python3 build instructions

### DIFF
--- a/editor/README_BUILD.md
+++ b/editor/README_BUILD.md
@@ -13,10 +13,10 @@ You can build and run the editor and use an existing released version of the Def
 cd defold
 
 # Setup the shell environment (consider putting it in an alias in your bash profile)
-python2 ./scripts/build.py shell
+python ./scripts/build.py shell
 
 # you only need to do this once
-python2 ./scripts/build.py install_ext
+python ./scripts/build.py install_ext
 
 # Change directory to the editor directory
 cd editor


### PR DESCRIPTION
Updated the BUILD readme to be inline with [python3 setup instructions](https://github.com/defold/defold/blob/dev/README_SETUP_WINDOWS.md#required-software---python-3) changed [in August](https://github.com/defold/defold/commit/dea9605203dd6bbd53726eb569883b1dbb442ddf).