### PR TITLE
Use pixel coordinates for sprite attribute local space

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -125,7 +125,8 @@ namespace dmGameSystem
             uint32_t                           m_ValueByteSize;
         } m_Infos[dmGraphics::MAX_VERTEX_STREAM_COUNT];
 
-        uint8_t m_NumInfos;
+        uint32_t m_NumInfos                  : 4; // dmGraphics::MAX_VERTEX_STREAM_COUNT is 8
+        uint32_t m_HasLocalPositionAttribute : 1;
     };
 
     DM_GAMESYS_PROP_VECTOR3(SPRITE_PROP_SCALE, scale, false);
@@ -451,6 +452,12 @@ namespace dmGameSystem
             SpriteAttributeInfo::Info& info = infos->m_Infos[i];
             info.m_Attribute                = material_attributes + i;
             dmRender::GetMaterialProgramAttributeValues(material, i, &info.m_ValuePtr, &info.m_ValueByteSize);
+
+            if (info.m_Attribute->m_SemanticType    == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION &&
+                info.m_Attribute->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+            {
+                infos->m_HasLocalPositionAttribute = 1;
+            }
         }
     }
 
@@ -496,7 +503,7 @@ namespace dmGameSystem
 
     static void CreateVertexDataSlice9(dmRender::HMaterial material, uint8_t* vertices, uint8_t* indices, bool is_indices_16_bit,
         const Matrix4& transform, Vector3 sprite_size, Vector4 slice9, uint32_t vertex_offset, uint32_t vertex_stride,
-        const float* tc, float texture_width, float texture_height, uint8_t page_index, bool flip_u, bool flip_v, bool use_local_position,
+        const float* tc, float texture_width, float texture_height, uint8_t page_index, bool flip_u, bool flip_v,
         SpriteAttributeInfo* sprite_infos)
     {
         // render 9-sliced node
@@ -579,7 +586,7 @@ namespace dmGameSystem
                 }
 
                 Point3 p_local;
-                if (use_local_position)
+                if (sprite_infos->m_HasLocalPositionAttribute)
                 {
                     p_local = Point3(p.getX() * sprite_size.getX(), p.getY() * sprite_size.getY(), 0.0f);
                 }
@@ -627,21 +634,6 @@ namespace dmGameSystem
         }
     }
 
-    static inline bool HasLocalPositionAttribute(const SpriteAttributeInfo* attribute_infos)
-    {
-        for (int i = 0; i < attribute_infos->m_NumInfos; ++i)
-        {
-            const SpriteAttributeInfo::Info& info = attribute_infos->m_Infos[i];
-
-            if (info.m_Attribute->m_SemanticType    == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION &&
-                info.m_Attribute->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
     static void CreateVertexData(SpriteWorld* sprite_world, SpriteAttributeInfo* material_attribute_info, uint32_t vertex_stride, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("CreateVertexData");
@@ -680,15 +672,13 @@ namespace dmGameSystem
             float sp_width  = component->m_Size.getX();
             float sp_height = component->m_Size.getY();
 
-            // Fill in the custom sprite attributes (if specified), otherwise fallck to use the material attributes
+            // Fill in the custom sprite attributes (if specified), otherwise fallback to use the material attributes
             SpriteAttributeInfo* sprite_attribute_info_ptr = material_attribute_info;
             if (sprite_attribute_count > 0)
             {
                 FillSpriteAttributeInfos(material_attribute_info, component->m_Resource->m_DDF->m_Attributes.m_Data, sprite_attribute_count, &sprite_attribute_info);
                 sprite_attribute_info_ptr = &sprite_attribute_info;
             }
-
-            bool use_local_position = HasLocalPositionAttribute(sprite_attribute_info_ptr);
 
             // We need to pad the buffer if the vertex stride doesn't start at an even byte offset from the start
             const uint32_t vb_buffer_offset = vertices - sprite_world->m_VertexBufferData;
@@ -732,7 +722,7 @@ namespace dmGameSystem
                     Point3 p = Point3(x, y, 0.0f);
                     Point3 p_local;
 
-                    if (use_local_position)
+                    if (sprite_attribute_info_ptr->m_HasLocalPositionAttribute)
                     {
                         p_local = Point3(x * sp_width, y * sp_height, 0.0f);
                     }
@@ -806,7 +796,7 @@ namespace dmGameSystem
                         w, component->m_Size, component->m_Resource->m_DDF->m_Slice9, vertex_offset, vertex_stride, tc,
                         dmGraphics::GetTextureWidth(texture_set->m_Texture->m_Texture),
                         dmGraphics::GetTextureHeight(texture_set->m_Texture->m_Texture),
-                        page_index, flipx, flipy, use_local_position, sprite_attribute_info_ptr);
+                        page_index, flipx, flipy, sprite_attribute_info_ptr);
 
                     indices       += index_type_size * SPRITE_INDEX_COUNT_SLICE9;
                     vertices      += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
@@ -824,7 +814,7 @@ namespace dmGameSystem
                     Point3 p2_local;
                     Point3 p3_local;
 
-                    if (use_local_position)
+                    if (sprite_attribute_info_ptr->m_HasLocalPositionAttribute)
                     {
                         p0_local = Point3(-0.5f * sp_width, -0.5f * sp_height, 0.0f);
                         p1_local = Point3(-0.5f * sp_width,  0.5f * sp_height, 0.0f);


### PR DESCRIPTION
Fixed an issue where using the `local coordinate space` for a custom vertex stream used by a sprite produced coordinates in the `[-0.5, 0.5]` range. We now produce the data in pixel coordinates instead, which is already what the editor was doing prior.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
