### PR TITLE
Revert to old sound library for HTML5

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -1778,7 +1778,7 @@ def detect(conf):
         conf.env['LIB_OPENAL'] = ['OpenSLES']
     elif platform in ('win32', 'x86_64-win32'):
         conf.env['LIB_OPENAL'] = ['OpenAL32']
-    elif platform in ('x86_64-linux','js-web','wasm-web'):
+    elif platform in ('x86_64-linux',):
         conf.env['LIB_OPENAL'] = ['openal']
 
     conf.env['STLIB_DLIB'] = ['dlib', 'mbedtls', 'zip']

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -126,7 +126,7 @@ def build(bld):
               '%s/share/java/gamesys_android.jar' % (dynamo_home),
               '%s/share/java/sound_android.jar' % (dynamo_home)]
 
-    web_libs = ['library_glfw.js', 'library_sys.js', 'library_script.js']
+    web_libs = ['library_glfw.js', 'library_sys.js', 'library_script.js', 'library_sound.js']
 
     main_cpp = 'common/main.cpp'
 

--- a/engine/sound/src/devices/device_js.cpp
+++ b/engine/sound/src/devices/device_js.cpp
@@ -1,0 +1,107 @@
+// Copyright 2020-2023 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+// 
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <dlib/array.h>
+#include <dlib/log.h>
+#include <dlib/math.h>
+#include <dlib/time.h>
+#include <dlib/profile.h>
+
+#include "sound.h"
+
+extern "C" {
+    // Implementation in library_sound.js
+    int dmDeviceJSOpen(int buffers);
+    int dmGetDeviceSampleRate(int device);
+    void dmDeviceJSQueue(int device, const int16_t* samples, uint32_t sample_count);
+    int dmDeviceJSFreeBufferSlots(int device);
+}
+
+
+namespace dmDeviceJS
+{
+    struct JSDevice
+    {
+        int devId;
+        bool isStarted;
+    };
+
+    dmSound::Result DeviceJSOpen(const dmSound::OpenDeviceParams* params, dmSound::HDevice* device)
+    {
+        assert(params);
+        assert(device);
+        JSDevice *dev = new JSDevice();
+        int deviceId = dmDeviceJSOpen(params->m_BufferCount);
+        if (deviceId < 0)
+        {
+            return dmSound::RESULT_DEVICE_NOT_FOUND;
+        }
+        dev->devId = deviceId;
+        dev->isStarted = false;
+        *device = dev;
+        return dmSound::RESULT_OK;
+    }
+
+    void DeviceJSClose(dmSound::HDevice device)
+    {
+        assert(device);
+        delete (JSDevice*)(device);
+    }
+
+    dmSound::Result DeviceJSQueue(dmSound::HDevice device, const int16_t* samples, uint32_t sample_count)
+    {
+        assert(device);
+        JSDevice *dev = (JSDevice*) device;
+        if (!dev->isStarted)
+        {
+            return dmSound::RESULT_INIT_ERROR;
+        }
+        dmDeviceJSQueue(dev->devId, samples, sample_count);
+        return dmSound::RESULT_OK;
+    }
+
+    uint32_t DeviceJSFreeBufferSlots(dmSound::HDevice device)
+    {
+        assert(device);
+        JSDevice *dev = (JSDevice*) device;
+        return dmDeviceJSFreeBufferSlots(dev->devId);
+    }
+
+    void DeviceJSDeviceInfo(dmSound::HDevice device, dmSound::DeviceInfo* info)
+    {
+        assert(device);
+        assert(info);
+        JSDevice *dev = (JSDevice*) device;
+        info->m_MixRate = dmGetDeviceSampleRate(dev->devId);
+    }
+
+    void DeviceJSStart(dmSound::HDevice device)
+    {
+        assert(device);
+        JSDevice *dev = (JSDevice*) device;
+        dev->isStarted = true;
+    }
+
+    void DeviceJSStop(dmSound::HDevice device)
+    {
+        assert(device);
+        JSDevice *dev = (JSDevice*) device;
+        dev->isStarted = false;
+    }
+
+    DM_DECLARE_SOUND_DEVICE(DefaultSoundDevice, "default", DeviceJSOpen, DeviceJSClose, DeviceJSQueue, DeviceJSFreeBufferSlots, DeviceJSDeviceInfo, DeviceJSStart, DeviceJSStop);
+}

--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -1,0 +1,98 @@
+var LibrarySoundDevice = 
+{
+   $DefoldSoundDevice: {
+      TryResumeAudio: function() {
+         var audioCtx = window._dmJSDeviceShared.audioCtx;
+         if (audioCtx !== undefined && audioCtx.state != "running") {
+             audioCtx.resume();
+         }
+      }
+   },
+   dmDeviceJSOpen: function(bufferCount) {
+
+        // globally shared data        
+        var shared = window._dmJSDeviceShared;
+        if (shared === undefined) {
+            shared = { 
+                count: 0,
+                devices: {}
+            };
+            window._dmJSDeviceShared = shared;
+        }
+        
+        var id = shared.count++;
+        var device;
+
+        if (window.AudioContext || window.webkitAudioContext) {
+            if (shared.audioCtx === undefined) {
+                shared.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+            }                
+            // Construct web audio device.
+            device = {
+                sampleRate: shared.audioCtx.sampleRate,
+                bufferedTo: 0,
+                bufferDuration: 0,
+                // functions
+                _queue: function(samples, sample_count) {
+                    var buf = shared.audioCtx.createBuffer(2, sample_count, this.sampleRate);
+                    var c0 = buf.getChannelData(0);
+                    var c1 = buf.getChannelData(1);
+                    for (var i=0;i<sample_count;i++) {
+                        c0[i] = getValue(samples+4*i, 'i16') / 32768;
+                        c1[i] = getValue(samples+4*i+2, 'i16') / 32768;
+                    }
+                    var source = shared.audioCtx.createBufferSource();
+                    source.buffer = buf;
+                    source.connect(shared.audioCtx.destination);
+                    var len = sample_count / this.sampleRate;
+                    var t = shared.audioCtx.currentTime;
+                    if (this.bufferedTo <= t) {
+                        source.start(t);
+                        this.bufferedTo = t + len;
+                    } else {
+                        source.start(this.bufferedTo);
+                        this.bufferedTo = this.bufferedTo + len;
+                    }
+                    // use real buffer length next time.
+                    this.bufferDuration = len;
+                },
+                _freeBufferSlots: function() {
+                    // before knowing the length of each buffer.
+                    if (this.bufferDuration == 0)
+                        return 1;
+                    var ahead = this.bufferedTo - shared.audioCtx.currentTime;
+                    var inqueue = Math.ceil(ahead / this.bufferDuration);
+                    if (inqueue < 0) {
+                        inqueue = 0;
+                    }
+                    var left = bufferCount - inqueue;
+                    if (left < 0) {
+                        return 0;
+                    }
+                    return left;
+                }
+            };
+        }
+        
+        if (device != null) {
+            shared.devices[id] = device;
+            return id;
+        } 
+        return -1;
+    },
+    
+    dmDeviceJSQueue: function(id, samples, sample_count) {
+        window._dmJSDeviceShared.devices[id]._queue(samples, sample_count)
+    },
+    
+    dmDeviceJSFreeBufferSlots: function(id) {
+        return window._dmJSDeviceShared.devices[id]._freeBufferSlots();
+    },
+
+    dmGetDeviceSampleRate: function(id) {
+        return window._dmJSDeviceShared.devices[id].sampleRate;
+    }
+}
+
+autoAddDeps(LibrarySoundDevice, '$DefoldSoundDevice');
+mergeInto(LibraryManager.library, LibrarySoundDevice);

--- a/engine/sound/src/test/wscript
+++ b/engine/sound/src/test/wscript
@@ -59,7 +59,12 @@ def gen_dc(task):
 def build(bld):
     platform = bld.env['PLATFORM']
 
-    if 'win32' in platform:
+    if 'web' in platform:
+        lib_dirs = {}
+        lib_dirs['library_sound.js'] = '../src/js'
+        bld.env['JS_LIB_PATHS'] = lib_dirs
+
+    elif 'win32' in platform:
         src_dir = "%s/ext/lib/%s" % (bld.env['PREFIX'], platform)
         if not waflib.Options.options.skip_build_tests:
           copy_file_task(bld, "%s/OpenAL32.dll" % src_dir)
@@ -142,6 +147,7 @@ def build(bld):
         bld.program(features = 'cxx embed test',
                     includes = '../../src .',
                     use = 'TESTMAIN DLIB SOCKET PROFILE_NULL sound embedded_wavs embedded_oggs'.split() + soundlibs,
+                    web_libs = ['library_sound.js'],
                     exported_symbols = exported_symbols,
                     target = 'test_sound_perf',
                     source = 'test_sound_perf.cpp')
@@ -154,6 +160,7 @@ def build(bld):
     foo = bld.program(features = 'cxx embed test'.split() + extra_features,
                 includes = '../../src .',
                 use = 'TESTMAIN DLIB SOCKET PROFILE_NULL sound embedded_wavs embedded_oggs'.split() + soundlibs,
+                web_libs = ['library_sound.js'],
                 exported_symbols = exported_symbols,
                 target = 'test_sound',
                 source = 'test_sound.cpp')
@@ -163,6 +170,7 @@ def build(bld):
     bld.program(features = 'cxx embed test',
                     includes = '../../src .',
                     use = 'TESTMAIN DLIB SOCKET PROFILE_NULL sound_null embedded_wavs embedded_oggs',
+                    web_libs = ['library_sound.js'],
                     exported_symbols = exported_symbols,
                     target = 'test_sound_null',
                     source = 'test_sound_null.cpp')

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -29,14 +29,19 @@ def build(bld):
 
     if 'android' in bld.env.PLATFORM:
         source += ['devices/device_opensl.cpp']
+    elif 'web' in bld.env.PLATFORM:
+        source += ['devices/device_js.cpp']
     elif 'nx64' in bld.env.PLATFORM:
         source += ['devices/device_nx64.cpp']
     elif bld.env.PLATFORM in ('x86_64-ps4','x86_64-ps5',):
         source += ['devices/device_ps4.cpp']
     else:
         source += ['devices/device_openal.cpp']
+        bld.recurse('openal')
 
-    if re.match('arm.*?android', bld.env['PLATFORM']):
+    if 'web' in bld.env['PLATFORM']:
+        bld.install_files('${PREFIX}/lib/%s/js' % bld.env['PLATFORM'], 'js/library_sound.js', postpone = False)
+    elif re.match('arm.*?android', bld.env['PLATFORM']):
         classpath = ['%s/ext/share/java/android.jar' % bld.env.DYNAMO_HOME]
         classpath = os.pathsep.join(classpath)
         bld.env['JAVACFLAGS'] = '-g -source 1.7 -target 1.7'.split()

--- a/engine/sound/src/wscript
+++ b/engine/sound/src/wscript
@@ -37,7 +37,6 @@ def build(bld):
         source += ['devices/device_ps4.cpp']
     else:
         source += ['devices/device_openal.cpp']
-        bld.recurse('openal')
 
     if 'web' in bld.env['PLATFORM']:
         bld.install_files('${PREFIX}/lib/%s/js' % bld.env['PLATFORM'], 'js/library_sound.js', postpone = False)

--- a/share/extender/build_input.yml
+++ b/share/extender/build_input.yml
@@ -376,7 +376,7 @@ platforms:
         EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_2_0_11}}"
         MANIFEST_MERGE_TOOL:    "{{env.MANIFEST_MERGE_TOOL}}"
     context:
-        engineJsLibs: ["glfw", "sys", "script"]
+        engineJsLibs: ["glfw", "sys", "script", "sound"]
         engineLibs: ["engine", "engine_service", "mbedtls", "zip", "webviewext", "profile_null", "remotery_null", "profilerext_null", "facebookext", "iapext", "pushext", "iacext", "record_null", "gameobject", "ddf", "resource", "gamesys", "graphics", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "LinearMath", "Box2D", "render", "script", "lua", "extension", "hid", "input", "particle", "rig", "dlib", "dmglfw", "gui", "crashext", "liveupdate", "sound"]
         libPaths:   ["{{dynamo_home}}/lib/js-web", "{{dynamo_home}}/ext/lib/js-web"]
         defines:    ["DM_PLATFORM_HTML5", "GL_ES_VERSION_2_0"]
@@ -412,7 +412,7 @@ platforms:
         EMSCRIPTEN_BIN:         "{{env.EMSCRIPTEN_BIN_2_0_11}}"
         MANIFEST_MERGE_TOOL:    "{{env.MANIFEST_MERGE_TOOL}}"
     context:
-        engineJsLibs: ["glfw", "sys", "script"]
+        engineJsLibs: ["glfw", "sys", "script", "sound"]
         engineLibs: ["engine", "engine_service", "mbedtls", "zip", "webviewext", "profile_null", "remotery_null", "profilerext_null", "facebookext", "iapext", "pushext", "iacext", "record_null", "gameobject", "ddf", "resource", "gamesys", "graphics", "graphics_transcoder_basisu", "basis_transcoder", "physics", "BulletDynamics", "BulletCollision", "LinearMath", "Box2D", "render", "script", "lua", "extension", "hid", "input", "particle", "rig", "dlib", "dmglfw", "gui", "crashext", "liveupdate", "sound"]
         libPaths:   ["{{dynamo_home}}/lib/wasm-web", "{{dynamo_home}}/ext/lib/wasm-web"]
         defines:    ["DM_PLATFORM_HTML5", "GL_ES_VERSION_2_0"]


### PR DESCRIPTION
Due to some issues with the Emscripten OpenAL sound library, we decided to go back to our previous sound library for now.
We'll revisit the issues that are affected by this change.

### Technical notes

This reverts commit 6379aef7a78ab4e20b0d0b42aef60767d79cb022.
Revert "Updated HTML5 build to use Emscriptens OpenAL library (#8015)"

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
