### PR TITLE
Add TEXTURE_FORMAT_RGBA32UI support for vulkan

### DIFF
--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -162,6 +162,7 @@ namespace dmGraphics
      * @member TEXTURE_FORMAT_RG16F
      * @member TEXTURE_FORMAT_R32F
      * @member TEXTURE_FORMAT_RG32F
+     * @member TEXTURE_FORMAT_RGBA32UI
      * @member TEXTURE_FORMAT_COUNT
      */
     enum TextureFormat
@@ -198,13 +199,30 @@ namespace dmGraphics
         TEXTURE_FORMAT_RG16F                = 27,
         TEXTURE_FORMAT_R32F                 = 28,
         TEXTURE_FORMAT_RG32F                = 29,
+        // Internal formats (not exposed via script APIs)
+        TEXTURE_FORMAT_RGBA32UI             = 30,
 
         TEXTURE_FORMAT_COUNT
     };
 
+    /*#
+     * Get the attachment texture from a render target. Returns zero if no such attachment texture exists.
+     * @name GetRenderTargetAttachment
+     * @param render_target [type: dmGraphics::HRenderTarget] the render target
+     * @param attachment_type [type: dmGraphics::RenderTargetAttachment] the attachment to get
+     * @return attachment [type: dmGraphics::HTexture] the attachment texture
+     */
     HTexture GetRenderTargetAttachment(HRenderTarget render_target, RenderTargetAttachment attachment_type);
-    HandleResult GetTextureHandle(HTexture texture, void** out_handle);
 
+    /*#
+     * Get the native graphics API texture object from an engine texture handle. This depends on the graphics backend and is not
+     * guaranteed to be implemented on the currently running adapter.
+     * @name GetTextureHandle
+     * @param texture [type: dmGraphics::HTexture] the texture handle
+     * @param out_handle [type: void**] a pointer to where the raw object should be stored
+     * @return handle_result [type: dmGraphics::HandleResult] the result of the query
+     */
+    HandleResult GetTextureHandle(HTexture texture, void** out_handle);
 
     /*#
      * @enum

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -189,6 +189,7 @@ namespace dmGraphics
             GRAPHICS_ENUM_TO_STR_CASE(TEXTURE_FORMAT_RG16F);
             GRAPHICS_ENUM_TO_STR_CASE(TEXTURE_FORMAT_R32F);
             GRAPHICS_ENUM_TO_STR_CASE(TEXTURE_FORMAT_RG32F);
+            GRAPHICS_ENUM_TO_STR_CASE(TEXTURE_FORMAT_RGBA32UI);
             default:break;
         }
         return "<unknown dmGraphics::TextureFormat>";
@@ -502,6 +503,7 @@ namespace dmGraphics
         case TEXTURE_FORMAT_RG16F:              return 32;
         case TEXTURE_FORMAT_R32F:               return 32;
         case TEXTURE_FORMAT_RG32F:              return 64;
+        case TEXTURE_FORMAT_RGBA32UI:           return 128;
         default:
             assert(false && "Unknown texture format");
             return TEXTURE_FORMAT_COUNT;
@@ -586,6 +588,7 @@ namespace dmGraphics
         switch(format)
         {
             case dmGraphics::TEXTURE_FORMAT_RGBA:
+            case dmGraphics::TEXTURE_FORMAT_RGBA32UI:
             case dmGraphics::TEXTURE_FORMAT_RGBA_BC7:
             case dmGraphics::TEXTURE_FORMAT_RGBA_BC3:
             case dmGraphics::TEXTURE_FORMAT_RGBA_ASTC_4x4:

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -792,6 +792,7 @@ namespace dmGraphics
                                             TEXTURE_FORMAT_LUMINANCE_ALPHA,
                                             TEXTURE_FORMAT_RGBA,
 
+                                            // Float formats
                                             TEXTURE_FORMAT_RGB16F,
                                             TEXTURE_FORMAT_RGB32F,
                                             TEXTURE_FORMAT_RGBA16F,
@@ -800,6 +801,9 @@ namespace dmGraphics
                                             TEXTURE_FORMAT_RG16F,
                                             TEXTURE_FORMAT_R32F,
                                             TEXTURE_FORMAT_RG32F,
+
+                                            // Misc formats
+                                            TEXTURE_FORMAT_RGBA32UI,
 
                                             // Apparently these aren't supported on macOS/Metal
                                             TEXTURE_FORMAT_RGB_16BPP,
@@ -1469,7 +1473,12 @@ bail:
     {
         assert(size > 0);
         DeviceBuffer* buffer = new DeviceBuffer(VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
-        DeviceBufferUploadHelper((VulkanContext*) context, data, size, 0, (DeviceBuffer*) buffer);
+
+        if (size > 0)
+        {
+            DeviceBufferUploadHelper((VulkanContext*) context, data, size, 0, buffer);
+        }
+
         return (HIndexBuffer) buffer;
     }
 
@@ -2903,6 +2912,7 @@ bail:
             case TEXTURE_FORMAT_RG16F:              return VK_FORMAT_R16G16_SFLOAT;
             case TEXTURE_FORMAT_R32F:               return VK_FORMAT_R32_SFLOAT;
             case TEXTURE_FORMAT_RG32F:              return VK_FORMAT_R32G32_SFLOAT;
+            case TEXTURE_FORMAT_RGBA32UI:           return VK_FORMAT_R32G32B32A32_UINT;
             default:                                return VK_FORMAT_UNDEFINED;
         };
     }


### PR DESCRIPTION
Some extensions require this format to work on Vulkan. It should not be adopted engine-wide yet, but since the texture formats are exposed in dmsdk we need to make that API change as well.. 