### PR TITLE
Start language servers in the project folder

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2491,7 +2491,7 @@
                    messages)})
 
 (defn- hover-view [^Canvas canvas {:keys [hovered-element layout lines]}]
-  (let [r ^Rect (->> hovered-element
+  (let [^Rect r (->> hovered-element
                      :region
                      (data/adjust-cursor-range lines)
                      (data/cursor-range-rects layout lines)

--- a/editor/src/clj/editor/error_reporting.clj
+++ b/editor/src/clj/editor/error_reporting.clj
@@ -108,8 +108,12 @@
      (let [{:keys [ex-map suppressed?]} (record-exception! exception)]
        (if suppressed?
          (when (system/defold-dev?)
-           (log/debug :msg "Suppressed unhandled" :exception exception))
-         (do (log/error :exception exception)
+           (if-let [data (ex-data exception)]
+             (log/debug :msg "Suppressed unhandled" :exception exception :ex-data data)
+             (log/debug :msg "Suppressed unhandled" :exception exception)))
+         (do (if-let [data (ex-data exception)]
+               (log/error :exception exception :ex-data data)
+               (log/error :exception exception))
              (analytics/track-exception! exception)
              (let [sentry-id-promise (sentry-reporter exception thread)]
                (exception-notifier ex-map sentry-id-promise)

--- a/editor/src/clj/editor/lsp/jsonrpc.clj
+++ b/editor/src/clj/editor/lsp/jsonrpc.clj
@@ -39,7 +39,7 @@
     {:jsonrpc "2.0"
      :id (:id message)
      :result (let [handler (or (request-handlers (:method message))
-                               (throw (ex-info "Method not found" {:jsonrpc/code -32601})))]
+                               (throw (ex-info "Method not found" {:jsonrpc/code -32601 :method (:method message)})))]
                (handler (:params message)))}
     (catch Throwable e
       (error-reporting/report-exception! e)

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -62,7 +62,8 @@
                    "/extension1/lib/common/file"
                    "/extension1/lib/x86_64-osx/file"
                    "/extension1/lib/osx/file"
-                   "/subdir/extension2/ext.manifest"}
+                   "/subdir/extension2/ext.manifest"
+                   "/subdir/extension2/src/.gitkeep"}
                  (platform-resources project "x86_64-macos"))))))
     (testing "arm64-ios"
       (with-clean-system
@@ -76,7 +77,8 @@
                    "/extension1/lib/common/file"
                    "/extension1/lib/arm64-ios/file"
                    "/extension1/lib/ios/file"
-                   "/subdir/extension2/ext.manifest"}
+                   "/subdir/extension2/ext.manifest"
+                   "/subdir/extension2/src/.gitkeep"}
                  (platform-resources project "arm64-ios"))))))))
 
 (defn- dummy-file [] (fs/create-temp-file! "dummy" ""))

--- a/editor/test/integration/lsp_test.clj
+++ b/editor/test/integration/lsp_test.clj
@@ -35,7 +35,7 @@
 
 (defn- make-test-server-launcher [request-handlers]
   (reify lsp.server/Launcher
-    (launch [_]
+    (launch [_ _]
       (let [private-out (PipedOutputStream.)
             public-in (PipedInputStream. private-out)
             private-in (PipedInputStream.)


### PR DESCRIPTION
We now start language servers in the project folder so it's possible to specify the launch command executable as a relative path.

Related to #3885