### PR TITLE
Added engine loader fallback when WebAssembly streaming fails

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -107,38 +107,23 @@ var EngineLoader = {
 
     stream_wasm: false,
 
-    script_loaded: false,
-
-    // load .wasm file using XMLHttpRequest
-    loadWasmFileAsync: function(src, fromProgress, toProgress, callback) {
+    // load and instantiate .wasm file using XMLHttpRequest
+    loadWasmFileAsync: function(src, fromProgress, toProgress, imports, successCallback) {
         FileLoader.load(src, "arraybuffer", EngineLoader.wasm_size,
             function(loaded, total) { Progress.calculateProgress(fromProgress, toProgress, loaded, total); },
             function(error) { throw error; },
-            function(wasm) { callback(wasm); });
+            function(wasm) {
+                var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasm), imports).then(function(output) {
+                    successCallback(output.instance);
+                }).catch(function(e) {
+                    console.log('wasm instantiation failed! ' + e);
+                    throw e;
+                });
+            });
     },
 
-    // instantiate a .wasm file
-    instantiateWasmFileAsync: function(wasm, imports, successCallback) {
-        var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasm), imports).then(function(output) {
-            successCallback(output.instance);
-        }).catch(function(e) {
-            console.log('wasm instantiation failed! ' + e);
-            throw e;
-        });
-        return {}; // Compiling asynchronously, no exports.
-    },
-
-    loadAndInstantiateWasmAsync: function(exeName, fromProgress, toProgress, callback) {
-        var src = exeName + ".wasm";
-        EngineLoader.loadWasmFileAsync(src, fromProgress, toProgress, function(wasm) {
-            Module.instantiateWasm = function(imports, successCallback) {
-                EngineLoader.instantiateWasmFileAsync(wasm, imports, successCallback);
-            };
-            callback();
-        });
-    },
-
-    fetch: function() {
+    // stream and instantiate .wasm file
+    streamWasmFileAsync: async function(src, fromProgress, toProgress, imports, successCallback) {
         // https://stackoverflow.com/a/69179454
         var fetchFn = fetch;
         if (typeof TransformStream === "function" && ReadableStream.prototype.pipeThrough) {
@@ -155,7 +140,6 @@ var EngineLoader = {
                 const ts = new TransformStream({
                     transform (chunk, controller) {
                         bytesLoaded += chunk.byteLength;
-                        if (0 == 0) throw new Error("foobar");
                         Progress.calculateProgress(fromProgress, toProgress, bytesLoaded, total);
                         controller.enqueue(chunk);
                     }
@@ -165,40 +149,30 @@ var EngineLoader = {
             }
             fetchFn = fetchWithProgress;
         }
-        return fetchFn;
-    },
 
-    streamAndInstantiateWasmAsync: async function(exeName, fromProgress, toProgress) {
-        var src = exeName + ".wasm";
-        Module.instantiateWasm = function(imports, successCallback) {
-            console.log("setupWasmStreamAsync instantiateWasm");
-            WebAssembly.instantiateStreaming(EngineLoader.fetch(src), imports).then(function(output) {
-                console.log("setupWasmStreamAsync output");
-                Progress.calculateProgress(fromProgress, toProgress, 1, 1);
-                successCallback(output.instance);
-            }).catch(function(e) {
-                console.log('wasm streaming instantiation failed! ' + e);
-                console.log("Fallback to wasm loading");
-                EngineLoader.loadWasmFileAsync(src, fromProgress, toProgress, function(wasm) {
-                    EngineLoader.instantiateWasmFileAsync(wasm, imports, successCallback);
-                });
-            });
-            return {}; // Compiling asynchronously, no exports.
-        }
+        WebAssembly.instantiateStreaming(fetchFn(src), imports).then(function(output) {
+            Progress.calculateProgress(fromProgress, toProgress, 1, 1);
+            successCallback(output.instance);
+        }).catch(function(e) {
+            console.log('wasm streaming instantiation failed! ' + e);
+            console.log('Fallback to wasm loading');
+            EngineLoader.loadWasmFileAsync(src, fromProgress, toProgress, imports, successCallback);
+        });
     },
 
     // instantiate the .wasm file either by streaming it or first loading and then instantiate it
     // https://github.com/emscripten-core/emscripten/blob/main/test/manual_wasm_instantiate.html
     loadWasmAsync: function(exeName) {
-        if (EngineLoader.stream_wasm && (typeof WebAssembly.instantiateStreaming === "function")) {
-            EngineLoader.streamAndInstantiateWasmAsync(exeName, 10, 50);
-            EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, 0, 10);
-        }
-        else {
-            EngineLoader.loadAndInstantiateWasmAsync(exeName, 0, 40, function() {
-                EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, 40, 50);
-            });
-        }
+        Module.instantiateWasm = function(imports, successCallback) {
+            if (EngineLoader.stream_wasm && (typeof WebAssembly.instantiateStreaming === "function")) {
+                EngineLoader.streamWasmFileAsync(exeName + ".wasm", 10, 50, imports, successCallback);
+            }
+            else {
+                EngineLoader.loadWasmFileAsync(exeName + ".wasm", 10, 50, imports, successCallback);
+            }
+            return {}; // Compiling asynchronously, no exports.
+        };
+        EngineLoader.loadAndRunScriptAsync(exeName + '_wasm.js', EngineLoader.wasmjs_size, 0, 10);
     },
 
     loadAsmJsAsync: function(exeName) {
@@ -207,20 +181,14 @@ var EngineLoader = {
 
     // load and start engine script (asm.js or wasm.js)
     loadAndRunScriptAsync: function(src, estimatedSize, fromProgress, toProgress) {
-        if (EngineLoader.script_loaded == true) return;
         FileLoader.load(src, "text", estimatedSize,
             function(loaded, total) { Progress.calculateProgress(fromProgress, toProgress, loaded, total); },
             function(error) { throw error; },
             function(response) {
-                console.log("loadAndRunScriptAsync " + src);
-                console.log("loadAndRunScriptAsync loaded = " + EngineLoader.script_loaded);
-                // prevent double loading of the engine script
-                if (EngineLoader.script_loaded == false) {
-                    var tag = document.createElement("script");
-                    tag.text = response;
-                    document.body.appendChild(tag);
-                    EngineLoader.script_loaded = true;
-                }
+                var tag = document.createElement("script");
+                tag.text = response;
+                document.body.appendChild(tag);
+                EngineLoader.script_loaded = true;
             });
     },
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -108,7 +108,7 @@ var EngineLoader = {
     stream_wasm: false,
 
     // load and instantiate .wasm file using XMLHttpRequest
-    loadWasmFileAsync: function(src, fromProgress, toProgress, imports, successCallback) {
+    loadAndInstantiateWasmAsync: function(src, fromProgress, toProgress, imports, successCallback) {
         FileLoader.load(src, "arraybuffer", EngineLoader.wasm_size,
             function(loaded, total) { Progress.calculateProgress(fromProgress, toProgress, loaded, total); },
             function(error) { throw error; },
@@ -123,7 +123,7 @@ var EngineLoader = {
     },
 
     // stream and instantiate .wasm file
-    streamWasmFileAsync: async function(src, fromProgress, toProgress, imports, successCallback) {
+    streamAndInstantiateWasmAsync: async function(src, fromProgress, toProgress, imports, successCallback) {
         // https://stackoverflow.com/a/69179454
         var fetchFn = fetch;
         if (typeof TransformStream === "function" && ReadableStream.prototype.pipeThrough) {
@@ -156,7 +156,7 @@ var EngineLoader = {
         }).catch(function(e) {
             console.log('wasm streaming instantiation failed! ' + e);
             console.log('Fallback to wasm loading');
-            EngineLoader.loadWasmFileAsync(src, fromProgress, toProgress, imports, successCallback);
+            EngineLoader.loadAndInstantiateWasmAsync(src, fromProgress, toProgress, imports, successCallback);
         });
     },
 
@@ -165,10 +165,10 @@ var EngineLoader = {
     loadWasmAsync: function(exeName) {
         Module.instantiateWasm = function(imports, successCallback) {
             if (EngineLoader.stream_wasm && (typeof WebAssembly.instantiateStreaming === "function")) {
-                EngineLoader.streamWasmFileAsync(exeName + ".wasm", 10, 50, imports, successCallback);
+                EngineLoader.streamAndInstantiateWasmAsync(exeName + ".wasm", 10, 50, imports, successCallback);
             }
             else {
-                EngineLoader.loadWasmFileAsync(exeName + ".wasm", 10, 50, imports, successCallback);
+                EngineLoader.loadAndInstantiateWasmAsync(exeName + ".wasm", 10, 50, imports, successCallback);
             }
             return {}; // Compiling asynchronously, no exports.
         };

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -188,7 +188,6 @@ var EngineLoader = {
                 var tag = document.createElement("script");
                 tag.text = response;
                 document.body.appendChild(tag);
-                EngineLoader.script_loaded = true;
             });
     },
 


### PR DESCRIPTION
The engine loader will now use XMLHttpRequest as a fallback when WebAssembly compilation and instantiation from a streamed source fails.

Fixes #7836 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
