### PR TITLE
Removed `system_font.font` from `builtins`

### DIFF
--- a/editor/resources/templates/template.label
+++ b/editor/resources/templates/template.label
@@ -1,5 +1,5 @@
 text: 'Label'
-font: '/builtins/fonts/system_font.font'
+font: '/builtins/fonts/default.font'
 material: '/builtins/fonts/label.material'
 size { x: 128 y: 32 z: 0 }
 color { x: 1 y: 1 z: 1 w: 1 }

--- a/editor/resources/templates/template.label
+++ b/editor/resources/templates/template.label
@@ -1,6 +1,6 @@
 text: 'Label'
 font: '/builtins/fonts/default.font'
-material: '/builtins/fonts/label.material'
+material: '/builtins/fonts/label-df.material'
 size { x: 128 y: 32 z: 0 }
 color { x: 1 y: 1 z: 1 w: 1 }
 outline { x: 0 y: 0 z: 0 w: 1 }

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2842,7 +2842,7 @@
       (g/make-nodes graph-id [fonts-node FontsNode
                               no-font [FontNode
                                        :name ""
-                                       :font (workspace/resolve-resource resource "/builtins/fonts/system_font.font")]]
+                                       :font (workspace/resolve-resource resource "/builtins/fonts/default.font")]]
                     (g/connect fonts-node :_node-id self :fonts-node) ; for the tests :/
                     (g/connect fonts-node :_node-id self :nodes)
                     (g/connect fonts-node :build-errors self :build-errors)

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -132,7 +132,7 @@
                                    :scale [0.0 0.0 0.0 0.0], ; Default from legacy field added by editor.protobuf/field-desc-default. Not in actual Label$LabelDesc.
                                    :blend-mode :blend-mode-alpha,
                                    :leading 1.0,
-                                   :font "/builtins/fonts/system_font.fontc",
+                                   :font "/builtins/fonts/default.fontc",
                                    :size [128.0 32.0 0.0 0.0],
                                    :tracking 0.0,
                                    :material "/builtins/fonts/label.materialc",
@@ -618,7 +618,7 @@
         (is (= "/gui/gui.a.texturesetc" (get textures "main")))
         (is (= "/graphics/atlas.a.texturesetc" (get textures "sub_main"))))
       (let [fonts (zipmap (map :name (:fonts desc)) (map :font (:fonts desc)))]
-        (is (= "/builtins/fonts/system_font.fontc" (get fonts "system_font")))
+        (is (= "/builtins/fonts/default.fontc" (get fonts "default_font")))
         (is (= "/fonts/big_score.fontc" (get fonts "sub_font")))))))
 
 (deftest build-game-project

--- a/editor/test/integration/gui_test.clj
+++ b/editor/test/integration/gui_test.clj
@@ -330,7 +330,7 @@
           text (gui-node node-id "scene/text")]
       (is (= ["" "main/particle_blob" "main_super/particle_blob"] (options box :texture)))
       (is (= ["" "layer"] (options text :layer)))
-      (is (= ["system_font" "system_font_super"] (options text :font)))
+      (is (= ["default_font" "default_font_super"] (options text :font)))
       (g/transact (g/set-property text :layer "layer"))
       (let [l (gui-layer node-id "layer")]
         (g/transact (g/set-property l :name "new-name"))

--- a/editor/test/resources/build_project/SideScroller/main/label.label
+++ b/editor/test/resources/build_project/SideScroller/main/label.label
@@ -34,5 +34,5 @@ pivot: PIVOT_CENTER
 blend_mode: BLEND_MODE_ALPHA
 line_break: false
 text: "Label"
-font: "/builtins/fonts/system_font.font"
+font: "/builtins/fonts/default.font"
 material: "/builtins/fonts/label.material"

--- a/editor/test/resources/label_migration_project/scale_migration/embedded_scaled_label.collection
+++ b/editor/test/resources/label_migration_project/scale_migration/embedded_scaled_label.collection
@@ -41,7 +41,7 @@ embedded_instances {
   "blend_mode: BLEND_MODE_ALPHA\\n"
   "line_break: false\\n"
   "text: \\\"Label\\\"\\n"
-  "font: \\\"/builtins/fonts/system_font.font\\\"\\n"
+  "font: \\\"/builtins/fonts/default.font\\\"\\n"
   "material: \\\"/builtins/fonts/label.material\\\"\\n"
   "\"\n"
   "  position {\n"

--- a/editor/test/resources/label_migration_project/scale_migration/embedded_scaled_label.go
+++ b/editor/test/resources/label_migration_project/scale_migration/embedded_scaled_label.go
@@ -37,7 +37,7 @@ embedded_components {
   "blend_mode: BLEND_MODE_ALPHA\n"
   "line_break: false\n"
   "text: \"Label\"\n"
-  "font: \"/builtins/fonts/system_font.font\"\n"
+  "font: \"/builtins/fonts/default.font\"\n"
   "material: \"/builtins/fonts/label.material\"\n"
   ""
   position {

--- a/editor/test/resources/label_migration_project/scale_migration/embedded_scaled_label_child.collection
+++ b/editor/test/resources/label_migration_project/scale_migration/embedded_scaled_label_child.collection
@@ -62,7 +62,7 @@ embedded_instances {
   "blend_mode: BLEND_MODE_ALPHA\\n"
   "line_break: false\\n"
   "text: \\\"Label\\\"\\n"
-  "font: \\\"/builtins/fonts/system_font.font\\\"\\n"
+  "font: \\\"/builtins/fonts/default.font\\\"\\n"
   "material: \\\"/builtins/fonts/label.material\\\"\\n"
   "\"\n"
   "  position {\n"

--- a/editor/test/resources/label_migration_project/scale_migration/scaled_label.label
+++ b/editor/test/resources/label_migration_project/scale_migration/scaled_label.label
@@ -34,5 +34,5 @@ pivot: PIVOT_CENTER
 blend_mode: BLEND_MODE_ALPHA
 line_break: false
 text: "Label"
-font: "/builtins/fonts/system_font.font"
+font: "/builtins/fonts/default.font"
 material: "/builtins/fonts/label.material"

--- a/editor/test/resources/label_migration_project/scale_migration/unscaled_label.label
+++ b/editor/test/resources/label_migration_project/scale_migration/unscaled_label.label
@@ -28,5 +28,5 @@ pivot: PIVOT_CENTER
 blend_mode: BLEND_MODE_ALPHA
 line_break: false
 text: "Label"
-font: "/builtins/fonts/system_font.font"
+font: "/builtins/fonts/default.font"
 material: "/builtins/fonts/label.material"

--- a/editor/test/resources/override_project/main/button2.gui
+++ b/editor/test/resources/override_project/main/button2.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 background_color {
   x: 0.0
@@ -97,7 +97,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Sample"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
@@ -226,7 +226,7 @@ layouts {
   "p\n"
   "l\n"
   "e"
-    font: "system_font"
+    font: "default_font"
     id: "text"
     xanchor: XANCHOR_NONE
     yanchor: YANCHOR_NONE
@@ -297,7 +297,7 @@ layouts {
     type: TYPE_TEXT
     blend_mode: BLEND_MODE_ALPHA
     text: "S a m p l e"
-    font: "system_font"
+    font: "default_font"
     id: "text"
     xanchor: XANCHOR_NONE
     yanchor: YANCHOR_NONE

--- a/editor/test/resources/override_project/main/child.gui
+++ b/editor/test/resources/override_project/main/child.gui
@@ -78,7 +78,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "original"
-  font: "system_font"
+  font: "default_font"
   id: "template/text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/override_project/main/grandchild.gui
+++ b/editor/test/resources/override_project/main/grandchild.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 background_color {
   x: 0.0
@@ -43,7 +43,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "original"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/override_project/main/hud.gui
+++ b/editor/test/resources/override_project/main/hud.gui
@@ -173,7 +173,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Sample HUD"
-  font: "system_font"
+  font: "default_font"
   id: "template/template/text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
@@ -292,7 +292,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Default layout"
-  font: "system_font"
+  font: "default_font"
   id: "template/text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/override_project/main/panel2.gui
+++ b/editor/test/resources/override_project/main/panel2.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 background_color {
   x: 0.0
@@ -137,7 +137,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Sample"
-  font: "system_font"
+  font: "default_font"
   id: "template/text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
@@ -255,7 +255,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Default layout"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
@@ -320,7 +320,7 @@ layouts {
     type: TYPE_TEXT
     blend_mode: BLEND_MODE_ALPHA
     text: "Portrait"
-    font: "system_font"
+    font: "default_font"
     id: "text"
     xanchor: XANCHOR_NONE
     yanchor: YANCHOR_NONE
@@ -387,7 +387,7 @@ layouts {
     type: TYPE_TEXT
     blend_mode: BLEND_MODE_ALPHA
     text: "Sample"
-    font: "system_font"
+    font: "default_font"
     id: "template/text"
     xanchor: XANCHOR_NONE
     yanchor: YANCHOR_NONE
@@ -451,7 +451,7 @@ layouts {
     type: TYPE_TEXT
     blend_mode: BLEND_MODE_ALPHA
     text: "Landscape"
-    font: "system_font"
+    font: "default_font"
     id: "text"
     xanchor: XANCHOR_NONE
     yanchor: YANCHOR_NONE

--- a/editor/test/resources/override_project/main/parent.gui
+++ b/editor/test/resources/override_project/main/parent.gui
@@ -118,7 +118,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "original"
-  font: "system_font"
+  font: "default_font"
   id: "template/template/text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/reload_project/gui/scene.gui
+++ b/editor/test/resources/reload_project/gui/scene.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 background_color {
   x: 0.0

--- a/editor/test/resources/reload_project/label/label.label
+++ b/editor/test/resources/reload_project/label/label.label
@@ -34,5 +34,5 @@ pivot: PIVOT_CENTER
 blend_mode: BLEND_MODE_ALPHA
 line_break: false
 text: "Original"
-font: "/builtins/fonts/system_font.font"
+font: "/builtins/fonts/default.font"
 material: "/builtins/fonts/label.material"

--- a/editor/test/resources/reload_project/label/new_label.label
+++ b/editor/test/resources/reload_project/label/new_label.label
@@ -28,5 +28,5 @@ pivot: PIVOT_N
 blend_mode: BLEND_MODE_ADD
 line_break: true
 text: "Modified"
-font: "/builtins/fonts/system_font.font"
+font: "/builtins/fonts/default.font"
 material: "/builtins/fonts/label.material"

--- a/editor/test/resources/test_project/collection/all_embedded.collection
+++ b/editor/test/resources/test_project/collection/all_embedded.collection
@@ -124,7 +124,7 @@ embedded_instances {
   "blend_mode: BLEND_MODE_ALPHA\\n"
   "line_break: false\\n"
   "text: \\\"Label\\\"\\n"
-  "font: \\\"/builtins/fonts/system_font.font\\\"\\n"
+  "font: \\\"/builtins/fonts/default.font\\\"\\n"
   "material: \\\"/builtins/fonts/label.material\\\"\\n"
   "\"\n"
   "  position {\n"

--- a/editor/test/resources/test_project/collection/components/test.label
+++ b/editor/test/resources/test_project/collection/components/test.label
@@ -32,5 +32,5 @@ pivot: PIVOT_CENTER
 blend_mode: BLEND_MODE_ALPHA
 line_break: false
 text: "Label"
-font: "/builtins/fonts/system_font.font"
+font: "/builtins/fonts/default.font"
 material: "/builtins/fonts/label.material"

--- a/editor/test/resources/test_project/gui/empty.gui
+++ b/editor/test/resources/test_project/gui/empty.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "main"

--- a/editor/test/resources/test_project/gui/layers.gui
+++ b/editor/test/resources/test_project/gui/layers.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "main"
@@ -199,7 +199,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Test"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/test_project/gui/legacy_alpha.gui
+++ b/editor/test/resources/test_project/gui/legacy_alpha.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "main"
@@ -99,7 +99,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Test"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/test_project/gui/scene.gui
+++ b/editor/test/resources/test_project/gui/scene.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "main"
@@ -310,7 +310,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Test"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
@@ -382,7 +382,7 @@ layouts {
     type: TYPE_TEXT
     blend_mode: BLEND_MODE_ALPHA
     text: "Testing Text"
-    font: "system_font"
+    font: "default_font"
     id: "text"
     xanchor: XANCHOR_NONE
     yanchor: YANCHOR_NONE

--- a/editor/test/resources/test_project/gui/simple.gui
+++ b/editor/test/resources/test_project/gui/simple.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "main"
@@ -100,7 +100,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "\346\227\245"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/editor/test/resources/test_project/gui/sub_scene.gui
+++ b/editor/test/resources/test_project/gui/sub_scene.gui
@@ -1,7 +1,7 @@
 script: ""
 adjust_reference: ADJUST_REFERENCE_PARENT
 fonts {
-  name: "system_font"
+  name: "default_font"
   font: "/fonts/big_score.font"
 }
 fonts {

--- a/editor/test/resources/test_project/gui/super_scene.gui
+++ b/editor/test/resources/test_project/gui/super_scene.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
-  name: "system_font_super"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font_super"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "main_super"
@@ -357,7 +357,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "Test"
-  font: "system_font"
+  font: "default_font"
   id: "scene/text"
   parent: "scene"
   xanchor: XANCHOR_NONE

--- a/editor/test/resources/test_project/gui_resources/gui_resources.gui
+++ b/editor/test/resources/test_project/gui_resources/gui_resources.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
   name: "font"
-  font: "/builtins/fonts/system_font.font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "texture"

--- a/editor/test/resources/test_project/gui_resources/replaces_broken_gui_resources.gui
+++ b/editor/test/resources/test_project/gui_resources/replaces_broken_gui_resources.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
   name: "replaced_font"
-  font: "/builtins/fonts/system_font.font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "replaced_texture"

--- a/editor/test/resources/test_project/gui_resources/replaces_gui_resources.gui
+++ b/editor/test/resources/test_project/gui_resources/replaces_gui_resources.gui
@@ -1,7 +1,7 @@
 script: ""
 fonts {
   name: "replaced_font"
-  font: "/builtins/fonts/system_font.font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "replaced_texture"

--- a/editor/test/resources/test_project/label/embedded_label.collection
+++ b/editor/test/resources/test_project/label/embedded_label.collection
@@ -41,7 +41,7 @@ embedded_instances {
   "blend_mode: BLEND_MODE_ALPHA\\n"
   "line_break: false\\n"
   "text: \\\"Label\\\"\\n"
-  "font: \\\"/builtins/fonts/system_font.font\\\"\\n"
+  "font: \\\"/builtins/fonts/default.font\\\"\\n"
   "material: \\\"/builtins/fonts/label.material\\\"\\n"
   "\"\n"
   "  position {\n"

--- a/editor/test/resources/test_project/label/embedded_label.go
+++ b/editor/test/resources/test_project/label/embedded_label.go
@@ -37,7 +37,7 @@ embedded_components {
   "blend_mode: BLEND_MODE_ALPHA\n"
   "line_break: false\n"
   "text: \"Label\"\n"
-  "font: \"/builtins/fonts/system_font.font\"\n"
+  "font: \"/builtins/fonts/default.font\"\n"
   "material: \"/builtins/fonts/label.material\"\n"
   ""
   position {

--- a/editor/test/resources/test_project/label/test.label
+++ b/editor/test/resources/test_project/label/test.label
@@ -1,5 +1,5 @@
 text: 'Label'
-font: '/builtins/fonts/system_font.font'
+font: '/builtins/fonts/default.font'
 material: '/builtins/fonts/label.material'
 scale { x: 1 y: 1 z: 1 }
 size { x: 128 y: 32 z: 0 }

--- a/engine/engine/content/builtins/fonts/debug/always_on_top.font
+++ b/engine/engine/content/builtins/fonts/debug/always_on_top.font
@@ -1,0 +1,7 @@
+font: "/builtins/fonts/vera_mo_bd.ttf"
+material: "/builtins/fonts/debug/always_on_top_font.material"
+size: 14
+antialias: 1
+alpha: 1.0
+shadow_alpha: 0.0
+shadow_blur: 0

--- a/engine/engine/content/builtins/fonts/debug/always_on_top_font.material
+++ b/engine/engine/content/builtins/fonts/debug/always_on_top_font.material
@@ -1,5 +1,5 @@
-name: "system_font"
-tags: "text"
+name: "always_on_top_font"
+tags: "debug_text"
 vertex_program: "/builtins/fonts/font.vp"
 fragment_program: "/builtins/fonts/font.fp"
 vertex_constants {

--- a/engine/engine/content/builtins/fonts/default.font
+++ b/engine/engine/content/builtins/fonts/default.font
@@ -1,7 +1,8 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/system_font.material"
-size: 14
+material: "/builtins/fonts/font-df.material"
+size: 16
 antialias: 1
 alpha: 1.0
 shadow_alpha: 0.0
 shadow_blur: 0
+output_format: TYPE_DISTANCE_FIELD

--- a/engine/engine/content/builtins/fonts/default.font
+++ b/engine/engine/content/builtins/fonts/default.font
@@ -1,6 +1,6 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
 material: "/builtins/fonts/font.material"
-size: 16
+size: 14
 antialias: 1
 alpha: 1.0
 shadow_alpha: 0.0

--- a/engine/engine/content/builtins/fonts/default.font
+++ b/engine/engine/content/builtins/fonts/default.font
@@ -1,7 +1,8 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/font.material"
+material: "/builtins/fonts/font-df.material"
 size: 14
 antialias: 1
 alpha: 1.0
 shadow_alpha: 0.0
 shadow_blur: 0
+output_format: TYPE_DISTANCE_FIELD

--- a/engine/engine/content/builtins/fonts/default.font
+++ b/engine/engine/content/builtins/fonts/default.font
@@ -1,8 +1,7 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/font-df.material"
+material: "/builtins/fonts/font.material"
 size: 16
 antialias: 1
 alpha: 1.0
 shadow_alpha: 0.0
 shadow_blur: 0
-output_format: TYPE_DISTANCE_FIELD

--- a/engine/engine/content/builtins/render/default.render_script
+++ b/engine/engine/content/builtins/render/default.render_script
@@ -136,7 +136,7 @@ local function create_state()
 end
 
 function init(self)
-    self.predicates = create_predicates("tile", "gui", "text", "particle", "model")
+    self.predicates = create_predicates("tile", "gui", "particle", "model", "debug_text")
 
     -- default is stretch projection. copy from builtins and change for different projection
     -- or send a message to the render script to change projection:
@@ -204,7 +204,7 @@ function update(self)
 
     render.enable_state(render.STATE_STENCIL_TEST)
     render.draw(predicates.gui, camera_gui.frustum)
-    render.draw(predicates.text, camera_gui.frustum)
+    render.draw(predicates.debug_text, camera_gui.frustum)
     render.disable_state(render.STATE_STENCIL_TEST)
     render.disable_state(render.STATE_BLEND)
 end

--- a/engine/engine/content/wscript
+++ b/engine/engine/content/wscript
@@ -58,6 +58,7 @@ def build(bld):
     start_dir = bld.path.find_dir('builtins')
     bld.install_files('${PREFIX}/content/builtins', start_dir.ant_glob('manifests/**/*'), cwd = start_dir, relative_trick = True)
     bld.install_files('${PREFIX}/content/builtins', start_dir.ant_glob('assets/**/*'), cwd = start_dir, relative_trick = True)
+    bld.install_files('${PREFIX}/content/builtins', start_dir.ant_glob('fonts/**/*'), cwd = start_dir, relative_trick = True)
 
     if not waflib.Options.options.skip_build_tests:
         bld(name = 'bob-engine',

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1983,7 +1983,7 @@ bail:
     {
         dmResource::Result fact_error;
 #if !defined(DM_RELEASE)
-        const char* system_font_map = "/builtins/fonts/system_font.fontc";
+        const char* system_font_map = "/builtins/fonts/debug/always_on_top.fontc";
         fact_error = dmResource::Get(engine->m_Factory, system_font_map, (void**) &engine->m_SystemFontMap);
         if (fact_error != dmResource::RESULT_OK)
         {

--- a/engine/engine/src/test/def-3575/def-3575-bitmap.font
+++ b/engine/engine/src/test/def-3575/def-3575-bitmap.font
@@ -1,5 +1,5 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/system_font.material"
+material: "/builtins/fonts/font.material"
 size: 14
 antialias: 1
 alpha: 1.0

--- a/engine/engine/src/test/def-3575/def-3575-bitmap.font
+++ b/engine/engine/src/test/def-3575/def-3575-bitmap.font
@@ -1,5 +1,5 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/font.material"
+material: "/builtins/fonts/font-fnt.material"
 size: 14
 antialias: 1
 alpha: 1.0

--- a/engine/engine/src/test/def-3575/def-3575-df.font
+++ b/engine/engine/src/test/def-3575/def-3575-df.font
@@ -1,5 +1,5 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/system_font.material"
+material: "/builtins/fonts/font-df.material"
 size: 14
 antialias: 1
 alpha: 1.0

--- a/engine/engine/src/test/label/label.font
+++ b/engine/engine/src/test/label/label.font
@@ -1,5 +1,5 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/system_font.material"
+material: "/builtins/fonts/label.material"
 size: 14
 antialias: 1
 alpha: 1.0

--- a/engine/engine/src/test/loading/loading.gui
+++ b/engine/engine/src/test/loading/loading.gui
@@ -1,7 +1,7 @@
 script: "/loading/loading.gui_script"
 fonts {
   name: "loading"
-  font: "/builtins/fonts/system_font.font"
+  font: "/builtins/fonts/default.font"
 }
 nodes {
   position {

--- a/engine/engine/src/test/script_props/gui/prop_gui.gui
+++ b/engine/engine/src/test/script_props/gui/prop_gui.gui
@@ -1,7 +1,7 @@
 script: "/script_props/gui/prop_gui.gui_script"
 fonts {
-  name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  name: "default_font"
+  font: "/builtins/fonts/default.font"
 }
 textures {
   name: "atlas1"
@@ -47,7 +47,7 @@ nodes {
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
   text: "<text>"
-  font: "system_font"
+  font: "default_font"
   id: "text"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE

--- a/engine/engine/src/test/script_props/gui/prop_gui.script
+++ b/engine/engine/src/test/script_props/gui/prop_gui.script
@@ -52,7 +52,7 @@ function late_init(self)
 
     -- Test replace fonts works
     assert_not_error(function()
-            go.set("#gui", "fonts", self.big_font, {key = "system_font"})
+            go.set("#gui", "fonts", self.big_font, {key = "default_font"})
         end)
 
     -- Test set fonts with index failed
@@ -62,7 +62,7 @@ function late_init(self)
 
     -- Test set fonts with both index and key failed
     assert_error(function()
-            go.set("#gui", "fonts", self.big_font, {key = "system_font", index = 992})
+            go.set("#gui", "fonts", self.big_font, {key = "default_font", index = 992})
         end)
 
     -- Test get fonts works

--- a/engine/engine/src/test/script_props/gui/system_font.font
+++ b/engine/engine/src/test/script_props/gui/system_font.font
@@ -1,5 +1,5 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/system_font.material"
+material: "/builtins/fonts/debug/always_on_top_font.material"
 size: 14
 antialias: 1
 alpha: 1.0

--- a/engine/engine/src/test/script_props/gui/system_font_big.font
+++ b/engine/engine/src/test/script_props/gui/system_font_big.font
@@ -1,5 +1,5 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
-material: "/builtins/fonts/system_font.material"
+material: "/builtins/fonts/debug/always_on_top_font.material"
 size: 28
 antialias: 1
 alpha: 1.0


### PR DESCRIPTION
This breaking change was implemented to clarify the usage of predefined fonts in `builtins`. The old `system_font.font` has been completely removed from the `builtins`, and two new fonts have been introduced:
1. `builtins/fonts/default.font`, which uses the default df material and can serve as a font for the development process.
2. `builtins/fonts/debug/always_on_top.font`, which utilizes a special material `builtins/fonts/debug/always_on_top_font.material` with the `debug_text` tag. This font is intended to be drawn on top of other elements and is used for debugging purposes (such as the profiler and the `draw_debug_text` message) as replacement of old `system_font.font`. Additionally, changes are required in `default.render_script`, where the old `text` predicate has been replaced with the `debug_text` predicate for clarity.

Fix https://github.com/defold/defold/issues/7988
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   3. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
