### PR TITLE
Fix for certain models not getting correct textures assigned

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -280,49 +280,56 @@ namespace dmGameSystem
         return GetMaterialResource(component, resource, index)->m_Material;
     }
 
-    TextureResource* GetTextureResource(const ModelComponent* component, uint32_t material_index, uint32_t texture_unit)
+    static TextureResource* GetTextureFromSamplerNameHash(const MaterialInfo* material_info, const MaterialResource* material, uint32_t material_texture_index, dmhash_t sampler_name_hash)
     {
-        assert(texture_unit < MAX_TEXTURE_COUNT);
-        TextureResource* texture;
+        // Material is the actual selected material (may be overridden at runtime)
 
-        // Overridden textures (from Lua code)
-        texture = component->m_Textures[texture_unit];
-        if (texture)
-            return texture;
-        // Overridden material (from Lua code)
-        MaterialResource* material = component->m_Material;
-        if (material)
+        // If the model has textures, let's find the one associated with the sampler name
+        for (uint32_t i = 0; i < material_info->m_TexturesCount; ++i)
         {
-            if (texture_unit < material->m_NumTextures)
-                texture = material->m_Textures[texture_unit];
+            if (material_info->m_Textures[i].m_SamplerNameHash == sampler_name_hash)
+                return material_info->m_Textures[i].m_Texture;
         }
-        if (texture)
-            return texture;
 
-        MaterialInfo* material_info = &component->m_Resource->m_Materials[material_index];
-        // Overridden textures (from .model)
-        MaterialTextureInfo* texture_infos = material_info->m_Textures;
-        if (material_info->m_Textures && texture_unit < material_info->m_TexturesCount)
-            texture = material_info->m_Textures[texture_unit].m_Texture;
-        if (texture)
-            return texture;
-
-        // The textures which are set in the .material file
-        material = material_info->m_Material;
-        if (material)
-            texture = material->m_Textures[texture_unit];
-        if (texture)
-            return texture;
+        // If it is contains materials, use that
+        if (material_texture_index < material->m_NumTextures)
+            return material->m_Textures[material_texture_index];
 
         return 0;
     }
 
-    dmGraphics::HTexture GetMaterialTexture(const ModelComponent* component, uint32_t material_index, uint32_t texture_unit)
+    // A bit legacy, as we don't want to set textures based on index anymore, but sampler names.
+    static TextureResource* GetTextureResource(const ModelComponent* component, uint32_t material_index, uint32_t material_texture_index)
     {
-        TextureResource* texture = GetTextureResource(component, material_index, texture_unit);
-        return texture ? texture->m_Texture : 0;
+        MaterialResource* material = GetMaterialResource(component, component->m_Resource, material_index);
+        MaterialInfo* material_info = &component->m_Resource->m_Materials[material_index];
+
+        TextureResource* texture_res = component->m_Textures[material_texture_index]; // Check if it's overridden
+        if (!texture_res && material_texture_index < material_info->m_TexturesCount)
+        {
+            texture_res = material_info->m_Textures[material_texture_index].m_Texture; // Check if the model has a texture
+        }
+        if (!texture_res && material_texture_index < material->m_NumTextures)
+        {
+            texture_res = material->m_Textures[material_texture_index]; // Check if the material has a texture
+        }
+        return texture_res;
     }
 
+    static void FillTextures(dmRender::RenderObject* ro, const ModelComponent* component, uint32_t material_index)
+    {
+        MaterialResource* material = GetMaterialResource(component, component->m_Resource, material_index);
+        for(uint32_t i = 0; i < material->m_NumTextures; ++i)
+        {
+            TextureResource* texture_res = component->m_Textures[i];
+            if (!texture_res)
+            {
+                texture_res = GetTextureFromSamplerNameHash(&component->m_Resource->m_Materials[material_index], material, i, material->m_SamplerNames[i]);
+            }
+
+            ro->m_Textures[i] = texture_res ? texture_res->m_Texture : 0;
+        }
+    }
     static void HashMaterial(HashState32* state, const dmGameSystem::MaterialResource* material)
     {
         dmHashUpdateBuffer32(state, &material->m_Material, sizeof(material->m_Material));
@@ -516,7 +523,6 @@ namespace dmGameSystem
         }
         create_params.m_MeshSet          = rig_resource->m_MeshSetRes->m_MeshSet;
 
-        dmRigDDF::MeshSet* mesh_set      = rig_resource->m_MeshSetRes->m_MeshSet;
         // Let's choose the first model for the animation
         create_params.m_ModelId          = 0; // Let's use all models
         create_params.m_DefaultAnimation = animation;
@@ -657,10 +663,7 @@ namespace dmGameSystem
             DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, buffers->m_VertexCount);
             DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, buffers->m_VertexCount * sizeof(dmRig::RigModelVertex));
 
-            for(uint32_t i = 0; i < MAX_TEXTURE_COUNT; ++i)
-            {
-                ro.m_Textures[i] = GetMaterialTexture(component, material_index, i);
-            }
+            FillTextures(&ro, component, material_index);
 
             if (component->m_RenderConstants) {
                 dmGameSystem::EnableRenderObjectConstants(&ro, component->m_RenderConstants);
@@ -771,10 +774,7 @@ namespace dmGameSystem
         ro.m_Material = GetMaterial(component, component->m_Resource, material_index);
         ro.m_WorldTransform = Matrix4::identity(); // Pass identity world transform if outputing world positions directly.
 
-        for(uint32_t i = 0; i < MAX_TEXTURE_COUNT; ++i)
-        {
-            ro.m_Textures[i] = GetMaterialTexture(component, material_index, i);
-        }
+        FillTextures(&ro, component, material_index);
 
         if (component->m_RenderConstants) {
             dmGameSystem::EnableRenderObjectConstants(&ro, component->m_RenderConstants);

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -292,7 +292,10 @@ namespace dmGameSystem
         // Overridden material (from Lua code)
         MaterialResource* material = component->m_Material;
         if (material)
-            texture = material->m_Textures[texture_unit];
+        {
+            if (texture_unit < material->m_NumTextures)
+                texture = material->m_Textures[texture_unit];
+        }
         if (texture)
             return texture;
 

--- a/engine/gamesys/src/gamesys/resources/res_material.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_material.cpp
@@ -125,10 +125,10 @@ namespace dmGameSystem
         dmRenderDDF::MaterialDesc::Sampler* sampler = ddf->m_Samplers.m_Data;
         for (uint32_t i = 0; i < ddf->m_Samplers.m_Count; i++)
         {
+            resources->m_SamplerNames[i] = sampler[i].m_NameHash;
             const char* texture_path = sampler[i].m_Texture;
             if (*texture_path != 0)
             {
-                resources->m_SamplerNames[i] = sampler[i].m_NameHash;
                 factory_e = dmResource::Get(factory, texture_path, (void**)&resources->m_Textures[i]);
                 if ( factory_e != dmResource::RESULT_OK)
                 {


### PR DESCRIPTION
In some cases, a model with multiple textures would get them assigned to incorrect texture units.

Fixes https://github.com/defold/defold/issues/8345

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
