### PR TITLE
Fix missing emitter fields of Initial Stretch X and Initial Stretch Y and Initial Angular Velocity for multiple emitters

### DIFF
--- a/editor/resources/templates/template.emitter
+++ b/editor/resources/templates/template.emitter
@@ -71,6 +71,21 @@ properties {
   points { x: 0.0 y: 0.0 t_x: 1.0  t_y: 0.0 }
   spread: 0.0
 }
+properties {
+  key: EMITTER_KEY_PARTICLE_STRETCH_FACTOR_X
+  points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0 }
+  spread: 0.0
+}
+properties {
+  key: EMITTER_KEY_PARTICLE_STRETCH_FACTOR_Y
+  points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0 }
+  spread: 0.0
+}
+properties {
+  key: EMITTER_KEY_PARTICLE_ANGULAR_VELOCITY
+  points { x: 0.0 y: 0.0 t_x: 1.0 t_y: 0.0}
+  spread: 0.0
+}
 particle_properties {
   key: PARTICLE_KEY_SCALE
   points { x: 0.0 y: 1.0 t_x: 1.0 t_y: 0.0 }


### PR DESCRIPTION
Adds emitter fields of `Initial Stretch X` and `Initial Stretch Y` and `Initial Angular Velocity` to emitters that added after a particle effects that use more then one emitter. Previously these fields were missing from `template.emitter` which caused these fields to be greyed out for particle effects that used more than one emitter. Also clicking on those fields and adding a value causes an error `java.lang.NullPointerException: Unknown`.

Fixes #7342
Fixes #5346

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
