### PR TITLE
Fix for making SSL connections thread safe

### DIFF
--- a/engine/dlib/scripts/start_http_server.sh
+++ b/engine/dlib/scripts/start_http_server.sh
@@ -5,10 +5,10 @@
 # Copyright 2009-2014 Ragnar Svensson, Christian Murray
 # Licensed under the Defold License version 1.0 (the "License"); you may not use
 # this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License, together with FAQs at
 # https://www.defold.com/license
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -31,6 +31,7 @@ CLASSPATH=$SCRIPTDIR/../ext/jetty-all-7.0.2.v20100331.jar${PATHSEP}$SCRIPTDIR/..
 
 echo $CLASSPATH
 
-java -cp $CLASSPATH TestHttpServer &
-echo $! > test_http_server.pid
+#DEBUG="-DDEBUG=true -Dorg.eclipse.jetty.LEVEL=DEBUG -Djavax.net.debug=ssl,handshake,data"
 
+java -cp $CLASSPATH ${DEBUG} TestHttpServer &
+echo $! > test_http_server.pid

--- a/engine/dlib/src/dlib/connection_pool.h
+++ b/engine/dlib/src/dlib/connection_pool.h
@@ -35,6 +35,7 @@ namespace dmConnectionPool
         uint32_t m_Free;
         uint32_t m_Connected;
         uint32_t m_InUse;
+        uint32_t m_InUseAndValid; // In use and has a valid socket
     };
 
     /**

--- a/engine/dlib/src/dlib/http_client.cpp
+++ b/engine/dlib/src/dlib/http_client.cpp
@@ -1175,6 +1175,16 @@ bail:
         dmConnectionPool::Reopen(pool);
     }
 
+    uint32_t GetNumPoolConnections()
+    {
+        dmConnectionPool::HPool pool = g_PoolCreator.GetPool();
+
+        dmConnectionPool::Stats stats;
+        dmConnectionPool::GetStats(pool, &stats);
+        return stats.m_InUseAndValid; // For the unit test to be able to wait for a connection in flight
+
+    }
+
 #undef HTTP_CLIENT_SENDALL_AND_BAIL
 
     #define DM_HTTPCLIENT_RESULT_TO_STRING_CASE(x) case RESULT_##x: return #x;

--- a/engine/dlib/src/dlib/http_client.h
+++ b/engine/dlib/src/dlib/http_client.h
@@ -292,6 +292,9 @@ namespace dmHttpClient
      * @return Result as string
      */
     const char* ResultToString(Result result);
+
+    // For unit tests
+    uint32_t GetNumPoolConnections();
 }
 
 #endif // DM_HTTP_CLIENT_H

--- a/engine/dlib/src/dlib/sslsocket.cpp
+++ b/engine/dlib/src/dlib/sslsocket.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -19,6 +19,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include <dlib/file_descriptor.h>
 
@@ -60,20 +61,19 @@ struct CustomNetContext
 
 struct SSLSocket
 {
-    mbedtls_ssl_context*    m_SSLContext;
-    CustomNetContext*       m_SSLNetContext;
-    uint64_t                m_TimeStart;  // for read timeouts
-    uint64_t                m_TimeLimit1;
-    uint64_t                m_TimeLimit2;
+    mbedtls_entropy_context*    m_MbedEntropy;
+    mbedtls_ctr_drbg_context*   m_MbedCtrDrbg;
+    mbedtls_ssl_config*         m_MbedConf;
+    mbedtls_ssl_context*        m_SSLContext;
+    CustomNetContext*           m_SSLNetContext;
+    uint64_t                    m_TimeStart;  // for read timeouts
+    uint64_t                    m_TimeLimit1;
+    uint64_t                    m_TimeLimit2;
 };
 
 struct SSLSocketContext
 {
-    mbedtls_entropy_context     m_MbedEntropy;
-    mbedtls_ctr_drbg_context    m_MbedCtrDrbg;
-    mbedtls_ssl_config          m_MbedConf;
-    mbedtls_x509_crt            m_x509CertChain;
-    bool                        m_SslKeysSet;
+    mbedtls_x509_crt*           m_x509CertChain;
 } g_SSLSocketContext;
 
 #define MBEDTLS_RESULT_TO_STRING_CASE(x) case x: return #x;
@@ -154,57 +154,37 @@ static dmSocket::Result SSLToSocket(int r) {
 
 Result Initialize()
 {
-    g_SSLSocketContext.m_SslKeysSet = false;
-    mbedtls_ssl_config_init( &g_SSLSocketContext.m_MbedConf );
-    mbedtls_ctr_drbg_init( &g_SSLSocketContext.m_MbedCtrDrbg );
-    mbedtls_entropy_init( &g_SSLSocketContext.m_MbedEntropy );
-
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_debug_set_threshold( MBED_DEBUG_LEVEL );
-    mbedtls_ssl_conf_dbg( &g_SSLSocketContext.m_MbedConf, mbedtls_debug, 0 );
-#endif
-    int ret = 0;
-
-    const char* pers = "defold_ssl_client";
-    if( ( ret = mbedtls_ctr_drbg_seed( &g_SSLSocketContext.m_MbedCtrDrbg, mbedtls_entropy_func, &g_SSLSocketContext.m_MbedEntropy,
-                               (const unsigned char *) pers,
-                               strlen( pers ) ) ) != 0 )
-    {
-        SSL_LOGE("mbedtls_ctr_drbg_seed failed", ret);
-        return RESULT_SSL_INIT_FAILED;
-    }
-
-    if( ( ret = mbedtls_ssl_config_defaults( &g_SSLSocketContext.m_MbedConf,
-                    MBEDTLS_SSL_IS_CLIENT,
-                    MBEDTLS_SSL_TRANSPORT_STREAM,
-                    MBEDTLS_SSL_PRESET_DEFAULT ) ) != 0 )
-    {
-        SSL_LOGE("mbedtls_ssl_config_defaults failed", ret);
-        return RESULT_SSL_INIT_FAILED;
-    }
-
-    mbedtls_ssl_conf_rng( &g_SSLSocketContext.m_MbedConf, mbedtls_ctr_drbg_random, &g_SSLSocketContext.m_MbedCtrDrbg );
-    mbedtls_ssl_conf_authmode( &g_SSLSocketContext.m_MbedConf, MBEDTLS_SSL_VERIFY_NONE );
-
+    g_SSLSocketContext.m_x509CertChain = 0;
     return RESULT_OK;
 }
 
 Result Finalize()
 {
-    if (g_SSLSocketContext.m_SslKeysSet)
+    if (g_SSLSocketContext.m_x509CertChain)
     {
-        mbedtls_x509_crt_free( &g_SSLSocketContext.m_x509CertChain );
+        mbedtls_x509_crt_free( g_SSLSocketContext.m_x509CertChain );
+        free((void*)g_SSLSocketContext.m_x509CertChain);
     }
-    mbedtls_ssl_config_free( &g_SSLSocketContext.m_MbedConf );
-    mbedtls_ctr_drbg_free( &g_SSLSocketContext.m_MbedCtrDrbg );
-    mbedtls_entropy_free( &g_SSLSocketContext.m_MbedEntropy );
+    g_SSLSocketContext.m_x509CertChain = 0;
     return RESULT_OK;
 }
 
 Result SetSslPublicKeys(const uint8_t* key, uint32_t keylen)
 {
     // The size of buf, including the terminating \c NULL byte in case of PEM encoded data.
-    int ret = mbedtls_x509_crt_parse(&g_SSLSocketContext.m_x509CertChain, key, keylen + 1);
+    if (g_SSLSocketContext.m_x509CertChain)
+    {
+        mbedtls_x509_crt_free( g_SSLSocketContext.m_x509CertChain );
+        free((void*)g_SSLSocketContext.m_x509CertChain);
+    }
+
+    g_SSLSocketContext.m_x509CertChain = (mbedtls_x509_crt*)calloc(1, sizeof(mbedtls_x509_crt));
+    if (!g_SSLSocketContext.m_x509CertChain)
+    {
+        return RESULT_UNKNOWN;
+    }
+
+    int ret = mbedtls_x509_crt_parse(g_SSLSocketContext.m_x509CertChain, key, keylen + 1);
     if (ret != 0)
     {
         char buffer[512] = "";
@@ -212,8 +192,6 @@ Result SetSslPublicKeys(const uint8_t* key, uint32_t keylen)
         dmLogError("SSLSocket mbedtls_x509_crt_parse: %s0x%04x - %s", ret < 0 ? "-":"", ret < 0 ? -ret:ret, buffer);
         return RESULT_SSL_INIT_FAILED;
     }
-    g_SSLSocketContext.m_SslKeysSet = true;
-    mbedtls_ssl_conf_authmode( &g_SSLSocketContext.m_MbedConf, MBEDTLS_SSL_VERIFY_REQUIRED );
     return RESULT_OK;
 }
 
@@ -290,6 +268,47 @@ Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, SSLSocke
     SSLSocket* c = (SSLSocket*)malloc(sizeof(SSLSocket));
     memset(c, 0, sizeof(SSLSocket));
 
+#define MBED_CALLOC(_TYPE) (_TYPE*)calloc(1, sizeof(_TYPE))
+
+    c->m_MbedConf       = MBED_CALLOC(mbedtls_ssl_config);
+    c->m_MbedCtrDrbg    = MBED_CALLOC(mbedtls_ctr_drbg_context);
+    c->m_MbedEntropy    = MBED_CALLOC(mbedtls_entropy_context);
+    c->m_SSLContext     = MBED_CALLOC(mbedtls_ssl_context);
+    c->m_SSLNetContext  = MBED_CALLOC(CustomNetContext);
+
+#undef MBED_CALLOC
+
+    mbedtls_ssl_config_init( c->m_MbedConf );
+    mbedtls_ctr_drbg_init( c->m_MbedCtrDrbg );
+    mbedtls_entropy_init( c->m_MbedEntropy );
+
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_debug_set_threshold( MBED_DEBUG_LEVEL );
+    mbedtls_ssl_conf_dbg( c->m_MbedConf, mbedtls_debug, 0 );
+#endif
+    int ret = 0;
+
+    const char* pers = "defold_ssl_client";
+    if( ( ret = mbedtls_ctr_drbg_seed( c->m_MbedCtrDrbg, mbedtls_entropy_func, c->m_MbedEntropy,
+                               (const unsigned char *) pers,
+                               strlen( pers ) ) ) != 0 )
+    {
+        SSL_LOGE("mbedtls_ctr_drbg_seed failed", ret);
+        return RESULT_SSL_INIT_FAILED;
+    }
+
+    if( ( ret = mbedtls_ssl_config_defaults( c->m_MbedConf,
+                    MBEDTLS_SSL_IS_CLIENT,
+                    MBEDTLS_SSL_TRANSPORT_STREAM,
+                    MBEDTLS_SSL_PRESET_DEFAULT ) ) != 0 )
+    {
+        SSL_LOGE("mbedtls_ssl_config_defaults failed", ret);
+        return RESULT_SSL_INIT_FAILED;
+    }
+
+    mbedtls_ssl_conf_rng( c->m_MbedConf, mbedtls_ctr_drbg_random, c->m_MbedCtrDrbg );
+    mbedtls_ssl_conf_authmode( c->m_MbedConf, MBEDTLS_SSL_VERIFY_NONE );
+
     // In order to not have it block (unless timeout == 0)
     dmSocket::SetSendTimeout(socket, (int)timeout);
     dmSocket::SetReceiveTimeout(socket, (int)timeout);
@@ -299,23 +318,22 @@ Result New(dmSocket::Socket socket, const char* host, uint64_t timeout, SSLSocke
         int mbed_ssl_timeout = dmMath::Max((int)timeout, dmSocket::SOCKET_TIMEOUT) / 1000;
         mbed_ssl_timeout = dmMath::Max(1, mbed_ssl_timeout);
         // Never go below 1 second, since that's the lowest supported by this function anyways
-        mbedtls_ssl_conf_handshake_timeout(&g_SSLSocketContext.m_MbedConf, 1, mbed_ssl_timeout);
+        mbedtls_ssl_conf_handshake_timeout(c->m_MbedConf, 1, mbed_ssl_timeout);
     }
 
     // See comment about timeout in c->m_SSLNetContext
-    c->m_SSLContext     = (mbedtls_ssl_context*)malloc(sizeof(mbedtls_ssl_context));
-    c->m_SSLNetContext  = (CustomNetContext*)malloc(sizeof(CustomNetContext));
     c->m_SSLNetContext->m_Timeout = timeout;
-
     mbedtls_ssl_init( c->m_SSLContext );
 
-    if (g_SSLSocketContext.m_SslKeysSet)
+
+    // The size of buf, including the terminating \c NULL byte in case of PEM encoded data.
+    if (g_SSLSocketContext.m_x509CertChain)
     {
-        mbedtls_ssl_conf_ca_chain( &g_SSLSocketContext.m_MbedConf, &g_SSLSocketContext.m_x509CertChain, NULL);
+        mbedtls_ssl_conf_authmode( c->m_MbedConf, MBEDTLS_SSL_VERIFY_REQUIRED );
+        mbedtls_ssl_conf_ca_chain( c->m_MbedConf, g_SSLSocketContext.m_x509CertChain, NULL);
     }
 
-    int ret = 0;
-    if( ( ret = mbedtls_ssl_setup( c->m_SSLContext, &g_SSLSocketContext.m_MbedConf ) ) != 0 )
+    if( ( ret = mbedtls_ssl_setup( c->m_SSLContext, c->m_MbedConf ) ) != 0 )
     {
         SSL_LOGE("mbedtls_ssl_setup failed", ret);
         return RESULT_HANDSHAKE_FAILED;
@@ -389,6 +407,10 @@ Result Delete(SSLSocket* socket)
         socket->m_SSLNetContext->m_Context.fd = -1;
         mbedtls_net_free( (mbedtls_net_context*)socket->m_SSLNetContext );
         mbedtls_ssl_free( socket->m_SSLContext );
+        mbedtls_ssl_config_free( socket->m_MbedConf );
+        mbedtls_ctr_drbg_free( socket->m_MbedCtrDrbg );
+        mbedtls_entropy_free( socket->m_MbedEntropy );
+
         free(socket->m_SSLNetContext);
         free(socket->m_SSLContext);
         free(socket);

--- a/engine/dlib/src/dmsdk/dlib/sslsocket.h
+++ b/engine/dlib/src/dmsdk/dlib/sslsocket.h
@@ -48,6 +48,7 @@ namespace dmSSLSocket
     enum Result
     {
         RESULT_OK = 0,
+        RESULT_UNKNOWN = -1,
         RESULT_SSL_INIT_FAILED = -2000,
         RESULT_HANDSHAKE_FAILED = -2001,
         RESULT_WOULDBLOCK = -2002,

--- a/engine/dlib/src/test/http_server/TestHttpServer.java
+++ b/engine/dlib/src/test/http_server/TestHttpServer.java
@@ -322,19 +322,19 @@ public class TestHttpServer extends AbstractHandler
         {
             Server server = new Server();
             SocketConnector connector = new SocketConnector();
-            connector.setMaxIdleTime(1000);
+            connector.setMaxIdleTime(10000);
             server.addConnector(connector);
 
             SslSocketConnector sslConnector = new SslSocketConnector();
-            sslConnector.setHandshakeTimeout(1000);
-            sslConnector.setMaxIdleTime(1000);
+            sslConnector.setHandshakeTimeout(10000);
+            sslConnector.setMaxIdleTime(10000);
             sslConnector.setKeystore("src/test/data/keystore");
             sslConnector.setKeyPassword("defold");
             server.addConnector(sslConnector);
 
             TestSslSocketConnector testsslConnector = new TestSslSocketConnector();
-            testsslConnector.setHandshakeTimeout(1000);
-            testsslConnector.setMaxIdleTime(1000);
+            testsslConnector.setHandshakeTimeout(10000);
+            testsslConnector.setMaxIdleTime(10000);
             testsslConnector.setKeystore("src/test/data/keystore");
             testsslConnector.setKeyPassword("defold");
             server.addConnector(testsslConnector);


### PR DESCRIPTION
If two ssl connections happens to be made at the same time, it was possible for them to use and write to shared data in an non thread safe manner.
This fix made sure that each https request owns its own ssl config data.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
