### PR TITLE
Add ability to ignore bundling for native extensions in `.defignore` 

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -461,7 +461,7 @@ public class Bob {
         addOption(options, "tc", "texture-compression", true, "Use texture compression as specified in texture profiles", true);
         addOption(options, "k", "keep-unused", false, "Keep unused resources in archived output", true);
 
-        addOption(options, null, "exclude-build-folder", true, "Comma separated list of folders to exclude from the build", true);
+        addOption(options, null, "exclude-build-folder", true, "DEPRECATED! Use '.defignore' file instead", true);
 
         addOption(options, "br", "build-report", true, "DEPRECATED! Use --build-report-json instead", false);
         addOption(options, "brjson", "build-report-json", true, "Filepath where to save a build report as JSON", false);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -664,6 +664,11 @@ public class Bob {
             return;
         }
 
+        if (cmd.hasOption("exclude-build-folder")) {
+            // Deprecated in 1.5.1. Just a message for now.
+            System.out.println("--exclude-build-folder option is deprecated. Use '.defignore' file instead");
+        }
+
         String[] commands = cmd.getArgs();
         if (commands.length == 0) {
             commands = new String[] { "build" };

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -135,6 +135,7 @@ public class Project {
     private List<URL> libUrls = new ArrayList<URL>();
     private List<String> propertyFiles = new ArrayList<String>();
     private List<String> buildServerHeaders = new ArrayList<String>();
+    private List<String> excluedFilesAndFoldersEntries = new ArrayList<String>();
 
     private BobProjectProperties projectProperties;
     private Publisher publisher;
@@ -499,11 +500,15 @@ public class Project {
         return sortedInputs;
     }
 
-    private List<String> loadDefoldIgnore() throws CompileExceptionError {
+    private void loadIgnoredFilesAndFolders() throws CompileExceptionError {
+        String excludeFoldersStr = this.option("exclude-build-folder", "");
+        List<String> excludeFolders = BundleHelper.createArrayFromString(excludeFoldersStr);
+        excluedFilesAndFoldersEntries.addAll(excludeFolders);
+        List<String> defIgnoreEntries = new ArrayList<String>();
         final File defIgnoreFile = new File(getRootDirectory(), ".defignore");
         if (defIgnoreFile.isFile()) {
             try {
-                return FileUtils.readLines(defIgnoreFile, "UTF-8")
+                defIgnoreEntries = FileUtils.readLines(defIgnoreFile, "UTF-8")
                         .stream()
                         .filter(s -> !s.isEmpty())
                         .collect(Collectors.toList());
@@ -512,7 +517,14 @@ public class Project {
                 throw new CompileExceptionError("Unable to read .defignore", e);
             }
         }
-        return Collections.emptyList();
+        excluedFilesAndFoldersEntries.addAll(defIgnoreEntries);
+        // remove initial "/" from excluded folder names
+        for(int i = 0; i < excluedFilesAndFoldersEntries.size(); i++) {
+            String entry = excluedFilesAndFoldersEntries.get(i);
+            if (entry.startsWith("/")) {
+                excluedFilesAndFoldersEntries.set(i, entry.substring(1));
+            }
+        }
     }
 
     private void createTasks() throws CompileExceptionError {
@@ -521,22 +533,12 @@ public class Project {
 
         // To currently know the output resources, we need to parse the main.collectionc
         // We would need to alter that to get a correct behavior (e.g. using GameProjectBuilder.findResources(this, rootNode))
-        String excludeFoldersStr = this.option("exclude-build-folder", "");
-        List<String> excludeFolders = BundleHelper.createArrayFromString(excludeFoldersStr);
-        excludeFolders.addAll(loadDefoldIgnore());
 
-        // remove initial "/" from excluded folder names
-        for(int i = 0; i < excludeFolders.size(); i++) {
-            String excludeFolder = excludeFolders.get(i);
-            if (excludeFolder.startsWith("/")) {
-                excludeFolders.set(i, excludeFolder.substring(1));
-            }
-        }
         // create tasks for inputs that are not excluded
         for (String input : sortedInputs) {
             boolean skipped = false;
-            for (String excludeFolder : excludeFolders) {
-                if (input.startsWith(excludeFolder)) {
+            for (String excludeEntry : excluedFilesAndFoldersEntries) {
+                if (input.startsWith(excludeEntry)) {
                     skipped = true;
                     break;
                 }
@@ -1392,7 +1394,7 @@ public class Project {
             switch (command) {
                 case "build": {
                     ExtenderUtil.checkProjectForDuplicates(this); // Throws if there are duplicate files in the project (i.e. library and local files conflict)
-
+                    loadIgnoredFilesAndFolders(); // load once before building to be able to use it in a few places
                     final String[] platforms = getPlatformStrings();
                     Future<Void> remoteBuildFuture = null;
                     // Get or build engine binary
@@ -2047,7 +2049,16 @@ run:
         final String path = Project.stripLeadingSlash(_path);
         fileSystem.walk(path, new FileSystemWalker() {
             public void handleFile(String path, Collection<String> results) {
-                results.add(FilenameUtils.normalize(path, true));
+                boolean shouldAdd = true;
+                for (String prefix : excluedFilesAndFoldersEntries) {
+                    if (path.startsWith(prefix)) {
+                        shouldAdd = false;
+                        break;
+                    }
+                }
+                if (shouldAdd) {
+                    results.add(FilenameUtils.normalize(path, true));
+                }
             }
         }, result);
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -500,6 +500,11 @@ public class Project {
         return sortedInputs;
     }
 
+    /*
+        The same logic implemented in the Editor.
+        If you change something here, make sure you change it in resource.clj
+        (defignore-pred).
+    */
     private void loadIgnoredFilesAndFolders() throws CompileExceptionError {
         String excludeFoldersStr = this.option("exclude-build-folder", "");
         List<String> excludeFolders = BundleHelper.createArrayFromString(excludeFoldersStr);
@@ -537,6 +542,8 @@ public class Project {
         // create tasks for inputs that are not excluded
         for (String input : sortedInputs) {
             boolean skipped = false;
+            // Ignore for resources.
+            // Check comment for loadIgnoredFilesAndFolders()
             for (String excludeEntry : excluedFilesAndFoldersEntries) {
                 if (input.startsWith(excludeEntry)) {
                     skipped = true;
@@ -2050,6 +2057,8 @@ run:
         fileSystem.walk(path, new FileSystemWalker() {
             public void handleFile(String path, Collection<String> results) {
                 boolean shouldAdd = true;
+                // Ignore for native extensions and the other systems.
+                // Check comment for loadIgnoredFilesAndFolders()
                 for (String prefix : excluedFilesAndFoldersEntries) {
                     if (path.startsWith(prefix)) {
                         shouldAdd = false;

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -107,6 +107,9 @@
   ;; path->{:mtime ... :pred ...}
   (atom {}))
 
+;; The same logic implemented in Project.java.
+;; If you change something here, plese change it there as well
+;; Search for excluedFilesAndFoldersEntries.
 ;; root -> pred if project path (string starting with /) is ignored
 (defn- defignore-pred [^File root]
   (let [defignore-file (io/file root ".defignore")


### PR DESCRIPTION
Added ability to use `.defignore` to ignore native extensions when bundle in `bob.jar`.

Fix https://github.com/defold/defold/issues/7191
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
