### PR TITLE
Update the list view width after showing the popup

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1814,7 +1814,8 @@
                   KeyCode/ENTER (accept! (first (ui/selection list-view)))
                   KeyCode/ESCAPE (.hide popup)
                   nil))))))
-      (.show popup (.getWindow (.getScene canvas)) (.getX anchor) (.getY anchor)))))
+      (.show popup (.getWindow (.getScene canvas)) (.getX anchor) (.getY anchor))
+      (popup/update-list-view! list-view 200.0 results 0))))
 
 (defn- show-no-language-server-for-resource-language-notification! [resource]
   (let [language (resource/language resource)]


### PR DESCRIPTION
`update-list-view!` reported incorrect (zero) widths for list items before it is added to the scene. This results in the popup being not wide enough when showing suggestions. Performing another refresh later solves the issue.

Related to #7692
