### PR TITLE
Use the WebGL 1.0 specific constant for the half float format.

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -159,7 +159,6 @@
     #if defined GL_ES_VERSION_2_0
         #undef GL_ARRAY_BUFFER_ARB
         #undef GL_ELEMENT_ARRAY_BUFFER_ARB
-        #define GL_HALF_FLOAT_OES 0x8D61
     #endif
 #else
     #error "Platform not supported."
@@ -3184,8 +3183,8 @@ static void LogFrameBufferError(GLenum status)
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGB;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB16F;
             EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_internal_format, DMGRAPHICS_TEXTURE_FORMAT_RGB);
-            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
-            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
+            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RGB32F:
             gl_type            = GL_FLOAT;
@@ -3198,8 +3197,8 @@ static void LogFrameBufferError(GLenum status)
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA16F;
             EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_internal_format, DMGRAPHICS_TEXTURE_FORMAT_RGBA);
-            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
-            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
+            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RGBA32F:
             gl_type            = GL_FLOAT;
@@ -3211,8 +3210,8 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RED;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_R16F;
-            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
-            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
+            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_R32F:
             gl_type            = GL_FLOAT;
@@ -3223,8 +3222,8 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RG;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG16F;
-            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
-            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
+            ANDROID_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RG32F:
             gl_type            = GL_FLOAT;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -3210,7 +3210,6 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RED;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_R16F;
-            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             ANDROID_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_R32F:
@@ -3222,7 +3221,6 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RG;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG16F;
-            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             ANDROID_ES2_BACKWARDS_COMPAT(gl_type, DMGRAPHICS_TYPE_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RG32F:

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -159,6 +159,7 @@
     #if defined GL_ES_VERSION_2_0
         #undef GL_ARRAY_BUFFER_ARB
         #undef GL_ELEMENT_ARRAY_BUFFER_ARB
+        #define GL_HALF_FLOAT_OES 0x8D61
     #endif
 #else
     #error "Platform not supported."
@@ -3183,6 +3184,7 @@ static void LogFrameBufferError(GLenum status)
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGB;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGB16F;
             EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_internal_format, DMGRAPHICS_TEXTURE_FORMAT_RGB);
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RGB32F:
@@ -3195,6 +3197,8 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RGBA;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RGBA16F;
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_internal_format, DMGRAPHICS_TEXTURE_FORMAT_RGBA);
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RGBA32F:
@@ -3207,6 +3211,7 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RED;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_R16F;
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_R32F:
@@ -3218,6 +3223,7 @@ static void LogFrameBufferError(GLenum status)
             gl_type            = DMGRAPHICS_TYPE_HALF_FLOAT;
             gl_format          = DMGRAPHICS_TEXTURE_FORMAT_RG;
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG16F;
+            EMSCRIPTEN_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             ANDROID_ES2_BACKWARDS_COMPAT(gl_type, GL_HALF_FLOAT_OES);
             break;
         case TEXTURE_FORMAT_RG32F:

--- a/engine/graphics/src/opengl/graphics_opengl_defines.h
+++ b/engine/graphics/src/opengl/graphics_opengl_defines.h
@@ -77,6 +77,12 @@
 #define DMGRAPHICS_TYPE_HALF_FLOAT                          (0x140B)
 #endif
 
+#ifdef GL_HALF_FLOAT_OES
+#define DMGRAPHICS_TYPE_HALF_FLOAT_OES                      (GL_HALF_FLOAT_OES)
+#else
+#define DMGRAPHICS_TYPE_HALF_FLOAT_OES                      (0x8D61)
+#endif
+
 // Texture arrays
 #ifdef GL_SAMPLER_2D_ARRAY
 #define DMGRAPHICS_SAMPLER_2D_ARRAY 						(GL_SAMPLER_2D_ARRAY)


### PR DESCRIPTION
WebGL 1.0 supports loading half float textures. But it requires the use of HALF_FLOAT_OES constant, which has a different value from the HALF_FLOAT constant from WebGL 2.0 / OpenGL ES 3.0. This fix enables to use half float texture format on WebGL 1.0 devices.

Fixes #8241

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.
