### PR TITLE
Fix issue when usage of semicolons in Lua may break compilation.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
@@ -493,7 +493,6 @@ public class LuaScannerTest {
         LuaScanner scanner = new LuaScanner();
         scanner.parse(luaCode);
         String expected = "do return nil end else end ";
-        System.out.println(scanner.getParsedLua());
         assertEquals(expected, scanner.getParsedLua());
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/LuaScannerTest.java
@@ -486,4 +486,14 @@ public class LuaScannerTest {
         assertEquals(expected, parsed);
     }
 
+    @Test
+    public void testSemicolon() throws Exception {
+        // Basic
+        String luaCode = "do return nil end;else end;";
+        LuaScanner scanner = new LuaScanner();
+        scanner.parse(luaCode);
+        String expected = "do return nil end else end ";
+        System.out.println(scanner.getParsedLua());
+        assertEquals(expected, scanner.getParsedLua());
+    }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaScanner.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/LuaScanner.java
@@ -203,6 +203,16 @@ public class LuaScanner extends LuaParserBaseListener {
                     rewriter.replace(token, System.lineSeparator().repeat(token.getText().split("\r\n|\r|\n").length - 1));
                 }
              }
+             else {
+                 /**
+                 * We use this to remove any semicolon statements.
+                 * The semicolon may cause problems if it is at the end of a go.property call
+                 * as it will be removed after it has been parsed.
+                 */
+                if (token.getType() == LuaLexer.SEMICOLON) {
+                    rewriter.replace(token, " ");
+                }
+             }
         }
 
         // parse code
@@ -472,22 +482,4 @@ public class LuaScanner extends LuaParserBaseListener {
         }
         return result;
     }
-
-    /**
-     * Callback from ANTLR when a statement is entered. We use this to remove
-     * any stand-alone semicolon statements. The semicolon may cause problems
-     * if it is at the end of a go.property call as it will be removed after it
-     * has been parsed.
-     * Note that semicolons used as field or return separators are not affected.
-     */
-    @Override public void enterStat(LuaParser.StatContext ctx) {
-        List<Token> tokens = getTokens(ctx, Token.DEFAULT_CHANNEL);
-        if (tokens.size() == 1) {
-            Token token = tokens.get(0);
-            if (token.getText().equals(";")) {
-                removeToken(token);
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
Fixed an issue when our Lua parser removes semicolons which shouldn't be removed, which breaks Lua compilation.

Fix https://github.com/defold/defold/issues/8323
## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
