### PR TITLE
Fixed an issue where `bob.jar` did not delete some temporary folders after the bundling process was completed.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/archive/test/ArchiveTest.java
@@ -41,6 +41,7 @@ import com.dynamo.bob.archive.ArchiveBuilder;
 import com.dynamo.bob.archive.ArchiveReader;
 import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.Project;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.fs.DefaultFileSystem;
 import com.dynamo.bob.pipeline.graph.ResourceNode;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
@@ -63,7 +64,7 @@ public class ArchiveTest {
     private String createDummyFile(String dir, String filepath, byte[] data) throws IOException {
         File tmp = new File(Paths.get(FilenameUtils.concat(dir, filepath)).toString());
         tmp.getParentFile().mkdirs();
-        tmp.deleteOnExit();
+        FileUtil.deleteOnExit(tmp);
 
         FileOutputStream fos = new FileOutputStream(tmp);
         fos.write(data);

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -67,6 +67,7 @@ import com.dynamo.bob.NullProgress;
 import com.dynamo.bob.Platform;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.TaskResult;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.archive.ArchiveBuilder;
 import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.archive.publisher.NullPublisher;
@@ -447,7 +448,7 @@ public class BundlerTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        file.deleteOnExit();
+        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/MacOSBundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/MacOSBundlerTest.java
@@ -36,6 +36,7 @@ import com.dynamo.bob.NullProgress;
 import com.dynamo.bob.ClassLoaderScanner;
 import com.dynamo.bob.Platform;
 import com.dynamo.bob.Project;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.archive.publisher.NullPublisher;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.bundle.MacOSBundler;
@@ -123,7 +124,7 @@ public class MacOSBundlerTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        file.deleteOnExit();
+        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/BobProjectPropertiesTest.java
@@ -23,6 +23,7 @@ import com.dynamo.bob.MultipleCompileException;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.fs.DefaultFileSystem;
+import com.dynamo.bob.util.FileUtil;
 
 import java.nio.file.Files;
 import java.io.File;
@@ -120,7 +121,7 @@ public class BobProjectPropertiesTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        file.deleteOnExit();
+        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -42,6 +42,7 @@ import com.dynamo.bob.NullProgress;
 import com.dynamo.bob.ClassLoaderScanner;
 import com.dynamo.bob.Project;
 import com.dynamo.bob.TaskResult;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.archive.publisher.NullPublisher;
 import com.dynamo.bob.archive.publisher.PublisherSettings;
 import com.dynamo.bob.fs.DefaultFileSystem;
@@ -221,7 +222,7 @@ public class ProjectBuildTest {
 
     private String createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
-        file.deleteOnExit();
+        FileUtil.deleteOnExit(file);
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
         return file.getAbsolutePath();
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/FontTest.java
@@ -45,6 +45,7 @@ import com.dynamo.bob.font.BMFont.ChannelData;
 import com.dynamo.bob.font.BMFont.Char;
 import com.dynamo.bob.font.Fontc;
 import com.dynamo.bob.font.Fontc.FontResourceResolver;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.render.proto.Font.FontDesc;
 import com.dynamo.render.proto.Font.FontMap;
 import com.dynamo.render.proto.Font.GlyphBank;
@@ -59,7 +60,7 @@ public class FontTest {
 
         InputStream inputStream = getClass().getResourceAsStream(resName);
         File outputFile = new File(outputPath);
-        outputFile.deleteOnExit();
+        FileUtil.deleteOnExit(outputFile);
         OutputStream outputStream = new FileOutputStream(outputFile);
         IOUtils.copy(inputStream, outputStream);
         inputStream.close();
@@ -212,7 +213,7 @@ public class FontTest {
 
         // temp output file
         File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        outfile.deleteOnExit();
+        FileUtil.deleteOnExit(outfile);
 
         // compile font
         Fontc fontc = new Fontc();
@@ -259,7 +260,7 @@ public class FontTest {
 
         // temp output file
         File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        outfile.deleteOnExit();
+        FileUtil.deleteOnExit(outfile);
 
         // compile font
         Fontc fontc = new Fontc();
@@ -302,7 +303,7 @@ public class FontTest {
 
         // temp output file
         File outfile = File.createTempFile("glyph-bank-output", ".glyph_bankc");
-        outfile.deleteOnExit();
+        FileUtil.deleteOnExit(outfile);
 
         // compile font
         Fontc fontc = new Fontc();
@@ -386,7 +387,7 @@ public class FontTest {
                 .build();
 
         File outfile = File.createTempFile("font-output", ".fontc");
-        outfile.deleteOnExit();
+        FileUtil.deleteOnExit(outfile);
 
         // compile font
         boolean success = true;
@@ -422,7 +423,7 @@ public class FontTest {
 
         // copy fnt and texture file
         final Path tmpDir = Files.createTempDirectory("fnt-tmp");
-        tmpDir.toFile().deleteOnExit();
+        FileUtil.deleteOnExit(tmpDir.toFile());
         String tmpFnt = copyResourceToDir(tmpDir.toString(), "bmfont.fnt");
         copyResourceToDir(tmpDir.toString(), "bmfont.png");
 
@@ -435,7 +436,7 @@ public class FontTest {
 
         // temp output file
         File outfile = File.createTempFile("font-output", ".fontc");
-        outfile.deleteOnExit();
+        FileUtil.deleteOnExit(outfile);
 
         // compile font
         Fontc fontc = new Fontc();
@@ -478,7 +479,7 @@ public class FontTest {
 
         // temp output file
         File outfile = File.createTempFile("font-output", ".fontc");
-        outfile.deleteOnExit();
+        FileUtil.deleteOnExit(outfile);
 
         // compile font
         Fontc fontc = new Fontc();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -62,6 +62,7 @@ import com.dynamo.bob.util.TimeProfiler;
 import com.dynamo.bob.util.HttpUtil;
 import com.dynamo.bob.cache.ResourceCacheKey;
 import com.dynamo.bob.pipeline.ExtenderUtil;
+import com.dynamo.bob.util.FileUtil;
 
 public class Bob {
     private static Logger logger = Logger.getLogger(Bob.class.getName());
@@ -166,7 +167,7 @@ public class Bob {
 
                     File dstFile = new File(toFolder, entry.getName());
                     if (deleteOnExit)
-                        dstFile.deleteOnExit();
+                        FileUtil.deleteOnExit(dstFile);
                     dstFile.getParentFile().mkdirs();
 
                     OutputStream fileStream = null;
@@ -354,7 +355,7 @@ public class Bob {
                 File file = new File(downloadFolder, exeName);
                 HttpUtil http = new HttpUtil();
                 http.downloadToFile(url, file);
-                file.deleteOnExit();
+                FileUtil.deleteOnExit(file);
                 binaryFiles.add(file);
             }
             catch (Exception e) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/AndroidBundler.java
@@ -55,6 +55,7 @@ import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec.Result;
 import com.dynamo.bob.util.TimeProfiler;
 
@@ -436,7 +437,7 @@ public class AndroidBundler implements IBundler {
     */
     private static File copyLocalResources(Project project, File outDir, BundleHelper helper, ICanceled canceled) throws IOException, CompileExceptionError {
         File androidResDir = createDir(outDir, "res");
-        androidResDir.deleteOnExit();
+        FileUtil.deleteOnExit(androidResDir);
 
         File resDir = new File(androidResDir, "com.defold.android");
         resDir.mkdirs();
@@ -460,7 +461,7 @@ public class AndroidBundler implements IBundler {
         try {
             // compile the resources using aapt2 to flat format files
             File compiledResourcesDir = Files.createTempDirectory("compiled_resources").toFile();
-            compiledResourcesDir.deleteOnExit();
+            FileUtil.deleteOnExit(compiledResourcesDir);
 
             String aapt2 = Bob.getLibExecPath(getAapt2Name());
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/BundleHelper.java
@@ -61,6 +61,7 @@ import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.pipeline.ExtenderUtil.FileExtenderResource;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec.Result;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.MustacheException;
@@ -749,7 +750,7 @@ public class BundleHelper {
 
         try {
             zipFile = File.createTempFile("build_" + sdkVersion, ".zip");
-            zipFile.deleteOnExit();
+            FileUtil.deleteOnExit(zipFile);
         } catch (IOException e) {
             throw new CompileExceptionError("Failed to create temp zip file", e.getCause());
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/IOSBundler.java
@@ -55,6 +55,7 @@ import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
 import com.dynamo.bob.util.Exec.Result;
+import com.dynamo.bob.util.FileUtil;
 
 @BundlerParams(platforms = {Platform.Arm64Ios, Platform.X86_64Ios})
 public class IOSBundler implements IBundler {
@@ -82,7 +83,7 @@ public class IOSBundler implements IBundler {
     private static File createTempDirectory() throws IOException {
         final File temp;
 
-        temp = File.createTempFile("temp", Long.toString(System.nanoTime()));
+        temp = File.createTempFile("temp_defold_", Long.toString(System.nanoTime()));
 
         if(!(temp.delete()))
         {
@@ -469,7 +470,7 @@ public class IOSBundler implements IBundler {
         BundleHelper.throwIfCanceled(canceled);
         // Create fat/universal binary
         File exe = File.createTempFile("dmengine", "");
-        exe.deleteOnExit();
+        FileUtil.deleteOnExit(exe);
 
         BundleHelper.throwIfCanceled(canceled);
 
@@ -519,8 +520,7 @@ public class IOSBundler implements IBundler {
 
         // Package zip file
         File tmpZipDir = createTempDirectory();
-        tmpZipDir.deleteOnExit();
-
+        FileUtil.deleteOnExit(tmpZipDir);
         File swiftSupportDir = new File(tmpZipDir, "SwiftSupport");
 
         // Copy any libswift*.dylib files from the Frameworks folder
@@ -557,7 +557,7 @@ public class IOSBundler implements IBundler {
             FileUtils.copyFile(new File(provisioningProfile), new File(appDir, "embedded.mobileprovision"));
 
             File textProvisionFile = File.createTempFile("mobileprovision", ".plist");
-            textProvisionFile.deleteOnExit();
+            FileUtil.deleteOnExit(textProvisionFile);
 
             Result securityResult = Exec.execResult("security", "cms", "-D", "-i", provisioningProfile, "-o", textProvisionFile.getAbsolutePath());
             if (securityResult.ret != 0) {
@@ -631,7 +631,7 @@ public class IOSBundler implements IBundler {
                     entitlements.initFileLocator(locator);
                     entitlements.write(writer);
                     writer.close();
-                    entitlementOut.deleteOnExit();
+                    FileUtil.deleteOnExit(entitlementOut);
                 }
                 catch (ConfigurationException e) {
                     logger.severe("Error reading provisioning profile '" + provisioningProfile + "'. Make sure this is a valid provisioning profile file." );

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/MacOSBundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/MacOSBundler.java
@@ -34,6 +34,7 @@ import com.dynamo.bob.pipeline.ExtenderUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.util.BobProjectProperties;
 import com.dynamo.bob.util.Exec;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec.Result;
 
 @BundlerParams(platforms = {Platform.X86_64MacOS, Platform.Arm64MacOS})
@@ -155,7 +156,7 @@ public class MacOSBundler implements IBundler {
 
         // Create fat/universal binary
         File exe = File.createTempFile("dmengine", "");
-        exe.deleteOnExit();
+        FileUtil.deleteOnExit(exe);
 
         BundleHelper.throwIfCanceled(canceled);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameProjectBuilder.java
@@ -60,6 +60,7 @@ import com.dynamo.bob.archive.ManifestBuilder;
 import com.dynamo.bob.archive.publisher.Publisher;
 import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.logging.Logger;
 import com.dynamo.bob.pipeline.graph.ResourceGraph;
 import com.dynamo.bob.pipeline.graph.ResourceNode;
@@ -96,7 +97,7 @@ public class GameProjectBuilder extends Builder<Void> {
     private static Logger logger = Logger.getLogger(GameProjectBuilder.class.getName());
 
     private RandomAccessFile createRandomAccessFile(File handle) throws IOException {
-        handle.deleteOnExit();
+        FileUtil.deleteOnExit(handle);
         RandomAccessFile file = new RandomAccessFile(handle, "rw");
         file.setLength(0);
         return file;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilerHelpers.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ShaderCompilerHelpers.java
@@ -47,6 +47,7 @@ import com.dynamo.bob.pipeline.ShaderUtil.SPIRVReflector;
 import com.dynamo.bob.pipeline.ShaderUtil.Common;
 import com.dynamo.bob.pipeline.ShaderProgramBuilder;
 import com.dynamo.bob.util.Exec;
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.bob.util.Exec.Result;
 import com.dynamo.bob.util.MurmurHash;
 
@@ -196,11 +197,11 @@ public class ShaderCompilerHelpers {
             ES2ToES3Converter.Result es3Result = ES2ToES3Converter.transform(shaderSource, shaderType, targetProfile, version, true);
 
             File file_in_compute = File.createTempFile(FilenameUtils.getName(resourceOutput), ".cp");
-            file_in_compute.deleteOnExit();
+            FileUtil.deleteOnExit(file_in_compute);
             FileUtils.writeByteArrayToFile(file_in_compute, es3Result.output.getBytes());
 
             file_out_spv = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-            file_out_spv.deleteOnExit();
+            FileUtil.deleteOnExit(file_out_spv);
 
             result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "glslc"),
                     "-w",
@@ -243,11 +244,11 @@ public class ShaderCompilerHelpers {
 
             // compile GLSL (ES3 or Desktop 140) to SPIR-V
             File file_in_glsl = File.createTempFile(FilenameUtils.getName(resourceOutput), ".glsl");
-            file_in_glsl.deleteOnExit();
+            FileUtil.deleteOnExit(file_in_glsl);
             FileUtils.writeByteArrayToFile(file_in_glsl, shaderSource.getBytes());
 
             file_out_spv = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-            file_out_spv.deleteOnExit();
+            FileUtil.deleteOnExit(file_out_spv);
 
             String spirvShaderStage = (shaderType == ES2ToES3Converter.ShaderType.VERTEX_SHADER ? "vert" : "frag");
             result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "glslc"),
@@ -269,7 +270,7 @@ public class ShaderCompilerHelpers {
         }
 
         File file_out_spv_opt = File.createTempFile(FilenameUtils.getName(resourceOutput), ".spv");
-        file_out_spv_opt.deleteOnExit();
+        FileUtil.deleteOnExit(file_out_spv_opt);
 
         // Run optimization pass
         result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "spirv-opt"),
@@ -287,7 +288,7 @@ public class ShaderCompilerHelpers {
 
         // Generate reflection data
         File file_out_refl = File.createTempFile(FilenameUtils.getName(resourceOutput), ".json");
-        file_out_refl.deleteOnExit();
+        FileUtil.deleteOnExit(file_out_refl);
 
         result = Exec.execResult(Bob.getExe(Platform.getHostPlatform(), "spirv-cross"),
             file_out_spv_opt.getAbsolutePath(),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/FileUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/FileUtil.java
@@ -22,11 +22,13 @@ import java.io.FileInputStream;
 import java.io.BufferedInputStream;
 import java.util.zip.Checksum;
 import java.util.zip.CRC32;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.FileUtils;
 
 public class FileUtil {
 
@@ -82,5 +84,18 @@ public class FileUtil {
 		updateDigest(file, digest);
 		return digest.digest();
 	}
+
+    public static void deleteOnExit(Path path) {
+        File f = path.toFile();
+        deleteOnExit(f);
+    }
+
+    public static void deleteOnExit(File f) {
+        if (f.isDirectory()) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(f)));
+        } else {
+            f.deleteOnExit();
+        }
+    }
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.common.test/src/com/dynamo/cr/common/cache/test/ETagCacheTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.common.test/src/com/dynamo/cr/common/cache/test/ETagCacheTest.java
@@ -24,7 +24,7 @@ import java.io.StringReader;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-
+import com.dynamo.bob.util.FileUtil;
 import com.dynamo.cr.common.cache.ETagCache;
 
 public class ETagCacheTest {
@@ -78,7 +78,7 @@ public class ETagCacheTest {
         ETagCache etagCache = new ETagCache(2);
 
         File tempFile = File.createTempFile("foo", "bar");
-        tempFile.deleteOnExit();
+        FileUtil.deleteOnExit(tempFile);
 
         FileWriter writer = new FileWriter(tempFile);
         IOUtils.copy(new StringReader("foo"), writer);

--- a/editor/src/java/com/defold/libs/ResourceUnpacker.java
+++ b/editor/src/java/com/defold/libs/ResourceUnpacker.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import com.defold.editor.Editor;
+import com.dynamo.bob.util.FileUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -234,7 +235,7 @@ public class ResourceUnpacker {
             return ensureDirectory(Editor.getSupportPath().resolve(Paths.get("unpack", sha1)));
         } else {
             Path tmpDir = Files.createTempDirectory("defold-unpack");
-            deleteOnExit(tmpDir);
+            FileUtil.deleteOnExit(tmpDir);
             return tmpDir;
         }
     }
@@ -245,16 +246,5 @@ public class ResourceUnpacker {
             f.mkdirs();
         }
         return path;
-    }
-
-    // Note! There is a method FileUtils#forceDeleteOnExit which does not seem to work,
-    // it does not delete the directory although the Javadoc says it should.
-    private static void deleteOnExit(Path path) {
-        File f = path.toFile();
-        if (f.isDirectory()) {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(f)));
-        } else {
-            f.deleteOnExit();
-        }
     }
 }

--- a/engine/ddf/src/java_test/com/dynamo/ddf/test/DDFLoaderTest.java
+++ b/engine/ddf/src/java_test/com/dynamo/ddf/test/DDFLoaderTest.java
@@ -39,6 +39,8 @@ import com.dynamo.ddf.proto.TestDDF.Simple01Repeated;
 import com.dynamo.ddf.proto.TestDDF.Simple02Repeated;
 import com.dynamo.ddf.proto.TestDDF.StringRepeated;
 import com.dynamo.ddf.proto.TestDDF.Mesh.Primitive;
+import com.dynamo.bob.util.FileUtil;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
@@ -75,8 +77,8 @@ public class DDFLoaderTest
     private <T> T saveLoad(Message m, Descriptor descriptor, Class<T> klass)
             throws IOException
     {
-        File f = File.createTempFile("tmp", ".pb");
-        f.deleteOnExit();
+        File f = File.createTempFile("tmp_defold_", ".pb");
+        FileUtil.deleteOnExit(f);
 
         FileWriter w = new FileWriter(f);
         w.write(TextFormat.printToString(m));


### PR DESCRIPTION
Fixed an issue where, in some cases, `bob.jar` did not delete temporary folders. This could quickly fill up the disk on a CI machine.

Fix https://github.com/defold/defold/issues/8483
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
