### PR TITLE
Improve resource node modification perf by ~3-5%

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -508,10 +508,12 @@
           rn-dependencies-evaluation-context (g/make-evaluation-context)
           old-resource-node-dependencies (memoize
                                            (fn [node-id]
-                                             (let [deps (du/measuring resource-metrics (resource/proj-path (g/node-value node-id :resource rn-dependencies-evaluation-context)) :find-old-reload-dependencies
-                                                          (g/node-value node-id :reload-dependencies rn-dependencies-evaluation-context))]
-                                               (when-not (g/error? deps)
-                                                 deps))))
+                                             (let [resource (g/node-value node-id :resource rn-dependencies-evaluation-context)]
+                                               (du/measuring resource-metrics (resource/proj-path resource) :find-old-reload-dependencies
+                                                 (when-some [dependencies-fn (:dependencies-fn (resource/resource-type resource))]
+                                                   (let [save-value (g/node-value node-id :save-value rn-dependencies-evaluation-context)]
+                                                     (when-not (g/error? save-value)
+                                                       (dependencies-fn save-value))))))))
           resource->old-node (comp old-nodes-by-path resource/proj-path)
           new-nodes (du/measuring process-metrics :make-new-nodes
                       (make-nodes! project (:new plan)))

--- a/editor/src/clj/editor/resource_node.clj
+++ b/editor/src/clj/editor/resource_node.clj
@@ -62,9 +62,6 @@
                                          (when (and editable (resource/exists? resource))
                                            (resource-io/with-error-translation resource _node-id :source-value
                                              (read-fn resource))))))
-  (output reload-dependencies g/Any :cached (g/fnk [_node-id resource save-value]
-                                              (when-some [dependencies-fn (:dependencies-fn (resource/resource-type resource))]
-                                                (dependencies-fn save-value))))
   
   (output save-value g/Any (g/constantly nil))
 


### PR DESCRIPTION
This change removes the `reload-dependencies` output and inlines its only place of use. For highly-referenced scripts, the improvement is 5%. For GUI nodes, it's 3%.

Related to #5447
