### PR TITLE
Don't replace all occurences of empty string

### DIFF
--- a/editor/src/clj/editor/code/data.clj
+++ b/editor/src/clj/editor/code/data.clj
@@ -2728,6 +2728,7 @@
     (find-next lines cursor-ranges layout needle-lines case-sensitive? whole-word? wrap?)))
 
 (defn replace-all [lines regions ^LayoutInfo layout needle-lines replacement-lines case-sensitive? whole-word?]
+  {:pre [(not= [""] needle-lines)]}
   (-> (splice lines regions
               (loop [from-cursor document-start-cursor
                      splices (transient [])]

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -2163,14 +2163,16 @@
 
 (defn- replace-all! [view-node]
   (hide-suggestions! view-node)
-  (set-properties! view-node nil
-                   (data/replace-all (get-property view-node :lines)
-                                     (get-property view-node :regions)
-                                     (get-property view-node :layout)
-                                     (split-lines (.getValue find-term-property))
-                                     (split-lines (.getValue find-replacement-property))
-                                     (.getValue find-case-sensitive-property)
-                                     (.getValue find-whole-word-property))))
+  (let [^String find-term (.getValue find-term-property)]
+    (when (pos? (.length find-term))
+      (set-properties! view-node nil
+                       (data/replace-all (get-property view-node :lines)
+                                         (get-property view-node :regions)
+                                         (get-property view-node :layout)
+                                         (split-lines find-term)
+                                         (split-lines (.getValue find-replacement-property))
+                                         (.getValue find-case-sensitive-property)
+                                         (.getValue find-whole-word-property))))))
 
 (handler/defhandler :find-text :code-view
   (run [find-bar view-node]


### PR DESCRIPTION
The problem: when running `replace-all` with an empty string find term, the editor got stuck in an infinite loop finding the next occurrences.

User-facing changes: the editor no longer locks up executing the "Replace All" command in the code editor view when the search term is empty

Fixes #7790