### PR TITLE
Fix for calling Unmount when removing a live update archive

### DIFF
--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -803,7 +803,7 @@ namespace dmLiveUpdate
         dmMutex::HMutex mutex = dmResourceMounts::GetMutex(mounts);
         DM_MUTEX_SCOPED_LOCK(mutex);
 
-        dmResource::Result result = dmResourceMounts::RemoveMountByName(mounts, name);
+        dmResource::Result result = dmResourceMounts::RemoveAndUnmountByName(mounts, name);
         if (result != dmResource::RESULT_OK)
         {
             dmLogError("Failed to remove mount '%s': %s (%d)", name, dmResource::ResultToString(result), result);

--- a/engine/resource/src/resource_mounts.cpp
+++ b/engine/resource/src/resource_mounts.cpp
@@ -175,7 +175,7 @@ dmResource::Result RemoveMount(HContext ctx, dmResourceProvider::HArchive archiv
     return dmResource::RESULT_RESOURCE_NOT_FOUND;
 }
 
-dmResource::Result RemoveMountByName(HContext ctx, const char* name)
+dmResource::Result RemoveAndUnmountByName(HContext ctx, const char* name)
 {
     DM_MUTEX_SCOPED_LOCK(ctx->m_Mutex);
 
@@ -185,6 +185,7 @@ dmResource::Result RemoveMountByName(HContext ctx, const char* name)
         ArchiveMount& mount = ctx->m_Mounts[i];
         if (strcmp(mount.m_Name, name) == 0)
         {
+            dmResourceProvider::Unmount(mount.m_Archive);
             return RemoveMountByIndexInternal(ctx, i);
         }
     }

--- a/engine/resource/src/resource_mounts.h
+++ b/engine/resource/src/resource_mounts.h
@@ -30,14 +30,20 @@ namespace dmResourceMounts
     typedef struct ResourceMountsContext* HContext;
 
     HContext    Create(dmResourceProvider::HArchive base_archive);
+
+    // Calls Unmount on all archives
     void        Destroy(HContext context);
 
     dmMutex::HMutex GetMutex(HContext ctx);
 
+    // Does not call Unmount on the archives
     dmResource::Result AddMount(HContext ctx, const char* name, dmResourceProvider::HArchive archive, int priority, bool persist);
     dmResource::Result RemoveMount(HContext ctx, dmResourceProvider::HArchive archive);
-    dmResource::Result RemoveMountByName(HContext ctx, const char* name);
 
+    // Also calls Unmount on the archive
+    dmResource::Result RemoveAndUnmountByName(HContext ctx, const char* name);
+
+    // Loads and mounts archives
     dmResource::Result LoadMounts(HContext ctx, const char* app_support_path);
     dmResource::Result SaveMounts(HContext ctx, const char* app_support_path);
 


### PR DESCRIPTION
This fixes an issue where the memory and file handles of a live update archive would linger until the next reboot.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
