### PR TITLE
Slightly improve editor memory usage for large projects

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -3087,10 +3087,8 @@
         child-indices (g/node-value parent :child-indices)
         before? (partial > node-index)
         after? (partial < node-index)
-        ascending-order #(compare %1 %2)
-        descending-order #(compare %2 %1)
         neighbour (first (sort-by second
-                                  (if (= offset -1) descending-order ascending-order)
+                                  (if (= offset -1) coll/descending-order coll/ascending-order)
                                   (filter (comp (if (= offset -1) before? after?) second)
                                           child-indices)))]
     (when neighbour

--- a/editor/src/clj/editor/math.clj
+++ b/editor/src/clj/editor/math.clj
@@ -39,6 +39,19 @@
   ^double [^double rad]
   (* rad 180.0 recip-pi))
 
+(defn median [numbers]
+  (let [sorted-numbers (sort numbers)
+        count (count sorted-numbers)]
+    (if (zero? count)
+      (throw (ex-info "Cannot calculate the median of an empty sequence." {:numbers numbers}))
+      (let [middle-index (quot count 2)
+            middle-number (nth sorted-numbers middle-index)]
+        (if (odd? count)
+          middle-number
+          (-> middle-number
+              (+ (nth sorted-numbers (dec middle-index)))
+              (/ 2.0)))))))
+
 (defn round-with-precision
   "Slow but precise rounding to a specified precision. Use with UI elements that
   produce doubles, not for performance-sensitive code. The precision is expected

--- a/editor/src/clj/editor/welcome.clj
+++ b/editor/src/clj/editor/welcome.clj
@@ -35,6 +35,7 @@
             [editor.ui.fuzzy-choices :as fuzzy-choices]
             [editor.ui.updater :as ui.updater]
             [schema.core :as s]
+            [util.coll :as coll]
             [util.net :as net]
             [util.time :as time])
   (:import [clojure.lang ExceptionInfo]
@@ -194,9 +195,6 @@
                    :last-opened instant
                    :title title})))))))
 
-(defn- descending-order [a b]
-  (compare b a))
-
 (defn- recent-projects
   "Returns a sequence of recently opened projects. Project files that no longer
   exist will be filtered out. If the user has an older preference file that does
@@ -205,7 +203,7 @@
   the most recently opened project first."
   [prefs]
   (sort-by :last-opened
-           descending-order
+           coll/descending-order
            (if-some [timestamps-by-path (prefs/get-prefs prefs recent-projects-prefs-key nil)]
              (into [] xform-timestamps-by-path->recent-projects timestamps-by-path)
              (if-some [paths (prefs/get-prefs prefs legacy-recent-project-paths-prefs-key nil)]

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -13,7 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns internal.graph.types
-  (:import [clojure.lang IHashEq Keyword]
+  (:import [clojure.lang IHashEq Keyword Murmur3 Util]
            [com.defold.util WeakInterner]
            [java.io Writer]))
 
@@ -28,6 +28,9 @@
 (defn target-label [^Arc arc] (.target-label arc))
 (defn target [^Arc arc] [(.target-id arc) (.target-label arc)])
 
+(definline node-id-hash [node-id]
+  `(Murmur3/hashLong ~node-id))
+
 (deftype Endpoint [^Long node-id ^Keyword label]
   Comparable
   (compareTo [_ that]
@@ -38,15 +41,15 @@
         node-id-comparison)))
   IHashEq
   (hasheq [_]
-    (unchecked-add-int
-      (unchecked-multiply-int 31 (.hashCode node-id))
+    (Util/hashCombine
+      (node-id-hash node-id)
       (.hasheq label)))
   Object
   (toString [_]
     (str "#g/endpoint [" node-id " " label "]"))
   (hashCode [_]
-    (unchecked-add-int
-      (unchecked-multiply-int 31 (.hashCode node-id))
+    (Util/hashCombine
+      (node-id-hash node-id)
       (.hasheq label)))
   (equals [this that]
     (or (identical? this that)

--- a/editor/src/clj/internal/graph/types.clj
+++ b/editor/src/clj/internal/graph/types.clj
@@ -18,6 +18,7 @@
            [java.io Writer]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defrecord Arc [source-id source-label target-id target-label])
 
@@ -31,11 +32,11 @@
 (definline node-id-hash [node-id]
   `(Murmur3/hashLong ~node-id))
 
-(deftype Endpoint [^Long node-id ^Keyword label]
+(deftype Endpoint [^long node-id ^Keyword label]
   Comparable
   (compareTo [_ that]
     (let [^Endpoint that that
-          node-id-comparison (.compareTo node-id (.-node-id that))]
+          node-id-comparison (Long/compare node-id (.-node-id that))]
       (if (zero? node-id-comparison)
         (.compareTo label (.-label that))
         node-id-comparison)))
@@ -54,10 +55,8 @@
   (equals [this that]
     (or (identical? this that)
         (and (instance? Endpoint that)
-             (let [^Endpoint that that]
-               (and
-                 (.equals (.-node-id that) node-id)
-                 (.equals (.-label that) label)))))))
+             (= node-id (.-node-id ^Endpoint that))
+             (identical? label (.-label ^Endpoint that))))))
 
 (defmethod print-method Endpoint [^Endpoint ep ^Writer writer]
   (.write writer "#g/endpoint [")

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -21,6 +21,16 @@
 
 (def empty-sorted-map (sorted-map))
 
+(defn ascending-order
+  "Comparator that orders items in ascending order."
+  [a b]
+  (compare a b))
+
+(defn descending-order
+  "Comparator that orders items in descending order."
+  [a b]
+  (compare b a))
+
 (defn supports-transient?
   "Returns true if the supplied persistent collection can be made into a
   transient collection."

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -637,25 +637,13 @@
 (defn weak-interner-stats [^WeakInterner weak-interner]
   (let [info (weak-interner-info weak-interner)
         hash-table (:hash-table info)
-        entry-count (int (:count info))
+        entry-count (:count info)
         capacity (count hash-table)
         occupancy-factor (/ (double entry-count) (double capacity))
 
-        augmented-hash-table
-        (into []
-              (map-indexed
-                (fn [^long index entry-info]
-                  (when entry-info
-                    (let [ideal-index (mod (int (:hash-value entry-info)) capacity)
-                          displacement (case (:status entry-info)
-                                         :removed 0
-                                         (mod (- index ideal-index) capacity))]
-                      (assoc entry-info :displacement displacement)))))
-              hash-table)
-
-        displacement-frequencies
-        (->> augmented-hash-table
-             (keep :displacement)
+        attempt-frequencies
+        (->> hash-table
+             (keep :attempt)
              (frequencies)
              (into (sorted-map-by coll/descending-order)))]
 
@@ -663,7 +651,7 @@
      :capacity capacity
      :growth-threshold (:growth-threshold info)
      :occupancy-factor (math/round-with-precision occupancy-factor math/precision-general)
-     :displacement-frequencies displacement-frequencies}))
+     :attempt-frequencies attempt-frequencies}))
 
 (defn endpoint-interner-stats []
   (System/gc)

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -645,15 +645,30 @@
         (->> hash-table
              (keep :attempt)
              (frequencies)
-             (into (sorted-map-by coll/descending-order)))]
+             (into (sorted-map-by coll/descending-order)))
+
+        elapsed-nanosecond-values
+        (keep :elapsed hash-table)
+
+        median-elapsed-nanoseconds
+        (->> elapsed-nanosecond-values
+             (math/median)
+             (long))
+
+        max-elapsed-nanoseconds
+        (->> elapsed-nanosecond-values
+             (reduce max Long/MIN_VALUE))]
 
     {:count entry-count
      :capacity capacity
      :growth-threshold (:growth-threshold info)
      :occupancy-factor (math/round-with-precision occupancy-factor math/precision-general)
+     :median-elapsed-nanoseconds median-elapsed-nanoseconds
+     :max-elapsed-nanoseconds max-elapsed-nanoseconds
      :attempt-frequencies attempt-frequencies}))
 
 (defn endpoint-interner-stats []
+  ;; Trigger a GC and give it a moment to clear out unused weak references.
   (System/gc)
   (Thread/sleep 500)
   (weak-interner-stats gt/endpoint-interner))

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -651,13 +651,17 @@
         (keep :elapsed hash-table)
 
         median-elapsed-nanoseconds
-        (->> elapsed-nanosecond-values
-             (math/median)
-             (long))
+        (if (empty? elapsed-nanosecond-values)
+          0
+          (->> elapsed-nanosecond-values
+               (math/median)
+               (long)))
 
         max-elapsed-nanoseconds
-        (->> elapsed-nanosecond-values
-             (reduce max Long/MIN_VALUE))]
+        (if (empty? elapsed-nanosecond-values)
+          0
+          (->> elapsed-nanosecond-values
+               (reduce max Long/MIN_VALUE)))]
 
     {:count entry-count
      :capacity capacity

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -641,6 +641,11 @@
         capacity (count hash-table)
         occupancy-factor (/ (double entry-count) (double capacity))
 
+        next-capacity
+        (util/first-where
+          #(< capacity %)
+          (:growth-sequence info))
+
         attempt-frequencies
         (->> hash-table
              (keep :attempt)
@@ -665,6 +670,7 @@
 
     {:count entry-count
      :capacity capacity
+     :next-capacity next-capacity
      :growth-threshold (:growth-threshold info)
      :occupancy-factor (math/round-with-precision occupancy-factor math/precision-general)
      :median-elapsed-nanoseconds median-elapsed-nanoseconds

--- a/editor/src/java/com/defold/util/WeakInterner.java
+++ b/editor/src/java/com/defold/util/WeakInterner.java
@@ -79,12 +79,12 @@ public final class WeakInterner<T> {
             if (entry == null) {
                 entryInfo = null;
             } else if (entry == removedSentinelEntry) {
-                entryInfo = Map.of("status", "removed", "hashValue", entry.hashValue);
+                entryInfo = Map.of("status", "removed", "hash-value", entry.hashValue);
             } else {
                 final Object value = entry.get();
                 entryInfo = value == null
-                        ? Map.of("status", "stale", "hashValue", entry.hashValue)
-                        : Map.of("status", "valid", "hashValue", entry.hashValue, "value", value);
+                        ? Map.of("status", "stale", "hash-value", entry.hashValue)
+                        : Map.of("status", "valid", "hash-value", entry.hashValue, "value", value);
             }
 
             hashTableInfos.add(entryInfo);
@@ -92,9 +92,8 @@ public final class WeakInterner<T> {
 
         return Map.of(
                 "count", count,
-                "growthThreshold", growthThreshold,
-                "loadFactor", loadFactor,
-                "hashTable", Collections.unmodifiableList(hashTableInfos)
+                "growth-threshold", growthThreshold,
+                "hash-table", Collections.unmodifiableList(hashTableInfos)
         );
     }
 

--- a/editor/src/java/com/defold/util/WeakInterner.java
+++ b/editor/src/java/com/defold/util/WeakInterner.java
@@ -35,11 +35,27 @@ public final class WeakInterner<T> {
     private final Entry<T> removedSentinelEntry;
 
     static {
-        PRIME_CAPACITY_SEQUENCE = new int[30];
+        final ArrayList<Integer> primeCapacitySequence = new ArrayList<>();
+
+        for (int i = 0, len = 30; i < len; ++i) {
+            final int powerOfTwo = 1 << (i + 1);
+            final boolean addSubsteps = i > 21;
+
+            if (addSubsteps) {
+                primeCapacitySequence.add(getNextPrime(powerOfTwo + powerOfTwo / 4));
+            }
+
+            primeCapacitySequence.add(getNextPrime(powerOfTwo + powerOfTwo / 2));
+
+            if (addSubsteps) {
+                primeCapacitySequence.add(getNextPrime(powerOfTwo + powerOfTwo / 4 * 3));
+            }
+        }
+
+        PRIME_CAPACITY_SEQUENCE = new int[primeCapacitySequence.size()];
 
         for (int i = 0, len = PRIME_CAPACITY_SEQUENCE.length; i < len; ++i) {
-            final int powerOfTwo = 1 << (i + 1);
-            PRIME_CAPACITY_SEQUENCE[i] = getNextPrime(powerOfTwo + powerOfTwo / 2);
+            PRIME_CAPACITY_SEQUENCE[i] = primeCapacitySequence.get(i);
         }
 
         MAX_CAPACITY = PRIME_CAPACITY_SEQUENCE[PRIME_CAPACITY_SEQUENCE.length - 1];

--- a/editor/src/java/com/defold/util/WeakInterner.java
+++ b/editor/src/java/com/defold/util/WeakInterner.java
@@ -18,6 +18,9 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.*;
 
+// Sources:
+// https://www.scaler.com/topics/data-structures/open-addressing/
+
 public final class WeakInterner<T> {
     private static final int MAX_CAPACITY = 1 << 30;
     private static final float DEFAULT_LOAD_FACTOR = 0.75f;
@@ -79,10 +82,11 @@ public final class WeakInterner<T> {
             if (entry == null) {
                 entryInfo = null;
             } else if (entry == removedSentinelEntry) {
-                entryInfo = Map.of("status", "removed", "hash-value", entry.hashValue, "attempts", 0);
+                entryInfo = Map.of("status", "removed", "hash-value", entry.hashValue, "attempt", 0, "elapsed", 0);
             } else {
                 final int hashValue = entry.hashValue;
                 int attempt = 0;
+                final long startTime = System.nanoTime();
 
                 while (attempt < capacity) {
                     final int index = getSlotIndex(hashValue, attempt, capacity);
@@ -94,10 +98,11 @@ public final class WeakInterner<T> {
                     ++attempt;
                 }
 
+                final long elapsed = System.nanoTime() - startTime;
                 final Object value = entry.get();
                 entryInfo = value == null
-                        ? Map.of("status", "stale", "hash-value", hashValue, "attempt", attempt)
-                        : Map.of("status", "valid", "hash-value", hashValue, "attempt", attempt, "value", value);
+                        ? Map.of("status", "stale", "hash-value", hashValue, "attempt", attempt, "elapsed", elapsed)
+                        : Map.of("status", "valid", "hash-value", hashValue, "attempt", attempt, "elapsed", elapsed, "value", value);
             }
 
             hashTableInfos.add(entryInfo);

--- a/editor/test/util/weak_interner_test.clj
+++ b/editor/test/util/weak_interner_test.clj
@@ -27,40 +27,40 @@
 
 (deftest interning-test
   (let [weak-interner (WeakInterner. 16)
-        interned-endpoint (.intern weak-interner (gt/endpoint 12345 :label))]
-    (is (= interned-endpoint (gt/endpoint 12345 :label)))
-    (is (identical? interned-endpoint (.intern weak-interner (gt/endpoint 12345 :label))))))
+        interned-endpoint (.intern weak-interner (gt/->Endpoint 12345 :label))]
+    (is (= interned-endpoint (gt/->Endpoint 12345 :label)))
+    (is (identical? interned-endpoint (.intern weak-interner (gt/->Endpoint 12345 :label))))))
 
 (deftest growth-test
   (let [weak-interner (WeakInterner. 0)
-        first-endpoint (.intern weak-interner (gt/endpoint 1 :first))
-        second-endpoint (.intern weak-interner (gt/endpoint 2 :second))
-        third-endpoint (.intern weak-interner (gt/endpoint 3 :third))]
-    (is (identical? first-endpoint (.intern weak-interner (gt/endpoint 1 :first))))
-    (is (identical? second-endpoint (.intern weak-interner (gt/endpoint 2 :second))))
-    (is (identical? third-endpoint (.intern weak-interner (gt/endpoint 3 :third))))))
+        first-endpoint (.intern weak-interner (gt/->Endpoint 1 :first))
+        second-endpoint (.intern weak-interner (gt/->Endpoint 2 :second))
+        third-endpoint (.intern weak-interner (gt/->Endpoint 3 :third))]
+    (is (identical? first-endpoint (.intern weak-interner (gt/->Endpoint 1 :first))))
+    (is (identical? second-endpoint (.intern weak-interner (gt/->Endpoint 2 :second))))
+    (is (identical? third-endpoint (.intern weak-interner (gt/->Endpoint 3 :third))))))
 
 (deftest cleanup-test
   (let [weak-interner (WeakInterner. 4)
         references-atom (atom {})]
-    (swap! references-atom assoc :first-endpoint (.intern weak-interner (gt/endpoint 1 :first)))
-    (swap! references-atom assoc :second-endpoint (.intern weak-interner (gt/endpoint 2 :second)))
+    (swap! references-atom assoc :first-endpoint (.intern weak-interner (gt/->Endpoint 1 :first)))
+    (swap! references-atom assoc :second-endpoint (.intern weak-interner (gt/->Endpoint 2 :second)))
     (let [{:keys [first-endpoint second-endpoint]} @references-atom
           first-id (System/identityHashCode first-endpoint)
           second-id (System/identityHashCode second-endpoint)]
-      (is (= first-id (System/identityHashCode (.intern weak-interner (gt/endpoint 1 :first)))))
-      (is (= second-id (System/identityHashCode (.intern weak-interner (gt/endpoint 2 :second)))))
+      (is (= first-id (System/identityHashCode (.intern weak-interner (gt/->Endpoint 1 :first)))))
+      (is (= second-id (System/identityHashCode (.intern weak-interner (gt/->Endpoint 2 :second)))))
       (reset! references-atom {})
       (System/gc)
-      (is (not= first-id (System/identityHashCode (.intern weak-interner (gt/endpoint 1 :first)))))
-      (is (not= second-id (System/identityHashCode (.intern weak-interner (gt/endpoint 2 :second))))))))
+      (is (not= first-id (System/identityHashCode (.intern weak-interner (gt/->Endpoint 1 :first)))))
+      (is (not= second-id (System/identityHashCode (.intern weak-interner (gt/->Endpoint 2 :second))))))))
 
 (deftest multi-threaded-access-test
   (let [weak-interner (WeakInterner. 0)
 
         interned-endpoints-by-node-id
         (->> (repeatedly 1000000 #(long (rand-int 100)))
-             (pmap #(.intern weak-interner (gt/endpoint % :label)))
+             (pmap #(.intern weak-interner (gt/->Endpoint % :label)))
              (vec)
              (group-by gt/endpoint-node-id))]
 


### PR DESCRIPTION
Slightly improve editor memory usage in projects with a large number of node endpoints. This typically corresponds to the number of files in the project, but varies significantly by file type.

Improves #8261

### Technical changes
* Changed the hash map implementation inside the `WeakInterner` to use a weak addressing scheme instead of linked-list buckets. This saves having to store a reference to the next `Entry` inside each `Entry` in the hash map.
* Updated the hash map implementation inside the `WeakInterner` to use prime number hash table sizes. This is necessary to achieve optimal distribution of values, which is critical when using a weak addressing scheme.
* Updated the `hashCode` and `hashEq` implementations for `Endpoint` to produce better hash values, which also helps with the value distribution.
* Store the `node-id` as a primitive `long` instead of a boxed `Long` in the `Endpoint`. This does not appear to save any memory at present, but does have an effect on the performance of `hashCode`, `hashEq`, and equality comparisons between `Endpoints`, measurably improving lookup times.
* Added functions to the `dev` module to get statistics from the `WeakInterner` used to intern `Endpoints`.