### PR TITLE
Support uniform buffers for Vulkan

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilerHelpers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilerHelpers.java
@@ -213,10 +213,6 @@ public class ShaderCompilerHelpers {
             es3Result.shaderVersion = Integer.parseInt(es3Result.shaderVersion) < 140 ? "140" : es3Result.shaderVersion;
         }
 
-        System.out.println("-----------------");
-        System.out.println("COMPILED SOURCE:");
-        System.out.println(es3Result.output);
-
         // compile GLSL (ES3 or Desktop 140) to SPIR-V
         File file_in_glsl = File.createTempFile(FilenameUtils.getName(resourceOutput), ".glsl");
         file_in_glsl.deleteOnExit();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderUtil.java
@@ -39,14 +39,14 @@ import com.dynamo.bob.pipeline.antlr.glsl.GLSLLexer;
 
 public class ShaderUtil {
     public static class Common {
-        public static final int     MAX_ARRAY_SAMPLERS             = 8;
-        public static final String  glSampler2DArrayRegex          = "(.+)sampler2DArray\\s+(\\w+);";
-        public static final Pattern regexUniformKeywordPattern     = Pattern.compile("((?<keyword>uniform)\\s+|(?<layout>layout\\s*\\(.*\\n*.*\\)\\s*)\\s+|(?<precision>lowp|mediump|highp)\\s+)*(?<type>\\S+)\\s+(?<identifier>\\S+)\\s*(?<any>.*)\\s*;");
-        public static final Pattern regexUniformBlockBeginKeywordPattern     = Pattern.compile("((?<keyword>uniform)\\s+|(?<layout>layout\\s*\\(.*\\n*.*\\)\\s*)\\s+)*(?<type>\\S+)\\s*");
-        public static String        includeDirectiveReplaceBaseStr = "[^\\S\r\n]?\\s*\\#include\\s+(?:<%s>|\"%s\")";
-        public static String        includeDirectiveBaseStr        = "^\\s*\\#include\\s+(?:<(?<pathbrackets>[^\"<>|\b]+)>|\"(?<pathquotes>[^\"<>|\b]+)\")\\s*(?://.*)?$";
-        public static final Pattern includeDirectivePattern        = Pattern.compile(includeDirectiveBaseStr);
-        public static final Pattern arrayArraySamplerPattern       = Pattern.compile("^\\s*uniform(?<qualifier>.*)sampler2DArray\\s+(?<uniform>\\w+);$");
+        public static final int     MAX_ARRAY_SAMPLERS                   = 8;
+        public static final String  glSampler2DArrayRegex                = "(.+)sampler2DArray\\s+(\\w+);";
+        public static final Pattern regexUniformKeywordPattern           = Pattern.compile("((?<keyword>uniform)\\s+|(?<layout>layout\\s*\\(.*\\n*.*\\)\\s*)\\s+|(?<precision>lowp|mediump|highp)\\s+)*(?<type>\\S+)\\s+(?<identifier>\\S+)\\s*(?<any>.*)\\s*;");
+        public static final Pattern regexUniformBlockBeginKeywordPattern = Pattern.compile("((?<keyword>uniform)\\s+|(?<layout>layout\\s*\\(.*\\n*.*\\)\\s*)\\s+)*(?<type>\\S+)\\s*");
+        public static String        includeDirectiveReplaceBaseStr       = "[^\\S\r\n]?\\s*\\#include\\s+(?:<%s>|\"%s\")";
+        public static String        includeDirectiveBaseStr              = "^\\s*\\#include\\s+(?:<(?<pathbrackets>[^\"<>|\b]+)>|\"(?<pathquotes>[^\"<>|\b]+)\")\\s*(?://.*)?$";
+        public static final Pattern includeDirectivePattern              = Pattern.compile(includeDirectiveBaseStr);
+        public static final Pattern arrayArraySamplerPattern             = Pattern.compile("^\\s*uniform(?<qualifier>.*)sampler2DArray\\s+(?<uniform>\\w+);$");
 
         public static class GLSLCompileResult
         {
@@ -524,12 +524,12 @@ public class ShaderUtil {
                             }
                         }
                     } else {
-                        Matcher uniformHeaderMatcher = Common.regexUniformBlockBeginKeywordPattern.matcher(line);
-                        if (uniformHeaderMatcher.find()) {
-                            String keyword = uniformHeaderMatcher.group("keyword");
+                        Matcher uniforBlockBeginMatcher = Common.regexUniformBlockBeginKeywordPattern.matcher(line);
+                        if (uniforBlockBeginMatcher.find()) {
+                            String keyword = uniforBlockBeginMatcher.group("keyword");
                             if(keyword != null) {
-                                String layout = uniformHeaderMatcher.group("layout");
-                                String type   = uniformHeaderMatcher.group("type");
+                                String layout = uniforBlockBeginMatcher.group("layout");
+                                String type   = uniforBlockBeginMatcher.group("type");
 
                                 boolean blockScopeBegin = line.contains("{");
 

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -209,8 +209,7 @@ namespace dmGameSystem
         bool result = dmRender::GetMaterialProgramConstantInfo(material, name_hash, &constant_id, &element_ids, &element_index, &num_components);
         if (result)
         {
-            int32_t location = dmRender::GetMaterialConstantLocation(material, constant_id);
-            if (location >= 0)
+            if (dmRender::GetMaterialConstantLocation(material, constant_id) != dmGraphics::INVALID_UNIFORM_LOCATION)
             {
                 if (constant_id == name_hash)
                 {

--- a/engine/graphics/proto/graphics/graphics_ddf.proto
+++ b/engine/graphics/proto/graphics/graphics_ddf.proto
@@ -250,6 +250,7 @@ message ShaderDesc
         SHADER_TYPE_SAMPLER3D       = 11;
         SHADER_TYPE_SAMPLER_CUBE    = 12;
         SHADER_TYPE_SAMPLER2D_ARRAY = 13;
+        SHADER_TYPE_UNIFORM_BUFFER  = 14;
     }
 
     message ResourceBinding
@@ -262,12 +263,23 @@ message ShaderDesc
         optional uint32         binding       = 6 [default=0];
     }
 
+    message ResourceBlock
+    {
+        required string          name          = 1;
+        required uint64          name_hash     = 2;
+        repeated ResourceBinding bindings      = 3;
+        required ShaderDataType  type          = 4;
+        optional uint32          element_count = 5 [default=1];
+        optional uint32          set           = 6 [default=0];
+        optional uint32          binding       = 7 [default=0];
+    }
+
     message Shader
     {
         required Language        language              = 1;
         optional bytes           source                = 2;
         optional string          name                  = 3;
-        repeated ResourceBinding uniforms              = 4;
+        repeated ResourceBlock   resources             = 4;
         repeated ResourceBinding inputs                = 5;
         repeated ResourceBinding outputs               = 6;
         optional bool            variant_texture_array = 7 [default = false];

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -86,6 +86,13 @@ namespace dmGraphics
     typedef uintptr_t HIndexBuffer;
 
     /*#
+     * Uniform location handle
+     * @typedef
+     * @name HUniformLocation
+     */
+    typedef int64_t HUniformLocation;
+
+    /*#
      * Vertex declaration handle
      * @typedef
      * @name HVertexDeclaration

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1029,19 +1029,19 @@ namespace dmGraphics
     {
         return g_functions.m_GetUniformCount(prog);
     }
-    int32_t  GetUniformLocation(HProgram prog, const char* name)
+    HUniformLocation GetUniformLocation(HProgram prog, const char* name)
     {
         return g_functions.m_GetUniformLocation(prog, name);
     }
-    void SetConstantV4(HContext context, const dmVMath::Vector4* data, int count, int base_register)
+    void SetConstantV4(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location)
     {
-        g_functions.m_SetConstantV4(context, data, count, base_register);
+        g_functions.m_SetConstantV4(context, data, count, base_location);
     }
-    void SetConstantM4(HContext context, const dmVMath::Vector4* data, int count, int base_register)
+    void SetConstantM4(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location)
     {
-        g_functions.m_SetConstantM4(context, data, count, base_register);
+        g_functions.m_SetConstantM4(context, data, count, base_location);
     }
-    void SetSampler(HContext context, int32_t location, int32_t unit)
+    void SetSampler(HContext context, HUniformLocation location, int32_t unit)
     {
         g_functions.m_SetSampler(context, location, unit);
     }

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -79,6 +79,7 @@ namespace dmGraphics
 
     static const HVertexProgram   INVALID_VERTEX_PROGRAM_HANDLE   = ~0u;
     static const HFragmentProgram INVALID_FRAGMENT_PROGRAM_HANDLE = ~0u;
+    static const HUniformLocation INVALID_UNIFORM_LOCATION        = ~0u;
 
     enum AssetType
     {
@@ -364,6 +365,31 @@ namespace dmGraphics
         uint64_t m_PolygonOffsetFillEnabled : 1;
     };
 
+    /*
+    static const uint64_t INVALID_UNIFORM_LOCATION = -1;
+
+    union UniformLocation
+    {
+        UniformLocation()
+        : m_LocationKey(INVALID_UNIFORM_LOCATION)
+        {}
+        inline bool Valid()
+        {
+            return m_LocationKey != INVALID_UNIFORM_LOCATION;
+        }
+
+        struct
+        {
+            uint16_t m_LocationVs;
+            uint16_t m_LocationVsMember;
+            uint16_t m_LocationFs;
+            uint16_t m_LocationFsMember;
+        };
+
+        uint64_t m_LocationKey;
+    };
+    */
+
     /** Creates a graphics context
      * Currently, there can only be one context active at a time.
      * @return New graphics context
@@ -569,13 +595,13 @@ namespace dmGraphics
     void             GetAttributeValues(const dmGraphics::VertexAttribute& attribute, const uint8_t** data_ptr, uint32_t* data_size);
     dmGraphics::Type GetGraphicsType(dmGraphics::VertexAttribute::DataType data_type);
 
-    uint32_t GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
-    uint32_t GetUniformCount(HProgram prog);
-    int32_t  GetUniformLocation(HProgram prog, const char* name);
+    uint32_t         GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
+    uint32_t         GetUniformCount(HProgram prog);
+    HUniformLocation GetUniformLocation(HProgram prog, const char* name);
 
-    void SetConstantV4(HContext context, const dmVMath::Vector4* data, int count, int base_register);
-    void SetConstantM4(HContext context, const dmVMath::Vector4* data, int count, int base_register);
-    void SetSampler(HContext context, int32_t location, int32_t unit);
+    void SetConstantV4(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location);
+    void SetConstantM4(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location);
+    void SetSampler(HContext context, HUniformLocation location, int32_t unit);
     void SetViewport(HContext context, int32_t x, int32_t y, int32_t width, int32_t height);
 
     void EnableState(HContext context, State state);

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -79,7 +79,7 @@ namespace dmGraphics
 
     static const HVertexProgram   INVALID_VERTEX_PROGRAM_HANDLE   = ~0u;
     static const HFragmentProgram INVALID_FRAGMENT_PROGRAM_HANDLE = ~0u;
-    static const HUniformLocation INVALID_UNIFORM_LOCATION        = ~0u;
+    static const HUniformLocation INVALID_UNIFORM_LOCATION        = ~0ull;
 
     enum AssetType
     {

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -365,31 +365,6 @@ namespace dmGraphics
         uint64_t m_PolygonOffsetFillEnabled : 1;
     };
 
-    /*
-    static const uint64_t INVALID_UNIFORM_LOCATION = -1;
-
-    union UniformLocation
-    {
-        UniformLocation()
-        : m_LocationKey(INVALID_UNIFORM_LOCATION)
-        {}
-        inline bool Valid()
-        {
-            return m_LocationKey != INVALID_UNIFORM_LOCATION;
-        }
-
-        struct
-        {
-            uint16_t m_LocationVs;
-            uint16_t m_LocationVsMember;
-            uint16_t m_LocationFs;
-            uint16_t m_LocationFsMember;
-        };
-
-        uint64_t m_LocationKey;
-    };
-    */
-
     /** Creates a graphics context
      * Currently, there can only be one context active at a time.
      * @return New graphics context

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -115,10 +115,10 @@ namespace dmGraphics
     typedef void (*GetAttributeFn)(HProgram prog, uint32_t index, dmhash_t* name_hash, Type* type, uint32_t* element_count, uint32_t* num_values, int32_t* location);
     typedef uint32_t (*GetUniformNameFn)(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
     typedef uint32_t (*GetUniformCountFn)(HProgram prog);
-    typedef int32_t (* GetUniformLocationFn)(HProgram prog, const char* name);
-    typedef void (*SetConstantV4Fn)(HContext context, const dmVMath::Vector4* data, int count, int base_register);
-    typedef void (*SetConstantM4Fn)(HContext context, const dmVMath::Vector4* data, int count, int base_register);
-    typedef void (*SetSamplerFn)(HContext context, int32_t location, int32_t unit);
+    typedef HUniformLocation (* GetUniformLocationFn)(HProgram prog, const char* name);
+    typedef void (*SetConstantV4Fn)(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location);
+    typedef void (*SetConstantM4Fn)(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location);
+    typedef void (*SetSamplerFn)(HContext context, HUniformLocation location, int32_t unit);
     typedef void (*SetViewportFn)(HContext context, int32_t x, int32_t y, int32_t width, int32_t height);
     typedef void (*EnableStateFn)(HContext context, State state);
     typedef void (*DisableStateFn)(HContext context, State state);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -916,7 +916,7 @@ namespace dmGraphics
         return (uint32_t)strlen(buffer);
     }
 
-    static int32_t NullGetUniformLocation(HProgram prog, const char* name)
+    static HUniformLocation NullGetUniformLocation(HProgram prog, const char* name)
     {
         Program* program = (Program*)prog;
         uint32_t count = program->m_Uniforms.Size();
@@ -928,7 +928,7 @@ namespace dmGraphics
                 return (int32_t)uniform.m_Index;
             }
         }
-        return -1;
+        return INVALID_UNIFORM_LOCATION;
     }
 
     static void NullSetViewport(HContext context, int32_t x, int32_t y, int32_t width, int32_t height)
@@ -937,31 +937,31 @@ namespace dmGraphics
     }
 
     // Tests Only
-    const Vector4& GetConstantV4Ptr(HContext _context, int base_register)
+    const Vector4& GetConstantV4Ptr(HContext _context, HUniformLocation base_location)
     {
         assert(_context);
         NullContext* context = (NullContext*) _context;
         assert(context->m_Program != 0x0);
-        return context->m_ProgramRegisters[base_register];
+        return context->m_ProgramRegisters[base_location];
     }
 
-    static void NullSetConstantV4(HContext _context, const Vector4* data, int count, int base_register)
+    static void NullSetConstantV4(HContext _context, const Vector4* data, int count, HUniformLocation base_location)
     {
         assert(_context);
         NullContext* context = (NullContext*) _context;
         assert(context->m_Program != 0x0);
-        memcpy(&context->m_ProgramRegisters[base_register], data, sizeof(Vector4) * count);
+        memcpy(&context->m_ProgramRegisters[base_location], data, sizeof(Vector4) * count);
     }
 
-    static void NullSetConstantM4(HContext _context, const Vector4* data, int count, int base_register)
+    static void NullSetConstantM4(HContext _context, const Vector4* data, int count, HUniformLocation base_location)
     {
         assert(_context);
         NullContext* context = (NullContext*) _context;
         assert(context->m_Program != 0x0);
-        memcpy(&context->m_ProgramRegisters[base_register], data, sizeof(Vector4) * 4 * count);
+        memcpy(&context->m_ProgramRegisters[base_location], data, sizeof(Vector4) * 4 * count);
     }
 
-    static void NullSetSampler(HContext context, int32_t location, int32_t unit)
+    static void NullSetSampler(HContext context, HUniformLocation location, int32_t unit)
     {
     }
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2244,7 +2244,7 @@ static void LogFrameBufferError(GLenum status)
         return (uint32_t)uniform_name_length;
     }
 
-    static int32_t OpenGLGetUniformLocation(HProgram prog, const char* name)
+    static HUniformLocation OpenGLGetUniformLocation(HProgram prog, const char* name)
     {
         OpenGLProgram* program_ptr = (OpenGLProgram*) prog;
         GLint location = glGetUniformLocation(program_ptr->m_Id, name);
@@ -2253,7 +2253,7 @@ static void LogFrameBufferError(GLenum status)
             // Clear error if uniform isn't found
             CLEAR_GL_ERROR
         }
-        return (uint32_t) location;
+        return (HUniformLocation) location;
     }
 
     static void OpenGLSetViewport(HContext context, int32_t x, int32_t y, int32_t width, int32_t height)
@@ -2264,22 +2264,22 @@ static void LogFrameBufferError(GLenum status)
         CHECK_GL_ERROR;
     }
 
-    static void OpenGLSetConstantV4(HContext context, const Vector4* data, int count, int base_register)
+    static void OpenGLSetConstantV4(HContext context, const Vector4* data, int count, HUniformLocation base_location)
     {
-        glUniform4fv(base_register, count, (const GLfloat*) data);
+        glUniform4fv(base_location, count, (const GLfloat*) data);
         CHECK_GL_ERROR;
     }
 
-    static void OpenGLSetConstantM4(HContext context, const Vector4* data, int count, int base_register)
+    static void OpenGLSetConstantM4(HContext context, const Vector4* data, int count, HUniformLocation base_location)
     {
-        glUniformMatrix4fv(base_register, count, 0, (const GLfloat*) data);
+        glUniformMatrix4fv(base_location, count, 0, (const GLfloat*) data);
         CHECK_GL_ERROR;
     }
 
-    static void OpenGLSetSampler(HContext context, int32_t base_register, int32_t unit)
+    static void OpenGLSetSampler(HContext context, HUniformLocation location, int32_t unit)
     {
         assert(context);
-        glUniform1i(base_register, unit);
+        glUniform1i(location, unit);
         CHECK_GL_ERROR;
     }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1761,11 +1761,11 @@ bail:
         //     This means that we might get side-effects since we are basically binding the first data buffer
         //     to the stream as an R8 value, but uh yeah not sure what do to about that right now.
         context->m_MainVertexDeclaration = {0};
-        context->m_MainVertexDeclaration.m_StreamCount = vertex_shader->m_InputCount;
+        context->m_MainVertexDeclaration.m_StreamCount = vertex_shader->m_Inputs.Size();
         context->m_MainVertexDeclaration.m_Stride      = vertex_declaration->m_Stride;
         context->m_MainVertexDeclaration.m_Hash        = vertex_declaration->m_Hash;
 
-        for (uint32_t i = 0; i < vertex_shader->m_InputCount; i++)
+        for (uint32_t i = 0; i < vertex_shader->m_Inputs.Size(); i++)
         {
             ShaderResourceBinding& input      = vertex_shader->m_Inputs[i];
             VertexDeclaration::Stream& stream = context->m_MainVertexDeclaration.m_Streams[i];
@@ -1796,7 +1796,7 @@ bail:
         return vertex_declaration->m_Stride;
     }
 
-    static inline bool IsUniformTextureSampler(ShaderResourceBinding uniform)
+    static inline bool IsUniformTextureSampler(const ShaderResourceBinding& uniform)
     {
         return uniform.m_Type == ShaderDesc::SHADER_TYPE_SAMPLER2D       ||
                uniform.m_Type == ShaderDesc::SHADER_TYPE_SAMPLER3D       ||
@@ -1837,21 +1837,21 @@ bail:
         else if (module_type == Program::MODULE_TYPE_FRAGMENT)
         {
             shader_module        = program->m_FragmentModule;
-            uniform_data_offsets = &program->m_UniformDataOffsets[program->m_VertexModule->m_UniformCount];
-            dynamic_offsets      = &dynamic_offsets_out[program->m_VertexModule->m_UniformCount];
+            uniform_data_offsets = &program->m_UniformDataOffsets[program->m_VertexModule->m_Uniforms.Size()];
+            dynamic_offsets      = &dynamic_offsets_out[program->m_VertexModule->m_Uniforms.Size()];
         }
         else
         {
             assert(0);
         }
 
-        if (shader_module->m_UniformCount == 0)
+        if (shader_module->m_Uniforms.Size() == 0)
         {
             return;
         }
 
         const uint8_t max_write_descriptors = 16;
-        uint16_t uniforms_to_write          = shader_module->m_UniformCount;
+        uint16_t uniforms_to_write          = shader_module->m_Uniforms.Size();
         uint16_t uniform_to_write_index     = 0;
         uint16_t uniform_index              = 0;
         uint16_t image_to_write_index       = 0;
@@ -1893,8 +1893,10 @@ bail:
             else
             {
                 dynamic_offsets[res.m_UniformDataIndex] = (uint32_t) scratch_buffer->m_MappedDataCursor;
-                const uint32_t uniform_size_nonalign    = GetShaderTypeSize(res.m_Type) * res.m_ElementCount;
+                const uint32_t uniform_size_nonalign    = res.m_DataSize; //GetShaderTypeSize(res.m_Type) * res.m_ElementCount;
                 const uint32_t uniform_size             = DM_ALIGN(uniform_size_nonalign, dynamic_alignment);
+
+                assert(uniform_size_nonalign > 0);
 
                 // Copy client data to aligned host memory
                 // The data_offset here is the offset into the programs uniform data,
@@ -2153,22 +2155,24 @@ bail:
 
     static void CreateShaderResourceBindings(ShaderModule* shader, ShaderDesc::Shader* ddf, uint32_t dynamicAlignment)
     {
-        if (ddf->m_Uniforms.m_Count > 0)
+        if (ddf->m_Resources.m_Count > 0)
         {
-            shader->m_Uniforms                 = new ShaderResourceBinding[ddf->m_Uniforms.m_Count];
-            shader->m_UniformCount             = ddf->m_Uniforms.m_Count;
+            shader->m_Uniforms.SetCapacity(ddf->m_Resources.m_Count);
+            shader->m_Uniforms.SetSize(ddf->m_Resources.m_Count);
+
             uint32_t uniform_data_size_aligned = 0;
             uint32_t texture_sampler_count     = 0;
             uint32_t uniform_buffer_count      = 0;
+            uint32_t total_uniform_count       = 0;
 
-            for (uint32_t i=0; i < ddf->m_Uniforms.m_Count; i++)
+            for (uint32_t i=0; i < ddf->m_Resources.m_Count; i++)
             {
                 ShaderResourceBinding& res = shader->m_Uniforms[i];
-                res.m_Binding              = ddf->m_Uniforms[i].m_Binding;
-                res.m_Set                  = ddf->m_Uniforms[i].m_Set;
-                res.m_Type                 = ddf->m_Uniforms[i].m_Type;
-                res.m_ElementCount         = ddf->m_Uniforms[i].m_ElementCount;
-                res.m_Name                 = strdup(ddf->m_Uniforms[i].m_Name);
+                res.m_Binding              = ddf->m_Resources[i].m_Binding;
+                res.m_Set                  = ddf->m_Resources[i].m_Set;
+                res.m_Type                 = ddf->m_Resources[i].m_Type;
+                res.m_ElementCount         = ddf->m_Resources[i].m_ElementCount;
+                res.m_Name                 = strdup(ddf->m_Resources[i].m_Name);
                 res.m_NameHash             = 0;
 
                 assert(res.m_Set <= 1);
@@ -2179,21 +2183,40 @@ bail:
                 }
                 else
                 {
-                    res.m_UniformDataIndex     = uniform_buffer_count;
-                    uniform_data_size_aligned += DM_ALIGN(GetShaderTypeSize(res.m_Type) * res.m_ElementCount, dynamicAlignment);
+                    res.m_BlockMembers.SetCapacity(ddf->m_Resources[i].m_Bindings.m_Count);
+                    res.m_BlockMembers.SetSize(ddf->m_Resources[i].m_Bindings.m_Count);
+
+                    uint32_t uniform_size = 0;
+                    for (uint32_t j = 0; j < ddf->m_Resources[i].m_Bindings.m_Count; ++j)
+                    {
+                        ShaderDesc::ResourceBinding& member  = ddf->m_Resources[i].m_Bindings[j];
+                        res.m_BlockMembers[j].m_Name         = strdup(member.m_Name); // TODO: Free!
+                        res.m_BlockMembers[j].m_NameHash     = member.m_NameHash;
+                        res.m_BlockMembers[j].m_Type         = member.m_Type;
+                        res.m_BlockMembers[j].m_ElementCount = member.m_ElementCount;
+                        res.m_BlockMembers[j].m_Offset       = uniform_size;
+                        uniform_size += GetShaderTypeSize(member.m_Type) * member.m_ElementCount;
+                    }
+
+                    res.m_UniformDataIndex = uniform_buffer_count;
+                    res.m_DataSize         = uniform_size;
+                    uniform_data_size_aligned += DM_ALIGN(uniform_size, dynamicAlignment);
                     uniform_buffer_count++;
                 }
+
+                total_uniform_count += ddf->m_Resources[i].m_Bindings.m_Count;
             }
 
             shader->m_UniformDataSizeAligned = uniform_data_size_aligned;
             shader->m_UniformBufferCount     = uniform_buffer_count;
             shader->m_TextureSamplerCount    = texture_sampler_count;
+            shader->m_TotalUniformCount      = total_uniform_count;
         }
 
         if (ddf->m_Inputs.m_Count > 0)
         {
-            shader->m_Inputs     = new ShaderResourceBinding[ddf->m_Inputs.m_Count];
-            shader->m_InputCount = ddf->m_Inputs.m_Count;
+            shader->m_Inputs.SetCapacity(ddf->m_Inputs.m_Count);
+            shader->m_Inputs.SetSize(ddf->m_Inputs.m_Count);
 
             for (uint32_t i=0; i < ddf->m_Inputs.m_Count; i++)
             {
@@ -2269,7 +2292,7 @@ bail:
     {
         uint32_t byte_offset         = byte_offset_base;
         uint32_t num_uniform_buffers = 0;
-        for(uint32_t i=0; i < module->m_UniformCount; i++)
+        for(uint32_t i=0; i < module->m_Uniforms.Size(); i++)
         {
             // Process uniform data size
             ShaderResourceBinding& res = module->m_Uniforms[i];
@@ -2286,8 +2309,14 @@ bail:
             else
             {
                 assert(num_uniform_buffers < byte_offset_list_size);
+                uint32_t uniform_size = 0;
+                for (uint32_t j = 0; j < res.m_BlockMembers.Size(); ++j)
+                {
+                    uniform_size += GetShaderTypeSize(res.m_BlockMembers[j].m_Type) * res.m_BlockMembers[j].m_ElementCount;
+                }
+
                 byte_offset_list_out[res.m_UniformDataIndex] = byte_offset;
-                byte_offset                                 += GetShaderTypeSize(res.m_Type) * res.m_ElementCount;
+                byte_offset                                 += uniform_size;
                 vk_descriptor_type                           = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
                 num_uniform_buffers++;
             }
@@ -2334,7 +2363,7 @@ bail:
         HashState64 program_hash;
         dmHashInit64(&program_hash, false);
 
-        for (uint32_t i=0; i < vertex_module->m_InputCount; i++)
+        for (uint32_t i=0; i < vertex_module->m_Inputs.Size(); i++)
         {
             dmHashUpdateBuffer64(&program_hash, &vertex_module->m_Inputs[i].m_Binding, sizeof(vertex_module->m_Inputs[i].m_Binding));
         }
@@ -2343,7 +2372,7 @@ bail:
         dmHashUpdateBuffer64(&program_hash, &fragment_module->m_Hash, sizeof(fragment_module->m_Hash));
         program->m_Hash = dmHashFinal64(&program_hash);
 
-        const uint32_t num_uniforms = vertex_module->m_UniformCount + fragment_module->m_UniformCount;
+        const uint32_t num_uniforms = vertex_module->m_Uniforms.Size() + fragment_module->m_Uniforms.Size();
         if (num_uniforms > 0)
         {
             VkDescriptorSetLayoutBinding* vk_descriptor_set_bindings = new VkDescriptorSetLayoutBinding[num_uniforms];
@@ -2362,7 +2391,7 @@ bail:
                 &vs_last_offset, vk_descriptor_set_bindings);
             CreateProgramUniforms(fragment_module, VK_SHADER_STAGE_FRAGMENT_BIT,
                 vs_last_offset, &program->m_UniformDataOffsets[vertex_module->m_UniformBufferCount], num_buffers,
-                &fs_last_offset, &vk_descriptor_set_bindings[vertex_module->m_UniformCount]);
+                &fs_last_offset, &vk_descriptor_set_bindings[vertex_module->m_Uniforms.Size()]);
 
             program->m_UniformData = new uint8_t[vs_last_offset + fs_last_offset];
             memset(program->m_UniformData, 0, vs_last_offset + fs_last_offset);
@@ -2371,11 +2400,11 @@ bail:
             memset(&vk_set_create_info, 0, sizeof(vk_set_create_info));
             vk_set_create_info[Program::MODULE_TYPE_VERTEX].sType          = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
             vk_set_create_info[Program::MODULE_TYPE_VERTEX].pBindings      = vk_descriptor_set_bindings;
-            vk_set_create_info[Program::MODULE_TYPE_VERTEX].bindingCount   = vertex_module->m_UniformCount;
+            vk_set_create_info[Program::MODULE_TYPE_VERTEX].bindingCount   = vertex_module->m_Uniforms.Size();
 
             vk_set_create_info[Program::MODULE_TYPE_FRAGMENT].sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-            vk_set_create_info[Program::MODULE_TYPE_FRAGMENT].pBindings    = &vk_descriptor_set_bindings[vertex_module->m_UniformCount];
-            vk_set_create_info[Program::MODULE_TYPE_FRAGMENT].bindingCount = fragment_module->m_UniformCount;
+            vk_set_create_info[Program::MODULE_TYPE_FRAGMENT].pBindings    = &vk_descriptor_set_bindings[vertex_module->m_Uniforms.Size()];
+            vk_set_create_info[Program::MODULE_TYPE_FRAGMENT].bindingCount = fragment_module->m_Uniforms.Size();
 
             vkCreateDescriptorSetLayout(context->m_LogicalDevice.m_Device,
                 &vk_set_create_info[Program::MODULE_TYPE_VERTEX],
@@ -2435,18 +2464,20 @@ bail:
 
         DestroyShaderModule(g_VulkanContext->m_LogicalDevice.m_Device, shader);
 
-        for (uint32_t i=0; i < shader->m_UniformCount; i++)
+        for (uint32_t i=0; i < shader->m_Uniforms.Size(); i++)
         {
             free(shader->m_Uniforms[i].m_Name);
+
+            for (uint32_t j = 0; j < shader->m_Uniforms[i].m_BlockMembers.Size(); ++j)
+            {
+                free(shader->m_Uniforms[i].m_BlockMembers[j].m_Name);
+            }
         }
 
-        for (uint32_t i=0; i < shader->m_InputCount; i++)
+        for (uint32_t i=0; i < shader->m_Inputs.Size(); i++)
         {
             free(shader->m_Inputs[i].m_Name);
         }
-
-        delete[] shader->m_Inputs;
-        delete[] shader->m_Uniforms;
     }
 
     static bool ReloadShader(ShaderModule* shader, ShaderDesc::Shader* ddf)
@@ -2518,7 +2549,7 @@ bail:
     static uint32_t VulkanGetAttributeCount(HProgram prog)
     {
         Program* program_ptr = (Program*) prog;
-        return program_ptr->m_VertexModule->m_InputCount;
+        return program_ptr->m_VertexModule->m_Inputs.Size();
     }
 
     // TODO: Move to graphics.cpp
@@ -2548,7 +2579,7 @@ bail:
     static void VulkanGetAttribute(HProgram prog, uint32_t index, dmhash_t* name_hash, Type* type, uint32_t* element_count, uint32_t* num_values, int32_t* location)
     {
         Program* program_ptr = (Program*) prog;
-        assert(index < program_ptr->m_VertexModule->m_InputCount);
+        assert(index < program_ptr->m_VertexModule->m_Inputs.Size());
         ShaderResourceBinding& attr = program_ptr->m_VertexModule->m_Inputs[index];
 
         *name_hash     = attr.m_NameHash;
@@ -2563,7 +2594,7 @@ bail:
         assert(prog);
         Program* program_ptr = (Program*) prog;
         assert(program_ptr->m_VertexModule && program_ptr->m_FragmentModule);
-        return program_ptr->m_VertexModule->m_UniformCount + program_ptr->m_FragmentModule->m_UniformCount;
+        return program_ptr->m_VertexModule->m_TotalUniformCount + program_ptr->m_FragmentModule->m_TotalUniformCount;
     }
 
     static uint32_t VulkanGetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size)
@@ -2572,22 +2603,50 @@ bail:
         Program* program_ptr = (Program*) prog;
         ShaderModule* module = program_ptr->m_VertexModule;
 
-        if (index >= program_ptr->m_VertexModule->m_UniformCount)
+        if (index >= program_ptr->m_VertexModule->m_TotalUniformCount)
         {
             module = program_ptr->m_FragmentModule;
-            index -= program_ptr->m_VertexModule->m_UniformCount;
+            index -= program_ptr->m_VertexModule->m_TotalUniformCount;
         }
 
-        if (index >= module->m_UniformCount)
+        if (index >= module->m_TotalUniformCount)
         {
             return 0;
         }
 
-        ShaderResourceBinding* res = &module->m_Uniforms[index];
-        *type = ShaderDataTypeToGraphicsType(res->m_Type);
-        *size = res->m_ElementCount;
+        uint32_t search_index = 0;
+        for (int i = 0; i < module->m_Uniforms.Size(); ++i)
+        {
+            if (IsUniformTextureSampler(module->m_Uniforms[i]))
+            {
+                if (search_index == index)
+                {
+                    ShaderResourceBinding* res = &module->m_Uniforms[index];
+                    *type = ShaderDataTypeToGraphicsType(res->m_Type);
+                    *size = res->m_ElementCount;
+                    return (uint32_t)dmStrlCpy(buffer, res->m_Name, buffer_size);
+                }
+                search_index++;
+            }
+            else
+            {
+                for (int j = 0; j < module->m_Uniforms[i].m_BlockMembers.Size(); ++j)
+                {
+                    if (search_index == index)
+                    {
+                        UniformBlockMember& member = module->m_Uniforms[i].m_BlockMembers[j];
+                        *type = ShaderDataTypeToGraphicsType(member.m_Type);
+                        *size = member.m_ElementCount;
+                        return (uint32_t) dmStrlCpy(buffer, member.m_Name, buffer_size);
+                    }
 
-        return (uint32_t)dmStrlCpy(buffer, res->m_Name, buffer_size);
+                    search_index++;
+                }
+            }
+        }
+
+        assert(0); // Should not happen
+        return 0;
     }
 
     // In OpenGL, there is a single global resource identifier between
@@ -2596,93 +2655,120 @@ bail:
     // of this ourselves. Because of this we pack resource locations
     // for uniforms in a single base register with 15 bits
     // per shader location. If uniform is not found, we return -1 as usual.
-    #define UNIFORM_LOCATION_MAX         0x00007FFF
-    #define UNIFORM_LOCATION_BIT_COUNT   15
-    #define UNIFORM_LOCATION_GET_VS(loc) (loc  & UNIFORM_LOCATION_MAX)
-    #define UNIFORM_LOCATION_GET_FS(loc) ((loc & (UNIFORM_LOCATION_MAX << UNIFORM_LOCATION_BIT_COUNT)) >> UNIFORM_LOCATION_BIT_COUNT)
+    #define UNIFORM_LOCATION_MAX                ((uint64_t) 0xFFFF)
+    #define UNIFORM_LOCATION_GET_VS(loc)        (loc & UNIFORM_LOCATION_MAX)
+    #define UNIFORM_LOCATION_GET_VS_MEMBER(loc) ((loc & (UNIFORM_LOCATION_MAX << 16)) >> 16)
+    #define UNIFORM_LOCATION_GET_FS(loc)        ((loc & (UNIFORM_LOCATION_MAX << 32)) >> 32)
+    #define UNIFORM_LOCATION_GET_FS_MEMBER(loc) ((loc & (UNIFORM_LOCATION_MAX << 48)) >> 48)
 
     // TODO, comment from the PR (#4544):
     //   "These frequent lookups could be improved by sorting on the key beforehand,
     //   and during lookup, do a lower_bound, to find the item (or not).
     //   E.g see: engine/render/src/render/material.cpp#L446"
-    static bool GetUniformIndex(ShaderResourceBinding* uniforms, uint32_t uniformCount, const char* name, uint32_t* index_out)
+    static bool GetUniformIndices(const dmArray<ShaderResourceBinding>& uniforms, dmhash_t name_hash, uint64_t* index_out, uint64_t* index_member_out)
     {
-        assert(uniformCount < UNIFORM_LOCATION_MAX);
-        for (uint32_t i = 0; i < uniformCount; ++i)
+        assert(uniforms.Size() < UNIFORM_LOCATION_MAX);
+        for (uint32_t i = 0; i < uniforms.Size(); ++i)
         {
-            if (dmStrCaseCmp(uniforms[i].m_Name, name) == 0)
+            if (uniforms[i].m_NameHash == name_hash)
             {
                 *index_out = i;
+                *index_member_out = 0;
                 return true;
+            }
+            else
+            {
+                for (uint32_t j = 0; j < uniforms[i].m_BlockMembers.Size(); ++j)
+                {
+                    if (uniforms[i].m_BlockMembers[j].m_NameHash == name_hash)
+                    {
+                        *index_out = i;
+                        *index_member_out = j;
+                        return true;
+                    }
+                }
             }
         }
 
         return false;
     }
 
-    static int32_t VulkanGetUniformLocation(HProgram prog, const char* name)
+    static HUniformLocation VulkanGetUniformLocation(HProgram prog, const char* name)
     {
         assert(prog);
         Program* program_ptr = (Program*) prog;
         ShaderModule* vs     = program_ptr->m_VertexModule;
         ShaderModule* fs     = program_ptr->m_FragmentModule;
-        uint32_t vs_location = UNIFORM_LOCATION_MAX;
-        uint32_t fs_location = UNIFORM_LOCATION_MAX;
-        bool vs_found        = GetUniformIndex(vs->m_Uniforms, vs->m_UniformCount, name, &vs_location);
-        bool fs_found        = GetUniformIndex(fs->m_Uniforms, fs->m_UniformCount, name, &fs_location);
+
+        uint64_t vs_location        = UNIFORM_LOCATION_MAX,
+                 vs_location_member = UNIFORM_LOCATION_MAX;
+        uint64_t fs_location        = UNIFORM_LOCATION_MAX,
+                 fs_location_member = UNIFORM_LOCATION_MAX;
+
+        HUniformLocation loc = INVALID_UNIFORM_LOCATION;
+        dmhash_t name_hash   = dmHashString64(name);
+        bool vs_found        = GetUniformIndices(vs->m_Uniforms, name_hash, &vs_location, &vs_location_member);
+        bool fs_found        = GetUniformIndices(fs->m_Uniforms, name_hash, &fs_location, &fs_location_member);
 
         if (vs_found || fs_found)
         {
-            return vs_location | (fs_location << UNIFORM_LOCATION_BIT_COUNT);
+            loc = vs_location | vs_location_member << 16 | fs_location << 32 | fs_location_member << 48;
+            assert(loc != INVALID_UNIFORM_LOCATION);
         }
 
-        return -1;
+        return loc;
     }
 
-    static void VulkanSetConstantV4(HContext context, const dmVMath::Vector4* data, int count, int base_register)
+    static void VulkanSetConstantV4(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location)
     {
         assert(g_VulkanContext->m_CurrentProgram);
-        assert(base_register >= 0);
+        assert(base_location >= 0);
         Program* program_ptr = (Program*) g_VulkanContext->m_CurrentProgram;
 
-        uint32_t index_vs  = UNIFORM_LOCATION_GET_VS(base_register);
-        uint32_t index_fs  = UNIFORM_LOCATION_GET_FS(base_register);
+        uint32_t index_vs        = UNIFORM_LOCATION_GET_VS(base_location);
+        uint32_t index_vs_member = UNIFORM_LOCATION_GET_VS_MEMBER(base_location);
+        uint32_t index_fs        = UNIFORM_LOCATION_GET_FS(base_location);
+        uint32_t index_fs_member = UNIFORM_LOCATION_GET_FS_MEMBER(base_location);
         assert(!(index_vs == UNIFORM_LOCATION_MAX && index_fs == UNIFORM_LOCATION_MAX));
 
         if (index_vs != UNIFORM_LOCATION_MAX)
         {
             ShaderResourceBinding& res = program_ptr->m_VertexModule->m_Uniforms[index_vs];
-            assert(index_vs < program_ptr->m_VertexModule->m_UniformCount);
+            UniformBlockMember& member = res.m_BlockMembers[index_vs_member];
+
             assert(!IsUniformTextureSampler(res));
             uint32_t offset_index      = res.m_UniformDataIndex;
-            uint32_t offset            = program_ptr->m_UniformDataOffsets[offset_index];
+            uint32_t offset            = program_ptr->m_UniformDataOffsets[offset_index] + member.m_Offset;
             memcpy(&program_ptr->m_UniformData[offset], data, sizeof(dmVMath::Vector4) * count);
         }
 
         if (index_fs != UNIFORM_LOCATION_MAX)
         {
             ShaderResourceBinding& res = program_ptr->m_FragmentModule->m_Uniforms[index_fs];
-            assert(index_fs < program_ptr->m_FragmentModule->m_UniformCount);
+            UniformBlockMember& member = res.m_BlockMembers[index_fs_member];
+
             assert(!IsUniformTextureSampler(res));
             // Fragment uniforms are packed behind vertex uniforms hence the extra offset here
             uint32_t offset_index = program_ptr->m_VertexModule->m_UniformBufferCount + res.m_UniformDataIndex;
-            uint32_t offset       = program_ptr->m_UniformDataOffsets[offset_index];
+            uint32_t offset       = program_ptr->m_UniformDataOffsets[offset_index] + member.m_Offset;
             memcpy(&program_ptr->m_UniformData[offset], data, sizeof(dmVMath::Vector4) * count);
         }
     }
 
-    static void VulkanSetConstantM4(HContext context, const dmVMath::Vector4* data, int count, int base_register)
+    static void VulkanSetConstantM4(HContext context, const dmVMath::Vector4* data, int count, HUniformLocation base_location)
     {
         Program* program_ptr = (Program*) g_VulkanContext->m_CurrentProgram;
 
-        uint32_t index_vs  = UNIFORM_LOCATION_GET_VS(base_register);
-        uint32_t index_fs  = UNIFORM_LOCATION_GET_FS(base_register);
+        uint32_t index_vs        = UNIFORM_LOCATION_GET_VS(base_location);
+        uint32_t index_vs_member = UNIFORM_LOCATION_GET_VS_MEMBER(base_location);
+        uint32_t index_fs        = UNIFORM_LOCATION_GET_FS(base_location);
+        uint32_t index_fs_member = UNIFORM_LOCATION_GET_FS_MEMBER(base_location);
         assert(!(index_vs == UNIFORM_LOCATION_MAX && index_fs == UNIFORM_LOCATION_MAX));
 
         if (index_vs != UNIFORM_LOCATION_MAX)
         {
             ShaderResourceBinding& res = program_ptr->m_VertexModule->m_Uniforms[index_vs];
-            assert(index_vs < program_ptr->m_VertexModule->m_UniformCount);
+            assert(index_vs < program_ptr->m_VertexModule->m_Uniforms.Size());
             assert(!IsUniformTextureSampler(res));
             uint32_t offset_index      = res.m_UniformDataIndex;
             uint32_t offset            = program_ptr->m_UniformDataOffsets[offset_index];
@@ -2692,7 +2778,7 @@ bail:
         if (index_fs != UNIFORM_LOCATION_MAX)
         {
             ShaderResourceBinding& res = program_ptr->m_FragmentModule->m_Uniforms[index_fs];
-            assert(index_fs < program_ptr->m_FragmentModule->m_UniformCount);
+            assert(index_fs < program_ptr->m_FragmentModule->m_Uniforms.Size());
             assert(!IsUniformTextureSampler(res));
             // Fragment uniforms are packed behind vertex uniforms hence the extra offset here
             uint32_t offset_index = program_ptr->m_VertexModule->m_UniformBufferCount + res.m_UniformDataIndex;
@@ -2701,7 +2787,7 @@ bail:
         }
     }
 
-    static void VulkanSetSampler(HContext context, int32_t location, int32_t unit)
+    static void VulkanSetSampler(HContext context, HUniformLocation location, int32_t unit)
     {
         assert(context && g_VulkanContext->m_CurrentProgram);
         Program* program_ptr = (Program*) g_VulkanContext->m_CurrentProgram;
@@ -2713,7 +2799,7 @@ bail:
         if (index_vs != UNIFORM_LOCATION_MAX)
         {
             ShaderResourceBinding& res = program_ptr->m_VertexModule->m_Uniforms[index_vs];
-            assert(index_vs < program_ptr->m_VertexModule->m_UniformCount);
+            assert(index_vs < program_ptr->m_VertexModule->m_Uniforms.Size());
             assert(IsUniformTextureSampler(res));
             program_ptr->m_VertexModule->m_Uniforms[index_vs].m_TextureUnit = (uint16_t) unit;
         }
@@ -2721,16 +2807,17 @@ bail:
         if (index_fs != UNIFORM_LOCATION_MAX)
         {
             ShaderResourceBinding& res = program_ptr->m_FragmentModule->m_Uniforms[index_fs];
-            assert(index_fs < program_ptr->m_FragmentModule->m_UniformCount);
+            assert(index_fs < program_ptr->m_FragmentModule->m_Uniforms.Size());
             assert(IsUniformTextureSampler(res));
             program_ptr->m_FragmentModule->m_Uniforms[index_fs].m_TextureUnit = (uint16_t) unit;
         }
     }
 
     #undef UNIFORM_LOCATION_MAX
-    #undef UNIFORM_LOCATION_BIT_COUNT
     #undef UNIFORM_LOCATION_GET_VS
+    #undef UNIFORM_LOCATION_GET_VS_MEMBER
     #undef UNIFORM_LOCATION_GET_FS
+    #undef UNIFORM_LOCATION_GET_FS_MEMBER
 
     static void VulkanSetViewport(HContext context, int32_t x, int32_t y, int32_t width, int32_t height)
     {

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1893,7 +1893,7 @@ bail:
             else
             {
                 dynamic_offsets[res.m_UniformDataIndex] = (uint32_t) scratch_buffer->m_MappedDataCursor;
-                const uint32_t uniform_size_nonalign    = res.m_DataSize; //GetShaderTypeSize(res.m_Type) * res.m_ElementCount;
+                const uint32_t uniform_size_nonalign    = res.m_DataSize;
                 const uint32_t uniform_size             = DM_ALIGN(uniform_size_nonalign, dynamic_alignment);
 
                 assert(uniform_size_nonalign > 0);
@@ -2678,6 +2678,7 @@ bail:
             }
             else
             {
+                assert(uniforms[i].m_BlockMembers.Size() < UNIFORM_LOCATION_MAX);
                 for (uint32_t j = 0; j < uniforms[i].m_BlockMembers.Size(); ++j)
                 {
                     if (uniforms[i].m_BlockMembers[j].m_NameHash == name_hash)

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -234,14 +234,25 @@ namespace dmGraphics
         VkCommandPool m_CommandPool;
     };
 
-    struct ShaderResourceBinding
+    struct UniformBlockMember
     {
         char*                      m_Name;
         uint64_t                   m_NameHash;
         ShaderDesc::ShaderDataType m_Type;
+        uint32_t                   m_Offset;
         uint16_t                   m_ElementCount;
-        uint16_t                   m_Set;
-        uint16_t                   m_Binding;
+    };
+
+    struct ShaderResourceBinding
+    {
+        char*                       m_Name;
+        uint64_t                    m_NameHash;
+        ShaderDesc::ShaderDataType  m_Type;
+        dmArray<UniformBlockMember> m_BlockMembers;
+        uint32_t                    m_DataSize;
+        uint16_t                    m_ElementCount;
+        uint16_t                    m_Set;
+        uint16_t                    m_Binding;
         union
         {
             uint16_t               m_UniformDataIndex;
@@ -251,15 +262,14 @@ namespace dmGraphics
 
     struct ShaderModule
     {
-        uint64_t               m_Hash;
-        VkShaderModule         m_Module;
-        ShaderResourceBinding* m_Uniforms;
-        ShaderResourceBinding* m_Inputs;
-        uint32_t               m_UniformDataSizeAligned;
-        uint16_t               m_UniformCount;
-        uint16_t               m_UniformBufferCount;
-        uint16_t               m_InputCount;
-        uint16_t               m_TextureSamplerCount;
+        uint64_t                       m_Hash;
+        VkShaderModule                 m_Module;
+        dmArray<ShaderResourceBinding> m_Uniforms;
+        dmArray<ShaderResourceBinding> m_Inputs;
+        uint32_t                       m_UniformDataSizeAligned;
+        uint16_t                       m_UniformBufferCount;
+        uint16_t                       m_TextureSamplerCount;
+        uint16_t                       m_TotalUniformCount;
     };
 
     struct Program

--- a/engine/render/src/dmsdk/render/render.h
+++ b/engine/render/src/dmsdk/render/render.h
@@ -466,15 +466,15 @@ namespace dmRender
      * @param constant [type: dmRender::HConstant] The shader constant
      * @return location [type: int32_t] the location
     */
-    int32_t GetConstantLocation(HConstant constant);
+    dmGraphics::HUniformLocation GetConstantLocation(HConstant constant);
 
     /*#
      * Sets the shader program constant location
      * @name SetConstantLocation
      * @param constant [type: dmRender::HConstant] The shader constant
-     * @param location [type: int32_t] the location
+     * @param location [type: dmGraphics::HUniformLocation] the location
     */
-    void SetConstantLocation(HConstant constant, int32_t location);
+    void SetConstantLocation(HConstant constant, dmGraphics::HUniformLocation location);
 
     /*#
      * Gets the type of the constant

--- a/engine/render/src/render/constant.cpp
+++ b/engine/render/src/render/constant.cpp
@@ -22,7 +22,7 @@ namespace dmRender
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Constant::Constant() {}
-Constant::Constant(dmhash_t name_hash, int32_t location)
+Constant::Constant(dmhash_t name_hash, dmGraphics::HUniformLocation location)
     : m_Values(0)
     , m_NameHash(name_hash)
     , m_Type(dmRenderDDF::MaterialDesc::CONSTANT_TYPE_USER)
@@ -76,12 +76,12 @@ void SetConstantName(HConstant constant, dmhash_t name)
     constant->m_NameHash = name;
 }
 
-int32_t GetConstantLocation(HConstant constant)
+dmGraphics::HUniformLocation GetConstantLocation(HConstant constant)
 {
     return constant->m_Location;
 }
 
-void SetConstantLocation(HConstant constant, int32_t location)
+void SetConstantLocation(HConstant constant, dmGraphics::HUniformLocation location)
 {
     constant->m_Location = location;
 }
@@ -364,7 +364,7 @@ struct ApplyConstantContext
 
 static inline void ApplyConstant(ApplyConstantContext* context, const uint64_t* name_hash, NamedConstantBuffer::Constant* constant)
 {
-    int32_t* location = context->m_Material->m_NameHashToLocation.Get(*name_hash);
+    dmGraphics::HUniformLocation* location = context->m_Material->m_NameHashToLocation.Get(*name_hash);
     if (location)
     {
         dmVMath::Vector4* values = &context->m_ConstantBuffer->m_Values[constant->m_ValueIndex];

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -77,11 +77,11 @@ namespace dmRender
         dmVMath::Vector4*                       m_Values;
         dmhash_t                                m_NameHash;
         dmRenderDDF::MaterialDesc::ConstantType m_Type;         // TODO: Make this a uint16_t as well
-        int32_t                                 m_Location;     // Vulkan encodes vs/fs location in the lower/upper bits
+        dmGraphics::HUniformLocation            m_Location;     // Vulkan encodes vs/fs location in the lower/upper bits
         uint16_t                                m_NumValues;
 
         Constant();
-        Constant(dmhash_t name_hash, int32_t location);
+        Constant(dmhash_t name_hash, dmGraphics::HUniformLocation location);
     };
 
     struct MaterialConstant
@@ -229,7 +229,7 @@ namespace dmRender
     bool                            GetMaterialProgramConstantInfo(HMaterial material, dmhash_t name_hash, dmhash_t* out_constant_id, dmhash_t* out_element_ids[4], uint32_t* out_element_index, uint16_t* out_num_components);
 
     void                            SetMaterialProgramConstant(HMaterial material, dmhash_t name_hash, dmVMath::Vector4* constant, uint32_t count);
-    int32_t                         GetMaterialConstantLocation(HMaterial material, dmhash_t name_hash);
+    dmGraphics::HUniformLocation    GetMaterialConstantLocation(HMaterial material, dmhash_t name_hash);
     bool                            SetMaterialSampler(HMaterial material, dmhash_t name_hash, uint32_t unit, dmGraphics::TextureWrap u_wrap, dmGraphics::TextureWrap v_wrap, dmGraphics::TextureFilter min_filter, dmGraphics::TextureFilter mag_filter, float max_anisotropy);
     HRenderContext                  GetMaterialRenderContext(HMaterial material);
     void                            SetMaterialVertexSpace(HMaterial material, dmRenderDDF::MaterialDesc::VertexSpace vertex_space);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -45,9 +45,9 @@ namespace dmRender
         dmGraphics::TextureFilter m_MagFilter;
         dmGraphics::TextureWrap   m_UWrap;
         dmGraphics::TextureWrap   m_VWrap;
+        dmGraphics::HUniformLocation m_Location;
         float                     m_MaxAnisotropy;
-        int32_t                   m_Location       : 24;
-        int32_t                   m_UnitValueCount : 8;
+        uint8_t                   m_UnitValueCount;
 
         Sampler()
             : m_NameHash(0)
@@ -56,8 +56,8 @@ namespace dmRender
             , m_MagFilter(dmGraphics::TEXTURE_FILTER_LINEAR)
             , m_UWrap(dmGraphics::TEXTURE_WRAP_CLAMP_TO_EDGE)
             , m_VWrap(dmGraphics::TEXTURE_WRAP_CLAMP_TO_EDGE)
+            , m_Location(dmGraphics::INVALID_UNIFORM_LOCATION)
             , m_MaxAnisotropy(1.0f)
-            , m_Location(-1)
             , m_UnitValueCount(0)
         {
         }
@@ -88,7 +88,7 @@ namespace dmRender
         dmGraphics::HVertexProgram              m_VertexProgram;
         dmGraphics::HFragmentProgram            m_FragmentProgram;
         dmGraphics::HVertexDeclaration          m_VertexDeclaration;
-        dmHashTable64<int32_t>                  m_NameHashToLocation;
+        dmHashTable64<dmGraphics::HUniformLocation> m_NameHashToLocation;
         dmArray<dmGraphics::VertexAttribute>    m_VertexAttributes;
         dmArray<MaterialAttribute>              m_MaterialAttributes;
         dmArray<uint8_t>                        m_MaterialAttributeValues;
@@ -279,7 +279,6 @@ namespace dmRender
     void                            GetMaterialTagList(HRenderContext context, uint32_t list_hash, MaterialTagList* list);
 
     bool GetCanBindTexture(dmGraphics::HTexture texture, HSampler sampler, uint32_t unit);
-    uint32_t ApplyTextureAndSampler(dmRender::HRenderContext render_context, dmGraphics::HTexture texture, HSampler sampler, uint8_t unit);
 
     // Exposed here for unit testing
     struct RenderListEntrySorter

--- a/engine/render/src/test/test_material.cpp
+++ b/engine/render/src/test/test_material.cpp
@@ -28,7 +28,7 @@ using namespace dmVMath;
 
 namespace dmGraphics
 {
-    extern const Vector4& GetConstantV4Ptr(dmGraphics::HContext context, int base_register);
+    extern const Vector4& GetConstantV4Ptr(dmGraphics::HContext context, dmGraphics::HUniformLocation base_register);
 }
 
 class dmRenderMaterialTest : public jc_test_base_class
@@ -103,7 +103,7 @@ TEST_F(dmRenderMaterialTest, TestMaterialConstants)
     // test setting constant
     dmGraphics::HProgram program = dmRender::GetMaterialProgram(material);
     dmGraphics::EnableProgram(m_GraphicsContext, program);
-    uint32_t tint_loc = dmGraphics::GetUniformLocation(program, "tint");
+    dmGraphics::HUniformLocation tint_loc = dmGraphics::GetUniformLocation(program, "tint");
     ASSERT_EQ(0, tint_loc);
     dmRender::ApplyNamedConstantBuffer(m_RenderContext, material, ro.m_ConstantBuffer);
     const Vector4& v = dmGraphics::GetConstantV4Ptr(m_GraphicsContext, tint_loc);
@@ -232,7 +232,7 @@ TEST_F(dmRenderMaterialTest, TestMaterialConstantsOverride)
 
     // using the null graphics device, constant locations are assumed to be in declaration order.
     // test setting constant, no override material
-    uint32_t tint_loc = dmGraphics::GetUniformLocation(program, "tint");
+    dmGraphics::HUniformLocation tint_loc = dmGraphics::GetUniformLocation(program, "tint");
     ASSERT_EQ(0, tint_loc);
     dmGraphics::EnableProgram(m_GraphicsContext, program);
     dmRender::ApplyNamedConstantBuffer(m_RenderContext, material, ro.m_ConstantBuffer);
@@ -246,7 +246,7 @@ TEST_F(dmRenderMaterialTest, TestMaterialConstantsOverride)
     test_v = Vector4(2.0f, 1.0f, 1.0f, 1.0f);
     dmRender::ClearNamedConstantBuffer(constants);
     dmRender::SetNamedConstant(constants, dmHashString64("tint"), &test_v, 1);
-    uint32_t tint_loc_ovr = dmGraphics::GetUniformLocation(program_ovr, "tint");
+    dmGraphics::HUniformLocation tint_loc_ovr = dmGraphics::GetUniformLocation(program_ovr, "tint");
     ASSERT_EQ(1, tint_loc_ovr);
     dmGraphics::EnableProgram(m_GraphicsContext, program_ovr);
     dmRender::ApplyNamedConstantBuffer(m_RenderContext, material_ovr, ro.m_ConstantBuffer);


### PR DESCRIPTION
This PR adds:
* Support for uniform buffers for the Vulkan backend. 
* If a shader has specified a #version it will not be transformed from ES2 to ES3 (SPIR-V only)
