### PR TITLE
Increased length of debug prints for urls to 256 per part and 512 in total

### DIFF
--- a/engine/script/src/script_msg.cpp
+++ b/engine/script/src/script_msg.cpp
@@ -58,7 +58,7 @@ namespace dmScript
 
     const char* UrlToString(const dmMessage::URL* url, char* buffer, uint32_t buffer_size)
     {
-        char tmp[32];
+        char tmp[256];
         *buffer = '\0';
 
         const char* unknown = "<unknown>";
@@ -95,7 +95,7 @@ namespace dmScript
     static int URL_tostring(lua_State *L)
     {
         dmMessage::URL* url = (dmMessage::URL*)lua_touserdata(L, 1);
-        char buffer[64];
+        char buffer[512];
         UrlToString(url, buffer, sizeof(buffer));
         lua_pushfstring(L, "%s: [%s]", SCRIPT_TYPE_NAME_URL, buffer);
         return 1;
@@ -105,7 +105,7 @@ namespace dmScript
     {
         const char* s = luaL_checkstring(L, 1);
         dmMessage::URL* url = CheckURL(L, 2);
-        char buffer[64];
+        char buffer[512];
         UrlToString(url, buffer, sizeof(buffer));
         lua_pushfstring(L, "%s[%s]", s, buffer);
         return 1;

--- a/engine/script/src/test/test_script_msg.cpp
+++ b/engine/script/src/test/test_script_msg.cpp
@@ -388,13 +388,25 @@ TEST_F(ScriptMsgTest, TestURLToString)
     ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::NewSocket("socket", &socket));
     ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::NewSocket("very_very_very_very_very_very_very_very_very_very_very_very_socket", &overflow_socket));
     ASSERT_TRUE(dmScriptTest::RunString(L,
-        "local url = msg.url()\n"
-        "print(tostring(url))\n"
-        "url = msg.url(\"socket\", \"path\", \"test\")\n"
-        "print(tostring(url))\n"
-        "-- overflow\n"
-        "url = msg.url(\"very_very_very_very_very_very_very_very_very_very_very_very_socket\", \"path\", \"test\")\n"
-        "print(tostring(url))\n"
+        "test_msg_fn = function (url, expected)\n"
+        "    local s = tostring(url)\n"
+        "    local e = string.format('url: [%s]', expected)\n"
+        "    if s ~= e then\n"
+        "        print('Expected url:', e)\n"
+        "        print('     but got:', s)\n"
+        "        assert(false)\n"
+        "    else\n"
+        "        print(s)\n"
+        "    end\n"
+        "end\n"
+        "test_msg_fn(msg.url(), 'default_socket:<unknown>#<unknown>')\n"
+        "test_msg_fn(msg.url('socket', 'path', 'test'), 'socket:path#test')\n"
+        "\n" // test the per part concatenation
+        "local long_s = string.rep('x', 300)\n"
+        "local expected_s = string.rep('x', 255)\n" // current limit is 256 per part
+        "test_msg_fn(msg.url(long_s, 'path', 'test'), expected_s .. ':path#test')\n"
+        "\n" // test the rotal length
+        "test_msg_fn(msg.url(long_s, long_s, 'test'), expected_s .. ':' .. expected_s)\n" // max is 512. 255+1+255+'\0' == 512
         ));
     ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::DeleteSocket(socket));
     ASSERT_EQ(dmMessage::RESULT_OK, dmMessage::DeleteSocket(overflow_socket));
@@ -402,9 +414,9 @@ TEST_F(ScriptMsgTest, TestURLToString)
     ASSERT_TRUE(dmScriptTest::RunString(L,
         "local url = msg.url()\n"
         "-- the socket doesn't exist yet\n"
-        "url = msg.url(\"socket_not_exist\", \"path\", \"test\")\n"
-        "print(tostring(url))\n"
-        "assert(url.socket == hash(\"socket_not_exist\"))\n"
+        "url = msg.url('socket_not_exist', 'path', 'test')\n"
+        "test_msg_fn(url, 'socket_not_exist:path#test')\n"
+        "assert(url.socket == hash('socket_not_exist'))\n"
         ));
 
     ASSERT_EQ(top, lua_gettop(L));


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/8321

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
