### PR TITLE
Add gui.get_tree()

### DIFF
--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -369,6 +369,49 @@ TEST_F(dmGuiScriptTest, TestCloneTree)
     dmGui::DeleteScript(script);
 }
 
+TEST_F(dmGuiScriptTest, TestGetTree)
+{
+    dmGui::HScript script = NewScript(m_Context);
+
+    dmGui::NewSceneParams params;
+    params.m_MaxNodes = 64;
+    params.m_MaxAnimations = 32;
+    params.m_UserData = this;
+    //params.m_RigContext = m_RigContext;
+    dmGui::HScene scene = dmGui::NewScene(m_Context, &params);
+    dmGui::SetSceneScript(scene, script);
+
+    const char* src =
+            "function init(self)\n"
+            "    local n1 = gui.new_box_node(vmath.vector3(1, 1, 1), vmath.vector3(1, 1, 1))\n"
+            "    gui.set_id(n1, \"n1\")\n"
+            "    local n2 = gui.new_box_node(vmath.vector3(2, 2, 2), vmath.vector3(1, 1, 1))\n"
+            "    gui.set_id(n2, \"n2\")\n"
+            "    local n3 = gui.new_box_node(vmath.vector3(3, 3, 3), vmath.vector3(1, 1, 1))\n"
+            "    gui.set_id(n3, \"n3\")\n"
+            "    local n4 = gui.new_text_node(vmath.vector3(3, 3, 3), \"TEST\")\n"
+            "    gui.set_id(n4, \"n4\")\n"
+            "    gui.set_parent(n2, n1)\n"
+            "    gui.set_parent(n3, n2)\n"
+            "    gui.set_parent(n4, n3)\n"
+            "    local t = gui.get_tree(n1)\n"
+            "    assert(t.n1 == n1)\n"
+            "    assert(t.n2 == n2)\n"
+            "    assert(t.n3 == n3)\n"
+            "    assert(t.n4 == n4)\n"
+            "end\n";
+
+    dmGui::Result result = SetScript(script, LuaSourceFromStr(src));
+    ASSERT_EQ(dmGui::RESULT_OK, result);
+
+    result = dmGui::InitScene(scene);
+    ASSERT_EQ(dmGui::RESULT_OK, result);
+
+    dmGui::DeleteScene(scene);
+
+    dmGui::DeleteScript(script);
+}
+
 TEST_F(dmGuiScriptTest, TestPieNodeScript)
 {
     dmGui::HScript script = NewScript(m_Context);


### PR DESCRIPTION
Added `gui.get_tree(node)` to get a table with a node and all of its children, exactly like `gui.clone_tree()` does, but without creating any new nodes.

```
local foo = gui.get_node("foo")
local tree = gui.get_tree(foo)
for id,node in pairs(tree) do
    print(id, node)
end
```

Fixes #7736 

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
