### PR TITLE
Improvements for EDN encoder in debugger

### DIFF
--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -127,14 +127,11 @@ local function collect_refs(depth, val, refs, dups)
 end
 
 local function encode_structure(val)
-  local start_time = socket.gettime()
   local dups = {}
   local refs = {}
   collect_refs(0, val, refs, dups)
   local encoded_refs = encode_refs(refs)
   local str = "#lua/structure{:value " .. encode_as_primitive(val) .. " :refs " .. encoded_refs .. "}"
-  print("Result time = ", socket.gettime() - start_time)
-  print(str)
   return str
 end
 

--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -54,8 +54,16 @@ local function encode_number(val)
   end
 end
 
+local strings_cache = {}
+local strings_cache_count = 0
 local function encode_string(val)
-  return '"'..val:gsub('[%z\1-\31\\"]', escape_char)..'"'
+  if strings_cache[val] then
+    return strings_cache[val]
+  end
+  local str = '"'..val:gsub('[%z\1-\31\\"]', escape_char)..'"'
+  strings_cache[val] = str
+  strings_cache_count = strings_cache_count + 1
+  return str
 end
 
 local function encode_table(val)
@@ -132,6 +140,10 @@ local function encode_structure(val)
   collect_refs(0, val, refs, dups)
   local encoded_refs = encode_refs(refs)
   local str = "#lua/structure{:value " .. encode_as_primitive(val) .. " :refs " .. encoded_refs .. "}"
+  if strings_cache_count > 5000000 then
+    strings_cache_count = 0
+    strings_cache = {}
+  end
   return str
 end
 


### PR DESCRIPTION
Pay attention that here we are talking about 450 000 - 500 000 only tables or refs to tables + huge amount of the other values
```
Test prj
DEBUG:SCRIPT: table_counter	180900
DEBUG:SCRIPT: ref_counter	450000

Before:
DEBUG:SCRIPT: Result time = 	3.1616051197052
DEBUG:SCRIPT: Result time = 	3.0216929912567
DEBUG:SCRIPT: Result time = 	3.0465228557587
DEBUG:SCRIPT: Result time = 	3.0130741596222
DEBUG:SCRIPT: Result time = 	3.0043928623199
DEBUG:SCRIPT: Result time = 	3.0025200843811
DEBUG:SCRIPT: Result time = 	3.0001330375671

After:
DEBUG:SCRIPT: Result time = 	1.7840061187744
DEBUG:SCRIPT: Result time = 	1.8551151752472
DEBUG:SCRIPT: Result time = 	1.8466029167175
DEBUG:SCRIPT: Result time = 	1.7579870223999
DEBUG:SCRIPT: Result time = 	1.8628711700439


Another big test project:
Before:
DEBUG:SCRIPT: Result time = 	8.8547360897064
DEBUG:SCRIPT: Result time = 	8.8110229969025
DEBUG:SCRIPT: Result time = 	8.5735511779785
DEBUG:SCRIPT: Result time = 	8.6874620914459

After:
DEBUG:SCRIPT: Result time = 	5.7142062187195	 cached_string	2056917	 encoded_strs	476642
DEBUG:SCRIPT: Result time = 	5.2303631305695	 cached_string	2533328	 encoded_strs	68
DEBUG:SCRIPT: Result time = 	5.1561901569366	 cached_string	2533404	 encoded_strs	40
DEBUG:SCRIPT: Result time = 	5.0541839599609	 cached_string	2533514	 encoded_strs	60
DEBUG:SCRIPT: Result time = 	5.0240840911865	 cached_string	2533549	 encoded_strs	34
```

(these changes shouldn't be in Release Notes)