### PR TITLE
Improve GUI modification performance by 15%

### DIFF
--- a/editor/src/clj/editor/gviz.clj
+++ b/editor/src/clj/editor/gviz.clj
@@ -261,7 +261,6 @@
                 ranksep=2
                 rankdir=LR
                 overlap=false
-                layout=neato
                 splines=true
                 node [shape=none]
                 edge [ arrowsize = 0.5, color=\"#666666\" ]


### PR DESCRIPTION
User-facing changes: the editor is more performant when modifying highly-referenced GUI nodes

Note: not sure how to make it easy to verify the changes, but when working on this PR I went through all GuiSceneNodes in a big project and compared their `:rt-pb-msg` and `(comp pb-msg->pb-rt-msg :pb-msg)` outputs and worked until there were no important differences. The remaining differences:
- spine GUI node's `:spine-skin` is no longer set to `""` if it was `nil`. Seems to work fine;
- spine GUI node was unnecessarily reordered after its children.

Related to #5447
