### PR TITLE
Make sure go.get_world_position() returns the correct value when called from the init() function.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/CollectionBuilderTest.java
@@ -25,6 +25,7 @@ import javax.vecmath.Point3d;
 import javax.vecmath.Quat4d;
 import javax.vecmath.Vector3d;
 
+import com.dynamo.gameobject.proto.GameObject;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -913,5 +914,49 @@ public class CollectionBuilderTest extends AbstractProtoBuilderTest {
                 Assert.assertEquals((int)ComponentsCounter.DYNAMIC_VALUE, type.getMaxCount());
             }
         }
+    }
+
+    /**
+     * Test that the objects in the collection sorted according to its transform hierarhy
+     * Structure:
+     * - go "0"
+     *   - go "1"
+     *      - go "2"
+     *          - go "3"
+     * @throws Exception
+     */
+    @Test
+    public void testEmbeddedInstancesOrder() throws Exception {
+        StringBuilder src = new StringBuilder();
+        src.append("name: \"Example\"\n");
+        src.append("scale_along_z: 0\n");
+        src.append("embedded_instances {\n");
+        src.append("  id: \"3\"\n"); // Create the last object in hierarhy the first in the source file
+        src.append("  data: \"\"\n");
+        src.append("}\n");
+        src.append("embedded_instances {\n");
+        src.append("  id: \"0\"\n");
+        src.append("  children: \"1\"\n");
+        src.append("  data: \"\"\n");
+        src.append("}\n");
+        src.append("embedded_instances {\n");
+        src.append("  id: \"1\"\n");
+        src.append("  children: \"2\"\n");
+        src.append("  data: \"\"\n");
+        src.append("}\n");
+        src.append("embedded_instances {\n");
+        src.append("  id: \"2\"\n");
+        src.append("  children: \"3\"\n");
+        src.append("  data: \"\"\n");
+        src.append("}\n");
+
+        CollectionDesc collection = (CollectionDesc) build("/test.collection", src.toString()).get(0);
+        List<GameObject.InstanceDesc> instances = collection.getInstancesList();
+
+        Assert.assertEquals("Order of instances should be 0, 1, 2, 3", 4, instances.size());
+        Assert.assertEquals("First instance ID should be '0'", "/0", instances.get(0).getId());
+        Assert.assertEquals("Second instance ID should be '1'", "/1", instances.get(1).getId());
+        Assert.assertEquals("Third instance ID should be '2'", "/2", instances.get(2).getId());
+        Assert.assertEquals("Fourth instance ID should be '3'", "/3", instances.get(3).getId());
     }
 }

--- a/editor/src/clj/editor/collection_common.clj
+++ b/editor/src/clj/editor/collection_common.clj
@@ -226,6 +226,33 @@
 (defn- pose->transform-properties [pose]
   (pose/to-map pose :position :rotation :scale3))
 
+(defn- sort-instance-descs-for-build-output [instance-descs]
+  (let [instance-id->parent-id
+        (into {}
+              (mapcat (fn [instance-desc]
+                        (let [instance-id (:id instance-desc)
+                              child-ids (:children instance-desc)]
+                          (map (fn [child-id]
+                                 (pair child-id instance-id))
+                               child-ids))))
+              instance-descs)
+
+        instance-id->hierarchy-depth
+        (fn instance-id->hierarchy-depth [instance-id]
+          (->> instance-id
+               (iterate instance-id->parent-id)
+               (take-while some?)
+               (count)))
+
+        instance-desc->order-key
+        (fn instance-desc->order-key [instance-desc]
+          (let [instance-id (:id instance-desc)
+                hierarchy-depth (instance-id->hierarchy-depth instance-id)]
+            (pair hierarchy-depth instance-id)))]
+
+    (sort-by instance-desc->order-key
+             instance-descs)))
+
 (defn- build-collection [build-resource dep-resources user-data]
   ;; Please refer to `/engine/gameobject/proto/gameobject/gameobject_ddf.proto`
   ;; when reading this. It will clear up how the output binaries are structured.
@@ -270,19 +297,8 @@
         property-resource-paths (into (sorted-set)
                                       (comp cat cat (keep properties/try-get-go-prop-proj-path))
                                       go-instance-component-go-props)
-        instance-id->parent-id (into {}
-                                     (mapcat (fn [{:keys [id children]}]
-                                               (map (fn [child-id]
-                                                      (pair child-id id))
-                                                    children)))
-                                     instance-descs)
-        instance-desc->hierarchy-depth (fn [instance-desc]
-                                         (->> (:id instance-desc)
-                                              (iterate instance-id->parent-id)
-                                              (take-while some?)
-                                              (count)))
         collection-desc {:name name
-                         :instances (sort-by instance-desc->hierarchy-depth instance-descs)
+                         :instances (sort-instance-descs-for-build-output instance-descs)
                          :scale-along-z (if scale-along-z 1 0)
                          :property-resources property-resource-paths}]
     {:resource build-resource

--- a/editor/test/editor/collection_common_test.clj
+++ b/editor/test/editor/collection_common_test.clj
@@ -1,0 +1,104 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.collection-common-test
+  (:require [clojure.test :refer :all]
+            [editor.collection-common :as collection-common]))
+
+(set! *warn-on-reflection* true)
+
+(deftest sort-instance-descs-for-build-output-test
+  (is (= [{:id "chest"
+           :children ["left-shoulder"
+                      "right-shoulder"]}
+          {:id "left-shoulder"
+           :children ["left-upper-arm"]}
+          {:id "right-shoulder"
+           :children ["right-upper-arm"]}
+          {:id "left-upper-arm"
+           :children ["left-elbow"]}
+          {:id "right-upper-arm"
+           :children ["right-elbow"]}
+          {:id "left-elbow"
+           :children ["left-lower-arm"]}
+          {:id "right-elbow"
+           :children ["right-lower-arm"]}
+          {:id "left-lower-arm"
+           :children ["left-hand"]}
+          {:id "right-lower-arm"
+           :children ["right-hand"]}
+          {:id "left-hand"
+           :children ["left-thumb"
+                      "left-index-finger"
+                      "left-middle-finger"
+                      "left-ring-finger"
+                      "left-pinkie-finger"]}
+          {:id "right-hand"
+           :children ["right-thumb"
+                      "right-index-finger"
+                      "right-middle-finger"
+                      "right-ring-finger"
+                      "right-pinkie-finger"]}
+          {:id "left-index-finger"}
+          {:id "left-middle-finger"}
+          {:id "left-pinkie-finger"}
+          {:id "left-ring-finger"}
+          {:id "left-thumb"}
+          {:id "right-index-finger"}
+          {:id "right-middle-finger"}
+          {:id "right-pinkie-finger"}
+          {:id "right-ring-finger"}
+          {:id "right-thumb"}]
+         (#'collection-common/sort-instance-descs-for-build-output
+           [{:id "right-thumb"}
+            {:id "right-index-finger"}
+            {:id "right-middle-finger"}
+            {:id "right-ring-finger"}
+            {:id "right-pinkie-finger"}
+            {:id "right-hand"
+             :children ["right-thumb"
+                        "right-index-finger"
+                        "right-middle-finger"
+                        "right-ring-finger"
+                        "right-pinkie-finger"]}
+            {:id "right-lower-arm"
+             :children ["right-hand"]}
+            {:id "right-elbow"
+             :children ["right-lower-arm"]}
+            {:id "right-upper-arm"
+             :children ["right-elbow"]}
+            {:id "right-shoulder"
+             :children ["right-upper-arm"]}
+            {:id "left-thumb"}
+            {:id "left-index-finger"}
+            {:id "left-middle-finger"}
+            {:id "left-ring-finger"}
+            {:id "left-pinkie-finger"}
+            {:id "left-hand"
+             :children ["left-thumb"
+                        "left-index-finger"
+                        "left-middle-finger"
+                        "left-ring-finger"
+                        "left-pinkie-finger"]}
+            {:id "left-lower-arm"
+             :children ["left-hand"]}
+            {:id "left-elbow"
+             :children ["left-lower-arm"]}
+            {:id "left-upper-arm"
+             :children ["left-elbow"]}
+            {:id "left-shoulder"
+             :children ["left-upper-arm"]}
+            {:id "chest"
+             :children ["left-shoulder"
+                        "right-shoulder"]}]))))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -513,7 +513,7 @@
   (with-build-results "/script/props.collection"
     (doseq [[res-path pb decl-path] [["/script/props.script" Lua$LuaModule [:properties]]
                                      ["/script/props.go" GameObject$PrototypeDesc [:components 0 :property-decls]]
-                                     ["/script/props.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls]]]]
+                                     ["/script/props.collection" GameObject$CollectionDesc [:instances 1 :component-properties 0 :property-decls]]]]
       (let [content (get content-by-source res-path)
             desc (protobuf/bytes->map pb content)
             decl (get-in desc decl-path)]
@@ -545,7 +545,7 @@
       (is (not-empty (:hash-values decl)))
       (is (not-empty (:string-values decl)))))
   (with-build-results "/script/sub_props.collection"
-    (doseq [[res-path pb decl-path] [["/script/sub_props.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls]]]]
+    (doseq [[res-path pb decl-path] [["/script/sub_props.collection" GameObject$CollectionDesc [:instances 1 :component-properties 0 :property-decls]]]]
       (let [content (get content-by-source res-path)
             desc (protobuf/bytes->map pb content)
             decl (get-in desc decl-path)]
@@ -562,7 +562,7 @@
     ;; Sub-collections should not be built separately
     (is (not (contains? content-by-source "/script/props.collection"))))
   (with-build-results "/script/sub_sub_props.collection"
-    (doseq [[res-path pb decl-path] [["/script/sub_sub_props.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls]]]]
+    (doseq [[res-path pb decl-path] [["/script/sub_sub_props.collection" GameObject$CollectionDesc [:instances 1 :component-properties 0 :property-decls]]]]
       (let [content (get content-by-source res-path)
             desc (protobuf/bytes->map pb content)
             decl (get-in desc decl-path)]
@@ -593,7 +593,7 @@
                                                  desc (protobuf/bytes->map pb-class content)
                                                  float-values (get-in desc val-path)]
                                              (= [expected] float-values))
-      "/script/override_parent.collection" GameObject$CollectionDesc [:instances 0 :component-properties 0 :property-decls :float-values] 4.0)))
+      "/script/override_parent.collection" GameObject$CollectionDesc [:instances 1 :component-properties 0 :property-decls :float-values] 4.0)))
 
 (deftest build-gui-templates
   ;; Reads from test_project rather than build_project


### PR DESCRIPTION
Fixed an issue where objects in deep hierarchies returned the wrong value for `go.get_world_position()` when called from `init()`.

Fix https://github.com/defold/defold/issues/7522

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
