### PR TITLE
[Web] Fix sound play while AudioContext is suspended

### DIFF
--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -58,6 +58,9 @@ var LibrarySoundDevice =
                     var len = sample_count / this.sampleRate;
                     // use real buffer length next time.
                     this.bufferDuration = len;
+                    // only append overall length of audio buffer in suspended stay
+                    // it helps prevent sound instance consume on the engine side
+                    // because from engine point of view - sound plays.
                     if (!this._isContextRunning()) {
                         this.suspendedBufferedTo += len;
                         return;
@@ -89,6 +92,10 @@ var LibrarySoundDevice =
                             return 1;
                         ahead = this.bufferedTo - shared.audioCtx.currentTime;
                     } else {
+                        // if audio context in suspended or closed state we simulate audio play
+                        // by calculating play time
+                        // when audio context become active - start filling audio buffer from the beginning
+                        // and start using audioCtx.currentTime
                         ahead = this.suspendedBufferedTo - this._getCurrentSuspendedTime();
                     }
                     var inqueue = Math.ceil(ahead / this.bufferDuration);

--- a/engine/sound/src/js/library_sound.js
+++ b/engine/sound/src/js/library_sound.js
@@ -19,7 +19,7 @@ var LibrarySoundDevice =
             };
             window._dmJSDeviceShared = shared;
         }
-        
+
         var id = shared.count++;
         var device;
 
@@ -39,8 +39,29 @@ var LibrarySoundDevice =
                 sampleRate: shared.audioCtx.sampleRate,
                 bufferedTo: 0,
                 bufferDuration: 0,
+                creatingTime: Date.now() / 1000,
+                lastTimeInSuspendedState: Date.now() / 1000,
+                suspendedBufferedTo: 0,
                 // functions
+                _isContextRunning: function() {
+                    var audioCtx = window._dmJSDeviceShared.audioCtx;
+                    return audioCtx !== undefined && audioCtx.state == "running"
+                },
+                _getCurrentSuspendedTime: function() {
+                    if (!this._isContextRunning()) {
+                        this.lastTimeInSuspendedState = Date.now() / 1000;
+                        return this.lastTimeInSuspendedState - this.creatingTime;
+                    }
+                    return 0;
+                },
                 _queue: function(samples, sample_count) {
+                    var len = sample_count / this.sampleRate;
+                    // use real buffer length next time.
+                    this.bufferDuration = len;
+                    if (!this._isContextRunning()) {
+                        this.suspendedBufferedTo += len;
+                        return;
+                    }
                     var buf = shared.audioCtx.createBuffer(2, sample_count, this.sampleRate);
                     var c0 = buf.getChannelData(0);
                     var c1 = buf.getChannelData(1);
@@ -51,7 +72,6 @@ var LibrarySoundDevice =
                     var source = shared.audioCtx.createBufferSource();
                     source.buffer = buf;
                     source.connect(shared.audioCtx.destination);
-                    var len = sample_count / this.sampleRate;
                     var t = shared.audioCtx.currentTime;
                     if (this.bufferedTo <= t) {
                         source.start(t);
@@ -60,14 +80,17 @@ var LibrarySoundDevice =
                         source.start(this.bufferedTo);
                         this.bufferedTo = this.bufferedTo + len;
                     }
-                    // use real buffer length next time.
-                    this.bufferDuration = len;
                 },
                 _freeBufferSlots: function() {
-                    // before knowing the length of each buffer.
-                    if (this.bufferDuration == 0)
-                        return 1;
-                    var ahead = this.bufferedTo - shared.audioCtx.currentTime;
+                    var ahead = 0;
+                    if (this._isContextRunning()) {
+                        // before knowing the length of each buffer.
+                        if (this.bufferDuration == 0)
+                            return 1;
+                        ahead = this.bufferedTo - shared.audioCtx.currentTime;
+                    } else {
+                        ahead = this.suspendedBufferedTo - this._getCurrentSuspendedTime();
+                    }
                     var inqueue = Math.ceil(ahead / this.bufferDuration);
                     if (inqueue < 0) {
                         inqueue = 0;
@@ -82,6 +105,16 @@ var LibrarySoundDevice =
         }
         
         if (device != null) {
+            shared.audioCtx.onstatechanged = function() {
+                if (device._isContextRunning()) {
+                    device.timeInSuspendedState = Date.now() / 1000;
+                } else {
+                    // reset all counters for suspended or closed state
+                    device.creatingTime = Date.now() / 1000;
+                    device.lastTimeInSuspendedState = Date.now() / 1000;
+                    device.suspendedBufferedTo = 0;
+                }
+            };
             shared.devices[id] = device;
             return id;
         } 


### PR DESCRIPTION
Fixes #8238 

### Technical changes
If AudioContext is suspended we calculate play offset but don't create audio buffers and audio sources on JS side.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
