### PR TITLE
Add a read timeout when fetching libraries from the editor

### DIFF
--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -28,6 +28,7 @@
 (set! *warn-on-reflection* true)
 
 (def ^:const connect-timeout 2000)
+(def ^:const read-timeout 2000)
 
 (defn parse-library-uris [uri-string]
   (settings-core/parse-setting-value {:type :list :element {:type :url}} uri-string))
@@ -127,6 +128,7 @@
         (.setRequestProperty http-connection "If-None-Match" tag))
       (.setRequestProperty http-connection "Accept" "application/zip"))
     (.setConnectTimeout connection connect-timeout)
+    (.setReadTimeout connection read-timeout)
     (.connect connection)
     (let [status (parse-status http-connection)
           headers (.getHeaderFields connection)


### PR DESCRIPTION
Added a timeout when fetching libraries from the editor so it doesn't block indefinitely if a server stops responding.