### PR TITLE
Pass all known model scene attributes to shaders in editor viewport

### DIFF
--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -18,6 +18,7 @@
             [editor.gl.shader :as shader]
             [editor.gl.vertex2 :as vtx]
             [editor.properties :as properties]
+            [editor.protobuf :as protobuf]
             [editor.types :as types]
             [editor.util :as eutil]
             [editor.validation :as validation]
@@ -26,7 +27,8 @@
             [util.coll :refer [pair]]
             [util.murmur :as murmur]
             [util.num :as num])
-  (:import [com.google.protobuf ByteString]
+  (:import [com.dynamo.graphics.proto Graphics$VertexAttribute$SemanticType]
+           [com.google.protobuf ByteString]
            [com.jogamp.opengl GL2]
            [editor.gl.vertex2 VertexBuffer]
            [java.nio ByteBuffer]))
@@ -512,15 +514,20 @@
         world-transform (:world-transform renderable-data)]
     (geom/transf-p4 world-transform local-positions)))
 
-(defn- renderable-data->world-normal-v3 [renderable-data]
-  (let [local-normals (:normal-data renderable-data)
+(defn- renderable-data->world-direction-v3 [renderable-data->local-directions renderable-data]
+  (let [local-directions (renderable-data->local-directions renderable-data)
         normal-transform (:normal-transform renderable-data)]
-    (geom/transf-n normal-transform local-normals)))
+    (geom/transf-n normal-transform local-directions)))
 
-(defn- renderable-data->world-normal-v4 [renderable-data]
-  (let [local-normals (:normal-data renderable-data)
+(defn- renderable-data->world-direction-v4 [renderable-data->local-directions renderable-data]
+  (let [local-directions (renderable-data->local-directions renderable-data)
         normal-transform (:normal-transform renderable-data)]
-    (geom/transf-n4 normal-transform local-normals)))
+    (geom/transf-n4 normal-transform local-directions)))
+
+(def ^:private renderable-data->world-normal-v3 (partial renderable-data->world-direction-v3 :normal-data))
+(def ^:private renderable-data->world-normal-v4 (partial renderable-data->world-direction-v4 :normal-data))
+(def ^:private renderable-data->world-tangent-v3 (partial renderable-data->world-direction-v3 :tangent-data))
+(def ^:private renderable-data->world-tangent-v4 (partial renderable-data->world-direction-v4 :tangent-data))
 
 (defn put-attributes! [^VertexBuffer vbuf renderable-datas]
   (let [vertex-description (.vertex-description vbuf)
@@ -555,15 +562,45 @@
                   attribute-byte-offset
                   renderable-datas))
 
-        texcoord-index-vol (volatile! -1)
-        page-index-vol (volatile! -1)]
+        mesh-data-exists?
+        (let [renderable-data (first renderable-datas)
+              texcoord-datas (:texcoord-datas renderable-data)]
+          (if (nil? renderable-data)
+            (constantly false)
+            (fn mesh-data-exists? [semantic-type ^long channel]
+              (case semantic-type
+                :semantic-type-position
+                (and (zero? channel)
+                     (some? (:position-data renderable-data)))
 
-    (reduce (fn [^long attribute-byte-offset attribute]
+                :semantic-type-texcoord
+                (some? (get-in texcoord-datas [channel :uv-data]))
+
+                :semantic-type-page-index
+                (some? (get-in texcoord-datas [channel :page-index]))
+
+                :semantic-type-color
+                (and (zero? channel)
+                     (some? (:color-data renderable-data)))
+
+                :semantic-type-normal
+                (and (zero? channel)
+                     (some? (:normal-data renderable-data)))
+
+                :semantic-type-tangent
+                (and (zero? channel)
+                     (some? (:tangent-data renderable-data)))
+
+                false))))]
+
+    (reduce (fn [reduce-info attribute]
               (let [semantic-type (:semantic-type attribute)
                     buffer-data-type (:type attribute)
                     element-count (long (:components attribute))
                     normalize (:normalize attribute)
                     name-key (:name-key attribute)
+                    ^long attribute-byte-offset (:attribute-byte-offset reduce-info)
+                    channel (get reduce-info semantic-type)
 
                     put-attribute-bytes!
                     (fn put-attribute-bytes!
@@ -581,51 +618,77 @@
                         (catch Exception e
                           (throw (decorate-attribute-exception e attribute (first vertices))))))]
 
-                (case semantic-type
-                  :semantic-type-position
-                  (case (:coordinate-space attribute)
-                    :coordinate-space-world
-                    (let [renderable-data->world-position
-                          (case element-count
-                            3 renderable-data->world-position-v3
-                            4 renderable-data->world-position-v4)]
-                      (put-renderables! attribute-byte-offset renderable-data->world-position put-attribute-doubles!))
-                    (put-renderables! attribute-byte-offset :position-data put-attribute-doubles!))
+                (if (mesh-data-exists? semantic-type channel)
 
-                  :semantic-type-texcoord
-                  (let [i (vswap! texcoord-index-vol inc)]
-                    (put-renderables! attribute-byte-offset #(get-in % [:texcoord-datas i :uv-data]) put-attribute-doubles!))
+                  ;; Mesh data exists for this attribute. It takes precedence
+                  ;; over any attribute values specified on the material or
+                  ;; overrides.
+                  (case semantic-type
+                    :semantic-type-position
+                    (case (:coordinate-space attribute)
+                      :coordinate-space-world
+                      (let [renderable-data->world-position
+                            (case element-count
+                              3 renderable-data->world-position-v3
+                              4 renderable-data->world-position-v4)]
+                        (put-renderables! attribute-byte-offset renderable-data->world-position put-attribute-doubles!))
+                      (put-renderables! attribute-byte-offset :position-data put-attribute-doubles!))
 
-                  :semantic-type-page-index
-                  (let [i (vswap! page-index-vol inc)]
+                    :semantic-type-texcoord
+                    (put-renderables! attribute-byte-offset #(get-in % [:texcoord-datas channel :uv-data]) put-attribute-doubles!)
+
+                    :semantic-type-page-index
                     (put-renderables! attribute-byte-offset
                                       (fn [renderable-data]
                                         (let [vertex-count (count (:position-data renderable-data))
-                                              page-index (get-in renderable-data [:texcoord-datas i :page-index])]
+                                              page-index (get-in renderable-data [:texcoord-datas channel :page-index])]
                                           (repeat vertex-count [(double page-index)])))
-                                      put-attribute-doubles!))
+                                      put-attribute-doubles!)
 
-                  :semantic-type-normal
-                  (case (:coordinate-space attribute)
-                    :coordinate-space-world
-                    (let [renderable-data->world-normal
-                          (case element-count
-                            3 renderable-data->world-normal-v3
-                            4 renderable-data->world-normal-v4)]
-                      (put-renderables! attribute-byte-offset renderable-data->world-normal put-attribute-doubles!))
-                    (put-renderables! attribute-byte-offset :normal-data put-attribute-doubles!))
+                    :semantic-type-color
+                    (put-renderables! attribute-byte-offset :color-data put-attribute-doubles!)
 
-                  ;; Default case.
+                    :semantic-type-normal
+                    (case (:coordinate-space attribute)
+                      :coordinate-space-world
+                      (let [renderable-data->world-normal
+                            (case element-count
+                              3 renderable-data->world-normal-v3
+                              4 renderable-data->world-normal-v4)]
+                        (put-renderables! attribute-byte-offset renderable-data->world-normal put-attribute-doubles!))
+                      (put-renderables! attribute-byte-offset :normal-data put-attribute-doubles!))
+
+                    :semantic-type-tangent
+                    (case (:coordinate-space attribute)
+                      :coordinate-space-world
+                      (let [renderable-data->world-tangent
+                            (case element-count
+                              3 renderable-data->world-tangent-v3
+                              4 renderable-data->world-tangent-v4)]
+                        (put-renderables! attribute-byte-offset renderable-data->world-tangent put-attribute-doubles!))
+                      (put-renderables! attribute-byte-offset :tangent-data put-attribute-doubles!)))
+
+                  ;; Mesh data doesn't exist. Use the attribute data from the
+                  ;; material or overrides.
                   (put-renderables! attribute-byte-offset
                                     (fn [renderable-data]
                                       (let [vertex-count (count (:position-data renderable-data))
                                             attribute-bytes (get (:vertex-attribute-bytes renderable-data) name-key)]
                                         (repeat vertex-count attribute-bytes)))
                                     put-attribute-bytes!))
-
-                (+ attribute-byte-offset
-                   (vtx/attribute-size attribute))))
-            0
+                (-> reduce-info
+                    (update semantic-type inc)
+                    (assoc :attribute-byte-offset (+ attribute-byte-offset
+                                                     (vtx/attribute-size attribute))))))
+            ;; The reduce-info is a map of how many times we've encountered an
+            ;; attribute of a particular semantic-type. We also include a
+            ;; special key, :attribute-byte-offset, to keep track of where the
+            ;; next encountered attribute will start writing its data to the
+            ;; vertex buffer.
+            (into {:attribute-byte-offset 0}
+                  (map (fn [[semantic-type]]
+                         (pair semantic-type 0)))
+                  (protobuf/enum-values Graphics$VertexAttribute$SemanticType))
             (:attributes vertex-description))
     (.position buf (.limit buf))
     (vtx/flip! vbuf)))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -31,7 +31,8 @@
             [editor.scene-cache :as scene-cache]
             [editor.scene-picking :as scene-picking]
             [editor.workspace :as workspace]
-            [internal.graph.error-values :as error-values])
+            [internal.graph.error-values :as error-values]
+            [util.coll :as coll])
   (:import [com.google.protobuf ByteString]
            [com.jogamp.opengl GL GL2]
            [editor.gl.vertex2 VertexBuffer]
@@ -119,47 +120,56 @@
 
     out-indices))
 
+(defn- flat->vectors [^long component-count interleaved-component-values]
+  (let [vectors (into []
+                      (coll/partition-all-primitives :double component-count)
+                      interleaved-component-values)]
+    ;; Return nil if the interleaved component values cannot be evenly
+    ;; partitioned into the desired component count.
+    (when (or (coll/empty? vectors)
+              (= component-count (count (peek vectors))))
+      vectors)))
+
 (defn mesh->renderable-data [mesh]
-  (let [positions (doubles->floats (:positions mesh))
-        normals (doubles->floats (:normals mesh))
-        texcoord0s (doubles->floats (:texcoord0 mesh))
+  (let [positions (flat->vectors 3 (:positions mesh))
+        normals (flat->vectors 3 (:normals mesh))
+        tangents (flat->vectors 3 (:tangents mesh))
+        colors (flat->vectors 4 (:colors mesh))
+        texcoord0s (flat->vectors (:num-texcoord0-components mesh 0) (:texcoord0 mesh))
+        texcoord1s (flat->vectors (:num-texcoord1-components mesh 0) (:texcoord1 mesh))
         indices (bytes-to-indices (:indices mesh) (:indices-format mesh))
-        ^int texcoord0-component-count (:num-texcoord0-components mesh 0)
-        positions-count (/ (alength positions) 3)
-        normals-count (/ (alength normals) 3)
-        texcoord0-count (/ (alength texcoord0s) texcoord0-component-count)
-        max-index (reduce max 0 indices)]
-    (if (and (< max-index positions-count)
-             (or (zero? normals-count)
-                 (= positions-count normals-count))
-             (or (zero? texcoord0-count)
-                 (= positions-count texcoord0-count)))
-      (let [mesh-data-out
-            (reduce (fn [out-data ^long vi]
-                      (let [p-base (* 3 vi)
-                            p-0 (double (get positions p-base))
-                            p-1 (double (get positions (+ 1 p-base)))
-                            p-2 (double (get positions (+ 2 p-base)))
-
-                            tc0-base (* 2 vi)
-                            tc0-0 (double (get texcoord0s tc0-base))
-                            tc0-1 (double (get texcoord0s (+ 1 tc0-base)))
-
-                            n-base (* 3 vi)
-                            n-0 (get normals n-base)
-                            n-1 (get normals (+ 1 n-base))
-                            n-2 (get normals (+ 2 n-base))]
-                        (assoc out-data
-                          :position-data (conj (:position-data out-data) [p-0 p-1 p-2])
-                          :normal-data (conj (:normal-data out-data) [n-0 n-1 n-2])
-                          :uv-data (conj (:uv-data out-data) [tc0-0 tc0-1]))))
-                    {:position-data []
-                     :uv-data []
-                     :normal-data []}
-                    indices)]
-        (-> mesh-data-out
-            (dissoc :uv-data)
-            (assoc :texcoord-datas [{:uv-data (:uv-data mesh-data-out)}])))
+        max-index (reduce max 0 indices)
+        positions-count (count positions)]
+    (if (and (some? positions)
+             (some? normals)
+             (some? tangents)
+             (some? colors)
+             (some? texcoord0s)
+             (some? texcoord1s)
+             (< max-index positions-count)
+             (or (coll/empty? normals)
+                 (= positions-count (count normals)))
+             (or (coll/empty? tangents)
+                 (= positions-count (count tangents)))
+             (or (coll/empty? colors)
+                 (= positions-count (count colors)))
+             (or (coll/empty? texcoord0s)
+                 (= positions-count (count texcoord0s)))
+             (or (coll/empty? texcoord1s)
+                 (= positions-count (count texcoord1s))))
+      (let [position-data (some-> positions not-empty (mapv indices))
+            normal-data (some-> normals not-empty (mapv indices))
+            tangent-data (some-> tangents not-empty (mapv indices))
+            color-data (some-> colors not-empty (mapv indices))
+            texcoord0-data (some-> texcoord0s not-empty (mapv indices))
+            texcoord1-data (some-> texcoord1s not-empty (mapv indices))
+            texcoord-datas (cond-> [(when texcoord0-data {:uv-data texcoord0-data})]
+                                   texcoord1-data (conj {:uv-data texcoord1-data}))]
+        (cond-> {:position-data position-data}
+                normal-data (assoc :normal-data normal-data)
+                tangent-data (assoc :tangent-data tangent-data)
+                color-data (assoc :color-data color-data)
+                (some some? texcoord-datas) (assoc :texcoord-datas texcoord-datas)))
       (error-values/error-fatal "Failed to produce vertex buffers from mesh set. The scene might contain invalid data."))))
 
 (defn mesh->vb! [^VertexBuffer vbuf ^Matrix4d world-transform ^Matrix4d normal-transform vertex-attribute-bytes mesh-renderable-data]

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -14,7 +14,8 @@
 
 (ns util.coll
   (:refer-clojure :exclude [bounded-count empty?])
-  (:import [clojure.lang IEditableCollection MapEntry]))
+  (:import [clojure.lang IEditableCollection MapEntry]
+           [java.util ArrayList]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -131,6 +132,41 @@
    (into {}
          (map (pair-fn key-fn value-fn))
          coll)))
+
+(defn partition-all-primitives
+  "Returns a lazy sequence of primitive vectors. Like core.partition-all, but
+  creates a new vector of a single primitive-type for each partition. The
+  primitive-type must be one of :int :long :float :double :byte :short :char, or
+  :boolean. Returns a stateful transducer when no collection is provided."
+  {:added "1.2"
+   :static true}
+  ([primitive-type ^long partition-length]
+   (fn [rf]
+     (let [in-progress (ArrayList. partition-length)]
+       (fn
+         ([] (rf))
+         ([result]
+          (let [result
+                (if (.isEmpty in-progress)
+                  result
+                  (let [finished (apply vector-of primitive-type (.toArray in-progress))]
+                    (.clear in-progress)
+                    (unreduced (rf result finished))))]
+            (rf result)))
+         ([result input]
+          (.add in-progress input)
+          (if (= partition-length (.size in-progress))
+            (let [finished (apply vector-of primitive-type (.toArray in-progress))]
+              (.clear in-progress)
+              (rf result finished))
+            result))))))
+  ([primitive-type ^long partition-length coll]
+   (partition-all-primitives primitive-type partition-length partition-length coll))
+  ([primitive-type ^long partition-length ^long step coll]
+   (lazy-seq
+     (when-let [in-progress (seq coll)]
+       (let [finished (apply vector-of primitive-type (take partition-length in-progress))]
+         (cons finished (partition-all-primitives primitive-type partition-length step (nthrest in-progress step))))))))
 
 (defn separate-by
   "Separates items in the supplied collection into two based on a predicate.


### PR DESCRIPTION
The scene view will now pass all currently supported vertex attributes to the shader when rendering models.

Fixes #7407

### Technical changes
* Vertex attributes that are present in the Mesh data will take precedence over attribute values from the Material or the Model referencing the Mesh when rendered in the editor viewport.