### PR TITLE
Changed default animation playback mode for implicit one-image atlas animations

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -200,7 +200,7 @@
                          :fps             30
                          :flip-horizontal false
                          :flip-vertical   false
-                         :playback        :playback-once-forward}))
+                         :playback        :playback-none}))
 
 (defn- unique-id-error [node-id id id-counts]
   (or (validation/prop-error :fatal node-id :id validation/prop-empty? id "Id")


### PR DESCRIPTION
This change makes sure that implicit single image atlas animations use a playback mode of "none". Previously an editor build set the playback mode to "once forward" while a bundle set it to "none". This causes problems since "once forward" will generate an "animation_done" message while a playback mode of "none" doesn't.

Fixes #7263 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
