### PR TITLE
Increased stack size for resource loader thread to 128kb

### DIFF
--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -240,16 +240,29 @@ static bool UpdateAndWaitUntilDone(
     bool                               ignore_script_update_fail,
     const char*                        tests_done_key)
 {
-    uint64_t stop_time = dmTime::GetTime() + 1*1e6; // 1 second
+    uint64_t timeout = 1 * 1000000; // microseconds
+    uint64_t stop_time = dmTime::GetTime() + timeout;
     bool tests_done = false;
-    while (dmTime::GetTime() < stop_time && !tests_done)
+    while (!tests_done)
     {
+        if (dmTime::GetTime() >= stop_time)
+        {
+            dmLogError("Test timed out after %f seconds", timeout / 1000000.0f);
+            break;
+        }
+
         dmJobThread::Update(scriptlibcontext.m_JobThread);
         dmGameSystem::ScriptSysGameSysUpdate(scriptlibcontext);
         if (!dmGameSystem::GetScriptSysGameSysLastUpdateResult() && !ignore_script_update_fail)
+        {
+            dmLogError("Test failed on dmGameSystem::GetScriptSysGameSysLastUpdateResult()");
             return false;
+        }
         if (!dmGameObject::Update(collection, update_context))
+        {
+            dmLogError("Test failed on dmGameObject::Update()");
             return false;
+        }
 
         // check if tests are done
         lua_getglobal(scriptlibcontext.m_LuaState, tests_done_key);

--- a/engine/resource/src/async/load_queue_threaded.cpp
+++ b/engine/resource/src/async/load_queue_threaded.cpp
@@ -177,7 +177,7 @@ namespace dmLoadQueue
         q->m_BytesWaiting = 0;
         q->m_Mutex        = dmMutex::New();
         q->m_WakeupCond   = dmConditionVariable::New();
-        q->m_Thread       = dmThread::New(&LoadThread, 65536, q, "AsyncLoad");
+        q->m_Thread       = dmThread::New(&LoadThread, 128 * 1024, q, "AsyncLoad");
 
         return q;
     }


### PR DESCRIPTION
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
