### PR TITLE
Fix bug when debugger stops with an error if GUI text node contains newline

### DIFF
--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -109,7 +109,7 @@ end
 
 local function encode_node(val, val_type)
   local escaped_val = tostring(val):gsub('[%z\1-\31\\"]', escape_char)
-  return string.format('#lua/userdata"%s %p"', tostring(escaped_val), escaped_val)
+  return string.format('#lua/userdata"%s %p"', escaped_val, val)
 end
 
 local type_to_primitive_encoder = {

--- a/engine/engine/content/builtins/scripts/edn.lua
+++ b/engine/engine/content/builtins/scripts/edn.lua
@@ -108,7 +108,8 @@ local function encode_script(val, val_type)
 end
 
 local function encode_node(val, val_type)
-  return string.format('#lua/userdata"%s %p"', tostring(val), val)
+  local escaped_val = tostring(val):gsub('[%z\1-\31\\"]', escape_char)
+  return string.format('#lua/userdata"%s %p"', tostring(escaped_val), escaped_val)
 end
 
 local type_to_primitive_encoder = {


### PR DESCRIPTION
Fix issue when debugger stops if a text node has a newline symbol and then debugger tries to get information about such a node on the breakpoint.

Fix https://github.com/defold/defold/issues/7749

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
