### PR TITLE
Add new default filtering keyword for material samplers (Engine support)

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_material.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_material.cpp
@@ -35,13 +35,6 @@ namespace dmGameSystem
                                                  dmGraphics::TEXTURE_WRAP_MIRRORED_REPEAT,
                                                  dmGraphics::TEXTURE_WRAP_CLAMP_TO_EDGE};
 
-    static dmGraphics::TextureFilter filter_lut[] = {dmGraphics::TEXTURE_FILTER_NEAREST,
-                                                     dmGraphics::TEXTURE_FILTER_LINEAR,
-                                                     dmGraphics::TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST,
-                                                     dmGraphics::TEXTURE_FILTER_NEAREST_MIPMAP_LINEAR,
-                                                     dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST,
-                                                     dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR};
-
     static dmGraphics::TextureWrap WrapFromDDF(dmRenderDDF::MaterialDesc::WrapMode wrap_mode)
     {
         assert(wrap_mode <= dmRenderDDF::MaterialDesc::WRAP_MODE_CLAMP_TO_EDGE);
@@ -50,14 +43,30 @@ namespace dmGameSystem
 
     static dmGraphics::TextureFilter FilterMinFromDDF(dmRenderDDF::MaterialDesc::FilterModeMin min_filter)
     {
-        assert(min_filter <= dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_LINEAR_MIPMAP_LINEAR);
-        return filter_lut[min_filter];
+        switch(min_filter)
+        {
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_NEAREST:                return dmGraphics::TEXTURE_FILTER_NEAREST;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_LINEAR:                 return dmGraphics::TEXTURE_FILTER_LINEAR;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_NEAREST_MIPMAP_NEAREST: return dmGraphics::TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_NEAREST_MIPMAP_LINEAR:  return dmGraphics::TEXTURE_FILTER_NEAREST_MIPMAP_LINEAR;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_LINEAR_MIPMAP_NEAREST:  return dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_LINEAR_MIPMAP_LINEAR:   return dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MIN_DEFAULT:                return dmGraphics::TEXTURE_FILTER_DEFAULT;
+            default:break;
+        }
+        return dmGraphics::TEXTURE_FILTER_DEFAULT;
     }
 
     static dmGraphics::TextureFilter FilterMagFromDDF(dmRenderDDF::MaterialDesc::FilterModeMag mag_filter)
     {
-        assert(mag_filter <= dmRenderDDF::MaterialDesc::FILTER_MODE_MAG_LINEAR);
-        return filter_lut[mag_filter];
+        switch(mag_filter)
+        {
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MAG_NEAREST: return dmGraphics::TEXTURE_FILTER_NEAREST;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MAG_LINEAR:  return dmGraphics::TEXTURE_FILTER_LINEAR;
+            case dmRenderDDF::MaterialDesc::FILTER_MODE_MAG_DEFAULT: return dmGraphics::TEXTURE_FILTER_DEFAULT;
+            default:break;
+        }
+        return dmGraphics::TEXTURE_FILTER_DEFAULT;
     }
 
     static bool ValidateFormat(dmRenderDDF::MaterialDesc* material_desc)

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -706,9 +706,6 @@ namespace dmGraphics
     bool  UnmapVertexBuffer(HContext context, HVertexBuffer buffer);
     void* MapIndexBuffer(HContext context, HIndexBuffer buffer, BufferAccess access);
     bool  UnmapIndexBuffer(HContext context, HIndexBuffer buffer);
-
-    // Tests only:
-    void GetTextureFilters(HContext context, uint32_t unit, TextureFilter& min_filter, TextureFilter& mag_filter);
 }
 
 #endif // DM_GRAPHICS_H

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -706,6 +706,9 @@ namespace dmGraphics
     bool  UnmapVertexBuffer(HContext context, HVertexBuffer buffer);
     void* MapIndexBuffer(HContext context, HIndexBuffer buffer, BufferAccess access);
     bool  UnmapIndexBuffer(HContext context, HIndexBuffer buffer);
+
+    // Tests only:
+    void GetTextureFilters(HContext context, uint32_t unit, TextureFilter& min_filter, TextureFilter& mag_filter);
 }
 
 #endif // DM_GRAPHICS_H

--- a/engine/graphics/src/graphics_private.h
+++ b/engine/graphics/src/graphics_private.h
@@ -120,6 +120,7 @@ namespace dmGraphics
     // Test only functions:
     void     ResetDrawCount();
     uint64_t GetDrawCount();
+    void     GetTextureFilters(HContext context, uint32_t unit, TextureFilter& min_filter, TextureFilter& mag_filter);
     void     EnableVertexDeclaration(HContext _context, HVertexDeclaration vertex_declaration, uint32_t binding_index);
     void     SetOverrideShaderLanguage(HContext context, ShaderDesc::ShaderClass shader_class, ShaderDesc::Language language);
 }

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -76,6 +76,18 @@ namespace dmGraphics
         m_Window                  = params.m_Window;
         m_PrintDeviceInfo         = params.m_PrintDeviceInfo;
 
+        // We need to have some sort of valid default filtering
+        if (m_DefaultTextureMinFilter == TEXTURE_FILTER_DEFAULT)
+            m_DefaultTextureMinFilter = TEXTURE_FILTER_LINEAR;
+        if (m_DefaultTextureMagFilter == TEXTURE_FILTER_DEFAULT)
+            m_DefaultTextureMagFilter = TEXTURE_FILTER_LINEAR;
+
+        for (int i = 0; i < MAX_TEXTURE_COUNT; ++i)
+        {
+            m_Samplers[i].m_MinFilter = m_DefaultTextureMinFilter;
+            m_Samplers[i].m_MagFilter = m_DefaultTextureMagFilter;
+        }
+
         assert(dmPlatform::GetWindowStateParam(m_Window, dmPlatform::WINDOW_STATE_OPENED));
 
         m_TextureFormatSupport |= 1 << TEXTURE_FORMAT_LUMINANCE;
@@ -1372,6 +1384,8 @@ namespace dmGraphics
     static void NullSetTextureParams(HTexture texture, TextureFilter minfilter, TextureFilter magfilter, TextureWrap uwrap, TextureWrap vwrap, float max_anisotropy)
     {
         assert(texture);
+        g_NullContext->m_Samplers[g_NullContext->m_TextureUnit].m_MinFilter = minfilter == TEXTURE_FILTER_DEFAULT ? g_NullContext->m_DefaultTextureMinFilter : minfilter;
+        g_NullContext->m_Samplers[g_NullContext->m_TextureUnit].m_MagFilter = magfilter == TEXTURE_FILTER_DEFAULT ? g_NullContext->m_DefaultTextureMagFilter : magfilter;
     }
 
     static void NullSetTexture(HTexture texture, const TextureParams& params)
@@ -1401,9 +1415,13 @@ namespace dmGraphics
             tex->m_Height = params.m_Height;
         }
 
-        tex->m_Depth       = dmMath::Max((uint16_t) 1, params.m_Depth);
-        tex->m_MipMapCount = dmMath::Max(tex->m_MipMapCount, (uint8_t) (params.m_MipMap+1));
-        tex->m_MipMapCount = dmMath::Clamp(tex->m_MipMapCount, (uint8_t) 0, GetMipmapCount(dmMath::Max(tex->m_Width, tex->m_Height)));
+        tex->m_Depth               = dmMath::Max((uint16_t) 1, params.m_Depth);
+        tex->m_MipMapCount         = dmMath::Max(tex->m_MipMapCount, (uint8_t) (params.m_MipMap+1));
+        tex->m_MipMapCount         = dmMath::Clamp(tex->m_MipMapCount, (uint8_t) 0, GetMipmapCount(dmMath::Max(tex->m_Width, tex->m_Height)));
+        tex->m_Sampler.m_MinFilter = params.m_MinFilter;
+        tex->m_Sampler.m_MagFilter = params.m_MagFilter;
+        tex->m_Sampler.m_UWrap     = params.m_UWrap;
+        tex->m_Sampler.m_VWrap     = params.m_VWrap;
     }
 
     static uint32_t NullGetTextureResourceSize(HTexture texture)
@@ -1450,8 +1468,11 @@ namespace dmGraphics
         assert(unit < MAX_TEXTURE_COUNT);
         assert(texture);
         NullContext* context = (NullContext*) _context;
-        assert(GetAssetFromContainer<Texture>(context->m_AssetHandleContainer, texture)->m_Data);
+        Texture* tex = GetAssetFromContainer<Texture>(context->m_AssetHandleContainer, texture);
+        assert(tex->m_Data);
         context->m_Textures[unit] = texture;
+        context->m_TextureUnit = unit;
+        NullSetTextureParams(texture, tex->m_Sampler.m_MinFilter, tex->m_Sampler.m_MagFilter, tex->m_Sampler.m_UWrap, tex->m_Sampler.m_VWrap, tex->m_Sampler.m_Anisotropy);
     }
 
     static void NullDisableTexture(HContext context, uint32_t unit, HTexture texture)
@@ -1717,6 +1738,12 @@ namespace dmGraphics
         ib->m_Copy = new char[ib->m_Size];
         memcpy(ib->m_Copy, ib->m_Buffer, ib->m_Size);
         return ib->m_Copy;
+    }
+
+    void GetTextureFilters(HContext context, uint32_t unit, TextureFilter& min_filter, TextureFilter& mag_filter)
+    {
+        min_filter = ((NullContext*) context)->m_Samplers[unit].m_MinFilter;
+        mag_filter = ((NullContext*) context)->m_Samplers[unit].m_MagFilter;
     }
 
     static GraphicsAdapterFunctionTable NullRegisterFunctionTable()

--- a/engine/graphics/src/null/graphics_null_private.h
+++ b/engine/graphics/src/null/graphics_null_private.h
@@ -23,17 +23,27 @@ namespace dmGraphics
     const static uint32_t MAX_REGISTER_COUNT = 16;
     const static uint32_t MAX_TEXTURE_COUNT  = 32;
 
+    struct TextureSampler
+    {
+        TextureFilter m_MinFilter;
+        TextureFilter m_MagFilter;
+        TextureWrap   m_UWrap;
+        TextureWrap   m_VWrap;
+        float         m_Anisotropy;
+    };
+
     struct Texture
     {
-        void* m_Data;
-        TextureFormat   m_Format;
-        TextureType     m_Type;
-        uint32_t m_Width;
-        uint32_t m_Height;
-        uint32_t m_Depth;
-        uint32_t m_OriginalWidth;
-        uint32_t m_OriginalHeight;
-        uint8_t  m_MipMapCount;
+        void*          m_Data;
+        TextureFormat  m_Format;
+        TextureType    m_Type;
+        TextureSampler m_Sampler;
+        uint32_t       m_Width;
+        uint32_t       m_Height;
+        uint32_t       m_Depth;
+        uint32_t       m_OriginalWidth;
+        uint32_t       m_OriginalHeight;
+        uint8_t        m_MipMapCount;
     };
 
     struct VertexStreamBuffer
@@ -97,6 +107,7 @@ namespace dmGraphics
         dmOpaqueHandleContainer<uintptr_t> m_AssetHandleContainer;
         VertexStreamBuffer                 m_VertexStreams[MAX_VERTEX_STREAM_COUNT];
         dmVMath::Vector4                   m_ProgramRegisters[MAX_REGISTER_COUNT];
+        TextureSampler                     m_Samplers[MAX_TEXTURE_COUNT];
         HTexture                           m_Textures[MAX_TEXTURE_COUNT];
         HVertexBuffer                      m_VertexBuffer;
         FrameBuffer                        m_MainFrameBuffer;
@@ -110,6 +121,7 @@ namespace dmGraphics
         uint32_t                           m_Height;
         int32_t                            m_ScissorRect[4];
         uint32_t                           m_TextureFormatSupport;
+        uint32_t                           m_TextureUnit;
         // Only use for testing
         uint32_t                           m_RequestWindowClose : 1;
         uint32_t                           m_PrintDeviceInfo    : 1;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -410,6 +410,12 @@ static void LogFrameBufferError(GLenum status)
         m_Height                  = params.m_Height;
         m_Window                  = params.m_Window;
 
+        // We need to have some sort of valid default filtering
+        if (m_DefaultTextureMinFilter == TEXTURE_FILTER_DEFAULT)
+            m_DefaultTextureMinFilter = TEXTURE_FILTER_LINEAR;
+        if (m_DefaultTextureMagFilter == TEXTURE_FILTER_DEFAULT)
+            m_DefaultTextureMagFilter = TEXTURE_FILTER_LINEAR;
+
         assert(dmPlatform::GetWindowStateParam(m_Window, dmPlatform::WINDOW_STATE_OPENED));
 
         // Formats supported on all platforms
@@ -2902,10 +2908,9 @@ static void LogFrameBufferError(GLenum status)
     {
         OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
 
-        GLenum type = GetOpenGLTextureType(tex->m_Type);
-
-        GLenum gl_min_filter = GetOpenGLTextureFilter(minfilter);
-        GLenum gl_mag_filter = GetOpenGLTextureFilter(magfilter);
+        GLenum gl_type       = GetOpenGLTextureType(tex->m_Type);
+        GLenum gl_min_filter = GetOpenGLTextureFilter(minfilter == TEXTURE_FILTER_DEFAULT ? g_Context->m_DefaultTextureMinFilter : minfilter);
+        GLenum gl_mag_filter = GetOpenGLTextureFilter(magfilter == TEXTURE_FILTER_DEFAULT ? g_Context->m_DefaultTextureMagFilter : magfilter);
 
         // Using a mipmapped min filter without any mipmaps will break the sampler
         if (tex->m_MipMapCount <= 1 && IsTextureFilterMipmapped(gl_min_filter))
@@ -2913,21 +2918,21 @@ static void LogFrameBufferError(GLenum status)
             gl_min_filter = gl_mag_filter;
         }
 
-        glTexParameteri(type, GL_TEXTURE_MIN_FILTER, gl_min_filter);
+        glTexParameteri(gl_type, GL_TEXTURE_MIN_FILTER, gl_min_filter);
         CHECK_GL_ERROR;
 
-        glTexParameteri(type, GL_TEXTURE_MAG_FILTER, gl_mag_filter);
+        glTexParameteri(gl_type, GL_TEXTURE_MAG_FILTER, gl_mag_filter);
         CHECK_GL_ERROR;
 
-        glTexParameteri(type, GL_TEXTURE_WRAP_S, GetOpenGLTextureWrap(uwrap));
+        glTexParameteri(gl_type, GL_TEXTURE_WRAP_S, GetOpenGLTextureWrap(uwrap));
         CHECK_GL_ERROR
 
-        glTexParameteri(type, GL_TEXTURE_WRAP_T, GetOpenGLTextureWrap(vwrap));
+        glTexParameteri(gl_type, GL_TEXTURE_WRAP_T, GetOpenGLTextureWrap(vwrap));
         CHECK_GL_ERROR
 
         if (g_Context->m_AnisotropySupport && max_anisotropy > 1.0f)
         {
-            glTexParameterf(type, GL_TEXTURE_MAX_ANISOTROPY_EXT, dmMath::Min(max_anisotropy, g_Context->m_MaxAnisotropy));
+            glTexParameterf(gl_type, GL_TEXTURE_MAX_ANISOTROPY_EXT, dmMath::Min(max_anisotropy, g_Context->m_MaxAnisotropy));
             CHECK_GL_ERROR
         }
     }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -114,6 +114,12 @@ namespace dmGraphics
         m_Width                   = params.m_Width;
         m_Height                  = params.m_Height;
 
+        // We need to have some sort of valid default filtering
+        if (m_DefaultTextureMinFilter == TEXTURE_FILTER_DEFAULT)
+            m_DefaultTextureMinFilter = TEXTURE_FILTER_LINEAR;
+        if (m_DefaultTextureMagFilter == TEXTURE_FILTER_DEFAULT)
+            m_DefaultTextureMagFilter = TEXTURE_FILTER_LINEAR;
+
         assert(dmPlatform::GetWindowStateParam(m_Window, dmPlatform::WINDOW_STATE_OPENED));
 
         DM_STATIC_ASSERT(sizeof(m_TextureFormatSupport) * 8 >= TEXTURE_FORMAT_COUNT, Invalid_Struct_Size );
@@ -207,6 +213,11 @@ namespace dmGraphics
         VkSamplerAddressMode vk_wrap_u = GetVulkanSamplerAddressMode(uwrap);
         VkSamplerAddressMode vk_wrap_v = GetVulkanSamplerAddressMode(vwrap);
 
+        if (magfilter == TEXTURE_FILTER_DEFAULT)
+            magfilter = g_VulkanContext->m_DefaultTextureMagFilter;
+        if (minfilter == TEXTURE_FILTER_DEFAULT)
+            minfilter = g_VulkanContext->m_DefaultTextureMinFilter;
+
         // Convert mag filter to Vulkan type
         if (magfilter == TEXTURE_FILTER_NEAREST)
         {
@@ -284,6 +295,11 @@ namespace dmGraphics
     static int16_t GetTextureSamplerIndex(dmArray<TextureSampler>& texture_samplers, TextureFilter minfilter, TextureFilter magfilter,
         TextureWrap uwrap, TextureWrap vwrap, uint8_t maxLod, float max_anisotropy)
     {
+        if (minfilter == TEXTURE_FILTER_DEFAULT)
+            minfilter = g_VulkanContext->m_DefaultTextureMinFilter;
+        if (magfilter == TEXTURE_FILTER_DEFAULT)
+            magfilter = g_VulkanContext->m_DefaultTextureMagFilter;
+
         for (uint32_t i=0; i < texture_samplers.Size(); i++)
         {
             TextureSampler& sampler = texture_samplers[i];

--- a/engine/render/proto/render/material_ddf.proto
+++ b/engine/render/proto/render/material_ddf.proto
@@ -46,18 +46,20 @@ message MaterialDesc
 
     enum FilterModeMin
     {
-        FILTER_MODE_MIN_NEAREST = 0;
-        FILTER_MODE_MIN_LINEAR  = 1;
+        FILTER_MODE_MIN_NEAREST                = 0;
+        FILTER_MODE_MIN_LINEAR                 = 1;
         FILTER_MODE_MIN_NEAREST_MIPMAP_NEAREST = 2;
         FILTER_MODE_MIN_NEAREST_MIPMAP_LINEAR  = 3;
         FILTER_MODE_MIN_LINEAR_MIPMAP_NEAREST  = 4;
         FILTER_MODE_MIN_LINEAR_MIPMAP_LINEAR   = 5;
+        FILTER_MODE_MIN_DEFAULT                = 6;
     }
 
     enum FilterModeMag
     {
         FILTER_MODE_MAG_NEAREST = 0;
         FILTER_MODE_MAG_LINEAR  = 1;
+        FILTER_MODE_MAG_DEFAULT = 2;
     }
 
     message Sampler

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -368,12 +368,7 @@ namespace dmRender
         if (s->m_Location != -1)
         {
             dmGraphics::SetSampler(graphics_context, s->m_Location, unit);
-
-            if (s->m_MinFilter != dmGraphics::TEXTURE_FILTER_DEFAULT &&
-                s->m_MagFilter != dmGraphics::TEXTURE_FILTER_DEFAULT)
-            {
-                dmGraphics::SetTextureParams(texture, s->m_MinFilter, s->m_MagFilter, s->m_UWrap, s->m_VWrap, s->m_MaxAnisotropy);
-            }
+            dmGraphics::SetTextureParams(texture, s->m_MinFilter, s->m_MagFilter, s->m_UWrap, s->m_VWrap, s->m_MaxAnisotropy);
         }
     }
 

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -53,8 +53,10 @@ protected:
         m_Window = dmPlatform::NewWindow();
         dmPlatform::OpenWindow(m_Window, win_params);
 
-        dmGraphics::ContextParams graphics_context_params;
-        graphics_context_params.m_Window = m_Window;
+        dmGraphics::ContextParams graphics_context_params = {};
+        graphics_context_params.m_Window                  = m_Window;
+        graphics_context_params.m_DefaultTextureMinFilter = dmGraphics::TEXTURE_FILTER_DEFAULT;
+        graphics_context_params.m_DefaultTextureMagFilter = dmGraphics::TEXTURE_FILTER_DEFAULT;
 
         m_GraphicsContext = dmGraphics::NewContext(graphics_context_params);
         dmRender::RenderContextParams params;
@@ -445,6 +447,177 @@ TEST_F(dmRenderTest, TestRenderListDrawState)
     dmGraphics::DeleteFragmentProgram(fp);
     dmRender::DeleteMaterial(m_Context, material);
 
+    dmGraphics::DeleteVertexBuffer(vx_buffer);
+    dmGraphics::DeleteVertexDeclaration(vx_decl);
+}
+
+struct TestDefaultSamplerFiltersDispatchCtx
+{
+    dmRender::HRenderContext        m_Context;
+    dmRender::RenderObject          m_RenderObjects[2];
+    dmRender::HMaterial             m_Material[2];
+    dmGraphics::HVertexDeclaration  m_VertexDeclaration;
+    dmGraphics::HVertexBuffer       m_VertexBuffer;
+    dmGraphics::HTexture            m_Texture;
+    uint8_t                         m_Dispatch;
+};
+
+static void TestDefaultSamplerFiltersDispatch(dmRender::RenderListDispatchParams const & params)
+{
+    if (params.m_Operation == dmRender::RENDER_LIST_OPERATION_BATCH)
+    {
+        TestDefaultSamplerFiltersDispatchCtx* user_ctx = (TestDefaultSamplerFiltersDispatchCtx*) params.m_UserData;
+        dmRender::RenderObject* ro = &user_ctx->m_RenderObjects[user_ctx->m_Dispatch];
+
+        ro->Init();
+        ro->m_Material          = user_ctx->m_Material[user_ctx->m_Dispatch];
+        ro->m_VertexCount       = 1;
+        ro->m_VertexDeclaration = user_ctx->m_VertexDeclaration;
+        ro->m_VertexBuffer      = user_ctx->m_VertexBuffer;
+        ro->m_Textures[0]       = user_ctx->m_Texture;
+        ro->m_Textures[1]       = user_ctx->m_Texture;
+        ro->m_Textures[2]       = user_ctx->m_Texture;
+
+        AddToRender(user_ctx->m_Context, ro);
+    }
+}
+
+TEST_F(dmRenderTest, TestDefaultSamplerFilters)
+{
+    dmGraphics::TextureFilter gfx_min_filter_default;
+    dmGraphics::TextureFilter gfx_mag_filter_default;
+    dmGraphics::GetDefaultTextureFilters(m_GraphicsContext, gfx_min_filter_default, gfx_mag_filter_default);
+    ASSERT_EQ(dmGraphics::TEXTURE_FILTER_LINEAR, gfx_min_filter_default);
+    ASSERT_EQ(dmGraphics::TEXTURE_FILTER_LINEAR, gfx_mag_filter_default);
+
+    const char* shader_src = "uniform lowp sampler2D texture_sampler_1;\n"
+                             "uniform lowp sampler2D texture_sampler_2;\n"
+                             "uniform lowp sampler2D texture_sampler_3;\n";
+
+    dmGraphics::ShaderDesc::Shader shader    = MakeDDFShader(shader_src, strlen(shader_src));
+    dmGraphics::HVertexProgram vp            = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader);
+    dmGraphics::HFragmentProgram fp          = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader);
+    dmRender::HMaterial material             = dmRender::NewMaterial(m_Context, vp, fp);
+    dmRender::HMaterial material_no_samplers = dmRender::NewMaterial(m_Context, vp, fp);
+
+    dmhash_t tag = dmHashString64("tag");
+    dmRender::SetMaterialTags(material, 1, &tag);
+
+    dmGraphics::TextureCreationParams creation_params;
+    creation_params.m_Width          = 2;
+    creation_params.m_Height         = 2;
+    creation_params.m_OriginalWidth  = 2;
+    creation_params.m_OriginalHeight = 2;
+    dmGraphics::HTexture texture     = dmGraphics::NewTexture(m_GraphicsContext, creation_params);
+
+    uint8_t tex_data[creation_params.m_Width * creation_params.m_Height];
+    dmGraphics::TextureParams params;
+    params.m_DataSize  = sizeof(tex_data);
+    params.m_Data      = tex_data;
+    params.m_Width     = creation_params.m_Width;
+    params.m_Height    = creation_params.m_Height;
+    params.m_Format    = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+    params.m_MinFilter = dmGraphics::TEXTURE_FILTER_DEFAULT;
+    params.m_MagFilter = dmGraphics::TEXTURE_FILTER_DEFAULT;
+    dmGraphics::SetTexture(texture, params);
+
+    ASSERT_TRUE(dmRender::SetMaterialSampler(material,
+        dmHashString64("texture_sampler_1"), 0,
+        dmGraphics::TEXTURE_WRAP_REPEAT,
+        dmGraphics::TEXTURE_WRAP_REPEAT,
+        dmGraphics::TEXTURE_FILTER_NEAREST,
+        dmGraphics::TEXTURE_FILTER_NEAREST,
+        1.0f));
+
+    ASSERT_TRUE(dmRender::SetMaterialSampler(material,
+        dmHashString64("texture_sampler_2"), 1,
+        dmGraphics::TEXTURE_WRAP_REPEAT,
+        dmGraphics::TEXTURE_WRAP_REPEAT,
+        dmGraphics::TEXTURE_FILTER_DEFAULT,
+        dmGraphics::TEXTURE_FILTER_NEAREST,
+        1.0f));
+
+    ASSERT_TRUE(dmRender::SetMaterialSampler(material,
+        dmHashString64("texture_sampler_3"), 2,
+        dmGraphics::TEXTURE_WRAP_REPEAT,
+        dmGraphics::TEXTURE_WRAP_REPEAT,
+        dmGraphics::TEXTURE_FILTER_DEFAULT,
+        dmGraphics::TEXTURE_FILTER_DEFAULT,
+        1.0f));
+
+    dmGraphics::HVertexDeclaration vx_decl = dmGraphics::NewVertexDeclaration(m_GraphicsContext, 0, 0);
+    dmGraphics::HVertexBuffer vx_buffer = dmGraphics::NewVertexBuffer(m_GraphicsContext, 0, 0, dmGraphics::BUFFER_USAGE_STATIC_DRAW);
+
+    TestDefaultSamplerFiltersDispatchCtx user_ctx;
+    user_ctx.m_Context           = m_Context;
+    user_ctx.m_Dispatch          = 0;
+    user_ctx.m_Material[0]       = material;
+    user_ctx.m_Material[1]       = material_no_samplers;
+    user_ctx.m_Texture           = texture;
+    user_ctx.m_VertexDeclaration = vx_decl;
+    user_ctx.m_VertexBuffer      = vx_buffer;
+
+    dmRender::RenderListBegin(m_Context);
+    uint8_t dispatch = dmRender::RenderListMakeDispatch(m_Context, TestDefaultSamplerFiltersDispatch, 0, &user_ctx);
+
+    dmRender::RenderListEntry* out = dmRender::RenderListAlloc(m_Context, 1);
+    dmRender::RenderListEntry& entry = out[0];
+    entry.m_WorldPosition             = Point3(0,0,0);
+    entry.m_MajorOrder                = 0;
+    entry.m_MinorOrder                = 0;
+    entry.m_TagListKey                = 0;
+    entry.m_Order                     = 1;
+    entry.m_BatchKey                  = 0;
+    entry.m_Dispatch                  = dispatch;
+    entry.m_UserData                  = 0;
+
+    dmGraphics::TextureFilter gfx_min_filter_active;
+    dmGraphics::TextureFilter gfx_mag_filter_active;
+
+    {
+        dmRender::RenderListSubmit(m_Context, out, out + 1);
+        dmRender::RenderListEnd(m_Context);
+        dmRender::DrawRenderList(m_Context, 0, 0, 0);
+
+        dmGraphics::GetTextureFilters(m_GraphicsContext, 0, gfx_min_filter_active, gfx_mag_filter_active);
+        ASSERT_EQ(dmGraphics::TEXTURE_FILTER_NEAREST, gfx_min_filter_active);
+        ASSERT_EQ(dmGraphics::TEXTURE_FILTER_NEAREST, gfx_mag_filter_active);
+
+        dmGraphics::GetTextureFilters(m_GraphicsContext, 1, gfx_min_filter_active, gfx_mag_filter_active);
+        ASSERT_EQ(gfx_min_filter_default, gfx_min_filter_active);
+        ASSERT_EQ(dmGraphics::TEXTURE_FILTER_NEAREST, gfx_mag_filter_active);
+
+        dmGraphics::GetTextureFilters(m_GraphicsContext, 2, gfx_min_filter_active, gfx_mag_filter_active);
+        ASSERT_EQ(gfx_min_filter_default, gfx_min_filter_active);
+        ASSERT_EQ(gfx_mag_filter_default, gfx_mag_filter_active);
+    }
+
+    user_ctx.m_Dispatch++;
+
+    {
+        dmRender::RenderListSubmit(m_Context, out, out + 1);
+        dmRender::RenderListEnd(m_Context);
+        dmRender::DrawRenderList(m_Context, 0, 0, 0);
+
+        dmGraphics::GetTextureFilters(m_GraphicsContext, 0, gfx_min_filter_active, gfx_mag_filter_active);
+        ASSERT_EQ(gfx_min_filter_default, gfx_min_filter_active);
+        ASSERT_EQ(gfx_mag_filter_default, gfx_mag_filter_active);
+
+        dmGraphics::GetTextureFilters(m_GraphicsContext, 1, gfx_min_filter_active, gfx_mag_filter_active);
+        ASSERT_EQ(gfx_min_filter_default, gfx_min_filter_active);
+        ASSERT_EQ(gfx_mag_filter_default, gfx_mag_filter_active);
+
+        dmGraphics::GetTextureFilters(m_GraphicsContext, 2, gfx_min_filter_active, gfx_mag_filter_active);
+        ASSERT_EQ(gfx_min_filter_default, gfx_min_filter_active);
+        ASSERT_EQ(gfx_mag_filter_default, gfx_mag_filter_active);
+    }
+
+    dmGraphics::DeleteVertexProgram(vp);
+    dmGraphics::DeleteFragmentProgram(fp);
+    dmRender::DeleteMaterial(m_Context, material);
+    dmRender::DeleteMaterial(m_Context, material_no_samplers);
+
+    dmGraphics::DeleteTexture(texture);
     dmGraphics::DeleteVertexBuffer(vx_buffer);
     dmGraphics::DeleteVertexDeclaration(vx_decl);
 }

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -510,8 +510,7 @@ TEST_F(dmRenderTest, TestDefaultSamplerFilters)
     creation_params.m_OriginalHeight = 2;
     dmGraphics::HTexture texture     = dmGraphics::NewTexture(m_GraphicsContext, creation_params);
 
-    const uint32_t size = creation_params.m_Width * creation_params.m_Height;
-    uint8_t tex_data[size];
+    uint8_t tex_data[2 * 2];
     dmGraphics::TextureParams params;
     params.m_DataSize  = sizeof(tex_data);
     params.m_Data      = tex_data;

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -24,6 +24,8 @@
 #include <script/script.h>
 #include <algorithm> // std::stable_sort
 
+#include "../../../graphics/src/graphics_private.h"
+
 #include "render/render.h"
 #include "render/render_private.h"
 #include "render/font_renderer_private.h"

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -510,7 +510,8 @@ TEST_F(dmRenderTest, TestDefaultSamplerFilters)
     creation_params.m_OriginalHeight = 2;
     dmGraphics::HTexture texture     = dmGraphics::NewTexture(m_GraphicsContext, creation_params);
 
-    uint8_t tex_data[creation_params.m_Width * creation_params.m_Height];
+    const uint32_t size = creation_params.m_Width * creation_params.m_Height;
+    uint8_t tex_data[size];
     dmGraphics::TextureParams params;
     params.m_DataSize  = sizeof(tex_data);
     params.m_Data      = tex_data;


### PR DESCRIPTION
This PR adds new filtering keyword for material samplers called:

``` lua
FILTER_MODE_MIN_DEFAULT
FILTER_MODE_MAG_DEFAULT
```

When using these settings on a sampler in the material, the engine will pick the global min and mag settings that is specified in the `game.project -> graphics` setting. This can be useful for having a global base filtering method, while still being able to specialise settings per sampler if needed.

Fixes #8417 

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
