### PR TITLE
Fixed the way the HTML5 bundler splits and renames resource files.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/BundlerTest.java
@@ -587,22 +587,22 @@ public class BundlerTest {
                 expectedFiles.add("index.html");
                 expectedFiles.add("unnamed_wasm.js");
                 expectedFiles.add("unnamed.wasm");
-                expectedFiles.add("archive/game.arcd0");
-                expectedFiles.add("archive/game.arci0");
-                expectedFiles.add("archive/game.dmanifest0");
-                expectedFiles.add("archive/game.projectc0");
-                expectedFiles.add("archive/game.public.der0");
+                expectedFiles.add("archive/game0.arcd");
+                expectedFiles.add("archive/game0.arci");
+                expectedFiles.add("archive/game0.dmanifest");
+                expectedFiles.add("archive/game0.projectc");
+                expectedFiles.add("archive/game0.public.der");
                 expectedFiles.add("archive/archive_files.json");
                 break;
             case JsWeb:
                 expectedFiles.add("dmloader.js");
                 expectedFiles.add("index.html");
                 expectedFiles.add("unnamed_asmjs.js");
-                expectedFiles.add("archive/game.arcd0");
-                expectedFiles.add("archive/game.arci0");
-                expectedFiles.add("archive/game.dmanifest0");
-                expectedFiles.add("archive/game.projectc0");
-                expectedFiles.add("archive/game.public.der0");
+                expectedFiles.add("archive/game0.arcd");
+                expectedFiles.add("archive/game0.arci");
+                expectedFiles.add("archive/game0.dmanifest");
+                expectedFiles.add("archive/game0.projectc");
+                expectedFiles.add("archive/game0.public.der");
                 expectedFiles.add("archive/archive_files.json");
                 break;
             case Armv7Android:

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -165,6 +165,17 @@ public class HTML5Bundler implements IBundler {
             subdivisions = new ArrayList<File>();
         }
 
+        private static String insertNumberBeforeExtension(String filePath, int number) {
+            int dotIndex = filePath.indexOf('.');
+            if (dotIndex > 0) {
+                String baseName = filePath.substring(0, dotIndex);
+                String extension = filePath.substring(dotIndex);
+                return baseName + number + extension;
+            } else {
+                return filePath + number;
+            }
+        }
+
         void performSplit(File destDir) throws IOException {
             InputStream input = null;
             try {
@@ -176,8 +187,7 @@ public class HTML5Bundler implements IBundler {
                     byte[] readBuffer = new byte[thisRead];
                     long bytesRead = input.read(readBuffer, 0, thisRead);
                     assert(bytesRead == thisRead);
-
-                    File output = new File(destDir, source.getName() + subdivisions.size());
+                    File output = new File(destDir, insertNumberBeforeExtension(source.getName(), subdivisions.size()));
                     writeChunk(output, readBuffer);
                     subdivisions.add(output);
 


### PR DESCRIPTION
Instead of using names like `game.arcd0`, `game.arcd1`, `game.arci0` for resource files in the HTML5 bundle, this fix keeps the file extension as is and adds filename counters instead: `game0.arcd`, `game1.arcd`, `game0.arci`. This will facilitate the use of custom server settings for files based on their filetype.

Fix https://github.com/defold/defold/issues/8560
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
