### PR TITLE
Exclude evaluation-context from handler ex-info

### DIFF
--- a/editor/src/clj/editor/handler.clj
+++ b/editor/src/clj/editor/handler.clj
@@ -261,7 +261,7 @@
                 (ex-info (format "handler '%s' in context '%s' failed at '%s' with message '%s'"
                                  (:command handler) (:context handler) fsym (.getMessage e))
                          {:handler handler
-                          :command-context command-context}
+                          :command-context (update command-context :env dissoc :evaluation-context)}
                          e))
               nil)))
         default))))


### PR DESCRIPTION
### Technical changes
* Exclude the `evaluation-context` from `handler` exception info. Previously this resulted in huge amounts of error data being logged whenever a `handler` threw an exception.