### PR TITLE
New paramenter `--max-cpu-threads` for `bob.jar`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import java.lang.NumberFormatException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -538,6 +539,8 @@ public class Bob {
         addOption(options, null, "manifest-private-key", true, "Private key to use when signing manifest and archive.", false);
         addOption(options, null, "manifest-public-key", true, "Public key to use when signing manifest and archive.", false);
 
+        addOption(options, null, "max-cpu-threads", true, "Max count of threads that bob.jar can use", false);
+
         // debug options
         addOption(options, null, "debug-ne-upload", false, "Outputs the files sent to build server as upload.zip", false);
 
@@ -734,6 +737,18 @@ public class Bob {
         if (cmd.hasOption("build-report")) {
             System.out.println("--build-report option is deprecated. Use --build-report-json instead.");
             project.setOption("build-report-json", "true");
+        }
+
+        if (cmd.hasOption("max-cpu-threads")) {
+            try {
+                Integer.parseInt(cmd.getOptionValue("max-cpu-threads"));
+            }
+            catch (NumberFormatException ex) {
+                System.out.println("`--max-cpu-threads` expects integer value.");
+                ex.printStackTrace();
+                System.exit(1);
+                return;
+            }
         }
 
         Option[] options = cmd.getOptions();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -82,6 +82,7 @@ import com.dynamo.bob.fs.ZipMountPoint;
 import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.pipeline.IShaderCompiler;
 import com.dynamo.bob.pipeline.ShaderCompilers;
+import com.dynamo.bob.pipeline.TextureGenerator;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.LibraryUtil;
@@ -208,6 +209,27 @@ public class Project {
 
     public String getRemoteResourceCachePass() {
         return option("resource-cache-remote-pass", System.getenv("DM_BOB_RESOURCE_CACHE_REMOTE_PASS"));
+    }
+
+    public int getMaxCpuThreads() {
+        int maxThreads = 8;
+        String maxThreadsOpt = option("max-cpu-threads", null);
+        if (maxThreadsOpt == null) {
+            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            if (availableProcessors > 4) {
+                maxThreads = availableProcessors - 2;
+            }
+            else if (availableProcessors > 1) {
+                maxThreads = availableProcessors - 1;
+            }
+            else {
+                maxThreads = 1;
+            }
+        }
+        else {
+            maxThreads = Integer.parseInt(maxThreadsOpt);
+        }
+        return maxThreads;
     }
 
     public BobProjectProperties getProjectProperties() {
@@ -1406,6 +1428,8 @@ public class Project {
             allOutputs.addAll(task.getOutputs());
         }
         tasks.clear();
+
+        TextureGenerator.maxThreads = getMaxCpuThreads();
 
         // Keep track of the paths for all outputs
         outputs = new HashMap<>(allOutputs.size());

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -61,7 +61,7 @@ import com.sun.jna.Pointer;
 
 public class TextureGenerator {
 
-    // specify what is maximus of threads TextureGenerator may use
+    // specify what is maximum of threads TextureGenerator may use
     public static int maxThreads = 8;
 
     private static HashMap<TextureFormatAlternative.CompressionLevel, Integer> compressionLevelLUT = new HashMap<TextureFormatAlternative.CompressionLevel, Integer>();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/TextureGenerator.java
@@ -61,6 +61,9 @@ import com.sun.jna.Pointer;
 
 public class TextureGenerator {
 
+    // specify what is maximus of threads TextureGenerator may use
+    public static int maxThreads = 8;
+
     private static HashMap<TextureFormatAlternative.CompressionLevel, Integer> compressionLevelLUT = new HashMap<TextureFormatAlternative.CompressionLevel, Integer>();
     static {
         compressionLevelLUT.put(TextureFormatAlternative.CompressionLevel.FAST, CompressionLevel.CL_FAST);
@@ -341,9 +344,7 @@ public class TextureGenerator {
                     throw new TextureGeneratorException("could not generate mip-maps");
                 }
             }
-
-            int max_threads = 8;
-            if (!TexcLibrary.TEXC_Encode(texture, pixelFormat, ColorSpace.SRGB, texcCompressionLevel, texcCompressionType, generateMipMaps, max_threads)) {
+            if (!TexcLibrary.TEXC_Encode(texture, pixelFormat, ColorSpace.SRGB, texcCompressionLevel, texcCompressionType, generateMipMaps, maxThreads)) {
                 throw new TextureGeneratorException("could not encode");
             }
 

--- a/editor/src/clj/editor/texture/engine.clj
+++ b/editor/src/clj/editor/texture/engine.clj
@@ -89,7 +89,11 @@
 (defn- gen-mipmaps [texture]
   (TexcLibrary/TEXC_GenMipMaps texture))
 
-(def num-texc-threads 8)
+(defn num-texc-threads []
+  (let [count (.availableProcessors (Runtime/getRuntime))]
+    (cond (> count 4) (- count 2)
+          (> count 1) (- count 1)
+          :else 1)))
 
 (defn- transcode [texture pixel-format color-model compression-level compression-type mipmaps]
   (TexcLibrary/TEXC_Encode texture pixel-format color-model compression-level compression-type mipmaps (num-texc-threads)))


### PR DESCRIPTION
Added new parameter `--max-cpu-threads` for `bob.jar` which controls the maximum number of threads `bob.jar` can use. At the moment this value used only by the texture encoder.
Also, if texture compression is ON in the editor, the editor uses at least `detected_max_threads - 1` in case when 2–4 threads are available and `detected_max_threads - 2` if more than 4 cores are available.

Fix https://github.com/defold/defold/issues/7582

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
