### PR TITLE
Add support for luminance_alpha in image.load

### DIFF
--- a/engine/dlib/src/dlib/image.cpp
+++ b/engine/dlib/src/dlib/image.cpp
@@ -114,6 +114,26 @@ namespace dmImage
         memset(image, 0, sizeof(*image));
     }
 
+    Type GetType(HImage image)
+    {
+        return image->m_Type;
+    }
+
+    uint32_t GetWidth(HImage image)
+    {
+        return image->m_Width;
+    }
+
+    uint32_t GetHeight(HImage image)
+    {
+        return image->m_Height;
+    }
+
+    const void* GetData(HImage image)
+    {
+        return image->m_Buffer;
+    }
+
     uint32_t BytesPerPixel(Type type)
     {
         switch (type)

--- a/engine/dlib/src/dlib/image.cpp
+++ b/engine/dlib/src/dlib/image.cpp
@@ -35,7 +35,7 @@
 
 namespace dmImage
 {
-    void Premultiply(uint8_t* buffer, int width, int height)
+    void PremultiplyRGBA(uint8_t* buffer, int width, int height)
     {
         for (int y = 0; y < height; ++y) {
             for (int x = 0; x < width; ++x) {
@@ -47,6 +47,18 @@ namespace dmImage
                 buffer[index + 0] = r;
                 buffer[index + 1] = g;
                 buffer[index + 2] = b;
+            }
+        }
+    }
+
+    void PremultiplyLuminance(uint8_t* buffer, int width, int height)
+    {
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                int index     = (y * width + x) * 2;
+                uint32_t a    = buffer[index + 1];
+                uint32_t r    = (buffer[index] * a + 255) >> 8;
+                buffer[index] = r;
             }
         }
     }
@@ -66,17 +78,20 @@ namespace dmImage
                 i.m_Type = TYPE_LUMINANCE;
                 break;
             case 2:
-                // Luminance + alpha. Convert to luminance
-                i.m_Type = TYPE_LUMINANCE;
-                ret = stbi__convert_format(ret, 2, 1, x, y);
+                i.m_Type = TYPE_LUMINANCE_ALPHA;
+                if (premult)
+                {
+                    PremultiplyLuminance(ret, x, y);
+                }
                 break;
             case 3:
                 i.m_Type = TYPE_RGB;
                 break;
             case 4:
                 i.m_Type = TYPE_RGBA;
-                if (premult) {
-                    Premultiply(ret, x, y);
+                if (premult)
+                {
+                    PremultiplyRGBA(ret, x, y);
                 }
                 break;
             default:
@@ -109,6 +124,8 @@ namespace dmImage
             return 4;
         case dmImage::TYPE_LUMINANCE:
             return 1;
+        case dmImage::TYPE_LUMINANCE_ALPHA:
+            return 2;
         }
         return 0;
     }

--- a/engine/dlib/src/dlib/image.h
+++ b/engine/dlib/src/dlib/image.h
@@ -28,9 +28,10 @@ namespace dmImage
 
     enum Type
     {
-        TYPE_RGB        = 0,
-        TYPE_RGBA       = 1,
-        TYPE_LUMINANCE  = 2,
+        TYPE_RGB             = 0,
+        TYPE_RGBA            = 1,
+        TYPE_LUMINANCE       = 2,
+        TYPE_LUMINANCE_ALPHA = 3,
     };
 
     struct Image

--- a/engine/dlib/src/dlib/image.h
+++ b/engine/dlib/src/dlib/image.h
@@ -17,23 +17,10 @@
 
 #include <stdint.h>
 
+#include <dmsdk/dlib/image.h>
+
 namespace dmImage
 {
-    enum Result
-    {
-        RESULT_OK                   = 0,
-        RESULT_UNSUPPORTED_FORMAT   = -1,
-        RESULT_IMAGE_ERROR          = -2,
-    };
-
-    enum Type
-    {
-        TYPE_RGB             = 0,
-        TYPE_RGBA            = 1,
-        TYPE_LUMINANCE       = 2,
-        TYPE_LUMINANCE_ALPHA = 3,
-    };
-
     struct Image
     {
         Image() : m_Width(0), m_Height(0), m_Type(TYPE_RGB), m_Buffer(0) {}
@@ -44,36 +31,11 @@ namespace dmImage
     };
 
     /**
-     * Load image from buffer.
-     *
-     * <pre>
-     *   Supported formats:
-     *   png gray, gray + alpha, rgb and rgba
-     *   jpg
-     * </pre>
-     * 16-bit (or higher) channels are not supported.
-     *
-     * @param buffer image buffer
-     * @param buffer_size image buffer size
-     * @param premult premultiply alpha or not
-     * @param image output
-     * @return RESULT_OK on success
-     */
-    Result Load(const void* buffer, uint32_t buffer_size, bool premult, Image* image);
-
-    /**
-     * Free loaded image
-     * @param image image to free
-     */
-    void Free(Image* image);
-
-    /**
      * Get bytes per pixel
      * @param type
      * @return bytes per pixel. zero if the type is unknown
      */
     uint32_t BytesPerPixel(Type type);
-
 }
 
 #endif // #ifndef DM_IMAGE_H

--- a/engine/dlib/src/dmsdk/dlib/image.h
+++ b/engine/dlib/src/dmsdk/dlib/image.h
@@ -29,10 +29,10 @@
 
 namespace dmImage
 {
-	struct Image;
-	typedef Image* HImage;
+    struct Image;
+    typedef Image* HImage;
 
-	/*# result enumeration
+    /*# result enumeration
      *
      * @enum
      * @name Result
@@ -40,7 +40,7 @@ namespace dmImage
      * @member dmImage::RESULT_UNSUPPORTED_FORMAT = -1
      * @member dmImage::RESULT_IMAGE_ERROR = -2
      */
-	enum Result
+    enum Result
     {
         RESULT_OK                   = 0,
         RESULT_UNSUPPORTED_FORMAT   = -1,
@@ -117,4 +117,4 @@ namespace dmImage
     const void* GetData(HImage image);
 }
 
-#endif
+#endif // DMSDK_IMAGE

--- a/engine/dlib/src/dmsdk/dlib/image.h
+++ b/engine/dlib/src/dmsdk/dlib/image.h
@@ -1,0 +1,120 @@
+// Copyright 2020-2023 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DMSDK_IMAGE
+#define DMSDK_IMAGE
+
+#include <stdint.h>
+
+/*# SDK Image API documentation
+ *
+ * Image API functions.
+ *
+ * @document
+ * @name Image
+ * @namespace dmImage
+ * @path engine/dlib/src/dmsdk/dlib/image.h
+ */
+
+namespace dmImage
+{
+	struct Image;
+	typedef Image* HImage;
+
+	/*# result enumeration
+     *
+     * @enum
+     * @name Result
+     * @member dmImage::RESULT_OK = 0
+     * @member dmImage::RESULT_UNSUPPORTED_FORMAT = -1
+     * @member dmImage::RESULT_IMAGE_ERROR = -2
+     */
+	enum Result
+    {
+        RESULT_OK                   = 0,
+        RESULT_UNSUPPORTED_FORMAT   = -1,
+        RESULT_IMAGE_ERROR          = -2,
+    };
+
+    /*# type enumeration
+     *
+     * @enum
+     * @name Type
+     * @member dmImage::TYPE_RGB = 0
+     * @member dmImage::TYPE_RGBA = 1
+     * @member dmImage::TYPE_LUMINANCE = 2
+     * @member dmImage::TYPE_LUMINANCE_ALPHA = 3
+     */
+    enum Type
+    {
+        TYPE_RGB             = 0,
+        TYPE_RGBA            = 1,
+        TYPE_LUMINANCE       = 2,
+        TYPE_LUMINANCE_ALPHA = 3,
+    };
+
+    /**
+     * Load image from buffer.
+     *
+     * <pre>
+     *   Supported formats:
+     *   png gray, gray + alpha, rgb and rgba
+     *   jpg
+     * </pre>
+     * 16-bit (or higher) channels are not supported.
+     *
+     * @param buffer image buffer
+     * @param buffer_size image buffer size
+     * @param premult premultiply alpha or not
+     * @param image output
+     * @return RESULT_OK on success
+     */
+    Result Load(const void* buffer, uint32_t buffer_size, bool premult, HImage image);
+
+    /**
+     * Free loaded image
+     * @param image image to free
+     */
+    void Free(HImage image);
+
+    /**
+     * Get image type
+     * @param image [type: dmImage::HImage] the image handle
+     * @return type [type: Type] the image type
+     */
+    Type GetType(HImage image);
+
+    /**
+     * Get image width
+     * @param image [type: dmImage::HImage] the image handle
+     * @return width [type: uint32_t] the image width
+     */
+    uint32_t GetWidth(HImage image);
+
+    /**
+     * Get image height
+     * @param image [type: dmImage::HImage] the image handle
+     * @return height [type: uint32_t] the image height
+     */
+    uint32_t GetHeight(HImage image);
+
+    /**
+     * Get data pointer
+     * @param image [type: dmImage::HImage] the image handle
+     * @return data [type: uint32_t] the image height
+     */
+    const void* GetData(HImage image);
+}
+
+#endif

--- a/engine/dlib/src/test/test_image.cpp
+++ b/engine/dlib/src/test/test_image.cpp
@@ -210,21 +210,33 @@ TEST(dmImage, PngGray)
 
 TEST(dmImage, PngGrayAlpha)
 {
-    // Test implicit alpha channel removal for 2-component images.
     dmImage::Image image;
     dmImage::Result r =  dmImage::Load(GRAY_ALPHA_CHECK_2X2_PNG, GRAY_ALPHA_CHECK_2X2_PNG_SIZE, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(2U, image.m_Width);
     ASSERT_EQ(2U, image.m_Height);
-    ASSERT_EQ(dmImage::TYPE_LUMINANCE, image.m_Type);
+    ASSERT_EQ(dmImage::TYPE_LUMINANCE_ALPHA, image.m_Type);
     ASSERT_NE((void*) 0, image.m_Buffer);
 
     const uint8_t* b = (const uint8_t*) image.m_Buffer;
     int i = 0;
+
+    // Pixel 1
     ASSERT_EQ(0U, (uint32_t) b[i++]);
     ASSERT_EQ(255U, (uint32_t) b[i++]);
+
+    // Pixel 2
     ASSERT_EQ(255U, (uint32_t) b[i++]);
+    ASSERT_EQ(255U, (uint32_t) b[i++]);
+
+    // Pixel 3
+    ASSERT_EQ(255U, (uint32_t) b[i++]);
+    ASSERT_EQ(255U, (uint32_t) b[i++]);
+
+    // Pixel 4
     ASSERT_EQ(0U, (uint32_t) b[i++]);
+    ASSERT_EQ(255U, (uint32_t) b[i++]);
+
     dmImage::Free(&image);
 }
 

--- a/engine/dlib/src/test/test_image.cpp
+++ b/engine/dlib/src/test/test_image.cpp
@@ -218,6 +218,14 @@ TEST(dmImage, PngGrayAlpha)
     ASSERT_EQ(dmImage::TYPE_LUMINANCE_ALPHA, image.m_Type);
     ASSERT_NE((void*) 0, image.m_Buffer);
 
+    // DMSDK Test
+    dmImage::HImage h_image = &image;
+    ASSERT_EQ(2U, dmImage::GetWidth(h_image));
+    ASSERT_EQ(2U, dmImage::GetHeight(h_image));
+    ASSERT_EQ(dmImage::TYPE_LUMINANCE_ALPHA, dmImage::GetType(h_image));
+    ASSERT_NE((void*) 0, dmImage::GetData(h_image));
+    ASSERT_EQ(image.m_Buffer, dmImage::GetData(h_image));
+
     const uint8_t* b = (const uint8_t*) image.m_Buffer;
     int i = 0;
 

--- a/engine/script/src/script_image.cpp
+++ b/engine/script/src/script_image.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -59,6 +59,12 @@ namespace dmScript
      * @variable
      */
 
+    /*# luminance image type
+     *
+     * @name image.TYPE_LUMINANCE_ALPHA
+     * @variable
+     */
+
     /*# load image from buffer
     * Load image (PNG or JPEG) from buffer.
     *
@@ -73,6 +79,7 @@ namespace dmScript
     *     - `image.TYPE_RGB`
     *     - `image.TYPE_RGBA`
     *     - `image.TYPE_LUMINANCE`
+    *     - `image.TYPE_LUMINANCE_ALPHA`
     * - [type:string] `buffer`: the raw image data
     *
     * @examples
@@ -130,6 +137,9 @@ namespace dmScript
                 case dmImage::TYPE_LUMINANCE:
                     lua_pushliteral(L, "l");
                     break;
+                case dmImage::TYPE_LUMINANCE_ALPHA:
+                    lua_pushliteral(L, "la");
+                    break;
                 default:
                     assert(false);
             }
@@ -169,9 +179,8 @@ namespace dmScript
         SETCONSTANT(TYPE_RGB, "rgb")
         SETCONSTANT(TYPE_RGBA, "rgba")
         SETCONSTANT(TYPE_LUMINANCE, "l")
-
+        SETCONSTANT(TYPE_LUMINANCE_ALPHA, "la")
 #undef SETCONSTANT
-
 
         lua_pop(L, 1);
 


### PR DESCRIPTION
Moved internal dmImage functionality into the dmsdk for loading images from binary data. The API looks like this:

```c++
namespace dmImage
{
  Result Load(const void* buffer, uint32_t buffer_size, bool premult, HImage image);
  void Free(HImage image);
  Type GetType(HImage image);
  uint32_t GetWidth(HImage image);
  uint32_t GetHeight(HImage image);
  const void* GetData(HImage image);
}
```

NOTE: that this also changes the API for the script `image.load` function since we now will return `image.TYPE_LUMINANCE_ALPHA` for PNGs with both grayscale and alpha channels. This is considered a bugfix so please be aware of this if you are using that function!

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
