### PR TITLE
Make sure to call the gui flipbook animation callback on single frame animations

### DIFF
--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -3788,9 +3788,17 @@ Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
         }
 
         if(n->m_Node.m_TextureSetAnimDesc.m_State.m_Playback == PLAYBACK_NONE)
+        {
             CancelAnimationComponent(scene, node, &n->m_Node.m_FlipbookAnimPosition);
+            if (anim_complete_callback != 0x0)
+            {
+                anim_complete_callback(scene, node, true, callback_userdata1, callback_userdata2);
+            }
+        }
         else
+        {
             AnimateTextureSetAnim(scene, node, offset, playback_rate, anim_complete_callback, callback_userdata1, callback_userdata2);
+        }
         CalculateNodeSize(n);
         return RESULT_OK;
     }


### PR DESCRIPTION
Since Defold 1.3.1 single images in an atlas are not treated as implicit flipbook animations in a gui. This change saves resources, but it also has the unfortunate side-effect that calling `gui.play_flipbook()` on a single image will not invoke the callback if one is passed to `gui.play_flipbook()`.

Fixes #7758 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
