### PR TITLE
Use different colors for selected objects and their children

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -132,8 +132,9 @@
   [^GL2 gl render-args renderables]
   (doseq [renderable renderables]
     (let [user-data (-> renderable :user-data)
-          page-offset-x (get-rect-page-offset (:layout-width user-data) (:page-index user-data))]
-      (render-rect gl (:rect user-data) (if (:selected renderable) colors/selected-outline-color colors/outline-color) page-offset-x)))
+          page-offset-x (get-rect-page-offset (:layout-width user-data) (:page-index user-data))
+          color (colors/renderable-outline-color renderable)]
+      (render-rect gl (:rect user-data) color page-offset-x)))
   (doseq [renderable renderables]
     (let [user-data (-> renderable :user-data)
           page-offset-x (get-rect-page-offset (:layout-width user-data) (:page-index user-data))]

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -226,7 +226,7 @@
   (loop [renderables renderables
          vbuf (->color-vtx (* renderable-count camera-preview-mesh-vertices-count))]
     (if-let [renderable (first renderables)]
-      (let [color (if (:selected renderable) colors/selected-outline-color colors/outline-color)
+      (let [color (colors/renderable-outline-color renderable)
             cr (get color 0)
             cg (get color 1)
             cb (get color 2)

--- a/editor/src/clj/editor/colors.clj
+++ b/editor/src/clj/editor/colors.clj
@@ -61,6 +61,17 @@
 
 (def outline-color bright-grey)
 (def selected-outline-color defold-turquoise)
+(def parent-selected-outline-color defold-light-blue)
+
+(defn selection-color [selection-state]
+  (case selection-state
+    :self-selected selected-outline-color
+    :parent-selected parent-selected-outline-color
+    nil))
+
+(defn renderable-outline-color [renderable]
+  (or (selection-color (:selected renderable))
+      outline-color))
 
 ; https://en.wikipedia.org/wiki/HSL_and_HSV
 

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -166,9 +166,7 @@
     (when (pos? vcount)
       (vtx2/flip! (reduce (fn [vb {:keys [world-transform user-data selected] :as renderable}]
                             (let [{:keys [line-data line-color]} user-data
-                                  [r g b a] (or line-color
-                                                (and selected colors/selected-outline-color)
-                                                colors/outline-color)]
+                                  [r g b a] (or line-color (colors/renderable-outline-color renderable))]
                               (reduce (fn [vb [x y z]]
                                         (color-vtx-put! vb x y z r g b a))
                                       vb

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -99,7 +99,8 @@
     (when (pos? vcount)
       (vtx/flip! (reduce (fn [vb {:keys [world-transform user-data selected] :as renderable}]
                            (let [line-data (:line-data user-data)
-                                 [r g b a] (get user-data :line-color (if (:selected renderable) colors/selected-outline-color colors/outline-color))]
+                                 line-color (:line-color user-data)
+                                 [r g b a] (or line-color (colors/renderable-outline-color renderable))]
                              (reduce (fn [vb [x y z]]
                                        (color-vtx-put! vb x y z r g b a))
                                      vb

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -145,9 +145,6 @@
 
 (def line-id-shader (shader/make-shader ::line-id-shader line-id-vertex-shader line-id-fragment-shader {"id" :id}))
 
-(def color colors/outline-color)
-(def selected-color colors/selected-outline-color)
-
 (def mod-type->properties {:modifier-type-acceleration [:modifier-key-magnitude]
                            :modifier-type-drag [:modifier-key-magnitude]
                            :modifier-type-radial [:modifier-key-magnitude :modifier-key-max-distance]
@@ -212,7 +209,7 @@
             :when (> vcount 0)]
       (let [^Matrix4d world-transform (:world-transform renderable)
             world-transform-no-scale (orthonormalize world-transform)
-            color (if (:selected renderable) selected-color color)
+            color (colors/renderable-outline-color renderable)
             vs (into (vec (geom/transf-p world-transform-no-scale (geom/scale scale-f vs-screen)))
                      (geom/transf-p world-transform vs-world))
             render-args (if (= pass/selection (:pass render-args))

--- a/editor/src/clj/editor/render.clj
+++ b/editor/src/clj/editor/render.clj
@@ -111,7 +111,7 @@
 
 (defn- renderable->aabb-box!
   [vbuf renderable]
-  (let [color (if (:selected renderable) colors/selected-outline-color colors/outline-color)
+  (let [color (colors/renderable-outline-color renderable)
         [cr cg cb _] color
         aabb (:aabb renderable)]
     (conj-aabb-lines! vbuf aabb cr cg cb)))

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -146,9 +146,12 @@
    (if topmost? Long/MAX_VALUE (- Long/MAX_VALUE (z-distance view-proj world-transform)))
    (or index 0)])
 
-(defn- outline-render-key [^Matrix4d view-proj ^Matrix4d world-transform index topmost? selected?]
+(defn- outline-render-key [^Matrix4d view-proj ^Matrix4d world-transform index topmost? selection-state]
   ;; Draw selection outlines on top of other outlines.
-  [(boolean selected?)
+  [(case selection-state
+     :self-selected 2
+     :parent-selected 1
+     0)
    (boolean topmost?)
    (if topmost? Long/MAX_VALUE (- Long/MAX_VALUE (z-distance view-proj world-transform)))
    (or index 0)])
@@ -334,8 +337,11 @@
         world-translation (math/transform parent-world-transform (math/translation local-transform))
         world-rotation (doto (Quat4d. parent-world-rotation) (.mul local-rotation))
         world-scale (math/multiply-vector parent-world-scale (math/scale local-transform))
-        appear-selected? (some? (some selection-set node-id-path)) ; Child nodes appear selected if parent is.
-        picking-node-id (or (:picking-node-id scene) (peek node-id-path))
+        node-id (peek node-id-path)
+        picking-node-id (or (:picking-node-id scene) node-id)
+        selection-state (cond
+                          (contains? selection-set node-id) :self-selected ; This node is selected.
+                          (some selection-set node-id-path) :parent-selected) ; Child nodes appear dimly selected if their parent is selected.
         visible? (and parent-shows-children
                       (:visible-self? renderable true)
                       (not (contains? hidden-node-outline-key-paths node-outline-key-path))
@@ -354,12 +360,12 @@
                                    :world-scale world-scale
                                    :world-transform world-transform
                                    :parent-world-transform parent-world-transform
-                                   :selected appear-selected?
+                                   :selected selection-state
                                    :user-data (:user-data renderable)
                                    :batch-key (:batch-key renderable)
                                    :aabb (geom/aabb-transform aabb world-transform)
                                    :render-key (render-key view-proj world-transform (:index renderable) (:topmost? renderable))
-                                   :pass-overrides {pass/outline {:render-key (outline-render-key view-proj world-transform (:index renderable) (:topmost? renderable) appear-selected?)}}))
+                                   :pass-overrides {pass/outline {:render-key (outline-render-key view-proj world-transform (:index renderable) (:topmost? renderable) selection-state)}}))
         flat-renderable (if visible?
                           flat-renderable
                           (dissoc flat-renderable :updatable))
@@ -376,7 +382,7 @@
                        ;; within their outlines, and more importantly, the
                        ;; manipulator disappears, since it aligns to selection
                        ;; pass renderables.
-                       appear-selected?
+                       selection-state
                        (filterv #(or (= pass/outline %)
                                      (= pass/selection %))
                                 (:passes renderable)))

--- a/editor/src/clj/editor/scene_shapes.clj
+++ b/editor/src/clj/editor/scene_shapes.clj
@@ -246,6 +246,8 @@
 
 (def ^:private selected-shape-alpha 0.3)
 
+(def ^:private parent-selected-shape-alpha 0.2)
+
 (def ^:private no-point-scale (float-array 4 1.0))
 
 (def ^:private no-point-offset-by-w (float-array 4 0.0))
@@ -255,9 +257,8 @@
   (let [{:keys [selected user-data world-transform]} (first renderables)
         {:keys [color geometry]} user-data
         {:keys [primitive-type vbuf]} geometry
-        color (float-array (if selected
-                             colors/selected-outline-color
-                             (colors/alpha color 1.0)))
+        color (float-array (or (colors/selection-color selected)
+                               (colors/alpha color 1.0)))
         render-args (merge render-args
                            (math/derive-render-transforms
                              world-transform
@@ -285,8 +286,11 @@
                   (= pass/selection (:pass render-args))
                   (scene-picking/renderable-picking-id-uniform renderable)
 
-                  selected
+                  (= :self-selected selected)
                   (colors/alpha color selected-shape-alpha)
+
+                  (= :parent-selected selected)
+                  (colors/alpha color parent-selected-shape-alpha)
 
                   :else
                   (colors/alpha color shape-alpha)))

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -241,7 +241,7 @@
         ^VertexBuffer vbuf (->color-vtx (* count 8))
         ^ByteBuffer buf (.buf vbuf)]
     (doseq [renderable renderables]
-      (let [[cr cg cb] (if (:selected renderable) colors/selected-outline-color colors/outline-color)
+      (let [[cr cg cb] (colors/renderable-outline-color renderable)
             world-transform (:world-transform renderable)
             {:keys [animation size size-mode slice9]} (:user-data renderable)
             [quad-width quad-height] size

--- a/editor/test/integration/scene_test.clj
+++ b/editor/test/integration/scene_test.clj
@@ -19,13 +19,13 @@
             [editor.camera :as camera]
             [editor.geom :as geom]
             [editor.gl.pass :as pass]
+            [editor.math :as math]
             [editor.scene :as scene]
             [editor.system :as system]
             [editor.types :as types]
-            [editor.math :as math]
             [integration.test-util :as test-util])
   (:import [editor.types AABB]
-           [javax.vecmath Point3d Matrix4d Quat4d Vector3d]))
+           [javax.vecmath Matrix4d Quat4d Vector3d]))
 
 (defn- apply-scene-transforms-to-aabbs
   ([scene] (apply-scene-transforms-to-aabbs geom/Identity4d scene))
@@ -278,7 +278,9 @@
   (is (instance? Matrix4d (:parent-world-transform renderable)))
   (is (some? (:render-fn renderable)))
   (is (instance? Comparable (:render-key renderable)))
-  (is (or (true? (:selected renderable)) (false? (:selected renderable))))
+  (is (or (nil? (:selected renderable))
+          (= :self-selected (:selected renderable))
+          (= :parent-selected (:selected renderable))))
   (is (instance? Matrix4d (:world-transform renderable))))
 
 (defn- output-renderable-vector? [coll]
@@ -430,28 +432,28 @@
         [:apple-node-id :apple-node-id]
 
         [:tree-node-id]
-        [:tree-node-id :apple-node-id :apple-node-id]
+        [:apple-node-id :apple-node-id :tree-node-id]
 
         [:door-node-id]
-        [:door-node-id :door-handle-node-id]
+        [:door-handle-node-id :door-node-id]
 
         [:house-node-id]
-        [:house-node-id :door-node-id :door-handle-node-id]
+        [:door-node-id :door-handle-node-id :house-node-id]
 
         [:house-node-id :door-handle-node-id]
-        [:house-node-id :door-node-id :door-handle-node-id]
+        [:door-node-id :house-node-id :door-handle-node-id]
 
         [:bucket-node-id]
         [:bucket-node-id]
 
         [:rope-node-id]
-        [:rope-node-id :bucket-node-id]
+        [:bucket-node-id :rope-node-id]
 
         [:well-node-id]
-        [:well-node-id :rope-node-id :bucket-node-id]
+        [:rope-node-id :bucket-node-id :well-node-id]
 
         [:well-node-id :rope-node-id]
-        [:well-node-id :rope-node-id :bucket-node-id]))
+        [:bucket-node-id :well-node-id :rope-node-id]))
 
     (testing "Selected renderables are ordered"
       (are [selection]


### PR DESCRIPTION
Fixes #6154.

### User-facing changes
* Children of selected objects are now highlighted with a dimmer color than the objects that are selected.