### PR TITLE
Fix intermittent runtime fails for gamesys buffer tests

### DIFF
--- a/engine/gamesys/src/dmsdk/gamesys/script.h
+++ b/engine/gamesys/src/dmsdk/gamesys/script.h
@@ -19,6 +19,7 @@
 #include <dmsdk/dlib/log.h>
 #include <dmsdk/script/script.h>
 #include <dmsdk/gameobject/gameobject.h>
+#include <dmsdk/resource/resource.h>
 
 extern "C"
 {
@@ -143,7 +144,8 @@ namespace dmScript
      */
     struct LuaHBuffer
     {
-        union {
+        union
+        {
             dmBuffer::HBuffer   m_Buffer;
             void*               m_BufferRes;
         };
@@ -153,31 +155,14 @@ namespace dmScript
             LuaBufferOwnership  m_Owner;
         };
 
-        LuaHBuffer() {}
+        uint16_t m_BufferResVersion;
+        dmhash_t m_BufferResPathHash;
 
-        LuaHBuffer(dmBuffer::HBuffer buffer, LuaBufferOwnership ownership)
-        : m_Buffer(buffer)
-        , m_Owner(ownership)
-        {
-        }
-
-        LuaHBuffer(void* buffer_resource)
-        : m_BufferRes(buffer_resource)
-        , m_Owner(OWNER_RES)
-        {
-        }
-
-        LuaHBuffer(dmBuffer::HBuffer buffer, bool use_lua_gc)
-        : m_Buffer(buffer)
-        , m_UseLuaGC(use_lua_gc)
-        {
-            static int first = 1;
-            if (first)
-            {
-                first = 0;
-                dmLogWarning("The constructor is deprecated: dmScript::LuaHBuffer wrapper = { HBuffer, bool };");
-            }
-        }
+        LuaHBuffer();
+        LuaHBuffer(dmBuffer::HBuffer buffer, LuaBufferOwnership ownership);
+        LuaHBuffer(dmResource::HFactory factory, void* buffer_resource);
+        // Deprecated
+        LuaHBuffer(dmBuffer::HBuffer buffer, bool use_lua_gc);
     };
 
     /*# check if the value is a dmScript::LuaHBuffer

--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -1228,8 +1228,8 @@ namespace dmScript
     : m_Buffer(buffer)
     , m_UseLuaGC(use_lua_gc)
     {
-        assert(0);
         dmLogOnceWarning("The constructor is deprecated: dmScript::LuaHBuffer wrapper = { HBuffer, bool };");
+        assert(0);
     }
 
     static inline bool IsValidOwner(LuaBufferOwnership ownership)

--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -722,7 +722,7 @@ namespace dmGameSystem
             {
                 dmBuffer::Destroy(buffer->m_Buffer);
             }
-            else if (buffer->m_Owner == dmScript::OWNER_RES && buffer->m_BufferResVersion != RESOURCE_VERSION_INVALID)
+            else if (buffer->m_Owner == dmScript::OWNER_RES && buffer->m_BufferResVersion != dmResource::RESOURCE_VERSION_INVALID)
             {
                 uint16_t res_version   = dmResource::GetVersion(g_Factory, buffer->m_BufferRes);
                 dmhash_t res_path_hash = 0;
@@ -1216,7 +1216,7 @@ namespace dmScript
     LuaHBuffer::LuaHBuffer(dmResource::HFactory factory, void* buffer_resource)
     : m_BufferRes(buffer_resource)
     , m_Owner(OWNER_RES)
-    , m_BufferResVersion(RESOURCE_VERSION_INVALID)
+    , m_BufferResVersion(dmResource::RESOURCE_VERSION_INVALID)
     {
         if (factory)
         {

--- a/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_buffer.cpp
@@ -722,7 +722,7 @@ namespace dmGameSystem
             {
                 dmBuffer::Destroy(buffer->m_Buffer);
             }
-            else if (buffer->m_Owner == dmScript::OWNER_RES)
+            else if (buffer->m_Owner == dmScript::OWNER_RES && buffer->m_BufferResVersion != RESOURCE_VERSION_INVALID)
             {
                 uint16_t res_version   = dmResource::GetVersion(g_Factory, buffer->m_BufferRes);
                 dmhash_t res_path_hash = 0;
@@ -1216,6 +1216,7 @@ namespace dmScript
     LuaHBuffer::LuaHBuffer(dmResource::HFactory factory, void* buffer_resource)
     : m_BufferRes(buffer_resource)
     , m_Owner(OWNER_RES)
+    , m_BufferResVersion(RESOURCE_VERSION_INVALID)
     {
         if (factory)
         {

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -2406,7 +2406,7 @@ static int GetBuffer(lua_State* L)
     }
 
     dmResource::IncRef(g_ResourceModule.m_Factory, buffer_resource);
-    dmScript::LuaHBuffer luabuf((void*)buffer_resource);
+    dmScript::LuaHBuffer luabuf(g_ResourceModule.m_Factory, (void*)buffer_resource);
     PushBuffer(L, luabuf);
 
     assert(top + 1 == lua_gettop(L));

--- a/engine/gamesys/src/gamesys/test/resource/script_buffer.script
+++ b/engine/gamesys/src/gamesys/test/resource/script_buffer.script
@@ -28,6 +28,30 @@ local data_stream_desc = {{
     count = 3
 }}
 
+function test_create_garbage_collect(self)
+    local buf            = buffer.create(3, data_stream_desc)
+    local res_buffer     = resource.create_buffer("/my_buffer.bufferc", { buffer = buf }) -- ref: 2
+    local res_buffer_obj = resource.get_buffer(res_buffer) -- ref: 3
+
+    resource.release(res_buffer)
+    resource.release(res_buffer)
+    resource.release(res_buffer)
+
+    assert_error(function() resource.get_buffer(res_buffer) end)
+
+    local buf_2        = buffer.create(3, data_stream_desc)
+    local res_buffer_2 = resource.create_buffer("/my_buffer.bufferc", { buffer = buf_2}) -- ref: 2
+
+    collectgarbage("collect")
+    buf_2 = nil
+    collectgarbage("collect")
+
+    resource.release(res_buffer_2)
+    resource.release(res_buffer_2)
+
+    assert_error(function() resource.get_buffer(res_buffer_2) end)
+end
+
 function test_create_get(self)
     -- owner: lua
     local buf = buffer.create(3, data_stream_desc)
@@ -99,6 +123,7 @@ function test_create_set(self)
 end
 
 function init(self)
+    test_create_garbage_collect(self)
     test_create_get(self)
     test_create_ownership(self)
     test_create_ownership_data(self)

--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -140,6 +140,7 @@ namespace dmResource
         uint32_t m_ResourceSizeOnDisc;
         void*    m_ResourceType;
         uint32_t m_ReferenceCount;
+        uint16_t m_Version;
     };
 
 

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -119,6 +119,9 @@ struct SResourceFactory
     dmResourceMounts::HContext                   m_Mounts;
     dmResourceProvider::HArchive                 m_BuiltinMount;
     dmResourceProvider::HArchive                 m_BaseArchiveMount;
+
+    // Serial version that increases per resource insertion
+    uint16_t                                     m_Version;
 };
 
 SResourceType* FindResourceType(SResourceFactory* factory, const char* extension)
@@ -856,6 +859,8 @@ Result InsertResource(HFactory factory, const char* path, uint64_t canonical_pat
         factory->m_ResourceHashToFilename->Put(canonical_path_hash, strdup(canonical_path));
     }
 
+    descriptor->m_Version = factory->m_Version++;
+
     return RESULT_OK;
 }
 
@@ -1208,6 +1213,16 @@ void IncRef(HFactory factory, void* resource)
     assert(rd);
     assert(rd->m_ReferenceCount > 0);
     ++rd->m_ReferenceCount;
+}
+
+uint16_t GetVersion(HFactory factory, void* resource)
+{
+    uint64_t* resource_hash = factory->m_ResourceToHash->Get((uintptr_t) resource);
+    assert(resource_hash);
+
+    SResourceDescriptor* rd = factory->m_Resources->Get(*resource_hash);
+    assert(rd);
+    return rd->m_Version;
 }
 
 // For unit testing

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -124,6 +124,16 @@ struct SResourceFactory
     uint16_t                                     m_Version;
 };
 
+static inline uint16_t IncreaseVersion(HFactory factory)
+{
+    uint16_t next_version = factory->m_Version++;
+    if (next_version == RESOURCE_VERSION_INVALID)
+    {
+        return ++factory->m_Version;
+    }
+    return next_version;
+}
+
 SResourceType* FindResourceType(SResourceFactory* factory, const char* extension)
 {
     for (uint32_t i = 0; i < factory->m_ResourceTypesCount; ++i)
@@ -859,7 +869,7 @@ Result InsertResource(HFactory factory, const char* path, uint64_t canonical_pat
         factory->m_ResourceHashToFilename->Put(canonical_path_hash, strdup(canonical_path));
     }
 
-    descriptor->m_Version = factory->m_Version++;
+    descriptor->m_Version = IncreaseVersion(factory);
 
     return RESULT_OK;
 }
@@ -938,6 +948,7 @@ static Result DoReloadResource(HFactory factory, const char* name, SResourceDesc
     Result create_result = resource_type->m_RecreateFunction(params);
     if (create_result == RESULT_OK)
     {
+        rd->m_Version = IncreaseVersion(factory);
         params.m_Resource->m_ResourceSizeOnDisc = buffer_size;
         if (factory->m_ResourceReloadedCallbacks)
         {

--- a/engine/resource/src/resource.h
+++ b/engine/resource/src/resource.h
@@ -278,6 +278,15 @@ namespace dmResource
     void IncRef(HFactory factory, void* resource);
 
     /**
+     * Get the resource version. The resource version is a sequential serial number
+     * that increases with every resource insertion into the resource system.
+     * This is useful for checking resource validity for resource pointers.
+     * @param factory Factory handle
+     * @param resource Resource
+     */
+    uint16_t GetVersion(HFactory factory, void* resource);
+
+    /**
      * Create a new preloader
      * @param factory Factory handle
      * @param name Resource to load

--- a/engine/resource/src/resource.h
+++ b/engine/resource/src/resource.h
@@ -42,6 +42,8 @@ namespace dmResource
     // This is both for the total resource path, ie m_UriParts.X concatenated with relative path
     const uint32_t RESOURCE_PATH_MAX = 1024;
 
+    const uint16_t RESOURCE_VERSION_INVALID = 0xFFFF;
+
     /**
      * Configuration key used to tweak the max number of resources allowed.
      */


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
