### PR TITLE
Add world to local coordinate system conversion API.

### DIFF
--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -2279,6 +2279,64 @@ namespace dmGameObject
         return 1;
     }
 
+
+    /*# convert position to game object's coordinate space
+    *
+    * @name go.world_to_local_position
+    * @param position [type:vector3] position which need to be converted
+    * @param url [type:string|hash|url] url of the game object which coordinate system convert to
+    * @return converted_postion [type:vector3] converted position
+    *
+    * @examples
+    * Convert position of "test" game object into coordinate space of "child" object.
+    *
+    * ```lua
+    *   local test_pos = go.get_world_position("/test")
+    *   local child_pos = go.get_world_position("/child")
+    *   local new_position = go.world_to_local_position(test_pos, "/child")
+    * ```
+    */
+    int Script_WorldToLocalPosition(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmVMath::Vector3* world_position = dmScript::CheckVector3(L, 1);
+        Instance* instance = ResolveInstance(L, 2);
+        dmVMath::Matrix4 go_transform = dmGameObject::GetWorldMatrix(instance);
+        dmVMath::Matrix4 world_transform = dmVMath::Matrix4::identity();
+        world_transform.setTranslation(*world_position);
+        dmVMath::Matrix4 result_transfrom = world_transform * go_transform;
+        dmScript::PushVector3(L, result_transfrom.getTranslation());
+        return 1;
+    }
+
+
+    /*# convert transformation matrix to game object's coordinate space
+    *
+    * @name go.world_to_local_transform
+    * @param transformation [type:matrix4] transformation which need to be converted
+    * @param url [type:string|hash|url] url of the game object which coordinate system convert to
+    * @return converted_transform [type:matrix4] converted transformation
+    *
+    * @examples
+    * Convert transformation of "test" game object into coordinate space of "child" object.
+    *
+    * ```lua
+    *    local test_transform = go.get_world_transform("/test")
+    *    local child_transform = go.get_world_transform("/child")
+    *    local result_transform = go.world_to_local_transform(test_transform, "/child")
+    * ```
+    */
+    int Script_WorldToLocalTransfrom(lua_State* L)
+    {
+        DM_LUA_STACK_CHECK(L, 1);
+        dmVMath::Matrix4* world_transform = dmScript::CheckMatrix4(L, 1);
+        Instance* instance = ResolveInstance(L, 2);
+        const dmVMath::Matrix4& go_transform = dmGameObject::GetWorldMatrix(instance);
+
+        dmScript::PushMatrix4(L,  *world_transform * go_transform);
+        return 1;
+    }
+
     static const luaL_reg GO_methods[] =
     {
         {"get",                     Script_Get},
@@ -2306,6 +2364,8 @@ namespace dmGameObject
         {"screen_ray",              Script_ScreenRay},
         {"property",                Script_Property},
         {"exists",                  Script_Exists},
+        {"world_to_local_position", Script_WorldToLocalPosition},
+        {"world_to_local_transform",Script_WorldToLocalTransfrom},
         {0, 0}
     };
 


### PR DESCRIPTION
Add new APIs to convert world position and world transform to game object's coordinate space.
How to use:
 ```
    local test_pos = go.get_world_position("/test")
    local child_pos = go.get_world_position("/child")
    local new_position = go.world_to_local_position(test_pos, "/child")
 ```
 ```
    local test_transform = go.get_world_transform("/test")
    local child_transform = go.get_world_transform("/child")
    local result_transform = go.world_to_local_transform(test_transform, "/child")
 ```

Fixes #3561.
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
