### PR TITLE
Use EngineLoader.wasm_size if response doesn't have Content-Length header

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -132,7 +132,10 @@ var EngineLoader = {
             async function fetchWithProgress(path) {
                 const response = await fetch(path);
                 // May be incorrect if compressed
-                const contentLength = response.headers.get("Content-Length");
+                var contentLength = response.headers.get("Content-Length");
+                if (!contentLength){
+                    contentLength = EngineLoader.wasm_size;
+                }
                 const total = parseInt(contentLength, 10);
 
                 let bytesLoaded = 0;


### PR DESCRIPTION
dmloader.js will use EngineLoader.wasm_size if response doesn't have Content-Length header in setupWasmStreamAsync.

Fixes https://github.com/defold/defold/issues/7982
