### PR TITLE
Increase connection timeout during update

### DIFF
--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -128,7 +128,9 @@
                                       (track-download-progress!
                                         (progress/make "Downloading update" total current)))
                  :chunk-size (* 1024 1024)
-                 :cancelled-derefable cancelled-atom))
+                 :cancelled-derefable cancelled-atom
+                 :read-timeout 10000
+                 :connect-timeout 5000))
 
 (def ^:private execute-permission-flag
   "9 bits in 3 triples: [rwx][rwx][rwx]


### PR DESCRIPTION
The editor update sometimes fails due to connection timeouts when the update is downloaded on a slow or low quality network. This change increases the connection timeout to 5000ms and the read timeout to 10000ms.

Fixes #7182 