### PR TITLE
Fix issue when `CMD+H` doesn't hide the editor on MacOS

### DIFF
--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.awt.image.BufferedImage;
+import java.awt.Desktop;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -117,19 +118,7 @@ public class Start extends Application {
     @Override
     public void start(Stage primaryStage) throws Exception {
         try {
-            /*
-              Note
-              Don't remove
-
-              Background
-              Before the mysterious line below Command-H on OSX would open a generic Java about dialog instead of hiding the application.
-              The hypothosis is that awt must be initialized before JavaFX and in particular on the main thread as we're pooling stuff using
-              a threadpool.
-              Something even more mysterious is that if the construction of the buffered image is moved to "static void main(.." we get a null pointer in
-              clojure.java.io/resource..
-            */
-
-            new BufferedImage(1, 1, BufferedImage.TYPE_3BYTE_BGR);
+            Desktop.getDesktop().setAboutHandler(null);
 
             // Clean up old packages as they consume a lot of hard drive space.
             // NOTE! This is a temp hack to give some hard drive space back to users.

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -30,8 +30,10 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.awt.image.BufferedImage;
+import java.lang.SecurityException;
 import java.awt.Desktop;
 import java.io.File;
+import java.lang.UnsupportedOperationException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -119,7 +121,12 @@ public class Start extends Application {
     public void start(Stage primaryStage) throws Exception {
         try {
             Desktop.getDesktop().setAboutHandler(null);
-
+        } catch (final UnsupportedOperationException e) {
+            System.out.println("The os does not support: 'desktop.setAboutHandler'");
+        } catch (final SecurityException e) {
+            System.out.println("There was a security exception for: 'desktop.setAboutHandler'");
+        }
+        try {
             // Clean up old packages as they consume a lot of hard drive space.
             // NOTE! This is a temp hack to give some hard drive space back to users.
             // The proper fix would be an upgrade feature where users can upgrade and downgrade as desired.

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import java.awt.image.BufferedImage;
 import java.lang.SecurityException;
 import java.awt.Desktop;
 import java.io.File;


### PR DESCRIPTION
Fixed issue when `CMD+H`on MacOS shows Java About window instead of application hiding. 

Fix https://github.com/defold/defold/issues/7528

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
