### PR TITLE
Ignore errors thrown in __tostring

### DIFF
--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -35,17 +35,20 @@ local escape_char_map = {
 }
 
 local function str(val)
-  local mt = debug.getmetatable(val)
-  if mt then 
-    if mt.__metatable == NodeProxy then
-      return string.format("%s%p", val, val)
-    elseif type(val) == "table" and mt.__tostring then
-      return string.format("%s %p", val, val)
+  local success, error_or_result = pcall(function()
+    local mt = debug.getmetatable(val)
+    if mt then
+      if mt.__metatable == NodeProxy then
+        return string.format("%s%p", val, val)
+      elseif type(val) == "table" and mt.__tostring then
+        return string.format("%s %p", val, val)
+      end
+      return tostring(val)
+    else
+      return tostring(val)
     end
-    return tostring(val)
-  else
-    return tostring(val)
-  end
+  end)
+  return success and error_or_result or '???'
 end
 
 local function escape_char(c)
@@ -84,15 +87,15 @@ local function encode_table(val)
   return string.format('#lua/ref"%p"', val)
 end
 
-function encode_userdata(val)
+local function encode_userdata(val)
   return '#lua/userdata"'..str(val)..'"'
 end
 
-function encode_function(val)
+local function encode_function(val)
   return '#lua/function"'..str(val)..'"'
 end
 
-function encode_thread(val)
+local function encode_thread(val)
   return '#lua/thread"'..str(val)..'"'
 end
 

--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -48,7 +48,16 @@ local function str(val)
       return tostring(val)
     end
   end)
-  return success and error_or_result or '???'
+  if success then
+    return error_or_result
+  else
+    print("Debugger caught error in __tostring: " .. error_or_result)
+    local err_trace = debug.traceback();
+    if err_trace ~= nil then
+      print(err_trace)
+    end
+    return "???"
+  end
 end
 
 local function escape_char(c)


### PR DESCRIPTION
If an exception is thrown in the `__tostring` method of a serialized Lua object, the editor's debugger will not receive the state at a breakpoint. We now silently ignore such errors and serialize the string as `???`.

User-facing changes: the debugger will serialize Lua objects even if they throw errors in `__tostring`.

Fixes #7168
