### PR TITLE
Build remote engine and tasks in parallel

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -119,7 +119,7 @@ public class Project {
         ENCRYPTED
     }
 
-    private ExecutorService executor = Executors.newFixedThreadPool(10);
+    private ExecutorService executor = Executors.newCachedThreadPool();
     private ResourceCache resourceCache = new ResourceCache();
     private IFileSystem fileSystem;
     private Map<String, Class<? extends Builder<?>>> extToBuilder = new HashMap<String, Class<? extends Builder<?>>>();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1402,6 +1402,9 @@ public class Project {
                     }
 
                     if (remoteBuildFuture != null) {
+                        // get the result from the remote build and catch
+                        // if an exception was thrown in buildRemoteEngine() the
+                        // original exception is included in the ExecutionException
                         try {
                             remoteBuildFuture.get();
                         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -46,6 +46,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.ExecutionException;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -114,6 +119,7 @@ public class Project {
         ENCRYPTED
     }
 
+    private ExecutorService executor = Executors.newFixedThreadPool(10);
     private ResourceCache resourceCache = new ResourceCache();
     private IFileSystem fileSystem;
     private Map<String, Class<? extends Builder<?>>> extToBuilder = new HashMap<String, Class<? extends Builder<?>>>();
@@ -158,7 +164,7 @@ public class Project {
 
     // For the editor
     public Project(ClassLoader loader, IFileSystem fileSystem, String sourceRootDirectory, String buildDirectory) {
-        classLoader = loader;
+        this.classLoader = loader;
         this.rootDirectory = normalizeNoEndSeparator(new File(sourceRootDirectory).getAbsolutePath(), true);
         this.buildDirectory = normalizeNoEndSeparator(buildDirectory, true);
         this.fileSystem = fileSystem;
@@ -876,7 +882,7 @@ public class Project {
         throw new CompileExceptionError(null, -1, String.format("No shader compiler registered for platform %s", platform.getPair()));
     }
 
-    private static boolean anyFailing(Collection<TaskResult> results) {
+    private boolean anyFailing(Collection<TaskResult> results) {
         for (TaskResult taskResult : results) {
             if (!taskResult.isOk()) {
                 return true;
@@ -1189,6 +1195,163 @@ public class Project {
         scan(scanner, "com.defold.extension.pipeline");
     }
 
+    private Future buildRemoteEngine(IProgress monitor, ExecutorService executor) {
+        Callable<Void> callable = new Callable<>() {
+            public Void call() throws Exception {
+                logInfo("Build Remote Engine...");
+                TimeProfiler.start("Build Remote Engine");
+                final String variant = option("variant", Bob.VARIANT_RELEASE);
+                final Boolean withSymbols = hasOption("with-symbols");
+
+                Map<String, String> appmanifestOptions = new HashMap<>();
+                appmanifestOptions.put("baseVariant", variant);
+                appmanifestOptions.put("withSymbols", withSymbols.toString());
+
+                TimeProfiler.addData("withSymbols", withSymbols);
+                TimeProfiler.addData("variant", variant);
+
+                if (hasOption("build-artifacts")) {
+                    String s = option("build-artifacts", "");
+                    System.out.printf("build-artifacts: %s\n", s);
+                    appmanifestOptions.put("buildArtifacts", s);
+                }
+
+                Platform platform = getPlatform();
+
+                String[] architectures = platform.getArchitectures().getDefaultArchitectures();
+                String customArchitectures = option("architectures", null);
+                if (customArchitectures != null) {
+                    architectures = customArchitectures.split(",");
+                }
+
+                long tstart = System.currentTimeMillis();
+
+                buildEngine(monitor, architectures, appmanifestOptions);
+
+                long tend = System.currentTimeMillis();
+                logger.info("Engine build took %f s", (tend-tstart)/1000.0);
+                TimeProfiler.stop();
+
+                return (Void)null;
+            }
+        };
+        return executor.submit(callable);
+    }
+
+    private List<TaskResult> createAndRunTasks(IProgress monitor) throws IOException, CompileExceptionError {
+        // Do early test if report files are writable before we start building
+        boolean generateReport = this.hasOption("build-report") || this.hasOption("build-report-html");
+        FileWriter resourceReportJSONWriter = null;
+        FileWriter resourceReportHTMLWriter = null;
+        FileWriter excludedResourceReportJSONWriter = null;
+        FileWriter excludedResourceReportHTMLWriter = null;
+
+        if (this.hasOption("build-report")) {
+            String resourceReportJSONPath = this.option("build-report", "report.json");
+
+            File resourceReportJSONFile = new File(resourceReportJSONPath);
+            File resourceReportJSONFolder = resourceReportJSONFile.getParentFile();
+            resourceReportJSONWriter = new FileWriter(resourceReportJSONFile);
+
+            String excludedResourceReportJSONName = "excluded_" + resourceReportJSONFile.getName();
+            File excludedResourceReportJSONFile = new File(resourceReportJSONFolder, excludedResourceReportJSONName);
+            excludedResourceReportJSONWriter = new FileWriter(excludedResourceReportJSONFile);
+        }
+        if (this.hasOption("build-report-html")) {
+            String resourceReportHTMLPath = this.option("build-report-html", "report.html");
+            File resourceReportHTMLFile = new File(resourceReportHTMLPath);
+
+            File resourceReportHTMLFolder = resourceReportHTMLFile.getParentFile();
+            resourceReportHTMLWriter = new FileWriter(resourceReportHTMLFile);
+
+            String excludedResourceReportHTMLName = "excluded_" + resourceReportHTMLFile.getName();
+            File excludedResourceReportHTMLFile = new File(resourceReportHTMLFolder, excludedResourceReportHTMLName);
+            excludedResourceReportHTMLWriter = new FileWriter(excludedResourceReportHTMLFile);
+        }
+
+        IProgress m = monitor.subProgress(99);
+
+        IProgress mrep = m.subProgress(1);
+        mrep.beginTask("Reading tasks...", 1);
+        TimeProfiler.start("Create tasks");
+        BundleHelper.throwIfCanceled(monitor);
+        pruneSources();
+        createTasks();
+        validateBuildResourceMapping();
+        TimeProfiler.addData("TasksCount", tasks.size());
+        TimeProfiler.stop();
+        mrep.done();
+
+        BundleHelper.throwIfCanceled(monitor);
+        m.beginTask("Building...", tasks.size());
+        TimeProfiler.start("Build tasks");
+        TimeProfiler.addData("TasksCount", tasks.size());
+
+        BundleHelper.throwIfCanceled(monitor);
+        List<TaskResult> result = runTasks(m);
+        BundleHelper.throwIfCanceled(monitor);
+        m.done();
+
+        TimeProfiler.stop();
+
+        // Generate and save build report
+        TimeProfiler.start("Generating build size report");
+        if (generateReport) {
+            mrep = monitor.subProgress(1);
+            mrep.beginTask("Generating report...", 1);
+            ReportGenerator rg = new ReportGenerator(this);
+            String resourceReportJSON = rg.generateResourceReportJSON();
+            String excludedResourceReportJSON = rg.generateExcludedResourceReportJSON();
+
+            // Save JSON report
+            if (this.hasOption("build-report")) {
+                resourceReportJSONWriter.write(resourceReportJSON);
+                resourceReportJSONWriter.close();
+                excludedResourceReportJSONWriter.write(excludedResourceReportJSON);
+                excludedResourceReportJSONWriter.close();
+            }
+
+            // Save HTML report
+            if (this.hasOption("build-report-html")) {
+                String resourceReportHTML = rg.generateHTML(resourceReportJSON);
+                String excludedResourceReportHTML = rg.generateHTML(excludedResourceReportJSON);
+                resourceReportHTMLWriter.write(resourceReportHTML);
+                resourceReportHTMLWriter.close();
+                excludedResourceReportHTMLWriter.write(excludedResourceReportHTML);
+                excludedResourceReportHTMLWriter.close();
+            }
+            mrep.done();
+        }
+        TimeProfiler.stop();
+
+        return result;
+    }
+
+    private void clean(IProgress monitor, State state) {
+        IProgress m = monitor.subProgress(1);
+        List<String> paths = state.getPaths();
+        m.beginTask("Cleaning...", paths.size());
+        for (String path : paths) {
+            File f = new File(path);
+            if (f.exists()) {
+                state.removeSignature(path);
+                f.delete();
+                m.worked(1);
+                BundleHelper.throwIfCanceled(monitor);
+            }
+        }
+        m.done();
+    }
+
+    private void distClean(IProgress monitor) throws IOException {
+        IProgress m = monitor.subProgress(1);
+        m.beginTask("Cleaning...", 1);
+        BundleHelper.throwIfCanceled(monitor);
+        FileUtils.deleteDirectory(new File(FilenameUtils.concat(rootDirectory, buildDirectory)));
+        m.worked(1);
+        m.done();
+    }
+
     private List<TaskResult> doBuild(IProgress monitor, String... commands) throws IOException, CompileExceptionError, MultipleCompileException {
         resourceCache.init(getLocalResourceCacheDirectory(), getRemoteResourceCacheDirectory());
         resourceCache.setRemoteAuthentication(getRemoteResourceCacheUser(), getRemoteResourceCachePass());
@@ -1217,173 +1380,47 @@ public class Project {
                 case "build": {
                     ExtenderUtil.checkProjectForDuplicates(this); // Throws if there are duplicate files in the project (i.e. library and local files conflict)
 
-                    final Boolean withSymbols = this.hasOption("with-symbols");
                     final String[] platforms = getPlatformStrings();
+                    Future<Void> remoteBuildFuture = null;
                     // Get or build engine binary
-                    boolean buildRemoteEngine = ExtenderUtil.hasNativeExtensions(this);
-                    if (buildRemoteEngine) {
-                        logInfo("Build Remote Engine...");
-                        TimeProfiler.start("Build Remote Engine");
-                        final String variant = this.option("variant", Bob.VARIANT_RELEASE);
-
-                        Map<String, String> appmanifestOptions = new HashMap<>();
-                        appmanifestOptions.put("baseVariant", variant);
-                        appmanifestOptions.put("withSymbols", withSymbols.toString());
-
-                        TimeProfiler.addData("withSymbols", withSymbols);
-                        TimeProfiler.addData("variant", variant);
-
-                        if (this.hasOption("build-artifacts")) {
-                            String s = this.option("build-artifacts", "");
-                            System.out.printf("build-artifacts: %s\n", s);
-                            appmanifestOptions.put("buildArtifacts", s);
-                        }
-
-                        Platform platform = this.getPlatform();
-
-                        String[] architectures = platform.getArchitectures().getDefaultArchitectures();
-                        String customArchitectures = this.option("architectures", null);
-                        if (customArchitectures != null) {
-                            architectures = customArchitectures.split(",");
-                        }
-
-                        long tstart = System.currentTimeMillis();
-
-                        buildEngine(monitor, architectures, appmanifestOptions);
-
-                        long tend = System.currentTimeMillis();
-                        logger.info("Engine build took %f s", (tend-tstart)/1000.0);
-                        TimeProfiler.stop();
-
-                        if (!shouldBuildEngine()) {
-                            // If we only wanted to build the extensions, we simply continue here
-                            continue;
-                        }
-
-                    } else {
+                    boolean shouldBuildRemoteEngine = ExtenderUtil.hasNativeExtensions(this);
+                    if (shouldBuildRemoteEngine) {
+                        remoteBuildFuture = buildRemoteEngine(monitor, executor);
+                    }
+                    else {
                         // Remove the remote built executables in the build folder, they're still in the cache
                         cleanEngines(monitor, platforms);
-                        if (withSymbols) {
+                        if (hasOption("with-symbols")) {
                             IProgress progress = monitor.subProgress(1);
                             downloadSymbols(progress);
                             progress.done();
                         }
                     }
 
-                    BundleHelper.throwIfCanceled(monitor);
-
-                    // Do early test if report files are writable before we start building
-                    boolean generateReport = this.hasOption("build-report") || this.hasOption("build-report-html");
-                    FileWriter resourceReportJSONWriter = null;
-                    FileWriter resourceReportHTMLWriter = null;
-                    FileWriter excludedResourceReportJSONWriter = null;
-                    FileWriter excludedResourceReportHTMLWriter = null;
-
-                    if (this.hasOption("build-report")) {
-                        String resourceReportJSONPath = this.option("build-report", "report.json");
-
-                        File resourceReportJSONFile = new File(resourceReportJSONPath);
-                        File resourceReportJSONFolder = resourceReportJSONFile.getParentFile();
-                        resourceReportJSONWriter = new FileWriter(resourceReportJSONFile);
-
-                        String excludedResourceReportJSONName = "excluded_" + resourceReportJSONFile.getName();
-                        File excludedResourceReportJSONFile = new File(resourceReportJSONFolder, excludedResourceReportJSONName);
-                        excludedResourceReportJSONWriter = new FileWriter(excludedResourceReportJSONFile);
-                    }
-                    if (this.hasOption("build-report-html")) {
-                        String resourceReportHTMLPath = this.option("build-report-html", "report.html");
-                        File resourceReportHTMLFile = new File(resourceReportHTMLPath);
-
-                        File resourceReportHTMLFolder = resourceReportHTMLFile.getParentFile();
-                        resourceReportHTMLWriter = new FileWriter(resourceReportHTMLFile);
-
-                        String excludedResourceReportHTMLName = "excluded_" + resourceReportHTMLFile.getName();
-                        File excludedResourceReportHTMLFile = new File(resourceReportHTMLFolder, excludedResourceReportHTMLName);
-                        excludedResourceReportHTMLWriter = new FileWriter(excludedResourceReportHTMLFile);
+                    if (shouldBuildEngine()) {
+                        result = createAndRunTasks(monitor);
                     }
 
-                    IProgress m = monitor.subProgress(99);
-
-                    IProgress mrep = m.subProgress(1);
-                    mrep.beginTask("Reading tasks...", 1);
-                    TimeProfiler.start("Create tasks");
-                    pruneSources();
-                    createTasks();
-                    validateBuildResourceMapping();
-                    TimeProfiler.addData("TasksCount", tasks.size());
-                    TimeProfiler.stop();
-                    mrep.done();
-
-                    BundleHelper.throwIfCanceled(monitor);
-                    m.beginTask("Building...", tasks.size());
-                    TimeProfiler.start("Build tasks");
-                    TimeProfiler.addData("TasksCount", tasks.size());
-
-                    result = runTasks(m);
-                    m.done();
-
-                    TimeProfiler.stop();
+                    if (remoteBuildFuture != null) {
+                        try {
+                            remoteBuildFuture.get();
+                        }
+                        catch (ExecutionException|InterruptedException e) {
+                            throw new CompileExceptionError(e.getCause());
+                        }
+                    }
 
                     if (anyFailing(result)) {
                         break loop;
                     }
-                    BundleHelper.throwIfCanceled(monitor);
-
-                    // Generate and save build report
-                    TimeProfiler.start("Generating build size report");
-                    if (generateReport) {
-                        mrep = monitor.subProgress(1);
-                        mrep.beginTask("Generating report...", 1);
-                        ReportGenerator rg = new ReportGenerator(this);
-                        String resourceReportJSON = rg.generateResourceReportJSON();
-                        String excludedResourceReportJSON = rg.generateExcludedResourceReportJSON();
-
-                        // Save JSON report
-                        if (this.hasOption("build-report")) {
-                            resourceReportJSONWriter.write(resourceReportJSON);
-                            resourceReportJSONWriter.close();
-                            excludedResourceReportJSONWriter.write(excludedResourceReportJSON);
-                            excludedResourceReportJSONWriter.close();
-                        }
-
-                        // Save HTML report
-                        if (this.hasOption("build-report-html")) {
-                            String resourceReportHTML = rg.generateHTML(resourceReportJSON);
-                            String excludedResourceReportHTML = rg.generateHTML(excludedResourceReportJSON);
-                            resourceReportHTMLWriter.write(resourceReportHTML);
-                            resourceReportHTMLWriter.close();
-                            excludedResourceReportHTMLWriter.write(excludedResourceReportHTML);
-                            excludedResourceReportHTMLWriter.close();
-                        }
-                        mrep.done();
-                    }
-                    TimeProfiler.stop();
-
                     break;
                 }
                 case "clean": {
-                    IProgress m = monitor.subProgress(1);
-                    List<String> paths = state.getPaths();
-                    m.beginTask("Cleaning...", paths.size());
-                    for (String path : paths) {
-                        File f = new File(path);
-                        if (f.exists()) {
-                            state.removeSignature(path);
-                            f.delete();
-                            m.worked(1);
-                            BundleHelper.throwIfCanceled(monitor);
-                        }
-                    }
-                    m.done();
+                    clean(monitor, state);
                     break;
                 }
                 case "distclean": {
-                    IProgress m = monitor.subProgress(1);
-                    m.beginTask("Cleaning...", 1);
-                    BundleHelper.throwIfCanceled(monitor);
-                    FileUtils.deleteDirectory(new File(FilenameUtils.concat(rootDirectory, buildDirectory)));
-                    m.worked(1);
-                    m.done();
+                    distClean(monitor);
                     break;
                 }
                 case "bundle": {


### PR DESCRIPTION
This change moves the engine build to a separate thread so that the engine and game assets can be built in parallel. This change can reduce the build time for a project with many native extensions by anywhere from 5 seconds to several minutes.

<img width="867" alt="Screenshot 2023-06-22 at 14 53 14" src="https://github.com/defold/defold/assets/1300688/9aca879c-eea9-4b26-a8dc-808aa840669e">

Fixes #6897 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
