### PR TITLE
Removed duplicate Size property on Gui Text objects

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -525,7 +525,7 @@
 
 ;; Base nodes
 
-(def base-display-order [:id :generated-id scene/SceneNode :manual-size])
+(def base-display-order [:id :generated-id scene/SceneNode])
 
 (defn- validate-layer [emit-warnings? node-id layer-names layer]
   (when-not (empty? layer)


### PR DESCRIPTION
Fixes #7428

Gui Text nodes no longer show two Size properties.
