### PR TITLE
Escape underscore in menu

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2105,7 +2105,7 @@ If you do not specifically require different script states, consider changing th
                     (conj {:label :separator})
                     (into
                       (map (fn [[resource view-type :as resource+view-type]]
-                             {:label (str (resource/proj-path resource) " • " (:label view-type) " view")
+                             {:label (string/replace (str (resource/proj-path resource) " • " (:label view-type) " view") #"_" "__")
                               :command :open-selected-recent-file
                               :user-data resource+view-type}))
                       (recent-files/some-recent prefs workspace evaluation-context))


### PR DESCRIPTION
Fixes an issue where '_' was not shows in the Recent Files menu.

Fixes #7759 

Technical changes:
**Implement**
Just replaces "_" with "__" to escape.

**Demo**

![demo-2023-10-07-19h44m54s400](https://github.com/defold/defold/assets/6185205/0b7a7bb1-d808-4470-9769-b414b663eb2b)

