### PR TITLE
Added support for naming the sprite geometries in a dynamically created atlas

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -852,7 +852,8 @@ namespace dmGameSystem
                 frame_index = frame_indices[anim_frame_index];
 
                 // The name hash of the current single frame animation
-                frame_anim_id = texture_set_ddf->m_ImageNameHashes[frame_index];
+                if (frame_index < texture_set_ddf->m_ImageNameHashes.m_Count)
+                    frame_anim_id = texture_set_ddf->m_ImageNameHashes[frame_index];
             }
             else
             {

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -678,7 +678,7 @@ static void CheckTextureResource(lua_State* L, int i, const char* field_name, dm
  * - `resource.TEXTURE_FORMAT_LUMINANCE`
  * - `resource.TEXTURE_FORMAT_RGB`
  * - `resource.TEXTURE_FORMAT_RGBA`
- * 
+ *
  * These constants might not be available on the device:
  *
  * - `resource.TEXTURE_FORMAT_RGB_PVRTC_2BPPV1`
@@ -746,7 +746,7 @@ static void CheckTextureResource(lua_State* L, int i, const char* field_name, dm
  * ```lua
  * function init(self)
  *     -- Create a new buffer with 4 components and FLOAT32 type
- *     local tbuffer = buffer.create(128 * 128, { {name=hash("rgba"), type=buffer.VALUE_TYPE_FLOAT32, count=4} } )   
+ *     local tbuffer = buffer.create(128 * 128, { {name=hash("rgba"), type=buffer.VALUE_TYPE_FLOAT32, count=4} } )
  *     local tstream = buffer.get_stream(tbuffer, hash("rgba"))
  *
  *     -- Fill the buffer stream with some float values
@@ -759,7 +759,7 @@ static void CheckTextureResource(lua_State* L, int i, const char* field_name, dm
  *             tstream[index + 3] = 1.0
  *         end
  *     end
- *      
+ *
  *     -- Create a 2D Texture with a RGBA23F format
  *     local tparams = {
  *        width          = 128,
@@ -770,7 +770,7 @@ static void CheckTextureResource(lua_State* L, int i, const char* field_name, dm
  *
  *    -- Note that we pass the buffer as the last argument here!
  *    local my_texture_id = resource.create_texture("/my_custom_texture.texturec", tparams, tbuffer)
- *    
+ *
  *    -- assign the texture to a model
  *    go.set("#model", "texture0", my_texture_id)
  * end
@@ -1223,7 +1223,7 @@ static int SetTexture(lua_State* L)
  * end
  * ```
  */
-    
+
 static void PushTextureInfo(lua_State* L, dmGraphics::HTexture texture_handle)
 {
     uint32_t texture_width               = dmGraphics::GetTextureWidth(texture_handle);
@@ -1402,7 +1402,7 @@ static int GetRenderTargetInfo(lua_State* L)
         {
             lua_pushinteger(L, (lua_Integer) (attachment_count+1));
             lua_newtable(L);
-            
+
             PushTextureInfo(L, t);
 
             lua_pushinteger(L, color_buffer_flags[i]);
@@ -1447,6 +1447,7 @@ static void DestroyTextureSet(dmGameSystemDDF::TextureSet& texture_set)
     delete[] texture_set.m_Geometries.m_Data;
     delete[] texture_set.m_FrameIndices.m_Data;
     delete[] texture_set.m_TexCoords.m_Data;
+    delete[] texture_set.m_ImageNameHashes.m_Data;
 }
 
 // These lookup functions are needed because the values for the two enums are different,
@@ -1628,8 +1629,8 @@ static void MakeTextureSetFromLua(lua_State* L, dmhash_t texture_path_hash, dmGr
     texture_set_ddf->m_Animations.m_Count = num_animations;
     memset(texture_set_ddf->m_Animations.m_Data, 0, sizeof(dmGameSystemDDF::TextureSetAnimation) * num_animations);
 
-    // TODO: Fix script api to require each "image" to have an ID that we can use for as regular textureset
-    texture_set_ddf->m_ImageNameHashes.m_Count = 0;
+    texture_set_ddf->m_ImageNameHashes.m_Data  = new dmhash_t[num_geometries];
+    texture_set_ddf->m_ImageNameHashes.m_Count = num_geometries;
 
     const uint32_t num_tex_coords_per_quad  = 8;
     const uint32_t num_tex_coords_byte_size = num_animation_frames * num_tex_coords_per_quad * sizeof(float);
@@ -1657,6 +1658,15 @@ static void MakeTextureSetFromLua(lua_State* L, dmhash_t texture_path_hash, dmGr
             MakeNumberArrayFromLuaTable<float>(L, "vertices", (void**) &geometry.m_Vertices.m_Data, &geometry.m_Vertices.m_Count);
             MakeNumberArrayFromLuaTable<float>(L, "uvs", (void**) &geometry.m_Uvs.m_Data, &geometry.m_Uvs.m_Count);
             MakeNumberArrayFromLuaTable<int>(L, "indices", (void**) &geometry.m_Indices.m_Data, &geometry.m_Indices.m_Count);
+
+            dmhash_t id_hash = 0;
+            lua_getfield(L, -1, "id");
+            if (lua_isstring(L, -1))
+            {
+                id_hash = dmHashString64(lua_tostring(L, -1));
+            }
+            lua_pop(L, 1);
+            texture_set_ddf->m_ImageNameHashes[i] = id_hash;
 
             lua_pop(L, 1);
 
@@ -2613,7 +2623,7 @@ static int GetBuffer(lua_State* L)
  * To achieve this, set the `transfer_ownership` flag to true in the argument table. Transferring ownership from a lua buffer to a resource with this function
  * works exactly the same as [ref:resource.create_buffer]: the destination resource will take ownership of the buffer held by the lua reference, i.e the buffer will not automatically be removed
  * when the lua reference to the buffer is garbage collected.
- * 
+ *
  * Note: When setting a buffer with `transfer_ownership = true`, the currently bound buffer in the resource will be destroyed.
  *
  * @name resource.set_buffer

--- a/engine/gamesys/src/gamesys/scripts/script_resource.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_resource.cpp
@@ -1903,6 +1903,9 @@ static void MakeTextureSetFromLua(lua_State* L, dmhash_t texture_path_hash, dmGr
  * * `geometries`
  * : [type:table] A list of the geometries that should map to the texture data. Supports the following fields:
  *
+ * * `id`
+ * : [type:string] The name of the geometry. Used when matching animations between multiple atlases
+ *
  * * `vertices`
  * : [type:table] a list of the vertices in texture space of the geometry in the form {px0, py0, px1, py1, ..., pxn, pyn}
  *
@@ -1948,6 +1951,7 @@ static void MakeTextureSetFromLua(lua_State* L, dmhash_t texture_path_hash, dmGr
  *         },
  *         geometries = {
  *             {
+ *                 id = 'idle0',
  *                 vertices  = {
  *                     0,   0,
  *                     0,   128,


### PR DESCRIPTION
Using the naming of the image, it is possible to use multiple atlases at once, if the ids match.

Fixes https://github.com/defold/defold/issues/8573

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
