### PR TITLE
Prevent editor exception when key up is pressed in curve editor

### DIFF
--- a/editor/src/clj/internal/graph.clj
+++ b/editor/src/clj/internal/graph.clj
@@ -868,7 +868,8 @@
   gt/IBasis
   (node-by-id-at
     [this node-id]
-    (node-id->node (node-id->graph this node-id) node-id))
+    (when node-id
+      (node-id->node (node-id->graph this node-id) node-id)))
 
   (node-by-property
     [_ label value]


### PR DESCRIPTION
This prevents an exception from being thrown when manipulating a curve handle using key up in the curve editor.

Fixes #7357 