### PR TITLE
Fix issue when window (on Mac) opens without focus

### DIFF
--- a/engine/glfw/lib/cocoa/cocoa_init.m
+++ b/engine/glfw/lib/cocoa/cocoa_init.m
@@ -88,33 +88,6 @@ static NSString *findAppName( void )
         }
     }
 
-    // If we get here, we're unbundled
-    if( !_glfwLibrary.Unbundled )
-    {
-        // Wait for an (any) event before calling SetFrontProcess() below.
-        // If we skip this, sometimes the app/window become unresponsive
-        // right after start.
-        //
-        // This also fixes the bug where the correct menu won't show
-        // unless the user switches from the app and back again.
-        //
-        // Eclipse does something similar:
-        // https://bugs.eclipse.org/bugs/attachment.cgi?id=248969
-        [NSApp nextEventMatchingMask: NSAnyEventMask untilDate: nil
-            inMode: NSDefaultRunLoopMode dequeue: NO ];
-
-        // Could do this only if we discover we're unbundled, but it should
-        // do no harm...
-        ProcessSerialNumber psn = { 0, kCurrentProcess };
-        TransformProcessType( &psn, kProcessTransformToForegroundApplication );
-
-        // Having the app in front of the terminal window is also generally
-        // handy.  There is an NSApplication API to do this, but...
-        SetFrontProcess( &psn );
-
-        _glfwLibrary.Unbundled = GL_TRUE;
-    }
-
     char **progname = _NSGetProgname();
     if( progname && *progname )
     {

--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -127,9 +127,17 @@
     return NSTerminateCancel;
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
+- (void)applicationDidUpdate:(NSNotification *)notification
 {
-    [[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
+    // Wait for the first update to make window active
+    // It helps to avoid issue when the window opens inactive
+    // https://github.com/defold/defold/issues/6709
+    if( !_glfwLibrary.Unbundled ) {
+        ProcessSerialNumber psn = { 0, kCurrentProcess };
+        TransformProcessType( &psn, kProcessTransformToForegroundApplication );
+        [[NSApplication sharedApplication] activateIgnoringOtherApps: YES];
+        _glfwLibrary.Unbundled = GL_TRUE;
+    }
 }
 
 @end
@@ -715,6 +723,7 @@ int  _glfwPlatformOpenWindow( int width, int height,
     [_glfwWin.window setDelegate:_glfwWin.delegate];
     [_glfwWin.window setAcceptsMouseMovedEvents:YES];
     [_glfwWin.window center];
+    [_glfwWin.window makeKeyAndOrderFront:nil];
 
     if (_glfwWin.clientAPI == GLFW_OPENGL_API && wndconfig->highDPI)
     {
@@ -726,8 +735,6 @@ int  _glfwPlatformOpenWindow( int width, int height,
         CGCaptureAllDisplays();
         CGDisplaySetDisplayMode( CGMainDisplayID(), fullscreenMode, NULL );
     }
-
-    [_glfwWin.window makeKeyAndOrderFront:nil];
 
     if (_glfwWin.clientAPI == GLFW_OPENGL_API)
     {
@@ -810,7 +817,6 @@ int  _glfwPlatformOpenWindow( int width, int height,
         }
         _glfwWin.aux_context = [[NSOpenGLContext alloc] initWithFormat:_glfwWin.pixelFormat shareContext:_glfwWin.context];
 
-        [_glfwWin.window makeKeyAndOrderFront:nil];
         [_glfwWin.context setView:[_glfwWin.window contentView]];
 
         // Fetch the resulting width and height for backing buffer


### PR DESCRIPTION
Fixed an issue when a window on Mac opens without focus. In such cases, the window doesn't react to most input events, and only double-click works.

Fix https://github.com/defold/defold/issues/6709
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
