### PR TITLE
Added option to make DefoldActivity transparent on Android

### DIFF
--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -17,6 +17,7 @@ package com.dynamo.android;
 
 import android.app.Activity;
 import android.app.NativeActivity;
+import android.content.pm.ApplicationInfo;
 import android.content.res.Configuration;
 import android.content.Context;
 import android.content.Intent;
@@ -521,5 +522,40 @@ public class DefoldActivity extends NativeActivity {
             name = device.getName();
         }
         return name;
+    }
+
+	/**
+     * Method to get meta-data value by key from AndroidManifest.xml
+     * @param key
+     * @return String
+     */
+    protected String getMetadata(String key) {
+        try {
+            PackageManager packageManager = getPackageManager();
+            ApplicationInfo appInfo = packageManager.getApplicationInfo(getPackageName(),
+                    PackageManager.GET_META_DATA);
+            Bundle metaData = appInfo.metaData;
+            if (metaData != null) {
+                Object value = metaData.get(key);
+                if (value != null) {
+                    return value.toString();
+                }
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Method checks if alpha transparency is enabled for DefoldActivity
+     * @return boolean
+     */
+    public boolean isAlphaTransparencyEnabled() {
+        String alpha = getMetadata("alpha.transparency");
+        if (alpha != null) {
+            return alpha.equals("true");
+        }
+        return false;
     }
 }

--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -524,7 +524,7 @@ public class DefoldActivity extends NativeActivity {
         return name;
     }
 
-	/**
+    /**
      * Method to get meta-data value by key from AndroidManifest.xml
      * @param key
      * @return String

--- a/engine/glfw/lib/android/android_jni.c
+++ b/engine/glfw/lib/android/android_jni.c
@@ -1,0 +1,43 @@
+// Copyright 2020-2023 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+// 
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "android_jni.h"
+
+
+JNIEnv* JNIAttachCurrentThread()
+{
+    JavaVM* vm = g_AndroidApp->activity->vm;
+    JNIEnv* env = 0;
+
+    JavaVMAttachArgs lJavaVMAttachArgs;
+    lJavaVMAttachArgs.version = JNI_VERSION_1_6;
+    lJavaVMAttachArgs.name = "NativeThread";
+    lJavaVMAttachArgs.group = NULL;
+
+    (*vm)->AttachCurrentThread(vm, &env, &lJavaVMAttachArgs);
+    return env;
+}
+
+void JNIDetachCurrentThread()
+{
+    JavaVM* vm = g_AndroidApp->activity->vm;
+    (*vm)->DetachCurrentThread(vm);
+}
+
+jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, char* method, char* signature)
+{
+    if (instance == 0) return 0;
+    jclass clazz = (*env)->GetObjectClass(env, instance);
+    return (*env)->GetMethodID(env, clazz, method, signature);
+}

--- a/engine/glfw/lib/android/android_jni.h
+++ b/engine/glfw/lib/android/android_jni.h
@@ -1,0 +1,27 @@
+// Copyright 2020-2023 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+// 
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef _ANDROID_JNI_H_
+#define _ANDROID_JNI_H_
+
+#include "internal.h"
+#include <jni.h>
+
+extern struct android_app* g_AndroidApp;
+
+JNIEnv* JNIAttachCurrentThread();
+void JNIDetachCurrentThread();
+jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, char* method, char* signature);
+
+#endif // _ANDROID_JNI_H_

--- a/engine/glfw/lib/android/android_joystick.c
+++ b/engine/glfw/lib/android/android_joystick.c
@@ -14,11 +14,9 @@
 
 #include "internal.h"
 #include "android_joystick.h"
+#include "android_jni.h"
 #include "android_log.h"
 
-#include <jni.h>
-
-extern struct android_app* g_AndroidApp;
 
 static int glfwAndroidJoystickPresent( int joy )
 {
@@ -271,33 +269,6 @@ void glfwAndroidUpdateJoystick(const AInputEvent* event)
 // Discover connected joysticks
 // Called from android_window.c each frame
 //========================================================================
-
-static JNIEnv* JNIAttachCurrentThread()
-{
-    JavaVM* vm = g_AndroidApp->activity->vm;
-    JNIEnv* env = 0;
-
-    JavaVMAttachArgs lJavaVMAttachArgs;
-    lJavaVMAttachArgs.version = JNI_VERSION_1_6;
-    lJavaVMAttachArgs.name = "NativeThread";
-    lJavaVMAttachArgs.group = NULL;
-
-    (*vm)->AttachCurrentThread(vm, &env, &lJavaVMAttachArgs);
-    return env;
-}
-
-static void JNIDetachCurrentThread()
-{
-    JavaVM* vm = g_AndroidApp->activity->vm;
-    (*vm)->DetachCurrentThread(vm);
-}
-
-static jmethodID JNIGetMethodID(JNIEnv* env, jobject instance, char* method, char* signature)
-{
-    if (instance == 0) return 0;
-    jclass clazz = (*env)->GetObjectClass(env, instance);
-    return (*env)->GetMethodID(env, clazz, method, signature);
-}
 
 void glfwAndroidDiscoverJoysticks()
 {

--- a/engine/glfw/lib/android/android_util.c
+++ b/engine/glfw/lib/android/android_util.c
@@ -13,11 +13,30 @@
 // specific language governing permissions and limitations under the License.
 
 #include "android_util.h"
-
+#include "android_jni.h"
 #include "android_log.h"
 
+#include <stdbool.h>
 #include <pthread.h>
 #include <unistd.h>
+
+
+static bool is_alpha_transparency_enabled()
+{
+    bool result = false;
+    JNIEnv* env = JNIAttachCurrentThread();
+    if (env)
+    {
+        jobject native_activity = g_AndroidApp->activity->clazz;
+        jmethodID is_alpha_transparency_enabled_method = JNIGetMethodID(env, native_activity, "isAlphaTransparencyEnabled", "()Z");
+		if (is_alpha_transparency_enabled_method) {
+			jboolean jresult = (*env)->CallBooleanMethod(env, native_activity, is_alpha_transparency_enabled_method);
+			result = (JNI_TRUE == jresult);
+		}
+        JNIDetachCurrentThread();
+    }
+    return result;
+}
 
 typedef struct EglAttribSetting_t {
     EGLint m_Attribute;
@@ -64,6 +83,12 @@ static int add_egl_colour_attrib(EglAttribSetting* buffer, int size, int offset)
     return offset;
 }
 
+static int add_egl_alpha_attrib(EglAttribSetting* buffer, int size, int offset)
+{
+    const EglAttribSetting alpha = {EGL_ALPHA_SIZE, 8};
+    return add_egl_attrib(buffer, size, offset, &alpha);
+}
+
 static int add_egl_depth_attrib(EglAttribSetting* buffer, int size, int offset)
 {
     const EglAttribSetting depth = {EGL_DEPTH_SIZE, 16};
@@ -99,18 +124,24 @@ static int add_egl_concluding_attrib(EglAttribSetting* buffer, int size, int off
 static EGLint choose_egl_config(EGLDisplay display, EGLConfig* config)
 {
     EGLint result = 0;
-    const int max_settings = 9;
+    const int max_settings = 10;
     EglAttribSetting settings[max_settings];
+
+    bool is_alpha_enabled = is_alpha_transparency_enabled();
+    int actual_settings = is_alpha_enabled ? max_settings : max_settings - 1;
 
     int offset = 0;
     int stencil_offset;
 
-    offset = add_egl_base_attrib((EglAttribSetting*)&settings, max_settings, offset);
-    offset = add_egl_colour_attrib((EglAttribSetting*)&settings, max_settings, offset);
-    offset = add_egl_depth_attrib((EglAttribSetting*)&settings, max_settings, offset);
+    offset = add_egl_base_attrib((EglAttribSetting*)&settings, actual_settings, offset);
+    offset = add_egl_colour_attrib((EglAttribSetting*)&settings, actual_settings, offset);
+    if (is_alpha_enabled) {
+        offset = add_egl_alpha_attrib((EglAttribSetting*)&settings, actual_settings, offset);
+    }
+    offset = add_egl_depth_attrib((EglAttribSetting*)&settings, actual_settings, offset);
     stencil_offset = offset;
-    offset = add_egl_stencil_attrib((EglAttribSetting*)&settings, max_settings, offset);
-    offset = add_egl_concluding_attrib((EglAttribSetting*)&settings, max_settings, offset);
+    offset = add_egl_stencil_attrib((EglAttribSetting*)&settings, actual_settings, offset);
+    offset = add_egl_concluding_attrib((EglAttribSetting*)&settings, actual_settings, offset);
 
     eglChooseConfig(display, (const EGLint *)&settings[0], config, 1, &result);
     CHECK_EGL_ERROR
@@ -118,7 +149,7 @@ static EGLint choose_egl_config(EGLDisplay display, EGLConfig* config)
     {
         // Something along this sort of line when adding Tegra support?
         LOGV("egl config choice failed - removing stencil");
-        add_egl_concluding_attrib((EglAttribSetting*)&settings, max_settings, stencil_offset);
+        add_egl_concluding_attrib((EglAttribSetting*)&settings, actual_settings, stencil_offset);
         eglChooseConfig(display, (const EGLint *)&settings[0], config, 1, &result);
         CHECK_EGL_ERROR
     }

--- a/engine/glfw/lib/android/android_util.c
+++ b/engine/glfw/lib/android/android_util.c
@@ -29,10 +29,10 @@ static bool is_alpha_transparency_enabled()
     {
         jobject native_activity = g_AndroidApp->activity->clazz;
         jmethodID is_alpha_transparency_enabled_method = JNIGetMethodID(env, native_activity, "isAlphaTransparencyEnabled", "()Z");
-		if (is_alpha_transparency_enabled_method) {
-			jboolean jresult = (*env)->CallBooleanMethod(env, native_activity, is_alpha_transparency_enabled_method);
-			result = (JNI_TRUE == jresult);
-		}
+        if (is_alpha_transparency_enabled_method) {
+            jboolean jresult = (*env)->CallBooleanMethod(env, native_activity, is_alpha_transparency_enabled_method);
+            result = (JNI_TRUE == jresult);
+        }
         JNIDetachCurrentThread();
     }
     return result;


### PR DESCRIPTION
It is now possible to make the main Activity transparency by adding a meta-data option in `AndroidManifest.xml`:

```xml
    <meta-data android:name="alpha.transparency" android:value="true" />
```

Note: By default the feature is disabled and does not negatively impact performance.