### PR TITLE
Prevent crash when creating a joint in callback

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collision_object.cpp
@@ -1512,6 +1512,10 @@ namespace dmGameSystem
             return dmPhysics::RESULT_NOT_SUPPORTED;
         }
 
+        if (dmPhysics::IsWorldLocked(world->m_World2D)) {
+            return dmPhysics::RESULT_PHYSICS_WORLD_LOCKED;
+        }
+
         CollisionComponent* component_a = (CollisionComponent*)_component_a;
         CollisionComponent* component_b = (CollisionComponent*)_component_b;
 

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -516,6 +516,7 @@ namespace dmGameSystem
         "a joint with that id already exist",
         "joint id not found",
         "joint not connected",
+        "physics world locked (in the middle of a time step)",
         "unknown error",
     };
 

--- a/engine/physics/src/physics/physics.h
+++ b/engine/physics/src/physics/physics.h
@@ -51,6 +51,7 @@ namespace dmPhysics
 
     };
 
+    // Matches PhysicsResultString in script_physics.cpp
     enum JointResult
     {
         RESULT_OK = 0,
@@ -58,7 +59,8 @@ namespace dmPhysics
         RESULT_ID_EXISTS = 2,
         RESULT_ID_NOT_FOUND = 3,
         RESULT_NOT_CONNECTED = 4,
-        RESULT_UNKNOWN_ERROR = 5,
+        RESULT_PHYSICS_WORLD_LOCKED = 5,
+        RESULT_UNKNOWN_ERROR = 6,
     };
 
     /// 3D context handle.
@@ -1407,6 +1409,7 @@ namespace dmPhysics
     bool GetJointReactionTorque2D(HWorld2D world, HJoint joint, float& torque, float inv_dt);
     void FlipH2D(HCollisionObject2D collision_object);
     void FlipV2D(HCollisionObject2D collision_object);
+    bool IsWorldLocked(HWorld2D world);
 
     void              ReplaceShape3D(HCollisionObject3D object, HCollisionShape3D old_shape, HCollisionShape3D new_shape);
     HCollisionShape3D GetCollisionShape3D(HCollisionObject3D collision_object, uint32_t index);

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -350,6 +350,11 @@ namespace dmPhysics
         FlipBody(collision_object, 1, -1);
     }
 
+    bool IsWorldLocked(HWorld2D world)
+    {
+        return world->m_World.IsLocked();
+    }
+
     static inline float GetUniformScale2D(dmTransform::Transform& transform)
     {
         const float* v = transform.GetScalePtr();

--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -319,6 +319,11 @@ namespace dmPhysics
     {
     }
 
+    bool IsWorldLocked(HWorld2D world)
+    {
+        return false;
+    }
+
     void GetCollisionShapeRadius2D(HCollisionShape2D shape, float* radius)
     {
     }


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
