### PR TITLE
Fix for gltf models with unsorted bones

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
@@ -478,11 +478,12 @@ public class ColladaUtilTest {
          *  - Positions and scale don't change
          *  - Rotation is only increased on X-axis
          */
+        long boneId = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            assertEquals(0, track.getBoneIndex());
+            assertEquals(boneId, track.getBoneId());
 
             /*
              *  The collada file does not animate either position or scale for the bones,
@@ -536,29 +537,31 @@ public class ColladaUtilTest {
         float sampleRate = animSetBuilder.getAnimations(0).getSampleRate();
         int keyframeCount = (int)Math.ceil(duration*sampleRate);
 
+        long boneId0 = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
+        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            int boneIndex = track.getBoneIndex();
+            long boneId = track.getBoneId();
 
             // There should be no position or scale animation.
             assertAnimationSamePosScale(track);
 
             if (track.getRotationsCount() > 0) {
-                if (boneIndex == 0) {
+                if (boneId == boneId0) {
                     // Verify animations on root bone
                     assertAnimationRotation(track, 0, rotIdentity);
                     assertAnimationRotation(track, keyframeCount/2, rotIdentity);
                     assertAnimationRotation(track, keyframeCount, rot90ZAxis);
 
-                } else if (boneIndex == 1) {
+                } else if (boneId == boneId1) {
                     // Verify animation on secondary bone
                     assertAnimationRotation(track, 0, rotIdentity);
                     assertAnimationRotation(track, keyframeCount/2, rot90ZAxis);
                     assertAnimationRotation(track, keyframeCount, rotIdentity);
 
                 } else {
-                    fail("Animations on invalid bone index: " + boneIndex);
+                    fail("Animations on invalid bone index: " + boneId);
                 }
             }
         }
@@ -601,18 +604,20 @@ public class ColladaUtilTest {
         float sampleRate = animSetBuilder.getAnimations(0).getSampleRate();
         int keyframeCount = (int)Math.ceil(duration*sampleRate);
 
+        long boneId0 = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
+        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            int boneIndex = track.getBoneIndex();
+            long boneId = track.getBoneId();
 
-            if (boneIndex == 0 && track.getRotationsCount() > 0) {
+            if (boneId == boneId0 && track.getRotationsCount() > 0) {
                 // Verify animations on root bone
                 assertAnimationRotation(track, 0, rotIdentity);
                 assertAnimationRotation(track, keyframeCount/2, rotIdentity);
                 assertAnimationRotation(track, keyframeCount, rot90ZAxis);
 
-            } else if (boneIndex == 1 && track.getPositionsCount() > 0) {
+            } else if (boneId == boneId1 && track.getPositionsCount() > 0) {
                 // Verify animation on secondary bone
                 assertAnimationPosition(track, 0, new Vector3d(0.0, 1.0, 1.0));
                 assertAnimationPosition(track, keyframeCount/2, new Vector3d(0.0, 1.0, 0.0));
@@ -668,11 +673,12 @@ public class ColladaUtilTest {
          *  - Positions and scale don't change
          *  - Rotation is only decreased on X-axis
          */
+        long boneId = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            assertEquals(0, track.getBoneIndex());
+            assertEquals(boneId, track.getBoneId());
 
             /*
              *  The collada file does not animate either position or scale for the bones,
@@ -718,11 +724,15 @@ public class ColladaUtilTest {
         /*
          *  We go through all tracks and verify they behave as expected.
          */
+
+        long boneId0 = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
+        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
+        long boneId2 = MurmurHash.hash64(skeletonBuilder.getBones(2).getName());
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            int boneIndex = track.getBoneIndex();
+            long boneId = track.getBoneId();
 
             /*
              *  The collada file does not animate either position or scale for the bones,
@@ -731,7 +741,7 @@ public class ColladaUtilTest {
              */
             assertAnimationSamePosScale(track);
 
-            if (boneIndex == 0) {
+            if (boneId == boneId0) {
                 // Bone 0 doesn't have any "real" rotation animation.
                 Quat4d rotKey = new Quat4d(-0.495852, 0.499983, 0.499983, 0.504148);
                 int rotationKeys = track.getRotationsCount() / 4;
@@ -739,18 +749,18 @@ public class ColladaUtilTest {
                     assertAnimationRotation(track, i, rotKey);
                 }
 
-            } else if (boneIndex == 1) {
+            } else if (boneId == boneId1) {
                 if (track.getRotationsCount() > 0) {
                     assertAnimationRotationChanges(track, 0.0f, 0.0f, 1.0f);
                 }
-            } else if (boneIndex == 2) {
+            } else if (boneId == boneId2) {
                 if (track.getRotationsCount() > 0) {
                     assertAnimationRotationChanges(track, 1.0f, 0.0f, 0.0f);
                 }
 
             } else {
                 // There should only be animation on the bones specified above.
-                fail("Animation on invalid bone index: " + boneIndex);
+                fail("Animation on invalid bone index: " + boneId);
             }
         }
     }
@@ -772,11 +782,13 @@ public class ColladaUtilTest {
         /*
          *  We go through all tracks and verify they behave as expected.
          */
+
+        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            int boneIndex = track.getBoneIndex();
+            long boneId = track.getBoneId();
 
             /*
              *  The collada file does not animate either position or scale for the bones,
@@ -785,13 +797,13 @@ public class ColladaUtilTest {
              */
             assertAnimationSamePosScale(track);
 
-            if (boneIndex == 1) {
+            if (boneId == boneId1) {
                 if (track.getRotationsCount() > 0) {
                     assertAnimationRotationChanges(track, 0.0f, 0.0f, 1.0f);
                 }
             } else {
                 // There should only be animation on the bones specified above.
-                fail("Animation on invalid bone index: " + boneIndex);
+                fail("Animation on invalid bone index: " + boneId);
             }
         }
     }
@@ -836,12 +848,13 @@ public class ColladaUtilTest {
          *  - Positions will decrease on Z axis
          *  - Rotation don't change, is static the inverse of bind pose.
          */
+        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
         int trackCount = animation.getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animation.getTracks(trackIndex);
 
-            if (track.getBoneIndex() == 1) {
+            if (track.getBoneId() == boneId1) {
 
                 if (track.getRotationsCount() > 0) {
                     Quat4d rotIdentity = new Quat4d(0.0, 0.0, 0.0, 1.0);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ColladaUtilTest.java
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -478,7 +478,7 @@ public class ColladaUtilTest {
          *  - Positions and scale don't change
          *  - Rotation is only increased on X-axis
          */
-        long boneId = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
+        long boneId = skeletonBuilder.getBones(0).getId();
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
@@ -537,8 +537,8 @@ public class ColladaUtilTest {
         float sampleRate = animSetBuilder.getAnimations(0).getSampleRate();
         int keyframeCount = (int)Math.ceil(duration*sampleRate);
 
-        long boneId0 = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
-        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
+        long boneId0 = skeletonBuilder.getBones(0).getId();
+        long boneId1 = skeletonBuilder.getBones(1).getId();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
@@ -604,8 +604,8 @@ public class ColladaUtilTest {
         float sampleRate = animSetBuilder.getAnimations(0).getSampleRate();
         int keyframeCount = (int)Math.ceil(duration*sampleRate);
 
-        long boneId0 = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
-        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
+        long boneId0 = skeletonBuilder.getBones(0).getId();
+        long boneId1 = skeletonBuilder.getBones(1).getId();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
@@ -673,7 +673,7 @@ public class ColladaUtilTest {
          *  - Positions and scale don't change
          *  - Rotation is only decreased on X-axis
          */
-        long boneId = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
+        long boneId = skeletonBuilder.getBones(0).getId();
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
@@ -725,9 +725,9 @@ public class ColladaUtilTest {
          *  We go through all tracks and verify they behave as expected.
          */
 
-        long boneId0 = MurmurHash.hash64(skeletonBuilder.getBones(0).getName());
-        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
-        long boneId2 = MurmurHash.hash64(skeletonBuilder.getBones(2).getName());
+        long boneId0 = skeletonBuilder.getBones(0).getId();
+        long boneId1 = skeletonBuilder.getBones(1).getId();
+        long boneId2 = skeletonBuilder.getBones(2).getId();
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
@@ -783,7 +783,7 @@ public class ColladaUtilTest {
          *  We go through all tracks and verify they behave as expected.
          */
 
-        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
+        long boneId1 = skeletonBuilder.getBones(1).getId();
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
@@ -848,7 +848,7 @@ public class ColladaUtilTest {
          *  - Positions will decrease on Z axis
          *  - Rotation don't change, is static the inverse of bind pose.
          */
-        long boneId1 = MurmurHash.hash64(skeletonBuilder.getBones(1).getName());
+        long boneId1 = skeletonBuilder.getBones(1).getId();
         int trackCount = animation.getTracksCount();
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ModelUtilTest.java
@@ -387,6 +387,10 @@ public class ModelUtilTest {
          */
         Quat4d rotIdentity = new Quat4d(0.0, 0.0, 0.0, 1.0);
 
+        long boneId0 = skeletonBuilder.getBones(0).getId(); // Bottom
+        long boneId1 = skeletonBuilder.getBones(1).getId(); // Middle
+        long boneId2 = skeletonBuilder.getBones(2).getId(); // Top
+
         int trackCount = animSetBuilder.getAnimations(0).getTracksCount();
         float duration = animSetBuilder.getAnimations(0).getDuration();
         float sampleRate = animSetBuilder.getAnimations(0).getSampleRate();
@@ -394,33 +398,31 @@ public class ModelUtilTest {
         for (int trackIndex = 0; trackIndex < trackCount; trackIndex++) {
 
             Rig.AnimationTrack track = animSetBuilder.getAnimations(0).getTracks(trackIndex);
-            int boneIndex = track.getBoneIndex();
+            long boneId = track.getBoneId();
 
             // There should be no position or scale animation.
             assertAnimationSamePosScale(track);
 
             int rotKeyframeCount = track.getRotationsCount()/4;
 
-            System.out.printf("testTwoBoneAnimation: bone: %d. keyframeCount: %d, %d  #keyframes: %d\n", boneIndex, rotKeyframeCount, rotKeyframeCount/2, track.getRotationsCount()/4);
-
             if (track.getRotationsCount() > 0) {
-                if (boneIndex == 0) {
+                if (boneId == boneId0) {
                     // The root bone isn't animated so it only has one key
                     assertEquals(4, track.getRotationsCount());
                     assertAnimationRotation(track, 0, rotIdentity);
 
-                } else if (boneIndex == 1) {
+                } else if (boneId == boneId1) {
                     assertAnimationRotation(track, 0, rotIdentity);
                     assertAnimationRotation(track, rotKeyframeCount/2, new Quat4d(0.0, 0.0, -0.706773, 0.707440));
                     assertAnimationRotation(track, rotKeyframeCount-1, new Quat4d(0.0, 0.0, -0.706773, 0.707440));
 
-                } else if (boneIndex == 2) {
+                } else if (boneId == boneId2) {
                     assertAnimationRotation(track, 0, rotIdentity);
                     assertAnimationRotation(track, 28, rotIdentity);
                     assertAnimationRotation(track, rotKeyframeCount-1, new Quat4d(0.684243, -0.000646, -0.000000, 0.729254));
 
                 } else {
-                    fail("Animations on invalid bone index: " + boneIndex);
+                    fail("Animations on invalid bone index: " + boneId);
                 }
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
@@ -320,6 +320,7 @@ public class ColladaUtil {
     }
 
     public static void createAnimationTracks(Rig.RigAnimation.Builder animBuilder,
+                                             Bone bone,
                                              RigUtil.AnimationTrack posTrack,
                                              RigUtil.AnimationTrack rotTrack,
                                              RigUtil.AnimationTrack sclTrack,
@@ -327,7 +328,7 @@ public class ColladaUtil {
         double spf = 1.0 / sampleRate;
 
         Rig.AnimationTrack.Builder animTrackBuilder = Rig.AnimationTrack.newBuilder();
-        animTrackBuilder.setBoneIndex(boneIndex);
+        animTrackBuilder.setBoneId(MurmurHash.hash64(bone.getName()));
 
         samplePosTrack(animBuilder, animTrackBuilder, posTrack, duration, startTime, sampleRate, spf, true);
         sampleRotTrack(animBuilder, animTrackBuilder, rotTrack, duration, startTime, sampleRate, spf, true);
@@ -436,7 +437,7 @@ public class ColladaUtil {
 
                     ExtractKeys(bone, localToParent, assetSpace, animation, posTrack, rotTrack, sclTrack);
 
-                    createAnimationTracks(animBuilder, posTrack, rotTrack, sclTrack, refIndex, (float)duration, sceneStartTime, sceneFrameRate);
+                    createAnimationTracks(animBuilder, bone, posTrack, rotTrack, sclTrack, refIndex, (float)duration, sceneStartTime, sceneFrameRate);
 
                     break; // we only support one animation per file/bone
                 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ColladaUtil.java
@@ -328,7 +328,7 @@ public class ColladaUtil {
         double spf = 1.0 / sampleRate;
 
         Rig.AnimationTrack.Builder animTrackBuilder = Rig.AnimationTrack.newBuilder();
-        animTrackBuilder.setBoneId(MurmurHash.hash64(bone.getName()));
+        animTrackBuilder.setBoneId(MurmurHash.hash64(bone.getSourceId()));
 
         samplePosTrack(animBuilder, animTrackBuilder, posTrack, duration, startTime, sampleRate, spf, true);
         sampleRotTrack(animBuilder, animTrackBuilder, rotTrack, duration, startTime, sampleRate, spf, true);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
@@ -222,11 +222,12 @@ public class ModelUtil {
     }
 
     public static void createAnimationTracks(Rig.RigAnimation.Builder animBuilder, ModelImporter.NodeAnimation nodeAnimation,
-                                                    int boneIndex, double duration, double startTime, double sampleRate) {
+                                                    Bone bone, double duration, double startTime, double sampleRate) {
         double spf = 1.0 / sampleRate;
 
         Rig.AnimationTrack.Builder animTrackBuilder = Rig.AnimationTrack.newBuilder();
-        animTrackBuilder.setBoneIndex(boneIndex);
+        animTrackBuilder.setBoneIndex(bone.index);
+        animTrackBuilder.setBoneId(MurmurHash.hash64(bone.name));
 
         {
             RigUtil.AnimationTrack sparseTrack = new RigUtil.AnimationTrack();
@@ -362,7 +363,7 @@ public class ModelUtil {
                     continue;
                 }
 
-                createAnimationTracks(animBuilder, nodeAnimation, skeleton_bone.index, animation.duration, startTime, sampleRate);
+                createAnimationTracks(animBuilder, nodeAnimation, skeleton_bone, animation.duration, startTime, sampleRate);
             }
 
             animationSetBuilder.addAnimations(animBuilder.build());
@@ -903,8 +904,9 @@ public class ModelUtil {
             System.out.printf("--------------------------------------------\n");
             System.out.printf("Scene Bones:\n");
 
+            int bone_count = 0;
             for (Bone bone : scene.skins[0].bones) {
-                System.out.printf("  Scene Bone: %s  index: %d  id: %d  nodeid: %d  parent: %s\n", bone.name, bone.index,
+                System.out.printf("  Scene Bone %d: %s  index: %d  id: %d  nodeid: %d  parent: %s\n", bone_count++, bone.name, bone.index,
                                             ModelImporter.AddressOf(bone), ModelImporter.AddressOf(bone.node),
                                             bone.parent != null ? bone.parent.name : "");
                 System.out.printf("      local: id: %d\n", ModelImporter.AddressOf(bone.node.local));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
@@ -226,7 +226,6 @@ public class ModelUtil {
         double spf = 1.0 / sampleRate;
 
         Rig.AnimationTrack.Builder animTrackBuilder = Rig.AnimationTrack.newBuilder();
-        animTrackBuilder.setBoneIndex(bone.index);
         animTrackBuilder.setBoneId(MurmurHash.hash64(bone.name));
 
         {

--- a/editor/test/integration/animation_set_test.clj
+++ b/editor/test/integration/animation_set_test.clj
@@ -25,6 +25,7 @@
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/model/treasure_chest.animationset")
           {:keys [animations bone-list]} (g/node-value node-id :animation-set)]
+      
       (is (= 3 (count bone-list)))
       (is (= 3 (count animations)))
       (is (= #{(murmur/hash64 "treasure_chest")
@@ -41,21 +42,22 @@
         ; Tracks contain keyframes for position, rotation and scale channels.
         ; Several tracks can target the same bone, but there should not be
         ; multiple tracks that target the same channel for a bone.
-        (doseq [[bone-index data-by-channel] (->> (:tracks animation)
-                                                  (group-by :bone-index)
+        (doseq [[bone-id data-by-channel] (->> (:tracks animation)
+                                                  (group-by :bone-id)
                                                   (sort-by key)
-                                                  (map (fn [[bone-index bone-tracks]]
-                                                         [bone-index (->> bone-tracks
-                                                                          (map #(dissoc % :bone-index))
+                                                  (map (fn [[bone-id bone-tracks]]
+                                                         [bone-id (->> bone-tracks
+                                                                          (map #(dissoc % :bone-id))
                                                                           (map remove-empty-channels)
                                                                           (apply merge-with (constantly ::conflicting-data)))])))]
           (testing "Bone exists in skeleton"
-            (is (< bone-index bone-count)))
+            (prn "MAWE BONE ID" bone-id)
+            (is (some #(= bone-id %) bone-list)))
 
           (testing "Channels are not animated by multiple tracks"
             (doseq [[channel data] data-by-channel]
               (is (not= ::conflicting-data data)
-                  (str "Found multiple tracks targetting " channel " for bone " bone-index))))
+                  (str "Found multiple tracks targetting " channel " for bone " bone-id))))
 
           (testing "Channel data matches expected strides"
             (are [stride channel]

--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_skeleton.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_skeleton.h
@@ -17,13 +17,15 @@
 
 #include <stdint.h>
 
+#include <dlib/hashtable.h>
 #include <rig/rig_ddf.h>
 
 namespace dmGameSystem
 {
     struct SkeletonResource
     {
-        dmRigDDF::Skeleton* m_Skeleton;
+        dmRigDDF::Skeleton*     m_Skeleton;
+        dmHashTable64<uint32_t> m_BoneIndices; // Map from bone name hash to bone index
     };
 }
 

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -435,6 +435,7 @@ namespace dmGameSystem
         create_params.m_EventCBUserData2 = 0;
 
         create_params.m_BindPose         = &rig_resource->m_BindPose;
+        create_params.m_BoneIndices      = &rig_resource->m_SkeletonRes->m_BoneIndices;
         create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes == 0x0 ? 0x0 : rig_resource->m_AnimationSetRes->m_AnimationSet;
         create_params.m_Skeleton         = rig_resource->m_SkeletonRes == 0x0 ? 0x0 : rig_resource->m_SkeletonRes->m_Skeleton;
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;

--- a/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporter.java
+++ b/engine/modelc/src/java/com/dynamo/bob/pipeline/ModelImporter.java
@@ -4,24 +4,11 @@
 
 package com.dynamo.bob.pipeline;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.FileNotFoundException;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
-import java.util.Arrays;
 import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
 
 public class ModelImporter {
 

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -95,6 +95,7 @@ static void DestroySkin(Skin* skin)
     for (uint32_t i = 0; i < skin->m_BonesCount; ++i)
         DestroyBone(&skin->m_Bones[i]);
     delete[] skin->m_Bones;
+    delete[] skin->m_BoneRemap;
 }
 
 static void DestroyNodeAnimation(NodeAnimation* node_animation)

--- a/engine/modelc/src/modelimporter.h
+++ b/engine/modelc/src/modelimporter.h
@@ -93,13 +93,15 @@ namespace dmModelImporter
         dmTransform::Transform  m_Local;        // The local transform
         dmTransform::Transform  m_World;        // The world transform
         const char*             m_Name;
-        uint64_t                m_NameHash;
         Model*                  m_Model;        // not all nodes have a mesh
         Skin*                   m_Skin;         // not all nodes have a skin
         Node*                   m_Parent;
         Node**                  m_Children;
         uint32_t                m_ChildrenCount;
         uint32_t                m_Index;        // The index into the scene.nodes array
+
+        // internal
+        uint64_t                m_NameHash;
     };
 
     struct KeyFrame

--- a/engine/modelc/src/modelimporter.h
+++ b/engine/modelc/src/modelimporter.h
@@ -83,6 +83,9 @@ namespace dmModelImporter
         Bone*                   m_Bones;
         uint32_t                m_BonesCount;
         uint32_t                m_Index;        // The index into the scene.skins array
+
+        // internal
+        uint32_t*               m_BoneRemap;    // old index -> new index: for sorting the bones
     };
 
     struct DM_ALIGNED(16) Node
@@ -90,6 +93,7 @@ namespace dmModelImporter
         dmTransform::Transform  m_Local;        // The local transform
         dmTransform::Transform  m_World;        // The world transform
         const char*             m_Name;
+        uint64_t                m_NameHash;
         Model*                  m_Model;        // not all nodes have a mesh
         Skin*                   m_Skin;         // not all nodes have a skin
         Node*                   m_Parent;

--- a/engine/modelc/src/modelimporter_debug.cpp
+++ b/engine/modelc/src/modelimporter_debug.cpp
@@ -80,10 +80,10 @@ static void OutputMatrix(const dmTransform::Transform& transform)
     printf("    "); OutputVector4(mat.getRow(3));
 }
 
-static void OutputBone(Bone* bone, int indent)
+static void OutputBone(int i, Bone* bone, int indent)
 {
     OutputIndent(indent);
-    printf("%s  idx: %u parent: %u node: %s inv_bind_pose:\n", bone->m_Name, bone->m_Index, bone->m_ParentIndex, bone->m_Node?bone->m_Node->m_Name:"null");
+    printf("#%d: %s  idx: %u parent: %u node: %s inv_bind_pose:\n", i, bone->m_Name, bone->m_Index, bone->m_ParentIndex, bone->m_Node?bone->m_Node->m_Name:"null");
     OutputMatrix(bone->m_InvBindPose);
     printf("\n");
 }
@@ -96,7 +96,7 @@ static void OutputSkin(Skin* skin, int indent)
     printf("  Bones: count: %u\n", skin->m_BonesCount);
     for (uint32_t i = 0; i < skin->m_BonesCount; ++i)
     {
-        OutputBone(&skin->m_Bones[i], indent+1);
+        OutputBone(i, &skin->m_Bones[i], indent+1);
     }
 }
 

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -593,7 +593,7 @@ struct BoneSortInfo
 {
     Bone*    m_Bone;
     uint32_t m_Rank;     // The depth in the hierarchy
-    uint32_t m_OldIndex; // The depth in the hierarchy
+    uint32_t m_OldIndex;
 };
 
 struct BoneInfoSortPred
@@ -637,11 +637,6 @@ static void SortSkinBones(Skin* skin)
     {
         delete[] skin->m_BoneRemap;
         skin->m_BoneRemap = 0;
-
-        printf("MAWE: modelc: The indices don't differ!\n");
-    }
-    else {
-        printf("MAWE: modelc: The index order differs!\n");
     }
 
     // do the remapping
@@ -658,12 +653,6 @@ static void SortSkinBones(Skin* skin)
     }
 
     delete[] infos;
-}
-
-static void SortBones(Scene* scene, cgltf_data* gltf_data)
-{
-    for (uint32_t i = 0; i < scene->m_SkinsCount; ++i)
-        SortSkinBones(&scene->m_Skins[i]);
 }
 
 static void LoadSkins(Scene* scene, cgltf_data* gltf_data)

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
+#include <algorithm> // std::sort
 #include <dmsdk/dlib/math.h>
 #include <dmsdk/dlib/vmath.h>
 #include <dmsdk/dlib/hash.h>
@@ -277,7 +278,7 @@ static Skin* FindSkin(Scene* scene, cgltf_data* gltf_data, cgltf_skin* gltf_skin
 static uint32_t FindIndex(uintptr_t base_pointer, uintptr_t pointer)
 {
     if (!pointer)
-        return 0xFFFFFFFF;
+        return INVALID_INDEX;
     return (uint32_t)(pointer - base_pointer);
 }
 
@@ -340,6 +341,7 @@ static void LoadNodes(Scene* scene, cgltf_data* gltf_data)
 
         Node* node = &scene->m_Nodes[i];
         node->m_Name = CreateObjectName(gltf_node, "node", i);
+        node->m_NameHash = dmHashString64(node->m_Name);
         node->m_Index = i;
 
         // We link them together later
@@ -577,6 +579,93 @@ static uint32_t FindBoneIndex(cgltf_skin* gltf_skin, cgltf_node* joint)
     return INVALID_INDEX;
 }
 
+struct BoneSortPred
+{
+    bool operator()(const Bone& a, const Bone& b) const
+    {
+        int indexa = a.m_Index == INVALID_INDEX ? -1 : a.m_Index;
+        int indexb = b.m_Index == INVALID_INDEX ? -1 : b.m_Index;
+        return indexa < indexb;
+    }
+};
+
+struct BoneSortInfo
+{
+    Bone*    m_Bone;
+    uint32_t m_Rank;     // The depth in the hierarchy
+    uint32_t m_OldIndex; // The depth in the hierarchy
+};
+
+struct BoneInfoSortPred
+{
+    bool operator()(const BoneSortInfo& a, const BoneSortInfo& b) const
+    {
+        return a.m_Rank < b.m_Rank;
+    }
+};
+
+static uint32_t FindRank(Bone* bones, Bone* bone)
+{
+    if (bone->m_ParentIndex == INVALID_INDEX)
+        return 0;
+    return 1 + FindRank(bones, &bones[bone->m_ParentIndex]);
+}
+
+static void SortSkinBones(Skin* skin)
+{
+    BoneSortInfo* infos = new BoneSortInfo[skin->m_BonesCount];
+    for (uint32_t i = 0; i < skin->m_BonesCount; ++i)
+    {
+        infos[i].m_Bone = &skin->m_Bones[i];
+        infos[i].m_Rank = FindRank(skin->m_Bones, infos[i].m_Bone);
+        infos[i].m_OldIndex = i;
+    }
+
+    std::sort(infos, infos + skin->m_BonesCount, BoneInfoSortPred());
+
+    // build the remap array
+    skin->m_BoneRemap = new uint32_t[skin->m_BonesCount];
+    bool indices_differ = false;
+    for (uint32_t i = 0; i < skin->m_BonesCount; ++i)
+    {
+        uint32_t index_old = infos[i].m_OldIndex;
+        skin->m_BoneRemap[index_old] = i;
+        indices_differ |= index_old != i;
+    }
+    // If the indices don't differ, then we don't need to update the meshes bone indices either
+    if (!indices_differ)
+    {
+        delete[] skin->m_BoneRemap;
+        skin->m_BoneRemap = 0;
+
+        printf("MAWE: modelc: The indices don't differ!\n");
+    }
+    else {
+        printf("MAWE: modelc: The index order differs!\n");
+    }
+
+    // do the remapping
+    if (skin->m_BoneRemap)
+    {
+        for (uint32_t i = 0; i < skin->m_BonesCount; ++i)
+        {
+            Bone& bone = skin->m_Bones[i];
+            bone.m_Index = skin->m_BoneRemap[bone.m_Index];
+            bone.m_ParentIndex = bone.m_ParentIndex != INVALID_INDEX ? skin->m_BoneRemap[bone.m_ParentIndex] : INVALID_INDEX;
+        }
+
+        std::sort(skin->m_Bones, skin->m_Bones + skin->m_BonesCount, BoneSortPred());
+    }
+
+    delete[] infos;
+}
+
+static void SortBones(Scene* scene, cgltf_data* gltf_data)
+{
+    for (uint32_t i = 0; i < scene->m_SkinsCount; ++i)
+        SortSkinBones(&scene->m_Skins[i]);
+}
+
 static void LoadSkins(Scene* scene, cgltf_data* gltf_data)
 {
     if (gltf_data->skins_count == 0)
@@ -618,6 +707,8 @@ static void LoadSkins(Scene* scene, cgltf_data* gltf_data)
                 assert(false);
             }
         }
+
+        SortSkinBones(skin);
 
         // LOAD SKELETON?
     }
@@ -724,8 +815,30 @@ static void LinkNodesWithBones(Scene* scene, cgltf_data* gltf_data)
         for (uint32_t j = 0; j < gltf_skin->joints_count; ++j)
         {
             cgltf_node* gltf_joint = gltf_skin->joints[j];
-            Bone* bone = &skin->m_Bones[j];
+
+            Bone* bone = 0;
+            for (uint32_t b = 0; b < gltf_skin->joints_count; ++b)
+            {
+                if (strcmp(skin->m_Bones[b].m_Name, gltf_joint->name) == 0)
+                {
+                    bone = &skin->m_Bones[b];
+                    break;
+                }
+            }
             bone->m_Node = TranslateNode(gltf_joint, gltf_data, scene);
+        }
+    }
+}
+
+static void RemapMeshBoneIndices(Skin* skin, Mesh* mesh)
+{
+    uint32_t* remap_table = skin->m_BoneRemap;
+    for (uint32_t i = 0; i < mesh->m_VertexCount; ++i)
+    {
+        for (int j = 0; j < 4; ++j)
+        {
+            uint32_t old_index = mesh->m_Bones[i*4+j];
+            mesh->m_Bones[i*4+j] = remap_table[old_index];
         }
     }
 }
@@ -744,6 +857,15 @@ static void LinkMeshesWithNodes(Scene* scene, cgltf_data* gltf_data)
         assert(index < gltf_data->meshes_count);
 
         node->m_Model = &scene->m_Models[index];
+
+        // We need to compensate for any bone index remapping
+        if (node->m_Skin && node->m_Skin->m_BoneRemap)
+        {
+            for (uint32_t j = 0; j < node->m_Model->m_MeshesCount; ++j)
+            {
+                RemapMeshBoneIndices(node->m_Skin, &node->m_Model->m_Meshes[j]);
+            }
+        }
     }
 }
 
@@ -854,13 +976,15 @@ static void LoadAnimations(Scene* scene, cgltf_data* gltf_data)
     scene->m_Animations = new Animation[scene->m_AnimationsCount];
 
     // first, count number of animated nodes we have
-    for (uint32_t i = 0; i < gltf_data->animations_count; ++i)
+    for (uint32_t a = 0; a < gltf_data->animations_count; ++a)
     {
-        cgltf_animation* gltf_animation = &gltf_data->animations[i];
-        Animation* animation = &scene->m_Animations[i];
+        cgltf_animation* gltf_animation = &gltf_data->animations[a];
+        Animation* animation = &scene->m_Animations[a];
 
-        animation->m_Name = CreateObjectName(gltf_animation, "animation", i);
+        animation->m_Name = CreateObjectName(gltf_animation, "animation", a);
 
+        // Here we want to create a many individual tracks for different bones (name.type): "a.rot", "b.rot", "a.pos", "b.scale"...
+        // into a list of tracks that holds all 3 types: [a: {rot, pos, scale}, b: {rot, pos, scale}...]
         dmHashTable64<uint32_t> node_name_to_index;
         animation->m_NodeAnimationsCount = CountAnimatedNodes(gltf_animation, node_name_to_index);
         animation->m_NodeAnimations = new NodeAnimation[animation->m_NodeAnimationsCount];
@@ -870,15 +994,14 @@ static void LoadAnimations(Scene* scene, cgltf_data* gltf_data)
         {
             cgltf_animation_channel* channel = &gltf_animation->channels[i];
 
-            const char* node_name = channel->target_node->name;
-            dmhash_t node_name_hash = dmHashString64(node_name);
+            Node* node = TranslateNode(channel->target_node, gltf_data, scene);
+            dmhash_t node_name_hash = node->m_NameHash;
 
             uint32_t* node_index = node_name_to_index.Get(node_name_hash);
             assert(node_index != 0);
 
             NodeAnimation* node_animation = &animation->m_NodeAnimations[*node_index];
-            if (node_animation->m_Node == 0)
-                node_animation->m_Node = TranslateNode(channel->target_node, gltf_data, scene);
+            node_animation->m_Node = node;
 
             LoadChannel(node_animation, channel);
 

--- a/engine/rig/proto/rig/rig_ddf.proto
+++ b/engine/rig/proto/rig/rig_ddf.proto
@@ -41,14 +41,13 @@ message Skeleton
 
 message AnimationTrack
 {
-    required uint32 bone_index = 1;
-    required uint64 bone_id = 2;        // the bone name hash
+    required uint64 bone_id = 1;        // the bone name hash
     // x0, y0, z0, ...
-    repeated float positions = 3;
+    repeated float positions = 2;
     // x0, x0, z0, w0, …
-    repeated float rotations = 4;
+    repeated float rotations = 3;
     // x0, y0, z0, …
-    repeated float scale = 5;
+    repeated float scale = 4;
 }
 
 message EventKey

--- a/engine/rig/proto/rig/rig_ddf.proto
+++ b/engine/rig/proto/rig/rig_ddf.proto
@@ -14,8 +14,8 @@ message Bone
 
     // 0xFFFFFFFF means no parent
     required uint32 parent = 1;
-    required uint64 id = 2;
-    required string name = 3; // For easier debugging at runtime
+    required uint64 id = 2;         // the bone name hash
+    required string name = 3;       // For easier debugging at runtime
     required dmMath.Transform local = 4 [(field_align)=true]; // Deprecated/unused (only in unit test=)
     required dmMath.Transform world = 5 [(field_align)=true]; // Deprecated/unused
     required dmMath.Transform inverse_bind_pose = 6 [(field_align)=true];
@@ -42,12 +42,13 @@ message Skeleton
 message AnimationTrack
 {
     required uint32 bone_index = 1;
+    required uint64 bone_id = 2;        // the bone name hash
     // x0, y0, z0, ...
-    repeated float positions = 2;
+    repeated float positions = 3;
     // x0, x0, z0, w0, …
-    repeated float rotations = 3;
+    repeated float rotations = 4;
     // x0, y0, z0, …
-    repeated float scale = 4;
+    repeated float scale = 5;
 }
 
 message EventKey

--- a/engine/rig/src/dmsdk/rig/rig.h
+++ b/engine/rig/src/dmsdk/rig/rig.h
@@ -20,6 +20,7 @@
 #include <dmsdk/dlib/array.h>
 #include <dmsdk/dlib/align.h>
 #include <dmsdk/dlib/hash.h>
+#include <dmsdk/dlib/hashtable.h>
 #include <dmsdk/dlib/transform.h>
 #include <dmsdk/dlib/vmath.h>
 
@@ -139,10 +140,11 @@ namespace dmRig
         dmhash_t                      m_ModelId;
         dmhash_t                      m_DefaultAnimation;
 
-        const dmArray<struct RigBone>* m_BindPose;
-        const dmRigDDF::Skeleton*     m_Skeleton;
-        const dmRigDDF::MeshSet*      m_MeshSet;
-        const dmRigDDF::AnimationSet* m_AnimationSet;
+        const dmArray<struct RigBone>*  m_BindPose;
+        const dmHashTable64<uint32_t>*  m_BoneIndices;   // Map of bone name hash -> bone index
+        const dmRigDDF::Skeleton*       m_Skeleton;
+        const dmRigDDF::MeshSet*        m_MeshSet;
+        const dmRigDDF::AnimationSet*   m_AnimationSet;
 
         RigPoseCallback               m_PoseCallback;
         void*                         m_PoseCBUserData1;

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -388,7 +388,7 @@ namespace dmRig
         uint32_t sample = (uint32_t)fraction;
         fraction -= sample;
         // Sample animation tracks
-        dmHashTable64<uint32_t>* bone_indices = instance->m_BoneIndices;
+        const dmHashTable64<uint32_t>* bone_indices = instance->m_BoneIndices;
         uint32_t track_count = animation->m_Tracks.m_Count;
         for (uint32_t ti = 0; ti < track_count; ++ti)
         {

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -388,15 +388,14 @@ namespace dmRig
         uint32_t sample = (uint32_t)fraction;
         fraction -= sample;
         // Sample animation tracks
+        dmHashTable64<uint32_t>* bone_indices = instance->m_BoneIndices;
         uint32_t track_count = animation->m_Tracks.m_Count;
         for (uint32_t ti = 0; ti < track_count; ++ti)
         {
             const dmRigDDF::AnimationTrack* track = &animation->m_Tracks[ti];
 
-            const uint32_t* bone_index = instance->m_BoneIndices->Get(track->m_BoneId);
-            if (!bone_index) {
-            }
-            if (*bone_index >= pose.Size()) {
+            const uint32_t* bone_index = bone_indices->Get(track->m_BoneId);
+            if (!bone_index || *bone_index >= pose.Size()) {
                 continue;
             }
             dmTransform::Transform& transform = pose[*bone_index].m_Local;

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -376,7 +376,7 @@ namespace dmRig
         return t;
     }
 
-    static void ApplyAnimation(RigPlayer* player, dmArray<BonePose>& pose, dmArray<IKAnimation>& ik_animation, float blend_weight)
+    static void ApplyAnimation(RigInstance* instance, RigPlayer* player, dmArray<BonePose>& pose, dmArray<IKAnimation>& ik_animation, float blend_weight)
     {
         const dmRigDDF::RigAnimation* animation = player->m_Animation;
         if (!animation)
@@ -392,12 +392,14 @@ namespace dmRig
         for (uint32_t ti = 0; ti < track_count; ++ti)
         {
             const dmRigDDF::AnimationTrack* track = &animation->m_Tracks[ti];
-            uint32_t bone_index = track->m_BoneIndex;
-            if (bone_index >= pose.Size()) {
+
+            const uint32_t* bone_index = instance->m_BoneIndices->Get(track->m_BoneId);
+            if (!bone_index) {
+            }
+            if (*bone_index >= pose.Size()) {
                 continue;
             }
-
-            dmTransform::Transform& transform = pose[bone_index].m_Local;
+            dmTransform::Transform& transform = pose[*bone_index].m_Local;
 
             if (track->m_Positions.m_Count > 0)
             {
@@ -519,7 +521,7 @@ namespace dmRig
                 }
 
                 UpdatePlayer(instance, p, dt, blend_weight);
-                ApplyAnimation(p, pose, ik_animation, alpha);
+                ApplyAnimation(instance, p, pose, ik_animation, alpha);
                 if (player == p)
                 {
                     alpha = 1.0f - fade_rate;
@@ -533,7 +535,7 @@ namespace dmRig
         else
         {
             UpdatePlayer(instance, player, dt, 1.0f);
-            ApplyAnimation(player, pose, ik_animation, 1.0f);
+            ApplyAnimation(instance, player, pose, ik_animation, 1.0f);
         }
 
         // Normalize quaternions while we blend
@@ -1182,9 +1184,9 @@ namespace dmRig
         }
 
         RigInstance* instance = new RigInstance;
+        memset(instance, 0, sizeof(RigInstance));
 
         uint32_t index = context->m_Instances.Alloc();
-        memset(instance, 0, sizeof(RigInstance));
         instance->m_Index = index;
         context->m_Instances.Set(index, instance);
         instance->m_ModelId = params.m_ModelId;
@@ -1197,6 +1199,7 @@ namespace dmRig
         instance->m_EventCBUserData2 = params.m_EventCBUserData2;
 
         instance->m_BindPose           = params.m_BindPose;
+        instance->m_BoneIndices        = params.m_BoneIndices;
         instance->m_Skeleton           = params.m_Skeleton;
         instance->m_MeshSet            = params.m_MeshSet;
         instance->m_AnimationSet       = params.m_AnimationSet;

--- a/engine/rig/src/rig_private.h
+++ b/engine/rig/src/rig_private.h
@@ -56,10 +56,11 @@ namespace dmRig
         RigPlayer                     m_Players[2];
         uint32_t                      m_Index;
         /// Rig input data
-        const dmArray<RigBone>*       m_BindPose;
-        const dmRigDDF::Skeleton*     m_Skeleton;
-        const dmRigDDF::MeshSet*      m_MeshSet;
-        const dmRigDDF::AnimationSet* m_AnimationSet;
+        const dmArray<RigBone>*         m_BindPose;
+        const dmHashTable64<uint32_t>*  m_BoneIndices;   // Map of bone name hash -> bone index
+        const dmRigDDF::Skeleton*       m_Skeleton;
+        const dmRigDDF::MeshSet*        m_MeshSet;
+        const dmRigDDF::AnimationSet*   m_AnimationSet;
 
         RigPoseCallback               m_PoseCallback;
         void*                         m_PoseCBUserData1;

--- a/trigger
+++ b/trigger
@@ -1,1 +1,1 @@
-trigger 2
+trigger


### PR DESCRIPTION
This issue fixes a case where the bones in the file weren't sorted.
We now sort the bones at build time, and update the bone indices for the vertices as well.

We also updated the animation tracks to do the bone lookup at runtime as opposed to relying on a fixed bone structure. This will help in the future if we wish to play an animation which was authored using a different skeleton.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
