### PR TITLE
fixes mesh culling algorithm

### DIFF
--- a/engine/dlib/src/dlib/intersection.cpp
+++ b/engine/dlib/src/dlib/intersection.cpp
@@ -137,7 +137,7 @@ bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMa
     {
         // get plane normal/equation
         bool positive_found = false;
-        for (int corner_i=1; corner_i<8; corner_i++)
+        for (int corner_i=0; corner_i<8; corner_i++)
         {
             float distance = DistanceToPlane(frustum.m_Planes[plane_i], corner_points[corner_i]);
             if (distance >= 0)

--- a/engine/dlib/src/test/test_intersection.cpp
+++ b/engine/dlib/src/test/test_intersection.cpp
@@ -238,6 +238,81 @@ TEST(dmVMath, TestFrustumOBBPerspective)
 
 }
 
+TEST(dmVMath, TestFrustumOBBCorners)
+{
+    // Frustum's center is on origin on X, Y axes. On Z it's placed from -FRUSTUM_NEAR to -FRUSTUM_FAR.
+    dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(-FRUSTUM_WIDTH/2, FRUSTUM_WIDTH/2, -FRUSTUM_HEIGHT/2, FRUSTUM_HEIGHT/2, FRUSTUM_NEAR, FRUSTUM_FAR);
+    dmIntersection::Frustum frustum;
+    dmIntersection::CreateFrustumFromMatrix(proj, true, frustum);
+
+    float FRUSTUM_NEARFAR_MIDDLE = (FRUSTUM_NEAR + FRUSTUM_FAR)/2;
+    float BOX_SIDE = 2;
+    float BOX_DIAG = 2*sqrt(3);
+    dmVMath::Vector3 minPoint(-BOX_SIDE/2,-BOX_SIDE/2,-BOX_SIDE/2);
+    dmVMath::Vector3 maxPoint(BOX_SIDE/2,BOX_SIDE/2,BOX_SIDE/2); // note, the box lies in the +Z axis
+
+    float y_rotate_start = PI/4;
+    for (float y_rotate = y_rotate_start; y_rotate < 2*PI; y_rotate += (PI/2) ) // rotate in 4 positions around Y axis so that points are on X axis
+    {
+        float z_rotations[2] = {PI/4,-PI/4};
+        for (int i = 0; i<2; i++)
+        {
+            float z_rotate = z_rotations[i];
+
+            // place it diagonally with its center at the origin, protruding corners towards left, right, top, and bottom
+            dmVMath::Matrix4 trans_model = dmVMath::Matrix4::rotationZ(z_rotate) * dmVMath::Matrix4::rotationY(y_rotate);
+
+            // check against left side of frustum
+            dmVMath::Matrix4 trans = dmVMath::Matrix4::translation(dmVMath::Vector3(-BOX_DIAG/2-FRUSTUM_WIDTH/2-0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(-BOX_DIAG/2-FRUSTUM_WIDTH/2+0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+
+            // check against right side of frustum
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(BOX_DIAG/2+FRUSTUM_WIDTH/2+0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(BOX_DIAG/2+FRUSTUM_WIDTH/2-0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+
+            // check against bottom side of frustum
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, -BOX_DIAG/2-FRUSTUM_HEIGHT/2-0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, -BOX_DIAG/2-FRUSTUM_HEIGHT/2+0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+
+            // check against top side of frustum
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, BOX_DIAG/2+FRUSTUM_HEIGHT/2+0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, BOX_DIAG/2+FRUSTUM_HEIGHT/2-0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+
+        }
+
+        float x_rotations[2] = {PI/4,-PI/4};
+        for (int i = 0; i<2; i++)
+        {
+            float x_rotate = x_rotations[i];
+
+            // place it diagonally with its center at the origin, protruding corners towards front, back, top, and bottom
+            dmVMath::Matrix4 trans_model = dmVMath::Matrix4::rotationX(x_rotate) * dmVMath::Matrix4::rotationY(y_rotate);
+
+            // check against near side of frustum
+            dmVMath::Matrix4 trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, BOX_DIAG/2-FRUSTUM_NEAR+0.1)) * trans_model;
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0,0, BOX_DIAG/2-FRUSTUM_NEAR-0.1)) * trans_model;
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+
+            // check against far side of frustum
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0,0,-BOX_DIAG/2-FRUSTUM_FAR-0.1)) * trans_model;
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0,0,-BOX_DIAG/2-FRUSTUM_FAR+0.1)) * trans_model;
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+        }
+    }
+}
+
+
+
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Fixes faulty corner case of mesh culling algorithm.
When first AABB corner _only_ overlapped with frustum the algorithm returned a false negative.

Additional unit test cases are included.

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
