### PR TITLE
Added dmScript::CheckBufferUnpack to dmSdk

### DIFF
--- a/engine/gamesys/src/dmsdk/gamesys/script.h
+++ b/engine/gamesys/src/dmsdk/gamesys/script.h
@@ -190,28 +190,57 @@ namespace dmScript
      */
     void PushBuffer(lua_State* L, const LuaHBuffer& buffer);
 
-    /*# retrieve a HBuffer from the supplied lua state
-     *
-     * Check if the value in the supplied index on the lua stack is a HBuffer and returns it.
+    /*# retrieve a LuaHBuffer from the supplied lua state
+     * Retrieve a LuaHBuffer from the supplied lua state.
+     * Check if the value in the supplied index on the lua stack is a LuaHBuffer and returns it.
      *
      * @name dmScript::CheckBuffer
      * @param L [type:lua_State*] lua state
      * @param index [type:int] Index of the value
      * @return buffer [type:LuaHBuffer*] pointer to dmScript::LuaHBuffer
+     * @note The dmBuffer::IsBufferValid is already called on the returned buffer
      */
     LuaHBuffer* CheckBuffer(lua_State* L, int index);
 
-
-    /*# retrieve a HBuffer from the supplied lua state.
-     * Retrieve a HBuffer from the supplied lua state.
-     * Check if the value in the supplied index on the lua stack is a HBuffer and returns it.
+    /*# retrieve a LuaHBuffer from the supplied lua state.
+     * Retrieve a LuaHBuffer from the supplied lua state.
+     * Check if the value in the supplied index on the lua stack is a LuaHBuffer and returns it.
      * @note Returns 0 on error. Does not invoke lua_error.
      * @name dmScript::CheckBufferNoError
      * @param L [type:lua_State*] lua state
      * @param index [type:int] Index of the value
-     * @return buffer [type:LuaHBuffer*] pointer to dmScript::LuaHBuffer
+     * @return buffer [type:LuaHBuffer*] pointer to dmScript::LuaHBuffer or 0 if not valid
+     * @note The dmBuffer::IsBufferValid is already called on the returned buffer
      */
     LuaHBuffer* CheckBufferNoError(lua_State* L, int index);
+
+    /*# retrieve a HBuffer from the supplied lua state
+     * Retrieve a HBuffer from the supplied lua state
+     *
+     * Check if the value in the supplied index on the lua stack is a LuaHBuffer and it's valid, returns the HBuffer.
+     *
+     * @note The dmBuffer::IsBufferValid is already called on the returned buffer
+     *
+     * @name dmScript::CheckBufferUnpack
+     * @param L [type:lua_State*] lua state
+     * @param index [type:int] Index of the value
+     * @return buffer [type:dmBuffer::HBuffer] buffer if valid, 0 otherwise
+     */
+    dmBuffer::HBuffer CheckBufferUnpack(lua_State* L, int index);
+
+    /*# retrieve a HBuffer from the supplied lua state
+     * Retrieve a HBuffer from the supplied lua state
+     *
+     * Check if the value in the supplied index on the lua stack is a LuaHBuffer and it's valid, returns the HBuffer.
+     *
+     * @note The dmBuffer::IsBufferValid is already called on the returned buffer
+     *
+     * @name dmScript::CheckBufferUnpackNoError
+     * @param L [type:lua_State*] lua state
+     * @param index [type:int] Index of the value
+     * @return buffer [type:dmBuffer::HBuffer] buffer if valid, 0 otherwise
+     */
+    dmBuffer::HBuffer CheckBufferUnpackNoError(lua_State* L, int index);
 }
 
 #endif // DMSDK_GAMESYS_SCRIPT_H

--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -436,8 +436,7 @@ namespace dmGameSystem
     static int GetStream(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 1);
-        dmBuffer::HBuffer hbuffer = UnpackLuaBuffer(buffer);
+        dmBuffer::HBuffer hbuffer = dmScript::CheckBufferUnpack(L, 1);
         dmhash_t stream_name = dmScript::CheckHashOrString(L, 2);
         PushStream(L, 1, hbuffer, stream_name);
         return 1;
@@ -601,10 +600,8 @@ namespace dmGameSystem
     {
         DM_LUA_STACK_CHECK(L, 0);
 
-        dmScript::LuaHBuffer* _dstbuffer = dmScript::CheckBuffer(L, 1);
-        dmScript::LuaHBuffer* _srcbuffer = dmScript::CheckBuffer(L, 3);
-        dmBuffer::HBuffer dst_hbuffer = UnpackLuaBuffer(_dstbuffer);
-        dmBuffer::HBuffer src_hbuffer = UnpackLuaBuffer(_srcbuffer);
+        dmBuffer::HBuffer dst_hbuffer = dmScript::CheckBufferUnpack(L, 1);
+        dmBuffer::HBuffer src_hbuffer = dmScript::CheckBufferUnpack(L, 3);
         dmBuffer::HBuffer dstbuffer = dst_hbuffer;
         dmBuffer::HBuffer srcbuffer = src_hbuffer;
         int dstoffset = luaL_checkint(L, 2);
@@ -699,8 +696,7 @@ namespace dmGameSystem
     static int GetBytes(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 1);
-        dmBuffer::HBuffer hbuffer = UnpackLuaBuffer(buffer);
+        dmBuffer::HBuffer hbuffer = dmScript::CheckBufferUnpack(L, 1);
 
         uint8_t* data;
         uint32_t datasize;
@@ -736,10 +732,9 @@ namespace dmGameSystem
     static int Buffer_tostring(lua_State *L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 1);
 
         uint32_t num_streams;
-        dmBuffer::HBuffer hbuffer = UnpackLuaBuffer(buffer);
+        dmBuffer::HBuffer hbuffer = dmScript::CheckBufferUnpack(L, 1);
         dmBuffer::GetNumStreams(hbuffer, &num_streams);
 
         uint32_t out_element_count = 0;
@@ -787,8 +782,7 @@ namespace dmGameSystem
     static int Buffer_len(lua_State *L)
     {
         DM_LUA_STACK_CHECK(L, 1);
-        dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 1);
-        dmBuffer::HBuffer hbuffer = UnpackLuaBuffer(buffer);
+        dmBuffer::HBuffer hbuffer = dmScript::CheckBufferUnpack(L, 1);
         uint32_t count = 0;
         dmBuffer::Result r = dmBuffer::GetCount(hbuffer, &count);
         if (r != dmBuffer::RESULT_OK) {
@@ -948,8 +942,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 0);
 
         // get buffer
-        dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 1);
-        dmBuffer::HBuffer hbuffer = UnpackLuaBuffer(buffer);
+        dmBuffer::HBuffer hbuffer = dmScript::CheckBufferUnpack(L, 1);
 
         // get metadata entry name
         dmhash_t entry_name = dmScript::CheckHashOrString(L, 2);
@@ -1063,8 +1056,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 2);
 
         // get buffer
-        dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 1);
-        dmBuffer::HBuffer hbuffer = UnpackLuaBuffer(buffer);
+        dmBuffer::HBuffer hbuffer = dmScript::CheckBufferUnpack(L, 1);
 
         // get metadata entry name
         dmhash_t entry_name = dmScript::CheckHashOrString(L, 2);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2764,6 +2764,29 @@ TEST_F(ScriptBufferTest, PushCheckBuffer)
     dmScript::LuaHBuffer* buffer_ptr = dmScript::CheckBuffer(L, -1);
     ASSERT_NE((void*)0x0, buffer_ptr);
     ASSERT_EQ(m_Buffer, buffer_ptr->m_Buffer);
+
+    dmScript::LuaHBuffer* buffer_ptr2 = dmScript::CheckBufferNoError(L, -1);
+    ASSERT_NE((void*)0x0, buffer_ptr2);
+    ASSERT_EQ(m_Buffer, buffer_ptr2->m_Buffer);
+
+    lua_pop(L, 1);
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+TEST_F(ScriptBufferTest, PushCheckUnpackBuffer)
+{
+    int top = lua_gettop(L);
+    dmScript::LuaHBuffer luabuf(m_Buffer, dmScript::OWNER_C);
+    dmScript::PushBuffer(L, luabuf);
+
+    dmBuffer::HBuffer buf = dmScript::CheckBufferUnpack(L, -1);
+    ASSERT_NE((dmBuffer::HBuffer)0x0, buf);
+    ASSERT_EQ(m_Buffer, buf);
+
+    dmBuffer::HBuffer buf2 = dmScript::CheckBufferUnpackNoError(L, -1);
+    ASSERT_NE((dmBuffer::HBuffer)0x0, buf2);
+    ASSERT_EQ(m_Buffer, buf2);
+
     lua_pop(L, 1);
     ASSERT_EQ(top, lua_gettop(L));
 }


### PR DESCRIPTION
This allows the developer to get a `dmBuffer::HBuffer` handle directly from the Lua stack, without dealing with the dmScript::LuaHBuffer which is the actual Lua data type.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [-] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
