### PR TITLE
Use uniform scale for the particle fx in gui

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1028,11 +1028,9 @@ namespace dmGameSystem
             vertex_count += dmParticle::GetEmitterVertexCount(gui_world->m_ParticleContext, emitter_render_data->m_Instance, emitter_render_data->m_EmitterIndex);
 
             dmTransform::Transform transform = dmTransform::ToTransform(node_transforms[i]);
-            // Particlefx nodes have uniformly scaled x/y values from adjust mode, we use x here but y would be fine too.
-            float scale = transform.GetScalePtr()[0];
             dmParticle::SetPosition(gui_world->m_ParticleContext, emitter_render_data->m_Instance, Point3(transform.GetTranslation()));
             dmParticle::SetRotation(gui_world->m_ParticleContext, emitter_render_data->m_Instance, transform.GetRotation());
-            dmParticle::SetScale(gui_world->m_ParticleContext, emitter_render_data->m_Instance, scale);
+            dmParticle::SetScale(gui_world->m_ParticleContext, emitter_render_data->m_Instance, transform.GetUniformScale());
         }
 
         vertex_count = dmMath::Min(vertex_count, vb_max_size / (uint32_t)sizeof(ParticleGuiVertex));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -3207,10 +3207,9 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         Matrix4 trans;
         CalculateNodeTransform(scene, n, (CalculateNodeTransformFlags)(CALCULATE_NODE_INCLUDE_SIZE), trans);
         dmTransform::Transform transform = dmTransform::ToTransform(trans);
-        float scale = transform.GetScalePtr()[0];
         dmParticle::SetPosition(scene->m_ParticlefxContext, inst, Point3(transform.GetTranslation()));
         dmParticle::SetRotation(scene->m_ParticlefxContext, inst, transform.GetRotation());
-        dmParticle::SetScale(scene->m_ParticlefxContext, inst, scale);
+        dmParticle::SetScale(scene->m_ParticlefxContext, inst, transform.GetUniformScale());
 
         uint32_t count = scene->m_AliveParticlefxs.Size();
         scene->m_AliveParticlefxs.SetSize(count + 1);


### PR DESCRIPTION
The editor preview of particle effects in gui scenes did not show an accurate representation of the particle effect at runtime. After some investigation it turns out that it was in fact the runtime which was inaccurate and picked the x component of the scale at all times instead of the minimum scale value from a non-uniform scale. This means that a particle effect with scale [5.0 1.0 1.0] used scale 5.0 while a pfx with scale [1.0 5.0 1.0] used scale 1.0. The correct scale should be 1.0 in both cases since the smallest scale value should always be chosen.

This is likely a regression from a change introduced in [#2540](https://github.com/defold/defold/pull/2540) back in 2018. This is now fixed and particle effects both on game objects and in gui scenes will use the uniform minimum scale value in both the editor and engine.

Fixes #7163 