### PR TITLE
Use min x and y scale for particle effect scale in gui

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -1030,7 +1030,9 @@ namespace dmGameSystem
             dmTransform::Transform transform = dmTransform::ToTransform(node_transforms[i]);
             dmParticle::SetPosition(gui_world->m_ParticleContext, emitter_render_data->m_Instance, Point3(transform.GetTranslation()));
             dmParticle::SetRotation(gui_world->m_ParticleContext, emitter_render_data->m_Instance, transform.GetRotation());
-            dmParticle::SetScale(gui_world->m_ParticleContext, emitter_render_data->m_Instance, transform.GetUniformScale());
+            // we can't use transform.GetUniformScale() since the z-component is ignored by the gui
+            float scale = dmMath::Min(transform.GetScalePtr()[0], transform.GetScalePtr()[1]);
+            dmParticle::SetScale(gui_world->m_ParticleContext, emitter_render_data->m_Instance, scale);
         }
 
         vertex_count = dmMath::Min(vertex_count, vb_max_size / (uint32_t)sizeof(ParticleGuiVertex));

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -3209,7 +3209,9 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         dmTransform::Transform transform = dmTransform::ToTransform(trans);
         dmParticle::SetPosition(scene->m_ParticlefxContext, inst, Point3(transform.GetTranslation()));
         dmParticle::SetRotation(scene->m_ParticlefxContext, inst, transform.GetRotation());
-        dmParticle::SetScale(scene->m_ParticlefxContext, inst, transform.GetUniformScale());
+        // we can't use transform.GetUniformScale() since the z-component is ignored by the gui
+        float scale = dmMath::Min(transform.GetScalePtr()[0], transform.GetScalePtr()[1]);
+        dmParticle::SetScale(scene->m_ParticlefxContext, inst, scale);
 
         uint32_t count = scene->m_AliveParticlefxs.Size();
         scene->m_AliveParticlefxs.SetSize(count + 1);


### PR DESCRIPTION
The [previous fix](#7163) for particle effect scale only partially solved the problem of inconsistent particle effects scaling between gui and game objects. The original issue was that the x component of the scale was always used when scaling in the gui. The partial fix applied in #7163 used the smallest scale component of x, y and z, which made particle effect scaling in gui more consistent. The problem is that on window resize only the x and y component of the scale of a gui node is affected while the z component remains at its original value, which would produce an incorrect result for particle effects.

The correct solution, which is applied in this fix is to use the smallest of the x and y component when applying a scale to particle effects in gui. This is consistent with how other nodes are scaled and it is also consistent with how particle effects on game objects are scaled using smallest uniform scale value (using x, y, z in 3d/go and only x and y in 2d/gui).

Fixes #7163 
Fixes #7335