### PR TITLE
Fix issues with `physics.set_shape()` when `Allow Dynamic Transforms` is on

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1398,6 +1398,14 @@ namespace dmGameSystem
         return 1;
     }
 
+    static void Physics_CheckIfShapeSizeValid(lua_State* L, float value)
+    {
+        if (value == 0.0f)
+        {
+            luaL_error(L,"Shape size can't be 0");
+        }
+    }
+
     /*# set collision shape data
      * Sets collision shape data for a collision object. Please note that updating data in 3D
      * can be quite costly for box and capsules. Because of the physics engine, the cost
@@ -1462,6 +1470,7 @@ namespace dmGameSystem
                 lua_getfield(L, -1, "diameter");
                 shape_info.m_SphereDiameter = luaL_checknumber(L, -1);
                 lua_pop(L, 1);
+                Physics_CheckIfShapeSizeValid(L, shape_info.m_SphereDiameter);
             }
             else if (shape_info.m_Type == dmPhysicsDDF::CollisionShape::TYPE_BOX)
             {
@@ -1469,6 +1478,8 @@ namespace dmGameSystem
                 dmVMath::Vector3* box_dimensions = dmScript::CheckVector3(L, -1);
                 memcpy(shape_info.m_BoxDimensions, &box_dimensions[0], sizeof(shape_info.m_BoxDimensions));
                 lua_pop(L, 1);
+                Physics_CheckIfShapeSizeValid(L, box_dimensions->getX());
+                Physics_CheckIfShapeSizeValid(L, box_dimensions->getY());
             }
             else if (shape_info.m_Type == dmPhysicsDDF::CollisionShape::TYPE_CAPSULE)
             {
@@ -1479,6 +1490,8 @@ namespace dmGameSystem
                 lua_getfield(L, -1, "height");
                 shape_info.m_CapsuleDiameterHeight[1] = luaL_checknumber(L, -1);
                 lua_pop(L, 1);
+                Physics_CheckIfShapeSizeValid(L, shape_info.m_CapsuleDiameterHeight[0]);
+                Physics_CheckIfShapeSizeValid(L, shape_info.m_CapsuleDiameterHeight[1]);
             }
             else
             {

--- a/engine/gamesys/src/gamesys/test/collision_object/get_set_error_shape.collisionobject
+++ b/engine/gamesys/src/gamesys/test/collision_object/get_set_error_shape.collisionobject
@@ -1,0 +1,89 @@
+collision_shape: ""
+type: COLLISION_OBJECT_TYPE_DYNAMIC
+mass: 1.0
+friction: 0.0
+restitution: 0.0
+group: "1"
+mask: "1"
+embedded_collision_shape {
+  shapes {
+    shape_type: TYPE_SPHERE
+    position {
+      x: 7.0
+      y: -13.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    index: 0
+    count: 1
+    id: "shape_sphere_1"
+  }
+  shapes {
+    shape_type: TYPE_BOX
+    position {
+      x: -27.0
+      y: 1.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.104528464
+      w: 0.9945219
+    }
+    index: 1
+    count: 3
+    id: "shape_box_1"
+  }
+  shapes {
+    shape_type: TYPE_SPHERE
+    position {
+      x: 1.0
+      y: 16.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    }
+    index: 4
+    count: 1
+    id: "shape_sphere_2"
+  }
+  shapes {
+    shape_type: TYPE_BOX
+    position {
+      x: 25.0
+      y: 1.0
+      z: 0.0
+    }
+    rotation {
+      x: 0.0
+      y: 0.0
+      z: 0.25881904
+      w: 0.9659258
+    }
+    index: 5
+    count: 3
+    id: "shape_box_2"
+  }
+  data: 8.0
+  data: 10.0
+  data: 20.0
+  data: 30.0
+  data: 5.0
+  data: 12.0
+  data: 13.0
+  data: 14.0
+}
+linear_damping: 0.0
+angular_damping: 0.0
+locked_rotation: false
+bullet: false

--- a/engine/gamesys/src/gamesys/test/collision_object/get_set_error_shape.go
+++ b/engine/gamesys/src/gamesys/test/collision_object/get_set_error_shape.go
@@ -1,0 +1,8 @@
+components {
+  id: "collisionobject"
+  component: "/collision_object/get_set_error_shape.collisionobject"
+}
+components {
+  id: "script"
+  component: "/collision_object/get_set_error_shape.script"
+}

--- a/engine/gamesys/src/gamesys/test/collision_object/get_set_error_shape.script
+++ b/engine/gamesys/src/gamesys/test/collision_object/get_set_error_shape.script
@@ -1,0 +1,35 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+-- helper functions to verify test data.
+-- throws a Lua error if the assert(s) fails.
+local function assert_near(a, b)
+    local eps = 0.001
+    local diff = math.abs(a - b)
+    if not (diff < eps) then
+        local err_msg = "assert_near failed, a: " .. tostring(a) .. ", b: " .. tostring(b) .. " diff == " .. tostring(diff) .. " >= " .. tostring(eps)
+        error(debug.traceback(err_msg))
+    end
+end
+
+function init(self)
+	self.sphere_1 = physics.get_shape("/get_set_error_shape_go#collisionobject", "shape_sphere_1")
+	assert(self.sphere_1.diameter ~= nil)
+	assert_near(self.sphere_1.diameter, 16)
+end
+
+function final(self)
+	self.sphere_1.diameter = 0
+	physics.set_shape("/get_set_error_shape_go#collisionobject", "shape_sphere_1", self.sphere_1)
+end

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -4458,6 +4458,24 @@ TEST_F(ComponentTest, GetSetCollisionShape)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+TEST_F(ComponentTest, GetSetErrorCollisionShape)
+{
+    dmHashEnableReverseHash(true);
+    lua_State* L = dmScript::GetLuaState(m_ScriptContext);
+
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = L;
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    dmGameObject::HInstance go_base = Spawn(m_Factory, m_Collection, "/collision_object/get_set_error_shape.goc", dmHashString64("/get_set_error_shape_go"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go_base);
+
+    ASSERT_FALSE(dmGameObject::Final(m_Collection));
+}
+
 TEST_F(SysTest, LoadBufferSync)
 {
     dmGameSystem::ScriptLibContext scriptlibcontext;

--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -1044,6 +1044,7 @@ namespace dmPhysics
     {
         b2Shape* shape = (b2Shape*) _shape;
         shape->m_radius = radius * world->m_Context->m_Scale;
+        shape->m_creationScale = radius;
     }
 
     void SynchronizeObject2D(HWorld2D world, HCollisionObject2D collision_object)
@@ -1060,6 +1061,10 @@ namespace dmPhysics
             b2PolygonShape* polygon_shape = (b2PolygonShape*) _shape;
             float scale = world->m_Context->m_Scale;
             polygon_shape->SetAsBox(w * scale, h * scale, polygon_shape->m_centroid, angle);
+            for (int32 i = 0; i < polygon_shape->m_vertexCount; ++i)
+            {
+                polygon_shape->m_verticesOriginal[i] = polygon_shape->m_vertices[i];
+            }
         }
     }
 


### PR DESCRIPTION
Fix issues with `physics.set_shape()` which appears when `Allow Dynamic Transforms` option in `game.project` is on.

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
