### PR TITLE
Implement transpiler support

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/ILuaTranspiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/ILuaTranspiler.java
@@ -1,0 +1,114 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.defold.extension.pipeline;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Implement this interface in com.defold.extension.pipeline package with no-argument constructor
+ * to add support for transpiling a language to Lua that is then will be used during the build
+ */
+public interface ILuaTranspiler {
+
+    /**
+     * @return A resource path to a build file, a project-relative path starting with slash,
+     * e.g. {@code "/tlconfig.lua"}
+     */
+    String getBuildFileResourcePath();
+
+    /**
+     * @return A file extension for the source code files of the transpiled language,
+     * e.g. {@code "ext"}
+     */
+    String getSourceExt();
+
+    /**
+     * Build the project from the source dir to output dir
+     *
+     * @param pluginDir a dir inside the project root that contains unpacked plugins that may be
+     *                  used for compilation (i.e. transpiler binaries)
+     * @param sourceDir a dir that is guaranteed to have all the source code files as reported
+     *                  by {@link #getSourceExt()}, and a build file, as reported by
+     *                  {@link #getBuildFileResourcePath()}. This might be a real project dir,
+     *                  or it could be a temporary directory if some sources are coming from
+     *                  the dependency zip files.
+     * @param outputDir a dir to put the transpiled lua files to. All lua files from the
+     *                  directory will be compiled as a part of the project compilation. The
+     *                  directory is preserved over editor/bob transpiler runs and editor restarts,
+     *                  so it's a responsibility of the transpiler to clear it from the old files
+     * @return a possibly empty or nullable list of build issues
+     */
+    List<Issue> transpile(File pluginDir, File sourceDir, File outputDir) throws Exception;
+
+    final class Issue {
+        public final Severity severity;
+        public final String resourcePath;
+        public final int lineNumber;
+        public final String message;
+
+        /**
+         * @param severity     issue severity
+         * @param resourcePath compiled resource path of the build file or some of the source
+         *                     files relative to project root, must start with slash
+         * @param lineNumber   1-indexed line number
+         * @param message      issue message to present to the user
+         */
+        public Issue(Severity severity, String resourcePath, int lineNumber, String message) {
+            if (severity == null) {
+                throw new IllegalArgumentException("Issue severity must not be null");
+            }
+            if (resourcePath == null || resourcePath.isEmpty() || resourcePath.charAt(0) != '/') {
+                throw new IllegalArgumentException("Invalid issue resource path: " + resourcePath);
+            }
+            if (lineNumber <= 0) {
+                throw new IllegalArgumentException("Invalid issue line number: " + lineNumber);
+            }
+            if (message == null || message.isEmpty()) {
+                throw new IllegalArgumentException("Invalid issue message: " + message);
+            }
+            this.severity = severity;
+            this.resourcePath = resourcePath;
+            this.lineNumber = lineNumber;
+            this.message = message;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Issue issue = (Issue) o;
+            return lineNumber == issue.lineNumber && severity == issue.severity && Objects.equals(resourcePath, issue.resourcePath) && Objects.equals(message, issue.message);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(severity, resourcePath, lineNumber, message);
+        }
+
+        @Override
+        public String toString() {
+            return "Issue{" +
+                    "severity=" + severity +
+                    ", resourcePath='" + resourcePath + '\'' +
+                    ", lineNumber=" + lineNumber +
+                    ", message='" + message + '\'' +
+                    '}';
+        }
+    }
+
+    enum Severity {INFO, WARNING, ERROR}
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/ILuaTranspiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/defold/extension/pipeline/ILuaTranspiler.java
@@ -25,8 +25,8 @@ import java.util.Objects;
 public interface ILuaTranspiler {
 
     /**
-     * @return A resource path to a build file, a project-relative path starting with slash,
-     * e.g. {@code "/tlconfig.lua"}
+     * @return A resource path to a build file, i.e. a file that configures the transpiler;
+     * a project-relative path starting with slash, e.g. {@code "/tlconfig.lua"}
      */
     String getBuildFileResourcePath();
 
@@ -39,8 +39,14 @@ public interface ILuaTranspiler {
     /**
      * Build the project from the source dir to output dir
      *
-     * @param pluginDir a dir inside the project root that contains unpacked plugins that may be
-     *                  used for compilation (i.e. transpiler binaries)
+     * @param pluginDir a build plugins dir inside the project root that contains unpacked plugins
+     *                  from all project extensions, useful for distributing and using transpiler
+     *                  binaries. When directory is a native extension (i.e. has {@code "ext.manifest"}
+     *                  file), even if it comes from a dependency, files from
+     *                  {@code "${ext-dir}/plugins/bin/${platform}/"} (or {@code "${ext-dir}/plugins/bin/${platform}.zip"})
+     *                  will be extracted to the plugin dir, and then may be subsequently accessed (and
+     *                  executed) using this path, e.g. with {@code new File(pluginDir, "my-transpiler-lib/plugins/bin/"
+     *                  + Platform.getHostPlatform().getPair() + "/my-transpiler.exe")}
      * @param sourceDir a dir that is guaranteed to have all the source code files as reported
      *                  by {@link #getSourceExt()}, and a build file, as reported by
      *                  {@link #getBuildFileResourcePath()}. This might be a real project dir,
@@ -49,8 +55,9 @@ public interface ILuaTranspiler {
      * @param outputDir a dir to put the transpiled lua files to. All lua files from the
      *                  directory will be compiled as a part of the project compilation. The
      *                  directory is preserved over editor/bob transpiler runs and editor restarts,
-     *                  so it's a responsibility of the transpiler to clear it from the old files
-     * @return a possibly empty or nullable list of build issues
+     *                  so it's a responsibility of the transpiler to clear out unneeded files from
+     *                  previous runs
+     * @return a possibly empty (but not nullable!) list of build issues
      */
     List<Issue> transpile(File pluginDir, File sourceDir, File outputDir) throws Exception;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1446,6 +1446,10 @@ public class Project {
                             .map(this::getResource)
                             .collect(Collectors.toList());
                     if (!sources.isEmpty()) {
+                        // We transpile to lua from the project dir only if all the source code files exist on disc. Since
+                        // some source file may come as dependencies in zip archives, the transpiler will not be able to
+                        // transpile them. In this situation, we extract all source files to a temporary folder. Similar
+                        // logic is implemented in editor in editor.code.transpilers/produce-build-output function
                         boolean useProjectDir = buildFileResource instanceof DefaultResource && sources.stream().allMatch(s -> s instanceof DefaultResource);
                         File sourceDir;
                         if (useProjectDir) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/FileSystemMountPoint.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/fs/FileSystemMountPoint.java
@@ -1,0 +1,148 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.fs;
+
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+public class FileSystemMountPoint implements IMountPoint {
+
+    private final IFileSystem rootFileSystem;
+    private final IFileSystem fileSystem;
+
+    public FileSystemMountPoint(IFileSystem rootFileSystem, IFileSystem fileSystem) {
+        this.rootFileSystem = rootFileSystem;
+        this.fileSystem = fileSystem;
+    }
+
+    @Override
+    public IResource get(String path) {
+        IResource resource = fileSystem.get(path);
+        if (resource.exists()) {
+            return new MountedFileSystemResource(rootFileSystem, resource);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void mount() throws IOException {
+    }
+
+    @Override
+    public void unmount() {
+        fileSystem.close();
+    }
+
+    @Override
+    public void walk(String path, IFileSystem.IWalker walker, Collection<String> results) {
+        fileSystem.walk(path, walker, results);
+    }
+
+    public static class MountedFileSystemResource implements IResource {
+
+        private final IFileSystem rootFileSystem;
+        private final IResource resource;
+
+        public MountedFileSystemResource(IFileSystem rootFileSystem, IResource resource) {
+            this.rootFileSystem = rootFileSystem;
+            this.resource = resource;
+        }
+
+        @Override
+        public IResource changeExt(String ext) {
+            String name = ResourceUtil.changeExt(getPath(), ext);
+            return rootFileSystem.get(FilenameUtils.separatorsToUnix(FilenameUtils.concat(rootFileSystem.getBuildDirectory(), name)));
+        }
+
+        @Override
+        public byte[] getContent() throws IOException {
+            return resource.getContent();
+        }
+
+        @Override
+        public void setContent(byte[] content) throws IOException {
+            resource.setContent(content);
+        }
+
+        @Override
+        public byte[] sha1() throws IOException {
+            return resource.sha1();
+        }
+
+        @Override
+        public boolean exists() {
+            return resource.exists();
+        }
+
+        @Override
+        public boolean isFile() {
+            return resource.isFile();
+        }
+
+        @Override
+        public String getAbsPath() {
+            return resource.getAbsPath();
+        }
+
+        @Override
+        public String getPath() {
+            return resource.getPath();
+        }
+
+        @Override
+        public void remove() {
+            resource.remove();
+        }
+
+        @Override
+        public IResource getResource(String name) {
+            return resource.getResource(name);
+        }
+
+        @Override
+        public IResource output() {
+            return rootFileSystem.get(FilenameUtils.separatorsToUnix(FilenameUtils.concat(rootFileSystem.getBuildDirectory(), resource.getPath())));
+        }
+
+        @Override
+        public boolean isOutput() {
+            return false;
+        }
+
+        @Override
+        public void setContent(InputStream stream) throws IOException {
+            resource.setContent(stream);
+        }
+
+        @Override
+        public long getLastModified() {
+            return resource.getLastModified();
+        }
+
+        @Override
+        public IResource disableCache() {
+            return resource.disableCache();
+        }
+
+        @Override
+        public boolean isCacheable() {
+            return resource.isCacheable();
+        }
+    }
+}

--- a/editor/.idea/codeStyles/Project.xml
+++ b/editor/.idea/codeStyles/Project.xml
@@ -21,6 +21,7 @@
           <entry key="dynamo.graph/with-auto-or-fake-evaluation-context" value="-1" />
           <entry key="dynamo.graph/with-system" value="-1" />
           <entry key="editor.analytics-test/with-config!" value="-1" />
+          <entry key="editor.defold-project/with-transpiler-txs-fn" value="-1" />
           <entry key="editor.editor-extensions/execute-with!" value="-1" />
           <entry key="editor.editor-extensions/gen-query" value="-1" />
           <entry key="editor.editor-extensions/try-with-extension-exceptions" value="-1" />

--- a/editor/src/clj/editor/animation_set.clj
+++ b/editor/src/clj/editor/animation_set.clj
@@ -193,6 +193,7 @@
   (resource-node/register-ddf-resource-type workspace
     :ext "animationset"
     :icon animation-set-icon
+    :icon-class :property
     :label "Animation Set"
     :load-fn load-animation-set
     :sanitize-fn sanitize-animation-set

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1335,13 +1335,13 @@ If you do not specifically require different script states, consider changing th
 
 (defn- updated-build-resources [evaluation-context project old-etags new-etags proj-path-or-resource]
   (let [resource-node (project/get-resource-node project proj-path-or-resource evaluation-context)
-        build-targets (g/node-value resource-node :build-targets evaluation-context)
+        flat-build-targets (build/resolve-node-dependencies resource-node project evaluation-context)
         updated-build-resource-proj-paths (updated-build-resource-proj-paths old-etags new-etags)]
     (into []
           (keep (fn [{build-resource :resource :as _build-target}]
                   (when (contains? updated-build-resource-proj-paths (resource/proj-path build-resource))
                     build-resource)))
-          (rseq (pipeline/flatten-build-targets build-targets)))))
+          (rseq flat-build-targets))))
 
 (defn- can-hot-reload? [debug-view prefs evaluation-context]
   (when-some [target (targets/selected-target prefs)]

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -533,7 +533,7 @@
                              (when (workspace/has-template? workspace resource-type)
                                {:label (or (:label resource-type) (:ext resource-type))
                                 :icon (:icon resource-type)
-                                :style (resource/ext-style-classes (:ext resource-type))
+                                :style (resource/type-style-classes resource-type)
                                 :command :new-file
                                 :user-data {:resource-type resource-type}})))
                      (workspace/get-resource-type-map workspace))))))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -185,7 +185,7 @@
         page-offset-x (get-rect-page-offset layout-width (:page rect))]
     (doseq [p vertex-line-points]
       (let [x (+ (:x rect) (* 0.5 width) (* width (first p)) page-offset-x)
-            y (+ (:y rect) (* 0.5 height) (* height (second p)))  ]
+            y (+ (:y rect) (* 0.5 height) (* height (second p)))]
         (vtx/buf-push-floats! buf (gen-outline-vertex wt pt x y cr cg cb))))))
 
 (defn- gen-outline-vertex-buffer [renderables count]
@@ -954,15 +954,16 @@
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
-                                    :ext "atlas"
-                                    :label "Atlas"
-                                    :build-ext "a.texturesetc"
-                                    :node-type AtlasNode
-                                    :ddf-type AtlasProto$Atlas
-                                    :load-fn load-atlas
-                                    :icon atlas-icon
-                                    :view-types [:scene :text]
-                                    :view-opts {:scene {:grid false}}))
+    :ext "atlas"
+    :label "Atlas"
+    :build-ext "a.texturesetc"
+    :node-type AtlasNode
+    :ddf-type AtlasProto$Atlas
+    :load-fn load-atlas
+    :icon atlas-icon
+    :icon-class :design
+    :view-types [:scene :text]
+    :view-opts {:scene {:grid false}}))
 
 (defn- selection->atlas [selection] (handler/adapt-single selection AtlasNode))
 (defn- selection->animation [selection] (handler/adapt-single selection AtlasAnimation))

--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -14,11 +14,18 @@
 
 (ns editor.build
   (:require [clojure.set :as set]
+            [clojure.string :as string]
             [dynamo.graph :as g]
+            [editor.build-target :as bt]
+            [editor.code.transpilers :as code.transpilers]
             [editor.defold-project :as project]
             [editor.pipeline :as pipeline]
             [editor.progress :as progress]
-            [editor.workspace :as workspace]))
+            [editor.resource :as resource]
+            [editor.resource-io :as resource-io]
+            [editor.workspace :as workspace]
+            [util.coll :as coll])
+  (:import [java.util ArrayDeque HashMap HashSet]))
 
 (defn- batched-pmap [f batches]
   (->> batches
@@ -40,6 +47,118 @@
     (when (and (= label watched-label) (= state :begin) (= output-type :output))
       (swap! steps-atom conj node))))
 
+(defn- flatten-build-targets [build-targets]
+  (let [seen (HashSet.)
+        queue (doto (ArrayDeque.) (.add build-targets))]
+    (loop [acc (transient [])]
+      (if-let [batch (.pollFirst queue)]
+        (recur (transduce
+                 (filter
+                   (fn [target]
+                     (let [content-hash (target :content-hash)
+                           not-seen-before (.add seen content-hash)]
+                       (when not-seen-before
+                         (assert (bt/content-hash? content-hash)
+                                 (str "Build target has invalid content-hash: "
+                                      (resource/resource->proj-path (target :resource))))
+                         (let [deps (target :deps)]
+                           (when-not (coll/empty? deps)
+                             (.add queue deps))))
+                       not-seen-before)))
+                 conj!
+                 acc
+                 batch))
+        (persistent! acc)))))
+
+(defn- resolve-deps-impl
+  ([build-targets project proj-path->dynamic-build-targets evaluation-context]
+   (resolve-deps-impl (HashMap.) [] build-targets project proj-path->dynamic-build-targets evaluation-context))
+  ([^HashMap seen stack build-targets project proj-path->dynamic-build-targets evaluation-context]
+   (let [ret
+         (into
+           []
+           (comp
+             coll/flatten-xf
+             (map (fn [build-target]
+                    (if (g/error-value? build-target)
+                      build-target
+                      (let [content-hash (build-target :content-hash)]
+                        (if-let [resolved (.get seen content-hash)]
+                          resolved
+                          (let [result
+                                (if (reduce #(if (identical? %2 build-target) (reduced true) %1) false stack)
+                                  (let [cycle (into []
+                                                    (comp
+                                                      (drop-while #(not (identical? % build-target)))
+                                                      (keep (comp resource/proj-path :resource :resource)))
+                                                    (conj stack build-target))]
+                                    (g/map->error {:_node-id (build-target :node-id)
+                                                   :_label :build-targets
+                                                   :severity :fatal
+                                                   :message (str "Dependency cycle detected: " (string/join " -> " cycle))}))
+                                  (let [deps (build-target :deps)
+                                        dynamic-deps (build-target :dynamic-deps)
+                                        resolved-deps
+                                        (resolve-deps-impl
+                                          seen
+                                          (conj stack build-target)
+                                          [deps
+                                           (->Eduction
+                                             (map (fn [proj-path]
+                                                    (if-let [node (project/get-resource-node project proj-path evaluation-context)]
+                                                      (g/node-value node :build-targets evaluation-context)
+                                                      (or
+                                                        (proj-path->dynamic-build-targets proj-path)
+                                                        (resource-io/file-not-found-error (build-target :node-id) nil :fatal (project/resolve-path-or-resource project proj-path evaluation-context))))))
+                                             dynamic-deps)]
+                                          project
+                                          proj-path->dynamic-build-targets
+                                          evaluation-context)]
+                                    (if (g/error-value? resolved-deps)
+                                      resolved-deps
+                                      (-> build-target
+                                          (assoc :deps resolved-deps)
+                                          (dissoc :dynamic-deps)))))]
+                            (.put seen content-hash result)
+                            result)))))))
+           build-targets)]
+     (or (g/flatten-errors ret) ret))))
+
+(defn resolve-dependencies
+  "Fully resolve build target dependencies
+
+  Returns either:
+    - a flat vector of all resolved build targets collected with a breadth-first
+      order, de-duplicated by content hash
+    - error value"
+  ([build-targets project]
+   (g/with-auto-evaluation-context evaluation-context
+     (resolve-dependencies build-targets project evaluation-context)))
+  ([build-targets project evaluation-context]
+   (let [proj-path->dynamic-build-targets (code.transpilers/build-output
+                                            (project/code-transpilers (:basis evaluation-context) project)
+                                            evaluation-context)]
+     (if (g/error-value? proj-path->dynamic-build-targets)
+       proj-path->dynamic-build-targets
+       (let [ret (resolve-deps-impl build-targets project proj-path->dynamic-build-targets evaluation-context)]
+         (cond-> ret (not (g/error-value? ret)) flatten-build-targets))))))
+
+(defn resolve-node-dependencies
+  "Fully resolve node's build target dependencies
+
+  Returns either:
+    - a flat vector of all resolved build targets collected with a breadth-first
+      order, de-duplicated by content hash
+    - error value"
+  ([node project]
+   (g/with-auto-evaluation-context evaluation-context
+     (resolve-node-dependencies node project evaluation-context)))
+  ([node project evaluation-context]
+   (resolve-dependencies
+     (g/node-value node :build-targets evaluation-context)
+     project
+     evaluation-context)))
+
 (defn build-project!
   [project node evaluation-context extra-build-targets old-artifact-map render-progress!]
   (let [steps (atom [])
@@ -55,10 +174,8 @@
         prewarm-partitions (partition-all (max (quot step-count (+ (available-processors) 2)) 1000) (rseq @steps))
         _ (batched-pmap (fn [node-id] (g/node-value node-id :build-targets evaluation-context-with-progress-trace)) prewarm-partitions)
         node-build-targets (g/node-value node :build-targets evaluation-context)
-        build-targets (cond-> node-build-targets
-                              (seq extra-build-targets)
-                              (into extra-build-targets))
-        build-dir (workspace/build-path (project/workspace project))]
+        build-targets (resolve-dependencies [node-build-targets extra-build-targets] project evaluation-context)]
     (if (g/error? build-targets)
       {:error build-targets}
-      (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5)))))
+      (let [build-dir (workspace/build-path (project/workspace project))]
+        (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5))))))

--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -86,7 +86,7 @@
                         (if-let [resolved (.get seen content-hash)]
                           resolved
                           (let [result
-                                (if (reduce #(if (identical? %2 build-target) (reduced true) %1) false stack)
+                                (if (coll/some #(identical? build-target %) stack)
                                   (let [cycle (into []
                                                     (comp
                                                       (drop-while #(not (identical? % build-target)))
@@ -177,5 +177,5 @@
         build-targets (resolve-dependencies [node-build-targets extra-build-targets] project evaluation-context)]
     (if (g/error? build-targets)
       {:error build-targets}
-      (let [build-dir (workspace/build-path (project/workspace project))]
+      (let [build-dir (workspace/build-path (project/workspace project evaluation-context))]
         (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5))))))

--- a/editor/src/clj/editor/camera_editor.clj
+++ b/editor/src/clj/editor/camera_editor.clj
@@ -313,6 +313,7 @@
     :ddf-type Camera$CameraDesc
     :load-fn load-camera
     :icon camera-icon
+    :icon-class :property
     :view-types [:cljfx-form-view :text]
     :view-opts {}
     :tags #{:component}

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -13,33 +13,19 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns editor.code.script
-  (:require [clojure.string :as string]
-            [dynamo.graph :as g]
-            [editor.build-target :as bt]
+  (:require [dynamo.graph :as g]
             [editor.code.data :as data]
-            [editor.code.preprocessors :as preprocessors]
             [editor.code.resource :as r]
+            [editor.code.script-compilation :as script-compilation]
             [editor.code.script-intelligence :as script-intelligence]
             [editor.defold-project :as project]
             [editor.graph-util :as gu]
-            [editor.image :as image]
             [editor.lsp :as lsp]
             [editor.lua :as lua]
             [editor.lua-parser :as lua-parser]
-            [editor.luajit :as luajit]
             [editor.properties :as properties]
-            [editor.protobuf :as protobuf]
             [editor.resource :as resource]
-            [editor.types :as t]
-            [editor.util :as eutil]
-            [editor.validation :as validation]
-            [editor.workspace :as workspace]
-            [internal.util :as util]
-            [schema.core :as s]
-            [service.log :as log]
-            [util.coll :refer [pair]])
-  (:import [com.dynamo.lua.proto Lua$LuaModule]
-           [com.google.protobuf ByteString]))
+            [schema.core :as s]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -114,32 +100,6 @@
 
 (def lua-code-opts {:code {:grammar lua-grammar}})
 
-(defn script-property-type->property-type
-  "Controls how script property values are represented in the graph and edited."
-  [script-property-type]
-  (case script-property-type
-    :script-property-type-number   g/Num
-    :script-property-type-hash     g/Str
-    :script-property-type-url      g/Str
-    :script-property-type-vector3  t/Vec3
-    :script-property-type-vector4  t/Vec4
-    :script-property-type-quat     t/Vec3
-    :script-property-type-boolean  g/Bool
-    :script-property-type-resource resource/Resource))
-
-(defn script-property-type->go-prop-type
-  "Controls how script property values are represented in the file formats."
-  [script-property-type]
-  (case script-property-type
-    :script-property-type-number   :property-type-number
-    :script-property-type-hash     :property-type-hash
-    :script-property-type-url      :property-type-url
-    :script-property-type-vector3  :property-type-vector3
-    :script-property-type-vector4  :property-type-vector4
-    :script-property-type-quat     :property-type-quat
-    :script-property-type-boolean  :property-type-boolean
-    :script-property-type-resource :property-type-hash))
-
 (g/deftype ScriptPropertyType
   (s/enum :script-property-type-number
           :script-property-type-hash
@@ -188,60 +148,15 @@
 (defn- prop->key [p]
   (-> p :name properties/user-name->key))
 
-(def ^:private resource-kind->workspace->extensions
-  "Declares which file extensions are valid for different kinds of resource
-  properties. This affects the Property Editor, but is also used for validation."
-  {"atlas"       #(workspace/resource-kind-extensions % :atlas)
-   "font"        (constantly "font")
-   "material"    (constantly "material")
-   "buffer"      (constantly "buffer")
-   "texture"     (constantly (conj image/exts "cubemap" "render_target"))
-   "tile_source" (constantly "tilesource")})
-
-(def ^:private valid-resource-kind? (partial contains? resource-kind->workspace->extensions))
-
-(defn resource-kind-extensions [workspace resource-kind]
-  (when-let [workspace->extensions (resource-kind->workspace->extensions resource-kind)]
-    (workspace->extensions workspace)))
-
-(defn- script-property-edit-type [workspace prop-type resource-kind]
-  (if (= resource/Resource prop-type)
-    {:type prop-type :ext (resource-kind-extensions workspace resource-kind)}
-    {:type prop-type}))
-
-(defn- resource-assignment-error [node-id prop-kw prop-name resource expected-ext]
-  (when (some? resource)
-    (let [resource-ext (resource/ext resource)
-          ext-match? (if (coll? expected-ext)
-                       (some? (some (partial = resource-ext) expected-ext))
-                       (= expected-ext resource-ext))]
-      (cond
-        (not ext-match?)
-        (g/->error node-id prop-kw :fatal resource
-                   (format "%s '%s' is not of type %s"
-                           (validation/format-name prop-name)
-                           (resource/proj-path resource)
-                           (validation/format-ext expected-ext)))
-
-        (not (resource/exists? resource))
-        (g/->error node-id prop-kw :fatal resource
-                   (format "%s '%s' could not be found"
-                           (validation/format-name prop-name)
-                           (resource/proj-path resource)))))))
-
-(defn- validate-value-against-edit-type [node-id prop-kw prop-name value edit-type]
-  (when (= resource/Resource (:type edit-type))
-    (resource-assignment-error node-id prop-kw prop-name value (:ext edit-type))))
-
 (g/defnk produce-script-property-entries [_this _node-id deleted? name resource-kind type value]
   (when-not deleted?
     (let [project (project/get-project _node-id)
           workspace (project/workspace project)
           prop-kw (properties/user-name->key name)
-          prop-type (script-property-type->property-type type)
-          edit-type (script-property-edit-type workspace prop-type resource-kind)
-          error (validate-value-against-edit-type _node-id :value name value edit-type)
-          go-prop-type (script-property-type->go-prop-type type)
+          prop-type (script-compilation/script-property-type->property-type type)
+          edit-type (script-compilation/script-property-edit-type workspace prop-type resource-kind)
+          error (script-compilation/validate-value-against-edit-type _node-id :value name value edit-type)
+          go-prop-type (script-compilation/script-property-type->go-prop-type type)
           overridden? (g/node-property-overridden? _this :value)
           read-only? (not (g/node-override? _this))
           visible? (not deleted?)]
@@ -267,7 +182,7 @@
 
 (g/deftype NameNodeIDMap {s/Str s/Int})
 
-(g/deftype ResourceKind (apply s/enum (keys resource-kind->workspace->extensions)))
+(g/deftype ResourceKind (apply s/enum (keys script-compilation/resource-kind->workspace->extensions)))
 
 (g/deftype ScriptPropertyEntries
   {s/Keyword {:node-id s/Int
@@ -406,182 +321,15 @@
               (update :properties into (map (partial lift-error _node-id)) script-property-entries)
               (update :display-order into (map prop->key) script-properties))))
 
-(defn- go-property-declaration-cursor-ranges
-  "Find the CursorRanges that encompass each `go.property('name', ...)`
-  declaration among the specified lines. These will be replaced with whitespace
-  before the script is compiled for the engine."
-  [lines]
-  (loop [cursor-ranges (transient [])
-         tokens (lua-parser/tokens (data/lines-reader lines))
-         paren-count 0
-         consumed []]
-    (if-some [[text :as token] (first tokens)]
-      (case (count consumed)
-        0 (recur cursor-ranges (next tokens) 0 (case text "go" (conj consumed token) []))
-        1 (recur cursor-ranges (next tokens) 0 (case text "." (conj consumed token) []))
-        2 (recur cursor-ranges (next tokens) 0 (case text "property" (conj consumed token) []))
-        3 (case text
-            "(" (recur cursor-ranges (next tokens) (inc paren-count) consumed)
-            ")" (let [paren-count (dec paren-count)]
-                  (assert (not (neg? paren-count)))
-                  (if (pos? paren-count)
-                    (recur cursor-ranges (next tokens) paren-count consumed)
-                    (let [next-tokens (next tokens)
-                          [next-text :as next-token] (first next-tokens)
-                          [_ start-row start-col] (first consumed)
-                          [end-text end-row end-col] (if (= ";" next-text) next-token token)
-                          end-col (+ ^long end-col (count end-text))
-                          start-cursor (data/->Cursor start-row start-col)
-                          end-cursor (data/->Cursor end-row end-col)
-                          cursor-range (data/->CursorRange start-cursor end-cursor)]
-                      (recur (conj! cursor-ranges cursor-range)
-                             next-tokens
-                             0
-                             []))))
-            (recur cursor-ranges (next tokens) paren-count consumed)))
-      (persistent! cursor-ranges))))
-
-(defn- line->whitespace [line]
-  (string/join (repeat (count line) \space)))
-
-(defn- cursor-range->whitespace-lines [lines cursor-range]
-  (let [{:keys [first-line middle-lines last-line]} (data/cursor-range-subsequence lines cursor-range)]
-    (cond-> (into [(line->whitespace first-line)]
-                  (map line->whitespace)
-                  middle-lines)
-            (some? last-line) (conj (line->whitespace last-line)))))
-
-(defn- strip-go-property-declarations [lines]
-  (data/splice-lines lines (map (juxt identity (partial cursor-range->whitespace-lines lines))
-                                (go-property-declaration-cursor-ranges lines))))
-
-(defn- script->bytecode [lines proj-path arch]
-  (try
-    (luajit/bytecode (data/lines-reader lines) proj-path arch)
-    (catch Exception e
-      (let [{:keys [filename line message]} (ex-data e)]
-        (g/map->error
-          {:_label :modified-lines
-           :message (.getMessage e)
-           :severity :fatal
-           :user-data (assoc (r/make-code-error-user-data filename line)
-                        :message message)})))))
-
-(defn- build-script [resource dep-resources user-data]
-  ;; We always compile the full source code in order to find syntax errors.
-  ;; We then strip go.property() declarations and recompile if needed.
-  (let [lines (:lines user-data)
-        proj-path (:proj-path user-data)
-        bytecode-or-error (script->bytecode lines proj-path :64-bit)]
-    (g/precluding-errors
-      [bytecode-or-error]
-      (let [go-props (properties/build-go-props dep-resources (:go-props user-data))
-            modules (:modules user-data)
-            cleaned-lines (strip-go-property-declarations lines)]
-        {:resource resource
-         :content (protobuf/map->bytes
-                    Lua$LuaModule
-                    {:source {:script (ByteString/copyFromUtf8
-                                        (slurp (data/lines-reader cleaned-lines)))
-                              :filename (str "@" (luajit/luajit-path-to-chunk-name (resource/proj-path (:resource resource))))}
-                     :modules modules
-                     :resources (mapv lua/lua-module->build-path modules)
-                     :properties (properties/go-props->decls go-props true)
-                     :property-resources (into (sorted-set)
-                                               (keep properties/try-get-go-prop-proj-path)
-                                               go-props)})}))))
-
-(defn- lua-info->modules [lua-info]
-  (into []
-        (comp (map second)
-              (remove lua/preinstalled-modules))
-        (:requires lua-info)))
-
-(defn- lua-info->script-properties [lua-info]
-  (into []
-        (comp (filter #(= :ok (:status %)))
-              (util/distinct-by :name))
-        (:script-properties lua-info)))
-
-(def ^:const file-line-pattern #"(?<=^|\s|[<\"'`])(\/[^\s>\"'`:]+)(?::?)(\d+)?")
-
-(defn- try-parse-file-line [^String message]
-  (when-some [[_ proj-path line-number-string] (re-find file-line-pattern message)]
-    (let [line-number (some-> line-number-string Long/parseLong)]
-      (pair proj-path line-number))))
-
-(g/defnk produce-build-targets [_node-id resource lines lua-preprocessors script-properties module-build-targets original-resource-property-build-targets]
-  (let [workspace (resource/workspace resource)]
-    (if-some [errors
-              (not-empty
-                (keep (fn [{:keys [name resource-kind type value]}]
-                        (let [prop-type (script-property-type->property-type type)
-                              edit-type (script-property-edit-type workspace prop-type resource-kind)]
-                          (validate-value-against-edit-type _node-id :lines name value edit-type)))
-                      script-properties))]
-      (g/error-aggregate errors :_node-id _node-id :_label :build-targets)
-      (let [preprocessed-lines
-            (try
-              (preprocessors/preprocess-lua-lines lua-preprocessors lines resource :debug)
-              (catch Exception exception
-                exception))]
-        (if-some [exception-message (ex-message preprocessed-lines)]
-          (let [exception preprocessed-lines
-                build-error-message (str "Lua preprocessing failed.\n" exception-message)
-                log-error-message (format "Lua preprocessing failed for file '%s'." (resource/proj-path resource))]
-            (log/error :message log-error-message :exception exception)
-            (if-some [[proj-path line-number] (try-parse-file-line exception-message)]
-              (let [project (project/get-project _node-id)
-                    exception-resource (workspace/resolve-resource resource proj-path)
-                    exception-node-id (project/get-resource-node project exception-resource)
-                    error-node-id (or exception-node-id _node-id)
-                    error-resource (if (nil? exception-node-id) resource exception-resource)
-                    error-user-data (r/make-code-error-user-data proj-path line-number)]
-                (g/->error error-node-id :modified-lines :fatal error-resource build-error-message error-user-data))
-              (g/->error _node-id :modified-lines :fatal resource build-error-message)))
-          (let [preprocessed-lua-info
-                (with-open [reader (data/lines-reader preprocessed-lines)]
-                  (lua-parser/lua-info workspace valid-resource-kind? reader))
-
-                preprocessed-script-properties (lua-info->script-properties preprocessed-lua-info)
-                preprocessed-modules (lua-info->modules preprocessed-lua-info)
-                proj-path->module-build-target (bt/make-proj-path->build-target module-build-targets)
-                module->build-target (comp proj-path->module-build-target lua/lua-module->path)
-                missing-modules (filterv (complement module->build-target) preprocessed-modules)]
-            (if (pos? (count missing-modules))
-              (g/->error _node-id :build-targets :fatal resource
-                         (str "Can't find required modules: " (eutil/join-words ", " " and " missing-modules)))
-              (let [preprocessed-module-build-targets (map module->build-target preprocessed-modules)
-
-                    preprocessed-go-props-with-source-resources
-                    (map (fn [{:keys [name type value]}]
-                           (let [go-prop-type (script-property-type->go-prop-type type)
-                                 go-prop-value (properties/clj-value->go-prop-value go-prop-type value)]
-                             {:id name
-                              :type go-prop-type
-                              :value go-prop-value
-                              :clj-value value}))
-                         preprocessed-script-properties)
-
-                    proj-path->resource-property-build-target
-                    (bt/make-proj-path->build-target original-resource-property-build-targets)
-
-                    [preprocessed-go-props preprocessed-go-prop-dep-build-targets]
-                    (properties/build-target-go-props proj-path->resource-property-build-target preprocessed-go-props-with-source-resources)]
-                ;; NOTE: The :user-data must not contain any overridden data. If it does,
-                ;; the build targets won't be fused and the script will be recompiled
-                ;; for every instance of the script component. The :go-props here describe
-                ;; the original property values from the script, never overridden values.
-                [(bt/with-content-hash
-                   {:node-id _node-id
-                    :resource (workspace/make-build-resource resource)
-                    :build-fn build-script
-                    :user-data {:lines preprocessed-lines
-                                :go-props preprocessed-go-props
-                                :modules preprocessed-modules
-                                :proj-path (resource/proj-path resource)}
-                    :deps (into preprocessed-go-prop-dep-build-targets
-                                preprocessed-module-build-targets)})]))))))))
+(g/defnk produce-build-targets [_node-id resource lines lua-preprocessors script-properties original-resource-property-build-targets]
+  (script-compilation/build-targets
+    _node-id
+    resource
+    lines
+    lua-preprocessors
+    script-properties
+    original-resource-property-build-targets
+    (partial project/get-resource-node (project/get-project _node-id))))
 
 (g/defnk produce-completions [completion-info module-completion-infos script-intelligence-completions]
   (lua/combine-completions completion-info module-completion-infos script-intelligence-completions))
@@ -601,7 +349,6 @@
   (inherits r/CodeEditorResourceNode)
 
   (input lua-preprocessors g/Any)
-  (input module-build-targets g/Any :array)
   (input module-completion-infos g/Any :array :substitute gu/array-subst-remove-errors)
   (input script-intelligence-completions script-intelligence/ScriptCompletions)
   (input script-property-name+node-ids NameNodeIDPair :array)
@@ -621,11 +368,11 @@
                    (let [resource (g/node-value self :resource evaluation-context)
                          workspace (resource/workspace resource)
                          lua-info (with-open [reader (data/lines-reader new-value)]
-                                    (lua-parser/lua-info workspace valid-resource-kind? reader))
+                                    (lua-parser/lua-info workspace script-compilation/valid-resource-kind? reader))
                          own-module (lua/path->lua-module (resource/proj-path resource))
                          completion-info (assoc lua-info :module own-module)
-                         modules (lua-info->modules lua-info)
-                         script-properties (lua-info->script-properties lua-info)]
+                         modules (script-compilation/lua-info->modules lua-info)
+                         script-properties (script-compilation/lua-info->script-properties lua-info)]
                      (concat
                        (g/set-property self :completion-info completion-info)
                        (g/set-property self :modules modules)
@@ -638,14 +385,12 @@
                    (let [basis (:basis evaluation-context)
                          project (project/get-project basis self)]
                      (concat
-                       (g/disconnect-sources basis self :module-build-targets)
                        (g/disconnect-sources basis self :module-completion-infos)
                        (for [module new-value]
                          (let [path (lua/lua-module->path module)]
                            (:tx-data (project/connect-resource-node
                                        evaluation-context project path self
-                                       [[:build-targets :module-build-targets]
-                                        [:completion-info :module-completion-infos]])))))))))
+                                       [[:completion-info :module-completion-infos]])))))))))
 
   (property script-properties g/Any
             (default [])

--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -114,6 +114,7 @@
                    :language "lua"
                    :label "Script"
                    :icon "icons/32/Icons_12-Script-type.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts lua-code-opts
                    :tags #{:component :debuggable :non-embeddable :overridable-properties}
@@ -122,6 +123,7 @@
                    :language "lua"
                    :label "Render Script"
                    :icon "icons/32/Icons_12-Script-type.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts lua-code-opts
                    :tags #{:debuggable}}
@@ -129,6 +131,7 @@
                    :language "lua"
                    :label "Gui Script"
                    :icon "icons/32/Icons_12-Script-type.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts lua-code-opts
                    :tags #{:debuggable}}
@@ -136,6 +139,7 @@
                    :language "lua"
                    :label "Lua Module"
                    :icon "icons/32/Icons_11-Script-general.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts lua-code-opts
                    :tags #{:debuggable}}])

--- a/editor/src/clj/editor/code/script_compilation.clj
+++ b/editor/src/clj/editor/code/script_compilation.clj
@@ -1,0 +1,275 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.code.script-compilation
+  (:require [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.build-target :as bt]
+            [editor.code.data :as data]
+            [editor.code.preprocessors :as preprocessors]
+            [editor.code.resource :as r]
+            [editor.image :as image]
+            [editor.lua :as lua]
+            [editor.lua-parser :as lua-parser]
+            [editor.luajit :as luajit]
+            [editor.properties :as properties]
+            [editor.protobuf :as protobuf]
+            [editor.resource :as resource]
+            [editor.types :as t]
+            [editor.validation :as validation]
+            [editor.workspace :as workspace]
+            [internal.util :as util]
+            [service.log :as log]
+            [util.coll :refer [pair]])
+  (:import [com.dynamo.lua.proto Lua$LuaModule]
+           [com.google.protobuf ByteString]))
+
+(defn script-property-type->go-prop-type
+  "Controls how script property values are represented in the file formats."
+  [script-property-type]
+  (case script-property-type
+    :script-property-type-number   :property-type-number
+    :script-property-type-hash     :property-type-hash
+    :script-property-type-url      :property-type-url
+    :script-property-type-vector3  :property-type-vector3
+    :script-property-type-vector4  :property-type-vector4
+    :script-property-type-quat     :property-type-quat
+    :script-property-type-boolean  :property-type-boolean
+    :script-property-type-resource :property-type-hash))
+
+(defn script-property-type->property-type
+  "Controls how script property values are represented in the graph and edited."
+  [script-property-type]
+  (case script-property-type
+    :script-property-type-number g/Num
+    :script-property-type-hash g/Str
+    :script-property-type-url g/Str
+    :script-property-type-vector3 t/Vec3
+    :script-property-type-vector4 t/Vec4
+    :script-property-type-quat t/Vec3
+    :script-property-type-boolean g/Bool
+    :script-property-type-resource resource/Resource))
+
+(def resource-kind->workspace->extensions
+  "Declares which file extensions are valid for different kinds of resource
+  properties. This affects the Property Editor, but is also used for validation."
+  {"atlas"       #(workspace/resource-kind-extensions % :atlas)
+   "font"        (constantly "font")
+   "material"    (constantly "material")
+   "buffer"      (constantly "buffer")
+   "texture"     (constantly (conj image/exts "cubemap" "render_target"))
+   "tile_source" (constantly "tilesource")})
+
+(def valid-resource-kind? (partial contains? resource-kind->workspace->extensions))
+
+(defn resource-kind-extensions [workspace resource-kind]
+  (when-let [workspace->extensions (resource-kind->workspace->extensions resource-kind)]
+    (workspace->extensions workspace)))
+
+(defn script-property-edit-type [workspace prop-type resource-kind]
+  (if (= resource/Resource prop-type)
+    {:type prop-type :ext (resource-kind-extensions workspace resource-kind)}
+    {:type prop-type}))
+
+(defn- resource-assignment-error [node-id prop-kw prop-name resource expected-ext]
+  (when (some? resource)
+    (let [resource-ext (resource/ext resource)
+          ext-match? (if (coll? expected-ext)
+                       (some? (some (partial = resource-ext) expected-ext))
+                       (= expected-ext resource-ext))]
+      (cond
+        (not ext-match?)
+        (g/->error node-id prop-kw :fatal resource
+                   (format "%s '%s' is not of type %s"
+                           (validation/format-name prop-name)
+                           (resource/proj-path resource)
+                           (validation/format-ext expected-ext)))
+
+        (not (resource/exists? resource))
+        (g/->error node-id prop-kw :fatal resource
+                   (format "%s '%s' could not be found"
+                           (validation/format-name prop-name)
+                           (resource/proj-path resource)))))))
+
+(defn validate-value-against-edit-type [node-id prop-kw prop-name value edit-type]
+  (when (= resource/Resource (:type edit-type))
+    (resource-assignment-error node-id prop-kw prop-name value (:ext edit-type))))
+
+(defn lua-info->script-properties [lua-info]
+  (into []
+        (comp (filter #(= :ok (:status %)))
+              (util/distinct-by :name))
+        (:script-properties lua-info)))
+
+(defn lua-info->modules [lua-info]
+  (into []
+        (comp (map second)
+              (remove lua/preinstalled-modules))
+        (:requires lua-info)))
+
+(defn- script->bytecode [lines proj-path arch]
+  (try
+    (luajit/bytecode (data/lines-reader lines) proj-path arch)
+    (catch Exception e
+      (let [{:keys [filename line message]} (ex-data e)]
+        (g/map->error
+          {:_label :modified-lines
+           :message (.getMessage e)
+           :severity :fatal
+           :user-data (assoc (r/make-code-error-user-data filename line)
+                        :message message)})))))
+
+(defn- line->whitespace [line]
+  (string/join (repeat (count line) \space)))
+
+(defn- go-property-declaration-cursor-ranges
+  "Find the CursorRanges that encompass each `go.property('name', ...)`
+  declaration among the specified lines. These will be replaced with whitespace
+  before the script is compiled for the engine."
+  [lines]
+  (loop [cursor-ranges (transient [])
+         tokens (lua-parser/tokens (data/lines-reader lines))
+         paren-count 0
+         consumed []]
+    (if-some [[text :as token] (first tokens)]
+      (case (count consumed)
+        0 (recur cursor-ranges (next tokens) 0 (case text "go" (conj consumed token) []))
+        1 (recur cursor-ranges (next tokens) 0 (case text "." (conj consumed token) []))
+        2 (recur cursor-ranges (next tokens) 0 (case text "property" (conj consumed token) []))
+        3 (case text
+            "(" (recur cursor-ranges (next tokens) (inc paren-count) consumed)
+            ")" (let [paren-count (dec paren-count)]
+                  (assert (not (neg? paren-count)))
+                  (if (pos? paren-count)
+                    (recur cursor-ranges (next tokens) paren-count consumed)
+                    (let [next-tokens (next tokens)
+                          [next-text :as next-token] (first next-tokens)
+                          [_ start-row start-col] (first consumed)
+                          [end-text end-row end-col] (if (= ";" next-text) next-token token)
+                          end-col (+ ^long end-col (count end-text))
+                          start-cursor (data/->Cursor start-row start-col)
+                          end-cursor (data/->Cursor end-row end-col)
+                          cursor-range (data/->CursorRange start-cursor end-cursor)]
+                      (recur (conj! cursor-ranges cursor-range)
+                             next-tokens
+                             0
+                             []))))
+            (recur cursor-ranges (next tokens) paren-count consumed)))
+      (persistent! cursor-ranges))))
+
+(defn- cursor-range->whitespace-lines [lines cursor-range]
+  (let [{:keys [first-line middle-lines last-line]} (data/cursor-range-subsequence lines cursor-range)]
+    (cond-> (into [(line->whitespace first-line)]
+                  (map line->whitespace)
+                  middle-lines)
+            (some? last-line) (conj (line->whitespace last-line)))))
+
+(defn- strip-go-property-declarations [lines]
+  (data/splice-lines lines (map (juxt identity (partial cursor-range->whitespace-lines lines))
+                                (go-property-declaration-cursor-ranges lines))))
+
+(defn- build-script [resource dep-resources user-data]
+  ;; We always compile the full source code in order to find syntax errors.
+  ;; We then strip go.property() declarations and recompile if needed.
+  (let [lines (:lines user-data)
+        proj-path (:proj-path user-data)
+        bytecode-or-error (script->bytecode lines proj-path :64-bit)]
+    (g/precluding-errors
+      [bytecode-or-error]
+      (let [go-props (properties/build-go-props dep-resources (:go-props user-data))
+            modules (:modules user-data)
+            cleaned-lines (strip-go-property-declarations lines)]
+        {:resource resource
+         :content (protobuf/map->bytes
+                    Lua$LuaModule
+                    {:source {:script (ByteString/copyFromUtf8
+                                        (slurp (data/lines-reader cleaned-lines)))
+                              :filename (str "@" (luajit/luajit-path-to-chunk-name (resource/proj-path (:resource resource))))}
+                     :modules modules
+                     :resources (mapv lua/lua-module->build-path modules)
+                     :properties (properties/go-props->decls go-props true)
+                     :property-resources (into (sorted-set)
+                                               (keep properties/try-get-go-prop-proj-path)
+                                               go-props)})}))))
+
+(def ^:const file-line-pattern #"(?<=^|\s|[<\"'`])(\/[^\s>\"'`:]+)(?::?)(\d+)?")
+
+(defn- try-parse-file-line [^String message]
+  (when-some [[_ proj-path line-number-string] (re-find file-line-pattern message)]
+    (let [line-number (some-> line-number-string Long/parseLong)]
+      (pair proj-path line-number))))
+
+(defn build-targets [_node-id resource lines lua-preprocessors script-properties original-resource-property-build-targets proj-path->resource-node]
+  (let [workspace (resource/workspace resource)]
+    (if-some [errors
+              (not-empty
+                (keep (fn [{:keys [name resource-kind type value]}]
+                        (let [prop-type (script-property-type->property-type type)
+                              edit-type (script-property-edit-type workspace prop-type resource-kind)]
+                          (validate-value-against-edit-type _node-id :lines name value edit-type)))
+                      script-properties))]
+      (g/error-aggregate errors :_node-id _node-id :_label :build-targets)
+      (let [preprocessed-lines
+            (try
+              (preprocessors/preprocess-lua-lines lua-preprocessors lines resource :debug)
+              (catch Exception exception
+                exception))]
+        (if-some [exception-message (ex-message preprocessed-lines)]
+          (let [exception preprocessed-lines
+                build-error-message (str "Lua preprocessing failed.\n" exception-message)
+                log-error-message (format "Lua preprocessing failed for file '%s'." (resource/proj-path resource))]
+            (log/error :message log-error-message :exception exception)
+            (if-some [[proj-path line-number] (try-parse-file-line exception-message)]
+              (let [exception-resource (workspace/resolve-resource resource proj-path)
+                    exception-node-id (proj-path->resource-node proj-path)
+                    error-node-id (or exception-node-id _node-id)
+                    error-resource (if (nil? exception-node-id) resource exception-resource)
+                    error-user-data (r/make-code-error-user-data proj-path line-number)]
+                (g/->error error-node-id :modified-lines :fatal error-resource build-error-message error-user-data))
+              (g/->error _node-id :modified-lines :fatal resource build-error-message)))
+          (let [preprocessed-lua-info
+                (with-open [reader (data/lines-reader preprocessed-lines)]
+                  (lua-parser/lua-info workspace valid-resource-kind? reader))
+
+                preprocessed-script-properties (lua-info->script-properties preprocessed-lua-info)
+                preprocessed-modules (lua-info->modules preprocessed-lua-info)
+                preprocessed-go-props-with-source-resources
+                (map (fn [{:keys [name type value]}]
+                       (let [go-prop-type (script-property-type->go-prop-type type)
+                             go-prop-value (properties/clj-value->go-prop-value go-prop-type value)]
+                         {:id name
+                          :type go-prop-type
+                          :value go-prop-value
+                          :clj-value value}))
+                     preprocessed-script-properties)
+
+                proj-path->resource-property-build-target
+                (bt/make-proj-path->build-target original-resource-property-build-targets)
+
+                [preprocessed-go-props preprocessed-go-prop-dep-build-targets]
+                (properties/build-target-go-props proj-path->resource-property-build-target preprocessed-go-props-with-source-resources)]
+            ;; NOTE: The :user-data must not contain any overridden data. If it does,
+            ;; the build targets won't be fused and the script will be recompiled
+            ;; for every instance of the script component. The :go-props here describe
+            ;; the original property values from the script, never overridden values.
+            [(bt/with-content-hash
+               {:node-id _node-id
+                :resource (workspace/make-build-resource resource)
+                :build-fn build-script
+                :user-data {:lines preprocessed-lines
+                            :go-props preprocessed-go-props
+                            :modules preprocessed-modules
+                            :proj-path (resource/proj-path resource)}
+                :deps preprocessed-go-prop-dep-build-targets
+                :dynamic-deps (mapv lua/lua-module->path preprocessed-modules)})]))))))

--- a/editor/src/clj/editor/code/shader.clj
+++ b/editor/src/clj/editor/code/shader.clj
@@ -78,17 +78,20 @@
                    :language "glsl"
                    :label "Vertex Program"
                    :icon "icons/32/Icons_32-Vertex-shader.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts glsl-opts}
                   {:ext "fp"
                    :language "glsl"
                    :label "Fragment Program"
                    :icon "icons/32/Icons_33-Fragment-shader.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts glsl-opts}
                   {:ext "glsl"
                    :label "Shader Include"
                    :icon "icons/64/Icons_29-AT-Unknown.png"
+                   :icon-class :script
                    :view-types [:code :default]
                    :view-opts glsl-opts}])
 

--- a/editor/src/clj/editor/code/transpilers.clj
+++ b/editor/src/clj/editor/code/transpilers.clj
@@ -1,0 +1,243 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns editor.code.transpilers
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as string]
+            [dynamo.graph :as g]
+            [editor.code.resource :as r]
+            [editor.code.script-compilation :as script-compilation]
+            [editor.code.util :as code.util]
+            [editor.core :as core]
+            [editor.dialogs :as dialogs]
+            [editor.fs :as fs]
+            [editor.graph-util :as gu]
+            [editor.resource :as resource]
+            [editor.ui :as ui]
+            [editor.workspace :as workspace]
+            [internal.java :as java]
+            [internal.util :as util]
+            [service.log :as log]
+            [util.coll :refer [pair pair-map-by]])
+  (:import [com.defold.extension.pipeline ILuaTranspiler ILuaTranspiler$Issue ILuaTranspiler$Severity]
+           [com.dynamo.bob ClassLoaderScanner]
+           [java.io File]
+           [org.apache.commons.io FilenameUtils]))
+
+(defn- transpiler-issue->error-value [proj-path->node-id ^ILuaTranspiler$Issue issue]
+  (let [node-id (proj-path->node-id (.-resourcePath issue))]
+    (g/map->error
+      (cond-> {:_label :modified-lines
+               :severity (condp = (.-severity issue)
+                           ILuaTranspiler$Severity/INFO :info
+                           ILuaTranspiler$Severity/WARNING :warning
+                           ILuaTranspiler$Severity/ERROR :fatal)
+               :message (.-message issue)
+               :user-data (r/make-code-error-user-data (.-resourcePath issue) (.-lineNumber issue))}
+              node-id
+              (assoc :_node-id node-id)))))
+
+(defn- ->fatal-error [node-id issues]
+  (let [aggregate (g/error-aggregate issues :_node-id node-id :_label :modified-lines)]
+    (when (= :fatal (:severity aggregate))
+      aggregate)))
+
+(defn- make-temporary-compile-directory! [transpiler all-source-save-datas]
+  (let [dir (fs/create-temp-directory! (str "tr-" (.getSimpleName (class transpiler))))]
+    (run! (fn [{:keys [resource content dirty?]}]
+            (let [file (io/file dir (resource/path resource))]
+              (io/make-parents file)
+              (if content
+                (spit file content)
+                (with-open [is (io/input-stream resource)]
+                  (io/copy is file)))
+              (when-not dirty?
+                (.setLastModified file (.lastModified (io/file resource))))))
+          all-source-save-datas)
+    dir))
+
+(g/defnk produce-build-output [^ILuaTranspiler instance build-file-save-data source-code-save-datas root lua-preprocessors]
+  (when (and build-file-save-data (pos? (count source-code-save-datas)))
+    (let [build-file-node-id (:node-id build-file-save-data)
+          all-sources (conj source-code-save-datas build-file-save-data)
+          workspace (resource/workspace (:resource build-file-save-data))
+          proj-path->node-id (pair-map-by (comp resource/proj-path :resource) :node-id all-sources)
+          use-project-dir (every? (fn [{:keys [resource dirty?]}]
+                                    (and (not dirty?) (resource/file-resource? resource)))
+                                  all-sources)
+          source-dir (if use-project-dir
+                       (io/file root)
+                       (make-temporary-compile-directory! instance all-sources))
+          plugin-dir (io/file root (subs workspace/plugins-dir 1))
+          output-dir (io/file root "build" "tr" (.getSimpleName (class instance)))]
+      (fs/create-directories! output-dir)
+      (try
+        (let [issues (.transpile instance plugin-dir source-dir output-dir)]
+          (or (->> issues
+                   (mapv #(transpiler-issue->error-value proj-path->node-id %))
+                   (->fatal-error build-file-node-id))
+              (into {}
+                    (keep
+                      (fn [^File file]
+                        (when (= "lua" (FilenameUtils/getExtension (.getName file)))
+                          (let [resource (resource/make-file-resource workspace (str output-dir) file [] (constantly false))
+                                build-targets (script-compilation/build-targets build-file-node-id resource (code.util/split-lines (slurp resource)) lua-preprocessors [] [] proj-path->node-id)]
+                            (pair (resource/proj-path resource) build-targets)))))
+                    (fs/file-walker output-dir))))
+        (catch Exception e
+          (g/->error build-file-node-id :modified-lines :fatal (:resource build-file-save-data)
+                     (str "Compilation failed: " (ex-message e))))
+        (finally
+          (when-not use-project-dir
+            (fs/delete-directory! source-dir {:fail :silently})))))))
+
+(g/defnode TranspilerNode
+  (property build-file-proj-path g/Str)
+  (property instance ILuaTranspiler)
+  (input root g/Str)
+  (input build-file-save-data g/Any)
+  (input source-code-save-datas g/Any :array)
+  (input lua-preprocessors g/Any)
+  (output transpiler-info g/Any (g/fnk [_node-id build-file-proj-path instance :as info] info))
+  (output build-output g/Any :cached produce-build-output))
+
+(g/defnode CodeTranspilersNode
+  (inherits core/Scope)
+  (input transpiler-infos g/Any :array)
+  (input build-outputs g/Any :array)
+  (input lua-preprocessors g/Any)
+  (output lua-preprocessors g/Any (gu/passthrough lua-preprocessors))
+  (output transpiler-infos g/Any (gu/passthrough transpiler-infos))
+  (output build-file-proj-path->transpiler-node-id g/Any :cached
+          (g/fnk [transpiler-infos]
+            (case (count transpiler-infos)
+              0 (constantly nil)
+              1 (let [{:keys [build-file-proj-path _node-id]} (first transpiler-infos)]
+                  (fn [proj-path]
+                    (when (= proj-path build-file-proj-path) _node-id)))
+              (pair-map-by :build-file-proj-path :_node-id transpiler-infos))))
+  (output build-output g/Any :cached
+          (g/fnk [build-outputs]
+            (persistent! (reduce conj! (transient {}) build-outputs)))))
+
+(g/defnode SourceNode
+  (inherits r/CodeEditorResourceNode))
+
+(defn- report-error! [error-message faulty-class-names]
+  (ui/run-later
+    (dialogs/make-info-dialog
+      {:title "Unable to Load Plugin"
+       :size :large
+       :icon :icon/triangle-error
+       :always-on-top true
+       :header error-message
+       :content (string/join "\n"
+                             (concat
+                               ["The following classes from editor plugins are not compatible with this version of the editor:"
+                                ""]
+                               (mapv dialogs/indent-with-bullet (sort faulty-class-names))
+                               [""
+                                "The project might not build without them."
+                                "Please edit your project dependencies to refer to a suitable version."]))})))
+
+(defn- initialize-lua-transpiler-classes [^ClassLoader class-loader]
+  (let [{:keys [classes faulty-class-names]}
+        (->> (ClassLoaderScanner/scanClassLoader class-loader "com.defold.extension.pipeline")
+             (eduction
+               (keep
+                 (fn [^String class-name]
+                   (try
+                     (let [uninitialized-class (Class/forName class-name false class-loader)]
+                       (when (java/public-implementation? uninitialized-class ILuaTranspiler)
+                         (let [initialized-class (Class/forName class-name true class-loader)]
+                           (pair :classes initialized-class))))
+                     (catch Exception e
+                       (log/error :msg (str "Exception in static initializer of ILuaTranspiler implementation "
+                                            class-name ": " (.getMessage e))
+                                  :exception e)
+                       (pair :faulty-class-names class-name))))))
+             (util/group-into {} #{} key val))]
+    (when faulty-class-names
+      (throw (ex-info "Failed to initialize Lua transpiler plugins" {:faulty-class-names faulty-class-names})))
+    (or classes #{})))
+
+(defn- create-lua-transpilers [transpiler-classes]
+  (let [{:keys [transpilers faulty-class-names]}
+        (->> transpiler-classes
+             (eduction
+               (map (fn [^Class transpiler-plugin-class]
+                      (try
+                        (let [^ILuaTranspiler transpiler (java/invoke-no-arg-constructor transpiler-plugin-class)
+                              build-file-proj-path (.getBuildFileResourcePath transpiler)
+                              source-ext (.getSourceExt transpiler)]
+                          (when (or (not (string? build-file-proj-path))
+                                    (not (string/starts-with? build-file-proj-path "/")))
+                            (throw (Exception. (str "Invalid build file resource path: " build-file-proj-path))))
+                          (when (or (not (string? source-ext))
+                                    (string/starts-with? source-ext "."))
+                            (throw (Exception. (str "Invalid source extension: " source-ext))))
+                          (pair :transpilers {:build-file-proj-path build-file-proj-path
+                                              :source-ext source-ext
+                                              :instance transpiler}))
+                        (catch Exception e
+                          (let [class-name (.getSimpleName transpiler-plugin-class)]
+                            (log/error :msg (str "Failed to initialize transpiler " class-name) :exception e)
+                            (pair :faulty-class-names class-name)))))))
+             (util/group-into {} [] key val))]
+    (when faulty-class-names
+      (throw (ex-info "Failed to create Lua transpiler plugins" {:faulty-class-names faulty-class-names})))
+    transpilers))
+
+(defn reload-lua-transpilers! [code-transpilers workspace class-loader]
+  (try
+    (let [old-transpiler-class->node-id (pair-map-by
+                                          #(-> % :instance class)
+                                          :_node-id
+                                          (g/node-value code-transpilers :transpiler-infos))
+          old-transpiler-classes (set (keys old-transpiler-class->node-id))
+          new-transpiler-classes (initialize-lua-transpiler-classes class-loader)]
+      (when-not (= old-transpiler-classes new-transpiler-classes)
+        (let [removed (set/difference old-transpiler-classes new-transpiler-classes)
+              added (set/difference new-transpiler-classes old-transpiler-classes)]
+          (g/transact
+            (for [removed-class removed]
+              (g/delete-node (old-transpiler-class->node-id removed-class)))
+            (for [{:keys [source-ext build-file-proj-path instance]} (create-lua-transpilers added)]
+              (g/make-nodes (g/node-id->graph-id code-transpilers) [transpiler TranspilerNode]
+                (r/register-code-resource-type
+                  workspace
+                  :ext source-ext
+                  :icon "icons/32/Icons_12-Script-type.png"
+                  :node-type SourceNode
+                  :view-types [:code :default]
+                  :additional-load-fn (fn [_ self _]
+                                        (g/connect self :save-data transpiler :source-code-save-datas)))
+                (g/set-property transpiler :build-file-proj-path build-file-proj-path :instance instance)
+                (g/connect code-transpilers :lua-preprocessors transpiler :lua-preprocessors)
+                (g/connect workspace :root transpiler :root)
+                (g/connect transpiler :_node-id code-transpilers :nodes)
+                (g/connect transpiler :transpiler-info code-transpilers :transpiler-infos)
+                (g/connect transpiler :build-output code-transpilers :build-outputs))))))
+      nil)
+    (catch Exception e
+      (report-error! (ex-message e) (:faulty-class-names (ex-data e))))))
+
+(defn load-build-file-transaction-step [code-transpilers resource-node-id proj-path]
+  (let [f (g/node-value code-transpilers :build-file-proj-path->transpiler-node-id)]
+    (when-let [transpiler-node-id (f proj-path)]
+      (g/connect resource-node-id :save-data transpiler-node-id :build-file-save-data))))
+
+(defn build-output [code-transpilers evaluation-context]
+  (g/node-value code-transpilers :build-output evaluation-context))

--- a/editor/src/clj/editor/collection.clj
+++ b/editor/src/clj/editor/collection.clj
@@ -778,5 +778,6 @@
     :dependencies-fn (collection-common/make-collection-dependencies-fn #(workspace/get-resource-type workspace :editable "go"))
     :sanitize-fn (partial sanitize-collection workspace)
     :icon collection-common/collection-icon
+    :icon-class :design
     :view-types [:scene :text]
     :view-opts {:scene {:grid true}}))

--- a/editor/src/clj/editor/collection_non_editable.clj
+++ b/editor/src/clj/editor/collection_non_editable.clj
@@ -441,5 +441,6 @@
     :sanitize-fn (partial sanitize-non-editable-collection workspace)
     :load-fn load-non-editable-collection
     :icon collection-common/collection-icon
+    :icon-class :design
     :view-types [:scene :text]
     :view-opts {:scene {:grid true}}))

--- a/editor/src/clj/editor/collection_proxy.clj
+++ b/editor/src/clj/editor/collection_proxy.clj
@@ -125,13 +125,14 @@
 (defn register-resource-types
   [workspace]
   (resource-node/register-ddf-resource-type workspace
-                                    :ext "collectionproxy"
-                                    :node-type CollectionProxyNode
-                                    :ddf-type GameSystem$CollectionProxyDesc
-                                    :load-fn load-collection-proxy
-                                    :icon collection-proxy-icon
-                                    :view-types [:cljfx-form-view :text]
-                                    :view-opts {}
-                                    :tags #{:component}
-                                    :tag-opts {:component {:transform-properties #{}}}
-                                    :label "Collection Proxy"))
+    :ext "collectionproxy"
+    :node-type CollectionProxyNode
+    :ddf-type GameSystem$CollectionProxyDesc
+    :load-fn load-collection-proxy
+    :icon collection-proxy-icon
+    :icon-class :property
+    :view-types [:cljfx-form-view :text]
+    :view-opts {}
+    :tags #{:component}
+    :tag-opts {:component {:transform-properties #{}}}
+    :label "Collection Proxy"))

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -590,17 +590,18 @@
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
-                                    :ext "collisionobject"
-                                    :node-type CollisionObjectNode
-                                    :ddf-type Physics$CollisionObjectDesc
-                                    :load-fn load-collision-object
-                                    :sanitize-fn sanitize-collision-object
-                                    :icon collision-object-icon
-                                    :view-types [:scene :text]
-                                    :view-opts {:scene {:grid true}}
-                                    :tags #{:component}
-                                    :tag-opts {:component {:transform-properties #{}}}
-                                    :label "Collision Object"))
+    :ext "collisionobject"
+    :node-type CollisionObjectNode
+    :ddf-type Physics$CollisionObjectDesc
+    :load-fn load-collision-object
+    :sanitize-fn sanitize-collision-object
+    :icon collision-object-icon
+    :icon-class :design
+    :view-types [:scene :text]
+    :view-opts {:scene {:grid true}}
+    :tags #{:component}
+    :tag-opts {:component {:transform-properties #{}}}
+    :label "Collision Object"))
 
 ;; outline context menu
 

--- a/editor/src/clj/editor/cubemap.clj
+++ b/editor/src/clj/editor/cubemap.clj
@@ -311,4 +311,5 @@
     :ddf-type Graphics$Cubemap
     :load-fn load-cubemap
     :icon cubemap-icon
+    :icon-class :design
     :view-types [:scene :text]))

--- a/editor/src/clj/editor/disk.clj
+++ b/editor/src/clj/editor/disk.clj
@@ -164,7 +164,7 @@
               (do
                 (render-save-progress! (progress/make-indeterminate "Reading timestamps..."))
                 (let [touched-resources (into #{} (map :resource) save-data)]
-                  (workspace/reload-plugins! workspace touched-resources)
+                  (project/reload-plugins! project touched-resources)
                   (lsp/touch-resources! (lsp/get-node-lsp project) touched-resources))
                 (let [post-save-actions (make-post-save-actions save-data)]
                   (render-save-progress! progress/done)

--- a/editor/src/clj/editor/display_profiles.clj
+++ b/editor/src/clj/editor/display_profiles.clj
@@ -29,6 +29,7 @@
              :label "Display Profiles"
              :view-types [:cljfx-form-view :text]
              :icon "icons/32/Icons_50-Display-profiles.png"
+             :icon-class :property
              :pb-class Render$DisplayProfiles})
 
 (g/defnode ProfileNode
@@ -140,4 +141,5 @@
     :ddf-type Render$DisplayProfiles
     :load-fn (fn [project self resource pb] (load-display-profiles project self resource pb))
     :icon (:icon pb-def)
+    :icon-class (:icon-class pb-def)
     :view-types (:view-types pb-def)))

--- a/editor/src/clj/editor/factory.clj
+++ b/editor/src/clj/editor/factory.clj
@@ -155,27 +155,29 @@
 (defn register-resource-types
   [workspace]
   (concat
-   (resource-node/register-ddf-resource-type workspace
-                                     :textual? true
-                                     :ext "factory"
-                                     :node-type FactoryNode
-                                     :ddf-type GameSystem$FactoryDesc
-                                     :load-fn (partial load-factory :game-object)
-                                     :icon (get-in factory-types [:game-object :icon])
-                                     :view-types [:cljfx-form-view :text]
-                                     :view-opts {}
-                                     :tags #{:component}
-                                     :tag-opts {:component {:transform-properties #{}}}
-                                     :label "Factory")
-   (resource-node/register-ddf-resource-type workspace
-                                     :textual? true
-                                     :ext "collectionfactory"
-                                     :node-type FactoryNode
-                                     :ddf-type GameSystem$CollectionFactoryDesc
-                                     :load-fn (partial load-factory :collection)
-                                     :icon (get-in factory-types [:collection :icon])
-                                     :view-types [:cljfx-form-view :text]
-                                     :view-opts {}
-                                     :tags #{:component}
-                                     :tag-opts {:component {:transform-properties #{}}}
-                                     :label "Collection Factory")))
+    (resource-node/register-ddf-resource-type workspace
+      :textual? true
+      :ext "factory"
+      :node-type FactoryNode
+      :ddf-type GameSystem$FactoryDesc
+      :load-fn (partial load-factory :game-object)
+      :icon (get-in factory-types [:game-object :icon])
+      :icon-class :property
+      :view-types [:cljfx-form-view :text]
+      :view-opts {}
+      :tags #{:component}
+      :tag-opts {:component {:transform-properties #{}}}
+      :label "Factory")
+    (resource-node/register-ddf-resource-type workspace
+      :textual? true
+      :ext "collectionfactory"
+      :node-type FactoryNode
+      :ddf-type GameSystem$CollectionFactoryDesc
+      :load-fn (partial load-factory :collection)
+      :icon (get-in factory-types [:collection :icon])
+      :icon-class :property
+      :view-types [:cljfx-form-view :text]
+      :view-opts {}
+      :tags #{:component}
+      :tag-opts {:component {:transform-properties #{}}}
+      :label "Collection Factory")))

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -800,6 +800,7 @@
       :ddf-type Font$FontDesc
       :load-fn load-font
       :icon font-icon
+      :icon-class :design
       :view-types [:scene :text])
     (workspace/register-resource-type workspace
       :ext "glyph_bank")

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -591,5 +591,6 @@
     :dependencies-fn (game-object-common/make-game-object-dependencies-fn #(workspace/get-resource-type-map workspace))
     :sanitize-fn (partial sanitize-game-object workspace)
     :icon game-object-common/game-object-icon
+    :icon-class :design
     :view-types [:scene :text]
     :view-opts {:scene {:grid true}}))

--- a/editor/src/clj/editor/game_object_non_editable.clj
+++ b/editor/src/clj/editor/game_object_non_editable.clj
@@ -398,5 +398,6 @@
     :sanitize-fn (partial sanitize-non-editable-game-object workspace)
     :load-fn load-non-editable-game-object
     :icon game-object-common/game-object-icon
+    :icon-class :design
     :view-types [:scene :text]
     :view-opts {:scene {:grid true}}))

--- a/editor/src/clj/editor/game_project.clj
+++ b/editor/src/clj/editor/game_project.clj
@@ -258,4 +258,5 @@
     :load-fn load-game-project
     :meta-settings (:settings gpcore/basic-meta-info)
     :icon game-project-icon
+    :icon-class :property
     :view-types [:cljfx-form-view :text]))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -79,6 +79,7 @@
 (def pb-def {:ext "gui"
              :label "Gui"
              :icon gui-icon
+             :icon-class :design
              :pb-class Gui$SceneDesc
              :resource-fields [:script :material [:fonts :font] [:textures :texture] [:materials :material] [:particlefxs :particlefx] [:resources :path]]
              :tags #{:component :non-embeddable}
@@ -3074,6 +3075,7 @@
         :load-fn load-gui-scene
         :sanitize-fn sanitize-scene
         :icon (:icon def)
+        :icon-class (:icon-class def)
         :tags (:tags def)
         :tag-opts (:tag-opts def)
         :template (:template def)

--- a/editor/src/clj/editor/label.clj
+++ b/editor/src/clj/editor/label.clj
@@ -436,6 +436,7 @@
     :load-fn load-label
     :sanitize-fn sanitize-label
     :icon label-icon
+    :icon-class :design
     :view-types [:scene :text]
     :tags #{:component}
     :tag-opts {:component {:transform-properties #{:position :rotation :scale}

--- a/editor/src/clj/editor/material.clj
+++ b/editor/src/clj/editor/material.clj
@@ -593,4 +593,5 @@
     :load-fn load-material
     :sanitize-fn sanitize-material
     :icon "icons/32/Icons_31-Material.png"
+    :icon-class :property
     :view-types [:cljfx-form-view :text]))

--- a/editor/src/clj/editor/model.clj
+++ b/editor/src/clj/editor/model.clj
@@ -601,6 +601,7 @@
     :load-fn load-model
     :sanitize-fn sanitize-model
     :icon model-icon
+    :icon-class :design
     :view-types [:scene :text]
     :tags #{:component}
     :tag-opts {:component {:transform-properties #{:position :rotation}}}))

--- a/editor/src/clj/editor/model_scene.clj
+++ b/editor/src/clj/editor/model_scene.clj
@@ -434,11 +434,12 @@
 
 (defn register-resource-types [workspace]
   (workspace/register-resource-type workspace
-                                    :ext model-file-types
-                                    :label "Model Scene"
-                                    :node-type ModelSceneNode
-                                    :icon mesh-icon
-                                    :view-types [:scene :text]))
+    :ext model-file-types
+    :label "Model Scene"
+    :node-type ModelSceneNode
+    :icon mesh-icon
+    :icon-class :design
+    :view-types [:scene :text]))
 
 (defn- update-vb [^GL2 _gl ^VertexBuffer vb data]
   (let [{:keys [mesh-renderable-data ^Matrix4d world-transform ^Matrix4d normal-transform vertex-attribute-bytes]} data]

--- a/editor/src/clj/editor/particlefx.clj
+++ b/editor/src/clj/editor/particlefx.clj
@@ -1119,6 +1119,7 @@
     :load-fn load-particle-fx
     :sanitize-fn add-default-properties-to-modifiers
     :icon particle-fx-icon
+    :icon-class :design
     :tags #{:component :non-embeddable}
     :tag-opts {:component {:transform-properties #{:position :rotation}}}
     :view-types [:scene :text]

--- a/editor/src/clj/editor/pipeline.clj
+++ b/editor/src/clj/editor/pipeline.clj
@@ -21,7 +21,7 @@
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.workspace :as workspace]
-            [util.coll :refer [pair]]
+            [util.coll :as coll :refer [pair]]
             [util.digest :as digest])
   (:import [java.io File]))
 
@@ -103,43 +103,9 @@
 
 ;;--------------------------------------------------------------------
 
-(defn flatten-build-targets
-  "Breadth first traversal / collection of build-targets and their child :deps,
-  skipping seen targets identified by the :content-hash of each build-target."
-  ([build-targets]
-   (flatten-build-targets build-targets #{}))
-  ([build-targets seen-content-hashes]
-   (assert (set? seen-content-hashes))
-   (loop [targets build-targets
-          queue []
-          seen seen-content-hashes
-          result (transient [])]
-     (if-some [target (first targets)]
-       (let [content-hash (:content-hash target)]
-         (assert (bt/content-hash? content-hash)
-                 (str "Build target has invalid content-hash: "
-                      (resource/resource->proj-path (:resource target))))
-         (if (contains? seen content-hash)
-           (recur (rest targets)
-                  queue
-                  seen
-                  result)
-           (recur (rest targets)
-                  (conj queue (flatten (:deps target)))
-                  (conj seen content-hash)
-                  (conj! result target))))
-       (if-some [targets (first queue)]
-         (recur targets
-                (rest queue)
-                seen
-                result)
-         (persistent! result))))))
-
 (defn- make-build-targets-by-content-hash
-  [build-targets]
-  (into {}
-        (map (juxt :content-hash identity))
-        (flatten-build-targets build-targets)))
+  [flat-build-targets]
+  (coll/pair-map-by :content-hash flat-build-targets))
 
 (defn- make-dep-resources
   [deps build-targets-by-content-hash]
@@ -201,8 +167,8 @@
 (def ^:private expensive-batch-size 5)
 
 (defn build!
-  [build-targets build-dir old-artifact-map render-progress!]
-  (let [build-targets-by-content-hash (make-build-targets-by-content-hash build-targets)
+  [flat-build-targets build-dir old-artifact-map render-progress!]
+  (let [build-targets-by-content-hash (make-build-targets-by-content-hash flat-build-targets)
         pruned-old-artifact-map (prune-artifact-map old-artifact-map build-targets-by-content-hash)
         progress (atom (progress/make "" (count build-targets-by-content-hash)))]
     (prune-build-dir! build-dir build-targets-by-content-hash)

--- a/editor/src/clj/editor/protobuf_types.clj
+++ b/editor/src/clj/editor/protobuf_types.clj
@@ -29,6 +29,7 @@
 
 (def pb-defs [{:ext "input_binding"
                :icon "icons/32/Icons_35-Inputbinding.png"
+               :icon-class :property
                :pb-class Input$InputBinding
                :label "Input Binding"
                :view-types [:cljfx-form-view :text]}
@@ -41,6 +42,7 @@
               {:ext "gamepads"
                :label "Gamepads"
                :icon "icons/32/Icons_34-Gamepad.png"
+               :icon-class :property
                :pb-class Input$GamepadMaps
                :view-types [:cljfx-form-view :text]}
               {:ext "convexshape"
@@ -52,6 +54,7 @@
                :label "Texture Profiles"
                :view-types [:cljfx-form-view :text]
                :icon "icons/32/Icons_37-Texture-profile.png"
+               :icon-class :property
                :pb-class Graphics$TextureProfiles}])
 
 (defn- build-pb [resource dep-resources user-data]
@@ -95,6 +98,7 @@
         :ddf-type (:pb-class def)
         :load-fn (partial load-pb def)
         :icon (:icon def)
+        :icon-class (:icon-class def)
         :view-types (:view-types def)
         :view-opts (:view-opts def)
         :tags (:tags def)

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -192,5 +192,6 @@
     :load-fn load-render
     :sanitize-fn sanitize-render
     :icon "icons/32/Icons_30-Render.png"
+    :icon-class :property
     :view-types [:cljfx-form-view :text]
     :label "Render"))

--- a/editor/src/clj/editor/render_target.clj
+++ b/editor/src/clj/editor/render_target.clj
@@ -127,7 +127,7 @@
   (output pb-msg g/Any :cached produce-pb-msg)
   (output save-value g/Any (gu/passthrough pb-msg))
   (output form-data g/Any produce-form-data)
-  (output gpu-texture-generator g/Any {:f generate-gpu-texture })
+  (output gpu-texture-generator g/Any {:f generate-gpu-texture})
   (output build-targets g/Any :cached produce-build-targets)
   (output build-errors g/Any (g/fnk [_node-id color-attachments depth-stencil-attachment-width depth-stencil-attachment-height]
                                (g/package-errors _node-id
@@ -162,6 +162,7 @@
     :ddf-type RenderTarget$RenderTargetDesc
     :load-fn load-render-target
     :icon texture-icon
+    :icon-class :design
     :view-types [:cljfx-form-view :text]
     :view-opts {}
     :label "Render Target"))

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -446,7 +446,7 @@
 
 (def ^:private ext->style-class
   (let [config {"script" ["fp" "gui_script" "lua" "render_script" "script" "vp"
-                          "glsl"]
+                          "glsl" "tl"]
                 "design" ["atlas" "collection" "collisionobject" "cubemap" "dae"
                           "font" "go" "gui" "label" "model" "particlefx"
                           "spinemodel" "spinescene" "sprite" "tilemap"

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -20,7 +20,7 @@
             [editor.core :as core]
             [editor.fs :as fs]
             [schema.core :as s]
-            [util.coll :refer [pair]]
+            [util.coll :as coll :refer [pair]]
             [util.digest :as digest])
   (:import [clojure.lang PersistentHashMap]
            [java.io File FilterInputStream IOException InputStream]
@@ -445,16 +445,8 @@
       (.getAbsolutePath f))))
 
 (def ^:private ext->style-class
-  (let [config {"script" ["fp" "gui_script" "lua" "render_script" "script" "vp"
-                          "glsl" "tl"]
-                "design" ["atlas" "collection" "collisionobject" "cubemap" "dae"
-                          "font" "go" "gui" "label" "model" "particlefx"
-                          "spinemodel" "spinescene" "sprite" "tilemap"
-                          "tilesource" "render_target"]
-                "property" ["animationset" "camera" "collectionfactory"
-                            "collectionproxy" "display_profiles" "factory"
-                            "gamepads" "input_binding" "material" "project"
-                            "render" "sound" "texture_profiles"]}]
+  ;; TODO: make extension-spine use :icon-class
+  (let [config {"design" ["spinemodel" "spinescene"]}]
    (->> (for [[kind extensions] config
               :let [style-class (str "resource-kind-" kind)]
               ext extensions
@@ -463,17 +455,20 @@
         seq
         PersistentHashMap/createWithCheck)))
 
-(defn style-classes [resource]
-  (let [resource-kind-class (case (source-type resource)
-                              :file (some->> resource ext ext->style-class)
-                              :folder "resource-folder"
-                              nil)]
-    (cond-> #{"resource"} resource-kind-class (conj resource-kind-class))))
+(def icon-class->style-class
+  (coll/pair-map-by identity #(str "resource-kind-" (name %)) [:design :property :script]))
 
-(defn ext-style-classes [resource-ext]
-  (assert (or (nil? resource-ext) (string? resource-ext)))
-  (if-some [style-class (ext->style-class resource-ext)]
-    #{"resource" style-class}
+(defn type-style-classes [resource-type]
+  (if-let [explicit-class (or (some-> (:icon-class resource-type) icon-class->style-class)
+                              (some-> (:ext resource-type) ext->style-class))]
+    #{"resource" explicit-class}
+    #{"resource"}))
+
+(defn style-classes [resource]
+  (case (source-type resource)
+    :file (or (some-> (resource-type resource) type-style-classes)
+              #{"resource"})
+    :folder #{"resource" "resource-folder"}
     #{"resource"}))
 
 (defn filter-resources [resources query]

--- a/editor/src/clj/editor/sound.clj
+++ b/editor/src/clj/editor/sound.clj
@@ -214,6 +214,7 @@
       :ddf-type Sound$SoundDesc
       :load-fn load-sound
       :icon sound-icon
+      :icon-class :property
       :view-types [:cljfx-form-view :text]
       :view-opts {}
       :tags #{:component}

--- a/editor/src/clj/editor/sprite.clj
+++ b/editor/src/clj/editor/sprite.clj
@@ -694,6 +694,7 @@
     :load-fn load-sprite
     :sanitize-fn sanitize-sprite
     :icon sprite-icon
+    :icon-class :design
     :view-types [:scene :text]
     :tags #{:component}
     :tag-opts {:component {:transform-properties #{:position :rotation :scale}}}

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -1258,6 +1258,7 @@
     :ddf-type Tile$TileGrid
     :load-fn load-tile-map
     :icon tile-map-icon
+    :icon-class :design
     :view-types [:scene :text]
     :view-opts {:scene {:grid tile-map-grid/TileMapGrid
                         :tool-controller TileMapController}}

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -1006,12 +1006,13 @@
 
 (defn register-resource-types [workspace]
   (resource-node/register-ddf-resource-type workspace
-                                    :ext ["tilesource" "tileset"]
-                                    :label "Tile Source"
-                                    :build-ext "t.texturesetc"
-                                    :node-type TileSourceNode
-                                    :ddf-type Tile$TileSet
-                                    :load-fn load-tile-source
-                                    :icon tile-source-icon
-                                    :view-types [:scene :text]
-                                    :view-opts {:scene {:tool-controller ToolController}}))
+    :ext ["tilesource" "tileset"]
+    :label "Tile Source"
+    :build-ext "t.texturesetc"
+    :node-type TileSourceNode
+    :ddf-type Tile$TileSet
+    :load-fn load-tile-source
+    :icon tile-source-icon
+    :icon-class :design
+    :view-types [:scene :text]
+    :view-opts {:scene {:tool-controller ToolController}}))

--- a/editor/src/clj/editor/workspace.clj
+++ b/editor/src/clj/editor/workspace.clj
@@ -235,6 +235,8 @@ ordinary paths."
                         (a save value) to string
     :icon               classpath path to an icon image or project resource path
                         string; default \"icons/32/Icons_29-AT-Unknown.png\"
+    :icon-class         either :design, :script or :property, controls the
+                        resource icon color in UI
     :view-types         vector of alternative views that can be used for
                         resources of the resource type, e.g. :code, :scene,
                         :cljfx-form-view, :text, :html or :default.
@@ -261,7 +263,8 @@ ordinary paths."
     :auto-connect-save-data?    whether changes to the resource are saved
                                 to disc (this can also be enabled in load-fn)
                                 when there is a :write-fn, default true"
-  [workspace & {:keys [textual? language editable ext build-ext node-type load-fn dependencies-fn read-raw-fn sanitize-fn read-fn write-fn icon view-types view-opts tags tag-opts template test-info label stateless? auto-connect-save-data?]}]
+  [workspace & {:keys [textual? language editable ext build-ext node-type load-fn dependencies-fn read-raw-fn sanitize-fn read-fn write-fn icon icon-class view-types view-opts tags tag-opts template test-info label stateless? auto-connect-save-data?]}]
+  {:pre [(or (nil? icon-class) (resource/icon-class->style-class icon-class))]}
   (let [editable (if (nil? editable) true (boolean editable))
         textual (true? textual?)
         resource-type {:textual? textual
@@ -277,6 +280,7 @@ ordinary paths."
                        :read-raw-fn (or read-raw-fn read-fn)
                        :sanitize-fn sanitize-fn
                        :icon icon
+                       :icon-class icon-class
                        :view-types (mapv (partial get-view-type workspace) view-types)
                        :view-opts view-opts
                        :tags tags

--- a/editor/src/clj/internal/graph/error_values.clj
+++ b/editor/src/clj/internal/graph/error_values.clj
@@ -89,9 +89,7 @@
 
 (defn error-aggregate
   ([es]
-   (let [max-severity (->> es
-                           (->Eduction (keep :severity))
-                           (reduce #(max-key severity-levels %1 %2) :info))]
+   (let [max-severity (transduce (keep :severity) (completing #(max-key severity-levels %1 %2)) :info es)]
      (map->ErrorValue {:severity max-severity :causes (vec es)})))
   ([es & kvs]
    (apply assoc (error-aggregate es) kvs)))

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -244,3 +244,19 @@
               (assoc-in nested-map path value)))
           (empty path-map)
           path-map))
+
+(defn- preserving-reduced [rf]
+  #(let [result (rf %1 %2)]
+     (cond-> result (reduced? result) reduced)))
+
+(defn flatten-xf
+  "Like clojure.core/flatten, but transducer and treats nils as empty sequences"
+  [rf]
+  (fn xf
+    ([] (rf))
+    ([result] (rf result))
+    ([result input]
+     (cond
+       (nil? input) result
+       (sequential? input) (reduce (preserving-reduced xf) result input)
+       :else (rf result input)))))

--- a/editor/src/clj/util/coll.clj
+++ b/editor/src/clj/util/coll.clj
@@ -13,7 +13,7 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns util.coll
-  (:refer-clojure :exclude [bounded-count empty?])
+  (:refer-clojure :exclude [bounded-count empty? some])
   (:import [clojure.lang IEditableCollection MapEntry]
            [java.util ArrayList]))
 
@@ -260,3 +260,12 @@
        (nil? input) result
        (sequential? input) (reduce (preserving-reduced xf) result input)
        :else (rf result input)))))
+
+(defn some
+  "Like clojure.core/some, but uses reduce instead of lazy sequences"
+  [pred coll]
+  (reduce (fn [_ v]
+            (when-let [ret (pred v)]
+              (reduced ret)))
+          nil
+          coll))

--- a/editor/test/editor/build_target_test.clj
+++ b/editor/test/editor/build_target_test.clj
@@ -184,12 +184,10 @@
   (build/resolve-dependencies
     (->> (g/node-value project :nodes-by-resource-path)
          (sort-by key)
-         (->Eduction
-           (comp
-             (map val)
-             (map build-targets-or-error)
-             (remove g/error?)
-             (remove empty?))))
+         (map val)
+         (map build-targets-or-error)
+         (remove g/error?)
+         (remove empty?))
     project))
 
 (defn- build-target-content-hashes-by-path [project]

--- a/editor/test/editor/code/script_test.clj
+++ b/editor/test/editor/code/script_test.clj
@@ -17,7 +17,8 @@
             [clojure.test :refer :all]
             [editor.code.data :as data]
             [editor.code.data-test :refer [c cr layout-info]]
-            [editor.code.script :as script]))
+            [editor.code.script :as script]
+            [editor.code.script-compilation :as script-compilation]))
 
 (def ^:private indent-string "    ")
 (def ^:private indent-level-pattern (data/indent-level-pattern (count indent-string)))
@@ -234,7 +235,7 @@
     ["    s = 'will end something'"
      "    |"]))
 
-(def strip-go-prop-declarations #'script/strip-go-property-declarations)
+(def strip-go-prop-declarations #'script-compilation/strip-go-property-declarations)
 
 (deftest strip-go-prop-declarations-test
   (are [code expected]

--- a/editor/test/integration/app_view_test.clj
+++ b/editor/test/integration/app_view_test.clj
@@ -188,7 +188,6 @@
               project (test-util/setup-project! workspace)
               artifact-map (workspace/artifact-map workspace)
               game-project (test-util/resource-node project "/game.project")
-              game-project-build-targets (g/node-value game-project :build-targets)
               expected-cached-build-target-endpoints (into (sorted-set)
                                                            (mapcat (fn [{build-resource :resource :as build-target}]
                                                                      (let [source-resource (:resource build-resource)]
@@ -197,7 +196,7 @@
                                                                          ;; This is a project (i.e. not embedded) resource node.
                                                                          (when-some [source-node-id (test-util/resource-node project source-resource)]
                                                                            (node-cacheable-build-target-endpoints source-node-id))))))
-                                                           (pipeline/flatten-build-targets game-project-build-targets))]
+                                                           (build/resolve-node-dependencies game-project project))]
           (test-util/run-event-loop!
             (fn [exit-event-loop!]
               (g/clear-system-cache!)

--- a/editor/test/integration/extension_spine_test.clj
+++ b/editor/test/integration/extension_spine_test.clj
@@ -72,7 +72,7 @@
             (testing "Without the extension, resources with embedded Spine data report build errors due to invalid content."
               (letfn [(invalid-content-error? [error-resource-path error-value]
                         (is (g/error? error-value))
-                        (is (= :invalid-content (-> error-value :user-data :type)))
+                        (is (= :invalid-content (-> error-value :causes first :user-data :type)))
                         (let [error-tree (build-errors-view/build-resource-tree error-value)
                               error-item-of-parent-resource (first (:children error-tree))
                               error-item-of-faulty-node (first (:children error-item-of-parent-resource))]

--- a/editor/test/integration/extension_transpilers_test.clj
+++ b/editor/test/integration/extension_transpilers_test.clj
@@ -1,0 +1,32 @@
+;; Copyright 2020-2024 The Defold Foundation
+;; Copyright 2014-2020 King
+;; Copyright 2009-2014 Ragnar Svensson, Christian Murray
+;; Licensed under the Defold License version 1.0 (the "License"); you may not use
+;; this file except in compliance with the License.
+;;
+;; You may obtain a copy of the License, together with FAQs at
+;; https://www.defold.com/license
+;;
+;; Unless required by applicable law or agreed to in writing, software distributed
+;; under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+;; CONDITIONS OF ANY KIND, either express or implied. See the License for the
+;; specific language governing permissions and limitations under the License.
+
+(ns integration.extension-transpilers-test
+  (:require [clojure.test :refer :all]
+            [dynamo.graph :as g]
+            [editor.build :as build]
+            [editor.progress :as progress]
+            [editor.workspace :as workspace]
+            [integration.test-util :as test-util]))
+
+(deftest the-editor-can-build-a-project-with-transpilers
+  (test-util/with-loaded-project "test/resources/transpilers_project"
+    (let [build-result (g/with-auto-evaluation-context evaluation-context
+                         (build/build-project! project
+                                               (test-util/resource-node project "/game.project")
+                                               evaluation-context
+                                               nil
+                                               (workspace/artifact-map workspace)
+                                               progress/null-render-progress!))]
+      (is (nil? (:error build-result))))))

--- a/editor/test/integration/script_properties_test.clj
+++ b/editor/test/integration/script_properties_test.clj
@@ -20,6 +20,7 @@
             [dynamo.graph :as g]
             [editor.build-errors-view :as build-errors-view]
             [editor.code.script :as script]
+            [editor.code.script-compilation :as script-compilation]
             [editor.collection :as collection]
             [editor.collection-common :as collection-common]
             [editor.defold-project :as project]
@@ -214,7 +215,7 @@
 (defn- resource-kind-property? [resource-kind property value]
   (and (is (resource/resource? value))
        (let [workspace (resource/workspace value)
-             ext (script/resource-kind-extensions workspace resource-kind)]
+             ext (script-compilation/resource-kind-extensions workspace resource-kind)]
          (and (is (resource/resource? value))
               (is (= :property-type-hash (:go-prop-type property)))
               (is (= value (:value property)))

--- a/editor/test/integration/test_util.clj
+++ b/editor/test/integration/test_util.clj
@@ -1025,8 +1025,7 @@
   [node-id]
   (into #{}
         (map :resource)
-        (pipeline/flatten-build-targets
-          (g/node-value node-id :build-targets))))
+        (build/resolve-node-dependencies node-id (project/get-project node-id))))
 
 (defn node-built-source-paths
   "Returns the set of all source resource proj-paths that will be built when
@@ -1034,8 +1033,7 @@
   [node-id]
   (into #{}
         (keep (comp resource/proj-path :resource :resource))
-        (pipeline/flatten-build-targets
-          (g/node-value node-id :build-targets))))
+        (build/resolve-node-dependencies node-id (project/get-project node-id))))
 
 (defmacro saved-pb [node-id pb-class]
   (with-meta `(protobuf/str->pb ~pb-class (:content (g/node-value ~node-id :undecorated-save-data)))

--- a/editor/test/resources/build_cyclic_lua_project/.gitattributes
+++ b/editor/test/resources/build_cyclic_lua_project/.gitattributes
@@ -1,0 +1,42 @@
+# Defold Protocol Buffer Text Files (https://github.com/github/linguist/issues/5091)
+*.animationset linguist-language=JSON5
+*.atlas linguist-language=JSON5
+*.camera linguist-language=JSON5
+*.collection linguist-language=JSON5
+*.collectionfactory linguist-language=JSON5
+*.collectionproxy linguist-language=JSON5
+*.collisionobject linguist-language=JSON5
+*.cubemap linguist-language=JSON5
+*.display_profiles linguist-language=JSON5
+*.factory linguist-language=JSON5
+*.font linguist-language=JSON5
+*.gamepads linguist-language=JSON5
+*.go linguist-language=JSON5
+*.gui linguist-language=JSON5
+*.input_binding linguist-language=JSON5
+*.label linguist-language=JSON5
+*.material linguist-language=JSON5
+*.mesh linguist-language=JSON5
+*.model linguist-language=JSON5
+*.particlefx linguist-language=JSON5
+*.render linguist-language=JSON5
+*.sound linguist-language=JSON5
+*.sprite linguist-language=JSON5
+*.spinemodel linguist-language=JSON5
+*.spinescene linguist-language=JSON5
+*.texture_profiles linguist-language=JSON5
+*.tilemap linguist-language=JSON5
+*.tilesource linguist-language=JSON5
+
+# Defold JSON Files
+*.buffer linguist-language=JSON
+
+# Defold GLSL Shaders
+*.fp linguist-language=GLSL
+*.vp linguist-language=GLSL
+
+# Defold Lua Files
+*.editor_script linguist-language=Lua
+*.render_script linguist-language=Lua
+*.script linguist-language=Lua
+*.gui_script linguist-language=Lua

--- a/editor/test/resources/build_cyclic_lua_project/.gitignore
+++ b/editor/test/resources/build_cyclic_lua_project/.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/build_cyclic_lua_project/game.project
+++ b/editor/test/resources/build_cyclic_lua_project/game.project
@@ -1,0 +1,19 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = build_cyclic_lua_project
+
+[input]
+game_binding = /builtins/input/all.input_bindingc
+

--- a/editor/test/resources/build_cyclic_lua_project/main/1.lua
+++ b/editor/test/resources/build_cyclic_lua_project/main/1.lua
@@ -1,0 +1,1 @@
+require("main.2")

--- a/editor/test/resources/build_cyclic_lua_project/main/2.lua
+++ b/editor/test/resources/build_cyclic_lua_project/main/2.lua
@@ -1,0 +1,1 @@
+require("main.1")

--- a/editor/test/resources/build_cyclic_lua_project/main/main.collection
+++ b/editor/test/resources/build_cyclic_lua_project/main/main.collection
@@ -1,0 +1,39 @@
+name: "main"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"main\"\n"
+  "  component: \"/main/main.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "  property_decls {\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/editor/test/resources/build_cyclic_lua_project/main/main.script
+++ b/editor/test/resources/build_cyclic_lua_project/main/main.script
@@ -1,0 +1,1 @@
+require("main.1")

--- a/editor/test/resources/save_data_project/checked.tl
+++ b/editor/test/resources/save_data_project/checked.tl
@@ -1,0 +1,19 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local record Test
+    test: string
+end
+
+return Test

--- a/editor/test/resources/transpilers_project/.gitattributes
+++ b/editor/test/resources/transpilers_project/.gitattributes
@@ -1,0 +1,42 @@
+# Defold Protocol Buffer Text Files (https://github.com/github/linguist/issues/5091)
+*.animationset linguist-language=JSON5
+*.atlas linguist-language=JSON5
+*.camera linguist-language=JSON5
+*.collection linguist-language=JSON5
+*.collectionfactory linguist-language=JSON5
+*.collectionproxy linguist-language=JSON5
+*.collisionobject linguist-language=JSON5
+*.cubemap linguist-language=JSON5
+*.display_profiles linguist-language=JSON5
+*.factory linguist-language=JSON5
+*.font linguist-language=JSON5
+*.gamepads linguist-language=JSON5
+*.go linguist-language=JSON5
+*.gui linguist-language=JSON5
+*.input_binding linguist-language=JSON5
+*.label linguist-language=JSON5
+*.material linguist-language=JSON5
+*.mesh linguist-language=JSON5
+*.model linguist-language=JSON5
+*.particlefx linguist-language=JSON5
+*.render linguist-language=JSON5
+*.sound linguist-language=JSON5
+*.sprite linguist-language=JSON5
+*.spinemodel linguist-language=JSON5
+*.spinescene linguist-language=JSON5
+*.texture_profiles linguist-language=JSON5
+*.tilemap linguist-language=JSON5
+*.tilesource linguist-language=JSON5
+
+# Defold JSON Files
+*.buffer linguist-language=JSON
+
+# Defold GLSL Shaders
+*.fp linguist-language=GLSL
+*.vp linguist-language=GLSL
+
+# Defold Lua Files
+*.editor_script linguist-language=Lua
+*.render_script linguist-language=Lua
+*.script linguist-language=Lua
+*.gui_script linguist-language=Lua

--- a/editor/test/resources/transpilers_project/.gitignore
+++ b/editor/test/resources/transpilers_project/.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/transpilers_project/game.project
+++ b/editor/test/resources/transpilers_project/game.project
@@ -1,0 +1,20 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = transpilers_project
+dependencies#0 = https://github.com/defold/extension-teal/archive/main.zip
+
+[input]
+game_binding = /builtins/input/all.input_bindingc
+

--- a/editor/test/resources/transpilers_project/main/main.collection
+++ b/editor/test/resources/transpilers_project/main/main.collection
@@ -1,0 +1,39 @@
+name: "main"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"main\"\n"
+  "  component: \"/main/main.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "  property_decls {\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/editor/test/resources/transpilers_project/main/main.script
+++ b/editor/test/resources/transpilers_project/main/main.script
@@ -1,0 +1,5 @@
+local tl = require("modules.main")
+
+function init(self)
+	print(tl)
+end

--- a/editor/test/resources/transpilers_project/modules/main.tl
+++ b/editor/test/resources/transpilers_project/modules/main.tl
@@ -1,0 +1,1 @@
+return "hello from teal"

--- a/editor/test/resources/transpilers_project/tlconfig.lua
+++ b/editor/test/resources/transpilers_project/tlconfig.lua
@@ -1,0 +1,5 @@
+return {
+	gen_target = "5.1",
+	gen_compat = "off",
+	include = {"**/*.tl"}
+}

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -276,3 +276,26 @@
 
     (is (not (sorted? (:a (coll/path-map->nested-map {[:a :A] 1})))))
     (is (sorted? (:a (coll/path-map->nested-map (sorted-map [:a :A] 1)))))))
+
+(deftest flatten-xf-test
+  (testing "flatten behavior"
+    (are [test-coll] (= (flatten test-coll) (into [] coll/flatten-xf test-coll))
+      nil
+      []
+      [[[]] [[[]]] () () []]
+      [1 [3 [4 [3 [2 [22 [4]] 6] 6] 6] 54 [3]]]))
+  (testing "difference with clojure.core/flatten in nil handling"
+    (is (= [1 2 nil] (flatten [[1 [2 [nil]]]])))
+    (is (= [1 2] (into [] coll/flatten-xf [[1 [2 [nil]]]]))))
+  (testing "reduced support"
+    (is (= :stop
+           (transduce
+             (comp
+               coll/flatten-xf
+               (halt-when #{:stop}))
+             conj
+             []
+             [(range 100)
+              [[]]
+              [[:stop
+                (repeatedly #(throw (Exception. "Should not be reduced!")))]]])))))

--- a/editor/test/util/coll_test.clj
+++ b/editor/test/util/coll_test.clj
@@ -299,3 +299,11 @@
               [[]]
               [[:stop
                 (repeatedly #(throw (Exception. "Should not be reduced!")))]]])))))
+
+(deftest some-test
+  (testing "some behavior"
+    (are [pred coll ret] (= ret (some pred coll) (coll/some pred coll))
+      #{100} (range 1000) 100
+      #(= % 100) (range 1000) true
+      #(= % 100) (range 50) nil
+      #(= % 100) [] nil)))


### PR DESCRIPTION
This changeset adds initial Bob and Editor support for plugins that transpile 3rd-party languages to Lua. Transpiler plugins need to implement an `ILuaTranspiler` interface. See [the Teal extension](https://github.com/defold/extension-teal) for reference implementation.

Fixes #8291