### PR TITLE
Add a local storage of uniform constants values to the OpenGL renderer

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -67,6 +67,28 @@ namespace dmGraphics
         uint32_t                     m_BufferTypeFlags;
     };
 
+    struct OpenglVertexAttribute
+    {
+        dmhash_t m_NameHash;
+        int32_t  m_Location;
+        GLint    m_Count;
+        GLenum   m_Type;
+    };
+
+    struct OpenGLConstantValue
+    {
+        bool    m_ValueSet;
+        // The maximum size of a constant is 64 bytes (4x4 matrix is the largest).
+        uint8_t m_Value[64];
+    };
+
+    struct OpenGLProgram
+    {
+        GLuint                         m_Id;
+        dmArray<OpenglVertexAttribute> m_Attributes;
+        dmArray<OpenGLConstantValue>   m_ConstantValues;
+    };
+
     struct OpenGLContext
     {
         OpenGLContext(const ContextParams& params);
@@ -87,6 +109,7 @@ namespace dmGraphics
         WindowIconifyCallback   m_WindowIconifyCallback;
         void*                   m_WindowIconifyCallbackUserData;
         PipelineState           m_PipelineState;
+        OpenGLProgram*          m_ActiveProgram;
         uint32_t                m_Width;
         uint32_t                m_Height;
         uint32_t                m_WindowWidth;
@@ -141,20 +164,6 @@ namespace dmGraphics
     struct OpenGLShader
     {
         GLuint m_Id;
-    };
-
-    struct OpenglVertexAttribute
-    {
-        dmhash_t m_NameHash;
-        int32_t  m_Location;
-        GLint    m_Count;
-        GLenum   m_Type;
-    };
-
-    struct OpenGLProgram
-    {
-        GLuint                         m_Id;
-        dmArray<OpenglVertexAttribute> m_Attributes;
     };
 }
 #endif // __GRAPHICS_DEVICE_OPENGL__


### PR DESCRIPTION
This PR adds a local storage of uniform constant values to the OpenGL renderer. The point is not to send the same constants unless they differ between draw calls.

Fixes #8166 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
