### PR TITLE
Check node existence before querying it on load

### DIFF
--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -278,14 +278,18 @@
                            [comp-node tx-data]
                            (if override?
                              (let [workspace (project/workspace project)]
-                               (when-some [{connect-tx-data :tx-data comp-node :node-id} (project/connect-resource-node evaluation-context project new-resource self [])]
+                               (when-some [{connect-tx-data :tx-data
+                                            comp-node :node-id
+                                            created-in-tx :created-in-tx} (project/connect-resource-node evaluation-context project new-resource self [])]
                                  [comp-node
                                   (concat
                                     connect-tx-data
                                     (g/override comp-node {:traverse-fn g/always-override-traverse-fn}
                                                 (fn [evaluation-context id-mapping]
                                                   (let [or-comp-node (get id-mapping comp-node)
-                                                        comp-props (:properties (g/node-value comp-node :_properties evaluation-context))]
+                                                        comp-props (if created-in-tx
+                                                                     {}
+                                                                     (:properties (g/node-value comp-node :_properties evaluation-context)))]
                                                     (concat
                                                       (let [outputs (g/output-labels (:node-type (resource/resource-type new-resource)))]
                                                         (for [[from to] [[:_node-id :source-id]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -1252,12 +1252,17 @@
                          (g/delete-node current-scene)
                          [])
                        (if (and new-value (:resource new-value))
-                         (when-some [{connect-tx-data :tx-data scene-node :node-id} (project/connect-resource-node evaluation-context project (:resource new-value) self [])]
+                         (when-some [{connect-tx-data :tx-data
+                                      scene-node :node-id
+                                      created-in-tx :created-in-tx} (project/connect-resource-node evaluation-context project (:resource new-value) self [])]
                            (concat
                              connect-tx-data
                              (let [properties-by-node-id (comp (or (:overrides new-value) {})
-                                                               (into {} (map (fn [[k v]] [v k]))
-                                                                     (g/node-value scene-node :node-ids evaluation-context)))]
+                                                               (into {}
+                                                                     (map (fn [[k v]] [v k]))
+                                                                     (if created-in-tx
+                                                                       {}
+                                                                       (g/node-value scene-node :node-ids evaluation-context))))]
                                ;; TODO: Check if we can filter based on connection label instead of source-node-id to be able to share :traverse-fn with other overrides.
                                (g/override scene-node {:traverse-fn (g/make-override-traverse-fn
                                                                       (fn [basis ^Arc arc]


### PR DESCRIPTION
Technical notes:
The problem is that `editor.defold-project/connect-resource-node` might return a node id for a node that does not yet exist in the system in case where it has to create a new node. We cannot query such nodes using `g/node-value` because they don't exist yet. Users of `connect-resource-node` first need to check that the node already exists if they want to use `g/node-value` on it.

User-facing changes:
Projects that previously couldn't be opened due to broken resource references in files now can be opened.

Fixes #7174
