### PR TITLE
Fixed property schema validation in the editor

### DIFF
--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -470,14 +470,26 @@
         [_ declared-schema] (peek conditional-cases)]
     declared-schema))
 
+(defn- property-schema->declared-schema [property-schema]
+  ;; The property schema declared using g/deftype is wrapped in a Maybe to allow
+  ;; nil values.
+  (:schema property-schema)) ; Maybe -> Declared
+
+(defn- warn-declared-schema [node-id label node-type-name value declared-schema error]
+  (println "Schema validation failed for output" label "on" node-type-name node-id)
+  (println "Output value:" (pr-str value))
+  (println "Should match:" (s/explain declared-schema))
+  (println "But:" (pr-str error)))
+
 (defn warn-output-schema [node-id label node-type-name value output-schema error]
   (when-not *suppress-schema-warnings*
-    (let [output-name (symbol label)
-          declared-schema (output-schema->declared-schema output-schema)]
-      (println "Schema validation failed for output" output-name "on" node-type-name node-id)
-      (println "Output value:" (pr-str value))
-      (println "Should match:" (s/explain declared-schema))
-      (println "But:" (pr-str error)))))
+    (let [declared-schema (output-schema->declared-schema output-schema)]
+      (warn-declared-schema node-id label node-type-name value declared-schema error))))
+
+(defn warn-property-schema [node-id label node-type-name value output-schema error]
+  (when-not *suppress-schema-warnings*
+    (let [declared-schema (property-schema->declared-schema output-schema)]
+      (warn-declared-schema node-id label node-type-name value declared-schema error))))
 
 ;;; ----------------------------------------
 ;; Type checking

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -537,12 +537,13 @@
         (throw (Exception. (format "Setter of node %s (%s) %s could not be called" node-id node-type property) e))))))
 
 (defn- validate-property-value-impl [node-type node-id property-label property-value]
-  (let [value-type (some-> (in/property-type node-type property-label) deref in/schema s/maybe)]
+  (let [value-type (some-> (in/property-type node-type property-label) deref in/schema s/maybe)
+        node-type-name (in/type-name node-type)]
     (when-let [validation-error (some-> value-type (s/check property-value))]
-      (in/warn-output-schema node-id node-type property-label property-value value-type validation-error)
+      (in/warn-property-schema node-id property-label node-type-name property-value value-type validation-error)
       (throw (ex-info "SCHEMA-VALIDATION"
                       {:node-id node-id
-                       :type node-type
+                       :type node-type-name
                        :property property-label
                        :expected value-type
                        :actual property-value


### PR DESCRIPTION
### Technical changes
* Schema validation errors from node properties are now reported correctly instead of throwing an unhelpful exception.