### PR TITLE
Install and launch APKs after the Android bundle

### DIFF
--- a/editor/src/clj/editor/adb.clj
+++ b/editor/src/clj/editor/adb.clj
@@ -1,0 +1,144 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.adb
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [editor.prefs :as prefs]
+            [editor.process :as process]
+            [editor.util :as util]))
+
+(defmacro attempt [expr]
+  `(try ~expr (catch Exception _#)))
+
+(defn- existing-path [path]
+  (when (.exists (io/file path))
+    path))
+
+(def ^:private re-path-evaluator
+  #"(?x)        # enable comments and whitespace
+  \$([A-Z_]+)   # first group matches env var syntax
+  |
+  (^\~)         # second group matches home syntax (only allowed at the beginning of the string)
+  |
+  ([^$]+)       # third group is a path, excludes `$` that means env var syntax
+  |
+  (.+)          # error group, i.e. dangling `$`s at the end of the string")
+
+(defn- evaluate-path [raw-path]
+  (reduce
+    (fn [acc [_ env home path error]]
+      (cond
+        error (reduced nil)
+        env (if-let [var (System/getenv env)]
+              (str acc var)
+              (reduced nil))
+        home (str acc (System/getProperty "user.home"))
+        path (str acc path)))
+    ""
+    (re-seq re-path-evaluator raw-path)))
+
+(defn- infer-adb-location! []
+  (case (util/os)
+    :macos (or
+             (some-> (evaluate-path "$ANDROID_HOME/platform-tools/adb") existing-path)
+             (some-> (attempt (process/exec "which" "adb")) existing-path)
+             (some-> (evaluate-path "~/Library/Android/sdk/platform-tools/adb") existing-path)
+             (existing-path "/opt/homebrew/bin/adb"))
+    :linux (or
+             (some-> (evaluate-path "$ANDROID_HOME/platform-tools/adb") existing-path)
+             (some-> (attempt (process/exec "which" "adb")) existing-path)
+             (some-> (evaluate-path "~/Android/Sdk/platform-tools/adb") existing-path)
+             (existing-path "/usr/bin/adb")
+             (existing-path "/usr/lib/android-sdk/platform-tools/adb"))
+    :win32 (or
+             (some-> (evaluate-path "$ANDROID_HOME\\platform-tools\\adb.exe") existing-path)
+             (some-> (attempt (process/exec "where" "adb.exe")) existing-path)
+             (some-> (evaluate-path "~\\AppData\\Local\\Android\\sdk\\platform-tools\\adb.exe") existing-path)
+             (existing-path "C:\\Program Files (x86)\\Android\\android-sdk\\platform-tools\\adb.exe"))))
+
+(defn get-adb-path
+  "Find ADB path (a string) or throw if it wasn't found
+
+  Performs file IO"
+  [prefs]
+  (if-let [prefs-path (not-empty (prefs/get-prefs prefs "adb-path" nil))]
+    (or (existing-path prefs-path)
+        (throw (ex-info (str "ADB path defined in preferences does not exist: '" prefs-path "'")
+                        {:path prefs-path})))
+    (or (infer-adb-location!)
+        (throw (ex-info "Could not find ADB on this system, please install it and try again.
+If it's already installed, configure its path in the Preferences' Tools pane." {})))))
+
+(defn list-devices!
+  "Query and return a list of devices connected to this system
+
+  Might block for seconds while ADB is starting up its daemon"
+  [adb-path]
+  (let [output (process/exec adb-path "devices" "-l")]
+    (into []
+          (keep (fn [line]
+                  (when-let [[_ id kvs] (re-matches #"^([^\s]+)\s+device\s(.+)" line)]
+                    (let [{:strs [device model]} (into {}
+                                                       (map #(string/split % #":" 2))
+                                                       (string/split kvs #" "))]
+                      {:id id
+                       :label (cond
+                                (and device model) (str device " " model)
+                                device device
+                                model model
+                                :else id)}))))
+          (string/split-lines output))))
+
+(defn install!
+  "Perform an APK install on a device and block until the installation is done
+
+  Returns nil on success, throws exception on failure.
+
+  Args:
+    adb-path    path to adb command, can be obtained with [[get-adb-path]]
+    device      device to install on, can be obtained with [[list-devices!]]
+    apk-path    path to APK file to install, either String or File
+    out         an OutputStream used for piping the installation output, will
+                not be closed after use"
+  [adb-path device apk-path out]
+  {:pre [(string? (:id device))
+         (existing-path apk-path)]}
+  (let [process (process/start {:err :stdout} adb-path "-s" (:id device) "install" "-r" (str apk-path))]
+    (process/pipe (process/out process) out)
+    (when-not (process/exit-ok? (process/await-exit-code process))
+      (throw (ex-info "Failed to install APK" {:adb adb-path :device device :apk apk-path})))))
+
+(defn launch!
+  "Perform an application launch and block until the launch is done
+
+  Returns nil on success, throws exception on failure
+
+  Args:
+    adb-path    path to adb command, can be obtained with [[get-adb-path]]
+    device      device to install on, can be obtained with [[list-devices!]]
+    package     application package name to launch
+    out         an OutputStream used for piping the launch output, will not be
+                closed after use"
+  [adb-path device package out]
+  {:pre [(string? (:id device))]}
+  (let [process (process/start {:err :stdout}
+                               adb-path
+                               "-s" (:id device)
+                               "shell" "monkey"
+                               "-p" package
+                               "-c" "android.intent.category.LAUNCHER" "1")]
+    (process/pipe (process/out process) out)
+    (when-not (process/exit-ok? (process/await-exit-code process))
+      (throw (ex-info "Failed to launch the app" {:adb adb-path :device device :app package})))))

--- a/editor/src/clj/editor/adb.clj
+++ b/editor/src/clj/editor/adb.clj
@@ -133,6 +133,8 @@ If it's already installed, configure its path in the Preferences' Tools pane." {
                 closed after use"
   [adb-path device package out]
   {:pre [(string? (:id device))]}
+  ;; Using monkey is a convenient way to launch an Android app using only its
+  ;; package name. See also: https://stackoverflow.com/a/25398877
   (let [process (process/start! {:err :stdout}
                                 adb-path
                                 "-s" (:id device)

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -19,10 +19,11 @@
             [cljfx.fx.text-flow :as fx.text-flow]
             [cljfx.fx.tooltip :as fx.tooltip]
             [cljfx.fx.v-box :as fx.v-box]
-            [clojure.java.io :as io]
             [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.adb :as adb]
             [editor.build :as build]
             [editor.build-errors-view :as build-errors-view]
             [editor.bundle-dialog :as bundle-dialog]
@@ -78,17 +79,18 @@
             [internal.graph.types :as gt]
             [internal.util :refer [first-where]]
             [service.log :as log]
+            [service.smoke-log :as slog]
             [util.http-server :as http-server]
             [util.profiler :as profiler]
-            [util.thread-util :as thread-util]
-            [service.smoke-log :as slog])
+            [util.thread-util :as thread-util])
   (:import [clojure.lang ExceptionInfo]
            [com.defold.editor Editor]
            [com.defold.editor UIUtil]
            [com.dynamo.bob Platform]
            [com.sun.javafx.scene NodeHelper]
-           [java.io BufferedReader File IOException]
+           [java.io BufferedReader File IOException OutputStream PipedInputStream PipedOutputStream PrintWriter]
            [java.net URL]
+           [java.nio.charset StandardCharsets]
            [java.util Collection List]
            [javafx.beans.value ChangeListener]
            [javafx.collections ListChangeListener ObservableList]
@@ -728,7 +730,7 @@
     (future
       (error-reporting/catch-all!
         (extensions/execute-hook! project :on-target-launched hook-options)
-        (process/watchdog! process #(extensions/execute-hook! project :on-target-terminated hook-options))))))
+        (process/on-exit process #(extensions/execute-hook! project :on-target-terminated hook-options))))))
 
 (defn- target-cannot-swap-engine? [target]
   (and (some? target)
@@ -1207,6 +1209,12 @@ If you do not specifically require different script states, consider changing th
   (reset-console-stream! input-stream)
   (reset-remote-log-pump-thread! (start-log-pump! input-stream (make-remote-log-sink input-stream))))
 
+(defn- start-new-log-pipe!
+  ^PipedOutputStream []
+  (let [in (PipedInputStream.)]
+    (pipe-log-stream-to-console! in)
+    (PipedOutputStream. in)))
+
 (handler/defhandler :build-html5 :global
   (run [project prefs web-server build-errors-view changes-view main-stage tool-tab-pane]
     (let [main-scene (.getScene ^Stage main-stage)
@@ -1216,13 +1224,15 @@ If you do not specifically require different script states, consider changing th
           render-build-progress! (make-render-task-progress :build)
           task-cancelled? (make-task-cancelled-query :build)
           build-server-headers (native-extensions/get-build-server-headers prefs)
-          bob-args (bob/build-html5-bob-args project prefs)]
+          bob-args (bob/build-html5-bob-args project prefs)
+          out (start-new-log-pipe!)]
       (build-errors-view/clear-build-errors build-errors-view)
-      (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! pipe-log-stream-to-console! task-cancelled?
+      (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! out task-cancelled?
                              render-build-error! bob/build-html5-bob-commands bob-args build-server-headers project changes-view
                              (fn [successful?]
                                (when successful?
-                                 (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix))))))))
+                                 (ui/open-url (format "http://localhost:%d%s/index.html" (http-server/port web-server) bob/html5-url-prefix)))
+                               (.close out))))))
 
 (defn- updated-build-resource-proj-paths [old-etags new-etags]
   ;; We only want to return resources that were present in the old etags since
@@ -1480,7 +1490,7 @@ If you do not specifically require different script states, consider changing th
                               (case (.getOs (Platform/getHostPlatform))
                                 "macos" (io/file resources-path "../../")
                                 ("linux" "win32") (io/file resources-path)))]
-            (process/start! (system/defold-launcherpath) [] {:directory install-dir}))))
+            (process/start {:dir install-dir} (system/defold-launcherpath)))))
 
 (handler/register-menu! ::menubar
   [{:label "File"
@@ -2290,6 +2300,32 @@ If you do not specifically require different script states, consider changing th
           show-search-results-tab! (partial show-search-results! main-scene tool-tab-pane)]
       (search-results-view/show-search-in-files-dialog! search-results-view project prefs show-search-results-tab!))))
 
+(defn- adb-post-bundle! [prefs output-directory project ^OutputStream out launch]
+  (g/with-auto-evaluation-context evaluation-context
+    (let [game-project (project/get-resource-node project "/game.project" evaluation-context)
+          package (game-project/get-setting game-project ["android" "package"] evaluation-context)
+          project-title (game-project/get-setting game-project ["project" "title"] evaluation-context)
+          apk-path (io/file output-directory project-title (str project-title ".apk"))]
+      ;; Do the actual work asynchronously because adb commands are blocking.
+      (future
+        ;; We should close the out when we are done here
+        (with-open [writer (PrintWriter. out true StandardCharsets/UTF_8)]
+          (try
+            (.println writer (format "Resolving ADB location..." apk-path))
+            (let [adb-path (adb/get-adb-path prefs)
+                  _ (.println writer (format "Resolved to '%s'" adb-path))
+                  _ (.println writer "Listing devices...")
+                  device (or (first (adb/list-devices! adb-path))
+                             (throw (ex-info "No devices are connected" {:adb adb-path})))]
+              (.println writer (format "Installing on '%s'..." (:label device)))
+              (adb/install! adb-path device apk-path out)
+              (when launch
+                (.println writer (format "Launching %s..." package))
+                (adb/launch! adb-path device package out))
+              (.println writer (format "Install%s done." (if launch " and launch" ""))))
+            (catch Throwable e
+              (.println writer (.getMessage e)))))))))
+
 (defn- bundle! [main-stage tool-tab-pane changes-view build-errors-view project prefs platform bundle-options]
   (g/user-data! project :last-bundle-options (assoc bundle-options :platform-key platform))
   (let [main-scene (.getScene ^Stage main-stage)
@@ -2300,16 +2336,31 @@ If you do not specifically require different script states, consider changing th
         render-build-progress! (make-render-task-progress :build)
         task-cancelled? (make-task-cancelled-query :build)
         build-server-headers (native-extensions/get-build-server-headers prefs)
-        bob-args (bob/bundle-bob-args prefs platform bundle-options)]
+        bob-args (bob/bundle-bob-args prefs platform bundle-options)
+        out (start-new-log-pipe!)]
     (when-not (.exists output-directory)
       (fs/create-directories! output-directory))
     (build-errors-view/clear-build-errors build-errors-view)
-    (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! pipe-log-stream-to-console! task-cancelled?
+    (disk/async-bob-build! render-reload-progress! render-save-progress! render-build-progress! out task-cancelled?
                            render-build-error! bob/bundle-bob-commands bob-args build-server-headers project changes-view
                            (fn [successful?]
-                             (when successful?
+                             (if successful?
                                (if (some-> output-directory .isDirectory)
-                                 (when (prefs/get-prefs prefs "open-bundle-target-folder" true) (ui/open-file output-directory))
+                                 (do
+                                   (when (prefs/get-prefs prefs "open-bundle-target-folder" true)
+                                     (ui/open-file output-directory))
+                                   (cond
+                                     (and (= :android platform)
+                                          (:adb-install bundle-options)
+                                          (string/includes? (:bundle-format bundle-options) "apk"))
+                                     ;; will eventually close the output
+                                     (adb-post-bundle! prefs output-directory project out (:adb-launch bundle-options))
+
+                                     :else
+                                     (.close out)))
+                                 (.close out))
+                               (do
+                                 (.close out)
                                  (dialogs/make-info-dialog
                                    {:title "Bundle Failed"
                                     :icon :icon/triangle-error

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -428,8 +428,8 @@
     (ui/value! architecture-32bit-check-box (prefs/get-prefs prefs "bundle-android-architecture-32bit?" true))
     (ui/value! architecture-64bit-check-box (prefs/get-prefs prefs "bundle-android-architecture-64bit?" false))
     (ui/value! bundle-format-choice-box (prefs/get-prefs prefs "bundle-android-bundle-format" "apk"))
-    (ui/value! adb-install-check-box (prefs/get-prefs prefs "adb-install" false))
-    (ui/value! adb-launch-check-box (prefs/get-prefs prefs "adb-launch" false))))
+    (ui/value! adb-install-check-box (prefs/get-prefs prefs "bundle-android-adb-install" false))
+    (ui/value! adb-launch-check-box (prefs/get-prefs prefs "bundle-android-adb-launch" false))))
 
 (defn- save-android-prefs! [prefs view]
   (ui/with-controls view [keystore-text-field
@@ -446,8 +446,8 @@
     (prefs/set-prefs prefs "bundle-android-architecture-32bit?" (ui/value architecture-32bit-check-box))
     (prefs/set-prefs prefs "bundle-android-architecture-64bit?" (ui/value architecture-64bit-check-box))
     (set-string-pref! prefs "bundle-android-bundle-format" (ui/value bundle-format-choice-box))
-    (prefs/set-prefs prefs "adb-install" (ui/value adb-install-check-box))
-    (prefs/set-prefs prefs "adb-launch" (ui/value adb-launch-check-box))))
+    (prefs/set-prefs prefs "bundle-android-adb-install" (ui/value adb-install-check-box))
+    (prefs/set-prefs prefs "bundle-android-adb-launch" (ui/value adb-launch-check-box))))
 
 (defn- get-android-options [view]
   (ui/with-controls view [architecture-32bit-check-box

--- a/editor/src/clj/editor/bundle_dialog.clj
+++ b/editor/src/clj/editor/bundle_dialog.clj
@@ -16,6 +16,7 @@
   (:require [cljfx.fx.v-box :as fx.v-box]
             [clojure.java.io :as io]
             [clojure.set :as set]
+            [clojure.string :as string]
             [editor.bundle :as bundle]
             [editor.dialogs :as dialogs]
             [editor.fs :as fs]
@@ -26,7 +27,7 @@
             [editor.ui :as ui])
   (:import [java.io File]
            [javafx.scene Scene]
-           [javafx.scene.control Button CheckBox ChoiceBox Label TextField]
+           [javafx.scene.control Button CheckBox ChoiceBox Label Separator TextField]
            [javafx.scene.input KeyCode]
            [javafx.scene.layout ColumnConstraints GridPane HBox Priority VBox]
            [javafx.stage DirectoryChooser Window]
@@ -401,35 +402,90 @@
                      (labeled! "Bundle Format" (doto (make-choice-box refresh! [["APK" "apk"] ["AAB" "aab"] ["APK+AAB", "apk,aab"]])
                                                 (.setId "bundle-format-choice-box")))]))))
 
+(defn- android-post-bundle-controls [refresh!]
+  (doto (VBox.)
+    (ui/add-style! "settings")
+    (ui/add-style! "android")
+    (ui/children!
+      [(Separator.)
+       (labeled! "On APK Bundled" (doto (VBox.)
+                                    (ui/children!
+                                      [(make-labeled-check-box "Install on connected device" "adb-install-check-box" false refresh!)
+                                       (make-labeled-check-box "Launch installed app" "adb-launch-check-box" false refresh!)])))])))
+
 (defn- load-android-prefs! [prefs view]
-  (ui/with-controls view [keystore-text-field keystore-pass-text-field key-pass-text-field architecture-32bit-check-box architecture-64bit-check-box bundle-format-choice-box]
+  (ui/with-controls view [keystore-text-field
+                          keystore-pass-text-field
+                          key-pass-text-field
+                          architecture-32bit-check-box
+                          architecture-64bit-check-box
+                          bundle-format-choice-box
+                          adb-install-check-box
+                          adb-launch-check-box]
     (ui/value! keystore-text-field (get-string-pref prefs "bundle-android-keystore"))
     (ui/value! keystore-pass-text-field (get-string-pref prefs "bundle-android-keystore-pass"))
     (ui/value! key-pass-text-field (get-string-pref prefs "bundle-android-key-pass"))
     (ui/value! architecture-32bit-check-box (prefs/get-prefs prefs "bundle-android-architecture-32bit?" true))
     (ui/value! architecture-64bit-check-box (prefs/get-prefs prefs "bundle-android-architecture-64bit?" false))
-    (ui/value! bundle-format-choice-box (prefs/get-prefs prefs "bundle-android-bundle-format" "apk"))))
+    (ui/value! bundle-format-choice-box (prefs/get-prefs prefs "bundle-android-bundle-format" "apk"))
+    (ui/value! adb-install-check-box (prefs/get-prefs prefs "adb-install" false))
+    (ui/value! adb-launch-check-box (prefs/get-prefs prefs "adb-launch" false))))
 
 (defn- save-android-prefs! [prefs view]
-  (ui/with-controls view [keystore-text-field keystore-pass-text-field key-pass-text-field architecture-32bit-check-box architecture-64bit-check-box bundle-format-choice-box]
+  (ui/with-controls view [keystore-text-field
+                          keystore-pass-text-field
+                          key-pass-text-field
+                          architecture-32bit-check-box
+                          architecture-64bit-check-box
+                          bundle-format-choice-box
+                          adb-install-check-box
+                          adb-launch-check-box]
     (set-string-pref! prefs "bundle-android-keystore" (ui/value keystore-text-field))
     (set-string-pref! prefs "bundle-android-keystore-pass" (ui/value keystore-pass-text-field))
     (set-string-pref! prefs "bundle-android-key-pass" (ui/value key-pass-text-field))
     (prefs/set-prefs prefs "bundle-android-architecture-32bit?" (ui/value architecture-32bit-check-box))
     (prefs/set-prefs prefs "bundle-android-architecture-64bit?" (ui/value architecture-64bit-check-box))
-    (set-string-pref! prefs "bundle-android-bundle-format" (ui/value bundle-format-choice-box))))
+    (set-string-pref! prefs "bundle-android-bundle-format" (ui/value bundle-format-choice-box))
+    (prefs/set-prefs prefs "adb-install" (ui/value adb-install-check-box))
+    (prefs/set-prefs prefs "adb-launch" (ui/value adb-launch-check-box))))
 
 (defn- get-android-options [view]
-  (ui/with-controls view [architecture-32bit-check-box architecture-64bit-check-box keystore-text-field keystore-pass-text-field key-pass-text-field bundle-format-choice-box]
+  (ui/with-controls view [architecture-32bit-check-box
+                          architecture-64bit-check-box
+                          keystore-text-field
+                          keystore-pass-text-field
+                          key-pass-text-field
+                          bundle-format-choice-box
+                          adb-install-check-box
+                          adb-launch-check-box]
     {:architecture-32bit? (ui/value architecture-32bit-check-box)
      :architecture-64bit? (ui/value architecture-64bit-check-box)
      :keystore (get-file keystore-text-field)
      :keystore-pass (get-file keystore-pass-text-field)
      :key-pass (get-file key-pass-text-field)
-     :bundle-format (ui/value bundle-format-choice-box)}))
+     :bundle-format (ui/value bundle-format-choice-box)
+     :adb-install (ui/value adb-install-check-box)
+     :adb-launch (ui/value adb-launch-check-box)}))
 
-(defn- set-android-options! [view {:keys [architecture-32bit? architecture-64bit? keystore keystore-pass key-pass bundle-format] :as _options} issues]
-  (ui/with-controls view [architecture-32bit-check-box architecture-64bit-check-box keystore-text-field keystore-pass-text-field key-pass-text-field bundle-format-choice-box ok-button]
+(defn- set-android-options! [view
+                             {:keys [architecture-32bit?
+                                     architecture-64bit?
+                                     keystore
+                                     keystore-pass
+                                     key-pass
+                                     bundle-format
+                                     adb-install
+                                     adb-launch] :as _options}
+                             issues]
+  (ui/with-controls view [architecture-32bit-check-box
+                          architecture-64bit-check-box
+                          keystore-text-field
+                          keystore-pass-text-field
+                          key-pass-text-field
+                          bundle-format-choice-box
+                          ok-button
+                          adb-install-check-box
+                          adb-launch-check-box]
     (doto keystore-text-field
       (set-file! keystore)
       (set-field-status! (:keystore issues)))
@@ -448,6 +504,15 @@
     (doto bundle-format-choice-box
       (ui/value! bundle-format)
       (set-field-status! (:bundle-format issues)))
+    (let [install-disabled (not (string/includes? (or bundle-format "") "apk"))]
+      (doto ^CheckBox adb-install-check-box
+        (ui/value! adb-install)
+        (.setDisable install-disabled)
+        (set-field-status! (:adb-install issues)))
+      (doto ^CheckBox adb-launch-check-box
+        (ui/value! adb-launch)
+        (.setDisable (or install-disabled (not adb-install)))
+        (set-field-status! (:adb-launch issues))))
     (ui/enable! ok-button (and (nil? (:architecture issues))
                                (or (and (nil? keystore)
                                         (nil? keystore-pass)
@@ -460,44 +525,45 @@
   {:general (when (and (nil? keystore))
               [:info "Set keystore, or leave blank to sign with an auto-generated debug certificate."])
    :keystore (cond
-                  (and (some? keystore) (not (fs/existing-file? keystore)))
-                  [:fatal "Keystore file not found."]
+               (and (some? keystore) (not (fs/existing-file? keystore)))
+               [:fatal "Keystore file not found."]
 
-                  (and (some? keystore) (not (or (existing-file-of-type? "keystore" keystore) (existing-file-of-type? "jks" keystore))))
-                  [:fatal "Invalid keystore."]
+               (and (some? keystore) (not (or (existing-file-of-type? "keystore" keystore) (existing-file-of-type? "jks" keystore))))
+               [:fatal "Invalid keystore."]
 
-                  (and (nil? keystore) (some? keystore-pass))
-                  [:fatal "Keystore must be set if keystore password is specified."])
+               (and (nil? keystore) (some? keystore-pass))
+               [:fatal "Keystore must be set if keystore password is specified."])
    :keystore-pass (cond
-                  (and (some? keystore-pass) (not (fs/existing-file? keystore-pass)))
-                  [:fatal "Keystore password file not found."]
+                    (and (some? keystore-pass) (not (fs/existing-file? keystore-pass)))
+                    [:fatal "Keystore password file not found."]
 
-                  (and (some? keystore-pass) (not (existing-file-of-type? "txt" keystore-pass)))
-                  [:fatal "Invalid keystore password file."]
+                    (and (some? keystore-pass) (not (existing-file-of-type? "txt" keystore-pass)))
+                    [:fatal "Invalid keystore password file."]
 
-                  (and (some? keystore) (nil? keystore-pass))
-                  [:fatal "Keystore password must be set if keystore is specified."])
-   :key-pass      (cond
-                  (and (some? key-pass) (not (fs/existing-file? key-pass)))
-                  [:fatal "Key password file not found."]
+                    (and (some? keystore) (nil? keystore-pass))
+                    [:fatal "Keystore password must be set if keystore is specified."])
+   :key-pass (cond
+               (and (some? key-pass) (not (fs/existing-file? key-pass)))
+               [:fatal "Key password file not found."]
 
-                  (and (some? key-pass) (not (existing-file-of-type? "txt" key-pass)))
-                  [:fatal "Invalid key password file."]
+               (and (some? key-pass) (not (existing-file-of-type? "txt" key-pass)))
+               [:fatal "Invalid key password file."]
 
-                  (and (some? key-pass) (nil? keystore))
-                  [:fatal "Keystore must be set if key password is specified."])
+               (and (some? key-pass) (nil? keystore))
+               [:fatal "Keystore must be set if key password is specified."])
    :architecture (when-not (or architecture-32bit? architecture-64bit?)
                    [:fatal "At least one architecture must be selected."])
    :bundle-format (when-not bundle-format
-                   [:fatal "No bundle format selected."])})
+                    [:fatal "No bundle format selected."])})
 
 (deftype AndroidBundleOptionsPresenter [workspace view variant-choices compression-choices]
   BundleOptionsPresenter
   (make-views [this owner-window]
     (let [refresh! (make-presenter-refresher this)]
-      (into [(make-generic-headers "Bundle Android Application")
-             (make-android-controls refresh! owner-window)]
-            (make-generic-controls refresh! variant-choices compression-choices))))
+      (-> [(make-generic-headers "Bundle Android Application")
+           (make-android-controls refresh! owner-window)]
+          (into (make-generic-controls refresh! variant-choices compression-choices))
+          (conj (android-post-bundle-controls refresh!)))))
   (load-prefs! [_this prefs]
     (load-generic-prefs! prefs view)
     (load-android-prefs! prefs view))

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -181,7 +181,7 @@
     (do (render-error! (engine-build-errors/exception->error-value exception project evaluation-context))
         true)))
 
-(defn async-bob-build! [render-reload-progress! render-save-progress! render-build-progress! show-build-log-stream! task-cancelled? render-build-error! bob-commands bob-args build-server-headers project changes-view callback!]
+(defn async-bob-build! [render-reload-progress! render-save-progress! render-build-progress! log-output-stream task-cancelled? render-build-error! bob-commands bob-args build-server-headers project changes-view callback!]
   (disk-availability/push-busy!)
   (future
     (try
@@ -226,7 +226,7 @@
                              (let [evaluation-context (g/make-evaluation-context)]
                                (future
                                  (try
-                                   (let [result (bob/bob-build! project evaluation-context bob-commands bob-args build-server-headers render-build-progress! show-build-log-stream! task-cancelled?)]
+                                   (let [result (bob/bob-build! project evaluation-context bob-commands bob-args build-server-headers render-build-progress! log-output-stream task-cancelled?)]
                                      (extensions/execute-hook!
                                        project
                                        :on-bundle-finished

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -475,11 +475,11 @@
                  (workspace/project-path evaluation-context))]
     (doseq [cmd+args commands]
       (if (can-execute? ui cmd+args)
-        (let [process (doto (apply process/start {:dir root} cmd+args)
+        (let [process (doto (apply process/start! {:dir root} cmd+args)
                         (-> process/out (input-stream->console ui :out))
                         (-> process/err (input-stream->console ui :err)))
               exit-code (process/await-exit-code process)]
-          (when-not (process/exit-ok? exit-code)
+          (when-not (zero? exit-code)
             (throw (ex-info (str "Command \""
                                  (string/join " " cmd+args)
                                  "\" exited with code "

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -277,19 +277,18 @@
              "DM_QUIT_ON_ESC" (if (prefs/get-prefs prefs "general-quit-on-esc" false)
                                 "1" "0")
              ;; Windows only. Sets the correct symbol search path, since we're also setting the cwd (https://docs.microsoft.com/en-us/windows/win32/debug/symbol-paths)
-             "_NT_ALT_SYMBOL_PATH" (.getAbsolutePath (.getParentFile engine))}
-        removeenv ["MESA_GL_VERSION_OVERRIDE" "MESA_LOADER_DRIVER_OVERRIDE"]
-        opts {:directory project-directory
-              :redirect-error-stream? true
-              :env env
-              :removeenv removeenv}]
+             "_NT_ALT_SYMBOL_PATH" (.getAbsolutePath (.getParentFile engine))
+             "MESA_GL_VERSION_OVERRIDE" nil
+             "MESA_LOADER_DRIVER_OVERRIDE" nil}
+        opts {:dir project-directory
+              :err :stdout
+              :env env}]
     ;; Closing "is" seems to cause any dmengine output to stdout/err
     ;; to generate SIGPIPE and close/crash. Also we need to read
     ;; the output of dmengine because there is a risk of the stream
     ;; buffer filling up, stopping the process.
     ;; https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers
-    (let [p (process/start! command args opts)
-          is (.getInputStream p)]
+    (let [p (apply process/start opts command args)]
       {:process p
        :name (.getName engine)
-       :log-stream is})))
+       :log-stream (process/out p)})))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -288,7 +288,7 @@
     ;; the output of dmengine because there is a risk of the stream
     ;; buffer filling up, stopping the process.
     ;; https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers
-    (let [p (apply process/start opts command args)]
+    (let [p (apply process/start! opts command args)]
       {:process p
        :name (.getName engine)
        :log-stream (process/out p)})))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -244,8 +244,11 @@
       (set user-data path value))))
 
 (defn get-setting
-  [game-project path]
-  ((g/node-value game-project :settings-map) path))
+  ([game-project path]
+   (g/with-auto-evaluation-context evaluation-context
+     (get-setting game-project path evaluation-context)))
+  ([game-project path evaluation-context]
+   ((g/node-value game-project :settings-map evaluation-context) path)))
 
 (defn register-resource-types [workspace]
   (resource-node/register-settings-resource-type workspace

--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -76,6 +76,7 @@
         ^Parent control (create-control! prefs grid desc)]
     (GridPane/setConstraints label 0 row)
     (GridPane/setConstraints control 1 row)
+    (ui/tooltip! label (:tooltip desc))
     (when (:multi-line desc)
       (GridPane/setValignment label VPos/TOP))
     (.add (.getChildren grid) label)
@@ -114,7 +115,9 @@
                     {:label "Code Editor Font (Requires Restart)" :type :string :key "code-editor-font-name" :default "Dejavu Sans Mono"}]}
            {:name  "Extensions"
             :prefs [{:label "Build Server" :type :string :key "extensions-server" :default native-extensions/defold-build-server-url}
-                    {:label "Build Server Headers" :type :string :key "extensions-server-headers" :default native-extensions/defold-build-server-headers :multi-line true}]}]
+                    {:label "Build Server Headers" :type :string :key "extensions-server-headers" :default native-extensions/defold-build-server-headers :multi-line true}]}
+           {:name  "Tools"
+            :prefs [{:label "ADB path" :type :string :key "adb-path" :default "" :tooltip "Path to ADB command that might be used to start the Android app when it's bundled"}]}]
 
     (system/defold-dev?)
     (conj {:name "Dev"

--- a/editor/src/clj/editor/process.clj
+++ b/editor/src/clj/editor/process.clj
@@ -13,31 +13,157 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.process
-  (:require [clojure.java.io :as io])
-  (:import [java.lang Process ProcessBuilder]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string])
+  (:import [java.lang Process ProcessBuilder ProcessBuilder$Redirect]
+           [java.util List]
+           [java.io InputStream StringWriter OutputStream]))
 
 (set! *warn-on-reflection* true)
 
-(defn start! ^Process [^String command args {:keys [directory env removeenv redirect-error-stream?]
-                                             :or {redirect-error-stream? false}
-                                             :as opts}]
-  (let [pb (ProcessBuilder. ^"[Ljava.lang.String;" (into-array String (list* command args)))]
-    (when directory
-      (.directory pb directory))
+(defn- ->redirect
+  ^ProcessBuilder$Redirect [x]
+  (case x
+    :pipe ProcessBuilder$Redirect/PIPE
+    :inherit ProcessBuilder$Redirect/INHERIT
+    :discard ProcessBuilder$Redirect/DISCARD
+    x))
+
+(defn ^{:arglists '([& command+args] [opts & command+args])} start
+  "Start a process
+
+  Optional leading opts map:
+    :in     either:
+              :pipe - default, available as [[in]]
+              :inherit - connects to this process's stdin
+    :out    either:
+              :pipe - default, available as [[out]]
+              :discard
+              :inherit - connects to this process's stdout
+    :err    either:
+              :pipe - default, available as [[err]]
+              :discard
+              :inherit - connects to this process's stderr
+              :stdout - redirects to spawned process's out
+    :dir    the process working directory
+    :env    process env map, keys are env var names, vars are either strings
+            (values) or nil (removes the var from the process env)"
+  ^Process [& opts+args]
+  (let [has-opts (map? (first opts+args))
+        opts (if has-opts (first opts+args) {})
+        command (if has-opts (rest opts+args) opts+args)
+        {:keys [in out err dir env]} opts
+        pb (ProcessBuilder. ^List command)]
+    (when dir (.directory pb (io/file dir)))
+    (when in (.redirectInput pb (->redirect in)))
+    (when out (.redirectOutput pb (->redirect out)))
+    (when err
+      (if (= :stdout err)
+        (.redirectErrorStream pb true)
+        (.redirectError pb (->redirect err))))
     (when env
-      (let [environment (.environment pb)]
+      (let [m (.environment pb)]
         (doseq [[k v] env]
-          (.put environment k v))))
-    (when removeenv
-      (let [environment (.environment pb)]
-        (doseq [k removeenv]
-          (.remove environment k))))
-    (when (some? redirect-error-stream?)
-      (.redirectErrorStream pb (boolean redirect-error-stream?)))
+          (if v
+            (.put m k v)
+            (.remove m k)))))
     (.start pb)))
 
-(defn watchdog! ^Thread [^Process proc on-exit]
-  (doto (Thread. (fn []
-                   (.waitFor proc)
-                   (on-exit)))
-    (.start)))
+(defn out
+  "Get the process out, an InputStream that can be read from"
+  ^InputStream [^Process process]
+  (.getInputStream process))
+
+(defn in
+  "Get the process in, an OutputStream that can be written to"
+  ^OutputStream [^Process process]
+  (.getOutputStream process))
+
+(defn err
+  "Get the process err, an InputStream that can be read from"
+  ^InputStream [^Process process]
+  (.getErrorStream process))
+
+(defn ^{:arglists '([^InputStream in & {:keys [buffer-size encoding] :or {buffer-size 1024 encoding "UTF-8"}}])}
+  capture
+  "Given an InputStream such as process's out or err, consume it into a string
+
+  Returns a non-empty string with trimmed new lines or nil if it's empty
+
+  Optional kv-args:
+    :buffer-size    read buffer size, default 1024
+    :encoding       text encoding, default UTF-8"
+  [^InputStream input-stream & opts]
+  (let [w (StringWriter.)]
+    (apply io/copy input-stream w opts)
+    (let [s (string/trim-newline (.toString w))]
+      (when (pos? (.length s))
+        s))))
+
+(defn pipe
+  "Pipe data from the InputStream (e.g. [[out]] or [[err]]) to OutputStream
+
+  Similar to io/copy and InputStream::transferTo, but flushes on write"
+  [^InputStream in ^OutputStream out]
+  (let [buf (byte-array 1024)]
+    (loop []
+      (let [size (.read in buf)]
+        (when-not (neg? size)
+          (do (.write out buf 0 size)
+              (.flush out)
+              (recur)))))))
+
+(defn await-exit-code
+  "Blocks until process exits and returns the exit code"
+  [^Process process]
+  (.waitFor process))
+
+(defn exit-ok?
+  "Checks if the exit code of the process indicates success"
+  [exit-code]
+  {:pre [(int? exit-code)]}
+  (zero? exit-code))
+
+(defn exec
+  "Execute command and return the output on successful exit or throw otherwise
+
+  Returns a non-empty string with trimmed new lines or nil if it's empty
+
+  Optional leading opts map:
+    :in     either:
+              :pipe - default, available as [[in]]
+              :inherit - connects to this process's stdin
+    :out    either:
+              :pipe - default, available as [[out]]
+              :discard
+              :inherit - connects to this process's stdout
+    :err    either:
+              :pipe - default, available as [[err]]
+              :discard
+              :inherit - connects to this process's stderr
+              :stdout - redirects to spawned process's out
+    :dir    the process working directory
+    :env    process env map, keys are env var names, vars are either strings
+            (values) or nil (removes the var from the process env)"
+  [& opts+args]
+  (let [has-opts (map? (first opts+args))
+        opts (if has-opts (first opts+args) {})
+        command (if has-opts (rest opts+args) opts+args)
+        ^Process process (apply start (into {:err :inherit} opts) command)
+        output (future (capture (out process)))
+        exit-code (await-exit-code process)]
+    (if (exit-ok? exit-code)
+      @output
+      (throw (ex-info (format "Non-zero exit code for command '%s': %s"
+                              (string/join " " command)
+                              exit-code)
+                      {:command command
+                       :exit-code exit-code
+                       :opts opts
+                       :process process})))))
+
+(defn on-exit
+  "Invoke a Runnable (e.g. a 0-arg function) when process exits"
+  [^Process process on-exit]
+  (.thenRun (.onExit process) ^Runnable on-exit)
+  nil)

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -88,11 +88,11 @@
     (swap! launched-targets conj launched-target)
     (clear-selected-target-hint!)
     (invalidate-target-menu!)
-    (process/watchdog! (:process launched-target)
-                       (fn []
-                         (swap! launched-targets (partial remove #(= (:id %) (:id launched-target))))
-                         (clear-selected-target-hint!)
-                         (invalidate-target-menu!)))
+    (process/on-exit (:process launched-target)
+                     (fn []
+                       (swap! launched-targets (partial remove #(= (:id %) (:id launched-target))))
+                       (clear-selected-target-hint!)
+                       (invalidate-target-menu!)))
     launched-target))
 
 (defn- find-by-id [targets id]

--- a/editor/src/clj/editor/targets.clj
+++ b/editor/src/clj/editor/targets.clj
@@ -88,11 +88,11 @@
     (swap! launched-targets conj launched-target)
     (clear-selected-target-hint!)
     (invalidate-target-menu!)
-    (process/on-exit (:process launched-target)
-                     (fn []
-                       (swap! launched-targets (partial remove #(= (:id %) (:id launched-target))))
-                       (clear-selected-target-hint!)
-                       (invalidate-target-menu!)))
+    (process/on-exit! (:process launched-target)
+                      (fn []
+                        (swap! launched-targets (partial remove #(= (:id %) (:id launched-target))))
+                        (clear-selected-target-hint!)
+                        (invalidate-target-menu!)))
     launched-target))
 
 (defn- find-by-id [targets id]

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -278,7 +278,7 @@
 (defn restart! [updater]
   (let [{:keys [launcher-path install-dir]} updater]
     (log/info :message "Restarting editor")
-    (apply process/start {:dir install-dir} launcher-path *command-line-args*)
+    (apply process/start! {:dir install-dir} launcher-path *command-line-args*)
     (javafx.application.Platform/exit)))
 
 (defn delete-backup-files!

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -278,7 +278,7 @@
 (defn restart! [updater]
   (let [{:keys [launcher-path install-dir]} updater]
     (log/info :message "Restarting editor")
-    (process/start! launcher-path *command-line-args* {:directory install-dir})
+    (apply process/start {:dir install-dir} launcher-path *command-line-args*)
     (javafx.application.Platform/exit)))
 
 (defn delete-backup-files!

--- a/editor/styling/stylesheets/components/_separator.scss
+++ b/editor/styling/stylesheets/components/_separator.scss
@@ -1,15 +1,15 @@
 .separator {
-    -fx-background-color: red;
+    -fx-background-color: transparent;
     &:horizontal {
         .line {
-            -fx-border-color: -df-background;
+            -fx-border-color: rgba(255, 255, 255, 0.1);
             -fx-border-width: 1 0 0;
         }
     }
 
     &:vertical {
         .line {
-            -fx-border-color: -df-background;
+            -fx-border-color: rgba(255, 255, 255, 0.1);
             -fx-border-width: 0 1 0 0;
         }
     }

--- a/editor/test/editor/adb_test.clj
+++ b/editor/test/editor/adb_test.clj
@@ -1,3 +1,17 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
 (ns editor.adb-test
   (:require [clojure.test :refer :all]
             [editor.adb :as adb]))

--- a/editor/test/editor/adb_test.clj
+++ b/editor/test/editor/adb_test.clj
@@ -1,0 +1,16 @@
+(ns editor.adb-test
+  (:require [clojure.test :refer :all]
+            [editor.adb :as adb]))
+
+(deftest path-evaluator-test
+  (are [expected actual] (= expected (#'adb/evaluate-path actual))
+    ;; leading ~ is expanded
+    (System/getProperty "user.home") "~"
+    (str (System/getProperty "user.home") "/adb") "~/adb"
+    ;; non-leading ~ is preserved
+    "/usr/bin/~/adb" "/usr/bin/~/adb"
+    ;; $ENV vars are expanded
+    (System/getenv "USER") "$USER"
+    (str "/home/" (System/getenv "USER") "/adb") "/home/$USER/adb"
+    ;; absent env vars make the whole output collapse into nil
+    nil "/home/$UHHH"))

--- a/editor/test/editor/process_test.clj
+++ b/editor/test/editor/process_test.clj
@@ -1,3 +1,17 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
 (ns editor.process-test
   (:require [clojure.test :refer :all]
             [editor.process :as process]

--- a/editor/test/editor/process_test.clj
+++ b/editor/test/editor/process_test.clj
@@ -1,0 +1,40 @@
+(ns editor.process-test
+  (:require [clojure.test :refer :all]
+            [editor.process :as process])
+  (:import [java.io ByteArrayOutputStream]))
+
+(deftest start-test
+  (let [p (process/start "ls")
+        output (process/capture (process/out p))
+        exit (process/await-exit-code p)]
+    (is (process/exit-ok? exit))
+    (is (not-empty output))))
+
+(deftest exec-test
+  (let [output (process/exec "ls")]
+    (is (not-empty output))))
+
+(deftest env-test
+  (let [val "UHH"
+        out (process/exec {:env {"CUSTOM_VAR" val}} "printenv" "CUSTOM_VAR")]
+    (is (= val out))))
+
+(deftest remove-env-test
+  (is (not-empty (process/exec "printenv" "PATH")))
+  (is (thrown? Exception (process/exec {:env {"PATH" nil}} "printenv" "PATH"))))
+
+(deftest redirect-test
+  (is (nil? (process/exec "bash" "-c" "ls >&2")))
+  (is (not-empty (process/exec {:err :stdout} "bash" "-c" "ls >&2"))))
+
+(deftest pipe-test
+  (let [p (process/start "ls")
+        target (ByteArrayOutputStream.)]
+    (process/pipe (process/out p) target)
+    (is (not-empty (str target)))))
+
+(deftest on-exit-test
+  (let [p (process/start "ls")
+        done (promise)]
+    (process/on-exit p #(deliver done true))
+    (is (true? (deref done 100 false)))))

--- a/editor/test/editor/process_test.clj
+++ b/editor/test/editor/process_test.clj
@@ -1,40 +1,48 @@
 (ns editor.process-test
   (:require [clojure.test :refer :all]
-            [editor.process :as process])
+            [editor.process :as process]
+            [editor.util :as util])
   (:import [java.io ByteArrayOutputStream]))
 
 (deftest start-test
-  (let [p (process/start "ls")
-        output (process/capture (process/out p))
-        exit (process/await-exit-code p)]
-    (is (process/exit-ok? exit))
-    (is (not-empty output))))
+  (when-not (util/is-win32?)
+    (let [p (process/start! "ls")
+          output (process/capture! (process/out p))
+          exit (process/await-exit-code p)]
+      (is (zero? exit))
+      (is (not-empty output)))))
 
 (deftest exec-test
-  (let [output (process/exec "ls")]
-    (is (not-empty output))))
+  (when-not (util/is-win32?)
+    (let [output (process/exec! "ls")]
+      (is (not-empty output)))))
 
 (deftest env-test
-  (let [val "UHH"
-        out (process/exec {:env {"CUSTOM_VAR" val}} "printenv" "CUSTOM_VAR")]
-    (is (= val out))))
+  (when-not (util/is-win32?)
+    (let [val "UHH"
+          out (process/exec! {:env {"CUSTOM_VAR" val}} "printenv" "CUSTOM_VAR")]
+      (is (= val out)))))
 
 (deftest remove-env-test
-  (is (not-empty (process/exec "printenv" "PATH")))
-  (is (thrown? Exception (process/exec {:env {"PATH" nil}} "printenv" "PATH"))))
+  (when-not (util/is-win32?)
+    (is (not-empty (process/exec! "printenv" "PATH")))
+    (is (thrown? Exception (process/exec! {:env {"PATH" nil}} "printenv" "PATH")))))
 
 (deftest redirect-test
-  (is (nil? (process/exec "bash" "-c" "ls >&2")))
-  (is (not-empty (process/exec {:err :stdout} "bash" "-c" "ls >&2"))))
+  (when-not (util/is-win32?)
+    (is (nil? (process/exec! "bash" "-c" "ls >&2")))
+    (is (not-empty (process/exec! {:err :stdout} "bash" "-c" "ls >&2")))))
 
 (deftest pipe-test
-  (let [p (process/start "ls")
-        target (ByteArrayOutputStream.)]
-    (process/pipe (process/out p) target)
-    (is (not-empty (str target)))))
+  (when-not (util/is-win32?)
+    (let [p (process/start! "ls")
+          target (ByteArrayOutputStream.)]
+      (process/pipe! (process/out p) target)
+      (is (not-empty (str target))))))
 
 (deftest on-exit-test
-  (let [p (process/start "ls")
-        done (promise)]
-    (process/on-exit p #(deliver done true))
-    (is (true? (deref done 100 false)))))
+  (when-not (util/is-win32?)
+    (let [p (process/start! "ls")
+          done (promise)]
+      (process/on-exit! p #(deliver done true))
+      (is (true? (deref done 100 false))))))


### PR DESCRIPTION
Technical notes: I refactored the `editor.process` ns because I didn't like the API it had. I based the API on a new [Clojure process ns](https://github.com/clojure/clojure/blob/master/src/clj/clojure/java/process.clj) that we might want to migrate to when it matures (I [reported some issues to them](https://ask.clojure.org/index.php/12942/feedback-on-the-new-clojure-java-process-namespace) when I was working on it).

User-facing changes:
If you have [ADB](https://developer.android.com/tools/adb) installed on your computer, you can now install the built APK on the connected device from the editor. The Android bundle dialog now has checkboxes for performing installation and/or launch after the bundle is completed. The preferences window now has a Tools pane where you can configure the path to ADB installation if the editor couldn't find it. The editor shows the installation process output in its console.

Related to #5392
