### PR TITLE
Make maximum amount of text batches configurable via game.project.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -214,6 +214,10 @@ max_characters.type = number
 max_characters.help = maximum number of characters (text) that can be displayed each frame
 max_characters.default = 8192
 
+max_font_batches.type = number
+max_font_batches.help = maximum number of text batches
+max_font_batches.default = 128
+
 max_debug_vertices.type = number
 max_debug_vertices.help = maximum number of debug vertices. Used for physics shape rendering among other things, 10000 by default
 max_debug_vertices.default = 10000

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -278,6 +278,11 @@
    :path ["graphics" "max_characters"]}
   {:type :integer,
    :help
+   "maximum number of text that can be displayed each frame",
+   :default 128,
+   :path ["graphics" "max_font_batches"]}
+  {:type :integer,
+   :help
    "maximum number of debug vertices, used for physics shape rendering among other things, 10000 by default",
    :default 10000,
    :path ["graphics" "max_debug_vertices"]}

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -183,6 +183,7 @@ default_texture_min_filter = nearest
 default_texture_mag_filter = nearest
 max_draw_calls = 512
 max_characters = 4096
+max_font_batches = 128
 max_debug_vertices = 8192
 texture_profiles = /checked.texture_profiles
 verify_graphics_calls = 0

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1022,6 +1022,7 @@ namespace dmEngine
 #else
         render_params.m_MaxDebugVertexCount = 0;
 #endif
+        render_params.m_MaxBatches = (uint32_t) dmConfigFile::GetInt(engine->m_Config, "graphics.max_font_batches", 128);
         engine->m_RenderContext = dmRender::NewRenderContext(engine->m_GraphicsContext, render_params);
 
         dmGameObject::Initialize(engine->m_Register, engine->m_GOScriptContext);

--- a/engine/gamesys/src/gamesys/test/fontview/fontview.cpp
+++ b/engine/gamesys/src/gamesys/test/fontview/fontview.cpp
@@ -152,6 +152,7 @@ namespace dmFontView
             render_params.m_MaxRenderTypes = 10;
             render_params.m_MaxInstances = 100;
             render_params.m_MaxCharacters = 1024;
+            render_params.m_MaxBatches = 128;
             context->m_RenderContext = dmRender::NewRenderContext(context->m_GraphicsContext, render_params);
             dmRender::SetViewMatrix(context->m_RenderContext, Matrix4::identity());
             dmRender::SetProjectionMatrix(context->m_RenderContext, Matrix4::identity());

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -488,6 +488,7 @@ void GamesysTest<T>::SetUp()
     render_params.m_MaxRenderTargets = 10;
     render_params.m_ScriptContext = m_ScriptContext;
     render_params.m_MaxCharacters = 256;
+    render_params.m_MaxBatches = 128;
     m_RenderContext = dmRender::NewRenderContext(m_GraphicsContext, render_params);
 
     dmInput::NewContextParams input_params;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -398,7 +398,7 @@ namespace dmRender
         return font_map->m_Material;
     }
 
-    void InitializeTextContext(HRenderContext render_context, uint32_t max_characters)
+    void InitializeTextContext(HRenderContext render_context, uint32_t max_characters, uint32_t max_batches)
     {
         DM_STATIC_ASSERT(sizeof(GlyphVertex) % 16 == 0, Invalid_Struct_Size);
         DM_STATIC_ASSERT( MAX_FONT_RENDER_CONSTANTS == MAX_TEXT_RENDER_CONSTANTS, Constant_Arrays_Must_Have_Same_Size );
@@ -434,8 +434,6 @@ namespace dmRender
 
         dmGraphics::DeleteVertexStreamDeclaration(stream_declaration);
 
-        // Arbitrary number
-        const uint32_t max_batches = 128;
         text_context.m_ConstantBuffers.SetCapacity(max_batches); // 1:1 index mapping with render object
         text_context.m_RenderObjects.SetCapacity(max_batches);
         text_context.m_RenderObjectIndex = 0;
@@ -1053,7 +1051,7 @@ namespace dmRender
         GlyphVertex* vertices = (GlyphVertex*)text_context.m_ClientBuffer;
 
         if (text_context.m_RenderObjectIndex >= text_context.m_RenderObjects.Size()) {
-            dmLogWarning("Fontrenderer: Render object count reached limit (%d)", text_context.m_RenderObjectIndex);
+            dmLogWarning("Fontrenderer: Render object count reached limit (%d). Increase the capacity with graphics.max_font_batches", text_context.m_RenderObjectIndex);
             return;
         }
 

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -174,7 +174,7 @@ namespace dmRender
      */
     HMaterial GetFontMapMaterial(HFontMap font_map);
 
-    void InitializeTextContext(HRenderContext render_context, uint32_t max_characters);
+    void InitializeTextContext(HRenderContext render_context, uint32_t max_characters, uint32_t max_batches);
     void FinalizeTextContext(HRenderContext render_context);
 
     const int MAX_FONT_RENDER_CONSTANTS = 16;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -124,7 +124,7 @@ namespace dmRender
             InitializeDebugRenderer(context, params.m_MaxDebugVertexCount, params.m_VertexShaderDesc, params.m_VertexShaderDescSize, params.m_FragmentShaderDesc, params.m_FragmentShaderDescSize);
         }
 
-        InitializeTextContext(context, params.m_MaxCharacters);
+        InitializeTextContext(context, params.m_MaxCharacters, params.m_MaxBatches);
 
         context->m_OutOfResources = 0;
 

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -128,6 +128,7 @@ namespace dmRender
         uint32_t                        m_VertexShaderDescSize;
         uint32_t                        m_FragmentShaderDescSize;
         uint32_t                        m_MaxCharacters;
+        uint32_t                        m_MaxBatches;
         uint32_t                        m_CommandBufferSize;
         /// Max debug vertex count
         /// NOTE: This is per debug-type and not the total sum

--- a/engine/render/src/test/test_material.cpp
+++ b/engine/render/src/test/test_material.cpp
@@ -56,6 +56,7 @@ public:
         m_GraphicsContext        = dmGraphics::NewContext(graphics_context_params);
         m_Params.m_ScriptContext = dmScript::NewContext(0, 0, true);
         m_Params.m_MaxCharacters = 256;
+        m_Params.m_MaxBatches = 128;
         m_RenderContext          = dmRender::NewRenderContext(m_GraphicsContext, m_Params);
     }
     virtual void TearDown()

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -69,6 +69,7 @@ protected:
         params.m_ScriptContext = m_ScriptContext;
         params.m_MaxDebugVertexCount = 256;
         params.m_MaxCharacters = 256;
+        params.m_MaxBatches = 128;
         m_Context = dmRender::NewRenderContext(m_GraphicsContext, params);
 
         dmRender::FontMapParams font_map_params;

--- a/engine/render/src/test/test_render_buffer.cpp
+++ b/engine/render/src/test/test_render_buffer.cpp
@@ -47,6 +47,7 @@ public:
         m_GraphicsContext        = dmGraphics::NewContext(graphics_context_params);
         m_Params.m_ScriptContext = dmScript::NewContext(0, 0, true);
         m_Params.m_MaxCharacters = 256;
+        m_Params.m_MaxBatches    = 128;
         m_RenderContext          = dmRender::NewRenderContext(m_GraphicsContext, m_Params);
 
         m_MultiBufferingRequired = m_RenderContext->m_MultiBufferingRequired;

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -101,6 +101,7 @@ protected:
         params.m_MaxRenderTargets = 1;
         params.m_MaxInstances = 64;
         params.m_MaxCharacters = 32;
+        params.m_MaxBatches = 128;
         m_Context = dmRender::NewRenderContext(m_GraphicsContext, params);
 
         dmGraphics::ShaderDesc::Shader shader_ddf;


### PR DESCRIPTION
Maximum amount of text batches can be configured via game.project property `graphics.max_font_batches`. 

Fixes #7917 
## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
