### PR TITLE
Support environment-variable replacement for usernames in dependency URLs

### DIFF
--- a/editor/src/clj/editor/library.clj
+++ b/editor/src/clj/editor/library.clj
@@ -99,17 +99,25 @@
     (io/copy is f)
     f))
 
+(defn- replace-user-info-env-variable [^String user-info-token]
+  (if (and (some? user-info-token)
+           (str/starts-with? user-info-token "__")
+           (str/ends-with? user-info-token "__"))
+    (let [env-key (subs user-info-token 2 (- (count user-info-token) 2))
+          env-value (System/getenv env-key)]
+      (or env-value user-info-token))
+    user-info-token))
+
 (defn- make-basic-auth-headers
   [^String user-info]
-  (let [user-info-parts (str/split user-info #":")
-        username (get user-info-parts 0)
-        password (or (get user-info-parts 1) "")]
-    (if (and (str/starts-with? password "__") (str/ends-with? password "__"))
-      (let [password-env-key (subs password 2 (- (count password) 2))
-            password-env-value (or (System/getenv password-env-key) password)]
-         {"Authorization" (format "Basic %s" (str->b64 (str username ":" password-env-value)))})
-      {"Authorization" (format "Basic %s" (str->b64 user-info))})))
-  
+  (let [[username password] (str/split user-info #":")
+        username (replace-user-info-env-variable username)
+        password (replace-user-info-env-variable password)
+        user-info (cond-> username
+                          password (str ":" password))
+        user-info-b64 (str->b64 user-info)
+        authorization (format "Basic %s" user-info-b64)]
+    {"Authorization" authorization}))
 
 (defn- headers-for-uri [^URI lib-uri]
   (let [user-info (.getUserInfo lib-uri)]

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -957,7 +957,7 @@
                                                       num-strs)
                             first-col-width-fmt (str \% first-col-width \s)
                             rest-col-width-fmt (str \% rest-col-width \s)
-                            fmt-col (fn [index num-str]
+                            fmt-col (fn [^long index num-str]
                                       (let [element (case num-str
                                                       ("-0.000" "0.000") :number
                                                       :string)


### PR DESCRIPTION
The editor can now inject environment variables into both the username and password of library dependency URLs that use authentication.
