### PR TITLE
Set min/max size for quick help to zero

### DIFF
--- a/editor/resources/quick-help-view.fxml
+++ b/editor/resources/quick-help-view.fxml
@@ -4,7 +4,10 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
-<VBox id="quick-help-box" alignment="CENTER" spacing="10" visible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" xmlns="http://javafx.com/javafx/17.0.2-ea">
+<VBox id="quick-help-box" alignment="CENTER" spacing="10" visible="false"
+      AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"
+      minWidth="0" minHeight="0"
+      xmlns="http://javafx.com/javafx/17.0.2-ea">
     <ImageView id="quick-help-logo" fitWidth="300.0" pickOnBounds="true" preserveRatio="true">
         <Image url="@logo-ver-outline-white.png" />
         <VBox.margin>


### PR DESCRIPTION
Fixes #8111

Change min/max height of quick-help to zero. So the console log can be resize to maximum height.

**Demo:**

https://github.com/defold/defold/assets/6185205/6e384e0a-a264-4f27-86f0-6a21cb991b85



