### PR TITLE
Fixed an editor crash when loading a non-editable collection or game object with an embedded spine component referring to an out-of-date spinejson file

### DIFF
--- a/editor/src/clj/editor/game_object_non_editable.clj
+++ b/editor/src/clj/editor/game_object_non_editable.clj
@@ -15,6 +15,7 @@
 (ns editor.game-object-non-editable
   (:require [dynamo.graph :as g]
             [editor.build-target :as bt]
+            [editor.collection-string-data :as collection-string-data]
             [editor.defold-project :as project]
             [editor.game-object-common :as game-object-common]
             [editor.graph-util :as gu]
@@ -377,7 +378,13 @@
   (let [ext->embedded-component-resource-type (workspace/get-resource-type-map workspace :non-editable)]
     (game-object-common/sanitize-prototype-desc prototype-desc ext->embedded-component-resource-type :embed-data-as-maps)))
 
-(defn- load-non-editable-game-object [_project self _resource prototype-desc]
+(defn- load-non-editable-game-object [_project self resource prototype-desc]
+  ;; Validate the prototype-desc.
+  ;; We want to throw an exception if we encounter corrupt data to ensure our
+  ;; node gets marked defective at load-time.
+  (doseq [embedded-component-desc (:embedded-components prototype-desc)]
+    (collection-string-data/verify-string-decoded-embedded-component-desc! embedded-component-desc resource))
+
   (g/set-property self :prototype-desc prototype-desc))
 
 (defn register-resource-types [workspace]


### PR DESCRIPTION
Fixes #7689

### User-facing changes
* Fixed an issue where the editor would crash when loading a project containing a non-editable collection or game object with an embedded Spine component referring to an out-of-date `.spinejson` file.

### Technical details
For non-editable collections and game objects, the `:sanitize-fn` decodes embedded strings into map representations of the embedded game objects and components. This process can fail if a plugin such as `extension-spine` throws an exception as it reads the embedded string. In this case, the `:sanitize-fn` gives up and returns the data in its non-sanitized form. Normally this would cause the `:load-fn` to throw an exception, but in the case of non-editable resources, the read protobuf map is simply assigned to a property. This eventually trips an assert at an inopportune time, which in our case terminates the editor process in the middle of loading.

This PR ensures that the read data has been properly decoded into map format before assigning the property in the `:load-fn` so that an exception is thrown in the right place for the resource to be flagged as defective.