### PR TITLE
Vulkan bugfixes

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -268,12 +268,14 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
         file_out_spv.deleteOnExit();
 
         String spirvShaderStage = (shaderType == ES2ToES3Converter.ShaderType.VERTEX_SHADER ? "vert" : "frag");
+        String glslcBindingBaseStr = String.valueOf(glslcBindingBase);
 
         Result result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "glslc"),
                 "-w",
                 "-fauto-bind-uniforms",
                 "-fauto-map-locations",
-                "-fubo-binding-base", String.valueOf(glslcBindingBase),
+                "-fubo-binding-base", glslcBindingBaseStr,
+                "-ftexture-binding-base", glslcBindingBaseStr,
                 "-std=" + es3Result.shaderVersion + es3Result.shaderProfile,
                 "-fshader-stage=" + spirvShaderStage,
                 "-o", file_out_spv.getAbsolutePath(),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderProgramBuilder.java
@@ -241,6 +241,9 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
     static public SPIRVCompileResult compileGLSLToSPIRV(String shaderSource, ES2ToES3Converter.ShaderType shaderType, String resourceOutput, String targetProfile, boolean isDebug, boolean soft_fail)  throws IOException, CompileExceptionError {
         SPIRVCompileResult res = new SPIRVCompileResult();
 
+        // Start all bindings on 1, this means that we can catch unused uniforms
+        int glslcBindingBase = 1;
+
         int version = 140;
         if(targetProfile.equals("es"))
             version = 310;
@@ -270,6 +273,7 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
                 "-w",
                 "-fauto-bind-uniforms",
                 "-fauto-map-locations",
+                "-fubo-binding-base", String.valueOf(glslcBindingBase),
                 "-std=" + es3Result.shaderVersion + es3Result.shaderProfile,
                 "-fshader-stage=" + spirvShaderStage,
                 "-o", file_out_spv.getAbsolutePath(),
@@ -395,7 +399,7 @@ public abstract class ShaderProgramBuilder extends Builder<Void> {
             for (Map.Entry<Integer, BindingEntry> bindings : setEntry.entrySet()) {
                 Integer bindingIndex = bindings.getKey();
                 BindingEntry bindingEntry = bindings.getValue();
-                if (bindingEntry.size() > 1) {
+                if (bindingIndex >= glslcBindingBase && bindingEntry.size() > 1) {
                     String duplicateList = "";
                     for (int i = 0; i < bindingEntry.size(); i++) {
                         duplicateList += bindingEntry.get(i).name;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1248,15 +1248,25 @@ bail:
         float b = ((float)blue)/255.0f;
         float a = ((float)alpha)/255.0f;
 
+        const BufferType color_buffers[] = {
+            BUFFER_TYPE_COLOR0_BIT,
+            BUFFER_TYPE_COLOR1_BIT,
+            BUFFER_TYPE_COLOR2_BIT,
+            BUFFER_TYPE_COLOR3_BIT,
+        };
+
         for (int i = 0; i < context->m_CurrentRenderTarget->m_ColorAttachmentCount; ++i)
         {
-            VkClearAttachment& vk_color_attachment          = vk_clear_attachments[attachment_count++];
-            vk_color_attachment.aspectMask                  = VK_IMAGE_ASPECT_COLOR_BIT;
-            vk_color_attachment.colorAttachment             = i;
-            vk_color_attachment.clearValue.color.float32[0] = r;
-            vk_color_attachment.clearValue.color.float32[1] = g;
-            vk_color_attachment.clearValue.color.float32[2] = b;
-            vk_color_attachment.clearValue.color.float32[3] = a;
+            if (flags & color_buffers[i])
+            {
+                VkClearAttachment& vk_color_attachment          = vk_clear_attachments[attachment_count++];
+                vk_color_attachment.aspectMask                  = VK_IMAGE_ASPECT_COLOR_BIT;
+                vk_color_attachment.colorAttachment             = i;
+                vk_color_attachment.clearValue.color.float32[0] = r;
+                vk_color_attachment.clearValue.color.float32[1] = g;
+                vk_color_attachment.clearValue.color.float32[2] = b;
+                vk_color_attachment.clearValue.color.float32[3] = a;
+            }
         }
 
         // Clear depth / stencil


### PR DESCRIPTION
Fixed two issues with the Vulkan renderer:
* Set binding base 1 for shader bindings (uniforms & samplers) - this means that we can detect unused bindings and still produce valid spir-v which previously did not work
* Clearing render targets (also applies to backbuffer) always cleared color buffers as well, the clear flags should now be respected

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
