### PR TITLE
Added configfile extension functionality to dmSDK

### DIFF
--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -29,9 +29,49 @@
 #include "dstrings.h"
 #include "math.h"
 #include "sys.h"
+#include "static_assert.h"
 
 namespace dmConfigFile
 {
+    struct PluginDesc
+    {
+        const char* m_Name;
+        void (*m_Create)(HConfig config);
+        void (*m_Destroy)(HConfig config);
+        bool (*m_GetString)(HConfig config, const char* key, const char* default_value, const char** out);
+        bool (*m_GetInt)(HConfig config, const char* key, int32_t default_value, int32_t* out);
+        bool (*m_GetFloat)(HConfig config, const char* key, float default_value, float* out);
+        const PluginDesc* m_Next;
+    };
+
+    PluginDesc* g_FirstExtension = 0;
+    extern const uint32_t m_ExtensionDescBufferSize;
+
+    void Register(struct PluginDesc* desc,
+        uint32_t desc_size,
+        const char *name,
+        void (*create)(HConfig config),
+        void (*destroy)(HConfig config),
+        bool (*get_string)(HConfig config, const char* key, const char* default_value, const char** out),
+        bool (*get_int)(HConfig config, const char* key, int32_t default_value, int32_t* out),
+        bool (*get_float)(HConfig config, const char* key, float default_value, float* out))
+    {
+        DM_STATIC_ASSERT(dmConfigFile::m_ExtensionDescBufferSize >= sizeof(struct PluginDesc), Invalid_Struct_Size);
+        desc->m_Name = name;
+        desc->m_Create = create;
+        desc->m_Destroy = destroy;
+        desc->m_GetString = get_string;
+        desc->m_GetInt = get_int;
+        desc->m_GetFloat = get_float;
+
+        desc->m_Next = g_FirstExtension;
+        g_FirstExtension = desc;
+    }
+
+    static const PluginDesc* GetFirstExtension()
+    {
+        return g_FirstExtension;
+    }
 
     const int32_t CATEGORY_MAX_SIZE = 512;
 
@@ -459,6 +499,28 @@ namespace dmConfigFile
 
     }
 
+    static void PluginsCreate(HConfig config)
+    {
+        const PluginDesc* plugin = GetFirstExtension();
+        while (plugin != 0)
+        {
+            if (plugin->m_Create)
+                plugin->m_Create(config);
+            plugin = plugin->m_Next;
+        }
+    }
+
+    static void PluginsDestroy(HConfig config)
+    {
+        const PluginDesc* plugin = GetFirstExtension();
+        while (plugin != 0)
+        {
+            if (plugin->m_Destroy)
+                plugin->m_Destroy(config);
+            plugin = plugin->m_Next;
+        }
+    }
+
     static Result LoadFromFileInternal(const char* url, int argc, const char** argv, HConfig* config)
     {
 #ifdef __ANDROID__
@@ -535,10 +597,14 @@ namespace dmConfigFile
     Result LoadFromBuffer(const char* buffer, uint32_t buffer_size, int argc, const char** argv, HConfig* config)
     {
         Result r = LoadFromBufferInternal("<buffer>", buffer, buffer_size, argc, argv, config);
+        if (r == RESULT_OK)
+        {
+            PluginsCreate(*config);
+        }
         return r;
     }
 
-    Result Load(const char* url, int argc, const char** argv, HConfig* config)
+    static Result DoLoad(const char* url, int argc, const char** argv, HConfig* config)
     {
         assert(url);
         assert(config);
@@ -591,12 +657,23 @@ namespace dmConfigFile
         return RESULT_INVALID_URI;
     }
 
+    Result Load(const char* url, int argc, const char** argv, HConfig* config)
+    {
+        Result result = DoLoad(url, argc, argv, config);
+        if (result == RESULT_OK)
+        {
+            PluginsCreate(*config);
+        }
+        return result;
+    }
+
     void Delete(HConfig config)
     {
+        PluginsDestroy(config);
         delete config;
     }
 
-    const char* GetString(HConfig config, const char* key, const char* default_value)
+    static const char* GetBaseString(HConfig config, const char* key, const char* default_value)
     {
         uint64_t key_hash = dmHashString64(key);
         for (uint32_t i = 0; i < config->m_Entries.Size(); ++i)
@@ -611,9 +688,30 @@ namespace dmConfigFile
         return default_value;
     }
 
-    int32_t GetInt(HConfig config, const char* key, int32_t default_value)
+    static bool GetStringOverride(HConfig config, const char* key, const char* default_value, const char** out_value)
     {
-        const char* tmp = GetString(config, key, 0);
+        const PluginDesc* plugin = GetFirstExtension();
+        while (plugin != 0)
+        {
+            if (plugin->m_GetString && plugin->m_GetString(config, key, default_value, out_value))
+                return true;
+            plugin = plugin->m_Next;
+        }
+        return false;
+    }
+
+    const char* GetString(HConfig config, const char* key, const char* default_value)
+    {
+        const char* base_value = GetBaseString(config, key, default_value);
+        const char* out_value = 0;
+        if (GetStringOverride(config, key, base_value, &out_value))
+            return out_value;
+        return base_value;
+    }
+
+    static int32_t GetBaseInt(HConfig config, const char* key, int32_t default_value)
+    {
+        const char* tmp = GetBaseString(config, key, 0);
         if (tmp == 0)
             return default_value;
         int l = strlen(tmp);
@@ -627,9 +725,30 @@ namespace dmConfigFile
         return ret;
     }
 
-    float GetFloat(HConfig config, const char* key, float default_value)
+    static bool GetIntOverride(HConfig config, const char* key, int32_t default_value, int32_t* out_value)
     {
-        const char* tmp = GetString(config, key, 0);
+        const PluginDesc* plugin = GetFirstExtension();
+        while (plugin != 0)
+        {
+            if (plugin->m_GetInt && plugin->m_GetInt(config, key, default_value, out_value))
+                return true;
+            plugin = plugin->m_Next;
+        }
+        return false;
+    }
+
+    int32_t GetInt(HConfig config, const char* key, int32_t default_value)
+    {
+        int32_t base_value = GetBaseInt(config, key, default_value);
+        int32_t out_value = 0;
+        if (GetIntOverride(config, key, base_value, &out_value))
+            return out_value;
+        return base_value;
+    }
+
+    static float GetBaseFloat(HConfig config, const char* key, float default_value)
+    {
+        const char* tmp = GetBaseString(config, key, 0);
         if (tmp == 0)
             return default_value;
         int l = strlen(tmp);
@@ -641,6 +760,27 @@ namespace dmConfigFile
             return default_value;
         }
         return ret;
+    }
+
+    static bool GetFloatOverride(HConfig config, const char* key, float default_value, float* out_value)
+    {
+        const PluginDesc* plugin = GetFirstExtension();
+        while (plugin != 0)
+        {
+            if (plugin->m_GetFloat && plugin->m_GetFloat(config, key, default_value, out_value))
+                return true;
+            plugin = plugin->m_Next;
+        }
+        return false;
+    }
+
+    float GetFloat(HConfig config, const char* key, float default_value)
+    {
+        float base_value = GetBaseFloat(config, key, default_value);
+        float out_value = 0;
+        if (GetFloatOverride(config, key, base_value, &out_value))
+            return out_value;
+        return base_value;
     }
 
 }

--- a/engine/dlib/src/dmsdk/dlib/configfile.h
+++ b/engine/dlib/src/dmsdk/dlib/configfile.h
@@ -170,7 +170,7 @@ namespace dmConfigFile
      *
      * @examples
      *
-     * Register a new onfig file extension:
+     * Register a new config file extension:
      *
      * ```cpp
      * DM_DECLARE_CONFIGFILE_EXTENSION(MyConfigfileExtension, "MyConfigfileExtension", create, destroy, get_string, get_int, get_float);

--- a/engine/dlib/src/dmsdk/dlib/configfile.h
+++ b/engine/dlib/src/dmsdk/dlib/configfile.h
@@ -102,6 +102,84 @@ namespace dmConfigFile
      * ```
      */
     float GetFloat(HConfig config, const char* key, float default_value);
+
+    /**
+     * Configfile extension declaration helper. Internal function. Use DM_DECLARE_CONFIGFILE_EXTENSION
+     * @param desc
+     * @param desc_size bytesize of buffer holding desc
+     * @param name extension name. human readble
+     * @param app_init app-init function. May be null
+     * @param app_finalize app-final function. May be null
+     * @param initialize init function. May not be 0
+     * @param finalize function. May not be 0
+     * @param update update function. May be null
+     * @param on_event event callback function. May be null
+     */
+    void Register(struct PluginDesc* desc,
+        uint32_t desc_size,
+        const char *name,
+        void (*create)(HConfig config),
+        void (*destroy)(HConfig config),
+        bool (*get_string)(HConfig config, const char* key, const char* default_value, const char** out),
+        bool (*get_int)(HConfig config, const char* key, int32_t default_value, int32_t* out),
+        bool (*get_float)(HConfig config, const char* key, float default_value, float* out)
+    );
+
+    /**
+     * Extension declaration helper. Internal
+     */
+    #ifdef __GNUC__
+        // Workaround for dead-stripping on OSX/iOS. The symbol "name" is explicitly exported. See wscript "exported_symbols"
+        // Otherwise it's dead-stripped even though -no_dead_strip_inits_and_terms is passed to the linker
+        // The bug only happens when the symbol is in a static library though
+        #define DM_REGISTER_CONFIGFILE_EXTENSION(symbol, desc, desc_size, name, create, destroy, get_string, get_int, get_float) extern "C" void __attribute__((constructor)) symbol () { \
+            dmConfigFile::Register((struct dmConfigFile::PluginDesc*) &desc, desc_size, name, create, destroy, get_string, get_int, get_float); \
+        }
+    #else
+        #define DM_REGISTER_CONFIGFILE_EXTENSION(symbol, desc, desc_size, name, create, destroy, get_string, get_int, get_float) extern "C" void symbol () { \
+            dmConfigFile::Register((struct dmConfigFile::PluginDesc*) &desc, desc_size, name, create, destroy, get_string, get_int, get_float); \
+            }\
+            int symbol ## Wrapper(void) { symbol(); return 0; } \
+            __pragma(section(".CRT$XCU",read)) \
+            __declspec(allocate(".CRT$XCU")) int (* _Fp ## symbol)(void) = symbol ## Wrapper;
+    #endif
+
+    /**
+    * Extension desc bytesize declaration. Internal
+    */
+    const uint32_t m_ExtensionDescBufferSize = 64;
+
+    // internal
+    #define DM_EXTENSION_PASTE_SYMREG(x, y) x ## y
+    // internal
+    #define DM_EXTENSION_PASTE_SYMREG2(x, y) DM_EXTENSION_PASTE_SYMREG(x, y)
+
+    /*# declare a new config file extension
+     *
+     * Declare and register new config file extension to the engine.
+     * Each get function should return true if it sets a proper value. Otherwise return false.
+     *
+     * @macro
+     * @name DM_DECLARE_CONFIGFILE_EXTENSION
+     * @param symbol [type:symbol] external extension symbol description (no quotes).
+     * @param name [type:const char*] extension name. Human readable.
+     * @param init [type:function(dmConfigFile::HConfig)] init function. May be null.
+     * @param get_string [type:function(const char* section_plus_name, const char* default, const char** out)] Gets a string property. May be null.
+     * @param get_int [type:function(const char* section_plus_name, int default, int* out)] Gets an int property. May be null.
+     * @param get_float [type:function(const char* section_plus_name, float default, float* out)] Gets a float property. May be null.
+     *
+     * @examples
+     *
+     * Register a new onfig file extension:
+     *
+     * ```cpp
+     * DM_DECLARE_CONFIGFILE_EXTENSION(MyConfigfileExtension, "MyConfigfileExtension", create, destroy, get_string, get_int, get_float);
+     * ```
+     */
+    #define DM_DECLARE_CONFIGFILE_EXTENSION(symbol, name, create, destroy, get_string, get_int, get_float) \
+        uint8_t DM_ALIGNED(16) DM_EXTENSION_PASTE_SYMREG2(symbol, __LINE__)[dmConfigFile::m_ExtensionDescBufferSize]; \
+        DM_REGISTER_CONFIGFILE_EXTENSION(symbol, DM_EXTENSION_PASTE_SYMREG2(symbol, __LINE__), sizeof(DM_EXTENSION_PASTE_SYMREG2(symbol, __LINE__)), name, create, destroy, get_string, get_int, get_float);
+
 }
 
 #endif // DMSDK_CONFIGFILE_H

--- a/engine/dlib/src/test/data/test.config
+++ b/engine/dlib/src/test/data/test.config
@@ -14,3 +14,8 @@ value = foo_bar
 value = bla
 bad_int1 =
 bad_int2 = 123x
+
+[ext]
+string = hello
+int = 42
+float = 1.0

--- a/engine/dlib/src/test/test_configfile.cpp
+++ b/engine/dlib/src/test/test_configfile.cpp
@@ -97,9 +97,11 @@ public:
     virtual void TearDown()
     {
         delete [] m_Buffer;
+        m_Buffer = 0;
         if (config)
         {
             dmConfigFile::Delete(config);
+            config = 0;
         }
     }
 };
@@ -194,6 +196,15 @@ TEST_P(Test01, Test01)
 
     ASSERT_STREQ("missing_value", dmConfigFile::GetString(config, "missing_key", "missing_value"));
     ASSERT_EQ(1122, dmConfigFile::GetInt(config, "missing_int_key", 1122));
+
+    // The extension plugin hooks are disabled
+    ASSERT_STREQ("hello", dmConfigFile::GetString(config, "ext.string", 0));
+    ASSERT_STREQ("42", dmConfigFile::GetString(config, "ext.int", 0));
+    ASSERT_STREQ("1.0", dmConfigFile::GetString(config, "ext.float", 0));
+
+    ASSERT_EQ(42, dmConfigFile::GetInt(config, "ext.int", 0));
+    ASSERT_EQ(1.0f, dmConfigFile::GetFloat(config, "ext.float", 0));
+    ASSERT_EQ(0, dmConfigFile::GetInt(config, "ext.virtual", 0));
 }
 
 const TestParam params_test01[] = {
@@ -280,6 +291,100 @@ const TestParam params_long_value[] = {
 };
 
 INSTANTIATE_TEST_CASE_P(LongValue, LongValue, jc_test_values_in(params_long_value));
+
+static int g_ExtensionTestEnabled = 0;
+static int g_ExtensionTestCreated = 0;
+static int g_ExtensionTestDestroyed = 0;
+static const char* g_ExtensionTestString = "world";
+
+static void TestCreate(dmConfigFile::HConfig config)
+{
+    if (!g_ExtensionTestEnabled) return;
+    g_ExtensionTestCreated++;
+}
+static void TestDestroy(dmConfigFile::HConfig config)
+{
+    if (!g_ExtensionTestEnabled) return;
+    g_ExtensionTestDestroyed++;
+}
+static bool TestGetString(dmConfigFile::HConfig config, const char* key, const char* default_value, const char** out)
+{
+    if (!g_ExtensionTestEnabled) return false;
+    if (strstr(key, "ext.") != key)
+        return false;
+
+    if (strcmp("ext.string", key) == 0)
+    {
+        *out = g_ExtensionTestString;
+        return true;
+    }
+    return false;
+}
+static bool TestGetInt(dmConfigFile::HConfig config, const char* key, int32_t default_value, int32_t* out)
+{
+    if (!g_ExtensionTestEnabled) return false;
+    if (strstr(key, "ext.") != key)
+        return false;
+    if (strcmp("ext.virtual", key) == 0)
+    {
+        *out = 1301;
+        return true;
+    }
+    *out = default_value * 2;
+    return true;
+}
+static bool TestGetFloat(dmConfigFile::HConfig config, const char* key, float default_value, float* out)
+{
+    if (!g_ExtensionTestEnabled) return false;
+    if (strstr(key, "ext.") != key)
+        return false;
+    if (strcmp("ext.virtual", key) == 0)
+    {
+        *out = 4096;
+        return true;
+    }
+    *out = default_value * 2;
+    return true;
+}
+
+DM_DECLARE_CONFIGFILE_EXTENSION(TestConfigfileExtension, "TestConfigfileExtension", TestCreate, TestDestroy, TestGetString, TestGetInt, TestGetFloat);
+
+class ConfigfileExtension : public ConfigTest {
+    virtual void SetUp()
+    {
+        g_ExtensionTestEnabled = 1;
+        ConfigTest::SetUp();
+
+        ASSERT_EQ(g_ExtensionTestCreated, 1);
+    }
+    virtual void TearDown()
+    {
+        ConfigTest::TearDown();
+        g_ExtensionTestEnabled = 0;
+
+        ASSERT_EQ(g_ExtensionTestDestroyed, 1);
+    }
+};
+
+TEST_P(ConfigfileExtension, ConfigfileExtension)
+{
+    ASSERT_STREQ("world", dmConfigFile::GetString(config, "ext.string", 0));
+    ASSERT_STREQ("42", dmConfigFile::GetString(config, "ext.int", 0));
+    ASSERT_STREQ("1.0", dmConfigFile::GetString(config, "ext.float", 0));
+
+    ASSERT_EQ(84, dmConfigFile::GetInt(config, "ext.int", 0));
+    ASSERT_EQ(2.0f, dmConfigFile::GetFloat(config, "ext.float", 0));
+
+    ASSERT_EQ(1301, dmConfigFile::GetInt(config, "ext.virtual", 0));
+    ASSERT_EQ(4096.0f, dmConfigFile::GetFloat(config, "ext.virtual", 0));
+}
+
+const TestParam params_extension[] = {
+    TestParam("src/test/data/test.config"),
+};
+
+INSTANTIATE_TEST_CASE_P(ConfigfileExtension, ConfigfileExtension, jc_test_values_in(params_extension));
+
 
 
 static void Usage()

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -342,54 +342,46 @@ union SaveLoadBuffer
         return 1;
     }
 
-    /*# get config value
-     * Get config value from the game.project configuration file.
-     *
-     * In addition to the project file, configuration values can also be passed
-     * to the runtime as command line arguments with the `--config` argument.
-     *
-     * @name sys.get_config
-     * @param key [type:string] key to get value for. The syntax is SECTION.KEY
-     * @return value [type:string] config value as a string. nil if the config key doesn't exists
-     * @examples
-     *
-     * Get display width
-     *
-     * ```lua
-     * local width = tonumber(sys.get_config("display.width"))
-     * ```
-     *
-     * Start the engine with a bootstrap config override and a custom config value
-     *
-     * ```
-     * $ mygame --config=bootstrap.main_collection=/mytest.collectionc --config=mygame.testmode=1
-     * ```
-     *
-     * Set and read a custom config value
-     *
-     * ```lua
-     * local testmode = tonumber(sys.get_config("mygame.testmode"))
-     * ```
-     */
+    static dmConfigFile::HConfig GetConfigFile(lua_State* L)
+    {
+        HContext context = dmScript::GetScriptContext(L);
+        if (context)
+        {
+            return context->m_ConfigFile;
+        }
+        return 0;
+    }
 
-    /*# get config value with default value
-     * Get config value from the game.project configuration file with default value
+    /*# get string config value with optional default value
+     * Get string config value from the game.project configuration file with optional default value
      *
-     * @name sys.get_config
+     * @name sys.get_config_string
      * @param key [type:string] key to get value for. The syntax is SECTION.KEY
-     * @param default_value [type:string] default value to return if the value does not exist
-     * @return value [type:string] config value as a string. default_value if the config key does not exist
+     * @param [default_value] [type:string] (optional) default value to return if the value does not exist
+     * @return value [type:string] config value as a string. default_value if the config key does not exist. nil if no default value was supplied.
      * @examples
      *
      * Get user config value
      *
      * ```lua
-     * local speed = tonumber(sys.get_config("my_game.speed", "10.23"))
+     * local text = sys.get_config_string("my_game.text", "default text"))
+     * ```
+     *
+     * Start the engine with a bootstrap config override and add a custom config value
+     *
+     * ```
+     * $ dmengine --config=bootstrap.main_collection=/mytest.collectionc --config=mygame.testmode=1
+     * ```
+     *
+     * Read the custom config value from the command line
+     *
+     * ```lua
+     * local testmode = sys.get_config_int("mygame.testmode")
      * ```
      */
-    int Sys_GetConfig(lua_State* L)
+    static int Sys_GetConfigString(lua_State* L)
     {
-        int top = lua_gettop(L);
+        DM_LUA_STACK_CHECK(L, 1);
 
         const char* key = luaL_checkstring(L, 1);
         const char* default_value = 0;
@@ -398,31 +390,101 @@ union SaveLoadBuffer
             default_value = lua_tostring(L, 2);
         }
 
-        HContext context = dmScript::GetScriptContext(L);
-
-        dmConfigFile::HConfig config_file = 0;
-        if (context)
-        {
-            config_file = context->m_ConfigFile;
-        }
-
-        const char* value;
+        dmConfigFile::HConfig config_file = GetConfigFile(L);
         if (config_file)
-            value = dmConfigFile::GetString(config_file, key, default_value);
-        else
-            value = 0;
-
-        if (value)
         {
+            const char* value = dmConfigFile::GetString(config_file, key, default_value);
             lua_pushstring(L, value);
         }
         else
         {
             lua_pushnil(L);
         }
+        return 1;
+    }
 
-        assert(top + 1 == lua_gettop(L));
+    /*# get integer config value with optional default value
+     * Get integer config value from the game.project configuration file with optional default value
+     *
+     * @name sys.get_config_int
+     * @param key [type:string] key to get value for. The syntax is SECTION.KEY
+     * @param [default_value] [type:integer] (optional) default value to return if the value does not exist
+     * @return value [type:integer] config value as an integer. default_value if the config key does not exist. nil if no default value was supplied.
+     * @examples
+     *
+     * Get user config value
+     *
+     * ```lua
+     * local speed = sys.get_config_int("my_game.speed", 20) -- with default value
+     * ```
+     *
+     * ```lua
+     * local testmode = sys.get_config_int("my_game.testmode") -- without default value
+     * if testmode ~= nil then
+     *     -- do stuff
+     * end
+     * ```
+     */
+    static int Sys_GetConfigInt(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
 
+        const char* key = luaL_checkstring(L, 1);
+        int default_value = 0;
+        if (!lua_isnil(L, 2))
+        {
+            default_value = luaL_checkinteger(L, 2);
+        }
+
+        dmConfigFile::HConfig config_file = GetConfigFile(L);
+        if (config_file)
+        {
+            int value = dmConfigFile::GetInt(config_file, key, default_value);
+            lua_pushinteger(L, value);
+        }
+        else
+        {
+            lua_pushnil(L);
+        }
+        return 1;
+    }
+
+    /*# get number config value with optional default value
+     * Get number config value from the game.project configuration file with optional default value
+     *
+     * @name sys.get_config_number
+     * @param key [type:string] key to get value for. The syntax is SECTION.KEY
+     * @param [default_value] [type:number] (optional) default value to return if the value does not exist
+     * @return value [type:number] config value as an number. default_value if the config key does not exist. nil if no default value was supplied.
+     * @examples
+     *
+     * Get user config value
+     *
+     * ```lua
+     * local speed = sys.get_config_float("my_game.speed", 20.0)
+     * ```
+     */
+    static int Sys_GetConfigNumber(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+
+        const char* key = luaL_checkstring(L, 1);
+        float default_value = 0;
+        if (!lua_isnil(L, 2))
+        {
+            default_value = luaL_checknumber(L, 2);
+        }
+
+        dmConfigFile::HConfig config_file = GetConfigFile(L);
+        if (config_file)
+        {
+            float value = dmConfigFile::GetFloat(config_file, key, default_value);
+            lua_pushnumber(L, value);
+        }
+        else
+        {
+            lua_pushnil(L);
+        }
         return 1;
     }
 
@@ -1252,7 +1314,10 @@ union SaveLoadBuffer
         {"save", Sys_Save},
         {"load", Sys_Load},
         {"get_save_file", Sys_GetSaveFile},
-        {"get_config", Sys_GetConfig},
+        {"get_config", Sys_GetConfigString}, // deprecated
+        {"get_config_string", Sys_GetConfigString},
+        {"get_config_int", Sys_GetConfigInt},
+        {"get_config_number", Sys_GetConfigNumber},
         {"open_url", Sys_OpenURL},
         {"load_resource", Sys_LoadResource},
         {"get_sys_info", Sys_GetSysInfo},

--- a/engine/script/src/test/test_sys.lua
+++ b/engine/script/src/test/test_sys.lua
@@ -87,12 +87,16 @@ function test_sys()
     assert(data['name'] == data_prim['name'])
 
 
-    -- get_config
-    print("Testing get_config")
-    assert(sys.get_config("main.does_not_exists") == nil)
-    assert(sys.get_config("main.does_not_exists", "foobar") == "foobar")
-    assert(sys.get_config("foo.value") == "123")
-    assert(sys.get_config("foo.value", 456) == "123")
+    -- get_config_string
+    print("Testing get_config_string")
+    assert(sys.get_config_string("main.does_not_exists") == nil)
+    assert(sys.get_config_string("main.does_not_exists", "foobar") == "foobar")
+    assert(sys.get_config_string("foo.value") == "123")
+    assert(sys.get_config_string("foo.value", 456) == "123")
+
+    -- test get_config_int / get_config_number
+    assert(sys.get_config_int("foo.value", 456) == 123)
+    assert(sys.get_config_number("foo.value", 456) == 123)
 
     -- load_resource
     print("Load existing resource")


### PR DESCRIPTION
We've added new extension macro `DM_DECLARE_CONFIGFILE_EXTENSION` in `dmsdk/dlib/configfile.h`.
The extension allows extension developers to provide custom properties, or override existin ones.

In order to fully utilize this mechanic, we've created the `sys.get_config_string()`, `sys.get_config_int()` and `sys.get_config_number()` functions. The old `sys.get_config()`is now deprecated, in favor of `sys.get_config_string()`.

fixes #7178

## PR checklist (remove before merging)

* [x] Prepared the PR for release notes
	* [x] Proper description of feature or fix (see example x?)
	* [x] Added a #fixes ### if it fixes an issue
	* [x] Assigned issue to a project
* [x] Added documentation for public API changes
* [x] Is this a new feature?
	* [x] Added engine and/or editor unit tests
	* [-] Added or updated manual entry
