### PR TITLE
Fixed how mass is calculated for physics collision objects with more than one shape.

### DIFF
--- a/engine/gamesys/src/gamesys/test/collision_object/mass.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/mass.script
@@ -34,9 +34,13 @@ end
 function update(self)
 	self.frame = self.frame + 1
 	if self.frame == 2 then
-		local expected_mass = 10
-		physics.update_mass("#mass_object", expected_mass)
+		local expected_mass = 1 -- initial mass specified in collision object component
 		local mass = go.get("#mass_object", "mass")
+		assert_near(expected_mass, mass)
+
+		expected_mass = 10
+		physics.update_mass("#mass_object", expected_mass)
+		mass = go.get("#mass_object", "mass")
 		assert_near(expected_mass, mass)
 
 		expected_mass = 99

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -969,15 +969,14 @@ namespace dmPhysics
             f_def.filter.categoryBits = data.m_Group;
             f_def.filter.maskBits = data.m_Mask;
             f_def.shape = s;
-            b2MassData mass_data;
-            f_def.shape->ComputeMass(&mass_data, 1.0f);
-            f_def.density = data.m_Mass / mass_data.mass;
+            f_def.density = 1.0f;
             f_def.friction = data.m_Friction;
             f_def.restitution = data.m_Restitution;
             f_def.isSensor = data.m_Type == COLLISION_OBJECT_TYPE_TRIGGER;
             b2Fixture* fixture = body->CreateFixture(&f_def);
             (void)fixture;
         }
+        UpdateMass2D(body, data.m_Mass);
         return body;
     }
 
@@ -1412,15 +1411,14 @@ namespace dmPhysics
             for (b2Body* body = context->m_Worlds[i]->m_World.GetBodyList(); body; body = body->GetNext())
             {
                 b2Fixture* fixture = body->GetFixtureList();
+                float mass = body->GetMass();
                 while (fixture)
                 {
                     b2Fixture* next_fixture = fixture->GetNext();
                     if (fixture->GetShape() == old_shape)
                     {
-                        b2MassData mass_data;
-                        ((b2Shape*)new_shape)->ComputeMass(&mass_data, 1.0f);
                         b2FixtureDef def;
-                        def.density = body->GetMass() / mass_data.mass;
+                        def.density = 1.0f;
                         def.filter = fixture->GetFilterData(0);
                         def.friction = fixture->GetFriction();
                         def.isSensor = fixture->IsSensor();
@@ -1460,6 +1458,7 @@ namespace dmPhysics
                     }
                     fixture = next_fixture;
                 }
+                UpdateMass2D(body, mass);
             }
         }
     }


### PR DESCRIPTION
Fixed a bug where the mass specified in the Collision Object component was applied to each shape, resulting in the object's total mass becoming `Collision Object mass` x `Shapes count`.

With this fix, the mass will remain as specified in the Collision Object, and the density will be recalculated depending on it to be equal for each shape.

Fix https://github.com/defold/defold/issues/8458
## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
