### PR TITLE
Use required Accept header when contacting GitLab.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1588,6 +1588,9 @@ run:
                 logInfo("%2d: Downloading %s", i, url);
                 TimeProfiler.addData("url", url.toString());
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                // GitLab will respond with a 406 Not Acceptable if the request
+                // is made without an Accept header
+                connection.setRequestProperty("Accept", "application/zip");
 
                 String etag = null;
                 if (f != null) {

--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -122,7 +122,8 @@
       (doseq [[header value] http-headers]
         (.setRequestProperty http-connection header value))
       (when tag
-        (.setRequestProperty http-connection "If-None-Match" tag)))
+        (.setRequestProperty http-connection "If-None-Match" tag))
+      (.setRequestProperty http-connection "Accept" "application/zip"))
     (.connect connection)
     (let [status (parse-status http-connection)
           headers (.getHeaderFields connection)


### PR DESCRIPTION
This changes fixes an issues when using dependencies hosted on GitLab.

Fixes #7459