### PR TITLE
Fixed non-Western character input not working on Windows and MacOS.

### DIFF
--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -517,11 +517,15 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         markedText = [[NSMutableAttributedString alloc] initWithAttributedString:string];
     else
         markedText = [[NSMutableAttributedString alloc] initWithString:string];
+
+    _glfwSetMarkedText((char*)[[markedText string] UTF8String]);
 }
 
 - (void)unmarkText
 {
     [[markedText mutableString] setString:@""];
+
+    _glfwSetMarkedText("");
 }
 
 - (NSArray*)validAttributesForMarkedText

--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -291,10 +291,33 @@ static int convertMacKeyCode( unsigned int macKeyCode )
 // Content view class for the GLFW window
 //========================================================================
 
-@interface GLFWContentView : NSView
+// Defines a constant for empty ranges in NSTextInputClient
+//
+static const NSRange kEmptyRange = { NSNotFound, 0 };
+
+@interface GLFWContentView : NSView <NSTextInputClient>
+{
+    NSMutableAttributedString* markedText;
+}
+
 @end
 
 @implementation GLFWContentView
+
+- (instancetype)init
+{
+    if (self = [super init])
+    {
+        markedText = [[NSMutableAttributedString alloc] init];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [markedText release];
+    [super dealloc];
+}
 
 - (BOOL)wantsUpdateLayer
 {
@@ -409,8 +432,6 @@ static int convertMacKeyCode( unsigned int macKeyCode )
 
 - (void)keyDown:(NSEvent *)event
 {
-    NSUInteger length;
-    NSString* characters;
     int i, code = convertMacKeyCode( [event keyCode] );
 
     if( code != -1 )
@@ -424,17 +445,9 @@ static int convertMacKeyCode( unsigned int macKeyCode )
                 [super keyDown:event];
             }
         }
-        else if( code != GLFW_KEY_LEFT && code != GLFW_KEY_RIGHT && code != GLFW_KEY_UP && code != GLFW_KEY_DOWN )
-        {
-            characters = [event characters];
-            length = [characters length];
-
-            for( i = 0;  i < length;  i++ )
-            {
-                _glfwInputChar( [characters characterAtIndex:i], GLFW_PRESS );
-            }
-        }
     }
+
+     [self interpretKeyEvents:@[event]];
 }
 
 - (void)flagsChanged:(NSEvent *)event
@@ -457,21 +470,11 @@ static int convertMacKeyCode( unsigned int macKeyCode )
 
 - (void)keyUp:(NSEvent *)event
 {
-    NSUInteger length;
-    NSString* characters;
     int i, code = convertMacKeyCode( [event keyCode] );
 
     if( code != -1 )
     {
         _glfwInputKey( code, GLFW_RELEASE );
-
-        characters = [event characters];
-        length = [characters length];
-
-        for( i = 0;  i < length;  i++ )
-        {
-            _glfwInputChar( [characters characterAtIndex:i], GLFW_RELEASE );
-        }
     }
 }
 
@@ -484,6 +487,100 @@ static int convertMacKeyCode( unsigned int macKeyCode )
     {
         _glfwWin.mouseWheelCallback( _glfwInput.WheelPos );
     }
+}
+
+
+- (BOOL)hasMarkedText
+{
+    return [markedText length] > 0;
+}
+
+- (NSRange)markedRange
+{
+    if ([markedText length] > 0)
+        return NSMakeRange(0, [markedText length] - 1);
+    else
+        return kEmptyRange;
+}
+
+- (NSRange)selectedRange
+{
+    return kEmptyRange;
+}
+
+- (void)setMarkedText:(id)string
+        selectedRange:(NSRange)selectedRange
+     replacementRange:(NSRange)replacementRange
+{
+    [markedText release];
+    if ([string isKindOfClass:[NSAttributedString class]])
+        markedText = [[NSMutableAttributedString alloc] initWithAttributedString:string];
+    else
+        markedText = [[NSMutableAttributedString alloc] initWithString:string];
+}
+
+- (void)unmarkText
+{
+    [[markedText mutableString] setString:@""];
+}
+
+- (NSArray*)validAttributesForMarkedText
+{
+    return [NSArray array];
+}
+
+- (NSAttributedString*)attributedSubstringForProposedRange:(NSRange)range
+                                               actualRange:(NSRangePointer)actualRange
+{
+    return nil;
+}
+
+- (NSUInteger)characterIndexForPoint:(NSPoint)point
+{
+    return 0;
+}
+
+- (NSRect)firstRectForCharacterRange:(NSRange)range
+                         actualRange:(NSRangePointer)actualRange
+{
+    //const NSRect frame = [window->ns.view frame];
+    const NSRect frame = [_glfwWin.window contentRectForFrameRect:[_glfwWin.window frame]];
+    return NSMakeRect(frame.origin.x, frame.origin.y, 0.0, 0.0);
+}
+
+- (void)insertText:(id)string replacementRange:(NSRange)replacementRange
+{
+    NSString* characters;
+    NSEvent* event = [NSApp currentEvent];
+
+    if ([string isKindOfClass:[NSAttributedString class]])
+        characters = [string string];
+    else
+        characters = (NSString*) string;
+
+    NSRange range = NSMakeRange(0, [characters length]);
+    while (range.length)
+    {
+        uint32_t codepoint = 0;
+
+        if ([characters getBytes:&codepoint
+                       maxLength:sizeof(codepoint)
+                      usedLength:NULL
+                        encoding:NSUTF32StringEncoding
+                         options:0
+                           range:range
+                  remainingRange:&range])
+        {
+            if (codepoint >= 0xf700 && codepoint <= 0xf7ff)
+                continue;
+
+            _glfwInputChar(codepoint, GLFW_PRESS);
+        }
+    }
+}
+
+- (void)doCommandBySelector:(SEL)selector
+{
 }
 
 @end
@@ -606,6 +703,7 @@ int  _glfwPlatformOpenWindow( int width, int height,
     view.wantsLayer = _glfwWin.clientAPI == GLFW_NO_API ? YES : NO;
 
     [_glfwWin.window setContentView: view];
+    [_glfwWin.window makeFirstResponder: view];
     [_glfwWin.window setDelegate:_glfwWin.delegate];
     [_glfwWin.window setAcceptsMouseMovedEvents:YES];
     [_glfwWin.window center];

--- a/engine/glfw/lib/win32/platform.h
+++ b/engine/glfw/lib/win32/platform.h
@@ -44,6 +44,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <xinput.h>
+#include <imm.h>
 #include "../../include/GL/glfw.h"
 #include "../../include/GL/glfw_native.h"
 
@@ -256,6 +257,12 @@ typedef MMRESULT (WINAPI * JOYGETPOSEX_T) (UINT,LPJOYINFOEX);
 typedef DWORD (WINAPI * TIMEGETTIME_T) (void);
 #endif // _GLFW_NO_DLOAD_WINMM
 
+// imm32.dll function pointer typedefs
+#ifndef _GLFW_NO_DLOAD_IMM32
+typedef HIMC (WINAPI * IMMGETCONTEXT_T) (HWND);
+typedef BOOL (WINAPI * IMMRELEASECONTEXT_T) (HWND, HIMC);
+typedef BOOL (WINAPI * IMMGETCOMPOSITIONSTRING_T) (HIMC, DWORD, LPVOID, DWORD);
+#endif // _GLFW_NO_DLOAD_IMM32
 
 // gdi32.dll shortcuts
 #ifndef _GLFW_NO_DLOAD_GDI32
@@ -285,6 +292,16 @@ typedef DWORD (WINAPI * TIMEGETTIME_T) (void);
 #define _glfw_timeGetTime   timeGetTime
 #endif // _GLFW_NO_DLOAD_WINMM
 
+// Imm32.dll shortcuts
+#ifndef _GLFW_NO_DLOAD_IMM32
+#define _glfw_ImmGetContext             _glfwLibrary.Libs.ImmGetContext
+#define _glfw_ImmReleaseContext         _glfwLibrary.Libs.ImmReleaseContext
+#define _glfw_ImmGetCompositionString   _glfwLibrary.Libs.ImmGetCompositionStringW
+#else
+#define _glfw_ImmGetContext             ImmGetContext
+#define _glfw_ImmReleaseContext         ImmReleaseContext
+#define _glfw_ImmGetCompositionString   ImmGetCompositionStringW
+#endif // _GLFW_NO_DLOAD_IMM32
 
 //========================================================================
 // GLFW platform specific types
@@ -485,6 +502,15 @@ GLFWGLOBAL struct {
       JOYGETPOSEX_T         joyGetPosEx;
       TIMEGETTIME_T         timeGetTime;
 #endif // _GLFW_NO_DLOAD_WINMM
+
+      // imm32.dll
+#ifndef _GLFW_NO_DLOAD_IMM32
+      HINSTANCE                 imm32;
+      IMMGETCONTEXT_T           ImmGetContext;
+      IMMRELEASECONTEXT_T       ImmReleaseContext;
+      IMMGETCOMPOSITIONSTRING_T ImmGetCompositionStringW;
+#endif // _GLFW_NO_DLOAD_IMM32
+
   } Libs;
 #endif
 

--- a/engine/glfw/lib/win32/win32_init.c
+++ b/engine/glfw/lib/win32/win32_init.c
@@ -150,6 +150,32 @@ static int _glfwInitLibraries( void )
     }
 #endif // _GLFW_NO_DLOAD_WINMM
 
+    // imm32.dll (for input method support)
+#ifndef _GLFW_NO_DLOAD_IMM32
+    _glfwLibrary.Libs.imm32 = LoadLibrary( L"imm32.dll" );
+    if( _glfwLibrary.Libs.imm32 != NULL )
+    {
+        _glfwLibrary.Libs.ImmGetContext = (IMMGETCONTEXT_T)
+            GetProcAddress( _glfwLibrary.Libs.imm32, "ImmGetContext" );
+        _glfwLibrary.Libs.ImmReleaseContext      = (IMMRELEASECONTEXT_T)
+            GetProcAddress( _glfwLibrary.Libs.imm32, "ImmReleaseContext" );
+        _glfwLibrary.Libs.ImmGetCompositionStringW    = (IMMGETCOMPOSITIONSTRING_T)
+            GetProcAddress( _glfwLibrary.Libs.imm32, "ImmGetCompositionStringW" );
+        if( _glfwLibrary.Libs.ImmGetContext             == NULL ||
+            _glfwLibrary.Libs.ImmReleaseContext         == NULL ||
+            _glfwLibrary.Libs.ImmGetCompositionStringW  == NULL )
+        {
+            FreeLibrary( _glfwLibrary.Libs.imm32 );
+            _glfwLibrary.Libs.imm32 = NULL;
+            return GL_FALSE;
+        }
+    }
+    else
+    {
+        return GL_FALSE;
+    }
+#endif // _GLFW_NO_DLOAD_IMM32
+
     return GL_TRUE;
 }
 
@@ -186,6 +212,15 @@ static void _glfwFreeLibraries( void )
         _glfwLibrary.Libs.winmm = NULL;
     }
 #endif // _GLFW_NO_DLOAD_WINMM
+
+    // imm32.dll
+#ifndef _GLFW_NO_DLOAD_IMM32
+    if( _glfwLibrary.Libs.imm32 != NULL )
+    {
+        FreeLibrary( _glfwLibrary.Libs.imm32 );
+        _glfwLibrary.Libs.imm32 = NULL;
+    }
+#endif // _GLFW_NO_DLOAD_IMM32
 }
 
 

--- a/engine/glfw/lib/win32/win32_window.c
+++ b/engine/glfw/lib/win32/win32_window.c
@@ -909,6 +909,28 @@ static LRESULT CALLBACK windowProc( HWND hWnd, UINT uMsg,
                         }
                     }
                 }
+
+                if (lParam & GCS_RESULTSTR)
+                {
+                    LONG nSize = _glfw_ImmGetCompositionString(hIMC, GCS_RESULTSTR, NULL, 0);
+                    if (nSize)
+                    {
+                        LPWSTR psz = (LPWSTR)LocalAlloc(LPTR, nSize + sizeof(WCHAR));
+                        if (psz)
+                        {
+                            _glfw_ImmGetCompositionString(hIMC, GCS_RESULTSTR, psz, nSize);
+
+                            char* markedText = createUTF8FromWideStringWin32(psz);
+                            if (markedText)
+                            {
+                                _glfwSetMarkedText(markedText);
+                                free(markedText);
+                            }
+                            LocalFree(psz);
+                        }
+                    }
+                }
+
                 _glfw_ImmReleaseContext(hWnd, hIMC);
             }
             break;

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -182,28 +182,10 @@ void _glfwInputKey( int key, int action )
 
 void _glfwInputChar( int character, int action )
 {
-    int keyrepeat = 0;
-
     // Valid Unicode (ISO 10646) character?
     if( !( (character >= 32 && character <= 126) || character >= 160 ) )
     {
         return;
-    }
-
-    // Is this a key repeat?
-    if( action == GLFW_PRESS && _glfwInput.LastChar == character )
-    {
-        keyrepeat = 1;
-    }
-
-    // Store this character as last character (or clear it, if released)
-    if( action == GLFW_PRESS )
-    {
-        _glfwInput.LastChar = character;
-    }
-    else
-    {
-        _glfwInput.LastChar = 0;
     }
 
     if( action != GLFW_PRESS )
@@ -224,7 +206,7 @@ void _glfwInputChar( int character, int action )
         return;
     }
 
-    if( _glfwWin.charCallback && (_glfwInput.KeyRepeat || !keyrepeat) )
+    if( _glfwWin.charCallback )
     {
         _glfwWin.charCallback( character, action );
     }


### PR DESCRIPTION
It is now possible to input Chinese, Korean and other non-western language characters using a keyboard on Windows and macOS. The action table of the `on_input()` text event will contain the pressed key, just like for Western keyboard input.

Fixes https://github.com/defold/defold/issues/3351

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
