### PR TITLE
Select the default build server based on channel

### DIFF
--- a/editor/src/clj/editor/connection_properties.clj
+++ b/editor/src/clj/editor/connection_properties.clj
@@ -21,6 +21,8 @@
    :git-issues {:url "https://github.com/defold/defold"}
    :analytics-url "https://www.google-analytics.com/mp/collect?api_secret=TiZ0CR6kTQ6I5SxJvH2Veg&measurement_id=G-WPGB4YL1FQ"
    :analytics-validation-url "https://www.google-analytics.com/debug/mp/collect?api_secret=TiZ0CR6kTQ6I5SxJvH2Veg&measurement_id=G-WPGB4YL1FQ"
-   :native-extensions {:build-server-url "https://build.defold.com"}
+   :native-extensions {:build-server-url "https://build.defold.com"
+                       :custom-build-servers {"alpha" "https://build-stage.defold.com"
+                                              "beta" "https://build-stage.defold.com"}}
    :updater {:download-url-template "https://%s/archive/%s/%s/editor2/Defold-%s.zip"
              :update-url-template "https://%s/editor2/channels/%s/update-v4.json"}})

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -45,7 +45,11 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:const defold-build-server-url (get-in connection-properties [:native-extensions :build-server-url]))
+(def ^:const defold-build-server-url
+  (or
+    (get-in connection-properties [:native-extensions :custom-build-servers (system/defold-channel)])
+    (get-in connection-properties [:native-extensions :build-server-url])))
+
 (def ^:const defold-build-server-headers "")
 (def ^:const connect-timeout-ms (* 30 1000))
 (def ^:const read-timeout-ms (* 10 60 1000))


### PR DESCRIPTION
User-facing changes:
If the "Build Server" preference was never modified or is set to an empty string, the editor will pick either https://build-stage.defold.com or https://build.defold.com depending on the editor channel.

Fixes #7393