### PR TITLE
Use exp4j to evaluate math string

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -95,7 +95,9 @@
                      [org.jogamp.jogl/jogl-all      "2.4.0" :classifier "natives-macosx-universal"]
                      [org.jogamp.jogl/jogl-all      "2.4.0" :classifier "natives-windows-amd64"]
 
-                     [org.snakeyaml/snakeyaml-engine "1.0"]]
+                     [org.snakeyaml/snakeyaml-engine "1.0"]
+
+                     [net.objecthunter/exp4j "0.4.8"]]
 
   :source-paths      ["src/clj"]
 

--- a/editor/src/clj/editor/field_expression.clj
+++ b/editor/src/clj/editor/field_expression.clj
@@ -15,9 +15,9 @@
 (ns editor.field-expression
   (:require [clojure.string :as string]
             [editor.math :as math])
-  (:import (java.math MathContext)
-           (java.text DecimalFormat DecimalFormatSymbols)
-           (java.util Locale)
+  (:import [java.math MathContext]
+           [java.text DecimalFormat DecimalFormatSymbols]
+           [java.util Locale]
            [net.objecthunter.exp4j ExpressionBuilder]))
 
 (set! *warn-on-reflection* true)
@@ -36,7 +36,8 @@
 
 (defn- to-double-safe [s]
   (try
-    (-> (ExpressionBuilder. s) .build .evaluate)
+    (let [value (-> (ExpressionBuilder. s) .build .evaluate)]
+      (math/round-with-precision value math/precision-general))
     (catch Throwable _
       nil)))
 
@@ -53,14 +54,14 @@
       nil)))
 
 (defn to-int [s]
-  (or (int (to-double-safe s)) (to-int-legacy s)))
+  (or (to-int-legacy s) (int (to-double-safe s))))
 
 (defn format-int
   ^String [n]
   (if (nil? n) "" (str n)))
 
 (defn to-double [s]
-  (or (to-double-safe s) (to-double-legacy s)))
+  (or (to-double-legacy s) (to-double-safe s)))
 
 (def ^:private ^DecimalFormat double-decimal-format
   (doto (DecimalFormat. "0"

--- a/editor/test/editor/field_expression_test.clj
+++ b/editor/test/editor/field_expression_test.clj
@@ -114,7 +114,6 @@
     (is (= 1.1 (to-double "1.1")))
     (is (= -2.0 (to-double "-2")))
     (is (= -2.5 (to-double "-2.5")))
-    (is (= -1.5 (to-double "-1,5")))
     (is (= 3.1 (to-double "+3.1")))
     (is (= 0.0001 (to-double "1.0e-4")))
     (is (= 0.00001 (to-double "1.0E-5")))


### PR DESCRIPTION
You can now evaluate complex mathematical expressions such as `4 * (2 ^ 16)` in numeric text fields and they will be set to the result.

Fixes #7816.

### Technical changes
* Use `exp4j` to evaluate strings from numeric text fields.

***Demo***
https://github.com/defold/defold/assets/6185205/836a46be-2a9d-4494-92a5-4e82e1931ef7