### PR TITLE
Fixed an issue where a sprite image was erroneously rotated

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1064,13 +1064,6 @@ namespace dmGameSystem
                 float px = vertices[0];
                 float py = vertices[1];
 
-                if (rotated) // rotate back -90 degrees (CW)
-                {
-                    float t = py;
-                    py = -px;
-                    px = t;
-                }
-
                 float u = (center_x + px * image_width) / width;
                 float v = (center_y + -py * image_height) / height;
 
@@ -1080,6 +1073,13 @@ namespace dmGameSystem
                 // We grab the geometry as positions from the first texture
                 if (i == 0)
                 {
+                    if (rotated) // rotate 90 degrees (CCW)
+                    {
+                        float t = py;
+                        py = px;
+                        px = -t;
+                    }
+
                     (*scratch_pos)[j*2+0] = px * scale_x;
                     (*scratch_pos)[j*2+1] = py * scale_y;
                 }


### PR DESCRIPTION
### Technical changes
It happened when an atlas image was rotated and also used sprite trimming.
Setup a test scene for this.
Before/after screenshots:
<img width="718" alt="Screenshot 2024-02-13 at 10 58 51" src="https://github.com/defold/defold/assets/1349334/c5a11f5b-f1ed-489e-905d-316145d4f54e">
<img width="715" alt="Screenshot 2024-02-13 at 10 59 35" src="https://github.com/defold/defold/assets/1349334/4f41862b-60f9-4760-8437-59ee26a09273">


## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
