### PR TITLE
Fixes html5 gamepad released state detection

### DIFF
--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -502,8 +502,8 @@ namespace dmGameObject
                 lua_settable(L, -3);
 
                 lua_pushliteral(L, "gamepad_buttons");
-                lua_createtable(L, dmHID::MAX_GAMEPAD_AXIS_COUNT, 0);
-                for (int i = 0; i < dmHID::MAX_GAMEPAD_AXIS_COUNT; ++i)
+                lua_createtable(L, dmHID::MAX_GAMEPAD_BUTTON_COUNT, 0);
+                for (int i = 0; i < dmHID::MAX_GAMEPAD_BUTTON_COUNT; ++i)
                 {
                     lua_pushinteger(L, (lua_Integer) (i+1));
                     lua_pushnumber(L, dmHID::GetGamepadButton(&gamepadPacket, i));

--- a/engine/glfw/js/library_glfw.js
+++ b/engine/glfw/js/library_glfw.js
@@ -573,12 +573,12 @@ var LibraryGLFW = {
             var gamepad = GLFW.lastGamepadState[joy];
 
             if (gamepad) {
-              if (!GLFW.joys[joy] || GLFW.joys[joy].id_string != gamepad.id) {
+              var gamepad_id = (gamepad.mapping == "standard") ? "Standard Gamepad" : gamepad.id;
+              if (!GLFW.joys[joy] || GLFW.joys[joy].id_string != gamepad_id) {
                 if (GLFW.joys[joy]) {
                   //In case when user change gamepad while browser in background (minimized)
                   GLFW.disconnectJoystick(joy);
                 }
-                var gamepad_id = (gamepad.mapping == "standard") ? "Standard Gamepad" : gamepad.id;
                 GLFW.joys[joy] = {
                   id: allocate(intArrayFromString(gamepad_id), ALLOC_NORMAL),
                   id_string: gamepad_id,


### PR DESCRIPTION
Fixes a regression introduced from standard gamepad support in HTML5 where the released state of gamepads wasn't properly detected.