### PR TITLE
Fix for failing to pack macOS SDK

### DIFF
--- a/scripts/package/package_xcode_and_sdks.sh
+++ b/scripts/package/package_xcode_and_sdks.sh
@@ -65,7 +65,7 @@ function make_archive() {
 function package_platform() {
 	local platform=$1
 	pushd $PLATFORMS/${platform}.platform/Developer/SDKs/
-	PLATFORM_SYMLINK=$(find . -iname "${platform}*" -maxdepth 1 -type l)
+	PLATFORM_SYMLINK=$(find . -iname "${platform}*" -maxdepth 1 -type l | head -1)
 	PLATFORM_FOLDER=$(readlink ${PLATFORM_SYMLINK})
 
 	EXTRA_ARGS=""


### PR DESCRIPTION
When there are more than one macOS SDK installed the script fails with garbage output. The fix is to limit the number of the "find" command results to one.
