### PR TITLE
Fix sound message and its documentation

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sound.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sound.cpp
@@ -48,9 +48,12 @@ namespace dmGameSystem
         uintptr_t               m_LuaCallback;
         float                   m_Delay;
         uint32_t                m_PlayId;
-        uint32_t                m_StopRequested  : 1;
-        uint32_t                m_PauseRequested : 1;
-        uint32_t                m_Paused         : 1;
+
+        uint8_t                 m_StopRequested  : 1;
+        uint8_t                 m_PauseRequested : 1;
+        uint8_t                 m_Paused         : 1;
+        uint8_t                 m_isMessage      : 1;
+        uint8_t                                  : 4;
     };
 
     struct SoundComponent
@@ -184,7 +187,7 @@ namespace dmGameSystem
             dmLogError("Error deleting sound: (%d)", r);
             return dmGameObject::UPDATE_RESULT_UNKNOWN_ERROR;
         }
-        else if (entry.m_Listener.m_Fragment != 0x0 && entry.m_LuaCallback)
+        else if (entry.m_Listener.m_Fragment != 0x0 && (entry.m_LuaCallback || (entry.m_isMessage && entry.m_PlayId != dmSound::INVALID_PLAY_ID)))
         {
             DispatchSoundEvent(entry, entry.m_StopRequested ? SOUND_EVENT_STOPPED : SOUND_EVENT_DONE);
         }
@@ -269,6 +272,8 @@ namespace dmGameSystem
      *
      * [icon:attention] A sound will continue to play even if the game object the sound component belonged to is deleted. You can send a `stop_sound` to stop the sound.
      *
+     * [icon:attention] `play_id` should be specified in case you want to receive `sound_done` or `sound_stopped` in `on_message()`.
+     *
      * @message
      * @name play_sound
      * @param [delay] [type:number] delay in seconds before the sound starts playing, default is 0.
@@ -280,6 +285,19 @@ namespace dmGameSystem
      *
      * ```lua
      * msg.post("#sound", "play_sound", {delay = 1, gain = 0.5})
+     * ```
+     *
+     * ```lua
+     * -- use `play_id` if you want to recieve `sound_done` or `sound_stopped` in on_message() 
+     * function init()
+     *  msg.post("#sound", "play_sound", {play_id = 1, delay = 1, gain = 0.5})
+     * end
+     *
+     * function on_message(self, message_id, message)
+     *  if message_id == hash("sound_done") then
+     *      print("Sound play id: "..message.play_id)
+     *  end
+     * end
      * ```
      */
 
@@ -318,8 +336,8 @@ namespace dmGameSystem
      */
 
     /*# reports when a sound has finished playing
-     * This message is sent back to the sender of a `play_sound` message, if the sound
-     * could be played to completion.
+     * This message is sent back to the sender of a `play_sound` message 
+     * if the sound could be played to completion and a `play_id` was provided with the `play_sound` message.
      *
      * @message
      * @name sound_done
@@ -328,7 +346,7 @@ namespace dmGameSystem
 
     /*# reports when a sound has been manually stopped
      * This message is sent back to the sender of a `play_sound` message, if the sound
-     * has been manually stopped.
+     * has been manually stopped and a `play_id` was provided with the `play_sound` message.
      *
      * @message
      * @name sound_stopped
@@ -406,6 +424,7 @@ namespace dmGameSystem
                 entry.m_Sound = sound;
                 entry.m_StopRequested = 0;
                 entry.m_PauseRequested = 0;
+                entry.m_isMessage = 1;
                 entry.m_Paused = 0;
                 entry.m_Instance = params.m_Instance;
                 entry.m_Receiver = params.m_Message->m_Receiver;
@@ -430,7 +449,15 @@ namespace dmGameSystem
                     dmSound::SetLooping(entry.m_SoundInstance, sound->m_Looping, (sound->m_Looping && !sound->m_Loopcount) ? -1 : sound->m_Loopcount ); // loopcounter semantics differ a bit from loopcount. If -1, it means loopforever, otherwise it contains the # of loops remaining.
 
                     entry.m_Listener = params.m_Message->m_Sender;
-                    entry.m_LuaCallback = params.m_Message->m_UserData2;
+                    uintptr_t callback = params.m_Message->m_UserData2;
+                    if (callback != 0)
+                    {
+                        // UINTPTR_MAX used as default for `sound.play()` in `script_sound.cpp`
+                        // to make distinguish between function call and `play_sound` message
+                        entry.m_isMessage = 0;
+                        callback = callback == UINTPTR_MAX ? 0x0 : callback;
+                    }
+                    entry.m_LuaCallback = callback;
                 }
                 else
                 {

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -473,7 +473,7 @@ namespace dmGameSystem
      * `sender`
      * : [type:url] The invoker of the callback: the sound component.
      *
-     * @return id [type:number] The identifier for the sound voice
+     * @return play_id [type:number] The identifier for the sound voice
      *
      * @examples
      *
@@ -536,14 +536,16 @@ namespace dmGameSystem
 
         uint32_t play_id = dmSound::GetAndIncreasePlayCounter();
 
-        int functionref = 0;
+        // We use this value to know if it's function call without callback or `play_sound` message call from lua
+        // 
+        uintptr_t functionref = UINTPTR_MAX;
         if (top > 2) // completed cb
         {
             if (lua_isfunction(L, 3))
             {
                 lua_pushvalue(L, 3);
                 // NOTE: By convention m_FunctionRef is offset by LUA_NOREF, in order to have 0 for "no function"
-                functionref = dmScript::RefInInstance(L) - LUA_NOREF;
+                functionref = (uintptr_t)(dmScript::RefInInstance(L) - LUA_NOREF);
             }
         }
 
@@ -554,7 +556,7 @@ namespace dmGameSystem
         msg.m_Speed = speed;
         msg.m_PlayId = play_id;
 
-        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, (uintptr_t)functionref, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
+        dmMessage::Post(&sender, &receiver, dmGameSystemDDF::PlaySound::m_DDFDescriptor->m_NameHash, (uintptr_t)instance, functionref, (uintptr_t)dmGameSystemDDF::PlaySound::m_DDFDescriptor, &msg, sizeof(msg), 0);
 
         lua_pushnumber(L, (double) msg.m_PlayId);
 

--- a/engine/gamesys/src/gamesys/scripts/script_sound.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_sound.cpp
@@ -536,8 +536,8 @@ namespace dmGameSystem
 
         uint32_t play_id = dmSound::GetAndIncreasePlayCounter();
 
-        // We use this value to know if it's function call without callback or `play_sound` message call from lua
-        // 
+        // We use UINTPTR_MAX value to determine if it's a function call without a callback or a `play_sound` message call from Lua.
+        // Take a look at comp_sound -> CompSoundOnMessage for a better understanding of how it's used.
         uintptr_t functionref = UINTPTR_MAX;
         if (top > 2) // completed cb
         {


### PR DESCRIPTION
It wasn't easy to understand how it works.  Now I added documentation, so it should be easier in the future.

That's how it worked:
`sound.play()` - no messages in `on_message()`
`msg.post("#sound", "play_sound") ` - no messages in `on_message()`
`msg.post("#sound", "play_sound", {play_id = 1})` - receive messages in `on_message()`

So, I made fixes to make sure it works the same way it worked before.
I'll link this PR with https://github.com/defold/defold/pull/8544 and will change the description there (for better release notes).

This PR should be cherry-picked into 1.7.0 beta
