### PR TITLE
Using transfer_ownership when updating buffers should incref the resource

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -2502,10 +2502,13 @@ static int SetBuffer(lua_State* L)
             {
                 // We are transferring the ownership of the resource in the lua buffer
                 // to the destination resource, so we decref the source resource.
-                // We don't need to incref the destination resource in this case,
-                // because we are simply updating the content and not the resoure itself
                 dmResource::Release(g_ResourceModule.m_Factory, luabuf->m_BufferRes);
             }
+
+            // We need to incref the destination resource in this case,
+            // because otherwise the GC for the lua buffer will decref the resourec
+            // and eventually prematurely destroy the resource.
+            dmResource::IncRef(g_ResourceModule.m_Factory, resource);
         }
 
         luabuf->m_Owner     = dmScript::OWNER_RES;


### PR DESCRIPTION
Fixed an issue where calling set_buffer with transfer_ownership=true removes the resource prematurely due to garbage collection.

Fixes #7860 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
