### PR TITLE
Send correct Content-Length HTTP headers in responses to engine HEAD resource requests

### DIFF
--- a/editor/src/clj/editor/hot_reload.clj
+++ b/editor/src/clj/editor/hot_reload.clj
@@ -29,29 +29,38 @@
 (defn- content->bytes [content]
   (-> content io/input-stream IOUtils/toByteArray))
 
-(defn- handler [workspace project {:keys [url method headers]}]
+(defn- handler [workspace _project {:keys [url method headers]}]
   (let [build-path (FilenameUtils/normalize (str (workspace/build-path workspace)))
         path (subs url (count url-prefix))
         full-path (format "%s%s" build-path path)]
-   ;; Avoid going outside the build path with '..'
-   (if (string/starts-with? full-path build-path)
-     (let [etag (workspace/etag workspace path)
-           remote-etag (first (get headers "If-none-match"))
-           cached? (when remote-etag (= etag remote-etag))
-           content (when (not cached?)
-                     (try
-                       (with-open [is (io/input-stream full-path)]
-                         (IOUtils/toByteArray is))
-                       (catch FileNotFoundException _
-                         :not-found)))]
-       (if (= content :not-found)
-         http-util/not-found-response
-         (let [response-headers (cond-> {"ETag" etag}
-                                  (= method "GET") (assoc "Content-Length" (if content (str (count content)) "-1")))]
-           (cond-> {:code (if cached? 304 200)
-                    :headers response-headers}
-             (and (= method "GET") (not cached?)) (assoc :body content)))))
-     http-util/not-found-response)))
+    ;; Avoid going outside the build path with '..'
+    (if-not (string/starts-with? full-path build-path)
+      http-util/not-found-response
+      (let [etag (workspace/etag workspace path)
+            remote-etag (first (get headers "If-None-Match"))
+            is-cached (when remote-etag (= etag remote-etag))
+            file (io/file full-path)
+            content-length (.length file) ; Returns zero if not found.
+            content (when (not is-cached)
+                      (try
+                        (with-open [is (io/input-stream file)]
+                          (IOUtils/toByteArray is))
+                        (catch FileNotFoundException _
+                          :not-found)))]
+        (if (= content :not-found)
+          http-util/not-found-response
+          (let [response-headers
+                (cond-> {"ETag" etag}
+
+                        (or (= method "GET")
+                            (= method "HEAD"))
+                        (assoc "Content-Length" (str content-length)))]
+            (cond-> {:code (if is-cached 304 200)
+                     :headers response-headers}
+
+                    (and content
+                         (= method "GET"))
+                    (assoc :body content))))))))
 
 (defn build-handler [workspace project request]
   (handler workspace project request))
@@ -85,7 +94,7 @@
     (let [body-str (string/join "\n" (body->valid-entries workspace body))
           body (.getBytes body-str "UTF-8")]
       {:code 200
-       :headers {"Content-Length" (str (count body))}
+       :headers {"Content-Length" (str (alength ^bytes body))}
        :body body})))
 
 (defn verify-etags-handler [workspace project request]


### PR DESCRIPTION
Fixes #7944.

### User-facing changes
* Fixed an issue where rebuilding the game project with the game already running would shut down the game with an error message.
