### PR TITLE
Vertex declaration simplifcation

### DIFF
--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -439,10 +439,17 @@ namespace dmGraphics
         BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA = 14,
     };
 
+    /*#
+     * Vertex step function. Dictates how the data for a vertex attribute should be read in a vertex shader.
+     * @enum
+     * @name VertexStepFunction
+     * @member VERTEX_STEP_FUNCTION_VERTEX
+     * @member VERTEX_STEP_FUNCTION_INSTANCE
+     */
     enum VertexStepFunction
     {
-        VERTEX_STEP_VERTEX,
-        VERTEX_STEP_INSTANCE,
+        VERTEX_STEP_FUNCTION_VERTEX,
+        VERTEX_STEP_FUNCTION_INSTANCE,
     };
 
     /*#

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -439,6 +439,12 @@ namespace dmGraphics
         BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA = 14,
     };
 
+    enum VertexStepFunction
+    {
+        VERTEX_STEP_VERTEX,
+        VERTEX_STEP_INSTANCE,
+    };
+
     /*#
      * Create new vertex stream declaration. A stream declaration contains a list of vertex streams
      * that should be used to create a vertex declaration from.

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -491,6 +491,30 @@ namespace dmGraphics
         delete stream_declaration;
     }
 
+    void HashVertexDeclaration(HashState32* state, HVertexDeclaration vertex_declaration)
+    {
+        dmHashUpdateBuffer32(state, vertex_declaration->m_Streams, sizeof(VertexDeclaration::Stream) * vertex_declaration->m_StreamCount);
+    }
+
+    uint32_t GetVertexStreamOffset(HVertexDeclaration vertex_declaration, dmhash_t name_hash)
+    {
+        uint32_t count = vertex_declaration->m_StreamCount;
+        VertexDeclaration::Stream* streams = vertex_declaration->m_Streams;
+        for (int i = 0; i < count; ++i)
+        {
+            if (streams[i].m_NameHash == name_hash)
+            {
+                return streams[i].m_Offset;
+            }
+        }
+        return dmGraphics::INVALID_STREAM_OFFSET;
+    }
+
+    uint32_t GetVertexDeclarationStride(HVertexDeclaration vertex_declaration)
+    {
+        return vertex_declaration->m_Stride;
+    }
+
     #define DM_TEXTURE_FORMAT_TO_STR_CASE(x) case TEXTURE_FORMAT_##x: return #x;
     const char* TextureFormatToString(TextureFormat format)
     {
@@ -1108,14 +1132,6 @@ namespace dmGraphics
     {
         g_functions.m_DisableVertexDeclaration(context, vertex_declaration);
     }
-    void HashVertexDeclaration(HashState32* state, HVertexDeclaration vertex_declaration)
-    {
-        g_functions.m_HashVertexDeclaration(state, vertex_declaration);
-    }
-    uint32_t GetVertexDeclarationStride(HVertexDeclaration vertex_declaration)
-    {
-        return g_functions.m_GetVertexDeclarationStride(vertex_declaration);
-    }
     void EnableVertexBuffer(HContext context, HVertexBuffer vertex_buffer, uint32_t binding_index)
     {
         return g_functions.m_EnableVertexBuffer(context, vertex_buffer, binding_index);
@@ -1123,10 +1139,6 @@ namespace dmGraphics
     void DisableVertexBuffer(HContext context, HVertexBuffer vertex_buffer)
     {
         g_functions.m_DisableVertexBuffer(context, vertex_buffer);
-    }
-    uint32_t GetVertexStreamOffset(HVertexDeclaration vertex_declaration, uint64_t name_hash)
-    {
-        return g_functions.m_GetVertexStreamOffset(vertex_declaration, name_hash);
     }
     void DrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer)
     {

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -491,9 +491,23 @@ namespace dmGraphics
         delete stream_declaration;
     }
 
+    void DeleteVertexDeclaration(HVertexDeclaration vertex_declaration)
+    {
+        delete vertex_declaration;
+    }
+
     void HashVertexDeclaration(HashState32* state, HVertexDeclaration vertex_declaration)
     {
         dmHashUpdateBuffer32(state, vertex_declaration->m_Streams, sizeof(VertexDeclaration::Stream) * vertex_declaration->m_StreamCount);
+    }
+
+    bool SetStreamOffset(HVertexDeclaration vertex_declaration, uint32_t stream_index, uint16_t offset)
+    {
+        if (stream_index >= vertex_declaration->m_StreamCount) {
+            return false;
+        }
+        vertex_declaration->m_Streams[stream_index].m_Offset = offset;
+        return true;
     }
 
     uint32_t GetVertexStreamOffset(HVertexDeclaration vertex_declaration, dmhash_t name_hash)
@@ -1115,14 +1129,6 @@ namespace dmGraphics
     HVertexDeclaration NewVertexDeclaration(HContext context, HVertexStreamDeclaration stream_declaration, uint32_t stride)
     {
         return g_functions.m_NewVertexDeclarationStride(context, stream_declaration, stride);
-    }
-    bool SetStreamOffset(HVertexDeclaration vertex_declaration, uint32_t stream_index, uint16_t offset)
-    {
-        return g_functions.m_SetStreamOffset(vertex_declaration, stream_index, offset);
-    }
-    void DeleteVertexDeclaration(HVertexDeclaration vertex_declaration)
-    {
-        g_functions.m_DeleteVertexDeclaration(vertex_declaration);
     }
     void EnableVertexDeclaration(HContext context, HVertexDeclaration vertex_declaration, uint32_t binding_index, HProgram program)
     {

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -87,10 +87,7 @@ namespace dmGraphics
     typedef void (*DeleteVertexDeclarationFn)(HVertexDeclaration vertex_declaration);
     typedef void (*EnableVertexDeclarationFn)(HContext context, HVertexDeclaration vertex_declaration, uint32_t binding_index, HProgram program);
     typedef void (*DisableVertexDeclarationFn)(HContext context, HVertexDeclaration vertex_declaration);
-    typedef void (*HashVertexDeclarationFn)(HashState32* state, HVertexDeclaration vertex_declaration);
     typedef uint32_t (*GetVertexDeclarationFn)(HVertexDeclaration vertex_declaration);
-    typedef uint32_t (*GetVertexDeclarationStrideFn)(HVertexDeclaration vertex_declaration);
-    typedef uint32_t (*GetVertexStreamOffsetFn)(HVertexDeclaration vertex_declaration, dmhash_t name_hash);
 
     typedef void (*EnableVertexBufferFn)(HContext context, HVertexBuffer vertex_buffer, uint32_t binding_index);
     typedef void (*DisableVertexBufferFn)(HContext context, HVertexBuffer vertex_buffer);
@@ -213,11 +210,8 @@ namespace dmGraphics
         DeleteVertexDeclarationFn m_DeleteVertexDeclaration;
         EnableVertexDeclarationFn m_EnableVertexDeclaration;
         DisableVertexDeclarationFn m_DisableVertexDeclaration;
-        HashVertexDeclarationFn m_HashVertexDeclaration;
         EnableVertexBufferFn m_EnableVertexBuffer;
         DisableVertexBufferFn m_DisableVertexBuffer;
-        GetVertexDeclarationStrideFn m_GetVertexDeclarationStride;
-        GetVertexStreamOffsetFn m_GetVertexStreamOffset;
         DrawElementsFn m_DrawElements;
         DrawFn m_Draw;
         NewVertexProgramFn m_NewVertexProgram;
@@ -340,11 +334,8 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, EnableVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DisableVertexDeclaration); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, HashVertexDeclaration); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetVertexDeclarationStride); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, EnableVertexBuffer); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DisableVertexBuffer); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, GetVertexStreamOffset); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DrawElements); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, Draw); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewVertexProgram); \

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -82,9 +82,7 @@ namespace dmGraphics
     typedef uint32_t (*GetMaxElementsIndicesFn)(HContext context);
     typedef HVertexDeclaration (*NewVertexDeclarationFn)(HContext context, HVertexStreamDeclaration stream_declaration);
     typedef HVertexDeclaration (*NewVertexDeclarationStrideFn)(HContext context, HVertexStreamDeclaration stream_declaration, uint32_t stride);
-    typedef bool (*SetStreamOffsetFn)(HVertexDeclaration vertex_declaration, uint32_t stream_index, uint16_t offset);
 
-    typedef void (*DeleteVertexDeclarationFn)(HVertexDeclaration vertex_declaration);
     typedef void (*EnableVertexDeclarationFn)(HContext context, HVertexDeclaration vertex_declaration, uint32_t binding_index, HProgram program);
     typedef void (*DisableVertexDeclarationFn)(HContext context, HVertexDeclaration vertex_declaration);
     typedef uint32_t (*GetVertexDeclarationFn)(HVertexDeclaration vertex_declaration);
@@ -206,8 +204,6 @@ namespace dmGraphics
         GetMaxElementsIndicesFn m_GetMaxElementsIndices;
         NewVertexDeclarationFn m_NewVertexDeclaration;
         NewVertexDeclarationStrideFn m_NewVertexDeclarationStride;
-        SetStreamOffsetFn m_SetStreamOffset;
-        DeleteVertexDeclarationFn m_DeleteVertexDeclaration;
         EnableVertexDeclarationFn m_EnableVertexDeclaration;
         DisableVertexDeclarationFn m_DisableVertexDeclaration;
         EnableVertexBufferFn m_EnableVertexBuffer;
@@ -330,8 +326,6 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsIndexBufferFormatSupported); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewVertexDeclarationStride); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetStreamOffset); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, EnableVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DisableVertexDeclaration); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, EnableVertexBuffer); \

--- a/engine/graphics/src/graphics_private.h
+++ b/engine/graphics/src/graphics_private.h
@@ -49,6 +49,27 @@ namespace dmGraphics
         uint8_t      m_StreamCount;
     };
 
+    struct VertexDeclaration
+    {
+        struct Stream
+        {
+            dmhash_t m_NameHash;
+            int16_t  m_Location;
+            uint16_t m_Size;
+            uint16_t m_Offset;
+            Type     m_Type;
+            bool     m_Normalize;
+        };
+
+        Stream             m_Streams[MAX_VERTEX_STREAM_COUNT];
+        dmhash_t           m_PipelineHash; // Vulkan
+        uint16_t           m_StreamCount;
+        uint16_t           m_Stride;
+        VertexStepFunction m_StepFunction;
+        HProgram           m_BoundForProgram;     // OpenGL
+        uint32_t           m_ModificationVersion; // OpenGL
+    };
+
     struct UniformBlockMember
     {
         char*                      m_Name;

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -542,6 +542,7 @@ namespace dmGraphics
             VertexDeclaration::Stream& stream = vertex_declaration->m_Streams[i];
             if (stream.m_Size > 0)
             {
+                stream.m_Location = i;
                 EnableVertexStream(context, i, stream.m_Size, stream.m_Type, stride, &vb->m_Buffer[offset]);
                 offset += stream.m_Size * TYPE_SIZE[stream.m_Type - dmGraphics::TYPE_BYTE];
             }

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -482,21 +482,6 @@ namespace dmGraphics
         return vd;
     }
 
-    bool NullSetStreamOffset(HVertexDeclaration vertex_declaration, uint32_t stream_index, uint16_t offset)
-    {
-        if (stream_index > vertex_declaration->m_StreamCount)
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    static void NullDeleteVertexDeclaration(HVertexDeclaration vertex_declaration)
-    {
-        delete vertex_declaration;
-    }
-
     static void EnableVertexStream(HContext context, uint16_t stream, uint16_t size, Type type, uint16_t stride, const void* vertex_buffer)
     {
         assert(context);
@@ -576,21 +561,6 @@ namespace dmGraphics
             if (vertex_declaration->m_Streams[i].m_Size > 0)
                 DisableVertexStream(context, i);
     }
-
-    /*
-    static void NullHashVertexDeclaration(HashState32 *state, HVertexDeclaration vertex_declaration)
-    {
-        for (int i = 0; i < vertex_declaration->m_StreamCount; ++i)
-        {
-            VertexStream& stream = vertex_declaration->m_StreamDeclaration.m_Streams[i];
-            dmHashUpdateBuffer32(state, &stream.m_NameHash,  sizeof(dmhash_t));
-            dmHashUpdateBuffer32(state, &stream.m_Stream,    sizeof(stream.m_Stream));
-            dmHashUpdateBuffer32(state, &stream.m_Size,      sizeof(stream.m_Size));
-            dmHashUpdateBuffer32(state, &stream.m_Type,      sizeof(stream.m_Type));
-            dmHashUpdateBuffer32(state, &stream.m_Normalize, sizeof(stream.m_Normalize));
-        }
-    }
-    */
 
     static uint32_t GetIndex(Type type, HIndexBuffer ib, uint32_t index)
     {

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -464,21 +464,22 @@ namespace dmGraphics
     {
         VertexDeclaration* vd = new VertexDeclaration;
         memset(vd, 0, sizeof(VertexDeclaration));
-
-        vd->m_Stride = 0;
-        for (uint32_t i=0; i<stream_declaration->m_StreamCount; i++)
+        if (stream_declaration)
         {
-            VertexStream& stream = stream_declaration->m_Streams[i];
-            vd->m_Streams[i].m_NameHash  = stream.m_NameHash;
-            vd->m_Streams[i].m_Location  = -1;
-            vd->m_Streams[i].m_Size      = stream.m_Size;
-            vd->m_Streams[i].m_Type      = stream.m_Type;
-            vd->m_Streams[i].m_Normalize = stream.m_Normalize;
-            vd->m_Streams[i].m_Offset    = vd->m_Stride;
+            for (uint32_t i=0; i<stream_declaration->m_StreamCount; i++)
+            {
+                VertexStream& stream = stream_declaration->m_Streams[i];
+                vd->m_Streams[i].m_NameHash  = stream.m_NameHash;
+                vd->m_Streams[i].m_Location  = -1;
+                vd->m_Streams[i].m_Size      = stream.m_Size;
+                vd->m_Streams[i].m_Type      = stream.m_Type;
+                vd->m_Streams[i].m_Normalize = stream.m_Normalize;
+                vd->m_Streams[i].m_Offset    = vd->m_Stride;
 
-            vd->m_Stride += stream.m_Size * GetTypeSize(stream.m_Type);
+                vd->m_Stride += stream.m_Size * GetTypeSize(stream.m_Type);
+            }
+            vd->m_StreamCount = stream_declaration->m_StreamCount;
         }
-        vd->m_StreamCount = stream_declaration->m_StreamCount;
         return vd;
     }
 

--- a/engine/graphics/src/null/graphics_null_private.h
+++ b/engine/graphics/src/null/graphics_null_private.h
@@ -70,11 +70,6 @@ namespace dmGraphics
         uint32_t    m_StencilTextureBufferSize;
     };
 
-    struct VertexDeclaration
-    {
-        VertexStreamDeclaration m_StreamDeclaration;
-    };
-
     struct VertexBuffer
     {
         char*    m_Buffer;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1128,7 +1128,6 @@ static void LogFrameBufferError(GLenum status)
         // Hardcoded values for iOS and Android for now. The value is a hint, max number of vertices will still work with performance penalty
         // The below seems to be the reported sweet spot for modern or semi-modern hardware
         context->m_MaxElementVertices = 1024*1024;
-        context->m_MaxElementIndices = 1024*1024;
 #else
         // We don't accept values lower than 65k. It's a trade-off on drawcalls vs bufferdata upload
         GLint gl_max_elem_verts = 65536;
@@ -1143,7 +1142,6 @@ static void LogFrameBufferError(GLenum status)
         if (!legacy) {
             glGetIntegerv(GL_MAX_ELEMENTS_INDICES, &gl_max_elem_indices);
         }
-        context->m_MaxElementIndices = dmMath::Max(65536, gl_max_elem_indices);
         CLEAR_GL_ERROR;
 #endif
 
@@ -1488,11 +1486,6 @@ static void LogFrameBufferError(GLenum status)
         return (((OpenGLContext*) context)->m_IndexBufferFormatSupport & (1 << format)) != 0;
     }
 
-    static uint32_t OpenGLGetMaxElementIndices(HContext context)
-    {
-        return ((OpenGLContext*) context)->m_MaxElementIndices;
-    }
-
     // NOTE: This function doesn't seem to be used anywhere?
     static uint32_t OpenGLGetMaxElementsIndices(HContext context)
     {
@@ -1512,16 +1505,14 @@ static void LogFrameBufferError(GLenum status)
         memset(vd, 0, sizeof(VertexDeclaration));
 
         vd->m_Stride = 0;
-
         for (uint32_t i=0; i<stream_declaration->m_StreamCount; i++)
         {
-            vd->m_Streams[i].m_NameHash      = stream_declaration->m_Streams[i].m_NameHash;
-            vd->m_Streams[i].m_LogicalIndex  = i;
-            vd->m_Streams[i].m_PhysicalIndex = -1;
-            vd->m_Streams[i].m_Size          = stream_declaration->m_Streams[i].m_Size;
-            vd->m_Streams[i].m_Type          = stream_declaration->m_Streams[i].m_Type;
-            vd->m_Streams[i].m_Normalize     = stream_declaration->m_Streams[i].m_Normalize;
-            vd->m_Streams[i].m_Offset        = vd->m_Stride;
+            vd->m_Streams[i].m_NameHash  = stream_declaration->m_Streams[i].m_NameHash;
+            vd->m_Streams[i].m_Location  = -1;
+            vd->m_Streams[i].m_Size      = stream_declaration->m_Streams[i].m_Size;
+            vd->m_Streams[i].m_Type      = stream_declaration->m_Streams[i].m_Type;
+            vd->m_Streams[i].m_Normalize = stream_declaration->m_Streams[i].m_Normalize;
+            vd->m_Streams[i].m_Offset    = vd->m_Stride;
 
             vd->m_Stride += stream_declaration->m_Streams[i].m_Size * GetTypeSize(stream_declaration->m_Streams[i].m_Type);
         }
@@ -1563,14 +1554,14 @@ static void LogFrameBufferError(GLenum status)
 
             if (location != -1)
             {
-                streams[i].m_PhysicalIndex = location;
+                streams[i].m_Location = location;
             }
             else
             {
                 CLEAR_GL_ERROR
                 // TODO: Disabled irritating warning? Should we care about not used streams?
                 //dmLogWarning("Vertex attribute %s is not active or defined", streams[i].m_Name);
-                streams[i].m_PhysicalIndex = -1;
+                streams[i].m_Location = -1;
             }
         }
 
@@ -1605,12 +1596,12 @@ static void LogFrameBufferError(GLenum status)
 
         for (uint32_t i=0; i<vertex_declaration->m_StreamCount; i++)
         {
-            if (vertex_declaration->m_Streams[i].m_PhysicalIndex != -1)
+            if (vertex_declaration->m_Streams[i].m_Location != -1)
             {
-                glEnableVertexAttribArray(vertex_declaration->m_Streams[i].m_PhysicalIndex);
+                glEnableVertexAttribArray(vertex_declaration->m_Streams[i].m_Location);
                 CHECK_GL_ERROR;
                 glVertexAttribPointer(
-                        vertex_declaration->m_Streams[i].m_PhysicalIndex,
+                        vertex_declaration->m_Streams[i].m_Location,
                         vertex_declaration->m_Streams[i].m_Size,
                         GetOpenGLType(vertex_declaration->m_Streams[i].m_Type),
                         vertex_declaration->m_Streams[i].m_Normalize,
@@ -1631,9 +1622,9 @@ static void LogFrameBufferError(GLenum status)
 
         for (uint32_t i=0; i<vertex_declaration->m_StreamCount; i++)
         {
-            if (vertex_declaration->m_Streams[i].m_PhysicalIndex != -1)
+            if (vertex_declaration->m_Streams[i].m_Location != -1)
             {
-                glDisableVertexAttribArray(vertex_declaration->m_Streams[i].m_PhysicalIndex);
+                glDisableVertexAttribArray(vertex_declaration->m_Streams[i].m_Location);
                 CHECK_GL_ERROR;
             }
         }
@@ -1643,30 +1634,6 @@ static void LogFrameBufferError(GLenum status)
 
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, 0);
         CHECK_GL_ERROR;
-    }
-
-    static void OpenGLHashVertexDeclaration(HashState32* state, HVertexDeclaration vertex_declaration)
-    {
-        dmHashUpdateBuffer32(state, vertex_declaration->m_Streams, sizeof(VertexDeclaration::Stream) * vertex_declaration->m_StreamCount);
-    }
-
-    static uint32_t OpenGLGetVertexDeclarationStride(HVertexDeclaration vertex_declaration)
-    {
-        return vertex_declaration->m_Stride;
-    }
-
-    static uint32_t OpenGLGetVertexStreamOffset(HVertexDeclaration vertex_declaration, uint64_t name_hash)
-    {
-        uint32_t count = vertex_declaration->m_StreamCount;
-        VertexDeclaration::Stream* streams = vertex_declaration->m_Streams;
-        for (int i = 0; i < count; ++i)
-        {
-            if (streams[i].m_NameHash == name_hash)
-            {
-                return streams[i].m_Offset;
-            }
-        }
-        return dmGraphics::INVALID_STREAM_OFFSET;
     }
 
     static void OpenGLDrawElements(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1521,20 +1521,6 @@ static void LogFrameBufferError(GLenum status)
         return vd;
     }
 
-    static bool OpenGLSetStreamOffset(HVertexDeclaration vertex_declaration, uint32_t stream_index, uint16_t offset)
-    {
-        if (stream_index >= vertex_declaration->m_StreamCount) {
-            return false;
-        }
-        vertex_declaration->m_Streams[stream_index].m_Offset = offset;
-        return true;
-    }
-
-    static void OpenGLDeleteVertexDeclaration(HVertexDeclaration vertex_declaration)
-    {
-        delete vertex_declaration;
-    }
-
     static void BindVertexDeclarationProgram(HContext context, HVertexDeclaration vertex_declaration, HProgram program)
     {
         OpenGLProgram* program_ptr = (OpenGLProgram*) program;

--- a/engine/graphics/src/opengl/graphics_opengl_private.h
+++ b/engine/graphics/src/opengl/graphics_opengl_private.h
@@ -86,7 +86,6 @@ namespace dmGraphics
         TextureFilter           m_DefaultTextureMinFilter;
         TextureFilter           m_DefaultTextureMagFilter;
         uint32_t                m_MaxElementVertices;
-        uint32_t                m_MaxElementIndices;
         // Counter to keep track of various modifications. Used for cache flush etc
         // Version zero is never used
         uint32_t                m_ModificationVersion;
@@ -107,27 +106,6 @@ namespace dmGraphics
         uint32_t                m_PrintDeviceInfo                  : 1;
         uint32_t                m_IsGles3Version                   : 1; // 0 == gles 2, 1 == gles 3
         uint32_t                m_IsShaderLanguageGles             : 1; // 0 == glsl, 1 == gles
-    };
-
-    // JG: dmsdk/graphics.h defines this as a struct ptr so don't want to rename it yet..
-    struct VertexDeclaration
-    {
-        struct Stream
-        {
-            dmhash_t m_NameHash;
-            uint16_t m_LogicalIndex;
-            int16_t  m_PhysicalIndex;
-            uint16_t m_Size;
-            uint16_t m_Offset;
-            Type     m_Type;
-            bool     m_Normalize;
-        };
-
-        Stream      m_Streams[MAX_VERTEX_STREAM_COUNT];
-        uint16_t    m_StreamCount;
-        uint16_t    m_Stride;
-        HProgram    m_BoundForProgram;
-        uint32_t    m_ModificationVersion;
     };
 
     struct OpenGLShader

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -268,7 +268,7 @@ TEST_F(dmGraphicsTest, VertexStreamDeclaration)
     dmGraphics::AddVertexStream(stream_declaration, "stream0", 2, dmGraphics::TYPE_BYTE, true);
     dmGraphics::AddVertexStream(stream_declaration, "stream1", 4, dmGraphics::TYPE_FLOAT, false);
 
-    #define TEST_STREAM(streams, name, ix, size, type, normalize) \
+    #define TEST_STREAM_DECLARATION(streams, name, ix, size, type, normalize) \
         ASSERT_TRUE(streams[ix].m_NameHash == dmHashString64(name)); \
         ASSERT_EQ(streams[ix].m_Stream, ix); \
         ASSERT_EQ(streams[ix].m_Size, size); \
@@ -276,15 +276,24 @@ TEST_F(dmGraphicsTest, VertexStreamDeclaration)
         ASSERT_EQ(streams[ix].m_Normalize, normalize);
 
     ASSERT_EQ(stream_declaration->m_StreamCount, 2);
-    TEST_STREAM(stream_declaration->m_Streams, "stream0", 0, 2, dmGraphics::TYPE_BYTE, true);
-    TEST_STREAM(stream_declaration->m_Streams, "stream1", 1, 4, dmGraphics::TYPE_FLOAT, false);
+    TEST_STREAM_DECLARATION(stream_declaration->m_Streams, "stream0", 0, 2, dmGraphics::TYPE_BYTE, true);
+    TEST_STREAM_DECLARATION(stream_declaration->m_Streams, "stream1", 1, 4, dmGraphics::TYPE_FLOAT, false);
+
+    #undef TEST_STREAM_DECLARATION
+
+    #define TEST_STREAM(streams, name, ix, location, size, type, normalize) \
+        ASSERT_TRUE(streams[ix].m_NameHash == dmHashString64(name)); \
+        ASSERT_EQ(streams[ix].m_Location, location); \
+        ASSERT_EQ(streams[ix].m_Size, size); \
+        ASSERT_EQ(streams[ix].m_Type, type); \
+        ASSERT_EQ(streams[ix].m_Normalize, normalize);
 
     // Test that the stream declaration has been passed to the vertex declaration
     dmGraphics::HVertexDeclaration vertex_declaration = dmGraphics::NewVertexDeclaration(m_Context, stream_declaration);
     dmGraphics::VertexDeclaration* vx = (dmGraphics::VertexDeclaration*) vertex_declaration;
-    ASSERT_EQ(vx->m_StreamDeclaration.m_StreamCount, 2);
-    TEST_STREAM(vx->m_StreamDeclaration.m_Streams, "stream0", 0, 2, dmGraphics::TYPE_BYTE, true);
-    TEST_STREAM(vx->m_StreamDeclaration.m_Streams, "stream1", 1, 4, dmGraphics::TYPE_FLOAT, false);
+    ASSERT_EQ(vx->m_StreamCount, 2);
+    TEST_STREAM(vx->m_Streams, "stream0", 0, -1, 2, dmGraphics::TYPE_BYTE, true);
+    TEST_STREAM(vx->m_Streams, "stream1", 1, -1, 4, dmGraphics::TYPE_FLOAT, false);
 
     #undef TEST_STREAM
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -1781,7 +1781,7 @@ bail:
         VertexDeclaration* vd = CreateAndFillVertexDeclaration(&decl_hash_state, stream_declaration);
         dmHashUpdateBuffer64(&decl_hash_state, &vd->m_Stride, sizeof(vd->m_Stride));
         vd->m_PipelineHash = dmHashFinal64(&decl_hash_state);
-        vd->m_StepFunction = VERTEX_STEP_VERTEX;
+        vd->m_StepFunction = VERTEX_STEP_FUNCTION_VERTEX;
         return vd;
     }
 
@@ -1793,22 +1793,8 @@ bail:
         dmHashUpdateBuffer64(&decl_hash_state, &stride, sizeof(stride));
         vd->m_Stride       = stride;
         vd->m_PipelineHash = dmHashFinal64(&decl_hash_state);
-        vd->m_StepFunction = VERTEX_STEP_VERTEX;
+        vd->m_StepFunction = VERTEX_STEP_FUNCTION_VERTEX;
         return vd;
-    }
-
-    bool VulkanSetStreamOffset(HVertexDeclaration vertex_declaration, uint32_t stream_index, uint16_t offset)
-    {
-        if (stream_index >= vertex_declaration->m_StreamCount) {
-            return false;
-        }
-        vertex_declaration->m_Streams[stream_index].m_Offset = offset;
-        return true;
-    }
-
-    static void VulkanDeleteVertexDeclaration(HVertexDeclaration vertex_declaration)
-    {
-        delete (VertexDeclaration*) vertex_declaration;
     }
 
     static void VulkanEnableVertexBuffer(HContext _context, HVertexBuffer vertex_buffer, uint32_t binding_index)

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -670,7 +670,7 @@ namespace dmGraphics
         default_texture_creation_params.m_OriginalWidth  = default_texture_creation_params.m_Width;
         default_texture_creation_params.m_OriginalHeight = default_texture_creation_params.m_Height;
 
-        const uint8_t default_texture_data[4 * 6] = {0}; // RGBA * 6 (for cubemap)
+        const uint8_t default_texture_data[4 * 6] = {}; // RGBA * 6 (for cubemap)
 
         TextureParams default_texture_params;
         default_texture_params.m_Width  = 1;
@@ -1518,7 +1518,7 @@ bail:
 
         for (int i = 0; i < vertexDeclarationCount; ++i)
         {
-            dmHashUpdateBuffer64(&pipeline_hash_state, &vertexDeclaration[i]->m_Hash, sizeof(vertexDeclaration[i]->m_Hash));
+            dmHashUpdateBuffer64(&pipeline_hash_state, &vertexDeclaration[i]->m_PipelineHash, sizeof(vertexDeclaration[i]->m_PipelineHash));
             dmHashUpdateBuffer64(&pipeline_hash_state, &vertexDeclaration[i]->m_StepFunction, sizeof(vertexDeclaration[i]->m_StepFunction));
         }
 
@@ -1719,98 +1719,6 @@ bail:
         return 0;
     }
 
-    static inline VkFormat GetVertexAttributeFormat(Type type, uint16_t size, bool normalized)
-    {
-        if (type == TYPE_FLOAT)
-        {
-            switch(size)
-            {
-                case 1: return VK_FORMAT_R32_SFLOAT;
-                case 2: return VK_FORMAT_R32G32_SFLOAT;
-                case 3: return VK_FORMAT_R32G32B32_SFLOAT;
-                case 4: return VK_FORMAT_R32G32B32A32_SFLOAT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_INT)
-        {
-            switch(size)
-            {
-                case 1: return VK_FORMAT_R32_SINT;
-                case 2: return VK_FORMAT_R32G32_SINT;
-                case 3: return VK_FORMAT_R32G32B32_SINT;
-                case 4: return VK_FORMAT_R32G32B32A32_SINT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_UNSIGNED_INT)
-        {
-            switch(size)
-            {
-                case 1: return VK_FORMAT_R32_UINT;
-                case 2: return VK_FORMAT_R32G32_UINT;
-                case 3: return VK_FORMAT_R32G32B32_UINT;
-                case 4: return VK_FORMAT_R32G32B32A32_UINT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_BYTE)
-        {
-            switch(size)
-            {
-                case 1: return normalized ? VK_FORMAT_R8_SNORM : VK_FORMAT_R8_SINT;
-                case 2: return normalized ? VK_FORMAT_R8G8_SNORM : VK_FORMAT_R8G8_SINT;
-                case 3: return normalized ? VK_FORMAT_R8G8B8_SNORM : VK_FORMAT_R8G8B8_SINT;
-                case 4: return normalized ? VK_FORMAT_R8G8B8A8_SNORM : VK_FORMAT_R8G8B8A8_SINT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_UNSIGNED_BYTE)
-        {
-            switch(size)
-            {
-                case 1: return normalized ? VK_FORMAT_R8_UNORM : VK_FORMAT_R8_UINT;
-                case 2: return normalized ? VK_FORMAT_R8G8_UNORM : VK_FORMAT_R8G8_UINT;
-                case 3: return normalized ? VK_FORMAT_R8G8B8_UNORM : VK_FORMAT_R8G8B8_UINT;
-                case 4: return normalized ? VK_FORMAT_R8G8B8A8_UNORM : VK_FORMAT_R8G8B8A8_UINT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_SHORT)
-        {
-            switch(size)
-            {
-                case 1: return normalized ? VK_FORMAT_R16_SNORM : VK_FORMAT_R16_SINT;
-                case 2: return normalized ? VK_FORMAT_R16G16_SNORM : VK_FORMAT_R16G16_SINT;
-                case 3: return normalized ? VK_FORMAT_R16G16B16_SNORM : VK_FORMAT_R16G16B16_SINT;
-                case 4: return normalized ? VK_FORMAT_R16G16B16A16_SNORM : VK_FORMAT_R16G16B16A16_SINT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_UNSIGNED_SHORT)
-        {
-            switch(size)
-            {
-                case 1: return normalized ? VK_FORMAT_R16_UNORM : VK_FORMAT_R16_UINT;
-                case 2: return normalized ? VK_FORMAT_R16G16_UNORM : VK_FORMAT_R16G16_UINT;
-                case 3: return normalized ? VK_FORMAT_R16G16B16_UNORM : VK_FORMAT_R16G16B16_UINT;
-                case 4: return normalized ? VK_FORMAT_R16G16B16A16_UNORM : VK_FORMAT_R16G16B16A16_UINT;
-                default:break;
-            }
-        }
-        else if (type == TYPE_FLOAT_MAT4)
-        {
-            return VK_FORMAT_R32_SFLOAT;
-        }
-        else if (type == TYPE_FLOAT_VEC4)
-        {
-            return VK_FORMAT_R32G32B32A32_SFLOAT;
-        }
-
-        assert(0 && "Unable to deduce type from dmGraphics::Type");
-        return VK_FORMAT_UNDEFINED;
-    }
-
     static VertexDeclaration* CreateAndFillVertexDeclaration(HashState64* hash, HVertexStreamDeclaration stream_declaration)
     {
         VertexDeclaration* vd = new VertexDeclaration();
@@ -1848,15 +1756,17 @@ bail:
             }
         #endif
 
-            vd->m_Streams[i].m_NameHash = stream.m_NameHash;
-            vd->m_Streams[i].m_Format   = GetVertexAttributeFormat(stream.m_Type, stream.m_Size, stream.m_Normalize);
-            vd->m_Streams[i].m_Offset   = vd->m_Stride;
-            vd->m_Streams[i].m_Location = 0;
-            vd->m_Stride               += stream.m_Size * GetGraphicsTypeSize(stream.m_Type);
+            vd->m_Streams[i].m_NameHash  = stream.m_NameHash;
+            vd->m_Streams[i].m_Type      = stream.m_Type;
+            vd->m_Streams[i].m_Size      = stream.m_Size;
+            vd->m_Streams[i].m_Normalize = stream.m_Normalize;
+            vd->m_Streams[i].m_Offset    = vd->m_Stride;
+            vd->m_Streams[i].m_Location  = -1;
+            vd->m_Stride                += stream.m_Size * GetGraphicsTypeSize(stream.m_Type);
 
             dmHashUpdateBuffer64(hash, &stream.m_Size, sizeof(stream.m_Size));
             dmHashUpdateBuffer64(hash, &stream.m_Type, sizeof(stream.m_Type));
-            dmHashUpdateBuffer64(hash, &vd->m_Streams[i].m_Format, sizeof(vd->m_Streams[i].m_Format));
+            dmHashUpdateBuffer64(hash, &vd->m_Streams[i].m_Type, sizeof(vd->m_Streams[i].m_Type));
         }
 
         vd->m_Stride = DM_ALIGN(vd->m_Stride, 4);
@@ -1870,7 +1780,7 @@ bail:
         dmHashInit64(&decl_hash_state, false);
         VertexDeclaration* vd = CreateAndFillVertexDeclaration(&decl_hash_state, stream_declaration);
         dmHashUpdateBuffer64(&decl_hash_state, &vd->m_Stride, sizeof(vd->m_Stride));
-        vd->m_Hash         = dmHashFinal64(&decl_hash_state);
+        vd->m_PipelineHash = dmHashFinal64(&decl_hash_state);
         vd->m_StepFunction = VERTEX_STEP_VERTEX;
         return vd;
     }
@@ -1881,9 +1791,9 @@ bail:
         dmHashInit64(&decl_hash_state, false);
         VertexDeclaration* vd = CreateAndFillVertexDeclaration(&decl_hash_state, stream_declaration);
         dmHashUpdateBuffer64(&decl_hash_state, &stride, sizeof(stride));
-        vd->m_Stride          = stride;
-        vd->m_Hash            = dmHashFinal64(&decl_hash_state);
-        vd->m_StepFunction    = VERTEX_STEP_VERTEX;
+        vd->m_Stride       = stride;
+        vd->m_PipelineHash = dmHashFinal64(&decl_hash_state);
+        vd->m_StepFunction = VERTEX_STEP_VERTEX;
         return vd;
     }
 
@@ -1923,30 +1833,31 @@ bail:
         Program* program_ptr        = (Program*) program;
         ShaderModule* vertex_shader = program_ptr->m_VertexModule;
 
-        uint32_t num_inputs = vertex_shader->m_Inputs.Size();
-
-        context->m_MainVertexDeclaration[binding_index]                = {0};
+        context->m_MainVertexDeclaration[binding_index]                = {};
         context->m_MainVertexDeclaration[binding_index].m_Stride       = vertex_declaration->m_Stride;
         context->m_MainVertexDeclaration[binding_index].m_StepFunction = vertex_declaration->m_StepFunction;
-        context->m_MainVertexDeclaration[binding_index].m_Hash         = vertex_declaration->m_Hash;
+        context->m_MainVertexDeclaration[binding_index].m_PipelineHash = vertex_declaration->m_PipelineHash;
 
         context->m_CurrentVertexDeclaration[binding_index]             = &context->m_MainVertexDeclaration[binding_index];
 
         uint32_t stream_ix = 0;
+        uint32_t num_inputs = vertex_shader->m_Inputs.Size();
 
         for (int i = 0; i < vertex_declaration->m_StreamCount; ++i)
         {
-            for (int j = 0; j < vertex_shader->m_Inputs.Size(); ++j)
+            for (int j = 0; j < num_inputs; ++j)
             {
                 ShaderResourceBinding& input = vertex_shader->m_Inputs[j];
 
                 if (input.m_NameHash == vertex_declaration->m_Streams[i].m_NameHash)
                 {
                     VertexDeclaration::Stream& stream = context->m_MainVertexDeclaration[binding_index].m_Streams[stream_ix];
-                    stream.m_NameHash = input.m_NameHash;
-                    stream.m_Location = input.m_Binding;
-                    stream.m_Format   = vertex_declaration->m_Streams[i].m_Format;
-                    stream.m_Offset   = vertex_declaration->m_Streams[i].m_Offset;
+                    stream.m_NameHash  = input.m_NameHash;
+                    stream.m_Location  = input.m_Binding;
+                    stream.m_Type      = vertex_declaration->m_Streams[i].m_Type;
+                    stream.m_Offset    = vertex_declaration->m_Streams[i].m_Offset;
+                    stream.m_Size      = vertex_declaration->m_Streams[i].m_Size;
+                    stream.m_Normalize = vertex_declaration->m_Streams[i].m_Normalize;
                     stream_ix++;
 
                     context->m_MainVertexDeclaration[binding_index].m_StreamCount++;
@@ -1964,25 +1875,6 @@ bail:
             if (context->m_CurrentVertexDeclaration[i] == vertex_declaration)
                 context->m_CurrentVertexDeclaration[i] = 0;
         }
-    }
-
-    static uint32_t VulkanGetVertexDeclarationStride(HVertexDeclaration vertex_declaration)
-    {
-        return vertex_declaration->m_Stride;
-    }
-
-    static uint32_t VulkanGetVertexStreamOffset(HVertexDeclaration vertex_declaration, dmhash_t name_hash)
-    {
-        uint32_t count = vertex_declaration->m_StreamCount;
-        VertexDeclaration::Stream* streams = vertex_declaration->m_Streams;
-        for (int i = 0; i < count; ++i)
-        {
-            if (streams[i].m_NameHash == name_hash)
-            {
-                return streams[i].m_Offset;
-            }
-        }
-        return dmGraphics::INVALID_STREAM_OFFSET;
     }
 
     static inline bool IsUniformTextureSampler(const ShaderResourceBinding& uniform)
@@ -2302,11 +2194,6 @@ bail:
         }
 
         vkCmdBindVertexBuffers(vk_command_buffer, 0, num_vx_buffers, vk_buffers, vk_buffer_offsets);
-    }
-
-    static void VulkanHashVertexDeclaration(HashState32 *state, HVertexDeclaration vertex_declaration)
-    {
-        dmHashUpdateBuffer32(state, vertex_declaration->m_Streams, sizeof(VertexDeclaration::Stream) * vertex_declaration->m_StreamCount);
     }
 
     static void VulkanDrawElements(HContext _context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer)
@@ -4630,11 +4517,11 @@ bail:
         DeviceBuffer* vertex_buffer                  = (DeviceBuffer*) _vertex_buffer;
         VertexDeclaration* vertex_declaration        = (VertexDeclaration*) _vertex_declaration;
 
-        context->m_MainVertexDeclaration[binding]                = {0};
+        context->m_MainVertexDeclaration[binding]                = {};
         context->m_MainVertexDeclaration[binding].m_StreamCount  = vertex_declaration->m_StreamCount;
         context->m_MainVertexDeclaration[binding].m_Stride       = vertex_declaration->m_Stride;
         context->m_MainVertexDeclaration[binding].m_StepFunction = vertex_declaration->m_StepFunction;
-        context->m_MainVertexDeclaration[binding].m_Hash         = vertex_declaration->m_Hash;
+        context->m_MainVertexDeclaration[binding].m_PipelineHash = vertex_declaration->m_PipelineHash;
 
         context->m_CurrentVertexBuffer[binding]                  = vertex_buffer;
         context->m_CurrentVertexDeclaration[binding]             = &context->m_MainVertexDeclaration[binding];
@@ -4652,7 +4539,7 @@ bail:
                     VertexDeclaration::Stream& stream = context->m_MainVertexDeclaration[binding].m_Streams[stream_ix];
                     stream.m_NameHash = input.m_NameHash;
                     stream.m_Location = input.m_Binding;
-                    stream.m_Format   = vertex_declaration->m_Streams[i].m_Format;
+                    stream.m_Type     = vertex_declaration->m_Streams[i].m_Type;
                     stream.m_Offset   = vertex_declaration->m_Streams[i].m_Offset;
                     stream_ix++;
                     break;
@@ -4740,7 +4627,6 @@ bail:
     void VulkanMemorybarrier(HContext _context, HTexture _texture, uint32_t src_stage_flags, uint32_t dst_stage_flags, uint32_t src_access_flags, uint32_t dst_access_flags)
     {
         VulkanContext* context = (VulkanContext*) _context;
-        VulkanTexture* texture = GetAssetFromContainer<VulkanTexture>(context->m_AssetHandleContainer, _texture);
         assert(context->m_FrameBegun);
 
         const uint8_t image_ix            = context->m_SwapChain->m_ImageIndex;
@@ -4762,9 +4648,7 @@ bail:
     void VulkanGetUniformBinding(HContext context, HProgram prog, uint32_t index, uint32_t* set_out, uint32_t* binding_out, uint32_t* member_index_out)
     {
         assert(prog);
-        Program* program     = (Program*) prog;
-        ShaderModule* module = 0;
-
+        Program* program = (Program*) prog;
         uint32_t search_index = 0;
 
         for (int set = 0; set < program->m_MaxSet; ++set)

--- a/engine/graphics/src/vulkan/graphics_vulkan.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan.h
@@ -22,12 +22,6 @@ namespace dmGraphics
     static const uint8_t  SUBPASS_EXTERNAL 		    = -1;
     static const uint8_t  SUBPASS_ATTACHMENT_UNUSED = -1;
 
-    enum VertexStepFunction
-    {
-        VERTEX_STEP_VERTEX,
-        VERTEX_STEP_INSTANCE,
-    };
-
     enum BarrierStageFlags
     {
         STAGE_FLAG_QUEUE_BEGIN                = 1,

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -1104,8 +1104,8 @@ bail:
 
             vk_vx_input_descriptions[i].binding   = i;
             vk_vx_input_descriptions[i].stride    = vertexDeclarations[i]->m_Stride;
-            vk_vx_input_descriptions[i].inputRate = vertexDeclarations[i]->m_StepFunction == VERTEX_STEP_VERTEX ?
-                                                    VK_VERTEX_INPUT_RATE_VERTEX : VK_VERTEX_INPUT_RATE_INSTANCE;
+            vk_vx_input_descriptions[i].inputRate = vertexDeclarations[i]->m_StepFunction == VERTEX_STEP_FUNCTION_VERTEX ?
+                                                        VK_VERTEX_INPUT_RATE_VERTEX : VK_VERTEX_INPUT_RATE_INSTANCE;
         }
 
         assert(active_attributes != 0);

--- a/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan_device.cpp
@@ -55,21 +55,113 @@ namespace dmGraphics
         memset(this, 0, sizeof(*this));
     }
 
+    static inline VkFormat GetVertexAttributeFormat(Type type, uint16_t size, bool normalized)
+    {
+        if (type == TYPE_FLOAT)
+        {
+            switch(size)
+            {
+                case 1: return VK_FORMAT_R32_SFLOAT;
+                case 2: return VK_FORMAT_R32G32_SFLOAT;
+                case 3: return VK_FORMAT_R32G32B32_SFLOAT;
+                case 4: return VK_FORMAT_R32G32B32A32_SFLOAT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_INT)
+        {
+            switch(size)
+            {
+                case 1: return VK_FORMAT_R32_SINT;
+                case 2: return VK_FORMAT_R32G32_SINT;
+                case 3: return VK_FORMAT_R32G32B32_SINT;
+                case 4: return VK_FORMAT_R32G32B32A32_SINT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_UNSIGNED_INT)
+        {
+            switch(size)
+            {
+                case 1: return VK_FORMAT_R32_UINT;
+                case 2: return VK_FORMAT_R32G32_UINT;
+                case 3: return VK_FORMAT_R32G32B32_UINT;
+                case 4: return VK_FORMAT_R32G32B32A32_UINT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_BYTE)
+        {
+            switch(size)
+            {
+                case 1: return normalized ? VK_FORMAT_R8_SNORM : VK_FORMAT_R8_SINT;
+                case 2: return normalized ? VK_FORMAT_R8G8_SNORM : VK_FORMAT_R8G8_SINT;
+                case 3: return normalized ? VK_FORMAT_R8G8B8_SNORM : VK_FORMAT_R8G8B8_SINT;
+                case 4: return normalized ? VK_FORMAT_R8G8B8A8_SNORM : VK_FORMAT_R8G8B8A8_SINT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_UNSIGNED_BYTE)
+        {
+            switch(size)
+            {
+                case 1: return normalized ? VK_FORMAT_R8_UNORM : VK_FORMAT_R8_UINT;
+                case 2: return normalized ? VK_FORMAT_R8G8_UNORM : VK_FORMAT_R8G8_UINT;
+                case 3: return normalized ? VK_FORMAT_R8G8B8_UNORM : VK_FORMAT_R8G8B8_UINT;
+                case 4: return normalized ? VK_FORMAT_R8G8B8A8_UNORM : VK_FORMAT_R8G8B8A8_UINT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_SHORT)
+        {
+            switch(size)
+            {
+                case 1: return normalized ? VK_FORMAT_R16_SNORM : VK_FORMAT_R16_SINT;
+                case 2: return normalized ? VK_FORMAT_R16G16_SNORM : VK_FORMAT_R16G16_SINT;
+                case 3: return normalized ? VK_FORMAT_R16G16B16_SNORM : VK_FORMAT_R16G16B16_SINT;
+                case 4: return normalized ? VK_FORMAT_R16G16B16A16_SNORM : VK_FORMAT_R16G16B16A16_SINT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_UNSIGNED_SHORT)
+        {
+            switch(size)
+            {
+                case 1: return normalized ? VK_FORMAT_R16_UNORM : VK_FORMAT_R16_UINT;
+                case 2: return normalized ? VK_FORMAT_R16G16_UNORM : VK_FORMAT_R16G16_UINT;
+                case 3: return normalized ? VK_FORMAT_R16G16B16_UNORM : VK_FORMAT_R16G16B16_UINT;
+                case 4: return normalized ? VK_FORMAT_R16G16B16A16_UNORM : VK_FORMAT_R16G16B16A16_UINT;
+                default:break;
+            }
+        }
+        else if (type == TYPE_FLOAT_MAT4)
+        {
+            return VK_FORMAT_R32_SFLOAT;
+        }
+        else if (type == TYPE_FLOAT_VEC4)
+        {
+            return VK_FORMAT_R32G32B32A32_SFLOAT;
+        }
+
+        assert(0 && "Unable to deduce type from dmGraphics::Type");
+        return VK_FORMAT_UNDEFINED;
+    }
+
     static uint16_t FillVertexInputAttributeDesc(HVertexDeclaration vertexDeclaration, VkVertexInputAttributeDescription* vk_vertex_input_descs, uint32_t binding)
     {
         uint16_t num_attributes = 0;
         for (uint16_t i = 0; i < vertexDeclaration->m_StreamCount; ++i)
         {
-            if (vertexDeclaration->m_Streams[i].m_Location == 0xffff)
+            if (vertexDeclaration->m_Streams[i].m_Location == -1)
             {
                 continue;
             }
 
-            VertexDeclaration::Stream& stream_in           = vertexDeclaration->m_Streams[i];
+            VertexDeclaration::Stream& stream              = vertexDeclaration->m_Streams[i];
             vk_vertex_input_descs[num_attributes].binding  = binding;
-            vk_vertex_input_descs[num_attributes].location = stream_in.m_Location;
-            vk_vertex_input_descs[num_attributes].format   = stream_in.m_Format;
-            vk_vertex_input_descs[num_attributes].offset   = stream_in.m_Offset;
+            vk_vertex_input_descs[num_attributes].location = stream.m_Location;
+            vk_vertex_input_descs[num_attributes].format   = GetVertexAttributeFormat(stream.m_Type, stream.m_Size, stream.m_Normalize);
+            vk_vertex_input_descs[num_attributes].offset   = stream.m_Offset;
 
             num_attributes++;
         }

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -131,29 +131,6 @@ namespace dmGraphics
         void     Reset(VkDevice vk_device);
     };
 
-    /*
-    struct VertexDeclaration
-    {
-        struct Stream
-        {
-            uint64_t m_NameHash;
-            uint16_t m_Location;
-            uint16_t m_Offset;
-            VkFormat m_Format;
-
-            // TODO: Not sure how to deal with normalizing
-            //       a vertex stream in VK.
-            // bool        m_Normalize;
-        };
-
-        uint64_t           m_Hash;
-        Stream             m_Streams[MAX_VERTEX_STREAM_COUNT];
-        VertexStepFunction m_StepFunction;
-        uint16_t           m_StreamCount;
-        uint16_t           m_Stride;
-    };
-    */
-
     struct ScratchBuffer
     {
         ScratchBuffer()

--- a/engine/graphics/src/vulkan/graphics_vulkan_private.h
+++ b/engine/graphics/src/vulkan/graphics_vulkan_private.h
@@ -131,6 +131,7 @@ namespace dmGraphics
         void     Reset(VkDevice vk_device);
     };
 
+    /*
     struct VertexDeclaration
     {
         struct Stream
@@ -151,6 +152,7 @@ namespace dmGraphics
         uint16_t           m_StreamCount;
         uint16_t           m_Stride;
     };
+    */
 
     struct ScratchBuffer
     {

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -3,10 +3,10 @@
 // Copyright 2009-2014 Ragnar Svensson, Christian Murray
 // Licensed under the Defold License version 1.0 (the "License"); you may not use
 // this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License, together with FAQs at
 // https://www.defold.com/license
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the


### PR DESCRIPTION
This PR simplifies how vertex declarations are used in the various graphics adapters.
Instead of each adapter having their own structs to define this, we use the same representation across all adapters.

Pros: Simpler code, less to maintain, 
Cons: Slight increase of memory per adapter since we have to store some adapter specific data in the struct. In the future we can probably fix this by a second layer of separation, but this should be good enough for now.

TODO (not this PR):
* Update rive to use the new setup (vertex step enum is now in dmsdk)
* Update consoles (remove specific vx decl functions in PS4/PS5)