### PR TITLE
Use alpha propagation in GUI text nodes

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -204,7 +204,7 @@
   [gl user-data renderables]
   (let [font-data (get-in user-data [:text-data :font-data])
         text-entries (mapv (fn [r] (let [text-data (get-in r [:user-data :text-data])
-                                         alpha (* (get-in user-data [:color 3]) (get-in text-data [:color 3]))]
+                                         alpha (get-in (:user-data r) [:color 3])]
                                      (-> text-data
                                          (assoc :world-transform (:world-transform r))
                                          (update-in [:color 3] * alpha)


### PR DESCRIPTION
Bugfix for GUI text nodes in editor when using inherit-alpha. 

Fixes #6304 

## PR checklist

* [x] Code
	* [-] Add engine and/or editor unit tests.
	* [-] New and changed code follows the overall code style of existing code
	* [-] Add comments where needed
* [-] Documentation
	* [-] Make sure that API documentation is updated in code comments
	* [-] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project
	* [-] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [-] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
