### PR TITLE
Detect renderable float and half float texture formats on OpenGL ES 2.0 / WebGL 1.0 devices

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1179,6 +1179,22 @@ static void LogFrameBufferError(GLenum status)
             context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_R32F;
             context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RG32F;
         }
+        else
+        {
+            // https://registry.khronos.org/OpenGL/extensions/EXT/EXT_color_buffer_half_float.txt
+            if (OpenGLIsExtensionSupported(context, "EXT_color_buffer_half_float"))
+            {
+                context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGB16F;
+                context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA16F;
+            }
+
+            // https://registry.khronos.org/webgl/extensions/WEBGL_color_buffer_float/
+            if (OpenGLIsExtensionSupported(context, "WEBGL_color_buffer_float"))
+            {
+                context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGB32F;
+                context->m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_RGBA32F;
+            }
+        }
 
         // GL_NUM_COMPRESSED_TEXTURE_FORMATS is deprecated in newer OpenGL Versions
         GLint iNumCompressedFormats = 0;


### PR DESCRIPTION
Adds the ability to render to 16-bit and 32-bit floating-point color buffers on OpenGL ES 2.0 and WebGL 1.0 if the device supports them. The support depends on the extensions `EXT_color_buffer_half_float` and `WEBGL_color_buffer_float`.

Closes https://github.com/defold/defold/issues/8172

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
