### PR TITLE
Make suggest code editor autocomplete

### DIFF
--- a/editor/src/clj/editor/prefs_dialog.clj
+++ b/editor/src/clj/editor/prefs_dialog.clj
@@ -56,18 +56,25 @@
   (filter #(.exists (io/file %)) files))
 
 (defn- suggest-code-editor-macos []
-  (let [files (list "/Applications/Visual Studio Code.app/Contents/MacOS/Electron")]
+  (let [files (list "/Applications/Visual Studio Code.app/Contents/MacOS/Electron"
+                    "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
+                    "/Applications/TextMate.app/Contents/Resources/mate")]
     (filter-exist-files files)))
 
 (defn- suggest-code-editor-win []
   (let [files (list "C:/Program Files/Microsoft VS Code/Code.exe"
-                    "C:/Program Files (x86)/Microsoft VS Code/Code.exe")]
+                    "C:/Program Files (x86)/Microsoft VS Code/Code.exe"
+                    "C:/Program Files/Sublime Text/sublime_text.exe"
+                    "C:/Program Files (x86)/Sublime Text/sublime_text.exe"
+                    "C:/Program Files/Notepad++/notepad++.exe")]
     (filter-exist-files files)))
 
 (defn- suggest-code-editor-linux []
   (let [files (list "/usr/bin/code"
                     "/usr/share/code"
-                    "/snap/code/current")]
+                    "/snap/code/current"
+                    "/usr/bin/subl"
+                    "/snap/sublime-text/current/opt/sublime_text")]
     (filter-exist-files files)))
 
 (defn- suggest-code-editor []


### PR DESCRIPTION
Fixes #8016 

**Implement**
- Define list editor (name + path possible for each OS): https://github.com/defold/defold/pull/8105/files#diff-0da8130ad6435081bda29bc4ebabbf13ab067345a1e312ac96c7ac9c77209ef6R57


- Filter exist path then display in the dropdown box.

At the end of dropdown -> Add "Brower..."; So when user click -> open file picker to select file.
After the file (editor) is selected -> Put that item above "Browser..." and selected that item.

If user "Browser..." file again -> that replace previous "Browser... item" with the new one.

In the dropdown, the first item is "Defold Editor" that mean edit insider Defold editor itself.

**TODO**

Asking for help to add more editor here: https://github.com/defold/defold/pull/8105/files#diff-0da8130ad6435081bda29bc4ebabbf13ab067345a1e312ac96c7ac9c77209ef6R57

**Demo**

https://github.com/defold/defold/assets/6185205/c2d70232-0ea2-49b9-b61d-776cf2921c25


