### PR TITLE
Added support for trimmed images in atlases.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
@@ -119,7 +119,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, ids, iterator, 0, 0, 0, true, false, null);
+        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, null, ids, iterator, 0, 0, 0, true, false, null);
         TextureSet textureSet = result.builder.setTexture("").build();
         BufferedImage image = result.image;
         assertThat(image.getWidth(), is(32));
@@ -144,7 +144,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, ids, iterator, 0, 0, 0, true, false, null);
+        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, null, ids, iterator, 0, 0, 0, true, false, null);
         BufferedImage image = result.image;
         assertThat(image.getWidth(), is(32));
         assertThat(image.getHeight(), is(32));
@@ -172,7 +172,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, ids, iterator, 5, 0, 0, true, false, null);
+        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, null, ids, iterator, 5, 0, 0, true, false, null);
         BufferedImage image = result.image;
         assertThat(image.getWidth(), is(32));
         assertThat(image.getHeight(), is(32));
@@ -198,7 +198,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, ids, iterator, 0, 0, 0, true, false, null);
+        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, null, ids, iterator, 0, 0, 0, true, false, null);
 
         TextureSet textureSet = result.builder.setTexture("").build();
 
@@ -221,7 +221,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, ids, iterator, 0, 0, 0, true, false, null);
+        TextureSetResult result = TextureSetGenerator.generate(images, hullSizes, null, ids, iterator, 0, 0, 0, true, false, null);
 
         TextureSet textureSet = result.builder.setTexture("").build();
         assertUVTransform(0.0f, 1.0f, 0.5f, -0.5f, getUvTransforms(result.uvTransforms, textureSet, "anim1", 0));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -171,7 +171,7 @@ public class AtlasUtil {
         String transform(String path);
     }
 
-    private static List<MappedAnimDesc> createAnimDescs(Atlas atlas, PathTransformer transformer) {
+    private static List<MappedAnimDesc> createAnimDescs(Atlas atlas) {
         List<MappedAnimDesc> animDescs = new ArrayList<MappedAnimDesc>(atlas.getAnimationsCount()
                 + atlas.getImagesCount());
         for (AtlasAnimation anim : atlas.getAnimationsList()) {
@@ -219,16 +219,11 @@ public class AtlasUtil {
         }
         List<IResource> imageResources = toResources(atlasResource, imagePaths);
         List<BufferedImage> images = AtlasUtil.loadImages(imageResources);
-        PathTransformer transformer = new PathTransformer() {
-            @Override
-            public String transform(String path) {
-                return project.getResource(path).getPath();
-            }
-        };
-        List<MappedAnimDesc> animDescs = createAnimDescs(atlas, transformer);
+        List<MappedAnimDesc> animDescs = createAnimDescs(atlas);
         int imagePathCount = imagePaths.size();
         for (int i = 0; i < imagePathCount; ++i) {
-            imagePaths.set(i, transformer.transform(imagePaths.get(i)));
+            String path = project.getResource(imagePaths.get(i)).getPath();
+            imagePaths.set(i, path);
         }
         MappedAnimIterator iterator = new MappedAnimIterator(animDescs, atlasImages);
         TextureSetResult result = TextureSetGenerator.generate(images, imageHullSizes, imageSourceRects, imagePaths, iterator,

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -44,31 +44,31 @@ import com.dynamo.gamesys.proto.Tile.SpriteTrimmingMode;
 
 public class AtlasUtil {
     public static class MappedAnimDesc extends AnimDesc {
-        List<String> ids;
+        List<AtlasImage> ids;
 
-        public MappedAnimDesc(String id, List<String> ids, Playback playback, int fps, boolean flipHorizontal,
+        public MappedAnimDesc(String id, List<AtlasImage> ids, Playback playback, int fps, boolean flipHorizontal,
                 boolean flipVertical) {
             super(id, playback, fps, flipHorizontal, flipVertical);
             this.ids = ids;
         }
 
-        public MappedAnimDesc(String id, List<String> ids) {
+        public MappedAnimDesc(String id, List<AtlasImage> ids) {
             super(id, Playback.PLAYBACK_NONE, 0, false, false);
             this.ids = ids;
         }
 
-        public List<String> getIds() {
-            return this.ids;
+        public List<AtlasImage> getIds() {
+            return ids;
         }
     }
 
     public static class MappedAnimIterator implements AnimIterator {
         final List<MappedAnimDesc> anims;
-        final List<String> imageIds;
+        final List<AtlasImage> imageIds;
         int nextAnimIndex;
         int nextFrameIndex;
 
-        public MappedAnimIterator(List<MappedAnimDesc> anims, List<String> imageIds) {
+        public MappedAnimIterator(List<MappedAnimDesc> anims, List<AtlasImage> imageIds) {
             this.anims = anims;
             this.imageIds = imageIds;
         }
@@ -109,13 +109,13 @@ public class AtlasUtil {
         }
         @Override
         public int hashCode() {
-            return path.hashCode() + 31 * this.mode.hashCode() + 59 * this.rect.hashCode();
+            return path.hashCode() + 31 * mode.hashCode() + 59 * rect.hashCode();
         }
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             AtlasImageSortKey b = (AtlasImageSortKey)o;
-            return this.mode == b.mode && this.path.equals(b.path) && this.rect.equals(b.rect);
+            return mode == b.mode && path.equals(b.path) && rect.equals(b.rect);
         }
     }
 
@@ -175,15 +175,11 @@ public class AtlasUtil {
         List<MappedAnimDesc> animDescs = new ArrayList<MappedAnimDesc>(atlas.getAnimationsCount()
                 + atlas.getImagesCount());
         for (AtlasAnimation anim : atlas.getAnimationsList()) {
-            List<String> frameIds = new ArrayList<String>();
-            for (AtlasImage image : anim.getImagesList()) {
-                frameIds.add(transformer.transform(image.getImage()));
-            }
-            animDescs.add(new MappedAnimDesc(anim.getId(), frameIds, anim.getPlayback(), anim.getFps(), anim
+            animDescs.add(new MappedAnimDesc(anim.getId(), anim.getImagesList(), anim.getPlayback(), anim.getFps(), anim
                     .getFlipHorizontal() != 0, anim.getFlipVertical() != 0));
         }
         for (AtlasImage image : atlas.getImagesList()) {
-            MappedAnimDesc animDesc = new MappedAnimDesc(pathToId(image.getImage()), Collections.singletonList(transformer.transform(image.getImage())));
+            MappedAnimDesc animDesc = new MappedAnimDesc(pathToId(image.getImage()), Collections.singletonList(image));
             animDescs.add(animDesc);
         }
 
@@ -234,7 +230,7 @@ public class AtlasUtil {
         for (int i = 0; i < imagePathCount; ++i) {
             imagePaths.set(i, transformer.transform(imagePaths.get(i)));
         }
-        MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imagePaths);
+        MappedAnimIterator iterator = new MappedAnimIterator(animDescs, atlasImages);
         TextureSetResult result = TextureSetGenerator.generate(images, imageHullSizes, imageSourceRects, imagePaths, iterator,
                 Math.max(0, atlas.getMargin()),
                 Math.max(0, atlas.getInnerPadding()),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
@@ -137,7 +137,7 @@ public class TileSetGenerator {
         // Since all the images already are positioned optimally in a grid,
         // we tell TextureSetGenerator to NOT do its own packing and use this grid directly.
         Grid grid_size = new Grid(metrics.tilesPerRow, metrics.tilesPerColumn);
-        TextureSetResult result = TextureSetGenerator.generate(images, imageHullSizes, names, iterator, 0,
+        TextureSetResult result = TextureSetGenerator.generate(images, imageHullSizes, null, names, iterator, 0,
                 tileSet.getInnerPadding(),
                 tileSet.getExtrudeBorders(), false, true, grid_size );
 

--- a/editor/src/clj/editor/image_util.clj
+++ b/editor/src/clj/editor/image_util.clj
@@ -74,7 +74,7 @@
 
 (s/defn make-image :- Image
   [nm :- s/Any contents :- BufferedImage]
-  (Image. nm contents (.getWidth contents) (.getHeight contents) :sprite-trim-mode-off))
+  (Image. nm contents (.getWidth contents) (.getHeight contents) :sprite-trim-mode-off 0 0 0 0))
 
 (s/defn blank-image :- BufferedImage
   ([space :- Rect]

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -185,11 +185,15 @@
           :sprite-trim-mode-8))
 
 (s/defrecord Image
-  [path     :- s/Any
-   contents :- (s/maybe BufferedImage)
-   width    :- Int32
-   height   :- Int32
-   sprite-trim-mode :- sprite-trim-modes]
+  [path              :- s/Any
+   contents          :- (s/maybe BufferedImage)
+   width             :- Int32
+   height            :- Int32
+   sprite-trim-mode  :- sprite-trim-modes
+   source-position-x :- Int32
+   source-position-y :- Int32
+   source-width      :- Int32
+   source-height     :- Int32]
   ImageHolder
   (contents [this] contents))
 

--- a/editor/test/editor/image_test.clj
+++ b/editor/test/editor/image_test.clj
@@ -29,4 +29,8 @@
 (deftest image-loading
   (let [img (make-image (as-url (file "foo")) (BufferedImage. 128 192 BufferedImage/TYPE_4BYTE_ABGR))]
     (is (= 128 (.width img)))
-    (is (= 192 (.height img)))))
+    (is (= 192 (.height img)))
+    (is (= 0 (.source-position-x img)))
+    (is (= 0 (.source-position-y img)))
+    (is (= 0 (.source-width img)))
+    (is (= 0 (.source-height img)))))

--- a/engine/gamesys/proto/gamesys/atlas_ddf.proto
+++ b/engine/gamesys/proto/gamesys/atlas_ddf.proto
@@ -13,6 +13,10 @@ message AtlasImage
 {
     required string image                           = 1 [(resource) = true];
     optional SpriteTrimmingMode sprite_trim_mode    = 2 [default = SPRITE_TRIM_MODE_OFF];
+    optional int32 source_position_x                = 3 [default = 0];
+    optional int32 source_position_y                = 4 [default = 0];
+    optional uint32 source_width                    = 5 [default = 0];
+    optional uint32 source_height                   = 6 [default = 0];
 }
 
 message AtlasAnimation


### PR DESCRIPTION
Texture sizes can be greatly reduced by trimming transparent pixels around the actual sprite image.

The engine itself already has support for arbitrary vertex positions for each image which was introduced with the Sprite Trim Mode feature. Therefore only the editor and bob were modified to add the trimmed images support.

This feature introduces new fields for images in the atlas outline pane. Namely `Source Position X`, `Source Position Y`, `Source Width`, `Source Height`.

`Source Position X` and `Source Position Y` indicate the position offset of the trimmed image inside the original image from the top left corner. `Source Width` and `Source Height` indicate the original image size and they are needed to correctly center the trimmed image inside the animation frame.

This new information about the images can be entered by hand or a special user script can be used to prepare such atlases.

## TexturePacker support

https://github.com/Lerg/defold-texturepacker-exporter

To ease the generation of such atlases a custom exporter was created for TexturePacker. The exporter generates atlas file for Defold and a JSON file for the Spritesheet Split editor script.

The exported supports storing atlas settings and animations settings such as margin, padding, FPS, playback and so on.

### Spritesheet Split editor script

https://github.com/Lerg/defold-editor-script-spritesheet

An editor script was created that takes a spritesheet image generated by TexturePacker with a JSON file containing information on each image inside the spritesheet and splits up the image into individual files suitable for the atlas.

Resolves #3629