### PR TITLE
Removed python tarfile use

### DIFF
--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -23,7 +23,6 @@ import optparse
 import re
 import shutil
 import subprocess
-import tarfile
 import zipfile
 import configparser
 import datetime
@@ -77,15 +76,7 @@ def mkdirs(path):
         os.makedirs(path)
 
 def extract_tar(file, path, is_mac):
-    if is_mac:
-        # We use the system tar command for macOS because tar (and
-        # others) on macOS has special handling of ._ files that
-        # contain additional HFS+ attributes. See for example:
-        # http://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x
-        run.command(['tar', '-C', path, '-xzf', file])
-    else:
-        with tarfile.TarFile.open(file, 'r:gz') as tf:
-            tf.extractall(path)
+    run.command(['tar', '-C', path, '-xzf', file])
 
 def extract_zip(file, path, is_mac):
     if is_mac:
@@ -102,7 +93,7 @@ def extract(file, path, is_mac):
     print('Extracting %s to %s' % (file, path))
 
     if fnmatch.fnmatch(file, "*.tar.gz-*"):
-        extract_tar(file, path, is_mac)
+        extract_tar(file, path)
     elif fnmatch.fnmatch(file, "*.zip-*"):
         extract_zip(file, path, is_mac)
     else:

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -75,7 +75,7 @@ def mkdirs(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
-def extract_tar(file, path, is_mac):
+def extract_tar(file, path):
     run.command(['tar', '-C', path, '-xzf', file])
 
 def extract_zip(file, path, is_mac):

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -28,7 +28,6 @@ import release_to_github
 import BuildUtility
 import http_cache
 from urllib.parse import urlparse
-from tarfile import TarFile
 from glob import glob
 from threading import Thread, Event
 from queue import Queue
@@ -361,17 +360,8 @@ class Configuration(object):
 
     def _extract_tgz(self, file, path):
         self._log('Extracting %s to %s' % (file, path))
-        version = sys.version_info
-        suffix = os.path.splitext(file)[1]
-        # Avoid a bug in python 2.7 (fixed in 2.7.2) related to not being able to remove symlinks: http://bugs.python.org/issue10761
-        if self.host == 'x86_64-linux' and version[0] == 2 and version[1] == 7 and version[2] < 2:
-            fmts = {'.gz': 'z', '.xz': 'J', '.bzip2': 'j'}
-            run.env_command(self._form_env(), ['tar', 'xf%s' % fmts.get(suffix, 'z'), file], cwd = path)
-        else:
-            fmts = {'.gz': 'gz', '.xz': 'xz', '.bzip2': 'bz2'}
-            tf = TarFile.open(file, 'r:%s' % fmts.get(suffix, 'gz'))
-            tf.extractall(path)
-            tf.close()
+        fmts = {'.gz': 'z', '.xz': 'J', '.bzip2': 'j'}
+        run.env_command(self._form_env(), ['tar', 'xf%s' % fmts.get(suffix, 'z'), file], cwd = path)
 
     def _extract_tgz_rename_folder(self, src, target_folder, strip_components=1, format=None):
         src = src.replace('\\', '/')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -360,6 +360,7 @@ class Configuration(object):
 
     def _extract_tgz(self, file, path):
         self._log('Extracting %s to %s' % (file, path))
+        suffix = os.path.splitext(file)[1]
         fmts = {'.gz': 'z', '.xz': 'J', '.bzip2': 'j'}
         run.env_command(self._form_env(), ['tar', 'xf%s' % fmts.get(suffix, 'z'), file], cwd = path)
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -360,6 +360,7 @@ class Configuration(object):
 
     def _extract_tgz(self, file, path):
         self._log('Extracting %s to %s' % (file, path))
+        self._mkdirs(path)
         suffix = os.path.splitext(file)[1]
         fmts = {'.gz': 'z', '.xz': 'J', '.bzip2': 'j'}
         run.env_command(self._form_env(), ['tar', 'xf%s' % fmts.get(suffix, 'z'), file], cwd = path)
@@ -375,8 +376,7 @@ class Configuration(object):
         parentdir, dirname = os.path.split(target_folder)
         old_dir = os.getcwd()
         os.chdir(parentdir)
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        self._mkdirs(dirname)
 
         if format is None:
             suffix = os.path.splitext(src)[1]


### PR DESCRIPTION
This removes use of Python tarfile and instead relies on tar command being installed on the system.

Use instead of PR https://github.com/defold/defold/pull/7172

## PR checklist (remove before merging)

* [ ] Prepared the PR for release notes
	* [ ] Proper description of feature or fix (see example x?)
	* [ ] Added a #fixes ### if it fixes an issue
	* [ ] Assigned issue to a project
* [ ] Added documentation for public API changes
* [ ] Is this a new feature?
	* [ ] Added engine and/or editor unit tests
	* [ ] Added or updated manual entry
