### PR TITLE
Crash fix for animation files without bind pose

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -481,9 +481,19 @@ namespace dmGameSystem
         create_params.m_EventCBUserData2 = 0;
 
         create_params.m_BindPose         = &rig_resource->m_BindPose;
-        create_params.m_BoneIndices      = &rig_resource->m_SkeletonRes->m_BoneIndices;
-        create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes == 0x0 ? 0x0 : rig_resource->m_AnimationSetRes->m_AnimationSet;
         create_params.m_Skeleton         = rig_resource->m_SkeletonRes == 0x0 ? 0x0 : rig_resource->m_SkeletonRes->m_Skeleton;
+        if (create_params.m_Skeleton)
+        {
+            create_params.m_BoneIndices      = rig_resource->m_SkeletonRes == 0x0 ? 0x0 : &rig_resource->m_SkeletonRes->m_BoneIndices;
+            create_params.m_AnimationSet     = rig_resource->m_AnimationSetRes == 0x0 ? 0x0 : rig_resource->m_AnimationSetRes->m_AnimationSet;
+        }
+        else
+        {
+            if (rig_resource->m_AnimationSetRes)
+            {
+                dmLogWarning("Model has animations but no skeleton set");
+            }
+        }
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;
 
         dmRigDDF::MeshSet* mesh_set      = rig_resource->m_MeshSetRes->m_MeshSet;

--- a/engine/modelc/src/modelimporter.cpp
+++ b/engine/modelc/src/modelimporter.cpp
@@ -220,7 +220,11 @@ Scene* LoadFromPath(Options* options, const char* path)
     }
 
     Scene* scene = LoadFromBuffer(options, suffix, data, file_size);
-
+    if (!scene)
+    {
+        dmLogError("Failed to create scene from path '%s'", path);
+        return 0;
+    }
 
     char dirname[512];
     dmStrlCpy(dirname, path, sizeof(dirname));

--- a/engine/modelc/src/modelimporter_gltf.cpp
+++ b/engine/modelc/src/modelimporter_gltf.cpp
@@ -31,6 +31,7 @@
 #include <dmsdk/dlib/dstrings.h>
 #include <dmsdk/dlib/hashtable.h>
 #include <dmsdk/dlib/transform.h>
+#include <dmsdk/dlib/log.h>
 
 // Terminology:
 // Defold: Model, GLTF: Mesh
@@ -765,14 +766,20 @@ static void LoadSkins(Scene* scene, cgltf_data* gltf_data)
 
             // Cannot translate the bones here, since they're not created yet
             // bone->m_Node = ...
-
-            float matrix[16];
-            if (ReadAccessorMatrix4(accessor, j, matrix))
+            if (accessor)
             {
-                bone->m_InvBindPose = ToTransform(matrix);
-            } else
+                float matrix[16];
+                if (ReadAccessorMatrix4(accessor, j, matrix))
+                {
+                    bone->m_InvBindPose = ToTransform(matrix);
+                } else
+                {
+                    assert(false);
+                }
+            }
+            else
             {
-                assert(false);
+                bone->m_InvBindPose.SetIdentity();
             }
         }
 


### PR DESCRIPTION
This fixes a crash when an animation file doesn't have a bind pose in it.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
