### PR TITLE
Add `model` predicate to the default render script 

### DIFF
--- a/engine/engine/content/builtins/render/default.render_script
+++ b/engine/engine/content/builtins/render/default.render_script
@@ -136,7 +136,7 @@ local function create_state()
 end
 
 function init(self)
-    self.predicates = create_predicates("tile", "gui", "text", "particle")
+    self.predicates = create_predicates("tile", "gui", "text", "particle", "model")
 
     -- default is stretch projection. copy from builtins and change for different projection
     -- or send a message to the render script to change projection:
@@ -164,26 +164,36 @@ function update(self)
     local predicates = self.predicates
     -- clear screen buffers
     --
+    -- turn on depth_mask before `render.clear()` to clear it as well
     render.set_depth_mask(true)
     render.set_stencil_mask(0xff)
     render.clear(state.clear_buffers)
 
-    -- render world (sprites, tilemaps, particles etc)
+    -- setup camera view and projection
     --
     local camera_world = state.cameras.camera_world
     render.set_viewport(0, 0, state.window_width, state.window_height)
     render.set_view(camera_world.view)
     render.set_projection(camera_world.proj)
 
-    render.set_depth_mask(false)
-    render.disable_state(render.STATE_DEPTH_TEST)
-    render.disable_state(render.STATE_STENCIL_TEST)
-    render.enable_state(render.STATE_BLEND)
+    -- set states used for all the world predicates
     render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
+    render.enable_state(render.STATE_DEPTH_TEST)
+
+    -- render `model` predicate for default 3D material
+    --
+    render.enable_state(render.STATE_CULL_FACE)
+    render.draw(predicates.model, camera_world.frustum)
+    render.set_depth_mask(false)
     render.disable_state(render.STATE_CULL_FACE)
 
+    -- render the other components: sprites, tilemaps, particles etc
+    --
+    render.enable_state(render.STATE_BLEND)
     render.draw(predicates.tile, camera_world.frustum)
     render.draw(predicates.particle, camera_world.frustum)
+    render.disable_state(render.STATE_DEPTH_TEST)
+
     render.draw_debug3d()
 
     -- render GUI
@@ -191,10 +201,12 @@ function update(self)
     local camera_gui = state.cameras.camera_gui
     render.set_view(camera_gui.view)
     render.set_projection(camera_gui.proj)
+
     render.enable_state(render.STATE_STENCIL_TEST)
     render.draw(predicates.gui, camera_gui.frustum)
     render.draw(predicates.text, camera_gui.frustum)
     render.disable_state(render.STATE_STENCIL_TEST)
+    render.disable_state(render.STATE_BLEND)
 end
 
 function on_message(self, message_id, message)


### PR DESCRIPTION
`default.render_script` now draws predicate `model` which used in default `model.material` as the basic 3D material included in `builtins`. 

Fix https://github.com/defold/defold/issues/8158

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
