### PR TITLE
Crash fixes for the GDC tool

### DIFF
--- a/engine/hid/src/native/hid_native.cpp
+++ b/engine/hid/src/native/hid_native.cpp
@@ -185,6 +185,7 @@ namespace dmHID
                 return false;
             }
 
+            assert(context->m_Window && "No window has been set.");
             dmPlatform::SetKeyboardCharCallback(context->m_Window, GLFWAddKeyboardChar, (void*) context);
             dmPlatform::SetKeyboardMarkedTextCallback(context->m_Window, GLFWSetMarkedText, (void*) context);
             dmPlatform::SetKeyboardDeviceChangedCallback(context->m_Window, GLFWDeviceChangedCallback, (void*) context);

--- a/engine/tools/src/gdc/main.cpp
+++ b/engine/tools/src/gdc/main.cpp
@@ -102,6 +102,8 @@ int main(int argc, char *argv[])
     window_params.m_Height = 32;
     window_params.m_Title = "gdc";
     window_params.m_PrintDeviceInfo = false;
+    window_params.m_GraphicsApi = dmPlatform::PLATFORM_GRAPHICS_API_OPENGL;
+
     dmPlatform::HWindow window = dmPlatform::NewWindow();
     dmPlatform::OpenWindow(window, window_params);
 
@@ -118,6 +120,7 @@ int main(int argc, char *argv[])
     }
 
     g_HidContext = dmHID::NewContext(dmHID::NewContextParams());
+    dmHID::SetWindow(g_HidContext, window);
     dmHID::Init(g_HidContext);
 
 retry:


### PR DESCRIPTION
Fixed an issue where the GDC tool would crash immediately after starting. This is due to recent changes to our platform layer.

Fixes #8564 