### PR TITLE
Add `editor.create_directory()` and code completion to editor scripts

### DIFF
--- a/editor/src/clj/editor/editor_script.clj
+++ b/editor/src/clj/editor/editor_script.clj
@@ -17,6 +17,7 @@
             [dynamo.graph :as g]
             [editor.code.resource :as r]
             [editor.code.script :as script]
+            [editor.lua :as lua]
             [editor.luart :as luart]
             [editor.resource :as resource]))
 
@@ -26,9 +27,13 @@
     (catch Exception e
       (g/->error _node-id :prototype :fatal e "Could not compile editor extension"))))
 
+(def completions
+  (merge-with into lua/std-libs-docs lua/editor-completions))
+
 (g/defnode EditorScript
   (inherits r/CodeEditorResourceNode)
   (input globals g/Any)
+  (output completions g/Any (g/constantly completions))
   (output prototype g/Any :cached produce-prototype))
 
 (defn register-resource-types [workspace]

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -226,10 +226,15 @@
 
 ;; create directories, files
 
+(defn create-path-directories!
+  "Creates the directory path up to and including directory. Returns the directory as Path."
+  ^Path [^Path path]
+  (Files/createDirectories path empty-file-attrs))
+
 (defn create-directories!
-  "Creates the directory path up to and including directory. Returns the directory."
+  "Creates the directory path up to and including directory. Returns the directory as File."
   ^File [^File directory]
-  (.toFile (Files/createDirectories (.toPath directory) empty-file-attrs)))
+  (.toFile (create-path-directories! (.toPath directory))))
 
 (defn create-parent-directories!
   "Creates the directory path (if any) up to the parent directory of file. Returns the parent directory."

--- a/editor/src/clj/editor/lsp/server.clj
+++ b/editor/src/clj/editor/lsp/server.clj
@@ -246,8 +246,9 @@
             (let [script-intelligence (g/node-value project :script-intelligence evaluation-context)
                   completions (g/node-value script-intelligence :lua-completions evaluation-context)]
               {:runtime {:version "Lua 5.1" :pathStrict true}
-               :diagnostics {:globals (into lua/defined-globals
-                                            (lua/extract-globals-from-completions completions))}})
+               :diagnostics {:globals (-> lua/defined-globals
+                                          (into (lua/extract-globals-from-completions completions))
+                                          (into (lua/extract-globals-from-completions lua/editor-completions)))}})
 
             "files.associations"
             (let [workspace (g/node-value project :workspace evaluation-context)

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -20,6 +20,7 @@
             [clojure.string :as string]
             [editor.code-completion :as code-completion]
             [editor.protobuf :as protobuf]
+            [editor.system :as system]
             [internal.util :as util]
             [util.coll :refer [pair]])
   (:import [com.dynamo.scriptdoc.proto ScriptDoc$Document]
@@ -58,16 +59,8 @@
             string/join)
        "</dl>"))
 
-(defn- make-markdown-doc [raw-name ^URI base-url {:keys [description type examples parameters] :as el}]
-  (let [site-url (.resolve base-url
-                           (str "#"
-                                (string/replace
-                                  (str
-                                    raw-name
-                                    (when (= :function type)
-                                      (str ":" (string/join "-" (mapv :name parameters)))))
-                                  #"[\"#*]" "")))
-        sections (cond-> []
+(defn- make-markdown-doc [{:keys [description type examples parameters] :as el} ^URI base-url site-url]
+  (let [sections (cond-> []
                          (pos? (count description))
                          (conj description)
 
@@ -85,11 +78,12 @@
                          (pos? (count examples))
                          (conj (str "**Examples:**\n\n" examples))
 
-                         :always
+                         site-url
                          (conj (format "[Open in Browser](%s)" site-url)))]
-    {:type :markdown
-     :base-url base-url
-     :value (string/join "\n\n" sections)}))
+    (cond-> {:type :markdown
+             :value (string/join "\n\n" sections)}
+            base-url
+            (assoc :base-url base-url))))
 
 (defn- make-display-string [{:keys [name type parameters]}]
   (str name (when (= :function type)
@@ -145,6 +139,32 @@
 (s/def ::documentation
   (s/map-of string? (s/coll-of ::code-completion/completion)))
 
+(defn- make-completion
+  "Make a lua-specific code completion
+
+  Args:
+    el    documentation map with following keys:
+            :name            string, required, element name
+            :type            keyword
+            :parameters      for :function type, optional vector of parameter
+                             maps with following keys:
+                               :name     string, required
+                               :doc      optional html string
+                               :types    coll of strings, i.e. union
+            :returnvalues    for :function type, same as :parameters
+            :description     string, optional, markdown
+            :examples        string, optional, markdown
+
+  Optional kv-args:
+    :base-url    URI for resolving relative links in the docs and examples
+    :url         string, may be relative to :base-url if it was provided"
+  [el & {:keys [base-url url]}]
+  (code-completion/make (:name el)
+                        :type (:type el)
+                        :display-string (make-display-string el)
+                        :insert (make-snippet el)
+                        :doc (make-markdown-doc el base-url url)))
+
 (defn- defold-documentation []
   {:post [(s/assert ::documentation %)]}
   (make-completion-map
@@ -157,13 +177,16 @@
              (let [raw-name (:name raw-element)
                    name-parts (string/split raw-name #"\.")
                    ns-path (pop name-parts)
-                   {:keys [name type] :as el} (assoc raw-element :name (peek name-parts))
-                   base-url (URI. (str "https://defold.com/ref/" doc-name))]
-               [ns-path (code-completion/make name
-                                              :type type
-                                              :display-string (make-display-string el)
-                                              :insert (make-snippet el)
-                                              :doc (make-markdown-doc raw-name base-url el))])))
+                   {:keys [type parameters] :as el} (assoc raw-element :name (peek name-parts))
+                   base-url (URI. (str "https://defold.com/ref/" doc-name))
+                   site-url (str "#"
+                                 (string/replace
+                                   (str
+                                     raw-name
+                                     (when (= :function type)
+                                       (str ":" (string/join "-" (mapv :name parameters)))))
+                                   #"[\"#*]" ""))]
+               [ns-path (make-completion el :base-url base-url :url site-url)])))
       docs)))
 
 (def logic-keywords #{"and" "or" "not"})
@@ -287,3 +310,61 @@
               std-libs-docs
               script-intelligence-completions
               (make-ast-completions local-completion-info required-completion-infos)))
+
+(def editor-completions
+  (let [node-param {:name "node"
+                    :types ["string" "userdata"]
+                    :doc "Either resource path (e.g. <code>\"/main/game.script\"</code>), or internal node id passed to the script by the editor"}
+        property-param {:name "property"
+                        :types ["string"]
+                        :doc "Either <code>\"path\"</code>, <code>\"text\"</code>, or a property from the Outline view (hover the label to see its editor script name)"}]
+    (make-completion-map
+      [[[] (make-completion
+             {:name "editor"
+              :type :module
+              :description "The editor module, only available when the Lua code is run as [editor script](https://defold.com/manuals/editor-scripts/)."})]
+       [["editor"] (make-completion
+                     {:name "get"
+                      :type :function
+                      :parameters [node-param property-param]
+                      :returnvalues [{:name "value"
+                                      :types ["any"]}]
+                      :description "Get a value of a node inside the editor. Some properties might be read-only, and some might be unavailable in different contexts, so you should use `editor.can_get()` before reading them and `editor.can_set()` before making the editor set them."})]
+       [["editor"] (make-completion
+                     {:name "can_get"
+                      :type :function
+                      :parameters [node-param property-param]
+                      :returnvalues [{:name "value"
+                                      :types ["boolean"]}]
+                      :description "Check if you can get this property so `editor.get()` won't throw an error"})]
+       [["editor"] (make-completion
+                     {:name "can_set"
+                      :type :function
+                      :parameters [node-param property-param]
+                      :returnvalues [{:name "value"
+                                      :types ["boolean"]}]
+                      :description "Check if `\"set\"` action with this property won't throw an error"})]
+       [["editor"] (make-completion
+                     {:name "create_directory"
+                      :type :function
+                      :parameters [{:name "resource_path"
+                                    :types ["string"]
+                                    :doc "Resource path (starting with <code>/</code>) of a directory to create"}]
+                      :description "Create a directory if it does not exist, and all non-existent parent directories. Throws an error if the directory can't be created."
+                      :examples "```\neditor.create_directory(\"/assets/gen\")\n```"})]
+       [["editor"] (make-completion
+                     {:name "platform"
+                      :type :variable
+                      :description "A `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"})]
+       [["editor"] (make-completion
+                     {:name "version"
+                      :type :variable
+                      :description (format "A string, version name of Defold, e.g. `\"%s\"`" (system/defold-version))})]
+       [["editor"] (make-completion
+                     {:name "engine_sha1"
+                      :type :variable
+                      :description "A string, SHA1 of Defold engine"})]
+       [["editor"] (make-completion
+                     {:name "editor_sha1"
+                      :type :variable
+                      :description "A string, SHA1 of Defold editor"})]])))


### PR DESCRIPTION
User-facing changes:

This changeset adds a new function to editor scripts that allows the user to create a new directory. The function expects a resource path, i.e. a `/`-prefixed path from the root of the project, for example:
```lua
editor.create_directory("/assets/generated")
local file = io.open("assets/generated/build.json")
file:write(...)
file:flush()
file:close()
```

Additionally, the editor now provides code completions for functions in the `editor` module.

Fixes #8425 
