### PR TITLE
Add `editor.delete_directory()`

### DIFF
--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -15,15 +15,41 @@
 (ns editor.fs
   (:require [clojure.java.io :as io]
             [clojure.string :as string])
-  (:import [java.util UUID]
-           [java.io File FileNotFoundException IOException RandomAccessFile]
+  (:import [java.io File FileNotFoundException IOException RandomAccessFile]
            [java.nio.channels OverlappingFileLockException]
-           [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException Files FileVisitResult LinkOption NoSuchFileException NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
-           [java.nio.file.attribute BasicFileAttributes FileAttribute]))
+           [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException FileVisitResult Files LinkOption NoSuchFileException NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
+           [java.nio.file.attribute BasicFileAttributes FileAttribute]
+           [java.util UUID]))
 
 (set! *warn-on-reflection* true)
 
 ;; util
+
+(defonce ^:private empty-link-option-array (make-array LinkOption 0))
+(defonce ^:private empty-string-array (make-array String 0))
+
+(defprotocol PathCoercions
+  "Convert to Path objects."
+  (^Path as-path [this] "Coerce argument to a Path."))
+
+(extend-protocol PathCoercions
+  nil
+  (as-path [_this] nil)
+
+  File
+  (as-path [this] (.toPath this))
+
+  Path
+  (as-path [this] this)
+
+  String
+  (as-path [this] (Path/of this empty-string-array)))
+
+(defn to-real-path
+  "Returns the canonical, real path to an existing file system entry. Throws an
+  IOException if there was no matching entry in the file system."
+  ^Path [^Path path]
+  (.toRealPath path empty-link-option-array))
 
 (defn with-leading-slash
   ^String [^String path]
@@ -181,13 +207,19 @@
      (maybe-silently (fail-silently? opts) nil (do-delete-directory! directory opts)))))
 
 (defn delete-path-directory!
-  "Deletes a directory tree. Returns the deleted directory as Path if successful."
-  ^Path [^Path path]
+  "Deletes a directory tree. Returns true if the directory was deleted by us.
+  Throws NotDirectoryException if the path does not refer to a directory."
+  [^Path path]
   (let [file (.toFile path)]
-    (if (.exists file)
-      (if (.isDirectory file)
-        (delete-directory! file)
-        (throw (NotDirectoryException. (str file)))))))
+    (cond
+      (not (.exists file))
+      false
+
+      (.isDirectory file)
+      (some? (delete-directory! file))
+
+      :else
+      (throw (NotDirectoryException. (str path))))))
 
 (defn delete!
   "Deletes a file or directory tree. Returns the deleted directory or file if successful.

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -18,7 +18,7 @@
   (:import [java.util UUID]
            [java.io File FileNotFoundException IOException RandomAccessFile]
            [java.nio.channels OverlappingFileLockException]
-           [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException Files FileVisitResult LinkOption NoSuchFileException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
+           [java.nio.file AccessDeniedException CopyOption FileAlreadyExistsException Files FileVisitResult LinkOption NoSuchFileException NotDirectoryException OpenOption Path SimpleFileVisitor StandardCopyOption StandardOpenOption]
            [java.nio.file.attribute BasicFileAttributes FileAttribute]))
 
 (set! *warn-on-reflection* true)
@@ -179,6 +179,15 @@
   (^File [^File directory opts]
    (let [opts (merge delete-defaults opts)]
      (maybe-silently (fail-silently? opts) nil (do-delete-directory! directory opts)))))
+
+(defn delete-path-directory!
+  "Deletes a directory tree. Returns the deleted directory as Path if successful."
+  ^Path [^Path path]
+  (let [file (.toFile path)]
+    (if (.exists file)
+      (if (.isDirectory file)
+        (delete-directory! file)
+        (throw (NotDirectoryException. (str file)))))))
 
 (defn delete!
   "Deletes a file or directory tree. Returns the deleted directory or file if successful.

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -353,6 +353,15 @@
                       :description "Create a directory if it does not exist, and all non-existent parent directories. Throws an error if the directory can't be created."
                       :examples "```\neditor.create_directory(\"/assets/gen\")\n```"})]
        [["editor"] (make-completion
+                     {:name "delete_directory"
+                      :type :function
+                      :parameters [{:name "resource_path"
+                                    :types ["string"]
+                                    :doc "Resource path (starting with <code>/</code>) of a directory to delete"}]
+                      :description "Delete a directory if it exists, and all existent child directories and files. Throws an error if the directory can't be deleted."
+                      :examples "```\neditor.delete_directory(\"/assets/gen\")\n```"})]
+
+       [["editor"] (make-completion
                      {:name "platform"
                       :type :variable
                       :description "A `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"})]


### PR DESCRIPTION
Fixes #8472

### Technical changes
This changeset adds a new function to editor scripts that allows the user to delete an existing directory. The function expects a resource path, i.e. a /-prefixed path from the root of the project, for example:

```lua
editor.delete_directory("/assets/generated")
```