### PR TITLE
Fixed issue where liveupdate.remove_mount() didn't update the stored mount file

### DIFF
--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -797,6 +797,29 @@ namespace dmLiveUpdate
         return res == true ? RESULT_OK : RESULT_INVALID_RESOURCE;
     }
 
+    Result RemoveMountSync(const char* name)
+    {
+        dmResourceMounts::HContext mounts = g_LiveUpdate.m_ResourceMounts;
+        dmMutex::HMutex mutex = dmResourceMounts::GetMutex(mounts);
+        DM_MUTEX_SCOPED_LOCK(mutex);
+
+        dmResource::Result result = dmResourceMounts::RemoveMountByName(mounts, name);
+        if (result != dmResource::RESULT_OK)
+        {
+            dmLogError("Failed to remove mount '%s': %s (%d)", name, dmResource::ResultToString(result), result);
+            return dmLiveUpdate::ResourceResultToLiveupdateResult(result);
+        }
+
+        result = dmResourceMounts::SaveMounts(mounts, g_LiveUpdate.m_AppSupportPath);
+        if (result != dmResource::RESULT_OK)
+        {
+            dmLogError("Failed to save mounts file");
+            return dmLiveUpdate::ResourceResultToLiveupdateResult(result);
+        }
+
+        return RESULT_OK;
+    }
+
     // ******************************************************************
     // ** LiveUpdate utility functions
     // ******************************************************************

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -72,6 +72,7 @@ namespace dmLiveUpdate
 
     // The new api
     Result AddMountAsync(const char* name, const char* uri, int priority, void (*callback)(const char*, const char*, int, void*), void* cbk_ctx);
+    Result RemoveMountSync(const char* name);
 };
 
 #endif // DM_LIVEUPDATE_H

--- a/engine/liveupdate/src/script_liveupdate.cpp
+++ b/engine/liveupdate/src/script_liveupdate.cpp
@@ -316,11 +316,8 @@ namespace dmLiveUpdate
         if (name[0] == '_')
             return DM_LUA_ERROR("Cannot remove base mounts: %s", name);
 
-        dmResourceMounts::HContext mounts = dmResource::GetMountsContext(g_LUScriptCtx.m_Factory);
-        dmResource::Result result = dmResourceMounts::RemoveMountByName(mounts, name);
-
-        dmLiveUpdate::Result r = dmLiveUpdate::ResourceResultToLiveupdateResult(result);
-        lua_pushinteger(L, r);
+        dmLiveUpdate::Result result = dmLiveUpdate::RemoveMountSync(name);
+        lua_pushinteger(L, result);
         return 1;
     }
 


### PR DESCRIPTION
The issue would show the next time the game was launched, and the mount was back in the list.

Fixes: https://github.com/defold/defold/issues/7925

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
