### PR TITLE
Sound stopped event

### DIFF
--- a/engine/gamesys/proto/gamesys/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gamesys_ddf.proto
@@ -103,7 +103,7 @@ message PauseSound
     optional bool pause     = 1 [default=true];
 }
 
-message SoundDone
+message SoundEvent
 {
     optional int32 play_id = 1 [default = 0];
 }

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -144,8 +144,38 @@ namespace dmGameSystem
         return dmGameObject::CREATE_RESULT_OK;
     }
 
+    static void DispatchSoundEvent(PlayEntry& entry, dmhash_t message_id)
+    {
+        dmGameSystemDDF::SoundEvent message;
+        dmMessage::URL receiver = entry.m_Listener;
+        dmMessage::URL sender   = entry.m_Receiver;
+
+        if (dmMessage::IsSocketValid(sender.m_Socket) && dmMessage::IsSocketValid(receiver.m_Socket))
+        {
+            uintptr_t descriptor = (uintptr_t)dmGameSystemDDF::SoundEvent::m_DDFDescriptor;
+            uint32_t data_size = sizeof(dmGameSystemDDF::SoundEvent);
+
+            message.m_PlayId = entry.m_PlayId;
+
+            if (dmMessage::Post(&sender, &receiver, message_id, 0, (uintptr_t)entry.m_LuaCallback, descriptor, &message, data_size, 0) != dmMessage::RESULT_OK)
+            {
+                dmLogError("Could not send sound event (%s) to listener.", dmHashReverseSafe64(message_id));
+            }
+        }
+
+        // Currently this is a one-time-use since we reset the urls,
+        // if we want to reuse it for pause/resume events we need to move this out.
+        dmMessage::ResetURL(&entry.m_Receiver);
+        dmMessage::ResetURL(&entry.m_Listener);
+    }
+
     dmGameObject::UpdateResult CompSoundUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult&)
     {
+        // For reverse hashing to work for easier debugging we hash these ids here
+        // The hash container is enabled in engine init so it's too early in compilation unit scope
+        static const dmhash_t SOUND_EVENT_DONE    = dmHashString64("sound_done");
+        static const dmhash_t SOUND_EVENT_STOPPED = dmHashString64("sound_stopped");
+
         dmGameObject::UpdateResult update_result = dmGameObject::UPDATE_RESULT_OK;
         SoundWorld* world = (SoundWorld*)params.m_World;
         DM_PROPERTY_ADD_U32(rmtp_Sound, world->m_Components.Size());
@@ -182,36 +212,7 @@ namespace dmGameSystem
                         }
                         else if (entry.m_PlayId != dmSound::INVALID_PLAY_ID && entry.m_Listener.m_Fragment != 0x0)
                         {
-                            dmhash_t message_id = dmGameSystemDDF::SoundDone::m_DDFDescriptor->m_NameHash;
-                            dmGameSystemDDF::SoundDone message;
-
-                            dmMessage::URL receiver = entry.m_Listener;
-                            dmMessage::URL sender = entry.m_Receiver;
-
-                            if (dmMessage::IsSocketValid(sender.m_Socket) && dmMessage::IsSocketValid(receiver.m_Socket))
-                            {
-                                uintptr_t descriptor = (uintptr_t)dmGameSystemDDF::SoundDone::m_DDFDescriptor;
-                                uint32_t data_size = sizeof(dmGameSystemDDF::SoundDone);
-
-                                message.m_PlayId = entry.m_PlayId;
-
-                                if (dmMessage::Post(&sender, &receiver, message_id, 0, (uintptr_t)entry.m_LuaCallback, descriptor, &message, data_size, 0) != dmMessage::RESULT_OK)
-                                {
-                                    dmLogError("Could not send sound_done to listener.");
-                                }
-                            }
-
-                            dmMessage::ResetURL(&entry.m_Receiver);
-                            dmMessage::ResetURL(&entry.m_Listener);
-                        }
-                    }
-                    else if (entry.m_StopRequested)
-                    {
-                        dmSound::Result r = dmSound::Stop(entry.m_SoundInstance);
-                        if (r != dmSound::RESULT_OK)
-                        {
-                            dmLogError("Error deleting sound: (%d)", r);
-                            update_result = dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
+                            DispatchSoundEvent(entry, entry.m_StopRequested ? SOUND_EVENT_STOPPED : SOUND_EVENT_DONE);
                         }
                     }
                     else if (entry.m_PauseRequested)
@@ -221,6 +222,15 @@ namespace dmGameSystem
                         if (r != dmSound::RESULT_OK)
                         {
                             dmLogError("Error pausing sound: (%d)", r);
+                            update_result = dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
+                        }
+                    }
+                    else if (entry.m_StopRequested)
+                    {
+                        dmSound::Result r = dmSound::Stop(entry.m_SoundInstance);
+                        if (r != dmSound::RESULT_OK)
+                        {
+                            dmLogError("Error deleting sound: (%d)", r);
                             update_result = dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
                         }
                     }

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -315,6 +315,15 @@ namespace dmGameSystem
      * @param [play_id] [type:number] id number supplied when the message was posted.
      */
 
+    /*# reports when a sound has been manually stopped
+     * This message is sent back to the sender of a `play_sound` message, if the sound
+     * has been manually stopped.
+     *
+     * @message
+     * @name sound_stopped
+     * @param [play_id] [type:number] id number supplied when the message was posted.
+     */
+
     static dmGameObject::PropertyResult SoundSetParameter(SoundWorld* world, dmGameObject::HInstance instance, SoundComponent* component, dmSound::Parameter type, float value)
     {
         switch(type) {

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -457,13 +457,13 @@ namespace dmGameSystem
      * `speed`
      * : [type:number] sound speed where 1.0 is normal speed, 0.5 is half speed and 2.0 is double speed. The final speed of the sound will be a multiplication of this speed and the sound speed.
      *
-     * @param [complete_function] [type:function(self, message_id, message, sender))] function to call when the sound has finished playing.
+     * @param [complete_function] [type:function(self, message_id, message, sender))] function to call when the sound has finished playing or stopped manually via [ref:sound.stop].
      *
      * `self`
      * : [type:object] The current object.
      *
      * `message_id`
-     * : [type:hash] The name of the completion message, `"sound_done"`.
+     * : [type:hash] The name of the completion message, which can be either `"sound_done"` if the sound has finished playing, or `"sound_stopped"` if it was stopped manually.
      *
      * `message`
      * : [type:table] Information about the completion:

--- a/engine/gamesys/src/gamesys/test/sound/luacallback.script
+++ b/engine/gamesys/src/gamesys/test/sound/luacallback.script
@@ -12,18 +12,17 @@
 -- CONDITIONS OF ANY KIND, either express or implied. See the License for the
 -- specific language governing permissions and limitations under the License.
 
-local function sound_done(self, message_id, message, sender)
-    if message_id == hash("sound_done") then
+local function sound_evt_callback(self, message_id, message, sender)
+    if message_id == hash("sound_stopped") then
         self.sound_done = 1
         print("sound done!", self.count)
     end
 end
 
-
 function init(self)
     self.sound_done = 0
     self.count = 0
-    sound.play("#sound", nil, sound_done)
+    sound.play("#sound", nil, sound_evt_callback)
 end
 
 function final(self)


### PR DESCRIPTION
Added a new message id for the sound component when a sound instance has been stopped via `sound.stop`. The new sound message id is called `sound_stopped` and will be passed into the lua callback specified when playing a sound. 

Fixes #7775 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
