### PR TITLE
URL decode Bob resource path before attempting file operations

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ClassLoaderResourceScanner.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ClassLoaderResourceScanner.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -66,7 +67,7 @@ public class ClassLoaderResourceScanner implements IResourceScanner {
 
     private static void scanJar(URL resource, String filter, Set<String> results) throws IOException {
         String resPath = resource.getPath();
-        String jarPath = resPath.replaceFirst("[.]jar[!].*", ".jar").replaceFirst("file:", "");
+        String jarPath = URLDecoder.decode(resPath.replaceFirst("[.]jar[!].*", ".jar"), "UTF-8").replaceFirst("file:", "");
         try (JarFile jarFile = new JarFile(jarPath)){
             Enumeration<JarEntry> entries = jarFile.entries();
             while(entries.hasMoreElements()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ClassLoaderResourceScanner.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ClassLoaderResourceScanner.java
@@ -67,6 +67,8 @@ public class ClassLoaderResourceScanner implements IResourceScanner {
 
     private static void scanJar(URL resource, String filter, Set<String> results) throws IOException {
         String resPath = resource.getPath();
+
+        // resPath is URL-encoded, e.g. space characters represented as %20, so decode before deriving file paths from it
         String jarPath = URLDecoder.decode(resPath.replaceFirst("[.]jar[!].*", ".jar"), "UTF-8").replaceFirst("file:", "");
         try (JarFile jarFile = new JarFile(jarPath)){
             Enumeration<JarEntry> entries = jarFile.entries();


### PR DESCRIPTION
Bob now URL decodes the file:// URL that references the Bob jar file before attempting file operations.
Fixes #5930

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
