### PR TITLE
Fix navigating to referencing atlas from missing image build error

### DIFF
--- a/editor/test/integration/reload_test.clj
+++ b/editor/test/integration/reload_test.clj
@@ -13,8 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns integration.reload-test
-  (:require [clojure.java.io :as io]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
@@ -38,6 +37,8 @@
            [java.io File]
            [javax.imageio ImageIO]
            [org.apache.commons.io FilenameUtils]))
+
+(set! *warn-on-reflection* true)
 
 (def ^:private reload-project-path "test/resources/reload_project")
 
@@ -122,7 +123,7 @@
 (defn- touch-file
   ([workspace name]
    (touch-file workspace name true))
-  ([workspace name sync?]
+  ([workspace ^String name sync?]
    (let [f (File. (workspace/project-path workspace) name)]
      (fs/create-parent-directories! f)
      (touch-until-new-mtime f))
@@ -134,7 +135,7 @@
     (touch-file workspace name false))
   (sync! workspace))
 
-(defn- write-file [workspace name content]
+(defn- write-file [workspace ^String name content]
   (let [f (File. (workspace/project-path workspace) name)]
     (fs/create-parent-directories! f)
     (spit-until-new-mtime f content))
@@ -146,31 +147,31 @@
 (defn- add-file [workspace name]
   (write-file workspace name (template workspace name)))
 
-(defn- delete-file [workspace name]
+(defn- delete-file [workspace ^String name]
   (let [f (File. (workspace/project-path workspace) name)]
     (fs/delete-file! f))
   (sync! workspace))
 
 (defn- copy-file [workspace name new-name]
-  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) %) [name new-name])]
+  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) ^String %) [name new-name])]
     (fs/copy-file! f new-f))
   (sync! workspace))
 
 (defn- copy-directory [workspace name new-name]
-  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) %) [name new-name])]
+  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) ^String %) [name new-name])]
     (fs/copy-directory! f new-f))
   (sync! workspace))
 
 (defn- move-file [workspace name new-name]
-  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) %) [name new-name])]
+  (let [[f new-f] (mapv #(File. (workspace/project-path workspace) ^String %) [name new-name])]
     (fs/move-file! f new-f)
     (sync! workspace [[f new-f]])))
 
-(defn- add-img [workspace name width height]
+(defn- add-img [workspace ^String name width height]
   (let [img (BufferedImage. width height BufferedImage/TYPE_INT_ARGB)
         type (FilenameUtils/getExtension name)
         f (File. (workspace/project-path workspace) name)]
-    (do-until-new-mtime (fn [f] (ImageIO/write img type f)) f)
+    (do-until-new-mtime (fn [^File f] (ImageIO/write img type f)) f)
     (sync! workspace)))
 
 (defn- has-undo? [project]
@@ -247,9 +248,8 @@
                           invalidated-node ((g/node-value project :nodes-by-resource-path) img-path)]
                       (is (nil? node))
                       (is (= initial-node invalidated-node))
-                      (is (= nil (g/node-value invalidated-node :_output-jammers)))
-                      ;; as above, undo count should be unchanged - just invalidate the outputs of the resource node
-                      (is (= undo-count (count (undo-stack (g/node-id->graph-id project)))))
+                      ;; the node corresponding to the deleted resource should be marked defective.
+                      (is (seq (keys (g/node-value invalidated-node :_output-jammers))))
                       ;; TODO - fix node pollution
                       (log/without-logging
                         (is (g/error? (g/node-value atlas-node-id :anim-data)))))))))))))))


### PR DESCRIPTION
Fixed a regression where double-clicking a build error originating from an `.atlas` referencing a non-existent image resource would not take you to the referencing `.atlas`.

Fixes #8633.

### Technical changes
* Stateless resource nodes are now marked defective when their corresponding resource is removed from disk, just like they are if the resource is not present at load time.