### PR TITLE
Show informative error message on cyclic resource dependencies

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -800,12 +800,17 @@
   (let [basis (g/now)
         proj-path (some-> (owning-resource basis node-id) resource/proj-path)
         resource-path (or proj-path "'unknown'")]
-    (case node-type-name
-      "editor.collection/CollectionNode" (format "This is caused by a two or more collections referenced in a loop from either collection proxies or collection factories. One of the involved resources is: %s." resource-path)
-      "editor.game-object/GameObjectNode" (format "This is caused by two or more game objects referenced in a loop from game object factories. One of the involved resources is: %s." resource-path)
-      "editor.code.script/ScriptNode" (format "This is caused by two or more Lua modules required in a loop. One of the involved resources is: %s." resource-path)
-      (format "This is caused by two or more resources referenced in a loop. One of the involved resources is: %s." resource-path))))
+    (case (g/node-type-kw basis node-id)
+      :editor.collection/CollectionNode
+      (format "This is caused by a two or more collections referenced in a loop from either collection proxies or collection factories. One of the involved resources is: %s." resource-path)
 
+      :editor.game-object/GameObjectNode
+      (format "This is caused by two or more game objects referenced in a loop from game object factories. One of the involved resources is: %s." resource-path)
+
+      :editor.code.script/ScriptNode
+      (format "This is caused by two or more Lua modules required in a loop. One of the involved resources is: %s." resource-path)
+
+      (format "This is caused by two or more resources referenced in a loop. One of the involved resources is: %s." resource-path))))
 (defn- build-project!
   [project evaluation-context extra-build-targets old-artifact-map render-progress!]
   (let [game-project (project/get-resource-node project "/game.project" evaluation-context)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -800,7 +800,7 @@
   [node-type-name node-id]
   (let [basis (g/now)
         proj-path (some-> (owning-resource basis node-id) resource/proj-path)
-        resource-path (some? proj-path) proj-path "'unknown'"]
+        resource-path (or proj-path "'unknown'")]
     (case node-type-name
       "editor.collection/CollectionNode" (format "This is caused by a two or more collections referenced in a loop from either collection proxies or collection factories. One of the involved resources is: %s." resource-path)
       "editor.game-object/GameObjectNode" (format "This is caused by two or more game objects referenced in a loop from game object factories. One of the involved resources is: %s." resource-path)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -796,7 +796,7 @@
     (resource-node/resource basis owning-resource-node-id)))
 
 (defn- get-cycle-detected-help-message
-  [node-type-name node-id]
+  [node-id]
   (let [basis (g/now)
         proj-path (some-> (owning-resource basis node-id) resource/proj-path)
         resource-path (or proj-path "'unknown'")]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -811,6 +811,7 @@
       (format "This is caused by two or more Lua modules required in a loop. One of the involved resources is: %s." resource-path)
 
       (format "This is caused by two or more resources referenced in a loop. One of the involved resources is: %s." resource-path))))
+
 (defn- build-project!
   [project evaluation-context extra-build-targets old-artifact-map render-progress!]
   (let [game-project (project/get-resource-node project "/game.project" evaluation-context)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -793,8 +793,7 @@
 
 (defn- owning-resource [basis node-id]
   (when-some [owning-resource-node-id (core/scope-of-type basis node-id resource-node/ResourceNode)]
-             [owning-resource (resource-node/resource basis owning-resource-node-id)]
-    owning-resource))
+    (resource-node/resource basis owning-resource-node-id)))
 
 (defn- get-cycle-detected-help-message
   [node-type-name node-id]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -827,7 +827,7 @@
                :header "Cyclic resource dependency detected"
                :content {:fx/type fxui/label
                          :style-class "dialog-content-padding"
-                         :text (get-cycle-detected-help-message (-> e ex-data :node-type-name) (-> e ex-data :node-id))}}))
+                         :text (get-cycle-detected-help-message (-> e ex-data :node-id))}}))
           (error-reporting/report-exception! e)))
       (catch Throwable error
         (error-reporting/report-exception! error)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -798,15 +798,15 @@
         resource-path (or proj-path "'unknown'")]
     (case (g/node-type-kw basis node-id)
       :editor.collection/CollectionNode
-      (format "This is caused by a two or more collections referenced in a loop from either collection proxies or collection factories. One of the involved resources is: %s." resource-path)
+      (format "This is caused by a two or more collections referenced in a loop from either collection proxies or collection factories. One of the resources is: %s." resource-path)
 
       :editor.game-object/GameObjectNode
-      (format "This is caused by two or more game objects referenced in a loop from game object factories. One of the involved resources is: %s." resource-path)
+      (format "This is caused by two or more game objects referenced in a loop from game object factories. One of the resources is: %s." resource-path)
 
       :editor.code.script/ScriptNode
-      (format "This is caused by two or more Lua modules required in a loop. One of the involved resources is: %s." resource-path)
+      (format "This is caused by two or more Lua modules required in a loop. One of the resources is: %s." resource-path)
 
-      (format "This is caused by two or more resources referenced in a loop. One of the involved resources is: %s." resource-path))))
+      (format "This is caused by two or more resources referenced in a loop. One of the resources is: %s." resource-path))))
 
 (defn- build-project!
   [project evaluation-context extra-build-targets old-artifact-map render-progress!]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -814,7 +814,7 @@
       (ui/with-progress [render-progress! render-progress!]
         (build/build-project! project game-project evaluation-context extra-build-targets old-artifact-map render-progress!))
       (catch clojure.lang.ExceptionInfo e
-        (if (= "cycle-detected" (-> e ex-data :cause))
+        (if (= :cycle-detected (-> e ex-data :cause))
           (ui/run-later
             (dialogs/make-info-dialog
               {:title "Build Error"

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -162,6 +162,52 @@
     (and (g/error? value)
          (g/error-fatal? value))))
 
+(defn owner-resource-node
+  ([node-id]
+   (owner-resource-node (g/now) node-id))
+  ([basis node-id]
+   ;; The owner resource node is the first non-override ResourceNode we find by
+   ;; traversing the explicit :cascade-delete connections between nodes. I.e, we
+   ;; want to find the ResourceNode that will delete our node if the resource is
+   ;; deleted from the project.
+   (let [node (g/node-by-id basis node-id)]
+     ;; Embedded resources will be represented by ResourceNodes, but we want the
+     ;; ultimate owner of the embedded resource, so we keep looking if we
+     ;; encounter a d that is an override node.
+     (if (and (nil? (gt/original node))
+              (g/node-instance*? ResourceNode node))
+
+       ;; We found our owner ResourceNode. Return it.
+       node
+
+       ;; This is not our owner ResourceNode. Recursively follow the outgoing
+       ;; connections that connect to a :cascade-delete input.
+       (let [outgoing-arcs (gt/arcs-by-source basis node-id)
+             outgoing-arcs-by-target-id (group-by gt/target-id outgoing-arcs)]
+         (some (fn [[target-id outgoing-arcs]]
+                 (let [target-node-type (g/node-type* basis target-id)
+                       cascade-delete-input-labels (g/cascade-deletes target-node-type)
+                       connects-to-cascade-delete-input? (comp cascade-delete-input-labels gt/target-label)]
+                   (some (fn [outgoing-arc]
+                           (when (connects-to-cascade-delete-input? outgoing-arc)
+                             (owner-resource-node basis target-id)))
+                         outgoing-arcs)))
+               outgoing-arcs-by-target-id))))))
+
+(defn owner-resource-node-id
+  ([node-id]
+   (owner-resource-node-id (g/now) node-id))
+  ([basis node-id]
+   (some->> (owner-resource-node basis node-id)
+            (gt/node-id))))
+
+(defn owner-resource
+  ([node-id]
+   (owner-resource (g/now) node-id))
+  ([basis node-id]
+   (some->> (owner-resource-node basis node-id)
+            (resource-node-resource basis))))
+
 (defn make-ddf-dependencies-fn [ddf-type]
   (fn [source-value]
     (into []

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1335,11 +1335,8 @@
 
 (defn mark-in-production [node-id label evaluation-context]
   (if (contains? (:in-production evaluation-context) (gt/endpoint node-id label))
-    (throw (ex-info (format "Cycle detected on node type %s and output %s"
-                      (node-type-name node-id evaluation-context)
-                      label)
+    (throw (ex-info "Cycle detected on node"
                     {:cause :cycle-detected
-                     :node-type-name (node-type-name node-id evaluation-context)
                      :node-id node-id}))
     (update evaluation-context :in-production conj (gt/endpoint node-id label))))
 

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1338,7 +1338,7 @@
     (throw (ex-info (format "Cycle detected on node type %s and output %s"
                       (node-type-name node-id evaluation-context)
                       label)
-                    {:cause "cycle-detected"
+                    {:cause :cycle-detected
                      :node-type-name (node-type-name node-id evaluation-context)
                      :node-id node-id}))
     (update evaluation-context :in-production conj (gt/endpoint node-id label))))

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1333,12 +1333,16 @@
         node (gt/node-by-id-at basis node-id)]
     (type-name (gt/node-type node))))
 
-(defn mark-in-production [node-id label evaluation-context]
-  (if (contains? (:in-production evaluation-context) (gt/endpoint node-id label))
+(defn- update-in-production [in-production endpoint]
+  (if (contains? in-production endpoint)
     (throw (ex-info "Cycle detected on node"
                     {:cause :cycle-detected
-                     :node-id node-id}))
-    (update evaluation-context :in-production conj (gt/endpoint node-id label))))
+                     :endpoint endpoint
+                     :in-production in-production}))
+    (conj in-production endpoint)))
+
+(defn mark-in-production [node-id label evaluation-context]
+  (update evaluation-context :in-production update-in-production (gt/endpoint node-id label)))
 
 (defn- mark-in-production-form [node-id-sym label-sym evaluation-context-sym forms]
   `(let [~evaluation-context-sym (mark-in-production ~node-id-sym ~label-sym ~evaluation-context-sym)]

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1334,11 +1334,14 @@
     (type-name (gt/node-type node))))
 
 (defn mark-in-production [node-id label evaluation-context]
-  (assert (not (contains? (:in-production evaluation-context) (gt/endpoint node-id label)))
-          (format "Cycle detected on node type %s and output %s"
-                  (node-type-name node-id evaluation-context)
-                  label))
-  (update evaluation-context :in-production conj (gt/endpoint node-id label)))
+  (if (contains? (:in-production evaluation-context) (gt/endpoint node-id label))
+    (throw (ex-info (format "Cycle detected on node type %s and output %s"
+                      (node-type-name node-id evaluation-context)
+                      label)
+                    {:cause "cycle-detected"
+                     :node-type-name (node-type-name node-id evaluation-context)
+                     :node-id node-id}))
+    (update evaluation-context :in-production conj (gt/endpoint node-id label))))
 
 (defn- mark-in-production-form [node-id-sym label-sym evaluation-context-sym forms]
   `(let [~evaluation-context-sym (mark-in-production ~node-id-sym ~label-sym ~evaluation-context-sym)]

--- a/editor/test/internal/node_test.clj
+++ b/editor/test/internal/node_test.clj
@@ -324,24 +324,24 @@
   (testing "output dependent on itself"
     (with-clean-system
       (let [[node] (tx-nodes (g/make-node world DependencyNode))]
-        (is (thrown? AssertionError (g/node-value node :out-from-self))))))
+        (is (thrown? ExceptionInfo (g/node-value node :out-from-self))))))
   (testing "output dependent on itself connected to downstream input"
     (with-clean-system
       (let [[node0 node1] (tx-nodes (g/make-node world DependencyNode) (g/make-node world DependencyNode))]
         (g/transact
          (g/connect node0 :out-from-self node1 :in))
-        (is (thrown? AssertionError (g/node-value node1 :out-from-in))))))
+        (is (thrown? ExceptionInfo (g/node-value node1 :out-from-in))))))
   (testing "cycle of period 1"
     (with-clean-system
       (let [[node] (tx-nodes (g/make-node world DependencyNode))]
         (g/transact (g/connect node :out-from-in node :in))
-        (is (thrown? AssertionError (g/node-value node :out-from-in))))))
+        (is (thrown? ExceptionInfo (g/node-value node :out-from-in))))))
   (testing "cycle of period 2 (single transaction)"
     (with-clean-system
       (let [[node0 node1] (tx-nodes (g/make-node world DependencyNode) (g/make-node world DependencyNode))]
         (g/transact [(g/connect node0 :out-from-in node1 :in)
                      (g/connect node1 :out-from-in node0 :in)])
-        (is (thrown? AssertionError (g/node-value node1 :out-from-in)))))))
+        (is (thrown? ExceptionInfo (g/node-value node1 :out-from-in)))))))
 
 (g/defnode BasicNode
   (input basic-input g/Int)


### PR DESCRIPTION
Cyclic resource dependencies in the editor did not show a user friendly error message. The message did in fact seem to indicate an error with the editor rather than with the project structure. This change detect cyclic dependencies and shows a popup with an improved error message to clearly indicate the problem to the developer.

Fixes #4893 
Fixes #3919
Fixes #6724 