### PR TITLE
Check response status when fetch wasm for streaming instantiate.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -182,14 +182,18 @@ var EngineLoader = {
         if (typeof TransformStream === "function" && ReadableStream.prototype.pipeThrough) {
             async function fetchWithProgress(path) {
                 const response = await fetch(path);
-                const ts = new TransformStream({
-                    transform (chunk, controller) {
-                        ProgressUpdater.updateCurrent(chunk.byteLength);
-                        controller.enqueue(chunk);
-                    }
-                });
+                if (response.ok) {
+                    const ts = new TransformStream({
+                        transform (chunk, controller) {
+                            ProgressUpdater.updateCurrent(chunk.byteLength);
+                            controller.enqueue(chunk);
+                        }
+                    });
 
-                return new Response(response.body.pipeThrough(ts), response);
+                    return new Response(response.body.pipeThrough(ts), response);
+                } else {
+                    return new Response(null, response);
+                }
             }
             fetchFn = fetchWithProgress;
         }


### PR DESCRIPTION
Check if `fetch()` was successful during wasm loading. Otherwise return `Response` with null body to trigger fallback logic.

Fixes #8091 
### Technical changes
Check if `response.ok` is true. Otherwise construct empty Response object with all headers and statuses from original response.
According to https://developer.mozilla.org/en-US/docs/Web/API/Response/body#value response.body can be empty. I tried to simulate it in following steps:
1. Rename <game>.wasm in bundle dir to something else. For example, game1111.wasm.
2. Got error like `wasm streaming instantiation failed! TypeError: WebAssembly: Response has unsupported MIME type 'text/html;charset=utf-8' expected 'application/wasm'`
3. Simulate 404 with content-type = application/wasm.
4. Got error `wasm streaming instantiation failed! TypeError: WebAssembly: Response does not have ok status` (it was Response object that constructed as `new Response(null, response)`
5. Loading going to fallback logic.

P.S. I can't reproduce situation when response.body is undefined. In case of 404 it was filled with html page content.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   6. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
