### PR TITLE
HTML5: LiveUpdate returns "invalid resource" error due to inactive job queue

### DIFF
--- a/engine/liveupdate/src/liveupdate_async.cpp
+++ b/engine/liveupdate/src/liveupdate_async.cpp
@@ -212,7 +212,7 @@ namespace dmLiveUpdate
     void AsyncInitialize(const dmResource::HFactory factory)
     {
         m_ResourceFactory = factory;
-        m_Active = 0;
+        m_Active = 1;
     }
 
     void AsyncFinalize()


### PR DESCRIPTION
The pull request https://github.com/defold/defold/pull/7532 has changed the synchronisation way in the `liveupdate_async.cpp` code, but at the same time this change now prevents any resource from being stored on the HTML5 build, i.e. it always returns the error `Verification of liveupdate resource failed for expected hash for resource ...`. The flag `m_Active` should be set to `1` at the initialization stage.

Related issue in the ResZip extension - https://github.com/indiesoftby/defold-liveupdate-reszip/issues/5

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
