### PR TITLE
Add option to avoid copying or cloning buffer in resource.set_buffer

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -756,7 +756,7 @@ namespace dmGameSystem
         *s = 0;
         uint32_t version = 0;
         dmBuffer::GetContentVersion(hbuffer, &version);
-        dmSnPrintf(buf, sizeof(buf), "buffer.%s(count = %d, version = %u, ", SCRIPT_TYPE_NAME_BUFFER, out_element_count, version);
+        dmSnPrintf(buf, sizeof(buf), "buffer.%s(count = %d, version = %u, handle = %u, ", SCRIPT_TYPE_NAME_BUFFER, out_element_count, version, (uint32_t) hbuffer);
         dmStrlCat(s, buf, maxlen);
 
         for( uint32_t i = 0; i < num_streams; ++i )

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -2236,7 +2236,7 @@ static int SetSound(lua_State* L) {
  * end
  * ```
  *
- * * @examples
+ * @examples
  * Create a buffer resource from existing resource
  *
  * ```lua
@@ -2401,12 +2401,23 @@ static int GetBuffer(lua_State* L)
 }
 
 /*# set resource buffer
- * sets the buffer of a resource
+ * Sets the buffer of a resource. By default, setting the resource buffer will either copy the data from the incoming buffer object
+ * to the buffer stored in the destination resource, or make a new buffer object if the sizes between the source buffer and the destination buffer
+ * stored in the resource differs. In some cases, e.g performance reasons, it might be beneficial to just set the buffer object on the resource without copying or cloning.
+ * To achieve this, set the `transfer_ownership` flag to true in the argument table. Transferring ownership from a lua buffer to a resource with this function
+ * works exactly the same as [ref:resource.create_buffer]: the destination resource will take ownership of the buffer held by the lua reference, i.e the buffer will not automatically be removed
+ * when the lua reference to the buffer is garbage collected.
+ * 
+ * Note: When setting a buffer with `transfer_ownership = true`, the currently bound buffer in the resource will be destroyed.
  *
  * @name resource.set_buffer
  *
  * @param path [type:hash|string] The path to the resource
  * @param buffer [type:buffer] The resource buffer
+ * @param table [type:table] A table containing info about how to set the buffer. Supported entries:
+ *
+ * * `transfer_ownership`
+ * : [type:boolean] optional flag to determine wether or not the resource should take over ownership of the buffer object (default false)
  *
  * @examples
  * How to set the data from a buffer
@@ -2449,48 +2460,85 @@ static int SetBuffer(lua_State* L)
     int top = lua_gettop(L);
     dmhash_t path_hash           = dmScript::CheckHashOrString(L, 1);
     dmScript::LuaHBuffer* luabuf = dmScript::CheckBuffer(L, 2);
-    dmBuffer::HBuffer src_buffer = dmGameSystem::UnpackLuaBuffer(luabuf);
+    bool transfer_ownership      = false;
 
+    if (lua_istable(L, 3))
+    {
+        lua_pushvalue(L, 3);
+        transfer_ownership = CheckFieldValue<bool>(L, -1, "transfer_ownership", false);
+        lua_pop(L, 1); // args table
+    }
+
+    dmBuffer::HBuffer src_buffer                  = dmGameSystem::UnpackLuaBuffer(luabuf);
     void* resource                                = CheckResource(L, g_ResourceModule.m_Factory, path_hash, "bufferc");
     dmGameSystem::BufferResource* buffer_resource = (dmGameSystem::BufferResource*)resource;
     dmBuffer::HBuffer dst_buffer                  = buffer_resource->m_Buffer;
 
-    // Make sure the destination buffer has enough size (otherwise, resize it).
-    // TODO: Check if incoming buffer size is smaller than current size -> don't allocate new dmbuffer,
-    //       but copy smaller data and change "size".
-    uint32_t dst_count = 0;
-    dmBuffer::Result br = dmBuffer::GetCount(dst_buffer, &dst_count);
-    if (br != dmBuffer::RESULT_OK)
+    if (transfer_ownership)
     {
-        return luaL_error(L, "Unable to get buffer size for %s: %s (%d).", dmHashReverseSafe64(path_hash), dmBuffer::GetResultString(br), br);
-    }
-
-    uint32_t src_count = 0;
-    br = dmBuffer::GetCount(src_buffer, &src_count);
-    if (br != dmBuffer::RESULT_OK)
-    {
-        return luaL_error(L, "Unable to get buffer size for source buffer: %s (%d).", dmBuffer::GetResultString(br), br);
-    }
-
-    if (dst_count != src_count)
-    {
-        dmBuffer::HBuffer dst_buffer;
-        br = dmBuffer::Clone(src_buffer, &dst_buffer);
+        uint32_t src_count = 0;
+        dmBuffer::Result br = dmBuffer::GetCount(src_buffer, &src_count);
         if (br != dmBuffer::RESULT_OK)
         {
-            return luaL_error(L, "Unable to create cloned buffer: %s (%d)", dmBuffer::GetResultString(br), br);
+            return luaL_error(L, "Unable to get buffer size for source buffer: %s (%d).", dmBuffer::GetResultString(br), br);
         }
 
         dmBuffer::Destroy(buffer_resource->m_Buffer);
-        buffer_resource->m_Buffer       = dst_buffer;
+        buffer_resource->m_Buffer       = src_buffer;
         buffer_resource->m_ElementCount = src_count;
+        buffer_resource->m_Stride       = dmBuffer::GetStructSize(src_buffer);
+
+        if (luabuf->m_Owner == dmScript::OWNER_RES)
+        {
+            // We are transferring the ownership of the resource in the lua buffer
+            // to the destination resource, so we decref the source resource.
+            // We don't need to incref the destination resource in this case,
+            // because we are simply updating the content and not the resoure itself
+            dmResource::Release(g_ResourceModule.m_Factory, luabuf->m_BufferRes);
+        }
+
+        luabuf->m_Owner     = dmScript::OWNER_RES;
+        luabuf->m_BufferRes = resource;
     }
     else
     {
-        br = dmBuffer::Copy(dst_buffer, src_buffer);
+        // Make sure the destination buffer has enough size (otherwise, resize it).
+        // TODO: Check if incoming buffer size is smaller than current size -> don't allocate new dmbuffer,
+        //       but copy smaller data and change "size".
+        uint32_t dst_count = 0;
+        dmBuffer::Result br = dmBuffer::GetCount(dst_buffer, &dst_count);
         if (br != dmBuffer::RESULT_OK)
         {
-            return luaL_error(L, "Could not copy data from buffer: %s (%d).", dmBuffer::GetResultString(br), br);
+            return luaL_error(L, "Unable to get buffer size for %s: %s (%d).", dmHashReverseSafe64(path_hash), dmBuffer::GetResultString(br), br);
+        }
+
+        uint32_t src_count = 0;
+        br = dmBuffer::GetCount(src_buffer, &src_count);
+        if (br != dmBuffer::RESULT_OK)
+        {
+            return luaL_error(L, "Unable to get buffer size for source buffer: %s (%d).", dmBuffer::GetResultString(br), br);
+        }
+
+        if (dst_count != src_count)
+        {
+            dmBuffer::HBuffer dst_buffer;
+            br = dmBuffer::Clone(src_buffer, &dst_buffer);
+            if (br != dmBuffer::RESULT_OK)
+            {
+                return luaL_error(L, "Unable to create cloned buffer: %s (%d)", dmBuffer::GetResultString(br), br);
+            }
+
+            dmBuffer::Destroy(buffer_resource->m_Buffer);
+            buffer_resource->m_Buffer       = dst_buffer;
+            buffer_resource->m_ElementCount = src_count;
+        }
+        else
+        {
+            br = dmBuffer::Copy(dst_buffer, src_buffer);
+            if (br != dmBuffer::RESULT_OK)
+            {
+                return luaL_error(L, "Could not copy data from buffer: %s (%d).", dmBuffer::GetResultString(br), br);
+            }
         }
     }
 

--- a/engine/gamesys/src/gamesys/test/resource/script_buffer.script
+++ b/engine/gamesys/src/gamesys/test/resource/script_buffer.script
@@ -75,10 +75,30 @@ function test_create_ownership_data(self)
     for i=1,3 do
         assert(buffer_stream[i] == res_buffer_stream[i])
     end
+
+    resource.release(res_buffer)
+    resource.release(res_buffer)
+end
+
+function buffer_to_handle(buf)
+    local res_buf_str = tostring(buf)
+    local res_buf_handle = string.match(res_buf_str, "handle = (%d+)")
+    return tonumber(res_buf_handle)
+end
+
+function test_create_set(self)
+    local buf        = buffer.create(3, data_stream_desc)
+    local buf_bigger = buffer.create(6, data_stream_desc)
+    local res_buffer = resource.create_buffer("/my_buffer.bufferc", { buffer = buf })
+    resource.set_buffer("/my_buffer.bufferc", buf_bigger, { transfer_ownership=true })
+
+    -- test that transferring ownership doesn't trigger a new clone of the buffer
+    assert(buffer_to_handle(buf_bigger), buffer_to_handle(resource.get_buffer(res_buffer)))
 end
 
 function init(self)
     test_create_get(self)
     test_create_ownership(self)
     test_create_ownership_data(self)
+    test_create_set(self)
 end

--- a/engine/gamesys/src/gamesys/test/resource/script_buffer.script
+++ b/engine/gamesys/src/gamesys/test/resource/script_buffer.script
@@ -76,6 +76,8 @@ function test_create_ownership_data(self)
         assert(buffer_stream[i] == res_buffer_stream[i])
     end
 
+    -- We release the resource twice here to fully release the resource so we can reuse the resource name
+    -- 1 from resource.create_buffer and 1 from resource.get_buffer
     resource.release(res_buffer)
     resource.release(res_buffer)
 end


### PR DESCRIPTION
Added an argument table for `resource.set_buffer` with the optional flag `transfer_ownership` to set a buffer handle immediately on a resource instead of copying or cloning the incoming buffer to the destination buffer. This can be used to improve performance in some cases where heavy use of buffers will invoke lots of data copying. Similar to `resource.create_buffer`, to set the handle directly on a resource from an external lua buffer do this:

`resource.set_buffer(path, buf, { transfer_ownership = true })`

Fixes #7587 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
