### PR TITLE
Added options to control how json data is encoded and decoded

### DIFF
--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -461,7 +461,7 @@ static void json_create_config(lua_State *l)
 #endif // DEFOLD
 
 // DEFOLD
-static void json_initialize_config(json_config_t* cfg, int encode_keep_buffer)
+static void json_initialize_config(lua_State *l, json_config_t* cfg, int encode_keep_buffer)
 {
     int i;
 
@@ -528,6 +528,28 @@ static void json_initialize_config(json_config_t* cfg, int encode_keep_buffer)
     cfg->escape2char['f'] = '\f';
     cfg->escape2char['r'] = '\r';
     cfg->escape2char['u'] = 'u';          /* Unicode parsing required */
+
+    // read additional config values from options table
+    if (lua_istable(l, 2))
+    {
+        lua_pushvalue(l, 2); // push config table to top of stack
+
+        lua_getfield(l, -1, "decode_null_as_userdata");
+        if (!lua_isnil(l, -1))
+        {
+            cfg->decode_null_as_userdata = lua_toboolean(l, -1);
+        }
+        lua_pop(l, 1);
+
+        lua_getfield(l, -1, "encode_empty_table_as_object");
+        if (!lua_isnil(l, -1))
+        {
+            cfg->encode_empty_table_as_object = lua_toboolean(l, -1);
+        }
+        lua_pop(l, 1);
+
+        lua_pop(l, 1); // remove config table from top of stack
+    }
 }
 // END DEFOLD
 
@@ -939,9 +961,7 @@ int lua_cjson_encode(lua_State *l, char** json_str, size_t* json_length)
     strbuf_t local_encode_buf;
     strbuf_t *encode_buf;
 
-    luaL_argcheck(l, lua_gettop(l) == 1, 1, "expected 1 argument");
-
-    json_initialize_config(&cfg, DEFAULT_ENCODE_KEEP_BUFFER);
+    json_initialize_config(l, &cfg, DEFAULT_ENCODE_KEEP_BUFFER);
     if (!cfg.encode_keep_buffer) {
         /* Use private buffer */
         encode_buf = &local_encode_buf;
@@ -952,7 +972,9 @@ int lua_cjson_encode(lua_State *l, char** json_str, size_t* json_length)
         strbuf_reset(encode_buf);
     }
 
+    lua_pushvalue(l, 1); // make sure the table to encode is on the top of the stack
     json_append_data(l, &cfg, 0, encode_buf);
+    lua_pop(l, 1); // pop it again
 
     // DEFOLD: We store away the values
     int len;
@@ -1567,11 +1589,11 @@ static int json_decode(lua_State *l)
 // a user data object.
 int lua_cjson_decode(lua_State *l, const char* json_string, size_t json_len)
 {
-	json_config_t cfg;
+    json_config_t cfg;
     json_parse_t json;
     json_token_t token;
 
-    json_initialize_config(&cfg, 0);
+    json_initialize_config(l, &cfg, 0);
     json.cfg = &cfg;
     json.data = json_string;
     json.data_end = json_string + json_len;

--- a/engine/script/src/luacjson/lua_cjson.c
+++ b/engine/script/src/luacjson/lua_cjson.c
@@ -83,6 +83,7 @@
 #define DEFAULT_ENCODE_EMPTY_TABLE_AS_OBJECT 1
 #define DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT 0
 #define DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH 1
+#define DEFAULT_DECODE_NULL_AS_USERDATA 0
 
 #ifdef DISABLE_INVALID_NUMBERS
 #undef DEFAULT_DECODE_INVALID_NUMBERS
@@ -166,6 +167,7 @@ typedef struct {
     int decode_invalid_numbers;
     int decode_max_depth;
     int decode_array_with_array_mt;
+    int decode_null_as_userdata;
 } json_config_t;
 
 typedef struct {
@@ -475,6 +477,7 @@ static void json_initialize_config(json_config_t* cfg, int encode_keep_buffer)
     cfg->encode_empty_table_as_object = DEFAULT_ENCODE_EMPTY_TABLE_AS_OBJECT;
     cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
     cfg->encode_escape_forward_slash = DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH;
+    cfg->decode_null_as_userdata = DEFAULT_DECODE_NULL_AS_USERDATA;
 
     if (encode_keep_buffer > 0)
     {
@@ -1495,7 +1498,15 @@ static void json_process_value(lua_State *l, json_parse_t *json,
     case T_NULL:
         /* In Lua, setting "t[k] = nil" will delete k from the table.
          * Hence a NULL pointer lightuserdata object is used instead */
-        lua_pushlightuserdata(l, NULL);
+        // DEFOLD:
+        if (json->cfg->decode_null_as_userdata)
+        {
+            lua_pushlightuserdata(l, NULL);
+        }
+        else
+        {
+            lua_pushnil(l);
+        }
         break;;
     default:
         json_throw_parse_error(l, json, "value", token);

--- a/engine/script/src/script_json.cpp
+++ b/engine/script/src/script_json.cpp
@@ -70,7 +70,7 @@ namespace dmScript
      * @param json [type:string] json data
      * @param options [type:table] table with decode options
      *
-     * - [type:string] `decode_null_as_userdata`: wether to decode a JSON null value as json.null or nil
+     * - [type:string] `decode_null_as_userdata`: wether to decode a JSON null value as json.null or nil (default is nil)
      *
      * @return data [type:table] decoded json
      *
@@ -122,7 +122,7 @@ namespace dmScript
      * @param tbl [type:table] lua table to encode
      * @param options [type:table] table with encode options
      *
-     * - [type:string] `encode_empty_table_as_object`: wether to encode an empty table as an JSON object or array
+     * - [type:string] `encode_empty_table_as_object`: wether to encode an empty table as an JSON object or array (default is object)
      *
      * @return json [type:string] encoded json
      *

--- a/engine/script/src/script_json.cpp
+++ b/engine/script/src/script_json.cpp
@@ -68,6 +68,10 @@ namespace dmScript
      *
      * @name json.decode
      * @param json [type:string] json data
+     * @param options [type:table] table with decode options
+     *
+     * - [type:string] `decode_null_as_userdata`: wether to decode a JSON null value as json.null or nil
+     *
      * @return data [type:table] decoded json
      *
      * @examples
@@ -116,6 +120,10 @@ namespace dmScript
      *
      * @name json.encode
      * @param tbl [type:table] lua table to encode
+     * @param options [type:table] table with encode options
+     *
+     * - [type:string] `encode_empty_table_as_object`: wether to encode an empty table as an JSON object or array
+     *
      * @return json [type:string] encoded json
      *
      * @examples

--- a/engine/script/src/test/test_json.lua
+++ b/engine/script/src/test/test_json.lua
@@ -57,7 +57,9 @@ function test_json_invalid_primitive()
 end
 
 function test_json_valid_primitive()
-    assert(json.decode("null") == json.null)
+    assert(json.decode("null") == nil)
+    assert(json.decode("null", { decode_null_as_userdata = false }) == nil)
+    assert(json.decode("null", { decode_null_as_userdata = true }) == json.null)
     assert(json.decode("true") == true)
     assert(json.decode("false") == false)
 
@@ -161,6 +163,8 @@ end
 function test_json_encode()
     -- empty table becomes empty dict
     assert(json.encode({}) == "{}")
+    assert(json.encode({}, { encode_empty_table_as_object = true }) == "{}")
+    assert(json.encode({}, { encode_empty_table_as_object = false }) == "[]")
     -- table with nested table(s) becomes array of tables
     assert(json.encode({{}}) == "[{}]")
     -- table with elements becomes array of elements
@@ -169,7 +173,7 @@ function test_json_encode()
     assert(json.encode(nil) == "null")
     -- however, a table with nil becomes empty table
     assert(json.encode({nil}) == "{}")
-    -- interleaved nil becomse a null element (note: not in quotes)
+    -- interleaved nil becomes a null element (note: not in quotes)
     assert(json.encode({1,nil,2}) == "[1,null,2]")
 
     local v3_enc = json.encode(vmath.vector3()) -- user data

--- a/engine/script/src/test/test_json.lua
+++ b/engine/script/src/test/test_json.lua
@@ -117,6 +117,10 @@ function test_json_decode()
     assert(#nested[2] == 1)
     assert(nested[2][1] == 30)
 
+    -- https://github.com/defold/defold/issues/8317 
+    local t = json.decode('{"key":null}')
+    assert(t[key] == nil)
+
     print("Expected parsing errors ->")
     test_syntax_error("[")
     test_syntax_error("]")


### PR DESCRIPTION
It is now possible to configure the behaviour when encoding and decoding JSON data.

When encoding to JSON it is possible to control wether an empty Lua table should encode as a JSON object or array. The default behaviour when encoding an empty Lua table is to encode to a JSON object.

When decoding from JSON it is now possible to control wether a JSON null value should decode to `json-null` or `nil`. The default behaviour when decoding a JSON null value is to decode to nil.

```lua
local t = {}
json.encode(t, { encode_empty_table_as_object = true }) -- {}
json.encode(t, { encode_empty_table_as_object = false }) -- []
json.encode(t) -- {}


local s = "[ 1, 2, null, 3 ]"
json.decode(s, { decode_null_as_userdata = true}) -- { 1, 2, json.null, 4 }
json.decode(s, { decode_null_as_userdata = false}) -- { 1, 2, nil, 4 }
json.decode(s) -- { 1, 2, nil, 4 }
```

Fixes #8317

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
