### PR TITLE
Add support for render.set_render_target_size for render resources

### DIFF
--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -3411,6 +3411,9 @@ bail:
                     VK_IMAGE_LAYOUT_PREINITIALIZED,
                     texture_color);
                 CHECK_VK_ERROR(res);
+
+                texture_color->m_Width  = width;
+                texture_color->m_Height = height;
             }
         }
 
@@ -3439,6 +3442,9 @@ bail:
                 VK_IMAGE_ASPECT_DEPTH_BIT,
                 depth_stencil_texture);
             CHECK_VK_ERROR(res);
+
+            depth_stencil_texture->m_Width  = width;
+            depth_stencil_texture->m_Height = height;
         }
 
         DestroyRenderTarget(g_VulkanContext, rt);

--- a/engine/render/src/render/render_script.cpp
+++ b/engine/render/src/render/render_script.cpp
@@ -1193,12 +1193,7 @@ namespace dmRender
 
             if (render_resource == 0x0)
             {
-                char str[128];
-                char buffer[256];
-                dmSnPrintf(buffer, sizeof(buffer), "Could not find render target '%s' %llu",
-                    dmScript::GetStringFromHashOrString(L, index, str, sizeof(str)), (unsigned long long) rt_id); // since lua doesn't support proper format arguments
-
-                return luaL_error(L, "%s", buffer);
+                return luaL_error(L, "Could not find render target '%s'", dmHashReverseSafe64(rt_id));
             }
 
             if (render_resource->m_Type != RENDER_RESOURCE_TYPE_RENDER_TARGET)
@@ -1518,7 +1513,7 @@ namespace dmRender
      *     render.draw(self.my_pred)
      *     render.set_render_target(render.RENDER_TARGET_DEFAULT)
      *
-     *     render.enable_texture(0, 'my_rt_resource, render.BUFFER_COLOR_BIT)
+     *     render.enable_texture(0, 'my_rt_resource', render.BUFFER_COLOR_BIT)
      *     -- draw a predicate with the render target available as texture 0 in the predicate
      *     -- material shader.
      *     render.draw(self.my_pred)
@@ -2944,8 +2939,7 @@ namespace dmRender
      */
     int RenderScript_EnableMaterial(lua_State* L)
     {
-        int top = lua_gettop(L);
-        (void)top;
+        DM_LUA_STACK_CHECK(L, 0);
 
         RenderScriptInstance* i = RenderScriptInstance_Check(L);
         if (!lua_isnil(L, 1))
@@ -2955,33 +2949,26 @@ namespace dmRender
 
             if (render_resource == 0x0)
             {
-                assert(top == lua_gettop(L));
-                char str[128];
-                char buffer[256];
-                dmSnPrintf(buffer, sizeof(buffer), "Could not find material '%s' %llu", dmScript::GetStringFromHashOrString(L, 1, str, sizeof(str)), (unsigned long long)material_id); // since lua doesn't support proper format arguments
-                return luaL_error(L, "%s", buffer);
+                return DM_LUA_ERROR("Could not find material '%s'", dmHashReverseSafe64(material_id));
             }
             else if (render_resource->m_Type != RENDER_RESOURCE_TYPE_MATERIAL)
             {
-                return luaL_error(L, "Render resource is not a material.");
+                return DM_LUA_ERROR("Render resource is not a material.");
             }
 
             HMaterial material = (HMaterial) render_resource->m_Resource;
             if (InsertCommand(i, Command(COMMAND_TYPE_ENABLE_MATERIAL, (uint64_t)material)))
             {
-                assert(top == lua_gettop(L));
                 return 0;
             }
             else
             {
-                assert(top == lua_gettop(L));
-                return luaL_error(L, "Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
+                return DM_LUA_ERROR("Command buffer is full (%d).", i->m_CommandBuffer.Capacity());
             }
         }
         else
         {
-            assert(top == lua_gettop(L));
-            return luaL_error(L, "%s.enable_material was supplied nil as material.", RENDER_SCRIPT_LIB_NAME);
+            return DM_LUA_ERROR("%s.enable_material was supplied nil as material.", RENDER_SCRIPT_LIB_NAME);
         }
     }
 

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -1256,6 +1256,75 @@ static inline dmGraphics::ShaderDesc::Shader MakeDDFShader(const char* data, uin
     return ddf;
 }
 
+TEST_F(dmRenderScriptTest, TestRenderTargetResource)
+{
+    const char* script =
+        "function assert_rt_buffer_size(rt, buffer, exp_w, exp_h)\n"
+        "   assert(exp_w == render.get_render_target_width(rt, buffer))\n"
+        "   assert(exp_h == render.get_render_target_height(rt, buffer))\n"
+        "end\n"
+        "function assert_rt_size(rt, ds, ss, c0s, c1s, c2s, c3s)\n"
+        "   assert_rt_buffer_size(rt, render.BUFFER_DEPTH_BIT, ds, ds)\n"
+        "   assert_rt_buffer_size(rt, render.BUFFER_STENCIL_BIT, ss, ss)\n"
+        "   assert_rt_buffer_size(rt, render.BUFFER_COLOR0_BIT, c0s, c0s)\n"
+        "   assert_rt_buffer_size(rt, render.BUFFER_COLOR1_BIT, c1s, c1s)\n"
+        "   assert_rt_buffer_size(rt, render.BUFFER_COLOR2_BIT, c2s, c2s)\n"
+        "   assert_rt_buffer_size(rt, render.BUFFER_COLOR3_BIT, c3s, c3s)\n"
+        "end\n"
+        "function init(self)\n"
+        "   assert_rt_size('valid_rt', 8, 16, 32, 64, 96, 128)\n"
+        "   render.set_render_target_size('valid_rt', 512, 512)\n"
+        "   assert_rt_size('valid_rt', 512, 512, 512, 512, 512, 512)\n"
+        "end\n";
+
+    dmRender::HRenderScript render_script                  = dmRender::NewRenderScript(m_Context, LuaSourceFromString(script));
+    dmRender::HRenderScriptInstance render_script_instance = dmRender::NewRenderScriptInstance(m_Context, render_script);
+
+    dmGraphics::RenderTargetCreationParams params          = {};
+
+    params.m_DepthBufferCreationParams.m_Width          = 8;
+    params.m_DepthBufferCreationParams.m_Height         = 8;
+    params.m_DepthBufferCreationParams.m_OriginalWidth  = 8;
+    params.m_DepthBufferCreationParams.m_OriginalHeight = 8;
+
+    params.m_DepthBufferParams.m_Width  = params.m_DepthBufferCreationParams.m_Width;
+    params.m_DepthBufferParams.m_Height = params.m_DepthBufferCreationParams.m_Height;
+    params.m_DepthBufferParams.m_Format = dmGraphics::TEXTURE_FORMAT_DEPTH;
+
+    params.m_StencilBufferCreationParams.m_Width          = 16;
+    params.m_StencilBufferCreationParams.m_Height         = 16;
+    params.m_StencilBufferCreationParams.m_OriginalWidth  = 16;
+    params.m_StencilBufferCreationParams.m_OriginalHeight = 16;
+
+    params.m_StencilBufferParams.m_Width  = params.m_StencilBufferCreationParams.m_Width;
+    params.m_StencilBufferParams.m_Height = params.m_StencilBufferCreationParams.m_Height;
+    params.m_StencilBufferParams.m_Format = dmGraphics::TEXTURE_FORMAT_STENCIL;
+
+    for (int i = 0; i < DM_ARRAY_SIZE(params.m_ColorBufferCreationParams); ++i)
+    {
+        params.m_ColorBufferCreationParams[i].m_Width          = 32 + 32 * i;
+        params.m_ColorBufferCreationParams[i].m_Height         = 32 + 32 * i;
+        params.m_ColorBufferCreationParams[i].m_OriginalWidth  = 32 + 32 * i;
+        params.m_ColorBufferCreationParams[i].m_OriginalHeight = 32 + 32 * i;
+
+        params.m_ColorBufferParams[i].m_Width  = params.m_ColorBufferCreationParams[i].m_Width;
+        params.m_ColorBufferParams[i].m_Height = params.m_ColorBufferCreationParams[i].m_Height;
+        params.m_ColorBufferParams[i].m_Format = dmGraphics::TEXTURE_FORMAT_LUMINANCE;
+    }
+
+    uint32_t rt_flags = 0xffff;
+
+    dmGraphics::HRenderTarget rt = dmGraphics::NewRenderTarget(m_GraphicsContext, rt_flags, params);
+    dmRender::AddRenderScriptInstanceRenderResource(render_script_instance, "valid_rt", rt, dmRender::RENDER_RESOURCE_TYPE_RENDER_TARGET);
+    ASSERT_EQ(dmRender::RENDER_SCRIPT_RESULT_OK, dmRender::InitRenderScriptInstance(render_script_instance));
+
+    ClearRenderScriptInstanceRenderResources(render_script_instance);
+
+    dmGraphics::DeleteRenderTarget(rt);
+    dmRender::DeleteRenderScriptInstance(render_script_instance);
+    dmRender::DeleteRenderScript(m_Context, render_script);
+}
+
 TEST_F(dmRenderScriptTest, TestRenderResourceTable)
 {
     const char* script =


### PR DESCRIPTION
We have added render target resource support to the following render script functions:

```lua
render.set_render_target_size("my_rt_resource", 512, 512)
render.get_render_target_width("my_rt_resource", render.BUFFER_COLOR0_BIT)
render.get_render_target_height("my_rt_resource", render.BUFFER_COLOR0_BIT)
```