### PR TITLE
Fix issue with window focus on macOS Sonoma (14.0)

### DIFF
--- a/engine/glfw/lib/cocoa/cocoa_init.m
+++ b/engine/glfw/lib/cocoa/cocoa_init.m
@@ -243,6 +243,19 @@ int _glfwPlatformInit( void )
     // Setting up menu bar must go exactly here else weirdness ensues
     setUpMenuBar();
 
+    CFStringRef uti;
+    CFBundleRef bundle = CFBundleGetMainBundle();
+    CFURLRef bundleUrl = CFBundleCopyBundleURL(bundle);
+    if (CFURLCopyResourcePropertyForKey(bundleUrl, kCFURLTypeIdentifierKey, &uti, NULL) &&
+        uti && UTTypeConformsTo(uti, kUTTypeApplicationBundle))
+    {
+        _glfwLibrary.Unbundled = GL_FALSE;
+    } 
+    else
+    {
+        _glfwLibrary.Unbundled = GL_TRUE;
+    }
+
     [NSApp finishLaunching];
 
     // Install atexit routine

--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -132,10 +132,21 @@
     // Wait for the first update to make window inactive and then activate it again
     // It helps to avoid issue when the window opens inactive
     // https://github.com/defold/defold/issues/6709
-    if( !_glfwLibrary.Unbundled ) {
-        ProcessSerialNumber psn = { 0, kCurrentProcess };
-        TransformProcessType( &psn, kProcessTransformToBackgroundApplication );
-        [self performSelector:@selector(activateProcess) withObject:nil afterDelay:0.1];
+    if( !_glfwLibrary.Unbundled )
+    {
+        // Starting from macOS Sonoma (14.0) the old workaround isn't needed
+        NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+        if (version.majorVersion < 14)
+        {
+            ProcessSerialNumber psn = { 0, kCurrentProcess };
+            TransformProcessType( &psn, kProcessTransformToBackgroundApplication );
+            [self performSelector:@selector(activateProcess) withObject:nil afterDelay:0.1];
+        }
+        else
+        {
+            [self activateWindow];
+        }
+
         _glfwLibrary.Unbundled = GL_TRUE;
     }
 }

--- a/engine/glfw/lib/cocoa/cocoa_window.m
+++ b/engine/glfw/lib/cocoa/cocoa_window.m
@@ -153,6 +153,13 @@
     [[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
 }
 
+// macos 12+
+// https://sector7.computest.nl/post/2022-08-process-injection-breaking-all-macos-security-layers-with-a-single-vulnerability/
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    return YES;
+}
+
 @end
 
 // TODO: Need to find mappings for F13-F15, volume down/up/mute, and eject.

--- a/engine/glfw/lib/cocoa/platform.h
+++ b/engine/glfw/lib/cocoa/platform.h
@@ -161,6 +161,7 @@ GLFWGLOBAL struct {
     void *OpenGLFramework;
 
     int Unbundled;
+    int FirstUpdate;
 
     id DesktopMode;
 


### PR DESCRIPTION
Fixed issue when on macOS Sonoma (14.0) game window started without focus on it.

Fix https://github.com/defold/defold/issues/8066

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
