### PR TITLE
Fix http request timeout usage in HTML5 build

### DIFF
--- a/engine/script/src/script_http.cpp
+++ b/engine/script/src/script_http.cpp
@@ -84,9 +84,9 @@ namespace dmScript
      * @param [options] [type:table] optional table with request parameters. Supported entries:
      *
      * - [type:number] `timeout`: timeout in seconds
-     * - [type:string] `path`: path on disc where to download the file. Only overwrites the path if status is 200
-     * - [type:boolean] `ignore_cache`: don't return cached data if we get a 304
-     * - [type:boolean] `chunked_transfer`: use chunked transfer encoding for https requests larger than 16kb. Defaults to true.
+     * - [type:string] `path`: path on disc where to download the file. Only overwrites the path if status is 200. [icon:attention] Not available in HTML5 build
+     * - [type:boolean] `ignore_cache`: don't return cached data if we get a 304. [icon:attention] Not available in HTML5 build
+     * - [type:boolean] `chunked_transfer`: use chunked transfer encoding for https requests larger than 16kb. Defaults to true. [icon:attention] Not available in HTML5 build
      *
      *
      * @examples

--- a/engine/script/src/script_http_js.cpp
+++ b/engine/script/src/script_http_js.cpp
@@ -50,15 +50,27 @@ namespace dmScript
     struct RequestContext
     {
         dmMessage::URL  m_Requester;
+        void*           m_RequestData;
         int             m_Callback;
+    };
+
+    struct RequestParams
+    {
+        const char* m_Method;
+        const char* m_Url;
+        const char* m_Headers;
+        void* m_Args;
+        void* m_SendData;
+        size_t m_SendDataLength;
+        uint64_t m_RequestTimeout;
     };
 
     extern "C" void dmScriptHttpRequestAsync(const char* method, const char* url, const char* headers, void* arg, OnLoad onload, OnError onerror, const void* send_data, int send_data_length, int timeout);
 
-    void HttpRequestAsync(const char* method, const char* url, const char* headers, void *arg, OnLoad ol, OnError oe, const void* send_data, int send_data_length)
+    void HttpRequestAsync(const RequestParams& request_params, OnLoad ol, OnError oe)
     {
-        int timeout  = (int) g_Timeout;
-        dmScriptHttpRequestAsync(method, url, headers, arg, ol, oe, send_data, send_data_length, timeout);
+        dmScriptHttpRequestAsync(request_params.m_Method, request_params.m_Url, request_params.m_Headers,
+            request_params.m_Args, ol, oe, request_params.m_SendData, request_params.m_SendDataLength, request_params.m_RequestTimeout);
     }
 
     static void MessageDestroyCallback(dmMessage::Message* message)
@@ -96,6 +108,7 @@ namespace dmScript
     {
         RequestContext* ctx = (RequestContext*) context;
         SendResponse(ctx, status, headers, strlen(headers), (const char*) content, content_size);
+        free(ctx->m_RequestData);
         delete ctx;
     }
 
@@ -112,9 +125,11 @@ namespace dmScript
         int callback = 0;
         dmMessage::URL sender;
         if (dmScript::GetURL(L, &sender)) {
+            RequestParams request_params;
+            memset(&request_params, 0, sizeof(RequestParams));
 
-            const char* url = luaL_checkstring(L, 1);
-            const char* method = luaL_checkstring(L, 2);
+            request_params.m_Url = luaL_checkstring(L, 1);
+            request_params.m_Method = luaL_checkstring(L, 2);
             luaL_checktype(L, 3, LUA_TFUNCTION);
             lua_pushvalue(L, 3);
             // NOTE: By convention the runctionref is offset by LUA_NOREF
@@ -144,19 +159,18 @@ namespace dmScript
                 lua_pop(L, 1);
             }
             h.Push('\0');
+            request_params.m_Headers = h.Begin();
 
-            char* request_data = 0;
-            int request_data_length = 0;
             if (top > 4 && !lua_isnil(L, 5)) {
                 size_t len;
                 luaL_checktype(L, 5, LUA_TSTRING);
                 const char* r = luaL_checklstring(L, 5, &len);
-                request_data = (char*) malloc(len);
-                memcpy(request_data, r, len);
-                request_data_length = len;
+                request_params.m_SendData = (char*) malloc(len);
+                memcpy(request_params.m_SendData, r, len);
+                request_params.m_SendDataLength = len;
             }
 
-            uint64_t timeout = g_Timeout;
+            request_params.m_RequestTimeout = g_Timeout;
             if (top > 5 && !lua_isnil(L, 6)) {
                 luaL_checktype(L, 6, LUA_TTABLE);
                 lua_pushvalue(L, 6);
@@ -165,7 +179,7 @@ namespace dmScript
                     const char* attr = lua_tostring(L, -2);
                     if( strcmp(attr, "timeout") == 0 )
                     {
-                        timeout = luaL_checknumber(L, -1) * 1000000.0f;
+                        request_params.m_RequestTimeout = luaL_checknumber(L, -1) * 1000000.0f;
                     }
                     lua_pop(L, 1);
                 }
@@ -175,8 +189,11 @@ namespace dmScript
             RequestContext* ctx = new RequestContext;
             ctx->m_Callback = callback;
             ctx->m_Requester = sender;
+            ctx->m_RequestData = request_params.m_SendData;
 
-            HttpRequestAsync(method, url, h.Begin(), ctx, OnHttpLoad, OnHttpError, request_data, request_data_length);
+            request_params.m_Args = ctx;
+
+            HttpRequestAsync(request_params, OnHttpLoad, OnHttpError);
             assert(top == lua_gettop(L));
             return 0;
         } else {


### PR DESCRIPTION
* Fix timeout option usage in http module for HTML5 implementation. 
* Update `http` module documentation.
* Wrap `HttpRequestAsync` arguments with struct.
* Fix possible memory leak.


Fixes #8235.
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
