### PR TITLE
Make sure that symbols for default `dmengine` copied right

### DIFF
--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -443,6 +443,9 @@ def default_flags(self):
         target_arch = build_util.get_target_architecture()
 
         bp_arch, bp_os = self.env['BUILD_PLATFORM'].split('-')
+        # NDK doesn't support arm64 yet
+        if bp_arch == 'arm64':
+            bp_arch = 'x86_64';
         sysroot='%s/toolchains/llvm/prebuilt/%s-%s/sysroot' % (ANDROID_NDK_ROOT, bp_os, bp_arch)
 
         for f in ['CFLAGS', 'CXXFLAGS']:
@@ -1616,6 +1619,9 @@ def detect(conf):
         target_arch = build_util.get_target_architecture()
         api_version = getAndroidNDKAPIVersion(target_arch)
         clang_name  = getAndroidCompilerName(target_arch, api_version)
+        # NDK doesn't support arm64 yet
+        if bp_arch == 'arm64':
+            bp_arch = 'x86_64';
         bintools    = '%s/toolchains/llvm/prebuilt/%s-%s/bin' % (ANDROID_NDK_ROOT, bp_os, bp_arch)
         tool_name = "llvm"
 

--- a/build_tools/waf_dynamo.py
+++ b/build_tools/waf_dynamo.py
@@ -446,6 +446,8 @@ def default_flags(self):
         # NDK doesn't support arm64 yet
         if bp_arch == 'arm64':
             bp_arch = 'x86_64';
+        if bp_os == 'macos':
+            bp_os = 'darwin'
         sysroot='%s/toolchains/llvm/prebuilt/%s-%s/sysroot' % (ANDROID_NDK_ROOT, bp_os, bp_arch)
 
         for f in ['CFLAGS', 'CXXFLAGS']:

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -350,6 +350,7 @@ public class Bob {
             File f = new File(rootFolder, exeName);
             try {
                 URL url = new URL(String.format(artifactsURL + "%s/engine/%s/%s", EngineVersion.sha1, platform.getPair(), exeName));
+                logger.info("Download: %s", url);
                 File file = new File(downloadFolder, exeName);
                 HttpUtil http = new HttpUtil();
                 http.downloadToFile(url, file);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1112,9 +1112,16 @@ public class Project {
     }
 
     private void downloadSymbols(IProgress progress) throws IOException, CompileExceptionError {
-        final String[] platforms = getPlatformStrings();
+        String archs = this.option("architectures", null);
+        String[] platforms;
+        if (archs != null) {
+            platforms = archs.split(",");
+        }
+        else {
+            platforms = getPlatformStrings();
+        }
 
-        progress.beginTask("Downloading symbols...", platforms.length);
+        progress.beginTask(String.format("Downloading %s symbols...", platforms.length), platforms.length);
 
         final String variant = this.option("variant", Bob.VARIANT_RELEASE);
         String variantSuffix = "";
@@ -1129,9 +1136,12 @@ public class Project {
 
         for(String platform : platforms) {
             String symbolsFilename = null;
+            Platform p = Platform.get(platform);
             switch(platform) {
                 case "arm64-ios":
+                case "x86_64-ios":
                 case "x86_64-macos":
+                case "arm64-macos":
                     symbolsFilename = String.format("dmengine%s.dSYM.zip", variantSuffix);
                     break;
                 case "js-web":
@@ -1146,9 +1156,13 @@ public class Project {
             if (symbolsFilename != null) {
                 try {
                     URL url = new URL(String.format(Bob.ARTIFACTS_URL + "%s/engine/%s/%s", EngineVersion.sha1, platform, symbolsFilename));
-                    File file = new File(new File(getBinaryOutputDirectory(), platform), symbolsFilename);
+                    File targetFolder = new File(getBinaryOutputDirectory(), p.getExtenderPair());
+                    File file = new File(targetFolder, symbolsFilename);
                     HttpUtil http = new HttpUtil();
                     http.downloadToFile(url, file);
+                    if (symbolsFilename.endsWith(".zip")){
+                        BundleHelper.unzip(new FileInputStream(file), targetFolder.toPath());
+                    }
                 }
                 catch (Exception e) {
                     throw new CompileExceptionError(e);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -187,15 +187,18 @@ public class IOSBundler implements IBundler {
     private static final String SYMBOL_EXE_RELATIVE_PATH = String.format("Contents/Resources/DWARF/dmengine");
 
     public static List<File> getSymbolDirsFromArchitectures(File buildDir, List<Platform> architectures) {
+        final String[] prefixes = {"", "src" + File.separator};
         List<File> symbolDirectories = new ArrayList<File>();
         for (Platform architecture : architectures) {
 
             File platformDir = new File(buildDir, architecture.getExtenderPair());
-            File symbolsDir = new File(platformDir, "dmengine.dSYM");
-            if (symbolsDir.exists()) {
-                File symbols = new File(symbolsDir, SYMBOL_EXE_RELATIVE_PATH);
-                if (symbols.exists()) {
-                    symbolDirectories.add(symbolsDir);
+            for (String prefix: prefixes) {
+                File symbolsDir = new File(platformDir, prefix + "dmengine.dSYM");
+                if (symbolsDir.exists()) {
+                    File symbols = new File(symbolsDir, SYMBOL_EXE_RELATIVE_PATH);
+                    if (symbols.exists()) {
+                        symbolDirectories.add(symbolsDir);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix issue when symbols didn't copy for the "vanilla" `dmengine` 

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
