### PR TITLE
Added unit test for invalid sprite animation crash

### DIFF
--- a/engine/gamesys/src/gamesys/test/sprite/sprite_flipbook_anim.script
+++ b/engine/gamesys/src/gamesys/test/sprite/sprite_flipbook_anim.script
@@ -18,7 +18,9 @@ num_messages = 0
 
 local function callback(self, message_id, message, sender)
     num_finished = num_finished + 1
-    tests_done = num_finished == 2
+
+    self.waiting_to_render_invalid_texture = 1
+    sprite.play_flipbook("#sprite", "does_not_exist") -- see to it that we handle an invalid animation
 end
 
 function init(self)
@@ -26,16 +28,22 @@ function init(self)
 
     num_finished = 0
     num_messages = 0
+
+    self.waiting_to_render_invalid_texture = 0
 end
 
 function update(self, dt)
+    if self.waiting_to_render_invalid_texture == 1 then
+        self.waiting_to_render_invalid_texture = self.waiting_to_render_invalid_texture + 1
+    end
+
+    tests_done = num_finished == 2 and self.waiting_to_render_invalid_texture > 1
 end
 
 function on_message(self, message_id, message)
     if message_id == hash("animation_done") then
         num_finished = num_finished + 1
         num_messages = num_messages + 1
-        tests_done = num_finished == 2
 
         -- continue with the next animation
         sprite.play_flipbook("#sprite", "anim_once", callback)

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -954,17 +954,7 @@ TEST_F(SpriteTest, FlipbookAnim)
 
     lua_State* L = scriptlibcontext.m_LuaState;
 
-    bool tests_done = false;
-    while (!tests_done)
-    {
-        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
-        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
-
-        // check if tests are done
-        lua_getglobal(L, "tests_done");
-        tests_done = lua_toboolean(L, -1);
-        lua_pop(L, 1);
-    }
+    WaitForTestsDone(10000, true, 0);
 
     lua_getglobal(L, "num_finished");
     int num_finished = lua_tointeger(L, -1);
@@ -993,7 +983,7 @@ TEST_F(SpriteTest, FrameCount)
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/frame_count/sprite_frame_count.goc", dmHashString64("/go"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
-    WaitForTestsDone(100, 0);
+    WaitForTestsDone(100, false, 0);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
@@ -1014,7 +1004,7 @@ TEST_F(ParticleFxTest, PlayAnim)
     ASSERT_NE((void*)0, go);
 
     bool tests_done = false;
-    WaitForTestsDone(100, &tests_done);
+    WaitForTestsDone(100, true, &tests_done);
 
     if (!tests_done)
     {
@@ -1100,7 +1090,7 @@ TEST_F(GuiTest, GuiFlipbookAnim)
     m_UpdateContext.m_DT = 1.0f;
 
     bool tests_done = false;
-    WaitForTestsDone(100, &tests_done);
+    WaitForTestsDone(100, true, &tests_done);
 
     if (!tests_done)
     {

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -447,11 +447,6 @@ void GamesysTest<T>::SetUp()
     dmGraphics::InstallAdapter();
     dmGraphics::ResetDrawCount(); // for the unit test
 
-    dmPlatform::WindowParams win_params = {};
-
-    m_Window = dmPlatform::NewWindow();
-    dmPlatform::OpenWindow(m_Window, win_params);
-
     dmGraphics::ContextParams graphics_context_params;
     graphics_context_params.m_Window = m_Window;
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -27,6 +27,7 @@
 #include "gamesys/scripts/script_buffer.h"
 #include "../components/comp_gui_private.h" // BoxVertex
 #include "../components/comp_gui.h" // The GuiGetURLCallback et.al
+#include "../../../../graphics/src/graphics_private.h" // for unit test functions
 
 #include <dmsdk/script/script.h>
 #include <dmsdk/gamesys/script.h>
@@ -87,7 +88,7 @@ protected:
     virtual void TearDown();
     void SetupComponentCreateContext(dmGameObject::ComponentTypeCreateCtx& component_create_ctx);
 
-    void WaitForTestsDone(int update_count, bool* result);
+    void WaitForTestsDone(int update_count, bool render, bool* result);
 
     dmGameObject::UpdateContext m_UpdateContext;
     dmGameObject::HRegister m_Register;
@@ -433,6 +434,7 @@ void GamesysTest<T>::SetUp()
     dmResource::RegisterTypes(m_Factory, &m_Contexts);
 
     dmGraphics::InstallAdapter();
+    dmGraphics::ResetDrawCount(); // for the unit test
 
     dmPlatform::WindowParams win_params = {};
 
@@ -569,27 +571,38 @@ void GamesysTest<T>::TearDown()
 }
 
 template<typename T>
-void GamesysTest<T>::WaitForTestsDone(int update_count, bool* result)
+void GamesysTest<T>::WaitForTestsDone(int update_count, bool render, bool* result)
 {
     if (result)
         *result = false;
 
     lua_State* L = dmScript::GetLuaState(m_ScriptContext);
     bool tests_done = false;
-    while (!tests_done && --update_count > 0)
+    int count = update_count;
+    while (!tests_done && --count > 0)
     {
         ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
         ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
 
-        dmRender::RenderListBegin(m_RenderContext);
-        dmGameObject::Render(m_Collection);
+        if (render)
+        {
+            dmRender::RenderListBegin(m_RenderContext);
+            dmGameObject::Render(m_Collection);
+
+            dmRender::RenderListEnd(m_RenderContext);
+            dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+        }
 
         // check if tests are done
         lua_getglobal(L, "tests_done");
         tests_done = lua_toboolean(L, -1);
         lua_pop(L, 1);
     }
-    ASSERT_LT(0, update_count);
+    if (count >= 0)
+    {
+        dmLogError("Waited %d frames for test to finish. Aborting.", update_count);
+    }
+    ASSERT_LT(0, count);
 
     if (!result)
     {

--- a/engine/graphics/src/graphics_private.h
+++ b/engine/graphics/src/graphics_private.h
@@ -118,6 +118,7 @@ namespace dmGraphics
     }
 
     // Test only functions:
+    void     ResetDrawCount();
     uint64_t GetDrawCount();
     void     EnableVertexDeclaration(HContext _context, HVertexDeclaration vertex_declaration, uint32_t binding_index);
     void     SetOverrideShaderLanguage(HContext context, ShaderDesc::ShaderClass shader_class, ShaderDesc::Language language);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -615,6 +615,11 @@ namespace dmGraphics
     }
 
     // For tests
+    void ResetDrawCount()
+    {
+        g_DrawCount = 0;
+    }
+
     uint64_t GetDrawCount()
     {
         return g_DrawCount;

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -98,6 +98,7 @@ public:
         dmGui::DeleteContext(m_Context, m_ScriptContext);
         dmScript::Finalize(m_ScriptContext);
         dmScript::DeleteContext(m_ScriptContext);
+        dmHID::Final(m_HidContext);
         dmHID::DeleteContext(m_HidContext);
         dmPlatform::DeleteWindow(m_Window);
     }


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
