### PR TITLE
Allow per-project build server configuration

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2365,7 +2365,7 @@ If you do not specifically require different script states, consider changing th
         render-build-progress! (make-render-task-progress :build)
         task-cancelled? (make-task-cancelled-query :build)
         build-server-headers (native-extensions/get-build-server-headers prefs)
-        bob-args (bob/bundle-bob-args prefs platform bundle-options)
+        bob-args (bob/bundle-bob-args prefs project platform bundle-options)
         out (start-new-log-pipe!)]
     (when-not (.exists output-directory)
       (fs/create-directories! output-directory))

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -189,7 +189,7 @@
   [project evaluation-context prefs platform]
   (or (dev-custom-engine prefs platform)
       (if (native-extensions/has-engine-extensions? project evaluation-context)
-        (let [build-server-url (native-extensions/get-build-server-url prefs)
+        (let [build-server-url (native-extensions/get-build-server-url prefs project evaluation-context)
               build-server-headers (native-extensions/get-build-server-headers prefs)]
           (native-extensions/get-engine-archive project evaluation-context platform build-server-url build-server-headers))
         (bundled-engine platform))))

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -23,6 +23,7 @@
             [editor.fs :as fs]
             [editor.prefs :as prefs]
             [editor.resource :as resource]
+            [editor.shared-editor-settings :as shared-editor-settings]
             [editor.system :as system]
             [editor.workspace :as workspace]
             [util.http-client :as http])
@@ -290,8 +291,13 @@
             (throw (engine-build-errors/build-error extender-platform status log))))))))
 
 (defn get-build-server-url
-  ^String [prefs]
-  (prefs/get-prefs prefs "extensions-server" defold-build-server-url))
+  (^String [prefs project]
+   (g/with-auto-evaluation-context evaluation-context
+     (get-build-server-url prefs project evaluation-context)))
+  (^String [prefs project evaluation-context]
+   (or (not-empty (prefs/get-prefs prefs "extensions-server" ""))
+       (not-empty (shared-editor-settings/get-setting project ["extensions" "build_server"] evaluation-context))
+       defold-build-server-url)))
 
 (defn get-build-server-headers
   ^String [prefs]

--- a/editor/src/clj/editor/pipeline/bob.clj
+++ b/editor/src/clj/editor/pipeline/bob.clj
@@ -236,12 +236,12 @@
 ;; Bundling
 ;; -----------------------------------------------------------------------------
 
-(defn- generic-bundle-bob-args [prefs {:keys [variant texture-compression generate-debug-symbols? generate-build-report? publish-live-update-content? bundle-contentless? platform ^File output-directory] :as _bundle-options}]
+(defn- generic-bundle-bob-args [prefs project {:keys [variant texture-compression generate-debug-symbols? generate-build-report? publish-live-update-content? bundle-contentless? platform ^File output-directory] :as _bundle-options}]
   (assert (some? output-directory))
   (assert (or (not (.exists output-directory))
               (.isDirectory output-directory)))
   (assert (string? (not-empty platform)))
-  (let [build-server-url (native-extensions/get-build-server-url prefs)
+  (let [build-server-url (native-extensions/get-build-server-url prefs project)
         editor-texture-compression (if (prefs/get-prefs prefs "general-enable-texture-compression" false) "true" "false")
         build-report-path (.getAbsolutePath (io/file output-directory "report.html"))
         bundle-output-path (.getAbsolutePath output-directory)
@@ -339,14 +339,14 @@
 
 (def bundle-bob-commands ["distclean" "build" "bundle"])
 
-(defmulti bundle-bob-args (fn [_prefs platform _bundle-options] platform))
-(defmethod bundle-bob-args :default [_prefs platform _bundle-options] (throw (IllegalArgumentException. (str "Unsupported platform: " platform))))
-(defmethod bundle-bob-args :android [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) (android-bundle-bob-args bundle-options)))
-(defmethod bundle-bob-args :html5   [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) (html5-bundle-bob-args bundle-options)))
-(defmethod bundle-bob-args :ios     [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) (ios-bundle-bob-args bundle-options)))
-(defmethod bundle-bob-args :linux   [prefs _platform bundle-options] (generic-bundle-bob-args prefs bundle-options))
-(defmethod bundle-bob-args :macos   [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) (macos-bundle-bob-args bundle-options)))
-(defmethod bundle-bob-args :windows [prefs _platform bundle-options] (merge (generic-bundle-bob-args prefs bundle-options) {"architectures" (bundle-options :platform)}))
+(defmulti bundle-bob-args (fn [_prefs _project platform _bundle-options] platform))
+(defmethod bundle-bob-args :default [_prefs _project platform _bundle-options] (throw (IllegalArgumentException. (str "Unsupported platform: " platform))))
+(defmethod bundle-bob-args :android [prefs project _platform bundle-options] (merge (generic-bundle-bob-args prefs project bundle-options) (android-bundle-bob-args bundle-options)))
+(defmethod bundle-bob-args :html5   [prefs project _platform bundle-options] (merge (generic-bundle-bob-args prefs project bundle-options) (html5-bundle-bob-args bundle-options)))
+(defmethod bundle-bob-args :ios     [prefs project _platform bundle-options] (merge (generic-bundle-bob-args prefs project bundle-options) (ios-bundle-bob-args bundle-options)))
+(defmethod bundle-bob-args :linux   [prefs project _platform bundle-options] (generic-bundle-bob-args prefs project bundle-options))
+(defmethod bundle-bob-args :macos   [prefs project _platform bundle-options] (merge (generic-bundle-bob-args prefs project bundle-options) (macos-bundle-bob-args bundle-options)))
+(defmethod bundle-bob-args :windows [prefs project _platform bundle-options] (merge (generic-bundle-bob-args prefs project bundle-options) {"architectures" (bundle-options :platform)}))
 
 ;; -----------------------------------------------------------------------------
 ;; Build HTML5
@@ -362,7 +362,7 @@
 (defn build-html5-bob-args [project prefs]
   (let [output-path (build-html5-output-path project)
         proj-settings (project/settings project)
-        build-server-url (native-extensions/get-build-server-url prefs)
+        build-server-url (native-extensions/get-build-server-url prefs project)
         defold-sdk-sha1 (or (system/defold-engine-sha1) "")
         compress-archive? (get proj-settings ["project" "compress_archive"])]
     (cond-> {"platform" "js-web"

--- a/editor/src/clj/editor/settings.clj
+++ b/editor/src/clj/editor/settings.clj
@@ -235,7 +235,10 @@
   (output form-data g/Any (gu/passthrough form-data))
 
   (input save-value g/Any)
-  (output save-value g/Any (gu/passthrough save-value)))
+  (output save-value g/Any (gu/passthrough save-value))
+
+  (input settings-map g/Any)
+  (output settings-map g/Any (gu/passthrough settings-map)))
 
 (defn- load-simple-settings-resource-node [meta-info project self resource source-value]
   (let [graph-id (g/node-id->graph-id self)]
@@ -244,6 +247,7 @@
         (g/connect settings-node :_node-id self :nodes)
         (g/connect settings-node :save-value self :save-value)
         (g/connect settings-node :form-data self :form-data)
+        (g/connect settings-node :settings-map self :settings-map)
         (load-settings-node settings-node resource source-value meta-info nil)))))
 
 (defn register-simple-settings-resource-type [workspace & {:keys [ext label icon meta-info]}]

--- a/editor/src/clj/editor/shared_editor_settings.clj
+++ b/editor/src/clj/editor/shared_editor_settings.clj
@@ -15,6 +15,8 @@
 (ns editor.shared-editor-settings
   (:require [cljfx.fx.v-box :as fx.v-box]
             [clojure.java.io :as io]
+            [dynamo.graph :as g]
+            [editor.defold-project :as project]
             [editor.dialogs :as dialogs]
             [editor.fxui :as fxui]
             [editor.settings :as settings]
@@ -33,7 +35,8 @@
 
 (def ^:private setting-paths
   {:cache-capacity ["performance" "cache_capacity"]
-   :non-editable-directories ["performance" "non_editable_directories"]})
+   :non-editable-directories ["performance" "non_editable_directories"]
+   :build-server ["extensions" "build_server"]})
 
 (def ^:private meta-info
   (settings-core/finalize-meta-info
@@ -47,11 +50,21 @@
                  :label "Non-editable Directories"
                  :help "Project directories whose contents can't be edited. Use for externally generated content to conserve memory and project load time."
                  :element {:type :directory
-                           :in-project true}}]
+                           :in-project true}}
+                {:path (:build-server setting-paths)
+                 :type :string
+                 :label "Build Server"
+                 :help "Build server URL used for building native extensions"}]
      :group-order ["Shared Settings"]
      :default-category "performance"
      :categories {"performance" {:help "Editor performance tweaks for your project. Some settings may require restarting the editor to take effect."
-                                 :group "Shared Settings"}}}))
+                                 :group "Shared Settings"}
+                  "extensions" {:help "Common settings for native extensions"
+                                :group "Shared Settings"}}}))
+
+(defn get-setting [project setting-path evaluation-context]
+  (when-let [settings-node (project/get-resource-node project project-shared-editor-settings-proj-path evaluation-context)]
+    (get (g/node-value settings-node :settings-map evaluation-context) setting-path)))
 
 (defn- map->settings [map]
   (let [meta-settings (:settings meta-info)]

--- a/editor/test/integration/engine/native_extensions_test.clj
+++ b/editor/test/integration/engine/native_extensions_test.clj
@@ -143,7 +143,7 @@
     (let [workspace (test-util/setup-scratch-workspace! world "test/resources/trivial_extension")
           project (test-util/setup-project! workspace)
           test-prefs (test-util/make-test-prefs)]
-      (assert (= (native-extensions/get-build-server-url test-prefs) "https://build-stage.defold.com"))
+      (assert (= (native-extensions/get-build-server-url test-prefs project) "https://build-stage.defold.com"))
       (testing "clean project builds on server"
         (let [{:keys [error artifacts artifact-map etags engine]} (blocking-async-build! project test-prefs)]
           (is (nil? error))


### PR DESCRIPTION
User-facing changes: Now it's possible to set the game's build server in a shared settings file, available via `Project ▸ Shared Editor Settings` menu item.

Fixes #6415