### PR TITLE
Sprite animation frame count

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -128,6 +128,7 @@ namespace dmGameSystem
     static const dmhash_t SPRITE_PROP_CURSOR = dmHashString64("cursor");
     static const dmhash_t SPRITE_PROP_PLAYBACK_RATE = dmHashString64("playback_rate");
     static const dmhash_t SPRITE_PROP_ANIMATION = dmHashString64("animation");
+    static const dmhash_t SPRITE_PROP_FRAME_COUNT = dmHashString64("frame_count");
 
     // The 9 slice function produces 16 vertices (4 rows 4 columns)
     // and since there's 2 triangles per quad and 9 quads in total,
@@ -1234,6 +1235,14 @@ namespace dmGameSystem
         return component->m_PlaybackRate;
     }
 
+    static inline float GetAnimationFrameCount(SpriteComponent* component)
+    {
+        TextureSetResource* texture_set                     = GetTextureSet(component, component->m_Resource);
+        dmGameSystemDDF::TextureSet* texture_set_ddf        = texture_set->m_TextureSet;
+        dmGameSystemDDF::TextureSetAnimation* animation_ddf = &texture_set_ddf->m_Animations[component->m_AnimationID];
+        return (float)(animation_ddf->m_End - animation_ddf->m_Start);
+    }
+
     dmGameObject::UpdateResult CompSpriteOnMessage(const dmGameObject::ComponentOnMessageParams& params)
     {
         SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
@@ -1347,6 +1356,11 @@ namespace dmGameSystem
         else if (get_property == SPRITE_PROP_ANIMATION)
         {
             out_value.m_Variant = dmGameObject::PropertyVar(component->m_CurrentAnimation);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (get_property == SPRITE_PROP_FRAME_COUNT)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(GetAnimationFrameCount(component));
             return dmGameObject::PROPERTY_RESULT_OK;
         }
         return GetMaterialConstant(GetMaterial(component, component->m_Resource), get_property, params.m_Options.m_Index, out_value, false, CompSpriteGetConstantCallback, component);

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -200,6 +200,24 @@ namespace dmGameSystem
     * ```
     */
 
+    /*# [type:hash] sprite frame_count
+    *
+    * [mark:READ ONLY] The frame count of the currently playing animation.
+    *
+    * @name frame_count
+    * @property
+    *
+    * @examples
+    *
+    * How to get the `frame_count` on component "sprite":
+    *
+    * ```lua
+    * function init(self)
+    *   local frame_count = go.get("#sprite", "frame_count")
+    * end
+    * ```
+    */
+
     /*# set horizontal flipping on a sprite's animations
      * Sets horizontal flipping of the provided sprite's animations.
      * The sprite is identified by its URL.

--- a/engine/gamesys/src/gamesys/test/sprite/frame_count/sprite_frame_count.go
+++ b/engine/gamesys/src/gamesys/test/sprite/frame_count/sprite_frame_count.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/sprite/frame_count/sprite_frame_count.script"
+}
+components {
+  id: "sprite"
+  component: "/sprite/frame_count/sprite_frame_count.sprite"
+}

--- a/engine/gamesys/src/gamesys/test/sprite/frame_count/sprite_frame_count.script
+++ b/engine/gamesys/src/gamesys/test/sprite/frame_count/sprite_frame_count.script
@@ -1,0 +1,67 @@
+-- Copyright 2020-2023 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local function create_geometries(count)
+    local tbl = {}
+    for i=1,count do
+        table.insert(tbl, {
+                vertices = {},
+                uvs      = {},
+                indices  = {}})
+    end
+    return tbl
+end
+
+-- Check the default animation
+local function test_simple()
+    local frame_count = go.get("#sprite", "frame_count")
+    assert(frame_count == 4)
+end
+
+-- Check a custom atlas with x animation frames
+local function test_atlas()
+    local tparams = {
+       width          = 16,
+       height         = 16,
+       type           = resource.TEXTURE_TYPE_2D,
+       format         = resource.TEXTURE_FORMAT_RGBA,
+    }
+    local texture    = resource.create_texture("/my_texture.texturec", tparams)
+    local num_frames = 12
+    local aparams = {
+        texture = texture,
+        animations = {{
+                id          = "frames",
+                width       = 128,
+                height      = 128,
+                frame_start = 1,
+                frame_end   = num_frames + 1,
+            }
+        },
+        geometries = create_geometries(num_frames)
+    }
+    local atlas = resource.create_atlas("/my_atlas.texturesetc", aparams)
+    go.set("#sprite", "image", atlas)
+
+    local frame_count = go.get("#sprite", "frame_count")
+    assert(frame_count == num_frames)
+
+    resource.release(texture)
+    resource.release(atlas)
+end
+
+function init(self)
+    test_simple()
+    test_atlas()
+end

--- a/engine/gamesys/src/gamesys/test/sprite/frame_count/sprite_frame_count.sprite
+++ b/engine/gamesys/src/gamesys/test/sprite/frame_count/sprite_frame_count.sprite
@@ -1,0 +1,4 @@
+tile_set: "/tile/flipbook.tilesource"
+default_animation: "anim"
+material: "/sprite/sprite.material"
+blend_mode: BLEND_MODE_ALPHA

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -875,7 +875,7 @@ TEST_P(ResourcePropTest, ResourceRefCounting)
 }
 
 // Test that go.delete() does not influence other sprite animations in progress
-TEST_F(SpriteAnimTest, GoDeletion)
+TEST_F(SpriteTest, GoDeletion)
 {
     // Spawn 3 dumy game objects with one sprite in each
     dmGameObject::HInstance go1 = Spawn(m_Factory, m_Collection, "/sprite/valid_sprite.goc", dmHashString64("/go1"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
@@ -914,7 +914,7 @@ TEST_F(SpriteAnimTest, GoDeletion)
 }
 
 // Test that animation done event reaches either callback or onmessage
-TEST_F(SpriteAnimTest, FlipbookAnim)
+TEST_F(SpriteTest, FlipbookAnim)
 {
     dmGameSystem::ScriptLibContext scriptlibcontext;
     scriptlibcontext.m_Factory         = m_Factory;
@@ -952,6 +952,22 @@ TEST_F(SpriteAnimTest, FlipbookAnim)
 
     ASSERT_EQ(2, num_finished);
     ASSERT_EQ(1, num_messages);
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+TEST_F(SpriteTest, FrameCount)
+{
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/frame_count/sprite_frame_count.goc", dmHashString64("/go"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -248,10 +248,10 @@ public:
     virtual ~CollectionFactoryTest() {}
 };
 
-class SpriteAnimTest : public GamesysTest<const char*>
+class SpriteTest : public GamesysTest<const char*>
 {
 public:
-    virtual ~SpriteAnimTest() {}
+    virtual ~SpriteTest() {}
 };
 
 class ParticleFxTest : public GamesysTest<const char*>

--- a/engine/gamesys/src/gamesys/test/wscript
+++ b/engine/gamesys/src/gamesys/test/wscript
@@ -38,7 +38,7 @@ def build(bld):
             'resource/*',
             'script/*',
             'sound/*',
-            'sprite/*',
+            'sprite/**',
             'tile/*',
             'texture/*',
             'textureset/*',


### PR DESCRIPTION
Added the new property `frame_count` to sprite components to get the current running animations frame count:
`go.get("#sprite", "frame_count")`

Note that if you play a flipbook animation via `sprite.play_flipbook`, it will not be played until the next frame so retrieving the frame count at this time will get the value of the old animation that was previously playing.

Fixes #7639 
 
## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
