### PR TITLE
Fix Bob tests for arm64-osx

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -108,12 +108,13 @@ public class BundlerTest {
             data.add(new Platform[]{Platform.X86Win32});
             data.add(new Platform[]{Platform.X86_64Win32});
             data.add(new Platform[]{Platform.X86_64MacOS});
+            data.add(new Platform[]{Platform.Arm64MacOS});
             data.add(new Platform[]{Platform.X86_64Linux});
             data.add(new Platform[]{Platform.Armv7Android});
             data.add(new Platform[]{Platform.JsWeb});
 
             // Can only do this on OSX machines currently
-            if (Platform.getHostPlatform() == Platform.X86_64MacOS) {
+            if (Platform.getHostPlatform() == Platform.X86_64MacOS || Platform.getHostPlatform() == Platform.Arm64MacOS) {
                 data.add(new Platform[]{Platform.Arm64Ios});
                 data.add(new Platform[]{Platform.X86_64Ios});
             }
@@ -126,6 +127,7 @@ public class BundlerTest {
         switch (platform)
         {
             case X86_64MacOS:
+            case Arm64MacOS:
             case Arm64Ios:
             case X86_64Ios:
                     folderName = projectName + ".app";
@@ -238,6 +240,7 @@ public class BundlerTest {
             }
             break;
             case X86_64MacOS:
+            case Arm64MacOS:
                 List<String> names = Arrays.asList(
                     String.format("Contents/MacOS/%s", exeName),
                     "Contents/Info.plist"
@@ -647,6 +650,7 @@ public class BundlerTest {
                 expectedFiles.add("Payload/unnamed.app/Icon@2x.png");
                 break;
             case X86_64MacOS:
+            case Arm64MacOS:
                 expectedFiles.add("Contents/MacOS/unnamed");
                 expectedFiles.add("Contents/Info.plist");
                 expectedFiles.add("Contents/Resources/game.arcd");

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BundleResourcesTest.java
@@ -300,6 +300,7 @@ public class BundleResourcesTest {
         // Test data
         Map<Platform, String[]> expected = new HashMap<Platform, String[]>();
         expected.put(Platform.X86_64MacOS, new String[] { "osx.txt", "x86_64-osx.txt" });
+        expected.put(Platform.Arm64MacOS, new String[] { "osx.txt", "arm64-osx.txt" });
         expected.put(Platform.X86_64Linux, new String[] { "linux.txt", "x86_64-linux.txt" });
         expected.put(Platform.X86Win32, new String[] { "win32.txt", "x86-win32.txt" });
         expected.put(Platform.X86_64Win32, new String[] { "win32.txt", "x86_64-win32.txt" });


### PR DESCRIPTION
I found that I can't run 
>DM_BOB_BUNDLERTEST_ONLY_HOST=1 ./scripts/build.py build_bob

when I use arm64 JDK - tests fail.

So I fixed tests to make sure it works for `arm64-osx` as well

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
