### PR TITLE
Support sampler names in render.enable_texture

### DIFF
--- a/engine/graphics/src/null/glsl_uniform_parser.cpp
+++ b/engine/graphics/src/null/glsl_uniform_parser.cpp
@@ -183,7 +183,7 @@ namespace dmGraphics
             word_start = line_start;
             word_end   = line_start;
 
-        #if 1
+        #if 0
             char line_buf[256];
             size_t line_len = line_end - line_start;
             memcpy(line_buf, line_start, line_len);

--- a/engine/graphics/src/null/glsl_uniform_parser.cpp
+++ b/engine/graphics/src/null/glsl_uniform_parser.cpp
@@ -112,6 +112,11 @@ namespace dmGraphics
             *out_type = TYPE_SAMPLER_CUBE;
             return true;
         }
+        else if (STRNCMP("sampler2DArray", string, count))
+        {
+            *out_type = TYPE_SAMPLER_2D_ARRAY;
+            return true;
+        }
         return false;
     }
 
@@ -178,7 +183,7 @@ namespace dmGraphics
             word_start = line_start;
             word_end   = line_start;
 
-        #if 0
+        #if 1
             char line_buf[256];
             size_t line_len = line_end - line_start;
             memcpy(line_buf, line_start, line_len);

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -156,6 +156,10 @@ namespace dmGraphics
         context->m_PipelineState                        = GetDefaultPipelineState();
         context->m_AsyncProcessingSupport               = context->m_JobThread && dmThread::PlatformHasThreadSupport();
 
+        context->m_ContextFeatures |= 1 << CONTEXT_FEATURE_MULTI_TARGET_RENDERING;
+        context->m_ContextFeatures |= 1 << CONTEXT_FEATURE_TEXTURE_ARRAY;
+        context->m_ContextFeatures |= 1 << CONTEXT_FEATURE_COMPUTE_SHADER;
+
         if (context->m_AsyncProcessingSupport)
         {
             InitializeSetTextureAsyncState(context->m_SetTextureAsyncState);
@@ -1302,13 +1306,29 @@ namespace dmGraphics
         NullContext* context  = (NullContext*) _context;
         Texture* tex          = new Texture();
 
-        tex->m_Type        = params.m_Type;
-        tex->m_Width       = params.m_Width;
-        tex->m_Height      = params.m_Height;
-        tex->m_Depth       = params.m_Depth;
-        tex->m_MipMapCount = 0;
-        tex->m_Data        = 0;
-        tex->m_DataState   = 0;
+        uint16_t num_texture_ids = 1;
+        TextureType texture_type = params.m_Type;
+
+        if (params.m_Type == TEXTURE_TYPE_2D_ARRAY && !IsContextFeatureSupported(_context, CONTEXT_FEATURE_TEXTURE_ARRAY))
+        {
+            num_texture_ids = params.m_Depth;
+            texture_type    = TEXTURE_TYPE_2D;
+        }
+
+        tex->m_Type          = texture_type;
+        tex->m_Width         = params.m_Width;
+        tex->m_Height        = params.m_Height;
+        tex->m_Depth         = params.m_Depth;
+        tex->m_MipMapCount   = 0;
+        tex->m_Data          = 0;
+        tex->m_DataState     = 0;
+        tex->m_NumTextureIds = num_texture_ids;
+        tex->m_LastBoundUnit = new int32_t[num_texture_ids];
+
+        for (int i = 0; i < num_texture_ids; ++i)
+        {
+            tex->m_LastBoundUnit[i] = -1;
+        }
 
         if (params.m_OriginalWidth == 0)
         {
@@ -1505,7 +1525,7 @@ namespace dmGraphics
         return GetAssetFromContainer<Texture>(g_NullContext->m_AssetHandleContainer, texture)->m_OriginalHeight;
     }
 
-    static void NullEnableTexture(HContext _context, uint32_t unit, uint8_t value_index, HTexture texture)
+    static void NullEnableTexture(HContext _context, uint32_t unit, uint8_t id_index, HTexture texture)
     {
         assert(_context);
         assert(unit < MAX_TEXTURE_COUNT);
@@ -1516,6 +1536,8 @@ namespace dmGraphics
         context->m_Textures[unit] = texture;
         context->m_TextureUnit = unit;
         NullSetTextureParams(texture, tex->m_Sampler.m_MinFilter, tex->m_Sampler.m_MagFilter, tex->m_Sampler.m_UWrap, tex->m_Sampler.m_VWrap, tex->m_Sampler.m_Anisotropy);
+
+        tex->m_LastBoundUnit[id_index] = unit;
     }
 
     static void NullDisableTexture(HContext context, uint32_t unit, HTexture texture)
@@ -1761,12 +1783,13 @@ namespace dmGraphics
 
     static uint8_t NullGetNumTextureHandles(HTexture texture)
     {
-        return 1;
+        return GetAssetFromContainer<Texture>(g_NullContext->m_AssetHandleContainer, texture)->m_NumTextureIds;
     }
 
-    static bool NullIsContextFeatureSupported(HContext context, ContextFeature feature)
+    static bool NullIsContextFeatureSupported(HContext _context, ContextFeature feature)
     {
-        return true;
+        NullContext* context = (NullContext*) _context;
+        return (context->m_ContextFeatures & (1 << feature)) != 0;
     }
 
     static uint16_t NullGetTextureDepth(HTexture texture)

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -1353,6 +1353,8 @@ namespace dmGraphics
             {
                 delete [] (char*)tex->m_Data;
             }
+
+            delete [] tex->m_LastBoundUnit;
             delete tex;
         }
         return 0;

--- a/engine/graphics/src/null/graphics_null_private.h
+++ b/engine/graphics/src/null/graphics_null_private.h
@@ -43,6 +43,8 @@ namespace dmGraphics
         uint32_t          m_Depth;
         uint32_t          m_OriginalWidth;
         uint32_t          m_OriginalHeight;
+        uint16_t          m_NumTextureIds;
+        int32_t*          m_LastBoundUnit; // testing
         volatile uint16_t m_DataState; // data state per mip-map (mipX = bitX). 0=ok, 1=pending
         uint8_t           m_MipMapCount;
     };
@@ -115,6 +117,7 @@ namespace dmGraphics
         TextureFilter                      m_DefaultTextureMinFilter;
         TextureFilter                      m_DefaultTextureMagFilter;
         ShaderDesc::Language               m_ShaderClassLanguage[2];
+
         uint32_t                           m_Width;
         uint32_t                           m_Height;
         int32_t                            m_ScissorRect[4];
@@ -125,6 +128,7 @@ namespace dmGraphics
         uint32_t                           m_UseAsyncTextureLoad    : 1;
         uint32_t                           m_RequestWindowClose     : 1;
         uint32_t                           m_PrintDeviceInfo        : 1;
+        uint32_t                           m_ContextFeatures        : 3;
     };
 }
 

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -355,6 +355,18 @@ namespace dmRender
         return 0xFFFFFFFF;
     }
 
+    int32_t GetMaterialSamplerIndex(HMaterial material, dmhash_t name_hash)
+    {
+        for (int i = 0; i < material->m_Samplers.Size(); ++i)
+        {
+            if (material->m_Samplers[i].m_NameHash == name_hash)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     void ApplyMaterialSampler(dmRender::HRenderContext render_context, HMaterial material, HSampler sampler, uint8_t unit, dmGraphics::HTexture texture)
     {
         if (!sampler)

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -785,7 +785,6 @@ namespace dmRender
         // Trim the iteration space
         if (last_zero_index != -1)
         {
-            dmLogInfo("Trimming %d -> %d", render_context->m_TextureBindTable.Size(), last_zero_index);
             render_context->m_TextureBindTable.SetSize(last_zero_index);
         }
     }

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -716,6 +716,7 @@ namespace dmRender
         if (unit >= render_context->m_TextureBindTable.Size())
         {
             render_context->m_TextureBindTable.SetCapacity(unit + 1);
+            memset(render_context->m_TextureBindTable.Begin() + render_context->m_TextureBindTable.Size(), 0, render_context->m_TextureBindTable.Remaining());
             render_context->m_TextureBindTable.SetSize(render_context->m_TextureBindTable.Capacity());
         }
 

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -716,8 +716,13 @@ namespace dmRender
         if (unit >= render_context->m_TextureBindTable.Size())
         {
             render_context->m_TextureBindTable.SetCapacity(unit + 1);
-            memset(render_context->m_TextureBindTable.Begin() + render_context->m_TextureBindTable.Size(), 0, render_context->m_TextureBindTable.Remaining());
+
+            // Make sure new data area is zeroed out
+            uint32_t fill_index_start = render_context->m_TextureBindTable.Size();
+            uint32_t fill_size = render_context->m_TextureBindTable.Remaining() * sizeof(TextureBinding);
+
             render_context->m_TextureBindTable.SetSize(render_context->m_TextureBindTable.Capacity());
+            memset(&render_context->m_TextureBindTable[fill_index_start], 0, fill_size);
         }
 
         render_context->m_TextureBindTable[unit].m_Texture     = texture;

--- a/engine/render/src/render/render_command.cpp
+++ b/engine/render/src/render/render_command.cpp
@@ -81,12 +81,20 @@ namespace dmRender
                 }
                 case COMMAND_TYPE_ENABLE_TEXTURE:
                 {
-                    render_context->m_Textures[c->m_Operands[0]] = c->m_Operands[1];
+                    // operand order: Hash, Unit, Texture
+                    if (c->m_Operands[0])
+                        dmRender::SetTextureBindingByHash(render_context, c->m_Operands[0], c->m_Operands[2]);
+                    else
+                        dmRender::SetTextureBindingByUnit(render_context, c->m_Operands[1], c->m_Operands[2]);
                     break;
                 }
                 case COMMAND_TYPE_DISABLE_TEXTURE:
                 {
-                    render_context->m_Textures[c->m_Operands[0]] = 0;
+                    // operand order: Hash, Unit, Texture
+                    if (c->m_Operands[0])
+                        dmRender::SetTextureBindingByHash(render_context, c->m_Operands[0], 0);
+                    else
+                        dmRender::SetTextureBindingByUnit(render_context, c->m_Operands[1], 0);
                     break;
                 }
                 case COMMAND_TYPE_CLEAR:

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -234,9 +234,15 @@ namespace dmRender
         dmhash_t m_Tags[MAX_MATERIAL_TAG_COUNT];
     };
 
+    struct TextureBinding
+    {
+        dmhash_t             m_Samplerhash;
+        dmGraphics::HTexture m_Texture;
+    };
+
     struct RenderContext
     {
-        dmGraphics::HTexture        m_Textures[RenderObject::MAX_TEXTURE_COUNT];
+        TextureBinding              m_TextureBindTable[RenderObject::MAX_TEXTURE_COUNT];
         DebugRenderer               m_DebugRenderer;
         TextContext                 m_TextContext;
         dmScript::HContext          m_ScriptContext;
@@ -296,7 +302,9 @@ namespace dmRender
     // Gets the list associated with a hash of all the tags (see RegisterMaterialTagList)
     void                            GetMaterialTagList(HRenderContext context, uint32_t list_hash, MaterialTagList* list);
 
-    bool GetCanBindTexture(dmGraphics::HTexture texture, HSampler sampler, uint32_t unit);
+    void    SetTextureBinding(dmRender::HRenderContext render_context, dmhash_t sampler_hash, uint32_t unit, dmGraphics::HTexture texture);
+    bool    GetCanBindTexture(dmGraphics::HTexture texture, HSampler sampler, uint32_t unit);
+    int32_t GetMaterialSamplerIndex(HMaterial material, dmhash_t name_hash);
 
     // Exposed here for unit testing
     struct RenderListEntrySorter

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -242,7 +242,6 @@ namespace dmRender
 
     struct RenderContext
     {
-        TextureBinding              m_TextureBindTable[RenderObject::MAX_TEXTURE_COUNT];
         DebugRenderer               m_DebugRenderer;
         TextContext                 m_TextContext;
         dmScript::HContext          m_ScriptContext;
@@ -256,6 +255,7 @@ namespace dmRender
         dmArray<uint32_t>           m_RenderListSortBuffer;
         dmArray<uint32_t>           m_RenderListSortIndices;
         dmArray<RenderListRange>    m_RenderListRanges;         // Maps tagmask to a range in the (sorted) render list
+        dmArray<TextureBinding>     m_TextureBindTable;
         dmhash_t                    m_FrustumHash;
 
         dmHashTable32<MaterialTagList>  m_MaterialTagLists;
@@ -302,7 +302,8 @@ namespace dmRender
     // Gets the list associated with a hash of all the tags (see RegisterMaterialTagList)
     void                            GetMaterialTagList(HRenderContext context, uint32_t list_hash, MaterialTagList* list);
 
-    void    SetTextureBinding(dmRender::HRenderContext render_context, dmhash_t sampler_hash, uint32_t unit, dmGraphics::HTexture texture);
+    void    SetTextureBindingByHash(dmRender::HRenderContext render_context, dmhash_t sampler_hash, dmGraphics::HTexture texture);
+    void    SetTextureBindingByUnit(dmRender::HRenderContext render_context, uint32_t unit, dmGraphics::HTexture texture);
     bool    GetCanBindTexture(dmGraphics::HTexture texture, HSampler sampler, uint32_t unit);
     int32_t GetMaterialSamplerIndex(HMaterial material, dmhash_t name_hash);
 

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1439,15 +1439,25 @@ namespace dmRender
         return 0;
     }
 
-    /*# enables a texture for a render target
+    /*# sets a texture to the render state
      *
-     * Sets the specified render target's specified buffer to be
-     * used as texture with the specified unit.
-     * A material shader can then use the texture to sample from.
+     * Sets the specified texture handle for a render target attachment or a regular texture
+     * that should be used for rendering. The texture can be bound to either a texture unit
+     * or to a sampler name by a hash or a string.
+     * A texture can be bound to multiple units and sampler names at the same time,
+     * the actual binding will be applied to the shaders when a shader program is bound.
+     *
+     * When mixing binding using both units and sampler names, you might end up in situations
+     * where two different textures will be applied to the same bind location in the shader.
+     * In this case, the texture set to the named sampler will take precedence over the unit.
+     * 
+     * Note that you can bind multiple sampler names to the same texture, in case you want to reuse
+     * the same texture for differnt use-cases. It is however recommended that you use the same name
+     * everywhere for the textures that should be shared across different materials.
      *
      * @name render.enable_texture
-     * @param unit [type:number] texture unit to enable texture for
-     * @param render_target [type:handle] render target or texture from which to enable the specified texture unit
+     * @param binding [type:number|string|hash] texture binding, either by texture unit, string or hash for the sampler name that the texture should be bound to
+     * @param handle [type:texture] render target or texture handle that should be bound
      * @param [buffer_type] [type:constant] optional buffer type from which to enable the texture. Note that this argument only applies to render targets. Defaults to `render.BUFFER_COLOR_BIT`. These values are supported:
      *
      * - `render.BUFFER_COLOR_BIT`
@@ -1482,6 +1492,15 @@ namespace dmRender
      *     -- draw a predicate with the render target available as texture 0 in the predicate
      *     -- material shader.
      *     render.draw(self.my_pred)
+     * end
+     * ```
+     *
+     * ```lua
+     * function update(self, dt)
+     *     -- bind a texture to the texture unit 0
+     *     render.enable_texture(0, self.my_texture_handle)
+     *     -- bind the same texture to a named sampler
+     *     render.enable_texture("my_texture_sampler", self.my_texture_handle)
      * end
      * ```
      */
@@ -1556,12 +1575,12 @@ namespace dmRender
         }
     }
 
-    /*# disables a texture for a render target
+    /*# disables a texture on the render state
      *
-     * Disables a texture unit for a render target that has previourly been enabled.
+     * Disables a texture that has previourly been enabled.
      *
      * @name render.disable_texture
-     * @param unit [type:number] texture unit to disable
+     * @param binding [type:number|string|hash] texture binding, either by texture unit, string or hash that should be disabled
      * @examples
      *
      * ```lua

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1488,8 +1488,18 @@ namespace dmRender
     int RenderScript_EnableTexture(lua_State* L)
     {
         RenderScriptInstance* i = RenderScriptInstance_Check(L);
+        dmhash_t sampler_hash   = 0;
+        uint32_t unit           = 0;
 
-        uint32_t unit = luaL_checkinteger(L, 1);
+        if (lua_isnumber(L, 1))
+        {
+            unit = lua_tointeger(L, 1);
+        }
+        else
+        {
+            sampler_hash = dmScript::CheckHashOrString(L, 1);
+        }
+
         if (lua_isnumber(L, 2))
         {
             dmGraphics::HAssetHandle asset_handle = (dmGraphics::HAssetHandle) lua_tonumber(L, 2);
@@ -1527,7 +1537,7 @@ namespace dmRender
             // Texture can potentially still be zero if it's an attachment texture
             if(texture != 0)
             {
-                if (InsertCommand(i, Command(COMMAND_TYPE_ENABLE_TEXTURE, unit, texture)))
+                if (InsertCommand(i, Command(COMMAND_TYPE_ENABLE_TEXTURE, sampler_hash, unit, texture)))
                 {
                     return 0;
                 }
@@ -1568,8 +1578,19 @@ namespace dmRender
     int RenderScript_DisableTexture(lua_State* L)
     {
         RenderScriptInstance* i = RenderScriptInstance_Check(L);
-        uint32_t unit = luaL_checkinteger(L, 1);
-        if (InsertCommand(i, Command(COMMAND_TYPE_DISABLE_TEXTURE, unit)))
+        dmhash_t sampler_hash   = 0;
+        uint32_t unit           = 0;
+
+        if (lua_isnumber(L, 1))
+        {
+            unit = lua_tointeger(L, 1);
+        }
+        else
+        {
+            sampler_hash = dmScript::CheckHashOrString(L, 1);
+        }
+
+        if (InsertCommand(i, Command(COMMAND_TYPE_DISABLE_TEXTURE, sampler_hash, unit)))
             return 0;
         else
             return luaL_error(L, "Command buffer is full (%d).", i->m_CommandBuffer.Capacity());

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1177,11 +1177,12 @@ TEST_F(dmRenderScriptTest, TestAssetHandlesValidTexture)
 
     dmRender::Command* command = &commands[0];
     ASSERT_EQ(dmRender::COMMAND_TYPE_ENABLE_TEXTURE, command->m_Type);
-    ASSERT_EQ(unit,    command->m_Operands[0]);
-    ASSERT_EQ(texture, command->m_Operands[1]);
+    ASSERT_EQ(0,       command->m_Operands[0]);
+    ASSERT_EQ(unit,    command->m_Operands[1]);
+    ASSERT_EQ(texture, command->m_Operands[2]);
 
     dmRender::ParseCommands(m_Context, &commands[0], commands.Size());
-    ASSERT_EQ(m_Context->m_Textures[unit], texture);
+    ASSERT_EQ(m_Context->m_TextureBindTable[unit].m_Texture, texture);
 
     dmGraphics::DeleteTexture(texture);
 


### PR DESCRIPTION
Added support for enabling and disabling a sampler by a string or hash in a render script:

```lua
render.enable_texture(unit|name|hash, texture)
render.disable_texture(unit|name|hash, texture)
```

Previously a texture could only be bound to the renderer by texture units, which could cause issues when certain graphics adapters optimizes away unbound textures. With this new functionality, you can bind the same textures to multiple sampler names, which will be bound to the matching sampler name by the renderer when draw calls are issued:

```lua
render.enable_texture("my_global_texture", self.tex0)
render.enable_texture("some_other_sampler", self.tex0)
render.enable_texture("a_third_sampler", self.tex0)
```

It's however recommended that you use the same sampler name for all samplers in this case, this example just illustrates that it is possible to do so!

Fixes #8535
Fixes #7440

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
