### PR TITLE
Do not run build hooks when attaching debugger or hot-reloading

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -801,7 +801,7 @@
         (error-reporting/report-exception! error)
         nil))))
 
-(defn async-build! [project prefs {:keys [debug? engine?] :or {debug? false engine? true}} old-artifact-map render-build-progress! result-fn]
+(defn async-build! [project prefs {:keys [debug? engine? run-build-hooks?] :or {debug? false engine? true run-build-hooks? true}} old-artifact-map render-build-progress! result-fn]
   (let [;; After any pre-build hooks have completed successfully, we will start
         ;; the engine build on a separate background thread so the build servers
         ;; can work while we build the project. We will await the results of the
@@ -917,7 +917,9 @@
                   (build-project! project evaluation-context extra-build-targets old-artifact-map render-build-progress!)))
               (fn process-project-build-results-on-ui-thread! [project-build-results]
                 (project/update-system-cache-build-targets! evaluation-context)
-                (phase-4-run-post-build-hook! project-build-results)))))
+                (if run-build-hooks?
+                  (phase-4-run-post-build-hook! project-build-results)
+                  (phase-5-await-engine-build! project-build-results))))))
 
         phase-2-start-engine-build!
         (fn phase-2-start-engine-build! []
@@ -959,7 +961,9 @@
     ;; soon as they can.
     (assert (not @build-in-progress-atom))
     (reset! build-in-progress-atom true)
-    (phase-1-run-pre-build-hook!)))
+    (if run-build-hooks?
+      (phase-1-run-pre-build-hook!)
+      (phase-2-start-engine-build!))))
 
 (defn- handle-build-results! [workspace render-build-error! build-results]
   (let [{:keys [error artifact-map etags]} build-results]
@@ -979,7 +983,7 @@
         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
         skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))]
     (build-errors-view/clear-build-errors build-errors-view)
-    (async-build! project prefs {:debug? false :engine? (not skip-engine)} (workspace/artifact-map workspace)
+    (async-build! project prefs {:debug? false :engine? (not skip-engine) :run-build-hooks? true} (workspace/artifact-map workspace)
                   (make-render-task-progress :build)
                   (fn [build-results engine-descriptor build-engine-exception]
                     (when (handle-build-results! workspace render-build-error! build-results)
@@ -1015,7 +1019,7 @@ If you do not specifically require different script states, consider changing th
 (defn- run-with-debugger! [workspace project prefs debug-view render-build-error! web-server]
   (let [project-directory (io/file (workspace/project-path workspace))
         skip-engine (target-cannot-swap-engine? (targets/selected-target prefs))]
-    (async-build! project prefs {:debug? true :engine? (not skip-engine)} (workspace/artifact-map workspace)
+    (async-build! project prefs {:debug? true :engine? (not skip-engine) :run-build-hooks? true} (workspace/artifact-map workspace)
                   (make-render-task-progress :build)
                   (fn [build-results engine-descriptor build-engine-exception]
                     (when (handle-build-results! workspace render-build-error! build-results)
@@ -1029,7 +1033,7 @@ If you do not specifically require different script states, consider changing th
                           (engine-build-errors/handle-build-error! render-build-error! project evaluation-context build-engine-exception))))))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
-  (async-build! project prefs {:debug? true :engine? false} (workspace/artifact-map workspace)
+  (async-build! project prefs {:debug? true :engine? false :run-build-hooks? false} (workspace/artifact-map workspace)
                 (make-render-task-progress :build)
                 (fn [build-results _ _]
                   (when (handle-build-results! workspace render-build-error! build-results)
@@ -1118,7 +1122,7 @@ If you do not specifically require different script states, consider changing th
         old-etags (workspace/etags workspace)
         render-build-progress! (make-render-task-progress :build)
         render-build-error! (make-render-build-error main-scene tool-tab-pane build-errors-view)
-        opts {:debug? false :engine? false}]
+        opts {:debug? false :engine? false :run-build-hooks? false}]
     ;; NOTE: We must build the entire project even if we only want to reload a
     ;; subset of resources in order to maintain a functioning build cache.
     ;; If we decide to support hot reload of a subset of resources, we must


### PR DESCRIPTION
The pre- and post-build hooks were incorrectly run also when attaching the debugger and hot-reloading resources. This fix only runs the pre- and post-build hooks when building the project using the "Project->Build" and "Debug->Start with debugger" options.

Fixes #7149

Documentation PR: https://github.com/defold/doc/pull/318