### PR TITLE
Improve script_api documentation popup

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -64,6 +64,7 @@
                      [com.defold.lib/openmali                     "1.0"]
 
                      [org.commonmark/commonmark "0.21.0"]
+                     [org.commonmark/commonmark-ext-autolink "0.21.0"]
 
                      [com.cognitect.aws/api "0.8.673"]
                      [com.cognitect.aws/endpoints "1.1.12.478"]

--- a/editor/src/clj/editor/markdown.clj
+++ b/editor/src/clj/editor/markdown.clj
@@ -37,6 +37,7 @@
             [editor.workspace :as workspace])
   (:import [java.net URI]
            [javafx.scene.control ScrollPane]
+           [org.commonmark.ext.autolink AutolinkExtension]
            [org.commonmark.internal CustomHtmlBlockParser$Factory]
            [org.commonmark.parser Parser]
            [org.commonmark.renderer.html HtmlRenderer]
@@ -384,6 +385,7 @@
                 ;; Our custom HTML block parser fixes the issue by treating
                 ;; <div> tags the same way it treats <pre>.
                 (.customBlockParserFactory (CustomHtmlBlockParser$Factory.))
+                (.extensions [(AutolinkExtension/create)])
                 (.build)
                 (.parse content))
         html-string (.render (.build (HtmlRenderer/builder)) doc)

--- a/editor/test/editor/script_api_test.clj
+++ b/editor/test/editor/script_api_test.clj
@@ -70,7 +70,7 @@
   {""
    [{:type :function
      :name "fun"
-     :doc {:type :markdown :value "This is super great function!"}
+     :doc {:type :markdown :value "This is super great function!\n\n**Parameters:**<br><dl><dt><code>plopp <small>plupp</small></code></dt></dl>"}
      :display-string "fun(plopp)"
      :insert {:type :snippet :value "fun(${1:plopp})"}}]})
 
@@ -113,7 +113,9 @@
      :name "fun"
      :display-string "fun([optopt])"
      :insert {:type :snippet
-              :value "fun()"}}]})
+              :value "fun()"}
+     :doc {:type :markdown
+           :value "\n\n**Parameters:**<br><dl><dt><code>optopt <small>integer</small></code></dt></dl>"}}]})
 
 (defn convert
   [source]


### PR DESCRIPTION
User-facing changes:
The editor documentation popup now shows args, returns, and examples from `*.script_api` files.

Related to #7699