### PR TITLE
CI: Disable pull_request_target trigger and remove 'skip-ci' commit message check

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - 'DEFEDIT-*'
       - 'editor-dev'
-  pull_request_target:
-    branches:
-       - 'DEFEDIT-*'
-       - 'editor-dev'
-    types: [labeled]
 
 env:
   S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
@@ -30,7 +25,6 @@ env:
 
 jobs:
   build-editor:
-    if: "!contains(github.event.head_commit.message, 'skip-ci')"
     runs-on: ubuntu-20.04
     steps: [
       { name: 'Checkout', uses: actions/checkout@v3 },
@@ -49,7 +43,6 @@ jobs:
       }]
 
   sign-editor-macos:
-    if: "!contains(github.event.head_commit.message, 'skip-ci')"
     needs: [build-editor]
     runs-on: macOS-latest
     strategy:
@@ -81,7 +74,6 @@ jobs:
       }]
 
   sign-editor-windows:
-    if: "!contains(github.event.head_commit.message, 'skip-ci')"
     needs: [build-editor]
     runs-on: windows-latest
     strategy:
@@ -120,7 +112,6 @@ jobs:
 # ---- RELEASE ------------------
 
   release:
-    if: "!contains(github.event.head_commit.message, 'skip-ci')"
     needs: [sign-editor-macos, sign-editor-windows]
     runs-on: ubuntu-20.04
     steps: [

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -6,12 +6,6 @@ on:
        - 'skip-ci-*'
        - 'DEFEDIT-*'
        - 'editor-dev'
-  pull_request_target:
-    branches-ignore:
-       - 'skip-ci-*'
-       - 'DEFEDIT-*'
-       - 'editor-dev'
-    types: [labeled]
   repository_dispatch: {}
 
 env:
@@ -33,25 +27,8 @@ env:
 
 
 jobs:
-# ---- PRE-CHECK
-# ---- * Do not proceed if commit message contains "skip-ci"
-# ---- * If workflow is started from a "pull_request" event only proceed if coming from the Defold org
-# ---- * If workflow is started from a "pull_request_target" event only proceed if it has the label "ok to test"
-  pre-check:
-    runs-on: ubuntu-20.04
-    if: |
-      !contains(github.event.head_commit.message, 'skip-ci') &&
-      (github.event_name != 'pull_request'        || (github.event_name == 'pull_request'        && github.event.pull_request.head.repo.full_name == github.repository)) &&
-      (github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ok to test')))
-    steps: [
-      {
-        shell: bash,
-        run: 'echo "Pre-check ok"'
-      }]
-
 # ---- BUILD ENGINE VERSIONS ------------------
   bld-eng-windows:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [win32, x86_64-win32]
@@ -76,7 +53,6 @@ jobs:
       }]
 
   bld-eng-darwin:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [x86_64-macos, arm64-ios, x86_64-ios]
@@ -100,7 +76,6 @@ jobs:
       }]
 
   bld-eng-web:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [js-web, wasm-web]
@@ -124,7 +99,6 @@ jobs:
       }]
 
   bld-eng-android:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [armv7-android, arm64-android]
@@ -148,7 +122,6 @@ jobs:
       }]
 
   bld-eng-linux:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [x86_64-linux]
@@ -172,7 +145,6 @@ jobs:
       }]
 
   bld-eng-switch:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [arm64-nx64]
@@ -197,7 +169,6 @@ jobs:
       }]
 
   bld-eng-ps4:
-    needs: [pre-check]
     strategy:
       matrix:
         platform: [x86_64-ps4]


### PR DESCRIPTION
### Technical changes
* We no longer build as a result of the `pull_request_target` trigger, since it was not producing anything of value.
* We no longer skip CI for commits whose message contains the string `skip-ci`. This was troublesome when squashing.