### PR TITLE
Change code completions to be compatible with LSP

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -180,7 +180,7 @@
                       :cider {:plugins [[cider/cider-nrepl "0.24.0"]
                                         ;;[refactor-nrepl "2.4.0"] ;; -- this does not seem to work well together with cider-nrepl 0.24.0 so it might be better to just skip.
                                         [com.billpiel/sayid "0.0.18"]]}
-                      :release {:jvm-opts ["-Ddefold.build=release"]}
+                      :release {:jvm-opts ["-Ddefold.build=release" "-Dclojure.spec.compile-asserts=false"]}
                       :headless {:jvm-opts ["-Dtestfx.robot=glass" "-Dglass.platform=Monocle" "-Dmonocle.platform=Headless" "-Dprism.order=sw"]
                                  :dependencies [[org.testfx/openjfx-monocle "jdk-12.0.1+2"]]}
                       :smoke-test {:jvm-opts ["-Ddefold.smoke.log=true"]}
@@ -249,6 +249,7 @@
                                                     ;"-XX:+UnlockCommercialFeatures"
                                                     ;"-XX:+FlightRecorder"
                                                     "-XX:-OmitStackTraceInFastThrow"
+                                                    "-Dclojure.spec.check-asserts=true"
 
                                                     ;; Flags for async-profiler.
                                                     ;; From https://github.com/clojure-goes-fast/clj-async-profiler/blob/master/README.md

--- a/editor/resources/lsp-snippet.g4
+++ b/editor/resources/lsp-snippet.g4
@@ -1,0 +1,96 @@
+grammar Snippet;
+
+snippet:
+    (text
+    |text_esc
+    |rule
+    |err
+    |newline)*;
+
+text: (TEXT|ID);
+text_esc: BACK_SLASH (BACK_SLASH | DOLLAR);
+err:
+      DOLLAR
+    | BACK_SLASH
+    | OPEN
+    | CLOSE
+    | INT
+    | COLON
+    | PIPE
+    | COMMA;
+rule: tab_stop|placeholder|choice|variable;
+newline: NL|CR;
+
+tab_stop: naked_tab_stop | curly_tab_stop;
+naked_tab_stop: DOLLAR INT;
+curly_tab_stop: DOLLAR OPEN INT CLOSE;
+
+placeholder:
+    DOLLAR
+    OPEN
+    INT
+    COLON
+    placeholder_content
+    CLOSE;
+placeholder_content:
+    (rule
+    |placeholder_text
+    |placeholder_esc
+    |newline)*;
+placeholder_text:
+      TEXT
+    | ID
+    | INT
+    | OPEN
+    | COLON
+    | PIPE
+    | COMMA;
+placeholder_esc:
+    BACK_SLASH (BACK_SLASH | DOLLAR | CLOSE);
+
+choice:
+    DOLLAR
+    OPEN
+    INT
+    PIPE
+    choice_elements
+    PIPE
+    CLOSE;
+choice_elements:
+    (choice_element (COMMA choice_element)*)?;
+choice_element:
+    (choice_text
+    |choice_esc
+    |newline)+;
+choice_text: TEXT | ID | INT | OPEN | COLON;
+choice_esc:
+    BACK_SLASH
+    (BACK_SLASH | DOLLAR | CLOSE | PIPE | COMMA);
+
+variable:
+      naked_variable
+    | curly_variable
+    | placeholder_variable;
+variable_text: ID (ID|INT)*;
+naked_variable: DOLLAR variable_text;
+curly_variable: DOLLAR OPEN variable_text CLOSE;
+placeholder_variable:
+    DOLLAR
+    OPEN
+    variable_text
+    COLON
+    placeholder_content
+    CLOSE;
+
+TEXT: ~[\\$0-9{}:|,\r\n_a-zA-Z]+;
+ID: [_a-zA-Z]+;
+NL: '\r'? '\n';
+CR: '\r';
+INT: [0-9]+;
+DOLLAR: '$';
+BACK_SLASH: '\\';
+OPEN: '{';
+CLOSE: '}';
+COLON: ':';
+PIPE: '|';
+COMMA: ',';

--- a/editor/resources/lua-base-snippets.edn
+++ b/editor/resources/lua-base-snippets.edn
@@ -1,59 +1,40 @@
- [{:name "if",
-   :display-string "if                                if cond then",
-   :insert-string "if cond then\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["cond" "-- do things" "end"]}}
-  {:name "else",
-   :display-string "else                              else end",
-   :insert-string "else\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["-- do things"], :exit "end"}}
-  {:name "elsif",
-   :display-string "elsif                             elseif cond end",
-   :insert-string "elseif cond then\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["cond" "-- do things" "end"]}}
-  {:name "while",
-   :display-string "while                             while cond",
-   :insert-string "while cond do\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["cond" "-- do things"], :exit "end"}}
-  {:name "repeat",
-   :display-string "repeat                            repeat until cond",
-   :insert-string "repeat\n\t-- do things\nuntil cond",
-   :doc "",
-   :tab-triggers {:select ["-- do things" "cond"]}}
-  {:name "function",
-   :display-string "function                          function function_name()",
-   :insert-string "function function_name(self)\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["function_name" "self" "-- do things"]
-                  :types [:name :arglist :expr]
-                  :exit "end" :start "function"}}
-  {:name "local",
-   :display-string "local                             local name = value",
-   :insert-string "local name = value",
-   :doc "",
-   :tab-triggers {:select ["name" "value"]
-                  :types [:name :expr]}}
-  {:name "for",
-   :display-string "for                               for i = 1, 10",
-   :insert-string "for i = 1, 10 do\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["i" "1" "10" "-- do things"]
-                  :types [:name :expr :expr :expr]
-                  :exit "end" :start "for"}}
-  {:name "fori",
-   :display-string "fori                              for i, v in ipairs()",
-   :insert-string "for i, v in ipairs(table_name) do\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["i" "v" "table_name" "-- do things"]
-                  :types [:name :name :expr :expr]
-                  :exit "end" :start "for"}}
-  {:name "forp",
-   :display-string "forp                              for k, v in pairs()",
-   :insert-string "for k, v in pairs(table_name) do\n\t-- do things\nend",
-   :doc "",
-   :tab-triggers {:select ["k" "v" "table_name" "-- do things"]
-                  :types [:name :name :expr :expr]
-                  :exit "end" :start "for"}}]
+[{:name "if"
+  :display-string "if                                if cond then"
+  :insert {:type :snippet
+           :value "if ${1:cond} then\n\t${0:-- do things}\nend"}}
+ {:name "else"
+  :display-string "else                              else end"
+  :insert {:type :snippet
+           :value "else\n\t${0:-- do things}\nend"}}
+ {:name "elsif"
+  :display-string "elsif                             elseif cond end"
+  :insert {:type :snippet
+           :value "elseif ${1:cond} then\n\t${0:-- do things}\nend"}}
+ {:name "while"
+  :display-string "while                             while cond"
+  :insert {:type :snippet
+           :value "while ${1:cond} do\n\t${0:-- do things}\nend"}}
+ {:name "repeat"
+  :display-string "repeat                            repeat until cond"
+  :insert {:type :snippet
+           :value "repeat\n\t${0:-- do things}\nuntil ${1:cond}"}}
+ {:name "function"
+  :display-string "function                          function function_name()"
+  :insert {:type :snippet
+           :value "function ${1:function_name}(${2:self})\n\t${0:-- do things}\nend"}}
+ {:name "local"
+  :display-string "local                             local name = value"
+  :insert {:type :snippet
+           :value "local ${1:name} = ${0:value}"}}
+ {:name "for"
+  :display-string "for                               for i = 1, 10"
+  :insert {:type :snippet
+           :value "for ${1:i} = ${2:1}, ${3:10} do\n\t${0:-- do things}\nend"}}
+ {:name "fori"
+  :display-string "fori                              for i, v in ipairs()"
+  :insert {:type :snippet
+           :value "for ${1:i}, ${2:v} in ipairs(${3:table_name}) do\n\t${0:-- do things}\nend"}}
+ {:name "forp"
+  :display-string "forp                              for k, v in pairs()"
+  :insert {:type :snippet
+           :value "for ${1:k}, ${2:v} in pairs(${3:table_name}) do\n\t${0:-- do things}\nend"}}]

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -55,6 +55,10 @@
    :indent {:begin #"^([^-]|-(?!-))*((\b(else|function|then|do|repeat)\b((?!\b(end|until)\b)[^\"'])*)|(\{\s*))$"
             :end #"^\s*((\b(elseif|else|end|until)\b)|(\})|(\)))"}
    :line-comment "--"
+   :commit-characters {:method #{"("}
+                       :function #{"("}
+                       :field #{"."}
+                       :module #{"."}}
    :patterns [{:captures {1 {:name "keyword.control.lua"}
                           2 {:name "entity.name.function.scope.lua"}
                           3 {:name "entity.name.function.lua"}
@@ -575,7 +579,7 @@
                               preprocessed-module-build-targets)})])))))))
 
 (g/defnk produce-completions [completion-info module-completion-infos script-intelligence-completions]
-  (code-completion/combine-completions completion-info module-completion-infos script-intelligence-completions))
+  (lua/combine-completions completion-info module-completion-infos script-intelligence-completions))
 
 (g/defnk produce-breakpoints [resource regions]
   (into []

--- a/editor/src/clj/editor/code_completion.clj
+++ b/editor/src/clj/editor/code_completion.clj
@@ -57,7 +57,7 @@
     name    code completion identifier
 
   Optional kv-args:
-    :snippet              LSP-style snippet string for the code completion,
+    :insert-snippet       LSP-style snippet string for the code completion,
                           mutually exclusive with :insert-string
     :insert-string        literal snippet string for the code completion,
                           mutually exclusive with :snippet
@@ -73,13 +73,13 @@
                           documentation, otherwise, it can be either:
                           - {:type :plaintext :value \"literal doc\"}
                           - {:type :markdown  :value \"markdown doc\"}"
-  [name & {:keys [snippet insert-string display-string type commit-characters detail doc]}]
-  {:pre [(not (and insert-string snippet))]
+  [name & {:keys [insert-snippet insert-string display-string type commit-characters detail doc]}]
+  {:pre [(not (and insert-string insert-snippet))]
    :post [(s/assert ::completion %)]}
   (cond-> {:name name
            :display-string (or display-string name)
            :insert (cond
-                     snippet {:type :snippet :value snippet}
+                     insert-snippet {:type :snippet :value insert-snippet}
                      insert-string {:type :plaintext :value insert-string}
                      :else {:type :plaintext :value name})}
           type
@@ -154,7 +154,7 @@
     ;;    string
     ;;
     ;; Additionally, we don't support nested placeholders like ${1:aa ${2:bb}},
-    ;; but we still want to build meaning default strings (equivalent to
+    ;; but we still want to build meaningful default strings (equivalent to
     ;; ${1:aa bb}), we do this processing during the "collect tab trigger info"
     ;; step.
     (letfn [;; Part of step 1: convert ast of placeholder contents to string
@@ -165,7 +165,7 @@
                (case token
                  ;; :snippet, :text, :text_esc and :err are unreachable because
                  ;; they only exist on the top level, while content-string is
-                 ;; used to build string for choices,variables and placeholders
+                 ;; used to build string for choices, variables and placeholders
                  :rule (content-string sb (first children))
                  :newline (.append sb \newline)
                  ;; tab stop is LSP term, so we use it in the snippet

--- a/editor/src/clj/editor/code_completion.clj
+++ b/editor/src/clj/editor/code_completion.clj
@@ -13,55 +13,280 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.code-completion
-  (:require [clojure.set :as set]
-            [clojure.string :as string]
-            [editor.lua :as lua]
+  (:require [clj-antlr.core :as antlr]
+            [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [internal.util :as util]))
 
-(defn replace-alias [s alias]
-  (string/replace s #".*\." (str alias ".")))
+;; Completion spec
+(s/def ::name string?) ;; used for filtering
+(s/def ::display-string string?) ;; used for view
+(s/def :editor.code-completion.insert/type #{:snippet :plaintext})
+(s/def :editor.code-completion.insert/value string?)
+(s/def ::insert
+  (s/keys :req-un [:editor.code-completion.insert/type
+                   :editor.code-completion.insert/value]))
+(s/def ::type
+  #{;; defold-specific
+    :message
+    ;; shared with vscode
+    :text :method :function :constructor :field :variable :class :interface
+    :module :property :unit :value :enum :keyword :snippet :color :file
+    :reference :folder :enum-member :constant :struct :event :operator
+    :type-parameter})
+(defn- one-character-long? [^String s]
+  (= 1 (.length s)))
+(s/def ::commit-characters
+  (s/coll-of (s/and string? one-character-long?) :kind set?))
+;; Detail is rendered after :display-string less prominently, e.g. function
+;; signature or type annotation
+(s/def ::detail string?)
+(s/def :editor.code-completion.doc/type #{:markdown :plaintext})
+(s/def :editor.code-completion.doc/value string?)
+(s/def ::doc
+  (s/keys :req-un [:editor.code-completion.doc/type
+                   :editor.code-completion.doc/value]))
+(s/def ::completion
+  (s/keys :req-un [::name ::display-string ::insert]
+          :opt-un [::type ::commit-characters ::detail ::doc]))
 
-(defn make-completions [resource-completion include-locals? namespace-alias]
-  (let [{:keys [vars local-vars functions local-functions]} resource-completion
-        var-info (if include-locals? (set/union vars local-vars) vars)
-        vars (map (fn [v] (lua/create-code-hint :variable v))
-                  var-info)
-        fn-info (if include-locals? (merge functions local-functions) functions)
-        fns  (map (fn [[fname {:keys [params]}]]
-                    (let [n (if namespace-alias (replace-alias fname namespace-alias) fname)
-                          display-string (str n "(" (string/join ", " params)  ")")]
-                      (lua/create-code-hint :function n display-string display-string "" {:select params})))
-                  fn-info)]
-    (set (concat vars fns))))
+(defn make
+  "Create a code completion
 
-(defn make-local-completions
-  [completion-info]
-  {"" (make-completions completion-info true nil)})
+  Required arg:
+    name    code completion identifier
 
-(defn make-required-completions
-  [requires required-completion-infos]
-  (let [required-completion-info-by-module (into {} (map (juxt :module identity)) required-completion-infos)]
-    (reduce (fn [ret [alias module]]
-              (let [completion-info (required-completion-info-by-module module)
-                    completions (make-completions completion-info false alias)
-                    module-name (or alias "")]
-                (merge-with set/union
-                            ret
-                            {module-name completions}
-                            (when alias {"" #{(lua/create-code-hint :namespace alias)}}))))
-            {}
-            requires)))
+  Optional kv-args:
+    :snippet              LSP-style snippet string for the code completion,
+                          mutually exclusive with :insert-string
+    :insert-string        literal snippet string for the code completion,
+                          mutually exclusive with :snippet
+    :display-string       code completion label shown in the completion popup
+    :type                 completion type, either Defold-specific :message or
+                          LSP-style :module, :function, :property etc.
+    :commit-characters    a set of one character long strings that accept the
+                          suggested completion if typed when the completion is
+                          selected
+    :detail               string with additional information to display in the
+                          completion popup, e.g. type or symbol information
+    :doc                  if a string, it is assumed to be a markdown
+                          documentation, otherwise, it can be either:
+                          - {:type :plaintext :value \"literal doc\"}
+                          - {:type :markdown  :value \"markdown doc\"}"
+  [name & {:keys [snippet insert-string display-string type commit-characters detail doc]}]
+  {:pre [(not (and insert-string snippet))]
+   :post [(s/assert ::completion %)]}
+  (cond-> {:name name
+           :display-string (or display-string name)
+           :insert (cond
+                     snippet {:type :snippet :value snippet}
+                     insert-string {:type :plaintext :value insert-string}
+                     :else {:type :plaintext :value name})}
+          type
+          (assoc :type type)
+          commit-characters
+          (assoc :commit-characters commit-characters)
+          detail
+          (assoc :detail detail)
+          doc
+          (assoc :doc (if (string? doc)
+                        {:type :markdown :value doc}
+                        doc))))
 
-(defn combine-completions
-  [local-completion-info required-completion-infos script-intelligence-completions]
-  (merge-with (fn [dest new]
-                (let [taken-display-strings (into #{} (map :display-string) dest)]
-                  (into dest
-                        (comp (remove #(contains? taken-display-strings (:display-string %)))
-                              (util/distinct-by :display-string))
-                        new)))
-              lua/defold-docs
-              lua/lua-std-libs-docs
-              script-intelligence-completions
-              (make-local-completions local-completion-info)
-              (make-required-completions (:requires local-completion-info) required-completion-infos)))
+(def ^:private snippet-parser
+  (antlr/parser (slurp (io/resource "lsp-snippet.g4"))))
+
+;; Insertion spec
+(defn- monotonously-increasing-range? [{:keys [from to]}]
+  (<= from to))
+(s/def ::insert-string string?)
+(s/def ::range (s/and (s/cat :from int? :to int?) monotonously-increasing-range?))
+(defn- non-intersecting-sorted-ranges? [conformed-ranges]
+  (->> conformed-ranges
+       (partition 2 1)
+       (every? (fn [[a b]]
+                 (<= (:to a) (:from b))))))
+(s/def ::ranges (s/and (s/coll-of ::range :kind vector?) non-intersecting-sorted-ranges?))
+(s/def ::exit-ranges ::ranges)
+(s/def ::choices (s/coll-of string? :kind vector?))
+(s/def ::tab-trigger (s/keys :req-un [::ranges]
+                             :opt-un [::choices]))
+(s/def ::tab-triggers (s/coll-of ::tab-trigger :kind vector?))
+(s/def ::insertion
+  (s/keys :req-un [::insert-string]
+          :opt-un [::tab-triggers ::exit-ranges]))
+
+(defn evaluate-snippet
+  "Convert LSP-style snippet string to an editor snippet
+
+  The editor supports:
+    - positional tab stops (tab triggers in editor terms), e.g. $1 and ${1}
+    - escaping $, } and \\ with \\
+    - exit tab stops (triggers in editor terms) $0
+    - default values, e.g. ${1:default}
+    - choices, e.g. ${1|one,two,three|} (first choice is inserted by default)
+
+  The editor recognizes, but does not support:
+    - nested placeholders, ${1:foo ${2:bar}} — gets converted to ${1:foo bar}
+    - variables, ${TM_FILENAME:foo} — gets converted to foo
+  The editor does not recognize:
+    - variable transforms, e.g. ${TM_FILENAME/(.*)\\..+$/$1/} is error and gets
+      inserted as is
+
+  Returns insertion map (see [[insertion]] for details)
+
+  See also:
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax"
+  [snippet-string]
+  (let [ast (antlr/parse snippet-parser snippet-string)]
+    ;; Parsing notes
+    ;; Consider these 2 snippets: $1$1 and $1${1:fo}, what should the evaluated
+    ;; snippet be? In vscode, the former snippet evaluates to a string "" with
+    ;; a single tab trigger 0..0, while the latter evaluates to a string "fofo"
+    ;; with 2 tab triggers 0..2 and 2..4.
+    ;; To support this behavior, we need to process the ast 2 times:
+    ;; 1. collect information about tab triggers in the snippet, e.g. build a
+    ;;    map from tab trigger id to its choices and placeholder text. It is
+    ;;    possible to define both, multiple times, for the same placeholder! We
+    ;;    collect both, but otherwise use last-wins policy.
+    ;; 2. build the insert string using the collected tab trigger information,
+    ;;    and at the same time collect indices for tab triggers in the resulting
+    ;;    string
+    ;;
+    ;; Additionally, we don't support nested placeholders like ${1:aa ${2:bb}},
+    ;; but we still want to build meaning default strings (equivalent to
+    ;; ${1:aa bb}), we do this processing during the "collect tab trigger info"
+    ;; step.
+    (letfn [;; Part of step 1: convert ast of placeholder contents to string
+            (content-string
+              ([ast]
+               (str (content-string (StringBuilder.) ast)))
+              ([^StringBuilder sb [token & children]]
+               (case token
+                 ;; :snippet, :text, :text_esc and :err are unreachable because
+                 ;; they only exist on the top level, while content-string is
+                 ;; used to build string for choices,variables and placeholders
+                 :rule (content-string sb (first children))
+                 :newline (.append sb \newline)
+                 ;; tab stop is LSP term, so we use it in the snippet
+                 :tab_stop sb
+                 ;; :naked_tab_stop and :curly_tab_stop rules are unreachable
+                 ;; because we don't recurse into the :tab_stop
+                 :placeholder (content-string sb (nth children 4))
+                 :placeholder_content (reduce content-string sb children)
+                 :placeholder_text (.append sb (first children))
+                 :placeholder_esc (.append sb (second children))
+                 :choice (content-string sb (nth children 4))
+                 :choice_elements (if-let [ast (first children)]
+                                    (content-string sb ast)
+                                    sb)
+                 :choice_element (reduce content-string sb children)
+                 :choice_text (.append sb (first children))
+                 :choice_esc (.append sb (second children))
+                 :variable (content-string sb (first children))
+                 :naked_variable sb
+                 :curly_variable sb
+                 :placeholder_variable (content-string sb (nth children 4))
+                 sb)))
+            ;; Step 1: collect tab trigger information
+            (prepare-tab-triggers [tab-triggers [token & children]]
+              (case token
+                :snippet (reduce prepare-tab-triggers tab-triggers children)
+                :rule (prepare-tab-triggers tab-triggers (first children))
+                :tab_stop (reduce prepare-tab-triggers tab-triggers children)
+                :naked_tab_stop (update tab-triggers (nth children 1) #(or % {}))
+                :curly_tab_stop (update tab-triggers (nth children 2) #(or % {}))
+                :placeholder (update tab-triggers (nth children 2) assoc
+                                     :placeholder (content-string (nth children 4)))
+                :choice (update tab-triggers (nth children 2) assoc
+                                :choice (into []
+                                              (comp (partition-all 2)
+                                                    (map (comp content-string first)))
+                                              (next (nth children 4))))
+                tab-triggers))]
+      (let [;; Execute step 1:
+            prepared-tab-triggers (prepare-tab-triggers {} ast)
+            ;; Step 2: use collected tab trigger info to produce the resulting string
+            sb (StringBuilder.)]
+        (letfn [(content-with-ranges [tab-triggers tab-id]
+                  (let [start (.length sb)
+                        {:keys [placeholder choice]} (get tab-triggers tab-id)
+                        _ (.append sb (or placeholder (first choice) ""))
+                        end (.length sb)]
+                    (update-in tab-triggers [tab-id :ranges] (fnil conj []) [start end])))
+                (complete-snippet [tab-triggers [token & children]]
+                  (case token
+                    :snippet (reduce complete-snippet tab-triggers children)
+                    :text (do (.append sb (first children)) tab-triggers)
+                    :text_esc (do (.append sb (second children)) tab-triggers)
+                    :err (do (.append sb (first children)) tab-triggers)
+                    :newline (do (.append sb \newline) tab-triggers)
+                    :rule (complete-snippet tab-triggers (first children))
+                    :tab_stop (complete-snippet tab-triggers (first children))
+                    :naked_tab_stop (content-with-ranges tab-triggers (second children))
+                    :curly_tab_stop (content-with-ranges tab-triggers (nth children 2))
+                    :placeholder (content-with-ranges tab-triggers (nth children 2))
+                    :choice (content-with-ranges tab-triggers (nth children 2))
+                    :variable (complete-snippet tab-triggers (first children))
+                    :naked_variable tab-triggers
+                    :curly_variable tab-triggers
+                    :placeholder_variable (do (content-string sb (nth children 4)) tab-triggers)
+                    tab-triggers))]
+          (let [;; Execute step 2 using prepared tab triggers
+                tab-triggers (complete-snippet prepared-tab-triggers ast)
+                insert-string (.toString sb)
+                ;; Final post-processing:
+                ;; handle the exit tab trigger separately (identified as $0),
+                ;; sort the other tab triggers etc.
+                non-exit-tab-triggers (dissoc tab-triggers "0")
+                explicit-exit (get tab-triggers "0")]
+            (cond->
+              {:insert-string insert-string}
+              explicit-exit
+              (assoc :exit-ranges (vec (sort (into [] (dedupe) (:ranges explicit-exit)))))
+              (pos? (count non-exit-tab-triggers))
+              (assoc :tab-triggers
+                     ;; We want to merge tab triggers sharing the same range
+                     ;; into single tab trigger. We need to deduplicate the
+                     ;; ranges over all tab triggers, since we can get a snippet
+                     ;; like $1$2 in addition to $1$1.
+                     (->> non-exit-tab-triggers
+                          (eduction
+                            (mapcat
+                              (fn [[id tab-trigger]]
+                                (eduction
+                                  (map #(assoc tab-trigger :id id :range %))
+                                  (:ranges tab-trigger))))
+                            (util/distinct-by :range))
+                          (group-by :id)
+                          (sort-by key)
+                          (mapv (fn [[_ coll]]
+                                  (let [{:keys [choice]} (first coll)]
+                                    (cond-> {:ranges (vec (sort (mapv :range coll)))}
+                                            choice
+                                            (assoc :choices choice))))))))))))))
+
+(defn insertion
+  "Convert completion item to insertion item
+
+  Returns a map with following keys:
+    :insert-string    required, the string to insert
+    :exit-ranges      optional, non-empty sorted vector of non-intersecting
+                      from+to index pairs in the range [0, string-length] that
+                      defines the exit points for the snippet tab triggers. If
+                      absent, it is assumed that selection should move to the
+                      end of the inserted snippet
+    :tab-triggers     optional, present only if the completion snippet defines
+                      tab triggers, a vector of maps with following keys:
+                        :ranges     non-empty sorted vector of non-intersecting
+                                    from+to index pairs in the range
+                                    [0, string-length]
+                        :choices    optional, present only if the tab trigger
+                                    defines choices, a vector of strings"
+  [completion]
+  {:pre [(s/assert ::completion completion)]
+   :post [(s/assert ::insertion %)]}
+  (let [{:keys [type value]} (:insert completion)]
+    (case type
+      :plaintext {:insert-string value}
+      :snippet (evaluate-snippet value))))

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -20,6 +20,7 @@
             [dynamo.graph :as g]
             [editor.code.data :as data]
             [editor.lsp.async :as lsp.async]
+            [editor.code-completion :as code-completion]
             [editor.lsp.base :as lsp.base]
             [editor.lsp.jsonrpc :as lsp.jsonrpc]
             [editor.lua :as lua]
@@ -29,7 +30,7 @@
             [service.log :as log])
   (:import [editor.code.data Cursor CursorRange]
            [java.io File InputStream]
-           [java.lang ProcessHandle ProcessBuilder$Redirect]
+           [java.lang ProcessBuilder$Redirect ProcessHandle]
            [java.net URI]
            [java.util Map]
            [java.util.concurrent TimeUnit]
@@ -145,10 +146,14 @@
 (s/def ::pull-diagnostics #{:none :text-document :workspace})
 (s/def ::goto-definition boolean?)
 (s/def ::find-references boolean?)
+(s/def ::resolve boolean?) ;; if completion item can be resolved to add e.g. documentation
+(s/def ::trigger-characters (s/coll-of string? :kind set?))
+(s/def ::completion (s/keys :req-un [::resolve ::trigger-characters]))
 (s/def ::capabilities (s/keys :req-un [::text-document-sync
                                        ::pull-diagnostics
                                        ::goto-definition
-                                       ::find-references]))
+                                       ::find-references]
+                              :opt-un [::completion]))
 
 (defn- lsp-position->editor-cursor [{:keys [line character]}]
   (data/->Cursor line character))
@@ -199,33 +204,37 @@
 (defn- lsp-capabilities->editor-capabilities [{:keys [textDocumentSync
                                                       diagnosticProvider
                                                       definitionProvider
-                                                      referencesProvider]}]
-  {:text-document-sync (cond
-                         (nil? textDocumentSync)
-                         {:change :none :open-close false}
+                                                      referencesProvider
+                                                      completionProvider]}]
+  (cond-> {:text-document-sync (cond
+                                 (nil? textDocumentSync)
+                                 {:change :none :open-close false}
 
-                         (number? textDocumentSync)
-                         {:open-close true
-                          :change (lsp-text-document-sync-kind->editor-sync-kind textDocumentSync)}
+                                 (number? textDocumentSync)
+                                 {:open-close true
+                                  :change (lsp-text-document-sync-kind->editor-sync-kind textDocumentSync)}
 
-                         (map? textDocumentSync)
-                         {:open-close (:openClose textDocumentSync false)
-                          :change (lsp-text-document-sync-kind->editor-sync-kind (:change textDocumentSync 0))}
+                                 (map? textDocumentSync)
+                                 {:open-close (:openClose textDocumentSync false)
+                                  :change (lsp-text-document-sync-kind->editor-sync-kind (:change textDocumentSync 0))}
 
-                         :else
-                         (throw (ex-info "Invalid text document sync kind" {:value textDocumentSync})))
-   :pull-diagnostics (cond
-                       (nil? diagnosticProvider) :none
-                       (:workspaceDiagnostics diagnosticProvider) :workspace
-                       :else :text-document)
-   :goto-definition (cond
-                      (boolean? definitionProvider) definitionProvider
-                      (map? definitionProvider) true
-                      :else false)
-   :find-references (cond
-                      (boolean? referencesProvider) referencesProvider
-                      (map? referencesProvider) true
-                      :else false)})
+                                 :else
+                                 (throw (ex-info "Invalid text document sync kind" {:value textDocumentSync})))
+           :pull-diagnostics (cond
+                               (nil? diagnosticProvider) :none
+                               (:workspaceDiagnostics diagnosticProvider) :workspace
+                               :else :text-document)
+           :goto-definition (cond
+                              (boolean? definitionProvider) definitionProvider
+                              (map? definitionProvider) true
+                              :else false)
+           :find-references (cond
+                              (boolean? referencesProvider) referencesProvider
+                              (map? referencesProvider) true
+                              :else false)}
+          completionProvider
+          (assoc :completion {:resolve (boolean (:resolveProvider completionProvider))
+                              :trigger-characters (set (:triggerCharacters completionProvider))})))
 
 (defn- configuration-handler [project]
   (fn [{:keys [items]}]
@@ -254,6 +263,46 @@
             nil))
         items))))
 
+(def ^:private completion-item-tag-deprecated 1)
+(def ^:private completion-item-tag:lsp->editor
+  {completion-item-tag-deprecated :deprecated})
+
+(def ^:private insert-text-mode-as-is 1)
+(def ^:private insert-text-mode-adjust-indentation 2)
+
+(def ^:private insert-text-format-plaintext 1)
+(def ^:private insert-text-format-snippet 2)
+(def ^:private insert-text-format:lsp->editor
+  {insert-text-format-plaintext :plaintext
+   insert-text-format-snippet :snippet})
+
+(def ^:private completion-item-kind:lsp->editor
+  {1 :text
+   2 :method
+   3 :function
+   4 :constructor
+   5 :field
+   6 :variable
+   7 :class
+   8 :interface
+   9 :module
+   10 :property
+   11 :unit
+   12 :value
+   13 :enum
+   14 :keyword
+   15 :snippet
+   16 :color
+   17 :file
+   18 :reference
+   19 :folder
+   20 :enum-member
+   21 :constant
+   22 :struct
+   23 :event
+   24 :operator
+   25 :type-parameter})
+
 (defn- initialize [jsonrpc project]
   (lsp.jsonrpc/request!
     jsonrpc
@@ -266,7 +315,23 @@
          :capabilities {:workspace {:diagnostics {}}
                         :textDocument {:definition {:dynamicRegistration false
                                                     :linkSupport true}
-                                       :references {:dynamicRegistration false}}}
+                                       :references {:dynamicRegistration false}}
+                        :completion {:dynamicRegistration false
+                                     :completionItem {:snippetSupport true
+                                                      :commitCharactersSupport true
+                                                      :documentationFormat ["markdown" "plaintext"]
+                                                      :deprecatedSupport true
+                                                      :preselectSupport false
+                                                      :tagSupport {:valueSet [completion-item-tag-deprecated]}
+                                                      :insertReplaceSupport false
+                                                      :resolveSupport {:properties ["detail"
+                                                                                    "documentation"
+                                                                                    "additionalTextEdits"]}
+                                                      :insertTextModeSupport {:valueSet [insert-text-mode-as-is
+                                                                                         insert-text-mode-adjust-indentation]}
+                                                      :labelDetailsSupport false}
+                                     :completionItemKind {:valueSet (vec (sort (keys completion-item-kind:lsp->editor)))}
+                                     :insertTextMode insert-text-mode-adjust-indentation}}
          :workspaceFolders [{:uri uri :name title}]}))
     (* 60 1000)))
 
@@ -434,6 +499,72 @@
             (into []
                   (keep #(lsp-location-or-location-link->editor-location % project evaluation-context))
                   result)))))))
+
+(defn- markup-content:lsp->editor [{:keys [kind value]}]
+  {:pre [(#{"plaintext" "markdown"} kind)
+         (string? value)]}
+  {:type (keyword kind)
+   :value value})
+
+(defn- text-edit:lsp->editor [{:keys [range newText]}]
+  {:range (lsp-range->editor-cursor-range range)
+   :new-text newText})
+
+(defn- completion-item:lsp->editor
+  [{:keys [label filterText insertText tags deprecated kind
+           insertTextMode insertTextFormat commitCharacters
+           detail documentation additionalTextEdits]
+    :or {insertTextMode insert-text-mode-adjust-indentation
+         insertTextFormat insert-text-format-plaintext}
+    :as source}]
+  (let [text-format-key (case (insert-text-format:lsp->editor insertTextFormat)
+                          :plaintext :insert-string
+                          :snippet :snippet)]
+    {:completion (code-completion/make
+                   (or filterText label)
+                   :display-string label
+                   text-format-key (or insertText label)
+                   :commit-characters (set commitCharacters)
+                   :type (some-> kind completion-item-kind:lsp->editor)
+                   :detail detail
+                   :doc (cond
+                          (string? documentation) {:type :plaintext :value documentation}
+                          documentation (markup-content:lsp->editor documentation)))
+     ;; Not currently present in completions
+     :tags (into (if deprecated #{:deprecated} #{})
+                 (map completion-item-tag:lsp->editor)
+                 tags)
+     :additional-text-edits (mapv text-edit:lsp->editor additionalTextEdits)
+     ;; source item to use for detail/doc resolution
+     :raw-completion-item source}))
+
+(defn completion
+  "See also:
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion"
+  [resource cursor item-converter]
+  (raw-request
+    (lsp.jsonrpc/notification
+      "textDocument/completion"
+      {:textDocument {:uri (resource-uri resource)}
+       :position (editor-cursor->lsp-position cursor)})
+    (bound-fn [result _]
+      (let [{:keys [isIncomplete items]} (if (map? result)
+                                           result
+                                           {:isIncomplete false
+                                            :items result})]
+        {:complete (not isIncomplete)
+         :items (mapv (comp item-converter completion-item:lsp->editor) items)}))))
+
+(defn resolve-completion
+  "See also:
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem_resolve"
+  [completion-item item-converter]
+  (raw-request
+    (lsp.jsonrpc/notification "completionItem/resolve" (:raw-completion-item completion-item))
+    (bound-fn [result _]
+      (item-converter
+        (update completion-item :completion conj (select-keys (:completion (completion-item:lsp->editor result))
+                                                              [:detail :doc :additional-text-edits]))))))
 
 (defn find-references
   "See also:

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -56,6 +56,7 @@
   (let [sections (cond-> []
                          (pos? (count description))
                          (conj description)
+
                          (= :function type)
                          (into (let [{:keys [returnvalues parameters]} el]
                                  (cond-> []
@@ -66,6 +67,7 @@
                                          (pos? (count returnvalues))
                                          (conj (str "**Returns:**\n"
                                                     (make-doc-args-table returnvalues))))))
+
                          (pos? (count examples))
                          (conj (str "**Examples:**\n" examples)))]
     (when (pos? (count sections))
@@ -125,7 +127,7 @@
 (s/def ::documentation
   (s/map-of string? (s/coll-of ::code-completion/completion)))
 
-(defn defold-documentation []
+(defn- defold-documentation []
   {:post [(s/assert ::documentation %)]}
   (make-completion-map
     (eduction
@@ -137,7 +139,7 @@
                [ns-path (code-completion/make name
                                               :type type
                                               :display-string (make-display-string el)
-                                              :snippet (make-snippet el)
+                                              :insert-snippet (make-snippet el)
                                               :doc (make-markdown-doc el))])))
       docs)))
 
@@ -184,7 +186,7 @@
 (def defined-globals
   (extract-globals-from-completions defold-docs))
 
-(defn lua-base-documentation []
+(defn- lua-base-documentation []
   {:post [(s/assert ::documentation %)]}
   {"" (into []
             (util/distinct-by :display-string)
@@ -229,12 +231,12 @@
                            name
                            :type :function
                            :display-string (str name "(" (string/join ", " params) ")")
-                           :snippet (str name
-                                         "("
-                                         (->> params
-                                              (map-indexed #(format "${%s:%s}" (inc %1) %2))
-                                              (string/join ", "))
-                                         ")"))])))
+                           :insert-snippet (str name
+                                                "("
+                                                (->> params
+                                                     (map-indexed #(format "${%s:%s}" (inc %1) %2))
+                                                     (string/join ", "))
+                                                ")"))])))
        functions)]))
 
 (defn- make-ast-completions [local-completion-info required-completion-infos]

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -13,148 +13,133 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.lua
-  (:require [clojure.java.io :as io]
-            [clojure.edn :as edn]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.set :as set]
+            [clojure.spec.alpha :as s]
             [clojure.string :as string]
+            [editor.code-completion :as code-completion]
             [editor.protobuf :as protobuf]
-            [internal.util :as util]
-            [schema.core :as s]
-            [service.log :as log])
-  (:import [com.dynamo.scriptdoc.proto ScriptDoc$Type ScriptDoc$Document ScriptDoc$Element ScriptDoc$Parameter ScriptDoc$ReturnValue]
+            [internal.util :as util])
+  (:import [com.dynamo.scriptdoc.proto ScriptDoc$Document]
            [org.apache.commons.io FilenameUtils]))
 
 (set! *warn-on-reflection* true)
 
-(defn- load-sdoc [path]
-  (try
-    (with-open [in (io/input-stream (io/resource path))]
-      (let [^ScriptDoc$Document doc (.build (protobuf/read-text-into! (ScriptDoc$Document/newBuilder) in))
-            elements (.getElementsList doc)]
-        (reduce
-         (fn [ns-elements ^ScriptDoc$Element element]
-           (let [qname (.getName element)
-                 dot (.indexOf qname ".")
-                 ns (if (= dot -1) "" (subs qname 0 dot))]
-             (update ns-elements ns conj element)))
-         nil
-         elements)))
-    (catch Exception e
-      (log/warn :message "Failed to load documentation resource." :path path :exception e)
-      {})))
-
-(def ^:private docs (string/split "base bit buffer builtins camera collectionfactory collectionproxy coroutine crash debug facebook factory go gui html5 http iac iap image io json label math model msg os package particlefx physics profiler push render resource socket sound sprite string sys table tilemap timer vmath webview window zlib" #" "))
+(def ^:private docs
+  ["base" "bit" "buffer" "builtins" "camera" "collectionfactory"
+   "collectionproxy" "coroutine" "crash" "debug" "facebook" "factory" "go" "gui"
+   "html5" "http" "iac" "iap" "image" "io" "json" "label" "math" "model" "msg"
+   "os" "package" "particlefx" "physics" "profiler" "push" "render" "resource"
+   "socket" "sound" "sprite" "string" "sys" "table" "tilemap" "timer" "vmath"
+   "webview" "window" "zlib"])
 
 (defn- sdoc-path [doc]
   (format "doc/%s_doc.sdoc" doc))
 
-(defn load-documentation []
-  (let [ns-elements (reduce
-                     (fn [sofar doc]
-                       (merge-with concat sofar (load-sdoc (sdoc-path doc))))
-                     nil
-                     docs)
-        namespaces (keys ns-elements)]
-    (reduce
-     (fn [sofar ns]
-       (let [e (-> (ScriptDoc$Element/newBuilder)
-                   (.setType ScriptDoc$Type/NAMESPACE)
-                   (.setName ns)
-                   (.setBrief "")
-                   (.setDescription "")
-                   (.build))]
-         (if (not= (.getName e) "")
-           sofar
-           (update sofar "" conj e))))
-     ns-elements
-     namespaces)))
+(defn- load-sdoc [doc-name]
+  (:elements (protobuf/read-text ScriptDoc$Document (io/resource (sdoc-path doc-name)))))
 
-(defn- element-additional-info [^ScriptDoc$Element element]
-  (when (= (.getType element) ScriptDoc$Type/FUNCTION)
-    (string/join
-     (concat
-      [(.getDescription element)]
-      ["<br><br>"]
-      ["<b>Parameters:</b>"]
-      ["<br>"]
-      (for [^ScriptDoc$Parameter parameter (.getParametersList element)]
-        (concat
-         ["&#160;&#160;&#160;&#160;<b>"]
-         [(.getName parameter)]
-         ["</b> "]
-         [(.getDoc parameter)]
-         ["<br>"]))
-      (when (< 0 (.getReturnvaluesCount element))
-        (concat
-         ["<br>"]
-         ["<b>Returns:</b><br>"]
-         ["&#160;&#160;&#160;&#160;<b>"]
-         (for [^ScriptDoc$ReturnValue retval (.getReturnvaluesList element)]
-           [(format "%s: %s" (.getName retval) (.getDoc retval))])))))))
+(defn- make-doc-args-table [args]
+  (str "<table>"
+       (->> args
+            (map
+              (fn [{:keys [name doc types]}]
+                (format "<tr><td><code>%s</code></td><td><code>%s</code></td><td>%s</td></tr>"
+                        name
+                        (string/join ", " types)
+                        (or doc ""))))
+            string/join)
+       "</table>"))
 
-(defn- element-display-string [^ScriptDoc$Element element include-optional-params?]
-  (let [base (.getName element)
-        rest (when (= (.getType element) ScriptDoc$Type/FUNCTION)
-               (let [params (for [^ScriptDoc$Parameter parameter (.getParametersList element)]
-                              (.getName parameter))
-                     display-params (if include-optional-params? params (remove #(= \[ (first %)) params))]
-                 (str "(" (string/join ", " display-params) ")")))]
-    (str base rest)))
+(defn- make-markdown-doc [{:keys [description type examples] :as el}]
+  (let [sections (cond-> []
+                         (pos? (count description))
+                         (conj description)
+                         (= :function type)
+                         (into (let [{:keys [returnvalues parameters]} el]
+                                 (cond-> []
+                                         (pos? (count parameters))
+                                         (conj (str
+                                                 "**Parameters:**\n"
+                                                 (make-doc-args-table parameters)))
+                                         (pos? (count returnvalues))
+                                         (conj (str "**Returns:**\n"
+                                                    (make-doc-args-table returnvalues))))))
+                         (pos? (count examples))
+                         (conj (str "**Examples:**\n" examples)))]
+    (when (pos? (count sections))
+      (string/join "\n\n" sections))))
 
-(defn- element-tab-triggers [^ScriptDoc$Element element]
-  (when (= (.getType element) ScriptDoc$Type/FUNCTION)
-    (let [params (for [^ScriptDoc$Parameter parameter (.getParametersList element)]
-                   (.getName parameter))]
-      {:select (filterv #(not= \[ (first %)) params) :exit (when params ")")})))
+(defn- make-display-string [{:keys [name type parameters]}]
+  (str name (when (= :function type)
+              (str "(" (string/join ", " (mapv :name parameters)) ")"))))
 
-(defn create-code-hint
-  ([type name]
-   (create-code-hint type name name name nil nil))
-  ([type name display-string insert-string doc tab-triggers]
-   (cond-> {:type type
-            :name name
-            :display-string display-string
-            :insert-string insert-string}
+(defn- make-snippet [{:keys [name type parameters]}]
+  (str name (when (= :function type)
+              (str "("
+                   (->> parameters
+                        (keep-indexed (fn [i {:keys [name]}]
+                                        (when-not (string/starts-with? name "[")
+                                          (format "${%s:%s}" (inc i) name))))
+                        (string/join ", "))
+                   ")"))))
 
-           (not-empty doc)
-           (assoc :doc doc)
+(defn make-completion-map
+  "Make a completion map from reducible of ns path + completion tuples
 
-           (some? tab-triggers)
-           (assoc :tab-triggers tab-triggers))))
+  Args:
+    ns-path       a vector of strings that defines a nested context for the
+                  completion, e.g. [\"socket\" \"dns\"] with the completion
+                  \"toip\" defines a completion socket.dns.toip
+    completion    a completion map
 
-(def ^:private documentation-schema
-  {s/Str [{:type (s/enum :constant :function :message :namespace :property :snippet :variable :keyword)
-           :name s/Str
-           :display-string s/Str
-           :insert-string s/Str
-           (s/optional-key :doc) s/Str
-           (s/optional-key :tab-triggers) (s/constrained {:select [s/Str]
-                                                          (s/optional-key :types) [(s/enum :arglist :expr :name)]
-                                                          (s/optional-key :start) s/Str
-                                                          (s/optional-key :exit) s/Str}
-                                                         (fn [tab-trigger]
-                                                           (or (nil? (:types tab-trigger))
-                                                               (= (count (:select tab-trigger))
-                                                                  (count (:types tab-trigger)))))
-                                                         "specified :types count equals :select count")}]})
+  Returns a map from completion context string (e.g. \"socket.dns\") to
+  available completions for that context."
+  [ns-path+completions]
+  (letfn [(ensure-modules [acc ns-path]
+            (reduce (fn [acc module-path]
+                      (let [parent-path (pop module-path)
+                            module-name (peek module-path)
+                            k [:module module-name]]
+                        (update acc (string/join "." parent-path)
+                                (fn [m]
+                                  (if (contains? m k)
+                                    m
+                                    (assoc m k (code-completion/make module-name :type :module)))))))
+                    acc
+                    (drop 1 (reductions conj [] ns-path))))]
+    (let [context->key->completion
+          (reduce
+            (fn [acc [ns-path completion]]
+              (-> acc
+                  (ensure-modules ns-path)
+                  (update (string/join "." ns-path) assoc [(:type completion) (:display-string completion)] completion)))
+            {}
+            ns-path+completions)]
+      (into {}
+            (map (fn [[context key->completion]]
+                   [context (vec (sort-by :display-string (vals key->completion)))]))
+            context->key->completion))))
+
+(s/def ::documentation
+  (s/map-of string? (s/coll-of ::code-completion/completion)))
 
 (defn defold-documentation []
-  (s/validate documentation-schema
-    (reduce (fn [result [ns elements]]
-              (let [global-results (get result "" [])
-                    new-result (assoc result ns (into []
-                                                      (comp (map (fn [^ScriptDoc$Element e]
-                                                                   (create-code-hint (protobuf/pb-enum->val (.getType e))
-                                                                                     (.getName e)
-                                                                                     (element-display-string e true)
-                                                                                     (element-display-string e false)
-                                                                                     (element-additional-info e)
-                                                                                     (element-tab-triggers e))))
-                                                            (util/distinct-by :display-string))
-                                                      elements))]
-                (if (= "" ns) new-result (assoc new-result "" (conj global-results (create-code-hint :namespace ns))))))
-            {}
-            (load-documentation))))
+  {:post [(s/assert ::documentation %)]}
+  (make-completion-map
+    (eduction
+      (mapcat load-sdoc)
+      (map (fn [raw-element]
+             (let [name-parts (string/split (:name raw-element) #"\.")
+                   ns-path (pop name-parts)
+                   {:keys [name type] :as el} (assoc raw-element :name (peek name-parts))]
+               [ns-path (code-completion/make name
+                                              :type type
+                                              :display-string (make-display-string el)
+                                              :snippet (make-snippet el)
+                                              :doc (make-markdown-doc el))])))
+      docs)))
 
 (def helper-keywords #{"assert" "collectgarbage" "dofile" "error" "getfenv" "getmetatable" "ipairs" "loadfile" "loadstring" "module" "next" "pairs" "pcall"
                        "print" "rawequal" "rawget" "rawset" "require" "select" "setfenv" "setmetatable" "tonumber" "tostring" "type" "unpack" "xpcall"})
@@ -183,8 +168,8 @@
 
 (def base-globals
   (into #{"coroutine" "package" "string" "table" "math" "io" "file" "os" "debug"}
-        (map #(.getName ^ScriptDoc$Element %))
-        (get (load-sdoc (sdoc-path "base")) "")))
+        (map :name)
+        (load-sdoc "base")))
 
 (defn extract-globals-from-completions [completions]
   (into #{}
@@ -200,27 +185,19 @@
   (extract-globals-from-completions defold-docs))
 
 (defn lua-base-documentation []
-  (s/validate documentation-schema
-              {"" (into []
-                        (util/distinct-by :display-string)
-                        (concat (map #(assoc % :type :snippet)
-                                     (-> (io/resource "lua-base-snippets.edn")
-                                         slurp
-                                         edn/read-string))
-                                (map (fn [constant]
-                                       {:type :constant
-                                        :name constant
-                                        :display-string constant
-                                        :insert-string constant})
-                                     lua-constants)
-                                (map (fn [keyword]
-                                       {:type :keyword
-                                        :name keyword
-                                        :display-string keyword
-                                        :insert-string keyword})
-                                     all-keywords)))}))
+  {:post [(s/assert ::documentation %)]}
+  {"" (into []
+            (util/distinct-by :display-string)
+            (concat (map #(assoc % :type :snippet)
+                         (-> (io/resource "lua-base-snippets.edn")
+                             slurp
+                             edn/read-string))
+                    (map #(code-completion/make % :type :constant)
+                         lua-constants)
+                    (map #(code-completion/make % :type :keyword)
+                         all-keywords)))})
 
-(def lua-std-libs-docs (lua-base-documentation))
+(def std-libs-docs (lua-base-documentation))
 
 (defn lua-module->path [module]
   (str "/" (string/replace module #"\." "/") ".lua"))
@@ -232,3 +209,60 @@
 
 (defn lua-module->build-path [module]
   (str (lua-module->path module) "c"))
+
+(defn- make-completion-info-completions [vars functions module-alias]
+  (eduction
+    cat
+    [(eduction
+       (map (fn [var-name]
+              [[] (code-completion/make var-name :type :variable)]))
+       vars)
+     (eduction
+       (map (fn [[qualified-name {:keys [params]}]]
+              (let [name-parts (string/split qualified-name #"\.")
+                    ns-path (pop name-parts)
+                    ns-path (if (and module-alias (pos? (count ns-path)))
+                              (assoc ns-path 0 module-alias)
+                              ns-path)
+                    name (peek name-parts)]
+                [ns-path (code-completion/make
+                           name
+                           :type :function
+                           :display-string (str name "(" (string/join ", " params) ")")
+                           :snippet (str name
+                                         "("
+                                         (->> params
+                                              (map-indexed #(format "${%s:%s}" (inc %1) %2))
+                                              (string/join ", "))
+                                         ")"))])))
+       functions)]))
+
+(defn- make-ast-completions [local-completion-info required-completion-infos]
+  (make-completion-map
+    (eduction
+      cat
+      [(make-completion-info-completions
+         (set/union (:vars local-completion-info) (:local-vars local-completion-info))
+         (merge (:functions local-completion-info) (:local-functions local-completion-info))
+         nil)
+       (let [module->completion-info (into {} (map (juxt :module identity)) required-completion-infos)]
+         (eduction
+           (mapcat (fn [[alias module]]
+                     (let [completion-info (module->completion-info module)]
+                       (make-completion-info-completions (:vars completion-info)
+                                                         (:functions completion-info)
+                                                         alias))))
+           (:requires local-completion-info)))])))
+
+(defn combine-completions
+  [local-completion-info required-completion-infos script-intelligence-completions]
+  (merge-with (fn [dest new]
+                (let [taken-display-strings (into #{} (map :display-string) dest)]
+                  (into dest
+                        (comp (remove #(contains? taken-display-strings (:display-string %)))
+                              (util/distinct-by :display-string))
+                        new)))
+              defold-docs
+              std-libs-docs
+              script-intelligence-completions
+              (make-ast-completions local-completion-info required-completion-infos)))

--- a/editor/src/clj/editor/script_api.clj
+++ b/editor/src/clj/editor/script_api.clj
@@ -54,6 +54,7 @@
                 (into [[ns-path (code-completion/make name :type :module :doc desc)]]
                       (mapcat #(make-completions child-path %))
                       (:members el)))
+
               "function"
               (let [{:keys [parameters]} el]
                 [[ns-path (code-completion/make
@@ -61,7 +62,8 @@
                             :type :function
                             :doc desc
                             :display-string (str name (build-param-string parameters :display-string))
-                            :snippet (str name (build-param-string parameters :snippet)))]])
+                            :insert-snippet (str name (build-param-string parameters :snippet)))]])
+
               (when name
                 [[ns-path (code-completion/make name :type :variable :doc desc)]])))]
     (->> (yaml/load (data/lines-reader lines) keyword)

--- a/editor/src/clj/editor/script_api.clj
+++ b/editor/src/clj/editor/script_api.clj
@@ -15,10 +15,12 @@
 (ns editor.script-api
   (:require [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.code-completion :as code-completion]
             [editor.code.data :as data]
             [editor.code.resource :as r]
             [editor.code.script-intelligence :as si]
             [editor.defold-project :as project]
+            [editor.lua :as lua]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
             [editor.yaml :as yaml]))
@@ -26,115 +28,45 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-(defmulti convert
-  "Converts YAML documentation input to the internal auto-complete format defined
-  in `editor.lua` namespace."
-  :type)
-
-(defn- name-with-ns
-  [ns name]
-  (if (nil? ns)
-    name
-    (str ns \. name)))
-
-(defmethod convert "table"
-  [{:keys [ns name members desc]}]
-  (let [name (name-with-ns ns name)]
-    (into [{:type :namespace
-            :name name
-            :doc desc
-            :display-string name
-            :insert-string name}]
-          (comp
-            (filter map?)
-            (map #(convert (assoc % :ns name))))
-          members)))
-
 (defn- bracketname?
   [x]
   (= \[ (first (:name x))))
 
-(defn- optional-param?
-  [x]
-  (or (:optional x) (bracketname? x)))
+(defn- build-param-string [params mode]
+  (str "("
+       (->> params
+            (keep-indexed
+              (fn [i {:keys [name optional] :as param}]
+                (case mode
+                  :display-string (if (and optional (not (bracketname? param)))
+                                    (str "[" name "]")
+                                    name)
+                  :snippet (when (and (not optional) (not (bracketname? param)))
+                             (format "${%s:%s}" (inc ^long i) name)))))
+            (string/join ", "))
+       ")"))
 
-(defn- param-names
-  [params remove-optional?]
-  (let [filter-optionals (if remove-optional?
-                           (filter #(not (optional-param? %)))
-                           (map #(if (and (:optional %) (not (bracketname? %)))
-                                   (assoc % :name (str "[" (:name %) "]"))
-                                   %)))]
-    (into [] (comp filter-optionals (map :name)) params)))
-
-(defn- build-param-string
-  ([params]
-   (build-param-string params false))
-  ([params remove-optional?]
-   (str "(" (string/join ", " (param-names params remove-optional?)) ")")))
-
-(defmethod convert "function"
-  [{:keys [ns name desc parameters]}]
-  (let [name (name-with-ns ns name)]
-    {:type :function
-     :name name
-     :doc desc
-     :display-string (str name (build-param-string parameters))
-     :insert-string (str name (build-param-string parameters true))
-     :tab-triggers {:select (param-names parameters true) :exit (when parameters ")")}}))
-
-(defmethod convert :default
-  [{:keys [ns name desc]}]
-  (when name
-    (let [name (name-with-ns ns name)]
-      {:type :variable
-       :name name
-       :doc desc
-       :display-string name
-       :insert-string name})))
-
-(defn convert-lines
-  [lines]
-  (into []
-        (comp (map convert) (remove nil?))
-        (-> (data/lines-reader lines) (yaml/load keyword))))
-
-(defn combine-conversions
-  "This function combines the individual hierarchical conversions into a map where
-  all the namespaces are keys at the top level mapping to a vector of their
-  respective contents. A global namespace is also added with the empty string as
-  a name, which contains a vector of namespace entries to enable auto completion
-  of namespace names."
-  [conversions]
-  (first (reduce
-           (fn [[m ns] x]
-             (cond
-               ;; Recurse into sublevels and merge the current map with the
-               ;; result. Any key collisions will have vector values so we
-               ;; can merge them with into.
-               (vector? x) [(merge-with into m (combine-conversions x)) ns]
-
-               (= :namespace (:type x)) [(let [m (assoc m (:name x) [])
-                                               m (if-not (= "" ns)
-                                                   (update m ns conj x)
-                                                   m)]
-                                           ;; Always add namespaces as members
-                                           ;; of the global namespace.
-                                           (update m "" conj x))
-                                         (:name x)]
-
-               x [(update m ns conj x) ns]
-
-               ;; Don't add empty parse results. They are probably
-               ;; from syntactically valid but incomplete yaml
-               ;; records.
-               :else [m ns]))
-           [{"" []} ""]
-           conversions)))
-
-(defn lines->completion-info
-  [lines]
-  (combine-conversions (convert-lines lines)))
+(defn lines->completion-info [lines]
+  (letfn [(make-completions [ns-path {:keys [type name desc] :as el}]
+            (case type
+              "table"
+              (let [child-path (conj ns-path name)]
+                (into [[ns-path (code-completion/make name :type :module :doc desc)]]
+                      (mapcat #(make-completions child-path %))
+                      (:members el)))
+              "function"
+              (let [{:keys [parameters]} el]
+                [[ns-path (code-completion/make
+                            name
+                            :type :function
+                            :doc desc
+                            :display-string (str name (build-param-string parameters :display-string))
+                            :snippet (str name (build-param-string parameters :snippet)))]])
+              (when name
+                [[ns-path (code-completion/make name :type :variable :doc desc)]])))]
+    (->> (yaml/load (data/lines-reader lines) keyword)
+         (eduction (mapcat #(make-completions [] %)))
+         lua/make-completion-map)))
 
 (g/defnk produce-completions
   [parse-result]

--- a/editor/test/editor/code_completion_test.clj
+++ b/editor/test/editor/code_completion_test.clj
@@ -72,4 +72,6 @@
     "${1|a\\,b,b\\,c,c\\,d|}" "a,b"
 
     ;; newlines
-    "1\r2\n3\r\n4" "1\n2\n3\n4"))
+    "1\r2\n3\r\n4" "1\n2\n3\n4"
+    "foo\n\r\n\r" "foo\n\n\n"
+    "foo\r\n\n\n\n" "foo\n\n\n\n"))

--- a/editor/test/editor/code_completion_test.clj
+++ b/editor/test/editor/code_completion_test.clj
@@ -1,0 +1,75 @@
+(ns editor.code-completion-test
+  (:require [clojure.test :refer :all]
+            [editor.code-completion :as code-completion]))
+
+(deftest evaluate-snippet-test
+  (are [snippet-string evaluated-snippet]
+    (= evaluated-snippet (code-completion/evaluate-snippet snippet-string))
+    ;; tab triggers
+    "$1$1" {:insert-string ""
+            :tab-triggers [{:ranges [[0 0]]}]}
+    "$1$2$3" {:insert-string ""
+              :tab-triggers [{:ranges [[0 0]]}]}
+    "$1${1:foo}" {:insert-string "foofoo"
+                  :tab-triggers [{:ranges [[0 3] [3 6]]}]}
+
+    ;; exits
+    "function function_name($1)\n\t$0\nend" {:insert-string "function function_name()\n\t\nend"
+                                             :exit-ranges [[26 26]]
+                                             :tab-triggers [{:ranges [[23 23]]}]}
+    "double $0=$0" {:insert-string "double ="
+                    :exit-ranges [[7 7]
+                                  [8 8]]}
+    "$0$0" {:insert-string ""
+            :exit-ranges [[0 0]]}
+
+    ;; choices
+    "${1|a,b,c|}" {:insert-string "a"
+                   :tab-triggers [{:ranges [[0 1]]
+                                   :choices ["a" "b" "c"]}]}
+    "${1|a\\|b,c\\,d,e\\}f|}" {:insert-string "a|b"
+                               :tab-triggers [{:ranges [[0 3]]
+                                               :choices ["a|b" "c,d" "e}f"]}]}
+
+    ;; errors
+    "${1" {:insert-string "${1"}
+    "${1|a,b,|}" {:insert-string "${1|a,b,|}"}
+    "${1: $2" {:insert-string "${1: "
+               :tab-triggers [{:ranges [[5 5]]}]}))
+
+(deftest evaluate-snippet-insert-string-test
+  (are [snippet-string insert-string]
+    (= insert-string (:insert-string (code-completion/evaluate-snippet snippet-string)))
+    ;; tab triggers
+    "$1$2$3" ""
+    "<$1> {${2}}" "<> {}"
+
+    ;; placeholders
+    "${1:}" ""
+    "${1:foo}" "foo"
+    "${1:foo($2)}" "foo()"
+    "${1:foo${2:bar}}" "foobar"
+    "${1:foo(${2|a,b,c|})}" "foo(a)"
+    "${1:foo ${VAR:var}}" "foo var"
+    "${1:foo ${VAR:var ${3|choice|}}}" "foo var choice"
+
+    ;; choice
+    "${1|a,b,c|}" "a"
+    "${1||}" ""
+
+    ;; variable
+    "$VOO" ""
+    "${VOO}" ""
+    "${VOO:foo}" "foo"
+    "${VOO:foo(${2:bar})}" "foo(bar)"
+
+    ;; escaping
+    "${1:{\\}}" "{}"
+    "${VAR:\\$}" "$"
+    "${1:a\nb}" "a\nb"
+    "${1:a|b}" "a|b"
+    "${1|a\\|b,c,d|}" "a|b"
+    "${1|a\\,b,b\\,c,c\\,d|}" "a,b"
+
+    ;; newlines
+    "1\r2\n3\r\n4" "1\n2\n3\n4"))

--- a/editor/test/integration/script_test.clj
+++ b/editor/test/integration/script_test.clj
@@ -96,9 +96,9 @@
             project          (test-util/setup-project! workspace [module1-resource module2-resource script-resource])
             script-node      (project/get-resource-node project script-resource)
             completions      (g/node-value script-node :completions)]
-        (is (= #{"a.f1" "a.f2"}
+        (is (= #{"f1" "f2"}
                (set (map :name (get completions "a")))))
-        (is (= #{"b.f3"}
+        (is (= #{"f3"}
                (set (map :name (get completions "b"))))))))
   (testing "does not include completions from transitive requires"
     (test-util/with-loaded-project "test/resources/empty_project"
@@ -116,7 +116,7 @@
             project          (test-util/setup-project! workspace [module1-resource module2-resource script-resource])
             script-node      (project/get-resource-node project script-resource)
             completions      (g/node-value script-node :completions)]
-        (is (= #{"a.f"}
+        (is (= #{"f"}
                (set (map :name (get completions "a")))))))))
 
 (deftest inexact-require-casing-produces-build-error


### PR DESCRIPTION
User-facing changes:
Code completion becomes more similar to vscode:
- we no longer include module prefixes in completions, e.g. completions for `vmath.` prefix will look like `conj()` instead of `vmath.conj()`
- we added support for vscode-style snippet syntax when inserting completions (not extensible by the user), which means we can now differentiate between inserted tab triggers and tab exits, as well as navigate between tabs in the order specified by the snippet (e.g. `foo($2) bar($1)` will navigate first to `bar()`, and then to `foo()`). In practice, this can be noticed when inserting a `repeat` snippet
- we fixed how much text is replaced when inserting completion in the presence of multiple selections with different selection lengths

Technical notes:
Lots and lots of changes...
The main change in `editor.code.data/splice` is that now instead of 2-element tuples (`cursor-range` + `replacement-lines`), the function also supports 3-element tuples (`cursor-range` + `replacement-lines` + `replacement-regions`), where `replacement-regions` are regions local to the replacement lines. Some LSP-related changes don't affect the LSP integration: I added the ability to query completions from the REPL and left comments that do the querying. Those will be removed in a later PR since this one is already growing too big.

Related to #7699