### PR TITLE
Correct animation preview speed on high refresh rate screens

### DIFF
--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -1558,7 +1558,7 @@
                     g/tx-nodes-added
                     first)
         repaint-timer (ui/->timer 30 "refresh-form-view"
-                                  (fn [_timer _elapsed]
+                                  (fn [_timer _elapsed _dt]
                                     (g/node-value view-id :form-view)))]
     (g/node-value view-id :form-view)
     (ui/timer-start! repaint-timer)

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2526,7 +2526,7 @@
                                        :layout (g/node-value view-node :layout evaluation-context)
                                        :lines (g/node-value view-node :lines evaluation-context)})
                         (reset! state nil)))))
-        timer (ui/->timer 10 "hover-code-editor-timer" (fn [_ _]
+        timer (ui/->timer 10 "hover-code-editor-timer" (fn [_ _ _]
                                                          (when (and (.isSelected tab) (not (ui/ui-disabled?)))
                                                            (refresh))))]
     (fx/mount-renderer state (fx/create-renderer
@@ -2570,7 +2570,7 @@
         goto-line-bar (setup-goto-line-bar! (ui/load-fxml "goto-line.fxml") view-node)
         find-bar (setup-find-bar! (ui/load-fxml "find.fxml") view-node)
         replace-bar (setup-replace-bar! (ui/load-fxml "replace.fxml") view-node)
-        repainter (ui/->timer "repaint-code-editor-view" (fn [_ elapsed-time]
+        repainter (ui/->timer "repaint-code-editor-view" (fn [_ elapsed-time _]
                                                            (when (and (.isSelected tab) (not (ui/ui-disabled?)))
                                                              (repaint-view! view-node elapsed-time {:cursor-visible? true}))))
         dispose-hover! (create-hover! view-node canvas tab)

--- a/editor/src/clj/editor/console.clj
+++ b/editor/src/clj/editor/console.clj
@@ -577,7 +577,7 @@
                                  0 nil
                                  1 (open-resource! (first resource-candidates))
                                  (ui/show-simple-context-menu-at-mouse! resource->menu-item open-resource! resource-candidates event)))))
-        repainter (ui/->timer "repaint-console-view" (fn [_ elapsed-time]
+        repainter (ui/->timer "repaint-console-view" (fn [_ elapsed-time _]
                                                        (when (and (.isSelected console-tab) (not (ui/ui-disabled?)))
                                                          (repaint-console-view! view-node workspace on-region-click! elapsed-time))))
         context-env {:clipboard (Clipboard/getSystemClipboard)

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -420,7 +420,7 @@
 (defn- make-update-timer
   [project debug-view]
   (let [state   (volatile! {})
-        tick-fn (fn [timer _]
+        tick-fn (fn [timer _ _]
                   (when-not (ui/ui-disabled?)
                     ;; if we don't have a debug session going on, there is no point in pulling
                     ;; project/breakpoints or updating the "last breakpoints" state.

--- a/editor/src/clj/editor/html_view.clj
+++ b/editor/src/clj/editor/html_view.clj
@@ -273,7 +273,7 @@
         web-view      (make-web-view project)
         web-engine    (.getEngine web-view)
         view-id       (g/make-node! graph WebViewNode :web-view web-view)
-        repainter     (ui/->timer 1 "update-web-view!" (fn [_ _] (update-web-view! view-id project)))]
+        repainter     (ui/->timer 1 "update-web-view!" (fn [_ _ _] (update-web-view! view-id project)))]
 
     (.addListener (.locationProperty web-engine)
                   (ui/change-listener _ _ new-location (handle-location-change! project view-id new-location)))

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -372,7 +372,7 @@
     (let [[^Region toggles update-fn] (make-visibility-toggles-list scene-visibility)
           popup (popup/make-popup owner toggles)
           anchor (pref-popup-position owner (.getMinWidth toggles) -5)
-          refresh-timer (ui/->timer 13 "refresh-tag-filters" (fn [_ _] (update-fn)))]
+          refresh-timer (ui/->timer 13 "refresh-tag-filters" (fn [_ _ _] (update-fn)))]
       (update-fn)
       (ui/user-data! owner ::popup popup)
       (ui/on-closed! popup (fn [_] (ui/user-data! owner ::popup nil)))

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -61,7 +61,7 @@
 
 (defn- start-tree-update-timer! [tree-views progress-indicators results-fn]
   (let [timer (ui/->timer 5 "tree-update-timer"
-                          (fn [^AnimationTimer timer elapsed-time]
+                          (fn [^AnimationTimer timer elapsed-time _]
                             ;; Delay showing the progress indicator a bit to avoid flashing for
                             ;; searches that complete quickly.
                             (when (< 0.2 elapsed-time)

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1942,7 +1942,7 @@ command."
                                      (when (or (nil? interval) (> delta interval))
                                        (run-later
                                          (try
-                                           (tick-fn this (* elapsed 1e-9))
+                                           (tick-fn this (* elapsed 1e-9) (/ delta 1e9))
                                            (reset! last (- now (if interval
                                                                  (- delta interval)
                                                                  0)))


### PR DESCRIPTION
The update speed for flipbook animations and particle effects were locked to 60 updates per second even if previewing on a high refresh rate screen (eg 144Hz).

Fix #5075
Fix #6530 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
