### PR TITLE
Gamesys vertex attribute consolidation

### DIFF
--- a/editor/src/java/com/defold/libs/ParticleLibrary.java
+++ b/editor/src/java/com/defold/libs/ParticleLibrary.java
@@ -90,7 +90,7 @@ public class ParticleLibrary {
 
     public static native void Particle_Update(Pointer context, float dt, FetchAnimationCallback callback);
 
-    public static native int Particle_GenerateVertexData(Pointer context, float dt, Pointer instance, int emitterIndex, ParticleVertexAttributeInfos attributeInfos, Vector4 color, Buffer vb, int vbMaxSize, IntByReference outVbSize);
+    public static native int Particle_GenerateVertexData(Pointer context, float dt, Pointer instance, int emitterIndex, VertexAttributeInfos attributeInfos, Vector4 color, Buffer vb, int vbMaxSize, IntByReference outVbSize);
 
     public static native void Particle_RenderEmitter(Pointer context, Pointer instance, int emitterIndex, Pointer userContext, RenderInstanceCallback callback);
 
@@ -110,28 +110,31 @@ public class ParticleLibrary {
 
     public static native Pointer Particle_WriteAttributeToScratchBuffer(Pointer context, Buffer bytes, int byte_count);
 
-    public static class ParticleVertexAttributeInfo extends Structure {
+    public static class VertexAttributeInfo extends Structure {
         public long    nameHash;
         public int     semanticType;
+        public int     dataType;
         public int     coordinateSpace;
         public Pointer valuePtr;
         public int     valueByteSize;
+        public int     elementCount;
+        public boolean normalize;
 
         @Override
         protected List<String> getFieldOrder() {
-            return Arrays.asList("nameHash", "semanticType", "coordinateSpace", "valuePtr", "valueByteSize");
+            return Arrays.asList("nameHash", "semanticType", "dataType", "coordinateSpace", "valuePtr", "valueByteSize", "elementCount", "normalize");
         }
     }
 
-    public static class ParticleVertexAttributeInfos extends Structure {
-        public ParticleVertexAttributeInfos() {
+    public static class VertexAttributeInfos extends Structure {
+        public VertexAttributeInfos() {
             structSize = size();
         }
 
-        public ParticleVertexAttributeInfo[] infos = new ParticleVertexAttributeInfo[8]; // ==> dmGraphics::MAX_VERTEX_STREAM_COUNT
-        public int                           vertexStride;
-        public int                           numInfos;
-        public int                           structSize;
+        public VertexAttributeInfo[] infos = new VertexAttributeInfo[8]; // ==> dmGraphics::MAX_VERTEX_STREAM_COUNT
+        public int                   vertexStride;
+        public int                   numInfos;
+        public int                   structSize;
 
         @Override
         protected List<String> getFieldOrder() {

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -135,7 +135,7 @@ namespace dmGameSystem
         }
     }
 
-    static inline void FillAttribute(dmParticle::ParticleVertexAttributeInfo& info, dmhash_t name_hash, dmGraphics::VertexAttribute::SemanticType semantic_type, uint32_t element_count)
+    static inline void FillAttribute(dmGraphics::VertexAttributeInfo& info, dmhash_t name_hash, dmGraphics::VertexAttribute::SemanticType semantic_type, uint32_t element_count)
     {
         info.m_NameHash        = name_hash;
         info.m_SemanticType    = semantic_type;

--- a/engine/gamesys/src/gamesys/components/comp_gui_private.h
+++ b/engine/gamesys/src/gamesys/components/comp_gui_private.h
@@ -141,7 +141,7 @@ namespace dmGameSystem
         dmArray<BoxVertex>                       m_ClientVertexBuffer;
         dmGraphics::HTexture                     m_WhiteTexture;
         dmParticle::HParticleContext             m_ParticleContext;
-        dmParticle::ParticleVertexAttributeInfos m_ParticleAttributeInfos;
+        dmGraphics::VertexAttributeInfos         m_ParticleAttributeInfos;
         uint32_t                                 m_MaxParticleFXCount;
         uint32_t                                 m_MaxParticleCount;
         uint32_t                                 m_RenderedParticlesSize;

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -506,39 +506,6 @@ namespace dmGameSystem
         return false;
     }
 
-    static void FillAttributeInfos(dmRig::AttributeInfo* material_infos, uint32_t material_infos_count, const dmGraphics::VertexAttribute* attributes, uint32_t attribute_count, dmRig::AttributeInfo* attribute_infos)
-    {
-        for (int i = 0; i < material_infos_count; ++i)
-        {
-            int attribute_index        = FindAttributeIndex(attributes, attribute_count, material_infos[i].m_Attribute->m_NameHash);
-            dmRig::AttributeInfo& info = attribute_infos[i];
-            info.m_Attribute           = material_infos[i].m_Attribute;
-            info.m_ValuePtr            = material_infos[i].m_ValuePtr;
-            info.m_ValueByteSize       = material_infos[i].m_ValueByteSize;
-
-            if (attribute_index >= 0)
-            {
-                dmGraphics::GetAttributeValues(attributes[attribute_index], &info.m_ValuePtr, &info.m_ValueByteSize);
-            }
-        }
-    }
-
-    static uint32_t FillMaterialAttributeInfos(dmRender::HMaterial material, dmRig::AttributeInfo* infos)
-    {
-        const dmGraphics::VertexAttribute* attributes = 0;
-        uint32_t attributes_count                     = 0;
-        dmRender::GetMaterialProgramAttributes(material, &attributes, &attributes_count);
-        attributes_count = dmMath::Min(attributes_count, (uint32_t) dmGraphics::MAX_VERTEX_STREAM_COUNT);
-
-        for (int i = 0; i < attributes_count; ++i)
-        {
-            dmRig::AttributeInfo& info = infos[i];
-            info.m_Attribute = attributes + i;
-            dmRender::GetMaterialProgramAttributeValues(material, i, &info.m_ValuePtr, &info.m_ValueByteSize);
-        }
-        return attributes_count;
-    }
-
     static void SetupMeshAttributeRenderData(dmRender::HRenderContext render_context, dmRender::HMaterial material, const MeshRenderItem* render_item, dmGraphics::VertexAttribute* model_attributes, uint32_t model_attribute_count, MeshAttributeRenderData* rd)
     {
         assert(!rd->m_VertexBuffer);
@@ -548,32 +515,36 @@ namespace dmGameSystem
         dmGraphics::HVertexStreamDeclaration stream_declaration = dmGraphics::NewVertexStreamDeclaration(graphics_context);
         dmGraphics::HVertexDeclaration material_vx_decl         = dmRender::GetVertexDeclaration(material);
 
-        dmRig::AttributeInfo material_attributes[dmGraphics::MAX_VERTEX_STREAM_COUNT];
-        uint32_t material_attributes_count = FillMaterialAttributeInfos(material, material_attributes);
+        dmGraphics::VertexAttributeInfos material_infos;
+        FillMaterialAttributeInfos(material, material_vx_decl, &material_infos);
 
-        dmRig::AttributeInfo attributes[dmGraphics::MAX_VERTEX_STREAM_COUNT];
-        FillAttributeInfos(material_attributes, material_attributes_count, model_attributes, model_attribute_count, attributes);
+        dmGraphics::VertexAttributeInfos attribute_infos;
+        FillAttributeInfos(0, INVALID_DYNAMIC_ATTRIBUTE_INDEX, // Dynamic vertex attributes are not supported yet
+                    model_attributes,
+                    model_attribute_count,
+                    &material_infos,
+                    &attribute_infos);
 
         uint8_t* scratch_attribute_vertex = (uint8_t*) malloc(dmGraphics::GetVertexDeclarationStride(material_vx_decl));
         uint32_t custom_vertex_size       = 0;
 
-        for (int i = 0; i < material_attributes_count; ++i)
+        for (int i = 0; i < material_infos.m_NumInfos; ++i)
         {
-            const dmGraphics::VertexAttribute* attr = attributes[i].m_Attribute;
-            const dmGraphics::VertexAttribute* attr_material = material_attributes[i].m_Attribute;
+            const dmGraphics::VertexAttributeInfo& attr_material = material_infos.m_Infos[i];
+            const dmGraphics::VertexAttributeInfo& attr_model    = attribute_infos.m_Infos[i];
 
-            if (!IsDefaultStream(attr->m_NameHash, attr_material->m_SemanticType))
+            if (!IsDefaultStream(attr_model.m_NameHash, attr_material.m_SemanticType))
             {
-                assert(attr->m_NameHash == attr_material->m_NameHash);
+                assert(attr_model.m_NameHash == attr_material.m_NameHash);
                 dmGraphics::AddVertexStream(stream_declaration,
-                    attr->m_NameHash,
-                    attr_material->m_ElementCount, // Need the material attribute here to get the _actual_ element count
-                    dmGraphics::GetGraphicsType(attr->m_DataType),
-                    attr->m_Normalize);
+                    attr_model.m_NameHash,
+                    attr_material.m_ElementCount, // Need the material attribute here to get the _actual_ element count
+                    dmGraphics::GetGraphicsType(attr_model.m_DataType),
+                    attr_model.m_Normalize);
 
                 uint8_t* data_write_ptr = scratch_attribute_vertex + custom_vertex_size;
-                memcpy(data_write_ptr, attributes[i].m_ValuePtr, attributes[i].m_ValueByteSize);
-                custom_vertex_size += attributes[i].m_ValueByteSize;
+                memcpy(data_write_ptr, attr_model.m_ValuePtr, attr_model.m_ValueByteSize);
+                custom_vertex_size += attr_model.m_ValueByteSize;
             }
         }
 
@@ -873,8 +844,8 @@ namespace dmGameSystem
         dmRender::HMaterial material           = GetMaterial(component, component->m_Resource, material_index);
         dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
 
-        dmRig::AttributeInfo material_attributes[dmGraphics::MAX_VERTEX_STREAM_COUNT];
-        uint32_t material_attributes_count = FillMaterialAttributeInfos(material, material_attributes);
+        dmGraphics::VertexAttributeInfos material_infos;
+        FillMaterialAttributeInfos(material, vx_decl, &material_infos);
 
         uint32_t vertex_count = 0;
         uint32_t index_count = 0;
@@ -965,13 +936,14 @@ namespace dmGameSystem
                 // This should mean that we won't take a performance hit if we don't use attributes.
                 if (render_item->m_AttributeRenderDataIndex != ATTRIBUTE_RENDER_DATA_INDEX_UNUSED)
                 {
-                    dmRig::AttributeInfo attributes[dmGraphics::MAX_VERTEX_STREAM_COUNT];
-                    FillAttributeInfos(material_attributes, material_attributes_count,
+                    dmGraphics::VertexAttributeInfos attribute_infos;
+                    FillAttributeInfos(0, INVALID_DYNAMIC_ATTRIBUTE_INDEX, // Not supported yet
                         c->m_Resource->m_Model->m_Materials[material_index].m_Attributes.m_Data,
                         c->m_Resource->m_Model->m_Materials[material_index].m_Attributes.m_Count,
-                        attributes);
+                        &material_infos,
+                        &attribute_infos);
 
-                    vb_end = dmRig::GenerateVertexDataFromAttributes(world->m_RigContext, c->m_RigInstance, render_item->m_Mesh, world_matrix, attributes, material_attributes_count, vertex_stride, vb_end);
+                    vb_end = dmRig::GenerateVertexDataFromAttributes(world->m_RigContext, c->m_RigInstance, render_item->m_Mesh, world_matrix, &attribute_infos, vertex_stride, vb_end);
                 }
                 else
                 {

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -258,40 +258,6 @@ namespace dmGameSystem
         return dmGameObject::UPDATE_RESULT_OK;
     }
 
-    /*
-    static void FillEmitterAttributeInfos(const dmGraphics::VertexAttribute* attributes, uint32_t attributes_count, dmParticle::ParticleVertexAttributeInfos* infos)
-    {
-        for (int i = 0; i < infos->m_NumInfos; ++i)
-        {
-            int32_t emitter_attribute_index = FindAttributeIndex(attributes, attributes_count, infos->m_Infos[i].m_NameHash);
-            if (emitter_attribute_index >= 0)
-            {
-                infos->m_Infos[i].m_NameHash = attributes[emitter_attribute_index].m_NameHash;
-                dmGraphics::GetAttributeValues(attributes[emitter_attribute_index], (const uint8_t**) &infos->m_Infos[i].m_ValuePtr, &infos->m_Infos[i].m_ValueByteSize);
-            }
-        }
-    }
-
-    static void FillParticleMaterialAttributeInfos(dmRender::HMaterial material, dmParticle::ParticleVertexAttributeInfos* infos)
-    {
-        const dmGraphics::VertexAttribute* material_attributes;
-        uint32_t material_attributes_count;
-        dmRender::GetMaterialProgramAttributes(material, &material_attributes, &material_attributes_count);
-
-        infos->m_NumInfos     = dmMath::Min(material_attributes_count, (uint32_t) dmGraphics::MAX_VERTEX_STREAM_COUNT);
-        infos->m_VertexStride = dmGraphics::GetVertexDeclarationStride(dmRender::GetVertexDeclaration(material));
-
-        for (int i = 0; i < infos->m_NumInfos; ++i)
-        {
-            dmParticle::ParticleVertexAttributeInfo& info = infos->m_Infos[i];
-            infos->m_Infos[i].m_NameHash                  = material_attributes[i].m_NameHash;
-            infos->m_Infos[i].m_SemanticType              = material_attributes[i].m_SemanticType;
-            infos->m_Infos[i].m_CoordinateSpace           = material_attributes[i].m_CoordinateSpace;
-            dmRender::GetMaterialProgramAttributeValues(material, i, (const uint8_t**) &info.m_ValuePtr, &info.m_ValueByteSize);
-        }
-    }
-    */
-
     static void RenderBatch(ParticleFXWorld* pfx_world, dmRender::HRenderContext render_context, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("ParticleRenderBatch");
@@ -327,9 +293,6 @@ namespace dmGameSystem
         uint32_t vb_size      = vb_size_init;
         uint32_t vb_max_size  = pfx_world->m_VertexBufferData.Capacity();
 
-        // dmParticle::ParticleVertexAttributeInfos attribute_infos = {};
-        // FillParticleMaterialAttributeInfos(material_res->m_Material, &attribute_infos);
-
         dmGraphics::VertexAttributeInfos emitter_attribute_info = {};
         dmGraphics::VertexAttributeInfos material_attribute_info;
         FillMaterialAttributeInfos(material_res->m_Material, vx_decl, &material_attribute_info);
@@ -337,8 +300,6 @@ namespace dmGameSystem
         for (uint32_t *i = begin; i != end; ++i)
         {
             const dmParticle::EmitterRenderData* emitter_render_data = (dmParticle::EmitterRenderData*) buf[*i].m_UserData;
-
-            // FillEmitterAttributeInfos(emitter_render_data->m_Attributes, emitter_render_data->m_AttributeCount, &attribute_infos);
 
             FillAttributeInfos(0, INVALID_DYNAMIC_ATTRIBUTE_INDEX, // Not supported yet
                     emitter_render_data->m_Attributes,

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -258,6 +258,7 @@ namespace dmGameSystem
         return dmGameObject::UPDATE_RESULT_OK;
     }
 
+    /*
     static void FillEmitterAttributeInfos(const dmGraphics::VertexAttribute* attributes, uint32_t attributes_count, dmParticle::ParticleVertexAttributeInfos* infos)
     {
         for (int i = 0; i < infos->m_NumInfos; ++i)
@@ -289,6 +290,7 @@ namespace dmGameSystem
             dmRender::GetMaterialProgramAttributeValues(material, i, (const uint8_t**) &info.m_ValuePtr, &info.m_ValueByteSize);
         }
     }
+    */
 
     static void RenderBatch(ParticleFXWorld* pfx_world, dmRender::HRenderContext render_context, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
@@ -325,19 +327,28 @@ namespace dmGameSystem
         uint32_t vb_size      = vb_size_init;
         uint32_t vb_max_size  = pfx_world->m_VertexBufferData.Capacity();
 
-        dmParticle::ParticleVertexAttributeInfos attribute_infos = {};
+        // dmParticle::ParticleVertexAttributeInfos attribute_infos = {};
+        // FillParticleMaterialAttributeInfos(material_res->m_Material, &attribute_infos);
 
-        FillParticleMaterialAttributeInfos(material_res->m_Material, &attribute_infos);
+        dmGraphics::VertexAttributeInfos emitter_attribute_info = {};
+        dmGraphics::VertexAttributeInfos material_attribute_info;
+        FillMaterialAttributeInfos(material_res->m_Material, vx_decl, &material_attribute_info);
 
         for (uint32_t *i = begin; i != end; ++i)
         {
             const dmParticle::EmitterRenderData* emitter_render_data = (dmParticle::EmitterRenderData*) buf[*i].m_UserData;
 
-            FillEmitterAttributeInfos(emitter_render_data->m_Attributes, emitter_render_data->m_AttributeCount, &attribute_infos);
+            // FillEmitterAttributeInfos(emitter_render_data->m_Attributes, emitter_render_data->m_AttributeCount, &attribute_infos);
+
+            FillAttributeInfos(0, INVALID_DYNAMIC_ATTRIBUTE_INDEX, // Not supported yet
+                    emitter_render_data->m_Attributes,
+                    emitter_render_data->m_AttributeCount,
+                    &material_attribute_info,
+                    &emitter_attribute_info);
 
             dmParticle::GenerateVertexDataResult res = dmParticle::GenerateVertexData(particle_context,
                 pfx_world->m_DT, emitter_render_data->m_Instance, emitter_render_data->m_EmitterIndex,
-                attribute_infos, Vector4(1,1,1,1), (void*) vertex_buffer.Begin(), vb_max_size, &vb_size);
+                emitter_attribute_info, Vector4(1,1,1,1), (void*) vertex_buffer.Begin(), vb_max_size, &vb_size);
 
             if (res != dmParticle::GENERATE_VERTEX_DATA_OK)
             {
@@ -353,7 +364,7 @@ namespace dmGameSystem
             }
         }
 
-        uint32_t ro_vertex_count = (vb_size - vb_size_init) / attribute_infos.m_VertexStride;
+        uint32_t ro_vertex_count = (vb_size - vb_size_init) / material_attribute_info.m_VertexStride;
 
         vertex_buffer.SetSize(vb_size);
 

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -129,6 +129,7 @@ namespace dmGameSystem
         uint8_t                             m_ReallocBuffers : 1;
     };
 
+    /*
     struct SpriteAttributeInfo
     {
         struct Info
@@ -142,6 +143,7 @@ namespace dmGameSystem
         uint32_t m_NumInfos                  : 4; // dmGraphics::MAX_VERTEX_STREAM_COUNT is 8
         uint32_t m_HasLocalPositionAttribute : 1;
     };
+    */
 
     const uint32_t MAX_TEXTURE_COUNT = dmRender::RenderObject::MAX_TEXTURE_COUNT;
 
@@ -635,6 +637,7 @@ namespace dmGameSystem
         return dmGameObject::CREATE_RESULT_OK;
     }
 
+    /*
     // Prepares the list of sprite attributes that could potentially overrides an already specified material attribute
     static void FillSpriteAttributeInfos(DynamicAttributePool& dynamic_attribute_pool, const SpriteComponent* component, SpriteAttributeInfo* material_infos, SpriteAttributeInfo* sprite_infos)
     {
@@ -676,7 +679,9 @@ namespace dmGameSystem
             // 3. If all of the above failed, we fallback to using the material attribute instead
         }
     }
+    */
 
+    /*
     // Prepares the list of material attributes by getting all the vertex attributes and values for each attribute
     // as specified in the material
     static void FillMaterialAttributeInfos(dmRender::HMaterial material, dmGraphics::HVertexDeclaration vertex_declaration, SpriteAttributeInfo* infos)
@@ -701,17 +706,18 @@ namespace dmGameSystem
             }
         }
     }
+    */
 
     static void WriteSpriteVertex(uint8_t* vertices_write_ptr, uint32_t vertex_index,
         const Point3& p, const Point3& p_local, const Matrix4& w,
         uint32_t num_textures, dmArray<float>* uvs, uint32_t* page_indices,
-        const SpriteAttributeInfo* sprite_infos)
+        const dmGraphics::VertexAttributeInfos* sprite_infos)
     {
         uint32_t num_texcoords = 0;
         uint32_t num_page_indices = 0;
         for (int i = 0; i < sprite_infos->m_NumInfos; ++i)
         {
-            const SpriteAttributeInfo::Info* info = &sprite_infos->m_Infos[i];
+            const dmGraphics::VertexAttributeInfo* info = &sprite_infos->m_Infos[i];
             uint8_t* write_ptr = vertices_write_ptr + info->m_Offset;
 
             switch(info->m_Attribute->m_SemanticType)
@@ -789,7 +795,7 @@ namespace dmGameSystem
         const Matrix4& transform, Vector3 sprite_size, Vector4 slice9, uint32_t vertex_offset, uint32_t vertex_stride,
         TexturesData* textures, dmArray<float>* scratch_uvs,
         bool flip_u, bool flip_v,
-        SpriteAttributeInfo* sprite_infos)
+        dmGraphics::VertexAttributeInfos* sprite_infos)
     {
         // render 9-sliced node
         //   0 1     2 3
@@ -1166,7 +1172,7 @@ namespace dmGameSystem
         }
     }
 
-    static void CreateVertexData(SpriteWorld* sprite_world, SpriteAttributeInfo* material_attribute_info, uint32_t vertex_stride, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
+    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info, uint32_t vertex_stride, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("CreateVertexData");
 
@@ -1194,12 +1200,12 @@ namespace dmGameSystem
             textures.m_TextureSets[i] = textures.m_Resources[i]->m_TextureSet;
         }
 
-        SpriteAttributeInfo sprite_attribute_info = {};
+        dmGraphics::VertexAttributeInfos sprite_attribute_info = {};
 
         for (uint32_t* i = begin; i != end; ++i)
         {
-            uint32_t component_index                            = (uint32_t)buf[*i].m_UserData;
-            const SpriteComponent* component                    = (const SpriteComponent*) &components[component_index];
+            uint32_t component_index         = (uint32_t)buf[*i].m_UserData;
+            const SpriteComponent* component = (const SpriteComponent*) &components[component_index];
 
             float sp_width  = component->m_Size.getX();
             float sp_height = component->m_Size.getY();
@@ -1208,7 +1214,7 @@ namespace dmGameSystem
             ResolveAnimationData(&textures, component->m_CurrentAnimation, component->m_CurrentAnimationFrame);
 
             // Fill in the custom sprite attributes (if specified), otherwise fallback to use the material attributes
-            SpriteAttributeInfo* sprite_attribute_info_ptr = material_attribute_info;
+            dmGraphics::VertexAttributeInfos* sprite_attribute_info_ptr = material_attribute_info;
             if (component->m_Resource->m_DDF->m_Attributes.m_Count > 0 || component->m_DynamicVertexAttributeIndex != INVALID_DYNAMIC_ATTRIBUTE_INDEX)
             {
                 FillSpriteAttributeInfos(sprite_world->m_DynamicVertexAttributePool, component, material_attribute_info, &sprite_attribute_info);
@@ -1411,7 +1417,7 @@ namespace dmGameSystem
         dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
         uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
 
-        SpriteAttributeInfo material_attribute_info;
+        dmGraphics::VertexAttributeInfos material_attribute_info;
         FillMaterialAttributeInfos(material, vx_decl, &material_attribute_info);
 
         // Fill in vertex buffer

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -129,22 +129,6 @@ namespace dmGameSystem
         uint8_t                             m_ReallocBuffers : 1;
     };
 
-    /*
-    struct SpriteAttributeInfo
-    {
-        struct Info
-        {
-            const dmGraphics::VertexAttribute* m_Attribute;
-            const uint8_t*                     m_ValuePtr;
-            uint32_t                           m_ValueByteSize;
-            uint32_t                           m_Offset; // Offset into the vertex
-        } m_Infos[dmGraphics::MAX_VERTEX_STREAM_COUNT];
-
-        uint32_t m_NumInfos                  : 4; // dmGraphics::MAX_VERTEX_STREAM_COUNT is 8
-        uint32_t m_HasLocalPositionAttribute : 1;
-    };
-    */
-
     const uint32_t MAX_TEXTURE_COUNT = dmRender::RenderObject::MAX_TEXTURE_COUNT;
 
     struct TexturesData
@@ -637,77 +621,6 @@ namespace dmGameSystem
         return dmGameObject::CREATE_RESULT_OK;
     }
 
-    /*
-    // Prepares the list of sprite attributes that could potentially overrides an already specified material attribute
-    static void FillSpriteAttributeInfos(DynamicAttributePool& dynamic_attribute_pool, const SpriteComponent* component, SpriteAttributeInfo* material_infos, SpriteAttributeInfo* sprite_infos)
-    {
-        const dmGraphics::VertexAttribute* sprite_resource_attributes = component->m_Resource->m_DDF->m_Attributes.m_Data;
-        const uint32_t sprite_resource_attribute_count = component->m_Resource->m_DDF->m_Attributes.m_Count;
-
-        sprite_infos->m_NumInfos = material_infos->m_NumInfos;
-
-        for (int i = 0; i < material_infos->m_NumInfos; ++i)
-        {
-            dmhash_t name_hash       = material_infos->m_Infos[i].m_Attribute->m_NameHash;
-            sprite_infos->m_Infos[i] = material_infos->m_Infos[i];
-
-            // 1. Fill from dynamic attributes first
-            if (component->m_DynamicVertexAttributeIndex != INVALID_DYNAMIC_ATTRIBUTE_INDEX)
-            {
-                const DynamicAttributeInfo& dynamic_info = dynamic_attribute_pool.Get(component->m_DynamicVertexAttributeIndex);
-                int32_t dynamic_attribute_index = FindMaterialAttributeIndex(dynamic_info, name_hash);
-                if (dynamic_attribute_index >= 0)
-                {
-                    // TODO: We should optimally use converted values for this as well,
-                    //       but since we are not converting any other attribute value
-                    //       we will wait with that a bit.
-                    GetMaterialAttributeValues(dynamic_info, dynamic_attribute_index,
-                        material_infos->m_Infos[i].m_ValueByteSize,
-                        &sprite_infos->m_Infos[i].m_ValuePtr,
-                        &sprite_infos->m_Infos[i].m_ValueByteSize);
-                    continue;
-                }
-            }
-                
-            // 2. If that failed, we try to fill from the resource attribute
-            int sprite_attribute_index = FindAttributeIndex(sprite_resource_attributes, sprite_resource_attribute_count, name_hash);
-            if (sprite_attribute_index >= 0)
-            {
-                dmGraphics::GetAttributeValues(sprite_resource_attributes[sprite_attribute_index], &sprite_infos->m_Infos[i].m_ValuePtr, &sprite_infos->m_Infos[i].m_ValueByteSize);
-            }
-
-            // 3. If all of the above failed, we fallback to using the material attribute instead
-        }
-    }
-    */
-
-    /*
-    // Prepares the list of material attributes by getting all the vertex attributes and values for each attribute
-    // as specified in the material
-    static void FillMaterialAttributeInfos(dmRender::HMaterial material, dmGraphics::HVertexDeclaration vertex_declaration, SpriteAttributeInfo* infos)
-    {
-        const dmGraphics::VertexAttribute* material_attributes;
-        uint32_t material_attributes_count;
-        dmRender::GetMaterialProgramAttributes(material, &material_attributes, &material_attributes_count);
-
-        infos->m_NumInfos = dmMath::Min(material_attributes_count, (uint32_t) dmGraphics::MAX_VERTEX_STREAM_COUNT);
-        for (int i = 0; i < infos->m_NumInfos; ++i)
-        {
-            SpriteAttributeInfo::Info& info = infos->m_Infos[i];
-            info.m_Attribute                = material_attributes + i;
-            dmRender::GetMaterialProgramAttributeValues(material, i, &info.m_ValuePtr, &info.m_ValueByteSize);
-
-            info.m_Offset = dmGraphics::GetVertexStreamOffset(vertex_declaration, info.m_Attribute->m_NameHash);
-
-            if (info.m_Attribute->m_SemanticType    == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION &&
-                info.m_Attribute->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
-            {
-                infos->m_HasLocalPositionAttribute = 1;
-            }
-        }
-    }
-    */
-
     static void WriteSpriteVertex(uint8_t* vertices_write_ptr, uint32_t vertex_index,
         const Point3& p, const Point3& p_local, const Matrix4& w,
         uint32_t num_textures, dmArray<float>* uvs, uint32_t* page_indices,
@@ -715,23 +628,23 @@ namespace dmGameSystem
     {
         uint32_t num_texcoords = 0;
         uint32_t num_page_indices = 0;
+
         for (int i = 0; i < sprite_infos->m_NumInfos; ++i)
         {
             const dmGraphics::VertexAttributeInfo* info = &sprite_infos->m_Infos[i];
-            uint8_t* write_ptr = vertices_write_ptr + info->m_Offset;
 
-            switch(info->m_Attribute->m_SemanticType)
+            switch(info->m_SemanticType)
             {
                 case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
                 {
-                    if (info->m_Attribute->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD)
+                    if (info->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD)
                     {
                         Vector4 wp = w * p;
-                        memcpy(write_ptr, &wp, info->m_ValueByteSize);
+                        memcpy(vertices_write_ptr, &wp, info->m_ValueByteSize);
                     }
-                    else if (info->m_Attribute->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+                    else if (info->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
                     {
-                        memcpy(write_ptr, &p_local, info->m_ValueByteSize);
+                        memcpy(vertices_write_ptr, &p_local, info->m_ValueByteSize);
                     }
                     else assert(0);
                 } break;
@@ -740,26 +653,21 @@ namespace dmGameSystem
                     uint32_t unit = num_texcoords++;
                     if (unit >= num_textures)
                         unit = 0;
-                    memcpy(write_ptr, uvs[unit].Begin()+vertex_index*2, info->m_ValueByteSize);
+                    memcpy(vertices_write_ptr, uvs[unit].Begin()+vertex_index*2, info->m_ValueByteSize);
                 } break;
                 case dmGraphics::VertexAttribute::SEMANTIC_TYPE_PAGE_INDEX:
                 {
                     uint32_t unit = num_page_indices++;
                     float page_index = (float) page_indices[unit];
-
-                    if (info->m_Attribute->m_DataType != dmGraphics::VertexAttribute::TYPE_FLOAT)
-                    {
-                        dmLogOnceError("Unsupported data type for attribute %s, Data conversion is not yet supported for vertex attributes.",
-                            info->m_Attribute->m_Name);
-                    }
-
-                    memcpy(write_ptr, &page_index, info->m_ValueByteSize);
+                    memcpy(vertices_write_ptr, &page_index, info->m_ValueByteSize);
                 } break;
                 default:
                 {
-                    memcpy(write_ptr, info->m_ValuePtr, info->m_ValueByteSize);
+                    memcpy(vertices_write_ptr, info->m_ValuePtr, info->m_ValueByteSize);
                 } break;
             }
+
+            vertices_write_ptr += info->m_ValueByteSize;
         }
     }
 
@@ -791,7 +699,7 @@ namespace dmGameSystem
         }
     }
 
-    static void CreateVertexDataSlice9(uint8_t* vertices, uint8_t* indices, bool is_indices_16_bit,
+    static void CreateVertexDataSlice9(uint8_t* vertices, uint8_t* indices, bool is_indices_16_bit, bool has_local_position_attribute,
         const Matrix4& transform, Vector3 sprite_size, Vector4 slice9, uint32_t vertex_offset, uint32_t vertex_stride,
         TexturesData* textures, dmArray<float>* scratch_uvs,
         bool flip_u, bool flip_v,
@@ -911,7 +819,7 @@ namespace dmGameSystem
             {
                 Point3 p = Point3(xs[x] - 0.5, ys[y] - 0.5, 0);
                 Point3 p_local;
-                if (sprite_infos->m_HasLocalPositionAttribute)
+                if (has_local_position_attribute)
                 {
                     p_local = Point3(p.getX() * sprite_size.getX(), p.getY() * sprite_size.getY(), 0.0f);
                 }
@@ -1172,7 +1080,7 @@ namespace dmGameSystem
         }
     }
 
-    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info, uint32_t vertex_stride, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
+    static void CreateVertexData(SpriteWorld* sprite_world, dmGraphics::VertexAttributeInfos* material_attribute_info, bool has_local_position_attribute, uint8_t** vb_where, uint8_t** ib_where, dmRender::RenderListEntry* buf, uint32_t* begin, uint32_t* end)
     {
         DM_PROFILE("CreateVertexData");
 
@@ -1184,6 +1092,7 @@ namespace dmGameSystem
 
         // The offset for the indices
         uint32_t vertex_offset = sprite_world->m_VerticesWritten;
+        uint32_t vertex_stride = material_attribute_info->m_VertexStride;
 
         uint32_t component_index = (uint32_t)buf[*begin].m_UserData;
         const SpriteComponent* first = (const SpriteComponent*) &sprite_world->m_Components.GetRawObjects()[component_index];
@@ -1217,7 +1126,13 @@ namespace dmGameSystem
             dmGraphics::VertexAttributeInfos* sprite_attribute_info_ptr = material_attribute_info;
             if (component->m_Resource->m_DDF->m_Attributes.m_Count > 0 || component->m_DynamicVertexAttributeIndex != INVALID_DYNAMIC_ATTRIBUTE_INDEX)
             {
-                FillSpriteAttributeInfos(sprite_world->m_DynamicVertexAttributePool, component, material_attribute_info, &sprite_attribute_info);
+                FillAttributeInfos(&sprite_world->m_DynamicVertexAttributePool,
+                    component->m_DynamicVertexAttributeIndex,
+                    component->m_Resource->m_DDF->m_Attributes.m_Data,
+                    component->m_Resource->m_DDF->m_Attributes.m_Count,
+                    material_attribute_info,
+                    &sprite_attribute_info);
+
                 sprite_attribute_info_ptr = &sprite_attribute_info;
             }
 
@@ -1259,7 +1174,7 @@ namespace dmGameSystem
                     Point3 p = Point3(x, y, 0.0f);
                     Point3 p_local;
 
-                    if (sprite_attribute_info_ptr->m_HasLocalPositionAttribute)
+                    if (has_local_position_attribute)
                     {
                         p_local = Point3(x * sp_width, y * sp_height, 0.0f);
                     }
@@ -1311,7 +1226,7 @@ namespace dmGameSystem
                 {
                     int flipx = component->m_FlipHorizontal;
                     int flipy = component->m_FlipVertical;
-                    CreateVertexDataSlice9(vertices, indices, sprite_world->m_Is16BitIndex,
+                    CreateVertexDataSlice9(vertices, indices, sprite_world->m_Is16BitIndex, has_local_position_attribute,
                         w, component->m_Size, component->m_Resource->m_DDF->m_Slice9, vertex_offset, vertex_stride,
                         &textures, scratch_uvs, flipx, flipy, sprite_attribute_info_ptr);
 
@@ -1338,7 +1253,7 @@ namespace dmGameSystem
                     Point3 p2_local;
                     Point3 p3_local;
 
-                    if (sprite_attribute_info_ptr->m_HasLocalPositionAttribute)
+                    if (has_local_position_attribute)
                     {
                         p0_local = Point3(-0.5f * sp_width, -0.5f * sp_height, 0.0f);
                         p1_local = Point3(-0.5f * sp_width,  0.5f * sp_height, 0.0f);
@@ -1415,7 +1330,6 @@ namespace dmGameSystem
         MaterialResource*   material_resource  = GetMaterialResource(first);
         dmRender::HMaterial material           = material_resource->m_Material;
         dmGraphics::HVertexDeclaration vx_decl = dmRender::GetVertexDeclaration(material);
-        uint32_t vertex_stride                 = dmGraphics::GetVertexDeclarationStride(vx_decl);
 
         dmGraphics::VertexAttributeInfos material_attribute_info;
         FillMaterialAttributeInfos(material, vx_decl, &material_attribute_info);
@@ -1425,7 +1339,7 @@ namespace dmGameSystem
         uint8_t* ib_begin = (uint8_t*)sprite_world->m_IndexBufferWritePtr;
         uint8_t* vb_iter  = vb_begin;
         uint8_t* ib_iter  = ib_begin;
-        CreateVertexData(sprite_world, &material_attribute_info, vertex_stride, &vb_iter, &ib_iter, buf, begin, end);
+        CreateVertexData(sprite_world, &material_attribute_info, dmGraphics::HasLocalPositionAttribute(material_attribute_info), &vb_iter, &ib_iter, buf, begin, end);
 
         sprite_world->m_VertexBufferWritePtr = vb_iter;
         sprite_world->m_IndexBufferWritePtr = ib_iter;

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -98,9 +98,6 @@ namespace dmGameSystem
     dmRender::RenderResourceType ResourcePathToRenderResourceType(const char* path);
 
     // Vertex attributes
-    int32_t FindAttributeIndex(const dmGraphics::VertexAttribute* attributes, uint32_t attributes_count, dmhash_t name_hash);
-
-    // Dynamic Vertex Attribute
     static const uint16_t INVALID_DYNAMIC_ATTRIBUTE_INDEX  = 0xFFFF;
     static const uint8_t  DYNAMIC_ATTRIBUTE_INCREASE_COUNT = 1;
 
@@ -118,6 +115,10 @@ namespace dmGameSystem
 
     typedef dmObjectPool<DynamicAttributeInfo> DynamicAttributePool;
     typedef bool (*CompGetMaterialAttributeCallback)(void* user_data, dmhash_t name_hash, const dmGraphics::VertexAttribute** attribute);
+
+    int32_t FindAttributeIndex(const dmGraphics::VertexAttribute* attributes, uint32_t attributes_count, dmhash_t name_hash);
+    void    FillMaterialAttributeInfos(dmRender::HMaterial material, dmGraphics::HVertexDeclaration vx_decl, dmGraphics::VertexAttributeInfos* infos);
+    void    FillAttributeInfos(DynamicAttributePool* dynamic_attribute_pool, uint16_t component_dynamic_attribute_index, const dmGraphics::VertexAttribute* component_attributes, uint32_t num_component_attributes, dmGraphics::VertexAttributeInfos* material_infos, dmGraphics::VertexAttributeInfos* component_infos);
 
     int32_t                      FindMaterialAttributeIndex(const DynamicAttributeInfo& info, dmhash_t name_hash);
     void                         GetMaterialAttributeValues(const DynamicAttributeInfo& info, uint32_t dynamic_attribute_index, uint32_t max_value_size, const uint8_t** value_ptr, uint32_t* value_size);

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -416,6 +416,112 @@ namespace dmGraphics
         *data_size = attribute.m_Values.m_BinaryValues.m_Count;
     }
 
+    /*
+    static void WriteSpriteVertex(uint8_t* vertices_write_ptr, uint32_t vertex_index,
+        const Point3& p, const Point3& p_local, const Matrix4& w,
+        uint32_t num_textures, dmArray<float>* uvs, uint32_t* page_indices,
+        const dmGraphics::VertexAttributeInfos* sprite_infos)
+    {
+        uint32_t num_texcoords = 0;
+        uint32_t num_page_indices = 0;
+
+        for (int i = 0; i < sprite_infos->m_NumInfos; ++i)
+        {
+            const dmGraphics::VertexAttributeInfo* info = &sprite_infos->m_Infos[i];
+
+            switch(info->m_SemanticType)
+            {
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
+                {
+                    if (info->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD)
+                    {
+                        Vector4 wp = w * p;
+                        memcpy(vertices_write_ptr, &wp, info->m_ValueByteSize);
+                    }
+                    else if (info->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+                    {
+                        memcpy(vertices_write_ptr, &p_local, info->m_ValueByteSize);
+                    }
+                    else assert(0);
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
+                {
+                    uint32_t unit = num_texcoords++;
+                    if (unit >= num_textures)
+                        unit = 0;
+                    memcpy(vertices_write_ptr, uvs[unit].Begin()+vertex_index*2, info->m_ValueByteSize);
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_PAGE_INDEX:
+                {
+                    uint32_t unit = num_page_indices++;
+                    float page_index = (float) page_indices[unit];
+                    memcpy(vertices_write_ptr, &page_index, info->m_ValueByteSize);
+                } break;
+                default:
+                {
+                    memcpy(vertices_write_ptr, info->m_ValuePtr, info->m_ValueByteSize);
+                } break;
+            }
+
+            vertices_write_ptr += info->m_ValueByteSize;
+        }
+    }
+    */
+
+    uint8_t* WriteAttribute(const VertexAttributeInfos* attribute_infos, uint8_t* write_ptr, uint32_t vertex_index, const dmVMath::Matrix4& world_transform, const dmVMath::Vector3& p, const dmVMath::Vector3& p_local, const dmVMath::Vector4& color, float** uvs, uint32_t* page_indices, uint32_t num_textures)
+    {
+        uint32_t num_texcoords = 0;
+        uint32_t num_page_indices = 0;
+
+        for (int i = 0; i < attribute_infos->m_NumInfos; ++i)
+        {
+            const VertexAttributeInfo& info = attribute_infos->m_Infos[i];
+
+            switch(info.m_SemanticType)
+            {
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
+                {
+                    if (info.m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD)
+                    {
+                        dmVMath::Vector4 wp = world_transform * p;
+                        memcpy(write_ptr, &wp, info.m_ValueByteSize);
+                    }
+                    else if (info.m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+                    {
+                        memcpy(write_ptr, &p_local, info.m_ValueByteSize);
+                    }
+                    else assert(0);
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
+                {
+                    uint32_t unit = num_texcoords++;
+                    if (unit >= num_textures)
+                        unit = 0;
+                    memcpy(write_ptr, uvs[unit] + vertex_index * 2, info.m_ValueByteSize);
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_COLOR:
+                {
+                    memcpy(write_ptr, &color, info.m_ValueByteSize);
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_PAGE_INDEX:
+                {
+                    uint32_t unit = num_page_indices++;
+                    float page_index = (float) page_indices[unit];
+                    memcpy(write_ptr, &page_index, info.m_ValueByteSize);
+                } break;
+                default:
+                {
+                    assert(info.m_ValuePtr);
+                    memcpy(write_ptr, info.m_ValuePtr, info.m_ValueByteSize);
+                } break;
+            }
+
+            write_ptr += info.m_ValueByteSize;
+        }
+
+        return write_ptr;
+    }
+
     dmGraphics::Type GetGraphicsType(dmGraphics::VertexAttribute::DataType data_type)
     {
         switch(data_type)

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -416,59 +416,7 @@ namespace dmGraphics
         *data_size = attribute.m_Values.m_BinaryValues.m_Count;
     }
 
-    /*
-    static void WriteSpriteVertex(uint8_t* vertices_write_ptr, uint32_t vertex_index,
-        const Point3& p, const Point3& p_local, const Matrix4& w,
-        uint32_t num_textures, dmArray<float>* uvs, uint32_t* page_indices,
-        const dmGraphics::VertexAttributeInfos* sprite_infos)
-    {
-        uint32_t num_texcoords = 0;
-        uint32_t num_page_indices = 0;
-
-        for (int i = 0; i < sprite_infos->m_NumInfos; ++i)
-        {
-            const dmGraphics::VertexAttributeInfo* info = &sprite_infos->m_Infos[i];
-
-            switch(info->m_SemanticType)
-            {
-                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
-                {
-                    if (info->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD)
-                    {
-                        Vector4 wp = w * p;
-                        memcpy(vertices_write_ptr, &wp, info->m_ValueByteSize);
-                    }
-                    else if (info->m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
-                    {
-                        memcpy(vertices_write_ptr, &p_local, info->m_ValueByteSize);
-                    }
-                    else assert(0);
-                } break;
-                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
-                {
-                    uint32_t unit = num_texcoords++;
-                    if (unit >= num_textures)
-                        unit = 0;
-                    memcpy(vertices_write_ptr, uvs[unit].Begin()+vertex_index*2, info->m_ValueByteSize);
-                } break;
-                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_PAGE_INDEX:
-                {
-                    uint32_t unit = num_page_indices++;
-                    float page_index = (float) page_indices[unit];
-                    memcpy(vertices_write_ptr, &page_index, info->m_ValueByteSize);
-                } break;
-                default:
-                {
-                    memcpy(vertices_write_ptr, info->m_ValuePtr, info->m_ValueByteSize);
-                } break;
-            }
-
-            vertices_write_ptr += info->m_ValueByteSize;
-        }
-    }
-    */
-
-    uint8_t* WriteAttribute(const VertexAttributeInfos* attribute_infos, uint8_t* write_ptr, uint32_t vertex_index, const dmVMath::Matrix4& world_transform, const dmVMath::Vector3& p, const dmVMath::Vector3& p_local, const dmVMath::Vector4& color, float** uvs, uint32_t* page_indices, uint32_t num_textures)
+    uint8_t* WriteAttribute(const VertexAttributeInfos* attribute_infos, uint8_t* write_ptr, uint32_t vertex_index, const dmVMath::Matrix4* world_transform, const dmVMath::Point3& p, const dmVMath::Point3& p_local, const dmVMath::Vector4& color, float** uvs, uint32_t* page_indices, uint32_t num_textures)
     {
         uint32_t num_texcoords = 0;
         uint32_t num_page_indices = 0;
@@ -481,16 +429,15 @@ namespace dmGraphics
             {
                 case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
                 {
-                    if (info.m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD)
+                    if (info.m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_WORLD && world_transform)
                     {
-                        dmVMath::Vector4 wp = world_transform * p;
+                        dmVMath::Vector4 wp = *world_transform * p;
                         memcpy(write_ptr, &wp, info.m_ValueByteSize);
                     }
-                    else if (info.m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+                    else
                     {
                         memcpy(write_ptr, &p_local, info.m_ValueByteSize);
                     }
-                    else assert(0);
                 } break;
                 case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
                 {

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -357,7 +357,7 @@ namespace dmGraphics
             m_StructSize = sizeof(*this);
         }
 
-        VertexAttributeInfo m_Infos[dmGraphics::MAX_VERTEX_STREAM_COUNT];
+        VertexAttributeInfo m_Infos[MAX_VERTEX_STREAM_COUNT];
         uint32_t            m_VertexStride;
         uint32_t            m_NumInfos;
         uint32_t            m_StructSize;
@@ -576,8 +576,9 @@ namespace dmGraphics
     // Attributes
     uint32_t         GetAttributeCount(HProgram prog);
     void             GetAttribute(HProgram prog, uint32_t index, dmhash_t* name_hash, Type* type, uint32_t* element_count, uint32_t* num_values, int32_t* location);
-    void             GetAttributeValues(const dmGraphics::VertexAttribute& attribute, const uint8_t** data_ptr, uint32_t* data_size);
-    dmGraphics::Type GetGraphicsType(dmGraphics::VertexAttribute::DataType data_type);
+    void             GetAttributeValues(const VertexAttribute& attribute, const uint8_t** data_ptr, uint32_t* data_size);
+    Type             GetGraphicsType(VertexAttribute::DataType data_type);
+    uint8_t*         WriteAttribute(const VertexAttributeInfos* attribute_infos, uint8_t* write_ptr, uint32_t vertex_index, const dmVMath::Matrix4& world_transform, const dmVMath::Vector3& p, const dmVMath::Vector3& p_local, const dmVMath::Vector4& color, float** uvs, uint32_t* page_indices, uint32_t num_textures);
 
     uint32_t         GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
     uint32_t         GetUniformCount(HProgram prog);
@@ -690,12 +691,12 @@ namespace dmGraphics
                buffer_type == BUFFER_TYPE_COLOR3_BIT;
     }
 
-    static inline bool HasLocalPositionAttribute(const dmGraphics::VertexAttributeInfos& attribute_infos)
+    static inline bool HasLocalPositionAttribute(const VertexAttributeInfos& attribute_infos)
     {
         for (int i = 0; i < attribute_infos.m_NumInfos; ++i)
         {
-            if (attribute_infos.m_Infos[i].m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION &&
-                attribute_infos.m_Infos[i].m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+            if (attribute_infos.m_Infos[i].m_SemanticType == VertexAttribute::SEMANTIC_TYPE_POSITION &&
+                attribute_infos.m_Infos[i].m_CoordinateSpace == COORDINATE_SPACE_LOCAL)
             {
                 return true;
             }
@@ -717,7 +718,7 @@ namespace dmGraphics
      * @param format dmGraphics::TextureImage::CompressionType
      * @return true if the format is compressed
      */
-    bool IsFormatTranscoded(dmGraphics::TextureImage::CompressionType format);
+    bool IsFormatTranscoded(TextureImage::CompressionType format);
 
     /** checks if the texture format is compressed
      * @name Transcode
@@ -739,7 +740,7 @@ namespace dmGraphics
      */
     void ReadPixels(HContext context, void* buffer, uint32_t buffer_size);
 
-    uint32_t GetTypeSize(dmGraphics::Type type);
+    uint32_t GetTypeSize(Type type);
 
     // Both experimental + tests only:
     void* MapVertexBuffer(HContext context, HVertexBuffer buffer, BufferAccess access);

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -342,9 +342,12 @@ namespace dmGraphics
     {
         dmhash_t                      m_NameHash;
         VertexAttribute::SemanticType m_SemanticType;
+        VertexAttribute::DataType     m_DataType;
         CoordinateSpace               m_CoordinateSpace;
         const uint8_t*                m_ValuePtr;
         uint32_t                      m_ValueByteSize;
+        uint32_t                      m_ElementCount;
+        bool                          m_Normalize;
     };
 
     struct VertexAttributeInfos
@@ -685,6 +688,19 @@ namespace dmGraphics
                buffer_type == BUFFER_TYPE_COLOR1_BIT ||
                buffer_type == BUFFER_TYPE_COLOR2_BIT ||
                buffer_type == BUFFER_TYPE_COLOR3_BIT;
+    }
+
+    static inline bool HasLocalPositionAttribute(const dmGraphics::VertexAttributeInfos& attribute_infos)
+    {
+        for (int i = 0; i < attribute_infos.m_NumInfos; ++i)
+        {
+            if (attribute_infos.m_Infos[i].m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION &&
+                attribute_infos.m_Infos[i].m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -578,7 +578,7 @@ namespace dmGraphics
     void             GetAttribute(HProgram prog, uint32_t index, dmhash_t* name_hash, Type* type, uint32_t* element_count, uint32_t* num_values, int32_t* location);
     void             GetAttributeValues(const VertexAttribute& attribute, const uint8_t** data_ptr, uint32_t* data_size);
     Type             GetGraphicsType(VertexAttribute::DataType data_type);
-    uint8_t*         WriteAttribute(const VertexAttributeInfos* attribute_infos, uint8_t* write_ptr, uint32_t vertex_index, const dmVMath::Matrix4& world_transform, const dmVMath::Vector3& p, const dmVMath::Vector3& p_local, const dmVMath::Vector4& color, float** uvs, uint32_t* page_indices, uint32_t num_textures);
+    uint8_t*         WriteAttribute(const VertexAttributeInfos* attribute_infos, uint8_t* write_ptr, uint32_t vertex_index, const dmVMath::Matrix4* world_transform, const dmVMath::Point3& p, const dmVMath::Point3& p_local, const dmVMath::Vector4& color, float** uvs, uint32_t* page_indices, uint32_t num_textures);
 
     uint32_t         GetUniformName(HProgram prog, uint32_t index, char* buffer, uint32_t buffer_size, Type* type, int32_t* size);
     uint32_t         GetUniformCount(HProgram prog);

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -338,6 +338,28 @@ namespace dmGraphics
         uint64_t m_PolygonOffsetFillEnabled : 1;
     };
 
+    struct VertexAttributeInfo
+    {
+        dmhash_t                      m_NameHash;
+        VertexAttribute::SemanticType m_SemanticType;
+        CoordinateSpace               m_CoordinateSpace;
+        const uint8_t*                m_ValuePtr;
+        uint32_t                      m_ValueByteSize;
+    };
+
+    struct VertexAttributeInfos
+    {
+        VertexAttributeInfos()
+        {
+            m_StructSize = sizeof(*this);
+        }
+
+        VertexAttributeInfo m_Infos[dmGraphics::MAX_VERTEX_STREAM_COUNT];
+        uint32_t            m_VertexStride;
+        uint32_t            m_NumInfos;
+        uint32_t            m_StructSize;
+    };
+
     /** Creates a graphics context
      * Currently, there can only be one context active at a time.
      * @return New graphics context

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -1032,6 +1032,7 @@ namespace dmParticle
         particle->m_SourceAngularVelocity = emitter_properties[EMITTER_KEY_PARTICLE_ANGULAR_VELOCITY];
     }
 
+    // TODO: Use the shared dmGraphics function instead of this (needs to solve dynamic library linking for the particle library)
     static uint8_t* WriteParticleVertex(const dmGraphics::VertexAttributeInfos& attribute_infos, uint8_t* write_ptr, const Vector3& p, const Vector3& p_local, const Vector4& color, float* uv, float page_index)
     {
         for (int i = 0; i < attribute_infos.m_NumInfos; ++i)

--- a/engine/particle/src/particle.cpp
+++ b/engine/particle/src/particle.cpp
@@ -599,7 +599,7 @@ namespace dmParticle
     static void UpdateEmitterState(Instance* instance, Emitter* emitter, EmitterPrototype* emitter_prototype, dmParticleDDF::Emitter* emitter_ddf, float dt);
     static void EvaluateEmitterProperties(Emitter* emitter, Property* emitter_properties, float duration, float properties[EMITTER_KEY_COUNT]);
     static void EvaluateParticleProperties(Emitter* emitter, Property* particle_properties, dmParticleDDF::Emitter* emitter_ddf, float dt);
-    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf, const ParticleVertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt);
+    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf, const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt);
     static void GenerateKeys(Emitter* emitter, float max_particle_life_time);
     static void SortParticles(Emitter* emitter);
     static void Simulate(Instance* instance, Emitter* emitter, EmitterPrototype* prototype, dmParticleDDF::Emitter* ddf, float dt);
@@ -640,9 +640,9 @@ namespace dmParticle
         emitter->m_LastPosition = world_position;
     }
 
-    GenerateVertexDataResult GenerateVertexData(HParticleContext context, float dt, HInstance instance, uint32_t emitter_index,  const ParticleVertexAttributeInfos& attribute_infos, const Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size)
+    GenerateVertexDataResult GenerateVertexData(HParticleContext context, float dt, HInstance instance, uint32_t emitter_index,  const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size)
     {
-        assert(attribute_infos.m_StructSize == sizeof(ParticleVertexAttributeInfos));
+        assert(attribute_infos.m_StructSize == sizeof(dmGraphics::VertexAttributeInfos));
         assert(attribute_infos.m_VertexStride != 0);
 
         DM_PROFILE(__FUNCTION__);
@@ -1032,24 +1032,11 @@ namespace dmParticle
         particle->m_SourceAngularVelocity = emitter_properties[EMITTER_KEY_PARTICLE_ANGULAR_VELOCITY];
     }
 
-    static inline bool HasLocalPositionAttribute(const ParticleVertexAttributeInfos& attribute_infos)
+    static uint8_t* WriteParticleVertex(const dmGraphics::VertexAttributeInfos& attribute_infos, uint8_t* write_ptr, const Vector3& p, const Vector3& p_local, const Vector4& color, float* uv, float page_index)
     {
         for (int i = 0; i < attribute_infos.m_NumInfos; ++i)
         {
-            if (attribute_infos.m_Infos[i].m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION &&
-                attribute_infos.m_Infos[i].m_CoordinateSpace == dmGraphics::COORDINATE_SPACE_LOCAL)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static uint8_t* WriteParticleVertex(const ParticleVertexAttributeInfos& attribute_infos, uint8_t* write_ptr, const Vector3& p, const Vector3& p_local, const Vector4& color, float* uv, float page_index)
-    {
-        for (int i = 0; i < attribute_infos.m_NumInfos; ++i)
-        {
-            const ParticleVertexAttributeInfo& info = attribute_infos.m_Infos[i];
+            const dmGraphics::VertexAttributeInfo& info = attribute_infos.m_Infos[i];
 
             switch(info.m_SemanticType)
             {
@@ -1097,7 +1084,7 @@ namespace dmParticle
         1.0f, 1.0f,
     };
 
-    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf, const ParticleVertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt)
+    static GenerateVertexDataResult UpdateRenderData(HParticleContext context, Instance* instance, Emitter* emitter, dmParticleDDF::Emitter* ddf, const dmGraphics::VertexAttributeInfos& attribute_infos, const Vector4& color, uint32_t vertex_index, uint8_t* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* bytes_written, float dt)
     {
         DM_PROFILE(__FUNCTION__);
         static int tex_coord_order[] = {
@@ -1133,7 +1120,7 @@ namespace dmParticle
         bool anim_bwd = playback == ANIM_PLAYBACK_ONCE_BACKWARD || playback == ANIM_PLAYBACK_LOOP_BACKWARD;
         bool anim_ping_pong = playback == ANIM_PLAYBACK_ONCE_PINGPONG || playback == ANIM_PLAYBACK_LOOP_PINGPONG;
         bool use_pivot = length(pivot_vector) > 0.0f;
-        bool use_local_position = HasLocalPositionAttribute(attribute_infos);
+        bool use_local_position = dmGraphics::HasLocalPositionAttribute(attribute_infos);
 
         if (anim_ping_pong) {
             tile_count = dmMath::Max(1u, tile_count * 2 - 2);
@@ -2290,7 +2277,7 @@ namespace dmParticle
 
     DM_PARTICLE_TRAMPOLINE2(bool, IsSleeping, HParticleContext, HInstance);
     DM_PARTICLE_TRAMPOLINE3(void, Update, HParticleContext, float, FetchAnimationCallback);
-    DM_PARTICLE_TRAMPOLINE9(GenerateVertexDataResult, GenerateVertexData, HParticleContext, float, HInstance, uint32_t, const ParticleVertexAttributeInfos&, const Vector4&, void*, uint32_t, uint32_t*);
+    DM_PARTICLE_TRAMPOLINE9(GenerateVertexDataResult, GenerateVertexData, HParticleContext, float, HInstance, uint32_t, const dmGraphics::VertexAttributeInfos&, const Vector4&, void*, uint32_t, uint32_t*);
 
     DM_PARTICLE_TRAMPOLINE2(HPrototype, NewPrototype, const void*, uint32_t);
     DM_PARTICLE_TRAMPOLINE1(HPrototype, NewPrototypeFromDDF, dmParticleDDF::ParticleFX*);

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -139,6 +139,7 @@ namespace dmParticle
         GENERATE_VERTEX_DATA_MAX_PARTICLES_EXCEEDED = 2,
     };
 
+    /*
     struct ParticleVertexAttributeInfo
     {
         dmhash_t                                  m_NameHash;
@@ -160,6 +161,7 @@ namespace dmParticle
         uint32_t                    m_NumInfos;
         uint32_t                    m_StructSize;
     };
+    */
 
     struct EmitterRenderData
     {
@@ -384,7 +386,7 @@ namespace dmParticle
      * @param out_vertex_buffer_size Size in bytes of the total data written to vertex buffer.
      * @return Result enum value
      */
-    DM_PARTICLE_PROTO(GenerateVertexDataResult, GenerateVertexData, HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, const ParticleVertexAttributeInfos& attribute_infos, const dmVMath::Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size);
+    DM_PARTICLE_PROTO(GenerateVertexDataResult, GenerateVertexData, HParticleContext context, float dt, HInstance instance, uint32_t emitter_index, const dmGraphics::VertexAttributeInfos& attribute_infos, const dmVMath::Vector4& color, void* vertex_buffer, uint32_t vertex_buffer_size, uint32_t* out_vertex_buffer_size);
 
     /**
      * Debug render the status of the instances within the specified context.

--- a/engine/particle/src/particle.h
+++ b/engine/particle/src/particle.h
@@ -139,30 +139,6 @@ namespace dmParticle
         GENERATE_VERTEX_DATA_MAX_PARTICLES_EXCEEDED = 2,
     };
 
-    /*
-    struct ParticleVertexAttributeInfo
-    {
-        dmhash_t                                  m_NameHash;
-        dmGraphics::VertexAttribute::SemanticType m_SemanticType;
-        dmGraphics::CoordinateSpace               m_CoordinateSpace;
-        uint8_t*                                  m_ValuePtr;
-        uint32_t                                  m_ValueByteSize;
-    };
-
-    struct ParticleVertexAttributeInfos
-    {
-        ParticleVertexAttributeInfos()
-        {
-            m_StructSize = sizeof(*this);
-        }
-
-        ParticleVertexAttributeInfo m_Infos[dmGraphics::MAX_VERTEX_STREAM_COUNT];
-        uint32_t                    m_VertexStride;
-        uint32_t                    m_NumInfos;
-        uint32_t                    m_StructSize;
-    };
-    */
-
     struct EmitterRenderData
     {
         EmitterRenderData()

--- a/engine/particle/src/test/test_particle.cpp
+++ b/engine/particle/src/test/test_particle.cpp
@@ -45,7 +45,7 @@ struct TestVertex
     // Offset 40
 };
 
-static inline void FillAttribute(dmParticle::ParticleVertexAttributeInfo& info, dmhash_t name_hash, dmGraphics::VertexAttribute::SemanticType semantic_type, uint32_t element_count)
+static inline void FillAttribute(dmGraphics::VertexAttributeInfo& info, dmhash_t name_hash, dmGraphics::VertexAttribute::SemanticType semantic_type, uint32_t element_count)
 {
     info.m_NameHash        = name_hash;
     info.m_SemanticType    = semantic_type;
@@ -89,7 +89,7 @@ protected:
 
     dmParticle::HParticleContext m_Context;
     dmParticle::HPrototype m_Prototype;
-    dmParticle::ParticleVertexAttributeInfos m_AttributeInfos;
+    dmGraphics::VertexAttributeInfos m_AttributeInfos;
 
     uint8_t* m_VertexBuffer;
     uint32_t m_VertexBufferSize;

--- a/engine/rig/src/dmsdk/rig/rig.h
+++ b/engine/rig/src/dmsdk/rig/rig.h
@@ -29,7 +29,7 @@
 
 namespace dmGraphics
 {
-    struct VertexAttribute;
+    struct VertexAttributeInfos;
 }
 
 namespace dmRig
@@ -161,13 +161,6 @@ namespace dmRig
         bool                          m_ForceAnimatePose;
     };
 
-    struct AttributeInfo
-    {
-        const dmGraphics::VertexAttribute* m_Attribute;
-        const uint8_t*                     m_ValuePtr;
-        uint32_t                           m_ValueByteSize;
-    };
-
     Result NewContext(const NewContextParams& params, HRigContext* context);
     void DeleteContext(HRigContext context);
     Result Update(HRigContext context, float dt);
@@ -180,7 +173,7 @@ namespace dmRig
     dmhash_t GetAnimation(HRigInstance instance);
 
     // Returns the new position in the array
-    uint8_t* GenerateVertexDataFromAttributes(dmRig::HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const dmVMath::Matrix4& world_matrix, const AttributeInfo* attributes, uint32_t attributes_count, uint32_t vertex_stride, uint8_t* vertex_data_out);
+    uint8_t* GenerateVertexDataFromAttributes(dmRig::HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const dmVMath::Matrix4& world_matrix, const dmGraphics::VertexAttributeInfos* attribute_infos, uint32_t vertex_stride, uint8_t* vertex_data_out);
     RigModelVertex* GenerateVertexData(HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const dmVMath::Matrix4& world_matrix, RigModelVertex* vertex_data_out);
     uint32_t GetVertexCount(HRigInstance instance);
 

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -967,6 +967,7 @@ namespace dmRig
 
                 uint32_t num_texcoords = 0;
 
+                // TODO: Use the shared dmGraphics function instead of this
                 for (int a = 0; a < attribute_infos->m_NumInfos; ++a)
                 {
                     const dmGraphics::VertexAttributeInfo& info = attribute_infos->m_Infos[a];

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -933,7 +933,7 @@ namespace dmRig
         return out_buffer;
     }
 
-    static uint8_t* WriteVertexDataByAttributes(const dmRigDDF::Mesh* mesh, const float* positions, const float* normals, const float* tangents, const AttributeInfo* attributes, uint32_t attributes_count, uint32_t vertex_stride, uint8_t* out_write_ptr)
+    static uint8_t* WriteVertexDataByAttributes(const dmRigDDF::Mesh* mesh, const float* positions, const float* normals, const float* tangents, const dmGraphics::VertexAttributeInfos* attribute_infos, uint32_t vertex_stride, uint8_t* out_write_ptr)
     {
         const float* uv0 = mesh->m_Texcoord0.m_Count ? mesh->m_Texcoord0.m_Data : 0;
         const float* uv1 = mesh->m_Texcoord1.m_Count ? mesh->m_Texcoord1.m_Data : 0;
@@ -967,12 +967,12 @@ namespace dmRig
 
                 uint32_t num_texcoords = 0;
 
-                for (int a = 0; a < attributes_count; ++a)
+                for (int a = 0; a < attribute_infos->m_NumInfos; ++a)
                 {
-                    const dmGraphics::VertexAttribute* attr = attributes[a].m_Attribute;
-                    const size_t data_size = attributes[a].m_ValueByteSize;
+                    const dmGraphics::VertexAttributeInfo& info = attribute_infos->m_Infos[a];
+                    const size_t data_size                      = info.m_ValueByteSize;
 
-                    switch(attr->m_SemanticType)
+                    switch(info.m_SemanticType)
                     {
                         case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
                         {
@@ -1009,7 +1009,7 @@ namespace dmRig
                         } break;
                         default:
                         {
-                            memcpy(write_ptr, attributes[a].m_ValuePtr, data_size);
+                            memcpy(write_ptr, info.m_ValuePtr, data_size);
                         } break;
                     }
 
@@ -1108,7 +1108,7 @@ namespace dmRig
         array.SetSize(size);
     }
 
-    uint8_t* GenerateVertexDataFromAttributes(dmRig::HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const Matrix4& world_matrix, const AttributeInfo* attributes, uint32_t attributes_count, uint32_t vertex_stride, uint8_t* vertex_data_out)
+    uint8_t* GenerateVertexDataFromAttributes(dmRig::HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const dmVMath::Matrix4& world_matrix, const dmGraphics::VertexAttributeInfos* attribute_infos, uint32_t vertex_stride, uint8_t* vertex_data_out)
     {
         const dmRigDDF::Model* model = instance->m_Model;
 
@@ -1128,11 +1128,10 @@ namespace dmRig
         bool stream_position = false;
         bool stream_normal = false;
 
-        for (int i = 0; i < attributes_count; ++i)
+        for (int i = 0; i < attribute_infos->m_NumInfos; ++i)
         {
-            const dmGraphics::VertexAttribute* attr = attributes[i].m_Attribute;
-            stream_position |= attr->m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION;
-            stream_normal   |= attr->m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_NORMAL;
+            stream_position |= attribute_infos->m_Infos[i].m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION;
+            stream_normal   |= attribute_infos->m_Infos[i].m_SemanticType == dmGraphics::VertexAttribute::SEMANTIC_TYPE_NORMAL;
         }
 
         pose_matrices.SetSize(0);
@@ -1182,7 +1181,7 @@ namespace dmRig
             dmRig::GenerateNormalData(mesh, normal_matrix, pose_matrices, normals_buffer, tangents_buffer);
         }
 
-        return WriteVertexDataByAttributes(mesh, positions_buffer, normals_buffer, tangents_buffer, attributes, attributes_count, vertex_stride, vertex_data_out);
+        return WriteVertexDataByAttributes(mesh, positions_buffer, normals_buffer, tangents_buffer, attribute_infos, vertex_stride, vertex_data_out);
     }
 
     RigModelVertex* GenerateVertexData(dmRig::HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const Matrix4& world_matrix, RigModelVertex* vertex_data_out)


### PR DESCRIPTION
This PR consolidates some of the vertex attribute writing that happens in the engine for sprites, models and particles. 

TODO for the future:
* Use the shared vertex writer for the particle fx
* Use the shared vertex writer for models