### PR TITLE
Use locale independent case conversion in bob

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -644,17 +644,6 @@ public class Bob {
     private static void mainInternal(String[] args) throws IOException, CompileExceptionError, URISyntaxException, LibraryException {
         System.setProperty("java.awt.headless", "true");
         System.setProperty("file.encoding", "UTF-8");
-        try {
-            // Set default locale to root. This is done to avoid issues when
-            // calling String.toUpperCase when using a locale such as Turkish
-            // where a lowercase 'i' converts to 'İ'
-            // See: https://github.com/defold/defold/issues/7327
-            Locale.setDefault(Locale.ROOT);
-        }
-        catch(Exception e) {
-            System.err.println("Unable to set default locale to root");
-            e.printStackTrace();
-        }
         
         String cwd = new File(".").getAbsolutePath();
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Platform.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Platform.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 
+import com.dynamo.bob.util.StringUtil;
+
 import com.dynamo.graphics.proto.Graphics.PlatformProfile;
 import com.dynamo.graphics.proto.Graphics.PlatformProfile.OS;
 
@@ -173,8 +175,8 @@ public enum Platform {
     }
 
     public static Platform getJavaPlatform() {
-        String os_name = System.getProperty("os.name").toLowerCase();
-        String arch = System.getProperty("os.arch").toLowerCase();
+        String os_name = StringUtil.toLowerCase(System.getProperty("os.name"));
+        String arch = StringUtil.toLowerCase(System.getProperty("os.arch"));
 
         if (os_name.indexOf("win") != -1) {
             if (arch.equals("x86_64") || arch.equals("amd64")) {
@@ -197,8 +199,8 @@ public enum Platform {
     }
 
     public static Platform getHostPlatform() {
-        String os_name = System.getProperty("os.name").toLowerCase();
-        String arch = System.getProperty("os.arch").toLowerCase();
+        String os_name = StringUtil.toLowerCase(System.getProperty("os.name"));
+        String arch = StringUtil.toLowerCase(System.getProperty("os.arch"));
 
         if (os_name.indexOf("win") != -1) {
             if (arch.equals("x86_64") || arch.equals("amd64")) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -45,6 +45,7 @@ import com.dynamo.bob.Bob;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.Platform;
 import com.dynamo.bob.Project;
+import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.util.BobProjectProperties;
@@ -116,7 +117,7 @@ public class HTML5Bundler implements IBundler {
         properties.put("DEFOLD_ARCHIVE_LOCATION_SUFFIX", projectProperties.getStringValue("html5", "archive_location_suffix", ""));
         properties.put("DEFOLD_ENGINE_ARGUMENTS", engineArguments);
 
-        String scaleMode = projectProperties.getStringValue("html5", "scale_mode", "downscale_fit").toUpperCase();
+        String scaleMode = StringUtil.toUpperCase(projectProperties.getStringValue("html5", "scale_mode", "downscale_fit"));
         properties.put("DEFOLD_SCALE_MODE_IS_"+scaleMode, true);
 
         /// Legacy properties for backwards compatibility

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/BMFont.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/BMFont.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import com.dynamo.bob.util.StringUtil;
 
 public class BMFont
 {
@@ -317,7 +318,7 @@ public class BMFont
         while ((line = in.readLine()) != null) {
 
             String[] line_parts = line.split(" ", 2);
-            entry_id = line_parts[0].toLowerCase();
+            entry_id = StringUtil.toLowerCase(line_parts[0]);
             DefaultHashMap<String,String> entries = null;
 
             if (line_parts.length > 1)

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -65,6 +65,7 @@ import com.dynamo.bob.TexcLibrary.CompressionType;
 
 import com.dynamo.bob.pipeline.TextureGeneratorException;
 
+import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.font.BMFont.BMFontFormatException;
 import com.dynamo.bob.font.BMFont.Char;
 import com.dynamo.render.proto.Font.FontDesc;
@@ -164,6 +165,10 @@ public class Fontc {
 
     public InputFontFormat getInputFormat() {
         return inputFormat;
+    }
+
+    private boolean isBitmapFont(FontDesc fd) {
+        return StringUtil.toLowerCase(fd.getFont()).endsWith("fnt");
     }
 
     public void TTFBuilder(InputStream fontStream) throws FontFormatException, IOException {
@@ -365,7 +370,7 @@ public class Fontc {
         // Shadow_spread is the maximum distance to the glyph outline.
         float sdf_shadow_spread = 0.0f;
 
-        if (this.fontDesc.getFont().toLowerCase().endsWith("fnt"))
+        if (isBitmapFont(this.fontDesc))
         {
             padding = 0;
             cell_padding = 1;
@@ -940,7 +945,7 @@ public class Fontc {
         this.fontDesc = fontDesc;
         this.fontMapBuilder = FontMap.newBuilder();
 
-        if (fontDesc.getFont().toLowerCase().endsWith("fnt")) {
+        if (isBitmapFont(fontDesc)) {
             FNTBuilder(fontStream);
         } else {
             TTFBuilder(fontStream);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -33,6 +33,7 @@ import com.dynamo.bob.Task;
 import com.dynamo.bob.fs.IResource;
 import com.dynamo.bob.util.BobNLS;
 import com.dynamo.bob.util.MathUtil;
+import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.pipeline.ShaderUtil.Common;
 import com.dynamo.proto.DdfMath.Point3;
 import com.dynamo.proto.DdfMath.Quat;
@@ -174,7 +175,7 @@ public class ProtoBuilders {
     public static class CollisionObjectBuilder extends ProtoBuilder<CollisionObjectDesc.Builder> {
 
         private void ValidateShapeTypes(List<Shape> shapeList, IResource resource) throws IOException, CompileExceptionError {
-            String physicsTypeStr = this.project.getProjectProperties().getStringValue("physics", "type", "2D").toUpperCase();
+            String physicsTypeStr = StringUtil.toUpperCase(this.project.getProjectProperties().getStringValue("physics", "type", "2D"));
             for(Shape shape : shapeList) {
                 if(shape.getShapeType() == Type.TYPE_CAPSULE) {
                     if(physicsTypeStr.contains("2D")) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/BobProjectProperties.java
@@ -37,6 +37,8 @@ import java.lang.IllegalAccessException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.io.IOUtils;
+
+import com.dynamo.bob.util.StringUtil;
 import com.dynamo.bob.Bob;
 
 /**
@@ -88,7 +90,7 @@ public class BobProjectProperties {
                     this.value = value;
                     break;
                 case "type":
-                    this.type = PropertyType.valueOf(value.toUpperCase());
+                    this.type = PropertyType.valueOf(StringUtil.toUpperCase(value));
                     break;
                 case "default":
                     this.defaultValue = value;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/StringUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/StringUtil.java
@@ -30,7 +30,7 @@ public class StringUtil {
 	/**
 	 * Using String.toLowerCase() with Locale.ROOT
 	 * @param s String to convert to lower-case
-	 * @return The loweer-case version of the string
+	 * @return The lower-case version of the string
 	 */
 	public static String toLowerCase(String s) {
 		return s.toLowerCase(Locale.ROOT);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/StringUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/StringUtil.java
@@ -1,0 +1,38 @@
+// Copyright 2020-2023 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+// 
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.util;
+
+import java.util.Locale;
+
+public class StringUtil {
+
+	/**
+	 * Using String.toUpperCase() with Locale.ROOT
+	 * @param s String to convert to upper-case
+	 * @return The upper-case version of the string
+	 */
+	public static String toUpperCase(String s) {
+		return s.toUpperCase(Locale.ROOT);
+	}
+
+	/**
+	 * Using String.toLowerCase() with Locale.ROOT
+	 * @param s String to convert to lower-case
+	 * @return The loweer-case version of the string
+	 */
+	public static String toLowerCase(String s) {
+		return s.toLowerCase(Locale.ROOT);
+	}
+}


### PR DESCRIPTION
This changes the way we do case conversion (lower to upper or vice versa) in bob. We now decide on a case-by-case basis which locale to use, instead of setting a default locale on startup. This change will make sure the case conversion also works when using bob from within the editor.

Fixes #7327 