### PR TITLE
Particle effects crashfix

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -34,6 +34,7 @@
 
 #include "resources/res_particlefx.h"
 #include "resources/res_textureset.h"
+#include "resources/res_material.h"
 
 DM_PROPERTY_EXTERN(rmtp_Components);
 DM_PROPERTY_U32(rmtp_ParticleFx, 0, FrameReset, "# components", &rmtp_Components);
@@ -283,9 +284,11 @@ namespace dmGameSystem
         uint32_t ro_index = pfx_world->m_RenderObjects.Size();
         pfx_world->m_RenderObjects.SetSize(ro_index+1);
 
+        dmGameSystem::MaterialResource* material_res = (dmGameSystem::MaterialResource*) first->m_Material;
+
         dmRender::RenderObject& ro = pfx_world->m_RenderObjects[ro_index];
         ro.Init();
-        ro.m_Material = (dmRender::HMaterial) first->m_Material;
+        ro.m_Material = material_res->m_Material;
         ro.m_Textures[0] = (dmGraphics::HTexture) first->m_Texture;
         ro.m_VertexStart = vb_begin - vertex_buffer.Begin();
         ro.m_VertexCount = ro_vertex_count;
@@ -370,10 +373,12 @@ namespace dmGameSystem
                     dmParticle::EmitterRenderData* render_data;
                     dmParticle::GetEmitterRenderData(particle_context, c.m_ParticleInstance, j, &render_data);
 
+                    dmGameSystem::MaterialResource* material_res = (dmGameSystem::MaterialResource*) render_data->m_Material;
+
                     write_ptr->m_WorldPosition = Point3(render_data->m_Transform.getTranslation());
                     write_ptr->m_UserData = (uintptr_t) render_data;
                     write_ptr->m_BatchKey = render_data->m_MixedHash;
-                    write_ptr->m_TagListKey = dmRender::GetMaterialTagListKey((dmRender::HMaterial)render_data->m_Material);
+                    write_ptr->m_TagListKey = dmRender::GetMaterialTagListKey(material_res->m_Material);
                     write_ptr->m_Dispatch = dispatch;
                     write_ptr->m_MinorOrder = 0;
                     write_ptr->m_MajorOrder = dmRender::RENDER_ORDER_WORLD;

--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -94,6 +94,7 @@ namespace dmGameSystem
 
         if (!dmScript::SetupCallback(data.m_CallbackInfo))
         {
+            dmLogError("Failed to setup state changed callback (has the calling script been destroyed?)");
             dmScript::DestroyCallback(data.m_CallbackInfo);
             data.m_CallbackInfo = 0x0;
             return;

--- a/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_particlefx.cpp
@@ -81,7 +81,7 @@ namespace dmGameSystem
     void EmitterStateChangedCallback(uint32_t num_awake_emitters, dmhash_t emitter_id, dmParticle::EmitterState emitter_state, void* user_data)
     {
 
-        EmitterStateChangedScriptData data = *(EmitterStateChangedScriptData*)(user_data);
+        EmitterStateChangedScriptData& data = *(EmitterStateChangedScriptData*)(user_data);
 
         if (!dmScript::IsCallbackValid(data.m_CallbackInfo))
         {


### PR DESCRIPTION
Fixed a crash that occasionally happens a script is removed that started playing a particlefx with a state change callback.

Fixes #7142 (partially)

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
