### PR TITLE
Add override inspector

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -100,6 +100,8 @@
     :command :referencing-files}
    {:label "Dependencies..."
     :command :dependencies}
+   {:label "Show Overrides"
+    :command :show-overrides}
    {:label :separator}
    {:label "New"
     :command :new-file

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -175,9 +175,8 @@
           scene-visibility     (scene-visibility/make-scene-visibility-node! *view-graph*)
           app-view             (app-view/make-app-view *view-graph* project stage menu-bar editor-tabs-split tool-tabs prefs)
           outline-view         (outline-view/make-outline-view *view-graph* project outline app-view)
-          properties-view      (properties-view/make-properties-view workspace project app-view *view-graph* (.lookup root "#properties"))
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs)
-          open-resource        (partial app-view/open-resource app-view prefs workspace project)
+          open-resource        (partial #'app-view/open-resource app-view prefs workspace project)
           console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          (fn [resource selected-node-ids opts]
@@ -186,6 +185,7 @@
           search-results-view  (search-results-view/make-search-results-view! *view-graph*
                                                                               (.lookup root "#search-results-container")
                                                                               open-resource)
+          properties-view      (properties-view/make-properties-view workspace project app-view search-results-view *view-graph* (.lookup root "#properties"))
           changes-view         (changes-view/make-changes-view *view-graph* workspace prefs (.lookup root "#changes-container")
                                                                (fn [changes-view moved-files]
                                                                  (app-view/async-reload! app-view changes-view workspace moved-files)))

--- a/editor/src/clj/editor/changes_view.clj
+++ b/editor/src/clj/editor/changes_view.clj
@@ -88,6 +88,8 @@
     :command :referencing-files}
    {:label "Dependencies..."
     :command :dependencies}
+   {:label "Show Overrides"
+    :command :show-overrides}
    {:label :separator}
    {:label "View Diff"
     :icon "icons/32/Icons_S_06_arrowup.png"

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -1410,7 +1410,7 @@
         filter-term (:filter-term ui-state)
         sections-with-visibility (mapv #(set-section-visibility % values filter-term) sections)
         navigation (:navigation form-data true)]
-    {:fx/type with-anchor-pane-props
+    {:fx/type fxui/ext-with-anchor-pane-props
      :desc {:fx/type fxui/ext-value
             :value parent}
      :props {:children [(if navigation

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -93,9 +93,6 @@
 (defmethod handle-event :set [{:keys [path fx/event]}]
   {:set [path event]})
 
-(def with-anchor-pane-props
-  (fx/make-ext-with-props fx.anchor-pane/props))
-
 (def uri-string-converter
   (proxy [StringConverter] []
     (toString

--- a/editor/src/clj/editor/fxui.clj
+++ b/editor/src/clj/editor/fxui.clj
@@ -17,6 +17,7 @@
   (:require [cljfx.api :as fx]
             [cljfx.coerce :as fx.coerce]
             [cljfx.component :as fx.component]
+            [cljfx.fx.anchor-pane :as fx.anchor-pane]
             [cljfx.fx.button :as fx.button]
             [cljfx.fx.column-constraints :as fx.column-constraints]
             [cljfx.fx.grid-pane :as fx.grid-pane]
@@ -156,6 +157,9 @@
                    (.setVvalue pane (/ (.getMinY child-bounds)
                                        (- content-height viewport-height)))))))))
        fx.lifecycle/dynamic)}))
+
+(def ext-with-anchor-pane-props
+  (fx/make-ext-with-props fx.anchor-pane/props))
 
 (defn ext-ensure-scroll-pane-child-visible
   "Extension lifecycle that ensures ScrollPane's child node is visible

--- a/editor/src/clj/editor/outline_view.clj
+++ b/editor/src/clj/editor/outline_view.clj
@@ -235,6 +235,8 @@
     :command :referencing-files}
    {:label "Dependencies..."
     :command :dependencies}
+   {:label "Show Overrides"
+    :command :show-overrides}
    {:label :separator}
    {:label "Add"
     :icon "icons/32/Icons_M_07_plus.png"

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -403,7 +403,8 @@
   (:visible property true))
 
 (defn coalesce [properties]
-  (let [properties (mapv flatten-properties properties)
+  (let [node-ids (mapv :node-id properties)
+        properties (mapv flatten-properties properties)
         display-orders (mapv :display-order properties)
         properties (mapv :properties properties)
         node-count (count properties)
@@ -436,7 +437,8 @@
                                     [k prop]))
                                 common-props))]
     {:properties coalesced
-     :display-order (prune-display-order (first display-orders) (set (keys coalesced)))}))
+     :display-order (prune-display-order (first display-orders) (set (keys coalesced)))
+     :original-node-ids node-ids}))
 
 (defn values [property]
   (let [f (get-in property [:edit-type :to-type] identity)]

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -15,16 +15,18 @@
 (ns editor.properties-view
   (:require [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.app-view :as app-view]
+            [editor.field-expression :as field-expression]
+            [editor.handler :as handler]
+            [editor.jfx :as jfx]
+            [editor.math :as math]
+            [editor.properties :as properties]
+            [editor.resource :as resource]
+            [editor.resource-dialog :as resource-dialog]
+            [editor.types :as types]
             [editor.ui :as ui]
             [editor.ui.fuzzy-combo-box :as fuzzy-combo-box]
-            [editor.jfx :as jfx]
-            [editor.types :as types]
-            [editor.properties :as properties]
             [editor.workspace :as workspace]
-            [editor.resource :as resource]
-            [editor.math :as math]
-            [editor.field-expression :as field-expression]
-            [editor.resource-dialog :as resource-dialog]
             [util.id-vec :as iv]
             [util.profiler :as profiler])
   (:import [javafx.geometry Insets Point2D]
@@ -488,8 +490,27 @@
     (.setMinWidth Label/USE_PREF_SIZE)
     (.setMinHeight 28.0)))
 
-(defn- create-properties-row [context ^GridPane grid key property row property-fn]
-  (let [^Label label (create-property-label (properties/label property) key (properties/tooltip property))
+(handler/defhandler :show-overrides :property
+  (active? [evaluation-context selection]
+    (when-let [node-id (handler/selection->node-id selection)]
+      (pos? (count (g/overrides (:basis evaluation-context) node-id)))))
+  (run [property selection search-results-view app-view]
+    (app-view/show-override-inspector! app-view search-results-view (handler/selection->node-id selection) [(:key property)])))
+
+(handler/register-menu! ::properties-menu
+  [{:label "Show Overrides"
+    :command :show-overrides}])
+
+(defrecord SelectionProvider [original-node-ids]
+  handler/SelectionProvider
+  (selection [_] original-node-ids)
+  (succeeding-selection [_])
+  (alt-selection [_]))
+
+(defn- create-properties-row [context ^GridPane grid key property row original-node-ids property-fn]
+  (let [^Label label (doto (create-property-label (properties/label property) key (properties/tooltip property))
+                       (ui/context! :property (assoc context :property property) (->SelectionProvider original-node-ids))
+                       (ui/register-context-menu ::properties-menu true))
         [^Node control update-ctrl-fn] (create-property-control! (:edit-type property) context
                                                                  (fn [] (property-fn key)))
         reset-btn (doto (Button. nil (jfx/get-image-view "icons/32/Icons_S_02_Reset.png"))
@@ -540,13 +561,13 @@
 
     [key update-ui-fn]))
 
-(defn- create-properties [context grid properties property-fn]
+(defn- create-properties [context grid properties original-node-ids property-fn]
   ; TODO - add multi-selection support for properties view
   (doall (map-indexed (fn [row [key property]]
-                        (create-properties-row context grid key property row property-fn))
+                        (create-properties-row context grid key property row original-node-ids property-fn))
                       properties)))
 
-(defn- make-grid [parent context properties property-fn]
+(defn- make-grid [parent context properties original-node-ids property-fn]
   (let [grid (doto (GridPane.)
                (.setHgap grid-hgap)
                (.setVgap grid-vgap))
@@ -557,7 +578,7 @@
 
     (ui/add-child! parent grid)
     (ui/add-style! grid "form")
-    (create-properties context grid properties property-fn)))
+    (create-properties context grid properties original-node-ids property-fn)))
 
 (defn- create-category-label [label]
   (doto (Label. label) (ui/add-style! "property-category")))
@@ -574,8 +595,7 @@
       (let [property-fn   (fn [key]
                             (let [properties (:properties (ui/user-data vbox ::properties))]
                               (get properties key)))
-            display-order (:display-order properties)
-            properties    (:properties properties)
+            {:keys [display-order properties original-node-ids]} properties
             generics      [nil (mapv (fn [k] [k (get properties k)]) (filter (comp not properties/category?) display-order))]
             categories    (mapv (fn [order]
                                   [(first order) (mapv (fn [k] [k (get properties k)]) (rest order))])
@@ -589,7 +609,7 @@
                                                    (when category
                                                      (let [label (create-category-label category)]
                                                        (ui/add-child! vbox label)))
-                                                   (make-grid vbox context properties property-fn)))]
+                                                   (make-grid vbox context properties original-node-ids property-fn)))]
                                 (recur (rest sections) (into result update-fns)))
                               result))]
         ; NOTE: Note update-fns is a sequence of [[property-key update-ui-fn] ...]
@@ -632,18 +652,28 @@
   (property parent-view Parent)
   (property workspace g/Any)
   (property project g/Any)
+  (property app-view g/NodeID)
+  (property search-results-view g/NodeID)
 
   (input selected-node-properties g/Any)
 
-  (output pane Pane :cached (g/fnk [parent-view workspace project selected-node-properties]
-                                   (let [context {:workspace workspace :project project}]
+  (output pane Pane :cached (g/fnk [parent-view workspace project app-view search-results-view selected-node-properties]
+                                   (let [context {:workspace workspace
+                                                  :project project
+                                                  :app-view app-view
+                                                  :search-results-view search-results-view}]
                                      ;; Collecting the properties and then updating the view takes some time, but has no immediacy
                                      ;; This is effectively time-slicing it over two "frames" (or whenever JavaFX decides to run the second part)
                                      (ui/run-later
                                        (update-pane! parent-view context selected-node-properties))))))
 
-(defn make-properties-view [workspace project app-view view-graph ^Node parent]
-  (let [view-id       (g/make-node! view-graph PropertiesView :parent-view parent :workspace workspace :project project)
+(defn make-properties-view [workspace project app-view search-results-view view-graph ^Node parent]
+  (let [view-id       (g/make-node! view-graph PropertiesView
+                                    :parent-view parent
+                                    :workspace workspace
+                                    :project project
+                                    :app-view app-view
+                                    :search-results-view search-results-view)
         stage         (.. parent getScene getWindow)]
     (g/connect! app-view :selected-node-properties view-id :selected-node-properties)
     view-id))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -650,11 +650,11 @@
 
 (g/defnode PropertiesView
   (property parent-view Parent)
-  (property workspace g/Any)
-  (property project g/Any)
-  (property app-view g/NodeID)
-  (property search-results-view g/NodeID)
 
+  (input workspace g/Any)
+  (input project g/Any)
+  (input app-view g/NodeID)
+  (input search-results-view g/NodeID)
   (input selected-node-properties g/Any)
 
   (output pane Pane :cached (g/fnk [parent-view workspace project app-view search-results-view selected-node-properties]
@@ -668,12 +668,12 @@
                                        (update-pane! parent-view context selected-node-properties))))))
 
 (defn make-properties-view [workspace project app-view search-results-view view-graph ^Node parent]
-  (let [view-id       (g/make-node! view-graph PropertiesView
-                                    :parent-view parent
-                                    :workspace workspace
-                                    :project project
-                                    :app-view app-view
-                                    :search-results-view search-results-view)
-        stage         (.. parent getScene getWindow)]
-    (g/connect! app-view :selected-node-properties view-id :selected-node-properties)
-    view-id))
+  (first
+    (g/tx-nodes-added
+      (g/transact
+        (g/make-nodes view-graph [view [PropertiesView :parent-view parent]]
+          (g/connect workspace :_node-id view :workspace)
+          (g/connect project :_node-id view :project)
+          (g/connect app-view :_node-id view :app-view)
+          (g/connect app-view :selected-node-properties view :selected-node-properties)
+          (g/connect search-results-view :_node-id view :search-results-view))))))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -1411,67 +1411,64 @@
                                (:grid opts) (:grid opts)
                                :else grid/Grid)
         tool-controller-type (get opts :tool-controller scene-tools/ToolController)]
-    (concat
-      (g/make-nodes view-graph
-                    [background      background/Background
-                     selection       [selection/SelectionController :select-fn (fn [selection op-seq]
-                                                                                 (g/transact
-                                                                                   (concat
-                                                                                     (g/operation-sequence op-seq)
-                                                                                     (g/operation-label "Select")
-                                                                                     (select-fn selection))))]
-                     camera          [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000}))]
-                     grid            grid-type
-                     tool-controller [tool-controller-type :prefs prefs]
-                     rulers          [rulers/Rulers]]
+    (g/make-nodes view-graph
+                  [background      background/Background
+                   selection       [selection/SelectionController :select-fn (fn [selection op-seq]
+                                                                               (g/transact
+                                                                                 (concat
+                                                                                   (g/operation-sequence op-seq)
+                                                                                   (g/operation-label "Select")
+                                                                                   (select-fn selection))))]
+                   camera          [c/CameraController :local-camera (or (:camera opts) (c/make-camera :orthographic identity {:fov-x 1000 :fov-y 1000}))]
+                   grid            grid-type
+                   tool-controller [tool-controller-type :prefs prefs]
+                   rulers          [rulers/Rulers]]
 
-                    (g/connect resource-node   :scene                         view-id         :scene)
+                  (g/connect resource-node   :scene                         view-id         :scene)
 
-                    (g/connect background      :renderable                    view-id         :aux-renderables)
+                  (g/connect background      :renderable                    view-id         :aux-renderables)
 
-                    (g/connect camera          :camera                        view-id         :camera)
-                    (g/connect camera          :input-handler                 view-id         :input-handlers)
-                    (g/connect view-id         :scene-aabb                    camera          :scene-aabb)
-                    (g/connect view-id         :viewport                      camera          :viewport)
+                  (g/connect camera          :camera                        view-id         :camera)
+                  (g/connect camera          :input-handler                 view-id         :input-handlers)
+                  (g/connect view-id         :scene-aabb                    camera          :scene-aabb)
+                  (g/connect view-id         :viewport                      camera          :viewport)
 
-                    (g/connect app-view-id     :selected-node-ids             view-id         :selection)
-                    (g/connect app-view-id     :active-view                   view-id         :active-view)
-                    (g/connect app-view-id     :active-tool                   view-id         :active-tool)
-                    (g/connect app-view-id     :manip-space                   view-id         :manip-space)
-                    (g/connect app-view-id     :hidden-renderable-tags        view-id         :hidden-renderable-tags)
-                    (g/connect app-view-id     :hidden-node-outline-key-paths view-id         :hidden-node-outline-key-paths)
+                  (g/connect app-view-id     :selected-node-ids             view-id         :selection)
+                  (g/connect app-view-id     :active-view                   view-id         :active-view)
+                  (g/connect app-view-id     :active-tool                   view-id         :active-tool)
+                  (g/connect app-view-id     :manip-space                   view-id         :manip-space)
+                  (g/connect app-view-id     :hidden-renderable-tags        view-id         :hidden-renderable-tags)
+                  (g/connect app-view-id     :hidden-node-outline-key-paths view-id         :hidden-node-outline-key-paths)
 
-                    (g/connect tool-controller :input-handler                 view-id         :input-handlers)
-                    (g/connect tool-controller :info-text                     view-id         :tool-info-text)
-                    (g/connect tool-controller :renderables                   view-id         :tool-renderables)
-                    (g/connect view-id         :active-tool                   tool-controller :active-tool)
-                    (g/connect view-id         :manip-space                   tool-controller :manip-space)
-                    (g/connect view-id         :viewport                      tool-controller :viewport)
-                    (g/connect camera          :camera                        tool-controller :camera)
-                    (g/connect view-id         :selected-renderables          tool-controller :selected-renderables)
+                  (g/connect tool-controller :input-handler                 view-id         :input-handlers)
+                  (g/connect tool-controller :info-text                     view-id         :tool-info-text)
+                  (g/connect tool-controller :renderables                   view-id         :tool-renderables)
+                  (g/connect view-id         :active-tool                   tool-controller :active-tool)
+                  (g/connect view-id         :manip-space                   tool-controller :manip-space)
+                  (g/connect view-id         :viewport                      tool-controller :viewport)
+                  (g/connect camera          :camera                        tool-controller :camera)
+                  (g/connect view-id         :selected-renderables          tool-controller :selected-renderables)
 
-                    (attach-tool-controller tool-controller-type tool-controller view-id resource-node)
+                  (attach-tool-controller tool-controller-type tool-controller view-id resource-node)
 
-                    (if (:grid opts)
-                      (attach-grid grid-type grid view-id resource-node camera)
-                      (g/delete-node grid))
+                  (if (:grid opts)
+                    (attach-grid grid-type grid view-id resource-node camera)
+                    (g/delete-node grid))
 
-                    (g/connect resource-node   :_node-id                      selection       :root-id)
-                    (g/connect selection       :renderable                    view-id         :tool-renderables)
-                    (g/connect selection       :input-handler                 view-id         :input-handlers)
-                    (g/connect selection       :picking-rect                  view-id         :picking-rect)
-                    (g/connect view-id         :picking-selection             selection       :picking-selection)
-                    (g/connect view-id         :selection                     selection       :selection)
+                  (g/connect resource-node   :_node-id                      selection       :root-id)
+                  (g/connect selection       :renderable                    view-id         :tool-renderables)
+                  (g/connect selection       :input-handler                 view-id         :input-handlers)
+                  (g/connect selection       :picking-rect                  view-id         :picking-rect)
+                  (g/connect view-id         :picking-selection             selection       :picking-selection)
+                  (g/connect view-id         :selection                     selection       :selection)
 
-                    (g/connect camera :camera rulers :camera)
-                    (g/connect rulers :renderables view-id :aux-renderables)
-                    (g/connect view-id :viewport rulers :viewport)
-                    (g/connect view-id :cursor-pos rulers :cursor-pos)
+                  (g/connect camera :camera rulers :camera)
+                  (g/connect rulers :renderables view-id :aux-renderables)
+                  (g/connect view-id :viewport rulers :viewport)
+                  (g/connect view-id :cursor-pos rulers :cursor-pos)
 
-                    (when-not (:manual-refresh? opts)
-                      (g/connect view-id :_node-id app-view-id :scene-view-ids)))
-      (when-let [node-id (:select-node opts)]
-        (select-fn [node-id])))))
+                  (when-not (:manual-refresh? opts)
+                    (g/connect view-id :_node-id app-view-id :scene-view-ids)))))
 
 (defn make-view [graph ^Parent parent resource-node opts]
   (let [view-id (make-scene-view graph parent opts)]

--- a/editor/src/clj/editor/search_results_view.clj
+++ b/editor/src/clj/editor/search_results_view.clj
@@ -13,14 +13,34 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.search-results-view
-  (:require [clojure.string :as string]
+  (:require [cljfx.api :as fx]
+            [cljfx.fx.anchor-pane :as fx.anchor-pane]
+            [cljfx.fx.check-box :as fx.check-box]
+            [cljfx.fx.column-constraints :as fx.column-constraints]
+            [cljfx.fx.grid-pane :as fx.grid-pane]
+            [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.hyperlink :as fx.hyperlink]
+            [cljfx.fx.progress-indicator :as fx.progress-indicator]
+            [cljfx.fx.region :as fx.region]
+            [cljfx.fx.tree-item :as fx.tree-item]
+            [cljfx.fx.tree-table-cell :as fx.tree-table-cell]
+            [cljfx.fx.tree-table-column :as fx.tree-table-column]
+            [cljfx.fx.tree-table-view :as fx.tree-table-view]
+            [clojure.string :as string]
             [dynamo.graph :as g]
             [editor.code.data :as data]
             [editor.core :as core]
             [editor.defold-project-search :as project-search]
+            [editor.error-reporting :as error-reporting]
+            [editor.field-expression :as field-expression]
+            [editor.fxui :as fxui]
             [editor.icons :as icons]
+            [editor.outline :as outline]
             [editor.prefs :as prefs]
+            [editor.properties :as properties]
             [editor.resource :as resource]
+            [editor.resource-node :as resource-node]
+            [editor.types :as types]
             [editor.ui :as ui]
             [editor.workspace :as workspace])
   (:import [java.util Collection]
@@ -28,8 +48,9 @@
            [javafx.event Event]
            [javafx.geometry Pos]
            [javafx.scene Parent Scene]
-           [javafx.scene.control CheckBox Label ProgressIndicator SelectionMode TextField TreeItem TreeView]
-           [javafx.scene.input KeyCode KeyEvent]
+           [javafx.scene.control CheckBox Label ProgressIndicator SelectionMode TextField TreeItem TreeTableView TreeView]
+           [javafx.scene.input KeyCode KeyEvent MouseEvent]
+           [javafx.scene.paint Color]
            [javafx.scene.layout AnchorPane HBox Priority]
            [javafx.stage StageStyle]))
 
@@ -307,3 +328,267 @@
                           (update-search-results! search-results-view results-tab-tree-view progress-indicator)
                           (show-search-results-tab-fn))]
     (start-search-in-files! project prefs results-tab-tree-view progress-indicator open-fn show-matches-fn)))
+
+(defn- resource-cell [{:keys [resource qualifier]}]
+  {:graphic {:fx/type fx.h-box/lifecycle
+             :spacing 6
+             :children (cond-> [{:fx/type fxui/label
+                                 :text (resource/resource->proj-path resource)}]
+                               qualifier
+                               (conj {:fx/type fxui/label
+                                      :style {:-fx-text-fill :-df-text-darker}
+                                      :text qualifier}))}})
+
+(defn- property->edit-type-dispatch-value [property]
+  (let [edit-type (-> property :edit-type :type (or (:type property)))]
+    (or (g/value-type-dispatch-value edit-type)
+        edit-type)))
+
+(defmulti property-column-suffix property->edit-type-dispatch-value)
+(defmethod property-column-suffix :default [_] "")
+(defmethod property-column-suffix types/Vec2 [property]
+  (str ": " (string/join " " (:labels property ["X" "Y"]))))
+(defmethod property-column-suffix types/Vec3 [property]
+  (str ": " (string/join " " (:labels property ["X" "Y" "Z"]))))
+(defmethod property-column-suffix types/Vec4 [property]
+  (str ": " (string/join " " (:labels property ["X" "Y" "Z" "W"]))))
+
+(defmulti override-value-cell-view property->edit-type-dispatch-value)
+
+(defn- overridden-style-classes [property]
+  (if (contains? property :original-value)
+    ["overridden"]
+    []))
+
+(defmethod override-value-cell-view :default [{:keys [value] :as property}]
+  {:fx/type fx.h-box/lifecycle
+   :alignment (if (number? value) :top-right :top-left)
+   :children [{:fx/type fxui/label
+               :h-box/hgrow :always
+               :style-class (overridden-style-classes property)
+               :text (string/replace (str value) \newline \space)}]})
+
+(defmethod override-value-cell-view g/Bool [{:keys [value] :as property}]
+  {:fx/type fx.check-box/lifecycle
+   :disable true
+   :style-class (into ["check-box" "override-inspector-check-box"] (overridden-style-classes property))
+   :selected (boolean value)})
+
+(defn- multi-text-field [{:keys [value] :as property}]
+  {:fx/type fx.grid-pane/lifecycle
+   :hgap 5
+   :column-constraints (repeat (count value)
+                               {:fx/type fx.column-constraints/lifecycle
+                                :percent-width (/ 100.0 (max 1 (count value)))})
+   :children (into []
+                   (map-indexed
+                     (fn [i v]
+                       {:fx/type fxui/label
+                        :grid-pane/column i
+                        :grid-pane/halignment :right
+                        :style-class (overridden-style-classes property)
+                        :text (field-expression/format-number v)}))
+                   value)})
+
+(defmethod override-value-cell-view types/Vec2 [property]
+  (multi-text-field property))
+
+(defmethod override-value-cell-view types/Vec3 [property]
+  (multi-text-field property))
+
+(defmethod override-value-cell-view types/Vec4 [property]
+  (multi-text-field property))
+
+(defmethod override-value-cell-view types/Color [{:keys [value] :as property}]
+  (if value
+    (let [[r g b a] value
+          color (Color. r g b a)
+          nr (Math/round (double (* 255 r)))
+          ng (Math/round (double (* 255 g)))
+          nb (Math/round (double (* 255 b)))
+          na (Math/round (double (* 255 a)))]
+      {:fx/type fxui/label
+       :style-class (overridden-style-classes property)
+       :graphic {:fx/type fx.region/lifecycle
+                 :min-width 10
+                 :min-height 10
+                 :background {:fills [{:fill color}]}}
+       :text (if (= 255 na)
+               (format "#%02x%02x%02x" nr ng nb)
+               (format "#%02x%02x%02x%02x" nr ng nb na))})
+    {:fx/type fxui/label}))
+
+(defmethod override-value-cell-view :choicebox [{:keys [edit-type value] :as property}]
+  (let [labels (into {} (:options edit-type))]
+    {:fx/type fxui/label
+     :style-class (overridden-style-classes property)
+     :text (get labels value)}))
+
+(defn open-hyperlink-resource! [open-resource-fn resource _]
+  (open-resource-fn resource {}))
+
+(defmethod override-value-cell-view resource/Resource [{:keys [value open-resource-fn] :as property}]
+  {:fx/type fx.hyperlink/lifecycle
+   :style-class (into ["override-inspector-hyperlink"] (overridden-style-classes property))
+   :on-action (fxui/partial #'open-hyperlink-resource! open-resource-fn value)
+   :text (resource/resource->proj-path value)})
+
+(defn- value-cell [open-resource-fn property]
+  {:graphic (override-value-cell-view (assoc property :value (properties/value property)
+                                                      :open-resource-fn open-resource-fn))})
+
+(defn- property-value [property-keyword tree]
+  (-> tree :properties property-keyword))
+
+(defn- tree-table-view-event-filter [open-resource-fn ^Event e]
+  (when (and (instance? MouseEvent e)
+             (= MouseEvent/MOUSE_PRESSED (.getEventType e)))
+    (let [^MouseEvent e e]
+      (when (even? (.getClickCount e))
+        (.consume e)
+        (when-let [tree (-> e
+                            ^TreeTableView .getSource
+                            .getSelectionModel
+                            ^TreeItem .getSelectedItem
+                            (some-> .getValue))]
+          (open-resource-fn (:resource tree) {:select-node (:node-id tree)}))))))
+
+(defn- override-inspector-view [state parent open-resource-fn]
+  (letfn [(->tree-item [tree]
+            {:fx/type fx.tree-item/lifecycle
+             :expanded true
+             :value tree
+             :children (mapv ->tree-item (:children tree))})]
+    {:fx/type fxui/ext-with-anchor-pane-props
+     :desc {:fx/type fxui/ext-value
+            :value parent}
+     :props
+     {:children
+      [{:fx/type fx.anchor-pane/lifecycle
+        :anchor-pane/left 0
+        :anchor-pane/right 0
+        :anchor-pane/top 0
+        :anchor-pane/bottom 0
+        :children
+        [(if (= :search state)
+           {:fx/type fx.progress-indicator/lifecycle
+            :anchor-pane/right 10
+            :anchor-pane/bottom 10
+            :pref-width 28
+            :pref-height 28
+            :mouse-transparent true}
+           {:fx/type fx.tree-table-view/lifecycle
+            :anchor-pane/bottom 0
+            :anchor-pane/top 0
+            :anchor-pane/left 0
+            :anchor-pane/right 0
+            :fixed-cell-size 24
+            :show-root false
+            :event-filter (fxui/partial #'tree-table-view-event-filter open-resource-fn)
+            :columns (into [{:fx/type fx.tree-table-column/lifecycle
+                             :text "Resource"
+                             :cell-value-factory identity
+                             :cell-factory {:fx/cell-type fx.tree-table-cell/lifecycle
+                                            :describe #'resource-cell}}]
+                           (map (fn [property-keyword]
+                                  {:fx/type fx.tree-table-column/lifecycle
+                                   :text (str (properties/keyword->name property-keyword)
+                                              (property-column-suffix (property-value property-keyword state)))
+                                   :cell-value-factory (fxui/partial #'property-value property-keyword)
+                                   :cell-factory {:fx/cell-type fx.tree-table-cell/lifecycle
+                                                  :describe (fxui/partial #'value-cell open-resource-fn)}}))
+                           (:display-order state))
+            :root (->tree-item state)})]}]}}))
+
+(defn- make-override-tree [node-id properties {:keys [basis] :as evaluation-context}]
+  (let [property-pred (if (= :all properties)
+                        any?
+                        (set properties))]
+    (letfn [(make-tree
+              ([node-id]
+               (make-tree node-id false))
+              ([node-id root]
+               (let [property-map (:properties (g/node-value node-id :_properties evaluation-context))
+                     overridden-properties (into #{}
+                                                 (keep (fn [[k property]]
+                                                         (when (and (property-pred k)
+                                                                    (properties/visible? property)
+                                                                    (contains? property :original-value))
+                                                           k)))
+                                                 property-map)
+                     children (into []
+                                    (keep make-tree)
+                                    (g/overrides basis node-id))]
+                 (when (or root
+                           (pos? (count overridden-properties))
+                           (pos? (count children)))
+                   (let [owner-node-id (or (resource-node/owner-resource-node-id basis node-id)
+                                           (throw (ex-info "Can't find the owner resource node for an override node"
+                                                           {:node-id node-id})))
+                         resource (resource-node/resource basis owner-node-id)
+                         outline-ids (when (g/node-instance? basis outline/OutlineNode owner-node-id)
+                                       (->> (g/node-value owner-node-id :node-outline evaluation-context)
+                                            (tree-seq :children :children)
+                                            (into #{} (map :node-id))))
+                         select-node-id (or (when outline-ids
+                                              (loop [node-id node-id]
+                                                (cond
+                                                  (nil? node-id) nil
+                                                  (outline-ids node-id) node-id
+                                                  :else (recur (core/owner-node-id basis node-id)))))
+                                            node-id)
+                         select-node-type (g/node-type* basis select-node-id)
+                         qualifier (cond
+                                     (g/has-output? select-node-type :url)
+                                     (str (g/node-value select-node-id :url evaluation-context))
+
+                                     (g/has-output? select-node-type :id)
+                                     (str (g/node-value select-node-id :id evaluation-context))
+
+                                     :else
+                                     nil)]
+                     {:node-id select-node-id
+                      :qualifier qualifier
+                      :resource resource
+                      :properties property-map
+                      :overridden-properties overridden-properties
+                      :children children})))))]
+      (make-tree node-id true))))
+
+(defn show-override-inspector!
+  "Show override inspector tree table in a Search Results view
+
+  Args:
+    search-results-view    node id of a search result view
+    node-id                root node id whose overrides are inspected
+    properties             either :all or a coll of property keywords to include
+                           in the override inspector output"
+  [search-results-view node-id properties]
+  (let [evaluation-context (g/make-evaluation-context)
+        parent (g/node-value search-results-view :search-results-container evaluation-context)
+        display-order (into {}
+                            (map-indexed (fn [i k] [k i]))
+                            (:display-order (g/node-value node-id :_properties evaluation-context)))
+        open-resource-fn (partial open-resource! search-results-view)
+        renderer (fx/create-renderer
+                   :error-handler error-reporting/report-exception!
+                   :middleware
+                   (comp
+                     fxui/wrap-dedupe-desc
+                     (fx/wrap-map-desc #'override-inspector-view parent open-resource-fn)))]
+    (renderer :search)
+    (future
+      (try
+        (let [tree (make-override-tree node-id properties evaluation-context)]
+          (renderer
+            (assoc tree
+              :display-order (->> (tree-seq :children :children tree)
+                                  (into #{}
+                                        (comp
+                                          (drop 1)
+                                          (mapcat :overridden-properties)))
+                                  (sort-by display-order)
+                                  vec)))
+          (g/update-cache-from-evaluation-context! evaluation-context))
+        (catch Throwable ex
+          (error-reporting/report-exception! ex))))))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1356,10 +1356,27 @@
       (set-show-relative-to-window! cm true)
       (.show cm node (.getScreenX event) (.getScreenY event)))))
 
-(defn register-context-menu [^Control control menu-location]
-  (.addEventHandler control ContextMenuEvent/CONTEXT_MENU_REQUESTED
-    (event-handler event
-      (show-context-menu! menu-location event))))
+(defn register-context-menu
+  "Register a context menu listener on a control for the menu location
+
+  Args:
+    control          an instance of a Control
+    menu-location    keyword identifier of a menu location registered with
+                     [[editor.handler/register-menu!]]
+    focus            whether to focus on the control when the context menu is
+                     requested, default false. Focusing might be necessary in
+                     some cases because the context menu handlers are evaluated
+                     in the context of the focus owner of the scene, and some
+                     controls (e.g. Label) are not focused when a context menu
+                     is requested for them. Without a focus, any context these
+                     controls define will be lost."
+  ([control menu-location]
+   (register-context-menu control menu-location false))
+  ([^Control control menu-location focus]
+   (.addEventHandler control ContextMenuEvent/CONTEXT_MENU_REQUESTED
+     (event-handler event
+       (when focus (.requestFocus control))
+       (show-context-menu! menu-location event)))))
 
 (defn- event-targets-tab? [^Event event]
   (some? (closest-node-with-style "tab" (.getTarget event))))

--- a/editor/styling/stylesheets/_editor.scss
+++ b/editor/styling/stylesheets/_editor.scss
@@ -55,10 +55,28 @@ Links:
 
 /* Overrides */
 
+.override-inspector-hyperlink {
+  -fx-text-fill: -df-text;
+  &:hover {
+    -fx-underline: true;
+  }
+}
+
 .overridden {
   -fx-text-inner-color: -df-defold-blue-lighter;
   -fx-text-color-base: -df-defold-blue-lighter;
   -fx-text-fill: -df-defold-blue-lighter; }
+
+&.override-inspector-check-box {
+    -fx-opacity: 1;
+    -fx-padding: -2 0 0 0;
+    & > .box {
+      -fx-background-color: transparent !important;
+    }
+    &.overridden > .box > .mark {
+      -fx-background-color: -df-defold-blue-lighter;
+    }
+}
 
 .copyable-label, .copyable-label:focused {
   -fx-background-color: transparent;

--- a/editor/styling/stylesheets/components/_tree-table-view.scss
+++ b/editor/styling/stylesheets/components/_tree-table-view.scss
@@ -1,0 +1,40 @@
+.tree-table-view {
+    -fx-background-insets: 0;
+    -fx-border-width: 0;
+    -fx-border-color: transparent;
+    & > .column-header-background {
+        -fx-border-width: 0 0 1 0;
+        -fx-border-color: -df-background-lighter;
+        -fx-background-color: -df-background-light;
+        & > .nested-column-header > .column-header {
+                -fx-background-insets: 0;
+                -fx-border-width: 0 1 0 0;
+                -fx-border-color: -df-background-lighter;
+        }
+    }
+    .table-column {
+        -fx-background-insets: 0;
+        -fx-border-width: 0 1 0 0;
+        -fx-border-color: -df-background-lighter;
+        -fx-background-color: -df-background-light;
+    }
+    .filler {
+        -fx-background-insets: 0;
+        -fx-background-color: -df-background-light;
+    }
+    & > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell {
+      -fx-background-color: -df-background-light;
+      & > .tree-table-cell {
+        -fx-background-insets: 0;
+        -fx-border-width: 0 1 0 0;
+        -fx-border-color: -df-background-lighter;
+        -fx-background-color: transparent;
+      }
+      &:selected {
+        -fx-background-color: -df-background-lighter;
+        & > .tree-table-cell {
+           -fx-text-fill: -df-text-selected;
+         }
+      }
+    }
+}

--- a/editor/styling/stylesheets/editor.sass
+++ b/editor/styling/stylesheets/editor.sass
@@ -47,6 +47,7 @@
 @import 'components/_text-field';
 @import 'components/_titled-pane';
 @import 'components/_tree-view';
+@import 'components/_tree-table-view';
 @import 'components/_vcs-status';
 
 /* Targeted modules */

--- a/editor/styling/stylesheets/modules/_tool-tabs.scss
+++ b/editor/styling/stylesheets/modules/_tool-tabs.scss
@@ -42,10 +42,6 @@
         }
     }
 
-    GridPane {
-        -fx-padding: 10;
-    }
-
     .console-tab-base {
         -fx-background-position: 10 3;
         -fx-background-repeat: no-repeat;


### PR DESCRIPTION
User-facing changes:
This changeset adds an override inspector view that can be requested using the Show Overrides context menu action. This action is available for items in the Outline View and for individual properties in the Properties View. When the action is executed, the editor will search through the uses of this item and show every place that changes the properties of the item. In this override inspector table, you can double-click on a result row to open the place where the properties are overridden.

Fixes #7127