### PR TITLE
Produce SPIR-v shaders automatically on windows

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1386,10 +1386,7 @@ public class Project {
 
                     if (yamlPlatformContext != null) {
                         boolean vulkanSymbolFound = false;
-                        boolean vulkanLibraryFound = false;
-
                         List<String> symbols = (List<String>) yamlPlatformContext.getOrDefault("symbols", new ArrayList<String>());
-                        List<String> libs = (List<String>) yamlPlatformContext.getOrDefault("libs", new ArrayList<String>());
 
                         for (String symbol : symbols) {
                             if (symbol.equals("GraphicsAdapterVulkan")) {
@@ -1398,14 +1395,7 @@ public class Project {
                             }
                         }
 
-                        for (String lib : libs) {
-                            if (lib.equals("graphics_vulkan") || lib.equals("libgraphics_vulkan.lib")) {
-                                vulkanLibraryFound = true;
-                                break;
-                            }
-                        }
-
-                        return vulkanLibraryFound && vulkanSymbolFound;
+                        return vulkanSymbolFound;
                     }
                 }
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -1399,7 +1399,7 @@ public class Project {
                         }
 
                         for (String lib : libs) {
-                            if (lib.equals("graphics_vulkan")) {
+                            if (lib.equals("graphics_vulkan") || lib.equals("libgraphics_vulkan.lib")) {
                                 vulkanLibraryFound = true;
                                 break;
                             }


### PR DESCRIPTION
When we step through the manifest to look for the library + symbol we didn't consider that the lib file is named differently for windows ("lib" prefix + .lib extension).

Fixes #8894 