### PR TITLE
Increased editor UI contrast

### DIFF
--- a/editor/resources/splash.css
+++ b/editor/resources/splash.css
@@ -66,20 +66,20 @@ Label.emphasis {
 }
 
 * {
-  -df-background-darker: derive(#212428, -13%);
-  -df-background-dark: derive(#212428, -6%);
+  -df-background-darker: derive(#212428, -40%);
   -df-background: #212428;
-  -df-background-light: derive(#212428, 6%);
-  -df-background-lighter: derive(#212428, 13%);
-  -df-component-darker: derive(#52575c, -30%);
-  -df-component-dark: derive(#52575c, -15%);
-  -df-component: #52575c;
-  -df-component-light: derive(#52575c, 15%);
-  -df-component-lighter: derive(#52575c, 30%);
-  -df-text-dark: derive(#a2b0be, -30%);
+  -df-background-light: #2c2e33;
+  -df-background-lighter: #3B3F43;
+  -df-background-input: #292a2f;
+  -df-component-darker: #212428;
+  -df-component-dark: #393c41;
+  -df-component-light: #45474B;
+  -df-component-lighter: #52575c;
+  -df-component-icon: #8f9296;
+  -df-text-dark: #848484;
   -df-text: #a2b0be;
-  -df-text-light: derive(#a2b0be, 85%);
-  -df-text-selected: derive(#a2b0be, 85%);
+  -df-text-light: #f0f2f6;
+  -df-text-selected: #f0f2f6;
   -df-defold-red-dark: derive(#e32f44, -10%);
   -df-defold-red: #e32f44;
   -df-defold-red-light: derive(#e32f44, 10%);
@@ -179,7 +179,7 @@ Label.emphasis {
 }
 
 .progress-indicator {
-  -fx-progress-color: -df-component;
+  -fx-progress-color: -df-component-lighter;
 }
 
 @font-face {
@@ -243,7 +243,7 @@ Label.emphasis {
 }
 
 .button:hover {
-  -fx-background-color: -df-component;
+  -fx-background-color: -df-component-lighter;
 }
 
 .button:armed {

--- a/editor/resources/splash.css
+++ b/editor/resources/splash.css
@@ -66,20 +66,20 @@ Label.emphasis {
 }
 
 * {
-  -df-background-darker: derive(#212428, -10%);
-  -df-background-dark: derive(#212428, -5%);
+  -df-background-darker: derive(#212428, -13%);
+  -df-background-dark: derive(#212428, -6%);
   -df-background: #212428;
-  -df-background-light: derive(#212428, 10%);
-  -df-background-lighter: derive(#212428, 20%);
-  -df-component-darker: derive(#464c55, -20%);
-  -df-component-dark: derive(#464c55, -10%);
-  -df-component: #464c55;
-  -df-component-light: derive(#464c55, 10%);
-  -df-component-lighter: derive(#464c55, 20%);
-  -df-text-darker: derive(#b4bac1, -20%);
-  -df-text-dark: derive(#b4bac1, -40%);
-  -df-text: #b4bac1;
-  -df-text-selected: derive(#b4bac1, 20%);
+  -df-background-light: derive(#212428, 6%);
+  -df-background-lighter: derive(#212428, 13%);
+  -df-component-darker: derive(#52575c, -30%);
+  -df-component-dark: derive(#52575c, -15%);
+  -df-component: #52575c;
+  -df-component-light: derive(#52575c, 15%);
+  -df-component-lighter: derive(#52575c, 30%);
+  -df-text-dark: derive(#a2b0be, -30%);
+  -df-text: #a2b0be;
+  -df-text-light: derive(#a2b0be, 85%);
+  -df-text-selected: derive(#a2b0be, 85%);
   -df-defold-red-dark: derive(#e32f44, -10%);
   -df-defold-red: #e32f44;
   -df-defold-red-light: derive(#e32f44, 10%);
@@ -235,17 +235,17 @@ Label.emphasis {
   -fx-border-radius: 4;
   -fx-padding: 6px 17px;
   -fx-min-width: 100px;
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   -fx-background-insets: 0;
-  -fx-border-color: -df-background-dark;
+  -fx-border-color: -df-component-darker;
   -fx-border-width: 1;
   -fx-text-fill: -df-text;
 }
 
 .button:hover {
-  -fx-background-color: -df-component-darker;
+  -fx-background-color: -df-component;
 }
 
 .button:armed {
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-light;
 }

--- a/editor/styling/stylesheets/_dialogs.scss
+++ b/editor/styling/stylesheets/_dialogs.scss
@@ -95,7 +95,7 @@ $spacing-largest: 40px;
   -fx-text-fill: -df-text;
   -fx-background-radius: 2px;
   -fx-border-radius: 2px;
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   -fx-padding: 0;
   -fx-min-width: 28px;
   -fx-max-width: 28px;
@@ -106,7 +106,7 @@ $spacing-largest: 40px;
   -fx-focus-traversable: false;
   -fx-border-width: 0;
   &:hover {
-    -fx-background-color: -df-component;
+    -fx-background-color: -df-component-lighter;
   }
   &:armed {
     -fx-background-color: -df-background-light !important;
@@ -161,8 +161,8 @@ $spacing-largest: 40px;
   @include font-size-default();
   -fx-highlight-fill: -df-component-light;
   -fx-text-fill: -df-text-selected;
-  -fx-prompt-text-fill: -df-component;
-  -fx-background-color: -df-background-darker;
+  -fx-prompt-text-fill: -df-component-light;
+  -fx-background-color: -df-background-input;
   -fx-border-width: 1px;
 
   &:readonly {
@@ -240,10 +240,10 @@ $spacing-largest: 40px;
     -fx-background-radius: 5px;
     -fx-background-insets: 1px;
     &:hover {
-      -fx-background-color: -df-component;
+      -fx-background-color: -df-component-light;
     }
     &:pressed {
-      -fx-background-color: -df-component-lighter;
+      -fx-background-color: -df-component-light;
     }
   }
   &:vertical {
@@ -349,12 +349,12 @@ Text {
   }
 
   .track {
-    -fx-background-color: -df-component;
+    -fx-background-color: -df-component-light;
   }
 }
 
 .context-menu {
-  -fx-background-color: -df-component;
+  -fx-background-color: -df-component-light;
   -fx-background-radius: 2px;
   -fx-padding: 5px;
   .menu-item {

--- a/editor/styling/stylesheets/_editor.scss
+++ b/editor/styling/stylesheets/_editor.scss
@@ -85,12 +85,12 @@ Links:
 }
 
 .about-value {
-  -fx-text-fill: -df-component;
+  -fx-text-fill: -df-component-lighter;
 }
 
 #progress-hbox {
   .label {
-    -fx-text-fill: -df-component;
+    -fx-text-fill: -df-component-lighter;
   }
   -fx-alignment: center-left;
   -fx-spacing: 10px;
@@ -98,7 +98,7 @@ Links:
 
 /* Status bar */
 #status-label {
-  -fx-text-fill: -df-component;
+  -fx-text-fill: -df-component-lighter;
   -fx-padding: 7 0 7 15;
 }
 
@@ -121,7 +121,7 @@ Links:
 }
 
 #status-pane #progress-hbox #progress-cancel-button {
-    -fx-background-color: -df-background-lighter;
+    -fx-background-color: -df-background-dark;
     -cross-color: -df-text;
     -fx-background-radius: 50%;
     -fx-border-width: 0;
@@ -132,7 +132,7 @@ Links:
     -fx-max-height: 16px;
     -fx-content-display: center;
     &:hover {
-        -fx-background-color: -df-component-darker;
+        -fx-background-color: -df-component-lighter;
         -cross-color: -df-text-selected;
     }
     &:armed {

--- a/editor/styling/stylesheets/_splash.scss
+++ b/editor/styling/stylesheets/_splash.scss
@@ -67,6 +67,6 @@
   -fx-border-width: 1;
   -fx-text-fill: -df-text; }
   .button:hover {
-    -fx-background-color: -df-component; }
+    -fx-background-color: -df-component-lighter; }
   .button:armed {
     -fx-background-color: -df-component-light; }

--- a/editor/styling/stylesheets/_splash.scss
+++ b/editor/styling/stylesheets/_splash.scss
@@ -61,12 +61,12 @@
   -fx-border-radius: 4;
   -fx-padding: 6px 17px;
   -fx-min-width: 100px;
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   -fx-background-insets: 0;
-  -fx-border-color: -df-background-dark;
+  -fx-border-color: -df-component-darker;
   -fx-border-width: 1;
   -fx-text-fill: -df-text; }
   .button:hover {
-    -fx-background-color: -df-component-darker; }
+    -fx-background-color: -df-component; }
   .button:armed {
-    -fx-background-color: -df-background-lighter; }
+    -fx-background-color: -df-component-light; }

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -1,23 +1,23 @@
 * {
 	// Background
-	-df-background-darker:    derive(#212428, -10%);
-	-df-background-dark:      derive(#212428, -5%);
-	-df-background:           #212428;
-	-df-background-light:     derive(#212428, 10%);
-	-df-background-lighter:   derive(#212428, 20%);
+	-df-background-darker:    derive(#212428, -13%);	// dialog input field background
+	-df-background-dark:      derive(#212428, -6%);
+	-df-background:           #212428;					// background, #212428 (original: dark-grey #212428)
+	-df-background-light:     derive(#212428, 6%);		// panels, input field background, +6%=#c3036 (original: dark-grey-light #2c2e33)
+	-df-background-lighter:   derive(#212428, 13%);		// tree view selection, +13%=#3c4249 (original: dark-grey-selected #3B3F43)
 
 	// Component
-	-df-component-darker:     derive(#464c55, -20%);
-	-df-component-dark:       derive(#464c55, -10%);
-	-df-component:            #464c55;
-	-df-component-light:      derive(#464c55, 10%);
-	-df-component-lighter:    derive(#464c55, 20%);
+	-df-component-darker:     derive(#52575c, -30%);	// button outline, scene view controls panel, -30%=#222426 (original: dark-grey #212428)
+	-df-component-dark:       derive(#52575c, -15%);	// button, input field border, -15%=#383c3f (original: mid-grey #393c41)
+	-df-component:            #52575c;					// button hovered (original: grey #52575c)
+	-df-component-light:      derive(#52575c, 15%);		// input field border selected, +15%=#697076 (original: mid-grey-light #45474B)
+	-df-component-lighter:    derive(#52575c, 30%);		// button icon, +30%=#828990
 
 	// Text & icons
-	-df-text-darker:          derive(#b4bac1, -20%);
-	-df-text-dark:            derive(#b4bac1, -40%);
-	-df-text:                 #b4bac1;
-	-df-text-selected:        derive(#b4bac1, 20%);
+	-df-text-dark:            derive(#a2b0be, -30%);	// property components, -30%=#8698aa (original: #848484)
+	-df-text:                 #a2b0be;					// non editable text, input field hint (original: bright-grey-light #a2b0be)
+	-df-text-light:           derive(#a2b0be, 85%);		// editable text, +85%=#f1f3f5 (original: defold-white #f0f2f6)
+	-df-text-selected:        derive(#a2b0be, 85%);		// non editable selected text (original: defold-white #f0f2f6)
 
 	// Red
 	-df-defold-red-dark:     derive(#e32f44, -10%);
@@ -48,11 +48,11 @@
 	-df-defold-blue-lighter: derive(#4cb1ff, 20%);
 
 	/* Status colors */
-	-df-error-severity-fatal: -df-defold-red;
-	-df-error-severity-fatal-dim: -df-defold-red-dark;
-	-df-error-severity-warning: -df-defold-yellow;
+	-df-error-severity-fatal:       -df-defold-red;
+	-df-error-severity-fatal-dim:   -df-defold-red-dark;
+	-df-error-severity-warning:     -df-defold-yellow;
 	-df-error-severity-warning-dim: -df-defold-yellow-dark;
-	-df-error-severity-info: -df-defold-blue-lighter;
+	-df-error-severity-info:        -df-defold-blue-lighter;
 
 	/* Lua script colors */
 	-df-script-helper:         #33cccc;

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -8,12 +8,12 @@
 
 	// Component
 	-df-component-darker:     #212428;		// button outline, scene view controls panel (original name: dark-grey)
-	-df-component-dark:       #393c41;		// button, input field border (original name: mid-grey)
+	-df-component-dark:       #393c41;		// button, input field border, context menu (original name: mid-grey)
 	-df-component-light:      #45474B;		// button selected, input field border selected (original: mid-grey-light)
 	-df-component-lighter:    #52575c;		// button hovered (original name: grey)
 	-df-component-icon:       #8f9296;		// button icon (original name: bright-grey)
 
-	// Text & icons
+	// Text and icons
 	-df-text-dark:            #848484;		// property components (hardcoded in fxml in original css)
 	-df-text:                 #a2b0be;		// non editable text, input field hint (original name: bright-grey-light)
 	-df-text-light:           #f0f2f6;		// editable text (original name: defold-white)

--- a/editor/styling/stylesheets/base/_palette.scss
+++ b/editor/styling/stylesheets/base/_palette.scss
@@ -1,23 +1,23 @@
 * {
 	// Background
-	-df-background-darker:    derive(#212428, -13%);	// dialog input field background
-	-df-background-dark:      derive(#212428, -6%);
-	-df-background:           #212428;					// background, #212428 (original: dark-grey #212428)
-	-df-background-light:     derive(#212428, 6%);		// panels, input field background, +6%=#c3036 (original: dark-grey-light #2c2e33)
-	-df-background-lighter:   derive(#212428, 13%);		// tree view selection, +13%=#3c4249 (original: dark-grey-selected #3B3F43)
+	-df-background-darker:    derive(#212428, -40%);	// dialog input field background (original name: dark-grey-darker)
+	-df-background:           #212428;					// background (original name: dark-grey)
+	-df-background-light:     #2c2e33;					// panels (original name: dark-grey-light)
+	-df-background-lighter:   #3B3F43;					// tree view selection (original name: dark-grey-selected)
+	-df-background-input:     #292a2f;					// input field background (original name: input-background)
 
 	// Component
-	-df-component-darker:     derive(#52575c, -30%);	// button outline, scene view controls panel, -30%=#222426 (original: dark-grey #212428)
-	-df-component-dark:       derive(#52575c, -15%);	// button, input field border, -15%=#383c3f (original: mid-grey #393c41)
-	-df-component:            #52575c;					// button hovered (original: grey #52575c)
-	-df-component-light:      derive(#52575c, 15%);		// input field border selected, +15%=#697076 (original: mid-grey-light #45474B)
-	-df-component-lighter:    derive(#52575c, 30%);		// button icon, +30%=#828990
+	-df-component-darker:     #212428;		// button outline, scene view controls panel (original name: dark-grey)
+	-df-component-dark:       #393c41;		// button, input field border (original name: mid-grey)
+	-df-component-light:      #45474B;		// button selected, input field border selected (original: mid-grey-light)
+	-df-component-lighter:    #52575c;		// button hovered (original name: grey)
+	-df-component-icon:       #8f9296;		// button icon (original name: bright-grey)
 
 	// Text & icons
-	-df-text-dark:            derive(#a2b0be, -30%);	// property components, -30%=#8698aa (original: #848484)
-	-df-text:                 #a2b0be;					// non editable text, input field hint (original: bright-grey-light #a2b0be)
-	-df-text-light:           derive(#a2b0be, 85%);		// editable text, +85%=#f1f3f5 (original: defold-white #f0f2f6)
-	-df-text-selected:        derive(#a2b0be, 85%);		// non editable selected text (original: defold-white #f0f2f6)
+	-df-text-dark:            #848484;		// property components (hardcoded in fxml in original css)
+	-df-text:                 #a2b0be;		// non editable text, input field hint (original name: bright-grey-light)
+	-df-text-light:           #f0f2f6;		// editable text (original name: defold-white)
+	-df-text-selected:        #f0f2f6;		// non editable selected text (original name: defold-white)
 
 	// Red
 	-df-defold-red-dark:     derive(#e32f44, -10%);

--- a/editor/styling/stylesheets/components/_button.scss
+++ b/editor/styling/stylesheets/components/_button.scss
@@ -9,11 +9,11 @@
   -fx-border-width: 1;
   -fx-text-fill: -df-text;
   &:hover {
-    -fx-background-color: -df-component;
+    -fx-background-color: -df-component-lighter;
     -fx-text-fill: -df-text-selected;
   }
   &:armed {
-    -fx-background-color: -df-component;
+    -fx-background-color: -df-component-light;
     -fx-text-fill: -df-text-selected;
   }
   &.low-prio {
@@ -23,7 +23,7 @@
     -fx-font-weight: normal;
   }
   &.low-prio:hover {
-      -fx-background-color: -df-component-dark;
+      -fx-background-color: -df-component-light;
       -fx-text-fill: -df-text;
   }
   &.low-prio:armed {
@@ -48,7 +48,7 @@
 .clear-button {
   -fx-background-radius: 0;
   -fx-border-radius: 0;
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   -fx-padding: 0;
   -fx-min-width: 27px;
   -fx-max-width: 27px;
@@ -57,10 +57,10 @@
   -fx-border-width: 0;
   -fx-text-fill: -df-text;
   &:hover {
-      -fx-background-color: -df-component !important;
+      -fx-background-color: -df-component-lighter !important;
   }
   &:armed {
-      -fx-background-color: -df-background-light !important;
+      -fx-background-color: -df-component-light !important;
   }
 }
 
@@ -70,29 +70,29 @@
   -fx-padding: 4px;
   -fx-background-insets: 0px;
   -fx-border-insets: 0px;
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   &:hover {
-    -fx-background-color: -df-component-darker;
+    -fx-background-color: -df-component-lighter;
   }
   &:selected {
-    -fx-background-color: -df-background;
+    -fx-background-color: -df-component-light;
     & > .image-view {
       @include effect-lighten-blue()
     }
   }
   &:armed {
-    -fx-background-color: -df-background-light;
+    -fx-background-color: -df-component-light;
   }
 }
 
 .toggle-button,
 .color-picker.split-button > .color-picker-label {
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   -fx-background-insets: 0;
   -fx-background-radius: 4;
   -fx-border-width: 1;
   -fx-border-radius: 4;
-  -fx-border-color: -df-background;
+  -fx-border-color: -df-component-darker;
   -fx-text-fill: -fx-text-base-color;
 }
 

--- a/editor/styling/stylesheets/components/_cljfx-form.scss
+++ b/editor/styling/stylesheets/components/_cljfx-form.scss
@@ -47,8 +47,8 @@
   -fx-border-radius: 2px;
   -fx-padding: 0 0 1px 0;
   -fx-border-color: -df-component-dark;
-  -fx-background-color: -df-background-light;
-  -fx-background-radius: 20px;
+  -fx-background-color: -df-background-input;
+  -fx-background-radius: 0px;
   .list-cell {
     .text-field {
       -fx-border-width: 0;

--- a/editor/styling/stylesheets/components/_cljfx-form.scss
+++ b/editor/styling/stylesheets/components/_cljfx-form.scss
@@ -36,10 +36,10 @@
   -fx-focus-traversable: false;
   -fx-border-width: 0;
   &:hover {
-    -fx-background-color: -df-component !important;
+    -fx-background-color: -df-component-lighter !important;
   }
   &:armed {
-    -fx-background-color: -df-component !important;
+    -fx-background-color: -df-component-light !important;
   }
 }
 
@@ -151,9 +151,9 @@
     -fx-text-fill: -df-text;
     &:active {
       -fx-text-fill: -df-text-selected;
-      -fx-background-color: -df-component;
+      -fx-background-color: -df-component-dark;
       &:hover {
-        -fx-background-color: -df-component;
+        -fx-background-color: -df-component-lighter;
       }
     }
     &:hover {

--- a/editor/styling/stylesheets/components/_color-picker.scss
+++ b/editor/styling/stylesheets/components/_color-picker.scss
@@ -25,7 +25,7 @@
         -fx-border-width: 0;
         -fx-background-insets: 0;
         -fx-padding: 5 7;
-        -fx-background-color: -df-background-lighter;
+        -fx-background-color: -df-component-dark;
         &:hover {
             -fx-background-color: -df-component-darker;
         }

--- a/editor/styling/stylesheets/components/_composite-property-control.scss
+++ b/editor/styling/stylesheets/components/_composite-property-control.scss
@@ -7,18 +7,18 @@
         -fx-background-radius: 0px;
         -fx-border-radius: 0px;
         -fx-background-insets: 0;
-        -fx-background-color: -df-background-lighter;
+        -fx-background-color: -df-component-dark;
         -fx-border-width: 0;
         -fx-padding: 5 4;
         -fx-pref-width: 23;
         -fx-max-width: 24px;
-        -fx-text-fill: -df-text-dark;
+        -fx-text-fill: -df-component-icon;
         &:hover {
-            -fx-background-color: -df-component-darker !important;
+            -fx-background-color: -df-component-lighter !important;
             -fx-border-color: -df-background;
         }
         &:armed, &:pressed {
-            -fx-background-color: -df-background-light !important;
+            -fx-background-color: -df-component-light !important;
         }
     }
 }

--- a/editor/styling/stylesheets/components/_context-menu.scss
+++ b/editor/styling/stylesheets/components/_context-menu.scss
@@ -1,5 +1,5 @@
 .context-menu {
-    -fx-background-color: -df-component-darker;
+    -fx-background-color: -df-component-dark;
     -fx-background-radius: 0px;
     -fx-border-radius: 0px;
     -fx-border-width: 0px;
@@ -7,8 +7,8 @@
 
     .scroll-arrow {
         .menu-down-arrow, .menu-up-arrow {
-            -fx-fill: -df-component-darker;
-            -fx-background-color: -df-component-darker;
+            -fx-fill: -df-component-icon;
+            -fx-background-color: -df-component-icon;
         }
     }
 

--- a/editor/styling/stylesheets/components/_notification.scss
+++ b/editor/styling/stylesheets/components/_notification.scss
@@ -15,7 +15,7 @@
   }
   &-close-button {
     -fx-shape: "M 0,0 H1 L 4,3 7,0 H8 V1 L 5,4 8,7 V8 H7 L 4,5 1,8 H0 V7 L 3,4 0,1 Z";
-    -fx-background-color: -df-text-darker;
+    -fx-background-color: -df-text;
     -fx-effect: none;
     &:hover {
       -fx-background-color: -df-text-selected;

--- a/editor/styling/stylesheets/components/_notification.scss
+++ b/editor/styling/stylesheets/components/_notification.scss
@@ -4,13 +4,13 @@
     -fx-border-width: 1px 1px 1px 2px;
     -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.3), 12, 0, 0, 8);
     &:warning {
-      -fx-border-color: -df-component -df-component -df-component -df-error-severity-warning;
+      -fx-border-color: -df-component-lighter -df-component-lighter -df-component-lighter -df-error-severity-warning;
     }
     &:error {
-      -fx-border-color: -df-component -df-component -df-component -df-error-severity-fatal;
+      -fx-border-color: -df-component-lighter -df-component-lighter -df-component-lighter -df-error-severity-fatal;
     }
     &:info {
-      -fx-border-color: -df-component -df-component -df-component -df-error-severity-info;
+      -fx-border-color: -df-component-lighter -df-component-lighter -df-component-lighter -df-error-severity-info;
     }
   }
   &-close-button {
@@ -22,10 +22,10 @@
     }
   }
   &-button {
-    -fx-background-color: -df-component-light;
+    -fx-background-color: -df-component-dark;
     -fx-border-color: -df-component-darker;
     &:hover {
-      -fx-background-color: -df-component-lighter;
+      -fx-background-color: -df-component-light;
     }
   }
 }

--- a/editor/styling/stylesheets/components/_progress-indicator.scss
+++ b/editor/styling/stylesheets/components/_progress-indicator.scss
@@ -1,3 +1,3 @@
 .progress-indicator {
-    -fx-progress-color: -df-component;
+    -fx-progress-color: -df-component-lighter;
 }

--- a/editor/styling/stylesheets/components/_property.scss
+++ b/editor/styling/stylesheets/components/_property.scss
@@ -12,7 +12,7 @@
     -fx-padding: 0;
     .label {
         -fx-padding: 0 4px 0 4px;
-        -fx-text-fill: -df-text;
+        -fx-text-fill: -df-text-dark;
         -fx-alignment: center;
     }
     .text-field {

--- a/editor/styling/stylesheets/components/_slider.scss
+++ b/editor/styling/stylesheets/components/_slider.scss
@@ -1,11 +1,11 @@
 .slider {
     .track {
-        -fx-background-color: -df-background-light;
+        -fx-background-color: -df-component-darker;
         -fx-border-color: -df-component-dark;
         -fx-border-width: 1px;
     }
     .thumb {
-        -fx-background-color: -df-component;
+        -fx-background-color: -df-component-dark;
         &:pressed, &:hover {
             -fx-background-color: -df-component-lighter;
         }

--- a/editor/styling/stylesheets/components/_tab.scss
+++ b/editor/styling/stylesheets/components/_tab.scss
@@ -49,7 +49,7 @@
 
     &.inactive .tab {
         &:selected {
-            -fx-border-color: -df-component;
+            -fx-border-color: -df-component-lighter;
         }
     }
 }

--- a/editor/styling/stylesheets/components/_text-area.scss
+++ b/editor/styling/stylesheets/components/_text-area.scss
@@ -49,7 +49,7 @@
         -fx-padding: 4px 8px;
         -fx-cursor: text;
         -fx-background-radius: 0;
-        -fx-background-color: -df-background-light;
+        -fx-background-color: -df-background-input;
     }
 
     &:hover {

--- a/editor/styling/stylesheets/components/_text-field.scss
+++ b/editor/styling/stylesheets/components/_text-field.scss
@@ -3,7 +3,7 @@
     -fx-background-radius: 0px;
     -fx-border-radius: 0px;
     -fx-padding: 4px 8px;
-    -fx-background-color: -df-background-light;
+    -fx-background-color: -df-background-input;
     -fx-border-width: 1px 1px 1px 1px;
     -fx-border-color: -df-component-dark;
     -fx-text-fill: -df-text-light;
@@ -31,7 +31,7 @@
             -fx-background-color: -df-background-light;
             -fx-border-width: 1px 1px 1px 1px;
             -fx-border-color: -df-component-dark;
-            -fx-text-fill: -df-text;
+            -fx-text-fill: -df-text-light;
             -fx-prompt-text-fill: -df-text;
             -fx-min-height: 26px;
         }

--- a/editor/styling/stylesheets/components/_text-field.scss
+++ b/editor/styling/stylesheets/components/_text-field.scss
@@ -6,8 +6,8 @@
     -fx-background-color: -df-background-light;
     -fx-border-width: 1px 1px 1px 1px;
     -fx-border-color: -df-component-dark;
-    -fx-text-fill: -df-text;
-    -fx-prompt-text-fill: -df-text-dark;
+    -fx-text-fill: -df-text-light;
+    -fx-prompt-text-fill: -df-text;
     -fx-min-height: 26px;
     &:hover {
         -fx-border-color: -df-component-light;
@@ -18,7 +18,7 @@
         -fx-border-insets: 0px 0px 0px 0px;
         -fx-padding: 4px 8px 3px 8px;
         -fx-border-color: -df-component-light -df-component-light -df-defold-orange -df-component-light;
-        -fx-text-fill: -df-text;
+        -fx-text-fill: -df-text-light;
         -fx-border-radius: 0;
     }
     &:readonly {

--- a/editor/styling/stylesheets/mixins/_menu-elements.scss
+++ b/editor/styling/stylesheets/mixins/_menu-elements.scss
@@ -2,7 +2,7 @@
     .menu-item {
         -fx-border-width: 0;
         -fx-background-radius: 0;
-        -fx-background-color: -df-component-darker;
+        -fx-background-color: -df-component-dark;
         > .label {
             -fx-text-fill: -df-text;
         }
@@ -12,7 +12,7 @@
 
         &:disabled {
             -fx-opacity: 0.4;
-            -fx-background-color: -df-component-darker !important;
+            -fx-background-color: -df-component-dark !important;
             > .label {
                 -fx-opacity: 1.0;
                 -fx-text-fill: -df-text !important;
@@ -23,7 +23,7 @@
         }
 
         &:focused {
-            -fx-background-color: -df-component-dark;
+            -fx-background-color: -df-component-lighter;
             > .label {
                 -fx-text-fill: -df-text-selected;
             }

--- a/editor/styling/stylesheets/mixins/_menu-elements.scss
+++ b/editor/styling/stylesheets/mixins/_menu-elements.scss
@@ -42,7 +42,7 @@
             -fx-min-height: 0;
             -fx-background-color: transparent;
             .line {
-                -fx-border-color: -df-component-dark;
+                -fx-border-color: -df-background-light;
                 -fx-border-insets: 0;
                 -fx-border-width: 1 0 0 0;
             }

--- a/editor/styling/stylesheets/modules/_breakpoint-editor.scss
+++ b/editor/styling/stylesheets/modules/_breakpoint-editor.scss
@@ -9,7 +9,7 @@
   }
   &-background {
     -fx-background-color: -df-component-dark;
-    -fx-border-color: -df-component;
+    -fx-border-color: -df-component-lighter;
     -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.3), 12, 0, 0, 8);
   }
   &-content {
@@ -19,10 +19,10 @@
   &-arrow {
     -fx-shape: "M 1,0 L 0,-1 L 0,0";
     -fx-background-color: -df-component-dark;
-    -fx-border-color: -df-component;
+    -fx-border-color: -df-component-lighter;
   }
   &-button {
-    -fx-background-color: -df-component-light;
+    -fx-background-color: -df-component-dark;
     -fx-border-color: -df-component-darker;
     &:hover {
       -fx-background-color: -df-component-lighter;

--- a/editor/styling/stylesheets/modules/_console.scss
+++ b/editor/styling/stylesheets/modules/_console.scss
@@ -7,17 +7,17 @@
   -fx-padding: 0px 10px;
 
   &:hover {
-    -fx-background-color: -df-component-darker;
+    -fx-background-color: -df-component-lighter;
   }
 
   &:armed {
-    -fx-background-color: -df-background-light;
+    -fx-background-color: -df-component-light;
   }
 }
 
 .console-image-button-base {
   @extend .console-button-base;
-  -fx-background-color: -df-background-lighter;
+  -fx-background-color: -df-component-dark;
   -fx-background-position: center;
   -fx-background-repeat: no-repeat;
   -fx-background-size: 16 16;
@@ -69,7 +69,7 @@
       -fx-min-height: 6px;
       -fx-max-height: 6px;
       -fx-effect: none;
-      -fx-background-color: -df-component-lighter;
+      -fx-background-color: -df-component-icon;
       -fx-shape: "M 0 0 h 7 l -3.5 4 z";
       &:open {
         -fx-background-color: -df-text;
@@ -222,8 +222,8 @@
 }
 
 #debugger-prompt-field {
-  -fx-background-color: -df-background-light;
-  -fx-border-color: -df-background-lighter;
+  -fx-background-color: -df-background-input;
+  -fx-border-color: -df-component-dark;
   -fx-border-width: 1px 0px 0px 0px;
   -fx-font-family: $default-font-mono;
   -fx-font-size: 90%;
@@ -233,11 +233,11 @@
   -fx-text-fill: -df-text;
 
   &:focused {
-    -fx-background-color: -df-background-light;
-    -fx-border-color: -df-background-lighter;
+    -fx-background-color: -df-background-input;
+    -fx-border-color: -df-component-dark;
     -fx-border-width: 1px 0px 0px 0px;
     -fx-padding: 0px;
-    -fx-text-fill: -df-text-selected;
+    -fx-text-fill: -df-text-light;
     -fx-prompt-text-fill: transparent;
   }
 }

--- a/editor/styling/stylesheets/modules/_debugger.scss
+++ b/editor/styling/stylesheets/modules/_debugger.scss
@@ -21,7 +21,7 @@
       }
       .call-stack-line {
         -fx-padding: 0 3px;
-        -fx-background-color: -df-component;
+        -fx-background-color: -df-component-lighter;
         -fx-background-radius: 3px;
       }
       &:hover {

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -101,13 +101,13 @@
     .separator {
         &:horizontal {
             .line {
-                -fx-border-color: -df-component;
+                -fx-border-color: -df-component-lighter;
             }
         }
 
         &:vertical {
             .line {
-                -fx-border-color: -df-component;
+                -fx-border-color: -df-component-lighter;
             }
         }
     }

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -6,7 +6,7 @@
 }
 
 #toolbar {
-    -fx-background-color: -df-component-darker;
+    -fx-background-color: -df-component-dark;
     -fx-border-width: 0;
     -fx-border-insets: 0;
     -fx-background-insets: 0;

--- a/editor/styling/stylesheets/modules/_toolbar.scss
+++ b/editor/styling/stylesheets/modules/_toolbar.scss
@@ -65,14 +65,14 @@
     }
 
     .visibility-toggles-list {
-        -fx-background-color: -df-component-darker;
+        -fx-background-color: -df-component-dark;
         -fx-background-radius: 4px;
         -fx-padding: 0px 0px 7px 0px;
 
         > .first-entry {
             -fx-background-radius: 4px 4px 0px 0px;
             -fx-padding: 10px 8px 10px 8px;
-            -fx-background-color: -df-component-darker;
+            -fx-background-color: -df-component-dark;
         }
 
         > HBox {
@@ -81,7 +81,7 @@
 
         > Separator {
             -fx-padding: 7px 0px;
-            -fx-background-color: -df-component-darker;
+            -fx-background-color: -df-component-dark;
         }
     }
 

--- a/editor/styling/stylesheets/modules/_welcome-dialog.scss
+++ b/editor/styling/stylesheets/modules/_welcome-dialog.scss
@@ -1,5 +1,5 @@
 #welcome-dialog {
-  -fx-background-color: -df-background-light;
+  -fx-background-color: -df-background;
 
   HBox, VBox {
     -fx-spacing: 0; // Fight crazy non-zero default.
@@ -60,7 +60,7 @@
   }
 
   #left-pane {
-    -fx-background-color: -df-background;
+    -fx-background-color: -df-background-darker;
 
     .defold-logo {
       -fx-padding: 16px;
@@ -158,7 +158,7 @@
   }
 
   .form-pane {
-    -fx-background-color: -df-background-lighter;
+    -fx-background-color: -df-background-light;
     -fx-padding: 24px;
     -fx-spacing: 16px;
 
@@ -259,7 +259,7 @@
   }
 
   .template-entry {
-    -fx-background-color: -df-component-darker;
+    -fx-background-color: -df-component-dark;
     -fx-background-radius: 2px;
     -fx-border-width: 1px;
     -fx-border-color: transparent;
@@ -364,20 +364,20 @@
     Button {
       -fx-border-width: 0px;
       -fx-background-radius: 0px 2px 2px 0px;
-      -fx-background-color: -df-background-lighter;
+      -fx-background-color: -df-component-dark;
       -fx-min-width: 30px;
       -fx-padding: 0px;
       -fx-font-size: 90%;
 
       &:hover {
-        -fx-background-color: -df-component-light;
+        -fx-background-color: -df-component-lighter;
       }
     }
 
     .path-field {
       -fx-alignment: center-left;
       -fx-background-color: transparent;
-      -fx-border-color: -df-background-lighter;
+      -fx-border-color: -df-component-dark;
       -fx-border-width: 1px 0px 1px 1px;
       -fx-padding: 4px 8px;
     }


### PR DESCRIPTION
The editor color palette has been reverted back to what it looked like a few years ago with a higher contrast between text and other ui elements and the background.

Fixes #8384

LEFT = CURRENT LOW CONTRAST PALETTE, RIGHT = UPDATED HIGH CONTRAST PALETTE IN THIS PR

<img width="1512" alt="Screenshot 2024-04-26 at 09 15 19" src="https://github.com/defold/defold/assets/1300688/bdba002b-0b76-411d-a4ec-68a3115d2379">
<img width="1512" alt="Screenshot 2024-04-26 at 09 14 18" src="https://github.com/defold/defold/assets/1300688/6c1cfd41-c9e9-41e6-826d-866fb4954b1c">
<img width="1512" alt="Screenshot 2024-04-26 at 09 13 46" src="https://github.com/defold/defold/assets/1300688/26bbb84f-a797-41b4-a486-f112f95021f3">
<img width="1512" alt="Screenshot 2024-04-26 at 08 17 15" src="https://github.com/defold/defold/assets/1300688/9b055830-3402-42b5-865f-de3443d4f5db">
<img width="1512" alt="Screenshot 2024-04-26 at 08 19 20" src="https://github.com/defold/defold/assets/1300688/bed3fc38-ca26-4e07-a208-88ef91d7171f">
<img width="1512" alt="Screenshot 2024-04-26 at 09 40 47" src="https://github.com/defold/defold/assets/1300688/8c9a7e32-470c-4607-ae7f-a1d5e0eaadd6">
<img width="1512" alt="Screenshot 2024-04-26 at 09 40 35" src="https://github.com/defold/defold/assets/1300688/36d2e570-22c9-4beb-8b65-11a1807e79cb">

I was unable to build an editor from 2020, but there's a bunch of reference images in the documentation from that time:

https://github.com/defold/doc/tree/ce0109027b77aea1f05485b09e6e39bd1c98aa4e/docs/en/manuals/images
