### PR TITLE
Fix code syntax highlighting

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -204,13 +204,13 @@
      ["constant" (Color/valueOf "#FFBBFF")]
      ["support.function" (Color/valueOf "#33CCCC")]
      ["support.variable" (Color/valueOf "#FFBBFF")]
+     ["name.function" (Color/valueOf "#33CC33")]
+     ["parameter.function" (Color/valueOf "#E3A869")]
+     ["variable.language" (Color/valueOf "#E066FF")]
      ["editor.error" (Color/valueOf "#FF6161")]
      ["editor.warning" (Color/valueOf "#FF9A34")]
      ["editor.info" (Color/valueOf "#CCCFD3")]
-     ["editor.debug" (Color/valueOf "#3B8CF8")]
-     ["name.function" (Color/valueOf "#33CC33")]
-     ["parameter.function" (Color/valueOf "#E3A869")]
-     ["variable.language" (Color/valueOf "#E066FF")]]))
+     ["editor.debug" (Color/valueOf "#3B8CF8")]]))
 
 (defn color-lookup
   ^Paint [color-scheme key]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -506,11 +506,11 @@
   (let [^Color background-color (Color/valueOf "#27292D")
         ^Color selection-background-color (Color/valueOf "#264A8B")]
     (view/make-color-scheme
-      [["editor.error" (Color/valueOf "#FF6161")]
+      [["console.reload.successful" (Color/valueOf "#33CC33")]
+       ["editor.error" (Color/valueOf "#FF6161")]
        ["editor.warning" (Color/valueOf "#FF9A34")]
        ["editor.info" (Color/valueOf "#CCCFD3")]
        ["editor.debug" (Color/valueOf "#3B8CF8")]
-       ["console.reload.successful" (Color/valueOf "#33CC33")]
        ["editor.foreground" (Color/valueOf "#A2B0BE")]
        ["editor.background" background-color]
        ["editor.cursor" Color/TRANSPARENT]


### PR DESCRIPTION
On the left is a new editor with LSP, on the right is the old one:
![photo_2023-01-19 14 15 14](https://user-images.githubusercontent.com/732554/213452205-460f124c-7d1c-451d-91f6-70654ee42e6e.jpeg)

Somehow the order of palette entries broke highlighting...

Related to #3885