### PR TITLE
Editor model rendering optimizations and fixes

### DIFF
--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -238,7 +238,6 @@
 
   (input included-proj-paths+full-lines ProjPath+Lines :array)
 
-  (output build-targets g/Any :cached produce-build-targets)
   (output proj-path->full-lines g/Any (g/fnk [included-proj-paths+full-lines]
                                                 (into {} included-proj-paths+full-lines)))
   (output proj-path+full-lines ProjPath+Lines :cached produce-proj-path+full-lines)

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -13,10 +13,10 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.geom
-  (:require [schema.core :as s]
+  (:require [editor.math :as math]
             [editor.types :as types]
-            [editor.math :as math]
-            [internal.util :as util])
+            [internal.util :as util]
+            [schema.core :as s])
   (:import [com.defold.util Geometry]
            [com.dynamo.bob.textureset TextureSetGenerator$UVTransform]
            [editor.types AABB Frustum Rect]
@@ -536,6 +536,26 @@
                       [(.x p) (.y p) (.z p) 1.0])
                     ps)]
       res)))
+
+(defn transf-n
+  [^Matrix4d m4d normals]
+  (let [n (Vector3d.)]
+    (mapv (fn [[^double x ^double y ^double z]]
+            (.set n x y z)
+            (.transform m4d n)
+            (.normalize n) ; Need to normalize since the matrix may be scaled.
+            [(.x n) (.y n) (.z n)])
+          normals)))
+
+(defn transf-n4
+  [^Matrix4d m4d normals]
+  (let [n (Vector3d.)]
+    (mapv (fn [[^double x ^double y ^double z]]
+            (.set n x y z)
+            (.transform m4d n)
+            (.normalize n) ; Need to normalize since the matrix may be scaled.
+            [(.x n) (.y n) (.z n) 0.0])
+          normals)))
 
 (defn chain [n f ps]
   (loop [i n

--- a/editor/src/clj/editor/gl/shader.clj
+++ b/editor/src/clj/editor/gl/shader.clj
@@ -504,6 +504,9 @@ of GLSL strings and returns an object that satisfies GlBind and GlEnable."
   ([request-id verts frags uniforms array-sampler-name->uniform-names]
    (->ShaderLifecycle request-id verts frags uniforms array-sampler-name->uniform-names)))
 
+(defn shader-lifecycle? [value]
+  (instance? ShaderLifecycle value))
+
 (defn is-using-array-samplers? [shader-lifecycle]
   (pos? (count (:array-sampler-name->uniform-names shader-lifecycle))))
 

--- a/editor/src/clj/editor/gl/texture.clj
+++ b/editor/src/clj/editor/gl/texture.clj
@@ -130,6 +130,9 @@
           (.glActiveTexture ^GL2 gl GL/GL_TEXTURE0)  ; Set TEXTURE0 as the active texture unit in case anything outside of the bind / unbind cycle forgets to call (.glActiveTexture ...)
           (.disable tex gl))))))                     ; Disable the type of texturing e.g. GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
 
+(defn texture-lifecycle? [value]
+  (instance? TextureLifecycle value))
+
 (defn set-params [^TextureLifecycle tlc params]
   (update tlc :params merge params))
 

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -15,20 +15,21 @@
 (ns editor.graphics
   (:require [dynamo.graph :as g]
             [editor.geom :as geom]
-            [editor.gl.vertex2 :as vtx]
             [editor.gl.shader :as shader]
+            [editor.gl.vertex2 :as vtx]
             [editor.properties :as properties]
             [editor.types :as types]
-            [editor.util :as util]
+            [editor.util :as eutil]
             [editor.validation :as validation]
+            [internal.util :as iutil]
             [potemkin.namespaces :as namespaces]
-            [util.coll :as coll :refer [pair]]
+            [util.coll :refer [pair]]
             [util.murmur :as murmur]
             [util.num :as num])
-  (:import [com.jogamp.opengl GL2]
-           [com.google.protobuf ByteString]
-           [java.nio ByteBuffer]
-           [editor.gl.vertex2 VertexBuffer]))
+  (:import [com.google.protobuf ByteString]
+           [com.jogamp.opengl GL2]
+           [editor.gl.vertex2 VertexBuffer]
+           [java.nio ByteBuffer]))
 
 (set! *warn-on-reflection* true)
 
@@ -134,19 +135,40 @@
     (when (not-every? (fn [^double val]
                         (<= min val max))
                       double-values)
-      (util/format* "'%s' attribute components must be between %.0f and %.0f"
-                    (:name attribute)
-                    min
-                    max))))
+      (eutil/format* "'%s' attribute components must be between %.0f and %.0f"
+                     (:name attribute)
+                     min
+                     max))))
 
 (defn validate-doubles [double-values attribute node-id prop-kw]
   (validation/prop-error :fatal node-id prop-kw doubles-outside-attribute-range-error-message double-values attribute))
 
-(defn resize-doubles [double-values semantic-type element-count]
-  (let [fill-value (case semantic-type
-                     :semantic-type-color 1.0 ; Default to opaque white for color attributes.
-                     0.0)]
-    (coll/resize double-values element-count fill-value)))
+;; For positions, we want to have a 1.0 in the W coordinate so that they can be
+;; transformed correctly by a 4D matrix. For colors, we default to opaque white.
+(def ^:private default-attribute-element-values (vector-of :double 0.0 0.0 0.0 0.0))
+(def ^:private default-position-element-values (vector-of :double 0.0 0.0 0.0 1.0))
+(def ^:private default-color-element-values (vector-of :double 1.0 1.0 1.0 1.0))
+
+(defn resize-doubles [double-values semantic-type ^long new-element-count]
+  {:pre [(vector? double-values)
+         (keyword? semantic-type)
+         (nat-int? new-element-count)]}
+  (let [old-element-count (count double-values)]
+    (cond
+      (< new-element-count old-element-count)
+      (subvec double-values 0 new-element-count)
+
+      (> new-element-count old-element-count)
+      (let [default-element-values
+            (case semantic-type
+              :semantic-type-position default-position-element-values
+              :semantic-type-color default-color-element-values
+              default-attribute-element-values)]
+        (into double-values
+              (subvec default-element-values old-element-count new-element-count)))
+
+      :else
+      double-values)))
 
 (defn- default-attribute-doubles-raw [semantic-type element-count]
   (resize-doubles (vector-of :double) semantic-type element-count))
@@ -223,6 +245,28 @@
   (let [vtx-attributes (mapv attribute-info->vtx-attribute attribute-infos)]
     (vtx/make-vertex-description nil vtx-attributes)))
 
+(defn coordinate-space-info
+  "Returns a map of coordinate-space to sets of semantic-type that expect that
+  coordinate-space. Only :semantic-type-position and :semantic-type-normal
+  attributes are considered. We use this to determine if we need to include
+  a :world-transform or :normal-transform in the renderable-datas we supply to
+  the graphics/put-attributes! function. We can also use this information to
+  figure out if we should cancel out the world transform from the render
+  transforms we feed into shaders as uniforms in case the same shader is used to
+  render both world-space and local-space mesh data.
+
+  Example output:
+  {:coordinate-space-local #{:semantic-type-position}
+   :coordinate-space-world #{:semantic-type-position
+                             :semantic-type-normal}}"
+  [attribute-infos]
+  (->> attribute-infos
+       (filter (comp #{:semantic-type-position :semantic-type-normal} :semantic-type))
+       (iutil/group-into
+         {} #{}
+         #(:coordinate-space % :coordinate-space-local)
+         :semantic-type)))
+
 (defn sanitize-attribute [{:keys [data-type normalize] :as attribute}]
   ;; Graphics$VertexAttribute in map format.
   (let [attribute-value-keyword (attribute-value-keyword data-type normalize)
@@ -266,16 +310,18 @@
           :element-count 1}
          {:name "normal"
           :semantic-type :semantic-type-normal
+          :coordinate-space :coordinate-space-world
           :data-type :type-float
           :element-count 3}]))
 
-(defn shader-bound-attributes [^GL2 gl shader material-attribute-infos manufactured-stream-keys default-coordinate-space]
+(defn shader-bound-attributes [^GL2 gl shader material-attribute-infos manufactured-attribute-keys default-coordinate-space]
+  {:pre [(#{:coordinate-space-local :coordinate-space-world} default-coordinate-space)]}
   (let [shader-bound-attribute? (comp boolean (shader/attribute-infos shader gl) :name)
         declared-material-attribute-key? (into #{} (map :name-key) material-attribute-infos)
         manufactured-attribute-infos (into []
                                            (comp (remove declared-material-attribute-key?)
                                                  (map attribute-key->default-attribute-info))
-                                           manufactured-stream-keys)
+                                           manufactured-attribute-keys)
         manufactured-attribute-infos (mapv (fn [attribute]
                                              (if (contains? attribute :coordinate-space)
                                                (assoc attribute :coordinate-space default-coordinate-space)
@@ -456,17 +502,27 @@
                (assoc :vertex-elements (count vertex)))
            exception))
 
-(defn- attribute-data->world-position-v3 [data]
-  (let [local-positions (:position-data data)
-        world-transform (:world-transform data)]
+(defn- renderable-data->world-position-v3 [renderable-data]
+  (let [local-positions (:position-data renderable-data)
+        world-transform (:world-transform renderable-data)]
     (geom/transf-p world-transform local-positions)))
 
-(defn- attribute-data->world-position-v4 [data]
-  (let [local-positions (:position-data data)
-        world-transform (:world-transform data)]
+(defn- renderable-data->world-position-v4 [renderable-data]
+  (let [local-positions (:position-data renderable-data)
+        world-transform (:world-transform renderable-data)]
     (geom/transf-p4 world-transform local-positions)))
 
-(defn put-attributes! [^VertexBuffer vbuf attribute-data-arrays]
+(defn- renderable-data->world-normal-v3 [renderable-data]
+  (let [local-normals (:normal-data renderable-data)
+        normal-transform (:normal-transform renderable-data)]
+    (geom/transf-n normal-transform local-normals)))
+
+(defn- renderable-data->world-normal-v4 [renderable-data]
+  (let [local-normals (:normal-data renderable-data)
+        normal-transform (:normal-transform renderable-data)]
+    (geom/transf-n4 normal-transform local-normals)))
+
+(defn put-attributes! [^VertexBuffer vbuf renderable-datas]
   (let [vertex-description (.vertex-description vbuf)
         vertex-byte-stride (:size vertex-description)
         ^ByteBuffer buf (.buf vbuf)
@@ -492,12 +548,12 @@
 
         put-renderables!
         (fn put-renderables!
-          ^long [^long attribute-byte-offset semantic-type->data put-vertices!]
-          (reduce (fn [^long vertex-byte-offset attribute-data-array]
-                    (let [vertices (semantic-type->data attribute-data-array)]
+          ^long [^long attribute-byte-offset renderable-data->vertices put-vertices!]
+          (reduce (fn [^long vertex-byte-offset renderable-data]
+                    (let [vertices (renderable-data->vertices renderable-data)]
                       (put-vertices! vertex-byte-offset vertices)))
                   attribute-byte-offset
-                  attribute-data-arrays))
+                  renderable-datas))
 
         texcoord-index-vol (volatile! -1)
         page-index-vol (volatile! -1)]
@@ -527,13 +583,14 @@
 
                 (case semantic-type
                   :semantic-type-position
-                  (if (= (:coordinate-space attribute) :coordinate-space-local)
-                    (put-renderables! attribute-byte-offset :position-data put-attribute-doubles!)
+                  (case (:coordinate-space attribute)
+                    :coordinate-space-world
                     (let [renderable-data->world-position
                           (case element-count
-                            3 attribute-data->world-position-v3
-                            4 attribute-data->world-position-v4)]
-                      (put-renderables! attribute-byte-offset renderable-data->world-position put-attribute-doubles!)))
+                            3 renderable-data->world-position-v3
+                            4 renderable-data->world-position-v4)]
+                      (put-renderables! attribute-byte-offset renderable-data->world-position put-attribute-doubles!))
+                    (put-renderables! attribute-byte-offset :position-data put-attribute-doubles!))
 
                   :semantic-type-texcoord
                   (let [i (vswap! texcoord-index-vol inc)]
@@ -542,20 +599,27 @@
                   :semantic-type-page-index
                   (let [i (vswap! page-index-vol inc)]
                     (put-renderables! attribute-byte-offset
-                                      (fn [attribute-data]
-                                        (let [vertex-count (count (:position-data attribute-data))
-                                              page-index (get-in attribute-data [:texcoord-datas i :page-index])]
+                                      (fn [renderable-data]
+                                        (let [vertex-count (count (:position-data renderable-data))
+                                              page-index (get-in renderable-data [:texcoord-datas i :page-index])]
                                           (repeat vertex-count [(double page-index)])))
                                       put-attribute-doubles!))
 
                   :semantic-type-normal
-                  (put-renderables! attribute-byte-offset :normal-data put-attribute-doubles!)
+                  (case (:coordinate-space attribute)
+                    :coordinate-space-world
+                    (let [renderable-data->world-normal
+                          (case element-count
+                            3 renderable-data->world-normal-v3
+                            4 renderable-data->world-normal-v4)]
+                      (put-renderables! attribute-byte-offset renderable-data->world-normal put-attribute-doubles!))
+                    (put-renderables! attribute-byte-offset :normal-data put-attribute-doubles!))
 
                   ;; Default case.
                   (put-renderables! attribute-byte-offset
-                                    (fn [attribute-data]
-                                      (let [vertex-count (count (:position-data attribute-data))
-                                            attribute-bytes (get (:vertex-attribute-bytes attribute-data) name-key)]
+                                    (fn [renderable-data]
+                                      (let [vertex-count (count (:position-data renderable-data))
+                                            attribute-bytes (get (:vertex-attribute-bytes renderable-data) name-key)]
                                         (repeat vertex-count attribute-bytes)))
                                     put-attribute-bytes!))
 

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -6,7 +6,7 @@
 ;; 
 ;; You may obtain a copy of the License, together with FAQs at
 ;; https://www.defold.com/license
-;; 
+;;
 ;; Unless required by applicable law or agreed to in writing, software distributed
 ;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -18,7 +18,6 @@
             [dynamo.graph :as g]
             [editor.animation-set :as animation-set]
             [editor.build-target :as bt]
-            [editor.core :as core]
             [editor.defold-project :as project]
             [editor.geom :as geom]
             [editor.gl.pass :as pass]
@@ -37,13 +36,14 @@
             [editor.workspace :as workspace]
             [internal.util :as util]
             [schema.core :as s]
-            [util.coll :refer [pair]]
+            [util.coll :as coll]
             [util.digest :as digest])
   (:import [com.dynamo.gamesys.proto ModelProto$Model ModelProto$ModelDesc]
-           [editor.gl.shader ShaderLifecycle]
-           [editor.types AABB]))
+           [editor.gl.shader ShaderLifecycle]))
 
 (set! *warn-on-reflection* true)
+
+(def ^:private model-resource-type-label "Model")
 
 (def ^:private model-icon "icons/32/Icons_22-Model.png")
 
@@ -218,51 +218,11 @@
       explicit-textures
       samplers)))
 
-(g/defnk produce-scene [_node-id scene mesh-material-ids material-scene-infos]
-  (if (not scene)
+(g/defnk produce-scene [_node-id scene material-name->material-scene-info]
+  (if scene
+    (model-scene/augment-scene scene _node-id model-resource-type-label material-name->material-scene-info)
     {:aabb geom/empty-bounding-box
-     :renderable {:passes [pass/selection]}}
-    (let [{:keys [renderable aabb]} scene
-          material-index->meshes (->> renderable :user-data :meshes (group-by :material-index))
-          name->material-scene-info (into {}
-                                          (map (juxt :name identity))
-                                          material-scene-infos)
-          material-index->material-scene-info (into {}
-                                                    (keep-indexed
-                                                      (fn [i name]
-                                                        (when-let [info (name->material-scene-info name)]
-                                                          (pair i info))))
-                                                    mesh-material-ids)]
-      {:aabb geom/empty-bounding-box
-       :renderable {:passes [pass/selection]}
-       :children
-       (into (:children scene [])
-             (keep (fn [[material-index meshes]]
-                     (when-let [{:keys [shader vertex-space gpu-textures material-attribute-infos vertex-attribute-bytes]}
-                                ;; If we have no material associated with the index,
-                                ;; we mirror the engine behavior by picking the first one:
-                                ;; https://github.com/defold/defold/blob/a265a1714dc892eea285d54eae61d0846b48899d/engine/gamesys/src/gamesys/resources/res_model.cpp#L234-L238
-                                (or (material-index->material-scene-info material-index)
-                                    (first material-scene-infos))]
-                       {:node-id _node-id
-                        :aabb aabb
-                        :renderable (-> renderable
-                                        (dissoc :children)
-                                        (assoc-in [:user-data :shader] shader)
-                                        (assoc-in [:user-data :vertex-space] vertex-space)
-                                        (assoc-in [:user-data :textures] gpu-textures)
-                                        (assoc-in [:user-data :meshes] meshes)
-                                        (assoc-in [:user-data :material-attribute-infos] material-attribute-infos)
-                                        (assoc-in [:user-data :vertex-attribute-bytes] vertex-attribute-bytes)
-                                        (update :batch-key
-                                                (fn [old-key]
-                                                  ;; We can only batch-render models that use
-                                                  ;; :vertex-space-world. In :vertex-space-local
-                                                  ;; we must supply individual transforms for
-                                                  ;; each model instance in the shader uniforms.
-                                                  (when (= :vertex-space-world vertex-space)
-                                                    [old-key shader gpu-textures]))))})))
-             material-index->meshes)})))
+     :renderable {:passes [pass/selection]}}))
 
 (g/defnk produce-bones [skeleton-bones animations-bones]
   (or animations-bones skeleton-bones))
@@ -503,7 +463,6 @@
             (set (fn [evaluation-context self old-value new-value]
                    (project/resource-setter evaluation-context self old-value new-value
                                             [:resource :mesh-resource]
-                                            [:aabb :aabb]
                                             [:mesh-set-build-target :mesh-set-build-target]
                                             [:material-ids :mesh-material-ids]
                                             [:scene :scene])))
@@ -528,6 +487,17 @@
               material-binding-infos)))
   (input scene g/Any)
   (input material-scene-infos g/Any :array)
+
+  (output material-name->material-scene-info g/Any :cached
+          (g/fnk [material-scene-infos]
+            (let [material-scene-infos-by-material-name (coll/pair-map-by :name material-scene-infos)]
+              (fn material-name->material-scene-info [^String material-name]
+                ;; If we have no material associated with the index, we mirror the
+                ;; engine behavior by picking the first one:
+                ;; https://github.com/defold/defold/blob/a265a1714dc892eea285d54eae61d0846b48899d/engine/gamesys/src/gamesys/resources/res_model.cpp#L234-L238
+                (or (material-scene-infos-by-material-name material-name)
+                    (first material-scene-infos))))))
+
   (property skeleton resource/Resource
             (value (gu/passthrough skeleton-resource))
             (set (fn [evaluation-context self old-value new-value]
@@ -573,12 +543,9 @@
 
   (input animation-infos g/Any :array)
   (input animation-ids g/Any)
-  (input aabb AABB)
 
   (output bones g/Any produce-bones)
-
   (output animation-resources g/Any (g/fnk [animations-resource] [animations-resource]))
-
   (output animation-info g/Any :cached animation-set/produce-animation-info)
   (output animation-set-info g/Any :cached animation-set/produce-animation-set-info)
   (output animation-set g/Any :cached animation-set/produce-animation-set)
@@ -590,10 +557,7 @@
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-value g/Any :cached produce-save-value)
   (output build-targets g/Any :cached produce-build-targets)
-
   (output scene g/Any :cached produce-scene)
-
-  (output aabb AABB (gu/passthrough aabb))
   (output _properties g/Properties :cached produce-model-properties))
 
 (defn load-model [_project self resource {:keys [name default-animation mesh skeleton animations materials] :as pb}]
@@ -631,7 +595,7 @@
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
     :ext "model"
-    :label "Model"
+    :label model-resource-type-label
     :node-type ModelNode
     :ddf-type ModelProto$ModelDesc
     :load-fn load-model

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -27,6 +27,7 @@
             [editor.resource :as resource]
             [editor.resource-node :as resource-node]
             [editor.rig :as rig]
+            [editor.scene :as scene]
             [editor.scene-cache :as scene-cache]
             [editor.scene-picking :as scene-picking]
             [editor.workspace :as workspace]
@@ -34,9 +35,8 @@
   (:import [com.google.protobuf ByteString]
            [com.jogamp.opengl GL GL2]
            [editor.gl.vertex2 VertexBuffer]
-           [editor.types AABB]
-           [java.nio ByteBuffer ByteOrder FloatBuffer IntBuffer ShortBuffer]
-           [javax.vecmath Matrix3f Matrix4d Matrix4f Point3d Point3f Vector3f]))
+           [java.nio ByteOrder]
+           [javax.vecmath Matrix4d]))
 
 (set! *warn-on-reflection* true)
 
@@ -44,36 +44,35 @@
 (def model-file-types ["dae" "gltf" "glb"])
 (def animation-file-types ["animationset" "dae" "gltf" "glb"])
 
-(vtx/defvertex vtx-pos-nrm-tex
-  (vec3 position)
-  (vec3 normal)
-  (vec2 texcoord0))
-
-(vtx/defvertex vtx-pos-tex
-  (vec3 position)
-  (vec2 texcoord0))
-
-(shader/defshader shader-ver-pos-nrm-tex
+(shader/defshader preview-vertex-shader
+  (uniform mat4 world_view_proj_matrix)
+  (uniform mat4 normal_matrix)
   (attribute vec4 position)
-  (attribute vec3 normal)
+  (attribute vec4 normal)
   (attribute vec2 texcoord0)
   (varying vec3 var_normal)
   (varying vec2 var_texcoord0)
   (defn void main []
-    (setq gl_Position (* gl_ModelViewProjectionMatrix position))
+    (setq gl_Position (* world_view_proj_matrix position))
     (setq var_texcoord0 texcoord0)
-    (setq var_normal normal)))
+    (setq var_normal (normalize (.xyz (* normal_matrix normal))))))
 
-(shader/defshader shader-frag-pos-nrm-tex
+(shader/defshader preview-fragment-shader
   (varying vec3 var_normal)
   (varying vec2 var_texcoord0)
   (uniform sampler2D texture_sampler)
   (defn void main []
-    (setq gl_FragColor (vec4 (* (.xyz (texture2D texture_sampler var_texcoord0.xy)) var_normal.z) 1.0))))
+    (setq float brightness (.z var_normal))
+    (setq vec3 color (.xyz (texture2D texture_sampler var_texcoord0)))
+    (setq gl_FragColor (vec4 (* color brightness) 1.0))))
 
-(def shader-pos-nrm-tex (shader/make-shader ::shader shader-ver-pos-nrm-tex shader-frag-pos-nrm-tex))
+(def preview-shader (shader/make-shader ::shader preview-vertex-shader preview-fragment-shader {"normal_matrix" :normal "world_view_proj_matrix" :world-view-proj}))
 
-(shader/defshader model-id-vertex-shader
+(vtx/defvertex id-vertex
+  (vec3 position)
+  (vec2 texcoord0))
+
+(shader/defshader id-vertex-shader
   (attribute vec4 position)
   (attribute vec2 texcoord0)
   (varying vec2 var_texcoord0)
@@ -81,7 +80,7 @@
     (setq gl_Position (* gl_ModelViewProjectionMatrix position))
     (setq var_texcoord0 texcoord0)))
 
-(shader/defshader model-id-fragment-shader
+(shader/defshader id-fragment-shader
   (varying vec2 var_texcoord0)
   (uniform sampler2D texture_sampler)
   (uniform vec4 id)
@@ -91,214 +90,161 @@
       (setq gl_FragColor id)
       (discard))))
 
-(def id-shader (shader/make-shader ::model-id-shader model-id-vertex-shader model-id-fragment-shader {"id" :id}))
+(def id-shader (shader/make-shader ::id-shader id-vertex-shader id-fragment-shader {"id" :id}))
 
-(defn- transf-n
-  [^Matrix3f m3f normals]
-  (let [normal-tmp (Vector3f.)]
-    (mapv (fn [[^float x ^float y ^float z]]
-            (.set normal-tmp x y z)
-            (.transform m3f normal-tmp)
-            (.normalize normal-tmp) ; need to normalize since normal-transform may be scaled
-            [(.x normal-tmp) (.y normal-tmp) (.z normal-tmp)])
-          normals)))
+(defn- doubles->floats
+  ^floats [ds]
+  (float-array (map float ds)))
 
-(defn- mesh->attribute-data [mesh ^Matrix4d world-transform ^Matrix3f normal-transform vertex-attribute-bytes vertex-space]
-  (let [^ints indices (:indices mesh)
-        ^floats positions (:positions mesh)
-        ^floats texcoords (:texcoord0 mesh)
-        ^floats normals   (:normals mesh)
-        mesh-data-out
-        (reduce (fn [out-data ^long vi]
-                  (let [p-base (* 3 vi)
-                        p-0 (double (get positions p-base))
-                        p-1 (double (get positions (+ 1 p-base)))
-                        p-2 (double (get positions (+ 2 p-base)))
+(defn- bytes-to-indices
+  ^ints [^ByteString indices index-format]
+  (let [byte-buffer (.order (.asReadOnlyByteBuffer indices) ByteOrder/LITTLE_ENDIAN)
 
-                        tc0-base (* 2 vi)
-                        tc0-0 (double (get texcoords tc0-base))
-                        tc0-1 (double (get texcoords (+ 1 tc0-base)))
+        num-indices
+        (int (case index-format
+               :indexbuffer-format-16 (/ (.size indices) 2)
+               :indexbuffer-format-32 (/ (.size indices) 4)))
 
-                        n-base (* 3 vi)
-                        n-0 (get normals n-base)
-                        n-1 (get normals (+ 1 n-base))
-                        n-2 (get normals (+ 2 n-base))]
-                    (assoc out-data
-                      :position-data (conj (:position-data out-data) [p-0 p-1 p-2])
-                      :normal-data (conj (:normal-data out-data) [n-0 n-1 n-2])
-                      :uv-data (conj (:uv-data out-data) [tc0-0 tc0-1]))))
-                {:position-data []
-                 :uv-data []
-                 :normal-data []
-                 :world-transform world-transform
-                 :vertex-attribute-bytes vertex-attribute-bytes}
-                indices)]
-    (-> mesh-data-out
-        (cond-> (= vertex-space :vertex-space-world)
-                (assoc :position-data (geom/transf-p world-transform (:position-data mesh-data-out))
-                       :normal-data (transf-n normal-transform (:normal-data mesh-data-out))))
-        (assoc :texcoord-datas [{:uv-data (:uv-data mesh-data-out)}]))))
+        out-indices (int-array num-indices)]
 
-(defn mesh->vb! [^VertexBuffer vbuf ^Matrix4d world-transform vertex-space vertex-attribute-bytes mesh]
-  (let [normal-transform (let [tmp (Matrix3f.)]
-                           (.getRotationScale world-transform tmp)
-                           (.invert tmp)
-                           (.transpose tmp)
-                           tmp)
-        mesh-data (mesh->attribute-data mesh world-transform normal-transform vertex-attribute-bytes vertex-space)]
-    (graphics/put-attributes! vbuf [mesh-data])
+    (case index-format
+      :indexbuffer-format-16
+      (let [short-buffer (.asShortBuffer byte-buffer)]
+        (dotimes [i num-indices]
+          (aset out-indices i (int (.get short-buffer i)))))
+
+      :indexbuffer-format-32
+      (let [int-buffer (.asIntBuffer byte-buffer)]
+        (.get int-buffer out-indices)))
+
+    out-indices))
+
+(defn mesh->renderable-data [mesh]
+  (let [positions (doubles->floats (:positions mesh))
+        normals (doubles->floats (:normals mesh))
+        texcoord0s (doubles->floats (:texcoord0 mesh))
+        indices (bytes-to-indices (:indices mesh) (:indices-format mesh))
+        ^int texcoord0-component-count (:num-texcoord0-components mesh 0)
+        positions-count (/ (alength positions) 3)
+        normals-count (/ (alength normals) 3)
+        texcoord0-count (/ (alength texcoord0s) texcoord0-component-count)
+        max-index (reduce max 0 indices)]
+    (if (and (< max-index positions-count)
+             (or (zero? normals-count)
+                 (= positions-count normals-count))
+             (or (zero? texcoord0-count)
+                 (= positions-count texcoord0-count)))
+      (let [mesh-data-out
+            (reduce (fn [out-data ^long vi]
+                      (let [p-base (* 3 vi)
+                            p-0 (double (get positions p-base))
+                            p-1 (double (get positions (+ 1 p-base)))
+                            p-2 (double (get positions (+ 2 p-base)))
+
+                            tc0-base (* 2 vi)
+                            tc0-0 (double (get texcoord0s tc0-base))
+                            tc0-1 (double (get texcoord0s (+ 1 tc0-base)))
+
+                            n-base (* 3 vi)
+                            n-0 (get normals n-base)
+                            n-1 (get normals (+ 1 n-base))
+                            n-2 (get normals (+ 2 n-base))]
+                        (assoc out-data
+                          :position-data (conj (:position-data out-data) [p-0 p-1 p-2])
+                          :normal-data (conj (:normal-data out-data) [n-0 n-1 n-2])
+                          :uv-data (conj (:uv-data out-data) [tc0-0 tc0-1]))))
+                    {:position-data []
+                     :uv-data []
+                     :normal-data []}
+                    indices)]
+        (-> mesh-data-out
+            (dissoc :uv-data)
+            (assoc :texcoord-datas [{:uv-data (:uv-data mesh-data-out)}])))
+      (error-values/error-fatal "Failed to produce vertex buffers from mesh set. The scene might contain invalid data."))))
+
+(defn mesh->vb! [^VertexBuffer vbuf ^Matrix4d world-transform ^Matrix4d normal-transform vertex-attribute-bytes mesh-renderable-data]
+  (let [mesh-renderable-data
+        (cond-> mesh-renderable-data
+                world-transform (assoc :world-transform world-transform)
+                normal-transform (assoc :normal-transform normal-transform)
+                vertex-attribute-bytes (assoc :vertex-attribute-bytes vertex-attribute-bytes))]
+    (graphics/put-attributes! vbuf [mesh-renderable-data])
     vbuf))
 
-(defn- request-vb! [^GL2 gl node-id mesh ^Matrix4d world-transform vertex-space vertex-description vertex-attribute-bytes]
-  (let [clj-world (math/vecmath->clj world-transform)
-        request-id [node-id mesh]
-        data {:mesh mesh :world-transform clj-world :vertex-space vertex-space :vertex-description vertex-description :vertex-attribute-bytes vertex-attribute-bytes}]
+(defn- request-vb! [^GL2 gl request-id mesh-renderable-data ^Matrix4d attribute-world-transform ^Matrix4d attribute-normal-transform vertex-description vertex-attribute-bytes]
+  (let [data {:mesh-renderable-data mesh-renderable-data :world-transform attribute-world-transform :normal-transform attribute-normal-transform :vertex-description vertex-description :vertex-attribute-bytes vertex-attribute-bytes}]
     (scene-cache/request-object! ::vb request-id gl data)))
 
-(defn- render-scene-opaque [^GL2 gl render-args renderables rcount]
-  (let [renderable (first renderables)
-        user-data (:user-data renderable)
-        shader (:shader user-data)
-        textures (:textures user-data)
-        vertex-space (:vertex-space user-data)
-        meshes (:meshes user-data)
-        mesh (first meshes)
-        ^Matrix4d local-transform (:transform mesh) ; Each mesh uses the local matrix of the model it belongs to
-        ^Matrix4d world-transform (:world-transform renderable)
-        world-matrix (doto (Matrix4d. world-transform) (.mul local-transform))
-        vertex-space-world-transform (if (= vertex-space :vertex-space-world)
-                                       (doto (Matrix4d.) (.setIdentity)) ; already applied the world transform to vertices
-                                       world-matrix)
-        render-args (merge render-args
-                           (math/derive-render-transforms vertex-space-world-transform
-                                                          (:view render-args)
-                                                          (:projection render-args)
-                                                          (:texture render-args)))]
-    (gl/with-gl-bindings gl render-args [shader]
+(defn- render-mesh-opaque-impl [^GL2 gl render-args renderable request-prefix override-shader override-vertex-description extra-render-args]
+  (let [{:keys [node-id user-data ^Matrix4d world-transform]} renderable
+        {:keys [material-attribute-infos mesh-renderable-data textures vertex-attribute-bytes]} user-data
+        shader (or override-shader (:shader user-data))
+        default-coordinate-space (case (:vertex-space user-data :vertex-space-local)
+                                   :vertex-space-local :coordinate-space-local
+                                   :vertex-space-world :coordinate-space-world)
+        vertex-description (or override-vertex-description
+                               (let [manufactured-attribute-keys [:position :texcoord0 :normal]
+                                     shader-bound-attributes (graphics/shader-bound-attributes gl shader material-attribute-infos manufactured-attribute-keys default-coordinate-space)]
+                                 (graphics/make-vertex-description shader-bound-attributes)))
+        coordinate-space-info (graphics/coordinate-space-info (:attributes vertex-description))
+        render-transforms (math/derive-render-transforms world-transform
+                                                         (:view render-args)
+                                                         (:projection render-args)
+                                                         (:texture render-args)
+                                                         coordinate-space-info)
+        render-args (merge render-args render-transforms extra-render-args)
+        world-space-semantic-types (:coordinate-space-world coordinate-space-info)
+        attribute-world-transform (when (contains? world-space-semantic-types :semantic-type-position)
+                                    world-transform)
+        attribute-normal-transform (when (contains? world-space-semantic-types :semantic-type-normal)
+                                     (math/derive-normal-transform world-transform))
+        request-id (if (or attribute-world-transform attribute-normal-transform)
+                     [request-prefix node-id mesh-renderable-data vertex-attribute-bytes vertex-description] ; World-space attributes present. The request needs to be unique for this node-id.
+                     [request-prefix mesh-renderable-data vertex-attribute-bytes vertex-description]) ; No world-space attributes present. We can share the GPU objects between instances of this mesh.
+        vb (request-vb! gl request-id mesh-renderable-data attribute-world-transform attribute-normal-transform vertex-description vertex-attribute-bytes)
+        vertex-binding (vtx/use-with request-id vb shader)]
+    (gl/with-gl-bindings gl render-args [vertex-binding shader]
       (doseq [[name t] textures]
         (gl/bind gl t render-args)
         (shader/set-samplers-by-name shader gl name (:texture-units t)))
-      (.glBlendFunc gl GL/GL_ONE GL/GL_ONE_MINUS_SRC_ALPHA)
+      (gl/gl-disable gl GL/GL_BLEND)
       (gl/gl-enable gl GL/GL_CULL_FACE)
       (gl/gl-cull-face gl GL/GL_BACK)
-      (doseq [renderable renderables
-              :let [node-id (:node-id renderable)
-                    user-data (:user-data renderable)
-                    meshes (:meshes user-data)
-                    mesh (first meshes)
-
-                    ^Matrix4d local-transform (:transform mesh) ; Each mesh uses the local matrix of the model it belongs to
-                    ^Matrix4d world-transform (:world-transform renderable)
-                    world-matrix (doto (Matrix4d. world-transform) (.mul local-transform))
-
-                    shader-bound-attributes (graphics/shader-bound-attributes gl shader (:material-attribute-infos user-data) [:position :texcoord0 :normal] :coordinate-space-local)
-                    vertex-description (graphics/make-vertex-description shader-bound-attributes)
-                    vertex-attribute-bytes (:vertex-attribute-bytes user-data)]
-              mesh meshes
-              :let [vb (request-vb! gl node-id mesh world-matrix vertex-space vertex-description vertex-attribute-bytes)
-                    vertex-binding (vtx/use-with [node-id ::mesh] vb shader)]]
-          (gl/with-gl-bindings gl render-args [vertex-binding]
-            (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))))
+      (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))
       (gl/gl-disable gl GL/GL_CULL_FACE)
-      (.glBlendFunc gl GL/GL_SRC_ALPHA GL/GL_ONE_MINUS_SRC_ALPHA)
-      (doseq [[name t] textures]
+      (gl/gl-enable gl GL/GL_BLEND)
+      (doseq [[_name t] textures]
         (gl/unbind gl t render-args)))))
 
-(defn- render-scene-opaque-selection [^GL2 gl render-args renderables _rcount]
-  (let [renderable (first renderables)
-        user-data (:user-data renderable)
-        textures (:textures user-data)]
-    (gl/gl-enable gl GL/GL_CULL_FACE)
-    (gl/gl-cull-face gl GL/GL_BACK)
-    (doseq [renderable renderables
-            :let [node-id (:node-id renderable)
-                  user-data (:user-data renderable)
-                  meshes (:meshes user-data)
-                  mesh (first meshes)
-                  ^Matrix4d local-transform (:transform mesh) ; Each mesh uses the local matrix of the model it belongs to
-                  ^Matrix4d world-transform (:world-transform renderable)
-                  world-matrix (doto (Matrix4d. world-transform) (.mul local-transform))
-                  render-args (assoc render-args :id (scene-picking/renderable-picking-id-uniform renderable))]]
-      (gl/with-gl-bindings gl render-args [id-shader]
-        (doseq [[name t] textures]
-          (gl/bind gl t render-args)
-          (shader/set-samplers-by-name id-shader gl name (:texture-units t)))
-        (doseq [mesh meshes
-                :let [vb (request-vb! gl node-id mesh world-matrix :vertex-space-local vtx-pos-tex nil)
-                      vertex-binding (vtx/use-with [node-id ::mesh-selection] vb id-shader)]]
-          (gl/with-gl-bindings gl render-args [vertex-binding]
-            (gl/gl-draw-arrays gl GL/GL_TRIANGLES 0 (count vb))))
-        (doseq [[name t] textures]
-          (gl/unbind gl t render-args))))
-    (gl/gl-disable gl GL/GL_CULL_FACE)))
+(defn- render-mesh-opaque [^GL2 gl render-args renderable]
+  (render-mesh-opaque-impl gl render-args renderable ::mesh nil nil nil))
 
-(defn- render-scene [^GL2 gl render-args renderables rcount]
-  (let [pass (:pass render-args)]
+(defn- render-mesh-opaque-selection [^GL2 gl render-args renderable]
+  (let [extra-render-args {:id (scene-picking/renderable-picking-id-uniform renderable)}]
+    (render-mesh-opaque-impl gl render-args renderable ::mesh-selection id-shader id-vertex extra-render-args)))
+
+(defn- render-mesh [^GL2 gl render-args renderables rcount]
+  (assert (= 1 rcount) "Batching is disabled in the editor for simplicity.")
+  (let [pass (:pass render-args)
+        renderable (first renderables)]
     (condp = pass
       pass/opaque
-      (render-scene-opaque gl render-args renderables rcount)
+      (render-mesh-opaque gl render-args renderable)
 
       pass/opaque-selection
-      (render-scene-opaque-selection gl render-args renderables rcount))))
+      (render-mesh-opaque-selection gl render-args renderable))))
 
 (defn- render-outline [^GL2 gl render-args renderables rcount]
-  (let [pass (:pass render-args)]
-    (condp = pass
-      pass/outline
-      (let [renderable (first renderables)
-            node-id (:node-id renderable)]
-        (render/render-aabb-outline gl render-args [node-id ::outline] renderables rcount)))))
+  (assert (= 1 rcount) "Batching is disabled in the editor for simplicity.")
+  (let [pass (:pass render-args)
+        renderable (first renderables)
+        node-id (:node-id renderable)
+        request-id [::outline node-id]]
+    (assert (= pass/outline pass))
+    (render/render-aabb-outline gl render-args request-id renderables rcount)))
 
-(g/defnk produce-mesh-set [content]
-  (:mesh-set content))
-
-(defn- doubles->floats [ds]
-  (float-array (map float ds)))
-
-(defn- bytes-to-indices [^ByteString indices index-format]
-  (let [num-bytes (.size indices)
-        ba (byte-array num-bytes)
-        _ (.copyTo indices ba 0)
-        bb (ByteBuffer/wrap ba)
-        _ (.order bb ByteOrder/LITTLE_ENDIAN)
-        bo (if (= :indexbuffer-format-16 index-format)
-             (.asShortBuffer bb)
-             (.asIntBuffer bb))
-
-        ;; Make it into a human readable/printable int array
-        count (if (= :indexbuffer-format-16 index-format)
-                (/ num-bytes 2)
-                (/ num-bytes 4))
-        ia (int-array count)]
-    (if (= :indexbuffer-format-16 index-format)
-      (dotimes [i count]
-        (aset ia i (int (.get ^ShortBuffer bo i))))
-      (dotimes [i count]
-        (aset ia i (.get ^IntBuffer bo i))))
-    ia))
-
-(defn- arrayify [mesh]
-  (-> mesh
-      (update :positions doubles->floats)
-      (update :normals doubles->floats)
-      (update :texcoord0 doubles->floats)
-      (update :indices (fn [bytes] (bytes-to-indices bytes (:indices-format mesh))))))
-
-(defn- get-and-update-meshes [model]
-  (let [transform (:local model)
-        local-matrix (math/clj->mat4 (:translation transform) (:rotation transform) (:scale transform))
-        meshes (:meshes model)
-        out (map arrayify meshes)
-        out (map (fn [mesh] (assoc mesh :transform local-matrix)) out)]
-    out))
-
-(g/defnk produce-meshes [mesh-set]
-  (let [models (:models mesh-set)
-        meshes (flatten (map get-and-update-meshes models))]
-    meshes))
-
-(g/defnk produce-mesh-set-build-target [_node-id resource mesh-set]
-  (rig/make-mesh-set-build-target (resource/workspace resource) _node-id mesh-set))
+(g/defnk produce-mesh-set-build-target [_node-id resource content]
+  (rig/make-mesh-set-build-target (resource/workspace resource) _node-id (:mesh-set content)))
 
 (g/defnk produce-skeleton [content]
   (:skeleton content))
@@ -310,7 +256,7 @@
   (:bones content))
 
 (g/defnk produce-content [_node-id resource]
-      (model-loader/load-scene _node-id resource))
+  (model-loader/load-scene _node-id resource))
 
 (g/defnk produce-animation-info [resource]
   [{:path (resource/proj-path resource) :parent-id "" :resource resource}])
@@ -318,78 +264,165 @@
 (g/defnk produce-animation-ids [content]
   (:animation-ids content))
 
+(def ^:private default-material-ids ["default"])
+
 (g/defnk produce-material-ids [content]
   (let [ret (:material-ids content)]
     (if (zero? (count ret))
-      ["default"]
+      default-material-ids
       ret)))
 
-(defn- index-oob [vs is comp-count]
-  (> (* comp-count (reduce max 0 is)) (count vs)))
+(defn- make-renderable-mesh [mesh mesh-material-index->material-name]
+  (let [mesh-renderable-data (mesh->renderable-data mesh)]
+    (if (g/error-value? mesh-renderable-data)
+      mesh-renderable-data
+      (let [{:keys [aabb-min aabb-max ^int material-index]} mesh
+            mesh-aabb (geom/coords->aabb aabb-min aabb-max)
+            material-name (mesh-material-index->material-name material-index)]
+        {:aabb mesh-aabb
+         :material-name material-name
+         :renderable-data mesh-renderable-data}))))
 
-(defn- validate-meshes [meshes]
-  (when-let [es (seq (keep (fn [m]
-                             (let [{:keys [^floats positions ^floats normals ^floats texcoord0 ^ints indices]} m]
-                               (when (or (and (not= (alength normals) 0) (not= (alength positions) (alength normals))) ; normals optional
-                                         (index-oob positions indices 3))
-                                 (error-values/error-fatal "Failed to produce vertex buffers from mesh set. The scene might contain invalid data."))))
-                       meshes))]
-    (error-values/error-aggregate es)))
+(defn- make-renderable-model [model mesh-material-index->material-name]
+  (let [{:keys [translation rotation scale]} (:local model)
+        model-transform (math/clj->mat4 translation rotation scale)
 
-(g/defnk produce-scene [_node-id aabb meshes]
-  (or (validate-meshes meshes)
-      {:node-id _node-id
-       :aabb aabb
-       :renderable {:render-fn render-scene
-                    :tags #{:model}
-                    :batch-key _node-id
-                    :select-batch-key _node-id
-                    :user-data {:meshes meshes
-                                :shader shader-pos-nrm-tex
-                                :textures {"texture" @texture/white-pixel}}
-                    :passes [pass/opaque pass/opaque-selection]}
-       :children [{:node-id _node-id
-                   :aabb aabb
-                   :renderable {:render-fn render-outline
-                                :tags #{:model :outline}
-                                :batch-key _node-id
-                                :select-batch-key _node-id
-                                :passes [pass/outline]}}]}))
+        renderable-meshes
+        (mapv #(make-renderable-mesh % mesh-material-index->material-name)
+              (:meshes model))]
+
+    (g/precluding-errors renderable-meshes
+      (let [model-aabb (transduce
+                         (map :aabb)
+                         geom/aabb-union
+                         geom/null-aabb
+                         renderable-meshes)]
+        {:transform model-transform
+         :aabb model-aabb
+         :renderable-meshes renderable-meshes}))))
+
+(defn- make-renderable-mesh-set [mesh-set mesh-material-index->material-name]
+  (let [renderable-models
+        (mapv #(make-renderable-model % mesh-material-index->material-name)
+              (:models mesh-set))]
+
+    (g/precluding-errors renderable-models
+      (let [mesh-set-aabb (transduce
+                            (map (fn [{:keys [aabb transform]}]
+                                   (geom/aabb-transform aabb transform)))
+                            geom/aabb-union
+                            geom/null-aabb
+                            renderable-models)]
+        {:aabb mesh-set-aabb
+         :renderable-models renderable-models}))))
+
+(g/defnk produce-renderable-mesh-set [content]
+  (let [mesh-material-index->material-name
+        (or (some-> content :material-ids not-empty vec)
+            default-material-ids)]
+    (make-renderable-mesh-set (:mesh-set content) mesh-material-index->material-name)))
+
+(defn- make-mesh-scene [renderable-mesh model-scene-resource-node-id]
+  (let [{:keys [aabb material-name renderable-data]} renderable-mesh]
+    {:node-id model-scene-resource-node-id
+     :aabb aabb
+     :renderable {:render-fn render-mesh
+                  :tags #{:model}
+                  :batch-key nil ; Batching is disabled in the editor for simplicity.
+                  :select-batch-key model-scene-resource-node-id
+                  :passes [pass/opaque pass/opaque-selection]
+                  :user-data {:mesh-renderable-data renderable-data
+                              :vertex-space :vertex-space-local
+                              :material-name material-name
+                              :shader preview-shader
+                              :textures {"texture_sampler" @texture/white-pixel}}}}))
+
+(defn- make-model-scene [renderable-model model-scene-resource-node-id]
+  (let [{:keys [transform aabb renderable-meshes]} renderable-model
+        mesh-scenes (mapv #(make-mesh-scene % model-scene-resource-node-id)
+                          renderable-meshes)]
+    {:node-id model-scene-resource-node-id
+     :transform transform
+     :aabb aabb
+     :children mesh-scenes}))
+
+(defn- make-scene [renderable-mesh-set model-scene-resource-node-id]
+  (let [{:keys [aabb renderable-models]} renderable-mesh-set
+        model-scenes (mapv #(make-model-scene % model-scene-resource-node-id)
+                           renderable-models)]
+    {:node-id model-scene-resource-node-id
+     :aabb aabb
+     :renderable {:render-fn render-outline
+                  :tags #{:model :outline}
+                  :batch-key nil ; Batching is disabled in the editor for simplicity.
+                  :select-batch-key model-scene-resource-node-id
+                  :passes [pass/outline]}
+     :children model-scenes}))
+
+(g/defnk produce-scene [_node-id renderable-mesh-set]
+  (make-scene renderable-mesh-set _node-id))
+
+(defn- augment-mesh-scene [mesh-scene old-node-id new-node-id new-node-outline-key material-name->material-scene-info]
+  (let [mesh-renderable (:renderable mesh-scene)
+        material-name (:material-name mesh-renderable)
+        material-scene-info (material-name->material-scene-info material-name)
+        claimed-scene (scene/claim-child-scene old-node-id new-node-id new-node-outline-key mesh-scene)]
+    (if (nil? material-scene-info)
+      claimed-scene
+      (let [{:keys [gpu-textures material-attribute-infos shader vertex-attribute-bytes vertex-space]} material-scene-info]
+        (assert (map? gpu-textures))
+        (assert (every? string? (keys gpu-textures)))
+        (assert (every? texture/texture-lifecycle? (vals gpu-textures)))
+        (assert (every? map? material-attribute-infos))
+        (assert (every? keyword? (map :name-key material-attribute-infos)))
+        (assert (shader/shader-lifecycle? shader))
+        (assert (map? vertex-attribute-bytes))
+        (assert (every? keyword? (keys vertex-attribute-bytes)))
+        (assert (every? bytes? (vals vertex-attribute-bytes)))
+        (assert (#{:vertex-space-local :vertex-space-world} vertex-space))
+        (update
+          claimed-scene
+          :renderable
+          (fn [renderable]
+            (update
+              renderable
+              :user-data
+              assoc
+              :material-attribute-infos material-attribute-infos
+              :shader shader
+              :textures gpu-textures
+              :vertex-attribute-bytes vertex-attribute-bytes
+              :vertex-space vertex-space)))))))
+
+(defn- augment-model-scene [model-scene old-node-id new-node-id new-node-outline-key material-name->material-scene-info]
+  (let [mesh-scenes (:children model-scene)]
+    (assoc (scene/claim-child-scene old-node-id new-node-id new-node-outline-key model-scene)
+      :children (mapv #(augment-mesh-scene % old-node-id new-node-id new-node-outline-key material-name->material-scene-info)
+                      mesh-scenes))))
+
+(defn augment-scene [scene new-node-id new-node-outline-key material-name->material-scene-info]
+  (if (g/error-value? scene)
+    scene
+    (let [old-node-id (:node-id scene)
+          model-scenes (:children scene)]
+      (assoc scene
+        :node-id new-node-id
+        :node-outline-key new-node-outline-key
+        :children (mapv #(augment-model-scene % old-node-id new-node-id new-node-outline-key material-name->material-scene-info)
+                        model-scenes)))))
 
 (g/defnode ModelSceneNode
   (inherits resource-node/ResourceNode)
 
   (output content g/Any :cached produce-content)
-  
-  ; TODO: Ask for this info from the importer
-  (output aabb AABB :cached (g/fnk [meshes]
-                              (loop [aabb geom/null-aabb
-                                     meshes meshes]
-                                (if-let [m (first meshes)]
-                                  (let [^floats ps (:positions m)
-                                        c (alength ps)
-                                        ^Matrix4d local-transform (:transform m) ; Each mesh uses the local matrix of the model it belongs to
-                                        aabb (loop [i 0
-                                                    aabb aabb]
-                                               (if (< i c)
-                                                 (let [x (aget ps i)
-                                                       y (aget ps (+ 1 i))
-                                                       z (aget ps (+ 2 i))
-                                                       p (Point3d. x y z)
-                                                       _ (.transform local-transform p)]
-                                                   (recur (+ i 3) (geom/aabb-incorporate aabb p)))
-                                                 aabb))]
-                                    (recur aabb (next meshes)))
-                                  aabb))))
   (output bones g/Any produce-bones)
   (output animation-info g/Any produce-animation-info)
   (output animation-ids g/Any produce-animation-ids)
   (output material-ids g/Any produce-material-ids)
-  (output mesh-set g/Any produce-mesh-set)
-  (output meshes g/Any :cached produce-meshes)
   (output mesh-set-build-target g/Any :cached produce-mesh-set-build-target)
   (output skeleton g/Any produce-skeleton)
   (output skeleton-build-target g/Any :cached produce-skeleton-build-target)
+  (output renderable-mesh-set g/Any :cached produce-renderable-mesh-set)
   (output scene g/Any :cached produce-scene))
 
 (defn register-resource-types [workspace]
@@ -400,14 +433,15 @@
                                     :icon mesh-icon
                                     :view-types [:scene :text]))
 
-(defn- update-vb [^GL2 gl ^VertexBuffer vb data]
-  (let [{:keys [mesh world-transform vertex-space vertex-attribute-bytes]} data
-        world-transform (doto (Matrix4d.) (math/clj->vecmath world-transform))]
-    (mesh->vb! vb world-transform vertex-space vertex-attribute-bytes mesh)))
+(defn- update-vb [^GL2 _gl ^VertexBuffer vb data]
+  (let [{:keys [mesh-renderable-data ^Matrix4d world-transform ^Matrix4d normal-transform vertex-attribute-bytes]} data]
+    (mesh->vb! vb world-transform normal-transform vertex-attribute-bytes mesh-renderable-data)
+    vb))
 
 (defn- make-vb [^GL2 gl data]
-  (let [{:keys [mesh vertex-description]} data
-        vbuf (vtx/make-vertex-buffer vertex-description :dynamic (alength ^ints (:indices mesh)))]
+  (let [{:keys [mesh-renderable-data vertex-description]} data
+        position-data (:position-data mesh-renderable-data)
+        vbuf (vtx/make-vertex-buffer vertex-description :dynamic (count position-data))]
     (update-vb gl vbuf data)))
 
 (defn- destroy-vbs [^GL2 gl vbs _])

--- a/editor/src/clj/editor/scene.clj
+++ b/editor/src/clj/editor/scene.clj
@@ -870,6 +870,7 @@
       (.destroy drawable))
     (when-let [^GLAutoDrawable picking-drawable (g/node-value node-id :picking-drawable)]
       (gl/with-drawable-as-current picking-drawable
+        (scene-cache/drop-context! gl)
         (.glFinish gl))
       (.destroy picking-drawable))
     (g/transact

--- a/editor/test/integration/collada_scene_test.clj
+++ b/editor/test/integration/collada_scene_test.clj
@@ -12,37 +12,49 @@
 ;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations under the License.
 
-
-(ns integration.model-scene-test
+(ns integration.collada-scene-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [integration.test-util :as test-util]
+            [editor.gl.vertex2 :as vtx]
             [editor.math :as math]
             [editor.model-scene :as model-scene]
-            [editor.types :as types])
+            [editor.types :as types]
+            [integration.test-util :as test-util]
+            [service.log :as log])
   (:import [javax.vecmath Point3d]))
+
+(vtx/defvertex vtx-pos-nrm-tex
+  (vec3 position)
+  (vec3 normal)
+  (vec2 texcoord0))
 
 (deftest aabb
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/mesh/test.dae")
-          aabb (g/node-value node-id :aabb)
+          scene (g/node-value node-id :scene)
+          aabb (:aabb scene)
           min ^Point3d (types/min-p aabb)
           max ^Point3d (types/max-p aabb)
           dist (.distance max min)]
-      (is (and (> 20 dist) (< 10 dist))))))
+      (is (< 10 dist 20)))))
 
 (deftest vbs
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/mesh/test.dae")
-          mesh (first (g/node-value node-id :meshes))
           scene (g/node-value node-id :scene)
           user-data (get-in scene [:renderable :user-data])
-          vb (-> (model-scene/->vtx-pos-nrm-tex (alength (get-in user-data [:meshes 0 :position-indices])))
-                 (model-scene/mesh->vb! (math/->mat4) :vertex-space-world mesh (get user-data :scratch-arrays)))]
-      (is (= (count vb) (alength (get mesh :position-indices)))))))
+          world-transform (math/->mat4)
+          normal-transform (math/->mat4)
+          vertex-attribute-bytes (byte-array 0)
+          mesh-renderable-data (:mesh-renderable-data user-data)
+          vertex-count (count (:position-data mesh-renderable-data))
+          vb (-> (->vtx-pos-nrm-tex vertex-count)
+                 (model-scene/mesh->vb! world-transform normal-transform vertex-attribute-bytes mesh-renderable-data))]
+      (is (= vertex-count (count vb))))))
 
 (deftest invalid-scene
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/mesh/invalid.dae")
-          scene (g/node-value node-id :scene)]
+          scene (log/without-logging
+                  (g/node-value node-id :scene))]
       (is (g/error? scene)))))

--- a/editor/test/integration/model_scene_test.clj
+++ b/editor/test/integration/model_scene_test.clj
@@ -15,17 +15,24 @@
 (ns integration.model-scene-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [integration.test-util :as test-util]
+            [editor.gl.vertex2 :as vtx]
             [editor.math :as math]
             [editor.model-scene :as model-scene]
             [editor.types :as types]
+            [integration.test-util :as test-util]
             [service.log :as log])
   (:import [javax.vecmath Point3d]))
+
+(vtx/defvertex vtx-pos-nrm-tex
+  (vec3 position)
+  (vec3 normal)
+  (vec2 texcoord0))
 
 (deftest aabb
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/mesh/test.dae")
-          aabb (g/node-value node-id :aabb)
+          scene (g/node-value node-id :scene)
+          aabb (:aabb scene)
           min ^Point3d (types/min-p aabb)
           max ^Point3d (types/max-p aabb)
           dist (.distance max min)] ; distance in meters (converted from centimeters in the loader)
@@ -34,15 +41,16 @@
 (deftest vbs
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/mesh/test.dae")
-          mesh (first (g/node-value node-id :meshes))
           scene (g/node-value node-id :scene)
           user-data (get-in scene [:renderable :user-data])
-          meshes (:meshes user-data)
-          mesh (first meshes)
-          indices (:indices mesh)
-          vb (-> (model-scene/->vtx-pos-nrm-tex (alength ^ints indices))
-               (model-scene/mesh->vb! (math/->mat4) :vertex-space-world mesh (get user-data :scratch-arrays)))]
-      (is (= (count vb) (alength (get mesh :indices)))))))
+          world-transform (math/->mat4)
+          normal-transform (math/->mat4)
+          vertex-attribute-bytes (byte-array 0)
+          mesh-renderable-data (:mesh-renderable-data user-data)
+          vertex-count (count (:position-data mesh-renderable-data))
+          vb (-> (->vtx-pos-nrm-tex vertex-count)
+                 (model-scene/mesh->vb! world-transform normal-transform vertex-attribute-bytes mesh-renderable-data))]
+      (is (= vertex-count (count vb))))))
 
 (deftest invalid-scene
   (test-util/with-loaded-project

--- a/editor/test/integration/model_test.clj
+++ b/editor/test/integration/model_test.clj
@@ -15,19 +15,20 @@
 (ns integration.model-test
   (:require [clojure.test :refer :all]
             [dynamo.graph :as g]
-            [editor.protobuf :as protobuf]
-            [integration.test-util :as test-util]
-            [editor.workspace :as workspace]
-            [editor.types :as types]
             [editor.properties :as properties]
+            [editor.protobuf :as protobuf]
+            [editor.types :as types]
+            [editor.workspace :as workspace]
+            [integration.test-util :as test-util]
             [util.murmur :as murmur])
-  (:import [javax.vecmath Point3d]
-           [com.dynamo.gamesys.proto ModelProto$ModelDesc]))
+  (:import [com.dynamo.gamesys.proto ModelProto$ModelDesc]
+           [javax.vecmath Point3d]))
 
 (deftest aabb
   (test-util/with-loaded-project
     (let [node-id (test-util/resource-node project "/model/test.model")
-          aabb (g/node-value node-id :aabb)
+          scene (g/node-value node-id :scene)
+          aabb (:aabb scene)
           min ^Point3d (types/min-p aabb)
           max ^Point3d (types/max-p aabb)]
       (is (< 10 (.distance max min))))))


### PR DESCRIPTION
* Fixed a performance regression in the editor introduced by the recent addition of custom vertex attributes to models.
* Fixed broken preview of model scene files (`.gltf`, `.dae`, etc.). Previously you'd only see the bounding boxes if you opened a `.gltf` file in the editor.
* Fixed a memory leak of `scene-cache` data associated with the OpenGL context used for scene picking hit tests after closing an editor tab.
* The editor will now share vertex buffers among meshes, as long as they do not use any world-space attributes.
* The Coordinate Space setting of declared vertex attributes takes precedence, but the Vertex Space setting on the material will be used as the default for any undeclared vertex attributes where it has relevance.
* The editor will now produce world-space normal attributes correctly, if desired. 
* The editor will no longer produce a broken normal matrix for objects that have a non-uniformly scaled parent.

Fixes #8666.