### PR TITLE
Improve editor performance when changing highly referenced nodes

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -78,6 +78,8 @@
 
                      [org.luaj/luaj-jse "3.0.1"]
 
+                     [com.github.ben-manes.caffeine/caffeine "3.1.2"]
+
                      [cljfx "1.7.21"]
 
                      [org.openjfx/javafx-base "18"]

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -33,7 +33,7 @@
 
 (set! *warn-on-reflection* true)
 
-(namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id node-id? produce-value node-by-id-at endpoint-node-id endpoint-label])
+(namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? cached-dependencies Node node-id node-id? produce-value node-by-id-at endpoint-node-id endpoint-label])
 
 (namespaces/import-vars [internal.graph.error-values ->error error-aggregate error-fatal error-fatal? error-info error-info? error-message error-package? error-warning error-warning? error? flatten-errors map->error package-errors precluding-errors unpack-errors worse-than package-if-error])
 
@@ -149,7 +149,7 @@
 
   It returns the transaction result, (tx-result),  which is a map containing keys about the transaction.
   Transaction result-keys:
-  `[:status :basis :graphs-modified :nodes-added :nodes-modified :nodes-deleted :outputs-modified :label :sequence-label]`
+  `[:status :basis :graphs-modified :nodes-affected :nodes-added :nodes-modified :nodes-deleted :cached-outputs-modified :label :sequence-label]`
   "
   ([txs]
    (transact nil txs))
@@ -165,7 +165,7 @@
          tx-result (it/transact* transaction-context txs)]
      (when (and (not (:dry-run opts))
                 (= :ok (:status tx-result)))
-       (swap! *the-system* is/merge-graphs (get-in tx-result [:basis :graphs]) (:graphs-modified tx-result) (:outputs-modified tx-result) (:nodes-deleted tx-result)))
+       (swap! *the-system* is/merge-graphs (get-in tx-result [:basis :graphs]) (:graphs-modified tx-result) (:cached-outputs-modified tx-result) (:nodes-deleted tx-result)))
      tx-result)))
 
 ;; ---------------------------------------------------------------------------

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -236,7 +236,7 @@
                                                                (assoc :link maybe-image-resource :outline-show-link? true)))))
   (output ddf-message g/Any (g/fnk [maybe-image-resource order sprite-trim-mode]
                               {:image (resource/resource->proj-path maybe-image-resource) :order order :sprite-trim-mode sprite-trim-mode}))
-  (output scene g/Any :cached produce-image-scene)
+  (output scene g/Any produce-image-scene)
   (output build-errors g/Any (g/fnk [_node-id id id-counts maybe-image-resource]
                                (g/package-errors _node-id
                                                  (validate-image-resource _node-id maybe-image-resource)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -690,7 +690,7 @@
                                        (sort-by #(get-in % [0 :child-index])
                                                 node-rt-msgs)))))
   (output aabb g/Any :abstract)
-  (output scene-children g/Any :cached (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
+  (output scene-children g/Any (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
   (output scene-updatable g/Any (g/constantly nil))
   (output scene-renderable g/Any (g/constantly nil))
   (output scene-outline-renderable g/Any (g/constantly nil))
@@ -1245,12 +1245,12 @@
                        (if (some? template-scene)
                          (:aabb template-scene)
                          geom/empty-bounding-box)))
-  (output scene-children g/Any :cached (g/fnk [_node-id id template-scene]
-                                         (when (seq (:children template-scene))
-                                           (-> template-scene
-                                               (scene/claim-scene _node-id id)
-                                               (add-renderable-tags #{:gui})
-                                               :children))))
+  (output scene-children g/Any (g/fnk [_node-id id template-scene]
+                                 (when (seq (:children template-scene))
+                                   (-> template-scene
+                                       (scene/claim-scene _node-id id)
+                                       (add-renderable-tags #{:gui})
+                                       :children))))
   (output scene-renderable g/Any :cached (g/fnk [color+alpha child-index layer-index inherit-alpha enabled]
                                                 {:passes [pass/selection]
                                                  :child-index child-index
@@ -1694,16 +1694,16 @@
 
   (input child-scenes g/Any :array)
   (input child-indices NodeIndex :array)
-  (output child-scenes g/Any :cached (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
+  (output child-scenes g/Any (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
   (output node-outline outline/OutlineData :cached
           (gen-outline-fnk "Nodes" nil 0 true (mapv (fn [type-info] {:node-type (:node-cls type-info)
                                                                      :tx-attach-fn (gen-gui-node-attach-fn (:node-type type-info))})
                                                     (get-registered-node-type-infos))))
 
-  (output scene g/Any :cached (g/fnk [_node-id child-scenes]
-                                {:node-id _node-id
-                                 :aabb geom/null-aabb
-                                 :children child-scenes}))
+  (output scene g/Any (g/fnk [_node-id child-scenes]
+                        {:node-id _node-id
+                         :aabb geom/null-aabb
+                         :children child-scenes}))
   (input ids g/Str :array)
   (output id-counts NameCounts :cached (g/fnk [ids] (frequencies ids)))
   (input node-msgs g/Any :array)
@@ -2308,9 +2308,9 @@
   (input default-scene g/Any)
   (input layout-scenes g/Any :array)
   (output layout-scenes g/Any :cached (g/fnk [layout-scenes] (into {} layout-scenes)))
-  (output child-scenes g/Any :cached (g/fnk [default-scene layout-scenes current-layout]
-                                       (let [node-tree-scene (get layout-scenes current-layout default-scene)]
-                                         (:children node-tree-scene))))
+  (output child-scenes g/Any (g/fnk [default-scene layout-scenes current-layout]
+                               (let [node-tree-scene (get layout-scenes current-layout default-scene)]
+                                 (:children node-tree-scene))))
   (output scene g/Any :cached produce-scene)
   (output scene-dims g/Any :cached (g/fnk [project-settings current-layout display-profiles]
                                           (or (some #(and (= current-layout (:name %)) (first (:qualifiers %))) display-profiles)

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -114,9 +114,9 @@
                                                                           {:min-filter gl/nearest
                                                                            :mag-filter gl/nearest})))
 
-  (output gpu-texture-generator g/Any :cached (g/fnk [texture-image :as args]
-                                                     {:f    generate-gpu-texture
-                                                      :args args}))
+  (output gpu-texture-generator g/Any (g/fnk [texture-image :as args]
+                                             {:f    generate-gpu-texture
+                                              :args args}))
 
   (output build-targets g/Any :cached produce-build-targets))
 

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -31,9 +31,9 @@
   Comparable
   (compareTo [_ that]
     (let [^Endpoint that that
-          node-id-comparison (Long/compare node-id (.-node-id that))]
+          node-id-comparison (.compareTo node-id (.-node-id that))]
       (if (zero? node-id-comparison)
-        (compare label (.-label that))
+        (.compareTo label (.-label that))
         node-id-comparison)))
   IHashEq
   (hasheq [_]
@@ -115,11 +115,12 @@
   (connect          [this source-id source-label target-id target-label])
   (disconnect       [this source-id source-label target-id target-label])
   (connected?       [this source-id source-label target-id target-label])
-  (dependencies     [this endpoints]
+  (cached-dependencies     [this endpoints]
     "Follow arcs through the graphs, from outputs to the inputs
      connected to them, and from those inputs to the downstream
      outputs that use them, and so on. Continue following links until
-     all reachable outputs are found.
+     all reachable outputs are found. Returns all reachable cached
+     endpoints.
 
      Takes a coll of endpoints and returns a set of endpoints")
   (original-node    [this node-id]))

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -43,8 +43,8 @@
 
 (defrecord HistoryState [label graph sequence-label cache-keys])
 
-(defn history-state [graph outputs-modified]
-  (->HistoryState (:tx-label graph) graph (:tx-sequence-label graph) outputs-modified))
+(defn history-state [graph cached-outputs-modified]
+  (->HistoryState (:tx-label graph) graph (:tx-sequence-label graph) cached-outputs-modified))
 
 (defn- history-state-merge-cache-keys
   [new old]
@@ -64,9 +64,9 @@
   ([x y & more] (reduce =* (=* x y) more)))
 
 (defn merge-or-push-history
-  [history old-graph new-graph outputs-modified]
-  (assert (set? outputs-modified))
-  (let [new-state (history-state new-graph outputs-modified)
+  [history old-graph new-graph cached-outputs-modified]
+  (assert (set? cached-outputs-modified))
+  (let [new-state (history-state new-graph cached-outputs-modified)
         tape-op (if (=* (:tx-sequence-label new-graph) (:tx-sequence-label old-graph))
                   merge-into-top
                   conj)]
@@ -119,7 +119,7 @@
   (assert (every? gt/endpoint? outputs))
   ;; 'dependencies' takes a map, where outputs is a vec of node-id+label pairs
   (let [basis (basis system)
-        cache-entries (gt/dependencies basis outputs)]
+        cache-entries (gt/cached-dependencies basis outputs)]
     (-> system
         (update :cache c/cache-invalidate cache-entries)
         (update :invalidate-counters bump-invalidate-counters cache-entries))))
@@ -237,16 +237,16 @@
 (def ^:private meaningful-change? contains?)
 
 (defn- remember-change
-  [system graph-id before after outputs-modified]
-  (update-in system [:history graph-id] merge-or-push-history before after outputs-modified))
+  [system graph-id before after cached-outputs-modified]
+  (update-in system [:history graph-id] merge-or-push-history before after cached-outputs-modified))
 
 (defn merge-graphs
-  [system post-tx-graphs significantly-modified-graphs outputs-modified nodes-deleted]
-  (let [graph-id->outputs-modified (util/group-into
-                                     {}
-                                     #{}
-                                     #(gt/node-id->graph-id (gt/endpoint-node-id %))
-                                     outputs-modified)
+  [system post-tx-graphs significantly-modified-graphs cached-outputs-modified nodes-deleted]
+  (let [graph-id->cached-outputs-modified (util/group-into
+                                            {}
+                                            #{}
+                                            #(gt/node-id->graph-id (gt/endpoint-node-id %))
+                                            cached-outputs-modified)
         post-system (reduce (fn [system [graph-id graph]]
                               (let [start-tx (:tx-id graph -1)
                                     sidereal-tx (graph-time system graph-id)]
@@ -261,19 +261,19 @@
                                                       graph-after)
                                         system-after (if (and (has-history? system graph-id)
                                                               (meaningful-change? significantly-modified-graphs graph-id))
-                                                       (remember-change system graph-id graph-before graph-after (graph-id->outputs-modified graph-id #{}))
+                                                       (remember-change system graph-id graph-before graph-after (graph-id->cached-outputs-modified graph-id #{}))
                                                        system)]
                                     (assoc-in system-after [:graphs graph-id] graph-after)))))
                             system
                             post-tx-graphs)]
     (-> post-system
-        (update :cache c/cache-invalidate outputs-modified)
+        (update :cache c/cache-invalidate cached-outputs-modified)
         (update :user-data (fn [user-data]
                              (reduce (fn [user-data [graph-id deleted-node-ids]]
                                        (update user-data graph-id (partial apply dissoc) deleted-node-ids))
                                      user-data
                                      (group-by gt/node-id->graph-id (keys nodes-deleted)))))
-        (update :invalidate-counters bump-invalidate-counters outputs-modified))))
+        (update :invalidate-counters bump-invalidate-counters cached-outputs-modified))))
 
 (defn basis-graphs-identical? [basis1 basis2]
   (let [graph-ids (keys (:graphs basis1))]

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -828,7 +828,7 @@
     (update-in [:basis :graphs] map-vals-bargs #(assoc % :tx-label label))))
 
 (def tx-report-keys
-  (cond-> [:basis :graphs-modified :nodes-added :nodes-modified :nodes-deleted :outputs-modified :label :sequence-label]
+  (cond-> [:basis :graphs-modified :nodes-affected :nodes-added :nodes-modified :nodes-deleted :cached-outputs-modified :label :sequence-label]
           (du/metrics-enabled?) (conj :metrics)))
 
 (defn- finalize-update
@@ -845,7 +845,7 @@
    :nodes-added []
    :nodes-modified #{}
    :nodes-deleted {}
-   :outputs-modified #{}
+   :cached-outputs-modified #{}
    :graphs-modified #{}
    :override-nodes-affected-seen #{}
    :override-nodes-affected-ordered []
@@ -872,12 +872,13 @@
 
 (defn- trace-dependencies
   [ctx]
-  ;; at this point, :outputs-modified contains [node-id output] pairs.
-  ;; afterwards, it will have the transitive closure of all [node-id output] pairs
-  ;; reachable from the original collection.
+  ;; at this point, :cached-outputs-modified contains #g/endpoint [node-id output] values.
+  ;; afterwards, it will have the transitive closure of all cached
+  ;; #g/endpoint [node-id output] values reachable from the original
+  ;; collection.
   (du/measuring (:metrics ctx) :trace-dependencies
-    (let [outputs-modified (gt/dependencies (:basis ctx) (:nodes-affected ctx))]
-      (assoc ctx :outputs-modified outputs-modified))))
+    (let [cached-outputs-modified (gt/cached-dependencies (:basis ctx) (:nodes-affected ctx))]
+      (assoc ctx :cached-outputs-modified cached-outputs-modified))))
 
 (defn transact*
   [ctx actions]

--- a/editor/test/dynamo/integration/property_setters.clj
+++ b/editor/test/dynamo/integration/property_setters.clj
@@ -59,7 +59,7 @@
       #_(is (= provider (get-in (g/node-value user :_properties) [:properties :reference :value])))
       #_(is (= provider (g/node-value user :upstream))))))
 
-(defn- modified? [tx-report node property] (some #{(g/endpoint node property)} (:outputs-modified tx-report)))
+(defn- modified? [tx-report node property] (some #{(g/endpoint node property)} (ts/all-tx-modified-outputs tx-report)))
 
 (deftest dependencies-through-properties
   (testing "an output uses a property with a getter, changing the upstream node affects the output"

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -20,7 +20,7 @@
             [internal.system :as is]
             [internal.util :as util]
             [schema.core :as s]
-            [support.test-support :refer [tx-nodes with-clean-system]]
+            [support.test-support :as ts :refer [tx-nodes with-clean-system]]
             [internal.graph.types :as gt])
   (:import clojure.lang.ExceptionInfo))
 
@@ -166,7 +166,7 @@
   (with-clean-system
     (let [[node-id] (tx-nodes (g/make-node world node-type :foo "one"))
           tx-result (g/transact (f node-id))]
-      (let [modified (into #{} (map gt/endpoint-label) (:outputs-modified tx-result))]
+      (let [modified (into #{} (map gt/endpoint-label) (ts/all-tx-modified-outputs tx-result))]
         (is (= properties modified))))))
 
 (deftest invalidating-properties-output
@@ -189,7 +189,7 @@
           tx-result                     (g/set-property! source :foo "hi")
           properties-modified-on-target (set (keep #(when (= (gt/endpoint-node-id %) target)
                                                       (gt/endpoint-label %))
-                                                   (:outputs-modified tx-result)))]
+                                                   (ts/all-tx-modified-outputs tx-result)))]
       (is (= #{:_declared-properties :baz :_properties} properties-modified-on-target)))))
 
 (deftest visibility-properties
@@ -207,7 +207,7 @@
                                   (g/make-node world EnablementTestNode))]
       (g/transact (g/connect snode :foo enode :bar))
       (let [tx-result     (g/transact (g/set-property snode :foo 1))
-            enode-results (filter #(= (gt/endpoint-node-id %) enode) (:outputs-modified tx-result))
+            enode-results (filter #(= (gt/endpoint-node-id %) enode) (ts/all-tx-modified-outputs tx-result))
             modified      (into #{} (map gt/endpoint-label) enode-results)]
         (is (= #{:_declared-properties :baz :_properties} modified))))))
 

--- a/editor/test/internal/transaction_test.clj
+++ b/editor/test/internal/transaction_test.clj
@@ -151,7 +151,7 @@
 
 (defmacro affected-by [& forms]
   `(let [tx-result# (g/transact ~@forms)]
-     (set (:outputs-modified tx-result#))))
+     (set (ts/all-tx-modified-outputs tx-result#))))
 
 (defn pairwise [m]
   (for [[k vs] m
@@ -176,7 +176,7 @@
   (ts/with-clean-system
     (let [{:keys [calculator person first-name-cell greeter formal-greeter multi-node-target]} (build-network world)
           tx-result        (g/transact (g/invalidate person))
-          outputs-modified (:outputs-modified tx-result)]
+          outputs-modified (ts/all-tx-modified-outputs tx-result)]
       (doseq [output [:_node-id :_properties :friendly-name :full-name :date-of-birth :age]]
         (is (some #{(g/endpoint person output)} outputs-modified))))))
 
@@ -191,13 +191,13 @@
   (ts/with-clean-system
     (let [tx-result        (g/transact (g/make-node world CachedOutputInvalidation))
           real-id          (first (g/tx-nodes-added tx-result))
-          outputs-modified (:outputs-modified tx-result)]
+          outputs-modified (ts/all-tx-modified-outputs tx-result)]
       (is (some #{real-id} (map gt/endpoint-node-id outputs-modified)))
       (is (= #{:_declared-properties :_properties :_overridden-properties :_node-id :_output-jammers :self-dependent :a-property :ordinary}
              (into #{} (map gt/endpoint-label) outputs-modified)))
       (let [tx-data          [(it/update-property real-id :a-property (constantly "new-value") [])]
             tx-result        (g/transact tx-data)
-            outputs-modified (:outputs-modified tx-result)]
+            outputs-modified (ts/all-tx-modified-outputs tx-result)]
         (is (some #{real-id} (map gt/endpoint-node-id outputs-modified)))
         (is (= #{:_declared-properties :_properties :a-property :ordinary :self-dependent}
                (into #{} (map gt/endpoint-label) outputs-modified)))))))

--- a/editor/test/support/test_support.clj
+++ b/editor/test/support/test_support.clj
@@ -16,7 +16,8 @@
   (:require [clojure.java.io :as io]
             [dynamo.graph :as g]
             [editor.fs :as fs]
-            [internal.system :as is]))
+            [internal.system :as is])
+  (:import [java.util ArrayDeque HashSet]))
 
 (def enable-performance-tests
   (nil? (get (System/getenv)
@@ -78,5 +79,40 @@
 (defn graph-dependencies
   ([tgts]
    (graph-dependencies (g/now) tgts))
-  ([basis tgts]
-   (g/dependencies basis tgts)))
+  ([basis endpoints]
+   (let [graph-id->node-successor-map
+         (persistent!
+           (reduce-kv
+             (fn [acc graph-id graph]
+               (assoc! acc graph-id (:successors graph)))
+             (transient {})
+             (:graphs basis)))
+         endpoint->successors (fn [endpoint]
+                                (let [node-id (g/endpoint-node-id endpoint)
+                                      output (g/endpoint-label endpoint)]
+                                  (-> node-id
+                                      g/node-id->graph-id
+                                      graph-id->node-successor-map
+                                      (get node-id)
+                                      (get output))))
+         deque (ArrayDeque.)
+         result (HashSet.)]
+     (reduce (fn [_ endpoint]
+               (.push deque endpoint))
+             nil
+             endpoints)
+     (loop []
+       (when-some [endpoint (.pollLast deque)]
+         (when-not (.contains result endpoint)
+           (when-some [successors (endpoint->successors endpoint)]
+             (reduce
+               (fn [_ successor-endpoint]
+                 (.push deque successor-endpoint))
+               nil
+               successors)
+             (.add result endpoint)))
+         (recur)))
+     result)))
+
+(defn all-tx-modified-outputs [tx-result]
+  (graph-dependencies (:basis tx-result) (:nodes-affected tx-result)))


### PR DESCRIPTION
Technical changes:
- parallelize the computation of `basis-dependencies`;
- add caching layer for `basis-dependencies` for recent dependencies requests;
- remove `:cached` flag on some outputs;
- only return cached endpoints from `basis-dependencies` (and rename it reflect the new semantics).

Related to #5447
