### PR TITLE
Add warning when trying to load HTML5 build from local filesystem

### DIFF
--- a/engine/engine/content/builtins/manifests/web/engine_template.html
+++ b/engine/engine/content/builtins/manifests/web/engine_template.html
@@ -69,6 +69,11 @@
 </head>
 
 <body>
+	<div id="running-from-file-warning" style="display: none; margin: 3em;">
+		<h1>Running from local file ⚠️</h1>
+		<p>It seems like you have opened this file by double-clicking on it. In order to test your build in a browser <b>you need to load this file from a web server</b>. You can either upload this file and the rest of the files from a Defold HTML5 bundle to a web hosting service OR host them using a local web server on your home network.</p>
+		<p><a href="https://defold.com/manuals/html5/#testing-html5-build" target="_blank">Learn more about running a local web server in the Defold HTML5 manual</a>.</p>
+	</div>
 	<div id="app-container" class="canvas-app-container">
 		<div id="canvas-container" class="canvas-app-canvas-container">
 			<canvas id="canvas" class="canvas-app-canvas" tabindex="1" width="{{display.width}}" height="{{display.height}}"></canvas>
@@ -204,8 +209,15 @@
 	</script>
 
 	<script id='engine-start' type='text/javascript'>
-		EngineLoader.stream_wasm = "{{html5.wasm_streaming}}" === "true";
-		EngineLoader.load("canvas", "{{exe-name}}");
+		var runningFromFileWarning = document.getElementById("running-from-file-warning");
+		if (window.location.href.startsWith("file://")) {
+			runningFromFileWarning.style.display = "block";
+		}
+		else {
+			EngineLoader.stream_wasm = "{{html5.wasm_streaming}}" === "true";
+			EngineLoader.load("canvas", "{{exe-name}}");
+			runningFromFileWarning.parentNode.removeChild(runningFromFileWarning);
+		}
 	</script>
 </body>
 </html>


### PR DESCRIPTION
A common mistake for beginners is to double-click on index.html when attempting to test an HTML5 bundle. This will not work since the browser is unable to load the rest of the files required to run the Defold game. This change adds a warning message and instructions on how to test an HTML5 build locally:

![Screenshot 2023-03-13 at 15 47 05](https://user-images.githubusercontent.com/1300688/224737165-4138f33e-d657-4155-90b8-16a4f4a61203.png)

Fixes #7447 