### PR TITLE
Annotate protobuf fields as runtime-only to ignore in save data tests

### DIFF
--- a/editor/src/clj/editor/code/util.clj
+++ b/editor/src/clj/editor/code/util.clj
@@ -47,9 +47,9 @@
   ordered, the result is undefined. New items will be inserted after exact
   matches, or between two non-exact matches that each compare differently to
   item using the supplied comparator."
-  ([coll item]
+  (^long [coll item]
    (find-insert-index coll item compare))
-  ([^List coll item ^Comparator comparator]
+  (^long [^List coll item ^Comparator comparator]
    (let [search-result (Collections/binarySearch coll item comparator)]
      (->insert-index search-result))))
 

--- a/editor/test/integration/save_data_test.clj
+++ b/editor/test/integration/save_data_test.clj
@@ -30,8 +30,10 @@
             [lambdaisland.deep-diff2 :as deep-diff]
             [util.coll :as coll :refer [pair]]
             [util.diff :as diff]
+            [util.fn :as fn]
             [util.text-util :as text-util])
-  (:import [com.dynamo.gamesys.proto Gui$NodeDesc Gui$NodeDesc$Type Gui$SceneDesc Gui$SceneDesc$LayoutDesc]
+  (:import [com.dynamo.proto DdfExtensions]
+           [com.dynamo.gamesys.proto Gui$NodeDesc Gui$NodeDesc$Type Gui$SceneDesc Gui$SceneDesc$LayoutDesc]
            [com.google.protobuf Descriptors$Descriptor Descriptors$EnumDescriptor Descriptors$EnumValueDescriptor Descriptors$FieldDescriptor Descriptors$FieldDescriptor$JavaType Descriptors$GenericDescriptor Message]
            [java.io StringReader]))
 
@@ -59,7 +61,7 @@
     :non-editable    ; The field is expected to be read and written to the file, but cannot be edited by the user.
     :non-overridable ; The field is expected to be read and written to the file, but cannot be overridden from its base value by the user.
     :padding         ; The field is only present in the protobuf declaration to ensure consecutive values are byte-aligned to a desired boundary in the compiled binaries for the runtime.
-    :runtime-only    ; The field is only present in the compiled binaries for the runtime.
+    :runtime-only    ; The field is only present in the compiled binaries for the runtime. This also happens if you annotate a field with [(runtime_only)=true] in a .proto file.
     :unimplemented   ; The field was added to support a new feature in the runtime, but is not yet fully implemented in the editor. We don't need to load it, as it cannot be in the project files yet. This will eventually lead to a file format change, deprecated fields, and a test that covers the migration.
     :unused})        ; The field is not expected to have a value in either the project files or the compiled binaries for the runtime. Typically used with union-style protobuf types such as dmGuiDDF.NodeDesc, where the expected fields are dictated by the value of the "type" field.
 
@@ -168,22 +170,9 @@
     {\"data_type\" :allowed-default
      \"long_values\" :unused}}"
 
-  {'dmGameObjectDDF.CollectionDesc
-   {:default
-    {"component_types" :runtime-only
-     "property_resources" :runtime-only}}
-
-   'dmGameObjectDDF.CollectionInstanceDesc
+  {'dmGameObjectDDF.CollectionInstanceDesc
    {:default
     {"scale" :deprecated}} ; Migration tested in integration.save-data-test/silent-migrations-test.
-
-   'dmGameObjectDDF.ComponentDesc
-   {:default
-    {"property_decls" :runtime-only}}
-
-   'dmGameObjectDDF.ComponentPropertyDesc
-   {:default
-    {"property_decls" :runtime-only}}
 
    'dmGameObjectDDF.EmbeddedInstanceDesc
    {:default
@@ -197,10 +186,6 @@
    ['dmGameObjectDDF.PropertyDesc "[PROPERTY_TYPE_NUMBER]"]
    {:default
     {"type" :allowed-default}}
-
-   'dmGameObjectDDF.PrototypeDesc
-   {:default
-    {"property_resources" :runtime-only}}
 
    'dmGameSystemDDF.LabelDesc
    {:default
@@ -221,20 +206,8 @@
    {:default
     {"textures" :unimplemented}} ; Multiple textures for sprites are not supported yet.
 
-   'dmGameSystemDDF.TileLayer
-   {:default
-    {"id_hash" :runtime-only}}
-
-   'dmGameSystemDDF.TileSet
-   {:default
-    {"convex_hull_points" :runtime-only}}
-
    'dmGraphics.VertexAttribute
-   {:default
-    {"binary_values" :runtime-only
-     "name_hash" :runtime-only}
-
-    [["particlefx" "emitters" "[*]" "attributes"]
+   {[["particlefx" "emitters" "[*]" "attributes"]
      ["sprite" "attributes"]]
     {"coordinate_space" :unused
      "data_type" :unused
@@ -496,9 +469,7 @@
 
    'dmRenderDDF.MaterialDesc.Sampler
    {:default
-    {"name_hash" :runtime-only
-     "name_indirections" :runtime-only
-     "texture" :unimplemented}}}) ; Default texture resources not supported yet.
+    {"texture" :unimplemented}}}) ; Default texture resources not supported yet.
 
 (definline ^:private pb-descriptor-key [^Descriptors$Descriptor pb-desc]
   `(symbol (.getFullName ~(with-meta pb-desc {:tag `Descriptors$GenericDescriptor}))))
@@ -515,17 +486,34 @@
                     pb-path
                     pb-filter-path))))
 
-(defn- pb-field-ignore-reasons [pb-desc-key type-token pb-path]
-  (s/assert ::pb-desc-key pb-desc-key)
+(defn- pb-field-option-ignore-rules-raw [^Descriptors$Descriptor pb-desc]
+  (let [runtime-only-field-option-field-desc (.getDescriptor DdfExtensions/runtimeOnly)]
+    {:default
+     (into {}
+           (keep (fn [^Descriptors$FieldDescriptor field-desc]
+                   (let [field-name (.getName field-desc)
+                         field-options (.getOptions field-desc)]
+                     (when (.getField field-options runtime-only-field-option-field-desc)
+                       (pair field-name :runtime-only)))))
+           (.getFields pb-desc))}))
+
+(def ^:private pb-field-option-ignore-rules (fn/memoize pb-field-option-ignore-rules-raw))
+
+(defn- pb-field-ignore-rules-raw [^Descriptors$Descriptor pb-desc type-token]
+  (let [pb-desc-key (pb-descriptor-key pb-desc)]
+    (merge-with
+      merge
+      (pb-field-option-ignore-rules pb-desc)
+      (get pb-ignored-fields pb-desc-key)
+      (when type-token
+        (get pb-ignored-fields [pb-desc-key type-token])))))
+
+(def ^:private pb-field-ignore-rules (fn/memoize pb-field-ignore-rules-raw))
+
+(defn- pb-field-ignore-reasons [^Descriptors$Descriptor pb-desc type-token pb-path]
   (s/assert (s/nilable ::pb-type-token) type-token)
   (s/assert ::pb-path pb-path)
-  (let [pb-filter->pb-field->ignore-reason
-        (if (nil? type-token)
-          (get pb-ignored-fields pb-desc-key)
-          (merge-with
-            merge
-            (get pb-ignored-fields pb-desc-key)
-            (get pb-ignored-fields [pb-desc-key type-token])))
+  (let [pb-filter->pb-field->ignore-reason (pb-field-ignore-rules pb-desc type-token)
 
         matched
         (filterv (fn [[pb-filter]]
@@ -797,7 +785,7 @@
                 value)))
           values)))
 
-(def ^:private pb-enum-desc-usable-values (memoize pb-enum-desc-usable-values-raw))
+(def ^:private pb-enum-desc-usable-values (fn/memoize pb-enum-desc-usable-values-raw))
 
 (defn- pb-enum-desc-empty-frequencies-raw [^Descriptors$EnumDescriptor enum-desc]
   (let [type-token->ignore-reason (get pb-enum-ignored-values (pb-descriptor-key enum-desc))]
@@ -810,7 +798,7 @@
                       nil))))
           (pb-enum-desc-usable-values enum-desc))))
 
-(def ^:private pb-enum-desc-empty-frequencies (memoize pb-enum-desc-empty-frequencies-raw))
+(def ^:private pb-enum-desc-empty-frequencies (fn/memoize pb-enum-desc-empty-frequencies-raw))
 
 (defn- pb-field-has-single-valid-value? [^Descriptors$FieldDescriptor field-desc]
   ;; For protobuf fields that have a single valid value, we don't enforce the
@@ -846,8 +834,7 @@
   (s/assert (s/nilable ::pb-type-token) type-token)
   (s/assert ::pb-path pb-path)
   (s/assert ::ignore-reason-set disregarded-ignore-reasons)
-  (let [pb-desc-key (pb-descriptor-key pb-desc)
-        pb-field->ignore-reason (pb-field-ignore-reasons pb-desc-key type-token pb-path)
+  (let [pb-field->ignore-reason (pb-field-ignore-reasons pb-desc type-token pb-path)
         ignored-field? (fn [^Descriptors$FieldDescriptor field-desc]
                          (let [field-name (.getName field-desc)
                                ignore-reason (get pb-field->ignore-reason field-name)]
@@ -857,13 +844,12 @@
           (remove ignored-field?)
           (.getFields pb-desc))))
 
-(def ^:private pb-descriptor-expected-fields (memoize pb-descriptor-expected-fields-raw))
+(def ^:private pb-descriptor-expected-fields (fn/memoize pb-descriptor-expected-fields-raw))
 
-(defn- pb-type-field-name [pb-desc-key pb-path]
-  (s/assert ::pb-desc-key pb-desc-key)
+(defn- pb-type-field-name [^Descriptors$Descriptor pb-desc pb-path]
   (s/assert ::pb-path pb-path)
-  (when-let [type-field-name (pb-type-field-names pb-desc-key)]
-    (let [pb-field->ignore-reason (pb-field-ignore-reasons pb-desc-key nil pb-path)
+  (when-let [type-field-name (-> pb-desc pb-descriptor-key pb-type-field-names)]
+    (let [pb-field->ignore-reason (pb-field-ignore-reasons pb-desc nil pb-path)
           ignore-reason (get pb-field->ignore-reason type-field-name)]
       (case ignore-reason
         (nil :allowed-default :non-editable :non-overridable) type-field-name
@@ -872,8 +858,7 @@
 (defn- pb-nested-field-frequencies [^Message pb pb-path count-field-value?]
   (s/assert ::pb-path pb-path)
   (let [pb-desc (.getDescriptorForType pb)
-        pb-desc-key (pb-descriptor-key pb-desc)
-        type-field-name (pb-type-field-name pb-desc-key pb-path)
+        type-field-name (pb-type-field-name pb-desc pb-path)
         type-field-desc (some->> type-field-name (.findFieldByName pb-desc))
         type-field-value (some->> type-field-desc (.getField pb))
         type-token (some->> type-field-value pb-type-token)
@@ -1003,7 +988,9 @@
   ;; fields to the protobuf messages used by the editor, you must either add a
   ;; field ignore rule to the `pb-ignored-fields` map at the top of this file,
   ;; or set the field to a non-default value in a root-level file in the save
-  ;; data test project.
+  ;; data test project. Alternatively, if the field is only for the compiled
+  ;; binaries read by the runtime, you can annotate it [(runtime_only)=true]
+  ;; directly in the .proto file.
   (test-util/with-loaded-project project-path
     (let [uncovered-value-paths-by-ext
           (->> (checked-resources workspace)
@@ -1097,8 +1084,7 @@
                      (.getDescriptorForType altered-pb))]}
   (s/assert ::pb-path pb-path)
   (let [pb-desc (.getDescriptorForType original-pb)
-        pb-desc-key (pb-descriptor-key pb-desc)
-        type-field-name (pb-type-field-name pb-desc-key pb-path)
+        type-field-name (pb-type-field-name pb-desc pb-path)
         type-field-desc (some->> type-field-name (.findFieldByName pb-desc))
         type-field-value (some->> type-field-desc (.getField original-pb))
         type-token (some->> type-field-value pb-type-token)
@@ -1215,7 +1201,7 @@
   ;; the top of this file.
   (test-util/with-loaded-project project-path
     (let [proj-path->resource #(workspace/find-resource workspace %)
-          resource->gui-scene-pb (memoize #(protobuf/read-pb Gui$SceneDesc %))
+          resource->gui-scene-pb (fn/memoize #(protobuf/read-pb Gui$SceneDesc %))
           gui-scene-pb->node-pbs #(.getNodesList ^Gui$SceneDesc %)
           gui-proj-path->node-pbs (comp gui-scene-pb->node-pbs resource->gui-scene-pb proj-path->resource)
 

--- a/engine/ddf/src/ddf/ddf_extensions.proto
+++ b/engine/ddf/src/ddf/ddf_extensions.proto
@@ -14,6 +14,7 @@ extend google.protobuf.MessageOptions
 extend google.protobuf.FieldOptions
 {
     optional bool resource = 50100;
+    optional bool runtime_only = 50101;
     optional bool field_align = 50004;
 }
 

--- a/engine/gameobject/proto/gameobject/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject/gameobject_ddf.proto
@@ -37,7 +37,7 @@ message ComponentDesc
     optional dmMath.Point3  position    = 3;
     optional dmMath.Quat    rotation    = 4;
     repeated PropertyDesc properties    = 5;
-    optional dmPropertiesDDF.PropertyDeclarations property_decls = 6;
+    optional dmPropertiesDDF.PropertyDeclarations property_decls = 6 [(runtime_only) = true];
     optional dmMath.Vector3 scale       = 7;
 }
 
@@ -55,14 +55,14 @@ message PrototypeDesc
 {
     repeated ComponentDesc components = 1;
     repeated EmbeddedComponentDesc embedded_components = 2;
-    repeated string property_resources = 3 [(resource) = true];
+    repeated string property_resources = 3 [(runtime_only) = true, (resource) = true];
 }
 
 message ComponentPropertyDesc
 {
     required string id = 1;
     repeated PropertyDesc properties = 2;
-    optional dmPropertiesDDF.PropertyDeclarations property_decls = 3;
+    optional dmPropertiesDDF.PropertyDeclarations property_decls = 3 [(runtime_only) = true];
 }
 
 message ComponenTypeDesc
@@ -119,8 +119,8 @@ message CollectionDesc
     repeated CollectionInstanceDesc collection_instances    = 3;
     optional uint32                 scale_along_z           = 4 [default = 0];
     repeated EmbeddedInstanceDesc   embedded_instances      = 5;
-    repeated string                 property_resources      = 6 [(resource)=true];
-    repeated ComponenTypeDesc       component_types         = 7;
+    repeated string                 property_resources      = 6 [(runtime_only) = true, (resource) = true];
+    repeated ComponenTypeDesc       component_types         = 7 [(runtime_only) = true];
 }
 
 /*# Game object API documentation

--- a/engine/gamesys/proto/gamesys/tile_ddf.proto
+++ b/engine/gamesys/proto/gamesys/tile_ddf.proto
@@ -66,7 +66,7 @@ message TileSet
     optional string collision                       = 6 [(resource)=true];
     required string material_tag                    = 7 [default = "tile"];
     repeated ConvexHull convex_hulls                = 8;
-    repeated float convex_hull_points               = 9;
+    repeated float convex_hull_points               = 9 [(runtime_only)=true];
     repeated string collision_groups                = 10;
     repeated Animation animations                   = 11;
     optional uint32 extrude_borders                 = 12 [default = 0];
@@ -89,7 +89,7 @@ message TileLayer
     required string id          = 1 [default = "layer1"];
     required float z            = 2 [default = 0.0];
     required uint32 is_visible  = 3 [default = 1];
-    optional uint64 id_hash     = 4 [default = 0];
+    optional uint64 id_hash     = 4 [default = 0, (runtime_only)=true];
     repeated TileCell cell      = 6;
 }
 

--- a/engine/graphics/proto/graphics/graphics_ddf.proto
+++ b/engine/graphics/proto/graphics/graphics_ddf.proto
@@ -56,7 +56,7 @@ message VertexAttribute
     }
 
     required string          name             = 1;
-    optional uint64          name_hash        = 2;
+    optional uint64          name_hash        = 2 [(runtime_only) = true];
     optional SemanticType    semantic_type    = 3 [default = SEMANTIC_TYPE_NONE];
     optional int32           element_count    = 4 [default = 0];
     optional bool            normalize        = 5 [default = false];
@@ -69,7 +69,7 @@ message VertexAttribute
     {
         LongValues   long_values   = 8;  // Saved integer values (project files only)
         DoubleValues double_values = 9;  // Saved floating point values (project files only)
-        bytes        binary_values = 10; // Packed binary representation of the input values (engine only)
+        bytes        binary_values = 10 [(runtime_only) = true]; // Packed binary representation of the input values (engine only)
     }
 }
 

--- a/engine/render/proto/render/material_ddf.proto
+++ b/engine/render/proto/render/material_ddf.proto
@@ -68,9 +68,9 @@ message MaterialDesc
         required FilterModeMin filter_min = 4;
         required FilterModeMag filter_mag = 5;
         optional float max_anisotropy     = 6 [default = 1.0];
-        repeated uint64 name_indirections = 7; // sampler name -> list of shader uniform hashes
+        repeated uint64 name_indirections = 7 [(runtime_only)=true]; // sampler name -> list of shader uniform hashes
         optional string texture           = 8 [(resource)=true];
-        optional uint64 name_hash         = 9; // Internal, for faster lookups
+        optional uint64 name_hash         = 9 [(runtime_only)=true]; // Internal, for faster lookups
     }
 
     required string name = 1;


### PR DESCRIPTION
### Technical changes
* Annotating a field with `[(runtime_only)=true]` in a `.proto` file will prevent the editor save data tests from complaining about the field not having a significant value assigned in the save data test project. Note that this should strictly be reserved for fields that has only ever been part of the compiled binary output. Never do this instead of adding a `:deprecated` or `:unimplemented` ignore rule to `pb-ignored-fields` in `editor/test/integration/save_data_test.clj`, not even as a temporary hack, because we will quickly lose control of changes that need to be covered by migration tests, etc.