### PR TITLE
Add `gui.max_animation_count` propertin in `game.project`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -338,6 +338,9 @@ max_particlefx_count.default = 64
 max_particle_count.type = integer
 max_particle_count.help = max total number of living particles in gui, 1024 by default
 max_particle_count.default = 1024
+max_animation_count.type = integer
+max_animation_count.help = max total number of active animations in gui, 1024 by default
+max_animation_count.default = 1024
 
 [collection]
 help = Collection related settings
@@ -616,9 +619,6 @@ max_emitter_count.default = 64
 max_particle_count.type = integer
 max_particle_count.help = max total number of living particles in gui per collection, 1024 by default
 max_particle_count.default = 1024
-max_animation_count.type = integer
-max_animation_count.help = max total number of active animations in gui, 1024 by default
-max_animation_count.default = 1024
 
 [iap]
 help = In App Purchase related settings

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -614,8 +614,11 @@ max_emitter_count.type = integer
 max_emitter_count.help = max number of particle fx emitters, 64 by default
 max_emitter_count.default = 64
 max_particle_count.type = integer
-max_particle_count.help = max total number of living particles, 1024 by default
+max_particle_count.help = max total number of living particles in gui per collection, 1024 by default
 max_particle_count.default = 1024
+max_animation_count.type = integer
+max_animation_count.help = max total number of active animations in gui, 1024 by default
+max_animation_count.default = 1024
 
 [iap]
 help = In App Purchase related settings

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -617,7 +617,7 @@ max_emitter_count.type = integer
 max_emitter_count.help = max number of particle fx emitters, 64 by default
 max_emitter_count.default = 64
 max_particle_count.type = integer
-max_particle_count.help = max total number of living particles in gui per collection, 1024 by default
+max_particle_count.help = max total number of living particles, 1024 by default
 max_particle_count.default = 1024
 
 [iap]

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -420,6 +420,11 @@
    :path ["gui" "max_particlefx_count"]}
   {:type :integer,
    :help
+   "max total number of active animations in gui, 1024 by default",
+   :default 1024,
+   :path ["gui" "max_animation_count"]}
+  {:type :integer,
+   :help
    "max total number of living particles in gui per collection, 1024 by default",
    :default 1024,
    :path ["gui" "max_particle_count"]}

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -117,6 +117,7 @@ namespace dmGameSystem
         uint32_t                    m_MaxGuiComponents;
         uint32_t                    m_MaxParticleFXCount;
         uint32_t                    m_MaxParticleCount;
+        uint32_t                    m_MaxAnimationCount;
     };
 
     static void GuiResourceReloadedCallback(const dmResource::ResourceReloadedParams& params)
@@ -200,6 +201,7 @@ namespace dmGameSystem
         gui_world->m_MaxParticleFXCount = gui_context->m_MaxParticleFXCount;
         gui_world->m_MaxParticleCount = gui_context->m_MaxParticleCount;
         gui_world->m_ParticleContext = dmParticle::CreateContext(gui_world->m_MaxParticleFXCount, gui_world->m_MaxParticleCount);
+        gui_world->m_MaxAnimationCount = gui_context->m_MaxAnimationCount;
 
         gui_world->m_ScriptWorld = dmScript::NewScriptWorld(gui_context->m_ScriptContext);
 
@@ -729,11 +731,11 @@ namespace dmGameSystem
         // This is a hard cap since the render key has 13 bits for node index (see gui.cpp)
         assert(scene_desc->m_MaxNodes <= 8192);
         scene_params.m_MaxNodes = scene_desc->m_MaxNodes;
-        scene_params.m_MaxAnimations = 1024;
         scene_params.m_UserData = gui_component;
         scene_params.m_MaxFonts = 64;
         scene_params.m_MaxTextures = 128;
         scene_params.m_MaxMaterials = 16;
+        scene_params.m_MaxAnimations = gui_world->m_MaxAnimationCount;
         scene_params.m_MaxParticlefx = gui_world->m_MaxParticleFXCount;
         scene_params.m_ParticlefxContext = gui_world->m_ParticleContext;
         scene_params.m_FetchTextureSetAnimCallback = &FetchTextureSetAnimCallback;
@@ -2776,6 +2778,7 @@ namespace dmGameSystem
         gui_context->m_MaxGuiComponents = dmConfigFile::GetInt(ctx->m_Config, "gui.max_count", 64);
         gui_context->m_MaxParticleFXCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particlefx_count", 64);
         gui_context->m_MaxParticleCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_particle_count", 1024);
+        gui_context->m_MaxAnimationCount = dmConfigFile::GetInt(ctx->m_Config, "gui.max_animation_count", 1024);
 
         int32_t max_gui_count = dmConfigFile::GetInt(ctx->m_Config, "gui.max_instance_count", 128);
         gui_context->m_Worlds.SetCapacity(max_gui_count);

--- a/engine/gamesys/src/gamesys/components/comp_gui_private.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui_private.h
@@ -133,6 +133,7 @@ namespace dmGameSystem
         uint32_t                            m_MaxParticleFXCount;
         uint32_t                            m_MaxParticleCount;
         uint32_t                            m_RenderedParticlesSize;
+        uint32_t                            m_MaxAnimationCount;
         float                               m_DT;
         dmScript::ScriptWorld*              m_ScriptWorld;
         CompGuiContext*                     m_CompGuiContext;


### PR DESCRIPTION
Now it's possible to specify count of animations in GUI component in `gam.project`->`gui.max_animation_count` (by default 1024).

Fix https://github.com/defold/defold/issues/7667

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
