### PR TITLE
Fix focus on committing values in the form view

### DIFF
--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -1148,6 +1148,7 @@
             :always
             (conj (cond->
                     {:fx/type fx.label/lifecycle
+                     :fx/key [:label path]
                      :grid-pane/row row
                      :grid-pane/column 0
                      :grid-pane/valignment :top
@@ -1163,6 +1164,7 @@
             (and (form/optional-field? field)
                  (not= value ::no-value))
             (conj {:fx/type icon-button
+                   :fx/key [:clear path]
                    :grid-pane/row row
                    :grid-pane/column 1
                    :grid-pane/valignment :top
@@ -1175,6 +1177,7 @@
 
             :always
             (conj {:fx/type fx.v-box/lifecycle
+                   :fx/key [:control path]
                    :style-class (case (:severity error)
                                   :fatal ["cljfx-form-error"]
                                   :warning ["cljfx-form-warning"]


### PR DESCRIPTION
Technical notes:
When editing fields in the `game.project` it was possible to lose the input focus after committing the value if the value became clearable. This happened because a new node — reset button — was added to the grid pane children, and it caused the re-creation of this and subsequent inputs, so the view lost focus. Using `:fx/key` stabilized the component description -> JavaFX node mapping, enforcing that the input stays the same object and is not re-created.

User-facing changes:
We don't lose input focus when editing `game.project` fields.

Fixes #7613