### PR TITLE
Added back gesture support for Android 13

### DIFF
--- a/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
+++ b/engine/engine/content/builtins/manifests/android/AndroidManifest.xml
@@ -15,6 +15,7 @@
         {{/has-icons?}}
         android:label="{{project.title}}" android:hasCode="true"
         android:name="android.support.multidex.MultiDexApplication"
+        android:enableOnBackInvokedCallback="true"
         android:debuggable="{{android.debuggable}}">
 
         <meta-data android:name="android.max_aspect" android:value="2.1" />

--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -121,6 +121,7 @@ public class DefoldActivity extends NativeActivity {
      */
     public native void FakeBackspace();
     public native void FakeEnter();
+    public native void glfwInputBackButton();
     public native void glfwInputCharNative(int unicode);
     public native void glfwSetMarkedTextNative(String text);
 
@@ -239,12 +240,14 @@ public class DefoldActivity extends NativeActivity {
             throw new RuntimeException("Error getting activity info", e);
         }
 
-        if (Build.VERSION.SDK_INT >= 33) {
+        // Starting API 33 old implementation of the Back button doesn't work
+        // https://github.com/defold/defold/issues/6821
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
                 OnBackInvokedDispatcher.PRIORITY_DEFAULT, new OnBackInvokedCallback() {
                 @Override
                 public void onBackInvoked() {
-                    // Handle the back gesture here
+                    glfwInputBackButton();
                 }
             });
         }

--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -125,6 +125,8 @@ public class DefoldActivity extends NativeActivity {
     public native void glfwInputCharNative(int unicode);
     public native void glfwSetMarkedTextNative(String text);
 
+    private boolean keyboardActive;
+
     private class DefoldInputWrapper extends InputConnectionWrapper {
         private DefoldActivity _ctx;
         private String mComposingText = "";
@@ -247,6 +249,9 @@ public class DefoldActivity extends NativeActivity {
                 OnBackInvokedDispatcher.PRIORITY_DEFAULT, new OnBackInvokedCallback() {
                 @Override
                 public void onBackInvoked() {
+                    if (keyboardActive) {
+                        hideSoftInput();
+                    }
                     glfwInputBackButton();
                 }
             });
@@ -318,7 +323,7 @@ public class DefoldActivity extends NativeActivity {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
-
+                keyboardActive = true;
                 if (mTextEdit != null) {
                     mTextEdit.setVisibility(View.GONE);
                     ViewGroup vg = (ViewGroup)(mTextEdit.getParent());
@@ -461,6 +466,7 @@ public class DefoldActivity extends NativeActivity {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
+                keyboardActive = false;
                 IBinder windowToken = getWindow().getDecorView().getWindowToken();
                 imm.hideSoftInputFromWindow(windowToken, 0);
                 updateFullscreenMode();

--- a/engine/glfw/java/com/dynamo/android/DefoldActivity.java
+++ b/engine/glfw/java/com/dynamo/android/DefoldActivity.java
@@ -32,10 +32,12 @@ import android.view.KeyEvent;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.widget.FrameLayout;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.FrameLayout;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnectionWrapper;
 import android.view.inputmethod.InputConnection;
@@ -81,22 +83,15 @@ public class DefoldActivity extends NativeActivity {
 
     private ArrayList<Integer> mGameControllerDeviceIds = new ArrayList<Integer>();
 
-    /**
-     * Update immersive sticky mode based on current setting. This will only
-     * be done if Android OS version is equal to or above KitKat
-     * https://developer.android.com/training/system-ui/immersive.html
-     */
     private void updateFullscreenMode() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            if (mImmersiveMode) {
-                getWindow().getDecorView().setSystemUiVisibility(
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-            }
+        if (mImmersiveMode) {
+            getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             if (mDisplayCutout) {
@@ -243,6 +238,17 @@ public class DefoldActivity extends NativeActivity {
         } catch (PackageManager.NameNotFoundException e) {
             throw new RuntimeException("Error getting activity info", e);
         }
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                OnBackInvokedDispatcher.PRIORITY_DEFAULT, new OnBackInvokedCallback() {
+                @Override
+                public void onBackInvoked() {
+                    // Handle the back gesture here
+                }
+            });
+        }
+
         nativeOnCreate(this);
     }
 

--- a/engine/glfw/lib/android/android_init.c
+++ b/engine/glfw/lib/android/android_init.c
@@ -551,12 +551,17 @@ int32_t _glfwAndroidHandleInput(struct android_app* app, JNIEnv* env, struct Inp
             _glfwInputKey( GLFW_KEY_MENU, glfw_action );
             return 1;
         case AKEYCODE_BACK:
-            if (g_KeyboardActive) {
-                // Implicitly hide keyboard
-                _glfwShowKeyboard(0, 0, 0);
+            // Starting API 33 old implementation of the Back button doesn't work
+            // https://github.com/defold/defold/issues/6821
+            if (android_get_device_api_level() < 33) {
+                if (g_KeyboardActive) {
+                    // Implicitly hide keyboard
+                    _glfwShowKeyboard(0, 0, 0);
+                }
+                _glfwInputKey( GLFW_KEY_BACK, glfw_action );
+                return 1;
             }
-            _glfwInputKey( GLFW_KEY_BACK, glfw_action );
-            return 1;
+            return 0;
         case AKEYCODE_ESCAPE: _glfwInputKey( GLFW_KEY_ESC, glfw_action ); return 1;
         case AKEYCODE_F1: _glfwInputKey( GLFW_KEY_F1, glfw_action ); return 1;
         case AKEYCODE_F2: _glfwInputKey( GLFW_KEY_F2, glfw_action ); return 1;

--- a/engine/glfw/lib/android/android_window.c
+++ b/engine/glfw/lib/android/android_window.c
@@ -454,6 +454,7 @@ void _glfwPlatformPollEvents( void )
        if (g_SpecialKeyActive == 0) {
            _glfwInputKey( GLFW_KEY_BACKSPACE, GLFW_RELEASE );
            _glfwInputKey( GLFW_KEY_ENTER, GLFW_RELEASE );
+           _glfwInputKey( GLFW_KEY_BACK, GLFW_RELEASE );
        }
     }
 

--- a/engine/glfw/lib/android/android_window.c
+++ b/engine/glfw/lib/android/android_window.c
@@ -71,6 +71,12 @@ JNIEXPORT void JNICALL Java_com_dynamo_android_DefoldActivity_FakeEnter(JNIEnv* 
     _glfwInputKey( GLFW_KEY_ENTER, GLFW_PRESS );
 }
 
+JNIEXPORT void JNICALL Java_com_dynamo_android_DefoldActivity_glfwInputBackButton(JNIEnv* env, jobject obj)
+{
+    g_SpecialKeyActive = 10;
+    _glfwInputKey( GLFW_KEY_BACK, GLFW_PRESS );
+}
+
 JNIEXPORT void JNICALL Java_com_dynamo_android_DefoldActivity_glfwInputCharNative(JNIEnv* env, jobject obj, jint unicode)
 {
     struct Command cmd;

--- a/engine/sound/src/java/com/defold/sound/Sound.java
+++ b/engine/sound/src/java/com/defold/sound/Sound.java
@@ -25,32 +25,22 @@ public class Sound {
 
     public static int getSampleRate(Context context) {
         final int default_rate = 44100;
-        if (Build.VERSION.SDK_INT >= 17) {
-            AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-            String sampleRate = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
-            if (sampleRate == null) {
-                return default_rate;
-            }
-            return Integer.parseInt(sampleRate);
-        } else {
-            Log.w(SoundManager.TAG, "Android version < 17. Unable to determine hardware sample rate.");
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        String sampleRate = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
+        if (sampleRate == null) {
             return default_rate;
         }
+        return Integer.parseInt(sampleRate);
     }
 
     public static int getFramesPerBuffer(Context context) {
         final int default_frames = 1024;
-        if (Build.VERSION.SDK_INT >= 17) {
-            AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-            String framesPerBuffer = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
-            if (framesPerBuffer == null) {
-                return default_frames;
-            }
-            return Integer.parseInt(framesPerBuffer);
-        } else {
-            Log.w(SoundManager.TAG, "Android version < 17. Unable to determine hardware frame count.");
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        String framesPerBuffer = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
+        if (framesPerBuffer == null) {
             return default_frames;
         }
+        return Integer.parseInt(framesPerBuffer);
     }
 
 }


### PR DESCRIPTION
Android 13 doesn't support Back button anymore. Instead, it uses back gesture. This fix added support for this gesture in the engine using the same "Back" event in the input bindings. More info is available in t[he official Android documentation](https://developer.android.com/guide/navigation/predictive-back-gesture#migrate-app).

>⚠️ `AndroidManifes.xml` updated with new flag `android:enableOnBackInvokedCallback="true"` for the `<application>` tag. If you use your own manifest, make sure you apply the same changes.

Fix https://github.com/defold/defold/issues/6821

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
