### PR TITLE
Added support for throwing a Java exception from the model compiler

### DIFF
--- a/engine/dlib/src/dlib/win32/file_descriptor_win32.cpp
+++ b/engine/dlib/src/dlib/win32/file_descriptor_win32.cpp
@@ -27,7 +27,7 @@ namespace dmFileDescriptor
             case EVENT_READ: return POLLRDNORM;
             case EVENT_WRITE: return POLLWRNORM;
             case EVENT_ERROR: return POLLRDBAND;
-            default: assert(false);
+            default: assert(false); return -1;
         }
     }
     int PollReturnEventToNative(PollEvent event)
@@ -37,7 +37,7 @@ namespace dmFileDescriptor
             case EVENT_READ: return POLLRDNORM;
             case EVENT_WRITE: return POLLWRNORM;
             case EVENT_ERROR: return POLLHUP | POLLERR | POLLNVAL | POLLRDBAND;
-            default: assert(false);
+            default: assert(false); return -1;
         }
     }
 

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporter.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporter.java
@@ -473,15 +473,13 @@ public class ModelImporter {
         }
 
         // TODO: Setup a java test suite for the model importer
-        int i = 0;
-        for (String arg : args)
+        for (int i = 0; i < args.length; ++i)
         {
-            if (arg.equalsIgnoreCase("--test-exception"))
+            if (args[i].equalsIgnoreCase("--test-exception"))
             {
                 ModelImporter.TestException("Testing exception: " + args[i+1]);
                 return; // exit code 0
             }
-            ++i;
         }
 
         String path = args[0];       // name.glb/.gltf

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporter.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporter.java
@@ -73,6 +73,7 @@ public class ModelImporter {
     // The suffix of the path dictates which loader it will use
     public static native Scene LoadFromBufferInternal(String path, byte[] buffer, Object data_resolver);
     public static native int AddressOf(Object o);
+    public static native void TestException(String message);
 
     public static class ModelException extends Exception {
         public ModelException(String errorMessage) {
@@ -469,6 +470,18 @@ public class ModelImporter {
         if (args.length < 1) {
             Usage();
             return;
+        }
+
+        // TODO: Setup a java test suite for the model importer
+        int i = 0;
+        for (String arg : args)
+        {
+            if (arg.equalsIgnoreCase("--test-exception"))
+            {
+                ModelImporter.TestException("Testing exception: " + args[i+1]);
+                return; // exit code 0
+            }
+            ++i;
         }
 
         String path = args[0];       // name.glb/.gltf

--- a/engine/modelc/src/jni_util.cpp
+++ b/engine/modelc/src/jni_util.cpp
@@ -9,14 +9,16 @@
 #include <string.h>
 
 #ifdef __APPLE__
-#define UNW_LOCAL_ONLY
-#include <libunwind.h>
-#include <stdio.h>
-#endif
+    #define UNW_LOCAL_ONLY
+    #include <libunwind.h>
+    #include <stdio.h>
 
-#ifdef _WIN32
-#include <Windows.h>
-#include <Dbghelp.h>
+#elif defined(_WIN32)
+    #include <Windows.h>
+    #include <Dbghelp.h>
+
+#else
+    #include <execinfo.h>
 #endif
 
 
@@ -335,8 +337,22 @@ char* GenerateCallstack()
 
 char* GenerateCallstack()
 {
-    char* output = strdup("Callstack generation needs implementation for this platform!");
-    fprintf(stderr, "%s!\n", output);
+    int output_size = 0;
+    int output_cursor = 0;
+    char* output = 0;
+
+    void* buffer[64];
+    int num_pointers = backtrace(buffer, sizeof(buffer)/sizeof(buffer[0]));
+
+    char** stacktrace = backtrace_symbols(buffer, num_pointers);
+    for (uint32_t i = 0; i < num_pointers; ++i)
+    {
+        APPEND_STRING("    %p: %s\n", buffer[i], stacktrace[i]);
+    }
+
+    free(stacktrace);
+
+    APPEND_STRING("    # <- native");
     return output;
 }
 

--- a/engine/modelc/src/jni_util.cpp
+++ b/engine/modelc/src/jni_util.cpp
@@ -1,0 +1,201 @@
+#include "jni_util.h"
+#include <dlib/dstrings.h>
+
+#include <memory.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __APPLE__
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#include <stdio.h>
+#endif
+
+namespace dmJNI
+{
+
+static void* g_UserContext = 0;
+static void (*g_UserCallback)(int, void*) = 0;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    typedef void (*FSignalHandler)(int);
+    static FSignalHandler g_signal_handlers[4];
+#else
+    static struct sigaction g_signal_handlers[6];
+#endif
+
+static void DefaultSignalHandler(int sig) {
+    g_UserCallback(sig, g_UserContext);
+}
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+static void SetHandlers()
+{
+    g_signal_handlers[0] = signal(SIGILL, DefaultSignalHandler);
+    g_signal_handlers[1] = signal(SIGABRT, DefaultSignalHandler);
+    g_signal_handlers[2] = signal(SIGFPE, DefaultSignalHandler);
+    g_signal_handlers[3] = signal(SIGSEGV, DefaultSignalHandler);
+}
+
+static void UnsetHandlers()
+{
+    signal(SIGILL, g_signal_handlers[0]);
+    signal(SIGABRT, g_signal_handlers[1]);
+    signal(SIGFPE, g_signal_handlers[2]);
+    signal(SIGSEGV, g_signal_handlers[3]);
+}
+#else
+
+static void SetHandlers()
+{
+    #if !defined(_MSC_VER) && defined(__clang__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdisabled-macro-expansion"
+    #endif
+    struct sigaction handler;
+    memset(&handler, 0, sizeof(struct sigaction));
+    handler.sa_handler = DefaultSignalHandler;
+    sigaction(SIGILL, &handler, &g_signal_handlers[0]);
+    sigaction(SIGABRT, &handler, &g_signal_handlers[1]);
+    sigaction(SIGBUS, &handler, &g_signal_handlers[2]);
+    sigaction(SIGFPE, &handler, &g_signal_handlers[3]);
+    sigaction(SIGSEGV, &handler, &g_signal_handlers[4]);
+    sigaction(SIGPIPE, &handler, &g_signal_handlers[5]);
+    #if !defined(_MSC_VER) && defined(__clang__)
+        #pragma GCC diagnostic pop
+    #endif
+}
+static void UnsetHandlers()
+{
+    sigaction(SIGILL, &g_signal_handlers[0], 0);
+    sigaction(SIGABRT, &g_signal_handlers[1], 0);
+    sigaction(SIGBUS, &g_signal_handlers[2], 0);
+    sigaction(SIGFPE, &g_signal_handlers[3], 0);
+    sigaction(SIGSEGV, &g_signal_handlers[4], 0);
+    sigaction(SIGPIPE, &g_signal_handlers[5], 0);
+}
+#endif
+
+static void DefaultJniSignalHandler(int sig, void* ctx)
+{
+    JavaVM* vm = (JavaVM*)ctx;
+    JNIEnv* env;
+    if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return;
+    }
+
+    char* callstack = GenerateCallstack();
+
+    uint32_t size = 128 + strlen(callstack)+1;
+    char* message = (char*)malloc(size);
+
+    uint32_t written = 0;
+    written += dmSnPrintf(message+written, size, "Exception in Defold JNI code. Signal %d\n", sig);
+    written += dmSnPrintf(message+written, size, "%s", callstack);
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), message);
+
+    free((void*)callstack);
+}
+
+void EnableSignalHanders(void* ctx, void (*callback)(int signal, void* ctx))
+{
+    g_UserCallback = callback;
+    g_UserContext = ctx;
+
+    memset(&g_signal_handlers[0], 0, sizeof(g_signal_handlers));
+    SetHandlers();
+}
+
+void EnableDefaultSignalHanders(JavaVM* vm)
+{
+    EnableSignalHanders((void*)vm, DefaultJniSignalHandler);
+}
+
+void DisableSignalHanders()
+{
+    UnsetHandlers();
+    g_UserCallback = 0;
+    g_UserContext = 0;
+}
+
+
+void TestSignalFromString(const char* message)
+{
+    if (strstr(message, "SIGILL"))    raise(SIGILL);
+    if (strstr(message, "SIGABRT"))   raise(SIGABRT);
+    if (strstr(message, "SIGBUS"))    raise(SIGBUS);
+    if (strstr(message, "SIGFPE"))    raise(SIGFPE);
+    if (strstr(message, "SIGSEGV"))   raise(SIGSEGV);
+    if (strstr(message, "SIGPIPE"))   raise(SIGPIPE);
+    printf("No signal found in string: %s!\n", message);
+}
+
+#ifdef __APPLE__
+
+char* GenerateCallstack()
+{
+    // Call this function to get a backtrace.
+    unw_cursor_t cursor;
+    unw_context_t context;
+
+    // Initialize cursor to current frame for local unwinding.
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+
+    int output_size = 0;
+    int output_cursor = 0;
+    char* output = 0;
+
+#define APPEND_STRING(...) \
+    { \
+        int result; \
+        do { \
+            result = dmSnPrintf(output + output_cursor, output_size - output_cursor, __VA_ARGS__); \
+            if (result == -1) \
+            { \
+                output_size += 64; \
+                output = (char*)realloc(output, output_size); \
+            } else { \
+                output_cursor += result; \
+            } \
+        } while(result == -1); \
+    }
+
+    // Unwind frames one by one, going up the frame stack.
+    while (unw_step(&cursor) > 0) {
+        unw_word_t offset, pc;
+        unw_get_reg(&cursor, UNW_REG_IP, &pc);
+        if (pc == 0) {
+            break;
+        }
+
+        APPEND_STRING("    0x%016lx:", pc);
+
+        char sym[256];
+        if (unw_get_proc_name(&cursor, sym, sizeof(sym), &offset) == 0) {
+            APPEND_STRING(" (%s+0x%lx)\n", sym, offset);
+        }
+        else {
+            APPEND_STRING(" -- error: unable to obtain symbol name for this frame\n");
+        }
+    }
+
+    APPEND_STRING("    # <- native");
+
+    return output;
+}
+
+#else
+
+char* dmGenerateCallstack()
+{
+    char* output = strdup("Callstack generation needs implementation for this platform!");
+    return output;
+}
+
+#endif
+
+} // namespace

--- a/engine/modelc/src/jni_util.h
+++ b/engine/modelc/src/jni_util.h
@@ -1,0 +1,21 @@
+#ifndef DM_JNI_SIGNAL_HANDLER_H
+#define DM_JNI_SIGNAL_HANDLER_H
+
+#include <jni.h>
+
+namespace dmJNI
+{
+    void EnableDefaultSignalHanders(JavaVM* vm);
+    void EnableSignalHanders(void* ctx, void (*callback)(int signal, void* ctx));
+    void DisableSignalHanders();
+
+    // Caller has to free() the memory
+    char* GenerateCallstack();
+
+// for testing
+// Pass in a string containing any of the SIG* numbers
+    void TestSignalFromString(const char* signal);
+
+}
+
+#endif

--- a/engine/modelc/src/jni_util.h
+++ b/engine/modelc/src/jni_util.h
@@ -1,6 +1,7 @@
 #ifndef DM_JNI_SIGNAL_HANDLER_H
 #define DM_JNI_SIGNAL_HANDLER_H
 
+#include <stdint.h>
 #include <jni.h>
 
 namespace dmJNI
@@ -9,8 +10,26 @@ namespace dmJNI
     void EnableSignalHandlers(void* ctx, void (*callback)(int signal, void* ctx));
     void DisableSignalHandlers();
 
+    // Used to enable a jni context for a small period of time
+    bool IsContextAdded(JNIEnv* env);
+    void AddContext(JNIEnv* env);
+    void RemoveContext(JNIEnv* env);
+
+    struct SignalContextScope
+    {
+        JNIEnv* m_Env;
+        SignalContextScope(JNIEnv* env) : m_Env(env)
+        {
+            AddContext(m_Env);
+        }
+        ~SignalContextScope()
+        {
+            RemoveContext(m_Env);
+        }
+    };
+
     // Caller has to free() the memory
-    char* GenerateCallstack();
+    char* GenerateCallstack(char* buffer, uint32_t buffer_length);
 
 // for testing
 // Pass in a string containing any of the SIG* numbers

--- a/engine/modelc/src/jni_util.h
+++ b/engine/modelc/src/jni_util.h
@@ -5,9 +5,9 @@
 
 namespace dmJNI
 {
-    void EnableDefaultSignalHanders(JavaVM* vm);
-    void EnableSignalHanders(void* ctx, void (*callback)(int signal, void* ctx));
-    void DisableSignalHanders();
+    void EnableDefaultSignalHandlers(JavaVM* vm);
+    void EnableSignalHandlers(void* ctx, void (*callback)(int signal, void* ctx));
+    void DisableSignalHandlers();
 
     // Caller has to free() the memory
     char* GenerateCallstack();

--- a/engine/modelc/src/modelimporter_jni.cpp
+++ b/engine/modelc/src/modelimporter_jni.cpp
@@ -931,6 +931,7 @@ static jobject CreateJavaScene(JNIEnv* env, const dmModelImporter::Scene* scene)
 JNIEXPORT jobject JNICALL Java_ModelImporter_LoadFromBufferInternal(JNIEnv* env, jclass cls, jstring _path, jbyteArray array, jobject data_resolver)
 {
     dmLogDebug("Java_ModelImporter_LoadFromBufferInternal: env = %p\n", env);
+    dmJNI::SignalContextScope env_scope(env);
 
     ScopedString j_path(env, _path);
     const char* path = j_path.m_String;
@@ -1022,6 +1023,7 @@ JNIEXPORT jint JNICALL Java_ModelImporter_AddressOf(JNIEnv* env, jclass cls, job
 
 JNIEXPORT void JNICALL Java_ModelImporter_TestException(JNIEnv* env, jclass cls, jstring j_message)
 {
+    dmJNI::SignalContextScope env_scope(env);
     ScopedString s_message(env, j_message);
     const char* message = s_message.m_String;
     printf("Received message: %s\n", message);

--- a/engine/modelc/src/modelimporter_jni.cpp
+++ b/engine/modelc/src/modelimporter_jni.cpp
@@ -1031,7 +1031,7 @@ JNIEXPORT void JNICALL Java_ModelImporter_TestException(JNIEnv* env, jclass cls,
 JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
     dmLogDebug("JNI_OnLoad ->\n");
-    dmJNI::EnableDefaultSignalHanders(vm);
+    dmJNI::EnableDefaultSignalHandlers(vm);
 
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
@@ -1046,7 +1046,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       return JNI_ERR;
 
     // Register your class' native methods.
-    // Don't forget to add them ot the corresponding java file (e.g. ModelImporter.java)
+    // Don't forget to add them to the corresponding java file (e.g. ModelImporter.java)
     static const JNINativeMethod methods[] = {
         {"LoadFromBufferInternal", "(Ljava/lang/String;[BLjava/lang/Object;)L" CLASS_SCENE ";", reinterpret_cast<void*>(Java_ModelImporter_LoadFromBufferInternal)},
         {"AddressOf", "(Ljava/lang/Object;)I", reinterpret_cast<void*>(Java_ModelImporter_AddressOf)},
@@ -1059,6 +1059,11 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
     dmLogDebug("JNI_OnLoad return.\n");
     return JNI_VERSION_1_6;
+}
+
+JNIEXPORT void JNI_OnUnload(JavaVM *vm, void *reserved)
+{
+    dmLogDebug("JNI_OnUnload ->\n");
 }
 
 namespace dmModelImporter

--- a/engine/modelc/src/wscript
+++ b/engine/modelc/src/wscript
@@ -33,7 +33,7 @@ def build(bld):
     # Used by bob.jar + editor
     model_shared = bld(features = 'c cxx cshlib skip_asan extract_symbols',
                        includes = model.includes,
-                       uselib = 'DLIB_NOASAN PROFILE_NULL_NOASAN JDK',
+                       uselib = 'DLIB_NOASAN PLATFORM PROFILE_NULL_NOASAN JDK',
                        source = modelc_sources,
                        target = 'modelc_shared')
 


### PR DESCRIPTION
We've made the model compiler more robust and it will now catch any C/C++ errors, and then throw a Java error. This lets the editor handle such a case, and we minimise the risk of the user losing any edits in the project.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
