### PR TITLE
Update Screen Orientation options by Default on iOS and Android

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -859,12 +859,12 @@ public class AndroidBundler implements IBundler {
             Integer displayWidth = projectProperties.getIntValue("display", "width", 960);
             Integer displayHeight = projectProperties.getIntValue("display", "height", 640);
             if((displayWidth != null & displayHeight != null) && (displayWidth > displayHeight)) {
-                properties.put("orientation-support", "landscape");
+                properties.put("orientation-support", "userLandscape");
             } else {
-                properties.put("orientation-support", "portrait");
+                properties.put("orientation-support", "userPortrait");
             }
         } else {
-            properties.put("orientation-support", "sensor");
+            properties.put("orientation-support", "fullUser");
         }
 
         // Since we started to always fill in the default values to the propject properties

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -203,8 +203,10 @@ public class IOSBundler implements IBundler {
             Integer displayHeight = projectProperties.getIntValue("display", "height", 640);
             if((displayWidth != null & displayHeight != null) && (displayWidth > displayHeight)) {
                 orientationSupport.add("LandscapeRight");
+                orientationSupport.add("LandscapeLeft");
             } else {
                 orientationSupport.add("Portrait");
+                orientationSupport.add("PortraitUpsideDown");
             }
         } else {
             orientationSupport.add("Portrait");


### PR DESCRIPTION
Use `userLandscape`, `userPortrait` and `fullUser` for `android:screenOrientation` on Android ([read more](https://developer.android.com/guide/topics/manifest/activity-element#screen)). Use both `UIInterfaceOrientationPortrait` + `UIInterfaceOrientationPortraitUpsideDown` for portrait on iOS and `UIInterfaceOrientationLandscapeLeft` +`UIInterfaceOrientationLandscapeRight` for Landscape ([read more](https://developer.apple.com/documentation/bundleresources/information_property_list/uisupportedinterfaceorientations)).

Fix https://github.com/defold/defold/issues/7215
Fix #3762

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
