### PR TITLE
Clear the texture data if no buffer is passed in when using resource.create_texture

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -592,6 +592,7 @@ static void MakeTextureImage(uint16_t width, uint16_t height, uint8_t max_mipmap
     else
     {
         image_data = new uint8_t[image_data_size];
+        memset(image_data, 0, image_data_size);
     }
 
     // Note: Right now we only support creating compressed 2D textures with 1 mipmap,
@@ -652,6 +653,7 @@ static void CheckTextureResource(lua_State* L, int i, const char* field_name, dm
  * registered will trigger an error. If the intention is to instead modify an existing texture, use the [ref:resource.set_texture]
  * function. Also note that the path to the new texture resource must have a '.texturec' extension,
  * meaning "/path/my_texture" is not a valid path but "/path/my_texture.texturec" is.
+ * If the texture is created without a buffer, the pixel data will be blank.
  *
  * @name resource.create_texture
  *


### PR DESCRIPTION
We now explicitly clear the texture data before uploading it to the GPU texture when using resource.create_texture with no explicit buffer is being used.

Fixes #8489 