### PR TITLE
Identical names require the same values in templates

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -45,6 +45,7 @@
             [editor.scene-picking :as scene-picking]
             [editor.slice9 :as slice9]
             [editor.types :as types]
+            [editor.util :as eutil]
             [editor.validation :as validation]
             [editor.workspace :as workspace]
             [internal.graph.types :as gt]
@@ -2239,16 +2240,61 @@
                       :dep-resources dep-resources}
           :deps dep-build-targets})])))
 
+(defn- validate-template-build-targets [template-build-targets]
+  (let [gui-resource-type+name->value->resource-proj-paths
+        (persistent!
+          (reduce
+            (fn [acc [gui-resource-type gui-resource-name gui-resource-value template-resource]]
+              (let [k (pair gui-resource-type gui-resource-name)
+                    proj-path (resource/proj-path template-resource)]
+                (assoc! acc k (-> (acc k)
+                                  (or {})
+                                  (update gui-resource-value (fnil conj []) proj-path)))))
+            (transient {})
+            (for [template-build-target (flatten template-build-targets)
+                  :let [resource (-> template-build-target :resource :resource)
+                        pb (-> template-build-target :user-data :pb)]
+                  [gui-resource-pb-key gui-value-key] [[:textures :texture]
+                                                       [:fonts :font]
+                                                       [:particlefxs :particlefx]
+                                                       [:resources :path]]
+                  gui-resource (get pb gui-resource-pb-key)]
+              [gui-resource-pb-key (:name gui-resource) (get gui-resource gui-value-key) resource])))
+        errors (into []
+                     (comp
+                       (filter #(< 1 (-> % val count)))
+                       (map (fn [[[gui-resource-type gui-resource-name] value->proj-paths]]
+                              (format "%s \"%s\" has conflicting values in templates: %s"
+                                      (case gui-resource-type
+                                        :textures "Texture"
+                                        :fonts "Font"
+                                        :particlefxs "Particle FX"
+                                        :resources "Custom resource")
+                                      gui-resource-name
+                                      (->> (for [[value proj-paths] value->proj-paths
+                                                 proj-path proj-paths]
+                                             (format "%s (%s)" proj-path value))
+                                           (sort eutil/natural-order)
+                                           (eutil/join-words ", " " and "))))))
+                     (sort-by key
+                              (eutil/comparator-chain
+                                (eutil/comparator-on key)
+                                (eutil/comparator-on eutil/natural-order val))
+                              gui-resource-type+name->value->resource-proj-paths))]
+    (when (pos? (count errors))
+      (str/join "\n" errors))))
+
 (defn- validate-max-nodes [_node-id max-nodes node-ids]
     (or (validation/prop-error :fatal _node-id :max-nodes (partial validation/prop-outside-range? [1 8192]) max-nodes "Max Nodes")
         (validation/prop-error :fatal _node-id :max-nodes (fn [v] (let [c (count node-ids)]
                                                                     (when (> c max-nodes)
                                                                       (format "the actual number of nodes (%d) exceeds 'Max Nodes' (%d)" c max-nodes)))) max-nodes)))
 
-(g/defnk produce-own-build-errors [_node-id material max-nodes node-ids script]
+(g/defnk produce-own-build-errors [_node-id material max-nodes node-ids script ^:try template-build-targets]
   (g/package-errors _node-id
                     (when script (prop-resource-error _node-id :script script "Script"))
                     (prop-resource-error _node-id :material material "Material")
+                    (validation/prop-error :fatal _node-id nil validate-template-build-targets (gu/array-subst-remove-errors template-build-targets))
                     (validate-max-nodes _node-id max-nodes node-ids)))
 
 (g/defnk produce-build-errors [_node-id build-errors own-build-errors]

--- a/editor/src/reveal/editor/reveal.clj
+++ b/editor/src/reveal/editor/reveal.clj
@@ -24,12 +24,14 @@
             editor.code.data
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
+            editor.workspace
             [vlaaad.reveal :as r]
             [internal.system :as is])
   (:import [clojure.core.async.impl.channels ManyToManyChannel]
            [clojure.lang IRef]
            [editor.resource FileResource ZipResource]
            [editor.code.data Cursor CursorRange]
+           [editor.workspace BuildResource]
            [internal.graph.types Endpoint]
            [javafx.scene Parent]))
 
@@ -190,6 +192,12 @@
 (r/defstream ZipResource [resource]
   (r/horizontal
     (r/raw-string "#resource/zip" {:fill :object})
+    r/separator
+    (r/stream (resource/proj-path resource))))
+
+(r/defstream BuildResource [resource]
+  (r/horizontal
+    (r/raw-string "#resource/build" {:fill :object})
     r/separator
     (r/stream (resource/proj-path resource))))
 


### PR DESCRIPTION
User-facing changes: when multiple templates used in the same GUI define resources with clashing names, we now require them to refer to the same values. For instance, suppose a GUI file named `A.gui` contains two templates: `B.gui` and `C.gui`. If both templates define a font named "main_font" and the actual fonts used in each template are not the same, `A.gui` will not know which one to use and will randomly choose one. To prevent this issue, we will now display a build error when such clashes occur.

Fixes #7222
