### PR TITLE
Property editor fixes

### DIFF
--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -49,6 +49,7 @@
           <entry key="editor.ui/on-action!" value="-1" />
           <entry key="editor.ui/on-closing!" value="-1" />
           <entry key="editor.ui/with-controls" value="-1" />
+          <entry key="editor.ui/with-on-edit-event-suppressed" value="-1" />
           <entry key="editor.ui/with-progress" value="-1" />
           <entry key="editor.updater-test/with-server" value="2" />
           <entry key="editor.workspace/register-resource-type" value="-1" />

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -27,16 +27,17 @@
             [editor.ui :as ui]
             [editor.ui.fuzzy-combo-box :as fuzzy-combo-box]
             [editor.workspace :as workspace]
+            [util.coll :refer [pair]]
             [util.id-vec :as iv]
             [util.profiler :as profiler])
-  (:import [javafx.geometry Insets Point2D]
+  (:import [editor.properties Curve CurveSpread]
+           [javafx.geometry Insets Point2D]
            [javafx.scene Node Parent]
-           [javafx.scene.control Control Button CheckBox ColorPicker Label Slider TextField TextInputControl ToggleButton Tooltip TitledPane TextArea TreeItem Menu MenuItem MenuBar Tab ProgressBar]
+           [javafx.scene.control Button CheckBox ColorPicker Control Label Slider TextArea TextField TextInputControl ToggleButton Tooltip]
            [javafx.scene.input MouseEvent]
-           [javafx.scene.layout Pane AnchorPane GridPane HBox VBox Priority ColumnConstraints Region]
+           [javafx.scene.layout AnchorPane ColumnConstraints GridPane HBox Pane Priority Region VBox]
            [javafx.scene.paint Color]
-           [javafx.util Duration]
-           [editor.properties CurveSpread Curve]))
+           [javafx.util Duration]))
 
 (set! *warn-on-reflection* true)
 
@@ -634,13 +635,17 @@
       (when-let [update-ui-fn (get update-fns key)]
         (update-ui-fn property)))))
 
-(def ^:private ephemeral-edit-type-fields [:from-type :to-type :set-fn])
+(def ^:private ephemeral-edit-type-fields [:from-type :to-type :set-fn :clear-fn])
 
 (defn- edit-type->template [edit-type]
   (apply dissoc edit-type ephemeral-edit-type-fields))
 
 (defn- properties->template [properties]
-  (mapv (fn [[k v]] [k (edit-type->template (:edit-type v))]) (:properties properties)))
+  (into {}
+        (map (fn [[prop-kw {:keys [edit-type]}]]
+               (let [template (edit-type->template edit-type)]
+                 (pair prop-kw template))))
+        (:properties properties)))
 
 (defn- update-pane! [parent context properties]
   ; NOTE: We cache the ui based on the ::template and ::properties user-data

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -570,16 +570,43 @@
 
 (defn auto-commit! [^Node node commit-fn]
   (on-focus! node (fn [got-focus] (if got-focus
-                                    (user-data! node ::auto-commit? false)
-                                    (when (user-data node ::auto-commit?)
+                                    (user-data! node ::auto-commit false)
+                                    (when (user-data node ::auto-commit)
                                       (commit-fn nil)))))
-  (on-edit! node (fn [_old new]
-                   (if (user-data node ::suppress-auto-commit?)
-                     (user-data! node ::suppress-auto-commit? false)
-                     (user-data! node ::auto-commit? true)))))
+  (on-edit! node (fn [_old _new]
+                   (if (user-data node ::suppress-auto-commit)
+                     (user-data! node ::suppress-auto-commit false)
+                     (user-data! node ::auto-commit true)))))
 
 (defn suppress-auto-commit! [^Node node]
-  (user-data! node ::suppress-auto-commit? true))
+  (user-data! node ::suppress-auto-commit true))
+
+(defn increase-on-edit-event-suppress-count! [editable]
+  (when-some [suppress-count (user-data editable ::on-edit-event-suppress-count)]
+    (user-data! editable ::on-edit-event-suppress-count (inc (long suppress-count)))))
+
+(defn decrease-on-edit-event-suppress-count! [editable]
+  (when-some [suppress-count (user-data editable ::on-edit-event-suppress-count)]
+    (let [suppress-count (long suppress-count)]
+      (assert (pos? suppress-count))
+      (user-data! editable ::on-edit-event-suppress-count (dec suppress-count)))))
+
+(defmacro with-on-edit-event-suppressed! [editable & body]
+  `(let [editable# ~editable]
+     (increase-on-edit-event-suppress-count! editable#)
+     (try
+       ~@body
+       (finally
+         (decrease-on-edit-event-suppress-count! editable#)))))
+
+(defn- add-on-edit-event-fn! [editable observed-property listen-fn]
+  (when (nil? (user-data editable ::on-edit-event-suppress-count))
+    (user-data! editable ::on-edit-event-suppress-count 0))
+  (observe observed-property
+           (fn [_this old new]
+             (let [^long suppress-count (or (user-data editable ::on-edit-event-suppress-count) 0)]
+               (when (zero? suppress-count)
+                 (listen-fn old new))))))
 
 (defn- apply-default-css! [^Parent root]
   (.. root getStylesheets (add (str (io/resource "editor.css"))))
@@ -673,7 +700,7 @@
 (extend-type LongField
   HasValue
   (value [this] (Integer/parseInt (.getText this)))
-  (value! [this val] (.setText this (str val))))
+  (value! [this val] (text! this (str val))))
 
 (extend-type TextInputControl
   HasValue
@@ -682,28 +709,29 @@
   Text
   (text [this] (.getText this))
   (text! [this val]
-    (doto this
-      (.setText val)
-      (.end))
-    (when (.isFocused this)
-      (.selectAll this)))
+    (with-on-edit-event-suppressed! this
+      (doto this
+        (.setText val)
+        (.end))
+      (when (.isFocused this)
+        (.selectAll this))))
   Editable
   (editable [this] (.isEditable this))
   (editable! [this val] (.setEditable this val))
-  (on-edit! [this f] (observe (.textProperty this) (fn [this old new] (f old new)))))
+  (on-edit! [this f] (add-on-edit-event-fn! this (.textProperty this) f)))
 
 (extend-type ChoiceBox
   HasAction
   (on-action! [this fn] (.setOnAction this (event-handler e (fn e))))
   HasValue
   (value [this] (.getValue this))
-  (value! [this val] (.setValue this val)))
+  (value! [this val] (with-on-edit-event-suppressed! this (.setValue this val))))
 
 (extend-type ComboBoxBase
   Editable
   (editable [this] (not (.isDisabled this)))
   (editable! [this val] (.setDisable this (not val)))
-  (on-edit! [this f] (observe (.valueProperty this) (fn [this old new] (f old new)))))
+  (on-edit! [this f] (add-on-edit-event-fn! this (.valueProperty this) f)))
 
 (defn allow-user-input! [^ComboBoxBase cb e]
   (.setEditable cb e))
@@ -711,20 +739,25 @@
 (extend-type CheckBox
   HasValue
   (value [this] (.isSelected this))
-  (value! [this val] (.setSelected this val))
+  (value! [this val] (with-on-edit-event-suppressed! this (.setSelected this val)))
   Editable
   (editable [this] (not (.isDisabled this)))
   (editable! [this val] (.setDisable this (not val)))
-  (on-edit! [this f] (observe (.selectedProperty this) (fn [this old new] (f old new)))))
+  (on-edit! [this f] (add-on-edit-event-fn! this (.selectedProperty this) f)))
 
 (extend-type ColorPicker
   HasValue
   (value [this] (.getValue this))
-  (value! [this val] (.setValue this val)))
+  (value! [this val] (with-on-edit-event-suppressed! this (.setValue this val))))
 
 (extend-type TextField
   HasAction
-  (on-action! [this fn] (.setOnAction this (event-handler e (fn e)))))
+  (on-action! [node fn]
+    (.setOnAction node (event-handler e
+                         ;; Clear the auto-commit flag. Further edits will re-apply it.
+                         (when (user-data node ::auto-commit)
+                           (user-data! node ::auto-commit false))
+                         (fn e)))))
 
 (extend-type Labeled
   Text


### PR DESCRIPTION
### User-facing changes
* Fixed some situations where the Property Editor would take longer to redraw after editing a property.
* Fixed a situation where a property could be reverted to its previous value shortly after an edit.
* Fixed a situation where duplicate undo steps could be created after committing a property change with the Enter key.

### Technical changes
* Property editor controls are no longer re-created after an edit if there is a property with an `:edit-type` that has a `:clear-fn` present.
* The `on-edit!` callback is no longer called when the value of an `Editable` control is set programmatically.
* The `auto-commit` callback is no longer called after focus leaves a text field whose edits have already been committed using the Enter key.