### PR TITLE
Added `physics.set_listener(fn)` to set a function as the physics world listener

### DIFF
--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -278,8 +278,9 @@ message RequestRayCast
 
 /*# reports a ray cast hit
  *
- * This message is sent back to the sender of a `ray_cast_request`, if the ray hit a
- * collision object. See `physics.raycast_async` for examples of how to use it.
+ * This message is sent back to the sender of a [ref:ray_cast_request], or to the physics world listener
+ * if it is set (see [ref:physics.set_listener]), if the ray hits a collision object.
+ * See [ref:physics.raycast_async] for examples of how to use it.
  *
  * @message
  * @name ray_cast_response
@@ -302,8 +303,9 @@ message RayCastResponse
 
 /*# reports a ray cast miss
  *
- * This message is sent back to the sender of a `ray_cast_request`, if the ray didn't hit any
- * collision object. See `physics.raycast_async` for examples of how to use it.
+ * This message is sent back to the sender of a [ref:ray_cast_request], or to the physics world listener
+ * if it is set (see [ref:physics.set_listener]), if the ray didn't hit any collision object.
+ * See [ref:physics.raycast_async] for examples of how to use it.
  *
  * @message
  * @name ray_cast_missed

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -146,8 +146,8 @@ message ApplyForce
  * @name collision_response
  * @param other_id [type:hash] the id of the instance the collision object collided with
  * @param other_position [type:vector3] the world position of the instance the collision object collided with
- * @param other_group [type:hash] the collision group of the other collision object (hash)
- * @param own_group [type:hash] the collision group of the own collision object (hash)
+ * @param other_group [type:hash] the collision group of the other collision object
+ * @param own_group [type:hash] the collision group of the own collision object
  * @examples
  *
  * How to take action when a collision occurs:
@@ -193,8 +193,8 @@ message CollisionResponse
  * @param other_mass [type:number] the mass of the other collision object in kg
  * @param other_id [type:hash] the id of the instance the collision object is in contact with
  * @param other_position [type:vector3] the world position of the other collision object
- * @param other_group [type:hash] the collision group of the other collision object (hash)
- * @param own_group [type:hash] the collision group of the own collision object (hash)
+ * @param other_group [type:hash] the collision group of the other collision object
+ * @param own_group [type:hash] the collision group of the own collision object
  * @examples
  *
  * How to take action when a contact point occurs:
@@ -238,10 +238,10 @@ message ContactPointResponse
  *
  * @message
  * @name trigger_response
- * @param other_id [type:hash] the id of the instance the collision object collided with (hash)
+ * @param other_id [type:hash] the id of the instance the collision object collided with
  * @param enter [type:boolean] if the interaction was an entry or not
- * @param other_group [type:hash] the collision group of the triggering collision object (hash)
- * @param own_group [type:hash] the collision group of the own collision object (hash)
+ * @param other_group [type:hash] the collision group of the triggering collision object
+ * @param own_group [type:hash] the collision group of the own collision object
  * @examples
  *
  * How to take action when a trigger interaction occurs:
@@ -370,13 +370,13 @@ message ContactPoint
  * @param a [type:table] contact point information for object A
  *
  * `position`
- * : [type:vector3] The world position of object A.
+ * : [type:vector3] The world position of object A
  *
  * `id`
- * : [type:hash] The ID of object A.
+ * : [type:hash] The ID of object A
  *
  * `group`
- * : [type:hash] The collision group of object A (hash).
+ * : [type:hash] The collision group of object A
  *
  * `relative_velocity`
  * : [type:vector3] The relative velocity of the collision object A as observed from B object
@@ -390,13 +390,13 @@ message ContactPoint
  * @param b [type:table] contact point information for object B
  *
  * `position`
- * : [type:vector3] The world position of object B.
+ * : [type:vector3] The world position of object B
  *
  * `id`
- * : [type:hash] The ID of object B.
+ * : [type:hash] The ID of object B
  *
  * `group`
- * : [type:hash] The collision group of object B (hash).
+ * : [type:hash] The collision group of object B
  *
  * `relative_velocity`
  * : [type:vector3] The relative velocity of the collision object B as observed from A object
@@ -405,7 +405,7 @@ message ContactPoint
  * : [type:number] The mass of the collision object B in kg
  *
  * `normal`
- * : [type:vector3] normal in world space of the contact point, which points from A object towards  object
+ * : [type:vector3] normal in world space of the contact point, which points from A object towards B object
  *
  * @examples
  *
@@ -460,7 +460,7 @@ message Collision
  * This message is sent to a function specified in [ref:physics.set_listener]
  * when two collision objects collide.
  *
- * This message only reports that a collision has occurred and will be sent once per frame.
+ * This message only reports that a collision has occurred and will be sent once per frame and per colliding pair.
  * For more detailed information, check for the [ref:contact_point_event].
  *
  * @message
@@ -468,24 +468,24 @@ message Collision
  * @param a [type:table] collision information for object A
  *
  * `position`
- * : [type:vector3] The world position of object A.
+ * : [type:vector3] The world position of object A
  *
  * `id`
- * : [type:hash] The ID of object A.
+ * : [type:hash] The ID of object A
  *
  * `group`
- * : [type:hash] The collision group of object A (hash).
+ * : [type:hash] The collision group of object A
  *
  * @param b [type:table] collision information for object B
  *
  * `position`
- * : [type:vector3] The world position of object B.
+ * : [type:vector3] The world position of object B
  *
  * `id`
- * : [type:hash] The ID of object B.
+ * : [type:hash] The ID of object B
  *
  * `group`
- * : [type:hash] The collision group of object B (hash).
+ * : [type:hash] The collision group of object B
  *
  * @examples
  *
@@ -537,18 +537,18 @@ message Trigger
  * @param enter [type:boolean] if the interaction was an entry or not
  * @param a [type:table] interaction information for object A
  * `id`
- * : [type:hash] The ID of object A.
+ * : [type:hash] The ID of object A
  *
  * `group`
- * : [type:hash] The collision group of object A (hash).
+ * : [type:hash] The collision group of object A
  *
  * @param b [type:table] collision information for object B
  *
  * `id`
- * : [type:hash] The ID of object B.
+ * : [type:hash] The ID of object B
  *
  * `group`
- * : [type:hash] The collision group of object B (hash).
+ * : [type:hash] The collision group of object B
  *
  * @examples
  *

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -340,3 +340,47 @@ message EnableGridShapeLayer
     required uint32 shape = 1;
     required uint32 enable = 2;
 }
+
+message ContactPoint
+{
+    required dmMath.Point3  position                 = 1;
+    required dmMath.Vector3 normal                   = 2;
+    required dmMath.Vector3 relative_velocity        = 3;
+    required float          mass                     = 4;
+    required uint64         id                       = 5;
+    required uint64         group                    = 6;
+}
+
+message ContactPointEvent
+{   
+    required ContactPoint   a                         = 1;
+    required ContactPoint   b                         = 2;
+    required float          distance                  = 3;
+    required float          applied_impulse           = 4;
+}
+
+message Collision
+{
+    required dmMath.Point3 position                  = 1;
+    required uint64 id                               = 2;
+    required uint64 group                            = 3;
+}
+
+message CollisionEvent
+{
+    required Collision a                            = 1;
+    required Collision b                            = 2;
+}
+
+message Trigger
+{
+    required uint64 id                              = 1;
+    required uint64 group                           = 2;
+}
+
+message TriggerEvent
+{
+    required bool enter                             = 1;
+    required Trigger a                              = 2;
+    required Trigger b                              = 3;
+}

--- a/engine/gamesys/proto/gamesys/physics_ddf.proto
+++ b/engine/gamesys/proto/gamesys/physics_ddf.proto
@@ -351,6 +351,92 @@ message ContactPoint
     required uint64         group                    = 6;
 }
 
+/*# reports a contact point between two collision objects in cases where a listener is specified.
+ * See [ref:physics.set_listener].
+ *
+ * This message is sent to a function specified in [ref:physics.set_listener] when
+ * a collision object has contact points with another collision object.
+ *
+ * Since multiple contact points can occur for two colliding objects, this event can be sent
+ * multiple times in the same frame for the same two colliding objects. To only be notified once
+ * when the collision occurs, check for the [ref:collision_event] event instead.
+ *
+ * @message
+ * @name contact_point_event
+ * @param applied_impulse [type:number] the impulse the contact resulted in
+ * @param distance [type:number] the penetration distance between the objects, which is always positive
+ * @param a [type:table] contact point information for object A
+ *
+ * `position`
+ * : [type:vector3] The world position of object A.
+ *
+ * `id`
+ * : [type:hash] The ID of object A.
+ *
+ * `group`
+ * : [type:hash] The collision group of object A (hash).
+ *
+ * `relative_velocity`
+ * : [type:vector3] The relative velocity of the collision object A as observed from B object
+ *
+ * `mass`
+ * : [type:number] The mass of the collision object A in kg
+ *
+ * `normal`
+ * : [type:vector3] normal in world space of the contact point, which points from B object towards A object
+ *
+ * @param b [type:table] contact point information for object B
+ *
+ * `position`
+ * : [type:vector3] The world position of object B.
+ *
+ * `id`
+ * : [type:hash] The ID of object B.
+ *
+ * `group`
+ * : [type:hash] The collision group of object B (hash).
+ *
+ * `relative_velocity`
+ * : [type:vector3] The relative velocity of the collision object B as observed from A object
+ *
+ * `mass`
+ * : [type:number] The mass of the collision object B in kg
+ *
+ * `normal`
+ * : [type:vector3] normal in world space of the contact point, which points from A object towards  object
+ *
+ * @examples
+ *
+ * How to take action when a contact point occurs:
+ *
+ * ```lua
+ * physics.set_listener(function(self, event, data)
+ *  if event == hash("contact_point_event") then
+ *      pprint(data)
+ *      -- {
+ *      --  applied_impulse = 310.00769042969,
+ *      --  distance = 0.0714111328125,
+ *      --  a = {
+ *      --      position = vmath.vector3(446, 371, 0),
+ *      --      relative_velocity = vmath.vector3(1.1722083854693e-06, -20.667181015015, -0),
+ *      --      mass = 0,
+ *      --      group = hash: [default],
+ *      --      id = hash: [/flat],
+ *      --      normal = vmath.vector3(-0, -1, -0)
+ *      --  },
+ *      --  b = {
+ *      --      position = vmath.vector3(185, 657.92858886719, 0),
+ *      --      relative_velocity = vmath.vector3(-1.1722083854693e-06, 20.667181015015, 0),
+ *      --      mass = 10,
+ *      --      group = hash: [default],
+ *      --      id = hash: [/go2],
+ *      --      normal = vmath.vector3(0, 1, 0)
+ *      --  },
+ *      -- }
+ *   end
+ * end)
+ * ```
+ */
 message ContactPointEvent
 {   
     required ContactPoint   a                         = 1;
@@ -366,6 +452,63 @@ message Collision
     required uint64 group                            = 3;
 }
 
+/*# reports a collision between two collision objects in cases where a listener is specified.
+ * See [ref:physics.set_listener].
+ *
+ * This message is sent to a function specified in [ref:physics.set_listener]
+ * when two collision objects collide.
+ *
+ * This message only reports that a collision has occurred and will be sent once per frame.
+ * For more detailed information, check for the [ref:contact_point_event].
+ *
+ * @message
+ * @name collision_event
+ * @param a [type:table] collision information for object A
+ *
+ * `position`
+ * : [type:vector3] The world position of object A.
+ *
+ * `id`
+ * : [type:hash] The ID of object A.
+ *
+ * `group`
+ * : [type:hash] The collision group of object A (hash).
+ *
+ * @param b [type:table] collision information for object B
+ *
+ * `position`
+ * : [type:vector3] The world position of object B.
+ *
+ * `id`
+ * : [type:hash] The ID of object B.
+ *
+ * `group`
+ * : [type:hash] The collision group of object B (hash).
+ *
+ * @examples
+ *
+ * How to take action when a collision occurs:
+ *
+ * ```lua
+ * physics.set_listener(function(self, event, data)
+ *   if event == hash("collision_event") then
+ *       pprint(data)
+ *       -- {
+ *       --  a = {
+ *       --          group = hash: [default],
+ *       --          position = vmath.vector3(183, 666, 0),
+ *       --          id = hash: [/go1]
+ *       --      },
+ *       --  b = {
+ *       --          group = hash: [default],
+ *       --          position = vmath.vector3(185, 704.05865478516, 0),
+ *       --          id = hash: [/go2]
+ *       --      }
+ *       -- }
+ *   end
+ * end)
+ * ```
+ */
 message CollisionEvent
 {
     required Collision a                            = 1;
@@ -378,6 +521,61 @@ message Trigger
     required uint64 group                           = 2;
 }
 
+/*# reports interaction (enter/exit) between a trigger collision object and another collision object
+ * See [ref:physics.set_listener].
+ *
+ * This message is sent to a function specified in [ref:physics.set_listener]
+ * when a collision object interacts with another collision object and one of them is a trigger.
+ *
+ * This message only reports that an interaction actually happened and will be sent once per colliding pair and frame.
+ * For more detailed information, check for the [ref:contact_point_event].
+ *
+ * @message
+ * @name trigger_event
+ * @param enter [type:boolean] if the interaction was an entry or not
+ * @param a [type:table] interaction information for object A
+ * `id`
+ * : [type:hash] The ID of object A.
+ *
+ * `group`
+ * : [type:hash] The collision group of object A (hash).
+ *
+ * @param b [type:table] collision information for object B
+ *
+ * `id`
+ * : [type:hash] The ID of object B.
+ *
+ * `group`
+ * : [type:hash] The collision group of object B (hash).
+ *
+ * @examples
+ *
+ * How to take action when a trigger interaction occurs:
+ *
+ * ```lua
+ * physics.set_listener(function(self, event, data)
+ *  if event ==  hash("trigger_event") then
+ *      if data.enter then
+ *         -- take action for entry
+ *      else
+ *         -- take action for exit
+ *      end
+ *      pprint(data)
+ *      -- {
+ *      --  enter = true,
+ *      --  b = {
+ *      --      group = hash: [default],
+ *      --      id = hash: [/go2]
+ *      --  },
+ *      --  a = {
+ *      --      group = hash: [default],
+ *      --      id = hash: [/go1]
+ *      --  }
+ *      -- },
+ *   end
+ * end)
+ * ```
+ */
 message TriggerEvent
 {
     required bool enter                             = 1;

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -606,19 +606,17 @@ namespace dmGameSystem
 
             if (world->m_LuaListener != 0)
             {
-                dmPhysicsDDF::Collision a;
+                dmPhysicsDDF::CollisionEvent ddf;
+
+                dmPhysicsDDF::Collision& a = ddf.m_A;
                 a.m_Group =     group_hash_a;
                 a.m_Id =        instance_a_id;
                 a.m_Position =  dmGameObject::GetWorldPosition(instance_a);
 
-                dmPhysicsDDF::Collision b;
+                dmPhysicsDDF::Collision& b = ddf.m_B;
                 b.m_Group =     group_hash_b;
                 b.m_Id =        instance_b_id;
                 b.m_Position =  dmGameObject::GetWorldPosition(instance_b);
-
-                dmPhysicsDDF::CollisionEvent ddf;
-                ddf.m_A = a;
-                ddf.m_B = b;
 
                 dmGameObject::Result message_result = dmGameObject::PostDDF(&ddf, 0x0, &world->m_LuaListenerReceiver, world->m_LuaListener, false);
                 if (message_result != dmGameObject::RESULT_OK)
@@ -675,7 +673,11 @@ namespace dmGameSystem
 
             if (world->m_LuaListener != 0)
             {
-                dmPhysicsDDF::ContactPoint a;
+                dmPhysicsDDF::ContactPointEvent ddf;
+                ddf.m_AppliedImpulse = contact_point.m_AppliedImpulse;
+                ddf.m_Distance = contact_point.m_Distance;
+
+                dmPhysicsDDF::ContactPoint& a = ddf.m_A;
                 a.m_Group               = group_hash_a;
                 a.m_Id                  = instance_a_id;
                 a.m_Position            = dmGameObject::GetWorldPosition(instance_a);
@@ -683,19 +685,13 @@ namespace dmGameSystem
                 a.m_RelativeVelocity    = -contact_point.m_RelativeVelocity;
                 a.m_Normal              = -contact_point.m_Normal;
 
-                dmPhysicsDDF::ContactPoint b;
+                dmPhysicsDDF::ContactPoint& b = ddf.m_B;
                 b.m_Group               = group_hash_b;
                 b.m_Id                  = instance_b_id;
                 b.m_Position            = dmGameObject::GetWorldPosition(instance_b);
                 b.m_Mass                = mass_b;
                 b.m_RelativeVelocity    = contact_point.m_RelativeVelocity;
                 b.m_Normal              = contact_point.m_Normal;
-
-                dmPhysicsDDF::ContactPointEvent ddf;
-                ddf.m_A = a;
-                ddf.m_B = b;
-                ddf.m_AppliedImpulse = contact_point.m_AppliedImpulse;
-                ddf.m_Distance = contact_point.m_Distance;
 
                 dmGameObject::Result message_result = dmGameObject::PostDDF(&ddf, 0x0, &world->m_LuaListenerReceiver, world->m_LuaListener, false);
                 if (message_result != dmGameObject::RESULT_OK)
@@ -765,18 +761,17 @@ namespace dmGameSystem
 
         if (world->m_LuaListener != 0)
         {
-            dmPhysicsDDF::Trigger a;
-            a.m_Group       = group_hash_a;
-            a.m_Id          = instance_a_id;
-
-            dmPhysicsDDF::Trigger b;
-            b.m_Group       = group_hash_b;
-            b.m_Id          = instance_b_id;
 
             dmPhysicsDDF::TriggerEvent ddf;
             ddf.m_Enter = 1;
-            ddf.m_A = a;
-            ddf.m_B = b;
+
+            dmPhysicsDDF::Trigger& a = ddf.m_A;
+            a.m_Group       = group_hash_a;
+            a.m_Id          = instance_a_id;
+
+            dmPhysicsDDF::Trigger& b = ddf.m_B;
+            b.m_Group       = group_hash_b;
+            b.m_Id          = instance_b_id;
 
             dmGameObject::Result message_result = dmGameObject::PostDDF(&ddf, 0x0, &world->m_LuaListenerReceiver, world->m_LuaListener, false);
             if (message_result != dmGameObject::RESULT_OK)
@@ -819,19 +814,16 @@ namespace dmGameSystem
 
         if (world->m_LuaListener != 0)
         {
-            dmPhysicsDDF::Trigger a;
+            dmPhysicsDDF::TriggerEvent ddf;
+            ddf.m_Enter = 0;
+
+            dmPhysicsDDF::Trigger& a = ddf.m_A;
             a.m_Group       = group_hash_a;
             a.m_Id          = instance_a_id;
 
-            dmPhysicsDDF::Trigger b;
+            dmPhysicsDDF::Trigger& b = ddf.m_B;
             b.m_Group       = group_hash_b;
             b.m_Id          = instance_b_id;
-
-            dmPhysicsDDF::TriggerEvent ddf;
-            ddf.m_Enter = 0;
-            ddf.m_A = a;
-            ddf.m_B = b;
-
             dmGameObject::Result message_result = dmGameObject::PostDDF(&ddf, 0x0, &world->m_LuaListenerReceiver, world->m_LuaListener, false);
             if (message_result != dmGameObject::RESULT_OK)
             {
@@ -878,23 +870,23 @@ namespace dmGameSystem
         dmMessage::URL* resultReceiver = lua_listener == 0 ? &receiver : &world->m_LuaListenerReceiver;
         if (response.m_Hit)
         {
-            dmPhysicsDDF::RayCastResponse responsDDF;
+            dmPhysicsDDF::RayCastResponse response_ddf;
             CollisionComponent* component = (CollisionComponent*)response.m_CollisionObjectUserData;
 
-            responsDDF.m_Fraction = response.m_Fraction;
-            responsDDF.m_Id = dmGameObject::GetIdentifier(component->m_Instance);
-            responsDDF.m_Group = GetLSBGroupHash(world, response.m_CollisionObjectGroup);
-            responsDDF.m_Position = response.m_Position;
-            responsDDF.m_Normal = response.m_Normal;
-            responsDDF.m_RequestId = request.m_UserId & 0xff;
+            response_ddf.m_Fraction = response.m_Fraction;
+            response_ddf.m_Id = dmGameObject::GetIdentifier(component->m_Instance);
+            response_ddf.m_Group = GetLSBGroupHash(world, response.m_CollisionObjectGroup);
+            response_ddf.m_Position = response.m_Position;
+            response_ddf.m_Normal = response.m_Normal;
+            response_ddf.m_RequestId = request.m_UserId & 0xff;
 
-            message_result = dmGameObject::PostDDF(&responsDDF, 0x0, resultReceiver, lua_listener, false);
+            message_result = dmGameObject::PostDDF(&response_ddf, 0x0, resultReceiver, lua_listener, false);
         }
         else
         {
-            dmPhysicsDDF::RayCastMissed missedDDF;
-            missedDDF.m_RequestId = request.m_UserId & 0xff;
-            message_result = dmGameObject::PostDDF(&missedDDF, 0x0, resultReceiver, lua_listener, false);
+            dmPhysicsDDF::RayCastMissed missed_ddf;
+            missed_ddf.m_RequestId = request.m_UserId & 0xff;
+            message_result = dmGameObject::PostDDF(&missed_ddf, 0x0, resultReceiver, lua_listener, false);
         }
 
         if (message_result != dmGameObject::RESULT_OK)

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -562,8 +562,11 @@ namespace dmGameSystem
     };
 
     template <class DDFMessage>
-    static void BroadCast(DDFMessage* ddf, dmGameObject::HInstance instance, dmhash_t instance_id, uint16_t component_index, CollisionWorld* world)
+    static void BroadCast(DDFMessage* ddf, dmGameObject::HInstance instance, dmhash_t instance_id, uint16_t component_index)
     {
+        dmhash_t message_id = DDFMessage::m_DDFDescriptor->m_NameHash;
+        uintptr_t descriptor = (uintptr_t)DDFMessage::m_DDFDescriptor;
+        uint32_t data_size = sizeof(DDFMessage);
         dmMessage::URL sender;
         dmMessage::ResetURL(&sender);
         dmMessage::URL receiver;
@@ -577,8 +580,8 @@ namespace dmGameSystem
         {
             dmLogError("Could not retrieve sender component when reporting %s: %d", DDFMessage::m_DDFDescriptor->m_Name, r);
         }
-        dmGameObject::Result result = dmGameObject::PostDDF(ddf, &sender, &receiver, 0, false);
-        if (result != dmGameObject::RESULT_OK)
+        dmMessage::Result result = dmMessage::Post(&sender, &receiver, message_id, 0, descriptor, ddf, data_size, 0);
+        if (result != dmMessage::RESULT_OK)
         {
             dmLogError("Could not send %s to component: %d", DDFMessage::m_DDFDescriptor->m_Name, result);
         }
@@ -633,7 +636,7 @@ namespace dmGameSystem
             ddf.m_Group = group_hash_b;
             ddf.m_OtherId = instance_b_id;
             ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_b);
-            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex, world);
+            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
 
             // Broadcast to B components
             ddf.m_OwnGroup = group_hash_b;
@@ -641,7 +644,7 @@ namespace dmGameSystem
             ddf.m_Group = group_hash_a;
             ddf.m_OtherId = instance_a_id;
             ddf.m_OtherPosition = dmGameObject::GetWorldPosition(instance_a);
-            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex, world);
+            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
 
             return true;
         }
@@ -718,7 +721,7 @@ namespace dmGameSystem
             ddf.m_OwnGroup = group_hash_a;
             ddf.m_OtherGroup = group_hash_b;
             ddf.m_LifeTime = 0;
-            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex, world);
+            BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
 
             // Broadcast to B components
             ddf.m_Position = contact_point.m_PositionB;
@@ -734,7 +737,7 @@ namespace dmGameSystem
             ddf.m_OwnGroup = group_hash_b;
             ddf.m_OtherGroup = group_hash_a;
             ddf.m_LifeTime = 0;
-            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex, world);
+            BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
 
             return true;
         }
@@ -791,14 +794,14 @@ namespace dmGameSystem
         ddf.m_Group = group_hash_b;
         ddf.m_OwnGroup = group_hash_a;
         ddf.m_OtherGroup = group_hash_b;
-        BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex, world);
+        BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
 
         // Broadcast to B components
         ddf.m_OtherId = instance_a_id;
         ddf.m_Group = group_hash_a;
         ddf.m_OwnGroup = group_hash_b;
         ddf.m_OtherGroup = group_hash_a;
-        BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex, world);
+        BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
     }
 
     void TriggerExitedCallback(const dmPhysics::TriggerExit& trigger_exit, void* user_data)
@@ -845,14 +848,14 @@ namespace dmGameSystem
         ddf.m_Group = group_hash_b;
         ddf.m_OwnGroup = group_hash_a;
         ddf.m_OtherGroup = group_hash_b;
-        BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex, world);
+        BroadCast(&ddf, instance_a, instance_a_id, component_a->m_ComponentIndex);
 
         // Broadcast to B components
         ddf.m_OtherId = instance_a_id;
         ddf.m_Group = group_hash_a;
         ddf.m_OwnGroup = group_hash_b;
         ddf.m_OtherGroup = group_hash_a;
-        BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex, world);
+        BroadCast(&ddf, instance_b, instance_b_id, component_b->m_ComponentIndex);
     }
 
     struct RayCastUserData

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -132,7 +132,6 @@ namespace dmGameSystem
         uint64_t m_Groups[16];
 
         void* m_CallbackInfo;
-        void (*m_CallbackFunc)(void*, const dmDDF::Descriptor*, const char*);
 
         union
         {
@@ -589,7 +588,7 @@ namespace dmGameSystem
 
     void RunPhysicsCallback(CollisionWorld* world, const dmDDF::Descriptor* desc, const char* data)
     {
-        world->m_CallbackFunc(world->m_CallbackInfo, desc, data);
+        RunCollisionWorldCallback(world->m_CallbackInfo, desc, data);
     }
 
     bool CollisionCallback(void* user_data_a, uint16_t group_a, void* user_data_b, uint16_t group_b, void* user_data)
@@ -2013,11 +2012,10 @@ namespace dmGameSystem
         return world->m_CallbackInfo;
     }
 
-    void SetCollisionWorldCallback(void* _world, void* callback_info, void (*callback_func)(void*, const dmDDF::Descriptor*, const char*))
+    void SetCollisionWorldCallback(void* _world, void* callback_info)
     {
         CollisionWorld* world = (CollisionWorld*)_world;
         world->m_CallbackInfo = callback_info;
-        world->m_CallbackFunc = callback_func;
     }
 
     dmhash_t GetCollisionGroup(void* _world, void* _component)

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.h
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.h
@@ -84,7 +84,8 @@ namespace dmGameSystem
     bool SetCollisionMaskBit(void* _world, void* _component, dmhash_t group_hash, bool boolvalue);
 
     void* GetCollisionWorldCallback(void* _world);
-    void SetCollisionWorldCallback(void* _world, void* callback_info, void (*callback)(void*, const dmDDF::Descriptor*, const char*));
+    void SetCollisionWorldCallback(void* _world, void* callback_info);
+    void RunCollisionWorldCallback(void* callback_data, const dmDDF::Descriptor* desc, const char* data);
 
     struct ShapeInfo
     {

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.h
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.h
@@ -78,11 +78,13 @@ namespace dmGameSystem
     void SetCollisionFlipH(void* _component, bool flip);
     void SetCollisionFlipV(void* _component, bool flip);
     void WakeupCollision(void* _world, void* _component);
-    void SetWorldListener(void* _world, uintptr_t listener, dmMessage::URL* listenerReceiver);
     dmhash_t GetCollisionGroup(void* _world, void* _component);
     bool SetCollisionGroup(void* _world, void* _component, dmhash_t group_hash);
     bool GetCollisionMaskBit(void* _world, void* _component, dmhash_t group_hash, bool* maskbit);
     bool SetCollisionMaskBit(void* _world, void* _component, dmhash_t group_hash, bool boolvalue);
+
+    void* GetCollisionWorldCallback(void* _world);
+    void SetCollisionWorldCallback(void* _world, void* callback_info, void (*callback)(void*, const dmDDF::Descriptor*, const char*));
 
     struct ShapeInfo
     {

--- a/engine/gamesys/src/gamesys/components/comp_collision_object.h
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.h
@@ -78,6 +78,7 @@ namespace dmGameSystem
     void SetCollisionFlipH(void* _component, bool flip);
     void SetCollisionFlipV(void* _component, bool flip);
     void WakeupCollision(void* _world, void* _component);
+    void SetWorldListener(void* _world, uintptr_t listener, dmMessage::URL* listenerReceiver);
     dmhash_t GetCollisionGroup(void* _world, void* _component);
     bool SetCollisionGroup(void* _world, void* _component, dmhash_t group_hash);
     bool GetCollisionMaskBit(void* _world, void* _component, dmhash_t group_hash, bool* maskbit);

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -287,105 +287,6 @@ namespace dmGameSystem
      * end
      * ```
      */
-
-    /*# sets a physics world event listener. If a function is set, physics messages will no longer be sent.
-     *
-     * @name physics.set_listener
-     *
-     * @param callback [type:function(self, event, data)|nil] A callback that receives information about all the physics interactions in this physics world.
-     *
-     * `self`
-     * : [type:object] The calling script
-     *
-     * `event`
-     * : [type:constant] The type of event. Can be one of these messages:
-     *
-     *
-     * - [ref:contact_point_event]
-     * - [ref:collision_event]
-     * - [ref:trigger_event]
-     * - [ref:ray_cast_response]
-     * - [ref:ray_cast_missed]
-     *
-     * `data`
-     * : [type:table] The callback value data is a table that contains event-related data. See the documentation for details on the messages.
-     *
-     * @examples
-     *
-     * ```lua
-     * local function physics_world_listener(self, event, data)
-     *   if event == hash("contact_point_event") then
-     *     pprint(data)
-     *     -- {
-     *     --  distance = 0.0714111328125,
-     *     --  applied_impulse = 310.00769042969,
-     *     --  a = {
-     *     --      position = vmath.vector3(446, 371, 0),
-     *     --      relative_velocity = vmath.vector3(1.1722083854693e-06, -20.667181015015, -0),
-     *     --      mass = 0,
-     *     --      group = hash: [default],
-     *     --      id = hash: [/flat],
-     *     --      normal = vmath.vector3(-0, -1, -0)
-     *     --  },
-     *     --  b = {
-     *     --      position = vmath.vector3(185, 657.92858886719, 0),
-     *     --      relative_velocity = vmath.vector3(-1.1722083854693e-06, 20.667181015015, 0),
-     *     --      mass = 10,
-     *     --      group = hash: [default],
-     *     --      id = hash: [/go2],
-     *     --      normal = vmath.vector3(0, 1, 0)
-     *     --  }
-     *     -- }
-     *   elseif event == hash("collision_event") then
-     *     pprint(data)
-     *     -- {
-     *     --  a = {
-     *     --          group = hash: [default],
-     *     --          position = vmath.vector3(183, 666, 0),
-     *     --          id = hash: [/go1]
-     *     --      },
-     *     --  b = {
-     *     --          group = hash: [default],
-     *     --          position = vmath.vector3(185, 704.05865478516, 0),
-     *     --          id = hash: [/go2]
-     *     --      }
-     *     -- }
-     *   elseif event ==  hash("trigger_event") then
-     *     pprint(data)
-     *     -- {
-     *     --  enter = true,
-     *     --  b = {
-     *     --      group = hash: [default],
-     *     --      id = hash: [/go2]
-     *     --  },
-     *     --  a = {
-     *     --      group = hash: [default],
-     *     --      id = hash: [/go1]
-     *     --  }
-     *     -- },
-     *   elseif event ==  hash("ray_cast_response") then
-     *     pprint(data)
-     *     --{
-     *     --  group = hash: [default],
-     *     --  request_id = 0,
-     *     --  position = vmath.vector3(249.92222595215, 249.92222595215, 0),
-     *     --  fraction = 0.68759721517563,
-     *     --  normal = vmath.vector3(0, 1, 0),
-     *     --  id = hash: [/go]
-     *     -- }
-     *   elseif event ==  hash("ray_cast_missed") then
-     *     pprint(data)
-     *     -- {
-     *     --  request_id = 0
-     *     --},
-     *   end
-     * end
-     *
-     * function init(self)
-     *     physics.set_listener(physics_world_listener)
-     * end
-     * ```
-     */
     int Physics_RayCastAsync(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
@@ -1552,10 +1453,121 @@ namespace dmGameSystem
         return 0;
     }
 
+    /*# sets a physics world event listener. If a function is set, physics messages will no longer be sent.
+     *
+     * @name physics.set_listener
+     *
+     * @param callback [type:function(self, event, data)|nil] A callback that receives information about all the physics interactions in this physics world.
+     *
+     * `self`
+     * : [type:object] The calling script
+     *
+     * `event`
+     * : [type:constant] The type of event. Can be one of these messages:
+     *
+     *
+     * - [ref:contact_point_event]
+     * - [ref:collision_event]
+     * - [ref:trigger_event]
+     * - [ref:ray_cast_response]
+     * - [ref:ray_cast_missed]
+     *
+     * `data`
+     * : [type:table] The callback value data is a table that contains event-related data. See the documentation for details on the messages.
+     *
+     * @examples
+     *
+     * ```lua
+     * local function physics_world_listener(self, event, data)
+     *   if event == hash("contact_point_event") then
+     *     pprint(data)
+     *     -- {
+     *     --  distance = 0.0714111328125,
+     *     --  applied_impulse = 310.00769042969,
+     *     --  a = {
+     *     --      position = vmath.vector3(446, 371, 0),
+     *     --      relative_velocity = vmath.vector3(1.1722083854693e-06, -20.667181015015, -0),
+     *     --      mass = 0,
+     *     --      group = hash: [default],
+     *     --      id = hash: [/flat],
+     *     --      normal = vmath.vector3(-0, -1, -0)
+     *     --  },
+     *     --  b = {
+     *     --      position = vmath.vector3(185, 657.92858886719, 0),
+     *     --      relative_velocity = vmath.vector3(-1.1722083854693e-06, 20.667181015015, 0),
+     *     --      mass = 10,
+     *     --      group = hash: [default],
+     *     --      id = hash: [/go2],
+     *     --      normal = vmath.vector3(0, 1, 0)
+     *     --  }
+     *     -- }
+     *   elseif event == hash("collision_event") then
+     *     pprint(data)
+     *     -- {
+     *     --  a = {
+     *     --          group = hash: [default],
+     *     --          position = vmath.vector3(183, 666, 0),
+     *     --          id = hash: [/go1]
+     *     --      },
+     *     --  b = {
+     *     --          group = hash: [default],
+     *     --          position = vmath.vector3(185, 704.05865478516, 0),
+     *     --          id = hash: [/go2]
+     *     --      }
+     *     -- }
+     *   elseif event ==  hash("trigger_event") then
+     *     pprint(data)
+     *     -- {
+     *     --  enter = true,
+     *     --  b = {
+     *     --      group = hash: [default],
+     *     --      id = hash: [/go2]
+     *     --  },
+     *     --  a = {
+     *     --      group = hash: [default],
+     *     --      id = hash: [/go1]
+     *     --  }
+     *     -- },
+     *   elseif event ==  hash("ray_cast_response") then
+     *     pprint(data)
+     *     --{
+     *     --  group = hash: [default],
+     *     --  request_id = 0,
+     *     --  position = vmath.vector3(249.92222595215, 249.92222595215, 0),
+     *     --  fraction = 0.68759721517563,
+     *     --  normal = vmath.vector3(0, 1, 0),
+     *     --  id = hash: [/go]
+     *     -- }
+     *   elseif event ==  hash("ray_cast_missed") then
+     *     pprint(data)
+     *     -- {
+     *     --  request_id = 0
+     *     --},
+     *   end
+     * end
+     *
+     * function init(self)
+     *     physics.set_listener(physics_world_listener)
+     * end
+     * ```
+     */
     static int Physics_SetListener(lua_State* L)
     {
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
+        
+        dmScript::GetGlobal(L, PHYSICS_CONTEXT_HASH);
+        PhysicsScriptContext* context = (PhysicsScriptContext*)lua_touserdata(L, -1);
+        lua_pop(L, 1);
+
+        dmGameObject::HInstance sender_instance = CheckGoInstance(L);
+        dmGameObject::HCollection collection = dmGameObject::GetCollection(sender_instance);
+
+        void* world = dmGameObject::GetWorld(collection, context->m_ComponentIndex);
+        if (world == 0x0)
+        {
+            return DM_LUA_ERROR("Physics world doesn't exist. Make sure you have at least one physics component in collection.");
+        }
         int functionref = 0;
         if (top >= 1) // completed cb
         {
@@ -1565,17 +1577,6 @@ namespace dmGameSystem
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, in order to have 0 for "no function"
                 functionref = dmScript::RefInInstance(L) - LUA_NOREF;
             }
-        }
-        dmScript::GetGlobal(L, PHYSICS_CONTEXT_HASH);
-        PhysicsScriptContext* context = (PhysicsScriptContext*)lua_touserdata(L, -1);
-        lua_pop(L, 1);
-
-        dmGameObject::HInstance sender_instance = CheckGoInstance(L);
-        dmGameObject::HCollection collection = dmGameObject::GetCollection(sender_instance);
-        void* world = dmGameObject::GetWorld(collection, context->m_ComponentIndex);
-        if (world == 0x0)
-        {
-            return DM_LUA_ERROR("Physics world doesn't exist. Make sure you have at least one physics component in collection.");
         }
 
         dmMessage::URL listenerReceiver;

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -288,7 +288,7 @@ namespace dmGameSystem
      * ```
      */
 
-    /*# sets a physics world event listener.
+    /*# sets a physics world event listener. If a function is set, physics messages will no longer be sent.
      *
      * @name physics.set_listener
      *
@@ -317,6 +317,7 @@ namespace dmGameSystem
      *   if event == hash("contact_point_event") then
      *     pprint(data)
      *     -- {
+     *     --  distance = 0.0714111328125,
      *     --  applied_impulse = 310.00769042969,
      *     --  a = {
      *     --      position = vmath.vector3(446, 371, 0),
@@ -333,8 +334,7 @@ namespace dmGameSystem
      *     --      group = hash: [default],
      *     --      id = hash: [/go2],
      *     --      normal = vmath.vector3(0, 1, 0)
-     *     --  },
-     *     --  distance = 0.0714111328125
+     *     --  }
      *     -- }
      *   elseif event == hash("collision_event") then
      *     pprint(data)
@@ -353,11 +353,11 @@ namespace dmGameSystem
      *   elseif event ==  hash("trigger_event") then
      *     pprint(data)
      *     -- {
+     *     --  enter = true,
      *     --  b = {
      *     --      group = hash: [default],
      *     --      id = hash: [/go2]
      *     --  },
-     *     --  enter = true,
      *     --  a = {
      *     --      group = hash: [default],
      *     --      id = hash: [/go1]

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1507,10 +1507,10 @@ namespace dmGameSystem
         {"set_hflip",       Physics_SetFlipH},
         {"set_vflip",       Physics_SetFlipV},
         {"wakeup",          Physics_Wakeup},
-        {"get_group",		Physics_GetGroup},
-        {"set_group",		Physics_SetGroup},
-        {"get_maskbit",		Physics_GetMaskBit},
-        {"set_maskbit",		Physics_SetMaskBit},
+        {"get_group",       Physics_GetGroup},
+        {"set_group",       Physics_SetGroup},
+        {"get_maskbit",     Physics_GetMaskBit},
+        {"set_maskbit",     Physics_SetMaskBit},
         {"set_listener",    Physics_SetListener},
 
         // Shapes

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1458,7 +1458,7 @@ namespace dmGameSystem
         DM_LUA_STACK_CHECK(L, 0);
         int top = lua_gettop(L);
         int functionref = 0;
-        if (top == 1) // completed cb
+        if (top >= 1) // completed cb
         {
             if (lua_isfunction(L, 1))
             {

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -255,8 +255,8 @@ namespace dmGameSystem
      * through `groups`.
      * The actual ray cast will be performed during the physics-update.
      *
-     * - If an object is hit, the result will be reported via a `ray_cast_response` message.
-     * - If there is no object hit, the result will be reported via a `ray_cast_missed` message.
+     * - If an object is hit, the result will be reported via a [ref:ray_cast_response] message.
+     * - If there is no object hit, the result will be reported via a [ref:ray_cast_missed] message.
      *
      * @name physics.raycast_async
      * @param from [type:vector3] the world position of the start of the ray
@@ -284,6 +284,105 @@ namespace dmGameSystem
      *     elseif message_id == hash("ray_cast_missed") then
      *         -- act on the miss
      *     end
+     * end
+     * ```
+     */
+
+    /*# sets a physics world event listener.
+     *
+     * @name physics.set_listener
+     *
+     * @param callback [type:function(self, event, data)|nil] A callback that receives information about all the physics interactions in this physics world.
+     *
+     * `self`
+     * : [type:object] The calling script
+     *
+     * `event`
+     * : [type:constant] The type of event. Can be one of these messages:
+     *
+     *
+     * - [ref:contact_point_event]
+     * - [ref:collision_event]
+     * - [ref:trigger_event]
+     * - [ref:ray_cast_response]
+     * - [ref:ray_cast_missed]
+     *
+     * `data`
+     * : [type:table] The callback value data is a table that contains event-related data. See the documentation for details on the messages.
+     *
+     * @examples
+     *
+     * ```lua
+     * local function physics_world_listener(self, event, data)
+     *   if event == hash("contact_point_event") then
+     *     pprint(data)
+     *     -- {
+     *     --  applied_impulse = 310.00769042969,
+     *     --  a = {
+     *     --      position = vmath.vector3(446, 371, 0),
+     *     --      relative_velocity = vmath.vector3(1.1722083854693e-06, -20.667181015015, -0),
+     *     --      mass = 0,
+     *     --      group = hash: [default],
+     *     --      id = hash: [/flat],
+     *     --      normal = vmath.vector3(-0, -1, -0)
+     *     --  },
+     *     --  b = {
+     *     --      position = vmath.vector3(185, 657.92858886719, 0),
+     *     --      relative_velocity = vmath.vector3(-1.1722083854693e-06, 20.667181015015, 0),
+     *     --      mass = 10,
+     *     --      group = hash: [default],
+     *     --      id = hash: [/go2],
+     *     --      normal = vmath.vector3(0, 1, 0)
+     *     --  },
+     *     --  distance = 0.0714111328125
+     *     -- }
+     *   elseif event == hash("collision_event") then
+     *     pprint(data)
+     *     -- {
+     *     --  a = {
+     *     --          group = hash: [default],
+     *     --          position = vmath.vector3(183, 666, 0),
+     *     --          id = hash: [/go1]
+     *     --      },
+     *     --  b = {
+     *     --          group = hash: [default],
+     *     --          position = vmath.vector3(185, 704.05865478516, 0),
+     *     --          id = hash: [/go2]
+     *     --      }
+     *     -- }
+     *   elseif event ==  hash("trigger_event") then
+     *     pprint(data)
+     *     -- {
+     *     --  b = {
+     *     --      group = hash: [default],
+     *     --      id = hash: [/go2]
+     *     --  },
+     *     --  enter = true,
+     *     --  a = {
+     *     --      group = hash: [default],
+     *     --      id = hash: [/go1]
+     *     --  }
+     *     -- },
+     *   elseif event ==  hash("ray_cast_response") then
+     *     pprint(data)
+     *     --{
+     *     --  group = hash: [default],
+     *     --  request_id = 0,
+     *     --  position = vmath.vector3(249.92222595215, 249.92222595215, 0),
+     *     --  fraction = 0.68759721517563,
+     *     --  normal = vmath.vector3(0, 1, 0),
+     *     --  id = hash: [/go]
+     *     -- }
+     *   elseif event ==  hash("ray_cast_missed") then
+     *     pprint(data)
+     *     -- {
+     *     --  request_id = 0
+     *     --},
+     *   end
+     * end
+     *
+     * function init(self)
+     *     physics.set_listener(physics_world_listener)
      * end
      * ```
      */
@@ -379,7 +478,7 @@ namespace dmGameSystem
      * `all`
      * : [type:boolean] Set to `true` to return all ray cast hits. If `false`, it will only return the closest hit.
      *
-     * @return result [type:table|nil] It returns a list. If missed it returns `nil`. See `ray_cast_response` for details on the returned values.
+     * @return result [type:table|nil] It returns a list. If missed it returns `nil`. See [ref:ray_cast_response] for details on the returned values.
      * @examples
      *
      * How to perform a ray cast synchronously:

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1579,7 +1579,8 @@ namespace dmGameSystem
         }
 
         dmMessage::URL listenerReceiver;
-        if (!dmScript::GetURL(L, &listenerReceiver)) {
+        if (!dmScript::GetURL(L, &listenerReceiver))
+        {
             return luaL_error(L, "could not find a requesting instance for physics.set_listener()");
         }
 

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1453,29 +1453,6 @@ namespace dmGameSystem
         return 0;
     }
 
-    static void RunCollisionWorldCallback(void* callback_data, const dmDDF::Descriptor* desc, const char* data)
-    {
-        dmScript::LuaCallbackInfo* cbk = (dmScript::LuaCallbackInfo*)callback_data;
-        if (!dmScript::IsCallbackValid(cbk))
-        {
-            dmLogError("Physics world listener is invalid.");
-            return;
-        }
-        lua_State* L = dmScript::GetCallbackLuaContext(cbk);
-        DM_LUA_STACK_CHECK(L, 0);
-
-        if (!dmScript::SetupCallback(cbk))
-        {
-            dmLogError("Failed to setup physics.set_listener() callback");
-            return;
-        }
-        lua_pushstring(L, desc->m_Name);
-        dmScript::PushDDF(L, desc, data, false);
-        int ret = dmScript::PCall(L, 3, 0);
-        (void)ret;
-        dmScript::TeardownCallback(cbk);
-    }
-
     /*# sets a physics world event listener. If a function is set, physics messages will no longer be sent.
      *
      * @name physics.set_listener
@@ -1600,7 +1577,7 @@ namespace dmGameSystem
             if (cbk != 0x0)
             {
                 dmScript::DestroyCallback(cbk);
-                SetCollisionWorldCallback(world, 0x0, 0x0);
+                SetCollisionWorldCallback(world, 0x0);
             }
         }
         else if (type == LUA_TFUNCTION)
@@ -1608,16 +1585,39 @@ namespace dmGameSystem
             if (cbk != 0x0)
             {
                 dmScript::DestroyCallback(cbk);
-                SetCollisionWorldCallback(world, 0x0, 0x0);
+                SetCollisionWorldCallback(world, 0x0);
             }
             cbk = dmScript::CreateCallback(L, 1);
-            SetCollisionWorldCallback(world, cbk, RunCollisionWorldCallback);
+            SetCollisionWorldCallback(world, cbk);
         }
         else
         {
             return DM_LUA_ERROR("argument 1 to physics.set_listener() must be either nil or function");
         }
         return 0;
+    }
+
+    void RunCollisionWorldCallback(void* callback_data, const dmDDF::Descriptor* desc, const char* data)
+    {
+        dmScript::LuaCallbackInfo* cbk = (dmScript::LuaCallbackInfo*)callback_data;
+        if (!dmScript::IsCallbackValid(cbk))
+        {
+            dmLogError("Physics world listener is invalid.");
+            return;
+        }
+        lua_State* L = dmScript::GetCallbackLuaContext(cbk);
+        DM_LUA_STACK_CHECK(L, 0);
+
+        if (!dmScript::SetupCallback(cbk))
+        {
+            dmLogError("Failed to setup physics.set_listener() callback");
+            return;
+        }
+        lua_pushstring(L, desc->m_Name);
+        dmScript::PushDDF(L, desc, data, false);
+        int ret = dmScript::PCall(L, 3, 0);
+        (void)ret;
+        dmScript::TeardownCallback(cbk);
     }
 
     static const luaL_reg PHYSICS_FUNCTIONS[] =

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1456,6 +1456,11 @@ namespace dmGameSystem
     static void RunCollisionWorldCallback(void* callback_data, const dmDDF::Descriptor* desc, const char* data)
     {
         dmScript::LuaCallbackInfo* cbk = (dmScript::LuaCallbackInfo*)callback_data;
+        if (!dmScript::IsCallbackValid(cbk))
+        {
+            dmLogError("Physics world listener is invalid.");
+            return;
+        }
         lua_State* L = dmScript::GetCallbackLuaContext(cbk);
         DM_LUA_STACK_CHECK(L, 0);
 

--- a/engine/gamesys/src/gamesys/test/collision_object/callback_object.collisionobject
+++ b/engine/gamesys/src/gamesys/test/collision_object/callback_object.collisionobject
@@ -1,0 +1,30 @@
+collision_shape: ""
+type: COLLISION_OBJECT_TYPE_DYNAMIC
+mass: 1.0
+friction: 0.1
+restitution: 0.5
+group: "default"
+mask: "default"
+embedded_collision_shape {
+  shapes {
+    shape_type: TYPE_SPHERE
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    index: 0
+    count: 1
+  }
+  data: 10.0
+}
+linear_damping: 0.0
+angular_damping: 0.0
+locked_rotation: false
+bullet: false

--- a/engine/gamesys/src/gamesys/test/collision_object/callback_object.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/callback_object.go
@@ -1,0 +1,30 @@
+components {
+  id: "callback_object"
+  component: "/collision_object/callback_object.collisionobject"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}
+components {
+  id: "callback_object1"
+  component: "/collision_object/callback_object.script"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/collision_object/callback_object.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/callback_object.script
@@ -1,0 +1,50 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+-- Scenario: An object is on a trigger and sends an event every frame.
+-- When it sends 3 events, we set up a physics listener.
+-- When 3 events are collected in the listener, the listener is removed.
+-- On every switch, we make sure that events are sent only to either the message or the listener.
+
+tests_done = false -- flag end of test to C level
+
+function init(self)
+	self.listener_counter = 0
+	self.message_counter = 0
+	self.expected_count = 3
+end
+
+function update(self)
+	if self.check_next_frame then
+		self.check_next_frame = self.check_next_frame - 1
+		if self.check_next_frame == 0 then
+			assert(self.expected_count == self.listener_counter)
+			assert(5 == self.message_counter)
+			tests_done = true
+		end
+	end
+end
+
+function on_message(self, message_id, message, sender)
+	self.message_counter = self.message_counter + 1
+	if self.message_counter == self.expected_count then
+		physics.set_listener(function(self, message_id)
+			self.listener_counter = self.listener_counter + 1
+			if self.listener_counter == self.expected_count then
+				physics.set_listener(nil)
+				self.check_next_frame = self.expected_count
+			end
+		end)
+	end
+end

--- a/engine/gamesys/src/gamesys/test/collision_object/callback_trigger.collisionobject
+++ b/engine/gamesys/src/gamesys/test/collision_object/callback_trigger.collisionobject
@@ -1,0 +1,32 @@
+collision_shape: ""
+type: COLLISION_OBJECT_TYPE_TRIGGER
+mass: 0.0
+friction: 0.1
+restitution: 0.5
+group: "default"
+mask: "default"
+embedded_collision_shape {
+  shapes {
+    shape_type: TYPE_BOX
+    position {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    index: 0
+    count: 3
+  }
+  data: 250.0
+  data: 250.0
+  data: 10.0
+}
+linear_damping: 0.0
+angular_damping: 0.0
+locked_rotation: false
+bullet: false

--- a/engine/gamesys/src/gamesys/test/collision_object/callback_trigger.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/callback_trigger.go
@@ -1,0 +1,15 @@
+components {
+  id: "callback_trigger"
+  component: "/collision_object/callback_trigger.collisionobject"
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2231,6 +2231,56 @@ TEST_F(ComponentTest, JointTest)
 
 }
 
+/* Physics listener */
+TEST_F(ComponentTest, PhysicsListenerTest)
+{
+    /* Setup:
+    ** callback_object
+    ** - [collisionobject] collision_object/callback_object.collisionobject
+    ** - [script] collision_object/callback_object.script
+    ** callback_trigger
+    ** - [collisionobject] collision_object/callback_trigger.collisionobject
+    */
+
+    dmHashEnableReverseHash(true);
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    const char* path_test_object = "/collision_object/callback_object.goc";
+    const char* path_test_trigger = "/collision_object/callback_trigger.goc";
+
+    dmhash_t hash_go_object = dmHashString64("/test_object");
+    dmhash_t hash_go_trigger = dmHashString64("/test_trigger");
+
+    dmGameObject::HInstance go_b = Spawn(m_Factory, m_Collection, path_test_object, hash_go_object, 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go_b);
+
+    dmGameObject::HInstance go_a = Spawn(m_Factory, m_Collection, path_test_trigger, hash_go_trigger, 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go_a);
+
+    // Iteration 1: Handle proxy enable and input acquire messages from input_consume_no.script
+    bool tests_done = false;
+    while (!tests_done)
+    {
+        ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+        ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+        // check if tests are done
+        lua_getglobal(L, "tests_done");
+        tests_done = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+    }
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+
+}
+
 /* Camera */
 
 const char* valid_camera_resources[] = {"/camera/valid.camerac"};


### PR DESCRIPTION
Now, it is possible to set a function that will receive all physics interaction events in one place. If a function is set, physics messages will no longer be sent.

```lua
physics.set_listener(function(self, event, data)
  if event == hash("contact_point_event") then
    pprint(data)
    -- {
    -- 	applied_impulse = 310.00769042969,
    -- 	distance = 0.0714111328125,
    -- 	a = {
    -- 		position = vmath.vector3(446, 371, 0),
    -- 		relative_velocity = vmath.vector3(1.1722083854693e-06, -20.667181015015, -0),
    -- 		mass = 0,
    -- 		group = hash: [default],
    -- 		id = hash: [/flat],
    -- 		normal = vmath.vector3(-0, -1, -0)
    -- 	},
    -- 	b = {
    -- 		position = vmath.vector3(185, 657.92858886719, 0),
    -- 		relative_velocity = vmath.vector3(-1.1722083854693e-06, 20.667181015015, 0),
    -- 		mass = 10,
    -- 		group = hash: [default],
    -- 		id = hash: [/go2],
    -- 		normal = vmath.vector3(0, 1, 0)
    -- 	}
    -- }
  elseif event == hash("collision_event") then
    pprint(data)
    -- {
    -- 	a = {
    -- 			group = hash: [default],
    -- 			position = vmath.vector3(183, 666, 0),
    -- 			id = hash: [/go1]
    -- 		},
    -- 	b = {
    -- 			group = hash: [default],
    -- 			position = vmath.vector3(185, 704.05865478516, 0),
    -- 			id = hash: [/go2]
    -- 		}
    -- }
  elseif event ==  hash("trigger_event") then
    pprint(data)
    -- {
    -- 	enter = true,
    -- 	b = {
    -- 		group = hash: [default],
    -- 		id = hash: [/go2]
    -- 	},
    -- 	a = {
    -- 		group = hash: [default],
    -- 		id = hash: [/go1]
    -- 	}
    -- },
  elseif event ==  hash("ray_cast_response") then
    pprint(data)
    --{
    -- 	group = hash: [default],
    -- 	request_id = 0,
    -- 	position = vmath.vector3(249.92222595215, 249.92222595215, 0),
    -- 	fraction = 0.68759721517563,
    -- 	normal = vmath.vector3(0, 1, 0),
    -- 	id = hash: [/go]
    -- }
  elseif event ==  hash("ray_cast_missed") then
    pprint(data)
    -- {
    --  request_id = 0
    --},
  end
end)
```

Fix https://github.com/defold/defold/issues/7151

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
