### PR TITLE
Make the search for resource links more efficient

### DIFF
--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -23,7 +23,6 @@
             [editor.handler :as handler]
             [editor.resource :as resource]
             [editor.ui :as ui]
-            [editor.util :as util]
             [editor.workspace :as workspace])
   (:import [clojure.lang PersistentQueue]
            [editor.code.data Cursor CursorRange LayoutInfo Rect]
@@ -355,7 +354,6 @@
 
 (def ^:const line-sub-regions-pattern #"(?<=^|\s|[<\"'`])(\/[^\s>\"'`:]+)(?::?)(\d+)?")
 (def ^:private ^:const line-sub-regions-pattern-partial #"([^\s<>:]+):(\d+)")
-(def ^:private ^:const sub-region-strip-ellipsis-prefix-pattern #"^(?>\.{3})?(.*)")
 
 (def ^:private non-empty-string? (comp string? not-empty))
 
@@ -376,23 +374,36 @@
    (assoc (make-resource-reference-region row start-col end-col resource-proj-path-candidates on-click!)
      :row resource-row)))
 
-(defn- strip-ellipsis-prefix [partial-path]
-  (second (re-matches sub-region-strip-ellipsis-prefix-pattern partial-path)))
+(definline resource-path-suffix-key [^String resource-path]
+  `(.substring ~resource-path (max 0 (- (.length ~resource-path) 50))))
 
-(defn- find-project-resource-paths-from-potential-match [resource-map partial-path]
-  (if (contains? resource-map partial-path)
-    [partial-path] ; An exact match.
-    (let [partial-path-without-ellipsis-prefix (strip-ellipsis-prefix partial-path)]
-      (vec (sort util/natural-order
-                 (filter #(string/ends-with? % partial-path-without-ellipsis-prefix)
-                         (keys resource-map)))))))
+(defn- find-project-resource-paths-from-potential-match [resource-map resource-suffix-map-delay partial-path]
+  (cond
+    (string/starts-with? partial-path "/")
+    (when (contains? resource-map partial-path)
+      [partial-path])
 
-(defn- make-line-sub-regions [resource-map on-region-click! row line]
+    (string/starts-with? partial-path "...")
+    (let [suffix (subs partial-path 3)]
+      (->> (get @resource-suffix-map-delay (resource-path-suffix-key suffix))
+           (filter #(string/ends-with? % suffix))
+           sort
+           vec))
+
+    :else
+    (let [with-slash (str "/" partial-path)]
+      (when (contains? resource-map with-slash)
+        [with-slash]))))
+
+(defn make-resource-suffix-map-delay [resource-map]
+  (delay (group-by resource-path-suffix-key (keys resource-map))))
+
+(defn- make-line-sub-regions [resource-map resource-suffix-map-delay on-region-click! row line]
   (into []
         (comp
           (mapcat #(re-match-result-seq % line))
           (keep (fn [^MatchResult result]
-                  (when-some [resource-proj-path-candidates (not-empty (find-project-resource-paths-from-potential-match resource-map (.group result 1)))]
+                  (when-some [resource-proj-path-candidates (not-empty (find-project-resource-paths-from-potential-match resource-map resource-suffix-map-delay (.group result 1)))]
                     (let [resource-row (some-> (.group result 2) Long/parseUnsignedLong)
                           start-col (.start result)
                           end-col (if (string/ends-with? (.group result) ":")
@@ -413,26 +424,27 @@
                              (data/->Cursor row (count line)))
     :type type))
 
-(defn- make-line-regions [resource-map on-region-click! ^long row [type line]]
+;; todo fit in 4 args?
+(defn- make-line-regions [resource-map resource-suffix-map-delay on-region-click! row [type line]]
   (assert (keyword? type))
   (assert (string? line))
   (cons (make-whole-line-region type row line)
-        (make-line-sub-regions resource-map on-region-click! row line)))
+        (make-line-sub-regions resource-map resource-suffix-map-delay on-region-click! row line)))
 
-(defn- append-distinct-lines [{:keys [lines regions] :as props} entries resource-map on-region-click!]
+(defn- append-distinct-lines [{:keys [lines regions] :as props} entries resource-map resource-suffix-map-delay on-region-click!]
   (merge props
          (data/append-distinct-lines lines regions
                                      (mapv second entries)
-                                     (partial make-line-sub-regions resource-map on-region-click!))))
+                                     (partial make-line-sub-regions resource-map resource-suffix-map-delay on-region-click!))))
 
-(defn- append-regioned-lines [{:keys [lines regions] :as props} entries resource-map on-region-click!]
+(defn- append-regioned-lines [{:keys [lines regions] :as props} entries resource-map resource-suffix-map-delay on-region-click!]
   (assert (vector? lines))
   (assert (vector? regions))
   (let [clean-lines (if (= [""] lines) [] lines)
         lines' (into clean-lines (map second) entries)
         lines' (if (empty? lines') [""] lines')
         regions' (into regions
-                       (mapcat (partial make-line-regions resource-map on-region-click!)
+                       (mapcat (partial make-line-regions resource-map resource-suffix-map-delay on-region-click!)
                                (iterate inc (count clean-lines))
                                entries))]
     (cond-> (assoc props
@@ -442,37 +454,39 @@
             (empty? clean-lines)
             (assoc :invalidated-row 0))))
 
-(defn- append-entries [props entries resource-map on-region-click!]
+(defn- append-entries [props entries resource-map resource-suffix-map-delay on-region-click!]
   (assert (map? props))
   (assert (vector? (not-empty (:lines props))))
   (assert (vector? (:regions props)))
   (reduce (fn [props entries]
             (if (nil? (ffirst entries))
-              (append-distinct-lines props entries resource-map on-region-click!)
-              (append-regioned-lines props entries resource-map on-region-click!)))
+              (append-distinct-lines props entries resource-map resource-suffix-map-delay on-region-click!)
+              (append-regioned-lines props entries resource-map resource-suffix-map-delay on-region-click!)))
           props
           (partition-by #(nil? (first %)) entries)))
 
 (defn- repaint-console-view! [view-node workspace on-region-click! elapsed-time]
   (let [{:keys [clear? entries]} (dequeue-pending! 1000)]
     (when (or clear? (seq entries))
-      (let [resource-map (g/node-value workspace :resource-map)
-            ^LayoutInfo prev-layout (g/node-value view-node :layout)
-            prev-lines (g/node-value view-node :lines)
-            prev-regions (g/node-value view-node :regions)
-            prev-document-width (if clear? 0.0 (.document-width prev-layout))
-            appended-width (data/max-line-width (.glyph prev-layout) (.tab-stops prev-layout) (mapv second entries))
-            document-width (max prev-document-width ^double appended-width)
-            was-scrolled-to-bottom? (data/scrolled-to-bottom? prev-layout (count prev-lines))
-            props (append-entries {:lines (if clear? [""] prev-lines)
-                                   :regions (if clear? [] prev-regions)}
-                                  entries resource-map on-region-click!)]
-        (view/set-properties! view-node nil
-                              (cond-> (assoc props :document-width document-width)
-                                      was-scrolled-to-bottom? (assoc :scroll-y (data/scroll-to-bottom prev-layout (count (:lines props))))
-                                      clear? (assoc :cursor-ranges [data/document-start-cursor-range])
-                                      clear? (assoc :invalidated-row 0)
-                                      clear? (data/frame-cursor prev-layout))))))
+      (g/with-auto-evaluation-context evaluation-context
+        (let [resource-map (g/node-value workspace :resource-map evaluation-context)
+              ^LayoutInfo prev-layout (g/node-value view-node :layout evaluation-context)
+              prev-lines (g/node-value view-node :lines evaluation-context)
+              prev-regions (g/node-value view-node :regions evaluation-context)
+              prev-document-width (if clear? 0.0 (.document-width prev-layout))
+              appended-width (data/max-line-width (.glyph prev-layout) (.tab-stops prev-layout) (mapv second entries))
+              document-width (max prev-document-width ^double appended-width)
+              was-scrolled-to-bottom? (data/scrolled-to-bottom? prev-layout (count prev-lines))
+              resource-suffix-map-delay (make-resource-suffix-map-delay resource-map)
+              props (append-entries {:lines (if clear? [""] prev-lines)
+                                     :regions (if clear? [] prev-regions)}
+                                    entries resource-map resource-suffix-map-delay on-region-click!)]
+          (view/set-properties! view-node nil
+                                (cond-> (assoc props :document-width document-width)
+                                        was-scrolled-to-bottom? (assoc :scroll-y (data/scroll-to-bottom prev-layout (count (:lines props))))
+                                        clear? (assoc :cursor-ranges [data/document-start-cursor-range])
+                                        clear? (assoc :invalidated-row 0)
+                                        clear? (data/frame-cursor prev-layout)))))))
   (view/repaint-view! view-node elapsed-time {:cursor-visible? false}))
 
 (def ^:private console-grammar

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -424,7 +424,6 @@
                              (data/->Cursor row (count line)))
     :type type))
 
-;; todo fit in 4 args?
 (defn- make-line-regions [resource-map resource-suffix-map-delay on-region-click! row [type line]]
   (assert (keyword? type))
   (assert (string? line))

--- a/editor/test/editor/console_test.clj
+++ b/editor/test/editor/console_test.clj
@@ -81,7 +81,7 @@
                              "/main/yes_this_is_untitled_and_the_file_name_is_quite_long_how_will_you_deal_with_that_huh.script" 400})
 
 (defn- append-entries [props entries]
-  (#'console/append-entries props entries resource-map on-region-click!))
+  (#'console/append-entries props entries resource-map (console/make-resource-suffix-map-delay resource-map) on-region-click!))
 
 (defn- append-lines [props lines]
   ;; Entries are [type line] pairs. We use nil for untyped regular entries.
@@ -134,8 +134,11 @@
                        ["   via '/main.lua:8', '/main.lua:13'"]))))
 
 (deftest three-matches-on-same-line-where-two-are-partial
-  (is (= 3 (count
-             (#'console/make-line-sub-regions {"/absolute/project/path/file.lua" :WIN
-                                               "/some/really/long/path/to/some/resource/in/the/project/the_resource.script" :WIN}
-                                              identity 10
-                                              "urce/in/the/project/the_resource.script:25: in function <urce/in/the/project/the_resource.script:24> </absolute/project/path/file.lua:65>")))))
+  (let [resource-map {"/absolute/project/path/file.lua" :WIN
+                      "/some/really/long/path/to/some/resource/in/the/project/the_resource.script" :WIN}]
+   (is (= 3 (count
+              (#'console/make-line-sub-regions
+                resource-map
+                (console/make-resource-suffix-map-delay resource-map)
+                identity 10
+                "...to/some/resource/in/the/project/the_resource.script:25: in function <...to/some/resource/in/the/project/the_resource.script:24> </absolute/project/path/file.lua:65>"))))))

--- a/editor/test/editor/console_test.clj
+++ b/editor/test/editor/console_test.clj
@@ -142,3 +142,12 @@
                 (console/make-resource-suffix-map-delay resource-map)
                 identity 10
                 "...to/some/resource/in/the/project/the_resource.script:25: in function <...to/some/resource/in/the/project/the_resource.script:24> </absolute/project/path/file.lua:65>"))))))
+
+(deftest match-full-path-without-slash-prefix
+  (let [resource-map {"/foo/bar.json" true}]
+    (is (= 1 (count (#'console/make-line-sub-regions
+                      resource-map
+                      (console/make-resource-suffix-map-delay resource-map)
+                      identity
+                      10
+                      "DEBUG: foo/bar.json:1"))))))


### PR DESCRIPTION
On big projects with a lot of resources, it might take a lot of time to show output in the console because for every potential resource link we have to filter through all tracked resources. We now try to be smarter about it, both by limiting the candidates for search only to ellipsis-prefixed ones and by building a suffix map for the added lines batch so we have to go through all the resources less frequently.

Fixes #7176