### PR TITLE
Make sure to invert initial mouse y position on macOS

### DIFF
--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -726,7 +726,7 @@ int  _glfwPlatformOpenWindow( int width, int height,
 
         NSPoint point = [_glfwWin.window mouseLocationOutsideOfEventStream];
         _glfwInput.MousePosX = point.x;
-        _glfwInput.MousePosY = point.y;
+        _glfwInput.MousePosY = [[_glfwWin.window contentView] bounds].size.height - point.y;
 
         CVDisplayLinkRef displayLink;
         CVDisplayLinkCreateWithActiveCGDisplays(&displayLink);


### PR DESCRIPTION
The initial mouse y position on macOS uses inverted y coordinates with 0 starting at the top of the screen. This fix inverts the y position of the initial mouse position.

Fixes #4556 