### PR TITLE
Add a new option in `game.project`: `liveupdate.mount_on_start`, which disables auto-mounts at the start of the game.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -701,6 +701,10 @@ enabled.type = bool
 enabled.help = enables the use of live update
 enabled.default = 1
 
+mount_on_start.type = bool
+mount_on_start.help = enables auto-mount of previously mounted resources when the application starts
+mount_on_start.default = 1
+
 [tilemap]
 help = Tilemap related settings
 max_count.type = integer

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -861,6 +861,11 @@
    :help "liveupdate settings"
    :preserve-extension true,
    :path ["liveupdate" "settings"]}
+   {:type :boolean
+   :filter "settings"
+   :default true
+   :help "enables auto-mount of previously mounted resources when the application starts"
+   :path ["liveupdate" "mount_on_start"]}
   {:type :integer,
    :help "max number of concurrent tilemaps in a collection",
    :default 16,

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -32,7 +32,7 @@
 (def ^:private docs
   ["base" "bit" "buffer" "b2d" "b2d.body" "builtins" "camera" "collectionfactory"
    "collectionproxy" "coroutine" "crash" "debug" "factory" "go" "gui"
-   "html5" "http" "image" "io" "json" "label" "math" "model" "msg"
+   "html5" "http" "image" "io" "json" "label" "liveupdate" "math" "model" "msg"
    "os" "package" "particlefx" "physics" "profiler" "render" "resource"
    "socket" "sound" "sprite" "string" "sys" "table" "tilemap" "timer" "vmath"
    "window" "zlib"])

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -241,6 +241,7 @@ include_dirs = library
 
 [liveupdate]
 settings = /liveupdate.settings
+mount_on_start = 0
 
 [native_extension]
 app_manifest = /checked.appmanifest

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -946,7 +946,7 @@ namespace dmEngine
         int32_t liveupdate_mount_on_start = dmConfigFile::GetInt(engine->m_Config, "liveupdate.mount_on_start", 1);
         if (liveupdate_enable && liveupdate_mount_on_start)
         {
-            params.m_Flags |= RESOURCE_FACTORY_FLAGS_LIVE_UPDATE;
+            params.m_Flags |= RESOURCE_FACTORY_FLAGS_LIVE_UPDATE_MOUNTS_ON_START;
         }
 
 #if !defined(DM_RELEASE)

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -943,7 +943,8 @@ namespace dmEngine
         }
 
         int32_t liveupdate_enable = dmConfigFile::GetInt(engine->m_Config, "liveupdate.enabled", 1);
-        if (liveupdate_enable)
+        int32_t liveupdate_mount_on_start = dmConfigFile::GetInt(engine->m_Config, "liveupdate.mount_on_start", 1);
+        if (liveupdate_enable && liveupdate_mount_on_start)
         {
             params.m_Flags |= RESOURCE_FACTORY_FLAGS_LIVE_UPDATE;
         }

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -312,7 +312,7 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
 
     if (factory->m_BaseArchiveMount)
     {
-        if (params->m_Flags & RESOURCE_FACTORY_FLAGS_LIVE_UPDATE)
+        if (params->m_Flags & RESOURCE_FACTORY_FLAGS_LIVE_UPDATE_MOUNTS_ON_START)
         {
             dmResource::HManifest manifest;
             if (dmResourceProvider::RESULT_OK == dmResourceProvider::GetManifest(factory->m_BaseArchiveMount, &manifest))

--- a/engine/resource/src/resource.cpp
+++ b/engine/resource/src/resource.cpp
@@ -326,7 +326,7 @@ HFactory NewFactory(NewFactoryParams* params, const char* uri)
         }
         else
         {
-            dmLogInfo("Resource mounts support disabled.");
+            dmLogInfo("LiveUpdate resource mounts disabled.");
         }
     }
 

--- a/engine/resource/src/resource.h
+++ b/engine/resource/src/resource.h
@@ -70,7 +70,7 @@ namespace dmResource
     /**
      * Enable Live update
      */
-    #define RESOURCE_FACTORY_FLAGS_LIVE_UPDATE    (1 << 3)
+    #define RESOURCE_FACTORY_FLAGS_LIVE_UPDATE_MOUNTS_ON_START    (1 << 3)
 
     typedef uintptr_t ResourceType;
     typedef dmArray<char> LoadBufferType;


### PR DESCRIPTION
In some cases, it might be useful to fully control from the code what exactly needs to be mounted instead of using auto-mount at the start of the application. Now, this is possible to do using the `liveupdate.mount_on_start` checkbox in `game.project`.

Fix https://github.com/defold/defold/issues/8847

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
