### PR TITLE
Fix bug when some of embeded GOs maybe ignored by component counter

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollectionBuilder.java
@@ -68,7 +68,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
     }
 
     private void createGeneratedResources(Project project, CollectionDesc.Builder builder,
-        Map<Long, IResource> uniqueResources ) throws IOException, CompileExceptionError {
+        Map<Long, IResource> uniqueResources, Map<Long, IResource> allResources) throws IOException, CompileExceptionError {
 
         for (EmbeddedInstanceDesc desc : builder.getEmbeddedInstancesList()) {
             byte[] data = desc.getData().getBytes();
@@ -84,6 +84,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                 genResource.setContent(data);
                 uniqueResources.put(hash, genResource);
             }
+            allResources.put(hash, genResource);
         }
 
         for (CollectionInstanceDesc c : builder.getCollectionInstancesList()) {
@@ -91,7 +92,7 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
             CollectionDesc.Builder subCollectionBuilder = CollectionDesc.newBuilder();
             ProtoUtil.merge(collectionResource, subCollectionBuilder);
 
-            createGeneratedResources(project, subCollectionBuilder, uniqueResources);
+            createGeneratedResources(project, subCollectionBuilder, uniqueResources, allResources);
         }
     }
 
@@ -135,7 +136,8 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
         }
 
         Map<Long, IResource> uniqueResources = new HashMap<>();
-        createGeneratedResources(this.project, builder, uniqueResources);
+        Map<Long, IResource> allResources = new HashMap<>();
+        createGeneratedResources(this.project, builder, uniqueResources, allResources);
 
         List<Task<?>> embedTasks = new ArrayList<>();
         for (long hash : uniqueResources.keySet()) {
@@ -148,6 +150,10 @@ public class CollectionBuilder extends ProtoBuilder<CollectionDesc.Builder> {
                                                 String.format("Failed to create build task for component '%s'", genResource.getPath()));
             }
             embedTasks.add(embedTask);
+        }
+        
+        for (IResource genResource : allResources.values()) {
+            Task<?> embedTask = project.createTask(genResource);
             // if embeded objects have factories, they should be in input for our collection
             Set<IResource> counterInputs = ComponentsCounter.getCounterInputs(embedTask);
             for(IResource res : counterInputs) {


### PR DESCRIPTION
In a case when embedded GOs in a few different collections are the same, component counter didn't count the second and the following GOs.

Fix https://github.com/defold/defold/issues/7434


## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
