### PR TITLE
Make `.image-view` styling more efficient

### DIFF
--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -196,10 +196,9 @@
         style (case (:severity error-item)
                 :info #{"severity-info"}
                 :warning #{"severity-warning"}
-                #{"severity-error"})
-        image (icons/get-image-view icon 16)
-        text (Text. message)]
-    {:graphic (HBox. (ui/node-array [image text]))
+                #{"severity-error"})]
+    {:text message
+     :icon icon
      :style style}))
 
 (defn- find-outline-node [resource-node-id error-node-id]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -1213,11 +1213,6 @@
   {:control control
    :menu-id menu-id})
 
-(defn- wrap-menu-image [node]
-  (doto (Pane.)
-    (children! [node])
-    (add-style! "menu-image-wrapper")))
-
 (defn- make-submenu [id label icon ^Collection style-classes menu-items on-open]
   (when (seq menu-items)
     (let [menu (Menu. label)]
@@ -1225,7 +1220,7 @@
       (when on-open
         (.setOnShowing menu (event-handler e (on-open))))
       (when icon
-        (.setGraphic menu (wrap-menu-image (icons/get-image-view icon 16))))
+        (.setGraphic menu (icons/get-image-view icon 16)))
       (when style-classes
         (assert (set? style-classes))
         (doto (.getStyleClass menu)
@@ -1261,7 +1256,7 @@
     (when (and (some? key-combo) (nil? user-data))
       (.setAccelerator menu-item key-combo))
     (when icon
-      (.setGraphic menu-item (wrap-menu-image (icons/get-image-view icon 16))))
+      (.setGraphic menu-item (icons/get-image-view icon 16)))
     (when style-classes
       (assert (set? style-classes))
       (doto (.getStyleClass menu-item)

--- a/editor/styling/stylesheets/components/_button.scss
+++ b/editor/styling/stylesheets/components/_button.scss
@@ -76,7 +76,7 @@
   }
   &:selected {
     -fx-background-color: -df-background;
-    .image-view {
+    & > .image-view {
       @include effect-lighten-blue()
     }
   }

--- a/editor/styling/stylesheets/components/_flat-list-view.scss
+++ b/editor/styling/stylesheets/components/_flat-list-view.scss
@@ -35,7 +35,7 @@
             &:hover {
                 -fx-text-fill: -df-text-selected;
             }
-            .image-view {
+            & > .image-view {
                 @include effect-bright-grey();
             }
 

--- a/editor/styling/stylesheets/components/_list-view.scss
+++ b/editor/styling/stylesheets/components/_list-view.scss
@@ -19,7 +19,7 @@
             &:hover {
                 -fx-text-fill: -df-text-selected;
             }
-            .image-view {
+            & > .image-view {
                 @include effect-bright-grey();
             }
         }

--- a/editor/styling/stylesheets/components/_tab.scss
+++ b/editor/styling/stylesheets/components/_tab.scss
@@ -23,9 +23,6 @@
             -fx-background-insets: 0;
             .tab-label {
                 -fx-text-fill: -df-text-selected;
-                .image-view {
-                    @include effect-lighten();
-                }
             }
         }
         &:selected {
@@ -35,9 +32,6 @@
 
             .tab-label {
                 -fx-text-fill: -df-text-selected;
-                .image-view {
-                    @include effect-lighten();
-                }
             }
             .focus-indicator {
                 -fx-border-width: 0;
@@ -123,7 +117,7 @@
                 -fx-pref-width: 17px;
                 -fx-pref-height: 17px;
             }
-            .image-view {
+            & > .graphic-container > .image-view {
                 -fx-scale-x: 0.5;
                 -fx-scale-y: 0.5;
             }

--- a/editor/styling/stylesheets/components/_tree-view.scss
+++ b/editor/styling/stylesheets/components/_tree-view.scss
@@ -18,7 +18,7 @@
 
         &:hover {
             -fx-text-fill: -df-text-selected;
-            .image-view {
+            & > .image-view {
                 @include effect-bright-grey();
             }
             .label {
@@ -30,7 +30,7 @@
             -fx-border-color: -df-defold-orange;
             -fx-text-fill: -df-text-selected;
             -fx-background-color: -df-background-lighter;
-            .image-view {
+            & > .image-view {
                 @include effect-bright-grey();
             }
             .label {
@@ -38,7 +38,7 @@
             }
         }
 
-        .image-view {
+        & > .image-view {
             @include effect-icon-grey();
         }
 

--- a/editor/styling/stylesheets/components/_vcs-status.scss
+++ b/editor/styling/stylesheets/components/_vcs-status.scss
@@ -1,5 +1,5 @@
 @mixin colorize-image-view($color) {
-  .image-view { -fx-effect: innershadow(gaussian, $color, 20, 0.3, 0, 0); }
+  & > .image-view { -fx-effect: innershadow(gaussian, $color, 20, 0.3, 0, 0) !important; }
 }
 
 .list-view {

--- a/editor/styling/stylesheets/mixins/_file-extensions.scss
+++ b/editor/styling/stylesheets/mixins/_file-extensions.scss
@@ -1,27 +1,28 @@
 @mixin extension-template($element, $color, $active-color){
-    .image-view {
-        @include colorize-image-view($color);
-    }
-    @if($element == "menu") {
-        &:focused {
-            .image-view {
+    // tab, tree, menu
+    @if $element == "menu" {
+        & > .graphic-container > .image-view {
+            @include colorize-image-view($color);
+        }
+        &:focused > .graphic-container > .image-view {
+            @include colorize-image-view($active-color);
+        }
+    } @else if $element == "tab" {
+        & > .tab-container > .tab-label > .image-view {
+            @include colorize-image-view($color);
+        }
+        &:selected, &:hover {
+            & > .tab-container > .tab-label > .image-view {
                 @include colorize-image-view($active-color);
             }
         }
     } @else {
+        & > .image-view {
+            @include colorize-image-view($color);
+        }
         &:selected, &:hover {
-            @if($element == "tab") {
-                .tab-container {
-                    .tab-label {
-                        .image-view {
-                            @include colorize-image-view($active-color);
-                        }
-                    }
-                }
-            } @else {
-                .image-view {
-                    @include colorize-image-view($active-color);
-                }
+            & > .image-view {
+                @include colorize-image-view($active-color);
             }
         }
     }

--- a/editor/styling/stylesheets/mixins/_menu-elements.scss
+++ b/editor/styling/stylesheets/mixins/_menu-elements.scss
@@ -6,7 +6,7 @@
         > .label {
             -fx-text-fill: -df-text;
         }
-        .image-view {
+        & > .image-view, > .graphic-container > .image-view {
             @include colorize-image-view(-df-text);
         }
 
@@ -17,7 +17,7 @@
                 -fx-opacity: 1.0;
                 -fx-text-fill: -df-text !important;
             }
-            .image-view {
+            > .graphic-container > .image-view {
                 -fx-effect: innershadow(gaussian, -df-text, 20, 1.0, 0, 0) !important;
             }
         }
@@ -27,7 +27,7 @@
             > .label {
                 -fx-text-fill: -df-text-selected;
             }
-            .image-view {
+            & > .image-view, > .graphic-container > .image-view {
                 @include effect-lighten-blue();
             }
         }

--- a/editor/styling/stylesheets/modules/_outline.scss
+++ b/editor/styling/stylesheets/modules/_outline.scss
@@ -2,18 +2,18 @@
 
 @mixin colorize-icon($color, $active-color) {
   &:filled {
-    .image-view {
+    & > .image-view {
       -fx-effect: innershadow(gaussian, $color, 20, 1.0, 0, 0);
     }
 
     &:hover {
-      .image-view {
+      & > .image-view {
         -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);
       }
     }
 
     &:selected {
-      .image-view {
+      & > .image-view {
         -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);;
       }
     }
@@ -82,7 +82,7 @@
           -fx-opacity: 40%;
         }
       }
-      .image-view {
+      & > .image-view {
         -fx-opacity: 40%;
       }
       .text {

--- a/editor/styling/stylesheets/modules/_tool-tabs.scss
+++ b/editor/styling/stylesheets/modules/_tool-tabs.scss
@@ -119,11 +119,11 @@
         }
 
         @mixin colorize-severity($color, $active-color) {
-            .image-view {
+            & > .image-view {
                 -fx-effect: innershadow(gaussian, $color, 20, 1.0, 0, 0);
             }
             &:selected, &:hover {
-                .image-view {
+                & > .image-view {
                     -fx-effect: innershadow(gaussian, $active-color, 20, 1.0, 0, 0);
                 }
             }

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -24,18 +24,18 @@
         -fx-border-width: 0;
         -fx-alignment: center;
 
-        .image-view {
+        & > .image-view {
             -fx-effect: innershadow(gaussian, -df-text, 20, 0.3, 0, 0) !important;
         }
 
         &:hover {
-            .image-view {
+            & > .image-view {
                 -fx-effect: innershadow(gaussian, -df-text-selected, 20, 0.3, 0, 0) !important;
             }
         }
         &:selected {
             -fx-background-color: -df-background-light;
-            .image-view {
+            & > .image-view {
                 -fx-effect: innershadow(gaussian, -df-text-selected, 20, 0.3, 0, 0) !important;
             }
         }
@@ -120,7 +120,7 @@
         -fx-border-width: 0;
         -fx-border-insets: 0;
         -fx-background-color: transparent;
-        .image-view {
+        >.image-view {
             -fx-effect: innershadow(gaussian, -df-text, 20, 0.3, 0, 0) !important;
         }
         >.choice-box {

--- a/editor/styling/stylesheets/modules/_welcome-dialog.scss
+++ b/editor/styling/stylesheets/modules/_welcome-dialog.scss
@@ -14,11 +14,6 @@
       -fx-background-color: transparent;
       -fx-border-width: 0;
       -fx-padding: 0;
-
-      // Counteract too-broad application of styling from _file-extensions.scss.
-      .image-view {
-        -fx-effect: none;
-      }
     }
   }
 


### PR DESCRIPTION
User-facing changes:
Improve editor performance when scrolling the Assets pane

Technical changes:
Make CSS that affects the `.image-view` style class more efficient by replacing indirect children styling (e.g. `.foo .bar`) with direct children styling (e.g. `.foo > .bar`).

Fixes #7896
