### PR TITLE
Add arm64-macos editor build

### DIFF
--- a/.github/workflows/editor-only.yml
+++ b/.github/workflows/editor-only.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        platform: [x86_64-macos]
+        platform: [x86_64-macos, arm64-macos]
     steps: [
       { name: 'Checkout', uses: actions/checkout@v3 },
       { name: 'Install Python', uses: actions/setup-python@v3, with: { python-version: 3.x, architecture: x64 } },
@@ -66,7 +66,7 @@ jobs:
       },
       {
         name: 'Notarize editor',
-        run: 'ci/ci.sh --notarization-username="${{env.NOTARIZATION_USERNAME}}" --notarization-password="${{env.NOTARIZATION_PASSWORD}}" --notarization-itc-provider="${{env.NOTARIZATION_ITC_PROVIDER}}" notarize-editor'
+        run: 'ci/ci.sh --platform=${{ matrix.platform }} --notarization-username="${{env.NOTARIZATION_USERNAME}}" --notarization-password="${{env.NOTARIZATION_PASSWORD}}" --notarization-itc-provider="${{env.NOTARIZATION_ITC_PROVIDER}}" notarize-editor'
       },
       {
         name: 'Archive editor',

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -269,7 +269,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        platform: [x86_64-macos]
+        platform: [x86_64-macos, arm64-macos]
     steps: [
       { name: 'Checkout', uses: actions/checkout@v3, with: { ref: '${{env.BUILD_BRANCH}}' } },
       { name: 'Install Python', uses: actions/setup-python@v3, with: { python-version: 3.x, architecture: x64 } },
@@ -292,7 +292,7 @@ jobs:
       {
         name: 'Notarize editor',
         if: (github.event_name != 'repository_dispatch') || ((github.event_name == 'repository_dispatch') && (github.event.client_payload.skip_sign != true)),
-        run: 'ci/ci.sh --notarization-username="${{env.NOTARIZATION_USERNAME}}" --notarization-password="${{env.NOTARIZATION_PASSWORD}}" --notarization-itc-provider="${{env.NOTARIZATION_ITC_PROVIDER}}" notarize-editor'
+        run: 'ci/ci.sh --platform=${{ matrix.platform }} --notarization-username="${{env.NOTARIZATION_USERNAME}}" --notarization-password="${{env.NOTARIZATION_PASSWORD}}" --notarization-itc-provider="${{env.NOTARIZATION_ITC_PROVIDER}}" notarize-editor'
       },
       {
         name: 'Archive editor',

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -22,7 +22,7 @@ from argparse import ArgumentParser
 from ci_helper import is_platform_supported, is_platform_private, is_repo_private
 
 # The platforms we deploy our editor on
-PLATFORMS_DESKTOP = ('x86_64-linux', 'x86_64-win32', 'x86_64-macos')
+PLATFORMS_DESKTOP = ('x86_64-linux', 'x86_64-win32', 'x86_64-macos', 'arm64-macos')
 
 def call(args, failonerror = True):
     print(args)
@@ -303,7 +303,7 @@ def sign_editor2(platform, windows_cert = None, windows_cert_pass = None):
     call(cmd)
 
 
-def notarize_editor2(notarization_username = None, notarization_password = None, notarization_itc_provider = None):
+def notarize_editor2(notarization_username = None, notarization_password = None, notarization_itc_provider = None, platform = None):
     if not notarization_username or not notarization_password:
         print("No notarization username or password")
         exit(1)
@@ -312,7 +312,7 @@ def notarize_editor2(notarization_username = None, notarization_password = None,
     args = 'python scripts/build.py notarize_editor2'.split()
     opts = []
 
-    opts.append('--platform=x86_64-macos')
+    opts.append('--platform=%s' % platform)
 
     opts.append('--notarization-username="%s"' % notarization_username)
     opts.append('--notarization-password="%s"' % notarization_password)
@@ -534,7 +534,8 @@ def main(argv):
             notarize_editor2(
                 notarization_username = args.notarization_username,
                 notarization_password = args.notarization_password,
-                notarization_itc_provider = args.notarization_itc_provider)
+                notarization_itc_provider = args.notarization_itc_provider,
+                platform = platform)
         elif command == "sign-editor":
             if not platform:
                 raise Exception("No --platform specified.")

--- a/editor/project.clj
+++ b/editor/project.clj
@@ -78,36 +78,13 @@
 
                      [com.github.ben-manes.caffeine/caffeine "3.1.2"]
 
-                     [cljfx "1.7.22"]
-
-                     [org.openjfx/javafx-base "21-ea+23"]
-                     [org.openjfx/javafx-base "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-base "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-base "21-ea+23" :classifier "win"]
-                     [org.openjfx/javafx-controls "21-ea+23"]
-                     [org.openjfx/javafx-controls "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-controls "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-controls "21-ea+23" :classifier "win"]
-                     [org.openjfx/javafx-graphics "21-ea+23"]
-                     [org.openjfx/javafx-graphics "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-graphics "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-graphics "21-ea+23" :classifier "win"]
-                     [org.openjfx/javafx-media "21-ea+23"]
-                     [org.openjfx/javafx-media "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-media "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-media "21-ea+23" :classifier "win"]
-                     [org.openjfx/javafx-web "21-ea+23"]
-                     [org.openjfx/javafx-web "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-web "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-web "21-ea+23" :classifier "win"]
-                     [org.openjfx/javafx-fxml "21-ea+23"]
-                     [org.openjfx/javafx-fxml "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-fxml "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-fxml "21-ea+23" :classifier "win"]
-                     [org.openjfx/javafx-swing "21-ea+23"]
-                     [org.openjfx/javafx-swing "21-ea+23" :classifier "linux"]
-                     [org.openjfx/javafx-swing "21-ea+23" :classifier "mac"]
-                     [org.openjfx/javafx-swing "21-ea+23" :classifier "win"]
+                     [cljfx "1.7.22"
+                      :exclusions [org.clojure/clojure
+                                   org.openjfx/javafx-base
+                                   org.openjfx/javafx-graphics
+                                   org.openjfx/javafx-controls
+                                   org.openjfx/javafx-media
+                                   org.openjfx/javafx-web]]
 
                      [org.jogamp.gluegen/gluegen-rt "2.4.0"]
                      [org.jogamp.gluegen/gluegen-rt "2.4.0" :classifier "natives-linux-amd64"]
@@ -155,7 +132,8 @@
                       :source-maps false}
 
   :aliases           {"benchmark" ["with-profile" "+test" "trampoline" "run" "-m" "benchmark.graph-benchmark"]
-                      "preflight" ["with-profile" "+preflight,+dev,+test" "preflight"]}
+                      "preflight" ["with-profile" "+preflight,+dev,+test" "preflight"]
+                      "prerelease" ["do" "clean," "protobuf," "sass" "once," "javac," "with-profile" "dev,sidecar,release" "run" "-m" "aot"]}
 
   ;; used by `pack` task
   :packing           {:pack-path "resources/_unpack"}
@@ -184,15 +162,18 @@
 
   :uberjar-exclusions [#"^natives/"]
 
+  :javac-options ["-Xlint:unchecked" "-Xlint:deprecation"]
+
   :profiles          {:test    {:injections [(com.defold.libs.ResourceUnpacker/unpackResources)]
                                 :resource-paths ["test/resources"]
                                 :jvm-opts ["-Ddefold.tests=true"]}
                       :preflight {:dependencies [[jonase/kibit "0.1.6" :exclusions [org.clojure/clojure]]
                                                  [cljfmt-mg "0.6.4" :exclusions [org.clojure/clojure]]]}
-                      :uberjar {:prep-tasks  ^:replace ["clean" "protobuf" ["sass" "once"] "javac" ["run" "-m" "aot"]]
+                      :sidecar {:source-paths ["sidecar"]}
+                      :uberjar {:prep-tasks  ^:replace []
                                 :aot          :all
-                                :omit-source  true
-                                :source-paths ["sidecar"]}
+                                :auto-clean   false
+                                :omit-source  true}
                       :local-repl {:injections [(require 'dev) (future ((requiring-resolve 'editor/-main)))]
                                    :jvm-opts ["-Ddefold.nrepl=false"]}
                       :vscode {:plugins [[nrepl "0.6.0"]]}
@@ -208,7 +189,47 @@
                                :dependencies [[vlaaad/reveal "1.3.280"]]}
                       :metrics {:jvm-opts ["-Ddefold.metrics=true"]}
                       :no-asserts {:global-vars {*assert* false}}
-                      :dev     {:dependencies      [[com.clojure-goes-fast/clj-async-profiler "0.5.1"]
+                      :x86_64-linux {:dependencies [[org.openjfx/javafx-base "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-base]]
+                                                    [org.openjfx/javafx-controls "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-controls org.openjfx/javafx-graphics]]
+                                                    [org.openjfx/javafx-graphics "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-graphics org.openjfx/javafx-base]]
+                                                    [org.openjfx/javafx-media "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-media org.openjfx/javafx-graphics]]
+                                                    [org.openjfx/javafx-web "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-web org.openjfx/javafx-controls org.openjfx/javafx-media]]
+                                                    [org.openjfx/javafx-fxml "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-fxml org.openjfx/javafx-controls]]
+                                                    [org.openjfx/javafx-swing "21-ea+23" :classifier "linux" :exclusions [org.openjfx/javafx-swing org.openjfx/javafx-graphics]]]
+                                     :uberjar-name "editor-x86_64-linux-standalone.jar"}
+                      :x86_64-win32 {:dependencies [[org.openjfx/javafx-base "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-base]]
+                                                    [org.openjfx/javafx-controls "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-controls org.openjfx/javafx-graphics]]
+                                                    [org.openjfx/javafx-graphics "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-graphics org.openjfx/javafx-base]]
+                                                    [org.openjfx/javafx-media "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-media org.openjfx/javafx-graphics]]
+                                                    [org.openjfx/javafx-web "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-web org.openjfx/javafx-controls org.openjfx/javafx-media]]
+                                                    [org.openjfx/javafx-fxml "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-fxml org.openjfx/javafx-controls]]
+                                                    [org.openjfx/javafx-swing "21-ea+23" :classifier "win" :exclusions [org.openjfx/javafx-swing org.openjfx/javafx-graphics]]]
+                                     :uberjar-name "editor-x86_64-win32-standalone.jar"}
+                      :x86_64-macos {:dependencies [[org.openjfx/javafx-base "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-base]]
+                                                    [org.openjfx/javafx-controls "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-controls org.openjfx/javafx-graphics]]
+                                                    [org.openjfx/javafx-graphics "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-graphics org.openjfx/javafx-base]]
+                                                    [org.openjfx/javafx-media "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-media org.openjfx/javafx-graphics]]
+                                                    [org.openjfx/javafx-web "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-web org.openjfx/javafx-controls org.openjfx/javafx-media]]
+                                                    [org.openjfx/javafx-fxml "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-fxml org.openjfx/javafx-controls]]
+                                                    [org.openjfx/javafx-swing "21-ea+23" :classifier "mac" :exclusions [org.openjfx/javafx-swing org.openjfx/javafx-graphics]]]
+                                     :uberjar-name "editor-x86_64-macos-standalone.jar"}
+                      :arm64-macos {:dependencies [[org.openjfx/javafx-base "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-base]]
+                                                   [org.openjfx/javafx-controls "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-controls org.openjfx/javafx-graphics]]
+                                                   [org.openjfx/javafx-graphics "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-graphics org.openjfx/javafx-base]]
+                                                   [org.openjfx/javafx-media "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-media org.openjfx/javafx-graphics]]
+                                                   [org.openjfx/javafx-web "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-web org.openjfx/javafx-controls org.openjfx/javafx-media]]
+                                                   [org.openjfx/javafx-fxml "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-fxml org.openjfx/javafx-controls]]
+                                                   [org.openjfx/javafx-swing "21-ea+23" :classifier "mac-aarch64" :exclusions [org.openjfx/javafx-swing org.openjfx/javafx-graphics]]]
+                                    :uberjar-name "editor-arm64-macos-standalone.jar"}
+                      :dev     {:dependencies      [;; generic javafx dep picks up natives for the current platform
+                                                    [org.openjfx/javafx-base "21-ea+23"]
+                                                    [org.openjfx/javafx-controls "21-ea+23"]
+                                                    [org.openjfx/javafx-graphics "21-ea+23"]
+                                                    [org.openjfx/javafx-media "21-ea+23"]
+                                                    [org.openjfx/javafx-web "21-ea+23"]
+                                                    [org.openjfx/javafx-fxml "21-ea+23"]
+                                                    [org.openjfx/javafx-swing "21-ea+23"]
+                                                    [com.clojure-goes-fast/clj-async-profiler "0.5.1"]
                                                     [com.clojure-goes-fast/clj-memory-meter "0.1.2"]
                                                     [criterium "0.4.3"]
                                                     [org.clojure/test.check   "0.9.0"]

--- a/editor/resources/templates/template.appmanifest
+++ b/editor/resources/templates/template.appmanifest
@@ -41,6 +41,14 @@ platforms:
       libs: []
       linkFlags: []
       jetifier: true
+  arm64-osx:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
   x86_64-osx:
     context:
       excludeLibs: []

--- a/editor/scripts/bundle.py
+++ b/editor/scripts/bundle.py
@@ -20,6 +20,7 @@ import os.path as path
 import stat
 import sys
 import optparse
+import platform
 import re
 import shutil
 import subprocess
@@ -60,11 +61,13 @@ java_version = '17.0.5+8'
 
 platform_to_java = {'x86_64-linux': 'linux-x64',
                     'x86_64-macos': 'macos-x64',
+                    'arm64-macos': 'macos-arm64',
                     'x86_64-win32': 'windows-x64'}
 
-python_platform_to_java = {'linux': 'linux-x64',
-                           'win32': 'windows-x64',
-                           'darwin': 'macos-x64'}
+python_platform_to_java = {'x86_64-linux': 'linux-x64',
+                           'x86_64-win32': 'windows-x64',
+                           'x86_64-darwin': 'macos-x64',
+                           'arm64-darwin': 'macos-arm64'}
 
 def log(msg):
     print(msg)
@@ -217,7 +220,7 @@ def full_jdk_url(jdk_platform):
     return '%s/OpenJDK17U-jdk_%s_hotspot_%s.%s' % (CDN_PACKAGES_URL, platform, version, extension)
 
 def full_build_jdk_url():
-    return full_jdk_url(python_platform_to_java[sys.platform])
+    return full_jdk_url(python_platform_to_java["%s-%s" % (platform.machine(), sys.platform)])
 
 def download_build_jdk():
     print('Downloading build jdk')
@@ -281,7 +284,7 @@ def build(options):
     else:
         run.command(['env', java_cmd_env, 'bash', './scripts/lein', 'test'])
 
-    run.command(['env', java_cmd_env, 'bash', './scripts/lein', 'with-profile', '+release', 'uberjar'])
+    run.command(['env', java_cmd_env, 'bash', './scripts/lein', 'prerelease'])
 
 
 def get_exe_suffix(platform):
@@ -315,7 +318,7 @@ def remove_platform_files_from_archive(platform, jar):
     # find libs to remove in the root folder
     for file in files:
         if "/" not in file:
-            if platform == "x86_64-macos" and (file.endswith(".so") or file.endswith(".dll")):
+            if (platform == "x86_64-macos" or platform == "arm64-macos") and (file.endswith(".so") or file.endswith(".dll")):
                 files_to_remove.append(file)
             elif platform == "x86_64-win32" and (file.endswith(".so") or file.endswith(".dylib")):
                 files_to_remove.append(file)
@@ -337,12 +340,15 @@ def remove_platform_files_from_archive(platform, jar):
 
 
 def create_bundle(options):
-    jar_file = 'target/defold-editor-2.0.0-SNAPSHOT-standalone.jar'
     build_jdk = download_build_jdk()
     extracted_build_jdk = extract_build_jdk(build_jdk)
+    java_cmd_env = 'JAVA_CMD=%s/bin/java' % extracted_build_jdk
 
     mkdirs('target/editor')
     for platform in options.target_platform:
+        print("Creating uberjar for platform %s" % platform)
+        run.command(['env', java_cmd_env, 'bash', './scripts/lein', 'with-profile', 'release,%s' % platform, 'uberjar'])
+        jar_file = 'target/editor-%s-standalone.jar' % platform
         print("Creating bundle for platform %s" % platform)
         rmtree('tmp')
 
@@ -441,7 +447,7 @@ def sign(options):
         if 'win32' in platform:
             bundle_file = os.path.join(options.bundle_dir, "Defold-x86_64-win32.zip")
         elif 'macos' in platform:
-            bundle_file = os.path.join(options.bundle_dir, "Defold-x86_64-macos.zip")
+            bundle_file = os.path.join(options.bundle_dir, "Defold-%s.zip" % platform)
         else:
             print("No signing support for platform %s" % platform)
             continue
@@ -490,11 +496,11 @@ def find_files(root_dir, file_pattern):
                 matches.append(fullname)
     return matches
 
-def create_dmg(options):
+def create_dmg(options, platform):
     print("Creating .dmg from file in '%s'" % options.bundle_dir)
 
     # check that we have an editor bundle to create a dmg from
-    bundle_file = os.path.join(options.bundle_dir, "Defold-x86_64-macos.zip")
+    bundle_file = os.path.join(options.bundle_dir, "Defold-%s.zip" % platform)
     if not os.path.exists(bundle_file):
         print('Editor bundle %s does not exist' % bundle_file)
         run.command(['ls', '-la', options.bundle_dir])
@@ -514,7 +520,7 @@ def create_dmg(options):
     run.command(['ln', '-sf', '/Applications', '%s/Applications' % dmg_dir])
 
     # create dmg
-    dmg_file = os.path.join(options.bundle_dir, "Defold-x86_64-macos.dmg")
+    dmg_file = os.path.join(options.bundle_dir, "Defold-%s.dmg" % platform)
     if os.path.exists(dmg_file):
         os.remove(dmg_file)
     run.command(['hdiutil', 'create', '-fs', 'JHFS+', '-volname', 'Defold', '-srcfolder', dmg_dir, dmg_file])
@@ -532,9 +538,9 @@ def create_dmg(options):
 def create_installer(options):
     print("Creating installers")
     for platform in options.target_platform:
-        if platform == "x86_64-macos":
+        if platform == "x86_64-macos" or platform == "arm64-macos":
             print("Creating installer for platform %s" % platform)
-            create_dmg(options)
+            create_dmg(options, platform)
         else:
             print("Ignoring platform %s" % platform)
 
@@ -553,7 +559,7 @@ Commands:
     parser.add_option('--platform', dest='target_platform',
                       default = None,
                       action = 'append',
-                      choices = ['x86_64-linux', 'x86_64-macos', 'x86_64-win32'],
+                      choices = ['x86_64-linux', 'arm64-macos', 'x86_64-macos', 'x86_64-win32'],
                       help = 'Target platform to create editor bundle for. Specify multiple times for multiple platforms')
 
     parser.add_option('--version', dest='version',

--- a/editor/scripts/lein
+++ b/editor/scripts/lein
@@ -146,7 +146,7 @@ done
 
 BIN_DIR="$(dirname "$SCRIPT")"
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
 
 # This needs to be defined before we call HTTP_CLIENT below
 if [ "$HTTP_CLIENT" = "" ]; then

--- a/editor/sidecar/aot.clj
+++ b/editor/sidecar/aot.clj
@@ -93,16 +93,16 @@
 (defn compile-clj
   [namespaces]
   (binding [*compiler-options* (build->compiler-options build-type default-compiler-options)]
-    (println "Using build profile " build-type)
-    (println "Compiler options: " *compiler-options*)
+    (println "Using build profile:" build-type)
+    (println "Compiler options:" *compiler-options*)
     (doseq [n namespaces]
-      (println "Compiling " n)
+      (println "Compiling" n)
       (compile n))))
 
 (defn -main [& args]
   (defonce force-toolkit-init (javafx.application.Platform/startup (fn [])))
   (let [order (compile-order srcdirs build-type)]
-    (println "Compiling in order " order)
+    (println "Compiling in order" order)
     (compile-clj order))
   (println "Done compiling")
   (System/exit 0))

--- a/editor/src/clj/editor/app_manifest.clj
+++ b/editor/src/clj/editor/app_manifest.clj
@@ -28,7 +28,7 @@
 (def linux #{:x86_64-linux})
 
 (def vulkan
-  #{:x86_64-osx
+  #{:x86_64-osx :arm64-osx
     :x86_64-linux
     :x86-win32 :x86_64-win32
     :armv7-android :arm64-android
@@ -40,7 +40,7 @@
     ;; android
     :armv7-android :arm64-android
     ;; osx
-    :x86_64-osx
+    :x86_64-osx :arm64-osx
     ;; linux
     :x86_64-linux
     ;; windows
@@ -345,11 +345,11 @@
 
 (def vulkan-toggles
   (concat
-    (libs-toggles [:x86_64-osx :arm64-ios] ["graphics_vulkan" "MoltenVK"])
+    (libs-toggles [:x86_64-osx :arm64-osx :arm64-ios] ["graphics_vulkan" "MoltenVK"])
     (libs-toggles android ["graphics_vulkan"])
     (libs-toggles windows ["graphics_vulkan" "vulkan"])
     (libs-toggles linux ["graphics_vulkan" "X11-xcb"])
-    (generic-contains-toggles [:x86_64-osx] :frameworks ["Metal" "IOSurface" "QuartzCore"])
+    (generic-contains-toggles [:x86_64-osx :arm64-osx] :frameworks ["Metal" "IOSurface" "QuartzCore"])
     (generic-contains-toggles [:arm64-ios] :frameworks ["Metal" "QuartzCore"])
     (generic-contains-toggles vulkan :symbols ["GraphicsAdapterVulkan"])))
 
@@ -390,6 +390,7 @@
                   [:armv7-android platform-pattern]
                   [:arm64-android platform-pattern]
                   ;; osx
+                  [:arm64-osx platform-pattern]
                   [:x86_64-osx platform-pattern]
                   ;; linux
                   [:x86_64-linux platform-pattern]

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -168,7 +168,7 @@
 (def custom-engine-pref-key "dev-custom-engine")
 
 (defn current-platform []
-  (.getPair (Platform/getJavaPlatform)))
+  (.getPair (Platform/getHostPlatform)))
 
 (defn- dev-custom-engine
   [prefs platform]

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -103,7 +103,9 @@
 ;;; Extension discovery/processing
 
 (def ^:private extender-platforms
-  {(.getPair Platform/X86_64MacOS)  {:platform      "x86_64-osx"
+  {(.getPair Platform/Arm64MacOS)   {:platform      "arm64-osx"
+                                     :library-paths #{"osx" "arm64-osx"}}
+   (.getPair Platform/X86_64MacOS)  {:platform      "x86_64-osx"
                                      :library-paths #{"osx" "x86_64-osx"}}
    (.getPair Platform/Arm64Ios)     {:platform      "arm64-ios"
                                      :library-paths #{"ios" "arm64-ios"}}
@@ -320,6 +322,7 @@
 
 (defn- get-ne-platform [platform]
   (case platform
+    "arm64-macos" "arm64-osx"
     "x86_64-macos" "x86_64-osx"
     platform))
 
@@ -329,6 +332,7 @@
      "arm64-android" ["android" "manifest"]
      "arm64-ios"     ["ios" "infoplist"]
      "armv7-ios"     ["ios" "infoplist"]
+     "arm64-osx"     ["osx" "infoplist"]
      "x86_64-osx"    ["osx" "infoplist"]
      "js-web"        ["html5" "htmlfile"]
      "wasm-web"      ["html5" "htmlfile"]))
@@ -339,6 +343,7 @@
     "arm64-android" "AndroidManifest.xml"
     "arm64-ios"     "Info.plist"
     "armv7-ios"     "Info.plist"
+    "arm64-osx"     "Info.plist"
     "x86_64-osx"    "Info.plist"
     "js-web"        "engine_template.html"
     "wasm-web"      "engine_template.html"

--- a/editor/src/clj/editor/luajit.clj
+++ b/editor/src/clj/editor/luajit.clj
@@ -33,7 +33,7 @@
 
 (defn- luajit-exec-path
   [arch]
-  (str (system/defold-unpack-path) "/" (.getPair (Platform/getJavaPlatform)) (str (case arch
+  (str (system/defold-unpack-path) "/" (.getPair (Platform/getHostPlatform)) (str (case arch
                                                                                         :32-bit "/bin/luajit-32"
                                                                                         :64-bit "/bin/luajit-64"))))
 

--- a/editor/src/clj/editor/updater.clj
+++ b/editor/src/clj/editor/updater.clj
@@ -111,6 +111,7 @@
 
 (defn platform-supported? [updater]
   (contains? #{Platform/X86_64Linux
+               Platform/Arm64MacOS
                Platform/X86_64MacOS
                Platform/X86_64Win32}
              (:platform updater)))

--- a/editor/src/java/com/defold/editor/Start.java
+++ b/editor/src/java/com/defold/editor/Start.java
@@ -15,6 +15,7 @@
 package com.defold.editor;
 
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
 import ch.qos.logback.core.util.FileSize;
@@ -174,13 +175,13 @@ public class Start extends Application {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
 
-        RollingFileAppender appender = new RollingFileAppender();
+        RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
         appender.setName("FILE");
         appender.setAppend(true);
         appender.setPrudent(true);
         appender.setContext(root.getLoggerContext());
 
-        TimeBasedRollingPolicy rollingPolicy = new TimeBasedRollingPolicy();
+        TimeBasedRollingPolicy<Object> rollingPolicy = new TimeBasedRollingPolicy<>();
         rollingPolicy.setMaxHistory(30);
         rollingPolicy.setFileNamePattern(logDirectory.resolve("editor2.%d{yyyy-MM-dd}.log").toString());
         rollingPolicy.setTotalSizeCap(FileSize.valueOf("1GB"));

--- a/editor/src/java/com/defold/editor/providers/JsonProviders.java
+++ b/editor/src/java/com/defold/editor/providers/JsonProviders.java
@@ -127,15 +127,15 @@ public class JsonProviders {
 
             case VALUE_NUMBER_FLOAT:
                 if (type == FieldDescriptor.JavaType.FLOAT)
-                    return (float) node.getValueAsDouble();
+                    return (float) node.asDouble();
                 else if (type == FieldDescriptor.JavaType.DOUBLE)
-                    return node.getValueAsDouble();
+                    return node.asDouble();
 
             case VALUE_NUMBER_INT:
                 if (type == FieldDescriptor.JavaType.INT)
-                    return node.getValueAsInt();
+                    return node.asInt();
                 else if (type == FieldDescriptor.JavaType.LONG)
-                    return node.getValueAsLong();
+                    return node.asLong();
 
             case START_OBJECT:
                 return JsonToMessage(node, builder.newBuilderForField(fieldDescriptor));

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -88,12 +88,12 @@ public class ResourceUnpacker {
                 unpackResourceFile("builtins.zip", unpackPath.resolve("builtins"));
                 unpackResourceDir("/_unpack", unpackPath);
 
-                Path binDir = unpackPath.resolve(Platform.getJavaPlatform().getPair() + "/bin").toAbsolutePath();
+                Path binDir = unpackPath.resolve(Platform.getHostPlatform().getPair() + "/bin").toAbsolutePath();
                 if (binDir.toFile().exists()) {
                     Files.walk(binDir).forEach(path -> path.toFile().setExecutable(true));
                 }
 
-                unpackedLibDir = unpackPath.resolve(Platform.getJavaPlatform().getPair() + "/lib").toAbsolutePath();
+                unpackedLibDir = unpackPath.resolve(Platform.getHostPlatform().getPair() + "/lib").toAbsolutePath();
                 System.setProperty("java.library.path", unpackedLibDir.toString());
                 System.setProperty("jna.library.path", unpackedLibDir.toString());
 

--- a/editor/src/java/com/dynamo/upnp/SSDP.java
+++ b/editor/src/java/com/dynamo/upnp/SSDP.java
@@ -15,15 +15,7 @@
 package com.dynamo.upnp;
 
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.MulticastSocket;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
+import java.net.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,7 +38,7 @@ public class SSDP implements ISSDP {
             if (!addresses.isEmpty()) {
                 mcastSocket = new MulticastSocket(SSDP_MCAST_PORT);
                 mcastSocket.setNetworkInterface(networkInterface);
-                mcastSocket.joinGroup(SSDP_MCAST_ADDR);
+                mcastSocket.joinGroup(new InetSocketAddress(SSDP_MCAST_ADDR, 0), null);
                 mcastSocket.setSoTimeout(1);
                 mcastSocket.setTimeToLive(SSDP_MCAST_TTL);
                 sockets = new ArrayList<DatagramSocket>();

--- a/editor/tasks/leiningen/pack.clj
+++ b/editor/tasks/leiningen/pack.clj
@@ -27,6 +27,8 @@
 (def engine-artifacts
   {"x86_64-macos" {"bin" ["dmengine"]
                     "lib" ["libparticle_shared.dylib"]}
+   "arm64-macos" {"bin" ["dmengine"]
+                  "lib" ["libparticle_shared.dylib"]}
    "x86-win32"     {"bin" ["dmengine.exe" "dmengine.pdb"]
                     "lib" []}
    "x86_64-win32"  {"bin" ["dmengine.exe" "dmengine.pdb"]
@@ -57,11 +59,16 @@
    "${DYNAMO-HOME}/ext/bin/x86_64-macos/luajit-32"           "x86_64-macos/bin/luajit-32"
    "${DYNAMO-HOME}/ext/bin/x86_64-macos/luajit-64"           "x86_64-macos/bin/luajit-64"
 
+   "${DYNAMO-HOME}/ext/bin/arm64-macos/luajit-32"            "arm64-macos/bin/luajit-32"
+   "${DYNAMO-HOME}/ext/bin/arm64-macos/luajit-64"            "arm64-macos/bin/luajit-64"
+
    "$DYNAMO_HOME/ext/bin/x86_64-macos/glslc"                  "x86_64-macos/glslc"
+   "$DYNAMO_HOME/ext/bin/arm64-macos/glslc"                   "arm64-macos/glslc"
    "$DYNAMO_HOME/ext/bin/x86_64-linux/glslc"                  "x86_64-linux/glslc"
    "$DYNAMO_HOME/ext/bin/x86_64-win32/glslc.exe"              "x86_64-win32/glslc.exe"
 
    "$DYNAMO_HOME/ext/bin/x86_64-macos/spirv-cross"            "x86_64-macos/spirv-cross"
+   "$DYNAMO_HOME/ext/bin/arm64-macos/spirv-cross"             "arm64-macos/spirv-cross"
    "$DYNAMO_HOME/ext/bin/x86_64-linux/spirv-cross"            "x86_64-linux/spirv-cross"
    "$DYNAMO_HOME/ext/bin/x86_64-win32/spirv-cross.exe"        "x86_64-win32/spirv-cross.exe"
 
@@ -90,11 +97,11 @@
 ;; Manually re-pack JOGL natives, so we can avoid JOGLs automatic
 ;; library loading, see DEFEDIT-494.
 
-(def java-platform->platform
-  {"linux-amd64"      "x86_64-linux"
-   "macosx-universal" "x86_64-macos"
-   "windows-amd64"    "x86_64-win32"
-   "windows-x64"      "x86_64-win32"})
+(def jogl-classifier->platforms
+  {"linux-amd64"      ["x86_64-linux"]
+   "macosx-universal" ["arm64-macos" "x86_64-macos"]
+   "windows-amd64"    ["x86_64-win32"]
+   "windows-x64"      ["x86_64-win32"]})
 
 (defn jar-file
   [[artifact version & {:keys [classifier]} :as dependency]]
@@ -119,11 +126,12 @@
     (with-open [zip-file (ZipFile. (jar-file dependency))]
       (doseq [entry (enumeration-seq (.entries zip-file))]
         (when (.startsWith (.getName entry) natives-path)
-          (let [libname (.getName (io/file (.getName entry)))
-                dest (io/file pack-path (java-platform->platform java-platform) "lib" libname)]
-            (println (format "extracting '%s'/'%s' to '%s'" (.getName zip-file) (.getName entry) dest))
-            (io/make-parents dest)
-            (io/copy (.getInputStream zip-file entry) dest)))))))
+          (let [libname (.getName (io/file (.getName entry)))]
+            (doseq [target-platform (jogl-classifier->platforms java-platform)]
+              (let [dest (io/file pack-path target-platform "lib" libname)]
+                (println (format "extracting '%s'/'%s' to '%s'" (.getName zip-file) (.getName entry) dest))
+                (io/make-parents dest)
+                (io/copy (.getInputStream zip-file entry) dest)))))))))
 
 (defn pack-jogl-natives
   [pack-path dependencies]

--- a/editor/test/integration/extension_spine_test.clj
+++ b/editor/test/integration/extension_spine_test.clj
@@ -31,8 +31,7 @@
 
 (set! *warn-on-reflection* true)
 
-;; TODO: Restore this to main after 1.4.8 has been released.
-(defonce ^:private extension-spine-url "https://github.com/defold/extension-spine/archive/refs/tags/2.10.6.zip")
+(defonce ^:private extension-spine-url "https://github.com/defold/extension-spine/archive/main.zip")
 
 (def ^:private error-item-open-info-without-opts (comp pop build-errors-view/error-item-open-info))
 

--- a/editor/test/resources/test_project/app_manifest/exclude_many.appmanifest
+++ b/editor/test/resources/test_project/app_manifest/exclude_many.appmanifest
@@ -1,6 +1,15 @@
 # App manifest generated Fri Sep 02 2022 16:18:07 GMT+0200 (Central European Summer Time)
 # Settings: Record,Profiler,Sound,Input,LiveUpdate,Basis Transcoder,OpenGL
 platforms:
+    arm64-osx:
+        context:
+            excludeLibs: ["record","vpx","profilerext","sound","tremolo","hid","liveupdate","graphics_transcoder_basisu","basis_transcoder"]
+            excludeSymbols: ["ProfilerExt","DefaultSoundDevice","AudioDecoderWav","AudioDecoderStbVorbis","AudioDecoderTremolo"]
+            symbols: []
+            libs: ["record_null","profilerext_null","sound_null","hid_null","liveupdate_null","graphics_transcoder_null"]
+            frameworks: []
+            linkFlags: []
+
     x86_64-osx:
         context:
             excludeLibs: ["record","vpx","profilerext","sound","tremolo","hid","liveupdate","graphics_transcoder_basisu","basis_transcoder"]

--- a/editor/test/resources/test_project/app_manifest/exclude_physics.appmanifest
+++ b/editor/test/resources/test_project/app_manifest/exclude_physics.appmanifest
@@ -1,6 +1,15 @@
 # App manifest generated Fri Sep 02 2022 16:16:15 GMT+0200 (Central European Summer Time)
 # Settings: Physics2D,Physics3D,OpenGL
 platforms:
+    arm64-osx:
+        context:
+            excludeLibs: ["physics","LinearMath","BulletDynamics","BulletCollision","Box2D"]
+            excludeSymbols: []
+            symbols: []
+            libs: ["physics_null"]
+            frameworks: []
+            linkFlags: []
+
     x86_64-osx:
         context:
             excludeLibs: ["physics","LinearMath","BulletDynamics","BulletCollision","Box2D"]

--- a/editor/test/resources/test_project/app_manifest/exclude_physics_2d.appmanifest
+++ b/editor/test/resources/test_project/app_manifest/exclude_physics_2d.appmanifest
@@ -1,6 +1,15 @@
 # App manifest generated Fri Sep 02 2022 16:09:29 GMT+0200 (Central European Summer Time)
 # Settings: Physics2D,OpenGL
 platforms:
+    arm64-osx:
+        context:
+            excludeLibs: ["physics","Box2D"]
+            excludeSymbols: []
+            symbols: []
+            libs: ["physics_3d"]
+            frameworks: []
+            linkFlags: []
+
     x86_64-osx:
         context:
             excludeLibs: ["physics","Box2D"]

--- a/editor/test/resources/test_project/app_manifest/exclude_physics_3d.appmanifest
+++ b/editor/test/resources/test_project/app_manifest/exclude_physics_3d.appmanifest
@@ -1,6 +1,15 @@
 # App manifest generated Fri Sep 02 2022 16:15:35 GMT+0200 (Central European Summer Time)
 # Settings: Physics3D,OpenGL
 platforms:
+    arm64-osx:
+        context:
+            excludeLibs: ["physics","LinearMath","BulletDynamics","BulletCollision"]
+            excludeSymbols: []
+            symbols: []
+            libs: ["physics_2d"]
+            frameworks: []
+            linkFlags: []
+
     x86_64-osx:
         context:
             excludeLibs: ["physics","LinearMath","BulletDynamics","BulletCollision"]

--- a/editor/test/resources/test_project/app_manifest/vulkan.appmanifest
+++ b/editor/test/resources/test_project/app_manifest/vulkan.appmanifest
@@ -1,6 +1,15 @@
 # App manifest generated Fri Sep 02 2022 16:19:20 GMT+0200 (Central European Summer Time)
 # Settings: Vulkan
 platforms:
+    arm64-osx:
+        context:
+            excludeLibs: ["graphics"]
+            excludeSymbols: ["GraphicsAdapterOpenGL"]
+            symbols: ["GraphicsAdapterVulkan"]
+            libs: ["graphics_vulkan","MoltenVK"]
+            frameworks: ["Metal","IOSurface","QuartzCore"]
+            linkFlags: []
+
     x86_64-osx:
         context:
             excludeLibs: ["graphics"]

--- a/editor/test/resources/test_project/app_manifest/vulkan_and_opengl.appmanifest
+++ b/editor/test/resources/test_project/app_manifest/vulkan_and_opengl.appmanifest
@@ -1,6 +1,15 @@
 # App manifest generated Fri Sep 02 2022 16:20:52 GMT+0200 (Central European Summer Time)
 # Settings: Vulkan,OpenGL
 platforms:
+    arm64-osx:
+        context:
+            excludeLibs: []
+            excludeSymbols: []
+            symbols: ["GraphicsAdapterVulkan"]
+            libs: ["graphics_vulkan","MoltenVK"]
+            frameworks: ["Metal","IOSurface","QuartzCore"]
+            linkFlags: []
+
     x86_64-osx:
         context:
             excludeLibs: []


### PR DESCRIPTION
User-facing changes: 
This changeset adds support for the arm64 macOS version of the editor.

Technical notes:
I changed the editor `build` and `bundle` steps. 
Before: `build` prepares and compiles code, then creates an uberjar with deps for all platforms, `bundle` uses jar and platform JDK to create platform-dependent executable.
After: `build` prepares and compiles code, `bundle` creates uberjar with deps for the target platform, then uses jar and platform JDK to create platform-dependent executable.


Related to #7781