### PR TITLE
Fix issues with missing default values when getting config values

### DIFF
--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -409,7 +409,7 @@ union SaveLoadBuffer
      * @name sys.get_config_int
      * @param key [type:string] key to get value for. The syntax is SECTION.KEY
      * @param [default_value] [type:integer] (optional) default value to return if the value does not exist
-     * @return value [type:integer] config value as an integer. default_value if the config key does not exist. nil if no default value was supplied.
+     * @return value [type:integer] config value as an integer. default_value if the config key does not exist. 0 if no default value was supplied.
      * @examples
      *
      * Get user config value
@@ -431,7 +431,7 @@ union SaveLoadBuffer
 
         const char* key = luaL_checkstring(L, 1);
         int default_value = 0;
-        if (!lua_isnil(L, 2))
+        if (!lua_isnone(L, 2))
         {
             default_value = luaL_checkinteger(L, 2);
         }

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -455,7 +455,7 @@ union SaveLoadBuffer
      * @name sys.get_config_number
      * @param key [type:string] key to get value for. The syntax is SECTION.KEY
      * @param [default_value] [type:number] (optional) default value to return if the value does not exist
-     * @return value [type:number] config value as an number. default_value if the config key does not exist. nil if no default value was supplied.
+     * @return value [type:number] config value as an number. default_value if the config key does not exist. 0 if no default value was supplied.
      * @examples
      *
      * Get user config value
@@ -470,7 +470,7 @@ union SaveLoadBuffer
 
         const char* key = luaL_checkstring(L, 1);
         float default_value = 0;
-        if (!lua_isnil(L, 2))
+        if (!lua_isnone(L, 2))
         {
             default_value = luaL_checknumber(L, 2);
         }

--- a/engine/script/src/test/test_sys.lua
+++ b/engine/script/src/test/test_sys.lua
@@ -96,6 +96,8 @@ function test_sys()
 
     -- test get_config_int / get_config_number
     assert(sys.get_config_int("foo.value", 456) == 123)
+    assert(sys.get_config_int("main.does_not_exists") == 0)
+    assert(sys.get_config_int("main.does_not_exists", 456.7) == 456)
     assert(sys.get_config_number("foo.value", 456) == 123)
 
     -- load_resource

--- a/engine/script/src/test/test_sys.lua
+++ b/engine/script/src/test/test_sys.lua
@@ -99,6 +99,8 @@ function test_sys()
     assert(sys.get_config_int("main.does_not_exists") == 0)
     assert(sys.get_config_int("main.does_not_exists", 456.7) == 456)
     assert(sys.get_config_number("foo.value", 456) == 123)
+    assert(sys.get_config_number("main.does_not_exists") == 0)
+    assert(sys.get_config_number("main.does_not_exists", 456.7) - 456.7 < 0.1)
 
     -- load_resource
     print("Load existing resource")


### PR DESCRIPTION
The recently added functionality to get config values as strings, ints and numbers takes an optional second argument as the default value if the config value does not exist. In the case of getting an int or a number the code incorrectly required a default value or nil, but not the complete lack of a second argument. In addition to this the API reference also states that in the absence of a default value that nil should be returned when in fact a 0 is returned. Both of these issues are now fixed and it is now possible to call the function without a second argument, in which case 0 is returned if the config value doesn't exist.

Assuming a game.project with the following:

```
[test]
foo = 123
```

```lua
print(sys.get_config_int("test.foo")) --123
print(sys.get_config_int("test.bar")) -- 0
print(sys.get_config_int("test.bar", 345)) -- 345
print(sys.get_config_number("test.foo")) --123
print(sys.get_config_number("test.bar")) -- 0
print(sys.get_config_number("test.bar", 345.5)) -- 345.5
```

Fixes #7255 