### PR TITLE
Show model's Vertex Count in profiler for models in Local Vector Space

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -578,6 +578,9 @@ namespace dmGameSystem
             ro.m_IndexBuffer = buffers->m_IndexBuffer;              // May be 0
             ro.m_IndexType = buffers->m_IndexBufferElementType;
 
+            DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, ro.m_VertexCount);
+            DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, ro.m_VertexCount * sizeof(dmRig::RigModelVertex)); 
+
             for(uint32_t i = 0; i < MAX_TEXTURE_COUNT; ++i)
             {
                 ro.m_Textures[i] = GetTexture(component, component->m_Resource, i);

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -47,6 +47,7 @@
 
 DM_PROPERTY_EXTERN(rmtp_Components);
 DM_PROPERTY_U32(rmtp_Model, 0, FrameReset, "# components", &rmtp_Components);
+DM_PROPERTY_U32(rmtp_ModelIndexCount, 0, FrameReset, "# indices", &rmtp_Model);
 DM_PROPERTY_U32(rmtp_ModelVertexCount, 0, FrameReset, "# vertices", &rmtp_Model);
 DM_PROPERTY_U32(rmtp_ModelVertexSize, 0, FrameReset, "size of vertices in bytes", &rmtp_Model);
 
@@ -578,8 +579,9 @@ namespace dmGameSystem
             ro.m_IndexBuffer = buffers->m_IndexBuffer;              // May be 0
             ro.m_IndexType = buffers->m_IndexBufferElementType;
 
-            DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, ro.m_VertexCount);
-            DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, ro.m_VertexCount * sizeof(dmRig::RigModelVertex)); 
+            DM_PROPERTY_ADD_U32(rmtp_ModelIndexCount, buffers->m_IndexCount);
+            DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, buffers->m_VertexCount);
+            DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, buffers->m_VertexCount * sizeof(dmRig::RigModelVertex)); 
 
             for(uint32_t i = 0; i < MAX_TEXTURE_COUNT; ++i)
             {


### PR DESCRIPTION
Fix issue when models with Vector Space `Local` in its material aren't taken into account by the profiler.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
