### PR TITLE
Fix crash using wrong path in `*.set_prototype()` 

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_collection_factory.cpp
@@ -465,7 +465,7 @@ namespace dmGameSystem
 
             // check that the path is a .collectionc
             const char* ext = dmResource::GetExtFromPath(path);
-            if (strcmp(ext, ".collectionc") != 0)
+            if (!ext || strcmp(ext, ".collectionc") != 0)
             {
                 return luaL_error(L, "Trying to set '%s' as prototype to '%s:%s#%s'. Only .collectionc resources are allowed",
                                         path,

--- a/engine/gamesys/src/gamesys/scripts/script_factory.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_factory.cpp
@@ -421,7 +421,7 @@ namespace dmGameSystem
 
             // check that the path is a .goc
             const char* ext = dmResource::GetExtFromPath(path);
-            if (strcmp(ext, ".goc") != 0)
+            if (!ext || strcmp(ext, ".goc") != 0)
             {
                 return luaL_error(L, "Trying to set '%s' as prototype to '%s:%s#%s'. Only .goc resources are allowed",
                                         path,


### PR DESCRIPTION
Fixed a a crash that happens because of using of a path without a `.`(dot) in it as the second parameter for `factory.set_prototype()` or `collectionfactory.set_prototype()` 

Fix https://github.com/defold/defold/issues/8179
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
