### PR TITLE
Open engine log file by double-clicking the error

### DIFF
--- a/editor/src/clj/editor/build_errors_view.clj
+++ b/editor/src/clj/editor/build_errors_view.clj
@@ -17,7 +17,6 @@
             [dynamo.graph :as g]
             [editor.code.data :refer [CursorRange->line-number]]
             [editor.handler :as handler]
-            [editor.icons :as icons]
             [editor.outline :as outline]
             [editor.resource :as resource]
             [editor.resource-io :as resource-io]
@@ -25,12 +24,11 @@
             [editor.workspace :as workspace]
             [util.coll :refer [pair]])
   (:import [clojure.lang PersistentQueue]
+           [java.io File]
            [java.util Collection]
            [javafx.collections ObservableList]
            [javafx.scene.control TreeItem TreeView]
-           [javafx.scene.input Clipboard ClipboardContent]
-           [javafx.scene.layout HBox]
-           [javafx.scene.text Text]))
+           [javafx.scene.input Clipboard ClipboardContent]))
 
 (set! *warn-on-reflection* true)
 
@@ -91,7 +89,7 @@
          false)))
 
 (defn- error-item [evaluation-context root-cause]
-  (let [{:keys [message severity]} (first root-cause)
+  (let [{:keys [message severity file-path]} (first root-cause)
         cursor-range (error-cursor-range (first root-cause))
         errors (drop-while (comp (fn [node-id]
                                    (or (nil? node-id)
@@ -109,6 +107,9 @@
              :node-id outline-node-id
              :message (:message error)
              :severity (:severity error severity)}
+
+            file-path
+            (assoc :file-path file-path)
 
             (some? cursor-range)
             (assoc :cursor-range cursor-range))))
@@ -216,18 +217,24 @@
   "Returns data describing how an error should be opened when double-clicked.
   Having this as data simplifies writing unit tests."
   [error-item]
-  (if (= :resource (:type error-item))
-    (let [{resource :resource resource-node-id :node-id} (:value error-item)]
-      (when (and (resource/openable-resource? resource)
-                 (resource/exists? resource))
-        [resource resource-node-id {}]))
-    (let [{resource :resource resource-node-id :node-id} (:parent error-item)]
-      (when (and (resource/openable-resource? resource)
-                 (resource/exists? resource))
-        (let [error-node-id (:node-id error-item)
-              outline-node-id (find-outline-node resource-node-id error-node-id)
-              opts (select-keys error-item [:cursor-range])]
-          [resource outline-node-id opts])))))
+  (or (and (= :resource (:type error-item))
+           (let [{resource :resource resource-node-id :node-id} (:value error-item)]
+             (when (and (resource/openable-resource? resource)
+                        (resource/exists? resource))
+               {:type :resource
+                :args [resource resource-node-id {}]})))
+      (let [{resource :resource resource-node-id :node-id} (:parent error-item)]
+        (when (and (resource/openable-resource? resource)
+                   (resource/exists? resource))
+          (let [error-node-id (:node-id error-item)
+                outline-node-id (find-outline-node resource-node-id error-node-id)
+                opts (select-keys error-item [:cursor-range])]
+            {:type :resource
+             :args [resource outline-node-id opts]})))
+      (when-let [file-path (:file-path error-item)]
+        (let [file (.getCanonicalFile (File. ^String file-path))]
+          (when (.exists file)
+            {:type :file :file file})))))
 
 (defn- error-line-for-clipboard [error-item]
   (let [message (:message error-item)
@@ -269,8 +276,11 @@
     (.setShowRoot false)
     (ui/cell-factory! make-tree-cell)
     (ui/on-double! (fn [_]
-                     (when-some [[resource selected-node-id opts] (some-> errors-tree ui/selection first error-item-open-info)]
-                       (open-resource-fn resource [selected-node-id] opts))))
+                     (when-let [{:keys [type] :as open-info} (some-> errors-tree ui/selection first error-item-open-info)]
+                       (case type
+                         :resource (let [[resource selected-node-id opts] (:args open-info)]
+                                     (open-resource-fn resource [selected-node-id] opts))
+                         :file (ui/open-file (:file open-info))))))
     (ui/register-context-menu ::build-errors-menu)
     (ui/context! :build-errors-view
                  {:build-errors-view errors-tree}

--- a/editor/src/clj/editor/engine/build_errors.clj
+++ b/editor/src/clj/editor/engine/build_errors.clj
@@ -490,6 +490,7 @@
     [(g/map->error
       {:_node-id nil ;; The editor cannot currently reference files in the /build folder
        :message (str "For the full log, see " log-path)
+       :file-path log-path
        :severity :warning})]))
 
 (defn- multiple-compile-exception-error-causes [project evaluation-context ^MultipleCompileException exception]

--- a/editor/test/integration/build_errors_test.clj
+++ b/editor/test/integration/build_errors_test.clj
@@ -46,7 +46,7 @@
       (when-let [child-outline (util/first-where #(= (first labels) (:label %)) (:children node-outline))]
         (recur (next labels) child-outline)))))
 
-(def ^:private error-item-open-info-without-opts (comp pop build-errors-view/error-item-open-info))
+(def ^:private error-item-open-info-without-opts (comp pop :args build-errors-view/error-item-open-info))
 
 (deftest build-errors-test
   (test-util/with-loaded-project project-path

--- a/editor/test/integration/extension_spine_test.clj
+++ b/editor/test/integration/extension_spine_test.clj
@@ -33,7 +33,7 @@
 
 (defonce ^:private extension-spine-url "https://github.com/defold/extension-spine/archive/main.zip")
 
-(def ^:private error-item-open-info-without-opts (comp pop build-errors-view/error-item-open-info))
+(def ^:private error-item-open-info-without-opts (comp pop :args build-errors-view/error-item-open-info))
 
 (defn- save-data-content-by-proj-path [project]
   (into {}

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -308,7 +308,7 @@
                 item)))
           items)))
 
-(def ^:private error-item-open-info-without-opts (comp pop build-errors-view/error-item-open-info))
+(def ^:private error-item-open-info-without-opts (comp pop :args build-errors-view/error-item-open-info))
 
 (deftest edit-script-resource-properties-test
   (with-clean-system


### PR DESCRIPTION
User-facing changes:
Double-clicking on the build error "For the full log, see /file/path/log.txt" will now open the error log file.