### PR TITLE
Implement lazy loading of the debugged app state

### DIFF
--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -169,7 +169,7 @@
       (assert (= :suspended (mobdebug/state debug-session)))
       (console/append-console-entry! :eval-expression code)
       (future
-        (let [ret (mobdebug/eval debug-session code frame)]
+        (let [ret (mobdebug/exec debug-session code frame)]
           (cond
             (= :bad-request (:error ret))
             (console/append-console-entry! :eval-error "Bad request")

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1851,24 +1851,6 @@
        (finally
          ((second ~bindings) progress/done)))))
 
-(defn make-run-later-render-progress [render-progress!]
-  (let [render-inflight (ref false)
-        last-progress (ref nil)]
-    (progress/throttle-render-progress
-      (fn [progress]
-        (let [schedule (ref false)]
-          (dosync
-            (ref-set schedule (not @render-inflight))
-            (ref-set render-inflight true)
-            (ref-set last-progress progress))
-          (when @schedule
-            (run-later
-              (let [progress-snapshot (ref nil)]
-                (dosync
-                  (ref-set progress-snapshot @last-progress)
-                  (ref-set render-inflight false))
-                (render-progress! @progress-snapshot)))))))))
-
 (defn- set-scene-disable! [^Scene scene disable?]
   (when-some [root (.getRoot scene)]
     (.setDisable root disable?)
@@ -1912,19 +1894,6 @@
   [f]
   (reify EventHandler
     (handle [this event] (f event))))
-
-(defmacro defcommand
-  "Create a command with the given category and id. Binds
-the resulting command to the named variable.
-
-Label should be a human-readable string. It will appear
-directly in the UI (unless there is a translation for it.)
-
-If you use the same category-id and command-id more than once,
-this will create independent entities that refer to the same underlying
-command."
-  [name category-id command-id label]
-  `(def ^:command ~name [~label ~category-id ~command-id]))
 
 (defprotocol Future
   (cancel [this])

--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -81,10 +81,10 @@ local function encode_string(val, val_type)
   if strings_cache[val] then
     return strings_cache[val]
   end
-  local str = '"'..val:gsub('[%z\1-\31\\"]', escape_char)..'"'
-  strings_cache[val] = str
+  local result = '"'..val:gsub('[%z\1-\31\\"]', escape_char)..'"'
+  strings_cache[val] = result
   strings_cache_count = strings_cache_count + 1
-  return str
+  return result
 end
 
 local function encode_table(val, val_type)
@@ -146,90 +146,98 @@ local function encode_as_primitive(val)
   return encoder(val, val_type, mt)
 end
 
-local function encode_edn_table(val, key)
+local function encode_edn_table(ref, ref_table)
   local encoded_kvs = {}
-  for k, v in pairs(val) do
+  for k, v in pairs(ref_table) do
     encoded_kvs[#encoded_kvs + 1] = encode_as_primitive(k)
     encoded_kvs[#encoded_kvs + 1] = encode_as_primitive(v)
   end
-  local encoded_str = encode_string(str(key, type(key), debug.getmetatable(key)))
+  local encoded_str = encode_string(str(ref, type(ref), debug.getmetatable(ref)))
   return "#lua/table{:content [" .. table.concat(encoded_kvs, " ") .. "] :string " .. encoded_str .. "}"
 end
 
-local function encode_refs(refs, keys)
+local function encode_refs(ref_to_table)
   local encoded_refs = {}
-  local val
-  for i = 1, #refs do
-    val = refs[i]
-    encoded_refs[#encoded_refs + 1] = encode_as_primitive(val)
-    encoded_refs[#encoded_refs + 1] = encode_edn_table(keys[val], val)
+  for ref, ref_table in pairs(ref_to_table) do
+    encoded_refs[#encoded_refs+1] = encode_as_primitive(ref)
+    encoded_refs[#encoded_refs+1] = encode_edn_table(ref, ref_table)
   end
   return "{" .. table.concat(encoded_refs, " ") .. "}"
 end
 
-local registry
-
-local function collect_refs(depth, val, refs, keys)
+local function collect_refs(depth, val, internal_graph, edge_refs_set, registry)
   local val_type = type(val)
+  local ref_table
   if val_type == "table" then
-    if depth < 100 and not keys[val] then
-      keys[val] = val
-      refs[#refs + 1] = val
-      local next_depth = depth + 1
-      for k, v in pairs(val) do
-        collect_refs(next_depth, k, refs, keys)
-        collect_refs(next_depth, v, refs, keys)
-      end
-    end
+    ref_table = val
   elseif val_type == "userdata" then
     local mt = debug.getmetatable(val)
     if mt and has_data_in_registry[mt.__metatable] then
-      local script_val = registry[mt.__get_instance_data_table_ref(val)]
-      if script_val then
-        if depth < 100 and not keys[val] then
-          keys[val] = script_val
-          refs[#refs + 1] = val
-          local next_depth = depth + 1
-          for k, v in pairs(script_val) do
-            collect_refs(next_depth, k, refs, keys)
-            collect_refs(next_depth, v, refs, keys)
-          end
+      ref_table = registry[mt.__get_instance_data_table_ref(val)]
+    end
+  end
+  if ref_table then
+    if depth > 0 then
+      if not internal_graph[val] then
+        internal_graph[val] = ref_table
+        local next_depth = depth - 1
+        for k, v in pairs(ref_table) do
+          collect_refs(next_depth, k, internal_graph, edge_refs_set, registry)
+          collect_refs(next_depth, v, internal_graph, edge_refs_set, registry)
         end
       end
+    else -- depth 0, add to edges
+      edge_refs_set[val] = true
     end
   end
 end
 
-local function encode_structure(val)
-  local keys = {}
-  local refs = {}
-  collect_refs(0, val, refs, keys)
-  local encoded_refs = encode_refs(refs, keys)
-  local str = "#lua/structure{:value " .. encode_as_primitive(val) .. " :refs " .. encoded_refs .. "}"
+---Build a references graph for a value up to a certain depth for serialization
+---@param val any value to analyze
+---@param params {maxlevel: integer?}
+---@return table<any, table> internal_graph mapping from found references to a table of its contents
+---@return table<string, any> edge_refs mapping from hexademical pointer strings to  references that were found but will not be serialized
+function M.analyze(val, params)
+  local depth = params.maxlevel or 16
+  local internal_graph = {}
+  local edge_refs_set = {}
+  collect_refs(depth, val, internal_graph, edge_refs_set, debug.getregistry())
+  local edge_refs = {}
+  for edge_ref, _ in pairs(edge_refs_set) do
+    edge_refs[string.format("%p", edge_ref)] = edge_ref
+  end
+  return internal_graph, edge_refs
+end
+
+---Serialize a val to EDN, along with its internal graph that can be obtained with analyze
+---@param val any
+---@param internal_graph table<any, table> reference graph obtained from analyze
+---@return string edn serialized object graph
+function M.serialize(val, internal_graph)
+  local result = "#lua/structure{:value " .. encode_as_primitive(val) .. " :refs " .. encode_refs(internal_graph) .. "}"
   if strings_cache_count > 5000000 then
     strings_cache_count = 0
     strings_cache = {}
   end
-  return str
+  return result
 end
 
-function M.encode(val)
-  registry = debug.getregistry()
-  local err_trace
-  local success, error_or_result = xpcall(
-  function ()
-    return encode_structure(val)
-  end,
-  function (err)
-    err_trace = debug.traceback();
-    return err
+---Build a val reference graph up to a certain depth and serialize it to EDN
+---@param val any
+---@param params {maxlevel: integer?}
+---@return string edn serialized object graph
+function M.encode(val, params)
+  local ok, result = pcall(function ()
+    local graph = M.analyze(val, params)
+    return M.serialize(val, graph)
   end)
-  if success then
-    return error_or_result
+  if ok then
+    return result
   else
-    print("Debugger: " .. error_or_result)
-    if err_trace ~= nil then
-      print(err_trace)
+    print("Debugger: " .. result)
+    local trace = debug.traceback()
+    if trace then
+      print(trace)
     end
     return encode_nil()
   end

--- a/engine/engine/content/builtins/scripts/mobdebug.lua
+++ b/engine/engine/content/builtins/scripts/mobdebug.lua
@@ -804,8 +804,8 @@ end
 local function respond_with_edn(val, analyze_params)
   local analyze_ok, graph, edge_refs = pcall(edn.analyze, val, analyze_params)
   if analyze_ok then
-    for key, value in pairs(edge_refs) do
-      edn_edge_refs_cache[key] = value
+    for k, v in pairs(edge_refs) do
+      edn_edge_refs_cache[k] = v
     end
     local serialize_ok, edn_string = pcall(edn.serialize, val, graph)
     if serialize_ok then


### PR DESCRIPTION
How it's implemented:
1. EDN conversion in `edn.lua` is split into 2 parts: `analyze` and `serialize`. Analyze step collects a graph of reference data structures (tables, scripts) up to a certain depth, and returns them along with "edge refs" — a map from pointer string to a reference data structure referenced by the collected subgraph, but will not be serialized. Those are the references the editor might ask about. Serialize step does not use edge refs, but it does use the subgraph returned by `analyze` to serialize Lua VM objects into EDN.
2. `mobdebug.lua` tracks a cache of edge refs created by `analyze` step. This cache is written into when we serialize something to EDN when the debugger state is "suspended", and it's cleared when the execution resumes (i.e. on `RUN`, `STEP`, `OVER`, `OUT` and `DONE`). It also adds a new `REF` command that, given an edge reference pointer string (the editor has those), responds with another Lua VM object subgraph.
3. The editor changes `LuaStructure` definition to include a connection to `DebugSession`. Then, when something tries to access the contents of a reference that is unknown to the `LuaStructure`, it loads it from the debugged game using the `REF` command.

User-facing changes:
Debugger is now more responsive when debugging games with a lot of state.

Fix #7514
