### PR TITLE
Fix startup tip typo

### DIFF
--- a/editor/resources/tips.txt
+++ b/editor/resources/tips.txt
@@ -31,7 +31,7 @@ To move an object along its rotated axis, select Local Space from the Edit menu.
 
 To avoid breaking changes in [Library dependencies](https://www.defold.com/manuals/libraries/#_library_url) it is recommended to always depend on a versioned release instead of the latest code from the master branch.
 You can open the [Web Profiler](https://www.defold.com/manuals/profiling/#_the_web_profiler) from the Open Web Profiler menu option in the Debug menu.
-Did you know? You can tweak your game [without stopping it](https://www.defold.com/manuals/hot-reload/) — even on device!
+Did you know? You can tweak your game [without stopping it](https://www.defold.com/manuals/hot-reload/) — on any device!
 
 # Inspirational quotes
 


### PR DESCRIPTION
One of the tooltips when starting Defold has a typo/unclear wording:
`Did you know? You can tweak your game without stopping it -- even on device!`

After checking on Discord, it seems this should say `on any device!` 
([Discord conversation link](https://discord.com/channels/250018174974689280/898548002338271242/1146126255364767856))


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
