### PR TITLE
Added option frustum_planes to render.draw()

### DIFF
--- a/engine/dlib/src/dlib/intersection.cpp
+++ b/engine/dlib/src/dlib/intersection.cpp
@@ -37,14 +37,14 @@ static Plane NormalizePlane(Plane plane)
 // Gribb-Hartmann
 // https://www.gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
 
-void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, bool skip_near_far, Frustum& frustum)
+void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, int num_planes, Frustum& frustum)
 {
     dmVMath::Vector4 x = m.getRow(0);
     dmVMath::Vector4 y = m.getRow(1);
     dmVMath::Vector4 z = m.getRow(2);
     dmVMath::Vector4 w = m.getRow(3);
 
-    frustum.m_NumPlanes = skip_near_far ? 4 : 6;
+    frustum.m_NumPlanes = num_planes;
     frustum.m_Planes[0] = w + x; // left
     frustum.m_Planes[1] = w - x; // right
     frustum.m_Planes[2] = w + y; // bottom

--- a/engine/dlib/src/dlib/intersection.cpp
+++ b/engine/dlib/src/dlib/intersection.cpp
@@ -37,13 +37,14 @@ static Plane NormalizePlane(Plane plane)
 // Gribb-Hartmann
 // https://www.gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
 
-void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, Frustum& frustum)
+void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, bool skip_near_far, Frustum& frustum)
 {
     dmVMath::Vector4 x = m.getRow(0);
     dmVMath::Vector4 y = m.getRow(1);
     dmVMath::Vector4 z = m.getRow(2);
     dmVMath::Vector4 w = m.getRow(3);
 
+    frustum.m_NumPlanes = skip_near_far ? 4 : 6;
     frustum.m_Planes[0] = w + x; // left
     frustum.m_Planes[1] = w - x; // right
     frustum.m_Planes[2] = w + y; // bottom
@@ -53,7 +54,7 @@ void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, Frustum&
 
     if (normalize)
     {
-        for (int i = 0; i < 6; ++i)
+        for (int i = 0; i < frustum.m_NumPlanes; ++i)
         {
             frustum.m_Planes[i] = NormalizePlane(frustum.m_Planes[i]);
         }
@@ -61,12 +62,12 @@ void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, Frustum&
 }
 
 
-bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos, bool skip_near_far)
+bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos)
 {
     dmVMath::Vector4 vpos(pos);
 
-    uint32_t num_planes = skip_near_far ? 4 : 6;
-    for (uint32_t i = 0; i < num_planes; ++i)
+    int num_planes = frustum.m_NumPlanes;
+    for (int i = 0; i < num_planes; ++i)
     {
         float d = DistanceToPlane(frustum.m_Planes[i], vpos);
         if (d < 0.0f)
@@ -77,16 +78,16 @@ bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos, bool s
     return true;
 }
 
-bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq, bool skip_near_far)
+bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq)
 {
     dmVMath::Vector4 vpos(pos);
-    return TestFrustumSphereSq(frustum, vpos, radius_sq, skip_near_far);
+    return TestFrustumSphereSq(frustum, vpos, radius_sq);
 }
 
-bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq, bool skip_near_far)
+bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq)
 {
-    uint32_t num_planes = skip_near_far ? 4 : 6;
-    for (uint32_t i = 0; i < num_planes; ++i)
+    int num_planes = frustum.m_NumPlanes;
+    for (int i = 0; i < num_planes; ++i)
     {
         float d = DistanceToPlane(frustum.m_Planes[i], pos);
         if (d < 0 && (d*d) > radius_sq)
@@ -97,20 +98,21 @@ bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, fl
     return true;
 }
 
-bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius, bool skip_near_far)
+bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius)
 {
-    return TestFrustumSphereSq(frustum, pos, radius*radius, skip_near_far);
+    return TestFrustumSphereSq(frustum, pos, radius*radius);
 }
 
-bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius, bool skip_near_far)
+bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius)
 {
-    return TestFrustumSphereSq(frustum, pos, radius*radius, skip_near_far);
+    return TestFrustumSphereSq(frustum, pos, radius*radius);
 }
 
 // Returns 'false' if the bounding box is off the frustum. Returning 'true' does not guarantee that the object intersects the frustum or is inside it.
-bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMath::Vector3& aabb_min, dmVMath::Vector3& aabb_max, bool skip_near_far)
+bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMath::Vector3& aabb_min, dmVMath::Vector3& aabb_max)
 {
-    // calculate coordinates of all 8 corners of the bounding cube. To find them we'll take all points P(Xi,Yj,Zk) i=aabb_min.x|aabb_max.x, j=aabb_min.y|aabb_max.y, k=aabb_min.z|aabb_max.z
+    // calculate coordinates of all 8 corners of the bounding cube.
+    // To find them we'll take all points P(Xi,Yj,Zk) i=aabb_min.x|aabb_max.x, j=aabb_min.y|aabb_max.y, k=aabb_min.z|aabb_max.z
     dmVMath::Point3 point0 = dmVMath::Point3(aabb_min.getX(), aabb_min.getY(), aabb_min.getZ());
     dmVMath::Point3 point1 = dmVMath::Point3(aabb_min.getX(), aabb_min.getY(), aabb_max.getZ());
     dmVMath::Point3 point2 = dmVMath::Point3(aabb_min.getX(), aabb_max.getY(), aabb_min.getZ());
@@ -132,12 +134,12 @@ bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMa
     corner_points[7] = world * point7;
 
     // for any of the six frustum planes if the all corner points lie in the negative halfspace, do cull the object
-    int max_planes = skip_near_far ? 4 : 6;
-    for (int plane_i=0; plane_i<max_planes; plane_i++)
+    int num_planes = frustum.m_NumPlanes;
+    for (int plane_i = 0; plane_i < num_planes; ++plane_i)
     {
         // get plane normal/equation
         bool positive_found = false;
-        for (int corner_i=0; corner_i<8; corner_i++)
+        for (int corner_i = 0; corner_i < 8; ++corner_i)
         {
             float distance = DistanceToPlane(frustum.m_Planes[plane_i], corner_points[corner_i]);
             if (distance >= 0)
@@ -146,7 +148,7 @@ bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMa
                 break; // no need to check for the rest of the points
             }
         }
-        if (! positive_found) // if all corners are in the negative halfspace for the plane, we're done
+        if (!positive_found) // if all corners are in the negative halfspace for the plane, we're done
         {
             return false; // no intersection, do cull
         }

--- a/engine/dlib/src/dmsdk/dlib/intersection.h
+++ b/engine/dlib/src/dmsdk/dlib/intersection.h
@@ -55,6 +55,7 @@ namespace dmIntersection
     {
         // The plane normals point inwards
         Plane m_Planes[6]; // left, right, bottom, top, near, far
+        int   m_NumPlanes; // 4 or 6
     };
 
     /*#
@@ -64,7 +65,7 @@ namespace dmIntersection
      * @param normalize [type: bool] true if the normals should be normalized
      * @return frustum [type: dmIntersection::Frustum&] the frustum output
      */
-    void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, Frustum& frustum);
+    void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, bool skip_near_far, Frustum& frustum);
 
     // Returns true if the objects intersect
 
@@ -76,7 +77,7 @@ namespace dmIntersection
      * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
      * @return intersects [type: bool] Returns true if the objects intersect
      */
-    bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos, bool skip_near_far);
+    bool TestFrustumPoint(const Frustum& frustum, const dmVMath::Point3& pos);
 
     /*#
      * Tests intersection between a frustum and a sphere
@@ -87,7 +88,7 @@ namespace dmIntersection
      * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
      * @return intersects [type: bool] Returns true if the objects intersect
      */
-    bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius, bool skip_near_far);
+    bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Point3& pos, float radius);
 
     /*#
      * Tests intersection between a frustum and a sphere
@@ -98,7 +99,7 @@ namespace dmIntersection
      * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
      * @return intersects [type: bool] Returns true if the objects intersect
      */
-    bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius, bool skip_near_far);
+    bool TestFrustumSphere(const Frustum& frustum, const dmVMath::Vector4& pos, float radius);
 
     /*#
      * Tests intersection between a frustum and a sphere
@@ -109,7 +110,7 @@ namespace dmIntersection
      * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
      * @return intersects [type: bool] Returns true if the objects intersect
      */
-    bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq, bool skip_near_far);
+    bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Point3& pos, float radius_sq);
 
     /*#
      * Tests intersection between a frustum and a sphere
@@ -120,7 +121,7 @@ namespace dmIntersection
      * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
      * @return intersects [type: bool] Returns true if the objects intersect
      */
-    bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq, bool skip_near_far);
+    bool TestFrustumSphereSq(const Frustum& frustum, const dmVMath::Vector4& pos, float radius_sq);
 
     /*#
      * Tests intersection between a frustum and an oriented bounding box (OBB)
@@ -132,7 +133,7 @@ namespace dmIntersection
      * @param skip_near_far [type: bool] if true, the near+far planes of the frustum are ignored
      * @return intersects [type: bool] Returns true if the objects intersect
      */
-    bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMath::Vector3& aabb_min, dmVMath::Vector3& aabb_max, bool skip_near_far);
+    bool TestFrustumOBB(const Frustum& frustum, const dmVMath::Matrix4& world, dmVMath::Vector3& aabb_min, dmVMath::Vector3& aabb_max);
 
 } // dmIntersection
 

--- a/engine/dlib/src/dmsdk/dlib/intersection.h
+++ b/engine/dlib/src/dmsdk/dlib/intersection.h
@@ -65,7 +65,7 @@ namespace dmIntersection
      * @param normalize [type: bool] true if the normals should be normalized
      * @return frustum [type: dmIntersection::Frustum&] the frustum output
      */
-    void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, bool skip_near_far, Frustum& frustum);
+    void CreateFrustumFromMatrix(const dmVMath::Matrix4& m, bool normalize, int num_planes, Frustum& frustum);
 
     // Returns true if the objects intersect
 

--- a/engine/dlib/src/test/test_intersection.cpp
+++ b/engine/dlib/src/test/test_intersection.cpp
@@ -48,7 +48,7 @@ TEST(dmVMath, CreateFrustum)
     dmVMath::Matrix4 view_proj = proj * view;
 
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(view_proj, true, frustum);
+    dmIntersection::CreateFrustumFromMatrix(view_proj, true, false, frustum);
 
     float px = FRUSTUM_WIDTH / 2.0f;
     float py = FRUSTUM_HEIGHT / 2.0f;
@@ -80,43 +80,44 @@ TEST(dmVMath, TestFrustumSphere)
     dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(0.0f, FRUSTUM_WIDTH, 0.0f, FRUSTUM_HEIGHT, FRUSTUM_NEAR, FRUSTUM_FAR);
 
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(proj, true, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, false, frustum);
 
     const float RADIUS = 10.0f;
     float px = FRUSTUM_WIDTH / 2.0f;
     float py = FRUSTUM_HEIGHT / 2.0f;
     float pz = -FRUSTUM_NEAR -(FRUSTUM_FAR - FRUSTUM_NEAR) / 2.0f;
 
-    ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, pz), RADIUS, false) );
+    ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, pz), RADIUS) );
 
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(-11.0f, py, pz), RADIUS, false) );
-    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(-9.0f, py, pz), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(-11.0f, py, pz), RADIUS) );
+    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(-9.0f, py, pz), RADIUS) );
 
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(111.0f, py, pz), RADIUS, false) );
-    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(109.0f, py, pz), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(111.0f, py, pz), RADIUS) );
+    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(109.0f, py, pz), RADIUS) );
 
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, -11.0f, pz), RADIUS, false) );
-    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px,  -9.0f, pz), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, -11.0f, pz), RADIUS) );
+    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px,  -9.0f, pz), RADIUS) );
 
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, 91.0f, pz), RADIUS, false) );
-    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, 89.0f, pz), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, 91.0f, pz), RADIUS) );
+    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, 89.0f, pz), RADIUS) );
 
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, 1.0f), RADIUS, false) );
-    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1.0f), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, 1.0f), RADIUS) );
+    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1.0f), RADIUS) );
 
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -111.0f), RADIUS, false) );
-    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -109.0f), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -111.0f), RADIUS) );
+    ASSERT_TRUE(  dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -109.0f), RADIUS) );
 
     // Special test for 2D "spheres"
     // If we're using spheres to define the bounding volume for sprites, then the they will most likely always intersect the near/far
     // planes of the orthographic projecttions (e.g. the range is [0.1f, 1.0f], but the sphere has radius 2.0f).
-    ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1000.0f), RADIUS, true) );
-    ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py,  1000.0f), RADIUS, true) );
 
     // If we use all 6 planes, the far plane will reject the same spheres
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1000.0f), RADIUS, false) );
-    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py,  1000.0f), RADIUS, false) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1000.0f), RADIUS) );
+    ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py,  1000.0f), RADIUS) );
 
+    dmIntersection::CreateFrustumFromMatrix(proj, true, true, frustum);
+    ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1000.0f), RADIUS) );
+    ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py,  1000.0f), RADIUS) );
 }
 
 TEST(dmVMath, TestFrustumOBB)
@@ -125,7 +126,7 @@ TEST(dmVMath, TestFrustumOBB)
 
     // frustum lies on positive X axis from 0 to FRUSTUM_WIDTH, on Y from 0 to FRUSTUM_HEIGHT and on Z from -FRUSTUM_NEAR to -FRUSTUM_FAR
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(proj, true, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, false, frustum);
 
     float BOX_SIDE = 1;
     dmVMath::Vector3 minPoint(0,0,0);
@@ -135,43 +136,43 @@ TEST(dmVMath, TestFrustumOBB)
 
     // place BB at (0,0,0), outside the frustum that starts at -FRUSTUM_NEAR
     trans = dmVMath::Matrix4::identity();
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
     //place BB to the left of the frustum
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(-BOX_SIDE-0.1,0.0,-FRUSTUM_FAR));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(-BOX_SIDE+0.1,0.0,-FRUSTUM_FAR));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
     // place BB far deep right after the frustum
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0.0,0.0,-FRUSTUM_FAR-BOX_SIDE-0.1));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0.0,0.0,-FRUSTUM_FAR-BOX_SIDE+0.1));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
     // place BB close to the near plane
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0.0,0.0,-FRUSTUM_NEAR-0.1));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0.0,0.0,-FRUSTUM_NEAR+0.1));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
     // move BB outside to the far right of the frustum +- 0.1
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(FRUSTUM_WIDTH + 0.1,0.0,-FRUSTUM_NEAR));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(FRUSTUM_WIDTH - 0.1,0.0,-FRUSTUM_NEAR));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
     // move BB outside over the top of the frustum +- 0.1
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0.0,FRUSTUM_HEIGHT+0.1,-FRUSTUM_NEAR));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0.0,FRUSTUM_HEIGHT-0.1,-FRUSTUM_NEAR));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
     // rotate 45 degrees and move close to the left plane
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3( -sqrt(2)/2-0.1,0.0,-FRUSTUM_NEAR-BOX_SIDE)) * dmVMath::Matrix4::rotationZ(3.141592653/4); // 45 degrees counter-clockwise
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
     trans = dmVMath::Matrix4::translation(dmVMath::Vector3( -sqrt(2)/2+0.1,0.0,-FRUSTUM_NEAR-BOX_SIDE)) * dmVMath::Matrix4::rotationZ(3.141592653/4); // 45 degrees counter-clockwise
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 }
 
 
@@ -188,7 +189,7 @@ TEST(dmVMath, TestFrustumOBBPerspective)
     dmVMath::Matrix4 view_proj = proj * view;
 
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(view_proj, true, frustum);
+    dmIntersection::CreateFrustumFromMatrix(view_proj, true, false, frustum);
 
     dmVMath::Matrix4 world;
     dmVMath::Vector3 minPoint(0, 0, 0);
@@ -196,45 +197,46 @@ TEST(dmVMath, TestFrustumOBBPerspective)
 
     // left of the frustum near plane, Y = 0
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(-PER_FRUSTUM_WIDTH_NEAR/2 - BOX_SIDE - 0.1f, 0,  -PER_FRUSTUM_NEAR + 0.1f));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(-PER_FRUSTUM_WIDTH_NEAR/2 - BOX_SIDE + 0.1f, 0,  -PER_FRUSTUM_NEAR - 0.1f));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
     // center of frustum left plane
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(-PER_FRUSTUM_WIDTH_NEAR/2 -PER_FRUSTUM_DEPTH/2 - BOX_SIDE - 0.1f, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(-PER_FRUSTUM_WIDTH_NEAR/2 -PER_FRUSTUM_DEPTH/2 - BOX_SIDE + 0.1f, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
     // center of frustum right plane
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(PER_FRUSTUM_WIDTH_NEAR/2 + PER_FRUSTUM_DEPTH/2 + 0.1f, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(PER_FRUSTUM_WIDTH_NEAR/2 + PER_FRUSTUM_DEPTH/2 - 0.1f, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
     // center of frustum bottom plane
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, -PER_FRUSTUM_HEIGHT_NEAR/2 -PER_FRUSTUM_DEPTH/2 -BOX_SIDE -0.1f, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, -PER_FRUSTUM_HEIGHT_NEAR/2 -PER_FRUSTUM_DEPTH/2 -BOX_SIDE + 0.1f, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
     // center of frustum top plane
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, PER_FRUSTUM_HEIGHT_NEAR/2 +PER_FRUSTUM_DEPTH/2  +0.1f, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, PER_FRUSTUM_HEIGHT_NEAR/2 +PER_FRUSTUM_DEPTH/2  -0.1f, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH/2));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
     // center of back plane
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH -BOX_SIDE - 0.1f));
-    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH -BOX_SIDE + 0.1f));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, false));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
     // front and back plane should be ingored with skip_near_far = true
+    dmIntersection::CreateFrustumFromMatrix(view_proj, true, true, frustum);
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH -BOX_SIDE - 0.1f));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, true));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR + 0.1f));
-    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint, true));
+    ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
 }
 
@@ -243,7 +245,7 @@ TEST(dmVMath, TestFrustumOBBCorners)
     // Frustum's center is on origin on X, Y axes. On Z it's placed from -FRUSTUM_NEAR to -FRUSTUM_FAR.
     dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(-FRUSTUM_WIDTH/2, FRUSTUM_WIDTH/2, -FRUSTUM_HEIGHT/2, FRUSTUM_HEIGHT/2, FRUSTUM_NEAR, FRUSTUM_FAR);
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(proj, true, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, false, frustum);
 
     float FRUSTUM_NEARFAR_MIDDLE = (FRUSTUM_NEAR + FRUSTUM_FAR)/2;
     float BOX_SIDE = 2;
@@ -264,27 +266,27 @@ TEST(dmVMath, TestFrustumOBBCorners)
 
             // check against left side of frustum
             dmVMath::Matrix4 trans = dmVMath::Matrix4::translation(dmVMath::Vector3(-BOX_DIAG/2-FRUSTUM_WIDTH/2-0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(-BOX_DIAG/2-FRUSTUM_WIDTH/2+0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
             // check against right side of frustum
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(BOX_DIAG/2+FRUSTUM_WIDTH/2+0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(BOX_DIAG/2+FRUSTUM_WIDTH/2-0.1, 0, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
             // check against bottom side of frustum
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, -BOX_DIAG/2-FRUSTUM_HEIGHT/2-0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, -BOX_DIAG/2-FRUSTUM_HEIGHT/2+0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
             // check against top side of frustum
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, BOX_DIAG/2+FRUSTUM_HEIGHT/2+0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, BOX_DIAG/2+FRUSTUM_HEIGHT/2-0.1, -FRUSTUM_NEARFAR_MIDDLE/2)) * trans_model;
-            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
         }
 
@@ -298,15 +300,15 @@ TEST(dmVMath, TestFrustumOBBCorners)
 
             // check against near side of frustum
             dmVMath::Matrix4 trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, BOX_DIAG/2-FRUSTUM_NEAR+0.1)) * trans_model;
-            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0,0, BOX_DIAG/2-FRUSTUM_NEAR-0.1)) * trans_model;
-            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
 
             // check against far side of frustum
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0,0,-BOX_DIAG/2-FRUSTUM_FAR-0.1)) * trans_model;
-            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_FALSE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
             trans = dmVMath::Matrix4::translation(dmVMath::Vector3(0,0,-BOX_DIAG/2-FRUSTUM_FAR+0.1)) * trans_model;
-            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint, false));
+            ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, trans, minPoint, maxPoint));
         }
     }
 }

--- a/engine/dlib/src/test/test_intersection.cpp
+++ b/engine/dlib/src/test/test_intersection.cpp
@@ -48,7 +48,7 @@ TEST(dmVMath, CreateFrustum)
     dmVMath::Matrix4 view_proj = proj * view;
 
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(view_proj, true, false, frustum);
+    dmIntersection::CreateFrustumFromMatrix(view_proj, true, 6, frustum);
 
     float px = FRUSTUM_WIDTH / 2.0f;
     float py = FRUSTUM_HEIGHT / 2.0f;
@@ -80,7 +80,7 @@ TEST(dmVMath, TestFrustumSphere)
     dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(0.0f, FRUSTUM_WIDTH, 0.0f, FRUSTUM_HEIGHT, FRUSTUM_NEAR, FRUSTUM_FAR);
 
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(proj, true, false, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, 6, frustum);
 
     const float RADIUS = 10.0f;
     float px = FRUSTUM_WIDTH / 2.0f;
@@ -115,7 +115,7 @@ TEST(dmVMath, TestFrustumSphere)
     ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1000.0f), RADIUS) );
     ASSERT_FALSE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py,  1000.0f), RADIUS) );
 
-    dmIntersection::CreateFrustumFromMatrix(proj, true, true, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, 4, frustum);
     ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py, -1000.0f), RADIUS) );
     ASSERT_TRUE( dmIntersection::TestFrustumSphere(frustum, dmVMath::Point3(px, py,  1000.0f), RADIUS) );
 }
@@ -126,7 +126,7 @@ TEST(dmVMath, TestFrustumOBB)
 
     // frustum lies on positive X axis from 0 to FRUSTUM_WIDTH, on Y from 0 to FRUSTUM_HEIGHT and on Z from -FRUSTUM_NEAR to -FRUSTUM_FAR
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(proj, true, false, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, 6, frustum);
 
     float BOX_SIDE = 1;
     dmVMath::Vector3 minPoint(0,0,0);
@@ -189,7 +189,7 @@ TEST(dmVMath, TestFrustumOBBPerspective)
     dmVMath::Matrix4 view_proj = proj * view;
 
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(view_proj, true, false, frustum);
+    dmIntersection::CreateFrustumFromMatrix(view_proj, true, 6, frustum);
 
     dmVMath::Matrix4 world;
     dmVMath::Vector3 minPoint(0, 0, 0);
@@ -231,8 +231,8 @@ TEST(dmVMath, TestFrustumOBBPerspective)
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH -BOX_SIDE + 0.1f));
     ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
 
-    // front and back plane should be ingored with skip_near_far = true
-    dmIntersection::CreateFrustumFromMatrix(view_proj, true, true, frustum);
+    // front and back plane should be ignored
+    dmIntersection::CreateFrustumFromMatrix(view_proj, true, 4, frustum);
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR -PER_FRUSTUM_DEPTH -BOX_SIDE - 0.1f));
     ASSERT_TRUE(dmIntersection::TestFrustumOBB(frustum, world, minPoint, maxPoint));
     world = dmVMath::Matrix4::translation(dmVMath::Vector3(0, 0, -PER_FRUSTUM_NEAR + 0.1f));
@@ -245,7 +245,7 @@ TEST(dmVMath, TestFrustumOBBCorners)
     // Frustum's center is on origin on X, Y axes. On Z it's placed from -FRUSTUM_NEAR to -FRUSTUM_FAR.
     dmVMath::Matrix4 proj = dmVMath::Matrix4::orthographic(-FRUSTUM_WIDTH/2, FRUSTUM_WIDTH/2, -FRUSTUM_HEIGHT/2, FRUSTUM_HEIGHT/2, FRUSTUM_NEAR, FRUSTUM_FAR);
     dmIntersection::Frustum frustum;
-    dmIntersection::CreateFrustumFromMatrix(proj, true, false, frustum);
+    dmIntersection::CreateFrustumFromMatrix(proj, true, 6, frustum);
 
     float FRUSTUM_NEARFAR_MIDDLE = (FRUSTUM_NEAR + FRUSTUM_FAR)/2;
     float BOX_SIDE = 2;

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -830,7 +830,7 @@ namespace dmGameSystem
             dmVMath::Vector3 boundsMin(((float*)data)[0], ((float*)data)[1], ((float*)data)[2] );
             dmVMath::Vector3 boundsMax(((float*)data)[3], ((float*)data)[4], ((float*)data)[5] );
 
-            bool intersect      = dmIntersection::TestFrustumOBB(frustum, component_p->m_World, boundsMin, boundsMax, false);
+            bool intersect      = dmIntersection::TestFrustumOBB(frustum, component_p->m_World, boundsMin, boundsMax);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -846,7 +846,7 @@ namespace dmGameSystem
             dmRender::RenderListEntry* entry = &params.m_Entries[i];
             MeshRenderItem* render_item = (MeshRenderItem*)entry->m_UserData;
 
-            bool intersect = dmIntersection::TestFrustumOBB(frustum, render_item->m_World, render_item->m_AabbMin, render_item->m_AabbMax, true);
+            bool intersect = dmIntersection::TestFrustumOBB(frustum, render_item->m_World, render_item->m_AabbMin, render_item->m_AabbMax);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1206,7 +1206,7 @@ namespace dmGameSystem
 
             float radius_sq = radiuses[entry->m_UserData];
 
-            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, entry->m_WorldPosition, radius_sq, true);
+            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, entry->m_WorldPosition, radius_sq);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -275,6 +275,19 @@ namespace dmRender
     };
 
     /*#
+     * Frustum planes to use in a frustum
+     * @enum
+     * @name FrustumPlanes
+     * @member FRUSTUM_PLANES_SIDES
+     * @member FRUSTUM_PLANES_ALL
+     */
+    enum FrustumPlanes
+    {
+        FRUSTUM_PLANES_SIDES = 4,
+        FRUSTUM_PLANES_ALL   = 6
+    };
+
+    /*#
      * Frustum options used when setting up a draw call
      * @struct
      * @name FrustumOptions
@@ -284,7 +297,7 @@ namespace dmRender
     struct FrustumOptions
     {
         dmVMath::Matrix4 m_Matrix;
-        bool             m_SkipNearFarPlanes;
+        FrustumPlanes    m_NumPlanes;
     };
 
     /*#

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -275,6 +275,19 @@ namespace dmRender
     };
 
     /*#
+     * Frustum options used when setting up a draw call
+     * @struct
+     * @name FrustumOptions
+     * @member m_FrustumMatrix [type: matrix4] the frustum matrix
+     * @member m_SkipNearFarPlanes [type: bool] should the frustum culling use the near and far planes
+     */
+    struct FrustumOptions
+    {
+        dmVMath::Matrix4 m_Matrix;
+        bool             m_SkipNearFarPlanes;
+    };
+
+    /*#
      * Visibility dispatch function callback.
      * @struct
      * @name RenderListVisibilityParams

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -1138,7 +1138,7 @@ namespace dmRender
             dmRender::RenderListEntry* entry = &params.m_Entries[i];
             TextEntry* te = ((TextEntry*) entry->m_UserData);
 
-            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, te->m_FrustumCullingCenter, te->m_FrustumCullingRadiusSq, true);
+            bool intersect = dmIntersection::TestFrustumSphereSq(frustum, te->m_FrustumCullingCenter, te->m_FrustumCullingRadiusSq);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }
     }

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -691,7 +691,7 @@ namespace dmRender
             if (frustum_options)
             {
                 dmIntersection::Frustum frustum;
-                dmIntersection::CreateFrustumFromMatrix(frustum_options->m_Matrix, true, frustum_options->m_SkipNearFarPlanes, frustum);
+                dmIntersection::CreateFrustumFromMatrix(frustum_options->m_Matrix, true, (int)frustum_options->m_NumPlanes, frustum);
                 FrustumCulling(context, frustum);
             }
             else

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -667,7 +667,7 @@ namespace dmRender
         }
     }
 
-    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const dmVMath::Matrix4* frustum_matrix)
+    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const FrustumOptions* frustum_options)
     {
         DM_PROFILE("DrawRenderList");
 
@@ -682,16 +682,16 @@ namespace dmRender
             SortRenderList(context);
         }
 
-        dmhash_t frustum_hash = frustum_matrix ? dmHashBuffer64((const void*)frustum_matrix, 16*sizeof(float)) : 0;
+        dmhash_t frustum_hash = frustum_hash = frustum_options ? dmHashBuffer64((const void*)&frustum_options->m_Matrix, 16*sizeof(float)) : 0;
         if (context->m_FrustumHash != frustum_hash)
         {
             // We use this to avoid calling the culling functions more than once in a row
             context->m_FrustumHash = frustum_hash;
 
-            if (frustum_matrix)
+            if (frustum_options)
             {
                 dmIntersection::Frustum frustum;
-                dmIntersection::CreateFrustumFromMatrix(*frustum_matrix, true, frustum);
+                dmIntersection::CreateFrustumFromMatrix(frustum_options->m_Matrix, true, frustum_options->m_SkipNearFarPlanes, frustum);
                 FrustumCulling(context, frustum);
             }
             else
@@ -897,12 +897,12 @@ namespace dmRender
         return RESULT_OK;
     }
 
-    Result DrawDebug3d(HRenderContext context, const dmVMath::Matrix4* frustum_matrix)
+    Result DrawDebug3d(HRenderContext context, const FrustumOptions* frustum_options)
     {
         if (!context->m_DebugRenderer.m_RenderContext) {
             return RESULT_INVALID_CONTEXT;
         }
-        return DrawRenderList(context, &context->m_DebugRenderer.m_3dPredicate, 0, frustum_matrix);
+        return DrawRenderList(context, &context->m_DebugRenderer.m_3dPredicate, 0, frustum_options);
     }
 
     Result DrawDebug2d(HRenderContext context) // Deprecated

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -134,10 +134,10 @@ namespace dmRender
 
     // Takes the contents of the render list, sorts by view and inserts all the objects in the
     // render list, unless they already are in place from a previous call.
-    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const dmVMath::Matrix4* frustum_matrix);
+    Result DrawRenderList(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer, const FrustumOptions* frustum_options);
 
     Result Draw(HRenderContext context, HPredicate predicate, HNamedConstantBuffer constant_buffer);
-    Result DrawDebug3d(HRenderContext context, const dmVMath::Matrix4* frustum_matrix);
+    Result DrawDebug3d(HRenderContext context, const FrustumOptions* frustum_options);
     Result DrawDebug2d(HRenderContext context);
 
     /**

--- a/engine/render/src/render/render_command.cpp
+++ b/engine/render/src/render/render_command.cpp
@@ -168,18 +168,18 @@ namespace dmRender
                 }
                 case COMMAND_TYPE_DRAW:
                 {
-                    dmVMath::Matrix4* matrix = (dmVMath::Matrix4*)c->m_Operands[2];
+                    FrustumOptions* frustum_options = (FrustumOptions*)c->m_Operands[2];
                     dmRender::DrawRenderList(render_context, (dmRender::Predicate*)c->m_Operands[0],
                                                              (dmRender::HNamedConstantBuffer)c->m_Operands[1],
-                                                             matrix);
-                    delete matrix;
+                                                             frustum_options);
+                    delete frustum_options;
                     break;
                 }
                 case COMMAND_TYPE_DRAW_DEBUG3D:
                 {
-                    dmVMath::Matrix4* matrix = (dmVMath::Matrix4*)c->m_Operands[0];
-                    dmRender::DrawDebug3d(render_context, matrix);
-                    delete matrix;
+                    FrustumOptions* frustum_options = (FrustumOptions*)c->m_Operands[0];
+                    dmRender::DrawDebug3d(render_context, frustum_options);
+                    delete frustum_options;
                     break;
                 }
                 case COMMAND_TYPE_DRAW_DEBUG2D:

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -575,7 +575,7 @@ TEST_F(dmRenderTest, TestRenderListCulling)
         {
             dmRender::FrustumOptions frustum_options;
             frustum_options.m_Matrix = *frustum_matrices[c];
-            frustum_options.m_SkipNearFarPlanes = true;
+            frustum_options.m_NumPlanes = dmRender::FRUSTUM_PLANES_SIDES;
             dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options);
         }
         else

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -500,7 +500,7 @@ static void TestDrawVisibility(dmRender::RenderListVisibilityParams const &param
     for (uint32_t i = 0; i < params.m_NumEntries; ++i)
     {
         dmRender::RenderListEntry* entry = &params.m_Entries[i];
-        bool intersect = dmIntersection::TestFrustumPoint(*params.m_Frustum, entry->m_WorldPosition, true);
+        bool intersect = dmIntersection::TestFrustumPoint(*params.m_Frustum, entry->m_WorldPosition);
         entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
     }
 }
@@ -571,7 +571,17 @@ TEST_F(dmRenderTest, TestRenderListCulling)
         dmRender::RenderListSubmit(m_Context, out, out + n);
         dmRender::RenderListEnd(m_Context);
 
-        dmRender::DrawRenderList(m_Context, 0, 0, frustum_matrices[c]);
+        if (frustum_matrices[c])
+        {
+            dmRender::FrustumOptions frustum_options;
+            frustum_options.m_Matrix = *frustum_matrices[c];
+            frustum_options.m_SkipNearFarPlanes = true;
+            dmRender::DrawRenderList(m_Context, 0, 0, &frustum_options);
+        }
+        else
+        {
+            dmRender::DrawRenderList(m_Context, 0, 0, 0);
+        }
 
         ASSERT_EQ(ctx.m_BeginCalls, 2);
         ASSERT_GT(ctx.m_BatchCalls, 2);


### PR DESCRIPTION
The flag is set as `render.FRUSTUM_PLANES_SIDES` as default, making sure only the 4 side planes of the frustum is used.
By specifying `frustum_planes = render.FRUSTUM_PLANES_ALL`, the user can make sure all 6 frustum planes are used.

Example:
```lua
render.draw(self.model_pred, { frustum = proj * view, frustum_planes = render.FRUSTUM_PLANES_ALL})
```

Fixes https://github.com/defold/defold/issues/7959

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
