### PR TITLE
Fix small memory leak in `json.decode()`

### DIFF
--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -533,8 +533,8 @@ static void json_initialize_config(json_config_t* cfg, int encode_keep_buffer)
 static void json_encode_exception(lua_State *l, json_config_t *cfg, strbuf_t *json, int lindex,
                                   const char *reason)
 {
-    if (cfg->encode_keep_buffer)
-        strbuf_free(json);
+    // We don't need the buffer if error happened.
+    strbuf_free(json);
 
     luaL_error(l, "Cannot serialise %s: %s",
                   lua_typename(l, lua_type(l, lindex)), reason);
@@ -686,8 +686,8 @@ static void json_check_encode_depth(lua_State *l, json_config_t *cfg,
     if (current_depth <= cfg->encode_max_depth && lua_checkstack(l, 3))
         return;
 
-    if (cfg->encode_keep_buffer)
-        strbuf_free(json);
+    // We don't need the buffer if error happened.
+    strbuf_free(json);
 
     luaL_error(l, "Cannot serialise, excessive nesting (%d)",
                current_depth);

--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -1588,6 +1588,7 @@ int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len)
         json_throw_parse_error(l, &json, "the end", &token);
 
     strbuf_free(json.tmp);
+    strbuf_free(&cfg.encode_buf);
 
     return 1;
 }

--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -459,7 +459,7 @@ static void json_create_config(lua_State *l)
 #endif // DEFOLD
 
 // DEFOLD
-static void json_initialize_config(json_config_t* cfg)
+static void json_initialize_config(json_config_t* cfg, int encode_keep_buffer)
 {
     int i;
 
@@ -470,15 +470,16 @@ static void json_initialize_config(json_config_t* cfg)
     cfg->decode_max_depth = DEFAULT_DECODE_MAX_DEPTH;
     cfg->encode_invalid_numbers = DEFAULT_ENCODE_INVALID_NUMBERS;
     cfg->decode_invalid_numbers = DEFAULT_DECODE_INVALID_NUMBERS;
-    cfg->encode_keep_buffer = DEFAULT_ENCODE_KEEP_BUFFER;
+    cfg->encode_keep_buffer = encode_keep_buffer;
     cfg->encode_number_precision = DEFAULT_ENCODE_NUMBER_PRECISION;
     cfg->encode_empty_table_as_object = DEFAULT_ENCODE_EMPTY_TABLE_AS_OBJECT;
     cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
     cfg->encode_escape_forward_slash = DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH;
 
-#if DEFAULT_ENCODE_KEEP_BUFFER > 0
-    strbuf_init(&cfg->encode_buf, 0);
-#endif
+    if (encode_keep_buffer > 0)
+    {
+        strbuf_init(&cfg->encode_buf, 0);
+    }
 
     /* Decoding init */
 
@@ -532,8 +533,9 @@ static void json_initialize_config(json_config_t* cfg)
 static void json_encode_exception(lua_State *l, json_config_t *cfg, strbuf_t *json, int lindex,
                                   const char *reason)
 {
-    if (!cfg->encode_keep_buffer)
+    if (cfg->encode_keep_buffer)
         strbuf_free(json);
+
     luaL_error(l, "Cannot serialise %s: %s",
                   lua_typename(l, lua_type(l, lindex)), reason);
 }
@@ -684,7 +686,7 @@ static void json_check_encode_depth(lua_State *l, json_config_t *cfg,
     if (current_depth <= cfg->encode_max_depth && lua_checkstack(l, 3))
         return;
 
-    if (!cfg->encode_keep_buffer)
+    if (cfg->encode_keep_buffer)
         strbuf_free(json);
 
     luaL_error(l, "Cannot serialise, excessive nesting (%d)",
@@ -936,7 +938,7 @@ int lua_cjson_encode(lua_State *l, char** json_str, size_t* json_length)
 
     luaL_argcheck(l, lua_gettop(l) == 1, 1, "expected 1 argument");
 
-    json_initialize_config(&cfg);
+    json_initialize_config(&cfg, DEFAULT_ENCODE_KEEP_BUFFER);
     if (!cfg.encode_keep_buffer) {
         /* Use private buffer */
         encode_buf = &local_encode_buf;
@@ -1558,7 +1560,7 @@ int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len)
     json_parse_t json;
     json_token_t token;
 
-    json_initialize_config(&cfg);
+    json_initialize_config(&cfg, 0);
     json.cfg = &cfg;
     json.data = json_string;
     json.data_end = json_string + json_len;
@@ -1588,7 +1590,6 @@ int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len)
         json_throw_parse_error(l, &json, "the end", &token);
 
     strbuf_free(json.tmp);
-    strbuf_free(&cfg.encode_buf);
 
     return 1;
 }


### PR DESCRIPTION
Each `json.decode()` call allocates 1kb of memory, which should be freed after.

Fix https://github.com/defold/defold/issues/7685

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
