### PR TITLE
Resource get texture info

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1255,9 +1255,10 @@ namespace dmEngine
             }
         }
 
-        script_lib_context.m_Factory    = engine->m_Factory;
-        script_lib_context.m_Register   = engine->m_Register;
-        script_lib_context.m_HidContext = engine->m_HidContext;
+        script_lib_context.m_Factory         = engine->m_Factory;
+        script_lib_context.m_Register        = engine->m_Register;
+        script_lib_context.m_HidContext      = engine->m_HidContext;
+        script_lib_context.m_GraphicsContext = engine->m_GraphicsContext;
 
         if (engine->m_SharedScriptContext) {
             script_lib_context.m_LuaState = dmScript::GetLuaState(engine->m_SharedScriptContext);

--- a/engine/gamesys/src/gamesys/gamesys.h
+++ b/engine/gamesys/src/gamesys/gamesys.h
@@ -152,6 +152,7 @@ namespace dmGameSystem
         dmResource::HFactory    m_Factory;
         dmGameObject::HRegister m_Register;
         dmHID::HContext         m_HidContext;
+        dmGraphics::HContext    m_GraphicsContext;
     };
 
 

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1033,6 +1033,9 @@ static int SetTexture(lua_State* L)
  * `height`
  * : [type:integer] height of the texture
  *
+ * `depth`
+ * : [type:integer] depth of the texture (i.e 1 for a 2D texture and 6 for a cube map)
+ *
  * `mipmaps`
  * : [type:integer] number of mipmaps of the texture
  *
@@ -1041,6 +1044,7 @@ static int SetTexture(lua_State* L)
  *
  * - `resource.TEXTURE_TYPE_2D`
  * - `resource.TEXTURE_TYPE_CUBE_MAP`
+ * - `resource.TEXTURE_TYPE_2D_ARRAY`
  *
  * @examples
  * Create a new texture and get the metadata from it

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1119,7 +1119,7 @@ static int GetTextureInfo(lua_State* L)
 
     lua_newtable(L);
 
-    lua_pushinteger(L, texture_handle);
+    lua_pushnumber(L, texture_handle);
     lua_setfield(L, -2, "handle");
 
     lua_pushinteger(L, texture_width);

--- a/engine/gamesys/src/gamesys/test/resource/create_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/create_texture.script
@@ -131,14 +131,14 @@ function test_get_texture_info()
 
 	resource.release(t_id_cube)
 
-	-- test incorrect handles
-	assert_error(function()
-		resource.get_texture_info(1)
-	end)
+	-- test incorrect handles by basic types
+	assert_error(function() resource.get_texture_info(nil) end)
+	assert_error(function() resource.get_texture_info(false) end)
+	assert_error(function() resource.get_texture_info("invalid_type") end)
+	assert_error(function() resource.get_texture_info(1) end)
 
-	assert_error(function()
-		resource.get_texture_info(t_id)
-	end)
+	-- test incorrect handles by explicitly removed resource id
+	assert_error(function() resource.get_texture_info(t_id) end)
 end
 
 function update(self)

--- a/engine/gamesys/src/gamesys/test/resource/create_texture.script
+++ b/engine/gamesys/src/gamesys/test/resource/create_texture.script
@@ -31,7 +31,14 @@ local tparams = {
 	format         = resource.TEXTURE_FORMAT_RGBA,
 }
 
-local args_compressed = {
+local tparams_cube = {
+	width          = 128,
+	height         = 128,
+	type           = resource.TEXTURE_TYPE_CUBE_MAP,
+	format         = resource.TEXTURE_FORMAT_RGBA,
+}
+
+local tparams_compressed = {
 	type             = resource.TEXTURE_TYPE_2D,
 	width            = 32,
 	height           = 32,
@@ -87,13 +94,51 @@ function test_compressed()
 		stream[i] = c:byte(i)
 	end
 
-    resource.create_texture("/test_compressed.texturec", args_compressed, tex_buffer)
+    resource.create_texture("/test_compressed.texturec", tparams_compressed, tex_buffer)
 end
 
 function test_compressed_fail()
 	-- Note: res_texture won't yield an error here, we need to check the result of this operation on the C side
 	local tex_buffer = buffer.create(128, {{name = hash("data"), type = buffer.VALUE_TYPE_UINT8, count = 1 }})
-	resource.create_texture("/test_compressed_fail.texturec", args_compressed, tex_buffer)
+	resource.create_texture("/test_compressed_fail.texturec", tparams_compressed, tex_buffer)
+end
+
+function test_get_texture_info()
+	local t_id   = resource.create_texture("/test_get_texture_info.texturec", tparams)
+	local t_info = resource.get_texture_info(t_id)
+
+	assert(t_info.width  == tparams.width)
+	assert(t_info.height == tparams.height)
+	assert(t_info.type   == tparams.type)
+
+	local t_info_by_handle = resource.get_texture_info(t_info.handle)
+	assert(t_info_by_handle.width   == 128)
+	assert(t_info_by_handle.height  == 128)
+	assert(t_info_by_handle.depth   == 1)
+	assert(t_info_by_handle.mipmaps == 1)
+	assert(t_info_by_handle.type    == resource.TEXTURE_TYPE_2D)
+
+	resource.release(t_id)
+
+	local t_id_cube   = resource.create_texture("/test_get_texture_info_cube.texturec", tparams_cube)
+	local t_info_cube = resource.get_texture_info(t_id_cube)
+
+	assert(t_info_cube.width   == 128)
+	assert(t_info_cube.height  == 128)
+	assert(t_info_cube.depth   == 6)
+	assert(t_info_cube.mipmaps == 1)
+	assert(t_info_cube.type    == resource.TEXTURE_TYPE_CUBE_MAP)
+
+	resource.release(t_id_cube)
+
+	-- test incorrect handles
+	assert_error(function()
+		resource.get_texture_info(1)
+	end)
+
+	assert_error(function()
+		resource.get_texture_info(t_id)
+	end)
 end
 
 function update(self)
@@ -107,6 +152,7 @@ function update(self)
 		test_release_not_found,
 		test_compressed,
 		test_compressed_fail,
+		test_get_texture_info,
 	}
 
 	if tests[self.update_counter] ~= nil then

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -203,9 +203,10 @@ TEST_F(ResourceTest, TestReloadTextureSet)
 TEST_F(ResourceTest, TestCreateTextureFromScript)
 {
     dmGameSystem::ScriptLibContext scriptlibcontext;
-    scriptlibcontext.m_Factory    = m_Factory;
-    scriptlibcontext.m_Register   = m_Register;
-    scriptlibcontext.m_LuaState   = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
 
     dmGameSystem::InitializeScriptLibs(scriptlibcontext);
 
@@ -284,6 +285,11 @@ TEST_F(ResourceTest, TestCreateTextureFromScript)
 
     // Release the dmResource::Get call again
     dmResource::Release(m_Factory, texture_res);
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Test 8: test getting texture info
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
     // cleanup
     DeleteInstance(m_Collection, go);

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -913,6 +913,10 @@ namespace dmGraphics
     {
         return g_functions.m_GetTextureHeight(texture);
     }
+    uint16_t GetTextureDepth(HTexture texture)
+    {
+        return g_functions.m_GetTextureDepth(texture);
+    }
     uint16_t GetOriginalTextureWidth(HTexture texture)
     {
         return g_functions.m_GetOriginalTextureWidth(texture);
@@ -920,6 +924,10 @@ namespace dmGraphics
     uint16_t GetOriginalTextureHeight(HTexture texture)
     {
         return g_functions.m_GetOriginalTextureHeight(texture);
+    }
+    uint8_t GetTextureMipmapCount(HTexture texture)
+    {
+        return g_functions.m_GetTextureMipmapCount(texture);
     }
     TextureType GetTextureType(HTexture texture)
     {
@@ -976,6 +984,10 @@ namespace dmGraphics
     uint8_t GetNumTextureHandles(HTexture texture)
     {
         return g_functions.m_GetNumTextureHandles(texture);
+    }
+    bool IsAssetHandleValid(HContext context, HAssetHandle asset_handle)
+    {
+        return g_functions.m_IsAssetHandleValid(context, asset_handle);
     }
 
 #if defined(__MACH__) && ( defined(__arm__) || defined(__arm64__) || defined(IOS_SIMULATOR))

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -212,13 +212,13 @@ namespace dmGraphics
     struct TextureParams
     {
         TextureParams()
-        : m_Format(TEXTURE_FORMAT_RGBA)
+        : m_Data(0x0)
+        , m_DataSize(0)
+        , m_Format(TEXTURE_FORMAT_RGBA)
         , m_MinFilter(TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST)
         , m_MagFilter(TEXTURE_FILTER_LINEAR)
         , m_UWrap(TEXTURE_WRAP_CLAMP_TO_EDGE)
         , m_VWrap(TEXTURE_WRAP_CLAMP_TO_EDGE)
-        , m_Data(0x0)
-        , m_DataSize(0)
         , m_X(0)
         , m_Y(0)
         , m_Z(0)
@@ -229,13 +229,13 @@ namespace dmGraphics
         , m_SubUpdate(false)
         {}
 
+        const void*   m_Data;
+        uint32_t      m_DataSize;
         TextureFormat m_Format;
         TextureFilter m_MinFilter;
         TextureFilter m_MagFilter;
         TextureWrap   m_UWrap;
         TextureWrap   m_VWrap;
-        const void*   m_Data;
-        uint32_t      m_DataSize;
 
         // For sub texture updates
         uint32_t m_X;

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -60,6 +60,9 @@ namespace dmGraphics
     typedef int (*EngineUpdate)(void* engine);
     typedef void (*EngineGetResult)(void* engine, int* run_action, int* exit_code, int* argc, char*** argv);
 
+    // Decorated asset handle with 32 bits meta | 32 bits opaque handle
+    typedef uint64_t HAssetHandle;
+
     static const HVertexProgram INVALID_VERTEX_PROGRAM_HANDLE = ~0u;
     static const HFragmentProgram INVALID_FRAGMENT_PROGRAM_HANDLE = ~0u;
 
@@ -216,33 +219,34 @@ namespace dmGraphics
         , m_VWrap(TEXTURE_WRAP_CLAMP_TO_EDGE)
         , m_Data(0x0)
         , m_DataSize(0)
-        , m_MipMap(0)
-        , m_Width(0)
-        , m_Height(0)
-        , m_Depth(0)
-        , m_SubUpdate(false)
         , m_X(0)
         , m_Y(0)
         , m_Z(0)
+        , m_Width(0)
+        , m_Height(0)
+        , m_Depth(0)
+        , m_MipMap(0)
+        , m_SubUpdate(false)
         {}
 
         TextureFormat m_Format;
         TextureFilter m_MinFilter;
         TextureFilter m_MagFilter;
-        TextureWrap m_UWrap;
-        TextureWrap m_VWrap;
-        const void* m_Data;
-        uint32_t m_DataSize;
-        uint16_t m_MipMap;
-        uint16_t m_Width;
-        uint16_t m_Height;
-        uint16_t m_Depth; // For array texture, this is slice count
+        TextureWrap   m_UWrap;
+        TextureWrap   m_VWrap;
+        const void*   m_Data;
+        uint32_t      m_DataSize;
 
         // For sub texture updates
-        bool m_SubUpdate;
         uint32_t m_X;
         uint32_t m_Y;
         uint32_t m_Z; // For array texture, this is the slice to set
+
+        uint16_t m_Width;
+        uint16_t m_Height;
+        uint16_t m_Depth; // For array texture, this is slice count
+        uint8_t  m_MipMap    : 7;
+        uint8_t  m_SubUpdate : 1;
     };
 
     // Parameters structure for OpenWindow
@@ -610,16 +614,23 @@ namespace dmGraphics
     uint32_t    GetTextureResourceSize(HTexture texture);
     uint16_t    GetTextureWidth(HTexture texture);
     uint16_t    GetTextureHeight(HTexture texture);
+    uint16_t    GetTextureDepth(HTexture texture);
     uint16_t    GetOriginalTextureWidth(HTexture texture);
     uint16_t    GetOriginalTextureHeight(HTexture texture);
-    uint32_t    GetMaxTextureSize(HContext context);
-    uint8_t     GetNumTextureHandles(HTexture texture);
+    uint8_t     GetTextureMipmapCount(HTexture texture);
     TextureType GetTextureType(HTexture texture);
+    uint8_t     GetNumTextureHandles(HTexture texture);
+
     const char* GetTextureTypeLiteral(TextureType texture_type);
+    uint32_t    GetMaxTextureSize(HContext context);
     void        EnableTexture(HContext context, uint32_t unit, uint8_t id_index, HTexture texture);
     void        DisableTexture(HContext context, uint32_t unit, HTexture texture);
+
+    // Calculating mipmap info helpers
     uint16_t    GetMipmapSize(uint16_t size_0, uint8_t mipmap);
     uint8_t     GetMipmapCount(uint16_t size);
+
+    bool IsAssetHandleValid(HContext context, HAssetHandle asset_handle);
 
     /**
      * Get status of texture.

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -60,7 +60,9 @@ namespace dmGraphics
     typedef int (*EngineUpdate)(void* engine);
     typedef void (*EngineGetResult)(void* engine, int* run_action, int* exit_code, int* argc, char*** argv);
 
-    // Decorated asset handle with 32 bits meta | 32 bits opaque handle
+    // Decorated asset handle with 21 bits meta | 32 bits opaque handle
+    // Note: that we can only use a total of 53 bits out of the 64 due to how we expose the handles
+    //       to the users via lua. (See graphics_private.h::MAX_ASSET_HANDLE_VAL)
     typedef uint64_t HAssetHandle;
 
     static const HVertexProgram INVALID_VERTEX_PROGRAM_HANDLE = ~0u;

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -149,6 +149,8 @@ namespace dmGraphics
     typedef uint16_t (*GetTextureHeightFn)(HTexture texture);
     typedef uint16_t (*GetOriginalTextureWidthFn)(HTexture texture);
     typedef uint16_t (*GetOriginalTextureHeightFn)(HTexture texture);
+    typedef uint16_t (*GetTextureDepthFn)(HTexture texture);
+    typedef uint8_t (*GetTextureMipmapCountFn)(HTexture texture);
     typedef TextureType (*GetTextureTypeFn)(HTexture texture);
     typedef void (*EnableTextureFn)(HContext context, uint32_t unit, uint8_t id_index, HTexture texture);
     typedef void (*DisableTextureFn)(HContext context, uint32_t unit, HTexture texture);
@@ -162,6 +164,7 @@ namespace dmGraphics
     typedef const char* (*GetSupportedExtensionFn)(HContext context, uint32_t index);
     typedef uint8_t (*GetNumTextureHandlesFn)(HTexture texture);
     typedef bool (*IsContextFeatureSupportedFn)(HContext context, ContextFeature feature);
+    typedef bool (*IsAssetHandleValidFn)(HContext context, HAssetHandle asset_handle);
 
     struct GraphicsAdapterFunctionTable
     {
@@ -260,6 +263,8 @@ namespace dmGraphics
         GetTextureTypeFn m_GetTextureType;
         GetOriginalTextureWidthFn m_GetOriginalTextureWidth;
         GetOriginalTextureHeightFn m_GetOriginalTextureHeight;
+        GetTextureDepthFn m_GetTextureDepth;
+        GetTextureMipmapCountFn m_GetTextureMipmapCount;
         EnableTextureFn m_EnableTexture;
         DisableTextureFn m_DisableTexture;
         GetMaxTextureSizeFn m_GetMaxTextureSize;
@@ -273,6 +278,7 @@ namespace dmGraphics
         GetNumTextureHandlesFn m_GetNumTextureHandles;
         GetPipelineStateFn m_GetPipelineState;
         IsContextFeatureSupportedFn m_IsContextFeatureSupported;
+        IsAssetHandleValidFn m_IsAssetHandleValid;
     };
 
     #define DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, fn_name) \
@@ -371,6 +377,8 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetTextureHeight); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetOriginalTextureWidth); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetOriginalTextureHeight); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetTextureDepth); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetTextureMipmapCount); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetTextureType); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, EnableTexture); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DisableTexture); \
@@ -385,7 +393,8 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetSupportedExtension); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetNumTextureHandles); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetPipelineState); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsContextFeatureSupported);
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsContextFeatureSupported); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsAssetHandleValid);
 }
 
 #endif

--- a/engine/graphics/src/graphics_private.h
+++ b/engine/graphics/src/graphics_private.h
@@ -23,9 +23,6 @@ namespace dmGraphics
 {
     const static uint8_t MAX_VERTEX_STREAM_COUNT = 8;
 
-    // Decorated asset handle with 32 bits meta | 32 bits opaque handle
-    typedef uint64_t HAssetHandle;
-
     struct VertexStream
     {
         dmhash_t m_NameHash;
@@ -53,7 +50,6 @@ namespace dmGraphics
     bool  UnmapVertexBuffer(HVertexBuffer buffer);
     void* MapIndexBuffer(HIndexBuffer buffer, BufferAccess access);
     bool  UnmapIndexBuffer(HIndexBuffer buffer);
-    bool  IsAssetHandleValid(HContext context, HAssetHandle asset_handle);
     // <- end test functions
 
     static inline HAssetHandle MakeAssetHandle(HOpaqueHandle opaque_handle, AssetType asset_type)

--- a/engine/graphics/src/graphics_private.h
+++ b/engine/graphics/src/graphics_private.h
@@ -21,6 +21,9 @@
 
 namespace dmGraphics
 {
+    // Since an asset handle is exposed as a double / number in lua, we can only use 53 bits before we lose precision
+    // http://lua-users.org/wiki/NumbersTutorial
+    const static uint64_t MAX_ASSET_HANDLE_VAL   = 0x20000000000000-1; // 2^53 - 1
     const static uint8_t MAX_VERTEX_STREAM_COUNT = 8;
 
     struct VertexStream
@@ -76,7 +79,9 @@ namespace dmGraphics
             container.Allocate(8);
         }
         HOpaqueHandle opaque_handle = container.Put((uintptr_t*) asset);
-        return MakeAssetHandle(opaque_handle, type);
+        HAssetHandle asset_handle   = MakeAssetHandle(opaque_handle, type);
+        assert(asset_handle <= MAX_ASSET_HANDLE_VAL);
+        return asset_handle;
     }
 
     template <typename T>

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1037,19 +1037,23 @@ namespace dmGraphics
     static HTexture NullNewTexture(HContext _context, const TextureCreationParams& params)
     {
         NullContext* context  = (NullContext*) _context;
-        Texture* tex               = new Texture();
+        Texture* tex          = new Texture();
 
         tex->m_Type        = params.m_Type;
         tex->m_Width       = params.m_Width;
         tex->m_Height      = params.m_Height;
+        tex->m_Depth       = params.m_Depth;
         tex->m_MipMapCount = 0;
         tex->m_Data        = 0;
 
-        if (params.m_OriginalWidth == 0) {
-            tex->m_OriginalWidth = params.m_Width;
+        if (params.m_OriginalWidth == 0)
+        {
+            tex->m_OriginalWidth  = params.m_Width;
             tex->m_OriginalHeight = params.m_Height;
-        } else {
-            tex->m_OriginalWidth = params.m_OriginalWidth;
+        }
+        else
+        {
+            tex->m_OriginalWidth  = params.m_OriginalWidth;
             tex->m_OriginalHeight = params.m_OriginalHeight;
         }
 
@@ -1105,8 +1109,9 @@ namespace dmGraphics
         // Allocate even for 0x0 size so that the rendertarget dummies will work.
         tex->m_Data = new char[params.m_DataSize];
         if (params.m_Data != 0x0)
+        {
             memcpy(tex->m_Data, params.m_Data, params.m_DataSize);
-        tex->m_MipMapCount = dmMath::Max(tex->m_MipMapCount, (uint16_t)(params.m_MipMap+1));
+        }
 
         // The width/height of the texture can change from this function as well
         if (!params.m_SubUpdate && params.m_MipMap == 0)
@@ -1114,6 +1119,10 @@ namespace dmGraphics
             tex->m_Width  = params.m_Width;
             tex->m_Height = params.m_Height;
         }
+
+        tex->m_Depth       = dmMath::Max((uint16_t) 1, params.m_Depth);
+        tex->m_MipMapCount = dmMath::Max(tex->m_MipMapCount, (uint8_t) (params.m_MipMap+1));
+        tex->m_MipMapCount = dmMath::Clamp(tex->m_MipMapCount, (uint8_t) 0, GetMipmapCount(dmMath::Max(tex->m_Width, tex->m_Height)));
     }
 
     static uint32_t NullGetTextureResourceSize(HTexture texture)
@@ -1364,23 +1373,39 @@ namespace dmGraphics
         return true;
     }
 
-    ////////////////////////////////
-    // UNIT TEST FUNCTIONS
-    ////////////////////////////////
-    bool IsAssetHandleValid(HContext context, HAssetHandle asset_handle)
+    static uint16_t NullGetTextureDepth(HTexture texture)
     {
-        AssetType type = GetAssetType(asset_handle);
+        return GetAssetFromContainer<Texture>(g_NullContext->m_AssetHandleContainer, texture)->m_Depth;
+    }
+
+    static uint8_t NullGetTextureMipmapCount(HTexture texture)
+    {
+        return GetAssetFromContainer<Texture>(g_NullContext->m_AssetHandleContainer, texture)->m_MipMapCount;
+    }
+
+    static bool NullIsAssetHandleValid(HContext _context, HAssetHandle asset_handle)
+    {
+        assert(_context);
+        if (asset_handle == 0)
+        {
+            return false;
+        }
+        NullContext* context = (NullContext*) _context;
+        AssetType type       = GetAssetType(asset_handle);
         if (type == ASSET_TYPE_TEXTURE)
         {
-            return GetAssetFromContainer<Texture>(((NullContext*) context)->m_AssetHandleContainer, asset_handle) != 0;
+            return GetAssetFromContainer<Texture>(context->m_AssetHandleContainer, asset_handle) != 0;
         }
         else if (type == ASSET_TYPE_RENDER_TARGET)
         {
-            return GetAssetFromContainer<RenderTarget>(((NullContext*) context)->m_AssetHandleContainer, asset_handle) != 0;
+            return GetAssetFromContainer<RenderTarget>(context->m_AssetHandleContainer, asset_handle) != 0;
         }
         return false;
     }
 
+    ////////////////////////////////
+    // UNIT TEST FUNCTIONS
+    ////////////////////////////////
     void* MapIndexBuffer(HIndexBuffer buffer, BufferAccess access)
     {
         IndexBuffer* ib = (IndexBuffer*)buffer;

--- a/engine/graphics/src/null/graphics_null_private.h
+++ b/engine/graphics/src/null/graphics_null_private.h
@@ -30,9 +30,10 @@ namespace dmGraphics
         TextureType     m_Type;
         uint32_t m_Width;
         uint32_t m_Height;
+        uint32_t m_Depth;
         uint32_t m_OriginalWidth;
         uint32_t m_OriginalHeight;
-        uint16_t m_MipMapCount;
+        uint8_t  m_MipMapCount;
     };
 
     struct VertexStreamBuffer

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2651,7 +2651,7 @@ static void LogFrameBufferError(GLenum status)
 
     static void OpenGLDoDeleteTexture(void* context)
     {
-        HTexture texture   = (HTexture) (size_t) context;
+        HTexture texture   = (HTexture) context;
         OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
 
         glDeleteTextures(tex->m_NumTextureIds, tex->m_TextureIds);
@@ -2665,7 +2665,7 @@ static void LogFrameBufferError(GLenum status)
     static void OpenGLDeleteTextureAsync(HTexture texture)
     {
         JobDesc j;
-        j.m_Context = (void*)(size_t)texture;
+        j.m_Context = (void*)texture;
         j.m_Func = OpenGLDoDeleteTexture;
         j.m_FuncComplete = 0;
         JobQueuePush(j);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -500,25 +500,6 @@ static void LogFrameBufferError(GLenum status)
         return GL_FALSE;
     }
 
-    static Type ShaderDataTypeToGraphicsType(ShaderDesc::ShaderDataType shader_type)
-    {
-        switch(shader_type)
-        {
-            case ShaderDesc::SHADER_TYPE_INT:             return TYPE_INT;
-            case ShaderDesc::SHADER_TYPE_UINT:            return TYPE_UNSIGNED_INT;
-            case ShaderDesc::SHADER_TYPE_FLOAT:           return TYPE_FLOAT;
-            case ShaderDesc::SHADER_TYPE_VEC4:            return TYPE_FLOAT_VEC4;
-            case ShaderDesc::SHADER_TYPE_MAT4:            return TYPE_FLOAT_MAT4;
-            case ShaderDesc::SHADER_TYPE_SAMPLER2D:       return TYPE_SAMPLER_2D;
-            case ShaderDesc::SHADER_TYPE_SAMPLER_CUBE:    return TYPE_SAMPLER_CUBE;
-            case ShaderDesc::SHADER_TYPE_SAMPLER2D_ARRAY: return TYPE_SAMPLER_2D_ARRAY;
-            default: break;
-        }
-
-        // Not supported
-        return (Type) 0xffffffff;
-    }
-
     static HContext OpenGLNewContext(const ContextParams& params)
     {
         if (g_Context == 0x0)
@@ -2650,6 +2631,7 @@ static void LogFrameBufferError(GLenum status)
         tex->m_TextureIds    = gl_texture_ids;
         tex->m_Width         = params.m_Width;
         tex->m_Height        = params.m_Height;
+        tex->m_Depth         = params.m_Depth;
         tex->m_NumTextureIds = num_texture_ids;
 
         if (params.m_OriginalWidth == 0){
@@ -3014,15 +2996,19 @@ static void LogFrameBufferError(GLenum status)
 
         tex->m_Params = params;
 
-        if (!params.m_SubUpdate) {
+        if (!params.m_SubUpdate)
+        {
             if (params.m_MipMap == 0)
             {
                 tex->m_Width  = params.m_Width;
                 tex->m_Height = params.m_Height;
+                tex->m_Depth  = params.m_Depth;
             }
 
             if (params.m_MipMap == 0)
+            {
                 tex->m_ResourceSize = params.m_DataSize;
+            }
         }
 
         for (int i = 0; i < tex->m_NumTextureIds; ++i)
@@ -3219,32 +3205,37 @@ static void LogFrameBufferError(GLenum status)
 
     static uint16_t OpenGLGetTextureWidth(HTexture texture)
     {
-        OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
-        return tex->m_Width;
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_Width;
     }
 
     static uint16_t OpenGLGetTextureHeight(HTexture texture)
     {
-        OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
-        return tex->m_Height;
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_Height;
     }
 
     static uint16_t OpenGLGetOriginalTextureWidth(HTexture texture)
     {
-        OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
-        return tex->m_OriginalWidth;
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_OriginalWidth;
     }
 
     static uint16_t OpenGLGetOriginalTextureHeight(HTexture texture)
     {
-        OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
-        return tex->m_OriginalHeight;
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_OriginalHeight;
     }
 
     static TextureType OpenGLGetTextureType(HTexture texture)
     {
-        OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
-        return tex->m_Type;
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_Type;
+    }
+
+    static uint16_t OpenGLGetTextureDepth(HTexture texture)
+    {
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_Depth;
+    }
+
+    static uint8_t OpenGLGetTextureMipmapCount(HTexture texture)
+    {
+        return GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture)->m_MipMapCount;
     }
 
     static void OpenGLEnableTexture(HContext _context, uint32_t unit, uint8_t id_index, HTexture texture)
@@ -3556,6 +3547,27 @@ static void LogFrameBufferError(GLenum status)
         assert(context);
         glPolygonOffset(factor, units);
         CHECK_GL_ERROR;
+    }
+
+    static bool OpenGLIsAssetHandleValid(HContext _context, HAssetHandle asset_handle)
+    {
+        if (asset_handle == 0)
+        {
+            return false;
+        }
+
+        OpenGLContext* context = (OpenGLContext*) _context;
+        AssetType type         = GetAssetType(asset_handle);
+
+        if (type == ASSET_TYPE_TEXTURE)
+        {
+            return GetAssetFromContainer<OpenGLTexture>(context->m_AssetHandleContainer, asset_handle) != 0;
+        }
+        else if (type == ASSET_TYPE_RENDER_TARGET)
+        {
+            return GetAssetFromContainer<OpenGLRenderTarget>(context->m_AssetHandleContainer, asset_handle) != 0;
+        }
+        return false;
     }
 
     BufferType BUFFER_TYPES[MAX_BUFFER_TYPE_COUNT] = {BUFFER_TYPE_COLOR0_BIT, BUFFER_TYPE_DEPTH_BIT, BUFFER_TYPE_STENCIL_BIT};

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -30,6 +30,7 @@ namespace dmGraphics
         uint16_t    m_NumTextureIds;
         uint16_t    m_Width;
         uint16_t    m_Height;
+        uint16_t    m_Depth;
         uint16_t    m_OriginalWidth;
         uint16_t    m_OriginalHeight;
         uint16_t    m_MipMapCount;

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -779,6 +779,89 @@ TEST_F(dmGraphicsTest, TestTextureFormatBPP)
     }
 }
 
+TEST_F(dmGraphicsTest, TestGetTextureParams)
+{
+    const uint32_t texture_width  = 16;
+    const uint32_t texture_height = 16;
+
+    // Texture 2D
+    {
+        dmGraphics::TextureCreationParams creation_params;
+        dmGraphics::TextureParams params;
+
+        creation_params.m_Width          = texture_width;
+        creation_params.m_Height         = texture_height;
+        creation_params.m_OriginalWidth  = texture_width;
+        creation_params.m_OriginalHeight = texture_height;
+
+        // Note: the m_MipMapCount value is ignored on null and opengl, it's only updated in SetTexture
+        // creation_params.m_MipMapCount = 255;
+
+        dmGraphics::HTexture texture = dmGraphics::NewTexture(m_Context, creation_params);
+
+        // JG: I don't think we deal with mipmap data correctly in graphics_null,
+        //     we only allocate data for _this_ SetTexture call and not reallocate the buffer
+        //     depending on the actual data size..
+        params.m_MipMap = 127;
+        dmGraphics::SetTexture(texture, params);
+
+        ASSERT_EQ(1,                                         dmGraphics::GetTextureDepth(texture));
+        ASSERT_EQ(dmGraphics::TEXTURE_TYPE_2D,               dmGraphics::GetTextureType(texture));
+        ASSERT_EQ(dmGraphics::GetMipmapCount(texture_width), dmGraphics::GetTextureMipmapCount(texture));
+
+        dmGraphics::DeleteTexture(texture);
+    }
+    // Texture cube
+    {
+        dmGraphics::TextureCreationParams creation_params;
+        dmGraphics::TextureParams params;
+
+        creation_params.m_Type           = dmGraphics::TEXTURE_TYPE_CUBE_MAP;
+        creation_params.m_Width          = texture_width;
+        creation_params.m_Height         = texture_height;
+        creation_params.m_OriginalWidth  = texture_width;
+        creation_params.m_OriginalHeight = texture_height;
+
+        dmGraphics::HTexture texture = dmGraphics::NewTexture(m_Context, creation_params);
+
+        // JG: We don't really do bounds check for the depth either in graphics_null
+        params.m_MipMap = 127;
+        params.m_Depth  = 6;
+        dmGraphics::SetTexture(texture, params);
+
+        ASSERT_EQ(params.m_Depth,                            dmGraphics::GetTextureDepth(texture));
+        ASSERT_EQ(dmGraphics::TEXTURE_TYPE_CUBE_MAP,         dmGraphics::GetTextureType(texture));
+        ASSERT_EQ(dmGraphics::GetMipmapCount(texture_width), dmGraphics::GetTextureMipmapCount(texture));
+
+        dmGraphics::DeleteTexture(texture);
+    }
+
+    // Texture 2D array
+    {
+        dmGraphics::TextureCreationParams creation_params;
+        dmGraphics::TextureParams params;
+
+        creation_params.m_Type           = dmGraphics::TEXTURE_TYPE_2D_ARRAY;
+        creation_params.m_Width          = texture_width;
+        creation_params.m_Height         = texture_height;
+        creation_params.m_OriginalWidth  = texture_width;
+        creation_params.m_OriginalHeight = texture_height;
+
+        dmGraphics::HTexture texture = dmGraphics::NewTexture(m_Context, creation_params);
+
+        // JG: We don't really do bounds check for the depth either in graphics_null
+        params.m_MipMap = 127;
+        params.m_Depth  = 1337;
+        dmGraphics::SetTexture(texture, params);
+
+        ASSERT_EQ(params.m_Depth,                            dmGraphics::GetTextureDepth(texture));
+        ASSERT_EQ(dmGraphics::TEXTURE_TYPE_2D_ARRAY,         dmGraphics::GetTextureType(texture));
+        ASSERT_EQ(dmGraphics::GetMipmapCount(texture_width), dmGraphics::GetTextureMipmapCount(texture));
+
+        dmGraphics::DeleteTexture(texture);
+    }
+}
+
 TEST_F(dmGraphicsTest, TestGraphicsHandles)
 {
     const uint32_t texture_width  = 16;

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3170,7 +3170,7 @@ bail:
         tex->m_Type        = params.m_Type;
         tex->m_Width       = params.m_Width;
         tex->m_Height      = params.m_Height;
-        tex->m_Depth       = dmMath::Max((uint16_t) 1, params.m_Depth);
+        tex->m_Depth       = params.m_Depth;
         tex->m_MipMapCount = params.m_MipMapCount;
 
         if (params.m_OriginalWidth == 0)
@@ -3554,36 +3554,42 @@ bail:
 
     static uint16_t VulkanGetTextureWidth(HTexture texture)
     {
-        Texture* tex = GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture);
-        return tex->m_Width;
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_Width;
     }
 
     static uint16_t VulkanGetTextureHeight(HTexture texture)
     {
-        Texture* tex = GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture);
-        return tex->m_Height;
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_Height;
     }
 
     static uint16_t VulkanGetOriginalTextureWidth(HTexture texture)
     {
-        Texture* tex = GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture);
-        return tex->m_OriginalWidth;
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_OriginalWidth;
     }
 
     static uint16_t VulkanGetOriginalTextureHeight(HTexture texture)
     {
-        Texture* tex = GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture);
-        return tex->m_OriginalHeight;
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_OriginalHeight;
+    }
+
+    static uint16_t VulkanGetTextureDepth(HTexture texture)
+    {
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_Depth;
+    }
+
+    static uint8_t VulkanGetTextureMipmapCount(HTexture texture)
+    {
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_MipMapCount;
     }
 
     static TextureType VulkanGetTextureType(HTexture texture)
     {
-        Texture* tex = GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture);
-        return tex->m_Type;
+        return GetAssetFromContainer<Texture>(g_VulkanContext->m_AssetHandleContainer, texture)->m_Type;
     }
 
     static HandleResult VulkanGetTextureHandle(HTexture texture, void** out_handle)
     {
+        assert(0 && "GetTextureHandle is not implemented on Vulkan.");
         return HANDLE_RESULT_NOT_AVAILABLE;
     }
 
@@ -3615,7 +3621,10 @@ bail:
     }
 
     static void VulkanReadPixels(HContext context, void* buffer, uint32_t buffer_size)
-    {}
+    {
+        // JG: If someone needs this feature we should implement this at some point
+        assert(0 && "Not implemented on vulkan!");
+    }
 
     static void VulkanRunApplicationLoop(void* user_data, WindowStepMethod step_method, WindowIsRunning is_running)
     {
@@ -3633,6 +3642,27 @@ bail:
     static bool VulkanIsContextFeatureSupported(HContext context, ContextFeature feature)
     {
         return true;
+    }
+
+    static bool VulkanIsAssetHandleValid(HContext _context, HAssetHandle asset_handle)
+    {
+        if (asset_handle == 0)
+        {
+            return false;
+        }
+
+        VulkanContext* context = (VulkanContext*) _context;
+        AssetType type         = GetAssetType(asset_handle);
+
+        if (type == ASSET_TYPE_TEXTURE)
+        {
+            return GetAssetFromContainer<Texture>(context->m_AssetHandleContainer, asset_handle) != 0;
+        }
+        else if (type == ASSET_TYPE_RENDER_TARGET)
+        {
+            return GetAssetFromContainer<RenderTarget>(context->m_AssetHandleContainer, asset_handle) != 0;
+        }
+        return false;
     }
 
     static GraphicsAdapterFunctionTable VulkanRegisterFunctionTable()

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1080,7 +1080,7 @@ namespace dmRender
             luaL_error(L, "Unable to create render target.");
         }
 
-        lua_pushinteger(L, render_target);
+        lua_pushnumber(L, render_target);
 
         assert(top + 1 == lua_gettop(L));
         return 1;
@@ -1108,7 +1108,7 @@ namespace dmRender
 
         if (lua_isnumber(L, 1))
         {
-            render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 1);
+            render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 1);
         }
         if (render_target == 0x0)
             return luaL_error(L, "Invalid render target (nil) supplied to %s.enable_render_target.", RENDER_SCRIPT_LIB_NAME);
@@ -1170,7 +1170,7 @@ namespace dmRender
         {
             if(lua_isnumber(L, 1))
             {
-                render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 1);
+                render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 1);
             }
             else
             {
@@ -1238,7 +1238,7 @@ namespace dmRender
 
         if (lua_isnumber(L, 1))
         {
-            render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 1);
+            render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 1);
         }
         if (render_target == 0x0)
             return luaL_error(L, "Invalid render target (nil) supplied to %s.enable_render_target.", RENDER_SCRIPT_LIB_NAME);
@@ -1314,7 +1314,7 @@ namespace dmRender
 
         if (lua_isnumber(L, 1))
         {
-            render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 1);
+            render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 1);
             uint32_t width = luaL_checknumber(L, 2);
             uint32_t height = luaL_checknumber(L, 3);
             dmGraphics::SetRenderTargetSize(render_target, width, height);
@@ -1377,7 +1377,7 @@ namespace dmRender
         uint32_t unit = luaL_checknumber(L, 1);
         if (lua_isnumber(L, 2))
         {
-            render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 2);
+            render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 2);
             int buffer_type_value = (int)luaL_checknumber(L, 3);
             dmGraphics::BufferType buffer_type = (dmGraphics::BufferType) buffer_type_value;
 
@@ -1458,7 +1458,7 @@ namespace dmRender
 
         if (lua_isnumber(L, 1))
         {
-            render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 1);
+            render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 1);
         }
         else
         {
@@ -1509,7 +1509,7 @@ namespace dmRender
 
         if (lua_isnumber(L, 1))
         {
-            render_target = (dmGraphics::HRenderTarget) lua_tointeger(L, 1);
+            render_target = (dmGraphics::HRenderTarget) lua_tonumber(L, 1);
         }
         else
         {


### PR DESCRIPTION
Added the new function `resource.get_texture_info` to get metadata from a texture resource or handle:

```
local my_texture_info = resource.get_texture_info(my_texture_path)

-- my_texture_info is a table that contains
{
     handle, -- the numeric handle of the texture
     width, -- width of the texture
     height, -- height of the texture
     depth, -- depth of the texture (1 for a 2D texture, 6 for a cube map and [1...slice-count] for an array texture)
     mipmaps, -- number of mipmaps the texture has
     type -- texture type
}
```

Fixes #7564
Fixes #7362

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
