### PR TITLE
Fix for shutting down OpenAL in a more robust manner

### DIFF
--- a/engine/sound/src/devices/device_openal.cpp
+++ b/engine/sound/src/devices/device_openal.cpp
@@ -36,7 +36,8 @@ namespace dmDeviceOpenAL
     {
         ALCdevice*      m_Device;
         ALCcontext*     m_Context;
-        dmArray<ALuint> m_Buffers;
+        dmArray<ALuint> m_AllBuffers;   // All original buffers
+        dmArray<ALuint> m_Buffers;      // The pool
         ALuint          m_Source;
         uint32_t        m_MixRate;
 
@@ -90,10 +91,17 @@ namespace dmDeviceOpenAL
         openal->m_Device = al_device;
         openal->m_Context = al_context;
 
-        openal->m_Buffers.SetCapacity(params->m_BufferCount);
-        openal->m_Buffers.SetSize(params->m_BufferCount);
-        alGenBuffers(params->m_BufferCount, openal->m_Buffers.Begin());
+        openal->m_AllBuffers.SetCapacity(params->m_BufferCount);
+        openal->m_AllBuffers.SetSize(params->m_BufferCount);
+        openal->m_Buffers.SetCapacity(openal->m_AllBuffers.Capacity());
+        openal->m_Buffers.SetSize(openal->m_AllBuffers.Capacity());
+        alGenBuffers(params->m_BufferCount, openal->m_AllBuffers.Begin());
         CheckAndPrintError();
+
+        for (uint32_t i = 0; i < params->m_BufferCount; ++i)
+        {
+            openal->m_Buffers[i] = openal->m_AllBuffers[i];
+        }
 
         alGenSources(1, &openal->m_Source);
         CheckAndPrintError();
@@ -120,44 +128,12 @@ namespace dmDeviceOpenAL
         alcProcessContext(openal->m_Context);
 
         alSourceStop(openal->m_Source);
-
-        int iter = 0;
-        while (openal->m_Buffers.Size() != openal->m_Buffers.Capacity())
-        {
-            ALint num_queued = 0;
-            alcProcessContext(openal->m_Context);
-            alGetSourcei(openal->m_Source, AL_BUFFERS_QUEUED, &num_queued);
-            CheckAndPrintError();
-
-            while (num_queued > 0) {
-                ALuint buffer;
-                alSourceUnqueueBuffers(openal->m_Source, 1, &buffer);
-                if (CheckAndPrintError() != AL_NO_ERROR)
-                {
-                    dmLogError("Still buffers in OpenAL. Bailing.");
-                    break;
-                }
-
-                openal->m_Buffers.Push(buffer);
-
-                alGetSourcei(openal->m_Source, AL_BUFFERS_QUEUED, &num_queued);
-            }
-
-            if ((iter + 1) % 10 == 0) {
-                dmLogInfo("Waiting for OpenAL device to complete");
-            }
-            ++iter;
-            dmTime::Sleep(10 * 1000);
-
-            if (iter > 1000) {
-                dmLogError("Still buffers in OpenAL. Bailing.");
-                break;
-            }
-        }
+        CheckAndPrintError();
 
         alDeleteSources(1, &openal->m_Source);
+        CheckAndPrintError();
 
-        alDeleteBuffers(openal->m_Buffers.Size(), openal->m_Buffers.Begin());
+        alDeleteBuffers(openal->m_AllBuffers.Size(), openal->m_AllBuffers.Begin());
         CheckAndPrintError();
 
         bool active = alcMakeContextCurrent(0);

--- a/engine/sound/src/sound.cpp
+++ b/engine/sound/src/sound.cpp
@@ -764,14 +764,12 @@ namespace dmSound
         int ss_index = (g->m_NextMemorySlot - 1) % GROUP_MEMORY_BUFFER_COUNT;
         float max_peak_left_sq = 0;
         float max_peak_right_sq = 0;
-        int count = 0;
         while (left > 0) {
             max_peak_left_sq = dmMath::Max(max_peak_left_sq, g->m_PeakMemorySq[2 * ss_index + 0]);
             max_peak_right_sq = dmMath::Max(max_peak_right_sq, g->m_PeakMemorySq[2 * ss_index + 1]);
 
             left -= sound->m_FrameCount;
             ss_index = (ss_index - 1) % GROUP_MEMORY_BUFFER_COUNT;
-            count++;
         }
 
         *peak_left = sqrtf(max_peak_left_sq) / 32767.0f;


### PR DESCRIPTION
Instead of waiting for the OpenAL buffers to be finished processing, we instead stop the source and delete the buffers.
This seems to be the way it's done in 

### Technical changes

By looking at the public repo for [openal-soft](https://github.com/kcat/openal-soft)
they use a simpler approach:
https://github.com/kcat/openal-soft/blob/6675317107257c2cc16c947b359d557821d85bf2/examples/alstream.c#L115-L116

https://github.com/kcat/openal-soft/blob/6675317107257c2cc16c947b359d557821d85bf2/examples/common/alhelpers.c#L90-L104

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
