### PR TITLE
Fixed typos in annotations of lua interfaces

### DIFF
--- a/engine/crash/src/script_crash.cpp
+++ b/engine/crash/src/script_crash.cpp
@@ -84,7 +84,7 @@ namespace dmCrash
      * load, so loading is one-shot.
      *
      * @name crash.load_previous
-     * @return handle [type:number] handle to the loaded dump, or nil if no dump was found
+     * @return handle [type:number|nil] handle to the loaded dump, or `nil` if no dump was found
      */
     static int Crash_LoadPrevious(lua_State* L)
     {
@@ -221,7 +221,7 @@ namespace dmCrash
      * @name crash.get_sys_field
      * @param handle [type:number] crash dump handle
      * @param index [type:number] system field enum. Must be less than [ref:crash.SYSFIELD_MAX]
-     * @return value [type:string] value recorded in the crash dump, or nil if it didn't exist
+     * @return value [type:string|nil] value recorded in the crash dump, or `nil` if it didn't exist
      */
     static int Crash_GetSysField(lua_State* L)
     {

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -1394,7 +1394,7 @@ namespace dmGameObject
      *
      * @name go.get_parent
      * @param [id] [type:string|hash|url] optional id of the game object instance to get parent for, defaults to the instance containing the calling script
-     * @return parent_id [type:hash] parent instance or nil
+     * @return parent_id [type:hash|nil] parent instance or `nil`
      * @examples
      *
      * Get parent of the instance containing the calling script:
@@ -2951,7 +2951,7 @@ bail:
      * @param self [type:object] reference to the script state to be used for storing data
      * @param action_id [type:hash] id of the received input action, as mapped in the input_binding-file
      * @param action [type:table] a table containing the input data, see above for a description
-     * @return [consume] [type:boolean] optional boolean to signal if the input should be consumed (not passed on to others) or not, default is false
+     * @return consume [type:boolean|nil] optional boolean to signal if the input should be consumed (not passed on to others) or not, default is false
      * @examples
      *
      * This example demonstrates how a game object instance can be moved as a response to user input.

--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -1039,8 +1039,8 @@ namespace dmGameSystem
      * @name buffer.get_metadata
      * @param buf [type:buffer] the buffer to get the metadata from
      * @param metadata_name [type:hash|string] name of the metadata entry
-     * @return values [type:table] table of metadata values or nil if the entry does not exist
-     * @return value_type [type:constant] numeric type of values or nil
+     * @return values [type:table|nil] table of metadata values or `nil` if the entry does not exist
+     * @return value_type [type:constant|nil] numeric type of values or `nil`
      *
      * @examples
      * How to get a metadata entry from a buffer

--- a/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
@@ -156,7 +156,7 @@ namespace dmGameSystem
      *
      * @name collectionfactory.load
      * @param [url] [type:string|hash|url] the collection factory component to load
-     * @param [complete_function] [type:function(self, url, result))] function to call when resources are loaded.
+     * @param [complete_function] [type:function(self, url, result)] function to call when resources are loaded.
      *
      * `self`
      * : [type:object] The current object.

--- a/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
@@ -411,7 +411,7 @@ namespace dmGameSystem
      *
      * @name collectionfactory.set_prototype
      * @param [url] [type:string|hash|url] the collection factory component
-     * @param [prototype] [type:string|nil] the path to the new prototype, or nil
+     * @param [prototype] [type:string|nil] the path to the new prototype, or `nil`
      *
      * @note
      *   - Requires the factory to have the "Dynamic Prototype" set

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -134,7 +134,7 @@ namespace dmGameSystem
      *
      * @name factory.load
      * @param [url] [type:string|hash|url] the factory component to load
-     * @param [complete_function] [type:function(self, url, result))] function to call when resources are loaded.
+     * @param [complete_function] [type:function(self, url, result)] function to call when resources are loaded.
      *
      * `self`
      * : [type:object] The current object.

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -369,12 +369,12 @@ namespace dmGameSystem
      *
      * @name factory.set_prototype
      * @param [url] [type:string|hash|url] the factory component
-     * @param [prototype] [type:string|nil] the path to the new prototype, or nil
+     * @param [prototype] [type:string|nil] the path to the new prototype, or `nil`
      *
      * @note
      *   - Requires the factory to have the "Dynamic Prototype" set
      *   - Cannot be set when the state is COMP_FACTORY_STATUS_LOADING
-     *   - Setting the prototype to "nil" will revert back to the original prototype.
+     *   - Setting the prototype to `nil` will revert back to the original prototype.
      *
      * @examples
      *

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -379,7 +379,7 @@ namespace dmGameSystem
      * `all`
      * : [type:boolean] Set to `true` to return all ray cast hits. If `false`, it will only return the closest hit.
      *
-     * @return result [type:table] It returns a list. If missed it returns nil. See `ray_cast_response` for details on the returned values.
+     * @return result [type:table|nil] It returns a list. If missed it returns `nil`. See `ray_cast_response` for details on the returned values.
      * @examples
      *
      * How to perform a ray cast synchronously:
@@ -738,7 +738,7 @@ namespace dmGameSystem
      * @name physics.get_joint_properties
      * @param collisionobject [type:string|hash|url] collision object where the joint exist
      * @param joint_id [type:string|hash] id of the joint
-     * @return [type:table] properties table. See the joint types for what fields are available, the only field available for all types is:
+     * @return properties [type:table] properties table. See the joint types for what fields are available, the only field available for all types is:
      *
      * - [type:boolean] `collide_connected`: Set this flag to true if the attached bodies should collide.
      *
@@ -994,7 +994,7 @@ namespace dmGameSystem
      * Note: For 2D physics the z component will always be zero.
      *
      * @name physics.get_gravity
-     * @return [type:vector3] gravity vector of collection
+     * @return gravity [type:vector3] gravity vector of collection
      * @examples
      *
      * ```lua
@@ -1170,7 +1170,7 @@ namespace dmGameSystem
      *
      * @name physics.get_group
      * @param url [type:string|hash|url] the collision object to return the group of.
-     * @return [type:hash] hash value of the group.
+     * @return group [type:hash] hash value of the group.
      * ```lua
      * local function check_is_enemy()
      *     local group = physics.get_group("#collisionobject")
@@ -1234,7 +1234,7 @@ namespace dmGameSystem
      * @name physics.get_maskbit
      * @param url [type:string|hash|url] the collision object to check the mask of.
      * @param group [type:string] the name of the group to check for.
-     * @return [type:boolean] boolean value of the maskbit. 'true' if present, 'false' otherwise.
+     * @return maskbit [type:boolean] boolean value of the maskbit. 'true' if present, 'false' otherwise.
      * ```lua
      * local function is_invincible()
      *     -- check if the collisionobject would collide with the "bullet" group

--- a/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sprite.cpp
@@ -413,7 +413,7 @@ namespace dmGameSystem
      *
      * @name sprite.play_flipbook
      * @param url [type:string|hash|url] the sprite that should play the animation
-     * @param id hash name hash of the animation to play
+     * @param id [type:string|hash] hashed id of the animation to play
      * @param [complete_function] [type:function(self, message_id, message, sender))] function to call when the animation has completed.
      *
      * `self`

--- a/engine/gamesys/src/gamesys/scripts/script_window.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_window.cpp
@@ -103,7 +103,7 @@ static void RunCallback(CallbackInfo* cbinfo)
  *
  * @name window.set_listener
  *
- * @param callback [type:function(self, event, data)] A callback which receives info about window events. Pass an empty function or nil if you no longer wish to receive callbacks.
+ * @param callback [type:function(self, event, data)|nil] A callback which receives info about window events. Pass an empty function or `nil` if you no longer wish to receive callbacks.
  *
  * `self`
  * : [type:object] The calling script

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -3235,7 +3235,7 @@ namespace dmGui
      *
      * @name gui.get_parent
      * @param node [type:node] the node from which to retrieve its parent
-     * @return parent [type:node] parent instance or nil
+     * @return parent [type:node|nil] parent instance or `nil`
      */
     int LuaGetParent(lua_State* L)
     {
@@ -4295,7 +4295,7 @@ namespace dmGui
      *
      * @name gui.get_particlefx
      * @param node [type:node] node to get particle fx for
-     * @return [type:hash] particle fx id
+     * @return particlefx [type:hash] particle fx id
      */
     static int LuaGetParticlefx(lua_State* L)
     {
@@ -5122,7 +5122,7 @@ namespace dmGui
      * @param self [type:object] reference to the script state to be used for storing data
      * @param action_id [type:hash] id of the received input action, as mapped in the input_binding-file
      * @param action [type:table] a table containing the input data, see above for a description
-     * @return [consume] [type:boolean] optional boolean to signal if the input should be consumed (not passed on to others) or not, default is false
+     * @return consume [type:boolean|nil] optional boolean to signal if the input should be consumed (not passed on to others) or not, default is false
      * @examples
      *
      * ```lua

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -3190,7 +3190,7 @@ namespace dmGui
      *
      * @name gui.move_above
      * @param node [type:node] to move
-     * @param node [type:node|nil] reference node above which the first node should be moved
+     * @param reference [type:node|nil] reference node above which the first node should be moved
      */
     static int LuaMoveAbove(lua_State* L)
     {
@@ -3213,7 +3213,7 @@ namespace dmGui
      *
      * @name gui.move_below
      * @param node [type:node] to move
-     * @param node [type:node|nil] reference node below which the first node should be moved
+     * @param reference [type:node|nil] reference node below which the first node should be moved
      */
     static int LuaMoveBelow(lua_State* L)
     {
@@ -3944,7 +3944,7 @@ namespace dmGui
      *
      * @name gui.get_flipbook_cursor
      * @param node [type:node] node to get the cursor for (node)
-     * @return cursor value [type:number] cursor value
+     * @return cursor [type:number] cursor value
      */
     static int LuaGetFlipbookCursor(lua_State* L)
     {

--- a/engine/script/src/luasocket/luasocket.doc_h
+++ b/engine/script/src/luasocket/luasocket.doc_h
@@ -47,7 +47,7 @@
  *
  * @return sockets_r [type:table] a list with the sockets ready for reading.
  * @return sockets_w [type:table] a list with the sockets ready for writing.
- * @return error [type:string] an error message. "timeout" if a timeout condition was met, otherwise `nil`.
+ * @return error [type:string|nil] an error message. "timeout" if a timeout condition was met, otherwise `nil`.
  */
 
 
@@ -67,8 +67,8 @@
  * Note: The TCP object returned will have the option "ipv6-v6only" set to true.
  *
  * @name socket.tcp6
- * @return tcp_master [type:master] a new IPv6 TCP master object, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return tcp_master [type:master|nil] a new IPv6 TCP master object, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -88,8 +88,8 @@
  * Note: The UDP object returned will have the option "ipv6-v6only" set to true.
  *
  * @name socket.udp6
- * @return udp_unconnected [type:unconnected] a new unconnected IPv6 UDP object, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return udp_unconnected [type:unconnected|nil] a new unconnected IPv6 UDP object, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -100,7 +100,7 @@
  *
  * @name socket.dns.tohostname
  * @param address [type:string] an IPv4 address or host name.
- * @return hostname [type:string] the canonic host name of the given address, or `nil` in case of an error.
+ * @return hostname [type:string|nil] the canonic host name of the given address, or `nil` in case of an error.
  * @return resolved [type:table|string] a table with all information returned by the resolver, or if an error occurs, the error message string.
  */
 
@@ -111,7 +111,7 @@
  *
  * @name socket.dns.toip
  * @param address [type:string] a hostname or an IP address.
- * @return ip_address [type:string] the first IP address found for the hostname, or `nil` in case of an error.
+ * @return ip_address [type:string|nil] the first IP address found for the hostname, or `nil` in case of an error.
  * @return resolved [type:table|string] a table with all information returned by the resolver, or if an error occurs, the error message string.
  *
  */
@@ -151,8 +151,8 @@
  *
  * @name socket.dns.getaddrinfo
  * @param address [type:string] a hostname or an IPv4 or IPv6 address.
- * @return resolved [type:table] a table with all information returned by the resolver, or if an error occurs, `nil`.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return resolved [type:table|nil] a table with all information returned by the resolver, or if an error occurs, `nil`.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -173,8 +173,8 @@
  *
  * @name socket.dns.getnameinfo
  * @param address [type:string] a hostname or an IPv4 or IPv6 address.
- * @return resolved [type:table] a table with all information returned by the resolver, or if an error occurs, `nil`.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return resolved [type:table|nil] a table with all information returned by the resolver, or if an error occurs, `nil`.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -192,8 +192,8 @@
  * @param [locaddr] [type:string] optional local address to bind to.
  * @param [locport] [type:number] optional local port to bind to.
  * @param [family] [type:string] optional socket family to use, `"inet"` or `"inet6"`.
- * @return tcp_client [type:client] a new IPv6 TCP client object, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return tcp_client [type:client|nil] a new IPv6 TCP client object, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -202,8 +202,8 @@
  * Creates and returns an unconnected IPv4 UDP object. Unconnected objects support the `sendto`, `receive`, `receivefrom`, `getoption`, `getsockname`, `setoption`, `settimeout`, `setpeername`, `setsockname`, and `close` methods. The `setpeername` method is used to connect the object.
  *
  * @name socket.udp
- * @return udp_unconnected [type:unconnected] a new unconnected IPv4 UDP object, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return udp_unconnected [type:unconnected|nil] a new unconnected IPv4 UDP object, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -219,9 +219,9 @@
  * @param [ret1] [type:any] argument 1.
  * @param [ret2] [type:any] argument 2.
  * @param [retN] [type:any] argument N.
- * @return [retD+1] [type:any] argument D+1.
- * @return [retD+2] [type:any] argument D+2.
- * @return [retN] [type:any] argument N.
+ * @return retD+1 [type:any|nil] argument D+1.
+ * @return retD+2 [type:any|nil] argument D+2.
+ * @return retN [type:any|nil] argument N.
  * @examples
  *
  * Instead of doing the following with dummy variables:
@@ -243,8 +243,8 @@
  * Creates and returns an IPv4 TCP master object. A master object can be transformed into a server object with the method `listen` (after a call to `bind`) or into a client object with the method `connect`. The only other method supported by a master object is the `close` method.
  *
  * @name socket.tcp
- * @return tcp_master [type:master] a new IPv4 TCP master object, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return tcp_master [type:master|nil] a new IPv4 TCP master object, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -337,8 +337,8 @@
  * [icon:attention] Calling `socket.select` with a server object in the `recvt` parameter before a call to accept does not guarantee accept will return immediately. Use the `settimeout` method or accept might block until another client shows up.
  *
  * @name server:accept
- * @return tcp_client [type:client] if a connection is successfully initiated, a client object is returned, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred. The error is `"timeout"` if a timeout condition is met.
+ * @return tcp_client [type:client|nil] if a connection is successfully initiated, a client object is returned, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred. The error is `"timeout"` if a timeout condition is met.
  *
  */
 
@@ -349,8 +349,8 @@
  * @name master:bind
  * @param address [type:string] an IP address or a host name. If address is `"*"`, the system binds to all local interfaces using the `INADDR_ANY` constant.
  * @param port [type:number] the port to commect to, in the range [0..64K). If port is 0, the system automatically chooses an ephemeral port.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -393,8 +393,8 @@
  * @name master:connect
  * @param address [type:string] an IP address or a host name. If address is `"*"`, the system binds to all local interfaces using the `INADDR_ANY` constant.
  * @param port [type:number] the port to commect to, in the range [0..64K). If port is 0, the system automatically chooses an ephemeral port.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -469,8 +469,8 @@
  *
  * @name master:listen
  * @param backlog [type:number] the number of client connections that can be queued waiting for service. If the queue is full and another client attempts connection, the connection is refused.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -491,9 +491,9 @@
  * : causes the method to read a specified number of bytes from the socket.
  *
  * @param [prefix] [type:string] an optional string to be concatenated to the beginning of any received data before return.
- * @return data [type:string] the received pattern, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred. The error message can be the string `"closed"` in case the connection was closed before the transmission was completed or the string `"timeout"` in case there was a timeout during the operation.
- * @return partial [type:string] a (possibly empty) string containing the partial that was received, or `nil` if no error occurred.
+ * @return data [type:string|nil] the received pattern, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred. The error message can be the string `"closed"` in case the connection was closed before the transmission was completed or the string `"timeout"` in case there was a timeout during the operation.
+ * @return partial [type:string|nil] a (possibly empty) string containing the partial that was received, or `nil` if no error occurred.
  *
  */
 
@@ -508,9 +508,9 @@
  * @param data [type:string] the string to be sent.
  * @param [i] [type:number] optional starting index of the string.
  * @param [j] [type:number] optional end index of string.
- * @return index [type:number] the index of the last byte within [i, j] that has been sent, or `nil` in case of error. Notice that, if `i` is 1 or absent, this is effectively the total number of bytes sent.
- * @return error [type:string] the error message, or `nil` if no error occurred. The error message can be `"closed"` in case the connection was closed before the transmission was completed or the string `"timeout"` in case there was a timeout during the operation.
- * @return lastindex [type:number] in case of error, the index of the last byte within [i, j] that has been sent. You might want to try again from the byte following that. `nil` if no error occurred.
+ * @return index [type:number|nil] the index of the last byte within [i, j] that has been sent, or `nil` in case of error. Notice that, if `i` is 1 or absent, this is effectively the total number of bytes sent.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred. The error message can be `"closed"` in case the connection was closed before the transmission was completed or the string `"timeout"` in case there was a timeout during the operation.
+ * @return lastindex [type:number|nil] in case of error, the index of the last byte within [i, j] that has been sent. You might want to try again from the byte following that. `nil` if no error occurred.
  *
  */
 
@@ -542,8 +542,8 @@
  * : Setting this option to `true` restricts an inet6 socket to sending and receiving only IPv6 packets.
  *
  * @param [value] [type:any] the value to set for the specified option.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -575,8 +575,8 @@
  * : Setting this option to `true` restricts an inet6 socket to sending and receiving only IPv6 packets.
  *
  * @param [value] [type:any] the value to set for the specified option.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -592,8 +592,8 @@
  * - `"reuseaddr"`
  * - `"tcp-nodelay"`
  *
- * @return value [type:any] the option value, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return value [type:any|nil] the option value, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -609,8 +609,8 @@
  * - `"reuseaddr"`
  * - `"tcp-nodelay"`
  *
- * @return value [type:any] the option value, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return value [type:any|nil] the option value, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -622,7 +622,7 @@
  * @param received [type:number] the new number of bytes received.
  * @param sent [type:number] the new number of bytes sent.
  * @param age [type:number] the new age in seconds.
- * @return success [type:number] the value `1` in case of success, or `nil` in case of error.
+ * @return success [type:number|nil] the value `1` in case of success, or `nil` in case of error.
  *
  */
 
@@ -634,7 +634,7 @@
  * @param received [type:number] the new number of bytes received.
  * @param sent [type:number] the new number of bytes sent.
  * @param age [type:number] the new age in seconds.
- * @return success [type:number] the value `1` in case of success, or `nil` in case of error.
+ * @return success [type:number|nil] the value `1` in case of success, or `nil` in case of error.
  *
  */
 
@@ -646,7 +646,7 @@
  * @param received [type:number] the new number of bytes received.
  * @param sent [type:number] the new number of bytes sent.
  * @param age [type:number] the new age in seconds.
- * @return success [type:number] the value `1` in case of success, or `nil` in case of error.
+ * @return success [type:number|nil] the value `1` in case of success, or `nil` in case of error.
  *
  */
 
@@ -886,8 +886,8 @@
  *
  * @name connected:receive
  * @param [size] [type:number] optional maximum size of the datagram to be retrieved. If there are more than size bytes available in the datagram, the excess bytes are discarded. If there are less then size bytes available in the current datagram, the available bytes are returned. If size is omitted, the maximum datagram size is used (which is currently limited by the implementation to 8192 bytes).
- * @return datagram [type:string] the received datagram, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return datagram [type:string|nil] the received datagram, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -897,8 +897,8 @@
  *
  * @name unconnected:receive
  * @param [size] [type:number] optional maximum size of the datagram to be retrieved. If there are more than size bytes available in the datagram, the excess bytes are discarded. If there are less then size bytes available in the current datagram, the available bytes are returned. If size is omitted, the maximum datagram size is used (which is currently limited by the implementation to 8192 bytes).
- * @return datagram [type:string] the received datagram, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return datagram [type:string|nil] the received datagram, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -908,9 +908,9 @@
  *
  * @name unconnected:receivefrom
  * @param [size] [type:number] optional maximum size of the datagram to be retrieved.
- * @return datagram [type:string] the received datagram, or `nil` in case of error.
+ * @return datagram [type:string|nil] the received datagram, or `nil` in case of error.
  * @return ip_or_error [type:string] the IP address, or the error message in case of error.
- * @return port [type:number] the port number, or `nil` in case of error.
+ * @return port [type:number|nil] the port number, or `nil` in case of error.
  *
  */
 
@@ -932,8 +932,8 @@
  * - `"ip-add-membership"`
  * - `"ip-drop-membership"`
  *
- * @return value [type:any] the option value, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return value [type:any|nil] the option value, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -955,8 +955,8 @@
  * - `"ip-add-membership"`
  * - `"ip-drop-membership"`
  *
- * @return value [type:any] the option value, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return value [type:any|nil] the option value, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -968,8 +968,8 @@
  *
  * @name connected:send
  * @param datagram [type:string] a string with the datagram contents. The maximum datagram size for UDP is 64K minus IP layer overhead. However datagrams larger than the link layer packet size will be fragmented, which may deteriorate performance and/or reliability.
- * @return success [type:number] the value `1` on success, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return success [type:number|nil] the value `1` on success, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -983,8 +983,8 @@
  * @param datagram [type:string] a string with the datagram contents. The maximum datagram size for UDP is 64K minus IP layer overhead. However datagrams larger than the link layer packet size will be fragmented, which may deteriorate performance and/or reliability.
  * @param ip [type:string] the IP address of the recipient. Host names are not allowed for performance reasons.
  * @param port [type:number] the port number at the recipient.
- * @return success [type:number] the value `1` on success, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return success [type:number|nil] the value `1` on success, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -998,8 +998,8 @@
  *
  * @name connected:setpeername
  * @param "*" [type:string] if address is "*" and the object is connected, the peer association is removed and the object becomes an unconnected object again.
- * @return success [type:number] the value `1` on success, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return success [type:number|nil] the value `1` on success, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -1014,8 +1014,8 @@
  * @name unconnected:setpeername
  * @param address [type:string] an IP address or a host name.
  * @param port [type:number] the port number.
- * @return success [type:number] the value `1` on success, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return success [type:number|nil] the value `1` on success, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -1028,8 +1028,8 @@
  * @name unconnected:setsockname
  * @param address [type:string] an IP address or a host name. If address is "*" the system binds to all local interfaces using the constant `INADDR_ANY`.
  * @param port [type:number] the port number. If port is 0, the system chooses an ephemeral port.
- * @return success [type:number] the value `1` on success, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return success [type:number|nil] the value `1` on success, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -1076,8 +1076,8 @@
  * - [type:string] `interface` (IP address)
  *
  * @param [value] [type:any] the value to set for the specified option.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 
@@ -1125,8 +1125,8 @@
  * - [type:string] `interface` (IP address)
  *
  * @param [value] [type:any] the value to set for the specified option.
- * @return status [type:number] the value `1`, or `nil` in case of error.
- * @return error [type:string] the error message, or `nil` if no error occurred.
+ * @return status [type:number|nil] the value `1`, or `nil` in case of error.
+ * @return error [type:string|nil] the error message, or `nil` if no error occurred.
  *
  */
 

--- a/engine/script/src/script_html5_js.cpp
+++ b/engine/script/src/script_html5_js.cpp
@@ -129,7 +129,7 @@ namespace dmScript
      * or start playing sounds the first time the callback is invoked.
      *
      * @name html5.set_interaction_listener
-     * @param callback [type:function(self)] The interaction callback. Pass an empty function or nil if you no longer wish to receive callbacks.
+     * @param callback [type:function(self)|nil] The interaction callback. Pass an empty function or `nil` if you no longer wish to receive callbacks.
      *
      * `self`
      * : [type:object] The calling script

--- a/engine/script/src/script_html5_js.cpp
+++ b/engine/script/src/script_html5_js.cpp
@@ -129,7 +129,7 @@ namespace dmScript
      * or start playing sounds the first time the callback is invoked.
      *
      * @name html5.set_interaction_listener
-     * @param callback [type:function(self] The interaction callback. Pass an empty function or nil if you no longer wish to receive callbacks.
+     * @param callback [type:function(self)] The interaction callback. Pass an empty function or nil if you no longer wish to receive callbacks.
      *
      * `self`
      * : [type:object] The calling script

--- a/engine/script/src/script_image.cpp
+++ b/engine/script/src/script_image.cpp
@@ -65,7 +65,7 @@ namespace dmScript
     * @name image.load
     * @param buffer [type:string] image data buffer
     * @param [premult] [type:boolean] optional flag if alpha should be premultiplied. Defaults to `false`
-    * @return image [type:table] object or `nil` if loading fails. The object is a table with the following fields:
+    * @return image [type:table|nil] object or `nil` if loading fails. The object is a table with the following fields:
     *
     * - [type:number] `width`: image width
     * - [type:number] `height`: image height

--- a/engine/script/src/script_sys.cpp
+++ b/engine/script/src/script_sys.cpp
@@ -570,7 +570,7 @@ union SaveLoadBuffer
      *
      * Loads a custom resource. Specify the full filename of the resource that you want
      * to load. When loaded, the file data is returned as a string.
-     * If loading fails, the function returns nil plus the error message.
+     * If loading fails, the function returns `nil` plus the error message.
      *
      * In order for the engine to include custom resources in the build process, you need
      * to specify them in the "custom_resources" key in your "game.project" settings file.
@@ -582,8 +582,8 @@ union SaveLoadBuffer
      *
      * @name sys.load_resource
      * @param filename [type:string] resource to load, full path
-     * @return data [type:string] loaded data, or `nil` if the resource could not be loaded
-     * @return error [type:string] the error message, or `nil` if no error occurred
+     * @return data [type:string|nil] loaded data, or `nil` if the resource could not be loaded
+     * @return error [type:string|nil] the error message, or `nil` if no error occurred
      * @examples
      *
      * ```lua

--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -724,7 +724,7 @@ namespace dmScript
      *
      * @name  timer.get_info
      * @param handle [type:hash] the timer handle returned by timer.delay()
-     * @return data [type:table] or nil if timer is cancelled/completed. table with data in the following fields:
+     * @return data [type:table|nil] table or `nil` if timer is cancelled/completed. table with data in the following fields:
      *
      * `time_remaining`
      * : [type:number] Time remaining until the next time a timer.delay() fires.


### PR DESCRIPTION
Fixed typos in cpp files with base documantation for lua api. It's also required to generate more valid lua annotations.