### PR TITLE
Flip image flag for image.load

### DIFF
--- a/engine/dlib/src/dlib/image.cpp
+++ b/engine/dlib/src/dlib/image.cpp
@@ -67,7 +67,7 @@ namespace dmImage
     {
         Image* image = new Image();
 
-        if (Load(buffer, buffer_size, premult, image) != RESULT_OK)
+        if (Load(buffer, buffer_size, premult, false, image) != RESULT_OK)
         {
             delete image;
             return 0;
@@ -82,11 +82,16 @@ namespace dmImage
         delete image;
     }
 
-    Result Load(const void* buffer, uint32_t buffer_size, bool premult, Image* image)
+    Result Load(const void* buffer, uint32_t buffer_size, bool premult, bool flip_vertically, Image* image)
     {
         int x, y, comp;
 
+        stbi_set_flip_vertically_on_load(flip_vertically);
+
         unsigned char* ret = stbi_load_from_memory((const stbi_uc*) buffer, (int) buffer_size, &x, &y, &comp, 0);
+
+        // Reset to default state
+        stbi_set_flip_vertically_on_load(0);
 
         if (ret) {
             Image i;

--- a/engine/dlib/src/dlib/image.h
+++ b/engine/dlib/src/dlib/image.h
@@ -43,10 +43,11 @@ namespace dmImage
      * @param buffer image buffer
      * @param buffer_size image buffer size
      * @param premult premultiply alpha or not
+     * @param flip_vertically flip the image vertically
      * @param image output
      * @return RESULT_OK on success
      */
-    Result Load(const void* buffer, uint32_t buffer_size, bool premult, HImage image);
+    Result Load(const void* buffer, uint32_t buffer_size, bool premult, bool flip_vertically, HImage image);
 
     /**
      * Free loaded image

--- a/engine/dlib/src/test/test_image.cpp
+++ b/engine/dlib/src/test/test_image.cpp
@@ -40,7 +40,7 @@
 TEST(dmImage, Empty)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(0, 0, false, &image);
+    dmImage::Result r =  dmImage::Load(0, 0, false, false, &image);
     ASSERT_EQ(dmImage::RESULT_IMAGE_ERROR, r);
 }
 
@@ -50,7 +50,7 @@ TEST(dmImage, Corrupt)
     void* b = malloc(size);
     memset(b, 0, size);
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(b, size, false, &image);
+    dmImage::Result r =  dmImage::Load(b, size, false, false, &image);
     free(b);
     ASSERT_EQ(dmImage::RESULT_IMAGE_ERROR, r);
 }
@@ -59,7 +59,7 @@ TEST(dmImage, PngColor)
 {
     for (int iter = 0; iter < 2; iter++) {
         dmImage::Image image;
-        dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_PNG, COLOR_CHECK_2X2_PNG_SIZE, iter == 0, &image);
+        dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_PNG, COLOR_CHECK_2X2_PNG_SIZE, iter == 0, false, &image);
         ASSERT_EQ(dmImage::RESULT_OK, r);
         ASSERT_EQ(2U, image.m_Width);
         ASSERT_EQ(2U, image.m_Height);
@@ -91,7 +91,7 @@ TEST(dmImage, PngColor)
 TEST(dmImage, Premult)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_PREMULT_PNG, COLOR_CHECK_2X2_PREMULT_PNG_SIZE, true, &image);
+    dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_PREMULT_PNG, COLOR_CHECK_2X2_PREMULT_PNG_SIZE, true, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(2U, image.m_Width);
     ASSERT_EQ(2U, image.m_Height);
@@ -125,7 +125,7 @@ TEST(dmImage, Premult)
 TEST(dmImage, Indexed)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_INDEXED_PNG, COLOR_CHECK_2X2_INDEXED_PNG_SIZE, true, &image);
+    dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_INDEXED_PNG, COLOR_CHECK_2X2_INDEXED_PNG_SIZE, true, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(2U, image.m_Width);
     ASSERT_EQ(2U, image.m_Height);
@@ -160,7 +160,7 @@ TEST(dmImage, Png16Color)
     // ASSERT_EQ(dmImage::RESULT_IMAGE_ERROR, r);
     for (int iter = 0; iter < 2; iter++) {
         dmImage::Image image;
-        dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_PNG, COLOR_CHECK_2X2_PNG_SIZE, iter == 0, &image);
+        dmImage::Result r =  dmImage::Load(COLOR_CHECK_2X2_PNG, COLOR_CHECK_2X2_PNG_SIZE, iter == 0, false, &image);
         ASSERT_EQ(dmImage::RESULT_OK, r);
         ASSERT_EQ(2U, image.m_Width);
         ASSERT_EQ(2U, image.m_Height);
@@ -192,7 +192,7 @@ TEST(dmImage, Png16Color)
 TEST(dmImage, PngGray)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(GRAY_CHECK_2X2_PNG, GRAY_CHECK_2X2_PNG_SIZE, false, &image);
+    dmImage::Result r =  dmImage::Load(GRAY_CHECK_2X2_PNG, GRAY_CHECK_2X2_PNG_SIZE, false, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(2U, image.m_Width);
     ASSERT_EQ(2U, image.m_Height);
@@ -211,7 +211,7 @@ TEST(dmImage, PngGray)
 TEST(dmImage, PngGrayAlpha)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(GRAY_ALPHA_CHECK_2X2_PNG, GRAY_ALPHA_CHECK_2X2_PNG_SIZE, false, &image);
+    dmImage::Result r =  dmImage::Load(GRAY_ALPHA_CHECK_2X2_PNG, GRAY_ALPHA_CHECK_2X2_PNG_SIZE, false, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(2U, image.m_Width);
     ASSERT_EQ(2U, image.m_Height);
@@ -251,7 +251,7 @@ TEST(dmImage, PngGrayAlpha)
 TEST(dmImage, Jpeg)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(DEFOLD_64_JPG, DEFOLD_64_JPG_SIZE, false, &image);
+    dmImage::Result r =  dmImage::Load(DEFOLD_64_JPG, DEFOLD_64_JPG_SIZE, false, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(64U, image.m_Width);
     ASSERT_EQ(64U, image.m_Height);
@@ -263,7 +263,7 @@ TEST(dmImage, Jpeg)
 TEST(dmImage, ProgressiveJpeg)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(DEFOLD_64_PROGRESSIVE_JPG, DEFOLD_64_PROGRESSIVE_JPG_SIZE, false, &image);
+    dmImage::Result r =  dmImage::Load(DEFOLD_64_PROGRESSIVE_JPG, DEFOLD_64_PROGRESSIVE_JPG_SIZE, false, false, &image);
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(64U, image.m_Width);
     ASSERT_EQ(64U, image.m_Height);
@@ -275,7 +275,7 @@ TEST(dmImage, ProgressiveJpeg)
 TEST(dmImage, case2319)
 {
     dmImage::Image image;
-    dmImage::Result r =  dmImage::Load(CASE2319_JPG, CASE2319_JPG_SIZE, false, &image);
+    dmImage::Result r =  dmImage::Load(CASE2319_JPG, CASE2319_JPG_SIZE, false, false, &image);
 
     ASSERT_EQ(dmImage::RESULT_OK, r);
     ASSERT_EQ(165U, image.m_Width);

--- a/engine/gamesys/src/gamesys/scripts/script_image.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_image.cpp
@@ -102,7 +102,13 @@ namespace dmGameSystem
     *
     * @name image.load
     * @param buffer [type:string] image data buffer
-    * @param [premult] [type:boolean] optional flag if alpha should be premultiplied. Defaults to `false`
+    * @param [options] [type:table] An optional table containing parameters for loading the image. Supported entries:
+    *
+    * `premultiply_alpha`
+    * : [type:boolean] True if alpha should be premultiplied into the color components. Defaults to `false`.
+    *
+    * `flip_vertically`
+    * : [type:boolean] True if the image contents should be flipped vertically. Defaults to `false`.
     *
     * @return image [type:table|nil] object or `nil` if loading fails. The object is a table with the following fields:
     *
@@ -135,14 +141,36 @@ namespace dmGameSystem
         const char* buffer = lua_tolstring(L, 1, &buffer_len);
 
         bool premult = false;
+        bool flip_vertically = false;
 
         if (top >= 2)
         {
-            premult = lua_toboolean(L, 2);
+            // Parse as options table
+            if (lua_istable(L, 2))
+            {
+                lua_pushvalue(L, 2);
+
+                lua_getfield(L, -1, "premultiply_alpha");
+                if (!lua_isnil(L, -1))
+                    premult = dmScript::CheckBoolean(L, -1);
+                lua_pop(L, 1);
+
+                lua_getfield(L, -1, "flip_vertically");
+                if (!lua_isnil(L, -1))
+                    flip_vertically = dmScript::CheckBoolean(L, -1);
+                lua_pop(L, 1);
+
+                lua_pop(L, 1);
+            }
+            // backwards compatability
+            else
+            {
+                premult = dmScript::CheckBoolean(L, 2);
+            }
         }
 
         dmImage::Image image;
-        dmImage::Result r = dmImage::Load(buffer, buffer_len, premult, &image);
+        dmImage::Result r = dmImage::Load(buffer, buffer_len, premult, flip_vertically, &image);
         if (r == dmImage::RESULT_OK) {
 
             int bytes_per_pixel = dmImage::BytesPerPixel(image.m_Type);
@@ -176,7 +204,13 @@ namespace dmGameSystem
     *
     * @name image.load_buffer
     * @param buffer [type:string] image data buffer
-    * @param [premult] [type:boolean] optional flag if alpha should be premultiplied. Defaults to `false`
+    * @param [options] [type:table] An optional table containing parameters for loading the image. Supported entries:
+    *
+    * `premultiply_alpha`
+    * : [type:boolean] True if alpha should be premultiplied into the color components. Defaults to `false`.
+    *
+    * `flip_vertically`
+    * : [type:boolean] True if the image contents should be flipped vertically. Defaults to `false`.
     *
     * @return image [type:table|nil] object or `nil` if loading fails. The object is a table with the following fields:
     *
@@ -196,7 +230,7 @@ namespace dmGameSystem
     * ```lua
     * local imgurl = "http://www.site.com/image.png"
     * http.request(imgurl, "GET", function(self, id, response)
-    *         local img = image.load_buffer(response.response)
+    *         local img = image.load_buffer(response.response, { flip_vertically = true })
     *         local tparams = {
     *             width  = img.width,
     *             height = img.height,
@@ -208,6 +242,7 @@ namespace dmGameSystem
     *         go.set("/go1#model", "texture0", my_texture_id)
     *     end)
     * ```
+    *
     */
     static int Image_LoadBuffer(lua_State* L)
     {
@@ -217,14 +252,36 @@ namespace dmGameSystem
         const char* buffer = lua_tolstring(L, 1, &buffer_len);
 
         bool premult = false;
+        bool flip_vertically = false;
 
         if (top >= 2)
         {
-            premult = lua_toboolean(L, 2);
+            // Parse as options table
+            if (lua_istable(L, 2))
+            {
+                lua_pushvalue(L, 2);
+
+                lua_getfield(L, -1, "premultiply_alpha");
+                if (!lua_isnil(L, -1))
+                    premult = dmScript::CheckBoolean(L, -1);
+                lua_pop(L, 1);
+
+                lua_getfield(L, -1, "flip_vertically");
+                if (!lua_isnil(L, -1))
+                    flip_vertically = dmScript::CheckBoolean(L, -1);
+                lua_pop(L, 1);
+
+                lua_pop(L, 1);
+            }
+            // backwards compatability
+            else
+            {
+                premult = dmScript::CheckBoolean(L, 2);
+            }
         }
 
         dmImage::Image image;
-        dmImage::Result r = dmImage::Load(buffer, buffer_len, premult, &image);
+        dmImage::Result r = dmImage::Load(buffer, buffer_len, premult, flip_vertically, &image);
         if (r == dmImage::RESULT_OK) {
 
             int bytes_per_pixel = dmImage::BytesPerPixel(image.m_Type);
@@ -241,8 +298,25 @@ namespace dmGameSystem
 
             lua_pushliteral(L, "buffer");
 
+            uint8_t num_components = 1;
+            switch(image.m_Type)
+            {
+                case dmImage::TYPE_RGB:
+                    num_components = 3;
+                    break;
+                case dmImage::TYPE_RGBA:
+                    num_components = 4;
+                    break;
+                case dmImage::TYPE_LUMINANCE:
+                    num_components = 1;
+                    break;
+                case dmImage::TYPE_LUMINANCE_ALPHA:
+                    num_components = 2;
+                default:break;
+            }
+
             dmBuffer::StreamDeclaration streams_decl[] = {
-                { dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, 1 }
+                { dmHashString64("data"), dmBuffer::VALUE_TYPE_UINT8, num_components }
             };
 
             dmBuffer::HBuffer buffer = 0;

--- a/engine/gamesys/src/gamesys/test/image/test_image_buffer.script
+++ b/engine/gamesys/src/gamesys/test/image/test_image_buffer.script
@@ -28,16 +28,50 @@ local function verify_image(img, w, h)
     resource.release(my_texture_id)
 end
 
-local function load_and_verify_image(path, w, h)
+local function verify_image_flipped(img, img_non_flipped, w, h, num_components)
+    local img_stream = buffer.get_stream(img.buffer, "data")
+    local img_non_flipped_stream = buffer.get_stream(img_non_flipped.buffer, "data")
+
+    for y=0, h-1 do
+        for x=0, w-1 do
+            local px_start_0 = y * w * num_components + x * num_components + 1
+            local px_start_1 = (h - y - 1) * w * num_components + x * num_components + 1
+            for i=0,num_components-1 do
+                assert(img_stream[px_start_0 + i] == img_non_flipped_stream[px_start_1 + i])
+            end
+        end
+    end
+end
+
+local function img_to_component_count(img)
+    local tbl = {
+        rgb = 3,
+        rgba = 4,
+        l = 1,
+        la = 2}
+    return tbl[img.type]
+end
+
+local function load_and_verify_image(path, w, h, flip_vertically)
+
+    if flip_vertically then
+        print("Testing (inverted): " .. path)
+    else
+        print("Testing: " .. path)
+    end
+
     local file = io.open(path, "rb")
     assert(file ~= nil)
     local buf = file:read("*all")
     file:close()
 
-    print("Loading", path)
-    local img = image.load_buffer(buf)
-
+    local img = image.load_buffer(buf, { flip_vertically = flip_vertically })
     verify_image(img, w, h)
+
+    if flip_vertically then
+        img_non_flipped = image.load_buffer(buf)
+        verify_image_flipped(img, img_non_flipped, w, h, img_to_component_count(img))
+    end
 end
 
 g_host_fs = ""
@@ -53,4 +87,9 @@ function update(self)
     load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2.jpg.raw", 2, 2)
     load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2_16.png.raw", 2, 2)
     load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2_indexed.png.raw", 2, 2)
+
+    load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2.png.raw", 2, 2, true)
+    load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2.jpg.raw", 2, 2, true)
+    load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2_16.png.raw", 2, 2, true)
+    load_and_verify_image(g_host_fs .. "src/gamesys/test/image/color_check_2x2_indexed.png.raw", 2, 2, true)
 end


### PR DESCRIPTION
image.load and image.load_buffer can now flip images vertically when loading:

```
image.load_buffer(path, {  flip_vertically = true })
image.load(path, {  flip_vertically = true })
```

Note that the second argument will now accept an option table, with these arguments:

```
premultiply_alpha - True if alpha should be premultiplied into the color components. Defaults to `false`.
flip_vertically - True if the image contents should be flipped vertically. Defaults to `false`.
```

Fixes #8543 