### PR TITLE
Make sure that TimeProfiler doesn't fail

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1210,7 +1210,7 @@ public class Project {
         Callable<Void> callable = new Callable<>() {
             public Void call() throws Exception {
                 logInfo("Build Remote Engine...");
-                TimeProfiler.start("Build Remote Engine");
+                TimeProfiler.addMark("StartBuildRemoteEngine", "Build Remote Engine");
                 final String variant = option("variant", Bob.VARIANT_RELEASE);
                 final Boolean withSymbols = hasOption("with-symbols");
 
@@ -1218,8 +1218,10 @@ public class Project {
                 appmanifestOptions.put("baseVariant", variant);
                 appmanifestOptions.put("withSymbols", withSymbols.toString());
 
-                TimeProfiler.addData("withSymbols", withSymbols);
-                TimeProfiler.addData("variant", variant);
+                // temporary removed because TimeProfiler works only with a single thread
+                // see https://github.com/pyatyispyatil/flame-chart-js
+                // TimeProfiler.addData("withSymbols", withSymbols);
+                // TimeProfiler.addData("variant", variant);
 
                 if (hasOption("build-artifacts")) {
                     String s = option("build-artifacts", "");
@@ -1241,7 +1243,7 @@ public class Project {
 
                 long tend = System.currentTimeMillis();
                 logger.info("Engine build took %f s", (tend-tstart)/1000.0);
-                TimeProfiler.stop();
+                TimeProfiler.addMark("FinishedBuildRemoteEngine", "Build Remote Engine Finished");
 
                 return (Void)null;
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TimeProfiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TimeProfiler.java
@@ -68,6 +68,7 @@ public class TimeProfiler {
     private static class ProfilingMark {
         public String shortName;
         public String fullName;
+        public String color;
         public long timestamp;
     }
 
@@ -141,6 +142,8 @@ public class TimeProfiler {
                 generator.writeString(mark.shortName);
                 generator.writeFieldName("fullName");
                 generator.writeString(mark.fullName);
+                generator.writeFieldName("color");
+                generator.writeString(mark.color);
                 generator.writeFieldName("timestamp");
                 generator.writeNumber(mark.timestamp - buildTime);
                 generator.writeEndObject();
@@ -311,7 +314,7 @@ public class TimeProfiler {
         unsafeStop();
     }
 
-    public static void addMark(String shortName, String fullName) {
+    public static void addMark(String shortName, String fullName, String color) {
         if (rootScope == null) {
             return;
         }
@@ -319,11 +322,16 @@ public class TimeProfiler {
         mark.timestamp = time();
         mark.shortName = shortName;
         mark.fullName = fullName;
+        mark.color = color;
         marks.add(mark);
     }
 
     public static void addMark(String shortName) {
-        addMark(shortName, shortName);
+        addMark(shortName, shortName, "#EADDCA");
+    }
+
+    public static void addMark(String shortName, String fullName) {
+        addMark(shortName, shortName, "#EADDCA");
     }
 
     private static void unsafeAddData(String fieldName, String data) {


### PR DESCRIPTION
At the moment `TimeProfiler` is a single threaded tool. Using it from the different threads maybe a reason of a total mess. At the moment I use  `TimeProfiler.addMark()` instead of `start()` and `stop()` which may fail the build and break the report

Here is a ticket for a proper fix: https://github.com/defold/defold/issues/7885

That's how it looks like 
<img width="1259" alt="image" src="https://github.com/defold/defold/assets/2209596/ab3426f3-fdc0-41cb-a57a-88fd0012ce1f">


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
