### PR TITLE
Added option in preferences to prevent bundle target opening

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2143,7 +2143,7 @@ If you do not specifically require different script states, consider changing th
                            (fn [successful?]
                              (when successful?
                                (if (some-> output-directory .isDirectory)
-                                 (ui/open-file output-directory)
+                                 (when (prefs/get-prefs prefs "open-bundle-target-folder" false) (ui/open-file output-directory))
                                  (dialogs/make-info-dialog
                                    {:title "Bundle Failed"
                                     :icon :icon/triangle-error

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -204,13 +204,13 @@
      ["constant" (Color/valueOf "#FFBBFF")]
      ["support.function" (Color/valueOf "#33CCCC")]
      ["support.variable" (Color/valueOf "#FFBBFF")]
+     ["name.function" (Color/valueOf "#33CC33")]
+     ["parameter.function" (Color/valueOf "#E3A869")]
+     ["variable.language" (Color/valueOf "#E066FF")]
      ["editor.error" (Color/valueOf "#FF6161")]
      ["editor.warning" (Color/valueOf "#FF9A34")]
      ["editor.info" (Color/valueOf "#CCCFD3")]
-     ["editor.debug" (Color/valueOf "#3B8CF8")]
-     ["name.function" (Color/valueOf "#33CC33")]
-     ["parameter.function" (Color/valueOf "#E3A869")]
-     ["variable.language" (Color/valueOf "#E066FF")]]))
+     ["editor.debug" (Color/valueOf "#3B8CF8")]]))
 
 (defn color-lookup
   ^Paint [color-scheme key]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -506,11 +506,11 @@
   (let [^Color background-color (Color/valueOf "#27292D")
         ^Color selection-background-color (Color/valueOf "#264A8B")]
     (view/make-color-scheme
-      [["editor.error" (Color/valueOf "#FF6161")]
+      [["console.reload.successful" (Color/valueOf "#33CC33")]
+       ["editor.error" (Color/valueOf "#FF6161")]
        ["editor.warning" (Color/valueOf "#FF9A34")]
        ["editor.info" (Color/valueOf "#CCCFD3")]
        ["editor.debug" (Color/valueOf "#3B8CF8")]
-       ["console.reload.successful" (Color/valueOf "#33CC33")]
        ["editor.foreground" (Color/valueOf "#A2B0BE")]
        ["editor.background" background-color]
        ["editor.cursor" Color/TRANSPARENT]

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -494,19 +494,23 @@
    :patterns [{:match #"^INFO:RESOURCE: (.+?) was successfully reloaded\."
                :name "console.reload.successful"}
               {:match #"^ERROR:.+?:"
-               :name "editor.error"}
+               :name "console.error"}
               {:match #"^WARNING:.+?:"
-               :name "editor.warning"}
+               :name "console.warning"}
               {:match #"^INFO:.+?:"
-               :name "editor.info"}
+               :name "console.info"}
               {:match #"^DEBUG:.+?:"
-               :name "editor.debug"}]})
+               :name "console.debug"}]})
 
 (def ^:private console-color-scheme
   (let [^Color background-color (Color/valueOf "#27292D")
         ^Color selection-background-color (Color/valueOf "#264A8B")]
     (view/make-color-scheme
       [["console.reload.successful" (Color/valueOf "#33CC33")]
+       ["console.error" (Color/valueOf "#FF6161")]
+       ["console.warning" (Color/valueOf "#FF9A34")]
+       ["console.info" (Color/valueOf "#CCCFD3")]
+       ["console.debug" (Color/valueOf "#3B8CF8")]
        ["editor.error" (Color/valueOf "#FF6161")]
        ["editor.warning" (Color/valueOf "#FF9A34")]
        ["editor.info" (Color/valueOf "#CCCFD3")]

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -102,6 +102,7 @@
   []
   (cond-> [{:name  "General"
             :prefs [{:label "Load External Changes on App Focus" :type :boolean :key "external-changes-load-on-app-focus" :default true}
+                    {:label "Open Bundle Target Folder" :type :boolean :key "open-bundle-target-folder" :default true}
                     {:label "Enable Texture Compression" :type :boolean :key "general-enable-texture-compression" :default false}
                     {:label "Escape Quits Game" :type :boolean :key "general-quit-on-esc" :default false}
                     {:label "Track Active Tab in Asset Browser" :type :boolean :key "asset-browser-track-active-tab?" :default false}


### PR DESCRIPTION
Now it's possible to prevent default behaviour when bundle folder opens after bundling process is done.

Fix https://github.com/defold/defold/issues/5684

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
