### PR TITLE
Fix non-working Z handles on the Scale Manipulator

### DIFF
--- a/editor/src/clj/editor/scene_tools.clj
+++ b/editor/src/clj/editor/scene_tools.clj
@@ -470,7 +470,7 @@
                              1.0)
                            (case manip
                              (:scale-z :scale-xz :scale-yz)
-                             (div-fn (.y delta) (.y start-delta))
+                             (div-fn (.z delta) (.z start-delta))
                              1.0))]
         (for [{:keys [node-id]} original-values]
           (manip-scale evaluation-context node-id scale-factor))))


### PR DESCRIPTION
Fixes #8116.

### User-facing changes
* The Scale Manipulator now works as expected when scaling along the Z axis, the XZ plane, and the YZ plane.