### PR TITLE
Add an option to open a project from the editor

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -85,6 +85,7 @@
   (:import [clojure.lang ExceptionInfo]
            [com.defold.editor Editor]
            [com.defold.editor UIUtil]
+           [com.dynamo.bob Platform]
            [com.sun.javafx.scene NodeHelper]
            [java.io BufferedReader File IOException]
            [java.net URL]
@@ -1472,6 +1473,15 @@ If you do not specifically require different script states, consider changing th
 (handler/defhandler :reload-stylesheet :global
   (run [] (ui/reload-root-styles!)))
 
+(handler/defhandler :open-project :global
+  (active? [] (and (system/defold-resourcespath) (system/defold-launcherpath)))
+  (run [] (let [resources-path (system/defold-resourcespath)
+                install-dir (.getCanonicalFile
+                              (case (.getOs (Platform/getHostPlatform))
+                                "macos" (io/file resources-path "../../")
+                                ("linux" "win32") (io/file resources-path)))]
+            (process/start! (system/defold-launcherpath) [] {:directory install-dir}))))
+
 (handler/register-menu! ::menubar
   [{:label "File"
     :id ::file
@@ -1512,6 +1522,8 @@ If you do not specifically require different script states, consider changing th
                {:label "Hot Reload"
                 :command :hot-reload}
                {:label :separator}
+               {:label "Open Project..."
+                :command :open-project}
                {:label "Preferences..."
                 :command :preferences}
                {:label "Quit"

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -200,27 +200,19 @@ public class ResourceUnpacker {
         }
 
         if (unpackPath != null) {
-            return ensureDirectory(Paths.get(unpackPath), true);
+            return ensureDirectory(Paths.get(unpackPath));
         }
 
-        Path supportPath = Editor.getSupportPath();
         String sha1 = System.getProperty(DEFOLD_EDITOR_SHA1_KEY);
-        if (sha1 != null) {
-            return ensureDirectory(supportPath.resolve(Paths.get("unpack", sha1)), false);
-        }
-
-        Path tmpDir = Files.createTempDirectory("defold-unpack");
+        Path tmpDir = Files.createTempDirectory("defold-unpack" + (sha1 == null ? "" : "-" + sha1));
         deleteOnExit(tmpDir);
         return tmpDir;
     }
 
-    private static Path ensureDirectory(Path path, boolean userDir) throws IOException {
+    private static Path ensureDirectory(Path path) {
         File f = path.toFile();
         if (!f.exists()) {
             f.mkdirs();
-            if (!userDir) {
-                deleteOnExit(path);
-            }
         }
         return path;
     }


### PR DESCRIPTION
User-facing changes: Added a `Open Project...` menu item in the File menu. It will launch another instance of the editor.

Technical notes: The code to launch the process is based on the code in the `updater.clj` file. A notable modification has been made to the file unpacking process. Instead of using a stable folder in the "editor support path" location, we now always unpack files to a temporary folder. It turned out that using the support path was a mistake because it is intended for files that persist between application and system restarts, whereas the unpacked files were always deleted when the editor was closed. This meant that the behavior of the unpacked files was similar to that of a temporary directory, but they were being stored in the wrong place. This shared storage location was causing issues with running multiple instances of the editor at the same time — shutdown of one instance of the editor broke another.

Fixes #5689 