### PR TITLE
Copy HTML5 symbols to parent folder of application bundle

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -306,14 +306,18 @@ public class HTML5Bundler implements IBundler {
         }
 
         // Copy debug symbols if they were generated
+        String symbolsName = "dmengine.js.symbols";
+        if (variant.equals(Bob.VARIANT_RELEASE)) {
+            symbolsName = "dmengine_release.js.symbols";
+        }
         String zipDir = FilenameUtils.concat(extenderExeDir, Platform.JsWeb.getExtenderPair());
-        File bundleSymbols = new File(zipDir, "dmengine.js.symbols");
+        File bundleSymbols = new File(zipDir, symbolsName);
         if (!bundleSymbols.exists()) {
             zipDir = FilenameUtils.concat(extenderExeDir, Platform.WasmWeb.getExtenderPair());
-            bundleSymbols = new File(zipDir, "dmengine.js.symbols");
+            bundleSymbols = new File(zipDir, symbolsName);
         }
         if (bundleSymbols.exists()) {
-            File symbolsOut = new File(appDir, enginePrefix + ".symbols");
+            File symbolsOut = new File(appDir.getParentFile(), enginePrefix + ".symbols");
             FileUtils.copyFile(bundleSymbols, symbolsOut);
         }
 


### PR DESCRIPTION
When bundling an HTML5 build with debug symbols enabled the symbols are no longer copied into the bundle folder. This will prevent accidental upload of symbols to cloud storage or HTML5 game distribution platform. Note that this in itself is not a problem, but it will make the build look larger than it is. This change is also in line with how the symbols are copied for other platforms.

Fixes #7448 