### PR TITLE
More options for min filter in `game.project`->`Graphics`->`Default Texture Min Filter`

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -199,7 +199,7 @@ render.default = /builtins/render/default.renderc
 [graphics]
 help = Graphics related settings
 default_texture_min_filter.type = string
-default_texture_min_filter.help = which filtering to use for min filtering, linear (default) or nearest
+default_texture_min_filter.help = which filtering to use for min filtering, linear by default
 default_texture_min_filter.default = linear
 
 default_texture_mag_filter.type = string

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -255,9 +255,12 @@
    "which filtering to use for min filtering, linear by default",
    :default "linear",
    :path ["graphics" "default_texture_min_filter"]
-   :options [["linear" "linear"] ["nearest" "nearest"] ["nearest_mipmap_nearest" "nearest mipmap nearest"]
-   									["nearest_mipmap_linear" "nearest mipmap linear"] ["linear_mipmap_nearest" "linear mipmap nearest"]
-   									["linear_mipmap_linear" "linear mipmap linear"]]}
+   :options [["linear" "linear"]
+             ["nearest" "nearest"]
+             ["nearest_mipmap_nearest" "nearest mipmap nearest"]
+             ["nearest_mipmap_linear" "nearest mipmap linear"]
+             ["linear_mipmap_nearest" "linear mipmap nearest"]
+             ["linear_mipmap_linear" "linear mipmap linear"]]}
   {:type :string,
    :help
    "which filtering to use for mag filtering, linear (default) or nearest",

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -252,12 +252,12 @@
    :path ["physics" "max_fixed_timesteps"]},
   {:type :string,
    :help
-   "which filtering to use for min filtering, linear (default) or nearest",
+   "which filtering to use for min filtering, linear by default",
    :default "linear",
    :path ["graphics" "default_texture_min_filter"]
-   :options [["linear" "linear"] ["nearest" "nearest"] ["nearest_mipmap_nearest" "nearest_mipmap_nearest"]
-   									["nearest_mipmap_linear" "nearest_mipmap_linear"] ["linear_mipmap_nearest" "linear_mipmap_nearest"]
-   									["linear_mipmap_linear" "linear_mipmap_linear"]]}
+   :options [["linear" "linear"] ["nearest" "nearest"] ["nearest_mipmap_nearest" "nearest mipmap nearest"]
+   									["nearest_mipmap_linear" "nearest mipmap linear"] ["linear_mipmap_nearest" "linear mipmap nearest"]
+   									["linear_mipmap_linear" "linear mipmap linear"]]}
   {:type :string,
    :help
    "which filtering to use for mag filtering, linear (default) or nearest",

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -255,7 +255,9 @@
    "which filtering to use for min filtering, linear (default) or nearest",
    :default "linear",
    :path ["graphics" "default_texture_min_filter"]
-   :options [["linear" "linear"] ["nearest" "nearest"]]}
+   :options [["linear" "linear"] ["nearest" "nearest"] ["nearest_mipmap_nearest" "nearest_mipmap_nearest"]
+   									["nearest_mipmap_linear" "nearest_mipmap_linear"] ["linear_mipmap_nearest" "linear_mipmap_nearest"]
+   									["linear_mipmap_linear" "linear_mipmap_linear"]]}
   {:type :string,
    :help
    "which filtering to use for mag filtering, linear (default) or nearest",

--- a/editor/src/clj/editor/defold_project.clj
+++ b/editor/src/clj/editor/defold_project.clj
@@ -682,6 +682,10 @@
   (cond
     (.equalsIgnoreCase "nearest" s) gl/nearest
     (.equalsIgnoreCase "linear" s) gl/linear
+    (.equalsIgnoreCase "nearest_mipmap_nearest" s) gl/nearest-mipmap-nearest
+    (.equalsIgnoreCase "nearest_mipmap_linear" s) gl/nearest-mipmap-linear
+    (.equalsIgnoreCase "linear_mipmap_nearest" s) gl/linear-mipmap-nearest
+    (.equalsIgnoreCase "linear_mipmap_linear" s) gl/linear-mipmap-linear
     :else (g/error-fatal (format "Invalid value for filter param: '%s'" s))))
 
 (g/defnk produce-default-tex-params

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -21,8 +21,8 @@
             [internal.util :as util])
   (:import [com.dynamo.graphics.proto Graphics$TextureImage Graphics$TextureImage$Image Graphics$TextureImage$TextureFormat]
            [com.jogamp.opengl GL GL2 GL3 GLProfile]
-           [com.jogamp.opengl.util.texture Texture TextureIO TextureData]
            [com.jogamp.opengl.util.awt ImageUtil]
+           [com.jogamp.opengl.util.texture Texture TextureData TextureIO]
            [java.awt.image BufferedImage DataBufferByte]
            [java.nio Buffer ByteBuffer]))
 
@@ -56,28 +56,42 @@
    :wrap-t       GL2/GL_TEXTURE_WRAP_T
    :wrap-r       GL2/GL_TEXTURE_WRAP_R})
 
+(defn- gl-texture-filter->non-mipmap
+  ^long [^long gl-texture-filter]
+  (if (or (= GL2/GL_NEAREST gl-texture-filter)
+          (= GL2/GL_NEAREST_MIPMAP_NEAREST gl-texture-filter)
+          (= GL2/GL_NEAREST_MIPMAP_LINEAR gl-texture-filter))
+    GL2/GL_NEAREST
+    GL2/GL_LINEAR))
+
 (defn- apply-params!
-  [^GL2 gl ^long texture-target params]
+  [^GL2 gl ^long texture-target params has-mipmaps]
   (let [params (if-let [sampler-name (:name params)]
                  (when-let [program (gl/gl-current-program gl)]
                    (if (= -1 (.glGetUniformLocation gl program sampler-name))
                      (:default-tex-params params)
                      params))
                  params)]
-    (doseq [[p v] params]
-      (if-let [pname (texture-params p)]
-        (.glTexParameteri gl texture-target pname v)
-        (cond
-          (integer? p) (.glTexParameteri gl texture-target p v)
-          ;; Silently ignore extra sampler data
-          (= :name p) nil
-          (= :default-tex-params p) nil
-          :else (println "WARNING: ignoring unknown texture parameter " p))))))
+    (doseq [[param value] params]
+      (if-let [gl-param (or (texture-params param)
+                            (when (integer? param)
+                              param))]
+        (let [gl-value (if (and (= GL/GL_TEXTURE_MIN_FILTER gl-param)
+                                (not has-mipmaps))
+                         (gl-texture-filter->non-mipmap value)
+                         value)]
+          (.glTexParameteri gl texture-target gl-param gl-value))
+        (case param
+          (:default-tex-params :name) nil ; Silently ignore extra sampler data
+          (println "WARNING: ignoring unknown texture parameter " param))))))
 
 (defn- merge-request-ids [request-id sub-request-id]
   (if (vector? request-id)
     (conj request-id sub-request-id)
     [request-id sub-request-id]))
+
+(defn- texture-data-has-mipmaps? [^TextureData texture-data]
+  (< 1 (count (.getMipmapData texture-data))))
 
 (defprotocol TextureProxy
   (->texture ^Texture [this ^GL2 gl texture-array-index]))
@@ -93,13 +107,17 @@
   (bind [this gl _render-args]
     (doseq [texture-unit-index (range 0 (min (count texture-units) (count texture-datas)))]
       (let [texture-unit (texture-units texture-unit-index)
-            gl-texture-unit (+ texture-unit GL2/GL_TEXTURE0)]
+            texture-data (texture-datas texture-unit-index)
+            gl-texture-unit (+ texture-unit GL2/GL_TEXTURE0)
+            has-mipmaps (if (map? texture-data) ; Cubemaps have maps of side keywords to TextureData.
+                          (some-> texture-data first val texture-data-has-mipmaps?)
+                          (texture-data-has-mipmaps? texture-data))]
         (.glActiveTexture ^GL2 gl gl-texture-unit) ; Set the active texture unit. Implicit parameter to (.bind ...) and (->texture ...)
         (let [tex (->texture this gl texture-unit-index)
               tgt (.getTarget tex)]
-          (.enable tex gl)                           ; Enable the type of texturing e.g. GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
-          (.bind tex gl)                             ; Bind our texture to the active texture unit. Used for subsequent render calls. Also implicit parameter to (apply-params! ...)
-          (apply-params! gl tgt params)))))          ; Apply filtering settings to the bound texture
+          (.enable tex gl)                              ; Enable the type of texturing e.g. GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
+          (.bind tex gl)                                ; Bind our texture to the active texture unit. Used for subsequent render calls. Also implicit parameter to (apply-params! ...)
+          (apply-params! gl tgt params has-mipmaps))))) ; Apply filtering settings to the bound texture
 
   (unbind [this gl _render-args]
     (doseq [texture-unit-index (range 0 (min (count texture-units) (count texture-datas)))]

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -393,11 +393,27 @@ namespace dmEngine
     {
         if (strcmp(filter, "linear") == 0)
         {
-            return dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
+            return dmGraphics::TEXTURE_FILTER_LINEAR;
         }
-        else
+        else if (strcmp(filter, "nearest") == 0)
+        {
+            return dmGraphics::TEXTURE_FILTER_NEAREST;
+        }
+        else if (strcmp(filter, "nearest_mipmap_nearest") == 0)
         {
             return dmGraphics::TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST;
+        }
+        else if (strcmp(filter, "nearest_mipmap_linear") == 0)
+        {
+            return dmGraphics::TEXTURE_FILTER_NEAREST_MIPMAP_LINEAR;
+        }
+        else if (strcmp(filter, "linear_mipmap_nearest") == 0)
+        {
+            return dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST;
+        }
+        else if (strcmp(filter, "linear_mipmap_linear") == 0)
+        {
+            return dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR;
         }
     }
 

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2870,10 +2870,6 @@ static void LogFrameBufferError(GLenum status)
             case GL_NEAREST_MIPMAP_NEAREST:
             case GL_NEAREST_MIPMAP_LINEAR:
                 return GL_NEAREST;
-            case GL_LINEAR:
-            case GL_LINEAR_MIPMAP_NEAREST:
-            case GL_LINEAR_MIPMAP_LINEAR:
-                return GL_LINEAR;
             default:
                 return GL_LINEAR;
         }

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2862,6 +2862,22 @@ static void LogFrameBufferError(GLenum status)
                filter == GL_LINEAR_MIPMAP_LINEAR;
     }
 
+    static inline GLenum GetNonMipMapVersionOfFilter(GLenum filter)
+    {
+        switch (filter)
+        {
+            case GL_NEAREST_MIPMAP_NEAREST:
+            case GL_NEAREST_MIPMAP_LINEAR:
+                return GL_NEAREST;
+            case GL_LINEAR_MIPMAP_NEAREST:
+            case GL_LINEAR_MIPMAP_LINEAR:
+                return GL_LINEAR;
+            default:
+                return GL_LINEAR;
+        }
+    }
+
+
     static void OpenGLSetTextureParams(HTexture texture, TextureFilter minfilter, TextureFilter magfilter, TextureWrap uwrap, TextureWrap vwrap, float max_anisotropy)
     {
         OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
@@ -2873,7 +2889,7 @@ static void LogFrameBufferError(GLenum status)
         // Using a mipmapped min filter without any mipmaps will break the sampler
         if (tex->m_MipMapCount <= 1 && IsTextureFilterMipmapped(gl_min_filter))
         {
-            gl_min_filter = gl_mag_filter;
+            gl_min_filter = GetNonMipMapVersionOfFilter(gl_min_filter);
         }
 
         glTexParameteri(gl_type, GL_TEXTURE_MIN_FILTER, gl_min_filter);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2866,9 +2866,11 @@ static void LogFrameBufferError(GLenum status)
     {
         switch (filter)
         {
+            case GL_LINEAR:
             case GL_NEAREST_MIPMAP_NEAREST:
             case GL_NEAREST_MIPMAP_LINEAR:
                 return GL_NEAREST;
+            case GL_NEAREST:
             case GL_LINEAR_MIPMAP_NEAREST:
             case GL_LINEAR_MIPMAP_LINEAR:
                 return GL_LINEAR;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2866,11 +2866,11 @@ static void LogFrameBufferError(GLenum status)
     {
         switch (filter)
         {
-            case GL_LINEAR:
+            case GL_NEAREST:
             case GL_NEAREST_MIPMAP_NEAREST:
             case GL_NEAREST_MIPMAP_LINEAR:
                 return GL_NEAREST;
-            case GL_NEAREST:
+            case GL_LINEAR:
             case GL_LINEAR_MIPMAP_NEAREST:
             case GL_LINEAR_MIPMAP_LINEAR:
                 return GL_LINEAR;

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2854,14 +2854,6 @@ static void LogFrameBufferError(GLenum status)
         return texture_filter_lut[texture_filter];
     }
 
-    static inline bool IsTextureFilterMipmapped(GLenum filter)
-    {
-        return filter == GL_NEAREST_MIPMAP_NEAREST ||
-               filter == GL_NEAREST_MIPMAP_LINEAR  ||
-               filter == GL_LINEAR_MIPMAP_NEAREST  ||
-               filter == GL_LINEAR_MIPMAP_LINEAR;
-    }
-
     static inline GLenum GetNonMipMapVersionOfFilter(GLenum filter)
     {
         switch (filter)
@@ -2885,7 +2877,7 @@ static void LogFrameBufferError(GLenum status)
         GLenum gl_mag_filter = GetOpenGLTextureFilter(magfilter == TEXTURE_FILTER_DEFAULT ? g_Context->m_DefaultTextureMagFilter : magfilter);
 
         // Using a mipmapped min filter without any mipmaps will break the sampler
-        if (tex->m_MipMapCount <= 1 && IsTextureFilterMipmapped(gl_min_filter))
+        if (tex->m_MipMapCount <= 1)
         {
             gl_min_filter = GetNonMipMapVersionOfFilter(gl_min_filter);
         }


### PR DESCRIPTION
Now, the field `Default Texture Min Filter` in `game.project` -> `Graphics` has the same options as materials do.
This is a breaking change for projects that use mipmaps on their textures and the OpenGL graphics backend.

Old behavior was:
- Options `linear` and `nearest` as `Default Texture Min Filter` meant `TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST` and `TEXTURE_FILTER_NEAREST_MIPMAP_NEAREST` respectively.
- If a texture without mipmaps was used with a material where `Min Filter` was specified with mipmaps, it used the `Mag Filter` option instead.

Current behavior:
- Options `linear` and `nearest` as `Default Texture Min Filter` mean `TEXTURE_FILTER_LINEAR` and `TEXTURE_FILTER_NEAREST` respectively.
- If a texture without mipmaps is used with a material where `Min Filter` is specified with mipmaps, it simply ignores the mipmaps part of the filter. For example, for `TEXTURE_FILTER_LINEAR_MIPMAP_NEAREST`, it will be `TEXTURE_FILTER_LINEAR`, etc.

Fix https://github.com/defold/defold/issues/8443

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
