### PR TITLE
Add gui.get and gui.set

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -292,7 +292,8 @@ namespace dmGameSystem
 
         // properties
         dmGui::SetNodePosition(scene, n, Point3(node_desc->m_Position.getXYZ()));
-        dmGui::SetNodeProperty(scene, n, dmGui::PROPERTY_ROTATION, node_desc->m_Rotation);
+        dmGui::SetNodeProperty(scene, n, dmGui::PROPERTY_EULER, node_desc->m_Rotation);
+        dmGui::SetNodeProperty(scene, n, dmGui::PROPERTY_ROTATION, dmVMath::Vector4(dmVMath::EulerToQuat(node_desc->m_Rotation.getXYZ())));
         dmGui::SetNodeProperty(scene, n, dmGui::PROPERTY_SCALE, node_desc->m_Scale);
         Vector4 color;
         color.setXYZ(node_desc->m_Color.getXYZ());
@@ -2713,6 +2714,7 @@ namespace dmGameSystem
         const char* property_names[] = {
             "position",
             "rotation",
+            "euler",
             "scale",
             "color",
             "size",
@@ -2728,9 +2730,17 @@ namespace dmGameSystem
 
 
         const dmGui::Property properties_all[] = {
-            dmGui::PROPERTY_POSITION, dmGui::PROPERTY_ROTATION, dmGui::PROPERTY_SCALE, dmGui::PROPERTY_COLOR,
-            dmGui::PROPERTY_SIZE, dmGui::PROPERTY_OUTLINE, dmGui::PROPERTY_SHADOW, dmGui::PROPERTY_SLICE9,
-            dmGui::PROPERTY_PIE_PARAMS, dmGui::PROPERTY_TEXT_PARAMS,
+            dmGui::PROPERTY_POSITION,
+            dmGui::PROPERTY_ROTATION,
+            dmGui::PROPERTY_EULER,
+            dmGui::PROPERTY_SCALE,
+            dmGui::PROPERTY_COLOR,
+            dmGui::PROPERTY_SIZE,
+            dmGui::PROPERTY_OUTLINE,
+            dmGui::PROPERTY_SHADOW,
+            dmGui::PROPERTY_SLICE9,
+            dmGui::PROPERTY_PIE_PARAMS,
+            dmGui::PROPERTY_TEXT_PARAMS,
         };
         properties = properties_all;
         num_properties = DM_ARRAY_SIZE(properties_all);

--- a/engine/gui/src/dmsdk/gui/gui.h
+++ b/engine/gui/src/dmsdk/gui/gui.h
@@ -302,8 +302,9 @@ namespace dmGui
         PROPERTY_SLICE9     = 7,
         PROPERTY_PIE_PARAMS = 8,
         PROPERTY_TEXT_PARAMS= 9,
+        PROPERTY_EULER      = 10,
 
-        PROPERTY_COUNT      = 10,
+        PROPERTY_COUNT      = 11,
     };
 
     /*#

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -99,13 +99,6 @@ namespace dmGui
     { dmHashString64(#name ".z"), prop, 2 }, \
     { dmHashString64(#name ".w"), prop, 3 },
 
-    struct PropDesc
-    {
-        dmhash_t m_Hash;
-        Property m_Property;
-        uint8_t  m_Component;
-    };
-
     PropDesc g_Properties[] = {
             PROP(position, PROPERTY_POSITION )
             PROP(rotation, PROPERTY_ROTATION )
@@ -133,7 +126,7 @@ namespace dmGui
             { dmHashString64("slice"), PROPERTY_SLICE9, 0xff },
     };
 
-    static PropDesc* GetPropertyDesc(dmhash_t property_hash)
+    PropDesc* GetPropertyDesc(dmhash_t property_hash)
     {
         int n_props = sizeof(g_Properties) / sizeof(g_Properties[0]);
         for (int i = 0; i < n_props; ++i) {

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -2916,8 +2916,7 @@ namespace dmGui
         else if (property == PROPERTY_ROTATION)
         {
             Quat q = dmVMath::Quat(value);
-            Vector4 v_original = n->m_Node.m_Properties[PROPERTY_EULER]; 
-            Vector4 v = Vector4(dmVMath::QuatToEuler(q.getX(), q.getY(), q.getZ(), v_original.getW()));
+            Vector4 v = Vector4(dmVMath::QuatToEuler(q.getX(), q.getY(), q.getZ(), q.getW()));
             n->m_Node.m_Properties[PROPERTY_EULER] = v;
         }
 

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -530,6 +530,15 @@ namespace dmGui
     dmVMath::Vector4 CalculateReferenceScale(HScene scene, InternalNode* node);
 
     HNode GetNodeHandle(InternalNode* node);
+
+    struct PropDesc
+    {
+        dmhash_t m_Hash;
+        Property m_Property;
+        uint8_t  m_Component;
+    };
+
+    PropDesc* GetPropertyDesc(dmhash_t property_hash);
 }
 
 #endif

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -679,6 +679,7 @@ namespace dmGui
      *
      * - `"position"`
      * - `"rotation"`
+     * - `"euler"`
      * - `"scale"`
      * - `"color"`
      * - `"outline"`
@@ -688,14 +689,19 @@ namespace dmGui
      * - `"inner_radius"` (pie)
      * - `"slice9"` (slice9)
      *
-     * The value to set must either be a vmath.vector4, vmath.vector3 or a single number and depends on the property name you want to set.
+     * The value to set must either be a vmath.vector4, vmath.vector3, vmath.quat or a single number and depends on the property name you want to set.
      * I.e when setting the "position" property, you need to use a vmath.vector4 and when setting a single component of the property,
-     * such as "position.x", you need to use a single value. 
+     * such as "position.x", you need to use a single value.
+     *
+     * Note: When setting the rotation using the "rotation" property, you need to pass in a vmath.quat. This behaviour is different than from the gui.set_rotation function,
+     * the intention is to move new functionality closer to go namespace so that migrating between gui and go is easier. To set the rotation using degrees instead,
+     * use the "euler" property instead. The rotation and euler properties are linked, changing one of them will change the backing data of the other.
      *
      * @name gui.set
      * @param node [type:node] node to set the property for
      * @param property [type:string|hash|constant] the property to set 
-     * @param value [type:number|vector4|vector3] the property to set
+     * @param value [type:number|vector4|vector3|quat] the property to set
+     *
      * @examples
      *
      * Updates the position property on an existing node:
@@ -704,6 +710,19 @@ namespace dmGui
      * local node = gui.get_node("my_box_node")
      * local node_position = gui.get(node, "position")
      * gui.set(node, "position.x", node_position.x + 128)
+     * ```
+     *
+     * Updates the rotation property on an existing node:
+     *
+     * ```lua
+     * local node = gui.get_node("my_box_node")
+     * gui.set(node, "rotation", vmath.quat_rotation_z(math.rad(45)))
+     * -- this is equivalent to:
+     * gui.set(node, "euler.z", 45)
+     * -- or using the entire vector:
+     * gui.set(node, "euler", vmath.vector3(0,0,45))
+     * -- or using the set_rotation
+     * gui.set_rotation(node, vmath.vector3(0,0,45))
      * ```
      */
     static int LuaSet(lua_State* L)
@@ -1175,6 +1194,7 @@ namespace dmGui
      *
      * - `"position"`
      * - `"rotation"`
+     * - `"euler"`
      * - `"scale"`
      * - `"color"`
      * - `"outline"`
@@ -1188,6 +1208,7 @@ namespace dmGui
      *
      * - `gui.PROP_POSITION`
      * - `gui.PROP_ROTATION`
+     * - `gui.PROP_EULER`
      * - `gui.PROP_SCALE`
      * - `gui.PROP_COLOR`
      * - `gui.PROP_OUTLINE`
@@ -1367,6 +1388,7 @@ namespace dmGui
      *
      * - `"position"`
      * - `"rotation"`
+     * - `"euler"`
      * - `"scale"`
      * - `"color"`
      * - `"outline"`
@@ -4731,6 +4753,12 @@ namespace dmGui
      * @variable
      */
 
+    /*# euler property
+     *
+     * @name gui.PROP_EULER
+     * @variable
+     */
+
     /*# scale property
      *
      * @name gui.PROP_SCALE
@@ -4983,6 +5011,7 @@ namespace dmGui
 
         SETPROP(position, POSITION)
         SETPROP(rotation, ROTATION)
+        SETPROP(euler, EULER)
         SETPROP(scale, SCALE)
         SETPROP(color, COLOR)
         SETPROP(outline, OUTLINE)

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -2713,13 +2713,13 @@ TEST_F(dmGuiTest, Picking)
     ASSERT_TRUE(dmGui::PickNode(m_Scene, n1, tmax.getX(), tmin.getY()));
     ASSERT_FALSE(dmGui::PickNode(m_Scene, n1, ceil(size.getX() + 0.5f), size.getY()));
 
-    dmGui::SetNodeProperty(m_Scene, n1, dmGui::PROPERTY_ROTATION, Vector4(0, 45, 0, 0));
+    dmGui::SetNodeProperty(m_Scene, n1, dmGui::PROPERTY_EULER, Vector4(0, 45, 0, 0));
     Vector3 ext(pos);
     ext.setX(ext.getX() * cosf((float) (M_PI * 0.25)));
     ASSERT_TRUE(dmGui::PickNode(m_Scene, n1, pos.getX() + floor(ext.getX()), pos.getY()));
     ASSERT_FALSE(dmGui::PickNode(m_Scene, n1, pos.getX() + ceil(ext.getX()), pos.getY()));
 
-    dmGui::SetNodeProperty(m_Scene, n1, dmGui::PROPERTY_ROTATION, Vector4(0, 90, 0, 0));
+    dmGui::SetNodeProperty(m_Scene, n1, dmGui::PROPERTY_EULER, Vector4(0, 90, 0, 0));
     ASSERT_TRUE(dmGui::PickNode(m_Scene, n1, pos.getX(), pos.getY()));
     ASSERT_FALSE(dmGui::PickNode(m_Scene, n1, pos.getX() + 1.0f, pos.getY()));
 }
@@ -3904,7 +3904,7 @@ TEST_F(dmGuiTest, NodeTransform)
     ref_mat *= dmVMath::Matrix4::rotation(radians * 0.50f, Vector3(0.0f, 1.0f, 0.0f));
     ref_mat *= dmVMath::Matrix4::rotation(radians * 1.00f, Vector3(0.0f, 0.0f, 1.0f));
     ref_mat *= dmVMath::Matrix4::rotation(radians * 0.25f, Vector3(1.0f, 0.0f, 0.0f));
-    dmGui::SetNodeProperty(m_Scene, n1, dmGui::PROPERTY_ROTATION, Vector4(90.0f*0.25f, 90.0f*0.5f, 90.0f, 0.0f));
+    dmGui::SetNodeProperty(m_Scene, n1, dmGui::PROPERTY_EULER, Vector4(90.0f*0.25f, 90.0f*0.5f, 90.0f, 0.0f));
     dmGui::RenderScene(m_Scene, render_params, transforms);
     ASSERT_MAT4(transforms[0], ref_mat);
 

--- a/engine/gui/src/test/test_gui_script.cpp
+++ b/engine/gui/src/test/test_gui_script.cpp
@@ -1111,6 +1111,9 @@ TEST_F(dmGuiScriptTest, TestGuiGetSet)
 
     const char* src =
             "local EPSILON = 0.001\n"
+            "function assert_near(a,b)\n"
+            "    assert(math.abs(a-b) < EPSILON)\n"
+            "end\n"
             "function assert_near_vector4(a,b)\n"
             "    assert(math.abs(a.x-b.x) < EPSILON)\n"
             "    assert(math.abs(a.y-b.y) < EPSILON)\n"
@@ -1125,14 +1128,34 @@ TEST_F(dmGuiScriptTest, TestGuiGetSet)
             "    assert(not r)\n"
             "end\n"
             "function init(self)\n"
-            // Test valid
             "   local node = gui.new_box_node(vmath.vector3(1, 2, 3), vmath.vector3(4, 5, 6))\n"
+            // Test valid
             "   assert_near_vector4(vmath.vector4(1, 2, 3, 1), gui.get(node, 'position'))\n"
             "   assert_near_vector4(vmath.vector4(4, 5, 6, 0), gui.get(node, 'size'))\n"
             "   gui.set(node, 'position', vmath.vector3(99, 98, 97))\n"
             "   assert_near_vector4(vmath.vector4(99, 98, 97, 1), gui.get(node, 'position'))\n"
             "   gui.set(node, 'position', vmath.vector4(99, 98, 97, 1337))\n"
             "   assert_near_vector4(vmath.vector4(99, 98, 97, 1337), gui.get(node, 'position'))\n"
+            // Test valid subcomponents
+            "   gui.set(node, 'position.x', 2001)\n"
+            "   assert_near(2001, gui.get(node, 'position.x'))\n"
+            "   gui.set(node, 'position.y', 2002)\n"
+            "   assert_near(2002, gui.get(node, 'position.y'))\n"
+            "   gui.set(node, 'position.z', 2003)\n"
+            "   assert_near(2003, gui.get(node, 'position.z'))\n"
+            "   gui.set(node, 'position.w', 2004)\n"
+            "   assert_near(2004, gui.get(node, 'position.w'))\n"
+            "   assert_near_vector4(vmath.vector4(2001, 2002, 2003, 2004), gui.get(node, 'position'))\n"
+            // Test rotation <-> euler conversion
+            "   gui.set(node, 'rotation', vmath.quat_rotation_z(math.rad(45)))\n"
+            "   assert_near_vector4(vmath.vector4(0, 0, 45, 0), gui.get(node, 'euler'))\n"
+            "   gui.set(node, 'euler', vmath.vector3(0, 0, 45))\n"
+            "   assert_near_vector4(vmath.quat_rotation_z(math.rad(45)), gui.get(node, 'rotation'))\n"
+            // Test rotation <-> euler conversion subcomponents
+            "   gui.set(node, 'euler', vmath.vector4())\n"
+            "   assert_near_vector4(vmath.vector4(0,0,0,1), gui.get(node, 'rotation'))\n"
+            "   gui.set(node, 'euler.x', 180)\n"
+            "   assert_near(1, gui.get(node, 'rotation.x'))\n"
             // Incorrect input for get
             "   assert_error(function() gui.get('invalid', 'position') end)\n"
             "   assert_error(function() gui.get(hash('invalid'), 'position') end)\n"
@@ -1141,6 +1164,10 @@ TEST_F(dmGuiScriptTest, TestGuiGetSet)
             "   assert_error(function() gui.set('invalid', 'position', vmath.vector3()) end)\n"
             "   assert_error(function() gui.set(node, 'position', 'incorrect-string') end)\n"
             "   assert_error(function() gui.set(node, 'this_doesnt_exist', vmath.vector4()) end)\n"
+            "   assert_error(function() gui.set(node, 'rotation', vmath.vector3()) end)\n"
+            "   assert_error(function() gui.set(node, 'rotation', vmath.vector4()) end)\n"
+            "   assert_error(function() gui.set(node, 'rotation', 1) end)\n"
+            "   assert_error(function() gui.set(node, 'rotation.x', vmath.vector3()) end)\n"
             "end\n";
 
     dmGui::Result result = SetScript(script, LuaSourceFromStr(src));


### PR DESCRIPTION
Gui scripts can now query/set node properties via `gui.get` and `gui.set`:

```lua
local node = gui.get_node("my_node_id")
local node_pos = gui.get(node, "position")
local node_pos_x = gui.get(node, "position.x")

gui.set(node, "position", vmath.vector3(1, 2, 3))
gui.set(node, "position.x", 1)
```

We have also added a new property to the gui namespace `euler` which is linked with the `rotation` property. When changing one of them, both will change its underlying data. The important change between them is that the `rotation` property must be set by quaternion values, and the `euler` property must be set by degree values. You can set a single component of the rotation or the euler properties as usual:

```lua
gui.set(node, "rotation.x", math.rad(45))
gui.set(node, "euler.x", 45)
```

**There are no custom script properties available, you can only get and set the already existing node properties:**
```
"position"
"rotation"
"euler"
"scale"
"color"
"outline"
"shadow"
"size"
"fill_angle" (pie)
"inner_radius" (pie)
"slice9" (slice9)
```

Fixes #5090 