### PR TITLE
Added physics null implementations for new Box2D implemenation

### DIFF
--- a/engine/physics/src/physics/physics_2d_null.cpp
+++ b/engine/physics/src/physics/physics_2d_null.cpp
@@ -348,4 +348,15 @@ namespace dmPhysics
     void SynchronizeObject2D(HWorld2D world, HCollisionObject2D collision_object)
     {
     }
+
+    void* GetWorldContext2D(HWorld2D world)
+    {
+        return 0;
+    }
+
+    void* GetCollisionObjectContext2D(HCollisionObject2D collision_object)
+    {
+        return 0;
+    }
+
 }

--- a/engine/physics/src/physics/test/test_physics.h
+++ b/engine/physics/src/physics/test/test_physics.h
@@ -130,6 +130,8 @@ struct Funcs
     typedef void (*SetGravityFunc)(typename T::WorldType world, const dmVMath::Vector3& gravity);
     typedef bool (*IsBulletFunc)(typename T::CollisionObjectType collision_object);
     typedef void (*SetBulletFunc)(typename T::CollisionObjectType collision_object, bool value);
+    typedef void* (*GetWorldContextFunc)(typename T::WorldType world);
+    typedef void* (*GetCollisionObjectContextFunc)(typename T::CollisionObjectType collision_object);
     typedef dmVMath::Vector3 (*GetGravityFunc)(typename T::WorldType world);
 };
 
@@ -246,6 +248,8 @@ struct Test2D
     Funcs<Test2D>::GetGravityFunc                   m_GetGravityFunc;
     Funcs<Test2D>::IsBulletFunc                     m_IsBulletFunc;
     Funcs<Test2D>::SetBulletFunc                    m_SetBulletFunc;
+    Funcs<Test2D>::GetWorldContextFunc              m_GetWorldContextFunc;
+    Funcs<Test2D>::GetCollisionObjectContextFunc    m_GetCollisionObjectContextFunc;
 
     float*      m_Vertices;
     uint32_t    m_VertexCount;

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -119,6 +119,8 @@ Test2D::Test2D()
 , m_ReplaceShapeFunc(dmPhysics::ReplaceShape2D)
 , m_IsBulletFunc(dmPhysics::IsBullet2D)
 , m_SetBulletFunc(dmPhysics::SetBullet2D)
+, m_GetWorldContextFunc(dmPhysics::GetWorldContext2D)
+, m_GetCollisionObjectContextFunc(dmPhysics::GetCollisionObjectContext2D)
 , m_Vertices(new float[3*2])
 , m_VertexCount(3)
 , m_PolygonRadius(b2_polygonRadius)
@@ -1817,6 +1819,27 @@ TYPED_TEST(PhysicsTest, SetGridShapeEnable)
 
     (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, grid_co);
     dmPhysics::DeleteHullSet2D(hull_set);
+}
+
+TYPED_TEST(PhysicsTest, ScriptApiBox2D)
+{
+    ASSERT_NE((void*)0, (*TestFixture::m_Test.m_GetWorldContextFunc)(TestFixture::m_World));
+
+    dmPhysics::CollisionObjectData data;
+    VisualObject vo_b;
+    // the sphere is in the upper right quadrant
+    vo_b.m_Position = dmVMath::Point3(9.0f, 9.0f, 0.0f);
+    data.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_KINEMATIC;
+    data.m_Mass = 0.0f;
+    data.m_UserData = &vo_b;
+    data.m_Group = 0xffff;
+    data.m_Mask = 0xffff;
+    typename TypeParam::CollisionShapeType shape = (*TestFixture::m_Test.m_NewSphereShapeFunc)(TestFixture::m_Context, 8.0f);
+    typename TypeParam::CollisionObjectType dynamic_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data, &shape, 1u);
+
+    ASSERT_NE((void*)0, (*TestFixture::m_Test.m_GetCollisionObjectContextFunc)(dynamic_co));
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, dynamic_co);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
