### PR TITLE
Bugfix for using basis transcoding since paged atlas feature

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CubemapBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CubemapBuilder.java
@@ -88,6 +88,9 @@ public class CubemapBuilder extends Builder<Void> {
                 //
                 // So for cube map textures we don't flip on any axis, meaning the texture data begin at the
                 // upper left corner of the input image.
+
+
+                // NOTE: Setting the same input for more than one side will cause a NPE when generating!
                 TextureImage texture = TextureGenerator.generate(is, texProfile, compress, EnumSet.noneOf(FlipAxis.class));
                 textures[i] = texture;
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -218,31 +218,39 @@ public class TextureUtil {
             numTextures = 1;
         }
 
-        TextureImage.Builder textureImageBuilder = TextureImage.newBuilder(textures[0]);
-        for (int i = 0; i < textureImageBuilder.getAlternativesCount(); i++) {
-            Image.Builder imageBuilder = TextureImage.Image.newBuilder(textures[0].getAlternatives(i));
+        TextureImage.Builder combinedImageBuilder = TextureImage.newBuilder(textures[0]);
+        System.out.println(combinedImageBuilder.getAlternativesCount());
+
+        for (int i = 0; i < combinedImageBuilder.getAlternativesCount(); i++) {
+            Image.Builder alternativeImageBuilder = TextureImage.Image.newBuilder(textures[0].getAlternatives(i));
+
+            alternativeImageBuilder.clearMipMapSizeCompressed();
 
             ByteArrayOutputStream os = new ByteArrayOutputStream(1024 * 4);
-            for (int j = 0; j < imageBuilder.getMipMapSizeCount(); j++) {
-                int mipSize = imageBuilder.getMipMapSize(j);
-                byte[] buf = new byte[mipSize];
+            for (int j = 0; j < alternativeImageBuilder.getMipMapSizeCount(); j++) {
+
                 for (int k = 0; k < numTextures; k++) {
+                    int mipSize = textures[k].getAlternatives(i).getMipMapSize(j);
                     ByteString data = textures[k].getAlternatives(i).getData();
-                    int mipOffset = imageBuilder.getMipMapOffset(j);
+                    int mipOffset = alternativeImageBuilder.getMipMapOffset(j);
+                    alternativeImageBuilder.addMipMapSizeCompressed(mipSize);
+
+                    // Sizes can change between textures (maybe resize only if needed)
+                    byte[] buf = new byte[mipSize];
                     data.copyTo(buf, mipOffset, 0, mipSize);
                     os.write(buf);
                 }
             }
             os.flush();
-            imageBuilder.setData(ByteString.copyFrom(os.toByteArray()));
-            for (int j = 0; j < imageBuilder.getMipMapSizeCount(); j++) {
-                imageBuilder.setMipMapOffset(j, imageBuilder.getMipMapOffset(j) * numTextures);
+            alternativeImageBuilder.setData(ByteString.copyFrom(os.toByteArray()));
+            for (int j = 0; j < alternativeImageBuilder.getMipMapSizeCount(); j++) {
+                alternativeImageBuilder.setMipMapOffset(j, alternativeImageBuilder.getMipMapOffset(j) * numTextures);
             }
-            textureImageBuilder.setAlternatives(i, imageBuilder);
+            combinedImageBuilder.setAlternatives(i, alternativeImageBuilder);
         }
 
-        textureImageBuilder.setCount(numTextures);
-        textureImageBuilder.setType(type);
-        return textureImageBuilder.build();
+        combinedImageBuilder.setCount(numTextures);
+        combinedImageBuilder.setType(type);
+        return combinedImageBuilder.build();
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TextureUtil.java
@@ -219,7 +219,6 @@ public class TextureUtil {
         }
 
         TextureImage.Builder combinedImageBuilder = TextureImage.newBuilder(textures[0]);
-        System.out.println(combinedImageBuilder.getAlternativesCount());
 
         for (int i = 0; i < combinedImageBuilder.getAlternativesCount(); i++) {
             Image.Builder alternativeImageBuilder = TextureImage.Image.newBuilder(textures[0].getAlternatives(i));

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -102,7 +102,7 @@ namespace dmGameSystem
             {
                 num_mips = MAX_MIPMAP_COUNT;
                 output_format = dmGraphics::GetSupportedCompressionFormat(context, output_format, image->m_Width, image->m_Height);
-                bool result = dmGraphics::Transcode(path, image, output_format, image_desc->m_DecompressedData, image_desc->m_DecompressedDataSize, &num_mips);
+                bool result = dmGraphics::Transcode(path, image, image_desc->m_DDFImage->m_Count, output_format, image_desc->m_DecompressedData, image_desc->m_DecompressedDataSize, &num_mips);
                 if (!result)
                 {
                     dmLogError("Failed to transcode %s", path);
@@ -152,7 +152,7 @@ namespace dmGameSystem
                 creation_params.m_Depth          = image_desc->m_DDFImage->m_Count;
                 creation_params.m_OriginalWidth  = image->m_OriginalWidth;
                 creation_params.m_OriginalHeight = image->m_OriginalHeight;
-                creation_params.m_MipMapCount    = image->m_MipMapOffset.m_Count;
+                creation_params.m_MipMapCount    = num_mips;
                 texture                          = dmGraphics::NewTexture(context, creation_params);
             }
             else
@@ -292,8 +292,11 @@ namespace dmGameSystem
         for (uint32_t i = 0; i < MAX_MIPMAP_COUNT; ++i)
         {
             if(image_desc->m_DecompressedData[i])
+            {
                 delete[] image_desc->m_DecompressedData[i];
+            }
         }
+
         delete image_desc;
     }
 

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -608,6 +608,7 @@ static void DestroyTextureImage(dmGraphics::TextureImage& texture_image, bool de
         dmGraphics::TextureImage::Image& image = texture_image.m_Alternatives.m_Data[i];
         delete[] image.m_MipMapOffset.m_Data;
         delete[] image.m_MipMapSize.m_Data;
+        delete[] image.m_MipMapSizeCompressed.m_Data;
         if (destroy_image_data)
             delete[] image.m_Data.m_Data;
     }

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -648,7 +648,7 @@ namespace dmGraphics
      * @param format dmGraphics::TextureImage::CompressionType
      * @return true if the format is transcoded
      */
-    bool Transcode(const char* path, TextureImage::Image* image, TextureFormat format, uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips);
+    bool Transcode(const char* path, TextureImage::Image* image, uint8_t image_count, TextureFormat format, uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips);
 
     /**
      * Read frame buffer pixels in BGRA format

--- a/engine/graphics/src/transcoder/graphics_transcoder_basisu.cpp
+++ b/engine/graphics/src/transcoder/graphics_transcoder_basisu.cpp
@@ -111,117 +111,89 @@ namespace dmGraphics
 
     bool IsFormatTranscoded(dmGraphics::TextureImage::CompressionType compression_type)
     {
-        if (compression_type == dmGraphics::TextureImage::COMPRESSION_TYPE_BASIS_UASTC ||
-            compression_type == dmGraphics::TextureImage::COMPRESSION_TYPE_BASIS_ETC1S )
-            return true;
-        return false;
+        return compression_type == dmGraphics::TextureImage::COMPRESSION_TYPE_BASIS_UASTC ||
+               compression_type == dmGraphics::TextureImage::COMPRESSION_TYPE_BASIS_ETC1S;
     }
 
-    bool Transcode(const char* path, dmGraphics::TextureImage::Image* image, dmGraphics::TextureFormat format,
-                    uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips)
+    struct ImageTranscodeLevelData
     {
-        DM_PROFILE(__FUNCTION__);
-
-        static int first = 1;
-        if (first)
+        uint32_t m_OriginalWidth;
+        uint32_t m_OriginalHeight;
+        uint32_t m_TotalBlocks;
+        uint32_t m_Size;
+        union
         {
-            first = 0;
-            basist::basisu_transcoder_init();
+            uint32_t m_BytesPerBlock; // For compressed format
+            uint32_t m_BytesPerSlice; // For uncompressed format
+        };
+    };
+
+    struct ImageTranscodeState
+    {
+        ImageTranscodeState()
+        : m_Transcoder(0)
+        , m_LevelData(0)
+        , m_SrcDataPtr(0)
+        {}
+
+        basist::basisu_transcoder m_Transcoder;
+        basist::basisu_image_info m_Info;
+        ImageTranscodeLevelData*  m_LevelData;
+        uint8_t*                  m_SrcDataPtr;
+        uint32_t                  m_SrcDataSize;
+    };
+
+    static void TranscoderDeleteStateArray(ImageTranscodeState* states, uint8_t num_states)
+    {
+        for (int i = 0; i < num_states; ++i)
+        {
+            delete[] states[i].m_LevelData;
         }
 
-        basist::basisu_transcoder tr(0);
+        delete[] states;
+    }
 
-        uint32_t max_num_images = *num_transcoded_mips;
-        uint32_t total_size = 0;
-
-        // Currently storing one basis file with multiple mip map levels
-        uint32_t size = image->m_Data.m_Count;
-        uint8_t* ptr = image->m_Data.m_Data; // image->m_MipMapOffset[i];
-        if (!tr.validate_header(ptr, size))
+    static bool TranscodeInitializeState(const char* path, ImageTranscodeState& state, uint8_t* data_ptr, uint32_t data_size, basist::transcoder_texture_format transcoder_format)
+    {
+        if (!state.m_Transcoder.validate_header(data_ptr, data_size))
         {
             dmLogError("Failed to validate header (Basis) for file '%s'", path);
             return false;
         }
 
-        basist::basisu_image_info info;
-        tr.get_image_info(ptr, size, info, 0);
+        state.m_Transcoder.get_image_info(data_ptr, data_size, state.m_Info, 0);
+        state.m_Transcoder.start_transcoding(data_ptr, data_size);
+        state.m_SrcDataPtr        = data_ptr;
+        state.m_SrcDataSize       = data_size;
 
-        basist::transcoder_texture_format transcoder_format;
-        if (!TextureFormatToBasisFormat(format, transcoder_format))
+        state.m_LevelData = new ImageTranscodeLevelData[state.m_Info.m_total_levels];
+
+        int image_index = 0; // const
+        for (uint32_t level_index = 0; level_index < state.m_Info.m_total_levels; ++level_index)
         {
-            dmLogError("Failed to convert texture format %d to basis format %d for file '%s'", format, transcoder_format, path);
-            return false;
-        }
-
-#if defined(TEX_TRANSCODE_DEBUG)
-        dmLogInfo("Transcoding: %s from %d to %d (%s -> %s)", path, format, transcoder_format, ToString(format), ToString(transcoder_format));
-#endif
-
-        tr.start_transcoding(ptr, size);
-
-        uint32_t image_index = 0;
-        for (uint32_t level_index = 0; level_index < info.m_total_levels; ++level_index) {
-
             uint32_t orig_width, orig_height, total_blocks;
-            if (!tr.get_image_level_desc(ptr, size, image_index, level_index, orig_width, orig_height, total_blocks))
-                return 0;
+            if (!state.m_Transcoder.get_image_level_desc(data_ptr, data_size, image_index, level_index, orig_width, orig_height, total_blocks))
+            {
+                dmLogError("Failed to get image descriptor at level %d for (Basis) file '%s'", level_index, path);
+                return false;
+            }
 
-            // from basis_wrappers.cpp
-            uint32_t flags = 0;
+            state.m_LevelData[level_index].m_OriginalWidth  = orig_width;
+            state.m_LevelData[level_index].m_OriginalHeight = orig_height;
+            state.m_LevelData[level_index].m_TotalBlocks    = total_blocks;
 
-            bool status = false;
-            uint32_t level_size = 0;
-            uint8_t* level_data = 0;
             if (basist::basis_transcoder_format_is_uncompressed(transcoder_format))
             {
                 const uint32_t bytes_per_pixel = basist::basis_get_uncompressed_bytes_per_pixel(transcoder_format);
-                const uint32_t bytes_per_line = orig_width * bytes_per_pixel;
+                const uint32_t bytes_per_line  = orig_width * bytes_per_pixel;
                 const uint32_t bytes_per_slice = bytes_per_line * orig_height;
 
-                level_size = bytes_per_slice;
-                level_data = new uint8_t[bytes_per_slice];
-
-                status = tr.transcode_image_level(
-                    ptr, size, image_index, level_index,
-                    level_data, orig_width * orig_height,
-                    transcoder_format,
-                    flags,
-                    orig_width,
-                    nullptr,
-                    orig_height);
-
-                // If we wanted a Luminance, LuminanceAlpha or RGB
-                // let's convert back to those formats
-                if (transcoder_format == basist::transcoder_texture_format::cTFRGBA32 && format != dmGraphics::TEXTURE_FORMAT_RGBA)
-                {
-                    int num_channels = 0;
-                    if (format == dmGraphics::TEXTURE_FORMAT_LUMINANCE)
-                        num_channels = 1;
-                    else if (format == dmGraphics::TEXTURE_FORMAT_LUMINANCE_ALPHA)
-                        num_channels = 2;
-                    else if (format == dmGraphics::TEXTURE_FORMAT_RGB)
-                        num_channels = 3;
-                    if (num_channels > 0)
-                    {
-                        uint8_t* p = level_data;
-                        uint8_t* pend = level_data+bytes_per_slice;
-                        uint8_t* packed_dst = level_data;
-                        while (p < pend)
-                        {
-                            for (int c = 0; c < num_channels; ++c)
-                            {
-                                *packed_dst++ = p[c];
-                            }
-                            p += 4;
-                        }
-                    }
-                }
+                state.m_LevelData[level_index].m_Size = bytes_per_slice;
             }
             else
             {
                 uint32_t bytes_per_block = basis_get_bytes_per_block_or_pixel(transcoder_format);
-
-                uint32_t required_size = total_blocks * bytes_per_block;
+                uint32_t required_size   = total_blocks * bytes_per_block;
 
                 if (transcoder_format == basist::transcoder_texture_format::cTFPVRTC1_4_RGB ||
                     transcoder_format == basist::transcoder_texture_format::cTFPVRTC1_4_RGBA)
@@ -235,34 +207,158 @@ namespace dmGraphics
                     assert(required_size >= total_blocks * bytes_per_block);
                 }
 
-                level_size = required_size;
-                level_data = new uint8_t[required_size];
-
-                status = tr.transcode_image_level(
-                    ptr, size, image_index, level_index,
-                    level_data, level_size / bytes_per_block,
-                    transcoder_format,
-                    flags);
+                state.m_LevelData[level_index].m_BytesPerBlock = bytes_per_block;
+                state.m_LevelData[level_index].m_Size          = required_size;
             }
+        }
 
-            if (!status)
+        return true;
+    }
+
+    static bool TranscodeLevel(const char* path, ImageTranscodeState& state, uint8_t* level_data, uint8_t level_index,  basist::transcoder_texture_format transcoder_format, dmGraphics::TextureFormat graphics_format)
+    {
+        int image_index = 0;
+        uint32_t flags = 0;
+
+        if (basist::basis_transcoder_format_is_uncompressed(transcoder_format))
+        {
+            if (!state.m_Transcoder.transcode_image_level(
+                    state.m_SrcDataPtr,
+                    state.m_SrcDataSize,
+                    image_index,
+                    level_index,
+                    level_data,
+                    state.m_LevelData[level_index].m_OriginalWidth * state.m_LevelData[level_index].m_OriginalHeight,
+                    transcoder_format,
+                    flags,
+                    state.m_LevelData[level_index].m_OriginalWidth,
+                    nullptr,
+                    state.m_LevelData[level_index].m_OriginalHeight))
             {
-                dmLogError("Transcoding failed on level %d for %s\n", level_index, path);
-                if (level_data)
-                    delete[] level_data;
                 return false;
             }
 
-            if (level_index < max_num_images)
+            // If we wanted a Luminance, LuminanceAlpha or RGB
+            // let's convert back to those formats
+            if (transcoder_format == basist::transcoder_texture_format::cTFRGBA32 && graphics_format != dmGraphics::TEXTURE_FORMAT_RGBA)
             {
-                images[level_index] = level_data;
-                sizes[level_index] = level_size;
-
-                total_size += level_size;
+                int num_channels = 0;
+                if (graphics_format == dmGraphics::TEXTURE_FORMAT_LUMINANCE)
+                {
+                    num_channels = 1;
+                }
+                else if (graphics_format == dmGraphics::TEXTURE_FORMAT_LUMINANCE_ALPHA)
+                {
+                    num_channels = 2;
+                }
+                else if (graphics_format == dmGraphics::TEXTURE_FORMAT_RGB)
+                {
+                    num_channels = 3;
+                }
+                if (num_channels > 0)
+                {
+                    uint8_t* p = level_data;
+                    uint8_t* pend = level_data + state.m_LevelData[level_index].m_Size;
+                    uint8_t* packed_dst = level_data;
+                    while (p < pend)
+                    {
+                        for (int c = 0; c < num_channels; ++c)
+                        {
+                            *packed_dst++ = p[c];
+                        }
+                        p += 4;
+                    }
+                }
             }
-        };
+        }
+        else
+        {
+            return state.m_Transcoder.transcode_image_level(
+                state.m_SrcDataPtr,
+                state.m_SrcDataSize,
+                image_index,
+                level_index,
+                level_data,
+                state.m_LevelData[level_index].m_Size / state.m_LevelData[level_index].m_BytesPerBlock,
+                transcoder_format,
+                flags);
+        }
 
-        *num_transcoded_mips = info.m_total_levels;
+        return true;
+    }
+
+    bool Transcode(const char* path, dmGraphics::TextureImage::Image* image, uint8_t image_count, dmGraphics::TextureFormat format,
+                    uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips)
+    {
+        DM_PROFILE(__FUNCTION__);
+
+        assert(image_count > 0);
+
+        static int first = 1;
+        if (first)
+        {
+            first = 0;
+            basist::basisu_transcoder_init();
+        }
+
+        basist::transcoder_texture_format transcoder_format;
+        if (!TextureFormatToBasisFormat(format, transcoder_format))
+        {
+            dmLogError("Failed to convert texture format %d to basis format %d for file '%s'", format, transcoder_format, path);
+            return false;
+        }
+
+        uint32_t max_num_images = *num_transcoded_mips;
+        uint32_t slice_data_offset = 0;
+
+        ImageTranscodeState* image_transcoders = new ImageTranscodeState[image_count];
+
+    #if defined(TEX_TRANSCODE_DEBUG)
+        dmLogInfo("Transcoding: %s from %d to %d (%s -> %s)", path, format, transcoder_format, ToString(format), ToString(transcoder_format));
+    #endif
+
+        for (int i = 0; i < image_count; ++i)
+        {
+            uint32_t size = image->m_MipMapSizeCompressed[i];
+            uint8_t* ptr  = &image->m_Data.m_Data[slice_data_offset];
+
+            if (!TranscodeInitializeState(path, image_transcoders[i], ptr, size, transcoder_format))
+            {
+                return false;
+            }
+
+            slice_data_offset += size;
+        }
+
+        uint32_t num_levels = dmMath::Min(image_transcoders[0].m_Info.m_total_levels, max_num_images);
+        for (uint32_t level_index = 0; level_index < num_levels; ++level_index)
+        {
+            uint32_t data_size      = image_transcoders[0].m_LevelData[level_index].m_Size;
+            uint8_t* data_write_ptr = new uint8_t[data_size * image_count];
+
+            images[level_index] = data_write_ptr;
+            sizes[level_index]  = data_size;
+
+            bool level_result = true;
+            for (int i = 0; i < image_count && level_result; ++i)
+            {
+                assert(image_transcoders[i].m_Info.m_total_levels == num_levels);
+                level_result = TranscodeLevel(path, image_transcoders[i], data_write_ptr, level_index, transcoder_format, format);
+                data_write_ptr += data_size;
+            }
+
+            if (!level_result)
+            {
+                dmLogError("Transcoding failed on level %d for %s\n", level_index, path);
+                delete[] data_write_ptr;
+                TranscoderDeleteStateArray(image_transcoders, image_count);
+                return false;
+            }
+        }
+
+        *num_transcoded_mips = num_levels;
+
+        TranscoderDeleteStateArray(image_transcoders, image_count);
         return true;
     }
 }

--- a/engine/graphics/src/transcoder/graphics_transcoder_null.cpp
+++ b/engine/graphics/src/transcoder/graphics_transcoder_null.cpp
@@ -22,10 +22,11 @@ namespace dmGraphics
         return false;
     }
 
-    bool Transcode(const char* path, TextureImage::Image* image, TextureFormat format, uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips)
+    bool Transcode(const char* path, TextureImage::Image* image, uint8_t image_count, TextureFormat format, uint8_t** images, uint32_t* sizes, uint32_t* num_transcoded_mips)
     {
         (void)path;
         (void)image;
+        (void)image_count;
         (void)format;
         (void)images;
         (void)sizes;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3222,6 +3222,7 @@ bail:
                 params.m_MipMap, layer_count);
             CHECK_VK_ERROR(res);
 
+            // NOTE: We should check max layer count in the device properties!
             VkBufferImageCopy* vk_copy_regions = new VkBufferImageCopy[layer_count];
             for (int i = 0; i < layer_count; ++i)
             {

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3177,6 +3177,19 @@ bail:
         //        per mipmap instead of batching in one cmd
         if (useStageBuffer)
         {
+            uint32_t slice_size = texDataSize / layer_count;
+
+        #ifdef __MACH__
+            // Note: There is an annoying validation issue on osx for layered compressed data that causes a validation error
+            //       due to misalignment of the data when using a stage buffer. The offsets in the stage buffer needs to be
+            //       8 byte aligned but for compressed data that is not the case for the lowest mipmaps.
+            //       This might need some more investigation, but for now we don't want a crash at least...
+            if (slice_size < 8 && layer_count > 1)
+            {
+                return;
+            }
+        #endif
+
             // Create one-time commandbuffer to carry the copy command
             VkCommandBuffer vk_command_buffer;
             CreateCommandBuffers(vk_device, context->m_LogicalDevice.m_CommandPool, 1, &vk_command_buffer);
@@ -3195,6 +3208,7 @@ bail:
             vk_submit_info.pCommandBuffers    = &vk_command_buffer;
 
             DeviceBuffer stage_buffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
             res = CreateDeviceBuffer(context->m_PhysicalDevice.m_Device, vk_device, texDataSize,
                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &stage_buffer);
             CHECK_VK_ERROR(res);
@@ -3208,9 +3222,7 @@ bail:
                 params.m_MipMap, layer_count);
             CHECK_VK_ERROR(res);
 
-            uint32_t slice_size = texDataSize / layer_count;
-
-            VkBufferImageCopy vk_copy_regions[6];
+            VkBufferImageCopy* vk_copy_regions = new VkBufferImageCopy[layer_count];
             for (int i = 0; i < layer_count; ++i)
             {
                 VkBufferImageCopy& vk_copy_region = vk_copy_regions[i];
@@ -3249,6 +3261,8 @@ bail:
             DestroyDeviceBuffer(vk_device, &stage_buffer.m_Handle);
 
             vkFreeCommandBuffers(vk_device, context->m_LogicalDevice.m_CommandPool, 1, &vk_command_buffer);
+
+            delete[] vk_copy_regions;
         }
         else
         {


### PR DESCRIPTION
Fixed an issue with using basis compression together with cubemap generation, where the output of the texture encoding produced an empty result. To fix this issue, we have separated the transcoding into two passes - a preprocessing pass for memory allocation of the result, and one to do the actual transcoding.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [-] Documentation
	* [-] Make sure that API documentation is updated in code comments
	* [-] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [-] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [-] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [-] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [-] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
