### PR TITLE
Show notifications on resource collisions

### DIFF
--- a/editor/resources/editor.fxml
+++ b/editor/resources/editor.fxml
@@ -9,237 +9,242 @@
   <children>
     <MenuBar id="menu-bar" />
     <Region id="menu-bar-space" />
-    <SplitPane id="main-split" dividerPositions="0.228595178719867" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="160.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
-      <items>
-        <AnchorPane id="left-pane" prefHeight="160.0" prefWidth="100.0" SplitPane.resizableWithParent="false">
-          <children>
-            <SplitPane id="assets-split" dividerPositions="0.5746666666666667" layoutX="24.0" layoutY="398.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-              <items>
-                <AnchorPane prefHeight="100.0" prefWidth="160.0">
-                  <children>
-                    <TitledPane animated="false" collapsible="false" layoutX="30.0" layoutY="66.0" minHeight="200.0" minWidth="200.0" prefHeight="200.0" prefWidth="200.0" text="Assets" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                      <content>
-                        <AnchorPane prefHeight="200.0" prefWidth="200.0">
-                          <children>
-                            <TreeView id="assets" prefHeight="200.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                          </children>
-                        </AnchorPane>
-                      </content>
-                    </TitledPane>
-                  </children>
-                </AnchorPane>
-                <AnchorPane prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
-                  <children>
-                    <TitledPane animated="false" collapsible="false" layoutX="3.0" layoutY="38.0" prefHeight="200.0" prefWidth="200.0" text="Changed Files" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                      <content>
-                        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
-                          <children>
-                            <VBox id="changes-container" layoutX="64.0" layoutY="34.0" prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                              <children>
-                                <AnchorPane VBox.vgrow="ALWAYS">
-                                  <children>
-                                    <ListView id="changes" prefHeight="200.0" prefWidth="200.0" styleClass="flat-list-view" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                                  </children>
-                                </AnchorPane>
-                                <ToolBar prefHeight="30.0" prefWidth="200.0">
-                                  <items>
-                                    <Button id="changes-diff" mnemonicParsing="false" styleClass="button-small" text="Diff" />
-                                    <Button id="changes-revert" mnemonicParsing="false" styleClass="button-small" text="Revert" />
-                                  </items>
-                                </ToolBar>
-                              </children>
-                            </VBox>
-                          </children>
-                        </AnchorPane>
-                      </content>
-                    </TitledPane>
-                  </children>
-                </AnchorPane>
-              </items>
-            </SplitPane>
-          </children>
-        </AnchorPane>
-        <AnchorPane id="workbench" prefHeight="200.0" prefWidth="200.0">
-          <children>
-            <SplitPane id="workbench-split" dividerPositions="0.7" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="160.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-              <items>
-                <AnchorPane prefHeight="160.0" prefWidth="100.0">
-                  <children>
-                    <SplitPane id="center-split" dividerPositions="0.5746666666666667" layoutX="24.0" layoutY="398.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                      <items>
-                        <AnchorPane prefHeight="100.0" prefWidth="160.0">
-                          <children>
-                            <SplitPane id="editor-tabs-split" dividerPositions="0.5" orientation="HORIZONTAL" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                          </children>
-                        </AnchorPane>
-                        <AnchorPane id="bottom-pane" prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
-                          <children>
-                            <TabPane id="tool-tabs" layoutX="3.0" layoutY="38.0" prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                              <tabs>
-                                <Tab id="console-tab" text="Console"> <!--Console tab-->
-                                  <content>
-                                    <fx:include source="console-view.fxml" />
-                                  </content>
-                                </Tab>
-                                <Tab id="curve-editor-tab" text="Curve Editor">
-                                  <content>
-                                    <AnchorPane id="curve-editor-container" prefHeight="180.0" prefWidth="200.0">
-                                      <children>
-                                        <SplitPane dividerPositions="0.25" layoutX="151.0" layoutY="66.0" prefHeight="160.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                          <items>
-                                            <AnchorPane id="curve-editor-list-anchor" prefHeight="206.0" prefWidth="119.0" SplitPane.resizableWithParent="false">
-                                              <children>
-                                                <ListView id="curve-editor-list" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                                              </children>
-                                            </AnchorPane>
-                                            <AnchorPane id="curve-editor-view" focusTraversable="true" minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0" />
-                                          </items>
-                                        </SplitPane>
-                                    </children></AnchorPane>
-                                  </content>
-                                </Tab>
-                                <Tab id="build-errors-tab" text="Build Errors">
-                                  <content>
-                                    <AnchorPane id="build-errors-container" prefHeight="180.0" prefWidth="200.0">
-                                      <children>
-                                        <TreeView id="build-errors-tree" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                                      </children>
-                                    </AnchorPane>
-                                  </content>
-                                </Tab>
-                                <Tab id="search-results-tab" text="Search Results">
-                                  <content>
-                                    <AnchorPane id="search-results-container" styleClass="search-results-view" prefHeight="180.0" prefWidth="200.0" />
-                                  </content>
-                                </Tab>
-                                <Tab id="graph-tab" text="Graph">
-                                  <content>
-                                    <AnchorPane prefHeight="180.0" prefWidth="200.0">
-                                      <children>
-                                        <VBox spacing="5" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                          <children>
-                                            <Button id="graph-refresh" mnemonicParsing="false" text="Refresh" />
-                                            <ScrollPane prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
-                                              <content>
-                                                <ImageView id="graph-image" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" />
-                                              </content>
-                                            </ScrollPane>
-                                          </children>
-                                        </VBox>
-                                      </children>
-                                    </AnchorPane>
-                                  </content>
-                                </Tab>
-                                <Tab id="css-tab" text="CSS Test">
-                                  <content>
-                                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
-                                      <children>
-                                        <GridPane vgap="10.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                          <columnConstraints>
-                                            <ColumnConstraints hgrow="NEVER" minWidth="10.0" prefWidth="80.0" />
-                                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="80.0" />
-                                          </columnConstraints>
-                                          <rowConstraints>
-                                            <RowConstraints minHeight="10.0" vgrow="NEVER" />
-                                            <RowConstraints minHeight="10.0" vgrow="NEVER" />
-                                            <RowConstraints minHeight="10.0" vgrow="NEVER" />
-                                          </rowConstraints>
-                                          <children>
-                                            <TextField GridPane.columnIndex="1" />
-                                            <Label text="ID" />
-                                            <Label text="Layer" GridPane.rowIndex="1" />
-                                            <Label text="XYZ" GridPane.rowIndex="2" />
-                                            <CheckBox mnemonicParsing="false" text="CheckBox" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                                            <ChoiceBox prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                                          </children>
-                                          <padding>
-                                            <Insets bottom="6.0" left="6.0" right="6.0" top="6.0" />
-                                          </padding>
-                                        </GridPane>
-                                      </children>
-                                    </AnchorPane>
-                                  </content>
-                                </Tab>
-                              </tabs>
-                            </TabPane>
-                          </children>
-                        </AnchorPane>
-                      </items>
-                    </SplitPane>
-                  </children>
-                </AnchorPane>
-                <AnchorPane id="right-pane" prefHeight="160.0" prefWidth="100.0" SplitPane.resizableWithParent="false">
-                  <children>
-                    <SplitPane id="right-split" dividerPositions="0.4" layoutX="50.0" layoutY="182.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                      <items>
+    <StackPane VBox.vgrow="ALWAYS">
+      <SplitPane id="main-split" dividerPositions="0.228595178719867" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="160.0" prefWidth="200.0">
+        <items>
+          <AnchorPane id="left-pane" prefHeight="160.0" prefWidth="100.0" SplitPane.resizableWithParent="false">
+            <children>
+              <SplitPane id="assets-split" dividerPositions="0.5746666666666667" layoutX="24.0" layoutY="398.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                <items>
+                  <AnchorPane prefHeight="100.0" prefWidth="160.0">
+                    <children>
+                      <TitledPane animated="false" collapsible="false" layoutX="30.0" layoutY="66.0" minHeight="200.0" minWidth="200.0" prefHeight="200.0" prefWidth="200.0" text="Assets" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <content>
+                          <AnchorPane prefHeight="200.0" prefWidth="200.0">
+                            <children>
+                              <TreeView id="assets" prefHeight="200.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                            </children>
+                          </AnchorPane>
+                        </content>
+                      </TitledPane>
+                    </children>
+                  </AnchorPane>
+                  <AnchorPane prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
+                    <children>
+                      <TitledPane animated="false" collapsible="false" layoutX="3.0" layoutY="38.0" prefHeight="200.0" prefWidth="200.0" text="Changed Files" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <content>
+                          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                            <children>
+                              <VBox id="changes-container" layoutX="64.0" layoutY="34.0" prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                <children>
+                                  <AnchorPane VBox.vgrow="ALWAYS">
+                                    <children>
+                                      <ListView id="changes" prefHeight="200.0" prefWidth="200.0" styleClass="flat-list-view" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                                    </children>
+                                  </AnchorPane>
+                                  <ToolBar prefHeight="30.0" prefWidth="200.0">
+                                    <items>
+                                      <Button id="changes-diff" mnemonicParsing="false" styleClass="button-small" text="Diff" />
+                                      <Button id="changes-revert" mnemonicParsing="false" styleClass="button-small" text="Revert" />
+                                    </items>
+                                  </ToolBar>
+                                </children>
+                              </VBox>
+                            </children>
+                          </AnchorPane>
+                        </content>
+                      </TitledPane>
+                    </children>
+                  </AnchorPane>
+                </items>
+              </SplitPane>
+            </children>
+          </AnchorPane>
+          <AnchorPane id="workbench" prefHeight="200.0" prefWidth="200.0">
+            <children>
+              <SplitPane id="workbench-split" dividerPositions="0.7" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="160.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                <items>
+                  <AnchorPane prefHeight="160.0" prefWidth="100.0">
+                    <children>
+                      <SplitPane id="center-split" dividerPositions="0.5746666666666667" layoutX="24.0" layoutY="398.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <items>
+                          <AnchorPane prefHeight="100.0" prefWidth="160.0">
+                            <children>
+                              <SplitPane id="editor-tabs-split" dividerPositions="0.5" orientation="HORIZONTAL" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                            </children>
+                          </AnchorPane>
+                          <AnchorPane id="bottom-pane" prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
+                            <children>
+                              <TabPane id="tool-tabs" layoutX="3.0" layoutY="38.0" prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                <tabs>
+                                  <Tab id="console-tab" text="Console"> <!--Console tab-->
+                                    <content>
+                                      <fx:include source="console-view.fxml" />
+                                    </content>
+                                  </Tab>
+                                  <Tab id="curve-editor-tab" text="Curve Editor">
+                                    <content>
+                                      <AnchorPane id="curve-editor-container" prefHeight="180.0" prefWidth="200.0">
+                                        <children>
+                                          <SplitPane dividerPositions="0.25" layoutX="151.0" layoutY="66.0" prefHeight="160.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                            <items>
+                                              <AnchorPane id="curve-editor-list-anchor" prefHeight="206.0" prefWidth="119.0" SplitPane.resizableWithParent="false">
+                                                <children>
+                                                  <ListView id="curve-editor-list" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                                                </children>
+                                              </AnchorPane>
+                                              <AnchorPane id="curve-editor-view" focusTraversable="true" minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0" />
+                                            </items>
+                                          </SplitPane>
+                                        </children>
+                                      </AnchorPane>
+                                    </content>
+                                  </Tab>
+                                  <Tab id="build-errors-tab" text="Build Errors">
+                                    <content>
+                                      <AnchorPane id="build-errors-container" prefHeight="180.0" prefWidth="200.0">
+                                        <children>
+                                          <TreeView id="build-errors-tree" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                                        </children>
+                                      </AnchorPane>
+                                    </content>
+                                  </Tab>
+                                  <Tab id="search-results-tab" text="Search Results">
+                                    <content>
+                                      <AnchorPane id="search-results-container" styleClass="search-results-view" prefHeight="180.0" prefWidth="200.0" />
+                                    </content>
+                                  </Tab>
+                                  <Tab id="graph-tab" text="Graph">
+                                    <content>
+                                      <AnchorPane prefHeight="180.0" prefWidth="200.0">
+                                        <children>
+                                          <VBox spacing="5" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                            <children>
+                                              <Button id="graph-refresh" mnemonicParsing="false" text="Refresh" />
+                                              <ScrollPane prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
+                                                <content>
+                                                  <ImageView id="graph-image" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" />
+                                                </content>
+                                              </ScrollPane>
+                                            </children>
+                                          </VBox>
+                                        </children>
+                                      </AnchorPane>
+                                    </content>
+                                  </Tab>
+                                  <Tab id="css-tab" text="CSS Test">
+                                    <content>
+                                      <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                                        <children>
+                                          <GridPane vgap="10.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                            <columnConstraints>
+                                              <ColumnConstraints hgrow="NEVER" minWidth="10.0" prefWidth="80.0" />
+                                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="80.0" />
+                                            </columnConstraints>
+                                            <rowConstraints>
+                                              <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                              <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                              <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                                            </rowConstraints>
+                                            <children>
+                                              <TextField GridPane.columnIndex="1" />
+                                              <Label text="ID" />
+                                              <Label text="Layer" GridPane.rowIndex="1" />
+                                              <Label text="XYZ" GridPane.rowIndex="2" />
+                                              <CheckBox mnemonicParsing="false" text="CheckBox" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                              <ChoiceBox prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                                            </children>
+                                            <padding>
+                                              <Insets bottom="6.0" left="6.0" right="6.0" top="6.0" />
+                                            </padding>
+                                          </GridPane>
+                                        </children>
+                                      </AnchorPane>
+                                    </content>
+                                  </Tab>
+                                </tabs>
+                              </TabPane>
+                            </children>
+                          </AnchorPane>
+                        </items>
+                      </SplitPane>
+                    </children>
+                  </AnchorPane>
+                  <AnchorPane id="right-pane" prefHeight="160.0" prefWidth="100.0" SplitPane.resizableWithParent="false">
+                    <children>
+                      <SplitPane id="right-split" dividerPositions="0.4" layoutX="50.0" layoutY="182.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <items>
+                          <AnchorPane prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
+                            <children>
+                              <TitledPane animated="false" collapsible="false" text="Outline" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                <content>
+                                  <AnchorPane prefHeight="200.0" prefWidth="200.0">
+                                    <children>
+                                      <TreeView id="outline" prefHeight="326.0" prefWidth="269.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                                    </children>
+                                  </AnchorPane>
+                                </content>
+                              </TitledPane>
+                            </children>
+                          </AnchorPane>
+                          <AnchorPane prefHeight="100.0" prefWidth="160.0">
+                            <children>
+                              <!-- DEFEDIT-1427. We used to have a TitledPane here, but TitledPane + ScrollPane + AnchorPane + running
+                                   animation sometimes stopped the rendering of the whole right-split. Replacing the TitledPane with a
+                                   VBox + Label as below is a workaround. -->
+                              <VBox styleClass="fake-titled-pane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                <children>
+                                  <Label styleClass="fake-titled-pane-label" text="Properties" />
+                                  <ScrollPane fitToHeight="true" fitToWidth="true" prefViewportHeight="325.0" prefViewportWidth="269.0" VBox.vgrow="ALWAYS">
+                                    <content>
+                                      <AnchorPane id="properties" prefHeight="180.0" prefWidth="200.0" />
+                                    </content>
+                                  </ScrollPane>
+                                </children>
+                              </VBox>
+                            </children>
+                          </AnchorPane>
+                        </items>
+                      </SplitPane>
+                      <SplitPane id="debugger-data-split" visible="false" dividerPositions="0.33" orientation="VERTICAL" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                         <AnchorPane prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
-                          <children>
-                            <TitledPane animated="false" collapsible="false" text="Outline" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                              <content>
-                                <AnchorPane prefHeight="200.0" prefWidth="200.0">
-                                  <children>
-                                    <TreeView id="outline" prefHeight="326.0" prefWidth="269.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                                  </children>
-                                </AnchorPane>
-                              </content>
-                            </TitledPane>
-                          </children>
+                          <TitledPane animated="false" collapsible="false" text="Call Stack" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                            <ListView id="debugger-call-stack" />
+                          </TitledPane>
                         </AnchorPane>
                         <AnchorPane prefHeight="100.0" prefWidth="160.0">
-                          <children>
-                            <!-- DEFEDIT-1427. We used to have a TitledPane here, but TitledPane + ScrollPane + AnchorPane + running
-                                 animation sometimes stopped the rendering of the whole right-split. Replacing the TitledPane with a
-                                 VBox + Label as below is a workaround. -->
-                            <VBox styleClass="fake-titled-pane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                              <children>
-                                <Label styleClass="fake-titled-pane-label" text="Properties"/>
-                                <ScrollPane fitToHeight="true" fitToWidth="true" prefViewportHeight="325.0" prefViewportWidth="269.0" VBox.vgrow="ALWAYS">
-                                  <content>
-                                    <AnchorPane id="properties" prefHeight="180.0" prefWidth="200.0" />
-                                  </content>
-                                </ScrollPane>
-                              </children>
-                            </VBox>
-                          </children>
+                          <TitledPane animated="false" collapsible="false" text="Variables" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                            <TreeView id="debugger-variables" />
+                          </TitledPane>
                         </AnchorPane>
-                      </items>
-                    </SplitPane>
-                    <SplitPane id="debugger-data-split" visible="false" dividerPositions="0.33" orientation="VERTICAL" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                      <AnchorPane prefHeight="100.0" prefWidth="160.0" SplitPane.resizableWithParent="false">
-                        <TitledPane animated="false" collapsible="false" text="Call Stack" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                          <ListView id="debugger-call-stack"/>
-                        </TitledPane>
-                      </AnchorPane>
-                      <AnchorPane prefHeight="100.0" prefWidth="160.0">
-                        <TitledPane animated="false" collapsible="false" text="Variables" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                          <TreeView id="debugger-variables"/>
-                        </TitledPane>
-                      </AnchorPane>
-                    </SplitPane>
-                  </children>
-                </AnchorPane>
-              </items>
-            </SplitPane>
-          </children>
-        </AnchorPane>
-      </items>
-    </SplitPane>
-      <HBox id="status-bar">
-        <children>
-          <Label id="status-label" text="Ready" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308"/>
-          <StackPane id="status-pane">
-            <Hyperlink id="update-link" text="Update Available" visible="false" StackPane.alignment="CENTER_RIGHT"/>
-            <HBox id="progress-hbox" visible="false">
-              <Label id="progress-percentage-label"/>
-              <ProgressBar id="progress-bar" styleClass="really-small-progress-bar"/>
-              <Button id="progress-cancel-button" mnemonicParsing="false" visible="false">
-                <graphic>
-                  <Region id="cross"/>
-                </graphic>
-              </Button>
-            </HBox>
-          </StackPane>
-        </children>
-      </HBox>
+                      </SplitPane>
+                    </children>
+                  </AnchorPane>
+                </items>
+              </SplitPane>
+            </children>
+          </AnchorPane>
+        </items>
+      </SplitPane>
+      <VBox id="notifications" maxWidth="-Infinity" maxHeight="-Infinity" StackPane.alignment="BOTTOM_RIGHT" pickOnBounds="false">
+      </VBox>
+    </StackPane>
+    <HBox id="status-bar">
+      <children>
+        <Label id="status-label" text="Ready" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308" />
+        <StackPane id="status-pane">
+          <Hyperlink id="update-link" text="Update Available" visible="false" StackPane.alignment="CENTER_RIGHT" />
+          <HBox id="progress-hbox" visible="false">
+            <Label id="progress-percentage-label" />
+            <ProgressBar id="progress-bar" styleClass="really-small-progress-bar" />
+            <Button id="progress-cancel-button" mnemonicParsing="false" visible="false">
+              <graphic>
+                <Region id="cross" />
+              </graphic>
+            </Button>
+          </HBox>
+        </StackPane>
+      </children>
+    </HBox>
   </children>
 </VBox>

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -36,6 +36,7 @@
             [editor.hot-reload :as hot-reload]
             [editor.html-view :as html-view]
             [editor.icons :as icons]
+            [editor.notifications-view :as notifications-view]
             [editor.outline-view :as outline-view]
             [editor.pipeline.bob :as bob]
             [editor.properties-view :as properties-view]
@@ -172,6 +173,7 @@
           console-tab          (first (.getTabs tool-tabs))
           console-grid-pane    (.lookup root "#console-grid-pane")
           workbench            (.lookup root "#workbench")
+          notifications        (.lookup root "#notifications")
           scene-visibility     (scene-visibility/make-scene-visibility-node! *view-graph*)
           app-view             (app-view/make-app-view *view-graph* project stage menu-bar editor-tabs-split tool-tabs prefs)
           outline-view         (outline-view/make-outline-view *view-graph* project outline app-view)
@@ -179,6 +181,7 @@
           asset-browser        (asset-browser/make-asset-browser *view-graph* workspace assets prefs)
           open-resource        (partial app-view/open-resource app-view prefs workspace project)
           console-view         (console/make-console! *view-graph* workspace console-tab console-grid-pane open-resource)
+          _                    (notifications-view/init! (g/node-value workspace :notifications) notifications)
           build-errors-view    (build-errors-view/make-build-errors-view (.lookup root "#build-errors-tree")
                                                                          (fn [resource selected-node-ids opts]
                                                                            (when (open-resource resource opts)

--- a/editor/src/clj/editor/notifications.clj
+++ b/editor/src/clj/editor/notifications.clj
@@ -1,0 +1,109 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.notifications
+  (:require [clojure.spec.alpha :as s]
+            [dynamo.graph :as g]))
+
+(s/def ::type #{:info :warning :error})
+(s/def ::id any?)
+(s/def ::text string?)
+(s/def ::on-action ifn?)
+(s/def ::action (s/keys :req-un [::text ::on-action]))
+(s/def ::actions (s/coll-of ::action))
+(s/def ::notification (s/keys :req-un [::type ::text]
+                              :opt-un [::id ::actions]))
+
+(g/defnode NotificationsNode
+  (property notifications g/Any (default {:id->notification {}
+                                          :ids []})))
+
+(defn submit!
+  "Show a notification in the view
+
+  Args:
+    notifications-node    node id of NotificationsNode type
+    notification          map with following keys:
+                            :type       required, either info, :warn or :error
+                            :text       required, notification text string
+                            :id         optional id, anything; submitting
+                                        notification a second time with the same
+                                        id will overwrite the first one
+                            :actions    optional vector of maps with :text
+                                        strings and :on-action 0-arg callbacks"
+  [notifications-node notification]
+  {:pre [(s/valid? ::notification notification)]}
+  (g/update-property! notifications-node :notifications
+                      (fn [{:keys [id->notification] :as notifications}]
+                        (let [id (or (:id notification)
+                                     (gensym (str (symbol ::id))))
+                              exists (contains? id->notification id)]
+                          (-> notifications
+                              (update :id->notification assoc id notification)
+                              (cond-> (not exists) (update :ids conj id))))))
+  nil)
+
+(defn close!
+  "Close notification by id"
+  [notifications-node id]
+  (g/update-property! notifications-node :notifications
+                      (fn [{:keys [id->notification] :as notifications}]
+                        (if (contains? id->notification id)
+                          (-> notifications
+                              (update :id->notification dissoc id)
+                              (update :ids (fn [ids]
+                                             (filterv #(not= id %) ids))))
+                          notifications)))
+  nil)
+
+(defn close-latest!
+  "Close the latest (i.e. visible) notification"
+  [notifications-node]
+  (g/update-property! notifications-node :notifications
+                      (fn [{:keys [ids] :as notifications}]
+                        (if (pos? (count ids))
+                          (let [id (peek ids)]
+                            (-> notifications
+                                (update :ids pop)
+                                (update :id->notification dissoc id)))
+                          notifications)))
+  nil)
+
+(comment
+
+  (editor.ui/run-now
+    (submit! (g/node-value 0 :notifications)
+             {:type :info
+              :id ::updatable
+              :text (str "Updatable " (rand-int 10000))}))
+
+  (editor.ui/run-now
+    (submit! (g/node-value 0 :notifications)
+             {:type :error
+              :text "An error occurred"}))
+
+  (editor.ui/run-now
+    (submit! (g/node-value 0 :notifications)
+             {:type :warning
+              :text "!"}))
+
+  (editor.ui/run-now
+    (submit!
+      (g/node-value 0 :notifications)
+      {:type :warning
+       :text "Folder /defold-rive shadows a folder with the same name defined in a dependency: https://github.com/defold/extension-rive/archive/refs/tags/1.0.zip"
+       :actions [{:text "Suppress warning for this folder"
+                  :on-action #(tap> :suppress)}]}))
+
+  ,)

--- a/editor/src/clj/editor/notifications.clj
+++ b/editor/src/clj/editor/notifications.clj
@@ -29,7 +29,7 @@
   (property notifications g/Any (default {:id->notification {}
                                           :ids []})))
 
-(defn submit!
+(defn show!
   "Show a notification in the view
 
   Args:
@@ -67,39 +67,26 @@
                           notifications)))
   nil)
 
-(defn close-latest!
-  "Close the latest (i.e. visible) notification"
-  [notifications-node]
-  (g/update-property! notifications-node :notifications
-                      (fn [{:keys [ids] :as notifications}]
-                        (if (pos? (count ids))
-                          (let [id (peek ids)]
-                            (-> notifications
-                                (update :ids pop)
-                                (update :id->notification dissoc id)))
-                          notifications)))
-  nil)
-
 (comment
 
   (editor.ui/run-now
-    (submit! (g/node-value 0 :notifications)
-             {:type :info
-              :id ::updatable
-              :text (str "Updatable " (rand-int 10000))}))
+    (show! (g/node-value 0 :notifications)
+           {:type :info
+            :id ::updatable
+            :text (str "Updatable " (rand-int 10000))}))
 
   (editor.ui/run-now
-    (submit! (g/node-value 0 :notifications)
-             {:type :error
-              :text "An error occurred"}))
+    (show! (g/node-value 0 :notifications)
+           {:type :error
+            :text "An error occurred"}))
 
   (editor.ui/run-now
-    (submit! (g/node-value 0 :notifications)
-             {:type :warning
-              :text "!"}))
+    (show! (g/node-value 0 :notifications)
+           {:type :warning
+            :text "!"}))
 
   (editor.ui/run-now
-    (submit!
+    (show!
       (g/node-value 0 :notifications)
       {:type :warning
        :text "Folder /defold-rive shadows a folder with the same name defined in a dependency: https://github.com/defold/extension-rive/archive/refs/tags/1.0.zip"

--- a/editor/src/clj/editor/notifications_view.clj
+++ b/editor/src/clj/editor/notifications_view.clj
@@ -1,0 +1,113 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.notifications-view
+  (:require [cljfx.api :as fx]
+            [dynamo.graph :as g]
+            [editor.error-reporting :as error-reporting]
+            [editor.fxui :as fxui]
+            [cljfx.fx.v-box :as fx.v-box]
+            [editor.ui :as ui]
+            [cljfx.fx.flow-pane :as fx.flow-pane]
+            [cljfx.fx.stack-pane :as fx.stack-pane]
+            [cljfx.fx.region :as fx.region]
+            [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.button :as fx.button]
+            [editor.notifications :as notifications]))
+
+(def ^:private ext-with-v-box-props
+  (fx/make-ext-with-props fx.v-box/props))
+
+(defn- close-notification! [{:keys [notifications-node]}]
+  (notifications/close-latest! notifications-node))
+
+(defn- invoke-action! [{:keys [on-action] :as event}]
+  (try
+    (on-action)
+    (catch Exception e
+      (error-reporting/report-exception! e)))
+  (close-notification! event))
+
+(defn- notifications-view [{:keys [id->notification ids]} parent]
+  (let [n (count ids)]
+    {:fx/type ext-with-v-box-props
+     :desc {:fx/type fxui/ext-value :value parent}
+     :props
+     {:padding 10
+      :children
+      (cond-> []
+              (pos? n)
+              (conj
+                (let [typical-button-count 3
+                      horizontal-padding 14
+                      vertical-padding 8
+                      close-button-margin 4
+                      spacing 4
+                      {:keys [type text actions]} (id->notification (peek ids))]
+                  {:fx/type fx.stack-pane/lifecycle
+                   :max-width (+ (* typical-button-count 100) ;; min button width
+                                 (* 2 horizontal-padding)
+                                 (* (dec typical-button-count) spacing))
+                   :children
+                   [{:fx/type fx.region/lifecycle
+                     :style-class "notification-card-background"
+                     :pseudo-classes #{type}}
+                    {:fx/type fx.v-box/lifecycle
+                     :children
+                     (cond-> [{:fx/type fx.h-box/lifecycle
+                               :alignment :top-left
+                               :padding {:top vertical-padding
+                                         :bottom vertical-padding
+                                         :left horizontal-padding
+                                         :right (- horizontal-padding close-button-margin)}
+                               :spacing spacing
+                               :fill-height false
+                               :children [{:fx/type fxui/label
+                                           :h-box/hgrow :always
+                                           :max-width Double/MAX_VALUE
+                                           :text text}
+                                          {:fx/type fx.region/lifecycle
+                                           :h-box/margin close-button-margin
+                                           :on-mouse-clicked {:fn #'close-notification!}
+                                           :min-width 10
+                                           :min-height 10
+                                           :style-class "notification-card-close-button"}]}]
+                             (pos? (count actions))
+                             (conj {:fx/type fx.flow-pane/lifecycle
+                                    :hgap spacing
+                                    :vgap spacing
+                                    :padding {:left horizontal-padding
+                                              :right horizontal-padding
+                                              :bottom vertical-padding}
+                                    :children (mapv
+                                                (fn [{:keys [text on-action]}]
+                                                  {:fx/type fx.button/lifecycle
+                                                   :style-class ["button" "notification-card-button"]
+                                                   :text text
+                                                   :on-action {:fn #'invoke-action!
+                                                               :on-action on-action}})
+                                                actions)}))}]})))}}))
+
+(defn init! [notifications-node parent]
+  (let [renderer (fx/create-renderer
+                   :error-handler error-reporting/report-exception!
+                   :opts {:fx.opt/map-event-handler #((:fn %) (assoc % :notifications-node notifications-node))}
+                   :middleware (comp
+                                 fxui/wrap-dedupe-desc
+                                 (fx/wrap-map-desc #'notifications-view parent)))]
+    (ui/timer-start!
+      (ui/->timer 30 "notifications-view-timer"
+                  (fn [_timer _elapsed _dt]
+                    (renderer (g/node-value notifications-node :notifications)))))
+    nil))

--- a/editor/src/clj/editor/notifications_view.clj
+++ b/editor/src/clj/editor/notifications_view.clj
@@ -14,23 +14,23 @@
 
 (ns editor.notifications-view
   (:require [cljfx.api :as fx]
+            [cljfx.fx.button :as fx.button]
+            [cljfx.fx.flow-pane :as fx.flow-pane]
+            [cljfx.fx.h-box :as fx.h-box]
+            [cljfx.fx.region :as fx.region]
+            [cljfx.fx.stack-pane :as fx.stack-pane]
+            [cljfx.fx.v-box :as fx.v-box]
             [dynamo.graph :as g]
             [editor.error-reporting :as error-reporting]
             [editor.fxui :as fxui]
-            [cljfx.fx.v-box :as fx.v-box]
-            [editor.ui :as ui]
-            [cljfx.fx.flow-pane :as fx.flow-pane]
-            [cljfx.fx.stack-pane :as fx.stack-pane]
-            [cljfx.fx.region :as fx.region]
-            [cljfx.fx.h-box :as fx.h-box]
-            [cljfx.fx.button :as fx.button]
-            [editor.notifications :as notifications]))
+            [editor.notifications :as notifications]
+            [editor.ui :as ui]))
 
 (def ^:private ext-with-v-box-props
   (fx/make-ext-with-props fx.v-box/props))
 
-(defn- close-notification! [{:keys [notifications-node]}]
-  (notifications/close-latest! notifications-node))
+(defn- close-notification! [{:keys [notifications-node id]}]
+  (notifications/close! notifications-node id))
 
 (defn- invoke-action! [{:keys [on-action] :as event}]
   (try
@@ -54,7 +54,8 @@
                       vertical-padding 8
                       close-button-margin 4
                       spacing 4
-                      {:keys [type text actions]} (id->notification (peek ids))]
+                      id (peek ids)
+                      {:keys [type text actions]} (id->notification id)]
                   {:fx/type fx.stack-pane/lifecycle
                    :max-width (+ (* typical-button-count 100) ;; min button width
                                  (* 2 horizontal-padding)
@@ -79,7 +80,7 @@
                                            :text text}
                                           {:fx/type fx.region/lifecycle
                                            :h-box/margin close-button-margin
-                                           :on-mouse-clicked {:fn #'close-notification!}
+                                           :on-mouse-clicked {:fn #'close-notification! :id id}
                                            :min-width 10
                                            :min-height 10
                                            :style-class "notification-card-close-button"}]}]
@@ -96,6 +97,7 @@
                                                    :style-class ["button" "notification-card-button"]
                                                    :text text
                                                    :on-action {:fn #'invoke-action!
+                                                               :id id
                                                                :on-action on-action}})
                                                 actions)}))}]})))}}))
 

--- a/editor/src/clj/editor/resource_watch.clj
+++ b/editor/src/clj/editor/resource_watch.clj
@@ -156,7 +156,7 @@
   (reduce
    (fn [result snapshot]
      (if-let [collisions (seq (clojure.set/intersection (resource-paths result) (resource-paths snapshot)))]
-       (update result :errors conj {:collisions (select-keys (:status-map snapshot) collisions)})
+       (update result :errors conj {:type :collision :collisions (select-keys (:status-map snapshot) collisions)})
        (-> result
            (update :resources concat (:resources snapshot))
            (update :status-map merge (:status-map snapshot)))))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -24,6 +24,7 @@ ordinary paths."
             [editor.dialogs :as dialogs]
             [editor.fs :as fs]
             [editor.library :as library]
+            [editor.notifications :as notifications]
             [editor.prefs :as prefs]
             [editor.progress :as progress]
             [editor.resource :as resource]
@@ -67,6 +68,13 @@ ordinary paths."
      (code-preprocessors workspace evaluation-context)))
   ([workspace evaluation-context]
    (g/node-value workspace :code-preprocessors evaluation-context)))
+
+(defn notifications
+  ([workspace]
+   (g/with-auto-evaluation-context evaluation-context
+     (notifications workspace evaluation-context)))
+  ([workspace evaluation-context]
+   (g/node-value workspace :notifications evaluation-context)))
 
 (defn- skip-first-char [path]
   (subs path 1))
@@ -579,6 +587,38 @@ ordinary paths."
   (load-java-editor-plugins! workspace)
   (load-clojure-editor-plugins! workspace touched-resources))
 
+(defn- sync-snapshot-errors-notifications! [workspace old-errors new-errors]
+  (when (or old-errors new-errors)
+    (letfn [(errors->collision-resource-path+statuses [errors]
+              (into #{}
+                    (comp
+                      (filter #(= :collision (:type %)))
+                      (mapcat :collisions))
+                    errors))
+            (collision-notification-id [resource-path]
+              [::resource-collision-notification resource-path])]
+      (let [old-collisions (errors->collision-resource-path+statuses old-errors)
+            new-collisions (errors->collision-resource-path+statuses new-errors)
+            removed (set/difference old-collisions new-collisions)
+            added (set/difference new-collisions old-collisions)
+            notifications-node (notifications workspace)]
+        (->> removed
+             (eduction
+               (map key))
+             (run! #(notifications/close! notifications-node (collision-notification-id %))))
+        (->> added
+             (eduction
+               (map (fn [[resource-path {:keys [source] :as status}]]
+                      {:type :warning
+                       :id (collision-notification-id resource-path)
+                       :text (str "Folder '" resource-path "' is shadowing a folder with the same name"
+                                  (case source
+                                    :library (str " in a project dependency: " (:library status))
+                                    :builtins " in builtins"
+                                    :directory ""
+                                    source))})))
+             (run! #(notifications/submit! notifications-node %)))))))
+
 (defn resource-sync!
   ([workspace]
    (resource-sync! workspace []))
@@ -602,6 +642,7 @@ ordinary paths."
          old-snapshot (g/node-value workspace :resource-snapshot)
          old-map      (resource-watch/make-resource-map old-snapshot)
          changes      (resource-watch/diff old-snapshot new-snapshot)]
+     (sync-snapshot-errors-notifications! workspace (:errors old-snapshot) (:errors new-snapshot))
      (when (or (not (resource-watch/empty-diff? changes)) (seq moved-proj-paths))
        (g/set-property! workspace :resource-snapshot new-snapshot)
        (let [changes (into {} (map (fn [[type resources]] [type (filter #(= :file (resource/source-type %)) resources)]) changes))
@@ -693,6 +734,7 @@ ordinary paths."
   (property editable-proj-path? g/Any)
 
   (input code-preprocessors g/NodeID :cascade-delete)
+  (input notifications g/NodeID :cascade-delete)
 
   (output resource-tree FileResource :cached produce-resource-tree)
   (output resource-list g/Any :cached produce-resource-list)
@@ -796,8 +838,11 @@ ordinary paths."
                         :resource-listeners (atom [])
                         :build-settings build-settings
                         :editable-proj-path? editable-proj-path?]
-             code-preprocessors code.preprocessors/CodePreprocessorsNode]
-            (g/connect code-preprocessors :_node-id workspace :code-preprocessors)))))))
+             code-preprocessors code.preprocessors/CodePreprocessorsNode
+             notifications notifications/NotificationsNode]
+            (concat
+              (g/connect notifications :_node-id workspace :notifications)
+              (g/connect code-preprocessors :_node-id workspace :code-preprocessors))))))))
 
 (defn register-view-type
   "Register a new view type that can be used by resources

--- a/editor/styling/stylesheets/components/_notification.scss
+++ b/editor/styling/stylesheets/components/_notification.scss
@@ -1,0 +1,31 @@
+.notification-card {
+  &-background {
+    -fx-background-color: -df-component-dark;
+    -fx-border-width: 1px 1px 1px 2px;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.3), 12, 0, 0, 8);
+    &:warning {
+      -fx-border-color: -df-component -df-component -df-component -df-error-severity-warning;
+    }
+    &:error {
+      -fx-border-color: -df-component -df-component -df-component -df-error-severity-fatal;
+    }
+    &:info {
+      -fx-border-color: -df-component -df-component -df-component -df-error-severity-info;
+    }
+  }
+  &-close-button {
+    -fx-shape: "M 0,0 H1 L 4,3 7,0 H8 V1 L 5,4 8,7 V8 H7 L 4,5 1,8 H0 V7 L 3,4 0,1 Z";
+    -fx-background-color: -df-text-darker;
+    -fx-effect: none;
+    &:hover {
+      -fx-background-color: -df-text-selected;
+    }
+  }
+  &-button {
+    -fx-background-color: -df-component-light;
+    -fx-border-color: -df-component-darker;
+    &:hover {
+      -fx-background-color: -df-component-lighter;
+    }
+  }
+}

--- a/editor/styling/stylesheets/editor.sass
+++ b/editor/styling/stylesheets/editor.sass
@@ -31,6 +31,7 @@
 @import 'components/_list-view';
 @import 'components/_menu-bar';
 @import 'components/_menu-button';
+@import 'components/_notification';
 @import 'components/_progress-bar';
 @import 'components/_progress-indicator';
 @import 'components/_property';


### PR DESCRIPTION
User-facing changes:
When a local folder overrides a zip folder from a dependency, we now show a warning notification in the editor.

Technical notes:
This changeset implements a notification system in the editor. Resource sync diffs its errors with the old snapshot to show/hide notifications about folder overrides. I initially considered adding a "Rename Folder" action to the notification, but it required moving the renaming logic from the `editor.asset-browser` to the `editor.workspace` namespace that is UI-dependent (e.g. it shows a rename dialog, a resolve conflicts dialog). While it's doable, I don't like that it makes the workspace ns even more dependent on UI than it currently is. I think it should have logic only so we can eventually use it in Bob, but it will then require either adding a layer of indirection for "non-GUI UI". Another solution would be moving the collision notification handling somewhere out of `editor.workspace` ns (e.g. an error listener). Not showing any actions is a also viable solution here, since the notification is useful as it is, we can deliver stuff earlier to our users, and we still can add actions later if our users will need them.

Fixes #7375
