### PR TITLE
Removed license header from debugger bootstrap script

### DIFF
--- a/editor/bundle-resources/_defold/debugger/start.lua
+++ b/editor/bundle-resources/_defold/debugger/start.lua
@@ -1,24 +1,3 @@
--- Copyright 2020-2023 The Defold Foundation
--- Copyright 2014-2020 King
--- Copyright 2009-2014 Ragnar Svensson, Christian Murray
--- Licensed under the Defold License version 1.0 (the "License"); you may not use
--- this file except in compliance with the License.
--- 
--- You may obtain a copy of the License, together with FAQs at
--- https://www.defold.com/license
--- 
--- Unless required by applicable law or agreed to in writing, software distributed
--- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
--- CONDITIONS OF ANY KIND, either express or implied. See the License for the
--- specific language governing permissions and limitations under the License.
-
--- Copyright 2020 The Defold Foundation
--- Licensed under the Defold License version 1.0 (the "License"); you may not use
--- this file except in compliance with the License.
---
--- You may obtain a copy of the License, together with FAQs at
--- https://www.defold.com/license
-
 local debugger = require 'builtins.scripts.debugger'
 
 debugger.start(8172)


### PR DESCRIPTION
The Defold license was accidentally applied to the debugger bootstrap script which made the script too large to send as a message when attaching the debugger.

Fixes #7361 