### PR TITLE
Parallelize basis-dependencies calculation

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -78,6 +78,8 @@
 
                      [org.luaj/luaj-jse "3.0.1"]
 
+                     [com.github.ben-manes.caffeine/caffeine "3.1.2"]
+
                      [cljfx "1.7.21"]
 
                      [org.openjfx/javafx-base "18"]

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -236,7 +236,7 @@
                                                                (assoc :link maybe-image-resource :outline-show-link? true)))))
   (output ddf-message g/Any (g/fnk [maybe-image-resource order sprite-trim-mode]
                               {:image (resource/resource->proj-path maybe-image-resource) :order order :sprite-trim-mode sprite-trim-mode}))
-  (output scene g/Any :cached produce-image-scene)
+  (output scene g/Any produce-image-scene)
   (output build-errors g/Any (g/fnk [_node-id id id-counts maybe-image-resource]
                                (g/package-errors _node-id
                                                  (validate-image-resource _node-id maybe-image-resource)

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -690,7 +690,7 @@
                                        (sort-by #(get-in % [0 :child-index])
                                                 node-rt-msgs)))))
   (output aabb g/Any :abstract)
-  (output scene-children g/Any :cached (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
+  (output scene-children g/Any (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
   (output scene-updatable g/Any (g/constantly nil))
   (output scene-renderable g/Any (g/constantly nil))
   (output scene-outline-renderable g/Any (g/constantly nil))
@@ -1245,12 +1245,12 @@
                        (if (some? template-scene)
                          (:aabb template-scene)
                          geom/empty-bounding-box)))
-  (output scene-children g/Any :cached (g/fnk [_node-id id template-scene]
-                                         (when (seq (:children template-scene))
-                                           (-> template-scene
-                                               (scene/claim-scene _node-id id)
-                                               (add-renderable-tags #{:gui})
-                                               :children))))
+  (output scene-children g/Any (g/fnk [_node-id id template-scene]
+                                 (when (seq (:children template-scene))
+                                   (-> template-scene
+                                       (scene/claim-scene _node-id id)
+                                       (add-renderable-tags #{:gui})
+                                       :children))))
   (output scene-renderable g/Any :cached (g/fnk [color+alpha child-index layer-index inherit-alpha enabled]
                                                 {:passes [pass/selection]
                                                  :child-index child-index
@@ -1694,16 +1694,16 @@
 
   (input child-scenes g/Any :array)
   (input child-indices NodeIndex :array)
-  (output child-scenes g/Any :cached (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
+  (output child-scenes g/Any (g/fnk [child-scenes] (vec (sort-by (comp :child-index :renderable) child-scenes))))
   (output node-outline outline/OutlineData :cached
           (gen-outline-fnk "Nodes" nil 0 true (mapv (fn [type-info] {:node-type (:node-cls type-info)
                                                                      :tx-attach-fn (gen-gui-node-attach-fn (:node-type type-info))})
                                                     (get-registered-node-type-infos))))
 
-  (output scene g/Any :cached (g/fnk [_node-id child-scenes]
-                                {:node-id _node-id
-                                 :aabb geom/null-aabb
-                                 :children child-scenes}))
+  (output scene g/Any (g/fnk [_node-id child-scenes]
+                        {:node-id _node-id
+                         :aabb geom/null-aabb
+                         :children child-scenes}))
   (input ids g/Str :array)
   (output id-counts NameCounts :cached (g/fnk [ids] (frequencies ids)))
   (input node-msgs g/Any :array)
@@ -2308,9 +2308,9 @@
   (input default-scene g/Any)
   (input layout-scenes g/Any :array)
   (output layout-scenes g/Any :cached (g/fnk [layout-scenes] (into {} layout-scenes)))
-  (output child-scenes g/Any :cached (g/fnk [default-scene layout-scenes current-layout]
-                                       (let [node-tree-scene (get layout-scenes current-layout default-scene)]
-                                         (:children node-tree-scene))))
+  (output child-scenes g/Any (g/fnk [default-scene layout-scenes current-layout]
+                               (let [node-tree-scene (get layout-scenes current-layout default-scene)]
+                                 (:children node-tree-scene))))
   (output scene g/Any :cached produce-scene)
   (output scene-dims g/Any :cached (g/fnk [project-settings current-layout display-profiles]
                                           (or (some #(and (= current-layout (:name %)) (first (:qualifiers %))) display-profiles)

--- a/editor/src/clj/editor/image.clj
+++ b/editor/src/clj/editor/image.clj
@@ -114,9 +114,9 @@
                                                                           {:min-filter gl/nearest
                                                                            :mag-filter gl/nearest})))
 
-  (output gpu-texture-generator g/Any :cached (g/fnk [texture-image :as args]
-                                                     {:f    generate-gpu-texture
-                                                      :args args}))
+  (output gpu-texture-generator g/Any (g/fnk [texture-image :as args]
+                                        {:f    generate-gpu-texture
+                                         :args args}))
 
   (output build-targets g/Any :cached produce-build-targets))
 

--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -19,8 +19,10 @@
             [internal.util :as util]
             [util.coll :refer [pair]])
   (:import [clojure.lang IPersistentSet]
+           [com.github.benmanes.caffeine.cache Cache Caffeine]
            [internal.graph.types Arc]
-           [java.util ArrayDeque HashSet]))
+           [java.util.concurrent ConcurrentHashMap ForkJoinPool TimeUnit]
+           [java.util.function Function]))
 
 ;; A brief braindump on Overrides.
 ;;
@@ -813,6 +815,12 @@
                result')
         (persistent! result')))))
 
+(def ^:private ^Cache basis-dependencies-cache
+  (-> (Caffeine/newBuilder)
+      (.expireAfterAccess 10 TimeUnit/SECONDS)
+      (.maximumSize 32)
+      (.build)))
+
 (defn- basis-dependencies [basis endpoints]
   (assert (every? gt/endpoint? endpoints))
   (let [graph-id->node-successor-map
@@ -822,32 +830,39 @@
               (assoc! acc graph-id (:successors graph)))
             (transient {})
             (:graphs basis)))
-        endpoint->successors (fn [endpoint]
-                               (let [node-id (gt/endpoint-node-id endpoint)
-                                     output (gt/endpoint-label endpoint)]
-                                 (-> node-id
-                                     gt/node-id->graph-id
-                                     graph-id->node-successor-map
-                                     (get node-id)
-                                     (get output))))
-        deque (ArrayDeque.)
-        result (HashSet.)]
-    (reduce (fn [_ endpoint]
-              (.push deque endpoint))
-            nil
-            endpoints)
-    (loop []
-      (when-some [endpoint (.pollLast deque)]
-        (when-not (.contains result endpoint)
-          (when-some [successors (endpoint->successors endpoint)]
-            (reduce
-              (fn [_ successor-endpoint]
-                (.push deque successor-endpoint))
-              nil
-              successors)
-            (.add result endpoint)))
-        (recur)))
-    result))
+        cache-key (into [endpoints]
+                        (map #(System/identityHashCode (val %)))
+                        graph-id->node-successor-map)]
+    (.get basis-dependencies-cache
+          cache-key
+          (reify Function
+            (apply [_ _]
+              (let [pool (ForkJoinPool/commonPool)
+                    all-endpoints (ConcurrentHashMap.)
+                    make-task! (fn [endpoints]
+                                 (fn []
+                                   (into []
+                                         (mapcat
+                                           (fn [endpoint]
+                                             (when (nil? (.putIfAbsent all-endpoints endpoint true))
+                                               (let [node-id (gt/endpoint-node-id endpoint)
+                                                     output (gt/endpoint-label endpoint)]
+                                                 (-> node-id
+                                                     gt/node-id->graph-id
+                                                     graph-id->node-successor-map
+                                                     (get node-id)
+                                                     (get output))))))
+                                         endpoints)))
+                    endpoints->tasks-xf (comp (partition-all 512) (map make-task!))
+                    future->tasks-xf (comp (mapcat deref) endpoints->tasks-xf)]
+                (loop [tasks (into [] endpoints->tasks-xf endpoints)]
+                  (let [next-tasks
+                        (if (= 1 (count tasks))
+                          (into [] endpoints->tasks-xf ((nth tasks 0)))
+                          (into [] future->tasks-xf (.invokeAll pool tasks)))]
+                    (when (pos? (count next-tasks))
+                      (recur next-tasks))))
+                (.keySet all-endpoints)))))))
 
 (defrecord MultigraphBasis [graphs]
   gt/IBasis

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -31,9 +31,9 @@
   Comparable
   (compareTo [_ that]
     (let [^Endpoint that that
-          node-id-comparison (Long/compare node-id (.-node-id that))]
+          node-id-comparison (.compareTo node-id (.-node-id that))]
       (if (zero? node-id-comparison)
-        (compare label (.-label that))
+        (.compareTo label (.-label that))
         node-id-comparison)))
   IHashEq
   (hasheq [_]


### PR DESCRIPTION
This change improves the performance of changing highly-referenced resources by around 30%.

Related to #5447