### PR TITLE
Migrate texture fields to samplers

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
@@ -1,0 +1,84 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dynamo.render.proto.Material.MaterialDesc;
+import com.google.protobuf.Message;
+
+public class MaterialBuilderTest extends AbstractProtoBuilderTest {
+
+    @Before
+    public void setup() {
+        addTestFiles();
+    }
+
+    @Test
+    public void testModelMigrateTextures() throws Exception {
+
+		addFile("/test.material", "");
+        addFile("/test.vp", "");
+        addFile("/test.fp", "");
+
+        build("/test.vp", "");
+        build("/test.fp", "");
+
+        StringBuilder src = new StringBuilder();
+        src.append("name: \"test_material\"\n");
+        src.append("vertex_program: \"/test.vp\"\n");
+        src.append("fragment_program: \"/test.fp\"\n");
+
+        // these should be migrated
+        src.append("textures: \"tex0\"\n");
+        src.append("textures: \"tex1\"\n");
+        src.append("textures: \"tex2\"\n");
+
+        // these should not be migrated
+        src.append("textures: \"tex0_sampler\"\n");
+        src.append("textures: \"tex_already_exist_in_samplers\"\n");
+
+        src.append("samplers: {\n");
+        src.append("	name: \"tex0_sampler\"\n");
+        src.append("	wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("	wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("	filter_min: FILTER_MODE_MIN_LINEAR\n");
+        src.append("	filter_mag: FILTER_MODE_MAG_LINEAR\n");
+        src.append("}\n");
+
+        src.append("samplers: {\n");
+        src.append("	name: \"tex_already_exist_in_samplers\"\n");
+        src.append("	wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("	wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("	filter_min: FILTER_MODE_MIN_LINEAR\n");
+        src.append("	filter_mag: FILTER_MODE_MAG_LINEAR\n");
+        src.append("}\n");
+
+        MaterialDesc material = (MaterialDesc) build("/test.material", src.toString()).get(0);
+        assertEquals(0, material.getTexturesCount());
+        assertEquals(5, material.getSamplersCount());
+
+        List<MaterialDesc.Sampler> samplers = material.getSamplersList();
+        assertEquals("tex0_sampler", 				  samplers.get(0).getName());
+        assertEquals("tex_already_exist_in_samplers", samplers.get(1).getName());
+        assertEquals("tex0", 					      samplers.get(2).getName());
+        assertEquals("tex1", 					      samplers.get(3).getName());
+        assertEquals("tex2", 					      samplers.get(4).getName());
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/MaterialBuilderTest.java
@@ -31,9 +31,9 @@ public class MaterialBuilderTest extends AbstractProtoBuilderTest {
     }
 
     @Test
-    public void testModelMigrateTextures() throws Exception {
+    public void testMigrateTextures() throws Exception {
 
-		addFile("/test.material", "");
+        addFile("/test.material", "");
         addFile("/test.vp", "");
         addFile("/test.fp", "");
 
@@ -55,19 +55,19 @@ public class MaterialBuilderTest extends AbstractProtoBuilderTest {
         src.append("textures: \"tex_already_exist_in_samplers\"\n");
 
         src.append("samplers: {\n");
-        src.append("	name: \"tex0_sampler\"\n");
-        src.append("	wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
-        src.append("	wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
-        src.append("	filter_min: FILTER_MODE_MIN_LINEAR\n");
-        src.append("	filter_mag: FILTER_MODE_MAG_LINEAR\n");
+        src.append("    name: \"tex0_sampler\"\n");
+        src.append("    wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("    wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("    filter_min: FILTER_MODE_MIN_LINEAR\n");
+        src.append("    filter_mag: FILTER_MODE_MAG_LINEAR\n");
         src.append("}\n");
 
         src.append("samplers: {\n");
-        src.append("	name: \"tex_already_exist_in_samplers\"\n");
-        src.append("	wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
-        src.append("	wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
-        src.append("	filter_min: FILTER_MODE_MIN_LINEAR\n");
-        src.append("	filter_mag: FILTER_MODE_MAG_LINEAR\n");
+        src.append("    name: \"tex_already_exist_in_samplers\"\n");
+        src.append("    wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("    wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("    filter_min: FILTER_MODE_MIN_LINEAR\n");
+        src.append("    filter_mag: FILTER_MODE_MAG_LINEAR\n");
         src.append("}\n");
 
         MaterialDesc material = (MaterialDesc) build("/test.material", src.toString()).get(0);
@@ -75,10 +75,10 @@ public class MaterialBuilderTest extends AbstractProtoBuilderTest {
         assertEquals(5, material.getSamplersCount());
 
         List<MaterialDesc.Sampler> samplers = material.getSamplersList();
-        assertEquals("tex0_sampler", 				  samplers.get(0).getName());
+        assertEquals("tex0_sampler",                  samplers.get(0).getName());
         assertEquals("tex_already_exist_in_samplers", samplers.get(1).getName());
-        assertEquals("tex0", 					      samplers.get(2).getName());
-        assertEquals("tex1", 					      samplers.get(3).getName());
-        assertEquals("tex2", 					      samplers.get(4).getName());
+        assertEquals("tex0",                          samplers.get(2).getName());
+        assertEquals("tex1",                          samplers.get(3).getName());
+        assertEquals("tex2",                          samplers.get(4).getName());
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 
 import com.dynamo.bob.Bob;
 import com.dynamo.bob.Builder;
@@ -232,6 +233,27 @@ public class MaterialBuilder extends Builder<Void>  {
         }
     }
 
+    private static void migrateTexturesToSamplers(MaterialDesc.Builder materialBuilder) {
+        List<MaterialDesc.Sampler> samplers = materialBuilder.getSamplersList();
+
+        for (String texture : materialBuilder.getTexturesList()) {
+            // Cannot migrate textures that are already in samplers
+            if (samplers.stream().anyMatch(sampler -> sampler.getName().equals(texture))) {
+                continue;
+            }
+
+            MaterialDesc.Sampler.Builder samplerBuilder = MaterialDesc.Sampler.newBuilder();
+            samplerBuilder.setName(texture);
+            samplerBuilder.setWrapU(MaterialDesc.WrapMode.WRAP_MODE_CLAMP_TO_EDGE);
+            samplerBuilder.setWrapV(MaterialDesc.WrapMode.WRAP_MODE_CLAMP_TO_EDGE);
+            samplerBuilder.setFilterMin(MaterialDesc.FilterModeMin.FILTER_MODE_MIN_LINEAR);
+            samplerBuilder.setFilterMag(MaterialDesc.FilterModeMag.FILTER_MODE_MAG_LINEAR);
+            materialBuilder.addSamplers(samplerBuilder);
+        }
+
+        materialBuilder.clearTextures();
+    }
+
     @Override
     public Task<Void> create(IResource input) throws IOException, CompileExceptionError {
         TaskBuilder<Void> task = Task.<Void> newBuilder(this)
@@ -247,6 +269,8 @@ public class MaterialBuilder extends Builder<Void>  {
 
         task.addInput(vertexProgramOutputResource);
         task.addInput(fragmentProgramOutputResource);
+
+        migrateTexturesToSamplers(materialBuilder);
 
         for (MaterialDesc.Sampler materialSampler : materialBuilder.getSamplersList()) {
             String texture = materialSampler.getTexture();
@@ -269,6 +293,22 @@ public class MaterialBuilder extends Builder<Void>  {
         }
     }
 
+    private static void buildSamplers(MaterialDesc.Builder materialBuilder) throws CompileExceptionError {
+        for (int i=0; i < materialBuilder.getSamplersCount(); i++) {
+            MaterialDesc.Sampler materialSampler = materialBuilder.getSamplers(i);
+
+            MaterialDesc.Sampler.Builder samplerBuilder = MaterialDesc.Sampler.newBuilder(materialSampler);
+            samplerBuilder.setNameHash(MurmurHash.hash64(samplerBuilder.getName()));
+
+            String texture = materialSampler.getTexture();
+            if (!texture.isEmpty()) {
+                samplerBuilder.setTexture(ProtoBuilders.replaceTextureName(texture));
+            }
+
+            materialBuilder.setSamplers(i, samplerBuilder.build());
+        }
+    }
+
     @Override
     public void build(Task<Void> task) throws CompileExceptionError, IOException {
         IResource res                        = task.input(0);
@@ -288,25 +328,16 @@ public class MaterialBuilder extends Builder<Void>  {
         BuilderUtil.checkResource(this.project, res, "fragment program", fragmentBuildContext.buildPath);
         materialBuilder.setFragmentProgram(BuilderUtil.replaceExt(fragmentBuildContext.projectPath, ".fp", ".fpc"));
 
+        migrateTexturesToSamplers(materialBuilder);
         buildVertexAttributes(materialBuilder);
-
-        for (int i=0; i < materialBuilder.getSamplersCount(); i++) {
-            MaterialDesc.Sampler materialSampler = materialBuilder.getSamplers(i);
-
-            MaterialDesc.Sampler.Builder samplerBuilder = MaterialDesc.Sampler.newBuilder(materialSampler);
-            samplerBuilder.setNameHash(MurmurHash.hash64(samplerBuilder.getName()));
-
-            String texture = materialSampler.getTexture();
-            if (!texture.isEmpty())
-                samplerBuilder.setTexture(ProtoBuilders.replaceTextureName(texture));
-
-            materialBuilder.setSamplers(i, samplerBuilder.build());
-        }
+        buildSamplers(materialBuilder);
 
         MaterialDesc materialDesc = materialBuilder.build();
         task.output(0).setContent(materialDesc.toByteArray());
     }
 
+    // Running standalone:
+    // java -classpath $DYNAMO_HOME/share/java/bob-light.jar com.dynamo.bob.pipeline.MaterialBuilder <path-in.material> <path-out.materialc>
     public static void main(String[] args) throws IOException, CompileExceptionError {
 
         System.setProperty("java.awt.headless", "true");
@@ -323,7 +354,10 @@ public class MaterialBuilder extends Builder<Void>  {
             materialBuilder.setVertexProgram(BuilderUtil.replaceExt(materialBuilder.getVertexProgram(), ".vp", ".vpc"));
             materialBuilder.setFragmentProgram(BuilderUtil.replaceExt(materialBuilder.getFragmentProgram(), ".fp", ".fpc"));
 
+            migrateTexturesToSamplers(materialBuilder);
+
             buildVertexAttributes(materialBuilder);
+            buildSamplers(materialBuilder);
 
             MaterialDesc materialDesc = materialBuilder.build();
             materialDesc.writeTo(output);


### PR DESCRIPTION
Fixed an issue in bob when building materials, if the material has specified textures they will not be used in the engine because the texture field is now deprecated. The fix migrates all the textures of a material into samplers instead.

Fixes #8681 