### PR TITLE
Fix double-run web build in rare case.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -733,7 +733,6 @@ var Module = {
     _filesToPreload: [],
     _archiveLoaded: false,
     _preLoadDone: false,
-    _waitingForArchive: false,
     _isEngineLoaded: false,
 
     // Persistent storage
@@ -847,11 +846,7 @@ var Module = {
                     e.preventDefault();
                 };
             }
-            if (Module._archiveLoaded) {
-                // "Starting...."
-                ProgressUpdater.complete();
-                Module._callMain();
-            }
+            Module._preloadAndCallMain();
         } else {
             // "Unable to start game, WebGL not supported"
             ProgressUpdater.complete();
@@ -872,9 +867,7 @@ var Module = {
     onArchiveLoaded: function() {
         GameArchiveLoader.cleanUp();
         Module._archiveLoaded = true;
-        if (Module._waitingForArchive) {
-            Module._preloadAndCallMain();
-        }
+        Module._preloadAndCallMain();
     },
 
     toggleFullscreen: function(element) {
@@ -887,7 +880,6 @@ var Module = {
 
     preSync: function(done) {
         if (Module.persistentStorage != true) {
-            Module._syncInitial = true;
             done();
             return;
         }
@@ -992,16 +984,16 @@ var Module = {
     }],
 
     _preloadAndCallMain: function() {
-        // If the archive isn't loaded,
-        // we will have to wait with calling main.
-        if (!Module._archiveLoaded) {
-            Module._waitingForArchive = true;
-        } else {
-            Module.preloadAll();
-            if (Module._isEngineLoaded) {
-                // "Starting...."
-                ProgressUpdater.complete();
-                Module._callMain();
+        if (Module._syncInitial || Module.persistentStorage != true) {
+            // If the archive isn't loaded,
+            // we will have to wait with calling main.
+            if (Module._archiveLoaded) {
+                Module.preloadAll();
+                if (Module._isEngineLoaded) {
+                    // "Starting...."
+                    ProgressUpdater.complete();
+                    Module._callMain();
+                }
             }
         }
     },


### PR DESCRIPTION
Fixes #8848.

### Technical changes
Problem was in `FS.syncfs` operation tha runs in `Module.preInit`. Sometimes it can finish after engine and data loading. When engine starts it doesn't respect finished `syncfs` or not. Some screenshoots to illustrate when it happened
![Screenshot 2024-04-25 at 11 52 49](https://github.com/defold/defold/assets/770105/7f2ef397-326c-48a8-aa8c-a0cc35c22a5e)
![Screenshot 2024-04-25 at 11 52 59](https://github.com/defold/defold/assets/770105/39d6f172-4e40-4823-995a-ba77e446b520)
![Screenshot 2024-04-25 at 11 57 41](https://github.com/defold/defold/assets/770105/5c64be36-3d11-42fd-929b-b06328b103c9)
![Screenshot 2024-04-25 at 11 57 52](https://github.com/defold/defold/assets/770105/57dbfe17-b3c9-4e0d-9d59-2abc5bce4e81)
So solution is check `Module._initialSync` flag and use `Module._preloadAndCallMain` in `runApp` to have one entrypoint for all.
P.S. It doesn't help if several `Module._preloadAndCallMain` occurred after engine was start.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
