### PR TITLE
Use `:textual?` flag for Search in Files

### DIFF
--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -320,6 +320,12 @@
       (let [progress-tracer (make-progress-tracer :save-data (.get step-count) progress-message-fn render-progress!)]
         (dirty-save-data project (assoc evaluation-context :tracer progress-tracer))))))
 
+(defn textual-resource-type? [resource-type]
+  ;; Unregistered resources that are connected to the project
+  ;; save-data input are assumed to produce text data.
+  (or (nil? resource-type)
+      (resource/textual-resource-type? resource-type)))
+
 (defn write-save-data-to-disk! [save-data {:keys [render-progress!]
                                            :or {render-progress! progress/null-render-progress!}
                                            :as opts}]
@@ -333,7 +339,7 @@
                      (not (resource/read-only? resource)))
             ;; If the file is non-binary, convert line endings to the
             ;; type used by the existing file.
-            (if (and (resource/textual? resource)
+            (if (and (textual-resource-type? (resource/resource-type resource))
                      (resource/exists? resource)
                      (= :crlf (text-util/guess-line-endings (io/make-reader resource nil))))
               (spit resource (text-util/lf->crlf content))

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -320,12 +320,6 @@
       (let [progress-tracer (make-progress-tracer :save-data (.get step-count) progress-message-fn render-progress!)]
         (dirty-save-data project (assoc evaluation-context :tracer progress-tracer))))))
 
-(defn textual-resource-type? [resource-type]
-  ;; Unregistered resources that are connected to the project
-  ;; save-data input are assumed to produce text data.
-  (or (nil? resource-type)
-      (:textual? resource-type)))
-
 (defn write-save-data-to-disk! [save-data {:keys [render-progress!]
                                            :or {render-progress! progress/null-render-progress!}
                                            :as opts}]
@@ -339,7 +333,7 @@
                      (not (resource/read-only? resource)))
             ;; If the file is non-binary, convert line endings to the
             ;; type used by the existing file.
-            (if (and (textual-resource-type? (resource/resource-type resource))
+            (if (and (resource/textual? resource)
                      (resource/exists? resource)
                      (= :crlf (text-util/guess-line-endings (io/make-reader resource nil))))
               (spit resource (text-util/lf->crlf content))

--- a/editor/src/clj/editor/defold_project_search.clj
+++ b/editor/src/clj/editor/defold_project_search.clj
@@ -52,8 +52,9 @@
   (or (when (some? content)
         (make-line-coll #(BufferedReader. (StringReader. content))))
       (when (and (resource/exists? resource)
-                 (resource/textual? resource)
-                 (not (text-util/binary? resource)))
+                 (if-let [resource-type (resource/resource-type resource)]
+                   (resource/textual-resource-type? resource-type)
+                   (not (text-util/binary? resource))))
         (make-line-coll #(io/reader resource)))))
 
 (defn compile-find-in-files-regex

--- a/editor/src/clj/editor/html.clj
+++ b/editor/src/clj/editor/html.clj
@@ -28,6 +28,7 @@
   (workspace/register-resource-type workspace
                                     :ext "html"
                                     :label "HTML"
+                                    :textual? true
                                     :node-type HtmlNode
                                     :view-types [:html]
                                     :view-opts nil))

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -55,6 +55,7 @@
   (workspace/register-resource-type workspace
                                     :ext "md"
                                     :label "Markdown"
+                                    :textual? true
                                     :node-type MarkdownNode
                                     :load-fn load-markdown
                                     :view-types [:html :text]

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -437,6 +437,15 @@
   [resource]
   (string/starts-with? (resource->proj-path resource) "/_defold"))
 
+(defn textual?
+  "Returns whether the resource is configured to be textual or not
+
+  Unregistered resource types are assumed to produce text data. You should use
+  [[util.text-util/binary?]] to get a more accurate estimate of whether the
+  content of the resource is textual or not."
+  [resource]
+  (:textual? (resource-type resource) true))
+
 (def ^:private known-ext->language
   ;; See known language identifiers:
   ;; https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -437,14 +437,16 @@
   [resource]
   (string/starts-with? (resource->proj-path resource) "/_defold"))
 
-(defn textual?
-  "Returns whether the resource is configured to be textual or not
+(defn textual-resource-type?
+  "Returns whether the resource type is marked as textual
 
-  Unregistered resource types are assumed to produce text data. You should use
-  [[util.text-util/binary?]] to get a more accurate estimate of whether the
-  content of the resource is textual or not."
-  [resource]
-  (:textual? (resource-type resource) true))
+  Resource type is a required argument. If a resource does not specify a
+  resource type, you can use [[util.text-util/binary?]] to estimate if
+  the content of the resource is textual or not"
+  [resource-type]
+  {:pre [(some? resource-type)]
+   :post [(boolean? %)]}
+  (:textual? resource-type))
 
 (def ^:private known-ext->language
   ;; See known language identifiers:

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -197,8 +197,9 @@ ordinary paths."
   Optional kv-args:
     :node-type          a loaded resource node type; defaults to
                         editor.placeholder-resource/PlaceholderResourceNode
-    :textual?           whether the resource is saved as text and needs proper
-                        lf/crlf handling, default false
+    :textual?           whether the resource is textual, default false. This
+                        flag affects search in files availability for the
+                        resource type and lf/crlf handling on save
     :language           language identifier string used for textual resources
                         that can be opened as code, used for LSP interactions,
                         see https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers


### PR DESCRIPTION
Technical note: we now look at `:textual?` flag of a resource type to determine if a resource without save data might be textual.

User-facing changes:

We no longer search through `.glb` files when performing Search in Files.

Fixes #7586
