### PR TITLE
Added support for sprite to not have a texture assigned

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -374,12 +374,6 @@ public class ProtoBuilders {
             }
 
             List<String> images = getImageResources(spriteBuilder);
-
-            if (images.isEmpty())
-            {
-                throw new CompileExceptionError(input, 0, "An atlas or tileset must be assigned.");
-            }
-
             for (String atlas : images) {
                 IResource atlasOutput = project.getResource(atlas).changeExt(getTextureSetExt(atlas));
                 task.addInput(atlasOutput);

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -427,7 +427,7 @@ namespace dmGameSystem
             texture = &overrides->m_Textures[index];
         if (!texture || !texture->m_TextureSet)
             texture = &component->m_Resource->m_Textures[index];
-        return texture->m_TextureSet;
+        return texture ? texture->m_TextureSet : 0;
     }
 
     // Until we can set multiple play cursors, we'll use the first texture set as the driving animation
@@ -493,7 +493,7 @@ namespace dmGameSystem
     static bool PlayAnimation(SpriteComponent* component, dmhash_t animation, float offset, float playback_rate)
     {
         TextureSetResource* texture_set = GetFirstTextureSet(component);
-        uint32_t* anim_id = texture_set->m_AnimationIds.Get(animation);
+        uint32_t* anim_id = texture_set ? texture_set->m_AnimationIds.Get(animation) : 0;
         if (anim_id)
         {
             component->m_AnimationID = *anim_id;
@@ -611,8 +611,11 @@ namespace dmGameSystem
             component->m_Size[1] = component->m_Resource->m_DDF->m_Size.getY();
         }
 
-        PlayAnimation(component, resource->m_DefaultAnimation,
-                component->m_Resource->m_DDF->m_Offset, component->m_Resource->m_DDF->m_PlaybackRate);
+        if (GetNumTextures(component) > 0)
+        {
+            PlayAnimation(component, resource->m_DefaultAnimation,
+                    component->m_Resource->m_DDF->m_Offset, component->m_Resource->m_DDF->m_PlaybackRate);
+        }
 
         *params.m_UserData = (uintptr_t)index;
         return dmGameObject::CREATE_RESULT_OK;
@@ -741,6 +744,26 @@ namespace dmGameSystem
         array.SetSize(size);
     }
 
+    static void FillSlice9Uvs(const float us[4], const float vs[4], bool rotated, float uvs[SPRITE_VERTEX_COUNT_SLICE9*2]) {
+        int index = 0;
+        for (int y=0; y<4; ++y)
+        {
+            for (int x=0; x<4; ++x, ++index)
+            {
+                if (rotated)
+                {
+                    uvs[index*2+0] = us[y];
+                    uvs[index*2+1] = vs[x];
+                }
+                else
+                {
+                    uvs[index*2+0] = us[x];
+                    uvs[index*2+1] = vs[y];
+                }
+            }
+        }
+    }
+
     static void CreateVertexDataSlice9(uint8_t* vertices, uint8_t* indices, bool is_indices_16_bit,
         const Matrix4& transform, Vector3 sprite_size, Vector4 slice9, uint32_t vertex_offset, uint32_t vertex_stride,
         TexturesData* textures, dmArray<float>* scratch_uvs,
@@ -813,30 +836,35 @@ namespace dmGameSystem
                 vs[vI[3]] = tc[3];
             }
 
-            int index = 0;
-            for (int y=0; y<4; ++y)
-            {
-                for (int x=0; x<4; ++x, ++index)
-                {
-                    if (uv_rotated)
-                    {
-                        uvs[index*2+0] = us[y];
-                        uvs[index*2+1] = vs[x];
-                    }
-                    else
-                    {
-                        uvs[index*2+0] = us[x];
-                        uvs[index*2+1] = vs[y];
-                    }
-                }
-            }
+            FillSlice9Uvs(us, vs, uv_rotated, uvs.Begin());
         }
 
-        // disable slice9 computation below a certain dimension
+        // disable slice9 computation below a certain threshold
         // (avoid div by zero)
         const float s9_min_dim = 0.001f;
-        const float sx         = sprite_size.getX() > s9_min_dim ? 1.0f / sprite_size.getX() : 0;
-        const float sy         = sprite_size.getY() > s9_min_dim ? 1.0f / sprite_size.getY() : 0;
+
+        if (textures->m_NumTextures == 0)
+        {
+            dmArray<float>& uvs = scratch_uvs[0];
+            EnsureSize(uvs, SPRITE_VERTEX_COUNT_SLICE9*2);
+
+            float us[4];
+            float vs[4];
+            us[0] = 0.0f;
+            us[1] = sprite_size.getX() > s9_min_dim ? slice9.getX() / sprite_size.getX() : 0.0f;
+            us[2] = 1.0f - (sprite_size.getX() > s9_min_dim ? slice9.getZ() / sprite_size.getX() : 0.0f);
+            us[3] = 1.0f;
+
+            vs[0] = 0.0f;
+            vs[1] = sprite_size.getY() > s9_min_dim ? slice9.getY() / sprite_size.getY() : 0.0f;
+            vs[2] = 1.0f - (sprite_size.getY() > s9_min_dim ? slice9.getW() / sprite_size.getY() : 0.0f);
+            vs[3] = 1.0f;
+
+            FillSlice9Uvs(us, vs, false, uvs.Begin());
+        }
+
+        const float sx = sprite_size.getX() > s9_min_dim ? 1.0f / sprite_size.getX() : 0;
+        const float sy = sprite_size.getY() > s9_min_dim ? 1.0f / sprite_size.getY() : 0;
 
         float xs[4], ys[4];
         // v are '1-v'
@@ -1018,6 +1046,28 @@ namespace dmGameSystem
             uvs[6] = tc[tex_lookup[4] * 2 + 0];
             uvs[7] = tc[tex_lookup[4] * 2 + 1];
         }
+
+        if (data->m_NumTextures == 0)
+        {
+            dmArray<float>& uvs = scratch_uvs[0];
+            EnsureSize(uvs, 4*2);
+
+            // top left
+            uvs[0] = 0.0f;
+            uvs[1] = 0.0f;
+
+            // bottom left
+            uvs[2] = 0.0f;
+            uvs[3] = 1.0f;
+
+            // bottom right
+            uvs[4] = 1.0f;
+            uvs[5] = 1.0f;
+
+            // top right
+            uvs[6] = 1.0f;
+            uvs[7] = 0.0f;
+        }
     }
 
     static inline bool CanUseQuads(const TexturesData* data)
@@ -1155,7 +1205,8 @@ namespace dmGameSystem
                 vertex_offset += 1;
             }
 
-            if (!CanUseQuads(&textures))
+            // if num_texture == 0, then we don't have a texture set to get any vertex/uv coordinates from
+            if (textures.m_NumTextures != 0 && !CanUseQuads(&textures))
             {
                 const dmGameSystemDDF::TextureSetAnimation* animation_ddf = textures.m_Animations[0];
 
@@ -1628,6 +1679,24 @@ namespace dmGameSystem
 
             TexturesData textures = {};
             textures.m_NumTextures = GetNumTextures(component);
+
+            if (textures.m_NumTextures == 0)
+            {
+                if (component->m_UseSlice9)
+                {
+                    num_vertices   += SPRITE_VERTEX_COUNT_SLICE9;
+                    num_indices    += SPRITE_INDEX_COUNT_SLICE9;
+                    vertex_memsize += SPRITE_VERTEX_COUNT_SLICE9 * vertex_stride;
+                }
+                else
+                {
+                    num_vertices   += SPRITE_VERTEX_COUNT_LEGACY;
+                    num_indices    += SPRITE_INDEX_COUNT_LEGACY;
+                    vertex_memsize += SPRITE_VERTEX_COUNT_LEGACY * vertex_stride;
+                }
+                continue;
+            }
+
             for (uint32_t i = 0; i < textures.m_NumTextures; ++i)
             {
                 textures.m_Resources[i] = GetTextureSet(component, i);
@@ -1998,11 +2067,17 @@ namespace dmGameSystem
         }
         else if (get_property == PROP_IMAGE)
         {
-            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetFirstTextureSet(component), out_value);
+            TextureSetResource* texture_set = GetFirstTextureSet(component);
+            if (!texture_set)
+                return dmGameObject::PROPERTY_RESULT_RESOURCE_NOT_FOUND;
+            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), texture_set, out_value);
         }
         else if (get_property == PROP_TEXTURE[0])
         {
-            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), GetFirstTextureSet(component)->m_Texture, out_value);
+            TextureSetResource* texture_set = GetFirstTextureSet(component);
+            if (!texture_set)
+                return dmGameObject::PROPERTY_RESULT_RESOURCE_NOT_FOUND;
+            return GetResourceProperty(dmGameObject::GetFactory(params.m_Instance), texture_set->m_Texture, out_value);
         }
         else if (get_property == SPRITE_PROP_ANIMATION)
         {
@@ -2070,7 +2145,7 @@ namespace dmGameSystem
             if (res == dmGameObject::PROPERTY_RESULT_OK)
             {
                 TextureSetResource* texture_set = GetFirstTextureSet(component);
-                uint32_t* anim_id =  texture_set->m_AnimationIds.Get(component->m_CurrentAnimation);
+                uint32_t* anim_id = texture_set ? texture_set->m_AnimationIds.Get(component->m_CurrentAnimation) : 0;
                 if (anim_id)
                 {
                     PlayAnimation(component, component->m_CurrentAnimation, GetCursor(component), component->m_PlaybackRate);

--- a/engine/gamesys/src/gamesys/resources/res_sprite.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_sprite.cpp
@@ -51,19 +51,6 @@ namespace dmGameSystem
                 resource->m_Textures[i].m_SamplerNameHash = dmHashString64(resource->m_DDF->m_Textures[i].m_Sampler);
             }
         }
-        else { // Fallback until the editor outputs the same format
-            num_textures = 1;
-            resource->m_NumTextures = 1;
-
-            resource->m_Textures = (SpriteTexture*)malloc(num_textures * sizeof(SpriteTexture));
-            memset(resource->m_Textures, 0, num_textures * sizeof(SpriteTexture));
-            dmResource::Result fr = dmResource::Get(factory, resource->m_DDF->m_TileSet, (void**)&resource->m_Textures[0].m_TextureSet);
-            if (fr != dmResource::RESULT_OK)
-            {
-                return fr;
-            }
-            resource->m_Textures[0].m_SamplerNameHash = dmHashString64("");
-        }
 
         fr = dmResource::Get(factory, resource->m_DDF->m_Material, (void**)&resource->m_Material);
         if (fr != dmResource::RESULT_OK)
@@ -76,7 +63,7 @@ namespace dmGameSystem
             return dmResource::RESULT_NOT_SUPPORTED;
         }
         resource->m_DefaultAnimation = dmHashString64(resource->m_DDF->m_DefaultAnimation);
-        if (!resource->m_Textures[0].m_TextureSet->m_AnimationIds.Get(resource->m_DefaultAnimation))
+        if (num_textures && !resource->m_Textures[0].m_TextureSet->m_AnimationIds.Get(resource->m_DefaultAnimation))
         {
             if (resource->m_DDF->m_DefaultAnimation == 0 || resource->m_DDF->m_DefaultAnimation[0] == '\0')
             {
@@ -103,7 +90,8 @@ namespace dmGameSystem
 
         for (uint32_t i = 0; i < resource->m_NumTextures; ++i)
         {
-            dmResource::Release(factory, resource->m_Textures[i].m_TextureSet);
+            if (resource->m_Textures[i].m_TextureSet)
+                dmResource::Release(factory, resource->m_Textures[i].m_TextureSet);
         }
         free((void*)resource->m_Textures);
     }


### PR DESCRIPTION
This fixes an issue where the engine crashed if the sprite had no textures at all.
Now, the UV coordinates will encompass the entire sprite (since it has no atlas).

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
