### PR TITLE
Improve Lua-related LSP configuration responses

### DIFF
--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -186,7 +186,7 @@
         (map #(.getName ^ScriptDoc$Element %))
         (get (load-sdoc (sdoc-path "base")) "")))
 
-(def defined-globals
+(defn extract-globals-from-completions [completions]
   (into #{}
         (comp
           (remove #(#{:message :property} (:type %)))
@@ -194,7 +194,10 @@
           (remove #(or (= "" %)
                        (string/includes? % ":")
                        (contains? base-globals %))))
-        (get defold-docs "")))
+        (get completions "")))
+
+(def defined-globals
+  (extract-globals-from-completions defold-docs))
 
 (defn lua-base-documentation []
   (s/validate documentation-schema


### PR DESCRIPTION
This changeset adds 2 improvements:
- for Lua language servers, the editor's LSP client now also reports globals defined in `.script_api` files, thus improving linting accuracy
- editor's LSP client now responds to `files.associations` configuration request with information about which file extensions correspond to which languages. This information might be used by language servers for filtering which files to lint when asked for workspace linting.

Related to #3885