### PR TITLE
Fix issue with components counter in some cases

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
@@ -627,7 +627,7 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
             if (type.getNameHash() == MurmurHash.hash64("collectionfactoryc")) {
                 Assert.assertEquals(1, type.getMaxCount());
             } else {
-                Assert.assertEquals(0xffffffff, type.getMaxCount());
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
     }
@@ -688,7 +688,7 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
             if (type.getNameHash() == MurmurHash.hash64("factoryc")) {
                 Assert.assertEquals(1, type.getMaxCount());
             } else {
-                Assert.assertEquals(0xffffffff, type.getMaxCount());
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
     }
@@ -740,7 +740,7 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
         addFile("/test1.go", goSrc.toString());
         ComponentsCounter.Storage compStorage = ComponentsCounter.createStorage();
         compStorage.add("factoryc", 1);
-        compStorage.add("sprite", -1);
+        compStorage.add("sprite", ComponentsCounter.DYNAMIC_VALUE);
         addFile(ComponentsCounter.replaceExt("/build/test1.go"), compStorage.toByteArray());
 
         StringBuilder src = new StringBuilder();
@@ -763,7 +763,7 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
             if (type.getNameHash() == MurmurHash.hash64("factoryc")) {
                 Assert.assertEquals(2, type.getMaxCount());
             } else {
-                Assert.assertEquals(0xffffffff, type.getMaxCount());
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
     }
@@ -902,7 +902,7 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
             if (type.getNameHash() == MurmurHash.hash64("collectionfactoryc")) {
                 Assert.assertEquals(1, type.getMaxCount());
             } else {
-                Assert.assertEquals(0xffffffff, type.getMaxCount());
+                Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -82,7 +82,7 @@ public class ComponentsCounter {
                 componentName = componentName.substring(1);
             }
             Integer currentValue = components.getOrDefault(componentName, 0);
-            if (count < 0) {
+            if (count == DYNAMIC_VALUE) {
                 components.put(componentName, DYNAMIC_VALUE);
             } 
             else if (currentValue != DYNAMIC_VALUE) {
@@ -104,7 +104,12 @@ public class ComponentsCounter {
         public void add(Storage storage, Integer count) {
             Map<String, Integer> comps = storage.get();
             for (Map.Entry<String,Integer> entry : comps.entrySet()) {
-                add(entry.getKey(), count == DYNAMIC_VALUE ? DYNAMIC_VALUE : entry.getValue() * count);
+                Integer value = entry.getValue() * count;
+                // We can't multiply or sum DYNAMIC_VALUE, just set it
+                if (count == DYNAMIC_VALUE || entry.getValue() == DYNAMIC_VALUE) {
+                    value = DYNAMIC_VALUE;
+                }
+                add(entry.getKey(), value);
             }
         }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -82,7 +82,7 @@ public class ComponentsCounter {
                 componentName = componentName.substring(1);
             }
             Integer currentValue = components.getOrDefault(componentName, 0);
-            if (count == DYNAMIC_VALUE) {
+            if (count < 0) {
                 components.put(componentName, DYNAMIC_VALUE);
             } 
             else if (currentValue != DYNAMIC_VALUE) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -82,12 +82,12 @@ public class ComponentsCounter {
                 componentName = componentName.substring(1);
             }
             Integer currentValue = components.getOrDefault(componentName, 0);
-            if (count == DYNAMIC_VALUE) {
-                components.put(componentName, DYNAMIC_VALUE);
-            } 
-            else if (currentValue != DYNAMIC_VALUE) {
-                components.put(componentName, currentValue + count);
+            Integer value = currentValue + count;
+            // We can't multiply or sum DYNAMIC_VALUE, just set it
+            if (count == DYNAMIC_VALUE || currentValue == DYNAMIC_VALUE) {
+                value = DYNAMIC_VALUE;
             }
+            components.put(componentName, value);
         }
 
         public void add(String componentName) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -84,7 +84,7 @@ public class ComponentsCounter {
             Integer currentValue = components.getOrDefault(componentName, 0);
             Integer value = currentValue + count;
             // We can't multiply or sum DYNAMIC_VALUE, just set it
-            if (count == DYNAMIC_VALUE || currentValue == DYNAMIC_VALUE) {
+            if (count.equals(DYNAMIC_VALUE) || currentValue.equals(DYNAMIC_VALUE)) {
                 value = DYNAMIC_VALUE;
             }
             components.put(componentName, value);
@@ -104,10 +104,13 @@ public class ComponentsCounter {
         public void add(Storage storage, Integer count) {
             Map<String, Integer> comps = storage.get();
             for (Map.Entry<String,Integer> entry : comps.entrySet()) {
-                Integer value = entry.getValue() * count;
+                Integer value = entry.getValue();
                 // We can't multiply or sum DYNAMIC_VALUE, just set it
-                if (count == DYNAMIC_VALUE || entry.getValue() == DYNAMIC_VALUE) {
+                if (count.equals(DYNAMIC_VALUE) || value.equals(DYNAMIC_VALUE)) {
                     value = DYNAMIC_VALUE;
+                }
+                else {
+                    value *= count;
                 }
                 add(entry.getKey(), value);
             }
@@ -300,7 +303,7 @@ public class ComponentsCounter {
             if (mergedComponents.containsKey(name)) {
                 Integer mergedValue = mergedComponents.get(name);
                 Integer value = entry.getValue();
-                if (mergedValue == DYNAMIC_VALUE || value == DYNAMIC_VALUE) {
+                if (mergedValue.equals(DYNAMIC_VALUE) || value.equals(DYNAMIC_VALUE)) {
                     mergedComponents.put(name, DYNAMIC_VALUE);
                 } else {
                     mergedComponents.put(name, mergedValue + value);


### PR DESCRIPTION
Fix the issue that occurs when there are multiple instances of the same object containing a factory, which causes the component counter to break.

Fix https://github.com/defold/defold/issues/7668

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
