### PR TITLE
Use `emptyStringIsFalse(true)` for mustache compiler

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -155,7 +155,7 @@ public class BundleHelper {
             return "";
         }
         String s = new String(data);
-        Template template = Mustache.compiler().compile(s);
+        Template template = Mustache.compiler().emptyStringIsFalse(true).compile(s);
         StringWriter sw = new StringWriter();
         template.execute(propertiesMap, properties, sw);
         sw.flush();


### PR DESCRIPTION
Now we have to create a new variable or replace value with custom logic if we want to use conditional property `{{#something}}` or `{{^something}}`, with this compiler flag empty value will be equal to false. 