### PR TITLE
Make adb devices parsing more resilient

### DIFF
--- a/editor/src/clj/editor/adb.clj
+++ b/editor/src/clj/editor/adb.clj
@@ -64,7 +64,9 @@ If it's already installed, configure its path in the Preferences' Tools pane." {
           (keep (fn [line]
                   (when-let [[_ id kvs] (re-matches #"^([^\s]+)\s+device\s(.+)" line)]
                     (let [{:strs [device model]} (into {}
-                                                       (map #(string/split % #":" 2))
+                                                       (keep #(let [kv (string/split % #":" 2)]
+                                                                (when (= 2 (count kv))
+                                                                  kv)))
                                                        (string/split kvs #" "))]
                       {:id id
                        :label (cond


### PR DESCRIPTION
User-facing changes:
APK installation on Android is now more resilient to different formats of `adb devices` output.

Fixes #7937