### PR TITLE
Hide texture formats and texture compressions from `*.textures_profiles` that are currently not supported.

### DIFF
--- a/editor/src/clj/editor/protobuf_forms.clj
+++ b/editor/src/clj/editor/protobuf_forms.clj
@@ -212,7 +212,24 @@
     :texture-format-r16f
     :texture-format-rg16f
     :texture-format-r32f
-    :texture-format-rg32f})
+    :texture-format-rg32f
+    :texture-format-r-bc4
+    :texture-format-rg-bc5
+    :texture-format-rgb-bc1
+    :texture-format-rgb-etc1
+    :texture-format-rgba-pvrtc-2bppv1
+    :texture-format-rgba-pvrtc-4bppv1
+    :texture-format-rgb-pvrtc-2bppv1
+    :texture-format-rgb-pvrtc-4bppv1
+    :texture-format-rgba-bc3
+    :texture-format-rgba-bc7
+    :texture-format-rgba-etc2
+    :texture-format-rgba-astc-4x4})
+
+(def texture-profiles-unsupported-compressions
+  #{:compression-type-webp
+    :compression-type-webp-lossy
+    :compression-type-basis-etc1s})
 
 (defmethod protobuf-form-data Graphics$TextureProfiles [_node-id pb _def]
   (let [os-values (protobuf/enum-values Graphics$PlatformProfile$OS)
@@ -220,6 +237,7 @@
         format-values-filtered (filterv (fn [fmt] (not (contains? texture-profiles-unsupported-formats (first fmt)))) format-values)
         compression-values (protobuf/enum-values Graphics$TextureFormatAlternative$CompressionLevel)
         compression-types (protobuf/enum-values Graphics$TextureImage$CompressionType)
+        compression-types-filtered (filterv (fn [fmt] (not (contains? texture-profiles-unsupported-compressions (first fmt)))) compression-types)
         profile-options (mapv #(do [% %]) (map :name (:profiles pb)))]
     {:navigation false
      :sections
@@ -270,8 +288,8 @@
                                                      {:path [:compression-type]
                                                       :label "Type"
                                                       :type :choicebox
-                                                      :options (make-options compression-types) ; Unsorted.
-                                                      :default (ffirst compression-types)}]}
+                                                      :options (make-options compression-types-filtered) ; Unsorted.
+                                                      :default (ffirst compression-types-filtered)}]}
                                           {:path [:mipmaps]
                                            :type :boolean
                                            :label "Mipmaps"}


### PR DESCRIPTION
All the unsupported texture formats and texture compressions are hidden from `*.texture_profiles`.

Fix https://github.com/defold/defold/issues/6377

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
