### PR TITLE
Changing from a material with an overridden vertex attribute causes an assert

### DIFF
--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -153,7 +153,6 @@
 
 (defn resize-doubles [double-values semantic-type ^long new-element-count]
   {:pre [(vector? double-values)
-         (keyword? semantic-type)
          (nat-int? new-element-count)]}
   (let [old-element-count (count double-values)]
     (cond

--- a/editor/src/clj/editor/graphics.clj
+++ b/editor/src/clj/editor/graphics.clj
@@ -153,6 +153,7 @@
 
 (defn resize-doubles [double-values semantic-type ^long new-element-count]
   {:pre [(vector? double-values)
+         (or (nil? semantic-type) (keyword? semantic-type))
          (nat-int? new-element-count)]}
   (let [old-element-count (count double-values)]
     (cond


### PR DESCRIPTION
Fixed an issue where a component has an overridden vertex attribute and the user changes the material where the attribute doesn't exist. In this case the editor triggers an assert which leaves the editor in a bad state.

Fixes #8869 