### PR TITLE
Show an error message when an added collection file is missing

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoUtil.java
@@ -26,6 +26,15 @@ import com.google.protobuf.TextFormat;
 public class ProtoUtil {
 
     public static void merge(IResource input, Builder builder) throws IOException, CompileExceptionError {
+        byte[] content = input.getContent();
+        if (content == null) {
+            if (!input.exists()) {
+                throw new CompileExceptionError(input, 0, "Resource does not exist");
+            }
+            else {
+                throw new CompileExceptionError(input, 0, "Resource is empty");
+            }
+        }
         try {
             TextFormat.merge(new String(input.getContent()), builder);
         } catch (TextFormat.ParseException e) {


### PR DESCRIPTION
Show a better error message when a collection file which has been added to a collection does not exist. Previously a NullPointerException error was shown with no reference to the missing file.

Fixes #7291 