### PR TITLE
Fixed radius calculation of sprites

### DIFF
--- a/engine/dlib/src/dlib/intersection.cpp
+++ b/engine/dlib/src/dlib/intersection.cpp
@@ -77,24 +77,36 @@ bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos, bool s
     return true;
 }
 
-bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius, bool skip_near_far)
+bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq, bool skip_near_far)
 {
     dmVMath::Vector4 vpos(pos);
-    return TestFrustumSphere(frustum, vpos, radius, skip_near_far);
+    return TestFrustumSphereSq(frustum, vpos, radius_sq, skip_near_far);
 }
 
-bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius, bool skip_near_far)
+bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq, bool skip_near_far)
 {
     uint32_t num_planes = skip_near_far ? 4 : 6;
     for (uint32_t i = 0; i < num_planes; ++i)
     {
         float d = DistanceToPlane(frustum.m_Planes[i], pos);
-        if (d < -radius)
+        if (d < 0 && (d*d) > radius_sq)
         {
+            //printf("Failed test for plane %d. distance to plane: %f for pos: %f, %f, %f\n", i, d, pos.getX(), pos.getY(), pos.getZ());
             return false;
         }
+        //printf("Plane %d. distance to plane: %f for pos: %f, %f, %f  radius_sq: %f\n", i, d, pos.getX(), pos.getY(), pos.getZ(), radius_sq);
     }
     return true;
+}
+
+bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius, bool skip_near_far)
+{
+    return TestFrustumSphereSq(frustum, pos, radius*radius, skip_near_far);
+}
+
+bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius, bool skip_near_far)
+{
+    return TestFrustumSphereSq(frustum, pos, radius*radius, skip_near_far);
 }
 
 // Returns 'false' if the bounding box is off the frustum. Returning 'true' does not guarantee that the object intersects the frustum or is inside it.

--- a/engine/dlib/src/dlib/intersection.cpp
+++ b/engine/dlib/src/dlib/intersection.cpp
@@ -91,10 +91,8 @@ bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, fl
         float d = DistanceToPlane(frustum.m_Planes[i], pos);
         if (d < 0 && (d*d) > radius_sq)
         {
-            //printf("Failed test for plane %d. distance to plane: %f for pos: %f, %f, %f\n", i, d, pos.getX(), pos.getY(), pos.getZ());
             return false;
         }
-        //printf("Plane %d. distance to plane: %f for pos: %f, %f, %f  radius_sq: %f\n", i, d, pos.getX(), pos.getY(), pos.getZ(), radius_sq);
     }
     return true;
 }

--- a/engine/dlib/src/dmsdk/dlib/intersection.h
+++ b/engine/dlib/src/dmsdk/dlib/intersection.h
@@ -28,24 +28,110 @@
 
 namespace dmIntersection
 {
+    /*#
+     * Plane struct (currently an alias for dmVMath::Vector4)
+     * @typedef
+     * @name Plane
+     */
     typedef dmVMath::Vector4 Plane;
 
+    /*#
+     * Returns the closest distance between a plane and a position
+     * @name DistanceToPlane
+     * @param plane [type: dmIntersection::Plane] plane equation
+     * @param pos [type: dmVMath::Point3] position
+     * @return distance [type: float] closest distance between plane and position
+     */
     float DistanceToPlane(Plane plane, dmVMath::Point3 pos);
 
+    /*# frustum
+     * Frustum
+     * @note The plane normals point inwards
+     * @struct
+     * @name Frustum
+     * @member m_Planes [type:dmIntersection::Plane[6]] plane equations: // left, right, bottom, top, near, far
+     */
     struct Frustum
     {
         // The plane normals point inwards
         Plane m_Planes[6]; // left, right, bottom, top, near, far
     };
 
+    /*#
+     * Constructs a dmIntersection::Frustum from a View*Projection matrix
+     * @name CreateFrustumFromMatrix
+     * @param m [type: dmVMath::Matrix4&] The matrix. Usually a "ViewProj" matrix
+     * @param normalize [type: bool] true if the normals should be normalized
+     * @return frustum [type: dmIntersection::Frustum&] the frustum output
+     */
     void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, Frustum& frustum);
 
     // Returns true if the objects intersect
+
+    /*#
+     * Tests intersection between a frustum and a point
+     * @name TestFrustumPoint
+     * @param frustum [type: dmIntersection::Frustum&] the frustum
+     * @param pos [type: dmVMath::Point3&] the position
+     * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
+     * @return intersects [type: bool] Returns true if the objects intersect
+     */
     bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos, bool skip_near_far);
+
+    /*#
+     * Tests intersection between a frustum and a sphere
+     * @name TestFrustumSphere
+     * @param frustum [type: dmIntersection::Frustum&] the frustum
+     * @param pos [type: dmVMath::Point3&] the center position of the sphere
+     * @param radius [type: float] the radius of the sphere
+     * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
+     * @return intersects [type: bool] Returns true if the objects intersect
+     */
     bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius, bool skip_near_far);
+
+    /*#
+     * Tests intersection between a frustum and a sphere
+     * @name TestFrustumSphere
+     * @param frustum [type: dmIntersection::Frustum&] the frustum
+     * @param pos [type: dmVMath::Vector4&] the center position of the sphere. The w component must be 1.
+     * @param radius [type: float] the radius of the sphere
+     * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
+     * @return intersects [type: bool] Returns true if the objects intersect
+     */
     bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius, bool skip_near_far);
+
+    /*#
+     * Tests intersection between a frustum and a sphere
+     * @name TestFrustumSphereSq
+     * @param frustum [type: dmIntersection::Frustum&] the frustum
+     * @param pos [type: dmVMath::Point3&] the center position of the sphere
+     * @param radius_sq [type: float] the squared radius of the sphere
+     * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
+     * @return intersects [type: bool] Returns true if the objects intersect
+     */
     bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq, bool skip_near_far);
+
+    /*#
+     * Tests intersection between a frustum and a sphere
+     * @name TestFrustumSphereSq
+     * @param frustum [type: dmIntersection::Frustum&] the frustum
+     * @param pos [type: dmVMath::Vector4&] the center position of the sphere. The w component must be 1.
+     * @param radius_sq [type: float] the squared radius of the sphere
+     * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
+     * @return intersects [type: bool] Returns true if the objects intersect
+     */
     bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq, bool skip_near_far);
+
+    /*#
+     * Tests intersection between a frustum and an oriented bounding box (OBB)
+     * @name TestFrustumOBB
+     * @param frustum [type: dmIntersection::Frustum&] the frustum
+     * @param world [type: dmVMath::Matrix4&] The world transform of the OBB
+     * @param aabb_min [type: dmVMath::Vector3&] the minimum corner of the object. In local space.
+     * @param aabb_max [type: dmVMath::Vector3&] the maximum corner of the object. In local space.
+     * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
+     * @return intersects [type: bool] Returns true if the objects intersect
+     */
     bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMath::Vector3& aabb_min, dmVMath::Vector3& aabb_max, bool skip_near_far);
 
 } // dmIntersection

--- a/engine/dlib/src/dmsdk/dlib/intersection.h
+++ b/engine/dlib/src/dmsdk/dlib/intersection.h
@@ -40,9 +40,12 @@ namespace dmIntersection
 
     void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, Frustum& frustum);
 
+    // Returns true if the objects intersect
     bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos, bool skip_near_far);
     bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius, bool skip_near_far);
     bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius, bool skip_near_far);
+    bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq, bool skip_near_far);
+    bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq, bool skip_near_far);
     bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMath::Vector3& aabb_min, dmVMath::Vector3& aabb_max, bool skip_near_far);
 
 } // dmIntersection

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1054,7 +1054,6 @@ namespace dmGameSystem
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_UserData;
         const float* radiuses = sprite_world->m_BoundingVolumes.Begin();
 
-        const dmArray<SpriteComponent>& components = sprite_world->m_Components.GetRawObjects();
         const dmIntersection::Frustum frustum = *params.m_Frustum;
         uint32_t num_entries = params.m_NumEntries;
         for (uint32_t i = 0; i < num_entries; ++i)

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -829,7 +829,10 @@ namespace dmGameSystem
                 Matrix4 world = dmGameObject::GetWorldMatrix(c->m_Instance);
                 Vector3 size( c->m_Size.getX() * c->m_Scale.getX(), c->m_Size.getY() * c->m_Scale.getY(), 1);
                 c->m_World = appendScale(world * local, size);
-                sprite_world->m_BoundingVolumes[i] = Vectormath::Aos::lengthSqr(dmVMath::Vector3(size.getX()*0.5f, size.getY()*0.5f, 0.0f));
+                // we need to consider the full scale here
+                // I.e. we want the length of the diagonal C, where C = X + Y
+                float radius_sq = Vectormath::Aos::lengthSqr((c->m_World.getCol(0).getXYZ() + c->m_World.getCol(1).getXYZ()) * 0.5f);
+                sprite_world->m_BoundingVolumes[i] = radius_sq;
             }
         } else
         {
@@ -841,7 +844,10 @@ namespace dmGameSystem
                 Matrix4 w = dmTransform::MulNoScaleZ(world, local);
                 Vector3 size( c->m_Size.getX() * c->m_Scale.getX(), c->m_Size.getY() * c->m_Scale.getY(), 1);
                 c->m_World = appendScale(w, size);
-                sprite_world->m_BoundingVolumes[i] = Vectormath::Aos::lengthSqr(dmVMath::Vector3(size.getX()*0.5f, size.getY()*0.5f, 0.0f));
+                // we need to consider the full scale here
+                // I.e. we want the length of the diagonal C, where C = X + Y
+                float radius_sq = Vectormath::Aos::lengthSqr((c->m_World.getCol(0).getXYZ() + c->m_World.getCol(1).getXYZ()) * 0.5f);
+                sprite_world->m_BoundingVolumes[i] = radius_sq;
             }
         }
 

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -593,7 +593,7 @@ namespace dmRender
         dmVMath::Vector4 centerpoint_world = te.m_Transform * centerpoint_local; // transform to world coordinates
         dmVMath::Vector4 cornerpoint_world = te.m_Transform * cornerpoint_local;
 
-        te.m_FrustumCullingRadius = Vectormath::Aos::length(cornerpoint_world - centerpoint_world);
+        te.m_FrustumCullingRadiusSq = Vectormath::Aos::lengthSqr(cornerpoint_world - centerpoint_world);
         te.m_FrustumCullingCenter = dmVMath::Point3(centerpoint_world.getXYZ());
 
 
@@ -1127,7 +1127,7 @@ namespace dmRender
             dmRender::RenderListEntry* entry = &params.m_Entries[i];
             TextEntry* te = ((TextEntry*) entry->m_UserData);
 
-            bool intersect = dmIntersection::TestFrustumSphere(frustum, te->m_FrustumCullingCenter, te->m_FrustumCullingRadius, true);
+            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, te->m_FrustumCullingCenter, te->m_FrustumCullingRadiusSq, true);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -143,7 +143,7 @@ namespace dmRender
         int32_t             m_Next;
         int32_t             m_Tail;
         dmVMath::Point3     m_FrustumCullingCenter;
-        float               m_FrustumCullingRadius;
+        float               m_FrustumCullingRadiusSq;
         uint32_t            m_Align : 2;
         uint32_t            m_VAlign : 2;
         uint32_t            m_StencilTestParamsSet : 1;


### PR DESCRIPTION
Fixed an issue where the culling radius of a sprite wasn't calculated correctly.
The issue caused some (rotated) sprites to cull prematurely.

## PR checklist (remove before merging)

* [x] Prepared the PR for release notes
	* [x] Proper description of feature or fix (see example x?)
	* [x] Added a #fixes ### if it fixes an issue
	* [x] Assigned issue to a project
* [-] Added documentation for public API changes
* [-] Is this a new feature?
	* [-] Added engine and/or editor unit tests
	* [-] Added or updated manual entry
