### PR TITLE
Fix bug when using go.animate after go.set

### DIFF
--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -439,6 +439,11 @@ namespace dmGameSystem
             return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
         }
 
+        out_desc.m_ElementIds[0] = info.m_ElementIds[0];
+        out_desc.m_ElementIds[1] = info.m_ElementIds[1];
+        out_desc.m_ElementIds[2] = info.m_ElementIds[2];
+        out_desc.m_ElementIds[3] = info.m_ElementIds[3];
+
         // If we have a dynamic attribute set, we return that data
         if (dynamic_attribute_index != INVALID_DYNAMIC_ATTRIBUTE_INDEX)
         {
@@ -471,11 +476,6 @@ namespace dmGameSystem
             VertexAttributeToFloats(info.m_Attribute, info.m_ValuePtr, values);
             out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(values, info.m_Attribute->m_ElementCount, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
         }
-
-        out_desc.m_ElementIds[0] = info.m_ElementIds[0];
-        out_desc.m_ElementIds[1] = info.m_ElementIds[1];
-        out_desc.m_ElementIds[2] = info.m_ElementIds[2];
-        out_desc.m_ElementIds[3] = info.m_ElementIds[3];
 
         return dmGameObject::PROPERTY_RESULT_OK;
     }

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -450,6 +450,9 @@ namespace dmRender
 
     bool GetMaterialProgramConstantInfo(HMaterial material, dmhash_t name_hash, dmhash_t* out_constant_id, dmhash_t* out_element_ids[4], uint32_t* out_element_index, uint16_t* out_array_size)
     {
+        if (name_hash == 0)
+            return false;
+
         dmArray<RenderConstant>& constants = material->m_Constants;
         uint32_t n = constants.Size();
         *out_element_index = ~0u;


### PR DESCRIPTION
Fix for beta 1.7.0 when using go.animate on a vertex attribute