### PR TITLE
Don't show submenu shortcuts for command options

### DIFF
--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1258,7 +1258,7 @@
     (user-data! menu-item ::menu-item-id id)
     (when command
       (.setId menu-item (name command)))
-    (when (some? key-combo)
+    (when (and (some? key-combo) (nil? user-data))
       (.setAccelerator menu-item key-combo))
     (when icon
       (.setGraphic menu-item (wrap-menu-image (icons/get-image-view icon 16))))


### PR DESCRIPTION
User-facing changes:
Previously, sub-menus like `File -> New` and `Game Object -> Add Component` showed the same shortcut on every option item. This changeset turns this behavior off.

Technical notes:
I implemented the fix by only showing the key combo if the menu item does not define custom user data since this is what differentiates the options from each other. It was wrong to show the key combinations on such options because invoking a command using a key combination does not supply this user data anyway.

Fixes #7442
