### PR TITLE
Update the path hash for the luabuffer when transferring ownership

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -2357,8 +2357,9 @@ static int CreateBuffer(lua_State* L)
             dmResource::IncRef(g_ResourceModule.m_Factory, resource);
         }
 
-        lua_buffer->m_Owner     = dmScript::OWNER_RES;
-        lua_buffer->m_BufferRes = resource;
+        lua_buffer->m_Owner             = dmScript::OWNER_RES;
+        lua_buffer->m_BufferRes         = resource;
+        lua_buffer->m_BufferResPathHash = canonical_path_hash;
     }
 
     dmGameObject::AddDynamicResourceHash(collection, canonical_path_hash);
@@ -2517,8 +2518,9 @@ static int SetBuffer(lua_State* L)
             dmResource::IncRef(g_ResourceModule.m_Factory, resource);
         }
 
-        luabuf->m_Owner     = dmScript::OWNER_RES;
-        luabuf->m_BufferRes = resource;
+        luabuf->m_Owner             = dmScript::OWNER_RES;
+        luabuf->m_BufferRes         = resource;
+        luabuf->m_BufferResPathHash = path_hash;
     }
     else
     {


### PR DESCRIPTION
Fixed an issue related to luabuffer GC when transferring ownership in resource.create_buffer and resource.set_buffer

Issue: https://forum.defold.com/t/defold-1-6-4-beta/75834/32