### PR TITLE
Fixed an issue where font metrics were incorrect for monospaced fonts.

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -752,6 +752,7 @@ public class Fontc {
             }
         }
         glyphBankBuilder.setIsMonospaced(is_monospaced);
+        glyphBankBuilder.setAaPadding(padding);
         return previewImage;
 
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -746,7 +746,10 @@ public class Fontc {
             }
 
             glyphBankBuilder.addGlyphs(glyphBuilder);
-            is_monospaced &= base_advance == glyph.advance;
+            if (base_advance != glyph.advance)
+            {
+                is_monospaced = false;
+            }
         }
         glyphBankBuilder.setIsMonospaced(is_monospaced);
         return previewImage;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -752,7 +752,7 @@ public class Fontc {
             }
         }
         glyphBankBuilder.setIsMonospaced(is_monospaced);
-        glyphBankBuilder.setAaPadding(padding);
+        glyphBankBuilder.setPadding(padding);
         return previewImage;
 
     }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -725,7 +725,8 @@ public class Fontc {
                 throw new FontFormatException("Could not generate font preview: " + e.getMessage());
             }
         }
-
+        boolean is_monospaced = true;
+        float base_advance = include_glyph_count > 0 ? glyphs.get(0).advance : 0;
         for (int i = 0; i < include_glyph_count; i++) {
             Glyph glyph = glyphs.get(i);
             GlyphBank.Glyph.Builder glyphBuilder = GlyphBank.Glyph.newBuilder()
@@ -745,8 +746,9 @@ public class Fontc {
             }
 
             glyphBankBuilder.addGlyphs(glyphBuilder);
+            is_monospaced &= base_advance == glyph.advance;
         }
-
+        glyphBankBuilder.setIsMonospaced(is_monospaced);
         return previewImage;
 
     }

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -162,7 +162,7 @@
       :defold)
     :distance-field))
 
-(defn- measure-line [is-monospaced glyphs text-tracking ^String line]
+(defn- measure-line [is-monospaced padding glyphs text-tracking ^String line]
   (let [w (transduce (comp
                        (map #(:advance (glyphs (int %)) 0.0))
                        (interpose text-tracking))
@@ -170,11 +170,11 @@
                      0.0
                      line)
         len (.length line)]
-    (if (not is-monospaced)
+    (if is-monospaced
+      (+ w padding)
       (if-let [last (get glyphs (and (pos? len) (int (.charAt line (dec len)))))]
         (- (+ w (:left-bearing last) (:width last)) (:advance last))
-        w)
-      w)))
+        w))))
 
 (defn- split-text [glyphs ^String text line-break? max-width text-tracking]
   (if line-break?
@@ -276,7 +276,7 @@
            line-height (+ (:max-descent font-map) (:max-ascent font-map))
            text-tracking (* line-height text-tracking)
            lines (split-text glyphs text line-break? max-width text-tracking)
-           line-widths (map (partial measure-line (:is-monospaced font-map) glyphs text-tracking) lines)
+           line-widths (map (partial measure-line (:is-monospaced font-map) (:padding font-map) glyphs text-tracking) lines)
            max-width (reduce max 0 line-widths)]
        [max-width (* line-height (+ 1 (* text-leading (dec (count lines)))))]))))
 
@@ -303,7 +303,7 @@
             line-height (+ (:max-descent font-map) (:max-ascent font-map))
             text-tracking (* line-height text-tracking)
             lines (split-text glyphs text line-break? max-width text-tracking)
-            line-widths (mapv (partial measure-line (:is-monospaced font-map) glyphs text-tracking) lines)
+            line-widths (mapv (partial measure-line (:is-monospaced font-map) (:padding font-map) glyphs text-tracking) lines)
             max-width (reduce max 0 line-widths)]
         (assoc text-layout
                :width max-width
@@ -406,14 +406,20 @@
         face-mask (if layer-mask-enabled
                     [1 0 0]
                     [1 1 1])
-        shadow-offset {:x (:shadow-x font-map), :y (:shadow-y font-map)}
+        shadow-offset {:x (if (:is-monospaced font-map)
+                                               (- (:shadow-x font-map) (* (:padding font-map) 0.5))
+                                               (:shadow-x font-map))
+                       :y (:shadow-y font-map)}
         alpha (:alpha font-map)
         outline-alpha (:outline-alpha font-map)
-        shadow-alpha (:shadow-alpha font-map)]
-    ;; Output glyphs per layer in back to front, if enabled but always output face layer.
+        shadow-alpha (:shadow-alpha font-map)
+        font-offset {:x (if (:is-monospaced font-map)
+                           (- 0 (* (:padding font-map) 0.5))
+                           0)
+                     :y 0}]
     (when (and layer-mask-enabled shadow-enabled) (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn [0 0 1] shadow-offset alpha outline-alpha shadow-alpha))
-    (when (and layer-mask-enabled outline-enabled) (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn [0 1 0] nil alpha outline-alpha shadow-alpha))
-    (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn face-mask nil alpha outline-alpha shadow-alpha)))
+    (when (and layer-mask-enabled outline-enabled) (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn [0 1 0] font-offset alpha outline-alpha shadow-alpha))
+    (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn face-mask font-offset alpha outline-alpha shadow-alpha)))
 
 (defn gen-vertex-buffer
   [^GL2 gl {:keys [type font-map] :as font-data} text-entries]

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -414,8 +414,8 @@
         outline-alpha (:outline-alpha font-map)
         shadow-alpha (:shadow-alpha font-map)
         font-offset {:x (if (:is-monospaced font-map)
-                           (- 0 (* (:padding font-map) 0.5))
-                           0)
+                          (- 0 (* (:padding font-map) 0.5))
+                          0)
                      :y 0}]
     (when (and layer-mask-enabled shadow-enabled) (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn [0 0 1] shadow-offset alpha outline-alpha shadow-alpha))
     (when (and layer-mask-enabled outline-enabled) (fill-vertex-buffer-quads vbuf text-entries put-pos-uv-fn line-height char->glyph glyph-cache put-glyph-quad-fn [0 1 0] font-offset alpha outline-alpha shadow-alpha))

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -407,8 +407,8 @@
                     [1 0 0]
                     [1 1 1])
         shadow-offset {:x (if (:is-monospaced font-map)
-                                               (- (:shadow-x font-map) (* (:padding font-map) 0.5))
-                                               (:shadow-x font-map))
+                            (- (:shadow-x font-map) (* (:padding font-map) 0.5))
+                            (:shadow-x font-map))
                        :y (:shadow-y font-map)}
         alpha (:alpha font-map)
         outline-alpha (:outline-alpha font-map)

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -233,7 +233,8 @@
        :cache-cell-max-ascent max-ascent
        :glyph-channels channel-count
        :glyph-data (ByteString/copyFrom glyph-data-bank)
-       :is-monospaced is-monospaced})))
+       :is-monospaced is-monospaced
+       :padding padding})))
 
 (defn- do-blend-rasters [^Raster src ^Raster dst-in ^WritableRaster dst-out]
   (let [width (min (.getWidth src) (.getWidth dst-in) (.getWidth dst-out))
@@ -504,7 +505,8 @@
      :alpha (:alpha font-desc)
      :outline-alpha (:outline-alpha font-desc)
      :shadow-alpha (:shadow-alpha font-desc)
-     :is-monospaced is-monospaced}))
+     :is-monospaced is-monospaced
+     :padding padding}))
 
 (defn- calculate-ttf-distance-field-edge-limit [^double width ^double spread ^double edge]
   (let [sdf-limit-value (- (/ width spread))]
@@ -697,7 +699,8 @@
      :alpha (:alpha font-desc)
      :outline-alpha (:outline-alpha font-desc)
      :shadow-alpha (:shadow-alpha font-desc)
-     :is-monospaced is-monospaced}))
+     :is-monospaced is-monospaced
+     :padding padding}))
 
 (defn compile-font [font-desc font-resource resolver]
   (let [font-ext (resource/type-ext font-resource)]

--- a/editor/src/clj/editor/pipeline/fontc.clj
+++ b/editor/src/clj/editor/pipeline/fontc.clj
@@ -148,6 +148,12 @@
 (defn- make-glyph-data-bank ^bytes [glyph-extents]
   (byte-array (transduce (map :glyph-data-size) + 0 glyph-extents)))
 
+(defn check-monospaced [semi-glyphs]
+  (let [base-advance (if-let [first-glyph (first semi-glyphs)]
+                       (:advance first-glyph)
+                       0)]
+    (every? #(= base-advance (:advance %)) semi-glyphs)))
+
 (def ^:private positive-glyph-extent-pairs-xf (comp (map pair) (filter (comp positive-wh? :glyph-wh second))))
 
 (defn- compile-fnt-bitmap [font-desc font-resource resolver]
@@ -173,7 +179,8 @@
         line-height (+ cache-cell-max-ascent cache-cell-max-descent)
         cache-cell-wh (max-glyph-cell-wh glyph-extents line-height padding glyph-cell-padding)
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
-        glyph-data-bank (make-glyph-data-bank glyph-extents)]
+        glyph-data-bank (make-glyph-data-bank glyph-extents)
+        is-monospaced (check-monospaced semi-glyphs)]
 
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
@@ -225,7 +232,8 @@
        :cache-cell-height (:height cache-cell-wh)
        :cache-cell-max-ascent max-ascent
        :glyph-channels channel-count
-       :glyph-data (ByteString/copyFrom glyph-data-bank)})))
+       :glyph-data (ByteString/copyFrom glyph-data-bank)
+       :is-monospaced is-monospaced})))
 
 (defn- do-blend-rasters [^Raster src ^Raster dst-in ^WritableRaster dst-out]
   (let [width (min (.getWidth src) (.getWidth dst-in) (.getWidth dst-out))
@@ -438,7 +446,8 @@
                               (update :width #(* (int (Math/ceil (/ ^double % 4.0))) 4)))
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)
-        layer-mask (font-desc->layer-mask font-desc)]
+        layer-mask (font-desc->layer-mask font-desc)
+        is-monospaced (check-monospaced semi-glyphs)]
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
               (let [^BufferedImage glyph-image (let [face-color (Color. ^double (:alpha font-desc) 0.0 0.0)
@@ -494,7 +503,8 @@
      :glyph-data (ByteString/copyFrom glyph-data-bank)
      :alpha (:alpha font-desc)
      :outline-alpha (:outline-alpha font-desc)
-     :shadow-alpha (:shadow-alpha font-desc)}))
+     :shadow-alpha (:shadow-alpha font-desc)
+     :is-monospaced is-monospaced}))
 
 (defn- calculate-ttf-distance-field-edge-limit [^double width ^double spread ^double edge]
   (let [sdf-limit-value (- (/ width spread))]
@@ -640,7 +650,8 @@
         cache-cell-wh (max-glyph-cell-wh glyph-extents line-height padding glyph-cell-padding)
         cache-wh (cache-wh font-desc cache-cell-wh (count semi-glyphs))
         glyph-data-bank (make-glyph-data-bank glyph-extents)
-        layer-mask (font-desc->layer-mask font-desc)]
+        layer-mask (font-desc->layer-mask font-desc)
+        is-monospaced (check-monospaced semi-glyphs)]
     (doall
       (pmap (fn [[semi-glyph glyph-extents]]
               (let [{:keys [^bytes field]} (draw-ttf-distance-field semi-glyph padding channel-count outline-width sdf-outline sdf-spread sdf-shadow-spread edge shadow-blur shadow-alpha)
@@ -685,7 +696,8 @@
      :glyph-data (ByteString/copyFrom glyph-data-bank)
      :alpha (:alpha font-desc)
      :outline-alpha (:outline-alpha font-desc)
-     :shadow-alpha (:shadow-alpha font-desc)}))
+     :shadow-alpha (:shadow-alpha font-desc)
+     :is-monospaced is-monospaced}))
 
 (defn compile-font [font-desc font-resource resolver]
   (let [font-ext (resource/type-ext font-resource)]

--- a/engine/engine/src/test/def-3575/def-3575.script
+++ b/engine/engine/src/test/def-3575/def-3575.script
@@ -56,7 +56,7 @@ function update(self, dt)
     local function test_label_bitmap()
         local metrics_valid = {
             max_ascent  = 13,
-            width       = 768,
+            width       = 774,
             height      = 17,
             max_descent = 4
         }
@@ -67,7 +67,7 @@ function update(self, dt)
     local function test_label_df()
         local metrics_valid ={
               max_ascent = 13,
-              width = 768,
+              width = 775,
               height = 17,
               max_descent = 4,
         }

--- a/engine/engine/src/test/def-3575/def-3575.script
+++ b/engine/engine/src/test/def-3575/def-3575.script
@@ -24,9 +24,9 @@ function init(self)
 end
 
 function update(self, dt)
-    -- Values are taken from the output from label.get_text_metrics from defold version 1.2.138
+    -- Values are taken from the output from resource.get_text_metrics from defold version 1.2.138
     -- The base settings used are:
-    --  font: "/builtins/fonts/vera_mo_bd.ttf"
+    --  font: "/builtins/fonts/vera_mo_bd.ttf" - monospaced
     --  size: 14
     --  antialias: 1
     --  alpha: 1.0
@@ -35,9 +35,11 @@ function update(self, dt)
     --  shadow_alpha: 1.0
     --  shadow_blur: 2
 
-    local function test_label_metrics(label_name,test_metrics)
+    local function test_label_metrics(label_name, test_metrics)
         -- Test that we are getting the expected value back from get_text_metrics
-        local metrics = label.get_text_metrics("#" .. label_name)
+        local comp = "#" .. label_name
+        local font = go.get(comp, "font")
+        local metrics = resource.get_text_metrics(font, label.get_text(comp))
 
         local result = test_metrics.max_ascent  == metrics.max_ascent and
                        test_metrics.max_descent == metrics.max_descent and
@@ -54,7 +56,7 @@ function update(self, dt)
     local function test_label_bitmap()
         local metrics_valid = {
             max_ascent  = 13,
-            width       = 781,
+            width       = 768,
             height      = 17,
             max_descent = 4
         }
@@ -65,7 +67,7 @@ function update(self, dt)
     local function test_label_df()
         local metrics_valid ={
               max_ascent = 13,
-              width = 783,
+              width = 768,
               height = 17,
               max_descent = 4,
         }

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -110,7 +110,7 @@ namespace dmGameSystem
         params.m_GlyphChannels      = glyph_bank->m_GlyphChannels;
         params.m_GlyphData          = glyph_bank->m_GlyphData.m_Data;
         params.m_IsMonospaced       = glyph_bank->m_IsMonospaced;
-        params.m_AApadding          = glyph_bank->m_AaPadding;
+        params.m_Padding          = glyph_bank->m_Padding;
 
         if (font_map == 0)
         {

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -109,6 +109,7 @@ namespace dmGameSystem
         params.m_ImageFormat        = glyph_bank->m_ImageFormat;
         params.m_GlyphChannels      = glyph_bank->m_GlyphChannels;
         params.m_GlyphData          = glyph_bank->m_GlyphData.m_Data;
+        params.m_IsMonospaced       = glyph_bank->m_IsMonospaced;
 
         if (font_map == 0)
         {

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -110,6 +110,7 @@ namespace dmGameSystem
         params.m_GlyphChannels      = glyph_bank->m_GlyphChannels;
         params.m_GlyphData          = glyph_bank->m_GlyphData.m_Data;
         params.m_IsMonospaced       = glyph_bank->m_IsMonospaced;
+        params.m_AApadding          = glyph_bank->m_AaPadding;
 
         if (font_map == 0)
         {

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -77,7 +77,8 @@ message GlyphBank
     optional uint32            cache_cell_height     = 15;
     optional uint32            cache_cell_max_ascent = 16;
 
-    optional bool              is_monospaced         = 17 [default = false];
+    optional uint32            aa_padding            = 17 [default = 0];
+    optional bool              is_monospaced         = 18 [default = false];
 }
 
 message FontMap

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -77,7 +77,7 @@ message GlyphBank
     optional uint32            cache_cell_height     = 15;
     optional uint32            cache_cell_max_ascent = 16;
 
-    optional uint32            aa_padding            = 17 [default = 0];
+    optional uint32            padding               = 17 [default = 0];
     optional bool              is_monospaced         = 18 [default = false];
 }
 

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -76,6 +76,8 @@ message GlyphBank
     optional uint32            cache_cell_width      = 14;
     optional uint32            cache_cell_height     = 15;
     optional uint32            cache_cell_max_ascent = 16;
+
+    optional bool              is_monospaced         = 17 [default = false];
 }
 
 message FontMap

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -521,7 +521,7 @@ namespace dmRender
                 center_x += metrics.m_Width/2; // move halfway to the right since we're aligning left
             break;
             case TEXT_ALIGN_RIGHT:
-                center_x -= metrics.m_Height/2; // move halfway to the left from pivot since we're aligning right
+                center_x -= metrics.m_Width/2; // move halfway to the left from pivot since we're aligning right
             break;
             // nothing to do for TEXT_ALIGN_CENTER. Pivot is already at the center of the text X-wise
         }

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -84,7 +84,7 @@ namespace dmRender
     , m_LayerMask(FACE)
     , m_ImageFormat(dmRenderDDF::TYPE_BITMAP)
     , m_IsMonospaced(false)
-    , m_AApadding(0)
+    , m_Padding(0)
     {
 
     }
@@ -114,7 +114,7 @@ namespace dmRender
         , m_CacheCellPadding(0)
         , m_LayerMask(FACE)
         , m_IsMonospaced(false)
-        , m_AApadding(0)
+        , m_Padding(0)
         {
 
         }
@@ -167,8 +167,7 @@ namespace dmRender
         uint8_t                 m_CacheCellPadding;
         uint8_t                 m_LayerMask;
         uint8_t                 m_IsMonospaced:1;
-        uint8_t                 m_AApadding:4;
-        uint8_t                 :3;
+        uint8_t                 m_Padding:7;
     };
 
     static float GetLineTextMetrics(HFontMap font_map, float tracking, const char* text, int n, bool measure_trailing_space);
@@ -243,7 +242,7 @@ namespace dmRender
 
         font_map->m_CellTempData = (uint8_t*)malloc(font_map->m_CacheCellWidth*font_map->m_CacheCellHeight*4);
         font_map->m_IsMonospaced = params.m_IsMonospaced;
-        font_map->m_AApadding = params.m_AApadding;
+        font_map->m_Padding = params.m_Padding;
 
         switch (params.m_GlyphChannels)
         {
@@ -335,7 +334,7 @@ namespace dmRender
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
         font_map->m_LayerMask = params.m_LayerMask;
         font_map->m_IsMonospaced = params.m_IsMonospaced;
-        font_map->m_AApadding = params.m_AApadding;
+        font_map->m_Padding = params.m_Padding;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -752,7 +751,7 @@ namespace dmRender
         float x_offset = OffsetX(te.m_Align, te.m_Width);
         if (font_map->m_IsMonospaced)
         {
-            x_offset -= font_map->m_AApadding;
+            x_offset -= font_map->m_Padding;
         }
         float y_offset = OffsetY(te.m_VAlign, te.m_Height, font_map->m_MaxAscent, font_map->m_MaxDescent, te.m_Leading, line_count);
 
@@ -1220,9 +1219,11 @@ namespace dmRender
         }
         if (n > 0 && 0 != last)
         {
-            if (!font_map->m_IsMonospaced) 
-            {
-                uint32_t last_width = (measure_trailing_space && last->m_Character == ' ') ? (int16_t)last->m_Advance : last->m_Width;
+            if (font_map->m_IsMonospaced) {
+                width += font_map->m_Padding;
+            }
+            else {
+                uint32_t last_width = (measure_trailing_space && last->m_Character == ' ') ? last->m_Advance : last->m_Width;
                 float last_end_point = last->m_LeftBearing + last_width;
                 float last_right_bearing = last->m_Advance - last_end_point;
                 width = width - last_right_bearing;

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -84,6 +84,7 @@ namespace dmRender
     , m_LayerMask(FACE)
     , m_ImageFormat(dmRenderDDF::TYPE_BITMAP)
     , m_IsMonospaced(false)
+    , m_AApadding(0)
     {
 
     }
@@ -113,6 +114,7 @@ namespace dmRender
         , m_CacheCellPadding(0)
         , m_LayerMask(FACE)
         , m_IsMonospaced(false)
+        , m_AApadding(0)
         {
 
         }
@@ -165,7 +167,8 @@ namespace dmRender
         uint8_t                 m_CacheCellPadding;
         uint8_t                 m_LayerMask;
         uint8_t                 m_IsMonospaced:1;
-        uint8_t                 :7;
+        uint8_t                 m_AApadding:4;
+        uint8_t                 :3;
     };
 
     static float GetLineTextMetrics(HFontMap font_map, float tracking, const char* text, int n, bool measure_trailing_space);
@@ -240,6 +243,7 @@ namespace dmRender
 
         font_map->m_CellTempData = (uint8_t*)malloc(font_map->m_CacheCellWidth*font_map->m_CacheCellHeight*4);
         font_map->m_IsMonospaced = params.m_IsMonospaced;
+        font_map->m_AApadding = params.m_AApadding;
 
         switch (params.m_GlyphChannels)
         {
@@ -331,6 +335,7 @@ namespace dmRender
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
         font_map->m_LayerMask = params.m_LayerMask;
         font_map->m_IsMonospaced = params.m_IsMonospaced;
+        font_map->m_AApadding = params.m_AApadding;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -745,6 +750,10 @@ namespace dmRender
         float layout_width;
         int line_count = Layout(text, width, lines, max_lines, &layout_width, lm, measure_trailing_space);
         float x_offset = OffsetX(te.m_Align, te.m_Width);
+        if (font_map->m_IsMonospaced)
+        {
+            x_offset -= font_map->m_AApadding;
+        }
         float y_offset = OffsetY(te.m_VAlign, te.m_Height, font_map->m_MaxAscent, font_map->m_MaxDescent, te.m_Leading, line_count);
 
         const Vector4 face_color    = dmGraphics::UnpackRGBA(te.m_FaceColor);

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -841,8 +841,8 @@ namespace dmRender
 
         for (int line = 0; line < line_count; ++line) {
             TextLine& l = lines[line];
-            int16_t x = (int16_t)(x_offset - OffsetX(te.m_Align, l.m_Width) + 0.5f);
-            int16_t y = (int16_t) (y_offset - line * leading + 0.5f);
+            float x = x_offset - OffsetX(te.m_Align, l.m_Width);
+            float y = y_offset - line * leading;
             const char* cursor = &text[l.m_Index];
             int n = l.m_Count;
             for (int j = 0; j < n; ++j)
@@ -1021,7 +1021,7 @@ namespace dmRender
                         vertexindex += vertices_per_quad;
                     }
                 }
-                x += (int16_t)(g->m_Advance + tracking);
+                x += g->m_Advance + tracking;
             }
         }
 
@@ -1207,8 +1207,7 @@ namespace dmRender
             }
 
             last = g;
-            // NOTE: We round advance here just as above in DrawText
-            width += (int16_t) (g->m_Advance + tracking);
+            width += g->m_Advance + tracking;
         }
         if (n > 0 && 0 != last)
         {

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -751,7 +751,7 @@ namespace dmRender
         float x_offset = OffsetX(te.m_Align, te.m_Width);
         if (font_map->m_IsMonospaced)
         {
-            x_offset -= font_map->m_Padding;
+            x_offset -= font_map->m_Padding * 0.5f;
         }
         float y_offset = OffsetY(te.m_VAlign, te.m_Height, font_map->m_MaxAscent, font_map->m_MaxDescent, te.m_Leading, line_count);
 

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -83,6 +83,7 @@ namespace dmRender
     , m_CacheCellPadding(0)
     , m_LayerMask(FACE)
     , m_ImageFormat(dmRenderDDF::TYPE_BITMAP)
+    , m_IsMonospaced(false)
     {
 
     }
@@ -111,6 +112,7 @@ namespace dmRender
         , m_CacheCellMaxAscent(0)
         , m_CacheCellPadding(0)
         , m_LayerMask(FACE)
+        , m_IsMonospaced(false)
         {
 
         }
@@ -162,6 +164,8 @@ namespace dmRender
         uint32_t                m_CacheCellMaxAscent;
         uint8_t                 m_CacheCellPadding;
         uint8_t                 m_LayerMask;
+        uint8_t                 m_IsMonospaced:1;
+        uint8_t                 :7;
     };
 
     static float GetLineTextMetrics(HFontMap font_map, float tracking, const char* text, int n, bool measure_trailing_space);
@@ -235,6 +239,7 @@ namespace dmRender
         uint32_t cell_count = font_map->m_CacheColumns * font_map->m_CacheRows;
 
         font_map->m_CellTempData = (uint8_t*)malloc(font_map->m_CacheCellWidth*font_map->m_CacheCellHeight*4);
+        font_map->m_IsMonospaced = params.m_IsMonospaced;
 
         switch (params.m_GlyphChannels)
         {
@@ -325,6 +330,7 @@ namespace dmRender
         font_map->m_OutlineAlpha = params.m_OutlineAlpha;
         font_map->m_ShadowAlpha = params.m_ShadowAlpha;
         font_map->m_LayerMask = params.m_LayerMask;
+        font_map->m_IsMonospaced = params.m_IsMonospaced;
 
         font_map->m_CacheWidth = params.m_CacheWidth;
         font_map->m_CacheHeight = params.m_CacheHeight;
@@ -1206,10 +1212,14 @@ namespace dmRender
         }
         if (n > 0 && 0 != last)
         {
-            uint32_t last_width = (measure_trailing_space && last->m_Character == ' ') ? (int16_t)last->m_Advance : last->m_Width;
-            float last_end_point = last->m_LeftBearing + last_width;
-            float last_right_bearing = last->m_Advance - last_end_point;
-            width = width - last_right_bearing - tracking;
+            if (!font_map->m_IsMonospaced) 
+            {
+                uint32_t last_width = (measure_trailing_space && last->m_Character == ' ') ? (int16_t)last->m_Advance : last->m_Width;
+                float last_end_point = last->m_LeftBearing + last_width;
+                float last_right_bearing = last->m_Advance - last_end_point;
+                width = width - last_right_bearing;
+            }
+            width -= tracking;
         }
 
         return width;

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -111,6 +111,8 @@ namespace dmRender
         uint32_t m_CacheCellMaxAscent;
         uint8_t m_CacheCellPadding;
         uint8_t m_LayerMask;
+        uint8_t m_IsMonospaced:1;
+        uint8_t :7;
 
         dmRenderDDF::FontTextureFormat m_ImageFormat;
     };

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -112,8 +112,7 @@ namespace dmRender
         uint8_t m_CacheCellPadding;
         uint8_t m_LayerMask;
         uint8_t m_IsMonospaced:1;
-        uint8_t m_AApadding:4;
-        uint8_t :3;
+        uint8_t m_Padding:7;
 
         dmRenderDDF::FontTextureFormat m_ImageFormat;
     };

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -112,7 +112,8 @@ namespace dmRender
         uint8_t m_CacheCellPadding;
         uint8_t m_LayerMask;
         uint8_t m_IsMonospaced:1;
-        uint8_t :7;
+        uint8_t m_AApadding:4;
+        uint8_t :3;
 
         dmRenderDDF::FontTextureFormat m_ImageFormat;
     };


### PR DESCRIPTION
Monospaced fonts should always use the fixed Advance Width for each symbol as its width, instead of the glyph's real width.

Fix https://github.com/defold/defold/issues/7900
Fix https://github.com/defold/defold/issues/7197
## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
