### PR TITLE
Fix case with mixing overridden attributes with non-overriden attribtues

### DIFF
--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -528,22 +528,19 @@ namespace dmGameSystem
         // Otherwise, we try to get it from the component itself via the callabck.
         // We need a callback mechanism here because we don't have a shared data layout for
         // the override attributes on component level (TODO: we should have).
-        else
+        const dmGraphics::VertexAttribute* comp_attribute;
+
+        // If this callback returns false, e.g a component resource might not have a value override for the attribute,
+        // we fallback to the material attribute data instead
+        if (callback(callback_user_data, info.m_AttributeNameHash, &comp_attribute))
         {
-            const dmGraphics::VertexAttribute* comp_attribute;
-
-            // If this callback returns false, e.g a component resource might not have a value override for the attribute,
-            // we fallback to the material attribute data instead
-            if (callback(callback_user_data, info.m_AttributeNameHash, &comp_attribute))
-            {
-                uint32_t value_byte_size;
-                dmGraphics::GetAttributeValues(*comp_attribute, &info.m_ValuePtr, &value_byte_size);
-            }
-
-            float values[4];
-            VertexAttributeToFloats(info.m_Attribute, info.m_ValuePtr, values);
-            out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(values, info.m_Attribute->m_ElementCount, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
+            uint32_t value_byte_size;
+            dmGraphics::GetAttributeValues(*comp_attribute, &info.m_ValuePtr, &value_byte_size);
         }
+
+        float values[4];
+        VertexAttributeToFloats(info.m_Attribute, info.m_ValuePtr, values);
+        out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(values, info.m_Attribute->m_ElementCount, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
 
         return dmGameObject::PROPERTY_RESULT_OK;
     }

--- a/engine/gamesys/src/gamesys/test/material/attributes_custom_multiple.vp
+++ b/engine/gamesys/src/gamesys/test/material/attributes_custom_multiple.vp
@@ -1,0 +1,19 @@
+attribute vec4 position;
+attribute vec4 custom_value_1;
+attribute vec4 custom_value_2;
+attribute vec4 custom_value_3;
+attribute vec4 custom_value_4;
+
+varying vec4 var_custom_value_1;
+varying vec4 var_custom_value_2;
+varying vec4 var_custom_value_3;
+varying vec4 var_custom_value_4;
+
+void main()
+{
+    gl_Position        = position;
+    var_custom_value_1 = custom_value_1;
+    var_custom_value_2 = custom_value_2;
+    var_custom_value_3 = custom_value_3;
+    var_custom_value_4 = custom_value_4;
+}

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse.go
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse.go
@@ -1,0 +1,13 @@
+components {
+  id: "script"
+  component: "/material/attributes_dynamic_go_set_get_sparse.script"
+}
+
+embedded_components {
+  id: "sprite"
+  type: "sprite"
+  data: "tile_set: \"/tile/flipbook.tilesource\"\n"
+  "default_animation: \"anim\"\n"
+  "material: \"/material/attributes_dynamic_go_set_get_sparse.material\"\n"
+  "blend_mode: BLEND_MODE_ALPHA\n"
+}

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse.material
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse.material
@@ -1,0 +1,54 @@
+name: "attributes_dynamic_go_set_get_sparse"
+vertex_program: "/material/attributes_custom_multiple.vp"
+fragment_program: "/fragment_program/valid.fp"
+
+attributes {
+  name: "custom_value_1"
+  data_type: TYPE_FLOAT
+  semantic_type: SEMANTIC_TYPE_NONE
+  element_count: 4
+  double_values {
+    v: 1.0
+    v: 2.0
+    v: 3.0
+    v: 4.0
+  }
+}
+attributes {
+  name: "custom_value_2"
+  data_type: TYPE_FLOAT
+  semantic_type: SEMANTIC_TYPE_NONE
+  element_count: 4
+  double_values {
+    v: 11.0
+    v: 12.0
+    v: 13.0
+    v: 14.0
+  }
+}
+
+attributes {
+  name: "custom_value_3"
+  data_type: TYPE_FLOAT
+  semantic_type: SEMANTIC_TYPE_NONE
+  element_count: 4
+  double_values {
+    v: 21.0
+    v: 22.0
+    v: 23.0
+    v: 24.0
+  }
+}
+
+attributes {
+  name: "custom_value_4"
+  data_type: TYPE_FLOAT
+  semantic_type: SEMANTIC_TYPE_NONE
+  element_count: 4
+  double_values {
+    v: 31.0
+    v: 32.0
+    v: 33.0
+    v: 34.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse.script
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse.script
@@ -1,0 +1,51 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local EPSILON = 0.001
+local function assert_near_vector4(a,b)
+    assert(math.abs(a.x-b.x) < EPSILON)
+    assert(math.abs(a.y-b.y) < EPSILON)
+    assert(math.abs(a.z-b.z) < EPSILON)
+    assert(math.abs(a.w-b.w) < EPSILON)
+end
+
+function assert_all(exp_v1,exp_v2,exp_v3,exp_v4)
+	local v1 = go.get("#sprite", "custom_value_1")
+	assert_near_vector4(exp_v1, v1)
+
+	local v2 = go.get("#sprite", "custom_value_2")
+	assert_near_vector4(exp_v2, v2)
+
+	local v3 = go.get("#sprite", "custom_value_3")
+	assert_near_vector4(exp_v3, v3)
+
+	local v4 = go.get("#sprite", "custom_value_4")
+	assert_near_vector4(exp_v4, v4)
+end
+
+function init(self)
+	assert_all(vmath.vector4(1,2,3,4), vmath.vector4(11,12,13,14), vmath.vector4(21,22,23,24), vmath.vector4(31,32,33,34))
+
+	go.set("#sprite", "custom_value_2", vmath.vector4(91, 92, 93, 94))
+	assert_all(vmath.vector4(1,2,3,4), vmath.vector4(91, 92, 93, 94), vmath.vector4(21,22,23,24), vmath.vector4(31,32,33,34))
+
+	go.set("#sprite", "custom_value_4", vmath.vector4(1337, 1338, 1339, 1340))
+	assert_all(vmath.vector4(1,2,3,4), vmath.vector4(91, 92, 93, 94), vmath.vector4(21,22,23,24), vmath.vector4(1337, 1338, 1339, 1340))
+
+	go.set("#sprite", "custom_value_1", vmath.vector4(-1, -2, -3, -4))
+	assert_all(vmath.vector4(-1, -2, -3, -4), vmath.vector4(91, 92, 93, 94), vmath.vector4(21,22,23,24), vmath.vector4(1337, 1338, 1339, 1340))
+
+	go.set("#sprite", "custom_value_3", vmath.vector4(-100, -101, -102, -103))
+	assert_all(vmath.vector4(-1, -2, -3, -4), vmath.vector4(91, 92, 93, 94), vmath.vector4(-100, -101, -102, -103), vmath.vector4(1337, 1338, 1339, 1340))
+end

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse_generated_0.sprite
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_go_set_get_sparse_generated_0.sprite
@@ -1,0 +1,4 @@
+tile_set: "/tile/flipbook.tilesource"
+default_animation: "anim"
+material: "/material/attributes_dynamic_go_set_get_sparse.material"
+blend_mode: BLEND_MODE_ALPHA

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -4770,6 +4770,25 @@ TEST_F(MaterialTest, DynamicVertexAttributesWithGoAnimate)
     dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
 }
 
+TEST_F(MaterialTest, DynamicVertexAttributesGoSetGetSparse)
+{
+    dmGameSystem::ScriptLibContext scriptlibcontext;
+    scriptlibcontext.m_Factory         = m_Factory;
+    scriptlibcontext.m_Register        = m_Register;
+    scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
+    scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
+
+    dmGameSystem::InitializeScriptLibs(scriptlibcontext);
+
+    ASSERT_TRUE(dmGameObject::Init(m_Collection));
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/material/attributes_dynamic_go_set_get_sparse.goc", dmHashString64("/attributes_dynamic_go_set_get_sparse"), 0, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+    dmGameSystem::FinalizeScriptLibs(scriptlibcontext);
+}
+
 TEST_F(MaterialTest, GoGetSetConstants)
 {
     dmGameSystem::ScriptLibContext scriptlibcontext;


### PR DESCRIPTION
A fix for beta 1.7.0 where overriding one of multiple attributes causes a go.get on any of the non-overriden attributes to always return zero.