### PR TITLE
Fix for consecutive render list dispatches per component

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -110,6 +110,7 @@ namespace dmGameSystem
         dmRig::HRigContext              m_RigContext;
         uint32_t                        m_MaxElementsVertices;
         uint32_t                        m_MaxBatchIndex;
+        uint32_t                        m_DispatchCount;
     };
 
     static const uint32_t VERTEX_BUFFER_MAX_BATCHES = 16;     // Max dmRender::RenderListEntry.m_MinorOrder (4 bits)
@@ -768,9 +769,14 @@ namespace dmGameSystem
         const ModelComponent* component = render_item->m_Component;
         uint32_t material_index = render_item->m_MaterialIndex;
 
+        if (dmRender::GetBufferIndex(render_context, gfx_vertex_buffer) < world->m_DispatchCount)
+        {
+            dmRender::AddRenderBuffer(render_context, gfx_vertex_buffer);
+        }
+
         ro.Init();
         ro.m_VertexDeclaration = world->m_VertexDeclaration;
-        ro.m_VertexBuffer = (dmGraphics::HVertexBuffer) dmRender::AddRenderBuffer(render_context, gfx_vertex_buffer);
+        ro.m_VertexBuffer = (dmGraphics::HVertexBuffer) dmRender::GetBuffer(render_context, gfx_vertex_buffer);
         ro.m_PrimitiveType = dmGraphics::PRIMITIVE_TRIANGLES;
         ro.m_VertexStart = vb_begin - vertex_buffer.Begin();
         ro.m_VertexCount = vb_end - vb_begin;
@@ -910,13 +916,14 @@ namespace dmGameSystem
         }
 
         assert(world->m_MaxBatchIndex < VERTEX_BUFFER_MAX_BATCHES);
-        for (int i = 0; i < world->m_MaxBatchIndex; ++i)
+        for (int i = 0; i <= world->m_MaxBatchIndex; ++i)
         {
             dmRender::TrimBuffer(context->m_RenderContext, world->m_VertexBuffers[i]);
             dmRender::RewindBuffer(context->m_RenderContext, world->m_VertexBuffers[i]);
         }
 
         world->m_MaxBatchIndex = 0;
+        world->m_DispatchCount = 0;
 
         update_result.m_TransformsUpdated = rig_res == dmRig::RESULT_UPDATED_POSE;
         return dmGameObject::UPDATE_RESULT_OK;
@@ -947,6 +954,7 @@ namespace dmGameSystem
             case dmRender::RENDER_LIST_OPERATION_BEGIN:
             {
                 world->m_RenderObjects.SetSize(0);
+
                 for (uint32_t batch_index = 0; batch_index < VERTEX_BUFFER_MAX_BATCHES; ++batch_index)
                 {
                     world->m_VertexBufferData[batch_index].SetSize(0);
@@ -976,9 +984,10 @@ namespace dmGameSystem
                     total_count += vertex_buffer_data.Size();
                 }
 
+                world->m_DispatchCount++;
+
                 DM_PROPERTY_ADD_U32(rmtp_ModelVertexCount, total_count);
                 DM_PROPERTY_ADD_U32(rmtp_ModelVertexSize, total_count * sizeof(dmRig::RigModelVertex));
-
                 break;
             }
             default:

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -81,6 +81,7 @@ namespace dmGameSystem
         dmArray<uint8_t>                        m_VertexBufferData;
         uint32_t                                m_VerticesWritten;
         uint32_t                                m_EmitterCount;
+        uint32_t                                m_DispatchCount;
         float                                   m_DT;
         uint32_t                                m_WarnOutOfROs : 1;
     };
@@ -199,6 +200,7 @@ namespace dmGameSystem
         ParticleFXWorld* w   = (ParticleFXWorld*)params.m_World;
         w->m_DT              = params.m_UpdateContext->m_DT;
         w->m_VerticesWritten = 0;
+        w->m_DispatchCount   = 0;
 
         dmArray<ParticleFXComponent>& components = w->m_Components;
         if (components.Empty())
@@ -371,6 +373,11 @@ namespace dmGameSystem
         uint32_t ro_index = pfx_world->m_RenderObjects.Size();
         pfx_world->m_RenderObjects.SetSize(ro_index+1);
 
+        if (dmRender::GetBufferIndex(render_context, pfx_world->m_VertexBuffer) < pfx_world->m_DispatchCount)
+        {
+            dmRender::AddRenderBuffer(render_context, pfx_world->m_VertexBuffer);
+        }
+
         dmRender::RenderObject& ro = pfx_world->m_RenderObjects[ro_index];
         ro.Init();
         ro.m_Material          = material_res->m_Material;
@@ -378,7 +385,7 @@ namespace dmGameSystem
         ro.m_Textures[0]       = (dmGraphics::HTexture) first->m_Texture;
         ro.m_VertexStart       = vertex_offset;
         ro.m_VertexCount       = ro_vertex_count;
-        ro.m_VertexBuffer      = (dmGraphics::HVertexBuffer) dmRender::AddRenderBuffer(render_context, pfx_world->m_VertexBuffer);
+        ro.m_VertexBuffer      = (dmGraphics::HVertexBuffer) dmRender::GetBuffer(render_context, pfx_world->m_VertexBuffer);
         ro.m_PrimitiveType     = dmGraphics::PRIMITIVE_TRIANGLES;
         ro.m_SetBlendFactors   = 1;
 
@@ -418,6 +425,7 @@ namespace dmGameSystem
             DM_PROPERTY_ADD_U32(rmtp_ParticleVertexCount, pfx_world->m_VerticesWritten);
             DM_PROPERTY_ADD_U32(rmtp_ParticleVertexSize, pfx_world->m_VertexBufferData.Size());
 
+            pfx_world->m_DispatchCount++;
         }
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -120,6 +120,7 @@ namespace dmGameSystem
         uint32_t                        m_VertexMemorySize;
         uint32_t                        m_VertexCount;
         uint32_t                        m_IndexCount;
+        uint32_t                        m_DispatchCount;
         uint8_t*                        m_IndexBufferData;
         uint8_t*                        m_IndexBufferWritePtr;
         uint8_t                         m_Is16BitIndex : 1;
@@ -1308,10 +1309,15 @@ namespace dmGameSystem
         sprite_world->m_VertexBufferWritePtr = vb_iter;
         sprite_world->m_IndexBufferWritePtr = ib_iter;
 
+        if (dmRender::GetBufferIndex(render_context, sprite_world->m_VertexBuffer) < sprite_world->m_DispatchCount)
+        {
+            dmRender::AddRenderBuffer(render_context, sprite_world->m_VertexBuffer);
+        }
+
         ro.Init();
         ro.m_VertexDeclaration = vx_decl;
-        ro.m_VertexBuffer = (dmGraphics::HVertexBuffer) dmRender::AddRenderBuffer(render_context, sprite_world->m_VertexBuffer);
-        ro.m_IndexBuffer = (dmGraphics::HIndexBuffer) dmRender::AddRenderBuffer(render_context, sprite_world->m_IndexBuffer);
+        ro.m_VertexBuffer = (dmGraphics::HVertexBuffer) dmRender::GetBuffer(render_context, sprite_world->m_VertexBuffer);
+        ro.m_IndexBuffer = (dmGraphics::HIndexBuffer) dmRender::GetBuffer(render_context, sprite_world->m_IndexBuffer);
         ro.m_Material = material;
         for(uint32_t i = 0; i < resource->m_NumTextures; ++i)
         {
@@ -1640,6 +1646,8 @@ namespace dmGameSystem
         dmRender::TrimBuffer(sprite_context->m_RenderContext, world->m_IndexBuffer);
         dmRender::RewindBuffer(sprite_context->m_RenderContext, world->m_IndexBuffer);
 
+        world->m_DispatchCount = 0;
+
         return dmGameObject::UPDATE_RESULT_OK;
     }
 
@@ -1693,6 +1701,8 @@ namespace dmGameSystem
 
                         DM_PROPERTY_ADD_U32(rmtp_SpriteIndexSize, index_size);
                     }
+
+                    world->m_DispatchCount++;
                 }
                 break;
             default:

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -129,6 +129,7 @@ namespace dmGameSystem
 
         uint32_t                        m_MaxTilemapCount;
         uint32_t                        m_MaxTileCount;
+        uint32_t                        m_DispatchCount;
     };
 
     static void TileGridWorldAllocate(TileGridWorld* world)
@@ -514,6 +515,7 @@ namespace dmGameSystem
         TilemapContext* context = (TilemapContext*)params.m_Context;
         dmRender::TrimBuffer(context->m_RenderContext, world->m_VertexBuffer);
         dmRender::RewindBuffer(context->m_RenderContext, world->m_VertexBuffer);
+        world->m_DispatchCount = 0;
 
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -648,9 +650,14 @@ namespace dmGameSystem
         TileGridVertex* vb_begin = world->m_VertexBufferWritePtr;
         world->m_VertexBufferWritePtr = CreateVertexData(world, vb_begin, texture_set, buf, begin, end);
 
+        if (dmRender::GetBufferIndex(render_context, world->m_VertexBuffer) < world->m_DispatchCount)
+        {
+            dmRender::AddRenderBuffer(render_context, world->m_VertexBuffer);
+        }
+
         ro.Init();
         ro.m_VertexDeclaration = world->m_VertexDeclaration;
-        ro.m_VertexBuffer      = (dmGraphics::HVertexBuffer) dmRender::AddRenderBuffer(render_context, world->m_VertexBuffer);
+        ro.m_VertexBuffer      = (dmGraphics::HVertexBuffer) dmRender::GetBuffer(render_context, world->m_VertexBuffer);
         ro.m_PrimitiveType = dmGraphics::PRIMITIVE_TRIANGLES;
         ro.m_VertexStart = vb_begin - world->m_VertexBufferData;
         ro.m_VertexCount = (world->m_VertexBufferWritePtr - vb_begin);
@@ -716,6 +723,8 @@ namespace dmGameSystem
                 DM_PROPERTY_ADD_U32(rmtp_TilemapTileCount, vertex_count/6);
                 DM_PROPERTY_ADD_U32(rmtp_TilemapVertexCount, vertex_count);
                 DM_PROPERTY_ADD_U32(rmtp_TilemapVertexSize, vertex_count * sizeof(TileGridVertex));
+
+                world->m_DispatchCount++;
             }
             break;
 

--- a/engine/render/src/render/buffer.cpp
+++ b/engine/render/src/render/buffer.cpp
@@ -72,10 +72,10 @@ namespace dmRender
         delete buffer;
     }
 
-    HRenderBuffer AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
+    void AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
     {
         if (!buffer)
-            return 0;
+            return;
 
         if (render_context->m_MultiBufferingRequired)
         {
@@ -91,18 +91,10 @@ namespace dmRender
                 CreateAndPush(render_context, buffer);
             }
         }
-        else
-        {
-            buffer->m_BufferIndex = 0;
-        }
-        return buffer->m_Buffers[buffer->m_BufferIndex];
     }
 
     void SetBufferData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t size, void* data, dmGraphics::BufferUsage buffer_usage)
     {
-        if (buffer->m_BufferIndex < 0)
-            return;
-
         switch(buffer->m_Type)
         {
             case RENDER_BUFFER_TYPE_VERTEX_BUFFER:
@@ -134,10 +126,20 @@ namespace dmRender
         buffer->m_Buffers.SetSize(new_buffer_count);
     }
 
+    HRenderBuffer GetBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
+    {
+        return buffer->m_Buffers[buffer->m_BufferIndex];
+    }
+
+    int32_t GetBufferIndex(HRenderContext render_context, HBufferedRenderBuffer buffer)
+    {
+        return buffer->m_BufferIndex;
+    }
+
     void RewindBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
     {
         if (!buffer)
             return;
-        buffer->m_BufferIndex = -1;
+        buffer->m_BufferIndex = 0;
     }
 }

--- a/engine/render/src/render/buffer.cpp
+++ b/engine/render/src/render/buffer.cpp
@@ -72,10 +72,10 @@ namespace dmRender
         delete buffer;
     }
 
-    void AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
+    HRenderBuffer AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
     {
         if (!buffer)
-            return;
+            return 0;
 
         if (render_context->m_MultiBufferingRequired)
         {
@@ -91,6 +91,8 @@ namespace dmRender
                 CreateAndPush(render_context, buffer);
             }
         }
+
+        return buffer->m_Buffers[buffer->m_BufferIndex];
     }
 
     void SetBufferData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t size, void* data, dmGraphics::BufferUsage buffer_usage)

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -292,7 +292,9 @@ namespace dmRender
      */
     HBufferedRenderBuffer           NewBufferedRenderBuffer(HRenderContext render_context, RenderBufferType type);
     void                            DeleteBufferedRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
-    HRenderBuffer                   AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
+    void                            AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
+    HRenderBuffer                   GetBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
+    int32_t                         GetBufferIndex(HRenderContext render_context, HBufferedRenderBuffer buffer);
     void                            SetBufferData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t size, void* data, dmGraphics::BufferUsage buffer_usage);
     void                            TrimBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     void                            RewindBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -292,7 +292,7 @@ namespace dmRender
      */
     HBufferedRenderBuffer           NewBufferedRenderBuffer(HRenderContext render_context, RenderBufferType type);
     void                            DeleteBufferedRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
-    void                            AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
+    HRenderBuffer                   AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     HRenderBuffer                   GetBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     int32_t                         GetBufferIndex(HRenderContext render_context, HBufferedRenderBuffer buffer);
     void                            SetBufferData(HRenderContext render_context, HBufferedRenderBuffer buffer, uint32_t size, void* data, dmGraphics::BufferUsage buffer_usage);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -275,7 +275,7 @@ namespace dmRender
     {
         dmArray<HRenderBuffer> m_Buffers;
         RenderBufferType       m_Type;
-        int16_t                m_BufferIndex;
+        uint16_t               m_BufferIndex;
     };
 
     void RenderTypeTextBegin(HRenderContext rendercontext, void* user_context);

--- a/engine/render/src/test/test_render_buffer.cpp
+++ b/engine/render/src/test/test_render_buffer.cpp
@@ -90,6 +90,7 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferSimple)
 
 TEST_F(dmRenderBufferTest, TestBufferedRenderBufferSetData)
 {
+    // We start off with 1 buffer, so size == 1
     dmRender::HBufferedRenderBuffer buffer = dmRender::NewBufferedRenderBuffer(m_RenderContext, dmRender::RENDER_BUFFER_TYPE_VERTEX_BUFFER);
     ASSERT_NE((void*) 0x0, buffer);
     ASSERT_EQ(1, buffer->m_Buffers.Size());
@@ -98,13 +99,13 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferSetData)
     m_RenderContext->m_MultiBufferingRequired = 1;
 
     dmRender::HRenderBuffer render_buffer_1 = dmRender::AddRenderBuffer(m_RenderContext, buffer);
-    ASSERT_EQ(1, buffer->m_Buffers.Size());
+    ASSERT_EQ(2, buffer->m_Buffers.Size());
 
     uint8_t buffer_1[] = { 255, 255, 0, 255 };
     dmRender::SetBufferData(m_RenderContext, buffer, sizeof(buffer_1), buffer_1, dmGraphics::BUFFER_USAGE_STATIC_DRAW);
 
     dmRender::HRenderBuffer render_buffer_2 = dmRender::AddRenderBuffer(m_RenderContext, buffer);
-    ASSERT_EQ(2, buffer->m_Buffers.Size());
+    ASSERT_EQ(3, buffer->m_Buffers.Size());
 
     uint8_t buffer_2[] = { 0, 127, 255, 127 };
     dmRender::SetBufferData(m_RenderContext, buffer, sizeof(buffer_2), buffer_2, dmGraphics::BUFFER_USAGE_STATIC_DRAW);
@@ -127,6 +128,7 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAddAndTrim)
     dmRender::HBufferedRenderBuffer buffer = dmRender::NewBufferedRenderBuffer(m_RenderContext, dmRender::RENDER_BUFFER_TYPE_VERTEX_BUFFER);
     ASSERT_NE((void*) 0x0, buffer);
     ASSERT_EQ(1, buffer->m_Buffers.Size());
+    ASSERT_EQ(0, buffer->m_BufferIndex);
 
     // Test that non-multi buffering doesn't allocate more than one buffers
     m_RenderContext->m_MultiBufferingRequired = 0;
@@ -135,8 +137,11 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAddAndTrim)
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
     ASSERT_EQ(1, buffer->m_Buffers.Size());
+    ASSERT_EQ(0, buffer->m_BufferIndex);
 
     dmRender::RewindBuffer(m_RenderContext, buffer);
+    ASSERT_EQ(0, buffer->m_BufferIndex);
+
     dmRender::TrimBuffer(m_RenderContext, buffer);
     ASSERT_EQ(1, buffer->m_Buffers.Size());
 
@@ -146,21 +151,25 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAddAndTrim)
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
-    ASSERT_EQ(3, buffer->m_Buffers.Size());
+    ASSERT_EQ(4, buffer->m_Buffers.Size());
+
+    dmRender::TrimBuffer(m_RenderContext, buffer);
+    ASSERT_EQ(4, buffer->m_Buffers.Size());
+    ASSERT_EQ(3, buffer->m_BufferIndex);
+
+    dmRender::RewindBuffer(m_RenderContext, buffer);
+    ASSERT_EQ(0, buffer->m_BufferIndex);
+    ASSERT_EQ(4, buffer->m_Buffers.Size());
+
+    dmRender::AddRenderBuffer(m_RenderContext, buffer);
+    ASSERT_EQ(1, buffer->m_BufferIndex);
+
+    dmRender::AddRenderBuffer(m_RenderContext, buffer);
+    ASSERT_EQ(2, buffer->m_BufferIndex);
 
     dmRender::TrimBuffer(m_RenderContext, buffer);
     ASSERT_EQ(3, buffer->m_Buffers.Size());
     ASSERT_EQ(2, buffer->m_BufferIndex);
-
-    dmRender::RewindBuffer(m_RenderContext, buffer);
-    ASSERT_EQ(0, buffer->m_BufferIndex);
-
-    dmRender::AddRenderBuffer(m_RenderContext, buffer);
-    dmRender::AddRenderBuffer(m_RenderContext, buffer);
-
-    dmRender::TrimBuffer(m_RenderContext, buffer);
-    ASSERT_EQ(2, buffer->m_Buffers.Size());
-    ASSERT_EQ(1, buffer->m_BufferIndex);
 
     dmRender::RewindBuffer(m_RenderContext, buffer);
     dmRender::TrimBuffer(m_RenderContext, buffer);

--- a/engine/render/src/test/test_render_buffer.cpp
+++ b/engine/render/src/test/test_render_buffer.cpp
@@ -122,7 +122,7 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferSetData)
     m_RenderContext->m_MultiBufferingRequired = m_MultiBufferingRequired;
 }
 
-TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAdvanceAndTrim)
+TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAddAndTrim)
 {
     dmRender::HBufferedRenderBuffer buffer = dmRender::NewBufferedRenderBuffer(m_RenderContext, dmRender::RENDER_BUFFER_TYPE_VERTEX_BUFFER);
     ASSERT_NE((void*) 0x0, buffer);
@@ -153,7 +153,7 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAdvanceAndTrim)
     ASSERT_EQ(2, buffer->m_BufferIndex);
 
     dmRender::RewindBuffer(m_RenderContext, buffer);
-    ASSERT_EQ(-1, buffer->m_BufferIndex);
+    ASSERT_EQ(0, buffer->m_BufferIndex);
 
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
     dmRender::AddRenderBuffer(m_RenderContext, buffer);
@@ -165,7 +165,7 @@ TEST_F(dmRenderBufferTest, TestBufferedRenderBufferAdvanceAndTrim)
     dmRender::RewindBuffer(m_RenderContext, buffer);
     dmRender::TrimBuffer(m_RenderContext, buffer);
     ASSERT_EQ(1, buffer->m_Buffers.Size());
-    ASSERT_EQ(-1, buffer->m_BufferIndex);
+    ASSERT_EQ(0, buffer->m_BufferIndex);
 
     dmRender::DeleteBufferedRenderBuffer(m_RenderContext, buffer);
 


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
