### PR TITLE
Support 'oneof' blocks in our DDF layer

### DIFF
--- a/engine/ddf/src/ddf/ddf.h
+++ b/engine/ddf/src/ddf/ddf.h
@@ -22,7 +22,7 @@
 
 #define DDF_OFFSET_OF(T, F) (((uintptr_t) (&((T*) 16)->F)) - 16)
 #define DDF_MAX_FIELDS (128)
-#define DDF_NO_ONE_OF_INDEX 0xFF
+#define DDF_NO_ONE_OF_INDEX 0
 
 namespace dmDDF
 {
@@ -52,7 +52,8 @@ namespace dmDDF
         Descriptor* m_MessageDescriptor;
         uint32_t    m_Offset;
         const char* m_DefaultValue;
-        uint8_t     m_OneOfIndex;
+        uint8_t     m_OneOfIndex : 7;
+        uint8_t     m_OneOfSet   : 1;
     };
 
     struct Descriptor

--- a/engine/ddf/src/ddf/ddf.h
+++ b/engine/ddf/src/ddf/ddf.h
@@ -22,6 +22,7 @@
 
 #define DDF_OFFSET_OF(T, F) (((uintptr_t) (&((T*) 16)->F)) - 16)
 #define DDF_MAX_FIELDS (128)
+#define DDF_NO_ONE_OF_INDEX 0xFF
 
 namespace dmDDF
 {
@@ -51,6 +52,7 @@ namespace dmDDF
         Descriptor* m_MessageDescriptor;
         uint32_t    m_Offset;
         const char* m_DefaultValue;
+        uint8_t     m_OneOfIndex;
     };
 
     struct Descriptor

--- a/engine/ddf/src/ddf/ddf_load.cpp
+++ b/engine/ddf/src/ddf/ddf_load.cpp
@@ -163,6 +163,8 @@ namespace dmDDF
                     assert(field_index < DDF_MAX_FIELDS);
                     read_fields[field_index] = 1;
 
+                    // do something here.. 
+
                     Result e;
                     e = message->ReadField(load_context, (WireType) type, field, input_buffer);
                     if (e != RESULT_OK)
@@ -181,7 +183,11 @@ namespace dmDDF
         for (int i = 0; i < desc->m_FieldCount; ++i)
         {
             const FieldDescriptor* f = &desc->m_Fields[i];
-            if (f->m_Label == LABEL_REQUIRED && read_fields[i] == 0)
+            if (f->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
+            {
+                continue;
+            }
+            else if (f->m_Label == LABEL_REQUIRED && read_fields[i] == 0)
             {
                 // Required but not read
                 dmLogWarning("Missing required field %s.%s", desc->m_Name, f->m_Name);

--- a/engine/ddf/src/ddf/ddf_load.cpp
+++ b/engine/ddf/src/ddf/ddf_load.cpp
@@ -111,6 +111,12 @@ namespace dmDDF
         for (int i = 0; i < desc->m_FieldCount; ++i)
         {
             const FieldDescriptor* f = &desc->m_Fields[i];
+            // We cannot support default values for oneof fields currently as we don't know which one to take
+            if (f->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
+            {
+                dmLogWarning("Default values for 'oneof' fields are not supported");
+                continue;
+            }
             DoLoadDefaultField(load_context, f, message);
         }
     }
@@ -168,6 +174,12 @@ namespace dmDDF
                     if (e != RESULT_OK)
                     {
                         return e;
+                    }
+
+                    if (field->m_OneOfIndex != DDF_NO_ONE_OF_INDEX)
+                    {
+                        FieldDescriptor* field_non_const = (FieldDescriptor*) field;
+                        field_non_const->m_OneOfSet = 1;
                     }
                 }
             }

--- a/engine/ddf/src/ddf/ddf_load.cpp
+++ b/engine/ddf/src/ddf/ddf_load.cpp
@@ -163,8 +163,6 @@ namespace dmDDF
                     assert(field_index < DDF_MAX_FIELDS);
                     read_fields[field_index] = 1;
 
-                    // do something here.. 
-
                     Result e;
                     e = message->ReadField(load_context, (WireType) type, field, input_buffer);
                     if (e != RESULT_OK)

--- a/engine/ddf/src/ddf/ddf_save.cpp
+++ b/engine/ddf/src/ddf/ddf_save.cpp
@@ -38,6 +38,11 @@ namespace dmDDF
             FieldDescriptor* field_desc = &desc->m_Fields[i];
             Type type = (Type) field_desc->m_Type;
 
+            if (field_desc->m_OneOfIndex != DDF_NO_ONE_OF_INDEX && field_desc->m_OneOfSet == 0)
+            {
+                continue;
+            }
+
     #define DDF_SAVEMESSAGE_CASE(t, wt, func) \
             write_result = output_stream.WriteTag(field_desc->m_Number, wt) && \
                            output_stream.func(*((t*) data)); \

--- a/engine/ddf/src/ddfc.py
+++ b/engine/ddf/src/ddfc.py
@@ -371,10 +371,13 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
 
         lst.append(tpl)
 
+    # For clarity, set the 'm_OneOfSet' bit in the field descriptor to zero
+    one_of_index_set = 0
+
     if len(lst) > 0:
         pp_cpp.begin("dmDDF::FieldDescriptor %s_%s_FIELDS_DESCRIPTOR[] = ", namespace, message_type.name)
         for name, number, type, label, one_of_index, msg_desc, offset, default_value in lst:
-            pp_cpp.p('{ "%s", %d, %d, %d, %s, %s, %s, %d},'  % (name, number, type, label, msg_desc, offset, default_value, one_of_index))
+            pp_cpp.p('{ "%s", %d, %d, %d, %s, %s, %s, %d, %d},'  % (name, number, type, label, msg_desc, offset, default_value, one_of_index, one_of_index_set))
         pp_cpp.end()
     else:
         pp_cpp.p("dmDDF::FieldDescriptor* %s_%s_FIELDS_DESCRIPTOR = 0x0;", namespace, message_type.name)

--- a/engine/ddf/src/ddfc.py
+++ b/engine/ddf/src/ddfc.py
@@ -181,6 +181,7 @@ def dot_to_cxx_namespace(str):
 
 def to_cxx_struct(context, pp, message_type):
     # Calculate maximum length of "type"
+
     max_len = 0
     for f in message_type.field:
         l = 0
@@ -213,10 +214,28 @@ def to_cxx_struct(context, pp, message_type):
     for nt in message_type.nested_type:
         to_cxx_struct(context, pp, nt)
 
+    oneof_scope = None
+
     for f in message_type.field:
         field_name = to_camel_case(f.name)
         field_align = context.should_align_field(f)
         align_str = ""
+
+        if f.HasField("oneof_index"):
+
+            oneof_decl = message_type.oneof_decl[f.oneof_index]
+
+            if oneof_scope == None or oneof_scope != oneof_decl.name:
+                if oneof_scope != None:
+                    pp.end(" m_%s", to_camel_case(oneof_scope))
+
+                oneof_scope = oneof_decl.name
+                pp.begin("union")
+        else:
+            if oneof_scope != None:
+                pp.end(" m_%s", to_camel_case(oneof_scope))
+                oneof_scope = None
+
         if (field_align):
             align_str = "DM_ALIGNED(16) "
         if f.label == FieldDescriptor.LABEL_REPEATED or f.type == FieldDescriptor.TYPE_BYTES:
@@ -246,6 +265,10 @@ def to_cxx_struct(context, pp, message_type):
             p(align_str + context.get_field_type_name(f), field_name)
         else:
             p(align_str + type_to_ctype[f.type], field_name)
+
+    if oneof_scope != None:
+        pp.end(" m_%s", to_camel_case(oneof_scope))
+
     pp.p('')
     pp.p('static dmDDF::Descriptor* m_DDFDescriptor;')
     pp.p('static const uint64_t m_DDFHash;')
@@ -307,9 +330,24 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
         if '"' in default:
             pp_cpp.p('char DM_ALIGNED(4) %s_%s_%s_DEFAULT_VALUE[] = %s;', namespace, message_type.name, f.name, default)
 
+    oneof_descs = {}
+    oneof_scope = None
     lst = []
     for f in message_type.field:
-        tpl = (f.name, f.number, f.type, f.label)
+
+        one_of_index = 0xff
+
+        if f.HasField("oneof_index"):
+            oneof_decl = message_type.oneof_decl[f.oneof_index]
+            one_of_index = f.oneof_index
+
+            if oneof_scope == None or oneof_scope != oneof_decl.name:
+                oneof_scope = oneof_decl.name
+        else:
+            if oneof_scope != None:
+                oneof_scope = None
+
+        tpl = (f.name, f.number, f.type, f.label, one_of_index)
         if f.type ==  FieldDescriptor.TYPE_MESSAGE:
             tmp = f.type_name.replace(".", "_")
             if tmp.startswith("_"):
@@ -318,7 +356,11 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
         else:
             tpl += ("0x0", )
 
-        tpl += ("(uint32_t)DDF_OFFSET_OF(%s::%s, m_%s)" % (namespace.replace("_", "::"), message_type.name, to_camel_case(f.name)), )
+        oneof_scope_name = ""
+        if oneof_scope != None:
+            oneof_scope_name = "m_%s." % to_camel_case(oneof_scope)
+
+        tpl += ("(uint32_t)DDF_OFFSET_OF(%s::%s, %sm_%s)" % (namespace.replace("_", "::"), message_type.name, oneof_scope_name, to_camel_case(f.name)), )
 
         default = to_cxx_default_value_string(context, f)
         if '"' in default:
@@ -330,8 +372,8 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
 
     if len(lst) > 0:
         pp_cpp.begin("dmDDF::FieldDescriptor %s_%s_FIELDS_DESCRIPTOR[] = ", namespace, message_type.name)
-        for name, number, type, label, msg_desc, offset, default_value in lst:
-            pp_cpp.p('{ "%s", %d, %d, %d, %s, %s, %s},'  % (name, number, type, label, msg_desc, offset, default_value))
+        for name, number, type, label, one_of_index, msg_desc, offset, default_value in lst:
+            pp_cpp.p('{ "%s", %d, %d, %d, %s, %s, %s, %d},'  % (name, number, type, label, msg_desc, offset, default_value, one_of_index))
         pp_cpp.end()
     else:
         pp_cpp.p("dmDDF::FieldDescriptor* %s_%s_FIELDS_DESCRIPTOR = 0x0;", namespace, message_type.name)
@@ -750,14 +792,13 @@ if __name__ == '__main__':
     for pf in request.proto_file:
         if pf.name == request.file_to_generate[0]:
             namespace = None
-            for x in pf.options.ListFields():
-                if x[0].name == 'ddf_namespace':
-                    namespace = x[1]
-
             includes = []
+
             for x in pf.options.ListFields():
                 if x[0].name == 'ddf_includes':
                     includes = x[1].split()
+                elif x[0].name == 'ddf_namespace':
+                    namespace = x[1]
 
             if options.cxx:
                 compile_cxx(context, pf, request.file_to_generate[0], namespace, includes)

--- a/engine/ddf/src/ddfc.py
+++ b/engine/ddf/src/ddfc.py
@@ -330,7 +330,6 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
         if '"' in default:
             pp_cpp.p('char DM_ALIGNED(4) %s_%s_%s_DEFAULT_VALUE[] = %s;', namespace, message_type.name, f.name, default)
 
-    oneof_descs = {}
     oneof_scope = None
     lst = []
     for f in message_type.field:

--- a/engine/ddf/src/ddfc.py
+++ b/engine/ddf/src/ddfc.py
@@ -333,12 +333,14 @@ def to_cxx_descriptor(context, pp_cpp, pp_h, message_type, namespace_lst):
     oneof_scope = None
     lst = []
     for f in message_type.field:
-
-        one_of_index = 0xff
+        one_of_index = 0
 
         if f.HasField("oneof_index"):
             oneof_decl = message_type.oneof_decl[f.oneof_index]
-            one_of_index = f.oneof_index
+
+            # indices start at zero, but we need to distinguish between which fields belong
+            # to a oneof block somehow
+            one_of_index = f.oneof_index + 1
 
             if oneof_scope == None or oneof_scope != oneof_decl.name:
                 oneof_scope = oneof_decl.name

--- a/engine/ddf/src/test/test_ddf.cpp
+++ b/engine/ddf/src/test/test_ddf.cpp
@@ -793,7 +793,33 @@ TEST(OneOfTests, LoadSimple)
     ASSERT_EQ(1337, message->m_OneOfFieldOne.m_IntVal);
     ASSERT_EQ(99,   message->m_NotInOneof);
     ASSERT_EQ(10,   message->m_NestedVal.m_NestedFieldName.m_NestedIntVal);
+    ASSERT_EQ(13,   message->m_NestedVal.m_NestedButNotInOneof);
     ASSERT_STREQ(simple_string_valid.c_str(), message->m_OneOfFieldTwo.m_SimpleStringTwo);
+
+    dmDDF::FreeMessage(message);
+}
+
+TEST(OneOfTests, Repeated)
+{
+    TestDDF::OneOfMessageRepeat oneof_message_desc;
+
+    TestDDF::OneOfMessageRepeat::Nested* nested_one_valid = oneof_message_desc.add_nested_one_of();
+    nested_one_valid->set_val_b(true);
+
+    TestDDF::OneOfMessageRepeat::Nested* nested_two_valid = oneof_message_desc.add_nested_one_of();
+    nested_two_valid->set_val_a(256);
+
+    std::string msg_str   = oneof_message_desc.SerializeAsString();
+    const char* msg_buf   = msg_str.c_str();
+    uint32_t msg_buf_size = msg_str.size();
+
+    DUMMY::TestDDF::OneOfMessageRepeat* message;
+    dmDDF::Result e = dmDDF::LoadMessage((void*) msg_buf, msg_buf_size, &DUMMY::TestDDF_OneOfMessageRepeat_DESCRIPTOR, (void**)&message);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+
+    ASSERT_EQ(2,    message->m_NestedOneOf.m_Count);
+    ASSERT_EQ(true, message->m_NestedOneOf[0].m_Values.m_ValB);
+    ASSERT_EQ(256,  message->m_NestedOneOf[1].m_Values.m_ValA);
 
     dmDDF::FreeMessage(message);
 }

--- a/engine/ddf/src/test/test_ddf.cpp
+++ b/engine/ddf/src/test/test_ddf.cpp
@@ -821,6 +821,7 @@ TEST(OneOfTests, Repeated)
     ASSERT_EQ(2,            message->m_NestedOneOf.m_Count);
     ASSERT_EQ(256,          message->m_NestedOneOf[0].m_Values.m_ValB);
     ASSERT_EQ(large_number, message->m_NestedOneOf[1].m_Values.m_ValA);
+    ASSERT_EQ(0,            message->m_NestedOneOfWithDefaults.m_Values.m_ValA);
 
     std::string save_str;
     e = DDFSaveToString(message, &DUMMY::TestDDF_OneOfMessageRepeat_DESCRIPTOR, save_str);

--- a/engine/ddf/src/test/test_ddf.cpp
+++ b/engine/ddf/src/test/test_ddf.cpp
@@ -875,6 +875,37 @@ TEST(OneOfTests, Save)
     dmDDF::FreeMessage(message);
 }
 
+TEST(OneOfTests, Nested)
+{
+    TestDDF::OneOfMessageNested oneof_message_desc;
+
+    TestDDF::OneOfMessageNested_SubTwo* sub_two = new TestDDF::OneOfMessageNested_SubTwo();
+    TestDDF::OneOfMessageNested_SubOne* sub_one_for_two = new TestDDF::OneOfMessageNested_SubOne;
+    sub_one_for_two->set_value_two(13.0f);
+    sub_one_for_two->set_non_one_of(1337);
+
+    sub_two->set_allocated_value_sub_one(sub_one_for_two);
+    oneof_message_desc.set_allocated_two(sub_two);
+
+    std::string msg_str   = oneof_message_desc.SerializeAsString();
+    const char* msg_buf   = msg_str.c_str();
+    uint32_t msg_buf_size = msg_str.size();
+
+    DUMMY::TestDDF::OneOfMessageNested* message;
+    dmDDF::Result e = dmDDF::LoadMessage((void*) msg_buf, msg_buf_size, &DUMMY::TestDDF_OneOfMessageNested_DESCRIPTOR, (void**)&message);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+
+    ASSERT_NEAR(13.0f, message->m_Composite.m_Two.m_Values.m_ValueSubOne.m_Values.m_ValueTwo, 0.0001f);
+    ASSERT_EQ(1337, message->m_Composite.m_Two.m_Values.m_ValueSubOne.m_NonOneOf);
+
+    std::string save_str;
+    e = DDFSaveToString(message, &DUMMY::TestDDF_OneOfMessageNested_DESCRIPTOR, save_str);
+    ASSERT_EQ(dmDDF::RESULT_OK, e);
+    ASSERT_EQ(msg_str, save_str);
+
+    dmDDF::FreeMessage(message);
+}
+
 int main(int argc, char **argv)
 {
     dmDDF::RegisterAllTypes();

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -268,6 +268,8 @@ message OneOfMessage
             int32  nested_int_val    = 1;
             string nested_string_val = 2;
         }
+
+        optional int32 nested_but_not_in_oneof = 3 [ default = 13 ];
     }
 
     oneof one_of_field_one
@@ -286,4 +288,18 @@ message OneOfMessage
 
     optional int32 not_in_oneof = 7;
     optional Nested nested_val  = 8;
+}
+
+message OneOfMessageRepeat
+{
+    message Nested
+    {
+        oneof values
+        {
+            int32 val_a = 1;
+            bool val_b  = 2;
+        }
+    }
+
+    repeated Nested nested_one_of = 3;
 }

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -306,6 +306,35 @@ message OneOfMessageRepeat
     optional Nested nested_one_of_with_defaults = 4;
 }
 
+message OneOfMessageNested
+{
+    message SubOne
+    {
+        oneof Values
+        {
+            int32 value_one = 1;
+            float value_two = 2;
+        }
+
+        optional uint64 non_one_of = 3;
+    }
+
+    message SubTwo
+    {
+        oneof Values
+        {
+            int32 value_one      = 1;
+            SubOne value_sub_one = 2;
+        }
+    }
+
+    oneof composite
+    {
+        int32  one = 1;
+        SubTwo two = 2;
+    }
+}
+
 message OneOfMessageSave
 {
     oneof one_of_field

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -296,10 +296,27 @@ message OneOfMessageRepeat
     {
         oneof values
         {
-            int32 val_a = 1;
-            bool val_b  = 2;
+            uint64 val_a = 1 [default = 2];
+            int32  val_b = 2 [default = 1];
         }
     }
 
     repeated Nested nested_one_of = 3;
+    optional Nested nested_one_of_with_defaults = 4;
 }
+
+message OneOfMessageSave
+{
+    oneof one_of_field
+    {
+        int32 int_val = 1;
+        bool bool_val = 2;
+    }
+
+    oneof one_of_field_string
+    {
+        int32 int_val_no_string = 3;
+        string string_val       = 4;
+    }
+}
+

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -259,3 +259,31 @@ message TestFieldAlignment
     required string needs_to_be_aligned2 = 3 [(field_align)=true];
 }
 
+message OneOfMessage
+{
+    message Nested
+    {
+        oneof nested_field_name
+        {
+            int32  nested_int_val    = 1;
+            string nested_string_val = 2;
+        }
+    }
+
+    oneof one_of_field_one
+    {
+        int32 int_val       = 1;
+        TestEnum enum_val   = 2;
+        Simple01 simple_val = 3;
+    }
+
+    oneof one_of_field_two
+    {
+        int32 int_val_two        = 4;
+        TestEnum enum_val_two    = 5;
+        string simple_string_two = 6;
+    }
+
+    optional int32 not_in_oneof = 7;
+    optional Nested nested_val  = 8;
+}

--- a/engine/ddf/src/test/test_ddf_proto.proto
+++ b/engine/ddf/src/test/test_ddf_proto.proto
@@ -294,6 +294,7 @@ message OneOfMessageRepeat
 {
     message Nested
     {
+        // Note: Default values are not supported for oneof blocks!
         oneof values
         {
             uint64 val_a = 1 [default = 2];


### PR DESCRIPTION
Based on https://github.com/defold/defold/pull/7520 but without the recursive support.