### PR TITLE
Expose "playback rate" and "offset" to sprite component

### DIFF
--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -223,12 +223,16 @@
   (cond-> {:tile-set (resource/resource->proj-path image)
            :default-animation default-animation
            :material (resource/resource->proj-path material)
-           :blend-mode blend-mode
-           :offset offset
-           :playback-rate playback-rate}
+           :blend-mode blend-mode}
 
           (not= [0.0 0.0 0.0 0.0] slice9)
           (assoc :slice9 slice9)
+
+          (not= 0.0 offset)
+          (assoc :offset offset)
+
+          (not= 1.0 playback-rate)
+          (assoc :playback-rate playback-rate)
 
           (not= :size-mode-auto size-mode)
           (cond-> :always

--- a/engine/gamesys/proto/gamesys/sprite_ddf.proto
+++ b/engine/gamesys/proto/gamesys/sprite_ddf.proto
@@ -31,6 +31,8 @@ message SpriteDesc
     optional dmMath.Vector4 slice9      = 5;
     optional dmMath.Vector4 size        = 6;
     optional SizeMode size_mode         = 7 [default = SIZE_MODE_AUTO];
+    optional float offset               = 8 [default = 0.0];
+    optional float playback_rate        = 9 [default = 1.0];
 }
 
 /*# Sprite API documentation

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -377,7 +377,8 @@ namespace dmGameSystem
             component->m_Size[1] = component->m_Resource->m_DDF->m_Size.getY();
         }
 
-        PlayAnimation(component, resource->m_DefaultAnimation, 0.0f, 1.0f);
+        PlayAnimation(component, resource->m_DefaultAnimation,
+                component->m_Resource->m_DDF->m_Offset, component->m_Resource->m_DDF->m_PlaybackRate);
 
         *params.m_UserData = (uintptr_t)index;
         return dmGameObject::CREATE_RESULT_OK;


### PR DESCRIPTION
Now it's possible to set `offset` and `playback rate` for animation in sprite components itself.

Fix https://github.com/defold/defold/issues/7449
## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
