### PR TITLE
Output correct layer-mask for bitmap fonts

### DIFF
--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -545,11 +545,6 @@
 (g/defnk produce-font-map [_node-id font type font-resource-map pb-msg]
   (make-font-map _node-id font type pb-msg (make-font-resource-resolver font font-resource-map)))
 
-(defn- font-desc->layer-mask [font-desc]
-  (if (= (:output-format font-desc) :type-distance-field)
-    (fontc/calculate-ttf-layer-mask font-desc)
-    0x1))
-
 (defn- build-glyph-bank [resource _dep-resources user-data]
   (let [{:keys [font-map]} user-data]
     (g/precluding-errors
@@ -588,7 +583,7 @@
                                                                         :alpha (:alpha pb-msg)
                                                                         :outline-alpha (:outline-alpha pb-msg)
                                                                         :shadow-alpha (:shadow-alpha pb-msg)
-                                                                        :layer-mask (font-desc->layer-mask pb-msg)}
+                                                                        :layer-mask (fontc/calculate-ttf-layer-mask pb-msg)}
                                                                        nil)]
         [(assoc protobuf-build-target :node-id _node-id)])))
 

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -583,7 +583,7 @@
                                                                         :alpha (:alpha pb-msg)
                                                                         :outline-alpha (:outline-alpha pb-msg)
                                                                         :shadow-alpha (:shadow-alpha pb-msg)
-                                                                        :layer-mask (fontc/calculate-ttf-layer-mask pb-msg)}
+                                                                        :layer-mask (fontc/font-desc->layer-mask pb-msg)}
                                                                        nil)]
         [(assoc protobuf-build-target :node-id _node-id)])))
 

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -394,7 +394,7 @@
       (throw (ex-info "No character glyphs were included! Maybe turn on 'all_chars'?" {})))
     semi-glyphs))
 
-(defn calculate-ttf-layer-mask [font-desc]
+(defn font-desc->layer-mask [font-desc]
   (let [^double alpha (:alpha font-desc)
         ^double shadow-alpha (:shadow-alpha font-desc)
         ^double outline-alpha (:outline-alpha font-desc)
@@ -438,7 +438,7 @@
                               (update :width #(* (int (Math/ceil (/ ^double % 4.0))) 4)))
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)
-        layer-mask (calculate-ttf-layer-mask font-desc)]
+        layer-mask (font-desc->layer-mask font-desc)]
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
               (let [^BufferedImage glyph-image (let [face-color (Color. ^double (:alpha font-desc) 0.0 0.0)
@@ -640,7 +640,7 @@
         cache-cell-wh (max-glyph-cell-wh glyph-extents line-height padding glyph-cell-padding)
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)
-        layer-mask (calculate-ttf-layer-mask font-desc)]
+        layer-mask (font-desc->layer-mask font-desc)]
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
               (let [{:keys [^bytes field]} (draw-ttf-distance-field semi-glyph padding channel-count outline-width sdf-outline sdf-spread sdf-shadow-spread edge shadow-blur shadow-alpha)


### PR DESCRIPTION
Editor fix for a regression that started happening since #7887. Comparing the output between 1.5.0 and 1.6.0 we can see that the editor doesn't output any layer-mask for bitmap fonts during building. Bob does the correct thing so only a small editor fix is needed.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
