### PR TITLE
Fix issue when Component Counter doesn't take into account all Dynamic Prototype checkboxes

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -228,7 +228,7 @@ public class ComponentsCounter {
         for (IResource res :  inputs) {
             if (isCompCounterStorage(res.getPath())) {
                 Storage inputStorage = Storage.load(res);
-                if (inputStorage.isDynamic() || targetStorage.isDynamic()) {
+                if (inputStorage.isDynamic()) {
                     targetStorage.makeDynamic();
                 }
                 else {
@@ -243,7 +243,7 @@ public class ComponentsCounter {
         for (IResource res :  inputs) {
             if (isCompCounterStorage(res.getPath())) {
                 Storage inputStorage = Storage.load(res);
-                if (inputStorage.isDynamic() || targetStorage.isDynamic()) {
+                if (inputStorage.isDynamic()) {
                     targetStorage.makeDynamic();
                 }
                 else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/ComponentsCounter.java
@@ -227,7 +227,13 @@ public class ComponentsCounter {
     public static void sumInputs(Storage targetStorage, List<IResource> inputs, Integer count) throws IOException, CompileExceptionError  {
         for (IResource res :  inputs) {
             if (isCompCounterStorage(res.getPath())) {
-                targetStorage.add(Storage.load(res), count);
+                Storage inputStorage = Storage.load(res);
+                if (inputStorage.isDynamic() || targetStorage.isDynamic()) {
+                    targetStorage.makeDynamic();
+                }
+                else {
+                    targetStorage.add(inputStorage, count);
+                }
             }
         }
     }
@@ -236,7 +242,13 @@ public class ComponentsCounter {
         Map<IResource, Integer> compCounterInputsCount) throws IOException, CompileExceptionError  {
         for (IResource res :  inputs) {
             if (isCompCounterStorage(res.getPath())) {
-                targetStorage.add(Storage.load(res), compCounterInputsCount.get(res));
+                Storage inputStorage = Storage.load(res);
+                if (inputStorage.isDynamic() || targetStorage.isDynamic()) {
+                    targetStorage.makeDynamic();
+                }
+                else {
+                    targetStorage.add(inputStorage, compCounterInputsCount.get(res));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed issue when in some cases `Dynamic Prototype` checkbox isn't detected and collection does not switch mode to using of the `game.project`'s counters.

Fix https://github.com/defold/defold/issues/8141

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
