### PR TITLE
Issue 3385 cpu usage android

### DIFF
--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -25,7 +25,6 @@ extern struct android_app* __attribute__((weak)) g_AndroidApp;
 
 void dmProfilerExt::SampleCpuUsage()
 {
-    // Should be implemented using JNI for Android 8+
     // see https://github.com/defold/defold/issues/3385
     int api_level = android_get_device_api_level();
     if (api_level >= 26)

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -27,7 +27,7 @@ void dmProfilerExt::SampleCpuUsage()
 {
     // Should be implemented using JNI for Android 8+
     // see https://github.com/defold/defold/issues/3385
-    dmProfilerExt::SampleProcCpuUsage();
+    dmProfilerExt::SampleProcCpuUsage(true); // TODO - use virtual_metric only for android 8+
 }
 
 uint64_t dmProfilerExt::GetMemoryUsage()

--- a/engine/profiler/src/profiler_android.cpp
+++ b/engine/profiler/src/profiler_android.cpp
@@ -27,7 +27,14 @@ void dmProfilerExt::SampleCpuUsage()
 {
     // Should be implemented using JNI for Android 8+
     // see https://github.com/defold/defold/issues/3385
-    dmProfilerExt::SampleProcCpuUsage(true); // TODO - use virtual_metric only for android 8+
+    int api_level = android_get_device_api_level();
+    if (api_level >= 26)
+    {
+        dmProfilerExt::SampleProcCpuUsage(true);
+    } else
+    {
+        dmProfilerExt::SampleProcCpuUsage(false);
+    }
 }
 
 uint64_t dmProfilerExt::GetMemoryUsage()

--- a/engine/profiler/src/profiler_linux.cpp
+++ b/engine/profiler/src/profiler_linux.cpp
@@ -17,7 +17,7 @@
 
 void dmProfilerExt::SampleCpuUsage()
 {
-    dmProfilerExt:SampleProcCpuUsage();
+    dmProfilerExt:SampleProcCpuUsage(false);
 }
 
 uint64_t dmProfilerExt::GetMemoryUsage()

--- a/engine/profiler/src/profiler_proc_utils.cpp
+++ b/engine/profiler/src/profiler_proc_utils.cpp
@@ -97,7 +97,7 @@ static int ParseCpuCount()
             if (result == EOF)
             {
                     break;
-            } else
+            }
             if (result != 1) // discard the line
             {
                     result = fscanf(fp, "%4095[^\n]\n", buffer);
@@ -114,7 +114,7 @@ static int ParseCpuCount()
     return max_cpuid; // in case no processor is detected, 0 is returned
 }
 
-long int VirtualTotalCpuUsageDelta(uint64_t interval_us)
+static long int VirtualTotalCpuUsageDelta(uint64_t interval_us)
 {
     // lazily initialize processor count
     if (_cpu_count == -1)

--- a/engine/profiler/src/profiler_proc_utils.h
+++ b/engine/profiler/src/profiler_proc_utils.h
@@ -21,7 +21,7 @@ namespace dmProfilerExt {
     /**
      * Call to sample CPU usage from proc in intevals.
      */
-    void SampleProcCpuUsage(bool virtual_metric);
+    void SampleProcCpuUsage(bool use_virtual_metric);
 
     /**
      * Get current memory usage in bytes from proc (resident/working set) for the process, as reported by OS.

--- a/engine/profiler/src/profiler_proc_utils.h
+++ b/engine/profiler/src/profiler_proc_utils.h
@@ -19,11 +19,8 @@
 
 namespace dmProfilerExt {
     /**
-     * Call to sample CPU usage from proc in intevals.
-     *
-     * Parameters
-     *
-     * boolean use_virtual_metric - If true it will guess the usage denominator from interval duration and cpu count. Otherwise, sum jiffies from /proc/stat.
+     * Call to sample CPU usage from proc in intervals.
+     * @param use_virtual_metric If true it will guess the usage denominator from interval duration and cpu count. Otherwise, sum jiffies from /proc/stat.
      */
     void SampleProcCpuUsage(bool use_virtual_metric);
 

--- a/engine/profiler/src/profiler_proc_utils.h
+++ b/engine/profiler/src/profiler_proc_utils.h
@@ -20,6 +20,10 @@
 namespace dmProfilerExt {
     /**
      * Call to sample CPU usage from proc in intevals.
+     *
+     * Parameters
+     *
+     * boolean use_virtual_metric - If true it will guess the usage denominator from interval duration and cpu count. Otherwise, sum jiffies from /proc/stat.
      */
     void SampleProcCpuUsage(bool use_virtual_metric);
 

--- a/engine/profiler/src/profiler_proc_utils.h
+++ b/engine/profiler/src/profiler_proc_utils.h
@@ -21,7 +21,7 @@ namespace dmProfilerExt {
     /**
      * Call to sample CPU usage from proc in intevals.
      */
-    void SampleProcCpuUsage();
+    void SampleProcCpuUsage(bool virtual_metric);
 
     /**
      * Get current memory usage in bytes from proc (resident/working set) for the process, as reported by OS.


### PR DESCRIPTION
Alternative CPU usage algorithm for android 8+. Fixes profiler.get_cpu_usage report as 0 on late android versions.

fixes #3385 