### PR TITLE
Use the 64-bit version of LuaJIT in the editor

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -472,7 +472,7 @@
   ;; We then strip go.property() declarations and recompile if needed.
   (let [lines (:lines user-data)
         proj-path (:proj-path user-data)
-        bytecode-or-error (script->bytecode lines proj-path :32-bit)]
+        bytecode-or-error (script->bytecode lines proj-path :64-bit)]
     (g/precluding-errors
       [bytecode-or-error]
       (let [go-props (properties/build-go-props dep-resources (:go-props user-data))


### PR DESCRIPTION
### Technical changes
* Use the 64-bit version of LuaJIT to compile Lua scripts when building the project. Previously we used the 32-bit version, which required users to install Rosetta 2 to build their projects on an Apple Silicon Mac.