### PR TITLE
Make editor load natives only for its platform

### DIFF
--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -531,11 +531,18 @@ ordinary paths."
 (defn- register-jar-file! [jar-file]
   (.addURL ^DynamicClassLoader class-loader (io/as-url jar-file)))
 
+(defn- native-library-parent-dir-allowed? [parent-dir-name]
+    (->> (Platform/getHostPlatform)
+         .getExtenderPaths
+         (some #(= parent-dir-name %))
+         boolean))
+
 (defn- register-shared-library-file! [^File shared-library-file]
-  (let [parent-dir (.getParent shared-library-file)]
-    ; TODO: Only add files for the current platform (e.g. dylib on macOS)
-    (add-to-path-property "jna.library.path" parent-dir)
-    (add-to-path-property "java.library.path" parent-dir)))
+  (let [parent-dir-file (.getParentFile shared-library-file)]
+    (when (native-library-parent-dir-allowed? (.getName parent-dir-file))
+      (let [parent-dir (str parent-dir-file)]
+        (add-to-path-property "jna.library.path" parent-dir)
+        (add-to-path-property "java.library.path" parent-dir)))))
 
 (defn unpack-resource!
   ([workspace resource]


### PR DESCRIPTION
Technical notes:
With both x64 and arm64 macOS platforms, the editor needs to differentiate between native libraries it might need to load. It can't blindly load all `*.dylib` files anymore.

Related to #7781
