### PR TITLE
Make sure that unloading of a gui component removes its dynamic textures

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -2338,6 +2338,7 @@ namespace dmGameSystem
             dmLogError("Error when finalizing gui component: %d.", result);
         }
         dmGui::ClearTextures(gui_component->m_Scene);
+        dmGui::ForceRemoveDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         dmGui::ClearFonts(gui_component->m_Scene);
         dmGui::ClearNodes(gui_component->m_Scene);
         dmGui::ClearLayouts(gui_component->m_Scene);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -807,7 +807,7 @@ namespace dmGameSystem
     {
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
         dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
-        dmGui::ForceRemoveDynamicTextures(gui_component->m_Scene, &DeleteTexture);
+        dmGui::ClearDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         if (result != dmGui::RESULT_OK)
         {
             // TODO: Translate result
@@ -2338,7 +2338,7 @@ namespace dmGameSystem
             dmLogError("Error when finalizing gui component: %d.", result);
         }
         dmGui::ClearTextures(gui_component->m_Scene);
-        dmGui::ForceRemoveDynamicTextures(gui_component->m_Scene, &DeleteTexture);
+        dmGui::ClearDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         dmGui::ClearFonts(gui_component->m_Scene);
         dmGui::ClearNodes(gui_component->m_Scene);
         dmGui::ClearLayouts(gui_component->m_Scene);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -807,7 +807,7 @@ namespace dmGameSystem
     {
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
         dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
-        dmGui::ClearDynamicTextures(gui_component->m_Scene, &DeleteTexture);
+        dmGui::DeleteDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         if (result != dmGui::RESULT_OK)
         {
             // TODO: Translate result
@@ -2338,7 +2338,7 @@ namespace dmGameSystem
             dmLogError("Error when finalizing gui component: %d.", result);
         }
         dmGui::ClearTextures(gui_component->m_Scene);
-        dmGui::ClearDynamicTextures(gui_component->m_Scene, &DeleteTexture);
+        dmGui::DeleteDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         dmGui::ClearFonts(gui_component->m_Scene);
         dmGui::ClearNodes(gui_component->m_Scene);
         dmGui::ClearLayouts(gui_component->m_Scene);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -806,8 +806,7 @@ namespace dmGameSystem
     static dmGameObject::CreateResult CompGuiFinal(const dmGameObject::ComponentFinalParams& params)
     {
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
-        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
-        dmGui::DeleteDynamicTextures(gui_component->m_Scene, &DeleteTexture);
+        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene, &DeleteTexture);
         if (result != dmGui::RESULT_OK)
         {
             // TODO: Translate result
@@ -2331,14 +2330,13 @@ namespace dmGameSystem
         GuiWorld* gui_world = (GuiWorld*)params.m_World;
         GuiSceneResource* scene_resource = (GuiSceneResource*) params.m_Resource;
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
-        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
+        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene, &DeleteTexture);
         if (result != dmGui::RESULT_OK)
         {
             // TODO: Translate result
             dmLogError("Error when finalizing gui component: %d.", result);
         }
         dmGui::ClearTextures(gui_component->m_Scene);
-        dmGui::DeleteDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         dmGui::ClearFonts(gui_component->m_Scene);
         dmGui::ClearNodes(gui_component->m_Scene);
         dmGui::ClearLayouts(gui_component->m_Scene);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -73,6 +73,7 @@ namespace dmGameSystem
     static void DestroyCustomNodeCallback(void* context, dmGui::HScene scene, dmGui::HNode node, uint32_t custom_type, void* node_data);
     static void UpdateCustomNodeCallback(void* context, dmGui::HScene scene, dmGui::HNode node, uint32_t custom_type, void* node_data, float dt);
     static const CompGuiNodeType* GetCompGuiCustomType(const CompGuiContext* gui_context, uint32_t custom_type);
+    static void DeleteTexture(dmGui::HScene scene, void* texture, void* context);
 
     // Translation table to translate from dmGameSystemDDF playback mode into dmGui playback mode.
     static struct PlaybackGuiToRig
@@ -806,6 +807,7 @@ namespace dmGameSystem
     {
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
         dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
+        dmGui::ForceRemoveDynamicTextures(gui_component->m_Scene, &DeleteTexture);
         if (result != dmGui::RESULT_OK)
         {
             // TODO: Translate result

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -49,7 +49,7 @@ DM_PROPERTY_U32(rmtp_GuiStaticTextures, 0, FrameReset, "", &rmtp_Gui);
 DM_PROPERTY_U32(rmtp_GuiDynamicTextures, 0, FrameReset, "", &rmtp_Gui);
 DM_PROPERTY_U32(rmtp_GuiTextures, 0, FrameReset, "", &rmtp_Gui);
 DM_PROPERTY_U32(rmtp_GuiParticlefx, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiDynamicTexturesSize, 0, NoFlags, "", &rmtp_Gui);
+DM_PROPERTY_U32(rmtp_GuiDynamicTexturesSize, 0, NoFlags, "size of dynamic tex in bytes", &rmtp_Gui);
 
 namespace dmGui
 {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -613,8 +613,7 @@ namespace dmGui
             t->m_Buffer = 0;
         }
 
-        float expected_buffer_size = t->m_Width * t->m_Height * dmImage::BytesPerPixel(t->m_Type) / 1024 / 1024;
-        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, -expected_buffer_size);
+        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - (buffer_size / 1024 / 1024));
 
         t->m_Buffer = malloc(buffer_size);
         if (flip) {
@@ -1058,8 +1057,8 @@ namespace dmGui
         if (texture->m_Deleted) {
             // handle might be null if the texture is created/destroyed in the same frame
             if (texture->m_Handle) {
-                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, -expected_buffer_size);
+                uint32_t buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
                 params->m_Params->m_DeleteTexture(scene, texture->m_Handle, context);
             }
             if (scene->m_DeletedDynamicTextures.Full()) {
@@ -1068,15 +1067,15 @@ namespace dmGui
             scene->m_DeletedDynamicTextures.Push(*key);
         } else {
             if (!texture->m_Handle && texture->m_Buffer) {
-                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, expected_buffer_size);
+                uint32_t buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, buffer_size);
                 texture->m_Handle = params->m_Params->m_NewTexture(scene, texture->m_Width, texture->m_Height, texture->m_Type, texture->m_Buffer, context);
                 params->m_NewCount++;
                 free(texture->m_Buffer);
                 texture->m_Buffer = 0;
             } else if (texture->m_Handle && texture->m_Buffer) {
-                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, expected_buffer_size);
+                uint32_t buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, buffer_size);
                 params->m_Params->m_SetTextureData(scene, texture->m_Handle, texture->m_Width, texture->m_Height, texture->m_Type, texture->m_Buffer, context);
                 free(texture->m_Buffer);
                 texture->m_Buffer = 0;
@@ -1104,6 +1103,24 @@ namespace dmGui
                 }
             }
         }
+    }
+
+    static void DeleteDynamicTextures(HScene scene, DeleteTexture delete_texture)
+    {
+        dmHashTable64<DynamicTexture>::Iterator dynamic_textures_iter = scene->m_DynamicTextures.GetIterator();
+        while(dynamic_textures_iter.Next())
+        {
+            const DynamicTexture texture = dynamic_textures_iter.GetValue();
+            if (texture.m_Buffer) {
+                free(texture.m_Buffer);
+            }
+            if (texture.m_Handle) {
+                float buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
+                delete_texture(scene, texture.m_Handle, scene->m_Context);
+            }
+        }
+        scene->m_DynamicTextures.Clear();
     }
 
     static void DeferredDeleteDynamicTextures(HScene scene, const RenderSceneParams& params, void* context)
@@ -2115,22 +2132,7 @@ namespace dmGui
         }
         scene->m_AliveParticlefxs.SetSize(0);
 
-        // Delete all the dynamic textures
-        dmHashTable<uint64_t, DynamicTexture>::Iterator dynamicTextureIter = scene->m_DynamicTextures.GetIterator();
-        while(dynamicTextureIter.Next())
-        {
-            const DynamicTexture texture = dynamicTextureIter.GetValue();
-            if (texture.m_Buffer) {
-                free(texture.m_Buffer);
-            }
-            if (texture.m_Handle) {
-                float expected_buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type) / 1024 / 1024;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, -expected_buffer_size);
-                delete_texture(scene, texture.m_Handle, scene->m_Context);
-            }
-        }
-        scene->m_DynamicTextures.Clear();
-
+        DeleteDynamicTextures(scene, delete_texture);
         ClearLayouts(scene);
         return result;
     }

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1065,6 +1065,7 @@ namespace dmGui
                 m_DeleteTexture(scene, texture.m_Handle, scene->m_Context);
             }
         }
+        scene->m_DynamicTextures.Clear();
     }
 
     static void UpdateDynamicTextures(UpdateDynamicTexturesParams* params, const dmhash_t* key, DynamicTexture* texture)

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1050,7 +1050,7 @@ namespace dmGui
         int    m_NewCount;
     };
 
-    void ClearDynamicTextures(HScene scene, DeleteTexture deleteTexture)
+    void DeleteDynamicTextures(HScene scene, DeleteTexture deleteTexture)
     {
         dmHashTable<uint64_t, DynamicTexture>::Iterator dynamicTextureIter = scene->m_DynamicTextures.GetIterator();
         while(dynamicTextureIter.Next())

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -49,7 +49,7 @@ DM_PROPERTY_U32(rmtp_GuiStaticTextures, 0, FrameReset, "", &rmtp_Gui);
 DM_PROPERTY_U32(rmtp_GuiDynamicTextures, 0, FrameReset, "", &rmtp_Gui);
 DM_PROPERTY_U32(rmtp_GuiTextures, 0, FrameReset, "", &rmtp_Gui);
 DM_PROPERTY_U32(rmtp_GuiParticlefx, 0, FrameReset, "", &rmtp_Gui);
-DM_PROPERTY_U32(rmtp_GuiDynamicTexturesSize, 0, NoFlags, "size of dynamic tex in bytes", &rmtp_Gui);
+DM_PROPERTY_F32(rmtp_GuiDynamicTexturesSizeMb, 0, NoFlags, "size of dynamic tex in Mb", &rmtp_Gui);
 
 namespace dmGui
 {
@@ -613,8 +613,8 @@ namespace dmGui
             t->m_Buffer = 0;
         }
 
-        uint32_t expected_buffer_size = t->m_Width * t->m_Height * dmImage::BytesPerPixel(t->m_Type);
-        DM_PROPERTY_ADD_U32(rmtp_GuiDynamicTexturesSize, -expected_buffer_size);
+        float expected_buffer_size = t->m_Width * t->m_Height * dmImage::BytesPerPixel(t->m_Type) / 1024 / 1024;
+        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, -expected_buffer_size);
 
         t->m_Buffer = malloc(buffer_size);
         if (flip) {
@@ -1060,8 +1060,8 @@ namespace dmGui
                 free(texture.m_Buffer);
             }
             if (texture.m_Handle) {
-                uint32_t expected_buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type);
-                DM_PROPERTY_ADD_U32(rmtp_GuiDynamicTexturesSize, -expected_buffer_size);
+                float expected_buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, -expected_buffer_size);
                 deleteTexture(scene, texture.m_Handle, scene->m_Context);
             }
         }
@@ -1076,8 +1076,8 @@ namespace dmGui
         if (texture->m_Deleted) {
             // handle might be null if the texture is created/destroyed in the same frame
             if (texture->m_Handle) {
-                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type);
-                DM_PROPERTY_ADD_U32(rmtp_GuiDynamicTexturesSize, -expected_buffer_size);
+                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, -expected_buffer_size);
                 params->m_Params->m_DeleteTexture(scene, texture->m_Handle, context);
             }
             if (scene->m_DeletedDynamicTextures.Full()) {
@@ -1086,15 +1086,15 @@ namespace dmGui
             scene->m_DeletedDynamicTextures.Push(*key);
         } else {
             if (!texture->m_Handle && texture->m_Buffer) {
-                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type);
-                DM_PROPERTY_ADD_U32(rmtp_GuiDynamicTexturesSize, expected_buffer_size);
+                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, expected_buffer_size);
                 texture->m_Handle = params->m_Params->m_NewTexture(scene, texture->m_Width, texture->m_Height, texture->m_Type, texture->m_Buffer, context);
                 params->m_NewCount++;
                 free(texture->m_Buffer);
                 texture->m_Buffer = 0;
             } else if (texture->m_Handle && texture->m_Buffer) {
-                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type);
-                DM_PROPERTY_ADD_U32(rmtp_GuiDynamicTexturesSize, expected_buffer_size);
+                uint32_t expected_buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024 / 1024;
+                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, expected_buffer_size);
                 params->m_Params->m_SetTextureData(scene, texture->m_Handle, texture->m_Width, texture->m_Height, texture->m_Type, texture->m_Buffer, context);
                 free(texture->m_Buffer);
                 texture->m_Buffer = 0;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -1050,7 +1050,7 @@ namespace dmGui
         int    m_NewCount;
     };
 
-    void ForceRemoveDynamicTextures(HScene scene, DeleteTexture m_DeleteTexture)
+    void ClearDynamicTextures(HScene scene, DeleteTexture deleteTexture)
     {
         dmHashTable<uint64_t, DynamicTexture>::Iterator dynamicTextureIter = scene->m_DynamicTextures.GetIterator();
         while(dynamicTextureIter.Next())
@@ -1062,7 +1062,7 @@ namespace dmGui
             if (texture.m_Handle) {
                 uint32_t expected_buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type);
                 DM_PROPERTY_ADD_U32(rmtp_GuiDynamicTexturesSize, -expected_buffer_size);
-                m_DeleteTexture(scene, texture.m_Handle, scene->m_Context);
+                deleteTexture(scene, texture.m_Handle, scene->m_Context);
             }
         }
         scene->m_DynamicTextures.Clear();

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -752,11 +752,11 @@ namespace dmGui
     void RenderScene(HScene scene, const RenderSceneParams& params, void* context);
 
     /**
-     * Remove all dynamic textures from the scene.
+     * Delete all dynamic textures from the scene.
      * @param scene Scene for which to remove the dynamic textures
      * @param deleteTexture DeleteTexture Callback to delete a texture
      */
-    void ClearDynamicTextures(HScene scene, DeleteTexture deleteTexture);
+    void DeleteDynamicTextures(HScene scene, DeleteTexture deleteTexture);
 
     /**
      * Run the init-function of the scene script.

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -752,13 +752,6 @@ namespace dmGui
     void RenderScene(HScene scene, const RenderSceneParams& params, void* context);
 
     /**
-     * Delete all dynamic textures from the scene.
-     * @param scene Scene for which to remove the dynamic textures
-     * @param deleteTexture DeleteTexture Callback to delete a texture
-     */
-    void DeleteDynamicTextures(HScene scene, DeleteTexture deleteTexture);
-
-    /**
      * Run the init-function of the scene script.
      * @param scene Scene for which to run the script
      * @return RESULT_OK on success
@@ -768,9 +761,10 @@ namespace dmGui
     /**
      * Run the final-function of the scene script.
      * @param scene Scene for which to run the script
+     * @param deleteTexture DeleteTexture Callback to delete a texture
      * @return RESULT_OK on success
      */
-    Result FinalScene(HScene scene);
+    Result FinalScene(HScene scene, DeleteTexture delete_texture);
 
     /**
      * Run the update-function of the scene script.

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -752,10 +752,11 @@ namespace dmGui
     void RenderScene(HScene scene, const RenderSceneParams& params, void* context);
 
     /**
-     * Force deletion of the dynamic textures of the scene
+     * Remove all dynamic textures from the scene.
      * @param scene Scene for which to remove the dynamic textures
+     * @param deleteTexture DeleteTexture Callback to delete a texture
      */
-    void ForceRemoveDynamicTextures(HScene scene, DeleteTexture m_DeleteTexture);
+    void ClearDynamicTextures(HScene scene, DeleteTexture deleteTexture);
 
     /**
      * Run the init-function of the scene script.

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -752,6 +752,12 @@ namespace dmGui
     void RenderScene(HScene scene, const RenderSceneParams& params, void* context);
 
     /**
+     * Force deletion of the dynamic textures of the scene
+     * @param scene Scene for which to remove the dynamic textures
+     */
+    void ForceRemoveDynamicTextures(HScene scene, DeleteTexture m_DeleteTexture);
+
+    /**
      * Run the init-function of the scene script.
      * @param scene Scene for which to run the script
      * @return RESULT_OK on success

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -325,7 +325,7 @@ namespace dmGui
         return RESULT_OK;
     }
 
-    Result FinalScene(HScene scene)
+    Result FinalScene(HScene scene, DeleteTexture delete_texture)
     {
         return RESULT_OK;
     }

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -1361,7 +1361,7 @@ TEST_F(dmGuiTest, ScriptAnimate)
 
     ASSERT_NEAR(dmGui::GetNodePosition(m_Scene, node).getX(), 1.0f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
     ASSERT_EQ(m_Scene->m_NodePool.Capacity(), m_Scene->m_NodePool.Remaining());
@@ -1412,7 +1412,7 @@ TEST_F(dmGuiTest, ScriptPlayback)
         dmGui::DeleteNode(m_Scene, node, true);
     }
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
     ASSERT_EQ(m_Scene->m_NodePool.Capacity(), m_Scene->m_NodePool.Remaining());
@@ -1445,7 +1445,7 @@ TEST_F(dmGuiTest, ScriptAnimatePreserveAlpha)
     ASSERT_NEAR(color.getX(), 1.0f, EPSILON);
     ASSERT_NEAR(color.getW(), 0.5f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -1478,7 +1478,7 @@ TEST_F(dmGuiTest, ScriptAnimateComponent)
     ASSERT_NEAR(color.getZ(), 0.9f, EPSILON);
     ASSERT_NEAR(color.getW(), 0.4f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -1592,7 +1592,7 @@ TEST_F(dmGuiTest, ScriptAnimateCancel1)
 
     ASSERT_NEAR(dmGui::GetNodeProperty(m_Scene, node, dmGui::PROPERTY_COLOR).getX(), 1.0f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -1636,7 +1636,7 @@ TEST_F(dmGuiTest, ScriptAnimateCancel2)
     // We can't use epsilon here because of precision errors when the animation is canceled, so half precision (= twice the error)
     ASSERT_NEAR(dmGui::GetNodePosition(m_Scene, node).getX(), 5.0f, 2*EPSILON);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -2683,7 +2683,7 @@ TEST_F(dmGuiTest, ScriptErroneousReturnValues)
     bool consumed;
     r = dmGui::DispatchInput(m_Scene, &action, 1, &consumed);
     ASSERT_NE(dmGui::RESULT_OK, r);
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_NE(dmGui::RESULT_OK, r);
     dmGui::DeleteNode(m_Scene, node, true);
 }
@@ -4884,7 +4884,7 @@ TEST_F(dmGuiTest, KeepParticlefxOnNodeDeletion)
     dmGui::DeleteNode(m_Scene, node_text, false);
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::UpdateScene(m_Scene, 1.0f / 60.0f));
     ASSERT_EQ(1U, dmGui::GetParticlefxCount(m_Scene));
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -4917,7 +4917,7 @@ TEST_F(dmGuiTest, PlayNodeParticlefx)
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::PlayNodeParticlefx(m_Scene, node_box, 0));
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::PlayNodeParticlefx(m_Scene, node_pie, 0));
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::PlayNodeParticlefx(m_Scene, node_text, 0));
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -4946,7 +4946,7 @@ TEST_F(dmGuiTest, PlayNodeParticlefxInitialTransform)
     Vector3 pos = dmParticle::GetPosition(m_Scene->m_ParticlefxContext, n->m_Node.m_ParticleInstance);
     ASSERT_EQ(10, pos.getX());
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -4975,7 +4975,7 @@ TEST_F(dmGuiTest, PlayNodeParticlefxAdjustModeStretch)
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeParticlefx(m_Scene, node_pfx, 0));
     ASSERT_EQ(dmGui::ADJUST_MODE_FIT, (dmGui::AdjustMode)n->m_Node.m_AdjustMode);
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5001,7 +5001,7 @@ TEST_F(dmGuiTest, NewNodeParticlefx)
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::SetNodeParticlefx(m_Scene, node_pfx, particlefx_id));
     ASSERT_EQ(dmGui::RESULT_RESOURCE_NOT_FOUND, dmGui::SetNodeParticlefx(m_Scene, node_pfx, particlefx_id_wrong));
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5065,7 +5065,7 @@ TEST_F(dmGuiTest, CallbackCalledCorrectNumTimes)
     dmGui::DeleteNode(m_Scene, node_pfx, true);
     dmGui::UpdateScene(m_Scene, dt);
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5097,7 +5097,7 @@ TEST_F(dmGuiTest, CallbackCalledSingleTimePerStateChange)
     dmGui::DeleteNode(m_Scene, node_pfx, true);
     dmGui::UpdateScene(m_Scene, dt);
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5131,7 +5131,7 @@ TEST_F(dmGuiTest, CallbackCalledMultipleEmitters)
     dmGui::DeleteNode(m_Scene, node_pfx, true);
     dmGui::UpdateScene(m_Scene, dt);
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5164,7 +5164,7 @@ TEST_F(dmGuiTest, StopNodeParticlefx)
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::StopNodeParticlefx(m_Scene, node_pie, false));
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::StopNodeParticlefx(m_Scene, node_text, false));
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5223,7 +5223,7 @@ TEST_F(dmGuiTest, StopNodeParticlefxMultiplePlaying)
 
     ASSERT_EQ(dmGui::GetParticlefxCount(m_Scene), 0);
 
-    dmGui::FinalScene(m_Scene);
+    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5325,7 +5325,7 @@ TEST_F(dmGuiTest, InheritAlpha)
     r = dmGui::UpdateScene(m_Scene, 1.0f / 60.0f);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -5423,7 +5423,7 @@ TEST_F(dmGuiTest, SetGetScreenPosition)
     Vector4 after_set = _GET_NODE_SCENE_POSITION(m_Scene, internal_node);
     ASSERT_EQ( before_set, after_set);
 
-    r = dmGui::FinalScene(m_Scene);
+    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 

--- a/engine/profiler/src/profile_render.cpp
+++ b/engine/profiler/src/profile_render.cpp
@@ -86,7 +86,7 @@ namespace dmProfileRender
     static const int SAMPLE_FRAMES_COUNT_WIDTH = 3 * CHARACTER_WIDTH;
 
     static const int COUNTERS_NAME_WIDTH  = 32 * CHARACTER_WIDTH;
-    static const int COUNTERS_COUNT_WIDTH = 8 * CHARACTER_WIDTH;
+    static const int COUNTERS_COUNT_WIDTH = 12 * CHARACTER_WIDTH;
 
     enum DisplayMode
     {

--- a/engine/profiler/src/profile_render.cpp
+++ b/engine/profiler/src/profile_render.cpp
@@ -86,7 +86,7 @@ namespace dmProfileRender
     static const int SAMPLE_FRAMES_COUNT_WIDTH = 3 * CHARACTER_WIDTH;
 
     static const int COUNTERS_NAME_WIDTH  = 32 * CHARACTER_WIDTH;
-    static const int COUNTERS_COUNT_WIDTH = 12 * CHARACTER_WIDTH;
+    static const int COUNTERS_COUNT_WIDTH = 10 * CHARACTER_WIDTH;
 
     enum DisplayMode
     {


### PR DESCRIPTION
Make sure that unloading a GUI component removes any dynamic textures associated with it to free up memory and prevent memory leaks.

Added `GuiDynamicTexturesSizeMb` counter to the profiler.

Fix https://github.com/defold/defold/issues/7743

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
