### PR TITLE
Fix crash when max sound instances is 0

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -83,7 +83,7 @@ namespace dmGameSystem
         world->m_Entries.SetCapacity(max_instances);
         world->m_Entries.SetSize(max_instances);
         world->m_EntryIndices.SetCapacity(max_instances);
-        memset(&world->m_Entries.Front(), 0, max_instances * sizeof(PlayEntry));
+        memset(world->m_Entries.Begin(), 0, max_instances * sizeof(PlayEntry));
 
         world->m_Components.SetCapacity(comp_count);
 


### PR DESCRIPTION
Fixed a crash when max sound instances is 0 in game.project

Fixes #7162 