### PR TITLE
Improve manual Size Mode handling in the editor

### DIFF
--- a/editor/src/clj/dev.clj
+++ b/editor/src/clj/dev.clj
@@ -164,6 +164,14 @@
 (defn console-view []
   (-> (view-of-type console/ConsoleNode) (g/targets-of :lines) ffirst))
 
+(defn node-values [node-id & labels]
+  (g/with-auto-evaluation-context evaluation-context
+    (into {}
+          (map (fn [label]
+                 (let [value (g/node-value node-id label evaluation-context)]
+                   (pair label value))))
+          labels)))
+
 (def node-type-key (comp :k g/node-type*))
 
 (defn- class-symbol [^Class class]

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -160,8 +160,9 @@
          basis (is/basis system)
          id-generators (is/id-generators system)
          override-id-generator (is/override-id-generator system)
+         tx-data-context-map (or (:tx-data-context-map opts) {})
          metrics-collector (:metrics opts)
-         transaction-context (it/new-transaction-context basis id-generators override-id-generator metrics-collector)
+         transaction-context (it/new-transaction-context basis id-generators override-id-generator tx-data-context-map metrics-collector)
          tx-result (it/transact* transaction-context txs)]
      (when (and (not (:dry-run opts))
                 (= :ok (:status tx-result)))

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -460,15 +460,29 @@
         new-value (from-fn new-value)]
     (set-value-txs evaluation-context node-id prop-kw key set-fn value new-value)))
 
-(defn- set-values [evaluation-context property values]
+(defn- resolve-set-operations
+  "Resolves the supplied property and sequence of new values to a vector of
+  individual [node-id prop-kw old-value new-value] vectors detailing the
+  low-level property set operations that will be performed as a result."
+  [property values]
+  (let [node-ids (:node-ids property)
+        prop-kws (:prop-kws property)
+        old-values (:values property)
+        new-values (if-some [from-fn (-> property :edit-type :from-type)]
+                     (mapv from-fn values)
+                     values)]
+    (mapv vector node-ids prop-kws old-values new-values)))
+
+(defn- edited-endpoints [set-operations]
+  (into #{}
+        (map (fn [[node-id prop-kw]]
+               (g/endpoint node-id prop-kw)))
+        set-operations))
+
+(defn- set-values [evaluation-context property set-operations]
   (let [key (:key property)
-        set-fn (get-in property [:edit-type :set-fn])
-        from-fn (get-in property [:edit-type :from-type] identity)]
-    (for [[node-id prop-kw old-value new-value] (map vector
-                                                     (:node-ids property)
-                                                     (:prop-kws property)
-                                                     (:values property)
-                                                     (map from-fn values))]
+        set-fn (get-in property [:edit-type :set-fn])]
+    (for [[node-id prop-kw old-value new-value] set-operations]
       (set-value-txs evaluation-context node-id prop-kw key set-fn old-value new-value))))
 
 (defn keyword->name [kw]
@@ -491,17 +505,35 @@
 (defn read-only? [property]
   (:read-only? property))
 
+(defn user-edit?
+  "Callable from a property setter function. Returns true if the setter function
+  is being invoked as a result of the user editing the specified property. It
+  will return false if the property setter is being called as a result of other
+  operations such as resource loading, script code being executed, etc."
+  [node-id prop-kw evaluation-context]
+  {:pre [(map? evaluation-context)]}
+  (true?
+    (some-> evaluation-context
+            :tx-data-context
+            deref
+            :edited-endpoints
+            (contains? (g/endpoint node-id prop-kw)))))
+
 (defn set-values!
+  "Set values as a result of a user-edit in the Property Editor."
   ([property values]
    (set-values! property values (gensym)))
   ([property values op-seq]
    (when (not (read-only? property))
-     (let [evaluation-context (g/make-evaluation-context)]
+     (let [evaluation-context (g/make-evaluation-context)
+           set-operations (resolve-set-operations property values)
+           edited-endpoints (edited-endpoints set-operations)]
        (g/transact
+         {:tx-data-context-map {:edited-endpoints edited-endpoints}}
          (concat
            (g/operation-label (str "Set " (label property)))
            (g/operation-sequence op-seq)
-           (set-values evaluation-context property values)))))))
+           (set-values evaluation-context property set-operations)))))))
 
 (defn unify-values [values]
   (loop [v0 (first values)

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -342,6 +342,15 @@
             (dynamic tip (validation/blend-mode-tip blend-mode Sprite$SpriteDesc$BlendMode))
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Sprite$SpriteDesc$BlendMode))))
   (property size-mode g/Keyword (default :size-mode-auto)
+            (set (fn [evaluation-context self old-value new-value]
+                   ;; Use the texture size for the :manual-size when the user switches
+                   ;; from :size-mode-auto to :size-mode-manual.
+                   (when (and (= :size-mode-auto old-value)
+                              (= :size-mode-manual new-value)
+                              (properties/user-edit? self :size-mode evaluation-context))
+                     (when-some [animation (g/node-value self :animation evaluation-context)]
+                       (let [texture-size [(double (:width animation)) (double (:height animation)) 0.0]]
+                         (g/set-property self :manual-size texture-size))))))
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Sprite$SpriteDesc$SizeMode))))
   (property manual-size types/Vec3 (default [0.0 0.0 0.0])
             (dynamic visible (g/constantly false)))
@@ -375,12 +384,13 @@
                                  default-tex-params)))
   (output gpu-texture g/Any (g/fnk [gpu-texture tex-params] (texture/set-params gpu-texture tex-params)))
   (output animation g/Any (g/fnk [anim-data default-animation] (get anim-data default-animation))) ; TODO - use placeholder animation
-  (output aabb AABB (g/fnk [animation] (if animation
-                                         (let [animation-width (* 0.5 (:width animation))
-                                               animation-height (* 0.5 (:height animation))]
-                                           (geom/make-aabb (Point3d. (- animation-width) (- animation-height) 0)
-                                                           (Point3d. animation-width animation-height 0)))
-                                         geom/empty-bounding-box)))
+  (output aabb AABB (g/fnk [size]
+                      (let [[^double width ^double height ^double depth] size
+                            half-width (* 0.5 width)
+                            half-height (* 0.5 height)
+                            half-depth (* 0.5 depth)]
+                        (geom/make-aabb (Point3d. (- half-width) (- half-height) (- half-depth))
+                                        (Point3d. half-width half-height half-depth)))))
   (output save-value g/Any produce-save-value)
   (output scene g/Any :cached produce-scene)
   (output build-targets g/Any :cached produce-build-targets))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -839,7 +839,8 @@
              :graphs-modified (into graphs-modified (map gt/node-id->graph-id nodes-modified)))))
 
 (defn new-transaction-context
-  [basis node-id-generators override-id-generator metrics-collector]
+  [basis node-id-generators override-id-generator tx-data-context-map metrics-collector]
+  {:pre [(map? tx-data-context-map)]}
   {:basis basis
    :nodes-affected #{}
    :nodes-added []
@@ -854,7 +855,7 @@
    :override-id-generator override-id-generator
    :completed []
    :txid (new-txid)
-   :tx-data-context (atom {})
+   :tx-data-context (atom tx-data-context-map)
    :deferred-setters []
    :metrics metrics-collector})
 


### PR DESCRIPTION
Fixes #7464

### User-facing changes
* Switching from auto to manual Size Mode on sprites or GUI objects will now set the manual size from the image size.
* Corrected the editor bounding box of sprites with manual Size Mode.