### PR TITLE
Cubemap + WebGL float type fixes

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1053,6 +1053,8 @@ static int SetTexture(lua_State* L)
     x               = dmMath::Max(0, x);
     y               = dmMath::Max(0, y);
 
+    uint8_t layer_count = type == dmGraphics::TEXTURE_TYPE_CUBE_MAP ? 6 : 1;
+
     dmScript::LuaHBuffer* buffer = dmScript::CheckBuffer(L, 3);
 
     uint8_t* data = 0;
@@ -1076,8 +1078,11 @@ static int SetTexture(lua_State* L)
     image.m_Data.m_Data          = data;
     image.m_Data.m_Count         = datasize;
 
+    // Note: When uploading cubemap faces on OpenGL, we expect that the "data size" is **per** slice
+    //       and not the entire data size of the buffer. For vulkan we don't look at this value but instead
+    //       calculate a slice size. Maybe we should do one or the other..
     uint32_t mip_map_offsets             = 0;
-    uint32_t mip_map_sizes               = datasize;
+    uint32_t mip_map_sizes               = datasize / layer_count;
     image.m_MipMapOffset.m_Data          = &mip_map_offsets;
     image.m_MipMapOffset.m_Count         = NUM_MIP_MAPS;
     image.m_MipMapSize.m_Data            = &mip_map_sizes;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1293,6 +1293,8 @@ static void LogFrameBufferError(GLenum status)
         }
 #endif
 
+        glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+
         return WINDOW_RESULT_OK;
     }
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1267,10 +1267,14 @@ static void LogFrameBufferError(GLenum status)
             context->m_IndexBufferFormatSupport |= 1 << INDEXBUFFER_FORMAT_32;
         }
 
+    #if !defined(__EMSCRIPTEN__)
+        // Note: This is enabled automatically for WebGL2, and the defined value is not available **at all** on WebGL1,
+        //       so if we don't want to do crazy workarounds for WebGL let's just ignore it and move on.
         if (context->m_IsGles3Version || OpenGLIsExtensionSupported(context, "GL_ARB_seamless_cube_map"))
         {
             glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
         }
+    #endif
 #else
         context->m_IndexBufferFormatSupport |= 1 << INDEXBUFFER_FORMAT_32;
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1283,7 +1283,7 @@ static void LogFrameBufferError(GLenum status)
         CLEAR_GL_ERROR;
 #endif
 
-        // if (params->m_PrintDeviceInfo)
+        if (params->m_PrintDeviceInfo)
         {
             OpenGLPrintDeviceInfo(context);
         }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1270,15 +1270,17 @@ static void LogFrameBufferError(GLenum status)
     #if !defined(__EMSCRIPTEN__)
         // Note: This is enabled automatically for WebGL2, and the defined value is not available **at all** on WebGL1,
         //       so if we don't want to do crazy workarounds for WebGL let's just ignore it and move on.
-        if (context->m_IsGles3Version || OpenGLIsExtensionSupported(context, "GL_ARB_seamless_cube_map"))
+        if (!context->m_IsGles3Version && OpenGLIsExtensionSupported(context, "GL_ARB_seamless_cube_map"))
         {
             glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+            CLEAR_GL_ERROR;
         }
     #endif
 #else
         context->m_IndexBufferFormatSupport |= 1 << INDEXBUFFER_FORMAT_32;
 
         glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+        CLEAR_GL_ERROR;
 #endif
 
         if (params->m_PrintDeviceInfo)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2905,7 +2905,8 @@ static void LogFrameBufferError(GLenum status)
             }
         }
 
-        if (unpackAlignment != 4) {
+        if (unpackAlignment != 4)
+        {
             glPixelStorei(GL_UNPACK_ALIGNMENT, unpackAlignment);
             CHECK_GL_ERROR;
         }
@@ -2916,34 +2917,34 @@ static void LogFrameBufferError(GLenum status)
 
         GLenum type = GetOpenGLTextureType(tex->m_Type);
         GLenum gl_format;
-        GLenum gl_type = GL_UNSIGNED_BYTE; // only used of uncompressed formats
+        GLenum gl_type        = GL_UNSIGNED_BYTE; // only used of uncompressed formats
         GLint internal_format = -1; // // Only used for uncompressed formats
         switch (params.m_Format)
         {
         case TEXTURE_FORMAT_LUMINANCE:
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
             break;
         case TEXTURE_FORMAT_LUMINANCE_ALPHA:
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
             break;
         case TEXTURE_FORMAT_RGB:
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGB;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
             break;
         case TEXTURE_FORMAT_RGBA:
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             break;
         case TEXTURE_FORMAT_RGB_16BPP:
-            gl_type = DMGRAPHICS_TYPE_UNSIGNED_SHORT_565;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            gl_type         = DMGRAPHICS_TYPE_UNSIGNED_SHORT_565;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGB;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
             break;
         case TEXTURE_FORMAT_RGBA_16BPP:
-            gl_type = DMGRAPHICS_TYPE_UNSIGNED_SHORT_4444;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_type         = DMGRAPHICS_TYPE_UNSIGNED_SHORT_4444;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             break;
 
@@ -2979,9 +2980,15 @@ static void LogFrameBufferError(GLenum status)
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA16F;
             break;
         case TEXTURE_FORMAT_RGBA32F:
-            gl_type = GL_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_type         = GL_FLOAT;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA32F;
+        #ifdef __EMSCRIPTEN__
+            if (!g_Context->m_IsGles3Version)
+            {
+                internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            }
+        #endif
             break;
         case TEXTURE_FORMAT_R16F:
             gl_type = DMGRAPHICS_TYPE_HALF_FLOAT;
@@ -2989,18 +2996,18 @@ static void LogFrameBufferError(GLenum status)
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_R16F;
             break;
         case TEXTURE_FORMAT_R32F:
-            gl_type = GL_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RED;
+            gl_type         = GL_FLOAT;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RED;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_R32F;
             break;
         case TEXTURE_FORMAT_RG16F:
-            gl_type = DMGRAPHICS_TYPE_HALF_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RG;
+            gl_type         = DMGRAPHICS_TYPE_HALF_FLOAT;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RG;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG16F;
             break;
         case TEXTURE_FORMAT_RG32F:
-            gl_type = GL_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RG;
+            gl_type         = GL_FLOAT;
+            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RG;
             internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG32F;
             break;
 
@@ -3032,9 +3039,15 @@ static void LogFrameBufferError(GLenum status)
             glBindTexture(type, tex->m_TextureIds[i]);
             CHECK_GL_ERROR;
 
-            if (!params.m_SubUpdate) {
+            if (!params.m_SubUpdate)
+            {
                 SetTextureParams(texture, params.m_MinFilter, params.m_MagFilter, params.m_UWrap, params.m_VWrap, 1.0f);
             }
+
+            dmLogInfo("SetTexture:");
+            dmLogInfo("gl_type: %d", (int) gl_type);
+            dmLogInfo("gl_format: %d", (int) gl_format);
+            dmLogInfo("internal_format: %d", (int) internal_format);
 
             switch (params.m_Format)
             {

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -176,6 +176,7 @@
     #define glUnmapBufferARB glUnmapBufferOES
     #define GL_ARRAY_BUFFER_ARB GL_ARRAY_BUFFER
     #define GL_ELEMENT_ARRAY_BUFFER_ARB GL_ELEMENT_ARRAY_BUFFER
+    #define GL_TEXTURE_CUBE_MAP_SEAMLESS 0x884F
 #endif
 
 DM_PROPERTY_EXTERN(rmtp_DrawCalls);
@@ -760,7 +761,6 @@ static void LogFrameBufferError(GLenum status)
         }
 
         dmLogInfo("Context features:");
-
     #define PRINT_FEATURE_IF_SUPPORTED(feature) \
         if (IsContextFeatureSupported(context, feature)) \
             dmLogInfo("  %s", #feature);
@@ -1266,8 +1266,15 @@ static void LogFrameBufferError(GLenum status)
         {
             context->m_IndexBufferFormatSupport |= 1 << INDEXBUFFER_FORMAT_32;
         }
+
+        if (context->m_IsGles3Version || OpenGLIsExtensionSupported(context, "GL_ARB_seamless_cube_map"))
+        {
+            glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+        }
 #else
         context->m_IndexBufferFormatSupport |= 1 << INDEXBUFFER_FORMAT_32;
+
+        glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 
         if (params->m_PrintDeviceInfo)
@@ -1292,8 +1299,6 @@ static void LogFrameBufferError(GLenum status)
             glBindVertexArray(vao);
         }
 #endif
-
-        glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 
         return WINDOW_RESULT_OK;
     }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2867,6 +2867,115 @@ static void LogFrameBufferError(GLenum status)
         return HANDLE_RESULT_OK;
     }
 
+    static inline void GetOpenGLSetTextureParams(OpenGLContext* context, TextureFormat format, GLint& gl_internal_format, GLenum& gl_format, GLenum& gl_type)
+    {
+    #ifdef __EMSCRIPTEN__
+        #define WEBGL1_WORKAROUND(fmt) \
+            if (!context->m_IsGles3Version) \
+            { \
+                gl_internal_format = fmt; \
+            }
+    #else
+        #define WEBGL1_WORKAROUND(fmt)
+    #endif
+
+        switch (format)
+        {
+        case TEXTURE_FORMAT_LUMINANCE:
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
+            break;
+        case TEXTURE_FORMAT_LUMINANCE_ALPHA:
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
+            break;
+        case TEXTURE_FORMAT_RGB:
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            break;
+        case TEXTURE_FORMAT_RGBA:
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            break;
+        case TEXTURE_FORMAT_RGB_16BPP:
+            gl_type            = DMGRAPHICS_TYPE_UNSIGNED_SHORT_565;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            break;
+        case TEXTURE_FORMAT_RGBA_16BPP:
+            gl_type            = DMGRAPHICS_TYPE_UNSIGNED_SHORT_4444;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            break;
+
+        case TEXTURE_FORMAT_RGB_PVRTC_2BPPV1:   gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_PVRTC_2BPPV1; break;
+        case TEXTURE_FORMAT_RGB_PVRTC_4BPPV1:   gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_PVRTC_4BPPV1; break;
+        case TEXTURE_FORMAT_RGBA_PVRTC_2BPPV1:  gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_PVRTC_2BPPV1; break;
+        case TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1:  gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1; break;
+        case TEXTURE_FORMAT_RGB_ETC1:           gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_ETC1; break;
+        case TEXTURE_FORMAT_R_ETC2:             gl_format = DMGRAPHICS_TEXTURE_FORMAT_R11_EAC; break;
+        case TEXTURE_FORMAT_RG_ETC2:            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RG11_EAC; break;
+        case TEXTURE_FORMAT_RGBA_ETC2:          gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA8_ETC2_EAC; break;
+        case TEXTURE_FORMAT_RGBA_ASTC_4x4:      gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR; break;
+        case TEXTURE_FORMAT_RGB_BC1:            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_DXT1; break;
+        case TEXTURE_FORMAT_RGBA_BC3:           gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_DXT5; break;
+        case TEXTURE_FORMAT_R_BC4:              gl_format = DMGRAPHICS_TEXTURE_FORMAT_RED_RGTC1; break;
+        case TEXTURE_FORMAT_RG_BC5:             gl_format = DMGRAPHICS_TEXTURE_FORMAT_RG_RGTC2; break;
+        case TEXTURE_FORMAT_RGBA_BC7:           gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_BPTC_UNORM; break;
+
+        // Float formats
+        case TEXTURE_FORMAT_RGB16F:
+            gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB16F;
+            WEBGL1_WORKAROUND(DMGRAPHICS_TEXTURE_FORMAT_RGB);
+            break;
+        case TEXTURE_FORMAT_RGB32F:
+            gl_type            = GL_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGB;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB32F;
+            WEBGL1_WORKAROUND(DMGRAPHICS_TEXTURE_FORMAT_RGB);
+            break;
+        case TEXTURE_FORMAT_RGBA16F:
+            gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA16F;
+            break;
+        case TEXTURE_FORMAT_RGBA32F:
+            gl_type            = GL_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA32F;
+            WEBGL1_WORKAROUND(DMGRAPHICS_TEXTURE_FORMAT_RGBA);
+            break;
+        case TEXTURE_FORMAT_R16F:
+            gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RED;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_R16F;
+            break;
+        case TEXTURE_FORMAT_R32F:
+            gl_type            = GL_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RED;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_R32F;
+            break;
+        case TEXTURE_FORMAT_RG16F:
+            gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RG;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG16F;
+            break;
+        case TEXTURE_FORMAT_RG32F:
+            gl_type            = GL_FLOAT;
+            gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RG;
+            gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG32F;
+            break;
+
+        default:
+            assert(0);
+            dmLogError("Texture format %s is not a valid format.", GetTextureFormatLiteral(format));
+            break;
+        }
+    #undef WEBGL1_WORKAROUND
+    }
+
     static void OpenGLSetTexture(HTexture texture, const TextureParams& params)
     {
         DM_PROFILE(__FUNCTION__);
@@ -2915,107 +3024,12 @@ static void LogFrameBufferError(GLenum status)
 
         tex->m_MipMapCount = dmMath::Max(tex->m_MipMapCount, (uint16_t)(params.m_MipMap+1));
 
-        GLenum type = GetOpenGLTextureType(tex->m_Type);
-        GLenum gl_format;
-        GLenum gl_type        = GL_UNSIGNED_BYTE; // only used of uncompressed formats
-        GLint internal_format = -1; // // Only used for uncompressed formats
-        switch (params.m_Format)
-        {
-        case TEXTURE_FORMAT_LUMINANCE:
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE;
-            break;
-        case TEXTURE_FORMAT_LUMINANCE_ALPHA:
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_LUMINANCE_ALPHA;
-            break;
-        case TEXTURE_FORMAT_RGB:
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGB;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
-            break;
-        case TEXTURE_FORMAT_RGBA:
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            break;
-        case TEXTURE_FORMAT_RGB_16BPP:
-            gl_type         = DMGRAPHICS_TYPE_UNSIGNED_SHORT_565;
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGB;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
-            break;
-        case TEXTURE_FORMAT_RGBA_16BPP:
-            gl_type         = DMGRAPHICS_TYPE_UNSIGNED_SHORT_4444;
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            break;
+        GLenum type              = GetOpenGLTextureType(tex->m_Type);
+        GLenum gl_format         = 0;
+        GLenum gl_type           = GL_UNSIGNED_BYTE; // only used of uncompressed formats
+        GLint gl_internal_format = -1;               // only used for uncompressed formats
 
-        case TEXTURE_FORMAT_RGB_PVRTC_2BPPV1:   gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_PVRTC_2BPPV1; break;
-        case TEXTURE_FORMAT_RGB_PVRTC_4BPPV1:   gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_PVRTC_4BPPV1; break;
-        case TEXTURE_FORMAT_RGBA_PVRTC_2BPPV1:  gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_PVRTC_2BPPV1; break;
-        case TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1:  gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1; break;
-        case TEXTURE_FORMAT_RGB_ETC1:           gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_ETC1; break;
-        case TEXTURE_FORMAT_R_ETC2:             gl_format = DMGRAPHICS_TEXTURE_FORMAT_R11_EAC; break;
-        case TEXTURE_FORMAT_RG_ETC2:            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RG11_EAC; break;
-        case TEXTURE_FORMAT_RGBA_ETC2:          gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA8_ETC2_EAC; break;
-        case TEXTURE_FORMAT_RGBA_ASTC_4x4:      gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_ASTC_4x4_KHR; break;
-        case TEXTURE_FORMAT_RGB_BC1:            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB_DXT1; break;
-        case TEXTURE_FORMAT_RGBA_BC3:           gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_DXT5; break;
-        case TEXTURE_FORMAT_R_BC4:              gl_format = DMGRAPHICS_TEXTURE_FORMAT_RED_RGTC1; break;
-        case TEXTURE_FORMAT_RG_BC5:             gl_format = DMGRAPHICS_TEXTURE_FORMAT_RG_RGTC2; break;
-        case TEXTURE_FORMAT_RGBA_BC7:           gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA_BPTC_UNORM; break;
-
-        // Float formats
-        case TEXTURE_FORMAT_RGB16F:
-            gl_type = DMGRAPHICS_TYPE_HALF_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB16F;
-            break;
-        case TEXTURE_FORMAT_RGB32F:
-            gl_type = GL_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGB;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB32F;
-            break;
-        case TEXTURE_FORMAT_RGBA16F:
-            gl_type = DMGRAPHICS_TYPE_HALF_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA16F;
-            break;
-        case TEXTURE_FORMAT_RGBA32F:
-            gl_type         = GL_FLOAT;
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA32F;
-        #ifdef __EMSCRIPTEN__
-            if (!g_Context->m_IsGles3Version)
-            {
-                internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
-            }
-        #endif
-            break;
-        case TEXTURE_FORMAT_R16F:
-            gl_type = DMGRAPHICS_TYPE_HALF_FLOAT;
-            gl_format = DMGRAPHICS_TEXTURE_FORMAT_RED;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_R16F;
-            break;
-        case TEXTURE_FORMAT_R32F:
-            gl_type         = GL_FLOAT;
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RED;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_R32F;
-            break;
-        case TEXTURE_FORMAT_RG16F:
-            gl_type         = DMGRAPHICS_TYPE_HALF_FLOAT;
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RG;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG16F;
-            break;
-        case TEXTURE_FORMAT_RG32F:
-            gl_type         = GL_FLOAT;
-            gl_format       = DMGRAPHICS_TEXTURE_FORMAT_RG;
-            internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG32F;
-            break;
-
-        default:
-            gl_format = 0;
-            assert(0);
-            break;
-        }
+        GetOpenGLSetTextureParams(g_Context, params.m_Format, gl_internal_format, gl_format, gl_type);
 
         tex->m_Params = params;
 
@@ -3044,11 +3058,6 @@ static void LogFrameBufferError(GLenum status)
                 SetTextureParams(texture, params.m_MinFilter, params.m_MagFilter, params.m_UWrap, params.m_VWrap, 1.0f);
             }
 
-            dmLogInfo("SetTexture:");
-            dmLogInfo("gl_type: %d", (int) gl_type);
-            dmLogInfo("gl_format: %d", (int) gl_format);
-            dmLogInfo("internal_format: %d", (int) internal_format);
-
             switch (params.m_Format)
             {
             case TEXTURE_FORMAT_LUMINANCE:
@@ -3073,7 +3082,7 @@ static void LogFrameBufferError(GLenum status)
                     }
                     else
                     {
-                        glTexImage2D(GL_TEXTURE_2D, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * i);
+                        glTexImage2D(GL_TEXTURE_2D, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * i);
                     }
                     CHECK_GL_ERROR;
                 } else if (tex->m_Type == TEXTURE_TYPE_2D_ARRAY) {
@@ -3091,7 +3100,7 @@ static void LogFrameBufferError(GLenum status)
                         }
                         else
                         {
-                            TEX_IMAGE_3D(GL_TEXTURE_2D_ARRAY, params.m_MipMap, internal_format, params.m_Width, params.m_Height, params.m_Depth, 0, gl_format, gl_type, params.m_Data);
+                            TEX_IMAGE_3D(GL_TEXTURE_2D_ARRAY, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, params.m_Depth, 0, gl_format, gl_type, params.m_Data);
                         }
                     #undef TEX_SUB_IMAGE_3D
                     #undef TEX_IMAGE_3D
@@ -3116,17 +3125,17 @@ static void LogFrameBufferError(GLenum status)
                     }
                     else
                     {
-                        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 0);
+                        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 0);
                         CHECK_GL_ERROR;
-                        glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 1);
+                        glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 1);
                         CHECK_GL_ERROR;
-                        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 2);
+                        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 2);
                         CHECK_GL_ERROR;
-                        glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 3);
+                        glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 3);
                         CHECK_GL_ERROR;
-                        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 4);
+                        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 4);
                         CHECK_GL_ERROR;
-                        glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 5);
+                        glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, params.m_MipMap, gl_internal_format, params.m_Width, params.m_Height, 0, gl_format, gl_type, p + params.m_DataSize * 5);
                         CHECK_GL_ERROR;
                     }
                 } else {

--- a/engine/graphics/src/opengl/graphics_opengl_defines.h
+++ b/engine/graphics/src/opengl/graphics_opengl_defines.h
@@ -162,7 +162,7 @@
 
 #if defined(GL_RGBA32F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGBA32F                   (GL_RGBA32F_EXT)
-#elif defined(GL_RGBA32F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_RGBA32F)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGBA32F                   (GL_RGBA32F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_RGBA32F                   (GL_RGBA)

--- a/engine/graphics/src/opengl/graphics_opengl_defines.h
+++ b/engine/graphics/src/opengl/graphics_opengl_defines.h
@@ -58,10 +58,11 @@
 #define DMGRAPHICS_TYPE_UNSIGNED_SHORT_4444                 (GL_UNSIGNED_SHORT_4_4_4_4)
 #define DMGRAPHICS_TYPE_UNSIGNED_SHORT_565                  (GL_UNSIGNED_SHORT_5_6_5)
 
-#ifdef GL_HALF_FLOAT_OES
-#define DMGRAPHICS_TYPE_HALF_FLOAT                          (GL_HALF_FLOAT_OES)
-#else
+
+#ifdef GL_HALF_FLOAT
 #define DMGRAPHICS_TYPE_HALF_FLOAT                          (GL_HALF_FLOAT)
+#else
+#define DMGRAPHICS_TYPE_HALF_FLOAT                          (0x140B)
 #endif
 
 // Texture arrays

--- a/engine/graphics/src/opengl/graphics_opengl_defines.h
+++ b/engine/graphics/src/opengl/graphics_opengl_defines.h
@@ -154,7 +154,7 @@
 
 #if defined(GL_RGB32F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB32F                    (GL_RGB32F_EXT)
-#elif defined(GL_RGB32F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_RGB32F)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB32F                    (GL_RGB32F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB32F                    (GL_RGB)
@@ -170,7 +170,7 @@
 
 #if defined(GL_RGB16F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB16F                    (GL_RGB16F_EXT)
-#elif defined(GL_RGB16F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_RGB16F)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB16F                    (GL_RGB16F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_RGB16F                    (GL_RGB)
@@ -178,7 +178,7 @@
 
 #if defined(GL_RGBA16F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGBA16F                   (GL_RGBA16F_EXT)
-#elif defined(GL_RGBA16F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_RGBA16F)
 #define DMGRAPHICS_TEXTURE_FORMAT_RGBA16F                   (GL_RGBA16F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_RGBA16F                   (GL_RGBA)
@@ -186,7 +186,7 @@
 
 #if defined(GL_R16F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_R16F                      (GL_R16F_EXT)
-#elif defined(GL_R16F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_R16F)
 #define DMGRAPHICS_TEXTURE_FORMAT_R16F                      (GL_R16F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_R16F                      (0x822D)
@@ -194,7 +194,7 @@
 
 #if defined(GL_R32F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_R32F                      (GL_R32F_EXT)
-#elif defined(GL_R32F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_R32F)
 #define DMGRAPHICS_TEXTURE_FORMAT_R32F                      (GL_R32F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_R32F                      (0x822E)
@@ -202,7 +202,7 @@
 
 #if defined(GL_RG16F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_RG16F                     (GL_RG16F_EXT)
-#elif defined(GL_RG16F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_RG16F)
 #define DMGRAPHICS_TEXTURE_FORMAT_RG16F                     (GL_RG16F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_RG16F                     (0x822F)
@@ -210,7 +210,7 @@
 
 #if defined(GL_RG32F_EXT)
 #define DMGRAPHICS_TEXTURE_FORMAT_RG32F                     (GL_RG32F_EXT)
-#elif defined(GL_RG32F) && !defined (__EMSCRIPTEN__)
+#elif defined(GL_RG32F)
 #define DMGRAPHICS_TEXTURE_FORMAT_RG32F                     (GL_RG32F)
 #else
 #define DMGRAPHICS_TEXTURE_FORMAT_RG32F                     (0x8230)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -868,7 +868,7 @@ namespace dmGraphics
             QueueFamily queue_family = GetQueueFamily(device, context->m_WindowSurface);
             if (!queue_family.IsValid())
             {
-                dmLogError("Device selection failed for device %s: Could not get a valid queue family.", device->m_Properties.deviceName);
+                dmLogError("Device selection failed for device %s (%d/%d): Could not get a valid queue family.", device->m_Properties.deviceName, i, device_count);
                 DESTROY_AND_CONTINUE(device)
             }
 
@@ -878,6 +878,7 @@ namespace dmGraphics
             {
                 if (!IsDeviceExtensionSupported(device, device_extensions[ext_i]))
                 {
+                    dmLogError("Required device extension '%s' is missing for device %s (%d/%d).", device_extensions[ext_i], device->m_Properties.deviceName, i, device_count);
                     all_extensions_found = false;
                     break;
                 }
@@ -903,7 +904,7 @@ namespace dmGraphics
 
             selected_device = device;
             selected_queue_family = queue_family;
-            break;
+            break; // Why do we break here? x_x
 
             #undef DESTROY_AND_CONTINUE
         }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -904,7 +904,7 @@ namespace dmGraphics
 
             selected_device = device;
             selected_queue_family = queue_family;
-            break; // Why do we break here? x_x
+            break;
 
             #undef DESTROY_AND_CONTINUE
         }


### PR DESCRIPTION
Fixed several issues with creating cubemap textures with float types. Creating cubemaps from scripts now also works correctly for all graphics adapters.