### PR TITLE
Add external tool endpoints to the editor http server

### DIFF
--- a/editor/doc/http-api.md
+++ b/editor/doc/http-api.md
@@ -1,0 +1,98 @@
+Editor HTTP API
+===============
+
+External tools can connect to the running editor and interact with it using a REST API.
+
+### Caveats
+* This HTTP API is currently in an experimental state. It might change drastically or even be removed completely if we deem it necessary. But hopefully it shouldn't come to that.
+* Currently, the port is assigned randomly from a broad subrange. The editor will log the local endpoint url if started from a terminal.
+
+### Overview
+The editor can be interacted with by performing GET requests to the following URLs:
+```
+http://localhost:[port]/command
+http://localhost:[port]/console
+```
+
+### The Command Endpoint
+The command endpoint exposes a subset of the commands available from the editor menu bar. To trigger a command, perform a GET request in the format:
+```
+http://localhost:[port]/command/[command]
+```
+You can obtain a list of the available commands along with a short description in JSON format from `http://localhost:[port]/command`. At the time of writing, this returns:
+```json
+{
+  "asset-portal"       : "Open the Asset Portal in a web browser.",
+  "async-reload"       : "Reload all modified files from disk.",
+  "build"              : "Build and run the project.",
+  "build-html5"        : "Build the project for HTML5 and open it in a web browser.",
+  "debugger-break"     : "Break into the debugger.",
+  "debugger-continue"  : "Resume execution in the debugger.",
+  "debugger-detach"    : "Detach the debugger from the running project.",
+  "debugger-start"     : "Start the project with the debugger attached.",
+  "debugger-step-into" : "Step into the current expression in the debugger.",
+  "debugger-step-out"  : "Step out of the current expression in the debugger.",
+  "debugger-step-over" : "Step over the current expression in the debugger.",
+  "debugger-stop"      : "Stop the debugger and the running project.",
+  "documentation"      : "Open the Defold documentation in a web browser.",
+  "donate-page"        : "Open the Donate to Defold page in a web browser.",
+  "editor-logs"        : "Show the directory containing the editor logs.",
+  "engine-profiler"    : "Open the Engine Profiler in a web browser.",
+  "fetch-libraries"    : "Download the latest version of the project library dependencies.",
+  "hot-reload"         : "Hot-reload all modified files into the running project.",
+  "issues"             : "Open the Defold Issue Tracker in a web browser.",
+  "rebuild"            : "Rebuild and run the project.",
+  "rebundle"           : "Re-bundle the project using the previous Bundle dialog settings.",
+  "reload-extensions"  : "Reload editor extensions.",
+  "reload-stylesheets" : "Reload editor stylesheets.",
+  "report-issue"       : "Open the Report Issue page in a web browser.",
+  "report-suggestion"  : "Open the Report Suggestion page in a web browser.",
+  "show-build-errors"  : "Show the Build Errors tab.",
+  "show-console"       : "Show the Console tab.",
+  "show-curve-editor"  : "Show the Curve Editor tab.",
+  "support-forum"      : "Open the Defold Support Forum in a web browser.",
+  "toggle-pane-bottom" : "Toggle visibility of the bottom editor pane.",
+  "toggle-pane-left"   : "Toggle visibility of the left editor pane.",
+  "toggle-pane-right"  : "Toggle visibility of the right editor pane."
+}
+```
+
+#### Response Codes
+Commands are fire-and-forget. You will not know if a command succeeds or not, only if your request was accepted. As such, all command requests will return the same response codes. They are as follows:
+
+* `202 Accepted` - The request was accepted and we are processing it. We use this instead of `200 OK` since we won't be able to tell you when it is done or how it went.
+* `400 Bad Request` - The request was malformed.
+* `404 Not Found` - The string after `command/` is not a supported command.
+* `405 Method Not Allowed` - The command is supported, but it can't be executed right now (for example if a build is already in progress).
+* `500 Internal Server Error` - Something unexpected went wrong when executing the command. The error will be logged in the editor log.
+
+### The Console Endpoint
+The console endpoint allows external tools to obtain the current contents of the Console View in the editor. Send a GET request to `http://localhost:[port]/console` to obtain the console contents in JSON format. The returned object contains `lines` and `regions`.
+
+* The `lines` are returned as an array of strings, each string representing a line in the Console.
+* The `regions` contain metadata about sub-regions of the `lines` that can inform formatting, etc.
+
+#### Region Objects
+Each region object will be in the following format:
+```json
+{
+  "from": {"row": 0, "col": 0},
+  "to":   {"row": 0, "col": 42},
+  "type": "repeat"
+}
+```
+* `from` and `to` specify the row and columns that encompass the region as zero-based indices into the `lines`.
+* `type` is the type of the region, and can inform formatting.
+
+#### Region Types
+Depending on the `type` of a region, it might have additional fields. Here is a non-exhaustive list of region types used in the editor.
+
+* `eval-expression` - An expression posted from the Evaluate Lua field in the debugger.
+* `eval-result` - The result returned by the `eval-expression`.
+* `eval-error` - A runtime error resulting from an `eval-expression`.
+* `extension-output` - Output from an editor script or extension.
+* `extension-error` - Errors from an editor script or extension.
+* `repeat` - Repeated console output that has been collapsed. Its `count` is the number of repeats.
+* `resource-reference` - A substring that matches an existing path in the project. It has a `proj-path-candidates` array of project-relative paths to matching resources, and can also have a zero-based `row` index into the resource if it is text-based.
+
+In particular, `resource-reference` regions could be made clickable to allow the user to  navigate to the source of a Lua error as the editor will attempt to parse this information from callstacks.

--- a/editor/doc/http-api.md
+++ b/editor/doc/http-api.md
@@ -15,21 +15,20 @@ http://localhost:[port]/console
 ```
 
 ### The Command Endpoint
-The command endpoint exposes a subset of the commands available from the editor menu bar. To trigger a command, perform a GET request in the format:
+The command endpoint exposes a subset of the commands available from the editor menu bar. To trigger a command, perform an empty POST request to an URL in the format:
 ```
 http://localhost:[port]/command/[command]
 ```
-You can obtain a list of the available commands along with a short description in JSON format from `http://localhost:[port]/command`. At the time of writing, this returns:
+You can obtain a list of the available commands along with a short description in JSON format by making a GET request to `http://localhost:[port]/command`. At the time of writing, this returns:
 ```json
 {
   "asset-portal"       : "Open the Asset Portal in a web browser.",
-  "async-reload"       : "Reload all modified files from disk.",
   "build"              : "Build and run the project.",
   "build-html5"        : "Build the project for HTML5 and open it in a web browser.",
   "debugger-break"     : "Break into the debugger.",
   "debugger-continue"  : "Resume execution in the debugger.",
   "debugger-detach"    : "Detach the debugger from the running project.",
-  "debugger-start"     : "Start the project with the debugger attached.",
+  "debugger-start"     : "Start the project with the debugger, or attach the debugger to the running project.",
   "debugger-step-into" : "Step into the current expression in the debugger.",
   "debugger-step-out"  : "Step out of the current expression in the debugger.",
   "debugger-step-over" : "Step over the current expression in the debugger.",
@@ -62,8 +61,9 @@ Commands are fire-and-forget. You will not know if a command succeeds or not, on
 
 * `202 Accepted` - The request was accepted and we are processing it. We use this instead of `200 OK` since we won't be able to tell you when it is done or how it went.
 * `400 Bad Request` - The request was malformed.
+* `403 Forbidden` - The command is supported, but it can't be executed right now (for example if a build is already in progress).
 * `404 Not Found` - The string after `command/` is not a supported command.
-* `405 Method Not Allowed` - The command is supported, but it can't be executed right now (for example if a build is already in progress).
+* `405 Method Not Allowed` - The request method is invalid. For example, trying to GET a command or POST to the console.
 * `500 Internal Server Error` - Something unexpected went wrong when executing the command. The error will be logged in the editor log.
 
 ### The Console Endpoint

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2204,8 +2204,8 @@ If you do not specifically require different script states, consider changing th
             allow))))
     (display-output! [_ type string]
       (let [[console-type prefix] (case type
-                                    :err [:extension-err "ERROR:EXT: "]
-                                    :out [:extension-out ""])]
+                                    :err [:extension-error "ERROR:EXT: "]
+                                    :out [:extension-output ""])]
         (doseq [line (string/split-lines string)]
           (console/append-console-entry! console-type (str prefix line)))))
     (on-transact-thread [_ f]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -22,6 +22,7 @@
             [editor.changes-view :as changes-view]
             [editor.cljfx-form-view :as cljfx-form-view]
             [editor.code.view :as code-view]
+            [editor.command-requests :as command-requests]
             [editor.console :as console]
             [editor.curve-view :as curve-view]
             [editor.debug-view :as debug-view]
@@ -180,7 +181,8 @@
                                                             web-profiler/url-prefix web-profiler/handler
                                                             hot-reload/url-prefix (partial hot-reload/build-handler workspace project)
                                                             hot-reload/verify-etags-url-prefix (partial hot-reload/verify-etags-handler workspace project)
-                                                            bob/html5-url-prefix (partial bob/html5-handler project)})
+                                                            bob/html5-url-prefix (partial bob/html5-handler project)
+                                                            command-requests/url-prefix (partial command-requests/request-handler root)})
                                    http-server/start!)
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
           console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -177,13 +177,6 @@
           outline-view         (outline-view/make-outline-view *view-graph* project outline app-view)
           properties-view      (properties-view/make-properties-view workspace project app-view *view-graph* (.lookup root "#properties"))
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs)
-          web-server           (-> (http-server/->server 0 {engine-profiler/url-prefix engine-profiler/handler
-                                                            web-profiler/url-prefix web-profiler/handler
-                                                            hot-reload/url-prefix (partial hot-reload/build-handler workspace project)
-                                                            hot-reload/verify-etags-url-prefix (partial hot-reload/verify-etags-handler workspace project)
-                                                            bob/html5-url-prefix (partial bob/html5-handler project)
-                                                            command-requests/url-prefix (command-requests/make-request-handler root (app-view/make-render-task-progress :resource-sync))})
-                                   http-server/start!)
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
           console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
@@ -205,7 +198,15 @@
                                                       project
                                                       root
                                                       open-resource
-                                                      (partial app-view/debugger-state-changed! scene tool-tabs))]
+                                                      (partial app-view/debugger-state-changed! scene tool-tabs))
+          web-server           (-> (http-server/->server 0 {engine-profiler/url-prefix engine-profiler/handler
+                                                            web-profiler/url-prefix web-profiler/handler
+                                                            hot-reload/url-prefix (partial hot-reload/build-handler workspace project)
+                                                            hot-reload/verify-etags-url-prefix (partial hot-reload/verify-etags-handler workspace project)
+                                                            bob/html5-url-prefix (partial bob/html5-handler project)
+                                                            command-requests/url-prefix (command-requests/make-request-handler root (app-view/make-render-task-progress :resource-sync))
+                                                            console/url-prefix (console/make-request-handler console-view)})
+                                   http-server/start!)]
       (ui/add-application-focused-callback! :main-stage app-view/handle-application-focused! app-view changes-view workspace prefs)
       (extensions/reload! project :all (app-view/make-extensions-ui workspace changes-view prefs))
 

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -182,7 +182,7 @@
                                                             hot-reload/url-prefix (partial hot-reload/build-handler workspace project)
                                                             hot-reload/verify-etags-url-prefix (partial hot-reload/verify-etags-handler workspace project)
                                                             bob/html5-url-prefix (partial bob/html5-handler project)
-                                                            command-requests/url-prefix (partial command-requests/request-handler root)})
+                                                            command-requests/url-prefix (command-requests/make-request-handler root (app-view/make-render-task-progress :resource-sync))})
                                    http-server/start!)
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
           console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource)
@@ -264,6 +264,7 @@
                                 result)))
 
       (ui/on-closed! stage (fn [_]
+                             (http-server/stop! web-server)
                              (ui/remove-application-focused-callback! :main-stage)
 
                              ;; TODO: This takes a long time in large projects.

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -18,31 +18,29 @@
             [dynamo.graph :as g]
             [editor.disk :as disk]
             [editor.ui :as ui]
-            [service.log :as log])
-  (:import [java.nio.charset StandardCharsets]))
+            [service.log :as log]
+            [util.http-util :as http-util]))
 
 (set! *warn-on-reflection* true)
 
 (defonce ^:const url-prefix "/command")
 
-(defonce ^:private supported-commands
+(def ^:private supported-commands
   ;; Notable exclusions:
   ;; :save-all, :quit, anything that would open a modal dialog.
   {:asset-portal
    {:ui-handler :asset-portal
     :help "Open the Asset Portal in a web browser."}
 
-   :async-reload
-   {:ui-handler :async-reload
-    :help "Reload all modified files from disk."}
-
    :build
    {:ui-handler :build
-    :help "Build and run the project."}
+    :help "Build and run the project."
+    :resource-sync true}
 
    :build-html5
    {:ui-handler :build-html5
-    :help "Build the project for HTML5 and open it in a web browser."}
+    :help "Build the project for HTML5 and open it in a web browser."
+    :resource-sync true}
 
    :debugger-break
    {:ui-handler :break
@@ -58,7 +56,8 @@
 
    :debugger-start
    {:ui-handler :start-debugger
-    :help "Start the project with the debugger attached."}
+    :help "Start the project with the debugger, or attach the debugger to the running project."
+    :resource-sync true}
 
    :debugger-step-into
    {:ui-handler :step-into
@@ -94,23 +93,32 @@
 
    :fetch-libraries
    {:ui-handler :fetch-libraries
-    :help "Download the latest version of the project library dependencies."}
+    :help "Download the latest version of the project library dependencies."
+    :resource-sync true}
 
    :hot-reload
    {:ui-handler :hot-reload
-    :help "Hot-reload all modified files into the running project."}
+    :help "Hot-reload all modified files into the running project."
+    :resource-sync true}
+
+   :issues
+   {:ui-handler :search-issues
+    :help "Open the Defold Issue Tracker in a web browser."}
 
    :rebuild
    {:ui-handler :rebuild
-    :help "Rebuild and run the project."}
+    :help "Rebuild and run the project."
+    :resource-sync true}
 
    :rebundle
    {:ui-handler :rebundle
-    :help "Re-bundle the project using the previous Bundle dialog settings."}
+    :help "Re-bundle the project using the previous Bundle dialog settings."
+    :resource-sync true}
 
    :reload-extensions
    {:ui-handler :reload-extensions
-    :help "Reload editor extensions."}
+    :help "Reload editor extensions."
+    :resource-sync true}
 
    :reload-stylesheets
    {:ui-handler :reload-stylesheet
@@ -123,10 +131,6 @@
    :report-suggestion
    {:ui-handler :report-suggestion
     :help "Open the Report Suggestion page in a web browser."}
-
-   :issues
-   {:ui-handler :search-issues
-    :help "Open the Defold Issue Tracker in a web browser."}
 
    :show-build-errors
    {:ui-handler :show-build-errors
@@ -156,7 +160,7 @@
    {:ui-handler :toggle-pane-right
     :help "Toggle visibility of the right editor pane."}})
 
-(defonce ^:private help-response
+(def ^:private api-response
   (let [longest-command-length
         (reduce (fn [result [command]]
                   (max result (count (name command))))
@@ -172,99 +176,94 @@
                   (sort-by key)
                   (map (fn [[command {:keys [help]}]]
                          (format command-format-string
-                                 (str \" (name command) \")
+                                 (json/write-str (name command))
                                  (json/write-str help))))
                   (string/join ",\n"))
-             "\n}\n")
+             "\n}\n")]
+    (http-util/make-json-response help-json-string)))
 
-        utf8-bytes
-        (.getBytes help-json-string StandardCharsets/UTF_8)]
-    {:code 200
-     :headers {"Content-Type" "text/plain;charset=UTF-8"
-               "Content-Length" (str (count utf8-bytes))}
-     :body utf8-bytes}))
-
-(defonce ^:private malformed-request-response
-  {:code 400
-   :body "400 Bad Request"})
-
-(defonce ^:private command-not-supported-response
-  {:code 404
-   :body "404 Not Found"})
-
-(defonce ^:private command-not-enabled-response
-  {:code 405
-   :body "405 Method Not Allowed"})
-
-(defonce ^:private internal-server-error-response
-  {:code 500
-   :body "500 Internal Server Error"})
-
-(defonce ^:private command-accepted-response
-  {:code 202
-   :body "202 Accepted"})
+(def ^:private command-accepted-response http-util/accepted-response)
+(def ^:private command-not-allowed-response http-util/forbidden-response)
+(def ^:private command-not-supported-response http-util/not-found-response)
 
 (defn- parse-command [request]
-  (let [url-string (:url request)]
+  (let [url-string (:url request)
+        method-string (:method request)]
     (case url-string
-      ("/command" "/command/") ::api
+      ("/command" "/command/") (if (= "GET" method-string)
+                                 ::api
+                                 ::only-get-allowed)
       (try
-        (keyword (subs url-string 9))
+        (let [command (keyword (subs url-string 9))]
+          (if (= "POST" method-string)
+            command
+            ::only-post-allowed))
         (catch Exception error
           (log/error :msg "Failed to parse command request"
                      :request request
                      :exception error)
-          nil)))))
+          ::bad-request)))))
 
-(defn- resolve-ui-handler-ctx [ui-node command user-data]
+(defn- resolve-ui-handler-ctx [ui-node ui-handler user-data]
   {:pre [(ui/node? ui-node)
-         (keyword? command)
+         (keyword? ui-handler)
          (map? user-data)]}
   (ui/run-now
     (let [command-contexts (ui/node-contexts ui-node true)]
-      (ui/resolve-handler-ctx command-contexts command user-data))))
+      (ui/resolve-handler-ctx command-contexts ui-handler user-data))))
+
+(defn- handle-request! [request ui-node render-reload-progress!]
+  (let [command (parse-command request)]
+    (case command
+      ::api api-response
+      ::bad-request http-util/bad-request-response
+      ::only-get-allowed http-util/only-get-allowed-response
+      ::only-post-allowed http-util/only-post-allowed-response
+      (let [command-info (some-> command supported-commands)]
+        (if (nil? command-info)
+          command-not-supported-response
+          (let [ui-handler (:ui-handler command-info)
+                ui-handler-ctx (resolve-ui-handler-ctx ui-node ui-handler {})]
+            (case ui-handler-ctx
+              (::ui/not-active ::ui/not-enabled) command-not-allowed-response
+              (let [{:keys [changes-view workspace]} (:env (second ui-handler-ctx))
+                    log-failure! (fn log-failure! [error]
+                                   (log/error :msg "Failed to handle command request"
+                                              :request request
+                                              :exception error))]
+                (assert (g/node-id? changes-view))
+                (assert (g/node-id? workspace))
+                (log/info :msg "Processing request"
+                          :command command)
+                (if-not (:resource-sync command-info)
+                  (try
+                    (ui/run-now
+                      (ui/execute-handler-ctx ui-handler-ctx)
+                      command-accepted-response)
+                    (catch Exception error
+                      (log-failure! error)
+                      http-util/internal-server-error-response))
+                  (fn request-handler-continuation [post-response!]
+                    {:pre [(fn? post-response!)]}
+                    (disk/async-reload!
+                      render-reload-progress! workspace [] changes-view
+                      (fn async-reload-continuation [success]
+                        ;; This callback is executed on the ui thread.
+                        (if success
+                          (try
+                            (ui/execute-handler-ctx ui-handler-ctx)
+                            (post-response! command-accepted-response)
+                            (catch Exception error
+                              (log-failure! error)
+                              (post-response! http-util/internal-server-error-response)))
+                          (do
+                            ;; Explicitly refresh the UI after the reload, since
+                            ;; the ui-handler will not have done so on failure.
+                            (ui/user-data! (ui/scene ui-node) ::ui/refresh-requested? true)
+                            (post-response! http-util/internal-server-error-response)))))))))))))))
 
 (defn make-request-handler [ui-node render-reload-progress!]
   {:pre [(ui/node? ui-node)
          (fn? render-reload-progress!)]}
   (fn request-handler [request]
-    (when (= "GET" (:method request))
-      (let [command (parse-command request)
-            ui-handler (some-> command supported-commands :ui-handler)]
-        (cond
-          (= ::api command)
-          help-response
-
-          (nil? command)
-          malformed-request-response
-
-          (nil? ui-handler)
-          command-not-supported-response
-
-          :else
-          (let [ui-handler-ctx (resolve-ui-handler-ctx ui-node ui-handler {})]
-            (case ui-handler-ctx
-              ::ui/not-active command-not-supported-response
-              ::ui/not-enabled command-not-enabled-response
-              (let [{:keys [changes-view workspace]} (:env (second ui-handler-ctx))]
-                (assert (g/node-id? changes-view))
-                (assert (g/node-id? workspace))
-                (log/info :msg "Processing request"
-                          :command command)
-                (fn request-handler-continuation [post-response!]
-                  {:pre [(fn? post-response!)]}
-                  (disk/async-reload!
-                    render-reload-progress! workspace [] changes-view
-                    (fn async-reload-continuation [success]
-                      (if success
-                        (try
-                          (ui/execute-handler-ctx ui-handler-ctx)
-                          (post-response! command-accepted-response)
-                          (catch Exception error
-                            (log/error :msg "Failed to handle command request"
-                                       :request request
-                                       :exception error)
-                            (post-response! internal-server-error-response)))
-                        (do
-                          (ui/user-data! (ui/scene ui-node) ::ui/refresh-requested? true)
-                          (post-response! internal-server-error-response))))))))))))))
+    (handle-request! request ui-node render-reload-progress!)))

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -14,7 +14,6 @@
 
 (ns editor.command-requests
   (:require [clojure.data.json :as json]
-            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.disk :as disk]
             [editor.ui :as ui]

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -13,20 +13,171 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.command-requests
-  (:require [dynamo.graph :as g]
+  (:require [clojure.data.json :as json]
+            [clojure.string :as string]
+            [dynamo.graph :as g]
             [editor.disk :as disk]
             [editor.ui :as ui]
-            [service.log :as log]))
+            [service.log :as log])
+  (:import [java.nio.charset StandardCharsets]))
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:const url-prefix "/command/")
+(defonce ^:const url-prefix "/command")
+
+(defonce ^:private supported-commands
+  ;; Notable exclusions:
+  ;; :save-all, :quit, anything that would open a modal dialog.
+  {:asset-portal
+   {:ui-handler :asset-portal
+    :help "Open the Asset Portal in a web browser."}
+
+   :async-reload
+   {:ui-handler :async-reload
+    :help "Reload all modified files from disk."}
+
+   :build
+   {:ui-handler :build
+    :help "Build and run the project."}
+
+   :build-html5
+   {:ui-handler :build-html5
+    :help "Build the project for HTML5 and open it in a web browser."}
+
+   :debugger-break
+   {:ui-handler :break
+    :help "Break into the debugger."}
+
+   :debugger-continue
+   {:ui-handler :continue
+    :help "Resume execution in the debugger."}
+
+   :debugger-detach
+   {:ui-handler :detach-debugger
+    :help "Detach the debugger from the running project."}
+
+   :debugger-start
+   {:ui-handler :start-debugger
+    :help "Start the project with the debugger attached."}
+
+   :debugger-step-into
+   {:ui-handler :step-into
+    :help "Step into the current expression in the debugger."}
+
+   :debugger-step-out
+   {:ui-handler :step-out
+    :help "Step out of the current expression in the debugger."}
+
+   :debugger-step-over
+   {:ui-handler :step-over
+    :help "Step over the current expression in the debugger."}
+
+   :debugger-stop
+   {:ui-handler :stop-debugger
+    :help "Stop the debugger and the running project."}
+
+   :documentation
+   {:ui-handler :documentation
+    :help "Open the Defold documentation in a web browser."}
+
+   :donate-page
+   {:ui-handler :donate
+    :help "Open the Donate to Defold page in a web browser."}
+
+   :editor-logs
+   {:ui-handler :show-logs
+    :help "Show the directory containing the editor logs."}
+
+   :engine-profiler
+   {:ui-handler :engine-profile-show
+    :help "Open the Engine Profiler in a web browser."}
+
+   :fetch-libraries
+   {:ui-handler :fetch-libraries
+    :help "Download the latest version of the project library dependencies."}
+
+   :hot-reload
+   {:ui-handler :hot-reload
+    :help "Hot-reload all modified files into the running project."}
+
+   :rebuild
+   {:ui-handler :rebuild
+    :help "Rebuild and run the project."}
+
+   :rebundle
+   {:ui-handler :rebundle
+    :help "Re-bundle the project using the previous Bundle dialog settings."}
+
+   :reload-extensions
+   {:ui-handler :reload-extensions
+    :help "Reload editor extensions."}
+
+   :reload-stylesheets
+   {:ui-handler :reload-stylesheet
+    :help "Reload editor stylesheets."}
+
+   :report-issue
+   {:ui-handler :report-issue
+    :help "Open the Report Issue page in a web browser."}
+
+   :report-suggestion
+   {:ui-handler :report-suggestion
+    :help "Open the Report Suggestion page in a web browser."}
+
+   :issues
+   {:ui-handler :search-issues
+    :help "Open the Defold Issue Tracker in a web browser."}
+
+   :show-build-errors
+   {:ui-handler :show-build-errors
+    :help "Show the Build Errors tab."}
+
+   :show-console
+   {:ui-handler :show-console
+    :help "Show the Console tab."}
+
+   :show-curve-editor
+   {:ui-handler :show-curve-editor
+    :help "Show the Curve Editor tab."}
+
+   :support-forum
+   {:ui-handler :support-forum
+    :help "Open the Defold Support Forum in a web browser."}
+
+   :toggle-pane-bottom
+   {:ui-handler :toggle-pane-bottom
+    :help "Toggle visibility of the bottom editor pane."}
+
+   :toggle-pane-left
+   {:ui-handler :toggle-pane-left
+    :help "Toggle visibility of the left editor pane."}
+
+   :toggle-pane-right
+   {:ui-handler :toggle-pane-right
+    :help "Toggle visibility of the right editor pane."}})
+
+(defonce ^:private help-response
+  (let [utf8-bytes (-> (let [sb (StringBuilder. 4096)]
+                         (.append sb "{\n")
+                         (doseq [[command {:keys [help]}] (sort-by key supported-commands)]
+                           (.append sb "  ")
+                           (.append sb (json/write-str (name command)))
+                           (.append sb ": ")
+                           (.append sb (json/write-str help))
+                           (.append sb "\n"))
+                         (.append sb "}")
+                         (.toString sb))
+                       (.getBytes StandardCharsets/UTF_8))]
+    {:code 200
+     :headers {"Content-Type" "text/plain;charset=UTF-8"
+               "Content-Length" (str (count utf8-bytes))}
+     :body utf8-bytes}))
 
 (defonce ^:private malformed-request-response
   {:code 400
    :body "400 Bad Request"})
 
-(defonce ^:private command-not-active-response
+(defonce ^:private command-not-supported-response
   {:code 404
    :body "404 Not Found"})
 
@@ -43,13 +194,16 @@
    :body "202 Accepted"})
 
 (defn- parse-command [request]
-  (try
-    (keyword (subs (:url request) 9))
-    (catch Exception error
-      (log/error :msg "Failed to parse command request"
-                 :request request
-                 :exception error)
-      nil)))
+  (let [url-string (:url request)]
+    (case url-string
+      ("/command" "/command/") ::api
+      (try
+        (keyword (subs url-string 9))
+        (catch Exception error
+          (log/error :msg "Failed to parse command request"
+                     :request request
+                     :exception error)
+          nil)))))
 
 (defn- resolve-ui-handler-ctx [ui-node command user-data]
   {:pre [(ui/node? ui-node)
@@ -64,12 +218,22 @@
          (fn? render-reload-progress!)]}
   (fn request-handler [request]
     (when (= "GET" (:method request))
-      (let [command (parse-command request)]
-        (if (nil? command)
+      (let [command (parse-command request)
+            ui-handler (some-> command supported-commands :ui-handler)]
+        (cond
+          (= ::api command)
+          help-response
+
+          (nil? command)
           malformed-request-response
-          (let [ui-handler-ctx (resolve-ui-handler-ctx ui-node command {})]
+
+          (nil? ui-handler)
+          command-not-supported-response
+
+          :else
+          (let [ui-handler-ctx (resolve-ui-handler-ctx ui-node ui-handler {})]
             (case ui-handler-ctx
-              ::ui/not-active command-not-active-response
+              ::ui/not-active command-not-supported-response
               ::ui/not-enabled command-not-enabled-response
               (let [{:keys [changes-view workspace]} (:env (second ui-handler-ctx))]
                 (assert (g/node-id? changes-view))

--- a/editor/src/clj/editor/command_requests.clj
+++ b/editor/src/clj/editor/command_requests.clj
@@ -1,0 +1,69 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.command-requests
+  (:require [editor.ui :as ui]
+            [service.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defonce ^:const url-prefix "/command/")
+
+(defonce ^:private malformed-request-response
+  {:code 400
+   :body "400 Bad Request"})
+
+(defonce ^:private command-not-active-response
+  {:code 404
+   :body "404 Not Found"})
+
+(defonce ^:private command-not-enabled-response
+  {:code 405
+   :body "405 Method Not Allowed"})
+
+(defonce ^:private unhandled-exception-response
+  {:code 500
+   :body "500 Internal Server Error"})
+
+(defonce ^:private command-accepted-response
+  {:code 202
+   :body "202 Accepted"})
+
+(defn- parse-command [request]
+  (try
+    (keyword (subs (:url request) 9))
+    (catch Exception error
+      (log/error :msg "Failed to parse command request"
+                 :request request
+                 :exception error)
+      nil)))
+
+(defn- run-command! [ui-node command]
+  (let [command-contexts (ui/node-contexts ui-node false)]
+    (ui/execute-command command-contexts command {})))
+
+(defn request-handler [ui-node request]
+  (if-some [command (parse-command request)]
+    (ui/run-now
+      (try
+        (case (run-command! ui-node command)
+          ::ui/not-active command-not-active-response
+          ::ui/not-enabled command-not-enabled-response
+          command-accepted-response)
+        (catch Exception error
+          (log/error :msg "Failed to handle command request"
+                     :request request
+                     :exception error)
+          unhandled-exception-response)))
+    malformed-request-response))

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -248,9 +248,14 @@
 ;; Setup
 ;; -----------------------------------------------------------------------------
 
+(defmulti json-compatible-region (fn [region] (:type region)))
+
+(defmethod json-compatible-region :default [region] (dissoc region :on-click!))
+
 (g/defnk produce-request-response-body [lines regions]
-  (let [body-data {:lines lines
-                   :regions regions}
+  (let [json-regions (keep json-compatible-region regions)
+        body-data {:lines lines
+                   :regions json-regions}
         ^String body-string (json/write-str body-data)]
     (.getBytes body-string StandardCharsets/UTF_8)))
 
@@ -330,13 +335,13 @@
             (.setFill gc gutter-eval-error-color)
             (.fillText gc "!" text-right text-y))
 
-          :extension-out
+          :extension-output
           (let [text-y (+ ascent line-y)]
             (.setFont gc font)
             (.setFill gc gutter-eval-expression-color)
             (.fillText gc "⚙" text-right text-y))
 
-          :extension-err
+          :extension-error
           (let [text-y (+ ascent line-y)]
             (.setFont gc font)
             (.setFill gc gutter-eval-error-color)

--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -15,10 +15,8 @@
 (ns editor.hot-reload
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
-            [dynamo.graph :as g]
-            [editor.pipeline :as pipeline]
             [editor.workspace :as workspace]
-            [editor.resource :as resource])
+            [util.http-util :as http-util])
   (:import [java.io FileNotFoundException]
            [java.net URI]
            [org.apache.commons.io FilenameUtils IOUtils]))
@@ -27,9 +25,6 @@
 
 (def ^:const url-prefix "/build")
 (def ^:const verify-etags-url-prefix "/__verify_etags__")
-
-(def ^:const not-found {:code 404})
-(def ^:const bad-request {:code 400})
 
 (defn- content->bytes [content]
   (-> content io/input-stream IOUtils/toByteArray))
@@ -50,13 +45,13 @@
                        (catch FileNotFoundException _
                          :not-found)))]
        (if (= content :not-found)
-         not-found
+         http-util/not-found-response
          (let [response-headers (cond-> {"ETag" etag}
                                   (= method "GET") (assoc "Content-Length" (if content (str (count content)) "-1")))]
            (cond-> {:code (if cached? 304 200)
                     :headers response-headers}
              (and (= method "GET") (not cached?)) (assoc :body content)))))
-     not-found)))
+     http-util/not-found-response)))
 
 (defn build-handler [workspace project request]
   (handler workspace project request))
@@ -86,7 +81,7 @@
 
 (defn- v-e-handler [workspace project {:keys [url method headers ^bytes body]}]
   (if (not= method "POST")
-    bad-request
+    http-util/bad-request-response
     (let [body-str (string/join "\n" (body->valid-entries workspace body))
           body (.getBytes body-str "UTF-8")]
       {:code 200

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -25,7 +25,8 @@
             [editor.view :as view]
             [editor.workspace :as workspace]
             [service.log :as log]
-            [util.http-server :as http-server])
+            [util.http-server :as http-server]
+            [util.http-util :as http-util])
   (:import [java.net URI URLDecoder]
            [javafx.scene Parent]
            [javafx.scene.control Tab]
@@ -72,9 +73,9 @@
 
         :else
         (do (log/warn :message (format "Unknown content-type %s for %s" resource-ext resource))
-            {:code 404})))
+            http-util/not-found-response)))
     (do (log/warn :message (format "Cannot find resource for %s" (:url request)))
-        {:code 404})))
+        http-util/not-found-response)))
 
 (defn- get-http-server!
   [project]

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -27,13 +27,14 @@
     [editor.system :as system]
     [editor.ui :as ui]
     [editor.prefs :as prefs]
-    [editor.workspace :as workspace])
+    [editor.workspace :as workspace]
+    [util.http-util :as http-util])
   (:import
     [com.dynamo.bob Bob ClassLoaderScanner IProgress IResourceScanner Project TaskResult]
     [com.dynamo.bob.fs DefaultFileSystem]
     [com.dynamo.bob.util PathUtil]
     [java.io File InputStream PrintStream PrintWriter PipedInputStream PipedOutputStream]
-    [java.net URI]
+    [java.net URI URL]
     [java.nio.charset StandardCharsets]
     [org.apache.commons.io FilenameUtils]
     [org.apache.commons.io.output WriterOutputStream]))
@@ -380,7 +381,7 @@
       {:code 302
        :headers {"Location" (str html5-url-prefix "/index.html")}}
 
-      (let [url-without-query-params  (.getPath (java.net.URL. (str "http://" url)))
+      (let [url-without-query-params  (.getPath (URL. (str "http://" url)))
             served-file   (try-resolve-html5-file project url-without-query-params)
             extra-headers {"Content-Type" (html5-mime-types
                                             (FilenameUtils/getExtension (clojure.string/lower-case url-without-query-params))
@@ -388,8 +389,7 @@
         (cond
           ;; The requested URL is a directory or located outside build-html5-output-path.
           (or (nil? served-file) (.isDirectory served-file))
-          {:code 403
-           :body "Forbidden"}
+          http-util/forbidden-response
 
           (.exists served-file)
           {:code 200
@@ -397,8 +397,7 @@
            :body served-file}
 
           :else
-          {:code 404
-           :body "Not found"})))))
+          http-util/not-found-response)))))
 
 (defn html5-handler [project req-headers]
   (handler project req-headers))

--- a/editor/src/clj/util/http_server.clj
+++ b/editor/src/clj/util/http_server.clj
@@ -99,8 +99,7 @@
   (.start server)
   (when-not (Boolean/getBoolean "defold.tests")
     (log/info :msg "Http server running"
-              :local-url (local-url server)
-              :url (url server)))
+              :local-url (local-url server)))
   server)
 
 (defn stop! [^HttpServer server]

--- a/editor/src/clj/util/http_util.clj
+++ b/editor/src/clj/util/http_util.clj
@@ -1,0 +1,49 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns util.http-util
+  (:import [java.nio.charset StandardCharsets]))
+
+(set! *warn-on-reflection* true)
+
+(def make-status-response
+  (memoize
+    (fn make-status-response [code description]
+      {:pre [(integer? code)
+             (string? (not-empty description))]}
+      {:code code
+       :body (.getBytes (str code \space description \newline) StandardCharsets/UTF_8)})))
+
+(defn make-json-response [^String json-string]
+  (let [utf8-bytes (.getBytes ^String json-string StandardCharsets/UTF_8)]
+    {:code 200
+     :headers {"Content-Type" "application/json"
+               "Content-Length" (str (count utf8-bytes))}
+     :body utf8-bytes}))
+
+
+(def accepted-response (make-status-response 202 "Accepted"))
+(def bad-request-response (make-status-response 400 "Bad Request"))
+(def forbidden-response (make-status-response 403 "Forbidden"))
+(def not-found-response (make-status-response 404 "Not Found"))
+(def method-not-allowed-response (make-status-response 405 "Method Not Allowed"))
+(def internal-server-error-response (make-status-response 500 "Internal Server Error"))
+
+(def only-get-allowed-response
+  (assoc method-not-allowed-response
+    :headers {"Allow" "GET"}))
+
+(def only-post-allowed-response
+  (assoc method-not-allowed-response
+    :headers {"Allow" "POST"}))


### PR DESCRIPTION
Implements #6604.

See the [documentation](https://github.com/defold/defold/blob/7ed47f3db3a24832522e16b0c5d3c5c82784376c/editor/doc/http-api.md).

### User-facing changes
* Add experimental `command` endpoint to editor http server. External tools can use this to trigger build, hot-reload, etc.
* Add experimental `console` endpoint to editor http server. External tools can use this to render console output similar to the editor.

#### Remaining work:
* We should make our port discoverable somehow. In `targets.clj`, we use an SSDP service to discover running engine targets on the network. Perhaps we could use a similar mechanism? Not sure if the editor should be the one broadcasting or listening, though.