### PR TITLE
Add view, projection and aspect_ratio as camera properties

### DIFF
--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -182,6 +182,7 @@ namespace dmGameObject
      * @member dmGameObject::PROPERTY_RESULT_RESOURCE_NOT_FOUND
      * @member dmGameObject::PROPERTY_RESULT_INVALID_INDEX
      * @member dmGameObject::PROPERTY_RESULT_INVALID_KEY
+     * @member dmGameObject::PROPERTY_RESULT_READ_ONLY
      */
     enum PropertyResult
     {
@@ -198,6 +199,7 @@ namespace dmGameObject
         PROPERTY_RESULT_RESOURCE_NOT_FOUND = -10,
         PROPERTY_RESULT_INVALID_INDEX = -11,
         PROPERTY_RESULT_INVALID_KEY = -12,
+        PROPERTY_RESULT_READ_ONLY = -13,
     };
 
     /*#

--- a/engine/gameobject/src/dmsdk/gameobject/gameobject.h
+++ b/engine/gameobject/src/dmsdk/gameobject/gameobject.h
@@ -552,7 +552,7 @@ namespace dmGameObject
      * @param instance [type: dmGameObject::HInstance] Instance
      * @param component_index [type: uint16_t] Component index
      * @param component_id [type: dmhash_t* Component id as out-argument
-     * @return result [type: dmGameObject::Result] RESULT_OK if the comopnent was found
+     * @return result [type: dmGameObject::Result] RESULT_OK if the component was found
      */
     Result GetComponentId(HInstance instance, uint16_t component_index, dmhash_t* component_id);
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -902,6 +902,10 @@ namespace dmGameObject
                 }
                 return luaL_error(L, "'%s' does not have any property called '%s'", name, dmHashReverseSafe64(property_id));
             }
+        case PROPERTY_RESULT_READ_ONLY:
+            {
+                return luaL_error(L, "Unable to set the property '%s' since it is read only", dmHashReverseSafe64(property_id));
+            }
         case PROPERTY_RESULT_UNSUPPORTED_TYPE:
         case PROPERTY_RESULT_TYPE_MISMATCH:
             {

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -170,3 +170,56 @@ message ReleaseCameraFocus {}
  * end
  * ```
  */
+
+/*# [type:float] camera projection
+ *
+ * [mark:READ ONLY] The calcualted projection matrix of the camera.
+ * The type of the property is matrix4.
+ *
+ * @name projection
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local projection = go.get("#camera", "projection")
+ * end
+ * ```
+ */
+
+/*# [type:float] camera view
+ *
+ * [mark:READ ONLY] The calcualted view matrix of the camera.
+ * The type of the property is matrix4.
+ *
+ * @name view
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local view = go.get("#camera", "view")
+ * end
+ * ```
+ */
+
+/*# [type:float] camera aspect ratio
+ *
+ * The aspect ratio of the camera. Used when calculating the
+ * projection of a perspective camera.
+ * The type of the property is number.
+ *
+ * @name aspect_ratio
+ * @property
+ *
+ * @examples
+ *
+ * ```lua
+ * function init(self)
+ *   local aspect_ratio = go.get("#camera", "aspect_ratio")
+ *   go.set("#camera", "aspect_ratio", 1.2)
+ * end
+ * ```
+ */

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -173,7 +173,7 @@ message ReleaseCameraFocus {}
 
 /*# [type:float] camera projection
  *
- * [mark:READ ONLY] The calcualted projection matrix of the camera.
+ * [mark:READ ONLY] The calculated projection matrix of the camera.
  * The type of the property is matrix4.
  *
  * @name projection
@@ -190,7 +190,7 @@ message ReleaseCameraFocus {}
 
 /*# [type:float] camera view
  *
- * [mark:READ ONLY] The calcualted view matrix of the camera.
+ * [mark:READ ONLY] The calculated view matrix of the camera.
  * The type of the property is matrix4.
  *
  * @name view

--- a/engine/gamesys/proto/gamesys/camera_ddf.proto
+++ b/engine/gamesys/proto/gamesys/camera_ddf.proto
@@ -207,7 +207,7 @@ message ReleaseCameraFocus {}
 
 /*# [type:float] camera aspect ratio
  *
- * The aspect ratio of the camera. Used when calculating the
+ * The ratio between the frustum width and height. Used when calculating the
  * projection of a perspective camera.
  * The type of the property is number.
  *

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -390,6 +390,12 @@ namespace dmGameSystem
             component->m_AspectRatio = params.m_Value.m_Number;
             return dmGameObject::PROPERTY_RESULT_OK;
         }
+        else if ((CAMERA_PROP_PROJECTION == set_property)
+            || (CAMERA_PROP_VIEW == set_property)
+            || (CAMERA_PROP_ASPECT_RATIO == set_property))
+        {
+            return dmGameObject::PROPERTY_RESULT_READ_ONLY;
+        }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 }

--- a/engine/gamesys/src/gamesys/components/comp_camera.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_camera.cpp
@@ -49,6 +49,8 @@ namespace dmGameSystem
         float m_NearZ;
         float m_FarZ;
         float m_OrthographicZoom;
+        dmVMath::Matrix4 m_View;
+        dmVMath::Matrix4 m_Projection;
         uint32_t m_AutoAspectRatio : 1;
         uint32_t m_AddedToUpdate : 1;
         uint32_t m_OrthographicProjection : 1;
@@ -65,6 +67,46 @@ namespace dmGameSystem
     static const dmhash_t CAMERA_PROP_NEAR_Z = dmHashString64("near_z");
     static const dmhash_t CAMERA_PROP_FAR_Z = dmHashString64("far_z");
     static const dmhash_t CAMERA_PROP_ORTHOGRAPHIC_ZOOM = dmHashString64("orthographic_zoom");
+    static const dmhash_t CAMERA_PROP_PROJECTION = dmHashString64("projection");
+    static const dmhash_t CAMERA_PROP_VIEW = dmHashString64("view");
+    static const dmhash_t CAMERA_PROP_ASPECT_RATIO = dmHashString64("aspect_ratio");
+
+
+    void CompCameraUpdateViewProjection(CameraComponent* camera, dmRender::RenderContext* render_context)
+    {
+        float width = (float)dmGraphics::GetWindowWidth(dmRender::GetGraphicsContext(render_context));
+        float height = (float)dmGraphics::GetWindowHeight(dmRender::GetGraphicsContext(render_context));
+
+        float aspect_ratio = camera->m_AspectRatio;
+        if (camera->m_AutoAspectRatio)
+        {
+            aspect_ratio = width / height;
+        }
+
+        dmVMath::Point3 pos = dmGameObject::GetWorldPosition(camera->m_Instance);
+        if (camera->m_OrthographicProjection)
+        {
+            float display_scale = dmGraphics::GetDisplayScaleFactor(dmRender::GetGraphicsContext(render_context));
+            float zoom = camera->m_OrthographicZoom;
+            float zoomed_width = width / display_scale / zoom;
+            float zoomed_height = height / display_scale / zoom;
+
+            float left = -zoomed_width / 2;
+            float right = zoomed_width / 2;
+            float bottom = -zoomed_height / 2;
+            float top = zoomed_height / 2;
+            camera->m_Projection = Matrix4::orthographic(left, right, bottom, top, camera->m_NearZ, camera->m_FarZ);
+        }
+        else
+        {
+            camera->m_Projection = Matrix4::perspective(camera->m_Fov, aspect_ratio, camera->m_NearZ, camera->m_FarZ);
+        }
+
+        dmVMath::Quat rot = dmGameObject::GetWorldRotation(camera->m_Instance);
+        Point3 look_at = pos + dmVMath::Rotate(rot, dmVMath::Vector3(0.0f, 0.0f, -1.0f));
+        Vector3 up = dmVMath::Rotate(rot, dmVMath::Vector3(0.0f, 1.0f, 0.0f));
+        camera->m_View = Matrix4::lookAt(pos, look_at, up);
+    }
 
     dmGameObject::CreateResult CompCameraNewWorld(const dmGameObject::ComponentNewWorldParams& params)
     {
@@ -103,6 +145,8 @@ namespace dmGameSystem
         camera.m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
         camera.m_AddedToUpdate = 0;
         camera.m_ComponentIndex = params.m_ComponentIndex;
+        dmRender::RenderContext* render_context = (dmRender::RenderContext*)params.m_Context;
+        CompCameraUpdateViewProjection(&camera, render_context);
         w->m_Cameras.Push(camera);
         *params.m_UserData = (uintptr_t)&w->m_Cameras[w->m_Cameras.Size() - 1];
         return dmGameObject::CREATE_RESULT_OK;
@@ -158,47 +202,15 @@ namespace dmGameSystem
         if (camera != 0x0 && camera->m_AddedToUpdate)
         {
             dmRender::RenderContext* render_context = (dmRender::RenderContext*)params.m_Context;
-            float width = (float)dmGraphics::GetWindowWidth(dmRender::GetGraphicsContext(render_context));
-            float height = (float)dmGraphics::GetWindowHeight(dmRender::GetGraphicsContext(render_context));
-
-            float aspect_ratio = camera->m_AspectRatio;
-            if (camera->m_AutoAspectRatio)
-            {
-                aspect_ratio = width / height;
-            }
-
-            dmVMath::Point3 pos = dmGameObject::GetWorldPosition(camera->m_Instance);
-            dmVMath::Matrix4 projection;
-            if (camera->m_OrthographicProjection)
-            {
-                float display_scale = dmGraphics::GetDisplayScaleFactor(dmRender::GetGraphicsContext(render_context));
-                float zoom = camera->m_OrthographicZoom;
-                float zoomed_width = width / display_scale / zoom;
-                float zoomed_height = height / display_scale / zoom;
-
-                float left = -zoomed_width / 2;
-                float right = zoomed_width / 2;
-                float bottom = -zoomed_height / 2;
-                float top = zoomed_height / 2;
-                projection = Matrix4::orthographic(left, right, bottom, top, camera->m_NearZ, camera->m_FarZ);
-            }
-            else
-            {
-                projection = Matrix4::perspective(camera->m_Fov, aspect_ratio, camera->m_NearZ, camera->m_FarZ);
-            }
-
-            dmVMath::Quat rot = dmGameObject::GetWorldRotation(camera->m_Instance);
-            Point3 look_at = pos + dmVMath::Rotate(rot, dmVMath::Vector3(0.0f, 0.0f, -1.0f));
-            Vector3 up = dmVMath::Rotate(rot, dmVMath::Vector3(0.0f, 1.0f, 0.0f));
-            dmVMath::Matrix4 view = Matrix4::lookAt(pos, look_at, up);
+            CompCameraUpdateViewProjection(camera, render_context);
 
             // Send the matrices to the render script
 
             dmhash_t message_id = dmGameSystemDDF::SetViewProjection::m_DDFDescriptor->m_NameHash;
 
             dmGameSystemDDF::SetViewProjection set_view_projection;
-            set_view_projection.m_View = view;
-            set_view_projection.m_Projection = projection;
+            set_view_projection.m_View = camera->m_View;
+            set_view_projection.m_Projection = camera->m_Projection;
 
             dmGameObject::Result go_result = dmGameObject::GetComponentId(camera->m_Instance, camera->m_ComponentIndex, &set_view_projection.m_Id);
             if (go_result != dmGameObject::RESULT_OK)
@@ -221,8 +233,8 @@ namespace dmGameSystem
             // JG: What does this TODO mean here?
             // Set matrices immediately
             // TODO: Remove this once render scripts are implemented everywhere
-            dmRender::SetProjectionMatrix(render_context, projection);
-            dmRender::SetViewMatrix(render_context, view);
+            dmRender::SetProjectionMatrix(render_context, camera->m_Projection);
+            dmRender::SetViewMatrix(render_context, camera->m_View);
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -301,6 +313,8 @@ namespace dmGameSystem
         camera->m_AutoAspectRatio = cam_resource->m_DDF->m_AutoAspectRatio != 0;
         camera->m_OrthographicProjection = cam_resource->m_DDF->m_OrthographicProjection != 0;
         camera->m_OrthographicZoom = cam_resource->m_DDF->m_OrthographicZoom;
+        dmRender::RenderContext* render_context = (dmRender::RenderContext*)params.m_Context;
+        CompCameraUpdateViewProjection(camera, render_context);
     }
 
     dmGameObject::PropertyResult CompCameraGetProperty(const dmGameObject::ComponentGetPropertyParams& params, dmGameObject::PropertyDesc& out_value)
@@ -326,6 +340,21 @@ namespace dmGameSystem
         else if (CAMERA_PROP_ORTHOGRAPHIC_ZOOM == get_property)
         {
             out_value.m_Variant = dmGameObject::PropertyVar(component->m_OrthographicZoom);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_PROJECTION == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_Projection);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_VIEW == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_View);
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_ASPECT_RATIO == get_property)
+        {
+            out_value.m_Variant = dmGameObject::PropertyVar(component->m_AspectRatio);
             return dmGameObject::PROPERTY_RESULT_OK;
         }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
@@ -354,6 +383,11 @@ namespace dmGameSystem
         else if (CAMERA_PROP_ORTHOGRAPHIC_ZOOM == set_property)
         {
             component->m_OrthographicZoom = params.m_Value.m_Number;
+            return dmGameObject::PROPERTY_RESULT_OK;
+        }
+        else if (CAMERA_PROP_ASPECT_RATIO == set_property)
+        {
+            component->m_AspectRatio = params.m_Value.m_Number;
             return dmGameObject::PROPERTY_RESULT_OK;
         }
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -1277,53 +1277,92 @@ namespace dmGameSystem
         CollisionComponent* component = (CollisionComponent*)*params.m_UserData;
         PhysicsContext* physics_context = (PhysicsContext*)params.m_Context;
 
-        if (params.m_PropertyId == PROP_LINEAR_VELOCITY) {
+        if (params.m_PropertyId == PROP_LINEAR_VELOCITY)
+        {
             if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR3)
+            {
                 return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
-            if (physics_context->m_3D) {
+            }
+            if (physics_context->m_3D)
+            {
                 dmPhysics::SetLinearVelocity3D(physics_context->m_Context3D, component->m_Object3D, dmVMath::Vector3(params.m_Value.m_V4[0], params.m_Value.m_V4[1], params.m_Value.m_V4[2]));
-            } else {
+            }
+            else
+            {
                 dmPhysics::SetLinearVelocity2D(physics_context->m_Context2D, component->m_Object2D, dmVMath::Vector3(params.m_Value.m_V4[0], params.m_Value.m_V4[1], params.m_Value.m_V4[2]));
             }
             return dmGameObject::PROPERTY_RESULT_OK;
-        } else if (params.m_PropertyId == PROP_ANGULAR_VELOCITY) {
+        }
+        else if (params.m_PropertyId == PROP_ANGULAR_VELOCITY)
+        {
             if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR3)
+            {
                 return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
-            if (physics_context->m_3D) {
+            }
+            if (physics_context->m_3D)
+            {
                 dmPhysics::SetAngularVelocity3D(physics_context->m_Context3D, component->m_Object3D, dmVMath::Vector3(params.m_Value.m_V4[0], params.m_Value.m_V4[1], params.m_Value.m_V4[2]));
-            } else {
+            }
+            else
+            {
                 dmPhysics::SetAngularVelocity2D(physics_context->m_Context2D, component->m_Object2D, dmVMath::Vector3(params.m_Value.m_V4[0], params.m_Value.m_V4[1], params.m_Value.m_V4[2]));
             }
             return dmGameObject::PROPERTY_RESULT_OK;
-        } else if (params.m_PropertyId == PROP_BULLET) {
+        }
+        else if (params.m_PropertyId == PROP_BULLET)
+        {
             if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_BOOLEAN)
+            {
                 return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
-            if (physics_context->m_3D) {
+            }
+            if (physics_context->m_3D)
+            {
                 dmLogWarning("'bullet' property not supported in 3d physics mode");
                 return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
-            } else {
+            }
+            else
+            {
                 dmPhysics::SetBullet2D(component->m_Object2D, params.m_Value.m_Bool);
             }
             return dmGameObject::PROPERTY_RESULT_OK;
-        } else if (params.m_PropertyId == PROP_LINEAR_DAMPING) {
+        }
+        else if (params.m_PropertyId == PROP_LINEAR_DAMPING) {
             if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER)
+            {
                 return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
-            if (physics_context->m_3D) {
+            }
+            if (physics_context->m_3D)
+            {
                 dmPhysics::SetLinearDamping3D(component->m_Object3D, params.m_Value.m_Number);
-            } else {
+            }
+            else
+            {
                 dmPhysics::SetLinearDamping2D(component->m_Object2D, params.m_Value.m_Number);
             }
             return dmGameObject::PROPERTY_RESULT_OK;
-        } else if (params.m_PropertyId == PROP_ANGULAR_DAMPING) {
+        }
+        else if (params.m_PropertyId == PROP_ANGULAR_DAMPING)
+        {
             if (params.m_Value.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER)
+            {
                 return dmGameObject::PROPERTY_RESULT_TYPE_MISMATCH;
-            if (physics_context->m_3D) {
+            }
+            if (physics_context->m_3D)
+            {
                 dmPhysics::SetAngularDamping3D(component->m_Object3D, params.m_Value.m_Number);
-            } else {
+            }
+            else
+            {
                 dmPhysics::SetAngularDamping2D(component->m_Object2D, params.m_Value.m_Number);
             }
             return dmGameObject::PROPERTY_RESULT_OK;
-        } else {
+        }
+        else if (params.m_PropertyId == PROP_MASS)
+        {
+            return dmGameObject::PROPERTY_RESULT_READ_ONLY;
+        }
+        else
+        {
             return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1442,6 +1442,10 @@ namespace dmGameSystem
             }
             return res;
         }
+        else if ((set_property == SPRITE_PROP_FRAME_COUNT) || (set_property == SPRITE_PROP_ANIMATION))
+        {
+            return dmGameObject::PROPERTY_RESULT_READ_ONLY;
+        }
         return SetMaterialConstant(GetMaterial(component, component->m_Resource), params.m_PropertyId, params.m_Value, params.m_Options.m_Index, CompSpriteSetConstantCallback, component);
     }
 


### PR DESCRIPTION
The view, projection and aspect ratio of a camera component are now available as properties on the component. The view and projection are read only using `go.get()`, while the aspect ratio can also be set using `go.set()`.

```lua
local view = go.get("#camera", "view")
local projection = go.get("#camera", "projection")
local aspect_ratio = go.get("#camera", "aspect_ratio")
go.set("#camera", "aspect_ratio", 1.4)
```

Fixes #7761 

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [x] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
