### PR TITLE
Fixed crash when sprite material uses N samplers but shaders uses less than N samplers.

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -259,11 +259,6 @@ namespace dmGameSystem
         return result;
     }
 
-    void CreateOverrides(SpriteComponent* component)
-    {
-        component->m_Overrides = new SpriteResourceOverrides;
-    }
-
     void DeleteOverrides(dmResource::HFactory factory, SpriteComponent* component)
     {
         SpriteResourceOverrides* overrides = component->m_Overrides;
@@ -417,7 +412,7 @@ namespace dmGameSystem
     static inline TextureSetResource* GetTextureSet(const SpriteComponent* component, uint32_t index) {
         const SpriteResourceOverrides* overrides = component->m_Overrides;
         const SpriteTexture* texture = 0;
-        if (overrides && !overrides->m_Textures.Empty())
+        if (overrides && index < overrides->m_Textures.Size())
             texture = &overrides->m_Textures[index];
         if (!texture || !texture->m_TextureSet)
             texture = &component->m_Resource->m_Textures[index];
@@ -435,7 +430,7 @@ namespace dmGameSystem
             return 0;
 
         const SpriteResourceOverrides* overrides = component->m_Overrides;
-        if (overrides)
+        if (overrides && texture_unit < overrides->m_Textures.Size())
         {
             if (overrides->m_Textures[texture_unit].m_TextureSet)
                 return overrides->m_Textures[texture_unit].m_TextureSet->m_Texture;


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/8842

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
