### PR TITLE
Add hot reload functionality for label component.

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_label.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_label.cpp
@@ -220,6 +220,20 @@ namespace dmGameSystem
         return delta_pivot;
     }
 
+    void InitParametersFromDescription(LabelComponent* label_component, dmGameSystemDDF::LabelDesc* label_desc)
+    {
+        label_component->m_Size     = Vector3(label_desc->m_Size[0], label_desc->m_Size[1], label_desc->m_Size[2]);
+        label_component->m_Color    = Vector4(label_desc->m_Color[0], label_desc->m_Color[1], label_desc->m_Color[2], label_desc->m_Color[3]);
+        label_component->m_Outline  = Vector4(label_desc->m_Outline[0], label_desc->m_Outline[1], label_desc->m_Outline[2], label_desc->m_Outline[3]);
+        label_component->m_Shadow   = Vector4(label_desc->m_Shadow[0], label_desc->m_Shadow[1], label_desc->m_Shadow[2], label_desc->m_Shadow[3]);
+        label_component->m_Pivot    = label_desc->m_Pivot;
+        label_component->m_Text = label_desc->m_Text;
+        label_component->m_ReHash = 1;
+        label_component->m_Leading = label_desc->m_Leading;
+        label_component->m_Tracking = label_desc->m_Tracking;
+        label_component->m_LineBreak = label_desc->m_LineBreak;
+    }
+
     dmGameObject::CreateResult CompLabelCreate(const dmGameObject::ComponentCreateParams& params)
     {
         LabelWorld* world = (LabelWorld*)params.m_World;
@@ -237,26 +251,18 @@ namespace dmGameSystem
         LabelComponent* component = &world->m_Components.Get(index);
         memset(component, 0, sizeof(LabelComponent));
         component->m_Instance = params.m_Instance;
-        component->m_Size     = Vector3(ddf->m_Size[0], ddf->m_Size[1], ddf->m_Size[2]);
         component->m_Scale    = params.m_Scale;
         component->m_Position = params.m_Position;
         component->m_Rotation = params.m_Rotation;
-        component->m_Color    = Vector4(ddf->m_Color[0], ddf->m_Color[1], ddf->m_Color[2], ddf->m_Color[3]);
-        component->m_Outline  = Vector4(ddf->m_Outline[0], ddf->m_Outline[1], ddf->m_Outline[2], ddf->m_Outline[3]);
-        component->m_Shadow   = Vector4(ddf->m_Shadow[0], ddf->m_Shadow[1], ddf->m_Shadow[2], ddf->m_Shadow[3]);
         component->m_Resource = resource;
-        component->m_Pivot    = ddf->m_Pivot;
         component->m_RenderConstants = 0;
         component->m_ListenerInstance = 0x0;
         component->m_ListenerComponent = 0xff;
         component->m_ComponentIndex = params.m_ComponentIndex;
         component->m_Enabled = 1;
-        component->m_Text = ddf->m_Text;
         component->m_UserAllocatedText = 0;
-        component->m_ReHash = 1;
-        component->m_Leading = ddf->m_Leading;
-        component->m_Tracking = ddf->m_Tracking;
-        component->m_LineBreak = ddf->m_LineBreak;
+
+        InitParametersFromDescription(component, ddf);
 
         *params.m_UserData = (uintptr_t)index;
         return dmGameObject::CREATE_RESULT_OK;
@@ -543,7 +549,12 @@ namespace dmGameSystem
 
     void CompLabelOnReload(const dmGameObject::ComponentOnReloadParams& params)
     {
-        (void)params;
+        LabelResource* resource = (LabelResource*)params.m_Resource;
+        dmGameSystemDDF::LabelDesc* ddf = resource->m_DDF;
+
+        LabelWorld* label_world = (LabelWorld*)params.m_World;
+        LabelComponent* component = &label_world->m_Components.Get(*params.m_UserData);
+        InitParametersFromDescription(component, ddf);
     }
 
     void* CompLabelGetComponent(const dmGameObject::ComponentGetParams& params)


### PR DESCRIPTION
Add hot reload functionality for label component.
Reread properties from reloaded label resource and mark component to be rehashed.

Fixes #3467

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
