### PR TITLE
Fix typo in profiler documentation (defold/defold.github.io#104)

### DIFF
--- a/engine/profiler/src/profiler.cpp
+++ b/engine/profiler/src/profiler.cpp
@@ -127,7 +127,7 @@ void RenderProfiler(dmProfile::HProfile profile, dmGraphics::HContext graphics_c
  *
  * OS                                | Value
  * ----------------------------------|------------------
- * [icon:ios] iOS<br/>[icon:macos] MacOS<br/>[icon:android]<br/>Androd<br/>[icon:linux] Linux | [Resident memory](https://en.wikipedia.org/wiki/Resident_set_size)
+ * [icon:ios] iOS<br/>[icon:macos] MacOS<br/>[icon:android]<br/>Android<br/>[icon:linux] Linux | [Resident memory](https://en.wikipedia.org/wiki/Resident_set_size)
  * [icon:windows] Windows            | [Working set](https://en.wikipedia.org/wiki/Working_set)
  * [icon:html5] HTML5                | [icon:attention] Not available
  *


### PR DESCRIPTION
Fix a typo in the profiler API documentation related to the available platforms at the function `profiler.get_memory_usage()`

Fixes defold/defold.github.io#104