### PR TITLE
Fixed root-level game object transforms inside referenced collections when building from the editor

### DIFF
--- a/editor/src/clj/editor/camera.clj
+++ b/editor/src/clj/editor/camera.clj
@@ -473,7 +473,7 @@
 
 (defn find-perspective-frame-distance
   ^double [points point->coord ^double fov-deg]
-  (let [^double half-fov-rad (math/deg->rad (* fov-deg 0.5))
+  (let [half-fov-rad (math/deg->rad (* fov-deg 0.5))
         comp-half-fov-rad (- ^double math/half-pi half-fov-rad)
         tan-comp-half-fov-rad (Math/tan comp-half-fov-rad)]
     (reduce (fn [^double max-distance ^Point3d point]
@@ -538,7 +538,7 @@
   (assert (= :orthographic (:type camera)))
   (let [^double fov-x-distance (:fov-x camera)
         ^double fov-y-distance (:fov-y camera)
-        ^double half-fov-y-rad (math/deg->rad (* fov-y-deg 0.5))
+        half-fov-y-rad (math/deg->rad (* fov-y-deg 0.5))
         aspect (/ fov-x-distance fov-y-distance)
         focus-distance (/ fov-y-distance 2.0 (Math/tan half-fov-y-rad))
         focus-pos (camera-focus-point camera)
@@ -559,8 +559,8 @@
         focus-distance (.length (math/subtract-vector focus-pos (:position camera)))
         ^double fov-x-deg (:fov-x camera)
         ^double fov-y-deg (:fov-y camera)
-        ^double half-fov-x-rad (math/deg->rad (* fov-x-deg 0.5))
-        ^double half-fov-y-rad (math/deg->rad (* fov-y-deg 0.5))
+        half-fov-x-rad (math/deg->rad (* fov-x-deg 0.5))
+        half-fov-y-rad (math/deg->rad (* fov-y-deg 0.5))
         fov-x-distance (* focus-distance 2.0 (Math/tan half-fov-x-rad))
         fov-y-distance (* focus-distance 2.0 (Math/tan half-fov-y-rad))
         cam-forward (camera-forward-vector camera)

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -177,7 +177,7 @@
    :icon ""
    :label ""})
 
-(g/defnk produce-go-build-targets [_node-id build-error build-resource ddf-message resource-property-build-targets source-build-targets transform]
+(g/defnk produce-go-build-targets [_node-id build-error build-resource ddf-message resource-property-build-targets source-build-targets pose]
   ;; Create a build-target for the referenced or embedded game object. Also tag
   ;; on :instance-data with the overrides for this instance. This will later be
   ;; extracted and compiled into the Collection - the overrides do not end up in
@@ -195,7 +195,7 @@
     (let [game-object-build-target (first source-build-targets)
           proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)
           instance-desc-with-go-props (dissoc ddf-message :data)] ; GameObject$InstanceDesc or GameObject$EmbeddedInstanceDesc in map format. We don't need the :data from GameObject$EmbeddedInstanceDesc.
-      [(collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props transform game-object-build-target proj-path->resource-property-build-target)])))
+      [(collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props pose game-object-build-target proj-path->resource-property-build-target)])))
 
 (g/defnode GameObjectInstanceNode
   (inherits scene/SceneNode)
@@ -463,7 +463,7 @@
                                                    (update res id (fn [id] (inc (or id 0)))))
                                                  {} ids))))
 
-(g/defnk produce-coll-inst-build-targets [_node-id source-resource id transform build-targets resource-property-build-targets ddf-properties]
+(g/defnk produce-coll-inst-build-targets [_node-id source-resource id pose build-targets resource-property-build-targets ddf-properties]
   (if-some [errors
             (not-empty
               (concat
@@ -476,7 +476,7 @@
     (let [proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)]
       (update build-targets 0
               (fn [collection-build-target]
-                (collection-common/collection-instance-build-target id transform ddf-properties collection-build-target proj-path->resource-property-build-target))))))
+                (collection-common/collection-instance-build-target id pose ddf-properties collection-build-target proj-path->resource-property-build-target))))))
 
 (g/defnk produce-coll-inst-outline [_node-id id source-outline source-resource]
   (-> {:node-id _node-id

--- a/editor/src/clj/editor/collection_common.clj
+++ b/editor/src/clj/editor/collection_common.clj
@@ -18,7 +18,7 @@
             [editor.game-object-common :as game-object-common]
             [editor.geom :as geom]
             [editor.gl.pass :as pass]
-            [editor.math :as math]
+            [editor.pose :as pose]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -29,7 +29,7 @@
             [service.log :as log])
   (:import [com.dynamo.gameobject.proto GameObject$CollectionDesc GameObject$PrototypeDesc]
            [java.io StringReader]
-           [javax.vecmath Matrix4d Point3d Quat4d Vector3d]))
+           [javax.vecmath Matrix4d]))
 
 (set! *warn-on-reflection* true)
 
@@ -119,11 +119,11 @@
                             nil))))
               (:embedded-instances source-value))))))
 
-(defn game-object-instance-build-target [build-resource instance-desc-with-go-props ^Matrix4d transform-matrix game-object-build-target proj-path->resource-property-build-target]
+(defn game-object-instance-build-target [build-resource instance-desc-with-go-props pose game-object-build-target proj-path->resource-property-build-target]
   {:pre [(workspace/build-resource? build-resource)
          (map? instance-desc-with-go-props) ; GameObject$InstanceDesc or GameObject$EmbeddedInstanceDesc in map format, but GameObject$PropertyDescs must have a :clj-value.
          (not (contains? instance-desc-with-go-props :data)) ; We don't need the :data from GameObject$EmbeddedInstanceDescs.
-         (instance? Matrix4d transform-matrix)
+         (pose/pose? pose)
          (map? game-object-build-target)
          (ifn? proj-path->resource-property-build-target)]}
   ;; Create a build-target for the referenced or embedded game object. Also tag
@@ -151,7 +151,7 @@
                                               (util/distinct-by (comp resource/proj-path :resource)))
                                         component-property-infos)
         game-object-instance-data {:resource build-resource
-                                   :transform transform-matrix
+                                   :pose pose
                                    :property-deps go-prop-dep-build-targets
                                    :instance-msg (if (seq component-property-descs)
                                                    (assoc instance-desc-with-go-props :component-properties component-property-descs)
@@ -173,8 +173,8 @@
       (vals)
       (vec)))
 
-(defn- flatten-game-object-instance-data [game-object-instance-data collection-instance-id ^Matrix4d collection-instance-transform child-game-object-instance-id? game-object-instance-id->component-property-descs proj-path->resource-property-build-target]
-  (let [{:keys [resource instance-msg ^Matrix4d transform]} game-object-instance-data
+(defn- flatten-game-object-instance-data [game-object-instance-data collection-instance-id collection-instance-pose child-game-object-instance-id? game-object-instance-id->component-property-descs proj-path->resource-property-build-target]
+  (let [{:keys [resource instance-msg pose]} game-object-instance-data
         {:keys [id children component-properties]} instance-msg
         build-target-go-props (partial properties/build-target-go-props proj-path->resource-property-build-target)
         component-properties (map source-resource-component-property-desc component-properties)
@@ -191,18 +191,17 @@
         instance-msg {:id (str collection-instance-id path-sep id)
                       :children (mapv #(str collection-instance-id path-sep %) children)
                       :component-properties component-property-descs}
-        transform (if (child-game-object-instance-id? id)
-                    transform
-                    (doto (Matrix4d. collection-instance-transform)
-                      (.mul transform)))]
+        pose (if (child-game-object-instance-id? id)
+               pose
+               (pose/pre-multiply pose collection-instance-pose))]
     {:resource resource
      :instance-msg instance-msg
-     :transform transform
+     :pose pose
      :property-deps go-prop-dep-build-targets}))
 
-(defn collection-instance-build-target [collection-instance-id ^Matrix4d transform-matrix instance-property-descs collection-build-target proj-path->resource-property-build-target]
+(defn collection-instance-build-target [collection-instance-id pose instance-property-descs collection-build-target proj-path->resource-property-build-target]
   {:pre [(string? collection-instance-id)
-         (instance? Matrix4d transform-matrix)
+         (pose/pose? pose)
          (seqable? instance-property-descs) ; GameObject$InstancePropertyDescs in map format.
          (map? collection-build-target)
          (ifn? proj-path->resource-property-build-target)]}
@@ -220,17 +219,11 @@
     (bt/with-content-hash
       (assoc-in collection-build-target [:user-data :instance-data]
                 (mapv (fn [game-object-instance-data]
-                        (flatten-game-object-instance-data game-object-instance-data collection-instance-id transform-matrix child-game-object-instance-id? game-object-instance-id->component-property-descs proj-path->resource-property-build-target))
+                        (flatten-game-object-instance-data game-object-instance-data collection-instance-id pose child-game-object-instance-id? game-object-instance-id->component-property-descs proj-path->resource-property-build-target))
                       game-object-instance-datas)))))
 
-(defn- matrix->transform-properties [^Matrix4d transform-matrix]
-  (let [position (Point3d.)
-        rotation (Quat4d.)
-        scale (Vector3d.)]
-    (math/split-mat4 transform-matrix position rotation scale)
-    {:position (math/vecmath->clj position)
-     :rotation (math/vecmath->clj rotation)
-     :scale3 (math/vecmath->clj scale)}))
+(defn- pose->transform-properties [pose]
+  (pose/to-map pose :position :rotation :scale3))
 
 (defn- build-collection [build-resource dep-resources user-data]
   ;; Please refer to `/engine/gameobject/proto/gameobject/gameobject_ddf.proto`
@@ -250,7 +243,7 @@
   (let [{:keys [name instance-data scale-along-z]} user-data
         build-go-props (partial properties/build-go-props dep-resources)
         go-instance-msgs (map :instance-msg instance-data)
-        go-instance-transform-properties (map (comp matrix->transform-properties :transform) instance-data)
+        go-instance-transform-properties (map (comp pose->transform-properties :pose) instance-data)
         go-instance-build-resource-paths (map (comp resource/proj-path dep-resources :resource) instance-data)
         go-instance-component-go-props (map (fn [instance-desc] ; GameObject$InstanceDesc in map form
                                               (map (fn [component-property-desc] ; GameObject$ComponentPropertyDesc in map form

--- a/editor/src/clj/editor/collection_non_editable.clj
+++ b/editor/src/clj/editor/collection_non_editable.clj
@@ -20,8 +20,8 @@
             [editor.game-object-common :as game-object-common]
             [editor.game-object-non-editable :as game-object-non-editable]
             [editor.graph-util :as gu]
-            [editor.math :as math]
             [editor.outline :as outline]
+            [editor.pose :as pose]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -46,14 +46,23 @@
             referenced-component-build-targets
             resource-property-build-targets)))
 
-(defn- any-instance-desc->transform-matrix
-  ^Matrix4d [{:keys [position rotation scale3] :as any-instance-desc}]
+(defn- any-instance-desc->pose [{:keys [position rotation scale3] :as any-instance-desc}]
   ;; GameObject$InstanceDesc, GameObject$EmbeddedInstanceDesc, or GameObject$CollectionInstanceDesc in map format.
-  (let [corrected-scale (if (or (nil? scale3)
-                                (protobuf/default-read-scale-value? scale3))
-                          (or (:scale any-instance-desc) 1.0) ; Legacy file format - use uniform scale.
-                          scale3)]
-    (math/clj->mat4 position rotation corrected-scale)))
+  (let [scale (if (or (nil? scale3)
+                      (protobuf/default-read-scale-value? scale3))
+
+                ;; Legacy file format - use uniform scale.
+                (let [uniform-scale (or (:scale any-instance-desc) 1.0)]
+                  [uniform-scale uniform-scale uniform-scale])
+
+                ;; Modern file format.
+                scale3)]
+    (pose/make position rotation scale)))
+
+(defn- any-instance-desc->transform-matrix
+  ^Matrix4d [any-instance-desc]
+  ;; GameObject$InstanceDesc, GameObject$EmbeddedInstanceDesc, or GameObject$CollectionInstanceDesc in map format.
+  (pose/to-mat4 (any-instance-desc->pose any-instance-desc)))
 
 (defn- component-property-desc-with-go-props [component-property-desc proj-path->source-resource]
   ;; GameObject$ComponentPropertyDesc in map format.
@@ -73,20 +82,20 @@
     (assoc instance-property-desc :properties (mapv #(component-property-desc-with-go-props % proj-path->source-resource) component-property-descs))
     (dissoc instance-property-desc :properties)))
 
-(defn- game-object-instance-build-target [build-resource instance-desc ^Matrix4d transform-matrix game-object-build-target proj-path->resource-property-build-target]
+(defn- game-object-instance-build-target [build-resource instance-desc pose game-object-build-target proj-path->resource-property-build-target]
   ;; GameObject$InstanceDesc or GameObject$EmbeddedInstanceDesc in map format.
   (let [proj-path->source-resource (comp :resource :resource proj-path->resource-property-build-target)
         instance-desc-with-go-props (cond-> (instance-desc-with-go-props instance-desc proj-path->source-resource)
 
                                             (empty? (:children instance-desc))
                                             (dissoc :children))]
-    (collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props transform-matrix game-object-build-target proj-path->resource-property-build-target)))
+    (collection-common/game-object-instance-build-target build-resource instance-desc-with-go-props pose game-object-build-target proj-path->resource-property-build-target)))
 
 (defn- instance-desc->game-object-instance-build-target [instance-desc game-object-build-target proj-path->build-target]
   ;; GameObject$InstanceDesc in map format.
   (let [build-resource (:resource game-object-build-target)
-        transform-matrix (any-instance-desc->transform-matrix instance-desc)]
-    (game-object-instance-build-target build-resource instance-desc transform-matrix game-object-build-target proj-path->build-target)))
+        pose (any-instance-desc->pose instance-desc)]
+    (game-object-instance-build-target build-resource instance-desc pose game-object-build-target proj-path->build-target)))
 
 (g/defnk produce-referenced-game-object-instance-build-targets [_node-id collection-desc proj-path->build-target resource]
   (let [build-targets
@@ -108,8 +117,8 @@
         embedded-game-object-build-target (game-object-common/game-object-build-target nil collection-node-id component-instance-datas component-build-targets)
         embedded-game-object-resource (workspace/make-embedded-resource workspace :non-editable "go" (:content-hash embedded-game-object-build-target)) ; Content determines hash for merging with embedded components in other .go files.
         embedded-game-object-build-resource (workspace/make-build-resource embedded-game-object-resource)
-        transform-matrix (any-instance-desc->transform-matrix embedded-instance-desc)]
-    (game-object-instance-build-target embedded-game-object-build-resource embedded-instance-desc transform-matrix embedded-game-object-build-target proj-path->build-target)))
+        pose (any-instance-desc->pose embedded-instance-desc)]
+    (game-object-instance-build-target embedded-game-object-build-resource embedded-instance-desc pose embedded-game-object-build-target proj-path->build-target)))
 
 (g/defnk produce-embedded-game-object-instance-build-targets [_node-id collection-desc embedded-component-resource-data->index embedded-component-build-targets referenced-component-build-targets resource proj-path->build-target]
   (let [workspace (resource/workspace resource)
@@ -141,10 +150,10 @@
               collection-instance-build-targets
               (mapv (fn [collection-instance-desc]
                       (let [collection-instance-id (:id collection-instance-desc)
-                            transform-matrix (any-instance-desc->transform-matrix collection-instance-desc)
+                            pose (any-instance-desc->pose collection-instance-desc)
                             referenced-collection-build-target (proj-path->build-target (:collection collection-instance-desc))
                             instance-property-descs (mapv #(instance-property-desc-with-go-props % proj-path->source-resource) (:instance-properties collection-instance-desc))]
-                        (collection-common/collection-instance-build-target collection-instance-id transform-matrix instance-property-descs referenced-collection-build-target proj-path->build-target)))
+                        (collection-common/collection-instance-build-target collection-instance-id pose instance-property-descs referenced-collection-build-target proj-path->build-target)))
                     collection-instance-descs)]
           [(collection-common/collection-build-target build-resource _node-id name scale-along-z game-object-instance-build-targets collection-instance-build-targets)]))))
 
@@ -275,9 +284,9 @@
          (ifn? child-id->desc)]}
   (letfn [(desc->instance-scene [desc]
             (let [id (:id desc)
-                  transform (any-instance-desc->transform-matrix desc)
+                  transform-matrix (any-instance-desc->transform-matrix desc)
                   source-scene (desc->source-scene desc)
-                  instance-scene (collection-common/any-instance-scene node-id id transform source-scene)
+                  instance-scene (collection-common/any-instance-scene node-id id transform-matrix source-scene)
                   child-instance-scenes (map (comp desc->instance-scene child-id->desc)
                                              (:children desc))]
               (cond-> instance-scene

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -140,7 +140,7 @@
       (update :display-order (fn [display-order]
                                (vec (distinct (concat display-order (:display-order source-properties))))))))
 
-(g/defnk produce-component-build-targets [_node-id build-resource ddf-message transform resource-property-build-targets source-build-targets]
+(g/defnk produce-component-build-targets [_node-id build-resource ddf-message pose resource-property-build-targets source-build-targets]
   ;; Create a build-target for the referenced or embedded component. Also tag on
   ;; :instance-data with the overrides for this instance. This will later be
   ;; extracted and compiled into the GameObject - the overrides do not end up in
@@ -157,9 +157,9 @@
                              (wrap-if-raw-sound _node-id))
             build-resource (:resource build-target) ; The wrap-if-raw-sound call might have changed this.
             instance-data (if is-embedded
-                            (game-object-common/embedded-component-instance-data build-resource ddf-message transform)
+                            (game-object-common/embedded-component-instance-data build-resource ddf-message pose)
                             (let [proj-path->resource-property-build-target (bt/make-proj-path->build-target resource-property-build-targets)]
-                              (game-object-common/referenced-component-instance-data build-resource ddf-message transform proj-path->resource-property-build-target)))
+                              (game-object-common/referenced-component-instance-data build-resource ddf-message pose proj-path->resource-property-build-target)))
             build-target (assoc build-target :instance-data instance-data)]
         [(bt/with-content-hash build-target)]))))
 

--- a/editor/src/clj/editor/game_object_common.clj
+++ b/editor/src/clj/editor/game_object_common.clj
@@ -18,6 +18,7 @@
             [editor.build-target :as bt]
             [editor.geom :as geom]
             [editor.gl.pass :as pass]
+            [editor.pose :as pose]
             [editor.properties :as properties]
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
@@ -158,25 +159,25 @@
               (mapcat #(embedded-component-desc->dependencies % ext->embedded-component-resource-type))
               (:embedded-components prototype-desc))))))
 
-(defn embedded-component-instance-data [build-resource embedded-component-desc ^Matrix4d transform-matrix]
+(defn embedded-component-instance-data [build-resource embedded-component-desc pose]
   {:pre [(workspace/build-resource? build-resource)
          (map? embedded-component-desc) ; GameObject$EmbeddedComponentDesc in map format.
          (contains? embedded-component-desc :scale)
-         (instance? Matrix4d transform-matrix)]}
+         (pose/pose? pose)]}
   {:resource build-resource
-   :transform transform-matrix
+   :pose pose
    :instance-msg (dissoc embedded-component-desc :type :data)})
 
-(defn referenced-component-instance-data [build-resource component-desc ^Matrix4d transform-matrix proj-path->resource-property-build-target]
+(defn referenced-component-instance-data [build-resource component-desc pose proj-path->resource-property-build-target]
   {:pre [(workspace/build-resource? build-resource)
          (map? component-desc) ; GameObject$ComponentDesc in map format, but PropertyDescs must have a :clj-value.
          (contains? component-desc :scale)
-         (instance? Matrix4d transform-matrix)
+         (pose/pose? pose)
          (ifn? proj-path->resource-property-build-target)]}
   (let [go-props-with-source-resources (:properties component-desc) ; Every PropertyDesc must have a :clj-value with actual Resource, etc.
         [go-props go-prop-dep-build-targets] (properties/build-target-go-props proj-path->resource-property-build-target go-props-with-source-resources)]
     {:resource build-resource
-     :transform transform-matrix
+     :pose pose
      :property-deps go-prop-dep-build-targets
      :instance-msg (cond-> component-desc
 

--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -19,19 +19,21 @@
 
 (set! *warn-on-reflection* true)
 
-(def epsilon 0.000001)
-(def epsilon-sq (* epsilon epsilon))
+(def ^:const epsilon 0.000001)
+(def ^:const epsilon-sq (* epsilon epsilon))
 
-(def pi Math/PI)
-(def half-pi (* 0.5 pi))
-(def two-pi (* 2.0 pi))
-(def recip-180 (/ 1.0 180.0))
-(def recip-pi (/ 1.0 Math/PI))
+(def ^:const pi Math/PI)
+(def ^:const half-pi (* 0.5 pi))
+(def ^:const two-pi (* 2.0 pi))
+(def ^:const recip-180 (/ 1.0 180.0))
+(def ^:const recip-pi (/ 1.0 Math/PI))
 
-(defn deg->rad [deg]
+(defn deg->rad
+  ^double [^double deg]
   (* deg Math/PI recip-180))
 
-(defn rad->deg [rad]
+(defn rad->deg
+  ^double [^double rad]
   (* rad 180.0 recip-pi))
 
 (defn round-with-precision

--- a/editor/src/clj/editor/pose.clj
+++ b/editor/src/clj/editor/pose.clj
@@ -1,0 +1,255 @@
+(ns editor.pose
+  (:require [clojure.spec.alpha :as s]
+            [editor.math :as math])
+  (:import [javax.vecmath Matrix4d]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(s/def ::num number?)
+(s/def ::num3 (s/tuple ::num ::num ::num))
+(s/def ::num4 (s/tuple ::num ::num ::num ::num))
+(s/def ::translation ::num3)
+(s/def ::rotation ::num4)
+(s/def ::scale ::num3)
+(s/def ::euler-rotation ::num3)
+
+(defrecord Pose [translation rotation scale])
+
+(defn pose? [value]
+  (instance? Pose value))
+
+(def default-translation (vector-of :double 0.0 0.0 0.0))
+(def default-rotation (vector-of :double 0.0 0.0 0.0 1.0))
+(def default-scale (vector-of :double 1.0 1.0 1.0))
+(def ^Pose default (->Pose default-translation default-rotation default-scale))
+
+(def ^:private mat4-identity (doto (Matrix4d.) (.setIdentity)))
+(def ^:private num4-zero (vector-of :double 0.0 0.0 0.0 0.0))
+
+(defn- significant-translation? [value]
+  (if-some [[^double x ^double y ^double z] value]
+    (not (and (zero? x)
+              (zero? y)
+              (zero? z)))
+    false))
+
+(defn- significant-rotation? [value]
+  (if-some [[^double x ^double y ^double z ^double w] value]
+    (not (and (zero? x)
+              (zero? y)
+              (zero? z)
+              (== 1.0 w)))
+    false))
+
+(defn- significant-scale? [value]
+  (if-some [[^double x ^double y ^double z] value]
+    (not (and (== 1.0 x)
+              (== 1.0 y)
+              (== 1.0 z)))
+    false))
+
+(defn- add-vector [[^double ax ^double ay ^double az] [^double bx ^double by ^double bz]]
+  (vector-of
+    :double
+    (+ ax bx)
+    (+ ay by)
+    (+ az bz)))
+
+(defn- multiply-vector [[^double ax ^double ay ^double az] [^double bx ^double by ^double bz]]
+  (vector-of
+    :double
+    (* ax bx)
+    (* ay by)
+    (* az bz)))
+
+(defn- rotate-vector [[^double vx ^double vy ^double vz] [^double qx ^double qy ^double qz ^double qw]]
+  (vector-of
+    :double
+    (- (+ (* vx qw qw)
+          (* vy qz qw -2.0)
+          (* vz qy qw 2.0)
+          (* vx qx qx)
+          (* vy qx qy 2.0)
+          (* vz qx qz 2.0))
+       (* vx qy qy)
+       (* vx qz qz))
+    (- (+ (* vx qx qy 2.0)
+          (* vy qy qy)
+          (* vz qy qz 2.0)
+          (* vx qz qw 2.0)
+          (* vy qw qw)
+          (* vz qx qw -2.0))
+       (* vy qx qx)
+       (* vy qz qz))
+    (- (+ (* vx qx qz 2.0)
+          (* vy qy qz 2.0)
+          (* vz qz qz)
+          (* vx qy qw -2.0)
+          (* vy qx qw 2.0)
+          (* vz qw qw))
+       (* vz qx qx)
+       (* vz qy qy))))
+
+(defn- rotate-quaternion [[^double ax ^double ay ^double az ^double aw] [^double bx ^double by ^double bz ^double bw]]
+  (vector-of
+    :double
+    (- (+ (* ax bw)
+          (* ay bz)
+          (* aw bx))
+       (* az by))
+    (- (+ (* ay bw)
+          (* az bx)
+          (* aw by))
+       (* ax bz))
+    (- (+ (* ax by)
+          (* az bw)
+          (* aw bz))
+       (* ay bx))
+    (- (* aw bw)
+       (* ax bx)
+       (* ay by)
+       (* az bz))))
+
+(defn translation-pose
+  ^Pose [^double x ^double y ^double z]
+  (if (and (zero? x) (zero? y) (zero? z))
+    default
+    (->Pose (vector-of :double x y z) default-rotation default-scale)))
+
+(defn rotation-pose
+  ^Pose [^double x ^double y ^double z ^double w]
+  (if (and (zero? x) (zero? y) (zero? z) (== 1.0 w))
+    default
+    (->Pose default-translation (vector-of :double x y z w) default-scale)))
+
+(defn euler-rotation [^double x-deg ^double y-deg ^double z-deg]
+  ;; Implementation based on:
+  ;; http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf
+  ;; Rotation sequence: 231 (YZX)
+  (if (== 0.0 x-deg y-deg)
+    (if (== 0.0 z-deg)
+      default-rotation
+      (let [ha (* 0.5 (math/deg->rad z-deg))
+            s (Math/sin ha)
+            c (Math/cos ha)]
+        (vector-of :double 0.0 0.0 s c)))
+    (let [t1 (math/deg->rad y-deg)
+          t2 (math/deg->rad z-deg)
+          t3 (math/deg->rad x-deg)
+          c1 (Math/cos (* t1 0.5))
+          s1 (Math/sin (* t1 0.5))
+          c2 (Math/cos (* t2 0.5))
+          s2 (Math/sin (* t2 0.5))
+          c3 (Math/cos (* t3 0.5))
+          s3 (Math/sin (* t3 0.5))
+          c1c2 (* c1 c2)
+          s2s3 (* s2 s3)
+          qx (+ (* s1 s2 c3)
+                (* s3 c1c2))
+          qy (+ (* s1 c2 c3)
+                (* s2s3 c1))
+          qz (+ (- (* s1 s3 c2))
+                (* s2 c1 c3))
+          qw (+ (- (* s1 s2s3))
+                (* c1c2 c3))
+          dp (+ (* qx qx) (* qy qy) (* qz qz) (* qw qw))]
+      (if (> dp 0.0)
+        (let [r (/ 1.0 (Math/sqrt dp))]
+          (vector-of :double (* qx r) (* qy r) (* qz r) (* qw r)))
+        num4-zero))))
+
+(defn euler-rotation-pose
+  ^Pose [^double x-deg ^double y-deg ^double z-deg]
+  (if (and (zero? x-deg) (zero? y-deg) (zero? z-deg))
+    default
+    (->Pose default-translation (euler-rotation x-deg y-deg z-deg) default-scale)))
+
+(defn scale-pose
+  ^Pose [^double x ^double y ^double z]
+  (if (and (== 1.0 x) (== 1.0 y) (== 1.0 z))
+    default
+    (->Pose default-translation default-rotation (vector-of :double x y z))))
+
+(defn make
+  ^Pose [translation rotation scale]
+  {:pre [(or (nil? translation) (s/valid? ::translation translation))
+         (or (nil? rotation) (s/valid? ::rotation rotation))
+         (or (nil? scale) (s/valid? ::scale scale))]}
+  (let [translated (significant-translation? translation)
+        rotated (significant-rotation? rotation)
+        scaled (significant-scale? scale)]
+    (if (or translated rotated scaled)
+      (->Pose (if translated translation default-translation)
+              (if rotated rotation default-rotation)
+              (if scaled scale default-scale))
+      default)))
+
+(defn from-translation
+  ^Pose [translation]
+  {:pre [(or (nil? translation) (s/valid? ::translation translation))]}
+  (if translation
+    (apply translation-pose translation)
+    default))
+
+(defn from-rotation
+  ^Pose [rotation]
+  {:pre [(or (nil? rotation) (s/valid? ::rotation rotation))]}
+  (if rotation
+    (apply rotation-pose rotation)
+    default))
+
+(defn from-euler-rotation
+  ^Pose [euler-rotation]
+  {:pre [(or (nil? euler-rotation) (s/valid? ::euler-rotation euler-rotation))]}
+  (if euler-rotation
+    (apply euler-rotation-pose euler-rotation)
+    default))
+
+(defn from-scale
+  ^Pose [scale]
+  {:pre [(or (nil? scale) (s/valid? ::scale scale))]}
+  (if scale
+    (apply scale-pose scale)
+    default))
+
+(defn pre-multiply
+  ^Pose [^Pose child-pose ^Pose parent-pose]
+  {:pre [(pose? child-pose)
+         (pose? parent-pose)]}
+  (let [child-translation (.-translation child-pose)
+        child-rotation (.-rotation child-pose)
+        child-scale (.-scale child-pose)
+        parent-translation (.-translation parent-pose)
+        parent-rotation (.-rotation parent-pose)
+        parent-scale (.-scale parent-pose)
+        parent-translated (significant-translation? parent-translation)
+        parent-rotated (significant-rotation? parent-rotation)
+        parent-scaled (significant-scale? parent-scale)]
+    (cond-> child-pose
+
+            parent-scaled
+            (assoc :scale (multiply-vector child-scale parent-scale))
+
+            parent-rotated
+            (assoc :rotation (rotate-quaternion child-rotation parent-rotation))
+
+            (or parent-scaled parent-rotated parent-translated)
+            (assoc :translation
+                   (cond-> child-translation
+                           parent-scaled (multiply-vector parent-scale)
+                           parent-rotated (rotate-vector parent-rotation)
+                           parent-translated (add-vector parent-translation))))))
+
+(defn to-map [^Pose pose translation-key rotation-key scale-key]
+  {:pre [(pose? pose)]}
+  {translation-key (.-translation pose)
+   rotation-key (.-rotation pose)
+   scale-key (.-scale pose)})
+
+(defn to-mat4
+  ^Matrix4d [^Pose pose]
+  {:pre [(pose? pose)]}
+  (if (identical? default pose)
+    mat4-identity
+    (math/clj->mat4 (.-translation pose) (.-rotation pose) (.-scale pose))))

--- a/editor/src/clj/editor/pose.clj
+++ b/editor/src/clj/editor/pose.clj
@@ -27,27 +27,21 @@
 (def ^:private mat4-identity (doto (Matrix4d.) (.setIdentity)))
 (def ^:private num4-zero (vector-of :double 0.0 0.0 0.0 0.0))
 
-(defn- significant-translation? [value]
-  (if-some [[^double x ^double y ^double z] value]
-    (not (and (zero? x)
-              (zero? y)
-              (zero? z)))
-    false))
+(defn- significant-translation? [[^double x ^double y ^double z]]
+  (not (and (zero? x)
+            (zero? y)
+            (zero? z))))
 
-(defn- significant-rotation? [value]
-  (if-some [[^double x ^double y ^double z ^double w] value]
-    (not (and (zero? x)
-              (zero? y)
-              (zero? z)
-              (== 1.0 w)))
-    false))
+(defn- significant-rotation? [[^double x ^double y ^double z ^double w]]
+  (not (and (zero? x)
+            (zero? y)
+            (zero? z)
+            (== 1.0 w))))
 
-(defn- significant-scale? [value]
-  (if-some [[^double x ^double y ^double z] value]
-    (not (and (== 1.0 x)
-              (== 1.0 y)
-              (== 1.0 z)))
-    false))
+(defn- significant-scale? [[^double x ^double y ^double z]]
+  (not (and (== 1.0 x)
+            (== 1.0 y)
+            (== 1.0 z))))
 
 (defn- add-vector [[^double ax ^double ay ^double az] [^double bx ^double by ^double bz]]
   (vector-of
@@ -176,9 +170,9 @@
   {:pre [(or (nil? translation) (s/valid? ::translation translation))
          (or (nil? rotation) (s/valid? ::rotation rotation))
          (or (nil? scale) (s/valid? ::scale scale))]}
-  (let [translated (significant-translation? translation)
-        rotated (significant-rotation? rotation)
-        scaled (significant-scale? scale)]
+  (let [translated (and translation (significant-translation? translation))
+        rotated (and rotation (significant-rotation? rotation))
+        scaled (and scale (significant-scale? scale))]
     (if (or translated rotated scaled)
       (->Pose (if translated translation default-translation)
               (if rotated rotation default-rotation)

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -27,6 +27,7 @@
             [editor.handler :as handler]
             [editor.input :as i]
             [editor.math :as math]
+            [editor.pose :as pose]
             [editor.properties :as properties]
             [editor.render :as render]
             [editor.resource :as resource]
@@ -48,6 +49,7 @@
   (:import [com.jogamp.opengl GL GL2 GLAutoDrawable GLContext GLOffscreenAutoDrawable]
            [com.jogamp.opengl.glu GLU]
            [com.jogamp.opengl.util GLPixelStorageModes]
+           [editor.pose Pose]
            [editor.types AABB Camera Rect Region]
            [java.awt.image BufferedImage]
            [java.lang Math Runnable]
@@ -1510,6 +1512,9 @@
 (g/defnk produce-transform [position rotation scale]
   (math/clj->mat4 position rotation scale))
 
+(g/defnk produce-pose [position rotation scale]
+  (pose/make position rotation scale))
+
 (def produce-no-transform-properties (g/constantly #{}))
 (def produce-scalable-transform-properties (g/constantly #{:position :rotation :scale}))
 (def produce-unscalable-transform-properties (g/constantly #{:position :rotation}))
@@ -1534,6 +1539,7 @@
 
   (output transform-properties g/Any :abstract)
   (output transform Matrix4d :cached produce-transform)
+  (output pose Pose produce-pose)
   (output scene g/Any :cached (g/fnk [^g/NodeID _node-id ^Matrix4d transform] {:node-id _node-id :transform transform})))
 
 (defmethod scene-tools/manip-movable? ::SceneNode [node-id]

--- a/editor/test/editor/pose_test.clj
+++ b/editor/test/editor/pose_test.clj
@@ -1,0 +1,215 @@
+(ns editor.pose-test
+  (:require [clojure.test :refer :all]
+            [editor.math :as math]
+            [editor.pose :as pose])
+  (:import [javax.vecmath Matrix4d Quat4d Vector3d]))
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- round-numbers [numbers]
+  (mapv #(math/round-with-precision % 0.001)
+        numbers))
+
+(deftest pose?-test
+  (is (false? (pose/pose? nil)))
+  (is (false? (pose/pose? {:translation [0.0 0.0 0.0]
+                           :rotation [0.0 0.0 0.0 1.0]
+                           :scale [1.0 1.0 1.0]})))
+  (is (true? (pose/pose? (pose/make [0.0 0.0 0.0]
+                                    [0.0 0.0 0.0 1.0]
+                                    [1.0 1.0 1.0]))))
+  (is (true? (pose/pose? (-> (pose/make [0.0 0.0 0.0]
+                                        [0.0 0.0 0.0 1.0]
+                                        [1.0 1.0 1.0])
+                             (assoc :extra "Extra Data"))))))
+
+(deftest make-test
+  (is (pose/pose? (pose/make nil nil nil)))
+  (is (pose/pose? (pose/make [1.0 0.0 0.0] [0.0 0.707 0.707 0.0] [2.0 1.0 1.0])))
+  (is (pose/pose? (pose/make [1 0 0] [0 1 0 1] [2 1 1])))
+  (is (pose/pose? (pose/make (vector-of :float 1.0 0.0 0.0) (vector-of :float 0.0 0.707 0.707 0.0) (vector-of :float 2.0 1.0 1.0))))
+  (is (thrown? Throwable (pose/make [1.0 0.0] nil nil))) ; Too few components in translation.
+  (is (thrown? Throwable (pose/make [1.0 0.0 0.0 0.0] nil nil))) ; Too many components in translation.
+  (is (thrown? Throwable (pose/make nil [0.0 0.707 0.707] nil))) ; Too few components in rotation.
+  (is (thrown? Throwable (pose/make nil [0.0 0.707 0.707 0.0 0.0] nil))) ; Too many components in rotation.
+  (is (thrown? Throwable (pose/make nil nil [2.0 1.0]))) ; Too few components in scale.
+  (is (thrown? Throwable (pose/make nil nil [2.0 1.0 1.0 1.0]))) ; Too many components in scale.
+  (is (thrown? Throwable (pose/make (Vector3d. 1.0 0.0 0.0) (Quat4d. 0.0 0.707 0.707 0.0) (Vector3d. 2.0 1.0 1.0)))))
+
+(deftest from-translation-test
+  (is (thrown? Throwable (pose/from-translation [1.0 2.0])))
+  (is (thrown? Throwable (pose/from-translation [1.0 2.0 3.0 4.0])))
+  (is (identical? pose/default (pose/from-translation nil)))
+  (is (identical? pose/default (pose/from-translation [0.0 0.0 0.0])))
+  (is (identical? pose/default (pose/from-translation [0 0 0])))
+  (let [pose (pose/from-translation [1.0 2.0 3.0])]
+    (is (= [1.0 2.0 3.0] (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/from-translation [1 2 3])]
+    (is (= [1.0 2.0 3.0] (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose)))))
+
+(deftest from-rotation-test
+  (is (thrown? Throwable (pose/from-rotation [1.0 2.0 3.0])))
+  (is (thrown? Throwable (pose/from-rotation [1.0 2.0 3.0 4.0 5.0])))
+  (is (identical? pose/default (pose/from-rotation nil)))
+  (is (identical? pose/default (pose/from-rotation [0.0 0.0 0.0 1.0])))
+  (is (identical? pose/default (pose/from-rotation [0 0 0 1])))
+  (let [pose (pose/from-rotation [1.0 2.0 3.0 4.0])]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [1.0 2.0 3.0 4.0] (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/from-rotation [1 2 3 4])]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [1.0 2.0 3.0 4.0] (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose)))))
+
+(deftest from-euler-rotation-test
+  (is (thrown? Throwable (pose/from-euler-rotation [1.0 2.0])))
+  (is (thrown? Throwable (pose/from-euler-rotation [1.0 2.0 3.0 4.0])))
+  (is (identical? pose/default (pose/from-euler-rotation nil)))
+  (is (identical? pose/default (pose/from-euler-rotation [0.0 0.0 0.0])))
+  (is (identical? pose/default (pose/from-euler-rotation [0 0 0])))
+  (let [pose (pose/from-euler-rotation [0.0 90.0 0.0])]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [0.0 0.707 0.0 0.707] (round-numbers (:rotation pose))))
+    (is (identical? pose/default-scale (:scale pose)))))
+
+(deftest from-scale-test
+  (is (thrown? Throwable (pose/from-scale [1.0 2.0])))
+  (is (thrown? Throwable (pose/from-scale [1.0 2.0 3.0 4.0])))
+  (is (identical? pose/default (pose/from-scale nil)))
+  (is (identical? pose/default (pose/from-scale [1.0 1.0 1.0])))
+  (is (identical? pose/default (pose/from-scale [1 1 1])))
+  (let [pose (pose/from-scale [1.0 2.0 3.0])]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (= [1.0 2.0 3.0] (:scale pose))))
+  (let [pose (pose/from-scale [1 2 3])]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (= [1.0 2.0 3.0] (:scale pose)))))
+
+(deftest translation-pose-test
+  (is (thrown? Throwable (pose/translation-pose nil nil nil)))
+  (is (identical? pose/default (pose/translation-pose 0.0 0.0 0.0)))
+  (let [pose (pose/translation-pose 1.0 2.0 3.0)]
+    (is (= [1.0 2.0 3.0] (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/translation-pose 1 2 3)]
+    (is (= [1.0 2.0 3.0] (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose)))))
+
+(deftest rotation-pose-test
+  (is (thrown? Throwable (pose/rotation-pose nil nil nil nil)))
+  (is (identical? pose/default (pose/rotation-pose 0.0 0.0 0.0 1.0)))
+  (let [pose (pose/rotation-pose 1.0 2.0 3.0 4.0)]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [1.0 2.0 3.0 4.0] (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/rotation-pose 1 2 3 4)]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [1.0 2.0 3.0 4.0] (:rotation pose)))
+    (is (identical? pose/default-scale (:scale pose)))))
+
+(deftest euler-rotation-pose-test
+  (is (thrown? Throwable (pose/euler-rotation-pose nil nil nil)))
+  (is (identical? pose/default (pose/euler-rotation-pose 0.0 0.0 0.0)))
+  (let [pose (pose/euler-rotation-pose 90.0 90.0 90.0)]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [0.707 0.707 0.0 0.0] (round-numbers (:rotation pose))))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/euler-rotation-pose 90 0 90)]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (= [0.5 0.5 0.5 0.5] (round-numbers (:rotation pose))))
+    (is (identical? pose/default-scale (:scale pose)))))
+
+(deftest scale-pose-test
+  (is (thrown? Throwable (pose/scale-pose nil nil nil)))
+  (is (identical? pose/default (pose/scale-pose 1.0 1.0 1.0)))
+  (let [pose (pose/scale-pose 1.0 2.0 3.0)]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (= [1.0 2.0 3.0] (:scale pose))))
+  (let [pose (pose/scale-pose 1 2 3)]
+    (is (identical? pose/default-translation (:translation pose)))
+    (is (identical? pose/default-rotation (:rotation pose)))
+    (is (= [1.0 2.0 3.0] (:scale pose)))))
+
+(deftest pre-multiply-test
+  (is (thrown? Throwable (pose/pre-multiply pose/default nil)))
+  (is (thrown? Throwable (pose/pre-multiply nil pose/default)))
+  (is (identical? pose/default (pose/pre-multiply pose/default pose/default)))
+  (let [original (pose/make [1.0 0.0 0.0]
+                            [0.0 0.707 0.707 1.0]
+                            [2.0 1.0 1.0])]
+    (is (identical? original (pose/pre-multiply original (pose/make [0.0 0.0 0.0]
+                                                                    [0.0 0.0 0.0 1.0]
+                                                                    [1.0 1.0 1.0])))))
+  (is (= (pose/translation-pose 3.0 0.0 0.0)
+         (pose/pre-multiply (pose/translation-pose 1.0 0.0 0.0)
+                            (pose/translation-pose 2.0 0.0 0.0))))
+  (is (= (pose/make [6.0 20.0 56.0]
+                    nil
+                    [2.0 4.0 8.0])
+         (pose/pre-multiply (pose/from-translation [3.0 5.0 7.0])
+                            (pose/from-scale [2.0 4.0 8.0]))))
+  (is (= (pose/euler-rotation-pose 40.0 0.0 0.0)
+         (pose/pre-multiply (pose/euler-rotation-pose 10.0 0.0 0.0)
+                            (pose/euler-rotation-pose 30.0 0.0 0.0))))
+  (is (= (pose/euler-rotation-pose 0.0 -40.0 0.0)
+         (pose/pre-multiply (pose/euler-rotation-pose 0.0 -10.0 0.0)
+                            (pose/euler-rotation-pose 0.0 -30.0 0.0))))
+  (is (= (pose/euler-rotation-pose 45.0 45.0 45.0)
+         (-> (pose/euler-rotation-pose 0.0 45.0 0.0)
+             (pose/pre-multiply (pose/euler-rotation-pose 0.0 0.0 45.0))
+             (pose/pre-multiply (pose/euler-rotation-pose 45.0 0.0 0.0)))))
+  (let [pose (pose/pre-multiply pose/default
+                                (pose/euler-rotation-pose -90.0 180.0 0.0))]
+    (is (= [0.0 0.0 0.0] (:translation pose)))
+    (is (= [0.0 0.707 0.707 0.0] (round-numbers (:rotation pose))))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/pre-multiply (pose/euler-rotation-pose 0.0 0.0 90.0)
+                                (pose/euler-rotation-pose 0.0 0.0 90.0))]
+    (is (= [0.0 0.0 0.0] (:translation pose)))
+    (is (= [0.0 0.0 1.0 0.0] (round-numbers (:rotation pose))))
+    (is (identical? pose/default-scale (:scale pose))))
+  (let [pose (pose/pre-multiply (pose/translation-pose 10.0 20.0 30.0)
+                                (pose/make [3.0 5.0 7.0]
+                                           (pose/euler-rotation 90.0 0.0 0.0)
+                                           [2.0 4.0 8.0]))]
+    (is (= [23.0 -235.0 87.0] (round-numbers (:translation pose))))
+    (is (= (pose/euler-rotation 90.0 0.0 0.0) (:rotation pose)))
+    (is (= [2.0 4.0 8.0] (:scale pose)))))
+
+(deftest to-map-test
+  (is (thrown? Throwable (pose/to-mat4 {:translation "Not a pose"})))
+  (is (= {:t [0.0 0.0 0.0]
+          :r [0.0 0.0 0.0 1.0]
+          :s [1.0 1.0 1.0]}
+         (pose/to-map pose/default :t :r :s)))
+  (is (= {:position [1.0 0.0 0.0]
+          :rotation [0.0 0.707 0.707 0.0]
+          :scale3 [2.0 1.0 1.0]}
+         (pose/to-map (pose/make [1.0 0.0 0.0]
+                                 [0.0 0.707 0.707 0.0]
+                                 [2.0 1.0 1.0])
+                      :position
+                      :rotation
+                      :scale3))))
+
+(deftest to-mat4-test
+  (is (thrown? Throwable (pose/to-mat4 {:translation "Not a pose"})))
+  (is (= (doto (Matrix4d.) (.setIdentity))
+         (pose/to-mat4 pose/default)))
+  (is (= (math/clj->mat4 [1.0 2.0 3.0]
+                         [0.0 0.707 0.707 0.0]
+                         [2.0 1.0 1.0])
+         (pose/to-mat4 (pose/make [1.0 2.0 3.0]
+                                  [0.0 0.707 0.707 0.0]
+                                  [2.0 1.0 1.0])))))


### PR DESCRIPTION
Fixes #7126.

### User-facing changes
* Fixed root-level game object transforms inside referenced collections when building from the editor

### Technical changes
* Introduced a `Pose` type in places where it is important to retain `position`, `rotation`, and `scale` properties.
* We no longer convert `position`, `rotation`, and `scale` into a `Matrix4` which we then decompose into `position`, `rotation`, and `scale` later in the build process. Doing so lost information and resulted in transforms that differ from how Bob was doing it, which was applying parent transforms to `position`, `rotation`, and `scale` in isolation.