### PR TITLE
Added options in `sound.stop(url, [options])` where it's possible to specify what exactly voice should be stopped

### DIFF
--- a/engine/gamesys/proto/gamesys/gamesys_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gamesys_ddf.proto
@@ -96,6 +96,7 @@ message PlaySound
 
 message StopSound
 {
+    optional uint32 play_id = 1 [default=0xffffffff]; // Must be same as dmSound::INVALID_PLAY_ID
 }
 
 message PauseSound

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -446,12 +446,22 @@ namespace dmGameSystem
         }
         else if (params.m_Message->m_Descriptor == (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor)
         {
+            dmGameSystemDDF::StopSound* stop_sound = (dmGameSystemDDF::StopSound*)params.m_Message->m_Data;
+            uint32_t play_id = stop_sound->m_PlayId;
             for (uint32_t i = 0; i < world->m_Entries.Size(); ++i)
             {
                 PlayEntry& entry = world->m_Entries[i];
                 if (entry.m_SoundInstance != 0 && entry.m_Sound == component->m_Resource && entry.m_Instance == params.m_Instance)
                 {
-                    entry.m_StopRequested = 1;
+                    if (play_id == dmSound::INVALID_PLAY_ID)
+                    {
+                        entry.m_StopRequested = 1;
+                    }
+                    else if (entry.m_PlayId == play_id)
+                    {
+                        entry.m_StopRequested = 1;
+                        break; 
+                    }
                 }
             }
         }

--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -184,7 +184,7 @@ namespace dmGameSystem
             dmLogError("Error deleting sound: (%d)", r);
             return dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
         }
-        else if (entry.m_PlayId != dmSound::INVALID_PLAY_ID && entry.m_Listener.m_Fragment != 0x0)
+        else if (entry.m_Listener.m_Fragment != 0x0)
         {
             DispatchSoundEvent(entry, entry.m_StopRequested ? SOUND_EVENT_STOPPED : SOUND_EVENT_DONE);
         }

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -509,7 +509,6 @@ namespace dmGameSystem
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
         float delay = 0.0f, gain = 1.0f, pan = 0.0f, speed = 1.0f;
-        uint32_t play_id = dmSound::INVALID_PLAY_ID;
 
         if (top > 1 && !lua_isnil(L,2)) // table with args
         {
@@ -535,7 +534,7 @@ namespace dmGameSystem
             lua_pop(L, 1);
         }
 
-        play_id = dmSound::GetAndIncreasePlayCounter();
+        uint32_t play_id = dmSound::GetAndIncreasePlayCounter();
 
         int functionref = 0;
         if (top > 2) // completed cb

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -535,13 +535,14 @@ namespace dmGameSystem
             lua_pop(L, 1);
         }
 
+        play_id = dmSound::GetAndIncreasePlayCounter();
+
         int functionref = 0;
         if (top > 2) // completed cb
         {
             if (lua_isfunction(L, 3))
             {
                 lua_pushvalue(L, 3);
-                play_id = dmSound::GetAndIncreasePlayCounter();
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, in order to have 0 for "no function"
                 functionref = dmScript::RefInInstance(L) - LUA_NOREF;
             }
@@ -562,10 +563,13 @@ namespace dmGameSystem
     }
 
     /*# stop a playing a sound(s)
-     * Stop playing all active voices
+     * Stop playing all active voices or just one voice if `play_id` provided
      *
      * @name sound.stop
-     * @param url [type:string|hash|url] the sound that should stop
+     * @param url [type:string|hash|url] the sound component that should stop
+     * @param [stop_properties] [type:table] optional table with properties:
+     * `play_id`
+     * : [type:number] the sequential play identifier that should be stopped (was given by the sound.play() function)
      *
      * @examples
      *
@@ -573,18 +577,39 @@ namespace dmGameSystem
      *
      * ```lua
      * sound.stop("#sound")
+     * local id = sound.play("#sound")
+     * sound.stop("#sound", {play_id = id})
      * ```
      */
     static int Sound_Stop(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
+        int top = lua_gettop(L);
         dmGameObject::HInstance instance = CheckGoInstance(L);
-
-        dmGameSystemDDF::StopSound msg;
 
         dmMessage::URL receiver;
         dmMessage::URL sender;
         dmScript::ResolveURL(L, 1, &receiver, &sender);
+
+        uint32_t play_id = dmSound::INVALID_PLAY_ID;
+
+        if (top > 1 && !lua_isnil(L,2)) // table with args
+        {
+            luaL_checktype(L, 2, LUA_TTABLE);
+            lua_pushvalue(L, 2);
+
+            lua_getfield(L, -1, "play_id");
+            if (!lua_isnil(L, -1))
+            {
+                play_id = luaL_checknumber(L, -1);
+            }
+            lua_pop(L, 1);
+
+            lua_pop(L, 1);
+        }
+
+        dmGameSystemDDF::StopSound msg;
+        msg.m_PlayId = play_id;
 
         dmMessage::Post(&sender, &receiver, dmGameSystemDDF::StopSound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)dmGameSystemDDF::StopSound::m_DDFDescriptor, &msg, sizeof(msg), 0);
         return 0;


### PR DESCRIPTION
Now it's possible to stop one particular voice of the sound component:
```lua
     sound.stop("#sound")
     local id = sound.play("#sound")
     sound.stop("#sound", {play_id = id}) -- stop only one voice
```

Fix https://github.com/defold/defold/issues/8413
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
