### PR TITLE
Produce local and world spaced models with correct custom attribute values

### DIFF
--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -357,6 +357,7 @@ namespace dmGraphics
     {
         VertexAttributeInfos()
         {
+            memset(this, 0, sizeof(*this));
             m_StructSize = sizeof(*this);
         }
 

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -139,7 +139,6 @@ namespace dmGraphics
         {
             next_id = DM_RENDERTARGET_BACKBUFFER_ID + 1;
         }
-
         return next_id++;
     }
 

--- a/engine/rig/src/dmsdk/rig/rig.h
+++ b/engine/rig/src/dmsdk/rig/rig.h
@@ -174,6 +174,7 @@ namespace dmRig
 
     // Returns the new position in the array
     uint8_t* GenerateVertexDataFromAttributes(dmRig::HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const dmVMath::Matrix4& world_matrix, const dmGraphics::VertexAttributeInfos* attribute_infos, uint32_t vertex_stride, uint8_t* vertex_data_out);
+    uint8_t* WriteSingleVertexDataByAttributes(uint8_t* write_ptr, uint32_t idx, const dmGraphics::VertexAttributeInfos* attribute_infos, const float* position, const float* normal, const float* tangent, const float* uv0, const float* uv1, const float* color);
     RigModelVertex* GenerateVertexData(HRigContext context, dmRig::HRigInstance instance, dmRigDDF::Mesh* mesh, const dmVMath::Matrix4& world_matrix, RigModelVertex* vertex_data_out);
     uint32_t GetVertexCount(HRigInstance instance);
 

--- a/engine/rig/src/rig.cpp
+++ b/engine/rig/src/rig.cpp
@@ -933,92 +933,87 @@ namespace dmRig
         return out_buffer;
     }
 
+    uint8_t* WriteSingleVertexDataByAttributes(uint8_t* write_ptr, uint32_t idx, const dmGraphics::VertexAttributeInfos* attribute_infos, const float* positions, const float* normals, const float* tangents, const float* uv0, const float* uv1, const float* colors)
+    {
+        uint32_t num_texcoords = 0;
+        for (int a = 0; a < attribute_infos->m_NumInfos; ++a)
+        {
+            const dmGraphics::VertexAttributeInfo& info = attribute_infos->m_Infos[a];
+            const size_t data_size                      = info.m_ValueByteSize;
+
+            switch(info.m_SemanticType)
+            {
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
+                {
+                    memcpy(write_ptr, &positions[idx*3], dmMath::Min(3 * sizeof(float), data_size));
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
+                {
+                    uint32_t src_copy_size = dmMath::Min(2 * sizeof(float), data_size);
+                    const float* uv = num_texcoords == 0 ? uv0 :
+                                      num_texcoords == 1 ? uv1 :
+                                      0;
+                    if (uv)
+                        memcpy(write_ptr, &uv[idx*2], src_copy_size);
+                    else
+                        memcpy(write_ptr, info.m_ValuePtr, data_size);
+
+                    num_texcoords++;
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_COLOR:
+                {
+                    uint32_t src_copy_size = dmMath::Min(4 * sizeof(float), data_size);
+                    if (colors)
+                        memcpy(write_ptr, &colors[idx*4], src_copy_size);
+                    else
+                        memcpy(write_ptr, info.m_ValuePtr, data_size);
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_NORMAL:
+                {
+                    memcpy(write_ptr, &normals[idx*3], dmMath::Min(3 * sizeof(float), data_size));
+                } break;
+                case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TANGENT:
+                {
+                    memcpy(write_ptr, &tangents[idx*3], dmMath::Min(3 * sizeof(float), data_size));
+                } break;
+                default:
+                {
+                    memcpy(write_ptr, info.m_ValuePtr, data_size);
+                } break;
+            }
+
+            write_ptr += data_size;
+        }
+        return write_ptr;
+    }
+
     static uint8_t* WriteVertexDataByAttributes(const dmRigDDF::Mesh* mesh, const float* positions, const float* normals, const float* tangents, const dmGraphics::VertexAttributeInfos* attribute_infos, uint32_t vertex_stride, uint8_t* out_write_ptr)
     {
         const float* uv0 = mesh->m_Texcoord0.m_Count ? mesh->m_Texcoord0.m_Data : 0;
         const float* uv1 = mesh->m_Texcoord1.m_Count ? mesh->m_Texcoord1.m_Data : 0;
         const float* colors = mesh->m_Colors.m_Count ? mesh->m_Colors.m_Data : 0;
 
-        if (mesh->m_Indices.m_Count == 0)
+        assert(mesh->m_Indices.m_Count > 0);
+
+        uint32_t* indices32 = 0;
+        uint16_t* indices16 = 0;
+        uint32_t num_indices;
+        if (mesh->m_IndicesFormat == dmRigDDF::INDEXBUFFER_FORMAT_32)
         {
-            assert(0);
+            indices32 = (uint32_t*)mesh->m_Indices.m_Data;
+            num_indices = mesh->m_Indices.m_Count / 4;
         }
         else
         {
-            uint32_t* indices32 = 0;
-            uint16_t* indices16 = 0;
-            uint32_t num_indices;
-            if (mesh->m_IndicesFormat == dmRigDDF::INDEXBUFFER_FORMAT_32)
-            {
-                indices32 = (uint32_t*)mesh->m_Indices.m_Data;
-                num_indices = mesh->m_Indices.m_Count / 4;
-            }
-            else
-            {
-                indices16 = (uint16_t*)mesh->m_Indices.m_Data;
-                num_indices = mesh->m_Indices.m_Count / 2;
-            }
+            indices16 = (uint16_t*)mesh->m_Indices.m_Data;
+            num_indices = mesh->m_Indices.m_Count / 2;
+        }
 
-            for (uint32_t i = 0; i < num_indices; ++i)
-            {
-                uint32_t idx = indices32?indices32[i]:indices16[i];
-
-                uint8_t* write_ptr = out_write_ptr;
-
-                uint32_t num_texcoords = 0;
-
-                // TODO: Use the shared dmGraphics function instead of this
-                for (int a = 0; a < attribute_infos->m_NumInfos; ++a)
-                {
-                    const dmGraphics::VertexAttributeInfo& info = attribute_infos->m_Infos[a];
-                    const size_t data_size                      = info.m_ValueByteSize;
-
-                    switch(info.m_SemanticType)
-                    {
-                        case dmGraphics::VertexAttribute::SEMANTIC_TYPE_POSITION:
-                        {
-                            memcpy(write_ptr, &positions[idx*3], dmMath::Min(3 * sizeof(float), data_size));
-                        } break;
-                        case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
-                        {
-                            uint32_t src_copy_size = dmMath::Min(2 * sizeof(float), data_size);
-                            const float* uv = num_texcoords == 0 ? uv0 :
-                                              num_texcoords == 1 ? uv1 :
-                                              0;
-                            if (uv)
-                                memcpy(write_ptr, &uv[idx*2], src_copy_size);
-                            else
-                                memset(write_ptr, 0, src_copy_size);
-
-                            num_texcoords++;
-                        } break;
-                        case dmGraphics::VertexAttribute::SEMANTIC_TYPE_COLOR:
-                        {
-                            uint32_t src_copy_size = dmMath::Min(4 * sizeof(float), data_size);
-                            if (colors)
-                                memcpy(write_ptr, &colors[idx*4], src_copy_size);
-                            else
-                                memset(write_ptr, 0, src_copy_size);
-                        } break;
-                        case dmGraphics::VertexAttribute::SEMANTIC_TYPE_NORMAL:
-                        {
-                            memcpy(write_ptr, &normals[idx*3], dmMath::Min(3 * sizeof(float), data_size));
-                        } break;
-                        case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TANGENT:
-                        {
-                            memcpy(write_ptr, &tangents[idx*3], dmMath::Min(3 * sizeof(float), data_size));
-                        } break;
-                        default:
-                        {
-                            memcpy(write_ptr, info.m_ValuePtr, data_size);
-                        } break;
-                    }
-
-                    write_ptr += data_size;
-                }
-
-                out_write_ptr += vertex_stride;
-            }
+        for (uint32_t i = 0; i < num_indices; ++i)
+        {
+            uint32_t idx = indices32?indices32[i]:indices16[i];
+            // TODO: Use the shared dmGraphics function instead of this
+            out_write_ptr = WriteSingleVertexDataByAttributes(out_write_ptr, idx, attribute_infos, positions, normals, tangents, uv0, uv1, colors);
         }
 
         return out_write_ptr;


### PR DESCRIPTION
Fixed an issue where models are using custom attributes with and without mesh colors available in the .glb file:
* When a model is using a mesh without color data, it should produce the overridden data from the custom vertex attributes
* When a model is using a mesh with color data, the color data should always take precedence over the custom vertex format

Fixes #8693 