### PR TITLE
Improve memory usage in large projects

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -33,7 +33,7 @@
 
 (set! *warn-on-reflection* true)
 
-(namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id node-id? produce-value node-by-id-at endpoint-node-id endpoint-label])
+(namespaces/import-vars [internal.graph.types node-id->graph-id node->graph-id sources targets connected? dependencies Node node-id node-id? produce-value node-by-id-at endpoint endpoint-node-id endpoint-label])
 
 (namespaces/import-vars [internal.graph.error-values ->error error-aggregate error-fatal error-fatal? error-info error-info? error-message error-package? error-warning error-warning? error-value? error? flatten-errors map->error package-errors precluding-errors unpack-errors worse-than package-if-error])
 
@@ -98,9 +98,6 @@
 (defn cache "The system cache of node values"
   []
   (is/system-cache @*the-system*))
-
-(defn endpoint [node-id label]
-  (gt/endpoint node-id label))
 
 (defn clear-system-cache!
   "Clears a cache (default *the-system* cache), useful when debugging"

--- a/editor/src/clj/editor/protobuf.clj
+++ b/editor/src/clj/editor/protobuf.clj
@@ -467,22 +467,113 @@ Macros currently mean no foreseeable performance gain however."
 (defn val->pb-enum [^Class enum-class val]
   (Enum/valueOf enum-class (s/replace (util/upper-case* (name val)) "-" "_")))
 
+(def ^:private float-zero (Float/valueOf 0.0))
+(def ^:private float-one (Float/valueOf 1.0))
+
+(def ^:private vector3-zero [float-zero float-zero float-zero])
+(def ^:private vector3-one [float-one float-one float-one])
+
+(def ^:private vector4-zero [float-zero float-zero float-zero float-zero])
+(def ^:private vector4-one [float-one float-one float-one float-one])
+(def ^:private vector4-xyz-zero-w-one [float-zero float-zero float-zero float-one])
+(def ^:private vector4-xyz-one-w-zero [float-one float-one float-one float-zero])
+
+(def ^:private quat-identity [float-zero float-zero float-zero float-one])
+
+(def ^:private matrix4-identity
+  [float-one float-zero float-zero float-zero
+   float-zero float-one float-zero float-zero
+   float-zero float-zero float-one float-zero
+   float-zero float-zero float-zero float-one])
+
+(definline intern-float [num]
+  `(let [float# ~num]
+     (cond
+       (= float-zero float#) float-zero
+       (= float-one float#) float-one
+       :else float#)))
+
 (extend-protocol PbConverter
   DdfMath$Point3
   (msg->vecmath [_pb v] (Point3d. (:x v) (:y v) (:z v)))
-  (msg->clj [_pb v] [(:x v) (:y v) (:z v)])
+  (msg->clj [_pb v]
+    (let [x (intern-float (:x v))
+          y (intern-float (:y v))
+          z (intern-float (:z v))]
+      (if (and (identical? float-zero x)
+               (identical? float-zero y)
+               (identical? float-zero z))
+        vector3-zero
+        [x y z])))
 
   DdfMath$Vector3
   (msg->vecmath [_pb v] (Vector3d. (:x v) (:y v) (:z v)))
-  (msg->clj [_pb v] [(:x v) (:y v) (:z v)])
+  (msg->clj [_pb v]
+    (let [x (intern-float (:x v))
+          y (intern-float (:y v))
+          z (intern-float (:z v))]
+      (cond
+        (and (identical? float-zero x)
+             (identical? float-zero y)
+             (identical? float-zero z))
+        vector3-zero
+
+        (and (identical? float-one x)
+             (identical? float-one y)
+             (identical? float-one z))
+        vector3-one
+
+        :else
+        [x y z])))
 
   DdfMath$Vector4
   (msg->vecmath [_pb v] (Vector4d. (:x v) (:y v) (:z v) (:w v)))
-  (msg->clj [_pb v] [(:x v) (:y v) (:z v) (:w v)])
+  (msg->clj [_pb v]
+    (let [x (intern-float (:x v))
+          y (intern-float (:y v))
+          z (intern-float (:z v))
+          w (intern-float (:w v))]
+      (cond
+        (and (identical? float-zero x)
+             (identical? float-zero y)
+             (identical? float-zero z)
+             (identical? float-zero w))
+        vector4-zero
+
+        (and (identical? float-one x)
+             (identical? float-one y)
+             (identical? float-one z)
+             (identical? float-one w))
+        vector4-one
+
+        (and (identical? float-zero x)
+             (identical? float-zero y)
+             (identical? float-zero z)
+             (identical? float-one w))
+        vector4-xyz-zero-w-one
+
+        (and (identical? float-one x)
+             (identical? float-one y)
+             (identical? float-one z)
+             (identical? float-zero w))
+        vector4-xyz-one-w-zero
+
+        :else
+        [x y z w])))
 
   DdfMath$Quat
   (msg->vecmath [_pb v] (Quat4d. (:x v) (:y v) (:z v) (:w v)))
-  (msg->clj [_pb v] [(:x v) (:y v) (:z v) (:w v)])
+  (msg->clj [_pb v]
+    (let [x (intern-float (:x v))
+          y (intern-float (:y v))
+          z (intern-float (:z v))
+          w (intern-float (:w v))]
+      (if (and (identical? float-zero x)
+               (identical? float-zero y)
+               (identical? float-zero z)
+               (identical? float-one w))
+        quat-identity
+        [x y z w])))
 
   DdfMath$Matrix4
   (msg->vecmath [_pb v]
@@ -491,10 +582,46 @@ Macros currently mean no foreseeable performance gain however."
                (:m20 v) (:m21 v) (:m22 v) (:m23 v)
                (:m30 v) (:m31 v) (:m32 v) (:m33 v)))
   (msg->clj [_pb v]
-    [(:m00 v) (:m01 v) (:m02 v) (:m03 v)
-     (:m10 v) (:m11 v) (:m12 v) (:m13 v)
-     (:m20 v) (:m21 v) (:m22 v) (:m23 v)
-     (:m30 v) (:m31 v) (:m32 v) (:m33 v)])
+    (let [m00 (intern-float (:m00 v))
+          m01 (intern-float (:m01 v))
+          m02 (intern-float (:m02 v))
+          m03 (intern-float (:m03 v))
+          m10 (intern-float (:m10 v))
+          m11 (intern-float (:m11 v))
+          m12 (intern-float (:m12 v))
+          m13 (intern-float (:m13 v))
+          m20 (intern-float (:m20 v))
+          m21 (intern-float (:m21 v))
+          m22 (intern-float (:m22 v))
+          m23 (intern-float (:m23 v))
+          m30 (intern-float (:m30 v))
+          m31 (intern-float (:m31 v))
+          m32 (intern-float (:m32 v))
+          m33 (intern-float (:m33 v))]
+      (if (and (identical? float-one m00)
+               (identical? float-zero m01)
+               (identical? float-zero m02)
+               (identical? float-zero m03)
+
+               (identical? float-zero m10)
+               (identical? float-one m11)
+               (identical? float-zero m12)
+               (identical? float-zero m13)
+
+               (identical? float-zero m20)
+               (identical? float-zero m21)
+               (identical? float-one m22)
+               (identical? float-zero m23)
+
+               (identical? float-zero m30)
+               (identical? float-zero m31)
+               (identical? float-zero m32)
+               (identical? float-one m33))
+        matrix4-identity
+        [m00 m01 m02 m03
+         m10 m11 m12 m13
+         m20 m21 m22 m23
+         m30 m31 m32 m33])))
 
   Message
   (msg->vecmath [_pb v] v)

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -14,6 +14,7 @@
 
 (ns internal.graph.types
   (:import [clojure.lang IHashEq Keyword]
+           [com.defold.util WeakInterner]
            [java.io Writer]))
 
 (set! *warn-on-reflection* true)
@@ -62,11 +63,13 @@
   (.write writer (str (.-label ep)))
   (.write writer "]"))
 
-(defn- read-endpoint [[node-id-expr label-expr]]
-  `(->Endpoint ~node-id-expr ~label-expr))
+(defonce ^WeakInterner endpoint-interner (WeakInterner. 65536))
 
 (definline endpoint [node-id label]
-  `(->Endpoint ~node-id ~label))
+  `(.intern endpoint-interner (->Endpoint ~node-id ~label)))
+
+(defn- read-endpoint [[node-id-expr label-expr]]
+  `(endpoint ~node-id-expr ~label-expr))
 
 (definline endpoint-node-id [endpoint]
   `(.-node-id ~(with-meta endpoint {:tag `Endpoint})))

--- a/editor/src/java/com/defold/util/WeakInterner.java
+++ b/editor/src/java/com/defold/util/WeakInterner.java
@@ -1,0 +1,286 @@
+// Copyright 2020-2023 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.defold.util;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+
+public final class WeakInterner<T> {
+    private static final int MAX_CAPACITY = 1 << 30;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+    private Entry<T>[] hashTable;
+    private int count;
+    private int growthThreshold;
+    private final float loadFactor;
+    private final ReferenceQueue<T> staleEntriesQueue;
+
+    /**
+     * Constructs a new WeakInterner with the specified initial capacity and a load factor of 0.75.
+     * @param initialCapacity The initial number of values we can intern before growing the internal storage.
+     */
+    public WeakInterner(final int initialCapacity) {
+        this(initialCapacity, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Constructs a new WeakInterner with the specified initial capacity and load factor.
+     * @param initialCapacity The initial number of values we can intern before growing the internal storage.
+     * @param loadFactor The ratio of accepted occupancy before growing the internal storage.
+     */
+    public WeakInterner(final int initialCapacity, final float loadFactor) {
+        if (initialCapacity < 0) {
+            throw new IllegalArgumentException("Initial capacity cannot be negative.");
+        }
+
+        if (initialCapacity > MAX_CAPACITY) {
+            throw new IllegalArgumentException("Initial capacity must not exceed " + MAX_CAPACITY + ".");
+        }
+
+        if (loadFactor <= 0.0f || Float.isNaN(loadFactor)) {
+            throw new IllegalArgumentException("Load factor must be a positive number.");
+        }
+
+        final int capacity = toPowerOfTwo(initialCapacity);
+        this.hashTable = makeHashTable(capacity);
+        this.count = 0;
+        this.loadFactor = loadFactor;
+        this.growthThreshold = (int)(capacity * loadFactor);
+        this.staleEntriesQueue = new ReferenceQueue<>();
+    }
+
+    /**
+     * Returns a canonical representation of an immutable value.
+     * Multiple calls to this method with equivalent values will return the
+     * previous instance. This can be used to ensure we only have a single
+     * canonical representation of a value instead of many duplicate instances.
+     * Values are retained as WeakReferences, and storage will be reclaimed once
+     * the canonical values are no longer reachable outside the WeakInterner.
+     *
+     * @param value The immutable value to intern.
+     * @return The canonical representation of the supplied value.
+     */
+    public T intern(final T value) {
+        if (value == null) {
+            throw new IllegalArgumentException("The interned value cannot be null.");
+        }
+
+        // First attempt to get the existing value without locking. If we don't
+        // find a match, lock access from other threads while adding it.
+        final int hashValue = getHashValue(value);
+        final Entry<T>[] hashTable = getHashTable();
+        final int bucketIndex = getBucketIndex(hashValue, hashTable.length);
+        final Entry<T> firstEntryInBucket = hashTable[bucketIndex];
+        final T existingValue = findExistingValue(firstEntryInBucket, value, hashValue);
+        return existingValue != null ? existingValue : internSynchronized(value, hashValue);
+    }
+
+    private synchronized T internSynchronized(final T value, final int hashValue) {
+        // Another thread might have modified the hash table while we were
+        // waiting for it to release the lock. Thus, we must get the hash table
+        // again and try to find an existing value once more before interning it
+        // ourselves.
+        final Entry<T>[] hashTable = getHashTable();
+        final int bucketIndex = getBucketIndex(hashValue, hashTable.length);
+        final Entry<T> firstEntryInBucket = hashTable[bucketIndex];
+        final T existingValue = findExistingValue(firstEntryInBucket, value, hashValue);
+
+        if (existingValue != null) {
+            // Another thread interned the value while we were waiting.
+            return existingValue;
+        }
+
+        // We get to intern the value.
+        hashTable[bucketIndex] = new Entry<>(value, staleEntriesQueue, hashValue, firstEntryInBucket);
+
+        if (++count >= growthThreshold) {
+            rehash(hashTable.length * 2);
+        }
+
+        return value;
+    }
+
+    private static <T> T findExistingValue(final Entry<T> firstEntryInBucket, final T value, final int hashValue) {
+        for (Entry<T> existingEntry = firstEntryInBucket; existingEntry != null; existingEntry = existingEntry.nextEntry) {
+            if (hashValue != existingEntry.hashValue) {
+                continue;
+            }
+
+            if (existingEntry.refersTo(value)) {
+                return value;
+            }
+
+            final T existingValue = existingEntry.get();
+
+            if (value.equals(existingValue)) {
+                return existingValue;
+            }
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Entry<T>[] makeHashTable(final int capacity) {
+        return (Entry<T>[]) new Entry<?>[capacity];
+    }
+
+    private Entry<T>[] getHashTable() {
+        removeStaleEntries();
+        return hashTable;
+    }
+
+    private void removeStaleEntries() {
+        for (Object staleEntry; (staleEntry = staleEntriesQueue.poll()) != null;) {
+            @SuppressWarnings("unchecked")
+            final Entry<T> removedEntry = (Entry<T>)staleEntry;
+            removeEntry(removedEntry);
+        }
+    }
+
+    private synchronized void removeEntry(final Entry<T> removedEntry) {
+        final int bucketIndex = getBucketIndex(removedEntry.hashValue, hashTable.length);
+        Entry<T> previousEntry = null;
+        Entry<T> entry = hashTable[bucketIndex];
+
+        while (entry != null) {
+            final Entry<T> nextEntry = entry.nextEntry;
+
+            if (entry == removedEntry) {
+                // We found it. Remove the entry from the bucket.
+                if (previousEntry == null) {
+                    hashTable[bucketIndex] = nextEntry;
+                } else {
+                    previousEntry.nextEntry = nextEntry;
+                }
+
+                // It should be safe to clear out references to other objects to
+                // help the garbage collector here, since nothing should have a
+                // reference to the entry.
+                entry.nextEntry = null;
+                --count;
+                return;
+            }
+
+            previousEntry = entry;
+            entry = nextEntry;
+        }
+    }
+
+    private void rehash(final int newCapacity) {
+        // Warning: This is expected to be called from a synchronized context.
+        final Entry<T>[] oldHashTable = getHashTable();
+        final int oldCapacity = oldHashTable.length;
+
+        if (oldCapacity == MAX_CAPACITY) {
+            // We've grown as far as we can. Disable future growth and return.
+            // Future insertions will just have to share buckets.
+            growthThreshold = Integer.MAX_VALUE;
+            return;
+        }
+
+        final Entry<T>[] newHashTable = makeHashTable(newCapacity);
+        count = transferEntries(oldHashTable, newHashTable);
+        hashTable = newHashTable;
+
+        if (count < growthThreshold / 2) {
+            // Corner case inspired by the JDK WeakHashMap implementation:
+            // During transfer, we removed a huge amount of stale entries. So
+            // many that we probably shouldn't grow, in fact. Transfer the
+            // compacted elements back to the old hash table.
+            count = transferEntries(newHashTable, oldHashTable);
+            hashTable = oldHashTable;
+        } else {
+            // We actually needed to grow. Adjust the growth threshold.
+            growthThreshold = (int) (newCapacity * loadFactor);
+        }
+    }
+
+    private static <T> int transferEntries(final Entry<T>[] sourceHashTable, final Entry<T>[] destinationHashTable) {
+        // Warning: This is expected to be called from a synchronized context.
+        int validEntryCount = 0;
+        final int destinationBucketCount = destinationHashTable.length;
+
+        for (int sourceBucketIndex = 0, sourceBucketCount = sourceHashTable.length; sourceBucketIndex < sourceBucketCount; ++sourceBucketIndex) {
+            Entry<T> entry = sourceHashTable[sourceBucketIndex];
+            sourceHashTable[sourceBucketIndex] = null;
+
+            while (entry != null) {
+                final Entry<T> nextEntry = entry.nextEntry;
+
+                if (entry.refersTo(null)) {
+                    // This is a stale entry. Don't count or attempt to transfer
+                    // it. We also clear out references to other objects to help
+                    // the garbage collector.
+                    entry.nextEntry = null;
+                } else {
+                    // This is a valid entry. Transfer it to the destination.
+                    int destinationBucketIndex = getBucketIndex(entry.hashValue, destinationBucketCount);
+                    entry.nextEntry = destinationHashTable[destinationBucketIndex];
+                    destinationHashTable[destinationBucketIndex] = entry;
+                    ++validEntryCount;
+                }
+
+                entry = nextEntry;
+            }
+        }
+
+        return validEntryCount;
+    }
+
+    private static int getHashValue(final Object value) {
+        // Bitwise trickery that ensures we have a hash of decent-quality
+        // necessitated by our use of power-of-two sized hash tables.
+        int hashValue = value.hashCode();
+        hashValue ^= (hashValue >>> 20) ^ (hashValue >>> 12);
+        return hashValue ^ (hashValue >>> 7) ^ (hashValue >>> 4);
+    }
+
+    private static int getBucketIndex(final int hashValue, final int bucketCount) {
+        return hashValue & (bucketCount - 1);
+    }
+
+    private static int toPowerOfTwo(final int num) {
+        int powerOfTwo = 1;
+
+        while (powerOfTwo < num) {
+            powerOfTwo <<= 1;
+        }
+
+        return powerOfTwo;
+    }
+
+    private static class Entry<T> extends WeakReference<T> {
+        final int hashValue;
+        Entry<T> nextEntry;
+
+        public Entry(final T value, final ReferenceQueue<T> staleEntriesQueue, final int hashValue, final Entry<T> nextEntry) {
+            super(value, staleEntriesQueue);
+            this.hashValue = hashValue;
+            this.nextEntry = nextEntry;
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return (other instanceof Entry<?> otherEntry) && Objects.equals(get(), otherEntry.get());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(get());
+        }
+    }
+}

--- a/editor/test/editor/protobuf_test.clj
+++ b/editor/test/editor/protobuf_test.clj
@@ -13,14 +13,11 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.protobuf-test
-  (:require [clojure.test :refer :all]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [editor.protobuf :as protobuf])
-  (:import [com.defold.editor.test TestDdf TestDdf$Msg TestDdf$SubMsg TestDdf$Transform TestDdf$DefaultValue
-            TestDdf$OptionalNoDefaultValue TestDdf$EmptyMsg TestDdf$Uint64Msg TestDdf$RepeatedUints
-            TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$BooleanMsg TestDdf$BytesMsg
-            TestAtlasProto$AtlasAnimation TestAtlasProto$AtlasImage TestDdf$JavaCasingMsg]
-           [javax.vecmath Point3d Vector3d]
+  (:import [com.defold.editor.test TestAtlasProto$AtlasAnimation TestDdf$BooleanMsg TestDdf$BytesMsg TestDdf$DefaultValue TestDdf$EmptyMsg TestDdf$JavaCasingMsg TestDdf$Msg TestDdf$NestedMessages TestDdf$NestedMessages$NestedEnum$Enum TestDdf$OptionalNoDefaultValue TestDdf$RepeatedUints TestDdf$SubMsg TestDdf$Transform TestDdf$Uint64Msg]
+           [com.dynamo.proto DdfMath$Matrix4 DdfMath$Point3 DdfMath$Quat DdfMath$Vector3 DdfMath$Vector4]
            [com.google.protobuf ByteString]))
 
 (defn- read-text [^java.lang.Class cls s]
@@ -150,3 +147,82 @@
   (is (= "StoreFrontImageUrl" (protobuf/underscores-to-camel-case "store_front_image_url")))
   (is (= "IOSExecutableUrl" (protobuf/underscores-to-camel-case "iOSExecutableUrl")))
   (is (= "SomeField_" (protobuf/underscores-to-camel-case "some_field#"))))
+
+(deftest msg->clj-test
+  (let [zero (Float/valueOf 0.0)
+        one (Float/valueOf 1.0)
+        point3 (DdfMath$Point3/getDefaultInstance)
+        vector3 (DdfMath$Vector3/getDefaultInstance)
+        vector4 (DdfMath$Vector4/getDefaultInstance)
+        quat (DdfMath$Quat/getDefaultInstance)
+        matrix4 (DdfMath$Matrix4/getDefaultInstance)]
+
+    (testing "Constructs vectors from maps."
+      (is (= [(float 1.0) (float 2.0) (float 3.0)]
+             (protobuf/msg->clj point3 {:x (float 1.0) :y (float 2.0) :z (float 3.0)})))
+      (is (= [(float 1.0) (float 2.0) (float 3.0)]
+             (protobuf/msg->clj vector3 {:x (float 1.0) :y (float 2.0) :z (float 3.0)})))
+      (is (= [(float 1.0) (float 2.0) (float 3.0) (float 4.0)]
+             (protobuf/msg->clj vector4 {:x (float 1.0) :y (float 2.0) :z (float 3.0) :w (float 4.0)})))
+      (is (= [(float 1.0) (float 2.0) (float 3.0) (float 4.0)]
+             (protobuf/msg->clj quat {:x (float 1.0) :y (float 2.0) :z (float 3.0) :w (float 4.0)})))
+      (is (= [(float 0.0) (float 0.1) (float 0.2) (float 0.3)
+              (float 1.0) (float 1.1) (float 1.2) (float 1.3)
+              (float 2.0) (float 2.1) (float 2.2) (float 2.3)
+              (float 3.0) (float 3.1) (float 3.2) (float 3.3)]
+             (protobuf/msg->clj matrix4 {:m00 (float 0.0) :m01 (float 0.1) :m02 (float 0.2) :m03 (float 0.3)
+                                         :m10 (float 1.0) :m11 (float 1.1) :m12 (float 1.2) :m13 (float 1.3)
+                                         :m20 (float 2.0) :m21 (float 2.1) :m22 (float 2.2) :m23 (float 2.3)
+                                         :m30 (float 3.0) :m31 (float 3.1) :m32 (float 3.2) :m33 (float 3.3)}))))
+
+    (testing "Common vecmath values share clj instances."
+      (is (identical? (protobuf/msg->clj point3 {:x zero :y zero :z zero})
+                      (protobuf/msg->clj point3 {:x zero :y zero :z zero})))
+      (is (identical? (protobuf/msg->clj vector3 {:x zero :y zero :z zero})
+                      (protobuf/msg->clj vector3 {:x zero :y zero :z zero})))
+      (is (identical? (protobuf/msg->clj vector3 {:x one :y one :z one})
+                      (protobuf/msg->clj vector3 {:x one :y one :z one})))
+      (is (identical? (protobuf/msg->clj vector4 {:x zero :y zero :z zero :w zero})
+                      (protobuf/msg->clj vector4 {:x zero :y zero :z zero :w zero})))
+      (is (identical? (protobuf/msg->clj vector4 {:x zero :y zero :z zero :w one})
+                      (protobuf/msg->clj vector4 {:x zero :y zero :z zero :w one})))
+      (is (identical? (protobuf/msg->clj vector4 {:x one :y one :z one :w one})
+                      (protobuf/msg->clj vector4 {:x one :y one :z one :w one})))
+      (is (identical? (protobuf/msg->clj vector4 {:x one :y one :z one :w zero})
+                      (protobuf/msg->clj vector4 {:x one :y one :z one :w zero})))
+      (is (identical? (protobuf/msg->clj quat {:x zero :y zero :z zero :w one})
+                      (protobuf/msg->clj quat {:x zero :y zero :z zero :w one})))
+      (is (identical? (protobuf/msg->clj matrix4 {:m00 one :m01 zero :m02 zero :m03 zero
+                                                  :m10 zero :m11 one :m12 zero :m13 zero
+                                                  :m20 zero :m21 zero :m22 one :m23 zero
+                                                  :m30 zero :m31 zero :m32 zero :m33 one})
+                      (protobuf/msg->clj matrix4 {:m00 one :m01 zero :m02 zero :m03 zero
+                                                  :m10 zero :m11 one :m12 zero :m13 zero
+                                                  :m20 zero :m21 zero :m22 one :m23 zero
+                                                  :m30 zero :m31 zero :m32 zero :m33 one}))))
+
+    (testing "Shared instances have correct values."
+      (is (= [zero zero zero]
+             (protobuf/msg->clj point3 {:x zero :y zero :z zero})))
+      (is (= [zero zero zero]
+             (protobuf/msg->clj vector3 {:x zero :y zero :z zero})))
+      (is (= [one one one]
+             (protobuf/msg->clj vector3 {:x one :y one :z one})))
+      (is (= [zero zero zero zero]
+             (protobuf/msg->clj vector4 {:x zero :y zero :z zero :w zero})))
+      (is (= [zero zero zero one]
+             (protobuf/msg->clj vector4 {:x zero :y zero :z zero :w one})))
+      (is (= [one one one one]
+             (protobuf/msg->clj vector4 {:x one :y one :z one :w one})))
+      (is (= [one one one zero]
+             (protobuf/msg->clj vector4 {:x one :y one :z one :w zero})))
+      (is (= [zero zero zero one]
+             (protobuf/msg->clj quat {:x zero :y zero :z zero :w one})))
+      (is (= [one zero zero zero
+              zero one zero zero
+              zero zero one zero
+              zero zero zero one]
+             (protobuf/msg->clj matrix4 {:m00 one :m01 zero :m02 zero :m03 zero
+                                         :m10 zero :m11 one :m12 zero :m13 zero
+                                         :m20 zero :m21 zero :m22 one :m23 zero
+                                         :m30 zero :m31 zero :m32 zero :m33 one}))))))

--- a/editor/test/util/weak_interner_test.clj
+++ b/editor/test/util/weak_interner_test.clj
@@ -1,0 +1,68 @@
+;; Copyright 2020-2023 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns util.weak-interner-test
+  (:require [clojure.test :refer :all]
+            [internal.graph.types :as gt])
+  (:import [com.defold.util WeakInterner]))
+
+(deftest constructor-test
+  (is (some? (WeakInterner. 16)))
+  (is (some? (WeakInterner. 16, 0.75)))
+  (is (thrown? IllegalArgumentException (WeakInterner. -1)))
+  (is (thrown? IllegalArgumentException (WeakInterner. Integer/MAX_VALUE)))
+  (is (thrown? IllegalArgumentException (WeakInterner. 16 -1.0)))
+  (is (thrown? IllegalArgumentException (WeakInterner. 16 Float/NaN))))
+
+(deftest interning-test
+  (let [weak-interner (WeakInterner. 16)
+        interned-endpoint (.intern weak-interner (gt/endpoint 12345 :label))]
+    (is (= interned-endpoint (gt/endpoint 12345 :label)))
+    (is (identical? interned-endpoint (.intern weak-interner (gt/endpoint 12345 :label))))))
+
+(deftest growth-test
+  (let [weak-interner (WeakInterner. 0)
+        first-endpoint (.intern weak-interner (gt/endpoint 1 :first))
+        second-endpoint (.intern weak-interner (gt/endpoint 2 :second))
+        third-endpoint (.intern weak-interner (gt/endpoint 3 :third))]
+    (is (identical? first-endpoint (.intern weak-interner (gt/endpoint 1 :first))))
+    (is (identical? second-endpoint (.intern weak-interner (gt/endpoint 2 :second))))
+    (is (identical? third-endpoint (.intern weak-interner (gt/endpoint 3 :third))))))
+
+(deftest cleanup-test
+  (let [weak-interner (WeakInterner. 4)
+        references-atom (atom {})]
+    (swap! references-atom assoc :first-endpoint (.intern weak-interner (gt/endpoint 1 :first)))
+    (swap! references-atom assoc :second-endpoint (.intern weak-interner (gt/endpoint 2 :second)))
+    (let [{:keys [first-endpoint second-endpoint]} @references-atom
+          first-id (System/identityHashCode first-endpoint)
+          second-id (System/identityHashCode second-endpoint)]
+      (is (= first-id (System/identityHashCode (.intern weak-interner (gt/endpoint 1 :first)))))
+      (is (= second-id (System/identityHashCode (.intern weak-interner (gt/endpoint 2 :second)))))
+      (reset! references-atom {})
+      (System/gc)
+      (is (not= first-id (System/identityHashCode (.intern weak-interner (gt/endpoint 1 :first)))))
+      (is (not= second-id (System/identityHashCode (.intern weak-interner (gt/endpoint 2 :second))))))))
+
+(deftest multi-threaded-access-test
+  (let [weak-interner (WeakInterner. 0)
+
+        interned-endpoints-by-node-id
+        (->> (repeatedly 1000000 #(long (rand-int 100)))
+             (pmap #(.intern weak-interner (gt/endpoint % :label)))
+             (vec)
+             (group-by gt/endpoint-node-id))]
+
+    (doseq [[first-endpoint & remaining-endpoints] (vals interned-endpoints-by-node-id)]
+      (is (every? #(identical? first-endpoint %) remaining-endpoints)))))


### PR DESCRIPTION
* Improved memory usage in large projects.
* We now report resources that fail to build due to an out-of-memory error to the Build Errors tab.

Fixes #8261

### Technical changes
* We now intern `Endpoints` using a new `WeakInterner` class, drastically decreasing memory spent on duplicate `Endpoint` instances.
* Common vector math values (i.e. things like default translation, rotation, and scale) now share values.