### PR TITLE
Fixed index buffer lookup in headless graphics backend

### DIFF
--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -593,33 +593,13 @@ namespace dmGraphics
     {
         const void* index_buffer = ((IndexBuffer*) ib)->m_Buffer;
 
-        if (type == dmGraphics::TYPE_BYTE)
+        if (type == dmGraphics::TYPE_UNSIGNED_SHORT)
         {
-            return ((char*)index_buffer)[index];
-        }
-        else if (type == dmGraphics::TYPE_UNSIGNED_BYTE)
-        {
-            return ((unsigned char*)index_buffer)[index];
-        }
-        else if (type == dmGraphics::TYPE_SHORT)
-        {
-            return ((short*)index_buffer)[index];
-        }
-        else if (type == dmGraphics::TYPE_UNSIGNED_SHORT)
-        {
-            return ((unsigned short*)index_buffer)[index];
-        }
-        else if (type == dmGraphics::TYPE_INT)
-        {
-            return ((int*)index_buffer)[index];
+            return ((unsigned short*)index_buffer)[index/2];
         }
         else if (type == dmGraphics::TYPE_UNSIGNED_INT)
         {
-            return ((unsigned int*)index_buffer)[index];
-        }
-        else if (type == dmGraphics::TYPE_FLOAT)
-        {
-            return (uint32_t)((float*)index_buffer)[index];
+            return ((unsigned int*)index_buffer)[index/4];
         }
 
         assert(0);

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -342,15 +342,15 @@ TEST_F(dmGraphicsTest, Drawing)
     dmGraphics::HIndexBuffer ib = dmGraphics::NewIndexBuffer(m_Context, sizeof(i), i, dmGraphics::BUFFER_USAGE_STREAM_DRAW);
 
     dmGraphics::EnableVertexDeclaration(m_Context, vd, vb);
-    dmGraphics::DrawElements(m_Context, dmGraphics::PRIMITIVE_TRIANGLES, 0, 3, dmGraphics::TYPE_UNSIGNED_INT, ib);
+    dmGraphics::DrawElements(m_Context, dmGraphics::PRIMITIVE_TRIANGLES, 0, 6, dmGraphics::TYPE_UNSIGNED_INT, ib);
     dmGraphics::DisableVertexDeclaration(m_Context, vd);
 
     dmGraphics::EnableVertexDeclaration(m_Context, vd, vb);
-    dmGraphics::DrawElements(m_Context, dmGraphics::PRIMITIVE_TRIANGLES, 3, 3, dmGraphics::TYPE_UNSIGNED_INT, ib);
+    dmGraphics::DrawElements(m_Context, dmGraphics::PRIMITIVE_TRIANGLES, 3, 6, dmGraphics::TYPE_UNSIGNED_INT, ib);
     dmGraphics::DisableVertexDeclaration(m_Context, vd);
 
     dmGraphics::EnableVertexDeclaration(m_Context, vd, vb);
-    dmGraphics::Draw(m_Context, dmGraphics::PRIMITIVE_TRIANGLES, 0, 3);
+    dmGraphics::Draw(m_Context, dmGraphics::PRIMITIVE_TRIANGLES, 0, 6);
     dmGraphics::DisableVertexDeclaration(m_Context, vd);
 
     dmGraphics::DeleteIndexBuffer(ib);


### PR DESCRIPTION
This fixes a buffer overrun issue when using index buffers with the headless graphics backend.

Fixes #7339