### PR TITLE
Refactor socket's tests. Use TYPED_TEST to avoid code duplication.

### DIFF
--- a/engine/dlib/src/test/test_socket.cpp
+++ b/engine/dlib/src/test/test_socket.cpp
@@ -252,10 +252,50 @@ TEST(Socket, New_InvalidDomain)
     ASSERT_EQ(dmSocket::RESULT_BADF, result);
 }
 
-TEST(Socket, SetReuseAddress_IPv4)
+struct TestIPv4
+{
+    uint32_t* NetworkAddress(dmSocket::Address* address)
+    {
+        return dmSocket::IPv4(address);
+    }
+
+    const char* loopback_address = DM_LOOPBACK_ADDRESS_IPV4;
+    const char* universal_bind_address = DM_UNIVERSAL_BIND_ADDRESS_IPV4;
+    const dmSocket::Domain domain_type = dmSocket::DOMAIN_IPV4;
+};
+
+struct TestIPv6
+{
+    uint32_t* NetworkAddress(dmSocket::Address* address)
+    {
+        return dmSocket::IPv6(address);
+    }
+
+    const char* loopback_address = DM_LOOPBACK_ADDRESS_IPV6;
+    const char* universal_bind_address = DM_UNIVERSAL_BIND_ADDRESS_IPV6;
+    const dmSocket::Domain domain_type = dmSocket::DOMAIN_IPV6;
+};
+
+template<typename T>
+class SocketTyped : public jc_test_base_class
+{
+protected:
+    T instance;
+};
+
+typedef 
+#if !defined(DM_IPV6_UNSUPPORTED)
+jc_test_type2<TestIPv4, TestIPv6>
+#else
+jc_test_type1<TestIPv4>
+#endif
+TestTypes;
+TYPED_TEST_CASE(SocketTyped, TestTypes);
+
+TYPED_TEST(SocketTyped, SetReuseAddress)
 {
     dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
 
     result = dmSocket::SetReuseAddress(instance, true);
@@ -266,57 +306,24 @@ TEST(Socket, SetReuseAddress_IPv4)
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, SetReuseAddress_IPv6)
+
+TYPED_TEST(SocketTyped, AddMembership)
 {
     dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-
-    result = dmSocket::SetReuseAddress(instance, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
-
-TEST(Socket, AddMembership_IPv4)
-{
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-
-    // ASSERT_FALSE("This test has not been implemented yet");
 
     // Teardown
     result = dmSocket::Delete(instance);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, AddMembership_IPv6)
+TYPED_TEST(SocketTyped, SetMulticastIf)
 {
     dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
 
-    // ASSERT_FALSE("This test has not been implemented yet");
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
-
-TEST(Socket, SetMulticastIf_IPv4)
-{
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-
-    uint32_t tests = 0;
     uint32_t count = 0;
     const uint32_t max_count = 16;
     dmSocket::IfAddr addresses[max_count];
@@ -331,80 +338,26 @@ TEST(Socket, SetMulticastIf_IPv4)
     for (uint32_t i = 0; i < count; ++i)
     {
         dmSocket::Address address = addresses[i].m_Address;
-        if (address.m_family == dmSocket::DOMAIN_IPV4)
+        if (address.m_family == TestFixture::instance.domain_type)
         {
-            tests += 1;
             result = dmSocket::SetMulticastIf(instance, address);
-            // ASSERT_EQ(dmSocket::RESULT_OK, result);
         }
     }
-
-    // ASSERT_GT(tests, 0);
 
     // Teardown
     result = dmSocket::Delete(instance);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, SetMulticastIf_IPv6)
+TYPED_TEST(SocketTyped, Delete)
 {
     dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-
-    uint32_t tests = 0;
-    uint32_t count = 0;
-    const uint32_t max_count = 16;
-    dmSocket::IfAddr addresses[max_count];
-    dmSocket::GetIfAddresses(addresses, max_count, &count);
-
-    // Test has been disabled since we can't test multicast interfaces without
-    // multiple interfaces. Neither the build infrastructure nor the
-    // development environment at King currently supports this, thus this
-    // functionality has to be tested manually.
-    printf("[   INFO   ] Test for SetMulticastIf is disabled.\n");
-
-    for (uint32_t i = 0; i < count; ++i)
-    {
-        dmSocket::Address address = addresses[i].m_Address;
-        if (address.m_family == dmSocket::DOMAIN_IPV6)
-        {
-            tests += 1;
-            result = dmSocket::SetMulticastIf(instance, address);
-            // ASSERT_EQ(dmSocket::RESULT_OK, result);
-        }
-    }
-
-    // ASSERT_GT(tests, 0);
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
-
-TEST(Socket, Delete_IPv4)
-{
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
 
     result = dmSocket::Delete(instance);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
-
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, Delete_IPv6)
-{
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
 
 TEST(Socket, Delete_InvalidSocket)
 {
@@ -419,17 +372,17 @@ TEST(Socket, Delete_InvalidSocket)
 
 // Bind
 
-TEST(Socket, Connect_IPv4_ThreadServer)
+TYPED_TEST(SocketTyped, Connect_ThreadServer)
 {
     // Setup server thread
     struct ServerThreadInfo info;
     info.port = CONST_TEST_PORT;
-    info.domain = dmSocket::DOMAIN_IPV4;
-    const char* hostname = DM_LOOPBACK_ADDRESS_IPV4;
+    info.domain = TestFixture::instance.domain_type;
+    const char* hostname = TestFixture::instance.loopback_address;
     dmThread::Thread thread = dmThread::New(&ServerThread, 0x80000, (void *) &info, "server");
 
     // Setup client
-    dmSocket::Socket socket = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket socket = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, socket);
     dmSocket::Address address;
     dmSocket::Result result = dmSocket::RESULT_OK;
@@ -457,47 +410,6 @@ TEST(Socket, Connect_IPv4_ThreadServer)
 
     dmThread::Join(thread);
 }
-
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, Connect_IPv6_ThreadServer)
-{
-    // Setup server thread
-    struct ServerThreadInfo info;
-    info.port = CONST_TEST_PORT;
-    info.domain = dmSocket::DOMAIN_IPV6;
-    dmThread::Thread thread = dmThread::New(&ServerThread, 0x80000, (void *) &info, "server");
-    const char* hostname = DM_LOOPBACK_ADDRESS_IPV6;
-
-    // Setup client
-    dmSocket::Socket socket = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, socket);
-    dmSocket::Address address;
-    dmSocket::Result result = dmSocket::RESULT_OK;
-
-    result = dmSocket::GetHostByName(hostname, &address, dmSocket::IsSocketIPv4(socket), dmSocket::IsSocketIPv6(socket));
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    WaitForBool(&info.listening, 5000);
-
-    result = dmSocket::Connect(socket, address, CONST_TEST_PORT);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    WaitForBool(&info.sent, 5000);
-
-    // Receive data from the server
-    int value = 0;
-    int read = 0;
-
-    result = dmSocket::Receive(socket, &value, sizeof(value), &read);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-    ASSERT_EQ(0x00def01d, value);
-
-    result = dmSocket::Delete(socket);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    dmThread::Join(thread);
-}
-#endif
 
 static void RefusingServerThread(void* arg)
 {
@@ -506,19 +418,19 @@ static void RefusingServerThread(void* arg)
     dmSocket::Delete(*server);
 }
 
-TEST(Socket, Connect_IPv4_ConnectionRefused)
+TYPED_TEST(SocketTyped, Connect_ConnectionRefused)
 {
-    dmSocket::Socket server = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket server = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, server);
-    dmSocket::Socket client = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket client = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, client);
     dmSocket::Result result = dmSocket::RESULT_OK;
     result = dmSocket::SetBlocking(client, true);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
-    const char* hostname = DM_LOOPBACK_ADDRESS_IPV4;
+    const char* hostname = TestFixture::instance.loopback_address;
     dmSocket::Address address;
 
-    result = dmSocket::GetHostByName(hostname, &address, true, false);
+    result = dmSocket::GetHostByName(hostname, &address, dmSocket::IsSocketIPv4(server), dmSocket::IsSocketIPv6(server));
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 
     result = dmSocket::Bind(server, address, 0);
@@ -537,58 +449,24 @@ TEST(Socket, Connect_IPv4_ConnectionRefused)
 
     dmThread::Join(thread);
 }
-
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, Connect_IPv6_ConnectionRefused)
-{
-    dmSocket::Socket server = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, server);
-    dmSocket::Socket client = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, client);
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    result = dmSocket::SetBlocking(client, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-    const char* hostname = DM_LOOPBACK_ADDRESS_IPV6;
-    dmSocket::Address address;
-
-    result = dmSocket::GetHostByName(hostname, &address, false, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    result = dmSocket::Bind(server, address, 0);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-    uint16_t port;
-    result = dmSocket::GetName(server, &address, &port);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-    dmThread::Thread thread = dmThread::New(&RefusingServerThread, 0x80000, (void *) &server, "server");
-
-    result = dmSocket::Connect(client, address, port);
-    ASSERT_EQ(dmSocket::RESULT_CONNREFUSED, result);
-
-    // Teardown
-    result = dmSocket::Delete(client);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    dmThread::Join(thread);
-}
-#endif
 
 // Listen
 
 // Shutdown
 
-TEST(Socket, GetName_IPv4_Connected)
+TYPED_TEST(SocketTyped, GetName_Connected)
 {
     // Setup server thread
     struct ServerThreadInfo info;
     info.port = CONST_TEST_PORT;
-    info.domain = dmSocket::DOMAIN_IPV4;
+    info.domain = TestFixture::instance.domain_type;
     dmThread::Thread thread = dmThread::New(&ServerThread, 0x80000, (void *) &info, "server");
 
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
 
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
     dmSocket::Result result = dmSocket::RESULT_OK;
-    const char* hostname = DM_LOOPBACK_ADDRESS_IPV4;
+    const char* hostname = TestFixture::instance.loopback_address;
     dmSocket::Address address;
     uint16_t port = CONST_TEST_PORT;
 
@@ -608,7 +486,7 @@ TEST(Socket, GetName_IPv4_Connected)
     result = dmSocket::GetName(instance, &actual_address, &actual_port);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
     ASSERT_EQ(address.m_family, actual_address.m_family);
-    ASSERT_EQ(*dmSocket::IPv4(&address), *dmSocket::IPv4(&actual_address));
+    ASSERT_EQ(*TestFixture::instance.NetworkAddress(&address), *TestFixture::instance.NetworkAddress(&actual_address));
 
     // Teardown
     result = dmSocket::Delete(instance);
@@ -617,55 +495,9 @@ TEST(Socket, GetName_IPv4_Connected)
     dmThread::Join(thread);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, GetName_IPv6_Connected)
+TYPED_TEST(SocketTyped, SetBlocking)
 {
-    // Setup server thread
-    struct ServerThreadInfo info;
-    info.port = CONST_TEST_PORT;
-    info.domain = dmSocket::DOMAIN_IPV6;
-    dmThread::Thread thread = dmThread::New(&ServerThread, 0x80000, (void *) &info, "server");
-
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
-
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    const char* hostname = DM_LOOPBACK_ADDRESS_IPV6;
-    dmSocket::Address address;
-    uint16_t port = CONST_TEST_PORT;
-
-    result = dmSocket::GetHostByName(hostname, &address, dmSocket::IsSocketIPv4(instance), dmSocket::IsSocketIPv6(instance));
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    WaitForBool(&info.listening, 20000);
-
-    dmTime::Sleep(500000);
-    ASSERT_TRUE(dmAtomicGet32(&info.listening)==1);
-
-    result = dmSocket::Connect(instance, address, port);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    uint16_t actual_port = 0;
-    dmSocket::Address actual_address;
-    result = dmSocket::GetName(instance, &actual_address, &actual_port);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-    ASSERT_EQ(address.m_family, actual_address.m_family);
-    ASSERT_EQ(address.m_address[0], actual_address.m_address[0]);
-    ASSERT_EQ(address.m_address[1], actual_address.m_address[1]);
-    ASSERT_EQ(address.m_address[2], actual_address.m_address[2]);
-    ASSERT_EQ(address.m_address[3], actual_address.m_address[3]);
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    dmThread::Join(thread);
-}
-#endif
-
-TEST(Socket, SetBlocking_IPv4)
-{
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
     dmSocket::Result result = dmSocket::RESULT_OK;
 
@@ -680,28 +512,9 @@ TEST(Socket, SetBlocking_IPv4)
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, SetBlocking_IPv6)
+TYPED_TEST(SocketTyped, SetNoDelay)
 {
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-    dmSocket::Result result = dmSocket::RESULT_OK;
-
-    result = dmSocket::SetBlocking(instance, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    result = dmSocket::SetBlocking(instance, false);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
-
-TEST(Socket, SetNoDelay_IPv4)
-{
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV4);
+    dmSocket::Socket instance = GetSocket(TestFixture::instance.domain_type);
     ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
     dmSocket::Result result = dmSocket::RESULT_OK;
 
@@ -716,32 +529,13 @@ TEST(Socket, SetNoDelay_IPv4)
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, SetNoDelay_IPv6)
-{
-    dmSocket::Socket instance = GetSocket(dmSocket::DOMAIN_IPV6);
-    ASSERT_NE(dmSocket::INVALID_SOCKET_HANDLE, instance);
-    dmSocket::Result result = dmSocket::RESULT_OK;
-
-    result = dmSocket::SetNoDelay(instance, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    result = dmSocket::SetNoDelay(instance, false);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
-
-TEST(Socket, SetTimeout_IPv4)
+TYPED_TEST(SocketTyped, SetTimeout)
 {
     dmSocket::Socket instance = 0;
     dmSocket::Result result = dmSocket::RESULT_OK;
     uint64_t timeout = 2000;
 
-    result = dmSocket::New(dmSocket::DOMAIN_IPV4, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &instance);
+    result = dmSocket::New(TestFixture::instance.domain_type, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &instance);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 
     result = dmSocket::SetSendTimeout(instance, timeout);
@@ -754,28 +548,6 @@ TEST(Socket, SetTimeout_IPv4)
     result = dmSocket::Delete(instance);
     ASSERT_EQ(dmSocket::RESULT_OK, result);
 }
-
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, SetTimeout_IPv6)
-{
-    dmSocket::Socket instance = 0;
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    uint64_t timeout = 2000;
-
-    result = dmSocket::New(dmSocket::DOMAIN_IPV6, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    result = dmSocket::SetSendTimeout(instance, timeout);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    result = dmSocket::SetReceiveTimeout(instance, timeout);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-
-    // Teardown
-    result = dmSocket::Delete(instance);
-    ASSERT_EQ(dmSocket::RESULT_OK, result);
-}
-#endif
 
 TEST(Socket, AddressToIPString_IPv4)
 {
@@ -904,7 +676,7 @@ TEST(Socket, GetHostByName_IPv6_External)
 }
 #endif
 
-TEST(Socket, GetHostByName_IPv4_Unavailable)
+TYPED_TEST(SocketTyped, GetHostByName_Unavailable)
 {
     dmSocket::Address address;
     dmSocket::Result result = dmSocket::RESULT_OK;
@@ -913,18 +685,6 @@ TEST(Socket, GetHostByName_IPv4_Unavailable)
     result = dmSocket::GetHostByName(hostname, &address, true, false);
     ASSERT_EQ(dmSocket::RESULT_HOST_NOT_FOUND, result);
 }
-
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, GetHostByName_IPv6_Unavailable)
-{
-    dmSocket::Address address;
-    dmSocket::Result result = dmSocket::RESULT_OK;
-    const char* hostname = "localhost.invalid";
-
-    result = dmSocket::GetHostByName(hostname, &address, false, true);
-    ASSERT_EQ(dmSocket::RESULT_HOST_NOT_FOUND, result);
-}
-#endif
 
 TEST(Socket, GetHostByName_NoValidAddressFamily)
 {
@@ -936,16 +696,16 @@ TEST(Socket, GetHostByName_NoValidAddressFamily)
     ASSERT_EQ(dmSocket::RESULT_HOST_NOT_FOUND, result);
 }
 
-TEST(Socket, ServerSocketIPv4)
+TYPED_TEST(SocketTyped, ServerSocket)
 {
     dmSocket::Socket socket;
-    dmSocket::Result r = dmSocket::New(dmSocket::DOMAIN_IPV4, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket);
+    dmSocket::Result r = dmSocket::New(TestFixture::instance.domain_type, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket);
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     const int port = 9003;
 
     dmSocket::Address bindaddress;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV4, &bindaddress, true, false);
+    r = dmSocket::GetHostByName(TestFixture::instance.universal_bind_address, &bindaddress, dmSocket::IsSocketIPv4(socket), dmSocket::IsSocketIPv6(socket));
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     r = dmSocket::Bind(socket, bindaddress, port);
@@ -958,47 +718,23 @@ TEST(Socket, ServerSocketIPv4)
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, ServerSocketIPv6)
-{
-    dmSocket::Socket socket;
-    dmSocket::Result r = dmSocket::New(dmSocket::DOMAIN_IPV6, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    const int port = 9003;
-
-    dmSocket::Address bindaddress;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV6, &bindaddress, false, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Bind(socket, bindaddress, port);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Listen(socket, 1000);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Delete(socket);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-}
-#endif
-
-TEST(Socket, ServerSocketIPv4_MultipleBind)
+TYPED_TEST(SocketTyped, ServerSocket_MultipleBind)
 {
     dmSocket::Socket socket1, socket2;
     dmSocket::Result r;
-    r = dmSocket::New(dmSocket::DOMAIN_IPV4, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket1);
+    r = dmSocket::New(TestFixture::instance.domain_type, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket1);
     ASSERT_EQ(dmSocket::RESULT_OK, r);
-    r = dmSocket::New(dmSocket::DOMAIN_IPV4, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket2);
+    r = dmSocket::New(TestFixture::instance.domain_type, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket2);
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     const int port = 9003;
 
     dmSocket::Address bindaddress1;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV4, &bindaddress1, true, false);
+    r = dmSocket::GetHostByName(TestFixture::instance.universal_bind_address, &bindaddress1, dmSocket::IsSocketIPv4(socket1), dmSocket::IsSocketIPv6(socket1));
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     dmSocket::Address bindaddress2;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV4, &bindaddress2, true, false);
+    r = dmSocket::GetHostByName(TestFixture::instance.universal_bind_address, &bindaddress2, dmSocket::IsSocketIPv4(socket2), dmSocket::IsSocketIPv6(socket2));
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     r = dmSocket::Bind(socket1, bindaddress1, port);
@@ -1015,44 +751,10 @@ TEST(Socket, ServerSocketIPv4_MultipleBind)
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 }
 
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, ServerSocketIPv6_MultipleBind)
-{
-    dmSocket::Socket socket1, socket2;
-    dmSocket::Result r;
-    r = dmSocket::New(dmSocket::DOMAIN_IPV6, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket1);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-    r = dmSocket::New(dmSocket::DOMAIN_IPV6, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket2);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    const int port = 9003;
-
-    dmSocket::Address bindaddress1;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV6, &bindaddress1, false, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    dmSocket::Address bindaddress2;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV6, &bindaddress2, false, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Bind(socket1, bindaddress1, port);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Bind(socket2, bindaddress2, port);
-    ASSERT_EQ(dmSocket::RESULT_ADDRINUSE, r);
-
-    r = dmSocket::Delete(socket1);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Delete(socket2);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-}
-#endif
-
-TEST(Socket, ServerSocketIPv4_Accept)
+TYPED_TEST(SocketTyped, ServerSocket_Accept)
 {
     dmSocket::Socket socket;
-    dmSocket::Result r = dmSocket::New(dmSocket::DOMAIN_IPV4, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket);
+    dmSocket::Result r = dmSocket::New(TestFixture::instance.domain_type, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket);
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     r = dmSocket::SetBlocking(socket, false);
@@ -1061,7 +763,7 @@ TEST(Socket, ServerSocketIPv4_Accept)
     const int port = 9003;
 
     dmSocket::Address bindaddress;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV4, &bindaddress, true, false);
+    r = dmSocket::GetHostByName(TestFixture::instance.universal_bind_address, &bindaddress, dmSocket::IsSocketIPv4(socket), dmSocket::IsSocketIPv6(socket));
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 
     r = dmSocket::Bind(socket, bindaddress, port);
@@ -1078,38 +780,6 @@ TEST(Socket, ServerSocketIPv4_Accept)
     r = dmSocket::Delete(socket);
     ASSERT_EQ(dmSocket::RESULT_OK, r);
 }
-
-#if !defined(DM_IPV6_UNSUPPORTED)
-TEST(Socket, ServerSocketIPv6_Accept)
-{
-    dmSocket::Socket socket;
-    dmSocket::Result r = dmSocket::New(dmSocket::DOMAIN_IPV6, dmSocket::TYPE_STREAM, dmSocket::PROTOCOL_TCP, &socket);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::SetBlocking(socket, false);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    const int port = 9003;
-
-    dmSocket::Address bindaddress;
-    r = dmSocket::GetHostByName(DM_UNIVERSAL_BIND_ADDRESS_IPV6, &bindaddress, false, true);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Bind(socket, bindaddress, port);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    r = dmSocket::Listen(socket, 1000);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-
-    dmSocket::Address address;
-    dmSocket::Socket client_socket;
-    r = dmSocket::Accept(socket, &address, &client_socket);
-    ASSERT_EQ(dmSocket::RESULT_WOULDBLOCK, r);
-
-    r = dmSocket::Delete(socket);
-    ASSERT_EQ(dmSocket::RESULT_OK, r);
-}
-#endif
 
 static void PrintFlags(uint32_t f) {
     if (f & dmSocket::FLAGS_UP) {


### PR DESCRIPTION
Fixes #3697.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
