### PR TITLE
Show more information in resource errors

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -89,7 +89,7 @@
               (load-registered-resource-node load-fn project node-id resource))
             (catch Exception e
               (log/warn :msg (format "Unable to load resource '%s'" (resource/proj-path resource)) :exception e)
-              (g/mark-defective node-id node-type (resource-io/invalid-content-error node-id nil :fatal resource)))))))
+              (g/mark-defective node-id node-type (resource-io/invalid-content-error node-id nil :fatal resource (.getMessage e))))))))
     (catch Throwable t
       (throw (ex-info (format "Error when loading resource '%s'" (resource/resource->proj-path resource))
                       {:node-type node-type

--- a/editor/src/clj/editor/resource_io.clj
+++ b/editor/src/clj/editor/resource_io.clj
@@ -24,8 +24,12 @@
 (defn file-not-found-error? [error]
   (= :file-not-found (-> error :user-data :type)))
 
-(defn invalid-content-error [node-id label severity resource]
-  (g/->error node-id label severity nil (format "The file '%s' could not be loaded." (resource/proj-path resource)) {:type :invalid-content :resource resource}))
+(defn invalid-content-error [node-id label severity resource message]
+  (g/->error node-id label severity nil
+             (format "The file '%s' could not be loaded%s"
+                     (resource/proj-path resource)
+                     (if message (str ": " message) "."))
+             {:type :invalid-content :resource resource}))
 
 (defmacro with-error-translation
   "Perform body, translate io exceptions to g/errors"
@@ -34,5 +38,5 @@
      ~@body
      (catch java.io.FileNotFoundException e#
        (file-not-found-error ~node-id ~label :fatal ~resource))
-     (catch Exception ~'_
-       (invalid-content-error ~node-id ~label :fatal ~resource))))
+     (catch Exception e#
+       (invalid-content-error ~node-id ~label :fatal ~resource (.getMessage e#)))))

--- a/editor/test/integration/extension_spine_test.clj
+++ b/editor/test/integration/extension_spine_test.clj
@@ -89,8 +89,9 @@
                               error-item-of-parent-resource (first (:children error-tree))
                               error-item-of-faulty-node (first (:children error-item-of-parent-resource))]
                           (is (= :resource (:type error-item-of-parent-resource)))
-                          (is (= (str "The file '" error-resource-path "' could not be loaded.")
-                                 (:message error-item-of-faulty-node)))))]
+                          (is (string/starts-with?
+                                (:message error-item-of-faulty-node)
+                                (str "The file '" error-resource-path "' could not be loaded")))))]
                 (is (invalid-content-error? "/main/main.collection" (test-util/build-error! main-collection)))
                 (is (invalid-content-error? "/main/main.gui" (test-util/build-error! main-gui))))))
           ;; Before unloading the project, generate the content for a migrated


### PR DESCRIPTION
Related to https://github.com/defold/extension-spine/issues/123. Load errors might have useful information, so why not show it?