### PR TITLE
Show `self` values in debugger for `*.render_script` and `*.script`

### DIFF
--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -34,19 +34,14 @@ local escape_char_map = {
   ["\t" ] = "\\t",
 }
 
-local function str(val)
+local function str(val, val_type, metatable)
   local success, error_or_result = pcall(function()
-    local mt = debug.getmetatable(val)
-    if mt then
-      if mt.__metatable == NodeProxy then
-        return string.format("%s%p", val, val)
-      elseif type(val) == "table" and mt.__tostring then
+    if metatable then
+      if val_type == "table" and metatable.__tostring then
         return string.format("%s %p", val, val)
       end
-      return tostring(val)
-    else
-      return tostring(val)
     end
+      return tostring(val)
   end)
   if success then
     return error_or_result
@@ -82,7 +77,7 @@ end
 
 local strings_cache = {}
 local strings_cache_count = 0
-local function encode_string(val)
+local function encode_string(val, val_type)
   if strings_cache[val] then
     return strings_cache[val]
   end
@@ -92,20 +87,28 @@ local function encode_string(val)
   return str
 end
 
-local function encode_table(val)
+local function encode_table(val, val_type)
   return string.format('#lua/ref"%p"', val)
 end
 
-local function encode_userdata(val)
-  return '#lua/userdata"'..str(val)..'"'
+local function encode_userdata(val, val_type, metatable)
+  return '#lua/userdata"'..str(val, val_type, metatable)..'"'
 end
 
-local function encode_function(val)
-  return '#lua/function"'..str(val)..'"'
+local function encode_function(val, val_type, metatable)
+  return '#lua/function"'..tostring(val)..'"'
 end
 
-local function encode_thread(val)
-  return '#lua/thread"'..str(val)..'"'
+local function encode_thread(val, val_type, metatable)
+  return '#lua/thread"'..tostring(val)..'"'
+end
+
+local function encode_script(val, val_type)
+  return '#lua/ref"' .. tostring(val) .. '"'
+end
+
+local function encode_node(val, val_type)
+  return string.format('#lua/userdata"%s %p"', tostring(val), val)
 end
 
 local type_to_primitive_encoder = {
@@ -118,53 +121,90 @@ local type_to_primitive_encoder = {
   ["function"] = encode_function,
   ["thread"] = encode_thread
 }
+local metatable_to_primitive_encoder = {
+  [GOScriptInstance] = encode_script,
+  -- [GuiScriptInstance] = encode_script, (it doesn't work for *.gui_script)
+  [RenderScriptInstance] = encode_script,
+  [NodeProxy] = encode_node
+}
 
-local function fail_on_unexpected_type(x)
-  error("unexpected type '" .. type(x) .. "'")
+local function fail_on_unexpected_type(x, val_type)
+  error("unexpected type '" .. val_type .. "'")
 end
 
 local function encode_as_primitive(val)
-  local encoder = type_to_primitive_encoder[type(val)] or fail_on_unexpected_type
-  return encoder(val)
+  local val_type = type(val)
+  local mt = debug.getmetatable(val)
+  local encoder = (mt and metatable_to_primitive_encoder[mt.__metatable]) or type_to_primitive_encoder[val_type] or fail_on_unexpected_type
+  return encoder(val, val_type, mt)
 end
 
-local function encode_table(val)
+local function encode_edn_table(val, key)
   local encoded_kvs = {}
   for k, v in pairs(val) do
-    encoded_kvs[#encoded_kvs + 1] = encode_as_primitive(k) .. " " .. encode_as_primitive(v)
+    encoded_kvs[#encoded_kvs + 1] = encode_as_primitive(k)
+    encoded_kvs[#encoded_kvs + 1] = encode_as_primitive(v)
   end
-  return "#lua/table{:content [" .. table.concat(encoded_kvs, " ") .. "] :string " .. encode_string(str(val)) .. "}"
+  local encoded_str = encode_string(str(key, type(key), debug.getmetatable(key)))
+  return "#lua/table{:content [" .. table.concat(encoded_kvs, " ") .. "] :string " .. encoded_str .. "}"
 end
 
-local function encode_refs(refs)
+local function encode_refs(refs, keys)
   local encoded_refs = {}
   local val
   for i = 1, #refs do
     val = refs[i]
-    encoded_refs[i] = encode_as_primitive(val).." "..encode_table(val)
+    encoded_refs[#encoded_refs + 1] = encode_as_primitive(val)
+    encoded_refs[#encoded_refs + 1] = encode_edn_table(keys[val], val)
   end
   return "{" .. table.concat(encoded_refs, " ") .. "}"
 end
 
-local function collect_refs(depth, val, refs, dups)
-  if type(val) == "table" then
-    if depth < 100 and not dups[val] then
-      dups[val] = true
+local registry
+local function find_variables_in_registry(val)
+  for i = 1, #registry do
+    if registry[i] == val then
+      return registry[i+1]
+    end
+  end
+end
+
+local function collect_refs(depth, val, refs, keys)
+  local val_type = type(val)
+  if val_type == "table" then
+    if depth < 100 and not keys[val] then
+      keys[val] = val
       refs[#refs + 1] = val
       local next_depth = depth + 1
       for k, v in pairs(val) do
-        collect_refs(next_depth, k, refs, dups)
-        collect_refs(next_depth, v, refs, dups)
+        collect_refs(next_depth, k, refs, keys)
+        collect_refs(next_depth, v, refs, keys)
+      end
+    end
+  elseif val_type == "userdata" then
+    local mt = debug.getmetatable(val)
+    if mt and metatable_to_primitive_encoder[mt.__metatable] then
+      local script_val = find_variables_in_registry(val)
+      if script_val then
+        if depth < 100 and not keys[val] then
+          keys[val] = script_val
+          refs[#refs + 1] = val
+          local next_depth = depth + 1
+          for k, v in pairs(script_val) do
+            collect_refs(next_depth, k, refs, keys)
+            collect_refs(next_depth, v, refs, keys)
+          end
+        end
       end
     end
   end
 end
 
 local function encode_structure(val)
-  local dups = {}
+  local keys = {}
   local refs = {}
-  collect_refs(0, val, refs, dups)
-  local encoded_refs = encode_refs(refs)
+  collect_refs(0, val, refs, keys)
+  local encoded_refs = encode_refs(refs, keys)
   local str = "#lua/structure{:value " .. encode_as_primitive(val) .. " :refs " .. encoded_refs .. "}"
   if strings_cache_count > 5000000 then
     strings_cache_count = 0
@@ -174,6 +214,7 @@ local function encode_structure(val)
 end
 
 function M.encode(val)
+  registry = debug.getregistry()
   local err_trace
   local success, error_or_result = xpcall(
   function ()

--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -41,7 +41,7 @@ local function str(val, val_type, metatable)
         return string.format("%s %p", val, val)
       end
     end
-      return tostring(val)
+    return tostring(val)
   end)
   if success then
     return error_or_result
@@ -121,6 +121,13 @@ local type_to_primitive_encoder = {
   ["function"] = encode_function,
   ["thread"] = encode_thread
 }
+
+local has_data_in_registry = {
+  [GOScriptInstance] = true,
+  -- [GuiScriptInstance] = true, (it doesn't work for *.gui_script)
+  [RenderScriptInstance] = true,
+}
+
 local metatable_to_primitive_encoder = {
   [GOScriptInstance] = encode_script,
   -- [GuiScriptInstance] = encode_script, (it doesn't work for *.gui_script)
@@ -183,7 +190,7 @@ local function collect_refs(depth, val, refs, keys)
     end
   elseif val_type == "userdata" then
     local mt = debug.getmetatable(val)
-    if mt and metatable_to_primitive_encoder[mt.__metatable] then
+    if mt and has_data_in_registry[mt.__metatable] then
       local script_val = find_variables_in_registry(val)
       if script_val then
         if depth < 100 and not keys[val] then


### PR DESCRIPTION
Show values from `self` table in debugger for `*.render_script` and `*.script`. 

Fix https://github.com/defold/defold/issues/7432

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
