### PR TITLE
Fixed editor reflection warning by removing unused functions

### DIFF
--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -23,8 +23,8 @@
             [editor.resource-node :as resource-node]
             [editor.workspace :as workspace]
             [schema.core :as s])
-  (:import (com.dynamo.bob.pipeline ShaderProgramBuilder ShaderUtil$ES2ToES3Converter$ShaderType ShaderUtil$SPIRVReflector$Resource)
-           (com.dynamo.graphics.proto Graphics$ShaderDesc$Language)))
+  (:import [com.dynamo.bob.pipeline ShaderProgramBuilder ShaderUtil$ES2ToES3Converter$ShaderType]
+           [com.dynamo.graphics.proto Graphics$ShaderDesc$Language]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -92,23 +92,6 @@
                    :view-types [:code :default]
                    :view-opts glsl-opts}])
 
-(defn- shader-type-from-str [^String shader-type-in]
-  (case shader-type-in
-    "int" :shader-type-int
-    "uint" :shader-type-uint
-    "float" :shader-type-float
-    "vec2" :shader-type-vec2
-    "vec3" :shader-type-vec3
-    "vec4" :shader-type-vec4
-    "mat2" :shader-type-mat2
-    "mat3" :shader-type-mat3
-    "mat4" :shader-type-mat4
-    "sampler2D" :shader-type-sampler2d
-    "sampler3D" :shader-type-sampler3d
-    "samplerCube" :shader-type-sampler-cube
-    "sampler2DArray" :shader-type-sampler2d-array
-    :shader-type-unknown))
-
 (defn shader-stage-from-ext
   ^ShaderUtil$ES2ToES3Converter$ShaderType [^String resource-ext]
   (case resource-ext
@@ -126,13 +109,6 @@
 
 (defn- error-string->error-value [^String error-string]
   (g/error-fatal (string/trim error-string)))
-
-(defn- shader-resource->map [^ShaderUtil$SPIRVReflector$Resource shader-resource]
-  {:name (.name shader-resource)
-   :type (shader-type-from-str (.type shader-resource))
-   :element-count (.elementCount shader-resource)
-   :set (.set shader-resource)
-   :binding (.binding shader-resource)})
 
 (defonce ^:private ^"[Lcom.dynamo.graphics.proto.Graphics$ShaderDesc$Language;" java-shader-languages-without-spirv
   (into-array Graphics$ShaderDesc$Language


### PR DESCRIPTION
Some fields were renamed as part of #8620, causing the editor to report a reflection warning for the missing `SPIRVReflector$Resource.elementCount` field. Fortunately, the editor function does not appear to be used anywhere.

This PR removes the affected unused function, as well as another function that is no longer used in the same file.