### PR TITLE
Editor: Ensure the workspace root path is canonical

### DIFF
--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -796,7 +796,7 @@ ordinary paths."
         (g/transact
           (g/make-nodes graph
             [workspace [Workspace
-                        :root project-path
+                        :root (.getCanonicalPath (io/file project-path))
                         :resource-snapshot (resource-watch/empty-snapshot)
                         :view-types {:default {:id :default}}
                         :resource-listeners (atom [])


### PR DESCRIPTION
Fix failing `custom-resources-cached` build-test on macOS due to a non-canonical workspace root path from temp directory messing up our new implementation of `resource/resolve-resource`.

Regression introduced in https://github.com/defold/defold/pull/6902.