### PR TITLE
Bundle dynamic extension frameworks

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -383,22 +383,6 @@ public class Bob {
         return binaryFiles;
     }
 
-    public static List<File> getNativeExtensionEngineBinaries(Platform platform, String extenderExeDir) throws IOException
-    {
-        List<String> binaryNames = platform.formatBinaryName("dmengine");
-        List<File> binaryFiles = new ArrayList<File>();
-        for (String binaryName : binaryNames) {
-            File extenderExe = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(platform.getExtenderPair(), binaryName)));
-
-            // All binaries must exist, otherwise return null
-            if (!extenderExe.exists()) {
-                return null;
-            }
-            binaryFiles.add(extenderExe);
-        }
-        return binaryFiles;
-    }
-
     public static String getLib(Platform platform, String name) throws IOException {
         init();
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -180,7 +180,7 @@ public class Project {
     }
 
     public String getPluginsDirectory() {
-        return FilenameUtils.concat(getRootDirectory(), PLUGINS_DIR);
+        return FilenameUtils.concat(rootDirectory, PLUGINS_DIR);
     }
 
     public String getBinaryOutputDirectory() {
@@ -188,11 +188,11 @@ public class Project {
     }
 
     public String getLibPath() {
-        return FilenameUtils.concat(this.rootDirectory, LIB_DIR);
+        return FilenameUtils.concat(rootDirectory, LIB_DIR);
     }
 
     public String getBuildCachePath() {
-        return FilenameUtils.concat(this.rootDirectory, CACHE_DIR);
+        return FilenameUtils.concat(rootDirectory, CACHE_DIR);
     }
 
     public String getLocalResourceCacheDirectory() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -233,10 +233,6 @@ public class AndroidBundler implements IBundler {
         return exeName;
     }
 
-    private static String getExtenderExeDir(Project project) {
-        return FilenameUtils.concat(project.getRootDirectory(), "build");
-    }
-
     private static List<Platform> getArchitectures(Project project) {
         return Platform.getArchitecturesFromString(project.option("architectures", ""), Platform.Armv7Android);
     }
@@ -250,8 +246,7 @@ public class AndroidBundler implements IBundler {
     */
     private static void copyEngineBinary(Project project, Platform architecture, File dest) throws IOException {
         // vanilla or extender exe?
-        final String extenderExeDir = getExtenderExeDir(project);
-        List<File> bundleExe = Bob.getNativeExtensionEngineBinaries(architecture, extenderExeDir);
+        List<File> bundleExe = ExtenderUtil.getNativeExtensionEngineBinaries(project, architecture);
         if (bundleExe == null) {
             final String variant = project.option("variant", Bob.VARIANT_RELEASE);
             bundleExe = Bob.getDefaultDmengineFiles(architecture, variant);
@@ -280,7 +275,7 @@ public class AndroidBundler implements IBundler {
      * The assets originate from resolved gradle dependencies (.aar files)
      */
     private static ArrayList<File> getExtenderAssets(Project project) throws IOException {
-        final String extenderExeDir = getExtenderExeDir(project);
+        final String extenderExeDir = project.getBinaryOutputDirectory();
         ArrayList<File> assets = new ArrayList<File>();
         for (Platform architecture : getArchitectures(project)) {
             File assetsDir = new File(FilenameUtils.concat(extenderExeDir, FilenameUtils.concat(architecture.getExtenderPair(), "assets")));
@@ -297,11 +292,11 @@ public class AndroidBundler implements IBundler {
     * Get a list of dex files to include in the aab
     */
     private static ArrayList<File> getClassesDex(Project project) throws IOException {
-        final String extenderExeDir = getExtenderExeDir(project);
         ArrayList<File> classesDex = new ArrayList<File>();
 
+        final String extenderExeDir = project.getBinaryOutputDirectory();
         for (Platform architecture : getArchitectures(project)) {
-            List<File> bundleExe = Bob.getNativeExtensionEngineBinaries(architecture, extenderExeDir);
+            List<File> bundleExe = ExtenderUtil.getNativeExtensionEngineBinaries(project, architecture);
             if (bundleExe == null) {
                 if (classesDex.isEmpty()) {
                     classesDex.add(new File(Bob.getPath("lib/classes.dex")));
@@ -672,11 +667,11 @@ public class AndroidBundler implements IBundler {
         File symbolsDir = new File(outDir, getProjectTitle(project) + ".apk.symbols");
         symbolsDir.mkdirs();
         final String exeName = getBinaryNameFromProject(project);
-        final String extenderExeDir = getExtenderExeDir(project);
+        final String extenderExeDir = project.getBinaryOutputDirectory();
         final List<Platform> architectures = getArchitectures(project);
         final String variant = project.option("variant", Bob.VARIANT_RELEASE);
         for (Platform architecture : architectures) {
-            List<File> bundleExe = Bob.getNativeExtensionEngineBinaries(architecture, extenderExeDir);
+            List<File> bundleExe = ExtenderUtil.getNativeExtensionEngineBinaries(project, architecture);
             if (bundleExe == null) {
                 bundleExe = Bob.getDefaultDmengineFiles(architecture, variant);
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -246,7 +246,6 @@ public class HTML5Bundler implements IBundler {
         final String variant = project.option("variant", Bob.VARIANT_RELEASE);
         String title = projectProperties.getStringValue("project", "title", "Unnamed");
         String enginePrefix = BundleHelper.projectNameToBinaryName(title);
-        String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
 
         List<File> binsAsmjs = null;
         List<File> binsWasm = null;
@@ -255,7 +254,7 @@ public class HTML5Bundler implements IBundler {
         // asmjs binaries
         {
             Platform targetPlatform = Platform.JsWeb;
-            binsAsmjs = Bob.getNativeExtensionEngineBinaries(targetPlatform, extenderExeDir);
+            binsAsmjs = ExtenderUtil.getNativeExtensionEngineBinaries(project, targetPlatform);
             if (binsAsmjs == null) {
                 binsAsmjs = Bob.getDefaultDmengineFiles(targetPlatform, variant);
             }
@@ -269,7 +268,7 @@ public class HTML5Bundler implements IBundler {
         // wasm binaries
         {
             Platform targetPlatform = Platform.WasmWeb;
-            binsWasm = Bob.getNativeExtensionEngineBinaries(targetPlatform, extenderExeDir);
+            binsWasm = ExtenderUtil.getNativeExtensionEngineBinaries(project, targetPlatform);
             if (binsWasm == null) {
                 binsWasm = Bob.getDefaultDmengineFiles(targetPlatform, variant);
             }
@@ -309,10 +308,10 @@ public class HTML5Bundler implements IBundler {
         if (variant.equals(Bob.VARIANT_RELEASE)) {
             symbolsName = "dmengine_release.js.symbols";
         }
-        String zipDir = FilenameUtils.concat(extenderExeDir, Platform.JsWeb.getExtenderPair());
+        String zipDir = FilenameUtils.concat(project.getBinaryOutputDirectory(), Platform.JsWeb.getExtenderPair());
         File bundleSymbols = new File(zipDir, symbolsName);
         if (!bundleSymbols.exists()) {
-            zipDir = FilenameUtils.concat(extenderExeDir, Platform.WasmWeb.getExtenderPair());
+            zipDir = FilenameUtils.concat(project.getBinaryOutputDirectory(), Platform.WasmWeb.getExtenderPair());
             bundleSymbols = new File(zipDir, symbolsName);
         }
         if (bundleSymbols.exists()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -252,11 +252,6 @@ public class IOSBundler implements IBundler {
         final String variant = project.option("variant", Bob.VARIANT_RELEASE);
         final boolean strip_executable = project.hasOption("strip-executable");
 
-        // If a custom engine was built we need to copy it
-        boolean hasExtensions = ExtenderUtil.hasNativeExtensions(project);
-        File extenderPlatformDir = new File(project.getBuildDirectory(), architectures.get(0).getExtenderPair());
-        String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
-
         // Loop over all architectures needed for bundling
         // Pickup each binary, either vanilla or from a extender build.
         List<File> binaries = new ArrayList<File>();
@@ -264,7 +259,8 @@ public class IOSBundler implements IBundler {
             List<File> bins = ExtenderUtil.getNativeExtensionEngineBinaries(project, architecture);
             if (bins == null) {
                 bins = Bob.getDefaultDmengineFiles(architecture, variant);
-            } else {
+            }
+            else {
                 logger.info("Using extender binary for " + architecture.getPair());
             }
 
@@ -282,6 +278,7 @@ public class IOSBundler implements IBundler {
 
         File buildDir = new File(project.getRootDirectory(), project.getBuildDirectory());
         File appDir = new File(bundleDir, title + ".app");
+        File frameworksDir = new File(appDir, "Frameworks");
         logger.info("Bundling to " + appDir.getPath());
 
         String provisioningProfile = project.option("mobileprovisioning", null);
@@ -292,14 +289,16 @@ public class IOSBundler implements IBundler {
         if (shouldSign) {
             if (provisioningProfile == null) {
                 throw new IOException("Cannot sign application without a provisioning profile, missing --mobileprovisioning argument.");
-            } else if (identity == null) {
+            }
+            else if (identity == null) {
                 throw new IOException("Cannot sign application without a signing identity, missing --identity argument.");
             }
         }
 
         if (shouldSign) {
             logger.info("Code signing enabled.");
-        } else {
+        }
+        else {
             logger.info("Code signing disabled.");
         }
 
@@ -307,6 +306,7 @@ public class IOSBundler implements IBundler {
 
         FileUtils.deleteDirectory(appDir);
         appDir.mkdirs();
+        frameworksDir.mkdirs();
 
         BundleHelper.throwIfCanceled(canceled);
 
@@ -321,8 +321,7 @@ public class IOSBundler implements IBundler {
 
         String launchScreen = projectProperties.getStringValue("ios", "launch_screen");
         // It might be null if the user uses the "bundle_resources" to copy everything
-        if (launchScreen != null)
-        {
+        if (launchScreen != null) {
             final String launchScreenBaseName = FilenameUtils.getName(launchScreen);
             IResource source = project.getResource(launchScreen);
             IResource storyboardPlist = project.getResource(launchScreen + "/Info.plist");
@@ -354,7 +353,8 @@ public class IOSBundler implements IBundler {
                     }
 
                     FileUtils.writeByteArrayToFile(target, r.getContent());
-                } catch (IOException e) {
+                }
+                catch (IOException e) {
                     logger.severe("Failed copying %s to %s\n", r.getPath(), target);
                     throw e;
                 }
@@ -366,8 +366,7 @@ public class IOSBundler implements IBundler {
 
         String iconsAsset = projectProperties.getStringValue("ios", "icons_asset");
         // It might be null if the user uses the "bundle_resources" to copy everything
-        if (iconsAsset != null)
-        {
+        if (iconsAsset != null) {
             final String iconsName = FilenameUtils.getName(iconsAsset);
             IResource source = project.getResource(iconsAsset);
             if (source == null) {
@@ -378,12 +377,13 @@ public class IOSBundler implements IBundler {
 
             try {
                 FileUtils.writeByteArrayToFile(target, source.getContent());
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 logger.severe("Failed copying %s to %s\n", source.getPath(), target);
                 throw e;
             }
-        } else
-        {
+        }
+        else {
             logger.warning("ios.icons_asset is not set");
         }
 
@@ -418,8 +418,7 @@ public class IOSBundler implements IBundler {
 
         BundleHelper.throwIfCanceled(canceled);
         // Strip executable
-        if( strip_executable )
-        {
+        if( strip_executable ) {
             Result stripResult = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "strip_ios"), exe);
             if (stripResult.ret == 0) {
                 logger.info("Stripped binary: " + getFileDescription(tmpFile));
@@ -437,21 +436,32 @@ public class IOSBundler implements IBundler {
         destExecutable.setExecutable(true);
         logger.info("Bundle binary: " + getFileDescription(destExecutable));
 
+        // Copy extension frameworks
+        logger.info("Copy frameworks");
+        for (Platform architecture : architectures) {
+            File extensionArchitectureDir = new File(project.getBinaryOutputDirectory(), architecture.getExtenderPair());
+            File extensionFrameworksDir = new File(extensionArchitectureDir, "frameworks");
+            for (File extensionFrameworkDir : extensionFrameworksDir.listFiles()) {
+                File dest = new File(frameworksDir, extensionFrameworkDir.getName());
+                FileUtils.copyDirectory(extensionFrameworkDir, dest);
+            }
+        }
+
+        logger.info("Copy debug symbols");
         // Copy debug symbols
         // Create list of dSYM binaries
         List<File> dSYMBinaries = new ArrayList<File>();
         for (Platform architecture : architectures) {
-            String zipDir = FilenameUtils.concat(extenderExeDir, architecture.getExtenderPair());
+            String zipDir = FilenameUtils.concat(project.getBinaryOutputDirectory(), architecture.getExtenderPair());
             File buildSymbols = new File(zipDir, "dmengine.dSYM");
             if (buildSymbols.exists()) {
                 dSYMBinaries.add(new File(buildSymbols, FilenameUtils.concat("Contents", FilenameUtils.concat("Resources", FilenameUtils.concat("DWARF", "dmengine")))));
             }
         }
 
-        if (dSYMBinaries.size() > 0)
-        {
+        if (dSYMBinaries.size() > 0) {
             // Copy one of debug symbols and use it as result for lipo
-            String zipDir = FilenameUtils.concat(extenderExeDir, architectures.get(0).getExtenderPair());
+            String zipDir = FilenameUtils.concat(project.getBinaryOutputDirectory(), architectures.get(0).getExtenderPair());
             File buildSymbols = new File(zipDir, "dmengine.dSYM");
             String symbolsDir = String.format("%s.dSYM", title);
             File bundleSymbols = new File(bundleDir, symbolsDir);
@@ -473,8 +483,6 @@ public class IOSBundler implements IBundler {
         File swiftSupportDir = new File(tmpZipDir, "SwiftSupport");
 
         // Copy any libswift*.dylib files from the Frameworks folder
-        File frameworksDir = new File(appDir, "Frameworks");
-
         if (frameworksDir.exists()) {
             logger.info("Copying to /SwiftSupport folder");
             File iphoneosDir = new File(swiftSupportDir, "iphoneos");
@@ -538,7 +546,8 @@ public class IOSBundler implements IBundler {
                     logger.severe("Error when loading custom entitlements from file '" + customEntitlementsProperty + "'.");
                     throw new RuntimeException(e);
                 }
-            } else {
+            }
+            else {
                 try {
                     XMLPropertyListConfiguration customEntitlements = new XMLPropertyListConfiguration();
                     XMLPropertyListConfiguration decodedProvision = new XMLPropertyListConfiguration();
@@ -582,10 +591,12 @@ public class IOSBundler implements IBundler {
                     entitlements.write(writer);
                     writer.close();
                     entitlementOut.deleteOnExit();
-                } catch (ConfigurationException e) {
+                }
+                catch (ConfigurationException e) {
                     logger.severe("Error reading provisioning profile '" + provisioningProfile + "'. Make sure this is a valid provisioning profile file." );
                     throw new RuntimeException(e);
-                } catch (IOException e) {
+                }
+                catch (IOException e) {
                     logger.severe("Error merging custom entitlements '" + customEntitlementsProperty +"' with entitlements in provisioning profile. Make sure that custom entitlements has corresponding wildcard entries in the provisioning profile.");
                     throw new RuntimeException(e);
                 }
@@ -607,7 +618,8 @@ public class IOSBundler implements IBundler {
                     Process process = processBuilder.start();
                     logProcess(process);
                 }
-            } else {
+            }
+            else {
                 System.out.printf("No ./Framework folder to sign\n");
             }
 
@@ -629,7 +641,8 @@ public class IOSBundler implements IBundler {
                     Process process = processBuilder.start();
                     logProcess(process);
                 }
-            } else {
+            }
+            else {
                 System.out.printf("No ./PlugIns folder to sign\n");
             }
 
@@ -664,10 +677,12 @@ public class IOSBundler implements IBundler {
 
         // NOTE: We replaced the java zip file implementation(s) due to the fact that XCode didn't want
         // to import the resulting zip files.
-        if (swiftSupportDir.exists())
+        if (swiftSupportDir.exists()) {
             processBuilder = new ProcessBuilder("zip", "-qr", zipFileTmp.getAbsolutePath(), payloadDir.getName(), swiftSupportDir.getName());
-        else
+        }
+        else {
             processBuilder = new ProcessBuilder("zip", "-qr", zipFileTmp.getAbsolutePath(), payloadDir.getName());
+        }
 
         processBuilder.directory(tmpZipDir);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -261,7 +261,7 @@ public class IOSBundler implements IBundler {
         // Pickup each binary, either vanilla or from a extender build.
         List<File> binaries = new ArrayList<File>();
         for (Platform architecture : architectures) {
-            List<File> bins = Bob.getNativeExtensionEngineBinaries(architecture, extenderExeDir);
+            List<File> bins = ExtenderUtil.getNativeExtensionEngineBinaries(project, architecture);
             if (bins == null) {
                 bins = Bob.getDefaultDmengineFiles(architecture, variant);
             } else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -421,7 +421,7 @@ public class IOSBundler implements IBundler {
         if( strip_executable ) {
             Result stripResult = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "strip_ios"), exe);
             if (stripResult.ret == 0) {
-                logger.info("Stripped binary: " + getFileDescription(tmpFile));
+                logger.fine("Stripped binary: " + getFileDescription(tmpFile));
             }
             else {
                 logger.severe("Error executing strip_ios command:\n" + new String(stripResult.stdOutErr));
@@ -434,20 +434,18 @@ public class IOSBundler implements IBundler {
         File destExecutable = new File(appDir, exeName);
         FileUtils.copyFile(new File(exe), destExecutable);
         destExecutable.setExecutable(true);
-        logger.info("Bundle binary: " + getFileDescription(destExecutable));
 
         // Copy extension frameworks
-        logger.info("Copy frameworks");
         for (Platform architecture : architectures) {
             File extensionArchitectureDir = new File(project.getBinaryOutputDirectory(), architecture.getExtenderPair());
             File extensionFrameworksDir = new File(extensionArchitectureDir, "frameworks");
             for (File extensionFrameworkDir : extensionFrameworksDir.listFiles()) {
                 File dest = new File(frameworksDir, extensionFrameworkDir.getName());
                 FileUtils.copyDirectory(extensionFrameworkDir, dest);
+                logger.fine("Copy framework " + extensionFrameworkDir);
             }
         }
 
-        logger.info("Copy debug symbols");
         // Copy debug symbols
         // Create list of dSYM binaries
         List<File> dSYMBinaries = new ArrayList<File>();
@@ -456,6 +454,7 @@ public class IOSBundler implements IBundler {
             File buildSymbols = new File(zipDir, "dmengine.dSYM");
             if (buildSymbols.exists()) {
                 dSYMBinaries.add(new File(buildSymbols, FilenameUtils.concat("Contents", FilenameUtils.concat("Resources", FilenameUtils.concat("DWARF", "dmengine")))));
+                logger.fine("Copy debug symbols");
             }
         }
 
@@ -484,7 +483,7 @@ public class IOSBundler implements IBundler {
 
         // Copy any libswift*.dylib files from the Frameworks folder
         if (frameworksDir.exists()) {
-            logger.info("Copying to /SwiftSupport folder");
+            logger.fine("Copying to /SwiftSupport folder");
             File iphoneosDir = new File(swiftSupportDir, "iphoneos");
 
             for (File file : frameworksDir.listFiles(File::isFile)) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/LinuxBundler.java
@@ -58,8 +58,7 @@ public class LinuxBundler implements IBundler {
 
     public void bundleApplicationForPlatform(Platform platform, Project project, File appDir, String exeName)
             throws IOException, CompileExceptionError {
-        String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
-        List<File> bundleExes = Bob.getNativeExtensionEngineBinaries(platform, extenderExeDir);
+        List<File> bundleExes = ExtenderUtil.getNativeExtensionEngineBinaries(project, platform);
         final String variant = project.option("variant", Bob.VARIANT_RELEASE);
         if (bundleExes == null) {
             bundleExes = Bob.getDefaultDmengineFiles(platform, variant);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/MacOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/MacOSBundler.java
@@ -110,11 +110,9 @@ public class MacOSBundler implements IBundler {
         File resourcesDir = new File(contentsDir, "Resources");
         File macosDir = new File(contentsDir, "MacOS");
 
-        String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
-
         BundleHelper.throwIfCanceled(canceled);
 
-        List<File> bundleExes = Bob.getNativeExtensionEngineBinaries(platform, extenderExeDir);
+        List<File> bundleExes = ExtenderUtil.getNativeExtensionEngineBinaries(project, platform);
         if (bundleExes == null) {
             bundleExes = Bob.getDefaultDmengineFiles(platform, variant);
         }
@@ -167,7 +165,7 @@ public class MacOSBundler implements IBundler {
         exeOut.setExecutable(true);
 
         // Copy debug symbols
-        String zipDir = FilenameUtils.concat(extenderExeDir, platform.getExtenderPair());
+        String zipDir = FilenameUtils.concat(project.getBinaryOutputDirectory(), platform.getExtenderPair());
         File buildSymbols = new File(zipDir, "dmengine.dSYM");
         if (buildSymbols.exists()) {
             String symbolsDir = String.format("%s.dSYM", title);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/Win32Bundler.java
@@ -73,8 +73,7 @@ public class Win32Bundler implements IBundler {
 
         BobProjectProperties projectProperties = project.getProjectProperties();
 
-        String extenderExeDir = FilenameUtils.concat(project.getRootDirectory(), "build");
-        List<File> bundleExes = Bob.getNativeExtensionEngineBinaries(platform, extenderExeDir);
+        List<File> bundleExes = ExtenderUtil.getNativeExtensionEngineBinaries(project, platform);
         if (bundleExes == null) {
             final String variant = project.option("variant", Bob.VARIANT_RELEASE);
             bundleExes = Bob.getDefaultDmengineFiles(platform, variant);
@@ -117,7 +116,7 @@ public class Win32Bundler implements IBundler {
         FileUtils.copyFileToDirectory(new File(wrap_oal_dll), appDir);
 
         // Copy debug symbols if they were generated
-        String zipDir = FilenameUtils.concat(extenderExeDir, platform.getExtenderPair());
+        String zipDir = FilenameUtils.concat(project.getBinaryOutputDirectory(), platform.getExtenderPair());
         File bundlePdb = new File(zipDir, "dmengine.pdb");
         if (bundlePdb.exists()) {
             File pdbOut = new File(appDir, "dmengine.pdb");

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ExtenderUtil.java
@@ -494,6 +494,25 @@ public class ExtenderUtil {
         return false;
     }
 
+
+
+    public static List<File> getNativeExtensionEngineBinaries(Project project, Platform platform) throws IOException {
+        final File platformDir = new File(project.getBinaryOutputDirectory(), platform.getExtenderPair());
+        List<String> binaryNames = platform.formatBinaryName("dmengine");
+        List<File> binaryFiles = new ArrayList<File>();
+        for (String binaryName : binaryNames) {
+            File extenderExe = new File(platformDir, binaryName);
+
+            // All binaries must exist, otherwise return null
+            if (!extenderExe.exists()) {
+                return null;
+            }
+            binaryFiles.add(extenderExe);
+        }
+        return binaryFiles;
+    }
+
+
     /**
      * Returns true if the project should build remotely
      * @param project


### PR DESCRIPTION
When Cocoapod dependencies include dynamic frameworks these need to be signed and included in the application bundle. This change will copy any frameworks from the extender build result into the application bundle. Part of https://github.com/defold/extender/issues/274.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
