### PR TITLE
Fix for lost material and texture assignments in pasted Model component

### DIFF
--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -277,7 +277,7 @@
       renames)))
 
 (g/defnode MaterialBinding
-  (inherits core/Scope)
+  (input copied-nodes g/Any :array :cascade-delete)
   (input dep-build-targets g/Any :array)
   (input shader ShaderLifecycle)
   (input vertex-space g/Keyword)
@@ -326,7 +326,7 @@
   (g/make-nodes (g/node-id->graph-id material-binding) [texture-binding [TextureBinding
                                                                          :sampler sampler
                                                                          :texture texture]]
-    (g/connect texture-binding :_node-id material-binding :nodes)
+    (g/connect texture-binding :_node-id material-binding :copied-nodes)
     (g/connect texture-binding :texture-binding-info material-binding :texture-binding-infos)
     (g/connect texture-binding :build-targets material-binding :dep-build-targets)))
 
@@ -334,7 +334,7 @@
   (g/make-nodes (g/node-id->graph-id model-node-id) [material-binding [MaterialBinding
                                                                        :name name
                                                                        :material material]]
-    (g/connect material-binding :_node-id model-node-id :nodes)
+    (g/connect material-binding :_node-id model-node-id :copied-nodes)
     (g/connect material-binding :dep-build-targets model-node-id :dep-build-targets)
     (g/connect material-binding :material-scene-info model-node-id :material-scene-infos)
     (g/connect material-binding :material-binding-info model-node-id :material-binding-infos)
@@ -464,6 +464,7 @@
                                   (prop-resource-error :fatal _node-id :mesh mesh "Mesh")))
             (dynamic edit-type (g/constantly {:type resource/Resource
                                               :ext model-scene/model-file-types})))
+  (input copied-nodes g/Any :array :cascade-delete)
   (input material-binding-infos g/Any :array)
   (output materials Materials :cached
           (g/fnk [material-binding-infos]

--- a/editor/src/clj/editor/outline.clj
+++ b/editor/src/clj/editor/outline.clj
@@ -126,11 +126,12 @@
   (let [src-node (.source-id arc)
         tgt-node (.target-id arc)
         tgt-label (.target-label arc)]
-    (and (or (= :child-outlines tgt-label)
-             (= :source-outline tgt-label))
-         (g/node-instance? basis OutlineNode tgt-node)
-         (not (and (g/node-instance? basis resource/ResourceNode src-node)
-                   (some? (resource/path (g/node-value src-node :resource (g/make-evaluation-context {:basis basis :cache c/null-cache})))))))))
+    (or (= :copied-nodes tgt-label)
+        (and (or (= :child-outlines tgt-label)
+                 (= :source-outline tgt-label))
+             (g/node-instance? basis OutlineNode tgt-node)
+             (not (and (g/node-instance? basis resource/ResourceNode src-node)
+                       (some? (resource/path (g/node-value src-node :resource (g/make-evaluation-context {:basis basis :cache c/null-cache}))))))))))
 
 (defn copy
   ([project src-item-iterators]


### PR DESCRIPTION
Fix an issue where pasting an embedded Model component would lose the material and texture bindings.

### Technical changes
* If a node is connected to a `:copied-nodes` input of a copied node, it will be traversed in the copied graph fragment.