### PR TITLE
Use ptr to resource instead of HTexture when getting animation callback

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -415,6 +415,7 @@ namespace dmEngine
         {
             return dmGraphics::TEXTURE_FILTER_LINEAR_MIPMAP_LINEAR;
         }
+        return (dmGraphics::TextureFilter) -1;
     }
 
     dmGraphics::TextureFilter ConvertMagTextureFilter(const char* filter)

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -366,11 +366,14 @@ namespace dmGameSystem
             dmRender::AddRenderBuffer(render_context, pfx_world->m_VertexBuffer);
         }
 
+        TextureResource* texture_res = (TextureResource*) first->m_Texture;
+        dmGraphics::HTexture texture = texture_res ? texture_res->m_Texture : 0;
+
         dmRender::RenderObject& ro = pfx_world->m_RenderObjects[ro_index];
         ro.Init();
         ro.m_Material          = material_res->m_Material;
         ro.m_VertexDeclaration = dmRender::GetVertexDeclaration(material_res->m_Material);
-        ro.m_Textures[0]       = (dmGraphics::HTexture) first->m_Texture;
+        ro.m_Textures[0]       = texture;
         ro.m_VertexStart       = vertex_offset;
         ro.m_VertexCount       = ro_vertex_count;
         ro.m_VertexBuffer      = (dmGraphics::HVertexBuffer) dmRender::GetBuffer(render_context, pfx_world->m_VertexBuffer);
@@ -676,10 +679,7 @@ namespace dmGameSystem
                 return dmParticle::FETCH_ANIMATION_UNKNOWN_ERROR;
             }
 
-            TextureResource* texture_res = texture_set_res->m_Texture;
-            dmGraphics::HTexture texture = texture_res ? texture_res->m_Texture : 0;
-
-            out_data->m_Texture = (void*) texture;
+            out_data->m_Texture = (void*) texture_set_res->m_Texture;
             out_data->m_TexCoords = (float*) texture_set_res->m_TextureSet->m_TexCoords.m_Data;
             out_data->m_TexDims = (float*) texture_set_res->m_TextureSet->m_TexDims.m_Data;
             out_data->m_PageIndices = texture_set_res->m_TextureSet->m_PageIndices.m_Data;

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -401,6 +401,7 @@ namespace dmGameSystem
             }
             return dmGameObject::PROPERTY_RESULT_OK;
         }
+        return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 
     static dmGameObject::PropertyVar DynamicAttributeValuesToPropertyVar(float* values, uint32_t element_count, uint32_t element_index, bool use_element_index)

--- a/engine/gamesys/src/gamesys/scripts/script_physics.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_physics.cpp
@@ -1392,7 +1392,10 @@ namespace dmGameSystem
                 lua_setfield(L, -2, "diameter");
                 lua_pushnumber(L, shape_info.m_CapsuleDiameterHeight[1]);
                 lua_setfield(L, -2, "height");
-            break;
+                break;
+            case dmPhysicsDDF::CollisionShape::TYPE_HULL:
+                break;
+            default:break;
         }
 
         return 1;

--- a/engine/gui/src/dmsdk/gui/gui.h
+++ b/engine/gui/src/dmsdk/gui/gui.h
@@ -58,6 +58,14 @@ namespace dmGui
     typedef struct Script* HScript;
 
     /*#
+     * A handle to a texture source, which can be a pointer to a resource,
+     * a dmGraphics::HTexture or a dynamic texture created from a gui script.
+     * @name HTextureSource
+     * @type typedef
+     */
+    typedef uint64_t HTextureSource;
+
+    /*#
      * Invalid node handle
      * @name INVALID_HANDLE
      * @type HNode
@@ -382,7 +390,7 @@ namespace dmGui
      * @param type [type:NodeTextureType] the type of texture
      * @param texture [type: void*] A pointer to a e.g. dmGameSystem::TextureSetResource*
      */
-    Result SetNodeTexture(HScene scene, HNode node, NodeTextureType type, void* texture);
+    Result SetNodeTexture(HScene scene, HNode node, NodeTextureType type, HTextureSource texture);
 
     // possibly use "add texture instead"
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -443,19 +443,19 @@ namespace dmGui
         return scene->m_UserData;
     }
 
-    Result AddTexture(HScene scene, dmhash_t texture_name_hash, void* texture, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
+    Result AddTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
     {
         if (scene->m_Textures.Full())
             return RESULT_OUT_OF_RESOURCES;
 
-        scene->m_Textures.Put(texture_name_hash, TextureInfo(texture, texture_type, original_width, original_height));
+        scene->m_Textures.Put(texture_name_hash, TextureInfo(texture_source, texture_type, original_width, original_height));
         uint32_t n = scene->m_Nodes.Size();
         InternalNode* nodes = scene->m_Nodes.Begin();
         for (uint32_t i = 0; i < n; ++i)
         {
             if (nodes[i].m_Node.m_TextureHash == texture_name_hash)
             {
-                nodes[i].m_Node.m_Texture     = texture;
+                nodes[i].m_Node.m_Texture     = texture_source;
                 nodes[i].m_Node.m_TextureType = texture_type;
             }
         }
@@ -500,7 +500,7 @@ namespace dmGui
         }
     }
 
-    void* GetTexture(HScene scene, dmhash_t texture_name_hash)
+    HTextureSource GetTexture(HScene scene, dmhash_t texture_name_hash)
     {
         TextureInfo* textureInfo = scene->m_Textures.Get(texture_name_hash);
         if (!textureInfo)
@@ -1073,7 +1073,7 @@ namespace dmGui
             if (texture->m_Handle) {
                 float buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024.0 / 1024.0;
                 DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
-                params->m_Params->m_DeleteTexture(scene, texture->m_Handle, context);
+                params->m_Params->m_DeleteTexture(scene, texture->m_Handle, NODE_TEXTURE_TYPE_DYNAMIC, context);
             }
             if (scene->m_DeletedDynamicTextures.Full()) {
                 scene->m_DeletedDynamicTextures.OffsetCapacity(16);
@@ -1131,7 +1131,7 @@ namespace dmGui
             if (texture.m_Handle) {
                 float buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type) / 1024.0 / 1024.0;
                 DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
-                delete_texture(scene, texture.m_Handle, scene->m_Context);
+                delete_texture(scene, texture.m_Handle, NODE_TEXTURE_TYPE_DYNAMIC, scene->m_Context);
             }
         }
         scene->m_DynamicTextures.Clear();
@@ -2985,7 +2985,7 @@ namespace dmGui
         return n->m_Node.m_MaterialNameHash;
     }
 
-    void* GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut)
+    HTextureSource GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut)
     {
         InternalNode* n = GetNode(scene, node);
         *textureTypeOut = n->m_Node.m_TextureType;
@@ -3071,7 +3071,7 @@ namespace dmGui
         return SetNodeTexture(scene, node, dmHashString64(texture_id));
     }
 
-    Result SetNodeTexture(HScene scene, HNode node, NodeTextureType type, void* texture)
+    Result SetNodeTexture(HScene scene, HNode node, NodeTextureType type, HTextureSource texture)
     {
         InternalNode* n = GetNode(scene, node);
         n->m_Node.m_TextureHash = (uintptr_t)texture;

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -103,7 +103,7 @@ namespace dmGui
     /**
      * Callback to fetch textureset animation info from a textureset source
      */
-    typedef FetchTextureSetAnimResult (*FetchTextureSetAnimCallback)(void* texture_set_ptr, dmhash_t anim, TextureSetAnimDesc* out_data);
+    typedef FetchTextureSetAnimResult (*FetchTextureSetAnimCallback)(HTextureSource texture_source, dmhash_t anim, TextureSetAnimDesc* out_data);
 
     /**
      * Callback to set node from node descriptor
@@ -422,15 +422,16 @@ namespace dmGui
      * @param buffer
      * @param context
      */
-    typedef void* (*NewTexture)(HScene scene, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context);
+    typedef HTextureSource (*NewTexture)(HScene scene, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context);
 
     /**
      * Delete texture callback
      * @param scene
      * @param texture
+     * @param type
      * @param context
      */
-    typedef void (*DeleteTexture)(HScene scene, void* texture, void* context);
+    typedef void (*DeleteTexture)(HScene scene, HTextureSource texture, NodeTextureType type, void* context);
 
     /**
      * Set texture (update) callback
@@ -442,7 +443,7 @@ namespace dmGui
      * @param buffer
      * @param context
      */
-    typedef void (*SetTextureData)(HScene scene, void* texture, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context);
+    typedef void (*SetTextureData)(HScene scene, HTextureSource texture, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context);
 
     typedef void (*AnimationComplete)(HScene scene,
                                       HNode node,
@@ -499,7 +500,7 @@ namespace dmGui
      * @param original_height Original Height of the texture
      * @return Outcome of the operation
      */
-    Result AddTexture(HScene scene, dmhash_t texture_name_hash, void* texture, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height);
+    Result AddTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height);
 
     /**
      * Removes a texture with the specified name from the scene.
@@ -522,7 +523,7 @@ namespace dmGui
      * @param scene Scene to get texture from
      * @param texture_name_hash Hashed name of the texture. 0 if unsuccessful
      */
-    void* GetTexture(HScene scene, dmhash_t texture_name_hash);
+    HTextureSource GetTexture(HScene scene, dmhash_t texture_name_hash);
 
     /**
      * Create a new dynamic texture
@@ -881,7 +882,7 @@ namespace dmGui
     void SetNodeTextTracking(HScene scene, HNode node, float tracking);
     float GetNodeTextTracking(HScene scene, HNode node);
 
-    void* GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut);
+    HTextureSource GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut);
     Result SetNodeTexture(HScene scene, HNode node, const char* texture_id);
 
     Result SetNodeParticlefx(HScene scene, HNode node, dmhash_t particlefx_id);

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -155,7 +155,7 @@ namespace dmGui
         return 0;
     }
 
-    Result AddTexture(HScene scene, dmhash_t texture_name_hash, void* texture, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
+    Result AddTexture(HScene scene, dmhash_t texture_name_hash, dmGui::HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
     {
         return RESULT_OK;
     }
@@ -168,7 +168,7 @@ namespace dmGui
     {
     }
 
-    void* GetTexture(HScene scene, dmhash_t texture_name_hash)
+    HTextureSource GetTexture(HScene scene, dmhash_t texture_name_hash)
     {
         return 0;
     }
@@ -524,7 +524,7 @@ namespace dmGui
         return 0.0f;
     }
 
-    void* GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut)
+    HTextureSource GetNodeTexture(HScene scene, HNode node, NodeTextureType* textureTypeOut)
     {
         return 0;
     }

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -146,8 +146,8 @@ namespace dmGui
 
         const char* m_Text;
 
-        uint64_t    m_TextureHash;
-        void*       m_Texture;
+        uint64_t        m_TextureHash;
+        HTextureSource  m_Texture;
         NodeTextureType m_TextureType;
 
         TextureSetAnimDesc m_TextureSetAnimDesc;
@@ -226,27 +226,27 @@ namespace dmGui
 
     struct TextureInfo
     {
-        TextureInfo(void* texture_source, NodeTextureType texture_source_type, uint32_t original_width, uint32_t original_height)
+        TextureInfo(HTextureSource texture_source, NodeTextureType texture_source_type, uint32_t original_width, uint32_t original_height)
         : m_TextureSource(texture_source)
         , m_TextureSourceType(texture_source_type)
         , m_OriginalWidth(original_width)
         , m_OriginalHeight(original_height) {}
 
-        void*    m_TextureSource;
+        HTextureSource  m_TextureSource;
         NodeTextureType m_TextureSourceType;
-        uint32_t m_OriginalWidth : 16;
-        uint32_t m_OriginalHeight : 16;
+        uint32_t        m_OriginalWidth : 16;
+        uint32_t        m_OriginalHeight : 16;
     };
 
     struct DynamicTexture
     {
-        DynamicTexture(void* handle)
+        DynamicTexture(HTextureSource handle)
         {
             memset(this, 0, sizeof(*this));
             m_Handle = handle;
             m_Type = (dmImage::Type) -1;
         }
-        void*           m_Handle;
+        HTextureSource  m_Handle;
         uint32_t        m_Created : 1;
         uint32_t        m_Deleted : 1;
         uint32_t        m_Width;

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -1704,7 +1704,7 @@ namespace dmGui
      * Dynamically create a new texture.
      *
      * @name gui.new_texture
-     * @param texture [type:string|hash] texture id
+     * @param texture_id [type:string|hash] texture id
      * @param width [type:number] texture width
      * @param height [type:number] texture height
      * @param type [type:string|constant] texture type

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -101,7 +101,7 @@ void OnWindowResizeCallback(const dmGui::HScene scene, uint32_t width, uint32_t 
     dmGui::SetDefaultResolution(scene->m_Context, width, height);
 }
 
-dmGui::FetchTextureSetAnimResult FetchTextureSetAnimCallback(void* texture_set_ptr, dmhash_t animation, dmGui::TextureSetAnimDesc* out_data)
+dmGui::FetchTextureSetAnimResult FetchTextureSetAnimCallback(dmGui::HTextureSource texture_source, dmhash_t animation, dmGui::TextureSetAnimDesc* out_data)
 {
     out_data->Init();
     static float uv_quad[] = {0,1,0,0, 1,0,1,1};
@@ -401,13 +401,13 @@ TEST_F(dmGuiTest, Layouts)
 TEST_F(dmGuiTest, NodeTextureType)
 {
     int t1, t2;
-    void* raw_tex;
+    dmGui::HTextureSource raw_tex;
     dmGui::Result r;
     dmGui::NodeTextureType node_texture_type;
     uint64_t fb_id;
 
     // Test NODE_TEXTURE_TYPE_TEXTURE_SET: Create and get type
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(0,0,0), Vector3(0,0,0), dmGui::NODE_TYPE_BOX, 0);
@@ -417,7 +417,7 @@ TEST_F(dmGuiTest, NodeTextureType)
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     raw_tex = dmGui::GetNodeTexture(m_Scene, node, &node_texture_type);
-    ASSERT_EQ(raw_tex, &t1);
+    ASSERT_EQ(raw_tex, (dmGui::HTextureSource) &t1);
     ASSERT_EQ(node_texture_type, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET);
 
     // Test NODE_TEXTURE_TYPE_TEXTURE_SET: Playing flipbook animation
@@ -428,14 +428,14 @@ TEST_F(dmGuiTest, NodeTextureType)
     ASSERT_EQ(dmHashString64("ta1"), fb_id);
 
     // Test NODE_TEXTURE_TYPE_TEXTURE: Create and get type
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t2"), (void*) &t2, dmGui::NODE_TEXTURE_TYPE_TEXTURE, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t2"), (dmGui::HTextureSource) &t2, dmGui::NODE_TEXTURE_TYPE_TEXTURE, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     raw_tex = dmGui::GetNodeTexture(m_Scene, node, &node_texture_type);
-    ASSERT_EQ(raw_tex, &t2);
+    ASSERT_EQ(raw_tex, (dmGui::HTextureSource) &t2);
     ASSERT_EQ(node_texture_type, dmGui::NODE_TEXTURE_TYPE_TEXTURE);
 
     // Test NODE_TEXTURE_TYPE_TEXTURE: Playing flipbook animation should not work!
@@ -454,7 +454,7 @@ TEST_F(dmGuiTest, SizeMode)
     int t1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX, 0);
@@ -480,7 +480,7 @@ TEST_F(dmGuiTest, FlipbookAnim)
     int t1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX, 0);
@@ -530,7 +530,7 @@ TEST_F(dmGuiTest, FlipbookAnim)
     fb_id = dmGui::GetNodeFlipbookAnimId(m_Scene, node);
     ASSERT_EQ(0U, fb_id);
 
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t2"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t2"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
@@ -547,8 +547,8 @@ TEST_F(dmGuiTest, TextureFontLayer)
 
     dmhash_t test_font_path = dmHashString64("test_font_path");
 
-    dmGui::AddTexture(m_Scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
-    dmGui::AddTexture(m_Scene, dmHashString64("t2"), (void*) &t2, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    dmGui::AddTexture(m_Scene, dmHashString64("t2"), (dmGui::HTextureSource) &t2, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     dmGui::AddFont(m_Scene, dmHashString64("f1"), &f1, 0);
     dmGui::AddFont(m_Scene, dmHashString64("f2"), &f2, 0);
     dmGui::AddFont(m_Scene, dmHashString64("test_font_id"), &f2, test_font_path);
@@ -573,11 +573,11 @@ TEST_F(dmGuiTest, TextureFontLayer)
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
-    dmGui::AddTexture(m_Scene, dmHashString64("t2"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
-    ASSERT_EQ(&t1, m_Scene->m_Nodes[node & 0xffff].m_Node.m_Texture);
+    dmGui::AddTexture(m_Scene, dmHashString64("t2"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    ASSERT_EQ((dmGui::HTextureSource) &t1, (dmGui::HTextureSource) m_Scene->m_Nodes[node & 0xffff].m_Node.m_Texture);
 
     dmGui::RemoveTexture(m_Scene, dmHashString64("t2"));
-    ASSERT_EQ((void*)0, m_Scene->m_Nodes[node & 0xffff].m_Node.m_Texture);
+    ASSERT_EQ((dmGui::HTextureSource) 0, (dmGui::HTextureSource) m_Scene->m_Nodes[node & 0xffff].m_Node.m_Texture);
 
     r = dmGui::SetNodeTexture(m_Scene, node, "t2");
     ASSERT_EQ(r, dmGui::RESULT_RESOURCE_NOT_FOUND);
@@ -627,18 +627,18 @@ TEST_F(dmGuiTest, TextureFontLayer)
     dmGui::DeleteNode(m_Scene, node, true);
 }
 
-static void* DynamicNewTexture(dmGui::HScene scene, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
+static dmGui::HTextureSource DynamicNewTexture(dmGui::HScene scene, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
 {
-    return malloc(16);
+    return (dmGui::HTextureSource) malloc(16);
 }
 
-static void DynamicDeleteTexture(dmGui::HScene scene, void* texture, void* context)
+static void DynamicDeleteTexture(dmGui::HScene scene, dmGui::HTextureSource texture_source, dmGui::NodeTextureType type, void* context)
 {
-    assert(texture);
-    free(texture);
+    assert(texture_source);
+    free((void*) texture_source);
 }
 
-static void DynamicSetTextureData(dmGui::HScene scene, void* texture, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
+static void DynamicSetTextureData(dmGui::HScene scene, dmGui::HTextureSource texture_source, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
 {
 }
 
@@ -805,7 +805,7 @@ TEST_F(dmGuiTest, ScriptFlipbookAnim)
     int t1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     const char* id = "n";
@@ -849,7 +849,7 @@ TEST_F(dmGuiTest, ScriptTextureFontLayer)
     int t;
     int f;
 
-    dmGui::AddTexture(m_Scene, dmHashString64("t"), (void*) &t, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    dmGui::AddTexture(m_Scene, dmHashString64("t"), (dmGui::HTextureSource) &t, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     dmGui::AddFont(m_Scene, dmHashString64("f"), &f, 0);
     dmGui::AddLayer(m_Scene, "l");
 
@@ -5362,7 +5362,7 @@ TEST_F(dmGuiTest, CloneNodeAndAnim)
     int t1;
     dmGui::Result r;
 
-    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    r = dmGui::AddTexture(m_Scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     dmGui::HNode node = dmGui::NewNode(m_Scene, Point3(5,5,0), Vector3(10,10,0), dmGui::NODE_TYPE_BOX, 0);

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -590,7 +590,7 @@ TEST_F(dmGuiScriptTest, TestSizeMode)
     dmGui::Result result;
 
     int t1;
-    result = dmGui::AddTexture(scene, dmHashString64("t1"), (void*) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
+    result = dmGui::AddTexture(scene, dmHashString64("t1"), (dmGui::HTextureSource) &t1, dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET, 1, 1);
     ASSERT_EQ(result, dmGui::RESULT_OK);
 
     const char* src =


### PR DESCRIPTION
Fixes an issue with web builds for particle effects and gui components, where a texture handle (64-bit) got truncated into a 32-bit value since it is cast to a void* which is 32-bit on web platform(s) due to emscripten.