### PR TITLE
Improved error message when running out of collection instances

### DIFF
--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -72,8 +72,8 @@ namespace dmGameObject
         HScript script = (HScript)params.m_Resource;
         CompScriptWorld* script_world = (CompScriptWorld*)params.m_World;
         if (script_world->m_Instances.Full())
-        {
-            dmLogError("Could not create script component, out of resources.");
+        {   
+            dmLogError("Could not create script component, out of resources. Increase the 'collection.max_instances' value in [game.project](defold://open?path=/game.project)");
             return CREATE_RESULT_UNKNOWN_ERROR;
         }
 

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -72,7 +72,7 @@ namespace dmGameObject
         HScript script = (HScript)params.m_Resource;
         CompScriptWorld* script_world = (CompScriptWorld*)params.m_World;
         if (script_world->m_Instances.Full())
-        {   
+        {
             dmLogError("Could not create script component, out of resources. Increase the 'collection.max_instances' value in [game.project](defold://open?path=/game.project)");
             return CREATE_RESULT_UNKNOWN_ERROR;
         }


### PR DESCRIPTION
The error message when running out of instances in a collection did not mention which value in game.project to change.

Fixes #8457