### PR TITLE
Show Defold version in window title of main editor window

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1680,7 +1680,7 @@ If you do not specifically require different script states, consider changing th
            (project/sub-select project-id active-resource-node sub-selection open-resource-nodes)))))))
 
 (defn- make-title
-  ([] (str "Defold Editor " (System/getProperty "defold.version" "No version")))
+  ([] (str "Defold " (System/getProperty "defold.version" "No version")))
   ([project-title] (str project-title " - " (make-title))))
 
 (defn- refresh-app-title! [^Stage stage project]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1680,7 +1680,7 @@ If you do not specifically require different script states, consider changing th
            (project/sub-select project-id active-resource-node sub-selection open-resource-nodes)))))))
 
 (defn- make-title
-  ([] (str "Defold Editor - " (System/getProperty "defold.version" "No version")))
+  ([] (str "Defold Editor " (System/getProperty "defold.version" "No version")))
   ([project-title] (str project-title " - " (make-title))))
 
 (defn- refresh-app-title! [^Stage stage project]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1680,7 +1680,7 @@ If you do not specifically require different script states, consider changing th
            (project/sub-select project-id active-resource-node sub-selection open-resource-nodes)))))))
 
 (defn- make-title
-  ([] (str "Defold " (System/getProperty "defold.version" "No version")))
+  ([] (str "Defold " (System/getProperty "defold.version" "(No version)")))
   ([project-title] (str project-title " - " (make-title))))
 
 (defn- refresh-app-title! [^Stage stage project]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1680,7 +1680,9 @@ If you do not specifically require different script states, consider changing th
            (project/sub-select project-id active-resource-node sub-selection open-resource-nodes)))))))
 
 (defn- make-title
-  ([] (str "Defold " (System/getProperty "defold.version" "(No version)")))
+  ([] (if-some [version (system/defold-version)]
+        (str "Defold " version)
+        "Defold"))
   ([project-title] (str project-title " - " (make-title))))
 
 (defn- refresh-app-title! [^Stage stage project]

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1680,7 +1680,7 @@ If you do not specifically require different script states, consider changing th
            (project/sub-select project-id active-resource-node sub-selection open-resource-nodes)))))))
 
 (defn- make-title
-  ([] "Defold Editor 2.0")
+  ([] (str "Defold Editor - " (System/getProperty "defold.version" "No version")))
   ([project-title] (str project-title " - " (make-title))))
 
 (defn- refresh-app-title! [^Stage stage project]


### PR DESCRIPTION
The main editor window title shows the confusing "Defold Editor 2.0" text. This version number has no correlation to the actual Defold version used. This has now been changed to instead show the actual Defold version used, eg "Defold Editor 1.4.5".

Fixes #7533 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
