### PR TITLE
Fix editor freeze after editing certain properties

### DIFF
--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -469,7 +469,7 @@
         prop-kws (:prop-kws property)
         old-values (:values property)
         new-values (if-some [from-fn (-> property :edit-type :from-type)]
-                     (mapv from-fn values)
+                     (map from-fn values) ; The values might be an infinite sequence, so we can't use mapv here.
                      values)]
     (mapv vector node-ids prop-kws old-values new-values)))
 


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/7486

### User-facing changes
* The editor no longer freezes after editing certain properties, such as the path of a referenced component.