### PR TITLE
Make bob skip the build dir

### DIFF
--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -47,7 +47,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def skip-dirs #{".git" "build/default" ".internal"})
+(def skip-dirs #{".git" "build" ".internal"})
 (def html5-url-prefix "/html5")
 (def html5-mime-types {"js" "application/javascript",
                        "json" "application/json",


### PR DESCRIPTION
This changeset cherry-picks editor changes from #7316 so we deliver them faster to our users.

Related to #7311
