### PR TITLE
Make it possible to change column size in the web profiler

### DIFF
--- a/editor/resources/engine-profiler/remotery/vis/Code/GridWindow.js
+++ b/editor/resources/engine-profiler/remotery/vis/Code/GridWindow.js
@@ -181,7 +181,7 @@ class GridWindow
         this.columns[0].headerNode.style.marginLeft = "-1px";
 
         // Setup for pan/wheel scrolling
-        this.mouseInteraction = new MouseInteraction(this.window.BodyNode);
+        this.mouseInteraction = new MouseInteraction(this.window.BodyNode, true);
         this.mouseInteraction.onMoveHandler = (mouse_state, mx, my) => this._OnMouseMove(mouse_state, mx, my);
         this.mouseInteraction.onScrollHandler = (mouse_state) => this._OnMouseScroll(mouse_state);
 
@@ -278,6 +278,25 @@ class GridWindow
 
     _OnMouseMove(mouse_state, mouse_offset_x, mouse_offset_y)
     {
+        var skipScroll = false;
+        for (let i in this.columns)
+        {
+            const column = this.columns[i];
+            const width = parseFloat(column.headerNode.style.width, 10);
+            if (column.width != width) {
+                if (width < 50) {
+                    break;
+                }
+                skipScroll = true;
+                column.width = width;
+                this._PositionHeaders();
+                break
+            }
+        }
+        if (skipScroll) {
+            return;
+        }
+        
         this.scrollPos[0] = Math.min(0, this.scrollPos[0] + mouse_offset_x);
         this.scrollPos[1] = Math.min(0, this.scrollPos[1] + mouse_offset_y);
 

--- a/editor/resources/engine-profiler/remotery/vis/Code/MouseInteraction.js
+++ b/editor/resources/engine-profiler/remotery/vis/Code/MouseInteraction.js
@@ -1,6 +1,6 @@
 class MouseInteraction
 {
-	constructor(node)
+	constructor(node, doNotPreventMouseDown)
 	{
 		this.node = node;
 
@@ -14,6 +14,8 @@ class MouseInteraction
 		this.onMoveHandler = null;
 		this.onHoverHandler = null;
         this.onScrollHandler = null;
+
+        this.doNotPreventMouseDown = doNotPreventMouseDown;
 
 		// Setup DOM handlers
 		DOM.Event.AddHandler(this.node, "mousedown", (evt) => this._OnMouseDown(evt));
@@ -31,6 +33,11 @@ class MouseInteraction
 		this.mouseDown = true;
 		this.lastMouseState = new Mouse.State(evt);
 		this.mouseMoved = false;
+
+		if (this.doNotPreventMouseDown) {
+			return;
+		}
+		
 		DOM.Event.StopDefaultAction(evt);
 	}
 

--- a/editor/resources/engine-profiler/remotery/vis/Styles/Remotery.css
+++ b/editor/resources/engine-profiler/remotery/vis/Styles/Remotery.css
@@ -85,6 +85,8 @@ body
 	border-left-color:#555;
 	border-bottom-color:#111;
 	border-right-color:#111;
+
+    resize:horizontal;
 }
 
 .TimelineBox

--- a/engine/dlib/src/remotery/issue-8146.patch
+++ b/engine/dlib/src/remotery/issue-8146.patch
@@ -1,0 +1,85 @@
+diff --git a/editor/resources/engine-profiler/remotery/vis/Code/GridWindow.js b/editor/resources/engine-profiler/remotery/vis/Code/GridWindow.js
+index d989b8d642..0f597443d7 100644
+--- a/editor/resources/engine-profiler/remotery/vis/Code/GridWindow.js
++++ b/editor/resources/engine-profiler/remotery/vis/Code/GridWindow.js
+@@ -181,7 +181,7 @@ class GridWindow
+         this.columns[0].headerNode.style.marginLeft = "-1px";
+ 
+         // Setup for pan/wheel scrolling
+-        this.mouseInteraction = new MouseInteraction(this.window.BodyNode);
++        this.mouseInteraction = new MouseInteraction(this.window.BodyNode, true);
+         this.mouseInteraction.onMoveHandler = (mouse_state, mx, my) => this._OnMouseMove(mouse_state, mx, my);
+         this.mouseInteraction.onScrollHandler = (mouse_state) => this._OnMouseScroll(mouse_state);
+ 
+@@ -278,6 +278,25 @@ class GridWindow
+ 
+     _OnMouseMove(mouse_state, mouse_offset_x, mouse_offset_y)
+     {
++        var skipScroll = false;
++        for (let i in this.columns)
++        {
++            const column = this.columns[i];
++            const width = parseFloat(column.headerNode.style.width, 10);
++            if (column.width != width) {
++                if (width < 50) {
++                    break;
++                }
++                skipScroll = true;
++                column.width = width;
++                this._PositionHeaders();
++                break
++            }
++        }
++        if (skipScroll) {
++            return;
++        }
++        
+         this.scrollPos[0] = Math.min(0, this.scrollPos[0] + mouse_offset_x);
+         this.scrollPos[1] = Math.min(0, this.scrollPos[1] + mouse_offset_y);
+ 
+diff --git a/editor/resources/engine-profiler/remotery/vis/Code/MouseInteraction.js b/editor/resources/engine-profiler/remotery/vis/Code/MouseInteraction.js
+index 41fd187d5a..7b45e87777 100644
+--- a/editor/resources/engine-profiler/remotery/vis/Code/MouseInteraction.js
++++ b/editor/resources/engine-profiler/remotery/vis/Code/MouseInteraction.js
+@@ -1,6 +1,6 @@
+ class MouseInteraction
+ {
+-	constructor(node)
++	constructor(node, doNotPreventMouseDown)
+ 	{
+ 		this.node = node;
+ 
+@@ -15,6 +15,8 @@ class MouseInteraction
+ 		this.onHoverHandler = null;
+         this.onScrollHandler = null;
+ 
++        this.doNotPreventMouseDown = doNotPreventMouseDown;
++
+ 		// Setup DOM handlers
+ 		DOM.Event.AddHandler(this.node, "mousedown", (evt) => this._OnMouseDown(evt));
+ 		DOM.Event.AddHandler(this.node, "mouseup", (evt) => this._OnMouseUp(evt));
+@@ -31,6 +33,11 @@ class MouseInteraction
+ 		this.mouseDown = true;
+ 		this.lastMouseState = new Mouse.State(evt);
+ 		this.mouseMoved = false;
++
++		if (this.doNotPreventMouseDown) {
++			return;
++		}
++		
+ 		DOM.Event.StopDefaultAction(evt);
+ 	}
+ 
+diff --git a/editor/resources/engine-profiler/remotery/vis/Styles/Remotery.css b/editor/resources/engine-profiler/remotery/vis/Styles/Remotery.css
+index 6a384f9cb5..5c2aeb726a 100644
+--- a/editor/resources/engine-profiler/remotery/vis/Styles/Remotery.css
++++ b/editor/resources/engine-profiler/remotery/vis/Styles/Remotery.css
+@@ -85,6 +85,8 @@ body
+ 	border-left-color:#555;
+ 	border-bottom-color:#111;
+ 	border-right-color:#111;
++
++    resize:horizontal;
+ }
+ 
+ .TimelineBox

--- a/engine/dlib/src/remotery/update_remotery.sh
+++ b/engine/dlib/src/remotery/update_remotery.sh
@@ -48,6 +48,7 @@ echo "Applying patch"
 # but we need a patched version to be served from the editor
 cp -v ${DEFOLD_REPO}/editor/resources/engine-profiler/remotery/vis/index.html ${DEFOLD_REPO}/editor/resources/engine-profiler/remotery/vis/orig.index.html
 (cd ${DEFOLD_REPO} && git apply ./engine/dlib/src/remotery/defoldvis.patch)
+(cd ${DEFOLD_REPO} && git apply ./engine/dlib/src/remotery/issue-8146.patch)
 cp -v ${DEFOLD_REPO}/editor/resources/engine-profiler/remotery/vis/index.html ${DEFOLD_REPO}/editor/resources/engine-profiler/remotery/vis/patched.index.html
 mv -v ${DEFOLD_REPO}/editor/resources/engine-profiler/remotery/vis/orig.index.html ${DEFOLD_REPO}/editor/resources/engine-profiler/remotery/vis/index.html
 


### PR DESCRIPTION
Now it is possible to change a column size in the web profiler:
![image](https://github.com/defold/defold/assets/2209596/b918ac96-9e68-449b-85c8-dc8084b2b220)


Fix https://github.com/defold/defold/issues/8146
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
