### PR TITLE
Make autocomplete less aggressive

### DIFF
--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -894,7 +894,7 @@
   (let [results (mapv (fn [^CursorRange cursor-range]
                         (let [suggestion-cursor (data/adjust-cursor lines (data/cursor-range-start cursor-range))
                               line (subs (lines (.-row suggestion-cursor)) 0 (.-col suggestion-cursor))
-                              prefix (re-find #"[a-zA-Z_0-9.]*$" line)
+                              prefix (or (re-find #"[a-zA-Z_][a-zA-Z_0-9.]*$" line) "")
                               affected-cursor (if (pos? (data/compare-cursor-position
                                                           (.-from cursor-range)
                                                           (.-to cursor-range)))


### PR DESCRIPTION
User-facing changes:
Auto-complete popup no longer appears on typing digits.

Fixes #8113
