### PR TITLE
Conform 'buffer is full' error messages

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -87,7 +87,7 @@ namespace dmGameSystem
         CameraWorld* w = (CameraWorld*)params.m_World;
         if (w->m_Cameras.Full())
         {
-            ShowFullBufferError("Camera", NULL, MAX_COUNT);
+            ShowFullBufferError("Camera", MAX_COUNT);
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         dmGameSystem::CameraResource* cam_resource = (CameraResource*)params.m_Resource;

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -70,7 +70,6 @@ namespace dmGameSystem
     {
         CameraWorld* cam_world = new CameraWorld();
         uint32_t comp_count = dmMath::Min(params.m_MaxComponentInstances, MAX_COUNT);
-        
         cam_world->m_Cameras.SetCapacity(comp_count);
         cam_world->m_FocusStack.SetCapacity(MAX_STACK_COUNT);
         *params.m_World = cam_world;
@@ -86,30 +85,27 @@ namespace dmGameSystem
     dmGameObject::CreateResult CompCameraCreate(const dmGameObject::ComponentCreateParams& params)
     {
         CameraWorld* w = (CameraWorld*)params.m_World;
-        if (!w->m_Cameras.Full())
+        if (w->m_Cameras.Full())
         {
-            dmGameSystem::CameraResource* cam_resource = (CameraResource*)params.m_Resource;
-            CameraComponent camera;
-            camera.m_Instance = params.m_Instance;
-            camera.m_World = w;
-            camera.m_AspectRatio = cam_resource->m_DDF->m_AspectRatio;
-            camera.m_Fov = cam_resource->m_DDF->m_Fov;
-            camera.m_NearZ = cam_resource->m_DDF->m_NearZ;
-            camera.m_FarZ = cam_resource->m_DDF->m_FarZ;
-            camera.m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
-            camera.m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection != 0;
-            camera.m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
-            camera.m_AddedToUpdate = 0;
-            camera.m_ComponentIndex = params.m_ComponentIndex;
-            w->m_Cameras.Push(camera);
-            *params.m_UserData = (uintptr_t)&w->m_Cameras[w->m_Cameras.Size() - 1];
-            return dmGameObject::CREATE_RESULT_OK;
-        }
-        else
-        {
-            dmLogError("Camera buffer is full (%d), component disregarded.", MAX_COUNT);
+            ShowFullBufferError("Camera", NULL, MAX_COUNT);
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
+        dmGameSystem::CameraResource* cam_resource = (CameraResource*)params.m_Resource;
+        CameraComponent camera;
+        camera.m_Instance = params.m_Instance;
+        camera.m_World = w;
+        camera.m_AspectRatio = cam_resource->m_DDF->m_AspectRatio;
+        camera.m_Fov = cam_resource->m_DDF->m_Fov;
+        camera.m_NearZ = cam_resource->m_DDF->m_NearZ;
+        camera.m_FarZ = cam_resource->m_DDF->m_FarZ;
+        camera.m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
+        camera.m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection != 0;
+        camera.m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
+        camera.m_AddedToUpdate = 0;
+        camera.m_ComponentIndex = params.m_ComponentIndex;
+        w->m_Cameras.Push(camera);
+        *params.m_UserData = (uintptr_t)&w->m_Cameras[w->m_Cameras.Size() - 1];
+        return dmGameObject::CREATE_RESULT_OK;
     }
 
     dmGameObject::CreateResult CompCameraDestroy(const dmGameObject::ComponentDestroyParams& params)
@@ -140,7 +136,7 @@ namespace dmGameSystem
                 return dmGameObject::CREATE_RESULT_OK;
             }
         }
-        dmLogError("Destroyed camera could not be found, something is fishy.");
+        dmLogError("Destroyed camera could not be found.");
         return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
     }
 
@@ -222,6 +218,7 @@ namespace dmGameSystem
 
             dmMessage::Post(0x0, &receiver, message_id, 0, (uintptr_t)dmGameSystemDDF::SetViewProjection::m_DDFDescriptor, &set_view_projection, sizeof(dmGameSystemDDF::SetViewProjection), 0);
 
+            // JG: What does this TODO mean here?
             // Set matrices immediately
             // TODO: Remove this once render scripts are implemented everywhere
             dmRender::SetProjectionMatrix(render_context, projection);
@@ -338,7 +335,7 @@ namespace dmGameSystem
     {
         CameraComponent* component = (CameraComponent*)*params.m_UserData;
         dmhash_t set_property = params.m_PropertyId;
-        
+
         if (CAMERA_PROP_FOV == set_property)
         {
             component->m_Fov = params.m_Value.m_Number;

--- a/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_factory.cpp
@@ -95,7 +95,7 @@ namespace dmGameSystem
         }
         else
         {
-            dmLogError("Can not create more collection factory components since the buffer is full (%d).", fw->m_Components.Size());
+            ShowFullBufferError("Collection factory", COLLECTION_FACTORY_MAX_COUNT_KEY, fw->m_Components.Size());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         return dmGameObject::CREATE_RESULT_OK;

--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -188,7 +188,7 @@ namespace dmGameSystem
         }
         else
         {
-            dmLogError("Collection proxy could not be created since the buffer is full (%d), tweak \"%s\" in the config file.", proxy_world->m_Components.Size(), COLLECTION_PROXY_MAX_COUNT_KEY);
+            ShowFullBufferError("Collection proxy", COLLECTION_PROXY_MAX_COUNT_KEY, proxy_world->m_Components.Size());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -28,6 +28,7 @@
 #include <gameobject/gameobject_ddf.h>
 
 #include "gamesys.h"
+#include "gamesys_private.h" // ShowFullBufferError
 #include "../resources/res_collision_object.h"
 #include "../resources/res_tilegrid.h"
 
@@ -866,7 +867,7 @@ namespace dmGameSystem
         }
         if (world->m_Components.Full())
         {
-            dmLogError("Collision Object could not be created since the buffer is full (%d). See 'physics.max_collision_object_count' in game.project", world->m_Components.Capacity());
+            ShowFullBufferError("Collision object", PHYSICS_MAX_COLLISION_OBJECTS_KEY, world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         CollisionComponent* component = (CollisionComponent*)*params.m_UserData;

--- a/engine/gamesys/src/gamesys/components/comp_factory.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_factory.cpp
@@ -92,7 +92,7 @@ namespace dmGameSystem
         }
         else
         {
-            dmLogError("Can not create more factory components since the buffer is full (%d). See '%s' in game.project", fw->m_Components.Size(), FACTORY_MAX_COUNT_KEY);
+            ShowFullBufferError("Factory", FACTORY_MAX_COUNT_KEY, fw->m_Components.Size());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         return dmGameObject::CREATE_RESULT_OK;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -139,7 +139,8 @@ namespace dmGameSystem
         }
         else
         {
-            dmLogWarning("The gui world could not be stored since the buffer is full (%d). Increase number in gui.max_instance_count", gui_context->m_Worlds.Size());
+            // JG: This seems deprecated?
+            dmLogWarning("The gui world could not be created since the buffer is full (%d). Increase the 'gui.max_instance_count' value in game.project", gui_context->m_Worlds.Size());
         }
 
         gui_world->m_CompGuiContext = gui_context;
@@ -683,6 +684,12 @@ namespace dmGameSystem
     {
         GuiWorld* gui_world = (GuiWorld*)params.m_World;
 
+        if (gui_world->m_Components.Full())
+        {
+            ShowFullBufferError("Gui", "gui.max_count", gui_world->m_Components.Capacity());
+            return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
+        }
+
         GuiSceneResource* scene_resource = (GuiSceneResource*) params.m_Resource;
         dmGuiDDF::SceneDesc* scene_desc = scene_resource->m_SceneDesc;
 
@@ -726,7 +733,9 @@ namespace dmGameSystem
         }
 
         *params.m_UserData = (uintptr_t)gui_component;
+
         gui_world->m_Components.Push(gui_component);
+
         return dmGameObject::CREATE_RESULT_OK;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -214,7 +214,7 @@ namespace dmGameSystem
 
         if (world->m_Components.Full())
         {
-            dmLogError("Label could not be created since the label buffer is full (%d).", world->m_Components.Capacity());
+            ShowFullBufferError("Label", "label.max_count", world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
 

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -322,7 +322,7 @@ namespace dmGameSystem
 
         if (world->m_Components.Full())
         {
-            dmLogError("Mesh could not be created since the buffer is full (%d).", world->m_Components.Capacity());
+            ShowFullBufferError("Mesh", "mesh.max_count", world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         uint32_t index = world->m_Components.Alloc();
@@ -745,9 +745,6 @@ namespace dmGameSystem
     static void RenderListFrustumCulling(dmRender::RenderListVisibilityParams const &params)
     {
         DM_PROFILE("Mesh");
-
-        MeshWorld* mesh_world = (MeshWorld*)params.m_UserData;
-
 
         const dmIntersection::Frustum frustum = *params.m_Frustum;
         uint32_t num_entries = params.m_NumEntries;

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -448,7 +448,7 @@ namespace dmGameSystem
 
         if (world->m_Components.Full())
         {
-            dmLogError("Model could not be created since the buffer is full (%d).", world->m_Components.Capacity());
+            ShowFullBufferError("Model", "model.max_count", world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         uint32_t index = world->m_Components.Alloc();

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -154,7 +154,7 @@ namespace dmGameSystem
         ParticleFXWorld* world = (ParticleFXWorld*)params.m_World;
         if (world->m_PrototypeIndices.Remaining() == 0)
         {
-            dmLogError("ParticleFX could not be created since the buffer is full (%d).", world->m_PrototypeIndices.Capacity());
+            ShowFullBufferError("ParticleFx", dmParticle::MAX_INSTANCE_COUNT_KEY, world->m_PrototypeIndices.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         uint32_t index = world->m_PrototypeIndices.Pop();

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -115,7 +115,7 @@ namespace dmGameSystem
         SoundWorld* world = (SoundWorld*)params.m_World;
         if (world->m_Components.Full())
         {
-            dmLogError("Sound component could not be created since the sound buffer is full (%d). Setting 'sound.max_component_count' in game.project.", world->m_Components.Capacity());
+            ShowFullBufferError("Sound", "sound.max_component_count", world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -345,7 +345,7 @@ namespace dmGameSystem
 
         if (sprite_world->m_Components.Full())
         {
-            dmLogError("Sprite could not be created since the sprite buffer is full (%d). See 'sprite.max_count' in game.project", sprite_world->m_Components.Capacity());
+            ShowFullBufferError("Sprite", "sprite.max_count", sprite_world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         uint32_t index = sprite_world->m_Components.Alloc();

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -403,7 +403,7 @@ namespace dmGameSystem
         TileGridWorld* world = (TileGridWorld*) params.m_World;
         if (world->m_Components.Full())
         {
-            dmLogError("Tilemap could not be created since the tilemap buffer is full (%d). You can change this with the config setting tilemap.max_count", world->m_Components.Capacity());
+            ShowFullBufferError("Tilemap", "tilemap.max_count", world->m_Components.Capacity());
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
 

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -59,7 +59,20 @@ namespace dmGameSystem
         dmLogError("%s", buf);
 
         va_end(lst);
+    }
 
+    void ShowFullBufferError(const char* object_name, const char* config_key, int max_count)
+    {
+        if (config_key)
+        {
+            dmLogError("%s could not be created since the buffer is full (%d). Increase the '%s' value in game.project",
+                object_name, max_count, config_key);
+        }
+        else
+        {
+            dmLogError("%s could not be created since the buffer is full (%d). This value cannot be changed",
+                object_name, max_count);
+        }
     }
 
     dmGameObject::PropertyResult GetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, int32_t value_index, dmGameObject::PropertyDesc& out_desc,

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -61,18 +61,15 @@ namespace dmGameSystem
         va_end(lst);
     }
 
+    void ShowFullBufferError(const char* object_name, int max_count)
+    {
+        dmLogError("%s could not be created since the buffer is full (%d). This value cannot be changed", object_name, max_count);
+    }
+
     void ShowFullBufferError(const char* object_name, const char* config_key, int max_count)
     {
-        if (config_key)
-        {
-            dmLogError("%s could not be created since the buffer is full (%d). Increase the '%s' value in game.project",
-                object_name, max_count, config_key);
-        }
-        else
-        {
-            dmLogError("%s could not be created since the buffer is full (%d). This value cannot be changed",
-                object_name, max_count);
-        }
+        dmLogError("%s could not be created since the buffer is full (%d). Increase the '%s' value in [game.project](defold://open?path=/game.project)",
+            object_name, max_count, config_key);
     }
 
     dmGameObject::PropertyResult GetMaterialConstant(dmRender::HMaterial material, dmhash_t name_hash, int32_t value_index, dmGameObject::PropertyDesc& out_desc,

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -76,6 +76,10 @@ namespace dmGameSystem
     // A wrapper for dmScript::CheckGoInstance
     dmGameObject::HInstance CheckGoInstance(lua_State* L);
 
+    // Logs an error for when a component buffer is full,
+    // if the config_key is NULL a variation of the message is displayed
+    void ShowFullBufferError(const char* object_name, const char* config_key, int max_count);
+
     /**
      * Log message error. The function will send a formatted printf-style string to dmLogError
      * and append message sender/receiver information on the following format:

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -76,9 +76,11 @@ namespace dmGameSystem
     // A wrapper for dmScript::CheckGoInstance
     dmGameObject::HInstance CheckGoInstance(lua_State* L);
 
-    // Logs an error for when a component buffer is full,
-    // if the config_key is NULL a variation of the message is displayed
+    // Logs an error for when a component buffer is full
     void ShowFullBufferError(const char* object_name, const char* config_key, int max_count);
+
+    // Logs an error for when a component buffer is full, but the buffer in question cannot be changed by the user
+    void ShowFullBufferError(const char* object_name, int max_count);
 
     /**
      * Log message error. The function will send a formatted printf-style string to dmLogError


### PR DESCRIPTION
When a component cannot be created we show an error message on where in the project that can be modified, but previously the messages had different wording. This change tries to conform most of these cases into the same format.

Fixes #7237 
Fixes #5252

## PR checklist (remove before merging)

* [x] Prepared the PR for release notes
	* [x] Proper description of feature or fix (see example x?)
	* [x] Added a #fixes ### if it fixes an issue
	* [x] Assigned issue to a project
* [-] Added documentation for public API changes
* [-] Is this a new feature?
	* [-] Added engine and/or editor unit tests
	* [-] Added or updated manual entry
