### PR TITLE
Support building a mesh without any samplers assigned

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MeshBuilder.java
@@ -49,6 +49,11 @@ public class MeshBuilder extends Builder<Void> {
         taskBuilder.addInput(res);
 
         for (String t : meshDescBuilder.getTexturesList()) {
+            // Same as models
+            // This check is based on the material samplers only, but should we check if the material actually needs textures?
+            if (t.isEmpty())
+                continue;
+
             res = BuilderUtil.checkResource(this.project, input, "texture", t);
             taskBuilder.addInput(res);
             Task<?> embedTask = this.project.createTask(res);
@@ -78,6 +83,8 @@ public class MeshBuilder extends Builder<Void> {
 
         List<String> newTextureList = new ArrayList<String>();
         for (String t : meshDescBuilder.getTexturesList()) {
+            if (t.isEmpty())
+                continue;
             BuilderUtil.checkResource(this.project, resource, "texture", t);
             newTextureList.add(ProtoBuilders.replaceTextureName(t));
         }


### PR DESCRIPTION
Bob can now bundle projects with meshes that have no textures specified.

Fixes #8735 