### PR TITLE
Added atomic and lock to make profiler more thread safe

### DIFF
--- a/engine/dlib/src/dlib/profile/profile_remotery.cpp
+++ b/engine/dlib/src/dlib/profile/profile_remotery.cpp
@@ -19,6 +19,8 @@
 
 #include "dlib/dlib.h"
 #include "dlib/log.h"
+#include "dlib/atomic.h"
+#include "dlib/spinlock.h"
 
 #include "dlib/hash.h"
 
@@ -26,11 +28,13 @@
 
 namespace dmProfile
 {
-    static Remotery* g_Remotery = 0;
+    static Remotery*                g_Remotery = 0;
     static FSampleTreeCallback      g_SampleTreeCallback = 0;
     static void*                    g_SampleTreeCallbackCtx = 0;
     static FPropertyTreeCallback    g_PropertyTreeCallback = 0;
     static void*                    g_PropertyTreeCallbackCtx = 0;
+    static int32_atomic_t           g_ProfilerInitialized = 0;
+    static dmSpinlock::Spinlock     g_ProfilerLock;
 
     static inline rmtSample* SampleFromHandle(HSample sample)
     {
@@ -49,8 +53,18 @@ namespace dmProfile
         return (HProperty)property;
     }
 
+    bool IsInitialized()
+    {
+        return dmAtomicGet32(&g_ProfilerInitialized) != 0 && g_Remotery != 0;
+    }
+
     static void SampleTreeCallback(void* ctx, rmtSampleTree* sample_tree)
     {
+        if (!IsInitialized())
+            return;
+
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
+
         if (g_SampleTreeCallback)
         {
             const char* thread_name = rmt_SampleTreeGetThreadName(sample_tree);
@@ -62,6 +76,11 @@ namespace dmProfile
 
     static void PropertyTreeCallback(void* ctx, rmtProperty* root)
     {
+        if (!IsInitialized())
+            return;
+
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
+
         if (g_PropertyTreeCallback)
         {
             g_PropertyTreeCallback(g_PropertyTreeCallbackCtx, PropertyToHandle(root));
@@ -102,24 +121,45 @@ namespace dmProfile
 
         rmt_SetCurrentThreadName("Main");
 
+        dmSpinlock::Create(&g_ProfilerLock);
+        dmAtomicStore32(&g_ProfilerInitialized, 1);
+
         dmLogInfo("Initialized Remotery (ws://127.0.0.1:%d/rmt)", settings->port);
+    }
+
+    static inline void WaitForFlag(int32_atomic_t* lock)
+    {
+        while (dmAtomicGet32(lock) == 0) {
+        }
+    }
+
+    static inline void AtomicUnlock(int32_atomic_t* lock)
+    {
+        dmAtomicStore32(lock, 0);
     }
 
     void Finalize()
     {
-        if (g_Remotery)
-            rmt_DestroyGlobalInstance(g_Remotery);
-        g_Remotery = 0;
-    }
+        {
+            DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
+            dmAtomicStore32(&g_ProfilerInitialized, 0);
 
-    bool IsInitialized()
-    {
-        return g_Remotery != 0;
+            g_SampleTreeCallback = 0;
+            g_SampleTreeCallbackCtx = 0;
+            g_PropertyTreeCallback = 0;
+            g_PropertyTreeCallbackCtx = 0;
+
+            if (g_Remotery)
+                rmt_DestroyGlobalInstance(g_Remotery);
+            g_Remotery = 0;
+        }
+
+        dmSpinlock::Destroy(&g_ProfilerLock);
     }
 
     HProfile BeginFrame()
     {
-        if (!g_Remotery)
+        if (!IsInitialized())
         {
             return 0;
         }
@@ -129,12 +169,15 @@ namespace dmProfile
 
     void SetThreadName(const char* name)
     {
+        if (!IsInitialized())
+            return;
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
         rmt_SetCurrentThreadName(name);
     }
 
     void EndFrame(HProfile profile)
     {
-        if (!g_Remotery)
+        if (!IsInitialized())
         {
             return;
         }
@@ -159,6 +202,11 @@ namespace dmProfile
 
     void LogText(const char* format, ...)
     {
+        if (!IsInitialized())
+        {
+            return;
+        }
+
         char buffer[DM_PROFILE_TEXT_LENGTH];
 
         va_list lst;
@@ -172,19 +220,21 @@ namespace dmProfile
 
     void SetSampleTreeCallback(void* ctx, FSampleTreeCallback callback)
     {
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
         g_SampleTreeCallback = callback;
         g_SampleTreeCallbackCtx = ctx;
     }
 
     void SetPropertyTreeCallback(void* ctx, FPropertyTreeCallback callback)
     {
+        DM_SPINLOCK_SCOPED_LOCK(g_ProfilerLock);
         g_PropertyTreeCallback = callback;
         g_PropertyTreeCallbackCtx = ctx;
     }
 
     void ProfileScope::StartScope(const char* name, uint64_t* name_hash)
     {
-        if (g_Remotery == NULL) {
+        if (!IsInitialized()) {
             return;
         }
         if (name != 0)
@@ -206,7 +256,7 @@ namespace dmProfile
 
     void ScopeBegin(const char* name, uint64_t* name_hash)
     {
-        if (g_Remotery == NULL) {
+        if (!IsInitialized()) {
             return;
         }
         _rmt_BeginCPUSample(name, RMTSF_Aggregate, (uint32_t*)name_hash);
@@ -214,7 +264,7 @@ namespace dmProfile
 
     void ScopeEnd()
     {
-        if (g_Remotery == NULL) {
+        if (!IsInitialized()) {
             return;
         }
         rmt_EndCPUSample();


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
