### PR TITLE
Upload Defold SDK and reference documentation to GitHub on release

### DIFF
--- a/build_tools/release_to_github.py
+++ b/build_tools/release_to_github.py
@@ -148,7 +148,7 @@ def release(config, tag_name, release_sha, s3_release, release_name=None, body=N
                                           'Defold-x86_64-win32.zip')
 
     def is_main_file(path):
-        return os.path.basename(path) in ('bob.jar',) or is_editor_file(path)
+        return os.path.basename(path) in ('bob.jar', 'defoldsdk.zip', 'ref-doc.zip') or is_editor_file(path)
 
     def is_platform_file(path):
         return os.path.basename(path) in ('gdc',

--- a/build_tools/release_to_github.py
+++ b/build_tools/release_to_github.py
@@ -148,7 +148,7 @@ def release(config, tag_name, release_sha, s3_release, release_name=None, body=N
                                           'Defold-x86_64-win32.zip')
 
     def is_main_file(path):
-        return os.path.basename(path) in ('bob.jar', 'defoldsdk.zip', 'ref-doc.zip') or is_editor_file(path)
+        return os.path.basename(path) in ('bob.jar', 'ref-doc.zip') or is_editor_file(path) or 'engine/defoldsdk.zip' in path
 
     def is_platform_file(path):
         return os.path.basename(path) in ('gdc',


### PR DESCRIPTION
This change will upload the defoldsdk.zip and ref-doc.zip to GitHub on every release of Defold.

Fixes #7518 