### PR TITLE
Exclude headless dmengine from `bob.jar`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
+++ b/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
@@ -99,19 +99,19 @@ copy () {
 
 copy x86_64-linux/stripped/dmengine x86_64-linux/dmengine
 copy x86_64-linux/stripped/dmengine_release x86_64-linux/dmengine_release
-copy x86_64-linux/stripped/dmengine_headless x86_64-linux/dmengine_headless
+# copy x86_64-linux/stripped/dmengine_headless x86_64-linux/dmengine_headless
 copy x86_64-macos/stripped/dmengine x86_64-macos/dmengine
 copy x86_64-macos/stripped/dmengine_release x86_64-macos/dmengine_release
-copy x86_64-macos/stripped/dmengine_headless x86_64-macos/dmengine_headless
+# copy x86_64-macos/stripped/dmengine_headless x86_64-macos/dmengine_headless
 copy arm64-macos/stripped/dmengine arm64-macos/dmengine
 copy arm64-macos/stripped/dmengine_release arm64-macos/dmengine_release
-copy arm64-macos/stripped/dmengine_headless arm64-macos/dmengine_headless
+# copy arm64-macos/stripped/dmengine_headless arm64-macos/dmengine_headless
 copy win32/dmengine.exe x86-win32/dmengine.exe
 copy win32/dmengine_release.exe x86-win32/dmengine_release.exe
-copy win32/dmengine_headless.exe x86-win32/dmengine_headless.exe
+# copy win32/dmengine_headless.exe x86-win32/dmengine_headless.exe
 copy x86_64-win32/dmengine.exe x86_64-win32/dmengine.exe
 copy x86_64-win32/dmengine_release.exe x86_64-win32/dmengine_release.exe
-copy x86_64-win32/dmengine_headless.exe x86_64-win32/dmengine_headless.exe
+# copy x86_64-win32/dmengine_headless.exe x86_64-win32/dmengine_headless.exe
 copy arm64-ios/stripped/dmengine arm64-ios/dmengine
 copy arm64-ios/stripped/dmengine_release arm64-ios/dmengine_release
 copy x86_64-ios/stripped/dmengine x86_64-ios/dmengine

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1145,7 +1145,7 @@ public class Project {
 
             if (symbolsFilename != null) {
                 try {
-                    URL url = new URL(String.format("http://d.defold.com/archive/%s/engine/%s/%s", EngineVersion.sha1, platform, symbolsFilename));
+                    URL url = new URL(String.format(Bob.ARTIFACTS_URL + "%s/engine/%s/%s", EngineVersion.sha1, platform, symbolsFilename));
                     File file = new File(new File(getBinaryOutputDirectory(), platform), symbolsFilename);
                     HttpUtil http = new HttpUtil();
                     http.downloadToFile(url, file);


### PR DESCRIPTION
Now "vanilla" `dmengine_headless` (headless dmengine binary without native extensions) will be downloaded from the server if needed. It's rarely used, but was shipped with each `bob.jar` for all the platforms.

Fix https://github.com/defold/defold/issues/7646
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
