### PR TITLE
Allow creating any file with any extension

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -107,6 +107,10 @@
     :command :new-file
     :expand? true
     :icon "icons/64/Icons_29-AT-Unknown.png"}
+   {:label "New File"
+    :command :new-file
+    :user-data {:any-file true}
+    :icon "icons/64/Icons_29-AT-Unknown.png"}
    {:label "New Folder"
     :command :new-folder
     :icon "icons/32/Icons_01-Folder-closed.png"}
@@ -430,10 +434,11 @@
                 {:title "Delete Files?"
                  :icon :icon/circle-question
                  :header "Are you sure you want to delete these files?"
-                 :content {:text (str "You are about to delete:\n" (->> selection
-                                                    (map #(str "\u00A0\u00A0\u2022\u00A0"
-                                                              (resource/resource-name %)))
-                                                    (string/join "\n")))}
+                 :content {:text (str "You are about to delete:\n"
+                                      (->> selection
+                                           (map #(str "\u00A0\u00A0\u2022\u00A0"
+                                                      (resource/resource-name %)))
+                                           (string/join "\n")))}
                  :buttons [{:text "Cancel"
                             :cancel-button true
                             :default-button true
@@ -465,35 +470,49 @@
                                                                                             resource/abs-path)))))
   (enabled? [] (disk-availability/available?))
   (run [selection user-data asset-browser app-view prefs workspace project]
-       (let [project-path (workspace/project-path workspace)
-             base-folder (-> (or (some-> (handler/adapt-every selection resource/Resource)
-                                   first
-                                   resource/abs-path
-                                   (File.))
-                                 project-path)
-                             fs/to-folder)
-             rt (:resource-type user-data)]
-         (when-let [desired-file (dialogs/make-new-file-dialog project-path base-folder (or (:label rt) (:ext rt)) (:ext rt))]
-           (when-let [[[_ new-file]] (resolve-any-conflicts [[nil desired-file]])]
-             (let [template (workspace/template workspace rt)]
-               (create-template-file! template new-file))
-             (workspace/resource-sync! workspace)
-             (let [resource-map (g/node-value workspace :resource-map)
-                   new-resource-path (resource/file->proj-path project-path new-file)
-                   resource (resource-map new-resource-path)]
-               (app-view/open-resource app-view prefs workspace project resource)
-               (select-resource! asset-browser resource))))))
+    (let [project-path (workspace/project-path workspace)
+          base-folder (-> (or (some-> (handler/adapt-every selection resource/Resource)
+                                first
+                                resource/abs-path
+                                (File.))
+                              project-path)
+                          fs/to-folder)
+          rt (:resource-type user-data)
+          any-file (:any-file user-data false)]
+      (when-let [desired-file (dialogs/make-new-file-dialog
+                                project-path
+                                base-folder
+                                (when-not any-file
+                                  (or (:label rt) (:ext rt)))
+                                (:ext rt))]
+        (when-let [[[_ ^File new-file]] (resolve-any-conflicts [[nil desired-file]])]
+          (let [rt (if (and any-file (not rt))
+                     (when-let [ext (second (re-find #"\.(.+)$" (.getName new-file)))]
+                       (workspace/get-resource-type workspace ext))
+                     rt)
+                template (or (workspace/template workspace rt) "")]
+            (create-template-file! template new-file))
+          (workspace/resource-sync! workspace)
+          (let [resource-map (g/node-value workspace :resource-map)
+                new-resource-path (resource/file->proj-path project-path new-file)
+                resource (resource-map new-resource-path)]
+            (app-view/open-resource app-view prefs workspace project resource)
+            (select-resource! asset-browser resource))))))
   (options [workspace selection user-data]
-           (when (not user-data)
-             (sort-by (comp string/lower-case :label)
-                      (keep (fn [[_ext resource-type]]
-                              (when (workspace/has-template? workspace resource-type)
-                                {:label (or (:label resource-type) (:ext resource-type))
-                                 :icon (:icon resource-type)
-                                 :style (resource/ext-style-classes (:ext resource-type))
-                                 :command :new-file
-                                 :user-data {:resource-type resource-type}}))
-                            (workspace/get-resource-type-map workspace))))))
+    (when-not (:any-file user-data false)
+      (sort-by (comp string/lower-case :label)
+               (into [{:label "File"
+                       :icon "icons/64/Icons_29-AT-Unknown.png"
+                       :command :new-file
+                       :user-data {:any-file true}}]
+                     (keep (fn [[_ext resource-type]]
+                             (when (workspace/has-template? workspace resource-type)
+                               {:label (or (:label resource-type) (:ext resource-type))
+                                :icon (:icon resource-type)
+                                :style (resource/ext-style-classes (:ext resource-type))
+                                :command :new-file
+                                :user-data {:resource-type resource-type}})))
+                     (workspace/get-resource-type-map workspace))))))
 
 (defn- resolve-sub-folder [^File base-folder ^String new-folder-name]
   (.toFile (.resolve (.toPath base-folder) new-folder-name)))

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -790,16 +790,15 @@
       string/trim
       (string/replace #"[/\\]" "") ; strip path separators
       (string/replace #"[\"']" "") ; strip quotes
-      (string/replace #"^\.+" "") ; prevent hiding files (.dotfile)
       (string/replace #"[<>:|?*]" ""))) ; Additional Windows forbidden characters
 
 (defn sanitize-file-name [extension name]
-  (-> name
-      sanitize-common
-      (#(if (empty? extension) (string/replace % #"\..*" "") %)) ; disallow adding extension = resource type
-      (#(if (and (seq extension) (seq %))
-          (str % "." extension)
-          %)))) ; append extension if there was one
+  (let [name (sanitize-common name)]
+    (cond-> name
+            ; disallow dots when extension is expected
+            (seq extension) (string/replace #"\." "")
+            ; append extension if there was one
+            (and (seq extension) (seq name)) (str "." extension))))
 
 (defn sanitize-folder-name [name]
   (sanitize-common name))
@@ -890,11 +889,11 @@
     {:fx/type dialog-stage
      :showing (fxui/dialog-showing? props)
      :on-close-request {:event-type :cancel}
-     :title (str "New " type)
+     :title (str "New " (or type "File"))
      :size :small
      :header {:fx/type fxui/label
               :variant :header
-              :text (str "Enter " type " File Name")}
+              :text (str "Enter " (or type "the") " File Name")}
      :content {:fx/type fxui/two-col-input-grid-pane
                :style-class "dialog-content-padding"
                :children [{:fx/type fxui/label

--- a/editor/src/clj/editor/dialogs.clj
+++ b/editor/src/clj/editor/dialogs.clj
@@ -797,6 +797,8 @@
     (cond-> name
             ; disallow dots when extension is expected
             (seq extension) (string/replace #"\." "")
+            ; disallow "." and ".." names (only necessary when there is no extension)
+            (not (seq extension)) (string/replace #"^\.{1,2}$" "")
             ; append extension if there was one
             (and (seq extension) (seq name)) (str "." extension))))
 


### PR DESCRIPTION
User-facing changes:
This changeset adds a new "File" option to the New File selector. When the option is selected, the user then can create any file with any extension. We still use file templates if the user types a registered file extension.

Technical notes:
I can't believe we didn't have it.

Related to #5301