### PR TITLE
Print generic error when OpenGL shader compilation or program linking fails

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1695,6 +1695,7 @@ static void LogFrameBufferError(GLenum status)
         glGetShaderiv(shader_id, GL_COMPILE_STATUS, &status);
         if (status == 0)
         {
+            dmLogError("Unable to compile %s shader.", type == GL_VERTEX_SHADER ? "vertex" : "fragment");
 #ifndef NDEBUG
             GLint logLength;
             glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &logLength);
@@ -1702,7 +1703,7 @@ static void LogFrameBufferError(GLenum status)
             {
                 GLchar *log = (GLchar *)malloc(logLength);
                 glGetShaderInfoLog(shader_id, logLength, &logLength, log);
-                dmLogError("%s\n", log);
+                dmLogError("%s", log);
                 free(log);
             }
 #endif
@@ -1879,13 +1880,14 @@ static void LogFrameBufferError(GLenum status)
         glGetShaderiv(prog, GL_COMPILE_STATUS, &status);
         if (status == 0)
         {
+            dmLogError("Unable to compile shader.");
             GLint logLength;
             glGetShaderiv(prog, GL_INFO_LOG_LENGTH, &logLength);
             if (logLength > 0)
             {
                 GLchar *log = (GLchar *)malloc(logLength);
                 glGetShaderInfoLog(prog, logLength, &logLength, log);
-                dmLogError("%s\n", log);
+                dmLogError("%s", log);
                 free(log);
             }
             CHECK_GL_ERROR;
@@ -2004,13 +2006,14 @@ static void LogFrameBufferError(GLenum status)
         glGetProgramiv(tmp_program, GL_LINK_STATUS, &status);
         if (status == 0)
         {
+            dmLogError("Unable to link program.");
             GLint logLength;
             glGetProgramiv(tmp_program, GL_INFO_LOG_LENGTH, &logLength);
             if (logLength > 0)
             {
                 GLchar *log = (GLchar *)malloc(logLength);
                 glGetProgramInfoLog(tmp_program, logLength, &logLength, log);
-                dmLogError("%s\n", log);
+                dmLogError("%s", log);
                 free(log);
             }
             success = false;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1831,6 +1831,7 @@ static void LogFrameBufferError(GLenum status)
         glGetProgramiv(p, GL_LINK_STATUS, &status);
         if (status == 0)
         {
+            dmLogError("Unable to link program.");
 #ifndef NDEBUG
             GLint logLength;
             glGetProgramiv(p, GL_INFO_LOG_LENGTH, &logLength);
@@ -1838,7 +1839,7 @@ static void LogFrameBufferError(GLenum status)
             {
                 GLchar *log = (GLchar *)malloc(logLength);
                 glGetProgramInfoLog(p, logLength, &logLength, log);
-                dmLogWarning("%s\n", log);
+                dmLogError("%s", log);
                 free(log);
             }
 #endif


### PR DESCRIPTION
Adds generic error message when OpenGL shader compilation or program linking fails. Previously, the shader error message was only printed if the GPU driver provided it. Depending on the implementation, the driver may not do this and so the developer would not get any message and could not understand why the game crashed.
Also for OpenGL program linking the warning is replaced by an error, because after this failure the game cannot continue to work.

Closes #8287

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.