### PR TITLE
Remove embedded builtins resources from release builds

### DIFF
--- a/build_tools/BuildUtility.py
+++ b/build_tools/BuildUtility.py
@@ -4,10 +4,10 @@
 # Copyright 2009-2014 Ragnar Svensson, Christian Murray
 # Licensed under the Defold License version 1.0 (the "License"); you may not use
 # this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License, together with FAQs at
 # https://www.defold.com/license
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -123,6 +123,12 @@ class BuildUtility:
         self._library_path = os.path.join(self._dynamo_home, 'lib', self._platform['platform'])
         self._binary_path = os.path.join(self._dynamo_home, 'bin', self._platform['platform'])
     # _initialise_paths
+
+    def get_defold_version(self):
+        path = os.path.normpath(os.path.join(os.environ['DYNAMO_HOME'], '../../VERSION'))
+        with open(path, 'r') as f:
+            version = f.readline().strip()
+        return version
 
 # class BuildUtility
 

--- a/engine/engine/content/wscript
+++ b/engine/engine/content/wscript
@@ -37,32 +37,20 @@ def package_bob(self):
 def build(bld):
     obj = bld(source = bld.path.ant_glob('materials/*'))
 
-    builtins = bld(features='barchive',
-                   source_root='default/content',
-                   content_root='../content',
-                   resource_name='builtins',
-                   source = bld.path.ant_glob([
-                       'builtins/input/**/*',
-                       'builtins/render/**/*',
-                       'builtins/fonts/**/*',
-                       'builtins/connect/**/*',
-                       'builtins/materials/**/*',
-                       'builtins/graphics/**/*',
-                       'builtins/scripts/**/*'],
-                       excl = ['**/*.ttf', '**/*.texture_profiles', '**/LICENSE']),
-                   use_compression=True)
-
-    # DEF-3259 - The resource build system doesn't take into account that several builds using same source contnt
-    # may be running at the same time. And, as a fix, we add a synchronization point here for the builds,
-    # to make sure that builtins + builtins_release are built consecutively.
-    bld.add_group()
-
-    builtins_release = bld(features='barchive',
-                           source_root='default/content',
-                           content_root='../content',
-                           resource_name='builtins_release',
-                           source = bld.path.ant_glob('builtins/fonts/*', excl=['builtins/fonts/*.ttf']),
-                           use_compression=True)
+    bld(features='barchive',
+       source_root='default/content',
+       content_root='../content',
+       resource_name='builtins',
+       source = bld.path.ant_glob([
+           'builtins/input/**/*',
+           'builtins/render/**/*',
+           'builtins/fonts/**/*',
+           'builtins/connect/**/*',
+           'builtins/materials/**/*',
+           'builtins/graphics/**/*',
+           'builtins/scripts/**/*'],
+           excl = ['**/*.ttf', '**/*.texture_profiles', '**/LICENSE']),
+       use_compression=True)
 
     for d in ['fonts', 'input', 'render', 'materials', 'graphics', 'scripts', 'docs', 'ca-certificates']:
         bld.install_files('${PREFIX}/content/builtins/%s' % d, bld.path.ant_glob('builtins/%s/*' % d))
@@ -82,4 +70,3 @@ def build(bld):
 
 def configure(conf):
     pass
-

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -962,7 +962,7 @@ namespace dmEngine
         render_params.m_MaxRenderTypes = 16;
         render_params.m_MaxInstances = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_draw_calls", 1024);
         render_params.m_MaxRenderTargets = 32;
-        render_params.m_MaxCharacters = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_characters", 2048 * 4);;
+        render_params.m_MaxCharacters = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_characters", 2048 * 4);
         render_params.m_CommandBufferSize = 1024;
         render_params.m_ScriptContext = engine->m_RenderScriptContext;
 #if !defined(DM_RELEASE)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1220,7 +1220,6 @@ namespace dmEngine
         }
 #endif
 
-        dmGui::SetDefaultFont(engine->m_GuiContext, engine->m_SystemFontMap);
         dmGui::SetDisplayProfiles(engine->m_GuiContext, engine->m_DisplayProfiles);
 
         // clear it a couple of times, due to initialization of extensions might stall the updates
@@ -1634,8 +1633,9 @@ bail:
                 dmEngineService::Update(engine->m_EngineService, profile);
             }
 
+#if !defined(DM_RELEASE)
             dmProfiler::RenderProfiler(profile, engine->m_GraphicsContext, engine->m_RenderContext, engine->m_SystemFontMap);
-
+#endif
             // Call post render functions for extensions, if available.
             // We do it here at the end of the frame (before swap buffers/flip)
             // in case any extension wants to render just before the Flip().
@@ -1921,7 +1921,7 @@ bail:
     bool LoadBootstrapContent(HEngine engine, dmConfigFile::HConfig config)
     {
         dmResource::Result fact_error;
-
+#if !defined(DM_RELEASE)
         const char* system_font_map = "/builtins/fonts/system_font.fontc";
         fact_error = dmResource::Get(engine->m_Factory, system_font_map, (void**) &engine->m_SystemFontMap);
         if (fact_error != dmResource::RESULT_OK)
@@ -1930,7 +1930,7 @@ bail:
             return false;
         }
         dmRender::SetSystemFontMap(engine->m_RenderContext, engine->m_SystemFontMap);
-
+#endif
         // The system font is currently the only resource we need from the connection app
         // After this point, the rest of the resources should be loaded the ordinary way
         if (!engine->m_ConnectionAppMode)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -74,15 +74,7 @@ extern uint32_t DEBUG_VPC_SIZE;
 extern unsigned char DEBUG_FPC[];
 extern uint32_t DEBUG_FPC_SIZE;
 
-#if defined(DM_RELEASE)
-    extern unsigned char BUILTINS_RELEASE_ARCD[];
-    extern uint32_t BUILTINS_RELEASE_ARCD_SIZE;
-    extern unsigned char BUILTINS_RELEASE_ARCI[];
-    extern uint32_t BUILTINS_RELEASE_ARCI_SIZE;
-    extern unsigned char BUILTINS_RELEASE_DMANIFEST[];
-    extern uint32_t BUILTINS_RELEASE_DMANIFEST_SIZE;
-
-#else
+#if !defined(DM_RELEASE)
     extern unsigned char BUILTINS_ARCD[];
     extern uint32_t BUILTINS_ARCD_SIZE;
     extern unsigned char BUILTINS_ARCI[];
@@ -901,14 +893,7 @@ namespace dmEngine
             params.m_Flags |= RESOURCE_FACTORY_FLAGS_LIVE_UPDATE;
         }
 
-#if defined(DM_RELEASE)
-        params.m_ArchiveIndex.m_Data = (const void*) BUILTINS_RELEASE_ARCI;
-        params.m_ArchiveIndex.m_Size = BUILTINS_RELEASE_ARCI_SIZE;
-        params.m_ArchiveData.m_Data = (const void*) BUILTINS_RELEASE_ARCD;
-        params.m_ArchiveData.m_Size = BUILTINS_RELEASE_ARCD_SIZE;
-        params.m_ArchiveManifest.m_Data = (const void*) BUILTINS_RELEASE_DMANIFEST;
-        params.m_ArchiveManifest.m_Size = BUILTINS_RELEASE_DMANIFEST_SIZE;
-#else
+#if !defined(DM_RELEASE)
         params.m_ArchiveIndex.m_Data = (const void*) BUILTINS_ARCI;
         params.m_ArchiveIndex.m_Size = BUILTINS_ARCI_SIZE;
         params.m_ArchiveData.m_Data = (const void*) BUILTINS_ARCD;
@@ -977,14 +962,18 @@ namespace dmEngine
         render_params.m_MaxRenderTypes = 16;
         render_params.m_MaxInstances = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_draw_calls", 1024);
         render_params.m_MaxRenderTargets = 32;
+        render_params.m_MaxCharacters = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_characters", 2048 * 4);;
+        render_params.m_CommandBufferSize = 1024;
+        render_params.m_ScriptContext = engine->m_RenderScriptContext;
+#if !defined(DM_RELEASE)
         render_params.m_VertexShaderDesc = ::DEBUG_VPC;
         render_params.m_VertexShaderDescSize = ::DEBUG_VPC_SIZE;
         render_params.m_FragmentShaderDesc = ::DEBUG_FPC;
         render_params.m_FragmentShaderDescSize = ::DEBUG_FPC_SIZE;
-        render_params.m_MaxCharacters = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_characters", 2048 * 4);;
-        render_params.m_CommandBufferSize = 1024;
-        render_params.m_ScriptContext = engine->m_RenderScriptContext;
         render_params.m_MaxDebugVertexCount = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_debug_vertices", 10000);
+#else
+        render_params.m_MaxDebugVertexCount = 0;
+#endif
         engine->m_RenderContext = dmRender::NewRenderContext(engine->m_GraphicsContext, render_params);
 
         dmGameObject::Initialize(engine->m_Register, engine->m_GOScriptContext);

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -42,13 +42,12 @@ def build(bld):
 
     bld.add_group()
 
-    bld.stlib(features = 'cxx ddf embed',
+    bld.stlib(features = 'cxx ddf',
                     includes = '../proto . ..',
                     target = 'engine_release',
                     defines = 'DM_RELEASE=1',
                     proto_gen_py = True,
                     protoc_includes = ['../proto', bld.env['PREFIX'] + '/share'],
-                    embed_source='../content/materials/debug.vpc ../content/materials/debug.fpc ../content/builtins_release.arci ../content/builtins_release.arcd ../content/builtins_release.dmanifest', # for draw_line/draw_text
                     source='engine.cpp engine_main.cpp engine_loop.cpp extension.cpp ../proto/engine/engine_ddf.proto ' + platform_main_cpp,
                     install_path = platform_lib_install_path,
                     use = 'engine_service_null')

--- a/engine/engine/wscript
+++ b/engine/engine/wscript
@@ -24,6 +24,30 @@ def options(opt):
     opt.load('waf_dynamo')
     opt.load('waf_ddf')
 
+def create_engine_version(self):
+    engine_version = """
+namespace dmEngineVersion
+{
+    static const char* PLATFORM = "%(platform)s";
+    static const char* VERSION = "%(version)s";
+    static const char* VERSION_SHA1 = "%(sha1)s";
+}
+"""
+    full = self.outputs[0].abspath()
+
+    try:
+        os.mkdir(os.path.dirname(full))
+    except:
+        pass
+    full = os.path.normpath(full)
+
+    sha1 = self.env['ENGINE_SHA1']
+    platform = self.env['ENGINE_PLATFORM']
+    version = self.env['ENGINE_VERSION']
+    with open(full, 'w') as f:
+        f.write(engine_version % {"version": version, "sha1": sha1, "platform": platform})
+
+
 def configure(conf):
     conf.load('waf_dynamo')
     conf.load('java')
@@ -34,29 +58,6 @@ def configure(conf):
         build_util = create_build_utility(conf.env)
     except BuildUtilityException as ex:
         conf.fatal(ex.msg)
-
-    engine_version = """
-namespace dmEngineVersion
-{
-    static const char* PLATFORM = "%(platform)s";
-    static const char* VERSION = "%(version)s";
-    static const char* VERSION_SHA1 = "%(sha1)s";
-}
-"""
-
-    engine_version_node = conf.path.make_node('%s/engine_version.h' % blddir)
-    full = engine_version_node.abspath()
-
-    try:
-        os.mkdir(os.path.dirname(full))
-    except:
-        pass
-    full = os.path.normpath(full)
-    with open('../../VERSION', 'r') as f:
-        version = f.readline().strip()
-    sha1 = build_util.git_sha1()
-    with open(full, 'w') as f:
-        f.write(engine_version % {"version": version, "sha1": sha1, "platform": build_util.get_target_platform()})
 
     waf_graphics.configure(conf)
     waf_ddf.configure(conf)
@@ -165,17 +166,23 @@ def build(bld):
     sys.path.insert(0, os.path.abspath('build/proto/engine'))
     sys.path.insert(0, os.path.abspath('proto/engine'))
 
-    bld.recurse('content')
-    bld.add_group()
-    bld.recurse('src')
-
-    bld.install_files('${PREFIX}/bin', 'scripts/dmengine_memprofile.sh', chmod=0O755)
-
     build_util = None
     try:
         build_util = create_build_utility(bld.env)
     except BuildUtilityException as ex:
-        conf.fatal(ex.msg)
+        bld.fatal(ex.msg)
+
+    bld.recurse('content')
+
+    b = bld(rule = create_engine_version, target = 'engine_version.h', always = True)
+    b.env['ENGINE_SHA1'] = build_util.git_sha1()
+    b.env['ENGINE_PLATFORM'] = build_util.get_target_platform()
+    b.env['ENGINE_VERSION'] = build_util.get_defold_version()
+
+    bld.add_group()
+    bld.recurse('src')
+
+    bld.install_files('${PREFIX}/bin', 'scripts/dmengine_memprofile.sh', chmod=0O755)
 
     if build_util.get_target_os() in ['web', 'macos', 'ios']:
         srcPath = os.path.join('build', 'src')

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -981,6 +981,8 @@ namespace dmGameSystem
             assert(node_type == dmGui::NODE_TYPE_TEXT);
 
             dmRender::HFontMap font_map  = (dmRender::HFontMap) dmGui::GetNodeFont(scene, node);
+            if (!font_map)
+                continue;
             dmRender::HMaterial material = GetTextNodeMaterial(gui_context, scene, node, font_map);
 
             dmRender::DrawTextParams params;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -278,11 +278,6 @@ namespace dmGui
         context->m_DisplayProfiles = display_profiles;
     }
 
-    void SetDefaultFont(HContext context, void* font)
-    {
-        context->m_DefaultFont = font;
-    }
-
     void SetSceneAdjustReference(HScene scene, AdjustReference adjust_reference)
     {
         scene->m_AdjustReference = adjust_reference;

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -465,8 +465,6 @@ namespace dmGui
 
     void SetDisplayProfiles(HContext context, void* display_profiles);
 
-    void SetDefaultFont(HContext context, void* font);
-
     void SetSceneAdjustReference(HScene scene, AdjustReference adjust_reference);
 
     HScene NewScene(HContext context, const NewSceneParams* params);

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -99,7 +99,6 @@ namespace dmGui
         dmArray<uint16_t>               m_StencilScopeIndices;
         dmArray<HNode>                  m_ScratchBoneNodes;
         dmHID::HContext                 m_HidContext;
-        void*                           m_DefaultFont;
         void*                           m_DisplayProfiles;
         SceneTraversalCache             m_SceneTraversalCache;
     };

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -1310,8 +1310,6 @@ namespace dmGui
         const char* text = luaL_checkstring(L, 2);
         Scene* scene = GuiScriptInstance_Check(L);
         void* font = scene->m_DefaultFont;
-        if (font == 0x0)
-            font = scene->m_Context->m_DefaultFont;
         Vector3 size = Vector3(1,1,1);
         if (font != 0x0)
         {

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -146,8 +146,6 @@ public:
         m_Context->m_SceneTraversalCache.m_Data.SetCapacity(MAX_NODES);
         m_Context->m_SceneTraversalCache.m_Data.SetSize(MAX_NODES);
 
-        // Bogus font for the metric callback to be run (not actually using the default font)
-        dmGui::SetDefaultFont(m_Context, (void*)0x1);
         dmGui::NewSceneParams params;
         params.m_MaxNodes = MAX_NODES;
         params.m_MaxAnimations = MAX_ANIMATIONS;
@@ -2495,6 +2493,9 @@ TEST_F(dmGuiTest, ScriptAnchoring)
     dmGui::SetPhysicalResolution(m_Context, physical_width, physical_height);
     dmGui::SetSceneResolution(m_Scene, width, height);
 
+    int f;
+    dmGui::AddFont(m_Scene, dmHashString64("_default"), &f, 0);
+
     Vector4 ref_scale = dmGui::CalculateReferenceScale(m_Scene, 0);
 
     const char* s = "function init(self)\n"
@@ -2536,6 +2537,8 @@ TEST_F(dmGuiTest, ScriptAnchoring)
     const float EPSILON = 0.0001f;
     ASSERT_NEAR(physical_width - 10.0f * ref_scale.getX(), pos2.getX() + ref_factor * TEXT_GLYPH_WIDTH, EPSILON);
     ASSERT_NEAR(physical_height - 10.0f * ref_scale.getY(), pos2.getY() + ref_factor * 0.5f * (TEXT_MAX_DESCENT + TEXT_MAX_ASCENT), EPSILON);
+
+    dmGui::ClearFonts(m_Scene);
 }
 
 TEST_F(dmGuiTest, ScriptPivot)
@@ -2755,6 +2758,9 @@ TEST_F(dmGuiTest, ScriptPicking)
     dmGui::SetSceneResolution(m_Scene, physical_width, physical_height);
     dmGui::SetDefaultResolution(m_Context, physical_width, physical_height);
 
+    int f;
+    dmGui::AddFont(m_Scene, dmHashString64("_default"), &f, 0);
+
     char buffer[1024];
 
     const char* s = "function init(self)\n"
@@ -2772,13 +2778,15 @@ TEST_F(dmGuiTest, ScriptPicking)
                     "    assert(not gui.pick_node(n1, size.x + 1, size.y))\n"
                     "end\n";
 
-    sprintf(buffer, s, TEXT_GLYPH_WIDTH, TEXT_MAX_ASCENT, TEXT_MAX_DESCENT, EPSILON);
+    dmSnPrintf(buffer, sizeof(buffer), s, TEXT_GLYPH_WIDTH, TEXT_MAX_ASCENT, TEXT_MAX_DESCENT, EPSILON);
     dmGui::Result r;
     r = dmGui::SetScript(m_Script, LuaSourceFromStr(buffer));
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
     r = dmGui::InitScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
+
+    dmGui::ClearFonts(m_Scene);
 }
 
 template <> char* jc_test_print_value(char* buffer, size_t buffer_len, Vector4 v) {
@@ -3436,7 +3444,7 @@ TEST_F(dmGuiTest, ScriptEnableDisable)
                     "    gui.set_enabled(self.n1, false)\n"
                     "    assert(not gui.is_enabled(self.n1))\n"
                     "end\n";
-    sprintf(buffer, s, TEXT_GLYPH_WIDTH, TEXT_MAX_ASCENT, TEXT_MAX_DESCENT);
+    dmSnPrintf(buffer, sizeof(buffer), s, TEXT_GLYPH_WIDTH, TEXT_MAX_ASCENT, TEXT_MAX_DESCENT);
     dmGui::Result r;
     r = dmGui::SetScript(m_Script, LuaSourceFromStr(buffer));
     ASSERT_EQ(dmGui::RESULT_OK, r);
@@ -3464,7 +3472,7 @@ TEST_F(dmGuiTest, ScriptRecursiveEnabled)
                     "    assert(not gui.is_enabled(self.n1))\n"
                     "    assert(not gui.is_enabled(self.n2, true))\n" // n2 node enabled but n1 disabled
                     "end\n";
-    sprintf(buffer, s, TEXT_GLYPH_WIDTH, TEXT_MAX_ASCENT, TEXT_MAX_DESCENT);
+    dmSnPrintf(buffer, sizeof(buffer), s, TEXT_GLYPH_WIDTH, TEXT_MAX_ASCENT, TEXT_MAX_DESCENT);
     dmGui::Result r;
     r = dmGui::SetScript(m_Script, LuaSourceFromStr(buffer));
     ASSERT_EQ(dmGui::RESULT_OK, r);


### PR DESCRIPTION
We've removed the system debug font as a default gui font. This will save some size in the final executable. This is a breaking change but it is likely to affect only a few users. If you are using gui text, and your gui scene doesn't have a font, the text will not show. If that is the case, then the fix is to add a font explicitly to your gui scene.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
