### PR TITLE
Make sure the resource system respects the liveupdate.enabled flag

### DIFF
--- a/engine/liveupdate/src/liveupdate.cpp
+++ b/engine/liveupdate/src/liveupdate.cpp
@@ -92,6 +92,7 @@ namespace dmLiveUpdate
             DM_LU_RESULT_TO_STR(FORMAT_ERROR);
             DM_LU_RESULT_TO_STR(IO_ERROR);
             DM_LU_RESULT_TO_STR(INVAL);
+            DM_LU_RESULT_TO_STR(NOT_INITIALIZED);
             DM_LU_RESULT_TO_STR(UNKNOWN);
             default: break;
         }
@@ -116,6 +117,7 @@ namespace dmLiveUpdate
         dmResource::HFactory            m_ResourceFactory;      // Resource system factory
         dmResourceProvider::HArchive    m_LiveupdateArchive;
         dmResource::HManifest           m_LiveupdateArchiveManifest;
+        bool                            m_IsEnabled;
 
     } g_LiveUpdate;
 
@@ -368,7 +370,13 @@ namespace dmLiveUpdate
         return archive;
     }
 
-    static bool IsLiveupdateDisabled()
+    static bool IsLiveupdateEnabled()
+    {
+        return g_LiveUpdate.m_IsEnabled;
+    }
+
+
+    static bool IsLiveupdateThreadDisabled()
     {
         if (!g_LiveUpdate.m_JobThread)
         {
@@ -479,6 +487,9 @@ namespace dmLiveUpdate
 
     Result StoreResourceAsync(const char* expected_digest, const uint32_t expected_digest_length, const dmResourceArchive::LiveUpdateResource* resource, void (*callback)(bool, void*), void* callback_data)
     {
+        if (!IsLiveupdateEnabled())
+            return RESULT_NOT_INITIALIZED;
+
         if (resource->m_Data == 0x0)
         {
             return RESULT_MEM_ERROR;
@@ -490,7 +501,7 @@ namespace dmLiveUpdate
             return RESULT_INVALID_RESOURCE;
         }
 
-        if(IsLiveupdateDisabled())
+        if(IsLiveupdateThreadDisabled())
         {
             return RESULT_INVAL;
         }
@@ -581,12 +592,15 @@ namespace dmLiveUpdate
 
     Result StoreManifestAsync(const uint8_t* manifest_data, uint32_t manifest_len, void (*callback)(int, void*), void* callback_data)
     {
+        if (!IsLiveupdateEnabled())
+            return RESULT_NOT_INITIALIZED;
+
         if (!manifest_data || manifest_len == 0)
         {
             return RESULT_INVAL;
         }
 
-        if(IsLiveupdateDisabled())
+        if(IsLiveupdateThreadDisabled())
         {
             return RESULT_INVAL;
         }
@@ -689,12 +703,15 @@ namespace dmLiveUpdate
 
     Result StoreArchiveAsync(const char* path, void (*callback)(const char*, int, void*), void* callback_data, const char* mountname, int priority, bool verify_archive)
     {
+        if (!IsLiveupdateEnabled())
+            return RESULT_NOT_INITIALIZED;
+
         if (!dmSys::Exists(path)) {
             dmLogError("File does not exist: '%s'", path);
             return RESULT_INVALID_RESOURCE;
         }
 
-        if(IsLiveupdateDisabled())
+        if(IsLiveupdateThreadDisabled())
         {
             return RESULT_INVAL;
         }
@@ -780,10 +797,10 @@ namespace dmLiveUpdate
 
     Result AddMountAsync(const char* name, const char* uri, int priority, void (*callback)(const char*, const char*, int, void*), void* callback_data)
     {
-        if(IsLiveupdateDisabled())
-        {
-            return RESULT_INVAL;
-        }
+        if (!IsLiveupdateEnabled())
+            return RESULT_NOT_INITIALIZED;
+        if(IsLiveupdateThreadDisabled())
+            return RESULT_NOT_INITIALIZED;
 
         AddMountInfo* info = new AddMountInfo;
         info->m_Archive = g_LiveUpdate.m_LiveupdateArchive;
@@ -799,6 +816,9 @@ namespace dmLiveUpdate
 
     Result RemoveMountSync(const char* name)
     {
+        if (!IsLiveupdateEnabled())
+            return RESULT_NOT_INITIALIZED;
+
         dmResourceMounts::HContext mounts = g_LiveUpdate.m_ResourceMounts;
         dmMutex::HMutex mutex = dmResourceMounts::GetMutex(mounts);
         DM_MUTEX_SCOPED_LOCK(mutex);
@@ -841,6 +861,9 @@ namespace dmLiveUpdate
 
     bool HasLiveUpdateMount()
     {
+        if (!IsLiveupdateEnabled())
+            return false;
+
         dmMutex::HMutex mutex = dmResourceMounts::GetMutex(g_LiveUpdate.m_ResourceMounts);
         DM_MUTEX_SCOPED_LOCK(mutex);
 
@@ -887,6 +910,13 @@ namespace dmLiveUpdate
 
     static dmExtension::Result Initialize(dmExtension::Params* params)
     {
+        int32_t liveupdate_enabled = dmConfigFile::GetInt(params->m_ConfigFile, "liveupdate.enabled", 1);
+        if (!liveupdate_enabled)
+        {
+            dmLogError("Liveupdate disabled due to project setting %s=%d", "liveupdate.enabled", liveupdate_enabled);
+            return dmExtension::RESULT_OK;
+        }
+
         dmResource::HFactory factory = params->m_ResourceFactory;
 
         g_LiveUpdate.m_ResourceFactory = factory;
@@ -931,6 +961,9 @@ namespace dmLiveUpdate
 
     static dmExtension::Result Finalize(dmExtension::Params* params)
     {
+        if (!IsLiveupdateEnabled())
+            return dmExtension::RESULT_OK;
+
         if (g_LiveUpdate.m_JobThread)
             dmJobThread::Destroy(g_LiveUpdate.m_JobThread);
         g_LiveUpdate.m_JobThread = 0;
@@ -940,6 +973,9 @@ namespace dmLiveUpdate
 
     static dmExtension::Result Update(dmExtension::Params* params)
     {
+        if (!IsLiveupdateEnabled())
+            return dmExtension::RESULT_OK;
+
         if (!g_LiveUpdate.m_ResourceBaseArchive)
             return dmExtension::RESULT_OK;
 

--- a/engine/liveupdate/src/liveupdate.h
+++ b/engine/liveupdate/src/liveupdate.h
@@ -48,6 +48,7 @@ namespace dmLiveUpdate
         RESULT_FORMAT_ERROR              = -9,
         RESULT_IO_ERROR                  = -10,
         RESULT_INVAL                     = -11,
+        RESULT_NOT_INITIALIZED           = -12,
         RESULT_UNKNOWN                   = -1000,
     };
 

--- a/engine/liveupdate/src/script_liveupdate.cpp
+++ b/engine/liveupdate/src/script_liveupdate.cpp
@@ -441,6 +441,7 @@ DEPRECATE_LU_FUNCTION("store_archive", Resource_StoreArchive);
         SETCONSTANT(FORMAT_ERROR);
         SETCONSTANT(IO_ERROR);
         SETCONSTANT(INVAL);
+        SETCONSTANT(NOT_INITIALIZED);
         SETCONSTANT(UNKNOWN);
     }
 

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -299,14 +299,21 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
 
     if (factory->m_BaseArchiveMount)
     {
-        dmResource::HManifest manifest;
-        if (dmResourceProvider::RESULT_OK == dmResourceProvider::GetManifest(factory->m_BaseArchiveMount, &manifest))
+        if (params->m_Flags & RESOURCE_FACTORY_FLAGS_LIVE_UPDATE)
         {
-            char app_support_path[DMPATH_MAX_PATH];
-            if (RESULT_OK == dmResource::GetApplicationSupportPath(manifest, app_support_path, sizeof(app_support_path)))
+            dmResource::HManifest manifest;
+            if (dmResourceProvider::RESULT_OK == dmResourceProvider::GetManifest(factory->m_BaseArchiveMount, &manifest))
             {
-                dmResourceMounts::LoadMounts(factory->m_Mounts, app_support_path);
+                char app_support_path[DMPATH_MAX_PATH];
+                if (RESULT_OK == dmResource::GetApplicationSupportPath(manifest, app_support_path, sizeof(app_support_path)))
+                {
+                    dmResourceMounts::LoadMounts(factory->m_Mounts, app_support_path);
+                }
             }
+        }
+        else
+        {
+            dmLogInfo("Resource mounts support disabled.");
         }
     }
 

--- a/scripts/copy_from_private_repo.py
+++ b/scripts/copy_from_private_repo.py
@@ -49,6 +49,7 @@ LOCAL_PATTERNS.append('dist/')
 LOCAL_PATTERNS.append('build/')
 LOCAL_PATTERNS.append('editor/target/classes/')
 LOCAL_PATTERNS.append('dynamo_home')
+LOCAL_PATTERNS.append('local_sdks')
 
 def is_local_file(path):
     for pattern in LOCAL_PATTERNS:


### PR DESCRIPTION
This fixes an issue where the liveupdate system wasn't fully disabled when the project setting was set to false (`liveupdate.enabled=0`)

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
