### PR TITLE
Added support for unpacking .dmanifest, .modelc, .fpc, .vpc and .luac

### DIFF
--- a/scripts/unpack_ddf.py
+++ b/scripts/unpack_ddf.py
@@ -1,13 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2020-2023 The Defold Foundation
 # Copyright 2014-2020 King
 # Copyright 2009-2014 Ragnar Svensson, Christian Murray
 # Licensed under the Defold License version 1.0 (the "License"); you may not use
 # this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License, together with FAQs at
 # https://www.defold.com/license
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -23,20 +23,66 @@ import os, sys
 from google.protobuf import text_format
 import google.protobuf.message
 
-import gamesys.texture_set_ddf_pb2
-import gamesys.model_ddf_pb2
-import rig.rig_ddf_pb2
 import gameobject.gameobject_ddf_pb2
+import gameobject.lua_ddf_pb2
+import gamesys.model_ddf_pb2
+import gamesys.texture_set_ddf_pb2
+import graphics.graphics_ddf_pb2
+import resource.liveupdate_ddf_pb2
+import rig.rig_ddf_pb2
 
 BUILDERS = {}
 BUILDERS['.texturesetc']    = gamesys.texture_set_ddf_pb2.TextureSet
+BUILDERS['.modelc']         = gamesys.model_ddf_pb2.Model
 BUILDERS['.meshsetc']       = rig.rig_ddf_pb2.MeshSet
 BUILDERS['.animationsetc']  = rig.rig_ddf_pb2.AnimationSet
 BUILDERS['.rigscenec']      = rig.rig_ddf_pb2.RigScene
 BUILDERS['.skeletonc']      = rig.rig_ddf_pb2.Skeleton
+BUILDERS['.dmanifest']      = resource.liveupdate_ddf_pb2.ManifestFile
+BUILDERS['.vpc']            = graphics.graphics_ddf_pb2.ShaderDesc
+BUILDERS['.fpc']            = graphics.graphics_ddf_pb2.ShaderDesc
 BUILDERS['.goc']            = gameobject.gameobject_ddf_pb2.PrototypeDesc
 BUILDERS['.collectionc']    = gameobject.gameobject_ddf_pb2.CollectionDesc
-BUILDERS['.modelc']         = gamesys.model_ddf_pb2.Model
+BUILDERS['.luac']           = gameobject.lua_ddf_pb2.LuaModule
+
+
+def print_dmanifest(manifest_file):
+    for field, data in manifest_file.ListFields():
+        if field.name == 'data':
+            t = resource.liveupdate_ddf_pb2.ManifestData()
+            t.MergeFromString(data)
+            print(field.name, ":")
+            print(t)
+
+        else:
+            print(field.name, ":", data)
+
+def print_shader(shader):
+    print("{")
+    for field, data in shader.ListFields():
+        if field.name == 'source':
+            lines = str(data.strip(), encoding="ascii").split("\n")
+            data = '\n    '.join(['']+lines)
+        print(field.name, ":", data)
+    print("}")
+
+def print_shader_file(shader_file):
+    def print_shader_code(text):
+        pass
+    print("shaders:")
+    for field, data in shader_file.ListFields():
+        for shader in data:
+            print_shader(shader)
+
+def text_printer(obj):
+    out = text_format.MessageToString(obj)
+    print(out)
+
+PRINTERS = {}
+PRINTERS['.dmanifest']  = print_dmanifest
+PRINTERS['.vpc']        = print_shader_file
+PRINTERS['.fpc']        = print_shader_file
+
 
 if __name__ == "__main__":
     path = sys.argv[1]
@@ -52,6 +98,6 @@ if __name__ == "__main__":
         obj = builder()
         obj.ParseFromString(content)
 
-        out = text_format.MessageToString(obj)
-        print(out)
+        printer = PRINTERS.get(ext, text_printer)
+        printer(obj)
 


### PR DESCRIPTION
Example dmanifest:

`python scripts/unpack_ddf.py /Users/mawe/work/projects/users/evgeniy/liverunner/_build_1/default/game.dmanifest `:

```
data :
header {
  magic_number: 1137405190
  version: 4
  resource_hash_algorithm: HASH_SHA1
  signature_hash_algorithm: HASH_SHA256
  signature_sign_algorithm: SIGN_RSA
  project_identifier {
    data: "\321{+z\200\216i\353\324u?\267\361\243\300\265\230\023\303f"
  }
}
engine_versions {
  data: "\303\000\nm\263\262x\032\030\237\277\252\221\247>mc\325g\311"
}
engine_versions {
  data: "\3329\243\356^kK\r2U\277\357\225`\030\220\257\330\007\t"
}
resources {
  url: "/_generated_229f753099226a1f.collectionproxyc"
  url_hash: 58822720356352074
  hash {
    data: "\215\255K,/\217\334\014q\003\354\253\377 o5\325%\245\307"
  }
  flags: 1
}
resources {
  url: "/builtins/render/default.display_profilesc"
  url_hash: 413181694535112601
  hash {
    data: "A\207\341\032\020\260\335\r\177\0334\323\256<\016\2262\334i\375"
  }
  flags: 1
}
. . .
```