### PR TITLE
Implement LSP file watchers

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2491,7 +2491,11 @@
                    messages)})
 
 (defn- hover-view [^Canvas canvas {:keys [hovered-element layout lines]}]
-  (let [r ^Rect (first (data/cursor-range-rects layout lines (:region hovered-element)))
+  (let [r ^Rect (->> hovered-element
+                     :region
+                     (data/adjust-cursor-range lines)
+                     (data/cursor-range-rects layout lines)
+                     first)
         anchor (.localToScreen canvas (.-x r) (.-y r))]
     {:fx/type fxui/with-popup
      :desc {:fx/type fxui/ext-value :value canvas}

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -20,6 +20,7 @@
             [editor.editor-extensions :as extensions]
             [editor.engine.build-errors :as engine-build-errors]
             [editor.error-reporting :as error-reporting]
+            [editor.lsp :as lsp]
             [editor.pipeline.bob :as bob]
             [editor.progress :as progress]
             [editor.resource :as resource]
@@ -141,6 +142,7 @@
               (complete! false)
               (do
                 (render-save-progress! (progress/make-indeterminate "Reading timestamps..."))
+                (lsp/touch-resources! (lsp/get-node-lsp project) (into #{} (map :resource) save-data))
                 (let [updated-file-resource-status-map-entries (mapv save-data-status-map-entry save-data)]
                   (render-save-progress! progress/done)
                   (ui/run-later

--- a/editor/src/clj/editor/lsp.clj
+++ b/editor/src/clj/editor/lsp.clj
@@ -453,7 +453,8 @@
 (let [method (-> Globs
                  (.getDeclaredMethod "toUnixRegexPattern" (into-array Class [String]))
                  (doto (.setAccessible true)))]
-  (defn- ^Pattern make-glob-pattern [s]
+  (defn- make-glob-pattern
+    ^Pattern [s]
     (re-pattern (.invoke method nil (into-array Object [s])))))
 
 (defn- notify-files-changed! [state change-type->resources]

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -286,3 +286,17 @@
                                   {:range (editor-cursor-range->lsp-range cursor-range)
                                    :text (string/join "\n" replacement)}))
                            incremental-diff)}))
+
+(defn watched-file-change
+  "See also:
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles"
+  [resource+change-types]
+  (lsp.jsonrpc/notification
+    "workspace/didChangeWatchedFiles"
+    {:changes (mapv (fn [[resource change-type]]
+                      {:uri (resource-uri resource)
+                       :type (case change-type
+                               :created 1
+                               :changed 2
+                               :deleted 3)})
+                    resource+change-types)}))

--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -103,8 +103,7 @@
 
 (defn- file-resource-filter [^File root ^File f]
   (not (or (let [file-name (.getName f)]
-             (and (str/starts-with? file-name ".")
-                  (not= file-name ".defignore")))
+             (= file-name ".DS_Store"))
            (reserved-proj-path? root (resource/file->proj-path root f)))))
 
 (defn- make-file-tree


### PR DESCRIPTION
While LSP does not define a static configuration for file watchers and recommends using dynamic registration instead, some language servers (like vscode-luacheck and lua-language-server) use static configuration defined using non-LSP vscode API. I mirrored the configuration by adding `:watched-files` server description key. The initial API only defines a `:pattern` glob to watch for, but later we might add other watcher options, i.e. excluding from the watcher some file change type (created/changed/deleted).

Notes:

- I added a `Globs` class that is based on `sun.nio.fs.Globs`, the main reason for forking it is to ensure the same behavior w.r.t. path separators on all platforms, because we use Unix-style path separators for resources on all platforms;
- I stopped hiding dot files since it's useful to view and edit them from the editor.

Related to #3885