### PR TITLE
Additional fixes to root-level game object transforms inside referenced collections when building from the editor

### DIFF
--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -147,6 +147,9 @@
 (defn quat->euler [^Quat4d quat]
   (quat-components->euler (.getX quat) (.getY quat) (.getZ quat) (.getW quat)))
 
+(defn clj-quat->euler [[^double x ^double y ^double z ^double w]]
+  (quat-components->euler x y z w))
+
 (defn offset-scaled
   ^Tuple3d [^Tuple3d original ^Tuple3d offset ^double scale-factor]
   (doto ^Tuple3d (.clone original) ; Overwritten - we just want an instance.

--- a/editor/src/clj/editor/pose.clj
+++ b/editor/src/clj/editor/pose.clj
@@ -85,7 +85,7 @@
        (* vz qx qx)
        (* vz qy qy))))
 
-(defn- rotate-quaternion [[^double ax ^double ay ^double az ^double aw] [^double bx ^double by ^double bz ^double bw]]
+(defn- multiply-quaternion [[^double ax ^double ay ^double az ^double aw] [^double bx ^double by ^double bz ^double bw]]
   (vector-of
     :double
     (- (+ (* ax bw)
@@ -223,10 +223,10 @@
     (cond-> child-pose
 
             parent-scaled
-            (assoc :scale (multiply-vector child-scale parent-scale))
+            (assoc :scale (multiply-vector parent-scale child-scale))
 
             parent-rotated
-            (assoc :rotation (rotate-quaternion child-rotation parent-rotation))
+            (assoc :rotation (multiply-quaternion parent-rotation child-rotation))
 
             (or parent-scaled parent-rotated parent-translated)
             (assoc :translation

--- a/editor/test/editor/pose_test.clj
+++ b/editor/test/editor/pose_test.clj
@@ -11,6 +11,10 @@
   (mapv #(math/round-with-precision % 0.001)
         numbers))
 
+(defn- round-euler-rotation [pose]
+  (round-numbers
+    (math/clj-quat->euler (:rotation pose))))
+
 (deftest pose?-test
   (is (false? (pose/pose? nil)))
   (is (false? (pose/pose? {:translation [0.0 0.0 0.0]
@@ -165,10 +169,17 @@
   (is (= (pose/euler-rotation-pose 0.0 -40.0 0.0)
          (pose/pre-multiply (pose/euler-rotation-pose 0.0 -10.0 0.0)
                             (pose/euler-rotation-pose 0.0 -30.0 0.0))))
-  (is (= (pose/euler-rotation-pose 45.0 45.0 45.0)
-         (-> (pose/euler-rotation-pose 0.0 45.0 0.0)
-             (pose/pre-multiply (pose/euler-rotation-pose 0.0 0.0 45.0))
-             (pose/pre-multiply (pose/euler-rotation-pose 45.0 0.0 0.0)))))
+  (is (= (pose/rotation-pose -0.6615634399999999 -0.24966735999999995 -0.2496673599999999 0.6615634400000001)
+         (pose/pre-multiply (pose/rotation-pose -0.5 -0.5 -0.4999999999999999 0.5000000000000001)
+                            (pose/rotation-pose 0.0 0.41189608 0.0 0.9112308))))
+  (is (= [-90.0 135.0 0.0]
+         (round-euler-rotation
+           (pose/pre-multiply (pose/euler-rotation-pose 0.0 90.0 0.0)
+                              (pose/euler-rotation-pose 45.0 0.0 90.0)))))
+  (is (= [3.342 103.606 68.165]
+         (round-euler-rotation
+           (pose/pre-multiply (pose/euler-rotation-pose 45.0 45.0 45.0)
+                              (pose/euler-rotation-pose 10.0 20.0 30.0)))))
   (let [pose (pose/pre-multiply pose/default
                                 (pose/euler-rotation-pose -90.0 180.0 0.0))]
     (is (= [0.0 0.0 0.0] (:translation pose)))


### PR DESCRIPTION
Fixes #7519
(Regression introduced by #7504)

### User-facing changes
* Additional fixes to root-level game object transforms inside referenced collections when building from the editor.