### PR TITLE
Speedup running of the build with debugger (run using F5)

### DIFF
--- a/engine/engine/content/builtins/scripts/debugger.lua
+++ b/engine/engine/content/builtins/scripts/debugger.lua
@@ -63,28 +63,30 @@ local function remove_breakpoint(line, file)
   end
 end
 
+local file_cache = {}
 -- This hook fires only on Lua functions calls and checks if this function has lines
 -- we have breakpoints on
-local function lightweight_hook()
-  local caller = debug.getinfo(2,"S")
-  local file = mobdebug.get_filename(caller.source)
+local function lightweight_hook(source, lastlinedefined, co)
+  local file = file_cache[source]
+  if not file then 
+    file = mobdebug.get_filename(source)
+    file_cache[source] = file
+  end
   mobdebug.get_server_data(file)
   local brk = breakpoints[file]
-  local co = coroutine.running()
   local in_co = false
   if co then
     -- If it's the first call after the [C] call - save function metricks
-    if caller.lastlinedefined ~= -1 and coroutines[co] == false then
+    if lastlinedefined ~= -1 and coroutines[co] == false then
         -- Coroutine provide this info only on the first coroutine fn call
         -- we should save it for later usage
         coroutines[co] = {
           ["lines"] = debug.getinfo(2,"L"),
-          ["file"] = file,
-          ["caller"] = caller
+          ["file"] = file
         }
     end
     -- Make sure [C] function call was before the first coroutine call
-    if not coroutines[co] and caller.lastlinedefined == -1 then
+    if not coroutines[co] and lastlinedefined == -1 then
       coroutines[co] = false
     end
     if not brk then
@@ -121,10 +123,10 @@ local function set_lightweight_hook(force, co)
     continue_execution = false
     if co then
       debug.sethook(co, nil, "lcr")
-      debug.sethook(co, lightweight_hook, "c")
+      sys.set_debugger_lightweight_hook(co, lightweight_hook)
     else
       debug.sethook(nil, "lcr")
-      debug.sethook(lightweight_hook, "c")
+      sys.set_debugger_lightweight_hook(lightweight_hook)
     end
   end
 end


### PR DESCRIPTION
Fixes an issue when big codebase or some massive function calls (for example a loop which creates a lot of objects with metatables on it) maybe a reason for a significant slowdown when you start game with debugger using F5. Now, this overhead is much lower.

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
