### PR TITLE
Fix reloading of implicitly stateless nodes

### DIFF
--- a/editor/src/clj/editor/resource_update.clj
+++ b/editor/src/clj/editor/resource_update.clj
@@ -91,12 +91,10 @@
                          (catch Exception _
                            nil))
             new-sha256 (try
-                         (if (and read-fn write-fn)
+                         (when (and read-fn write-fn)
                            (let [source-value (read-fn new-resource)
                                  sanitized-content (write-fn source-value)]
-                             (DigestUtils/sha256Hex ^String sanitized-content))
-                           (with-open [input-stream (io/input-stream new-resource)]
-                             (DigestUtils/sha256Hex ^InputStream input-stream)))
+                             (DigestUtils/sha256Hex ^String sanitized-content)))
                          (catch Exception _
                            nil))]
         (and (some? old-sha256)


### PR DESCRIPTION
Technical notes:
Implicitly stateless nodes are nodes that don't have the write and read functions, but have a load function, and are not explicitly marked as stateless. The problem was that `old-sha256` in such a case would be the same as `new-sha256`, since both are just reading and hashing the same resource file.

User-facing changes:
The Defold Editor now properly reloads changes to certain file types, such as `spinejson`, `md`, `ttf`, `fnt`, and `otf` files. Previously, if changes were made to these types of files and a build was performed, the editor would ignore the changes and use the previous version of the file instead. This update fixes this issue and ensures that changes to these file types are properly reflected in the editor.

Fixes #7397
