### PR TITLE
Add missing functions to null physics libraries

### DIFF
--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -1384,24 +1384,20 @@ namespace dmPhysics
     void FlipH2D(HCollisionObject2D collision_object);
     void FlipV2D(HCollisionObject2D collision_object);
 
-    void ReplaceShape3D(HCollisionObject3D object, HCollisionShape3D old_shape, HCollisionShape3D new_shape);
+    void              ReplaceShape3D(HCollisionObject3D object, HCollisionShape3D old_shape, HCollisionShape3D new_shape);
     HCollisionShape3D GetCollisionShape3D(HCollisionObject3D collision_object, uint32_t index);
+    void              GetCollisionShapeRadius3D(HCollisionShape3D shape, float* radius);
+    void              GetCollisionShapeHalfBoxExtents3D(HCollisionShape3D shape, float* xyz);
+    void              GetCollisionShapeCapsuleRadiusHeight3D(HCollisionShape3D shape, float* radius, float* half_height);
+    void              SetCollisionShapeRadius3D(HCollisionShape3D shape, float radius);
+    void              SetCollisionShapeHalfBoxExtents3D(HCollisionShape2D shape, float w, float h, float d);
 
-    void GetCollisionShapeRadius3D(HCollisionShape3D shape, float* radius);
-    void GetCollisionShapeHalfBoxExtents3D(HCollisionShape3D shape, float* xyz);
-    void GetCollisionShapeCapsuleRadiusHeight3D(HCollisionShape3D shape, float* radius, float* half_height);
-
-    void SetCollisionShapeRadius3D(HCollisionShape3D shape, float radius);
-    void SetCollisionShapeHalfBoxExtents3D(HCollisionShape2D shape, float w, float h, float d);
-
-    void GetCollisionShapeRadius2D(HCollisionShape2D shape, float* radius);
-    void GetCollisionShapePolygonVertices2D(HCollisionShape2D shape, float** vertices, uint32_t* vertex_count);
-
-    void SetCollisionShapeRadius2D(HCollisionShape2D shape, float radius);
-    void SetCollisionShapeBoxDimensions2D(HCollisionShape2D shape, float w, float h);
-
+    void              GetCollisionShapeRadius2D(HCollisionShape2D shape, float* radius);
+    void              GetCollisionShapePolygonVertices2D(HCollisionShape2D shape, float** vertices, uint32_t* vertex_count);
     HCollisionShape2D GetCollisionShape2D(HCollisionObject2D collision_object, uint32_t shape_index);
-    void SynchronizeObject2D(HCollisionObject2D collision_object);
+    void              SetCollisionShapeRadius2D(HCollisionShape2D shape, float radius);
+    void              SetCollisionShapeBoxDimensions2D(HCollisionShape2D shape, float w, float h);
+    void              SynchronizeObject2D(HCollisionObject2D collision_object);
 }
 
 #endif // DM_PHYSICS_H

--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -310,6 +310,31 @@ namespace dmPhysics
     }
 
     void FlipV2D(HCollisionObject2D collision_object)
+    {
+    }
+
+    void GetCollisionShapeRadius2D(HCollisionShape2D shape, float* radius)
+    {
+    }
+
+    void GetCollisionShapePolygonVertices2D(HCollisionShape2D shape, float** vertices, uint32_t* vertex_count)
+    {
+    }
+
+    HCollisionShape2D GetCollisionShape2D(HCollisionObject2D collision_object, uint32_t shape_index)
+    {
+        return 0;
+    }
+
+    void SetCollisionShapeRadius2D(HCollisionShape2D shape, float radius)
+    {
+    }
+
+    void SetCollisionShapeBoxDimensions2D(HCollisionShape2D shape, float w, float h)
+    {
+    }
+
+    void SynchronizeObject2D(HCollisionObject2D collision_object)
     {
     }
 }

--- a/engine/physics/src/physics/physics_3d_null.cpp
+++ b/engine/physics/src/physics/physics_3d_null.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -191,12 +191,12 @@ namespace dmPhysics
         return 0;
     }
 
-    uint16_t GetGroup3D(HCollisionObject3D collision_object) 
+    uint16_t GetGroup3D(HCollisionObject3D collision_object)
     {
         return 0;
     }
 
-    void SetGroup3D(HWorld3D world, HCollisionObject3D collision_object, uint16_t groupbit) 
+    void SetGroup3D(HWorld3D world, HCollisionObject3D collision_object, uint16_t groupbit)
     {
     }
 
@@ -204,8 +204,8 @@ namespace dmPhysics
     {
         return false;
     }
-	
-    void SetMaskBit3D(HWorld3D world, HCollisionObject3D collision_object, uint16_t groupbit, bool boolvalue) 
+
+    void SetMaskBit3D(HWorld3D world, HCollisionObject3D collision_object, uint16_t groupbit, bool boolvalue)
     {
     }
 
@@ -231,6 +231,41 @@ namespace dmPhysics
     }
 
     void ReplaceShape3D(HContext3D context, HCollisionShape3D old_shape, HCollisionShape3D new_shape)
+    {
+    }
+
+    HContext3D GetContext3D(HWorld3D world)
+    {
+        return 0;
+    }
+
+
+    void ReplaceShape3D(HCollisionObject3D object, HCollisionShape3D old_shape, HCollisionShape3D new_shape)
+    {
+    }
+
+    HCollisionShape3D GetCollisionShape3D(HCollisionObject3D collision_object, uint32_t index)
+    {
+        return 0;
+    }
+
+    void GetCollisionShapeRadius3D(HCollisionShape3D shape, float* radius)
+    {
+    }
+
+    void GetCollisionShapeHalfBoxExtents3D(HCollisionShape3D shape, float* xyz)
+    {
+    }
+
+    void GetCollisionShapeCapsuleRadiusHeight3D(HCollisionShape3D shape, float* radius, float* half_height)
+    {
+    }
+
+    void SetCollisionShapeRadius3D(HCollisionShape3D shape, float radius)
+    {
+    }
+
+    void SetCollisionShapeHalfBoxExtents3D(HCollisionShape2D shape, float w, float h, float d)
     {
     }
 }


### PR DESCRIPTION
Fixes #8347

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
