### PR TITLE
Use completions from language servers

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -59,6 +59,7 @@
                        :function #{"("}
                        :field #{"."}
                        :module #{"."}}
+   :completion-trigger-characters #{"."}
    :patterns [{:captures {1 {:name "keyword.control.lua"}
                           2 {:name "entity.name.function.scope.lua"}
                           3 {:name "entity.name.function.lua"}

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -162,7 +162,7 @@
                [ns-path (code-completion/make name
                                               :type type
                                               :display-string (make-display-string el)
-                                              :insert-snippet (make-snippet el)
+                                              :insert (make-snippet el)
                                               :doc (make-markdown-doc raw-name base-url el))])))
       docs)))
 
@@ -254,12 +254,12 @@
                            name
                            :type :function
                            :display-string (str name "(" (string/join ", " params) ")")
-                           :insert-snippet (str name
-                                                "("
-                                                (->> params
-                                                     (map-indexed #(format "${%s:%s}" (inc %1) %2))
-                                                     (string/join ", "))
-                                                ")"))])))
+                           :insert (str name
+                                        "("
+                                        (->> params
+                                             (map-indexed #(format "${%s:%s}" (inc %1) %2))
+                                             (string/join ", "))
+                                        ")"))])))
        functions)]))
 
 (defn- make-ast-completions [local-completion-info required-completion-infos]

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -166,9 +166,6 @@
                                               :doc (make-markdown-doc raw-name base-url el))])))
       docs)))
 
-(def helper-keywords #{"assert" "collectgarbage" "dofile" "error" "getfenv" "getmetatable" "ipairs" "loadfile" "loadstring" "module" "next" "pairs" "pcall"
-                       "print" "rawequal" "rawget" "rawset" "require" "select" "setfenv" "setmetatable" "tonumber" "tostring" "type" "unpack" "xpcall"})
-
 (def logic-keywords #{"and" "or" "not"})
 
 (def self-keyword #{"self"})
@@ -182,8 +179,7 @@
 (def lua-constants #{"nil" "false" "true"})
 
 (def all-keywords
-  (set/union helper-keywords
-             logic-keywords
+  (set/union logic-keywords
              self-keyword
              control-flow-keywords
              defold-keywords))

--- a/editor/src/clj/editor/script_api.clj
+++ b/editor/src/clj/editor/script_api.clj
@@ -96,7 +96,7 @@
                                         (str "\n\n**Examples:**<br>\n"
                                              (string/join "\n\n" (map :desc examples)))))
                             :display-string (str name (build-param-string parameters :display-string))
-                            :insert-snippet (str name (build-param-string parameters :snippet)))]])
+                            :insert (str name (build-param-string parameters :snippet)))]])
 
               (when name
                 [[ns-path (code-completion/make name :type :variable :doc desc)]])))]

--- a/editor/src/clj/editor/ui/fuzzy_choices.clj
+++ b/editor/src/clj/editor/ui/fuzzy_choices.clj
@@ -25,9 +25,7 @@
 
 (defn- option->fuzzy-matched-option [option->text pattern option]
   (when-some [[score matching-indices] (fuzzy-text/match-path pattern (option->text option))]
-    (with-meta option
-               {:score score
-                :matching-indices matching-indices})))
+    (vary-meta option assoc :score score :matching-indices matching-indices)))
 
 (defn- option-order [option->text a b]
   (let [a-meta (meta a)
@@ -117,6 +115,10 @@
                       [(make-text-run-cljfx (subs text start end) nil)])))
           (fuzzy-text/runs (.length text) matching-indices))))
 
-(defn make-matched-text-flow-cljfx [text matching-indices]
-  {:fx/type fx.text-flow/lifecycle
-   :children (matched-text-runs-cljfx text matching-indices)})
+(defn make-matched-text-flow-cljfx [text matching-indices & {:keys [deprecated]
+                                                             :or {deprecated false}}]
+  (cond->
+    {:fx/type fx.text-flow/lifecycle
+     :children (matched-text-runs-cljfx text matching-indices)}
+    deprecated
+    (assoc :style-class "deprecated")))

--- a/editor/src/clj/internal/util.clj
+++ b/editor/src/clj/internal/util.clj
@@ -696,3 +696,9 @@
           (do
             (vswap! unique-volatile conj item)
             item)))))
+
+(defn first-rf
+  "first as a reducing function"
+  ([] nil)
+  ([acc] acc)
+  ([_ v] (ensure-reduced v)))

--- a/editor/styling/stylesheets/components/_flat-list-view.scss
+++ b/editor/styling/stylesheets/components/_flat-list-view.scss
@@ -52,6 +52,10 @@
         }
     }
 }
+TextFlow.deprecated > Text {
+  -fx-strikethrough: true;
+  -fx-opacity: 0.75;
+}
 .flat-list-container {
   -fx-border-color: -df-background-lighter;
 }

--- a/editor/styling/stylesheets/components/_fuzzy-combo-box.scss
+++ b/editor/styling/stylesheets/components/_fuzzy-combo-box.scss
@@ -1,3 +1,5 @@
+@use "sass:string";
+
 .fuzzy-combo-box {
   -fx-border-color: -df-background-lighter;
   -fx-border-width: 1px;
@@ -64,4 +66,19 @@
   .scroll-bar:horizontal .decrement-button {
     -fx-padding: 0px;
   }
+}
+.completion-popup-list-view {
+  -fx-effect: string.unquote("null") !important;
+}
+.completion-popup-background {
+  -fx-background-color: -df-background-light;
+  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.2), 12, 0.0, 0, 8);
+}
+.completion-popup-hint {
+  -fx-background-color: -df-background-light;
+  -fx-border-color: -df-background;
+  -fx-border-width: 1px 0 0 0;
+  -fx-padding: 0 2px;
+  -fx-text-fill: -df-text-dark;
+  -fx-font-size: 11px;
 }

--- a/editor/styling/stylesheets/components/_markdown.scss
+++ b/editor/styling/stylesheets/components/_markdown.scss
@@ -51,6 +51,12 @@
       &-nb { -fx-fill: -df-script-operator; }
     }
   }
+  &-hr {
+    -fx-background-color: derive(#212428, 30%);
+    -fx-min-height: 1px;
+    -fx-background-insets: 0px 8px;
+    -fx-pref-width: Infinity;
+  }
   &-icon {
     -fx-background-color: -df-text;
     -fx-translate-y: 2px;

--- a/editor/test/editor/code/data_test.clj
+++ b/editor/test/editor/code/data_test.clj
@@ -1420,3 +1420,46 @@
 
     (->Cursor 4 0) (cr [0 15] [0 16])
     (->Cursor 4 1) (cr [0 15] [0 16])))
+
+(deftest differences-test
+  (testing "No overlap => same as A"
+    (is (= [#code/range [[0 5] [0 10]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 0] [0 5]])))
+    (is (= [#code/range [[0 5] [0 10]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 10] [0 15]])))
+    (is (= [#code/range [[0 5] [0 10]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 11] [0 15]]))))
+  (testing "A within B => empty"
+    (is (= []
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 5] [0 10]])))
+    (is (= []
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 5] [0 11]])))
+    (is (= []
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 4] [0 10]])))
+    (is (= []
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 4] [0 11]]))))
+  (testing "B within A => 2 ranges"
+    (is (= [#code/range [[0 5] [0 6]]
+            #code/range [[0 9] [0 10]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 6] [0 9]]))))
+  (testing "non-empty intersection => different cursor range"
+    (is (= [#code/range [[0 5] [0 6]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 6] [0 10]])))
+    (is (= [#code/range [[0 5] [0 6]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 6] [0 11]])))
+    (is (= [#code/range [[0 7] [0 10]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 4] [0 7]])))
+    (is (= [#code/range [[0 7] [0 10]]]
+           (data/cursor-range-differences #code/range [[0 5] [0 10]]
+                                          #code/range [[0 5] [0 7]])))))

--- a/editor/test/integration/lsp_test.clj
+++ b/editor/test/integration/lsp_test.clj
@@ -155,7 +155,8 @@
                      (<! (a/reduce conj [] out)))))))))))
 
 (g/defnode LSPViewNode
-  (property diagnostics g/Any (default [])))
+  (property diagnostics g/Any (default []))
+  (property completion-trigger-characters g/Any (default #{})))
 
 (deftest start-open-order-test
   (tu/with-scratch-project "test/resources/lsp_project"


### PR DESCRIPTION
This changeset adds support for showing completions from the running language servers in the code editor. Additionally, it updates the view of the completion popup so it now includes icons for completion types and a hint about toggling the documentation popup.

Fixes #7699