### PR TITLE
If the `hash` string is unknown, show its value instead.

### DIFF
--- a/engine/dlib/src/dlib/hash.cpp
+++ b/engine/dlib/src/dlib/hash.cpp
@@ -669,7 +669,7 @@ DM_DLLEXPORT const char* dmHashReverseSafe64(uint64_t hash)
     if (s == 0)
     {
         char tmp[64];
-        dmSnPrintf(tmp, sizeof(tmp), "<unknown:%llu>", hash);
+        dmSnPrintf(tmp, sizeof(tmp), "<unknown:%llu>", (unsigned long long)hash);
         return tmp;
     }
     return s;

--- a/engine/dlib/src/dlib/hash.cpp
+++ b/engine/dlib/src/dlib/hash.cpp
@@ -21,6 +21,7 @@
 #include "index_pool.h"
 #include "align.h"
 #include <dlib/mutex.h>
+#include <dlib/dstrings.h>
 #include <dlib/hashtable.h>
 
 struct ReverseHashEntry
@@ -665,12 +666,24 @@ DM_DLLEXPORT void dmHashReverseErase64(uint64_t hash)
 DM_DLLEXPORT const char* dmHashReverseSafe64(uint64_t hash)
 {
     const char* s = (const char*)dmHashReverse64(hash, 0);
-    return s != 0 ? s : "<unknown>";
+    if (s == 0)
+    {
+        char tmp[64];
+        dmSnPrintf(tmp, sizeof(tmp), "<unknown:%llu>", hash);
+        return tmp;
+    }
+    return s;
 }
 
 DM_DLLEXPORT const char* dmHashReverseSafe32(uint32_t hash)
 {
     const char* s = (const char*)dmHashReverse32(hash, 0);
-    return s != 0 ? s : "<unknown>";
+    if (s == 0)
+    {
+        char tmp[32];
+        dmSnPrintf(tmp, sizeof(tmp), "<unknown:%u>", hash);
+        return tmp;
+    }
+    return s;
 }
 


### PR DESCRIPTION
Instead of showing just `<unknown>` when the corresponding string value is unknown, print its numeric value. For example:
>`<unknown:2256903789829718645>`

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
