### PR TITLE
Use workspace diagnostics during the build

### DIFF
--- a/editor/resources/templates/template.script
+++ b/editor/resources/templates/template.script
@@ -18,7 +18,8 @@ end
 
 function fixed_update(self, dt)
 	-- This function is called if 'Fixed Update Frequency' is enabled in the Engine section of game.project
-	-- Can be coupled with fixed updates of the physics simulation if 'Use Fixed Timestep' is enabled in Physics section of game.project
+	-- Can be coupled with fixed updates of the physics simulation if 'Use Fixed Timestep' is enabled in
+	-- Physics section of game.project
 	-- Add update code here
 	-- Learn more: https://defold.com/manuals/script/
 	-- Remove this function if not needed

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1048,7 +1048,7 @@
                   :else (finish-with-result! project-build-results))))))
 
         phase-2-start-all-build-processes!
-        (fn phase-2-start-engine-build! []
+        (fn phase-2-start-all-build-processes! []
           (start-engine-build!)
           (start-lint!)
           (phase-3-build-project!))

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -178,7 +178,7 @@
         true)
 
     exception
-    (do (engine-build-errors/handle-build-error! render-error! project evaluation-context exception)
+    (do (render-error! (engine-build-errors/exception->error-value exception project evaluation-context))
         true)))
 
 (defn async-bob-build! [render-reload-progress! render-save-progress! render-build-progress! show-build-log-stream! task-cancelled? render-build-error! bob-commands bob-args build-server-headers project changes-view callback!]

--- a/editor/src/clj/editor/engine/build_errors.clj
+++ b/editor/src/clj/editor/engine/build_errors.clj
@@ -519,8 +519,8 @@
   [(g/map->error {:message (str "Failed: " (ex-message ex))
                   :severity :fatal})])
 
-(defn handle-build-error! [render-error! project evaluation-context exception]
-  (render-error!
+(defn exception->error-value [exception project evaluation-context]
+  (g/map->error
     {:causes (cond
                (unsupported-platform-error? exception)
                (unsupported-platform-error-causes project evaluation-context)

--- a/editor/src/clj/editor/lsp/async.clj
+++ b/editor/src/clj/editor/lsp/async.clj
@@ -14,9 +14,13 @@
 
 (ns editor.lsp.async
   (:require [clojure.core.async :as a :refer [<! >!]]
-            [editor.ui :as ui]))
+            [editor.ui :as ui])
+  (:import [clojure.core.async.impl.channels ManyToManyChannel]))
 
 (set! *warn-on-reflection* true)
+
+(defn chan? [x]
+  (instance? ManyToManyChannel x))
 
 (defn reduce-async
   "Reduce a channel ch with async function af

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -79,6 +79,35 @@
           (.redirectError ProcessBuilder$Redirect/INHERIT)
           (.directory directory))))))
 
+(defprotocol Message
+  (->jsonrpc [input project on-response]))
+
+(extend-protocol Message
+  Object
+  (->jsonrpc [input _ _] input)
+  nil
+  (->jsonrpc [input _ _] input))
+
+(deftype RawRequest [notification result-converter]
+  Message
+  (->jsonrpc [this _ _]
+    (throw (ex-info "Can't send raw request: use finalize-request first" {:request this}))))
+
+(defn finalize-request [^RawRequest raw-request id]
+  (reify Message
+    (->jsonrpc [_ project on-response]
+      (let [ch (a/chan 1)
+            result-converter (.-result-converter raw-request)
+            request (lsp.jsonrpc/notification->request (.-notification raw-request) ch)]
+        (a/take! ch (fn [response]
+                      (on-response
+                        id
+                        (cond-> response (not (:error response)) (update :result result-converter project)))))
+        request))))
+
+(defn- raw-request [notification result-converter]
+  (->RawRequest notification result-converter))
+
 (defn- make-uri-string [abs-path]
   (let [path (if (util/is-win32?)
                (str "/" (string/replace abs-path "\\" "/"))
@@ -91,11 +120,10 @@
 (defn- root-uri [workspace evaluation-context]
   (make-uri-string (g/node-value workspace :root evaluation-context)))
 
-(defn- maybe-resource [project uri]
-  (lsp.async/with-auto-evaluation-context evaluation-context
-    (let [workspace (g/node-value project :workspace evaluation-context)]
-      (when-let [proj-path (workspace/as-proj-path workspace (.getPath (URI. uri)) evaluation-context)]
-        (workspace/find-resource workspace proj-path evaluation-context)))))
+(defn- maybe-resource [project uri evaluation-context]
+  (let [workspace (g/node-value project :workspace evaluation-context)]
+    (when-let [proj-path (workspace/as-proj-path workspace (.getPath (URI. uri)) evaluation-context)]
+      (workspace/find-resource workspace proj-path evaluation-context))))
 
 ;; diagnostics
 (s/def ::severity #{:error :warning :information :hint})
@@ -103,13 +131,19 @@
 (s/def ::cursor #(instance? Cursor %))
 (s/def ::cursor-range #(instance? CursorRange %))
 (s/def ::diagnostic (s/and ::cursor-range (s/keys :req-un [::severity ::message])))
-(s/def ::diagnostics (s/coll-of ::diagnostic))
+(s/def ::result-id string?)
+(s/def ::version int?)
+(s/def ::items (s/coll-of ::diagnostic))
+(s/def ::diagnostics-result (s/keys :req-un [::items]
+                                    :opt-un [::result-id
+                                             ::version]))
 
 ;; capabilities
 (s/def ::open-close boolean?)
 (s/def ::change #{:none :full :incremental})
 (s/def ::text-document-sync (s/keys :req-un [::open-close ::change]))
-(s/def ::capabilities (s/keys :req-un [::text-document-sync]))
+(s/def ::pull-diagnostics #{:none :text-document :workspace})
+(s/def ::capabilities (s/keys :req-un [::text-document-sync ::pull-diagnostics]))
 
 (defn- lsp-position->editor-cursor [{:keys [line character]}]
   (data/->Cursor line character))
@@ -132,10 +166,20 @@
     :message message
     :severity ({1 :error 2 :warning 3 :information 4 :hint} severity :error)))
 
+(defn- lsp-diagnostic-result->editor-diagnostic-result
+  [{:keys [resultId version] :as lsp-diagnostics-result} diagnostics-key]
+  (cond-> {:items (mapv lsp-diagnostic->editor-diagnostic (get lsp-diagnostics-result diagnostics-key))}
+          resultId
+          (assoc :result-id resultId)
+          version
+          (assoc :version version)))
+
 (defn- diagnostics-handler [project out on-publish-diagnostics]
-  (fn [{:keys [uri diagnostics]}]
-    (when-let [resource (maybe-resource project uri)]
-      (a/put! out (on-publish-diagnostics resource (mapv lsp-diagnostic->editor-diagnostic diagnostics))))))
+  (fn [{:keys [uri] :as result}]
+    (lsp.async/with-auto-evaluation-context evaluation-context
+      (when-let [resource (maybe-resource project uri evaluation-context)]
+        (let [result (lsp-diagnostic-result->editor-diagnostic-result result :diagnostics)]
+          (a/put! out (on-publish-diagnostics resource result)))))))
 
 (def lsp-text-document-sync-kind-incremental 2)
 (def lsp-text-document-sync-kind-full 1)
@@ -147,7 +191,7 @@
     lsp-text-document-sync-kind-full :full
     lsp-text-document-sync-kind-incremental :incremental))
 
-(defn- lsp-capabilities->editor-capabilities [{:keys [textDocumentSync]}]
+(defn- lsp-capabilities->editor-capabilities [{:keys [textDocumentSync diagnosticProvider]}]
   {:text-document-sync (cond
                          (nil? textDocumentSync)
                          {:change :none :open-close false}
@@ -161,7 +205,11 @@
                           :change (lsp-text-document-sync-kind->editor-sync-kind (:change textDocumentSync 0))}
 
                          :else
-                         (throw (ex-info "Invalid text document sync kind" {:value textDocumentSync})))})
+                         (throw (ex-info "Invalid text document sync kind" {:value textDocumentSync})))
+   :pull-diagnostics (cond
+                       (nil? diagnosticProvider) :none
+                       (:workspaceDiagnostics diagnosticProvider) :workspace
+                       :else :text-document)})
 
 (defn- configuration-handler [project]
   (fn [{:keys [items]}]
@@ -227,13 +275,16 @@
                                hierarchy about published diagnostics
     :on-initialized            a function of 1 arg, a server capabilities map,
                                produces a value for out channel
+    :on-response               a function of 2 args: request id and response,
+                               produces a value for out channel
 
   Returns a channel that will close when the LSP server closes.
 
   See also:
     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#lifeCycleMessages"
   [project launcher in out & {:keys [on-publish-diagnostics
-                                     on-initialized]}]
+                                     on-initialized
+                                     on-response]}]
   (a/go
     (try
       (let [directory (lsp.async/with-auto-evaluation-context evaluation-context
@@ -253,7 +304,8 @@
                              "window/showMessageRequest" (constantly nil)
                              "window/workDoneProgress/create" (constantly nil)}
                             base-source
-                            base-sink)]
+                            base-sink)
+                  on-response (comp #(a/put! out %) on-response)]
               (a/alt!
                 (a/go
                   (try
@@ -262,7 +314,7 @@
                       (>! out (on-initialized (lsp-capabilities->editor-capabilities capabilities)))
                       (>! jsonrpc (lsp.jsonrpc/notification "initialized"))
                       ;; LSP lifecycle: serve requests
-                      (<! (lsp.async/pipe in jsonrpc false))
+                      (<! (lsp.async/pipe (a/map #(->jsonrpc % project on-response) [in]) jsonrpc false))
                       ;; LSP lifecycle: shutdown
                       (lsp.jsonrpc/unwrap-response (<! (lsp.jsonrpc/request! jsonrpc "shutdown" (* 10 1000))))
                       (>! jsonrpc (lsp.jsonrpc/notification "exit"))
@@ -288,6 +340,47 @@
                           :exception e))))))
       (finally
         (a/close! out)))))
+
+(defn- full-or-unchanged-diagnostic-result:lsp->editor [{:keys [kind] :as result}]
+  (case kind
+    "full" {:type :full
+            :result (lsp-diagnostic-result->editor-diagnostic-result result :items)}
+    "unchanged" {:type :unchanged
+                 :result-id (:resultId result)}))
+
+(defn pull-workspace-diagnostics [resource->previous-result-id result-converter]
+  (raw-request
+    (lsp.jsonrpc/notification
+      "workspace/diagnostic"
+      {:previousResultIds (into []
+                                (map (fn [[resource previous-result-id]]
+                                       {:uri (resource-uri resource)
+                                        :value previous-result-id}))
+                                resource->previous-result-id)})
+    (comp
+      result-converter
+      ;; bound-fn only needed for tests to pick up the test system
+      (bound-fn convert-result [{:keys [items]} project]
+        (lsp.async/with-auto-evaluation-context evaluation-context
+          (into {}
+                (keep
+                  (fn [{:keys [uri] :as item}]
+                    (when-let [resource (maybe-resource project uri evaluation-context)]
+                      [resource (full-or-unchanged-diagnostic-result:lsp->editor item)])))
+                items))))))
+
+(defn pull-document-diagnostics
+  [resource previous-result-id result-converter]
+  (raw-request
+    (lsp.jsonrpc/notification
+      "textDocument/diagnostic"
+      (cond-> {:textDocument {:uri (resource-uri resource)}}
+              previous-result-id
+              (assoc :previousResultId previous-result-id)))
+    (comp
+      result-converter
+      (fn convert-result [result _]
+        (full-or-unchanged-diagnostic-result:lsp->editor result)))))
 
 (defn open-text-document
   "See also:

--- a/editor/test/integration/lsp_test.clj
+++ b/editor/test/integration/lsp_test.clj
@@ -88,11 +88,12 @@
           :on-initialized #(vector :on-initialized %))
         (is (= [[:on-initialized
                  {:text-document-sync {:open-close true
-                                       :change :incremental}}]
+                                       :change :incremental}
+                  :pull-diagnostics :none}]
                 [:on-publish-diagnostics
                  (tu/resource workspace "/foo.json")
-                 [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
-                    :message "It's a bad start!" :severity :error)]]]
+                 {:items [(assoc (data/->CursorRange (data/->Cursor 0 0) (data/->Cursor 0 1))
+                            :message "It's a bad start!" :severity :error)]}]]
                (async-support/eventually
                  (a/go
                    (>! in (lsp.server/open-text-document (tu/resource workspace "/foo.json") ["{\"a\": 1}"]))
@@ -380,3 +381,129 @@
             _ (is (= #{} @server-opened-docs))]
         (test-support/spit-until-new-mtime foo-resource old-foo-content)
         (workspace/resource-sync! workspace)))))
+
+(deftest workspace-diagnostics-test
+  (testing "Workspace diagnostics with different pull diagnostics kinds"
+    (tu/with-loaded-project "test/resources/lsp_project"
+      (with-redefs [ui/do-run-later (fn [f] (f))]
+        (let [lsp (lsp/get-node-lsp project)
+              _ (lsp/set-servers!
+                  lsp
+                  #{;; full workspace lint
+                    {:languages #{"json"}
+                     :launcher
+                     (make-test-server-launcher
+                       {"initialize" (constantly {:capabilities {:diagnosticProvider {:workspaceDiagnostics true}}})
+                        "workspace/diagnostic" (fn [_ _]
+                                                 {:items [{:uri (lsp.server/resource-uri (workspace/find-resource workspace "/foo.json"))
+                                                           :kind "full"
+                                                           :items [{:range {:start {:line 0 :character 0}
+                                                                            :end {:line 0 :character 1}}
+                                                                    :message "Workspace diagnostics error"
+                                                                    :severity 1}]}]})
+                        "initialized" (constantly nil)
+                        "shutdown" (constantly nil)
+                        "exit" (constantly nil)})}
+                    ;; document lint
+                    {:languages #{"json"}
+                     :launcher
+                     (make-test-server-launcher
+                       {"initialize" (constantly {:capabilities {:diagnosticProvider {:workspaceDiagnostics false}}})
+                        "textDocument/diagnostic" (fn [_ _]
+                                                    {:kind "full"
+                                                     :items [{:range {:start {:line 0 :character 1}
+                                                                      :end {:line 0 :character 2}}
+                                                              :message "Text document diagnostics error"
+                                                              :severity 1}]})
+                        "initialized" (constantly nil)
+                        "shutdown" (constantly nil)
+                        "exit" (constantly nil)})}
+                    ;; no lint at all
+                    {:languages #{"json"}
+                     :launcher
+                     (make-test-server-launcher
+                       {"initialize" (constantly {:capabilities {:textDocumentSync lsp.server/lsp-text-document-sync-kind-none}})
+                        "initialized" (constantly nil)
+                        "shutdown" (constantly nil)
+                        "exit" (constantly nil)})}})
+              _ (Thread/sleep 100)
+              ret (promise)
+              _ (lsp/pull-workspace-diagnostics! lsp ret)]
+          (is
+            (= {(workspace/find-resource workspace "/foo.json")
+                (sorted-set
+                  (data/map->CursorRange
+                    {:from (data/->Cursor 0 0)
+                     :to (data/->Cursor 0 1)
+                     :message "Workspace diagnostics error"
+                     :severity :error})
+                  (data/map->CursorRange
+                    {:from (data/->Cursor 0 1)
+                     :to (data/->Cursor 0 2)
+                     :message "Text document diagnostics error"
+                     :severity :error}))}
+               @ret))))))
+  (testing "Failing server does not block workspace diagnostics"
+    (tu/with-loaded-project "test/resources/lsp_project"
+      (with-redefs [ui/do-run-later (fn [f] (f))]
+        (let [lsp (lsp/get-node-lsp project)
+              _ (lsp/set-servers!
+                  lsp
+                  #{;; working lint
+                    {:languages #{"json"}
+                     :launcher
+                     (make-test-server-launcher
+                       {"initialize" (constantly {:capabilities {:diagnosticProvider {:workspaceDiagnostics true}}})
+                        "workspace/diagnostic" (fn [_ _]
+                                                 {:items [{:uri (lsp.server/resource-uri (workspace/find-resource workspace "/foo.json"))
+                                                           :kind "full"
+                                                           :items [{:range {:start {:line 0 :character 0}
+                                                                            :end {:line 0 :character 1}}
+                                                                    :message "It's a bad start!"
+                                                                    :severity 1}]}]})
+                        "initialized" (constantly nil)
+                        "shutdown" (constantly nil)
+                        "exit" (constantly nil)})}
+                    ;; broken: fails on diagnostic request
+                    {:languages #{"json"}
+                     :launcher
+                     (make-test-server-launcher
+                       {"initialize" (constantly {:capabilities {:diagnosticProvider {:workspaceDiagnostics true}}})
+                        "initialized" (constantly nil)
+                        "workspace/diagnostic" (fn [_ _] (throw (ex-info "Fail!" {})))
+                        "shutdown" (constantly nil)
+                        "exit" (constantly nil)})}})
+              _ (Thread/sleep 100)
+              ret (promise)
+              _ (lsp/pull-workspace-diagnostics! lsp ret)]
+          (is (= {(workspace/find-resource workspace "/foo.json")
+                  (sorted-set (data/map->CursorRange
+                                {:from (data/->Cursor 0 0)
+                                 :to (data/->Cursor 0 1)
+                                 :message "It's a bad start!"
+                                 :severity :error}))}
+                 @ret))))))
+  (testing "the LSP client only waits up to a timeout"
+    (tu/with-loaded-project "test/resources/lsp_project"
+      (with-redefs [ui/do-run-later (fn [f] (f))]
+        (let [lsp (lsp/get-node-lsp project)
+              _ (lsp/set-servers!
+                  lsp
+                  #{{:languages #{"json"}
+                     :launcher (make-test-server-launcher
+                                 {"initialize" (constantly {:capabilities {:diagnosticProvider {:workspaceDiagnostics true}}})
+                                  "initialized" (constantly nil)
+                                  "workspace/diagnostic" (fn [_ _]
+                                                           (Thread/sleep 1000)
+                                                           {:items [{:uri (lsp.server/resource-uri (workspace/find-resource workspace "/foo.json"))
+                                                                     :kind "full"
+                                                                     :items [{:range {:start {:line 0 :character 0}
+                                                                                      :end {:line 0 :character 1}}
+                                                                              :message "It's a bad start!"
+                                                                              :severity 1}]}]})
+                                  "shutdown" (constantly nil)
+                                  "exit" (constantly nil)})}})
+              _ (Thread/sleep 100)
+              ret (promise)
+              _ (lsp/pull-workspace-diagnostics! lsp ret :timeout-ms 500)]
+          (is (nil? @ret)))))))


### PR DESCRIPTION
User-facing changes:
This changeset expands our LSP implementation by asking to diagnose the workspace on the build. Our fork of Sumneko's Lua language server was modified to respond to these diagnostic requests — you will need to use the [newest version](https://github.com/defold/lua-language-server/releases/tag/v0.0.4) to try it out.

Implementation notes:
- I cleaned up our `editor.app-view/async-build!` function. There were some issues with it. First, it had muddy semantics in terms of its results — it could return a map with results or errors, but it also could return `nil` when `editor.app-view/build-project!` threw an exception. It feels like it all worked by luck because `handle-build-results!` is used as a predicate of sorts to test whether the build was successful, and optionally show errors in the UI, and it happened that it returned the result if there was no `:error` key. And since the resulting map was `nil`, it was considered falsey and treated later as a failure. I streamlined it to always return a map with either successful results or error information. Second, it had a mix of positional and map args. Given how many args there were, I changed it to only accept kv-args to improve readability.
- The most complex part was designing request-response handling in the presence of asynchrony and the possibility of errors. In the end, I implemented it by tracking active requests in two places — at the LSP manager level, and on the individual language server level. All responses have to go through the LSP manager, and in the end, it allows us to atomically handle both server failures and responses when we have active requests.

Fixes #3885
