### PR TITLE
Disable Show/Hide Selected Objects command when nothing is selected

### DIFF
--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -47,7 +47,7 @@
 (def ^:private break-label "Break")
 (def ^:private continue-label "Continue")
 (def ^:private detach-debugger-label "Detach Debugger")
-(def ^:private start-debugger-label "Start / Attach")
+(def ^:private start-debugger-label "Start/Attach")
 (def ^:private step-into-label "Step Into")
 (def ^:private step-out-label "Step Out")
 (def ^:private step-over-label "Step Over")

--- a/editor/src/clj/editor/scene_visibility.clj
+++ b/editor/src/clj/editor/scene_visibility.clj
@@ -241,8 +241,11 @@
   (run [scene-visibility] (hide-outline-name-paths! scene-visibility (g/node-value scene-visibility :unselected-hideable-outline-name-paths))))
 
 (handler/defhandler :hide-toggle-selected :workbench
-  (active? [scene-visibility evaluation-context] true)
-  (enabled? [scene-visibility evaluation-context] true)
+  (active? [scene-visibility evaluation-context]
+           (g/node-value scene-visibility :active-scene-resource-node evaluation-context))
+  (enabled? [scene-visibility evaluation-context]
+            (or (g/node-value scene-visibility :selected-hideable-outline-name-paths evaluation-context)
+                (g/node-value scene-visibility :selected-showable-outline-name-paths evaluation-context)))
   (run [scene-visibility]
        (g/with-auto-evaluation-context evaluation-context
          (let [should-hide (g/node-value scene-visibility :selected-hideable-outline-name-paths evaluation-context)]


### PR DESCRIPTION
The **Show/Hide Selected Objects** command is now disabled unless something is selected. Invoking it with no selection used to cause an error.

Fixes #8128
Fixes #8210