### PR TITLE
Use arm64 dart-sass on Apple silicon

### DIFF
--- a/editor/tasks/leiningen/sass.clj
+++ b/editor/tasks/leiningen/sass.clj
@@ -54,14 +54,19 @@
                    "mac" "macos"
                    "win" "windows"
                    "linux" "linux")
+        arch (if (and (= "macos" platform)
+                      (= "aarch64" (System/getProperty "os.arch")))
+               "arm64"
+               "x64")
         ext (case platform
               ("macos" "linux") "tar.gz"
               "windows" "zip")
         url (format
-              "https://github.com/sass/dart-sass/releases/download/%s/dart-sass-%s-%s-x64.%s"
+              "https://github.com/sass/dart-sass/releases/download/%s/dart-sass-%s-%s-%s.%s"
               version
               version
               platform
+              arch
               ext)
         extract-path (io/file packages-path "dart-sass" version)]
     (when-not (.exists extract-path)


### PR DESCRIPTION
### Technical changes
* Use the `arm64` variant of `dart-sass` on Apple silicon, so contributors will not have to install Rosetta 2.