### PR TITLE
Allow receiving error values in graph outputs

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -226,6 +226,7 @@
   (let [param        (gensym "m")
         [alias argv] (strip-alias (vec argv))
         kargv        (mapv keyword argv)
+        annotations  (into {} (map (juxt keyword meta)) argv)
         arglist      (interleave argv (map #(list `get param %) kargv))]
     (if alias
       `(with-meta
@@ -233,11 +234,13 @@
            (let [~alias (select-keys ~param ~kargv)
                  ~@(vec arglist)]
              ~@tail))
-         {:arguments (quote ~kargv)})
+         {:arguments (quote ~kargv)
+          :annotations (quote ~annotations)})
       `(with-meta
          (fn [~param]
            (let ~(vec arglist) ~@tail))
-         {:arguments (quote ~kargv)}))))
+         {:arguments (quote ~kargv)
+          :annotations (quote ~annotations)}))))
 
 (defmacro defnk
   [symb & body]
@@ -335,6 +338,12 @@
   Define an output to produce values of type. The ':cached' flag is
   optional. _producer_ may be a var that names an fn, or fnk.  It may
   also be a function tail as [arglist] + forms.
+
+  In the arglist, you can specify ^:try metadata on arguments to allow
+  the computation of the output even when some of its arguments are
+  errors. Note that adding ^:try metadata on an array input will never
+  supply an error value to the output fnk; instead, it will provide
+  an array where some items might be errors.
 
   Values produced on an output with the :cached flag will be cached in
   memory until the node is affected by some change in inputs or

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -81,7 +81,7 @@
                          (if (contains? seen key)
                            (recur (rest s) seen)
                            (cons f (step (rest s) (conj seen key)))))))
-                    xs seen)))]
+                   xs seen)))]
      (step coll #{}))))
 
 (defn group-into
@@ -293,6 +293,30 @@
     (quoted-var? x) (inputs-needed (var-get (resolve (second x))))
     (pfnk-form? x)  (parse-fnk-arguments x)
     :else           #{}))
+
+(defn input-annotations [x]
+  (cond
+    (pfnk? x)
+    (:annotations (meta x))
+
+    (symbol? x)
+    (recur (resolve x))
+
+    (var? x)
+    (recur (var-get x))
+
+    (quoted-var? x)
+    (recur (var-get (resolve (second x))))
+
+    (pfnk-form? x)
+    (into {}
+          (comp
+            (take-while (complement #{:as :-}))
+            (map (juxt keyword meta)))
+          (second (maybe-expand-macros x)))
+
+    :else
+    {}))
 
 (defn- wrap-protocol
   [tp tp-form]

--- a/editor/test/internal/defnode_test.clj
+++ b/editor/test/internal/defnode_test.clj
@@ -15,6 +15,7 @@
 (ns internal.defnode-test
   (:require [clojure.test :refer :all]
             [clojure.set :as set]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [internal.graph.types :as gt]
             [internal.node :as in]
@@ -916,3 +917,218 @@
       (is (= #{:test :_node-id :_this} (set (keys (g/node-value n :inline-intrinsics)))))
       (is (= {:test "test"} (g/node-value n :defnk)))
       (is (= #{:test :_node-id :_this} (set (keys (g/node-value n :defnk-intrinsics))))))))
+
+;; try on output
+(g/defnode TryModifierOnErrorOutput
+  (output source g/Any (g/fnk [_node-id] (g/->error _node-id :source :fatal nil "Fail!")))
+  (output target g/Any (g/fnk [^:try source] {:result source})))
+(g/defnode WithoutTryModifierOnErrorOutput
+  (output source g/Any (g/fnk [_node-id] (g/->error _node-id :source :fatal nil "Fail!")))
+  (output target g/Any (g/fnk [source] {:result source})))
+
+;; try on input
+(g/defnode ErrorSource
+  (output out g/Any (g/fnk [_node-id] (g/->error _node-id :source :fatal nil "Fail!"))))
+(g/defnode TryModifierOnErrorInput
+  (input in g/Any)
+  (output target g/Any (g/fnk [^:try in] {:result in})))
+(g/defnode WithoutTryModifierOnErrorInput
+  (input in g/Any)
+  (output target g/Any (g/fnk [in] {:result in})))
+
+;; try on array input
+(g/defnode ValueSource
+  (property out g/Any))
+(g/defnode TryModifierOnArrayErrorInput
+  (input in g/Any :array)
+  (output target g/Any (g/fnk [^:try in] {:result in})))
+(g/defnode WithoutTryModifierOnArrayErrorInput
+  (input in g/Any :array)
+  (output target g/Any (g/fnk [in] {:result in})))
+
+;; try on array input with substitute
+(g/defnode TryModifierOnArrayErrorInputWithSubstitute
+  (input in g/Any :array :substitute [:substitute])
+  (output target g/Any (g/fnk [^:try in] {:result in})))
+(g/defnode WithoutTryModifierOnArrayErrorInputWithSubstitute
+  (input in g/Any :array :substitute [:substitute])
+  (output target g/Any (g/fnk [in] {:result in})))
+
+;; try on single value input with substitute
+(g/defnode TryModifierOnErrorInputWithSubstitute
+  (input in g/Any :substitute :substitute)
+  (output target g/Any (g/fnk [^:try in] {:result in})))
+(g/defnode WithoutTryModifierOnErrorInputWithSubstitute
+  (input in g/Any :substitute :substitute)
+  (output target g/Any (g/fnk [in] {:result in})))
+
+;; try on property
+(g/defnode TryModifierOnProperty
+  (property prop g/Any)
+  (output out g/Any (g/fnk [^:try prop] {:result prop})))
+(g/defnode WithoutTryModifierOnProperty
+  (property prop g/Any)
+  (output out g/Any (g/fnk [prop] {:result prop})))
+
+;; try on jammed output
+(g/defnode TryModifierOnJammedOutput
+  (output source g/Any (g/fnk [] :source))
+  (output target g/Any :unjammable (g/fnk [^:try source] {:result source})))
+(g/defnode WithoutTryModifierOnJammedOutput
+  (output source g/Any (g/fnk [] :source))
+  (output target g/Any :unjammable (g/fnk [source] {:result source})))
+
+;; try on output of same-named input
+(g/defnode TryModifierOnSameNameInput
+  (input port g/Any)
+  (output port g/Any (g/fnk [^:try port] {:result port})))
+(g/defnode WithoutTryModifierOnSameNameInput
+  (input port g/Any)
+  (output port g/Any (g/fnk [port] {:result port})))
+
+;; try on output of property value
+(g/defnode TryModifierOnPropertyValue
+  (property x g/Any)
+  (property y g/Any)
+  (property properties g/Any (value (g/fnk [x ^:try y] {:x x :y y}))))
+(g/defnode WithoutTryModifierOnPropertyValue
+  (property x g/Any)
+  (property y g/Any)
+  (property properties g/Any (value (g/fnk [x y] {:x x :y y}))))
+
+;; try on dynamic of property value
+(g/defnode TryModifierOnPropertyDynamic
+  (property prop g/Any (dynamic string (g/fnk [^:try prop] (str prop)))))
+(g/defnode WithoutTryModifierOnPropertyDynamic
+  (property prop g/Any (dynamic string (g/fnk [prop] (str prop)))))
+
+(deftest try-modifier-test
+  (testing "Trying on output forwards the error"
+    (with-clean-system
+      ;; sanity check - no :try errors the output
+      (let [[node-id] (tx-nodes (g/make-node world WithoutTryModifierOnErrorOutput))]
+        (is (g/error? (g/node-value node-id :target))))
+      ;; expected behavior with :try
+      (let [[node-id] (tx-nodes (g/make-node world TryModifierOnErrorOutput))]
+        (is (not (g/error? (g/node-value node-id :target))))
+        (is (g/error? (:result (g/node-value node-id :target)))))))
+  (testing "Trying on input forwards the error"
+    (with-clean-system
+      ;; sanity check - no :try on input errors the output
+      (let [[_ target-id] (tx-nodes (g/make-nodes world [source [ErrorSource]
+                                                         target [WithoutTryModifierOnErrorInput]]
+                                      (g/connect source :out target :in)))]
+        (is (g/error? (g/node-value target-id :target))))
+      ;; expected behavior with :try
+      (let [[_ target-id] (tx-nodes (g/make-nodes world [source [ErrorSource]
+                                                         target [TryModifierOnErrorInput]]
+                                      (g/connect source :out target :in)))]
+        (is (not (g/error? (g/node-value target-id :target))))
+        (is (g/error? (:result (g/node-value target-id :target)))))))
+  (testing "Trying on input with the same name forwards the error (i.e. we can implement :substitute with :try)"
+    (with-clean-system
+      ;; sanity check - no :try errors the output
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [WithoutTryModifierOnSameNameInput]
+                                                          source [ErrorSource]]
+                                       (g/connect source :out target :port))))]
+        (is (g/error? (g/node-value node-id :port))))
+      ;; expected behavior with :try
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [TryModifierOnSameNameInput]
+                                                          source [ErrorSource]]
+                                       (g/connect source :out target :port))))]
+        (is (not (g/error? (g/node-value node-id :port))))
+        (is (g/error? (:result (g/node-value node-id :port)))))))
+  (testing "Trying on array input makes it possible to receive errors in an array"
+    (with-clean-system
+      ;; sanity check - no :try on array input errors the output
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [WithoutTryModifierOnArrayErrorInput]
+                                                          in1 [ValueSource :out 1]
+                                                          in2 [ErrorSource]
+                                                          in3 [ValueSource :out 3]]
+                                       (g/connect in1 :out target :in)
+                                       (g/connect in2 :out target :in)
+                                       (g/connect in3 :out target :in))))]
+        (is (g/error? (g/node-value node-id :target))))
+      ;; expected behavior with :try
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [TryModifierOnArrayErrorInput]
+                                                          in1 [ValueSource :out 1]
+                                                          in2 [ErrorSource]
+                                                          in3 [ValueSource :out 3]]
+                                       (g/connect in1 :out target :in)
+                                       (g/connect in2 :out target :in)
+                                       (g/connect in3 :out target :in))))]
+        (is (not (g/error? (g/node-value node-id :target))))
+        (is (vector? (:result (g/node-value node-id :target))))
+        (is (= 1 (get (:result (g/node-value node-id :target)) 0)))
+        (is (g/error? (get (:result (g/node-value node-id :target)) 1)))
+        (is (= 3 (get (:result (g/node-value node-id :target)) 2))))))
+  (testing "Trying on array input with substitute performs substitution"
+    (with-clean-system
+      ;; sanity check - no :try also performs substitution
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [WithoutTryModifierOnArrayErrorInputWithSubstitute]
+                                                          in [ErrorSource]]
+                                       (g/connect in :out target :in))))]
+        (is (= {:result [:substitute]} (g/node-value node-id :target))))
+      ;; expected behavior with :try is equivalent to no :try because semantically
+      ;; substitution is similar to try-catch block on input
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [TryModifierOnArrayErrorInputWithSubstitute]
+                                                          in [ErrorSource]]
+                                       (g/connect in :out target :in))))]
+        (is (= {:result [:substitute]} (g/node-value node-id :target))))))
+  (testing "Trying on single value input with substitute performs substitution"
+    (with-clean-system
+      ;; sanity check - no :try also performs substitution
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [WithoutTryModifierOnErrorInputWithSubstitute]
+                                                          in [ErrorSource]]
+                                       (g/connect in :out target :in))))]
+        (is (= {:result :substitute} (g/node-value node-id :target))))
+      ;; expected behavior with :try is equivalent to no :try
+      (let [node-id (first (tx-nodes (g/make-nodes world [target [TryModifierOnErrorInputWithSubstitute]
+                                                          in [ErrorSource]]
+                                       (g/connect in :out target :in))))]
+        (is (= {:result :substitute} (g/node-value node-id :target))))))
+  (testing "Trying on property forwards the error"
+    (with-clean-system
+      ;; sanity check - no :try on error property errors the output
+      (let [[node-id] (tx-nodes (g/make-node world WithoutTryModifierOnProperty :prop (g/map->error {})))]
+        (is (g/error? (g/node-value node-id :out))))
+      ;; expected behavior
+      (let [[node-id] (tx-nodes (g/make-node world TryModifierOnProperty :prop (g/map->error {})))]
+        (is (not (g/error? (g/node-value node-id :out))))
+        (is (g/error? (:result (g/node-value node-id :out)))))))
+  (testing "Trying in custom property value forwards the error"
+    (with-clean-system
+      ;; sanity check
+      (let [node-id (first (tx-nodes (g/make-node world WithoutTryModifierOnPropertyValue
+                                                  :x 1
+                                                  :y (g/map->error {:severity :fatal}))))]
+        (is (g/error? (g/node-value node-id :properties))))
+      ;; expected behavior
+      (let [node-id (first (tx-nodes (g/make-node world TryModifierOnPropertyValue
+                                                  :x 1
+                                                  :y (g/map->error {:severity :fatal}))))]
+        (is (not (g/error? (g/node-value node-id :properties))))
+        (is (not (g/error? (:x (g/node-value node-id :properties)))))
+        (is (g/error? (:y (g/node-value node-id :properties)))))))
+  (testing "Trying in property dynamic forwards the error"
+    (with-clean-system
+      ;; sanity check - no :try errors the dynamic
+      (let [node-id (first (tx-nodes (g/make-node world WithoutTryModifierOnPropertyDynamic :prop (g/map->error {:severity :fatal}))))]
+        (is (g/error? (:string (:prop (:properties (g/node-value node-id :_properties)))))))
+      ;; expected behavior with :try forwards the error value
+      (let [node-id (first (tx-nodes (g/make-node world TryModifierOnPropertyDynamic :prop (g/map->error {:severity :fatal}))))]
+        (is (string? (:string (:prop (:properties (g/node-value node-id :_properties))))))
+        (is (string/includes? (:string (:prop (:properties (g/node-value node-id :_properties)))) "error")))))
+  (testing "Trying on jammed output forwards the error"
+    (with-clean-system
+      ;; sanity check - no :try jams the output
+      (let [node-id (first (tx-nodes (g/make-nodes world [node WithoutTryModifierOnJammedOutput]
+                                       (g/mark-defective node WithoutTryModifierOnJammedOutput
+                                                         (g/map->error {:severity :fatal})))))]
+        (is (g/error? (g/node-value node-id :target))))
+      ;; expected behavior with :try
+      (let [node-id (first (tx-nodes (g/make-nodes world [node TryModifierOnJammedOutput]
+                                       (g/mark-defective node TryModifierOnJammedOutput
+                                                         (g/map->error {:severity :fatal})))))]
+        (is (not (g/error? (g/node-value node-id :target))))
+        (is (g/error? (:result (g/node-value node-id :target))))))))


### PR DESCRIPTION
This changeset modifies the graph behavior in a way that allows us to receive error values in node outputs. The syntax to specify that an output allows errors is `^:try` meta on output `fnk`-s, e.g.:
```clj
(g/defnode MyNode
  (input in g/Any)
  (output out g/Any (g/fnk [^:try in]
                       (if (g/error? in)
                          ...
                          ...))))
```

Some notes:
- this `^:try` syntax also works on arguments for property dynamics, as well as on custom `value` of the property;
- input error substitution using `:substitute` takes precedence over `^:try` — if there is an error in the input, the substitution will be applied anyway;
- there are no user-facing changes because the introduced feature is not used anywhere yet. By the way, I tried using the feature on the fix for #7222 (PR #7388) to verify its usefulness, and it works as intended — the node outline is still produced when there are errors in template build targets;
- I decided to remove annotations from the node description because their presence could cause compile errors when argument metadata used tags (e.g. `^SplitPane editor-tabs-split`) — the tags would be `eval`-ed, which in turn would trigger class resolution. The class resolution will fail if the class isn't imported in ns which defines a node that inherits from a node from another ns where the class is imported. For example, `MockAppView` defined in `integration.test-util` would fail to resolve class `SplitPane` that is used in `AppView` node type defined in `editor.app-view`. Another alternative to the removal of annotations would be quoting them instead, but I thought since they are only used during the compilation of `g/defnode`, there is no need to keep them around.


Related to #7222
