### PR TITLE
Make sure to update euler or quaternion rotation before returning it to the user

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject.cpp
+++ b/engine/gameobject/src/gameobject/gameobject.cpp
@@ -2434,11 +2434,16 @@ namespace dmGameObject
         return a[0] == b[0] && a[1] == b[1] && a[2] == b[2];
     }
 
-    static void CheckEuler(Instance* instance)
+    static bool HasEulerChanged(Instance* instance)
     {
         Vector3& euler = instance->m_EulerRotation;
         Vector3& prev_euler = instance->m_PrevEulerRotation;
-        if (!Vec3Equals((uint32_t*)(&euler), (uint32_t*)(&prev_euler)))
+        return !Vec3Equals((uint32_t*)(&euler), (uint32_t*)(&prev_euler));
+    }
+
+    static void CheckEuler(Instance* instance)
+    {
+        if (HasEulerChanged(instance))
         {
             UpdateEulerToRotation(instance);
         }
@@ -3276,6 +3281,10 @@ namespace dmGameObject
             }
             else if (property_id == PROP_ROTATION)
             {
+                if (HasEulerChanged(instance))
+                {
+                    UpdateEulerToRotation(instance);
+                }
                 float* rotation = instance->m_Transform.GetRotationPtr();
                 out_value.m_ValuePtr = rotation;
                 out_value.m_ElementIds[0] = PROP_ROTATION_X;
@@ -3286,31 +3295,50 @@ namespace dmGameObject
             }
             else if (property_id == PROP_ROTATION_X)
             {
+                if (HasEulerChanged(instance))
+                {
+                    UpdateEulerToRotation(instance);
+                }
                 float* rotation = instance->m_Transform.GetRotationPtr();
                 out_value.m_ValuePtr = rotation;
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }
             else if (property_id == PROP_ROTATION_Y)
             {
+                if (HasEulerChanged(instance))
+                {
+                    UpdateEulerToRotation(instance);
+                }
                 float* rotation = instance->m_Transform.GetRotationPtr();
                 out_value.m_ValuePtr = rotation + 1;
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }
             else if (property_id == PROP_ROTATION_Z)
             {
+                if (HasEulerChanged(instance))
+                {
+                    UpdateEulerToRotation(instance);
+                }
                 float* rotation = instance->m_Transform.GetRotationPtr();
                 out_value.m_ValuePtr = rotation + 2;
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }
             else if (property_id == PROP_ROTATION_W)
             {
+                if (HasEulerChanged(instance))
+                {
+                    UpdateEulerToRotation(instance);
+                }
                 float* rotation = instance->m_Transform.GetRotationPtr();
                 out_value.m_ValuePtr = rotation + 3;
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }
             else if (property_id == PROP_EULER)
             {
-                UpdateRotationToEuler(instance);
+                if (!HasEulerChanged(instance))
+                {
+                    UpdateRotationToEuler(instance);
+                }
                 out_value.m_ValuePtr = (float*)&instance->m_EulerRotation;
                 out_value.m_ElementIds[0] = PROP_EULER_X;
                 out_value.m_ElementIds[1] = PROP_EULER_Y;
@@ -3319,19 +3347,28 @@ namespace dmGameObject
             }
             else if (property_id == PROP_EULER_X)
             {
-                UpdateRotationToEuler(instance);
-                out_value.m_ValuePtr = ((float*)&instance->m_EulerRotation);
+                if (!HasEulerChanged(instance))
+                {
+                    UpdateRotationToEuler(instance);
+                }
+               out_value.m_ValuePtr = ((float*)&instance->m_EulerRotation);
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }
             else if (property_id == PROP_EULER_Y)
             {
-                UpdateRotationToEuler(instance);
+                if (!HasEulerChanged(instance))
+                {
+                    UpdateRotationToEuler(instance);
+                }
                 out_value.m_ValuePtr = ((float*)&instance->m_EulerRotation) + 1;
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }
             else if (property_id == PROP_EULER_Z)
             {
-                UpdateRotationToEuler(instance);
+                if (!HasEulerChanged(instance))
+                {
+                    UpdateRotationToEuler(instance);
+                }
                 out_value.m_ValuePtr = ((float*)&instance->m_EulerRotation) + 2;
                 out_value.m_Variant = PropertyVar(*out_value.m_ValuePtr);
             }


### PR DESCRIPTION
This fixes an issue when getting the `rotation` or `euler` property of a game object in a `go.animate()` callback where the value was not updated to the final value at the time when the property was read.

In the case when getting an euler angle using `go.get()` and the **euler angle has not changed** it is first updated from the quaternion value. And in the case when getting a quaternion rotation using `go.get()` and the **euler angle has changed** the quaternion is updated with the value from the euler angle.

Fixes #7253 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
