### PR TITLE
Added the ability to redirect urls of published artifacts to move_s3_release.py

### DIFF
--- a/build_tools/s3.py
+++ b/build_tools/s3.py
@@ -196,3 +196,72 @@ def move_release(archive_path, sha1, channel):
         # update the redirect
         new_redirect = "http://%s/%s" % (bucket_name, new_key)
         key.set_redirect(new_redirect)
+
+def redirect_release(archive_path, sha1, channel):
+    u = urlparse(archive_path)
+    # get archive root and bucket name
+    # archive root:     s3://d.defold.com/archive -> archive
+    # bucket name:      s3://d.defold.com/archive -> d.defold.com
+    archive_root = u.path[1:]
+    bucket_name = u.hostname
+    bucket = get_bucket(bucket_name)
+
+    # the search prefix we use when listing keys
+    # we only want the keys associated with specifed sha1
+    prefix = "%s/%s/" % (archive_root, sha1)
+
+    # collect the redirects, ensuring all destination keys point to existing files
+    redirected_prefixes = [
+        prefix + "engine/",
+        prefix + "bob/"
+    ]
+
+    redirects = []
+
+    for key in bucket.get_all_keys(prefix = prefix):
+        if not any(key.name.startswith(x) for x in redirected_prefixes):
+            continue
+
+        old_target_url = key.get_redirect()
+
+        if not old_target_url:
+            continue
+
+        name = key.name.replace(prefix, "")
+        new_target_path = "archive/%s/%s/%s" % (channel, sha1, name)
+        new_target_url = "http://%s/%s" % (bucket_name, new_target_path)
+
+        if new_target_url == old_target_url:
+            continue
+
+        print("Preparing %s" % key.name)
+        print("     From %s" % old_target_url)
+        print("       To %s" % new_target_url)
+
+        # ensure we're redirecting to an existing file
+        new_target_key = bucket.get_key(new_target_path)
+        assert(new_target_key)
+        assert(not new_target_key.get_redirect())
+
+        redirect_url = "http://%s/%s" % (bucket_name, new_target_path)
+        redirects.append((key, new_target_url))
+
+    if redirects:
+        print()
+
+        for (key, new_target_url) in redirects:
+            print("Setting %s" % key.name)
+            print("     To %s" % new_target_url)
+            key.set_redirect(new_target_url)
+    
+        # output a list of Objects that should be invalidated in CloudFront.
+        # TODO: Use the boto.cloudfront API to do this automatically.
+        print()
+        print("You should invalidate these Objects in CloudFront:")
+        print("https://console.aws.amazon.com/cloudfront/v3/home")
+        print()
+
+        for (key, _) in redirects:
+            print("/%s" % key.name)
+
+        print()

--- a/scripts/move_s3_release.py
+++ b/scripts/move_s3_release.py
@@ -26,42 +26,49 @@ CDN_UPLOAD_URL="s3://d.defold.com/archive"
 if __name__ == '__main__':
     boto_path = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../packages/boto-2.28.0-py2.7.egg'))
     sys.path.insert(0, boto_path)
-    usage = '''usage: %prog [options] command(s)
+    usage = '''usage: %prog [options] command
 
 Commands:
-move_release - Move a release on S3 to a new channel
-
-Multiple commands can be specified
+move_release     - Move a release on S3 to a new channel
+redirect_release - Redirect a release on S3 to a new channel
 '''
     parser = optparse.OptionParser(usage)
 
     parser.add_option('--sha1', dest='sha1',
                       default = None,
-                      help = 'SHA1 of the release to move')
+                      help = 'SHA1 of the source release to move or redirect')
 
     parser.add_option('--to-channel', dest='to_channel',
                       default = None,
-                      help = 'Target channel to move release to')
+                      help = 'Target channel to move or redirect the release to')
 
     default_archive_path = CDN_UPLOAD_URL
     parser.add_option('--archive-path', dest='archive_path',
                       default = default_archive_path,
                       help = 'S3 path where archives are uploaded')
 
-    options, args = parser.parse_args()
+    options, commands = parser.parse_args()
 
-    if not args:
+    if len(commands) != 1:
         parser.print_help()
         exit(1)
 
-    for cmd in args:
-        if cmd == "move_release":
-            if not options.sha1:
-                print("No SHA1 specified")
-                exit(1)
-            if not options.to_channel:
-                print("No channel specified")
-                exit(1)
-            s3.move_release(options.archive_path, options.sha1, options.to_channel)
+    if not options.sha1:
+        print("No SHA1 specified")
+        exit(1)
+
+    if not options.to_channel:
+        print("No channel specified")
+        exit(1)
+
+    command = commands[0]
+
+    if command == "move_release":
+        s3.move_release(options.archive_path, options.sha1, options.to_channel)
+    elif command == "redirect_release":
+        s3.redirect_release(options.archive_path, options.sha1, options.to_channel)
+    else:
+        parser.print_help()
+        exit(1)
 
     print('Done')


### PR DESCRIPTION
This PR adds a new `redirect_release` command to the `move_s3_release.py` script. It takes the same arguments as the existing `move_release` command, but only updates the archive redirects so that they point to the requested channel.

This is useful if a build non-persisted build has been triggered from the same commit hash as a build from the `stable` channel, thereby potentially overwriting the redirects so that it points to the temporary build artifacts.

We recently ran into this when a `beta` build was triggered from the same commit as the `stable` build. Due to scheduling, the `beta` build completed the Windows engine job after the `stable` Windows engine, redirecting the archive URL to the `beta` artifact, which was then deleted to free up disk space a bit later.

To fix such a situation in the future, you would simply run:
```
./scripts/move_s3_release.py --sha1=<sha1> --to-channel=stable redirect_release
```
And then use the CloudFront dashboard to invalidate the cached redirects. We output a list of what needs to be invalidated after the script completes.