### PR TITLE
Fixed a fullscreen issue for newer macOS versions

### DIFF
--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -616,6 +616,8 @@ int  _glfwPlatformOpenWindow( int width, int height,
                               const _GLFWwndconfig *wndconfig,
                               const _GLFWfbconfig *fbconfig )
 {
+printf("%s %d: %u %u\n", __FUNCTION__ , __LINE__, _glfwWin.width, _glfwWin.height);
+
     _glfwWin.pixelFormat = nil;
     _glfwWin.window = nil;
     _glfwWin.context = nil;
@@ -702,6 +704,8 @@ int  _glfwPlatformOpenWindow( int width, int height,
                   styleMask:styleMask
                     backing:NSBackingStoreBuffered
                       defer:NO];
+
+    printf("%s %d: width height: %d %d\n", __FUNCTION__, __LINE__, width, height);
 
     GLFWContentView* view = [[GLFWContentView alloc] init];
     view.wantsLayer = _glfwWin.clientAPI == GLFW_NO_API ? YES : NO;
@@ -813,9 +817,17 @@ int  _glfwPlatformOpenWindow( int width, int height,
         // will differ from the input params on retina enabled windows.
         NSRect contentRect =
             [_glfwWin.window contentRectForFrameRect:[_glfwWin.window frame]];
+
+    printf("%s %d: contentRect: width height: %f %f\n", __FUNCTION__, __LINE__, contentRect.size.width, contentRect.size.height);
+
         contentRect = [[_glfwWin.window contentView] convertRectToBacking:contentRect];
+
+    printf("%s %d: contentRectBacking: width height: %f %f\n", __FUNCTION__, __LINE__, contentRect.size.width, contentRect.size.height);
+
+
         _glfwWin.width = contentRect.size.width;
         _glfwWin.height = contentRect.size.height;
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         if( wndconfig->mode == GLFW_FULLSCREEN )
         {
@@ -926,6 +938,7 @@ void _glfwPlatformSetWindowTitle( const char *title )
 
 void _glfwPlatformSetWindowSize( int width, int height )
 {
+printf("%s %d: %u %u\n", __FUNCTION__ , __LINE__, width, height);
     [_glfwWin.window setContentSize:NSMakeSize(width, height)];
 }
 
@@ -1088,11 +1101,32 @@ void _glfwPlatformRefreshWindowParams( void )
         _glfwWin.highDPI = 1;
     }
 
-    NSRect contentRect =
-        [_glfwWin.window contentRectForFrameRect:[_glfwWin.window frame]];
+printf("%s %d: size: rectFrame  %f %f\n", __FUNCTION__, __LINE__, contentRectFrame.size.width, contentRectFrame.size.height);
+printf("%s %d: size: contentRectBacking  %f %f\n", __FUNCTION__, __LINE__, contentRectBacking.size.width, contentRectBacking.size.height);
+printf("%s %d: highDPI  %d\n", __FUNCTION__, __LINE__, _glfwWin.highDPI);
+
+    NSRect contentRect = [_glfwWin.window contentRectForFrameRect:[_glfwWin.window frame]];
+
+printf("%s %d: size: contentRect  %f %f\n", __FUNCTION__, __LINE__, contentRect.size.width, contentRect.size.height);
+
     contentRect = [[_glfwWin.window contentView] convertRectToBacking:contentRect];
-    _glfwWin.width = contentRect.size.width;
-    _glfwWin.height = contentRect.size.height;
+
+printf("%s %d: size: contentRect  %f %f\n", __FUNCTION__, __LINE__, contentRect.size.width, contentRect.size.height);
+
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
+
+    if (_glfwWin.fullscreen)
+    {
+        _glfwWin.width = contentRectFrame.size.width;
+        _glfwWin.height = contentRectFrame.size.height;
+    }
+    else
+    {
+        _glfwWin.width = contentRect.size.width;
+        _glfwWin.height = contentRect.size.height;
+    }
+
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 }
 
 //========================================================================
@@ -1297,4 +1331,3 @@ float _glfwPlatformGetDisplayScaleFactor()
     CGDisplayModeRelease(mode);
     return scaling_factor;
 }
-

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -558,8 +558,6 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
     _glfwWin.height     = height;
     _glfwWin.fullscreen = (mode == GLFW_FULLSCREEN ? GL_TRUE : GL_FALSE);
 
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
-
     // Platform specific window opening routine
     if( !_glfwPlatformOpenWindow( width, height, &wndconfig, &fbconfig ) )
     {
@@ -567,19 +565,15 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin
         return GL_FALSE;
     }
 
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
-
     // Flag that window is now opened
     _glfwWin.opened = GL_TRUE;
 
     // Read back window and context parameters
     _glfwPlatformRefreshWindowParams();
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
     if (wndconfig.clientAPI != GLFW_NO_API)
     {
         _glfwRefreshContextParams();
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         if( _glfwWin.glMajor < wndconfig.glMajor ||
             ( _glfwWin.glMajor == wndconfig.glMajor &&
@@ -588,7 +582,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin
             glfwCloseWindow();
             return GL_FALSE;
         }
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         // Do we have non-power-of-two textures (added to core in version 2.0)?
         _glfwWin.has_GL_ARB_texture_non_power_of_two =
@@ -599,7 +592,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin
         _glfwWin.has_GL_SGIS_generate_mipmap =
             ( _glfwWin.glMajor >= 2 ) || ( _glfwWin.glMinor >= 4 ) ||
             glfwExtensionSupported( "GL_SGIS_generate_mipmap" );
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         //
         // The following check for glGetString(i) is a modification to improve compatibility
@@ -623,7 +615,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin
             }
         }
     }
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
     // If full-screen mode was requested, disable mouse cursor
     if( mode == GLFW_FULLSCREEN )
@@ -639,7 +630,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin
     // remains in our OpenGL window)
     // glClear( GL_COLOR_BUFFER_BIT );
     //_glfwPlatformSwapBuffers();
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
     return GL_TRUE;
 }
@@ -998,7 +988,6 @@ GLFWAPI void GLFWAPIENTRY glfwSetWindowSizeCallback( GLFWwindowsizefun cbfun )
     // window size
     if( cbfun )
     {
-printf("%s %d: %u %u\n", __FUNCTION__ , __LINE__, _glfwWin.width, _glfwWin.height);
         cbfun( _glfwWin.width, _glfwWin.height );
     }
 }

--- a/engine/glfw/lib/window.c
+++ b/engine/glfw/lib/window.c
@@ -558,6 +558,8 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
     _glfwWin.height     = height;
     _glfwWin.fullscreen = (mode == GLFW_FULLSCREEN ? GL_TRUE : GL_FALSE);
 
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
+
     // Platform specific window opening routine
     if( !_glfwPlatformOpenWindow( width, height, &wndconfig, &fbconfig ) )
     {
@@ -565,15 +567,19 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
         return GL_FALSE;
     }
 
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
+
     // Flag that window is now opened
     _glfwWin.opened = GL_TRUE;
 
     // Read back window and context parameters
     _glfwPlatformRefreshWindowParams();
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
     if (wndconfig.clientAPI != GLFW_NO_API)
     {
         _glfwRefreshContextParams();
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         if( _glfwWin.glMajor < wndconfig.glMajor ||
             ( _glfwWin.glMajor == wndconfig.glMajor &&
@@ -582,6 +588,7 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
             glfwCloseWindow();
             return GL_FALSE;
         }
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         // Do we have non-power-of-two textures (added to core in version 2.0)?
         _glfwWin.has_GL_ARB_texture_non_power_of_two =
@@ -592,6 +599,7 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
         _glfwWin.has_GL_SGIS_generate_mipmap =
             ( _glfwWin.glMajor >= 2 ) || ( _glfwWin.glMinor >= 4 ) ||
             glfwExtensionSupported( "GL_SGIS_generate_mipmap" );
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
         //
         // The following check for glGetString(i) is a modification to improve compatibility
@@ -615,6 +623,7 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
             }
         }
     }
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
     // If full-screen mode was requested, disable mouse cursor
     if( mode == GLFW_FULLSCREEN )
@@ -630,6 +639,7 @@ GLFWAPI int GLFWAPIENTRY glfwOpenWindow( int width, int height,
     // remains in our OpenGL window)
     // glClear( GL_COLOR_BUFFER_BIT );
     //_glfwPlatformSwapBuffers();
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, _glfwWin.width, _glfwWin.height);
 
     return GL_TRUE;
 }
@@ -988,6 +998,7 @@ GLFWAPI void GLFWAPIENTRY glfwSetWindowSizeCallback( GLFWwindowsizefun cbfun )
     // window size
     if( cbfun )
     {
+printf("%s %d: %u %u\n", __FUNCTION__ , __LINE__, _glfwWin.width, _glfwWin.height);
         cbfun( _glfwWin.width, _glfwWin.height );
     }
 }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -957,7 +957,6 @@ static void LogFrameBufferError(GLenum status)
         context->m_WindowIconifyCallbackUserData  = params->m_IconifyCallbackUserData;
         context->m_WindowOpened                   = 1;
 
-       // 960 640 in both cases
         context->m_Width                          = params->m_Width;
         context->m_Height                         = params->m_Height;
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -191,13 +191,13 @@ static void LogGLError(GLint err, const char* fnname, int line)
     const char* error_str = "<unknown-gl-error>";
     switch(err)
     {
-        case GL_INVALID_ENUM: 
+        case GL_INVALID_ENUM:
             error_str = "GL_INVALID_ENUM";
             break;
-        case GL_INVALID_VALUE: 
+        case GL_INVALID_VALUE:
             error_str = "GL_INVALID_VALUE";
             break;
-        case GL_INVALID_OPERATION: 
+        case GL_INVALID_OPERATION:
             error_str = "GL_INVALID_OPERATION";
             break;
         default:break;
@@ -555,6 +555,7 @@ static void LogFrameBufferError(GLenum status)
     static void OnWindowResize(int width, int height)
     {
         assert(g_Context);
+        printf("%s %d: %d %d\n", __FUNCTION__, __LINE__, width, height);
         g_Context->m_WindowWidth = (uint32_t)width;
         g_Context->m_WindowHeight = (uint32_t)height;
         if (g_Context->m_WindowResizeCallback != 0x0)
@@ -816,6 +817,8 @@ static void LogFrameBufferError(GLenum status)
             glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         }
 
+printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, params->m_Width, params->m_Height);
+
         int mode = GLFW_WINDOW;
         if (params->m_Fullscreen)
             mode = GLFW_FULLSCREEN;
@@ -956,6 +959,9 @@ static void LogFrameBufferError(GLenum status)
         context->m_WindowIconifyCallback          = params->m_IconifyCallback;
         context->m_WindowIconifyCallbackUserData  = params->m_IconifyCallbackUserData;
         context->m_WindowOpened                   = 1;
+
+        printf("Setting width/height: %d %d\n", params->m_Width, params->m_Height);
+       // 960 640 in both cases
         context->m_Width                          = params->m_Width;
         context->m_Height                         = params->m_Height;
 
@@ -1415,6 +1421,7 @@ static void LogFrameBufferError(GLenum status)
     static uint32_t OpenGLGetWindowWidth(HContext context)
     {
         assert(context);
+        printf("%s %d: %u\n", __FUNCTION__, __LINE__, ((OpenGLContext*) context)->m_WindowWidth);
         return ((OpenGLContext*) context)->m_WindowWidth;
     }
 
@@ -1434,6 +1441,7 @@ static void LogFrameBufferError(GLenum status)
     {
         assert(_context);
         OpenGLContext* context = (OpenGLContext*) _context;
+        printf("%s %d: width/height %u %u\n",  __FUNCTION__, __LINE__, width, height);
         if (context->m_WindowOpened)
         {
             context->m_Width = width;
@@ -1456,6 +1464,7 @@ static void LogFrameBufferError(GLenum status)
         assert(context);
         if (((OpenGLContext*) context)->m_WindowOpened)
         {
+printf("%s %d: %u %u\n", __FUNCTION__ , __LINE__, width, height);
             glfwSetWindowSize((int)width, (int)height);
         }
     }
@@ -2367,7 +2376,7 @@ static void LogFrameBufferError(GLenum status)
                 break;
             case ATTACHMENT_TYPE_TEXTURE:
                 attachment.m_Texture = NewTexture(context, creation_params);
-                break; 
+                break;
             default: assert(0);
         }
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -555,7 +555,6 @@ static void LogFrameBufferError(GLenum status)
     static void OnWindowResize(int width, int height)
     {
         assert(g_Context);
-        printf("%s %d: %d %d\n", __FUNCTION__, __LINE__, width, height);
         g_Context->m_WindowWidth = (uint32_t)width;
         g_Context->m_WindowHeight = (uint32_t)height;
         if (g_Context->m_WindowResizeCallback != 0x0)
@@ -817,8 +816,6 @@ static void LogFrameBufferError(GLenum status)
             glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         }
 
-printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, params->m_Width, params->m_Height);
-
         int mode = GLFW_WINDOW;
         if (params->m_Fullscreen)
             mode = GLFW_FULLSCREEN;
@@ -960,7 +957,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, params->m_Width, params-
         context->m_WindowIconifyCallbackUserData  = params->m_IconifyCallbackUserData;
         context->m_WindowOpened                   = 1;
 
-        printf("Setting width/height: %d %d\n", params->m_Width, params->m_Height);
        // 960 640 in both cases
         context->m_Width                          = params->m_Width;
         context->m_Height                         = params->m_Height;
@@ -1421,7 +1417,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, params->m_Width, params-
     static uint32_t OpenGLGetWindowWidth(HContext context)
     {
         assert(context);
-        printf("%s %d: %u\n", __FUNCTION__, __LINE__, ((OpenGLContext*) context)->m_WindowWidth);
         return ((OpenGLContext*) context)->m_WindowWidth;
     }
 
@@ -1441,7 +1436,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, params->m_Width, params-
     {
         assert(_context);
         OpenGLContext* context = (OpenGLContext*) _context;
-        printf("%s %d: width/height %u %u\n",  __FUNCTION__, __LINE__, width, height);
         if (context->m_WindowOpened)
         {
             context->m_Width = width;
@@ -1464,7 +1458,6 @@ printf("%s %d: size:  %d %d\n", __FUNCTION__, __LINE__, params->m_Width, params-
         assert(context);
         if (((OpenGLContext*) context)->m_WindowOpened)
         {
-printf("%s %d: %u %u\n", __FUNCTION__ , __LINE__, width, height);
             glfwSetWindowSize((int)width, (int)height);
         }
     }

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -244,7 +244,7 @@ namespace dmRender
 
                 if (RenderScriptSetNamedValueFromLua(L, -1, cb, name_hash, table_index_lua - 1) != RESULT_OK)
                 {
-                    return luaL_error(L, "Constant %s[%d] not set. Mixing types in array not allowed", dmHashReverseSafe64(name_hash), table_index_lua);                    
+                    return luaL_error(L, "Constant %s[%d] not set. Mixing types in array not allowed", dmHashReverseSafe64(name_hash), table_index_lua);
                 }
                 lua_pop(L, 1);
             }
@@ -301,7 +301,7 @@ namespace dmRender
 
         if (RenderScriptSetNamedValueFromLua(L, 3, cb, name_hash, table_index_lua - 1) != RESULT_OK)
         {
-            return luaL_error(L, "Constant %s[%d] not set. Mixing types in array not allowed", dmHashReverseSafe64(name_hash), table_index_lua);                    
+            return luaL_error(L, "Constant %s[%d] not set. Mixing types in array not allowed", dmHashReverseSafe64(name_hash), table_index_lua);
         }
         assert(top == lua_gettop(L));
 
@@ -401,7 +401,7 @@ namespace dmRender
      *      vmath.vector4(0, 1, 0, 1)
      *      vmath.vector4(0, 0, 1, 1)
      * }
-     * 
+     *
      * -- Add more constant to the array
      * constants.light_colors[4] = vmath.vector4(1, 1, 1, 1)
      * ```
@@ -2703,7 +2703,9 @@ namespace dmRender
     {
         RenderScriptInstance* i = RenderScriptInstance_Check(L);
         (void)i;
-        lua_pushnumber(L, dmGraphics::GetWindowWidth(i->m_RenderContext->m_GraphicsContext));
+        int width = dmGraphics::GetWindowWidth(i->m_RenderContext->m_GraphicsContext);
+        printf("%s %d: %d\n", __FUNCTION__, __LINE__,  width);
+        lua_pushnumber(L, width);
         return 1;
     }
 
@@ -3428,6 +3430,7 @@ bail:
             else if (descriptor == dmRenderDDF::Resize::m_DDFDescriptor)
             {
                 dmRenderDDF::Resize* resize_msg = (dmRenderDDF::Resize*)message->m_Data;
+printf("%s %s %d\n", __FILE__, __FUNCTION__, __LINE__);
                 dmGraphics::ResizeWindow(instance->m_RenderContext->m_GraphicsContext, resize_msg->m_Width, resize_msg->m_Height);
                 return;
             }

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -2703,9 +2703,7 @@ namespace dmRender
     {
         RenderScriptInstance* i = RenderScriptInstance_Check(L);
         (void)i;
-        int width = dmGraphics::GetWindowWidth(i->m_RenderContext->m_GraphicsContext);
-        printf("%s %d: %d\n", __FUNCTION__, __LINE__,  width);
-        lua_pushnumber(L, width);
+        lua_pushnumber(L, dmGraphics::GetWindowWidth(i->m_RenderContext->m_GraphicsContext));
         return 1;
     }
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -3428,7 +3428,6 @@ bail:
             else if (descriptor == dmRenderDDF::Resize::m_DDFDescriptor)
             {
                 dmRenderDDF::Resize* resize_msg = (dmRenderDDF::Resize*)message->m_Data;
-printf("%s %s %d\n", __FILE__, __FUNCTION__, __LINE__);
                 dmGraphics::ResizeWindow(instance->m_RenderContext->m_GraphicsContext, resize_msg->m_Width, resize_msg->m_Height);
                 return;
             }


### PR DESCRIPTION
The issue was that on macOS Ventura, the fullscreen mode would not render anything as it got a window size of (0, 0).
We now detect this case and then use the window frame rectangle.

FIxes https://github.com/defold/defold/issues/7922

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
