### PR TITLE
Set resource name based on filename

### DIFF
--- a/editor/resources/templates/template.collection
+++ b/editor/resources/templates/template.collection
@@ -1,1 +1,1 @@
-name: "__NAME__"
+name: "{{NAME}}"

--- a/editor/resources/templates/template.collection
+++ b/editor/resources/templates/template.collection
@@ -1,1 +1,1 @@
-name: "default"
+name: "__NAME__"

--- a/editor/resources/templates/template.material
+++ b/editor/resources/templates/template.material
@@ -1,3 +1,3 @@
-name: "unnamed"
+name: "{{NAME}}"
 vertex_program: ""
 fragment_program: ""

--- a/editor/resources/templates/template.model
+++ b/editor/resources/templates/template.model
@@ -1,3 +1,3 @@
 mesh: ""
 material: ""
-name: "unnamed"
+name: "{{NAME}}"

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -454,6 +454,12 @@
         (when (and (delete selection) next)
           (select-resource! asset-browser next))))))
 
+(defn- create-template-file [new-file template]
+  (let [split-filename (re-matches #"(.*)\.(.+)" (.getName new-file))
+        name (get split-filename 1)
+        new-file-contents (string/replace template #"__NAME__" name)]
+    (spit new-file new-file-contents)))
+
 (handler/defhandler :new-file :global
   (label [user-data] (if-not user-data
                        "New..."
@@ -475,7 +481,7 @@
              rt (:resource-type user-data)]
          (when-let [desired-file (dialogs/make-new-file-dialog project-path base-folder (or (:label rt) (:ext rt)) (:ext rt))]
            (when-let [[[_ new-file]] (resolve-any-conflicts [[nil desired-file]])]
-             (spit new-file (workspace/template workspace rt))
+             (create-template-file new-file (workspace/template workspace rt))
              (workspace/resource-sync! workspace)
              (let [resource-map (g/node-value workspace :resource-map)
                    new-resource-path (resource/file->proj-path project-path new-file)

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -16,43 +16,31 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [dynamo.graph :as g]
-            [editor.error-reporting :as error-reporting]
-            [editor.fs :as fs]
-            [editor.fxui :as fxui]
-            [editor.handler :as handler]
-            [editor.icons :as icons]
-            [editor.ui :as ui]
-            [editor.prefs :as prefs]
-            [editor.resource :as resource]
-            [editor.resource-watch :as resource-watch]
-            [editor.workspace :as workspace]
+            [editor.app-view :as app-view]
             [editor.dialogs :as dialogs]
             [editor.disk-availability :as disk-availability]
-            [editor.app-view :as app-view])
-  (:import [com.defold.editor Start]
+            [editor.error-reporting :as error-reporting]
+            [editor.fs :as fs]
+            [editor.handler :as handler]
+            [editor.icons :as icons]
+            [editor.prefs :as prefs]
+            [editor.protobuf :as protobuf]
+            [editor.resource :as resource]
+            [editor.resource-watch :as resource-watch]
+            [editor.ui :as ui]
+            [editor.workspace :as workspace])
+  (:import [com.defold.control TreeCell]
            [editor.resource FileResource]
-           [javafx.application Platform]
-           [javafx.collections FXCollections ObservableList]
-           [javafx.embed.swing SwingFXUtils]
-           [javafx.event ActionEvent Event EventHandler]
-           [javafx.fxml FXMLLoader]
-           [javafx.geometry Insets]
-           [javafx.scene.input Clipboard ClipboardContent]
-           [javafx.scene.input DragEvent TransferMode MouseEvent]
-           [javafx.scene Scene Node Parent]
-           [javafx.scene.control Button ColorPicker Label TextField TitledPane TextArea TreeItem TreeView Menu MenuItem SeparatorMenuItem MenuBar Tab ProgressBar ContextMenu SelectionMode]
-           [javafx.scene.image Image ImageView WritableImage PixelWriter]
-           [javafx.scene.input MouseEvent KeyCombination ContextMenuEvent]
-           [javafx.scene.layout AnchorPane GridPane StackPane HBox Priority]
-           [javafx.scene.paint Color]
-           [javafx.stage Stage FileChooser]
-           [javafx.util Callback]
            [java.io File]
            [java.nio.file Path Paths]
-           [java.util.prefs Preferences]
-           [com.jogamp.opengl GL GL2 GLContext GLProfile GLDrawableFactory GLCapabilities]
-           [org.apache.commons.io FilenameUtils]
-           [com.defold.control TreeCell]))
+           [javafx.collections FXCollections ObservableList]
+           [javafx.scene.input Clipboard ClipboardContent]
+           [javafx.scene.input DragEvent MouseEvent TransferMode]
+           [javafx.scene Node]
+           [javafx.scene.control SelectionMode TreeItem TreeView]
+           [javafx.scene.input MouseEvent]
+           [javafx.stage Stage]
+           [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 
@@ -454,11 +442,15 @@
         (when (and (delete selection) next)
           (select-resource! asset-browser next))))))
 
-(defn- create-template-file [new-file template]
-  (let [split-filename (re-matches #"(.*)\.(.+)" (.getName new-file))
-        name (get split-filename 1)
-        new-file-contents (string/replace template #"__NAME__" name)]
-    (spit new-file new-file-contents)))
+(defn replace-template-name
+  ^String [^String template ^String name]
+  (let [escaped-name (protobuf/escape-string name)]
+    (string/replace template "{{NAME}}" escaped-name)))
+
+(defn- create-template-file! [^String template ^File new-file]
+  (let [base-name (FilenameUtils/getBaseName (.getPath new-file))
+        contents (replace-template-name template base-name)]
+    (spit new-file contents)))
 
 (handler/defhandler :new-file :global
   (label [user-data] (if-not user-data
@@ -481,7 +473,8 @@
              rt (:resource-type user-data)]
          (when-let [desired-file (dialogs/make-new-file-dialog project-path base-folder (or (:label rt) (:ext rt)) (:ext rt))]
            (when-let [[[_ new-file]] (resolve-any-conflicts [[nil desired-file]])]
-             (create-template-file new-file (workspace/template workspace rt))
+             (let [template (workspace/template workspace rt)]
+               (create-template-file! template new-file))
              (workspace/resource-sync! workspace)
              (let [resource-map (g/node-value workspace :resource-map)
                    new-resource-path (resource/file->proj-path project-path new-file)
@@ -492,7 +485,7 @@
            (when (not user-data)
              (sort-by (comp string/lower-case :label)
                       (keep (fn [[_ext resource-type]]
-                              (when (workspace/template workspace resource-type)
+                              (when (workspace/has-template? workspace resource-type)
                                 {:label (or (:label resource-type) (:ext resource-type))
                                  :icon (:icon resource-type)
                                  :style (resource/ext-style-classes (:ext resource-type))

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -19,19 +19,19 @@ call the appropriate methods. Since this is very expensive (specifically
 fetching the Method from the Class), it uses memoization wherever possible.
 It should be possible to use macros instead and retain the same API.
 Macros currently mean no foreseeable performance gain however."
-  (:require [camel-snake-kebab :refer [->kebab-case ->CamelCase]]
+  (:require [camel-snake-kebab :refer [->CamelCase ->kebab-case]]
             [clojure.java.io :as io]
             [clojure.string :as s]
-            [internal.java :as j]
             [editor.util :as util]
             [editor.workspace :as workspace]
+            [internal.java :as j]
             [util.digest :as digest])
-  (:import [com.google.protobuf Message TextFormat ProtocolMessageEnum GeneratedMessage$Builder Descriptors$Descriptor DescriptorProtos$FieldOptions
-            Descriptors$FileDescriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$Type Descriptors$FieldDescriptor$JavaType]
-           [javax.vecmath Point3d Vector3d Vector4d Quat4d Matrix4d]
-           [com.dynamo.proto DdfExtensions DdfMath$Point3 DdfMath$Vector3 DdfMath$Vector4 DdfMath$Quat DdfMath$Matrix4]
-           [java.lang.reflect Method]
+  (:import [com.dynamo.proto DdfExtensions DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector4]
+           [com.google.protobuf DescriptorProtos$FieldOptions Descriptors$Descriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType Descriptors$FieldDescriptor$Type Descriptors$FileDescriptor GeneratedMessage$Builder Message ProtocolMessageEnum TextFormat]
            [java.io ByteArrayOutputStream StringReader]
+           [java.lang.reflect Method]
+           [java.nio.charset StandardCharsets]
+           [javax.vecmath Matrix4d Point3d Quat4d Vector3d Vector4d]
            [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
@@ -48,6 +48,12 @@ Macros currently mean no foreseeable performance gain however."
   (msg->clj [^Message pb v]))
 
 (def ^:private upper-pattern (re-pattern #"\p{javaUpperCase}"))
+
+(defn escape-string
+  ^String [^String string]
+  (-> string
+      (.getBytes StandardCharsets/UTF_8)
+      (TextFormat/escapeBytes)))
 
 (defn- new-builder ^GeneratedMessage$Builder
   [class]

--- a/editor/test/integration/asset_browser_test.clj
+++ b/editor/test/integration/asset_browser_test.clj
@@ -14,18 +14,20 @@
 
 (ns integration.asset-browser-test
   (:require [clojure.java.io :as io]
-            [clojure.test :refer :all]
             [clojure.string :as string]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
             [editor.asset-browser :as asset-browser]
-            [editor.dialogs :as dialogs]
-            [editor.workspace :as workspace]
             [editor.defold-project :as project]
+            [editor.dialogs :as dialogs]
             [editor.fs :as fs]
+            [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.resource-watch :as resource-watch]
+            [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :refer [with-clean-system]]))
+            [support.test-support :refer [with-clean-system]])
+  (:import [com.defold.editor.test TestDdf$DefaultValue]))
 
 (deftest workspace-tree
   (testing "The file system can be retrieved as a tree"
@@ -250,3 +252,19 @@
             (is (some? (resource-map "/collection/game.project")))
             (is (not (some? (resource-map "/car/car.script"))))
             (is (some? (resource-map "/collection/car.script")))))))))
+
+(deftest replace-template-name
+  (are [name]
+    (= name
+       (->> name
+            (asset-browser/replace-template-name "string_value: \"{{NAME}}\"")
+            (protobuf/str->pb TestDdf$DefaultValue)
+            (.getStringValue)))
+
+    "single-quoted: 'text in quotes'"
+    "double-quoted: \"text in quotes\""
+    "slash: /"
+    "backslash: \\"
+    "newline: \n"
+    "carriage-return: \r"
+    "unicode: \u3042"))

--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -13,7 +13,8 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns integration.reload-test
-  (:require [clojure.set :as set]
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
@@ -32,7 +33,7 @@
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
             [service.log :as log]
-            [support.test-support :refer [spit-until-new-mtime touch-until-new-mtime undo-stack with-clean-system do-until-new-mtime]])
+            [support.test-support :refer [do-until-new-mtime spit-until-new-mtime touch-until-new-mtime undo-stack with-clean-system]])
   (:import [java.awt.image BufferedImage]
            [java.io File]
            [javax.imageio ImageIO]
@@ -94,8 +95,11 @@
      [workspace project])))
 
 (defn- template [workspace name]
-  (let [resource (workspace/file-resource workspace name)]
-    (workspace/template workspace (resource/resource-type resource))))
+  (let [resource (workspace/file-resource workspace name)
+        resource-type (resource/resource-type resource)
+        template (workspace/template workspace resource-type)
+        base-name (FilenameUtils/getBaseName (resource/resource-name resource))]
+    (asset-browser/replace-template-name template base-name)))
 
 (def ^:dynamic *no-sync* nil)
 (def ^:dynamic *moved-files* nil)
@@ -187,7 +191,7 @@
         (let [initial-node (project/get-resource-node project "/test.collection")]
           (is (= (inc initial-node-count) (node-count)))
           (is (not (nil? initial-node)))
-          (is (= "default" (g/node-value initial-node :name)))
+          (is (= "test" (g/node-value initial-node :name)))
           (is (no-undo? project))
           (testing "Change internal file"
             (write-file workspace "/test.collection" "name: \"test_name\"")


### PR DESCRIPTION
A common source of problems when working with collection proxies is the fact that all collections are given the name "default", and if you are not careful and remember to change this name you will run into issues such as `The collection ‘default’ could not be created since there is already a socket with the same name.`. This change will give a created Collection, Material, or Model resources the same name as the filename.