### PR TITLE
Make the debugger more resilient to unexpected chars

### DIFF
--- a/editor/src/clj/editor/debugging/mobdebug.clj
+++ b/editor/src/clj/editor/debugging/mobdebug.clj
@@ -495,7 +495,7 @@
       (send-command! out "STACK")
       (let [[status rest] (read-status in)]
         (case status
-          "200" (when-let [[stack] (re-match #"^OK\s+(.*)$" rest)]
+          "200" (when-let [[stack] (re-match #"^OK\s+" rest)]
                   {:stack (stack-data (decode-serialized-data stack))})
           "401" (when-let [[size] (re-match #"^Error in Execution\s+(\d+)$" rest)]
                   (let [n (Integer/parseInt size)]


### PR DESCRIPTION
The problem is that somehow, in one of the projects the debugger stack reported by the game included a [NEL](https://www.compart.com/en/unicode/U+0085) character in the data. This resulted in regex `(.*)` failing, since `.` does not match the NEL character:

```clj
(re-match #"." "\u0085") => nil
(re-match #"." "\u0086") => []
```

The solution is to make the regex that separates `OK` from the EDN data structure only look at the `OK\s+` part of the string and get the remainder using `subs`, which `re-match` already does.

User-facing changes:
Debugger is more resilient to the stack information received from the game when it contains control characters like [NEL](https://www.compart.com/en/unicode/U+0085).

Fixes #7511