### PR TITLE
Render context lost handling pt.1

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/jsweb/dmloader.js
@@ -842,6 +842,13 @@ var Module = {
         if (Module.hasWebGLSupport()) {
             Module.canvas.focus();
 
+            Module.canvas.addEventListener("webglcontextlost", function(event) {
+                event.preventDefault();
+                dmRenderer.rendererContextEvent("context_lost");
+            }, false);
+            Module.canvas.addEventListener("webglcontextrestored", function(event) {
+                dmRenderer.rendererContextEvent("context_restored");
+            }, false);
             // Add context menu hide-handler if requested
             if (CUSTOM_PARAMETERS["disable_context_menu"])
             {

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -1652,7 +1652,8 @@ bail:
                 dmGameObject::Update(engine->m_MainCollection, &update_context);
 
                 // Don't render while iconified
-                if (!dmGraphics::GetWindowStateParam(engine->m_GraphicsContext, dmPlatform::WINDOW_STATE_ICONIFIED))
+                if (!dmGraphics::GetWindowStateParam(engine->m_GraphicsContext, dmPlatform::WINDOW_STATE_ICONIFIED)
+                    && !dmRender::IsRenderPaused(engine->m_RenderContext))
                 {
                     // Call pre render functions for extensions, if available.
                     // We do it here before we render rest of the frame
@@ -1986,6 +1987,10 @@ bail:
                     dmGameObject::LuaLoad(factory, self->m_GuiScriptContext, &run_script->m_Module);
                     dmGameObject::LuaLoad(factory, self->m_RenderScriptContext, &run_script->m_Module);
                 }
+            }
+            else if (descriptor == dmSystemDDF::ResumeRendering::m_DDFDescriptor)
+            {
+                dmRender::ResumeRender(self->m_RenderContext);
             }
             else
             {

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -119,7 +119,7 @@ def build(bld):
 
     glfw_js = '../../../ext/lib/%s/js/library_glfw.js' % bld.env.PLATFORM
 
-    web_libs = [glfw_js, 'library_sys.js', 'library_script.js', 'library_sound.js']
+    web_libs = [glfw_js, 'library_sys.js', 'library_script.js', 'library_sound.js', 'library_render.js']
 
     main_cpp = 'common/main.cpp'
 

--- a/engine/gameobject/proto/gameobject/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject/gameobject_ddf.proto
@@ -284,6 +284,10 @@ message Disable
 {
 }
 
+// Inner message to notify about render context lost
+message RenderContextLost
+{
+}
 
 // Script message wrapper for added typesafety
 message ScriptMessage

--- a/engine/gameobject/src/dmsdk/gameobject/component.h
+++ b/engine/gameobject/src/dmsdk/gameobject/component.h
@@ -81,6 +81,16 @@ namespace dmGameObject
      */
     typedef CreateResult (*ComponentDeleteWorld)(const ComponentDeleteWorldParams& params);
 
+    struct ComponentWorldRenderContextLostParams
+    {
+        /// Context for the component type
+        void* m_Context;
+        /// The pointer to the world to destroy
+        void* m_World;
+    };
+
+    typedef CreateResult (*ComponentWorldRenderContextLost)(const ComponentWorldRenderContextLostParams& params);
+
     /*#
      * Parameters to ComponentCreate callback.
      */
@@ -477,6 +487,8 @@ namespace dmGameObject
      * @param fn [type: ComponentDeleteWorld] callback
      */
     void ComponentTypeSetDeleteWorldFn(ComponentType* type, ComponentDeleteWorld fn);
+
+    void ComponentTypeSetWorldRenderContextLostFn(ComponentType* type, ComponentWorldRenderContextLost fn);
 
     /*# set the component create callback
      * Set the component create callback. Called when a component instance is created.

--- a/engine/gameobject/src/gameobject/component.cpp
+++ b/engine/gameobject/src/gameobject/component.cpp
@@ -105,6 +105,7 @@ Result DestroyRegisteredComponentTypes(const ComponentTypeCreateCtx* ctx)
 
 void ComponentTypeSetNewWorldFn(ComponentType* type, ComponentNewWorld fn)                  { type->m_NewWorldFunction = fn; }
 void ComponentTypeSetDeleteWorldFn(ComponentType* type, ComponentDeleteWorld fn)            { type->m_DeleteWorldFunction = fn; }
+void ComponentTypeSetWorldRenderContextLostFn(ComponentType* type, ComponentWorldRenderContextLost fn) { type->m_WorldRenderContextLost = fn; }
 void ComponentTypeSetCreateFn(ComponentType* type, ComponentCreate fn)                      { type->m_CreateFunction = fn; }
 void ComponentTypeSetDestroyFn(ComponentType* type, ComponentDestroy fn)                    { type->m_DestroyFunction = fn; }
 void ComponentTypeSetInitFn(ComponentType* type, ComponentInit fn)                          { type->m_InitFunction = fn; }

--- a/engine/gameobject/src/gameobject/component.h
+++ b/engine/gameobject/src/gameobject/component.h
@@ -35,6 +35,7 @@ namespace dmGameObject
         void*                   m_Context;
         ComponentNewWorld       m_NewWorldFunction;
         ComponentDeleteWorld    m_DeleteWorldFunction;
+        ComponentWorldRenderContextLost m_WorldRenderContextLost;
         ComponentCreate         m_CreateFunction;
         ComponentDestroy        m_DestroyFunction;
         ComponentInit           m_InitFunction;

--- a/engine/gameobject/src/gameobject/gameobject_props.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_props.cpp
@@ -129,6 +129,14 @@ namespace dmGameObject
         resources.SetCapacity(0);
     }
 
+    void InvalidatePropertyResources(dmResource::HFactory factory, dmArray<void*>& resources)
+    {
+        for (uint32_t i = 0; i < resources.Size(); ++i)
+        {
+            dmResource::InvalidateGraphicsHandle(factory, resources[i]);
+        }
+    }
+
     enum PropertyContainerType
     {
         PROPERTY_CONTAINER_TYPE_NUMBER = 0,

--- a/engine/gameobject/src/gameobject/gameobject_props.h
+++ b/engine/gameobject/src/gameobject/gameobject_props.h
@@ -76,6 +76,7 @@ namespace dmGameObject
     dmResource::Result LoadPropertyResources(dmResource::HFactory factory, const char** resource_paths, uint32_t resource_path_count, dmArray<void*>& out_resources);
     // dmResource::Release supplied paths and de-allocates through SetCapacity(0)
     void UnloadPropertyResources(dmResource::HFactory factory, dmArray<void*>& resources);
+    void InvalidatePropertyResources(dmResource::HFactory factory, dmArray<void*>& resources);
 
     typedef struct PropertyContainer* HPropertyContainer;
     typedef struct PropertyContainerBuilder* HPropertyContainerBuilder;

--- a/engine/gameobject/src/gameobject/res_anim.cpp
+++ b/engine/gameobject/src/gameobject/res_anim.cpp
@@ -28,7 +28,7 @@ namespace dmGameObject
 
     static dmResource::Result RegisterResourceTypeAnim(dmResource::ResourceTypeRegisterContext& ctx)
     {
-        return dmResource::RegisterType(ctx.m_Factory, ctx.m_Name,0,0,ResAnimCreate,0,ResAnimDestroy,0);
+        return dmResource::RegisterType(ctx.m_Factory, ctx.m_Name,0,0,ResAnimCreate,0,ResAnimDestroy,0,0);
     }
 }
 

--- a/engine/gameobject/src/gameobject/res_collection.cpp
+++ b/engine/gameobject/src/gameobject/res_collection.cpp
@@ -354,6 +354,24 @@ bail:
         return res;
     }
 
+    static dmResource::Result ResCollectionRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        HCollection hcollection = (HCollection) params.m_Resource->m_Resource;
+        InvalidatePropertyResources(params.m_Factory, hcollection->m_Collection->m_PropertyResources);
+        HRegister regist = hcollection->m_Collection->m_Register;
+        for (uint32_t i = 0; i < regist->m_ComponentTypeCount; ++i)
+        {
+            ComponentWorldRenderContextLostParams params;
+            params.m_Context = regist->m_ComponentTypes[i].m_Context;
+            params.m_World = hcollection->m_Collection->m_ComponentWorlds[i];
+            if (regist->m_ComponentTypes[i].m_WorldRenderContextLost)
+            {
+                regist->m_ComponentTypes[i].m_WorldRenderContextLost(params);
+            }
+        }
+        return dmResource::RESULT_OK;
+    }
+
     static dmResource::Result RegisterResourceTypeCollection(dmResource::ResourceTypeRegisterContext& ctx)
     {
         // The engine.cpp creates the contexts for our built in types.
@@ -366,7 +384,8 @@ bail:
                                            ResCollectionCreate,
                                            0,
                                            ResCollectionDestroy,
-                                           ResCollectionRecreate);
+                                           ResCollectionRecreate,
+                                           ResCollectionRenderContextLost);
     }
 }
 

--- a/engine/gameobject/src/gameobject/res_gameobject.cpp
+++ b/engine/gameobject/src/gameobject/res_gameobject.cpp
@@ -212,6 +212,19 @@ namespace dmGameObject
         return r;
     }
 
+    static dmResource::Result ResGameObjectRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        Prototype* proto = (Prototype*) params.m_Resource->m_Resource;
+        for (uint32_t i = 0; i < proto->m_ComponentCount; ++i)
+        {
+            Prototype::Component& c = proto->m_Components[i];
+            dmResource::InvalidateGraphicsHandle(params.m_Factory, c.m_Resource);
+        }
+
+        InvalidatePropertyResources(params.m_Factory, proto->m_PropertyResources);
+        return dmResource::RESULT_OK;
+    }
+
     static dmResource::Result RegisterResourceTypeGameObject(dmResource::ResourceTypeRegisterContext& ctx)
     {
         // The engine.cpp creates the contexts for our built in types.
@@ -224,7 +237,8 @@ namespace dmGameObject
                                            ResGameObjectCreate,
                                            0,
                                            ResGameObjectDestroy,
-                                           ResGameObjectRecreate);
+                                           ResGameObjectRecreate,
+                                           ResGameObjectRenderContextLost);
     }
 }
 

--- a/engine/gameobject/src/gameobject/res_lua.cpp
+++ b/engine/gameobject/src/gameobject/res_lua.cpp
@@ -163,7 +163,8 @@ namespace dmGameObject
                                            ResLuaCreate,
                                            0,
                                            ResLuaDestroy,
-                                           ResLuaRecreate);
+                                           ResLuaRecreate,
+                                           0);
     }
 }
 

--- a/engine/gameobject/src/gameobject/res_script.cpp
+++ b/engine/gameobject/src/gameobject/res_script.cpp
@@ -91,6 +91,13 @@ namespace dmGameObject
         return dmResource::RESULT_OK;
     }
 
+    static dmResource::Result ResScriptRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        HScript script = (HScript)params.m_Resource->m_Resource;
+        InvalidatePropertyResources(params.m_Factory, script->m_PropertyResources);
+        return dmResource::RESULT_OK;
+    }
+
     static dmResource::Result ResScriptRecreate(const dmResource::ResourceRecreateParams& params)
     {
         HScript script = (HScript) params.m_Resource->m_Resource;
@@ -143,7 +150,8 @@ namespace dmGameObject
                                            ResScriptCreate,
                                            0,
                                            ResScriptDestroy,
-                                           ResScriptRecreate);
+                                           ResScriptRecreate,
+                                           ResScriptRenderContextLost);
     }
 }
 

--- a/engine/gamesys/src/gamesys/components/comp_mesh.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_mesh.cpp
@@ -1142,6 +1142,22 @@ namespace dmGameSystem
         pit->m_FnIterateNext = CompMeshIterPropertiesGetNext;
     }
 
+    dmGameObject::CreateResult CompMeshWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params)
+    {
+        MeshWorld* world = (MeshWorld*)params.m_World;
+        for(uint32_t i = 0; i < world->m_VertexBufferPool.Size(); ++i)
+        {
+            dmGraphics::InvalidateVertexBuffer(world->m_VertexBufferPool[i]);
+        }
+
+        for(uint32_t i = 0; i < world->m_VertexBufferWorld.Size(); ++i)
+        {
+            dmGraphics::InvalidateVertexBuffer(world->m_VertexBufferWorld[i]);
+        }
+
+        return dmGameObject::CREATE_RESULT_OK;
+    }
+
     static dmGameObject::Result CompMeshTypeCreate(const dmGameObject::ComponentTypeCreateCtx* ctx, dmGameObject::ComponentType* type)
     {
         MeshContext* mesh_context = new MeshContext;
@@ -1164,6 +1180,8 @@ namespace dmGameSystem
         ComponentTypeSetSetPropertyFn(type, CompMeshSetProperty);
 
         ComponentTypeSetPropertyIteratorFn(type, CompMeshIterProperties);
+
+        ComponentTypeSetWorldRenderContextLostFn(type, CompMeshWorldRenderContextLost);
 
         return dmGameObject::RESULT_OK;
     }

--- a/engine/gamesys/src/gamesys/components/comp_model.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_model.cpp
@@ -1638,6 +1638,20 @@ namespace dmGameSystem
         pit->m_FnIterateNext = CompModelIterPropertiesGetNext;
     }
 
+    dmGameObject::CreateResult CompModelWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params)
+    {
+        dmLogError("Invaldiate model world buffers");
+        ModelWorld* world = (ModelWorld*)params.m_World;
+        // m_BoundProgram
+        // dmGraphics::DeleteVertexDeclaration(world->m_VertexDeclaration);
+        for (uint32_t i = 0; i < VERTEX_BUFFER_MAX_BATCHES; ++i)
+        {
+            dmRender::InvalidateBufferedRenderBuffer(world->m_VertexBuffers[i]);
+        }
+
+        return dmGameObject::CREATE_RESULT_OK;
+    }
+
     // For tests
     void GetModelWorldRenderBuffers(void* model_world, dmRender::HBufferedRenderBuffer** vx_buffers, uint32_t* vx_buffers_count)
     {

--- a/engine/gamesys/src/gamesys/components/comp_model.h
+++ b/engine/gamesys/src/gamesys/components/comp_model.h
@@ -47,6 +47,8 @@ namespace dmGameSystem
 
     void CompModelIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
 
+    dmGameObject::CreateResult CompModelWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params);
+
     // Used in the script_model.cpp
     struct ModelComponent;
     struct ModelWorld;

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.cpp
@@ -702,4 +702,21 @@ namespace dmGameSystem
         ParticleFXWorld* world = (ParticleFXWorld*) pfx_world;
         *vx_buffer = world->m_VertexBuffer;
     }
+
+    dmGameObject::CreateResult CompParticleFXWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params)
+    {
+        ParticleFXContext* ctx = (ParticleFXContext*)params.m_Context;
+        ParticleFXWorld* pfx_world = (ParticleFXWorld*)params.m_World;
+        //! TODO: look into particle prototype
+        // for (uint32_t i = 0; i < pfx_world->m_Components.Size(); ++i)
+        // {
+        //     ParticleFXComponent* c = &pfx_world->m_Components[i];
+            // dmResource::Release(pfx_world->m_Context->m_Factory, c->m_ParticlePrototype);
+        //     dmParticle::DestroyInstance(pfx_world->m_ParticleContext, c->m_ParticleInstance);
+        // }
+
+        dmRender::InvalidateBufferedRenderBuffer(pfx_world->m_VertexBuffer);
+
+        return dmGameObject::CREATE_RESULT_OK;
+    }
 }

--- a/engine/gamesys/src/gamesys/components/comp_particlefx.h
+++ b/engine/gamesys/src/gamesys/components/comp_particlefx.h
@@ -36,6 +36,8 @@ namespace dmGameSystem
     dmGameObject::UpdateResult CompParticleFXOnMessage(const dmGameObject::ComponentOnMessageParams& params);
 
     void CompParticleFXOnReload(const dmGameObject::ComponentOnReloadParams& params);
+
+    dmGameObject::CreateResult CompParticleFXWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_COMP_PARTICLEFX_H

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2226,6 +2226,24 @@ namespace dmGameSystem
         pit->m_FnIterateNext = CompSpriteIterPropertiesGetNext;
     }
 
+    dmGameObject::CreateResult CompSpriteWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params)
+    {
+        SpriteWorld* sprite_world = (SpriteWorld*)params.m_World;
+
+        DestroyMaterialAttributeInfos(sprite_world->m_DynamicVertexAttributePool);
+
+        //! TODO: Invaldiate RenderObjects
+        // for (uint32_t i = 0; i < sprite_world->m_RenderObjects.Size(); ++i)
+        // {
+        //     delete sprite_world->m_RenderObjects[i];
+        // }
+
+        dmRender::InvalidateBufferedRenderBuffer(sprite_world->m_VertexBuffer);
+        dmRender::InvalidateBufferedRenderBuffer(sprite_world->m_IndexBuffer);
+
+        return dmGameObject::CREATE_RESULT_OK;
+    }
+
     // For tests
     void GetSpriteWorldRenderBuffers(void* sprite_world, dmRender::HBufferedRenderBuffer* vx_buffer, dmRender::HBufferedRenderBuffer* ix_buffer)
     {

--- a/engine/gamesys/src/gamesys/components/comp_sprite.h
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.h
@@ -42,6 +42,8 @@ namespace dmGameSystem
     dmGameObject::PropertyResult CompSpriteSetProperty(const dmGameObject::ComponentSetPropertyParams& params);
 
     void CompSpriteIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
+
+    dmGameObject::CreateResult CompSpriteWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_COMP_SPRITE_H

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -969,6 +969,17 @@ namespace dmGameSystem
         pit->m_FnIterateNext = CompTileGridIterPropertiesGetNext;
     }
 
+    dmGameObject::CreateResult CompTileGridWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params)
+    {
+        TileGridWorld* world = (TileGridWorld*) params.m_World;
+        if (world->m_VertexDeclaration)
+        {
+            // dmGraphics::DeleteVertexDeclaration(world->m_VertexDeclaration);
+            dmRender::InvalidateBufferedRenderBuffer(world->m_VertexBuffer);
+        }
+        return dmGameObject::CREATE_RESULT_OK;
+    }
+
     // For tests
     void GetTileGridWorldRenderBuffers(void* tilegrid_world, dmRender::HBufferedRenderBuffer* vx_buffer)
     {

--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.h
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.h
@@ -46,6 +46,8 @@ namespace dmGameSystem
 
     void CompTileGridIterProperties(dmGameObject::SceneNodePropertyIterator* pit, dmGameObject::SceneNode* node);
 
+    dmGameObject::CreateResult CompTileGridWorldRenderContextLost(const dmGameObject::ComponentWorldRenderContextLostParams& params);
+
     // Script support
     struct TileGridComponent;
 

--- a/engine/gamesys/src/gamesys/gamesys.cpp
+++ b/engine/gamesys/src/gamesys/gamesys.cpp
@@ -85,8 +85,8 @@ namespace dmGameSystem
     {
         dmResource::Result e;
 
-#define REGISTER_RESOURCE_TYPE(extension, context, preload_func, create_func, post_create_func, destroy_func, recreate_func)\
-    e = dmResource::RegisterType(factory, extension, context, preload_func, create_func, post_create_func, destroy_func, recreate_func);\
+#define REGISTER_RESOURCE_TYPE(extension, context, preload_func, create_func, post_create_func, destroy_func, recreate_func, render_context_lost_func)\
+    e = dmResource::RegisterType(factory, extension, context, preload_func, create_func, post_create_func, destroy_func, recreate_func, render_context_lost_func);\
     if( e != dmResource::RESULT_OK )\
     {\
         dmLogFatal("Unable to register resource type: %s (%s)", extension, dmResource::ResultToString(e));\
@@ -95,43 +95,43 @@ namespace dmGameSystem
 
         dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
 
-        REGISTER_RESOURCE_TYPE("collectionproxyc", 0, 0, ResCollectionProxyCreate, 0, ResCollectionProxyDestroy, ResCollectionProxyRecreate);
-        REGISTER_RESOURCE_TYPE("collisionobjectc", physics_context, 0, ResCollisionObjectCreate, 0, ResCollisionObjectDestroy, ResCollisionObjectRecreate);
-        REGISTER_RESOURCE_TYPE("convexshapec", physics_context, 0, ResConvexShapeCreate, 0, ResConvexShapeDestroy, ResConvexShapeRecreate);
-        REGISTER_RESOURCE_TYPE("particlefxc", 0, ResParticleFXPreload, ResParticleFXCreate, 0, ResParticleFXDestroy, ResParticleFXRecreate);
-        REGISTER_RESOURCE_TYPE("texturec", graphics_context, ResTexturePreload, ResTextureCreate, ResTexturePostCreate, ResTextureDestroy, ResTextureRecreate);
-        REGISTER_RESOURCE_TYPE("vpc", graphics_context, ResVertexProgramPreload, ResVertexProgramCreate, 0, ResVertexProgramDestroy, ResVertexProgramRecreate);
-        REGISTER_RESOURCE_TYPE("fpc", graphics_context, ResFragmentProgramPreload, ResFragmentProgramCreate, 0, ResFragmentProgramDestroy, ResFragmentProgramRecreate);
-        REGISTER_RESOURCE_TYPE("fontc", render_context, ResFontMapPreload, ResFontMapCreate, 0, ResFontMapDestroy, ResFontMapRecreate);
-        REGISTER_RESOURCE_TYPE("bufferc", graphics_context, ResBufferPreload, ResBufferCreate, 0, ResBufferDestroy, ResBufferRecreate);
-        REGISTER_RESOURCE_TYPE("meshc", graphics_context, ResMeshPreload, ResMeshCreate, 0, ResMeshDestroy, ResMeshRecreate);
-        REGISTER_RESOURCE_TYPE("modelc", graphics_context, ResModelPreload, ResModelCreate, 0, ResModelDestroy, ResModelRecreate);
-        REGISTER_RESOURCE_TYPE("materialc", render_context, ResMaterialPreload, ResMaterialCreate, 0, ResMaterialDestroy, ResMaterialRecreate);
-        REGISTER_RESOURCE_TYPE("compute_programc", render_context, ResComputeProgramPreload, ResComputeProgramCreate, 0, ResComputeProgramDestroy, ResComputeProgramRecreate);
-        REGISTER_RESOURCE_TYPE("cpc", graphics_context, ResComputeShaderPreload, ResComputeShaderCreate, 0, ResComputeShaderDestroy, ResComputeShaderRecreate);
+        REGISTER_RESOURCE_TYPE("collectionproxyc", 0, 0, ResCollectionProxyCreate, 0, ResCollectionProxyDestroy, ResCollectionProxyRecreate, 0);
+        REGISTER_RESOURCE_TYPE("collisionobjectc", physics_context, 0, ResCollisionObjectCreate, 0, ResCollisionObjectDestroy, ResCollisionObjectRecreate, 0);
+        REGISTER_RESOURCE_TYPE("convexshapec", physics_context, 0, ResConvexShapeCreate, 0, ResConvexShapeDestroy, ResConvexShapeRecreate, 0);
+        REGISTER_RESOURCE_TYPE("particlefxc", 0, ResParticleFXPreload, ResParticleFXCreate, 0, ResParticleFXDestroy, ResParticleFXRecreate, 0);
+        REGISTER_RESOURCE_TYPE("texturec", graphics_context, ResTexturePreload, ResTextureCreate, ResTexturePostCreate, ResTextureDestroy, ResTextureRecreate, ResTextureRenderContextLost);
+        REGISTER_RESOURCE_TYPE("vpc", graphics_context, ResVertexProgramPreload, ResVertexProgramCreate, 0, ResVertexProgramDestroy, ResVertexProgramRecreate, ResVertexProgramRenderContextLost);
+        REGISTER_RESOURCE_TYPE("fpc", graphics_context, ResFragmentProgramPreload, ResFragmentProgramCreate, 0, ResFragmentProgramDestroy, ResFragmentProgramRecreate, ResFragmentProgramRenderContextLost);
+        REGISTER_RESOURCE_TYPE("fontc", render_context, ResFontMapPreload, ResFontMapCreate, 0, ResFontMapDestroy, ResFontMapRecreate, ResFontMapRenderContextLost);
+        REGISTER_RESOURCE_TYPE("bufferc", graphics_context, ResBufferPreload, ResBufferCreate, 0, ResBufferDestroy, ResBufferRecreate, 0);
+        REGISTER_RESOURCE_TYPE("meshc", graphics_context, ResMeshPreload, ResMeshCreate, 0, ResMeshDestroy, ResMeshRecreate, ResMeshRenderContextLost);
+        REGISTER_RESOURCE_TYPE("modelc", graphics_context, ResModelPreload, ResModelCreate, 0, ResModelDestroy, ResModelRecreate, ResModelRenderContextLost);
+        REGISTER_RESOURCE_TYPE("materialc", render_context, ResMaterialPreload, ResMaterialCreate, 0, ResMaterialDestroy, ResMaterialRecreate, ResMaterialRenderContextLost);
+        REGISTER_RESOURCE_TYPE("compute_programc", render_context, ResComputeProgramPreload, ResComputeProgramCreate, 0, ResComputeProgramDestroy, ResComputeProgramRecreate, 0);
+        REGISTER_RESOURCE_TYPE("cpc", graphics_context, ResComputeShaderPreload, ResComputeShaderCreate, 0, ResComputeShaderDestroy, ResComputeShaderRecreate, ResComputeShaderRenderContextLost);
         // guic: res_gui.cpp
         // gui_scriptc: res_gui_script.cpp
-        REGISTER_RESOURCE_TYPE("glyph_bankc", 0, ResGlyphBankPreload, ResGlyphBankCreate, 0, ResGlyphBankDestroy, ResGlyphBankRecreate);
-        REGISTER_RESOURCE_TYPE("wavc", 0, 0, ResSoundDataCreate, 0, ResSoundDataDestroy, ResSoundDataRecreate);
-        REGISTER_RESOURCE_TYPE("oggc", 0, 0, ResSoundDataCreate, 0, ResSoundDataDestroy, ResSoundDataRecreate);
-        REGISTER_RESOURCE_TYPE("soundc", 0, ResSoundPreload, ResSoundCreate, 0, ResSoundDestroy, ResSoundRecreate);
-        REGISTER_RESOURCE_TYPE("camerac", 0, 0, ResCameraCreate, 0, ResCameraDestroy, ResCameraRecreate);
-        REGISTER_RESOURCE_TYPE("input_bindingc", input_context, 0, ResInputBindingCreate, 0, ResInputBindingDestroy, ResInputBindingRecreate);
-        REGISTER_RESOURCE_TYPE("gamepadsc", 0, 0, ResGamepadMapCreate, 0, ResGamepadMapDestroy, ResGamepadMapRecreate);
-        REGISTER_RESOURCE_TYPE("factoryc", 0, ResFactoryPreload, ResFactoryCreate, 0, ResFactoryDestroy, ResFactoryRecreate);
-        REGISTER_RESOURCE_TYPE("collectionfactoryc", 0, ResCollectionFactoryPreload, ResCollectionFactoryCreate, 0, ResCollectionFactoryDestroy, ResCollectionFactoryRecreate);
-        REGISTER_RESOURCE_TYPE("labelc", 0, ResLabelPreload, ResLabelCreate, 0, ResLabelDestroy, ResLabelRecreate);
-        REGISTER_RESOURCE_TYPE("lightc", 0, 0, ResLightCreate, 0, ResLightDestroy, ResLightRecreate);
-        REGISTER_RESOURCE_TYPE("render_scriptc", render_context, 0, ResRenderScriptCreate, 0, ResRenderScriptDestroy, ResRenderScriptRecreate);
-        REGISTER_RESOURCE_TYPE("render_targetc", render_context, ResRenderTargetPreload, ResRenderTargetCreate, 0, ResRenderTargetDestroy, ResRenderTargetRecreate);
-        REGISTER_RESOURCE_TYPE("renderc", render_context, 0, ResRenderPrototypeCreate, 0, ResRenderPrototypeDestroy, ResRenderPrototypeRecreate);
-        REGISTER_RESOURCE_TYPE("spritec", 0, ResSpritePreload, ResSpriteCreate, 0, ResSpriteDestroy, ResSpriteRecreate);
-        REGISTER_RESOURCE_TYPE("texturesetc", physics_context, ResTextureSetPreload, ResTextureSetCreate, 0, ResTextureSetDestroy, ResTextureSetRecreate);
-        REGISTER_RESOURCE_TYPE(TILE_MAP_EXT, physics_context, ResTileGridPreload, ResTileGridCreate, 0, ResTileGridDestroy, ResTileGridRecreate);
-        REGISTER_RESOURCE_TYPE("meshsetc", 0, ResMeshSetPreload, ResMeshSetCreate, 0, ResMeshSetDestroy, ResMeshSetRecreate);
-        REGISTER_RESOURCE_TYPE("skeletonc", 0, ResSkeletonPreload, ResSkeletonCreate, 0, ResSkeletonDestroy, ResSkeletonRecreate);
-        REGISTER_RESOURCE_TYPE("rigscenec", 0, ResRigScenePreload, ResRigSceneCreate, 0, ResRigSceneDestroy, ResRigSceneRecreate);
-        REGISTER_RESOURCE_TYPE("display_profilesc", render_context, 0, ResDisplayProfilesCreate, 0, ResDisplayProfilesDestroy, ResDisplayProfilesRecreate);
+        REGISTER_RESOURCE_TYPE("glyph_bankc", 0, ResGlyphBankPreload, ResGlyphBankCreate, 0, ResGlyphBankDestroy, ResGlyphBankRecreate, 0);
+        REGISTER_RESOURCE_TYPE("wavc", 0, 0, ResSoundDataCreate, 0, ResSoundDataDestroy, ResSoundDataRecreate, 0);
+        REGISTER_RESOURCE_TYPE("oggc", 0, 0, ResSoundDataCreate, 0, ResSoundDataDestroy, ResSoundDataRecreate, 0);
+        REGISTER_RESOURCE_TYPE("soundc", 0, ResSoundPreload, ResSoundCreate, 0, ResSoundDestroy, ResSoundRecreate, 0);
+        REGISTER_RESOURCE_TYPE("camerac", 0, 0, ResCameraCreate, 0, ResCameraDestroy, ResCameraRecreate, 0);
+        REGISTER_RESOURCE_TYPE("input_bindingc", input_context, 0, ResInputBindingCreate, 0, ResInputBindingDestroy, ResInputBindingRecreate, 0);
+        REGISTER_RESOURCE_TYPE("gamepadsc", 0, 0, ResGamepadMapCreate, 0, ResGamepadMapDestroy, ResGamepadMapRecreate, 0);
+        REGISTER_RESOURCE_TYPE("factoryc", 0, ResFactoryPreload, ResFactoryCreate, 0, ResFactoryDestroy, ResFactoryRecreate, 0);
+        REGISTER_RESOURCE_TYPE("collectionfactoryc", 0, ResCollectionFactoryPreload, ResCollectionFactoryCreate, 0, ResCollectionFactoryDestroy, ResCollectionFactoryRecreate, 0);
+        REGISTER_RESOURCE_TYPE("labelc", 0, ResLabelPreload, ResLabelCreate, 0, ResLabelDestroy, ResLabelRecreate, 0);
+        REGISTER_RESOURCE_TYPE("lightc", 0, 0, ResLightCreate, 0, ResLightDestroy, ResLightRecreate, 0);
+        REGISTER_RESOURCE_TYPE("render_scriptc", render_context, 0, ResRenderScriptCreate, 0, ResRenderScriptDestroy, ResRenderScriptRecreate, 0);
+        REGISTER_RESOURCE_TYPE("render_targetc", render_context, ResRenderTargetPreload, ResRenderTargetCreate, 0, ResRenderTargetDestroy, ResRenderTargetRecreate, 0);
+        REGISTER_RESOURCE_TYPE("renderc", render_context, 0, ResRenderPrototypeCreate, 0, ResRenderPrototypeDestroy, ResRenderPrototypeRecreate, 0);
+        REGISTER_RESOURCE_TYPE("spritec", 0, ResSpritePreload, ResSpriteCreate, 0, ResSpriteDestroy, ResSpriteRecreate, 0);
+        REGISTER_RESOURCE_TYPE("texturesetc", physics_context, ResTextureSetPreload, ResTextureSetCreate, 0, ResTextureSetDestroy, ResTextureSetRecreate, 0);
+        REGISTER_RESOURCE_TYPE(TILE_MAP_EXT, physics_context, ResTileGridPreload, ResTileGridCreate, 0, ResTileGridDestroy, ResTileGridRecreate, 0);
+        REGISTER_RESOURCE_TYPE("meshsetc", 0, ResMeshSetPreload, ResMeshSetCreate, 0, ResMeshSetDestroy, ResMeshSetRecreate, 0);
+        REGISTER_RESOURCE_TYPE("skeletonc", 0, ResSkeletonPreload, ResSkeletonCreate, 0, ResSkeletonDestroy, ResSkeletonRecreate, 0);
+        REGISTER_RESOURCE_TYPE("rigscenec", 0, ResRigScenePreload, ResRigSceneCreate, 0, ResRigSceneDestroy, ResRigSceneRecreate, ResRigSceneRenderContextLost);
+        REGISTER_RESOURCE_TYPE("display_profilesc", render_context, 0, ResDisplayProfilesCreate, 0, ResDisplayProfilesDestroy, ResDisplayProfilesRecreate, 0);
 
 #undef REGISTER_RESOURCE_TYPE
 
@@ -162,7 +162,7 @@ namespace dmGameSystem
                                 update_func, fixed_update_func, render_func, post_update_func, on_message_func, on_input_func, \
                                 on_reload_func, get_property_func, set_property_func, \
                                 iter_child_func, iter_property_func, \
-                                set_reads_transforms)\
+                                set_reads_transforms, render_context_lost_func)\
     factory_result = dmResource::GetTypeFromExtension(factory, extension, &type);\
     if (factory_result != dmResource::RESULT_OK)\
     {\
@@ -175,6 +175,7 @@ namespace dmGameSystem
     component_type.m_Context = context;\
     component_type.m_NewWorldFunction = new_world_func;\
     component_type.m_DeleteWorldFunction = delete_world_func;\
+    component_type.m_WorldRenderContextLost = render_context_lost_func;\
     component_type.m_CreateFunction = create_func;\
     component_type.m_DestroyFunction = destroy_func;\
     component_type.m_InitFunction = init_func;\
@@ -210,7 +211,7 @@ namespace dmGameSystem
                 &CompCollectionProxyUpdate, 0, &CompCollectionProxyRender, &CompCollectionProxyPostUpdate, &CompCollectionProxyOnMessage, &CompCollectionProxyOnInput,
                 0, 0, 0,
                 &CompCollectionProxyIterChildren, 0,
-                0);
+                0, 0);
 
         // See gameobject_comp.cpp for these two component types:
         // Priority 200 is reserved for scriptc (read+write transforms)
@@ -224,7 +225,7 @@ namespace dmGameSystem
                 &CompCollisionObjectUpdate, CompCollisionObjectFixedUpdate, 0, &CompCollisionObjectPostUpdate, &CompCollisionObjectOnMessage, 0,
                 &CompCollisionObjectOnReload, CompCollisionObjectGetProperty, CompCollisionObjectSetProperty,
                 0, CompCollisionIterProperties,
-                1);
+                1, 0);
 
         REGISTER_COMPONENT_TYPE("camerac", 500, render_context,
                 &CompCameraNewWorld, &CompCameraDeleteWorld,
@@ -232,7 +233,7 @@ namespace dmGameSystem
                 &CompCameraUpdate, 0, 0, 0, &CompCameraOnMessage, 0,
                 &CompCameraOnReload, CompCameraGetProperty, CompCameraSetProperty,
                 0, 0,
-                1);
+                1, 0);
 
         REGISTER_COMPONENT_TYPE("soundc", 600, sound_context,
                 CompSoundNewWorld, CompSoundDeleteWorld,
@@ -240,7 +241,7 @@ namespace dmGameSystem
                 CompSoundUpdate, 0, 0, 0, CompSoundOnMessage, 0,
                 0, CompSoundGetProperty, CompSoundSetProperty,
                 0, 0,
-                0);
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("modelc", 700, model_context,
                 CompModelNewWorld, CompModelDeleteWorld,
@@ -248,7 +249,7 @@ namespace dmGameSystem
                 CompModelUpdate, 0, CompModelRender, 0, CompModelOnMessage, 0,
                 0, CompModelGetProperty, CompModelSetProperty,
                 0, CompModelIterProperties,
-                0);
+                0, CompModelWorldRenderContextLost);
 
         // prio: 725  comp_mesh.cpp
 
@@ -258,7 +259,7 @@ namespace dmGameSystem
                 &CompParticleFXUpdate, 0, &CompParticleFXRender, 0, &CompParticleFXOnMessage, 0,
                 &CompParticleFXOnReload, 0, 0,
                 0, 0,
-                1);
+                1, CompParticleFXWorldRenderContextLost);
 
         REGISTER_COMPONENT_TYPE("factoryc", 900, factory_context,
                 CompFactoryNewWorld, CompFactoryDeleteWorld,
@@ -266,7 +267,7 @@ namespace dmGameSystem
                 CompFactoryUpdate, 0, 0, 0, CompFactoryOnMessage, 0,
                 0, CompFactoryGetProperty, 0,
                 0, 0,
-                0);
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("collectionfactoryc", 950, collectionfactory_context,
                 CompCollectionFactoryNewWorld, CompCollectionFactoryDeleteWorld,
@@ -274,7 +275,7 @@ namespace dmGameSystem
                 CompCollectionFactoryUpdate, 0, 0, 0, 0, 0,
                 0, CompCollectionFactoryGetProperty, 0,
                 0, 0,
-                0);
+                0, 0);
 
         REGISTER_COMPONENT_TYPE("lightc", 1000, render_context,
                 CompLightNewWorld, CompLightDeleteWorld,
@@ -282,7 +283,7 @@ namespace dmGameSystem
                 CompLightUpdate, 0, 0, 0, CompLightOnMessage, 0,
                 0, 0, 0,
                 0, 0,
-                1);
+                1, 0);
 
         REGISTER_COMPONENT_TYPE("spritec", 1100, sprite_context,
                 CompSpriteNewWorld, CompSpriteDeleteWorld,
@@ -290,7 +291,7 @@ namespace dmGameSystem
                 CompSpriteUpdate, 0, CompSpriteRender, 0, CompSpriteOnMessage, 0,
                 CompSpriteOnReload, CompSpriteGetProperty, CompSpriteSetProperty,
                 0, CompSpriteIterProperties,
-                1);
+                1, CompSpriteWorldRenderContextLost);
 
         REGISTER_COMPONENT_TYPE(TILE_MAP_EXT, 1200, tilemap_context,
                 CompTileGridNewWorld, CompTileGridDeleteWorld,
@@ -298,7 +299,7 @@ namespace dmGameSystem
                 CompTileGridUpdate, 0, CompTileGridRender, 0, CompTileGridOnMessage, 0,
                 CompTileGridOnReload, CompTileGridGetProperty, CompTileGridSetProperty,
                 0, CompTileGridIterProperties,
-                1);
+                1, CompTileGridWorldRenderContextLost);
 
         REGISTER_COMPONENT_TYPE("labelc", 1400, label_context,
                 CompLabelNewWorld, CompLabelDeleteWorld,
@@ -306,7 +307,7 @@ namespace dmGameSystem
                 CompLabelUpdate, 0, CompLabelRender, 0, CompLabelOnMessage, 0,
                 CompLabelOnReload, CompLabelGetProperty, CompLabelSetProperty,
                 0, CompLabelIterProperties,
-                1);
+                1, 0);
 
         #undef REGISTER_COMPONENT_TYPE
 

--- a/engine/gamesys/src/gamesys/resources/res_animationset.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_animationset.cpp
@@ -96,7 +96,8 @@ namespace dmGameSystem
                                            ResAnimationSetCreate,
                                            0,
                                            ResAnimationSetDestroy,
-                                           ResAnimationSetRecreate);
+                                           ResAnimationSetRecreate,
+                                           0);
     }
 }
 

--- a/engine/gamesys/src/gamesys/resources/res_compute_shader.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_compute_shader.cpp
@@ -95,4 +95,11 @@ namespace dmGameSystem
         dmDDF::FreeMessage(ddf);
         return res;
     }
+
+    dmResource::Result ResComputeShaderRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        dmGraphics::HComputeProgram resource = (dmGraphics::HComputeProgram) params.m_Resource->m_Resource;
+        dmGraphics::InvalidateComputeProgram(resource);
+        return dmResource::RESULT_OK;
+    }
 }

--- a/engine/gamesys/src/gamesys/resources/res_compute_shader.h
+++ b/engine/gamesys/src/gamesys/resources/res_compute_shader.h
@@ -23,6 +23,7 @@ namespace dmGameSystem
     dmResource::Result ResComputeShaderCreate(const dmResource::ResourceCreateParams& params);
     dmResource::Result ResComputeShaderDestroy(const dmResource::ResourceDestroyParams& params);
     dmResource::Result ResComputeShaderRecreate(const dmResource::ResourceRecreateParams& params);
+    dmResource::Result ResComputeShaderRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_COMPUTE_SHADER_H

--- a/engine/gamesys/src/gamesys/resources/res_font_map.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.cpp
@@ -198,4 +198,14 @@ namespace dmGameSystem
         params.m_Resource->m_ResourceSize = dmRender::GetFontMapResourceSize(font_map);
         return dmResource::RESULT_OK;
     }
+
+    dmResource::Result ResFontMapRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        dmRender::HFontMap font_map = (dmRender::HFontMap)params.m_Resource->m_Resource;
+        Resources* resources = (Resources*) dmRender::GetFontMapUserData(font_map);
+        dmResource::InvalidateGraphicsHandle(params.m_Factory, (void*) resources->m_MaterialResource);
+        dmResource::InvalidateGraphicsHandle(params.m_Factory, (void*) resources->m_GlyphBankResource);
+        dmRender::InvalidateFontMap(font_map);
+        return dmResource::RESULT_OK;
+    }
 }

--- a/engine/gamesys/src/gamesys/resources/res_font_map.h
+++ b/engine/gamesys/src/gamesys/resources/res_font_map.h
@@ -27,6 +27,8 @@ namespace dmGameSystem
     dmResource::Result ResFontMapDestroy(const dmResource::ResourceDestroyParams& params);
 
     dmResource::Result ResFontMapRecreate(const dmResource::ResourceRecreateParams& params);
+
+    dmResource::Result ResFontMapRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_FONT_MAP_H

--- a/engine/gamesys/src/gamesys/resources/res_fragment_program.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_fragment_program.cpp
@@ -17,7 +17,7 @@
 
 namespace dmGameSystem
 {
-    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, dmGraphics::ShaderDesc* ddf, dmGraphics::HVertexProgram* program)
+    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, dmGraphics::ShaderDesc* ddf, dmGraphics::HFragmentProgram* program)
     {
         dmGraphics::ShaderDesc::Shader* shader = dmGraphics::GetShaderProgram(context, ddf);
         if (shader == 0x0)
@@ -49,7 +49,7 @@ namespace dmGameSystem
     dmResource::Result ResFragmentProgramCreate(const dmResource::ResourceCreateParams& params)
     {
         dmGraphics::ShaderDesc* ddf = (dmGraphics::ShaderDesc*)params.m_PreloadData;
-        dmGraphics::HVertexProgram resource = 0x0;
+        dmGraphics::HFragmentProgram resource = 0x0;
         dmResource::Result r = AcquireResources((dmGraphics::HContext) params.m_Context, params.m_Factory, ddf, &resource);
         if (r == dmResource::RESULT_OK)
         {
@@ -61,14 +61,14 @@ namespace dmGameSystem
 
     dmResource::Result ResFragmentProgramDestroy(const dmResource::ResourceDestroyParams& params)
     {
-        dmGraphics::HVertexProgram resource = (dmGraphics::HVertexProgram)params.m_Resource->m_Resource;
+        dmGraphics::HFragmentProgram resource = (dmGraphics::HFragmentProgram)params.m_Resource->m_Resource;
         dmGraphics::DeleteFragmentProgram(resource);
         return dmResource::RESULT_OK;
     }
 
     dmResource::Result ResFragmentProgramRecreate(const dmResource::ResourceRecreateParams& params)
     {
-        dmGraphics::HVertexProgram resource = (dmGraphics::HVertexProgram)params.m_Resource->m_Resource;
+        dmGraphics::HFragmentProgram resource = (dmGraphics::HFragmentProgram)params.m_Resource->m_Resource;
         if (resource == 0)
         {
             return dmResource::RESULT_FORMAT_ERROR;
@@ -94,5 +94,12 @@ namespace dmGameSystem
 
         dmDDF::FreeMessage(ddf);
         return res;
+    }
+
+    dmResource::Result ResFragmentProgramRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        dmGraphics::HFragmentProgram resource = (dmGraphics::HFragmentProgram)params.m_Resource->m_Resource;
+        dmGraphics::InvalidateFragmentProgram(resource);
+        return dmResource::RESULT_OK;
     }
 }

--- a/engine/gamesys/src/gamesys/resources/res_fragment_program.h
+++ b/engine/gamesys/src/gamesys/resources/res_fragment_program.h
@@ -27,6 +27,8 @@ namespace dmGameSystem
     dmResource::Result ResFragmentProgramDestroy(const dmResource::ResourceDestroyParams& params);
 
     dmResource::Result ResFragmentProgramRecreate(const dmResource::ResourceRecreateParams& params);
+
+    dmResource::Result ResFragmentProgramRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_FRAGMENT_PROGRAM_H

--- a/engine/gamesys/src/gamesys/resources/res_gui_script.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui_script.cpp
@@ -157,7 +157,8 @@ namespace dmGameSystem
                                            ResCreateGuiScript,
                                            0, // post create
                                            ResDestroyGuiScript,
-                                           ResRecreateGuiScript);
+                                           ResRecreateGuiScript,
+                                           0);
     }
 
     static dmResource::Result ResourceTypeGuiScript_Unregister(dmResource::ResourceTypeRegisterContext& ctx)

--- a/engine/gamesys/src/gamesys/resources/res_material.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_material.cpp
@@ -373,4 +373,25 @@ namespace dmGameSystem
         *params.m_PreloadData = ddf;
         return dmResource::RESULT_OK;
     }
+
+    dmResource::Result ResMaterialRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        dmRender::HRenderContext render_context = (dmRender::HRenderContext) params.m_Context;
+        MaterialResource* resource = (MaterialResource*) params.m_Resource->m_Resource;
+
+        for (uint32_t i = 0; i < dmRender::RenderObject::MAX_TEXTURE_COUNT; ++i)
+        {
+            if (resource->m_Textures[i])
+            {
+                dmResource::InvalidateGraphicsHandle(params.m_Factory, (void*)resource->m_Textures[i]);
+            }
+        }
+
+        dmRender::HMaterial material = resource->m_Material;
+        dmGraphics::InvalidateVertexProgram(dmRender::GetMaterialVertexProgram(material));
+        dmGraphics::InvalidateFragmentProgram(dmRender::GetMaterialFragmentProgram(material));
+        dmRender::InvalidateMaterial(render_context, material);
+
+        return dmResource::RESULT_OK;
+    }
 }

--- a/engine/gamesys/src/gamesys/resources/res_material.h
+++ b/engine/gamesys/src/gamesys/resources/res_material.h
@@ -27,6 +27,8 @@ namespace dmGameSystem
     dmResource::Result ResMaterialRecreate(const dmResource::ResourceRecreateParams& params);
 
     dmResource::Result ResMaterialPreload(const dmResource::ResourcePreloadParams& params);
+
+    dmResource::Result ResMaterialRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif

--- a/engine/gamesys/src/gamesys/resources/res_mesh.h
+++ b/engine/gamesys/src/gamesys/resources/res_mesh.h
@@ -32,6 +32,8 @@ namespace dmGameSystem
     dmResource::Result ResMeshRecreate(const dmResource::ResourceRecreateParams& params);
 
     bool BuildVertexDeclaration(BufferResource* buffer_resource, dmGraphics::HVertexDeclaration* out_vert_decl);
+
+    dmResource::Result ResMeshRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_MESH_H

--- a/engine/gamesys/src/gamesys/resources/res_model.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_model.cpp
@@ -438,4 +438,45 @@ namespace dmGameSystem
         model_resource->m_Model = ddf;
         return AcquireResources((dmGraphics::HContext) params.m_Context, params.m_Factory, model_resource, params.m_Filename);
     }
+
+    void InvalidateResources(dmResource::HFactory factory, ModelResource* resource)
+    {
+        for (uint32_t i = 0; i < resource->m_Meshes.Size(); ++i)
+        {
+            MeshInfo& info = resource->m_Meshes[i];
+            dmGraphics::InvalidateVertexBuffer(info.m_Buffers->m_VertexBuffer);
+            dmGraphics::InvalidateIndexBuffer(info.m_Buffers->m_IndexBuffer);
+        }
+
+        if (resource->m_RigScene != 0x0)
+        {
+            dmResource::InvalidateGraphicsHandle(factory, resource->m_RigScene);
+        }
+
+        for (uint32_t i = 0; i < resource->m_Materials.Size(); ++i)
+        {
+            MaterialInfo* material = &resource->m_Materials[i];
+            dmResource::InvalidateGraphicsHandle(factory, material->m_Material);
+
+            for (uint32_t t = 0; t < material->m_TexturesCount; ++t)
+            {
+                if (material->m_Textures[t].m_RenderTarget)
+                {
+                    dmResource::InvalidateGraphicsHandle(factory, (void*) material->m_Textures[t].m_RenderTarget);
+                }
+                else if (material->m_Textures[t].m_Texture)
+                {
+                    dmResource::InvalidateGraphicsHandle(factory, (void*) material->m_Textures[t].m_Texture);
+                }
+            }
+        }
+    }
+
+    dmResource::Result ResModelRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        ModelResource* model_resource = (ModelResource*)params.m_Resource->m_Resource;
+        InvalidateResources(params.m_Factory, model_resource);
+        return dmResource::RESULT_OK;
+
+    }
 }

--- a/engine/gamesys/src/gamesys/resources/res_model.h
+++ b/engine/gamesys/src/gamesys/resources/res_model.h
@@ -27,6 +27,8 @@ namespace dmGameSystem
     dmResource::Result ResModelDestroy(const dmResource::ResourceDestroyParams& params);
 
     dmResource::Result ResModelRecreate(const dmResource::ResourceRecreateParams& params);
+
+    dmResource::Result ResModelRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_MODEL_H

--- a/engine/gamesys/src/gamesys/resources/res_rig_scene.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_rig_scene.cpp
@@ -183,4 +183,18 @@ namespace dmGameSystem
         params.m_Resource->m_ResourceSize = GetResourceSize(ss_resource, params.m_BufferSize);
         return dmResource::RESULT_OK;
     }
+
+    dmResource::Result ResRigSceneRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        RigSceneResource* rig_resource = (RigSceneResource*)params.m_Resource->m_Resource;
+        if (rig_resource->m_TextureSet != 0x0)
+            dmResource::InvalidateGraphicsHandle(params.m_Factory, rig_resource->m_TextureSet);
+        if (rig_resource->m_SkeletonRes != 0x0)
+            dmResource::InvalidateGraphicsHandle(params.m_Factory, rig_resource->m_SkeletonRes);
+        if (rig_resource->m_AnimationSetRes != 0x0)
+            dmResource::InvalidateGraphicsHandle(params.m_Factory, rig_resource->m_AnimationSetRes);
+        if (rig_resource->m_MeshSetRes != 0x0)
+            dmResource::InvalidateGraphicsHandle(params.m_Factory, rig_resource->m_MeshSetRes);
+        return dmResource::RESULT_OK;
+    }
 }

--- a/engine/gamesys/src/gamesys/resources/res_rig_scene.h
+++ b/engine/gamesys/src/gamesys/resources/res_rig_scene.h
@@ -27,6 +27,8 @@ namespace dmGameSystem
     dmResource::Result ResRigSceneDestroy(const dmResource::ResourceDestroyParams& params);
 
     dmResource::Result ResRigSceneRecreate(const dmResource::ResourceRecreateParams& params);
+
+    dmResource::Result ResRigSceneRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_SPINE_SCENE_H

--- a/engine/gamesys/src/gamesys/resources/res_texture.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_texture.cpp
@@ -442,4 +442,11 @@ namespace dmGameSystem
         }
         return r;
     }
+
+    dmResource::Result ResTextureRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        TextureResource* texture_res = (TextureResource*) params.m_Resource->m_Resource;
+        dmGraphics::InvalidateTexture(texture_res->m_Texture);
+        return dmResource::RESULT_OK;
+    }
 }

--- a/engine/gamesys/src/gamesys/resources/res_texture.h
+++ b/engine/gamesys/src/gamesys/resources/res_texture.h
@@ -49,6 +49,8 @@ namespace dmGameSystem
     dmResource::Result ResTextureDestroy(const dmResource::ResourceDestroyParams& params);
 
     dmResource::Result ResTextureRecreate(const dmResource::ResourceRecreateParams& params);
+
+    dmResource::Result ResTextureRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif

--- a/engine/gamesys/src/gamesys/resources/res_vertex_program.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_vertex_program.cpp
@@ -66,6 +66,13 @@ namespace dmGameSystem
         return dmResource::RESULT_OK;
     }
 
+    dmResource::Result ResVertexProgramRenderContextLost(const dmResource::ResourceRenderContextLostParams& params)
+    {
+        dmGraphics::HVertexProgram resource = (dmGraphics::HVertexProgram)params.m_Resource->m_Resource;
+        dmGraphics::InvalidateVertexProgram(resource);
+        return dmResource::RESULT_OK;
+    }
+
     dmResource::Result ResVertexProgramRecreate(const dmResource::ResourceRecreateParams& params)
     {
         dmGraphics::HVertexProgram resource = (dmGraphics::HVertexProgram)params.m_Resource->m_Resource;

--- a/engine/gamesys/src/gamesys/resources/res_vertex_program.h
+++ b/engine/gamesys/src/gamesys/resources/res_vertex_program.h
@@ -27,6 +27,8 @@ namespace dmGameSystem
     dmResource::Result ResVertexProgramDestroy(const dmResource::ResourceDestroyParams& params);
 
     dmResource::Result ResVertexProgramRecreate(const dmResource::ResourceRecreateParams& params);
+
+    dmResource::Result ResVertexProgramRenderContextLost(const dmResource::ResourceRenderContextLostParams& params);
 }
 
 #endif // DM_GAMESYS_RES_VERTEX_PROGRAM_H

--- a/engine/graphics/src/dmsdk/graphics/graphics.h
+++ b/engine/graphics/src/dmsdk/graphics/graphics.h
@@ -78,12 +78,16 @@ namespace dmGraphics
      */
     typedef uintptr_t HVertexBuffer;
 
+    typedef HVertexBuffer& HVertexBufferRef;
+
     /*#
      * Index buffer handle
      * @typedef
      * @name HIndexBuffer
      */
     typedef uintptr_t HIndexBuffer;
+
+    typedef HIndexBuffer& HIndexBufferRef;
 
     /*#
      * Storage buffer handle

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1322,6 +1322,10 @@ namespace dmGraphics
     {
         g_functions.m_DeleteProgram(context, program);
     }
+    void InvalidateProgramHandle(HContext context, HProgram program)
+    {
+        g_functions.m_InvalidateProgramHandle(context, program);
+    }
     bool ReloadVertexProgram(HVertexProgram prog, ShaderDesc::Shader* ddf)
     {
         return g_functions.m_ReloadVertexProgram(prog, ddf);
@@ -1498,6 +1502,10 @@ namespace dmGraphics
     {
         g_functions.m_DeleteTexture(t);
     }
+    void InvalidateTexture(HTexture texture)
+    {
+        g_functions.m_InvalidateTexture(texture);
+    }
     void SetTexture(HTexture texture, const TextureParams& params)
     {
         g_functions.m_SetTexture(texture, params);
@@ -1611,6 +1619,27 @@ namespace dmGraphics
     {
         return g_functions.m_DeleteComputeProgram(prog);
     }
+    void InvalidateVertexProgram(HVertexProgram prog)
+    {
+        g_functions.m_InvalidateVertexProgram(prog);
+    }
+    void InvalidateFragmentProgram(HFragmentProgram prog)
+    {
+        g_functions.m_InvalidateFragmentProgram(prog);
+    }
+    void InvalidateComputeProgram(HComputeProgram prog)
+    {
+        g_functions.m_InvalidateComputeProgram(prog);
+    }
+    void InvalidateVertexBuffer(HVertexBufferRef buffer)
+    {
+        g_functions.m_InvalidateVertexBuffer(buffer);
+    }
+    void InvalidateIndexBuffer(HIndexBufferRef buffer)
+    {
+        g_functions.m_InvalidateIndexBuffer(buffer);
+    }
+
 
 #if defined(DM_PLATFORM_IOS)
     void AppBootstrap(int argc, char** argv, void* init_ctx, EngineInit init_fn, EngineExit exit_fn, EngineCreate create_fn, EngineDestroy destroy_fn, EngineUpdate update_fn, EngineGetResult result_fn)

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -545,6 +545,7 @@ namespace dmGraphics
     HProgram             NewProgram(HContext context, HComputeProgram compute_program);
     HProgram             NewProgram(HContext context, HVertexProgram vertex_program, HFragmentProgram fragment_program);
     void                 DeleteProgram(HContext context, HProgram program);
+    void                 InvalidateProgramHandle(HContext context, HProgram program);
 
     bool                 ReloadVertexProgram(HVertexProgram prog, ShaderDesc::Shader* ddf);
     bool                 ReloadFragmentProgram(HFragmentProgram prog, ShaderDesc::Shader* ddf);
@@ -552,6 +553,9 @@ namespace dmGraphics
     void                 DeleteVertexProgram(HVertexProgram prog);
     void                 DeleteFragmentProgram(HFragmentProgram prog);
     void                 DeleteComputeProgram(HComputeProgram prog);
+    void                 InvalidateVertexProgram(HVertexProgram prog);
+    void                 InvalidateFragmentProgram(HFragmentProgram prog);
+    void                 InvalidateComputeProgram(HComputeProgram prog);
 
     ShaderDesc::Language GetShaderProgramLanguage(HContext context, ShaderDesc::ShaderClass shader_class);
     ShaderDesc::Language GetProgramLanguage(HProgram program);
@@ -610,6 +614,7 @@ namespace dmGraphics
     uint32_t GetTextureFormatBitsPerPixel(TextureFormat format);
     HTexture NewTexture(HContext context, const TextureCreationParams& params);
     void DeleteTexture(HTexture t);
+    void InvalidateTexture(HTexture texture);
 
     /**
      * Set texture data. For textures of type TEXTURE_TYPE_CUBE_MAP it's assumed that
@@ -737,6 +742,9 @@ namespace dmGraphics
 
     uint32_t    GetTypeSize(Type type);
     const char* GetGraphicsTypeLiteral(Type type);
+
+    void InvalidateVertexBuffer(HVertexBufferRef buffer);
+    void InvalidateIndexBuffer(HIndexBufferRef buffer);
 
     // Test functions:
     void* MapVertexBuffer(HContext context, HVertexBuffer buffer, BufferAccess access);

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -87,10 +87,13 @@ namespace dmGraphics
     typedef HFragmentProgram (*NewFragmentProgramFn)(HContext context, ShaderDesc::Shader* ddf);
     typedef HProgram (*NewProgramFn)(HContext context, HVertexProgram vertex_program, HFragmentProgram fragment_program);
     typedef void (*DeleteProgramFn)(HContext context, HProgram program);
+    typedef void (*InvalidateProgramHandleFn)(HContext context, HProgram program);
     typedef bool (*ReloadVertexProgramFn)(HVertexProgram prog, ShaderDesc::Shader* ddf);
     typedef bool (*ReloadFragmentProgramFn)(HFragmentProgram prog, ShaderDesc::Shader* ddf);
     typedef void (*DeleteVertexProgramFn)(HVertexProgram prog);
+    typedef void (*InvalidateVertexProgramFn)(HVertexProgram prog);
     typedef void (*DeleteFragmentProgramFn)(HFragmentProgram prog);
+    typedef void (*InvalidateFragmentProgramFn)(HFragmentProgram prog);
     typedef ShaderDesc::Language (*GetShaderProgramLanguageFn)(HContext context, ShaderDesc::ShaderClass shader_class);
     typedef ShaderDesc::Language (*GetProgramLanguageFn)(HProgram program);
     typedef void (*EnableProgramFn)(HContext context, HProgram program);
@@ -131,6 +134,7 @@ namespace dmGraphics
     typedef bool (*IsTextureFormatSupportedFn)(HContext context, TextureFormat format);
     typedef HTexture (*NewTextureFn)(HContext context, const TextureCreationParams& params);
     typedef void (*DeleteTextureFn)(HTexture t);
+    typedef void (*InvalidateTextureFn)(HTexture texture);
     typedef void (*SetTextureFn)(HTexture texture, const TextureParams& params);
     typedef void (*SetTextureAsyncFn)(HTexture texture, const TextureParams& params, SetTextureAsyncCallback callback, void* user_data);
     typedef void (*SetTextureParamsFn)(HTexture texture, TextureFilter minfilter, TextureFilter magfilter, TextureWrap uwrap, TextureWrap vwrap, float max_anisotropy);
@@ -158,6 +162,9 @@ namespace dmGraphics
     typedef HComputeProgram (*NewComputeProgramFn)(HContext context, ShaderDesc::Shader* ddf);
     typedef HProgram (*NewProgramFromComputeFn)(HContext context, HComputeProgram compute_program);
     typedef void (*DeleteComputeProgramFn)(HComputeProgram prog);
+    typedef void (*InvalidateComputeProgramFn)(HComputeProgram prog);
+    typedef void (*InvalidateVertexBufferFn)(HVertexBufferRef buffer);
+    typedef void (*InvalidateIndexBufferFn)(HIndexBufferRef buffer);
 
     struct GraphicsAdapterFunctionTable
     {
@@ -198,10 +205,14 @@ namespace dmGraphics
         NewFragmentProgramFn m_NewFragmentProgram;
         NewProgramFn m_NewProgram;
         DeleteProgramFn m_DeleteProgram;
+        InvalidateProgramHandleFn m_InvalidateProgramHandle;
         ReloadVertexProgramFn m_ReloadVertexProgram;
         ReloadFragmentProgramFn m_ReloadFragmentProgram;
         DeleteVertexProgramFn m_DeleteVertexProgram;
         DeleteFragmentProgramFn m_DeleteFragmentProgram;
+        InvalidateVertexProgramFn m_InvalidateVertexProgram;
+        InvalidateFragmentProgramFn m_InvalidateFragmentProgram;
+        InvalidateComputeProgramFn m_InvalidateComputeProgram;
         GetProgramLanguageFn m_GetProgramLanguage;
         GetShaderProgramLanguageFn m_GetShaderProgramLanguage;
         EnableProgramFn m_EnableProgram;
@@ -240,6 +251,7 @@ namespace dmGraphics
         IsTextureFormatSupportedFn m_IsTextureFormatSupported;
         NewTextureFn m_NewTexture;
         DeleteTextureFn m_DeleteTexture;
+        InvalidateTextureFn m_InvalidateTexture;
         SetTextureFn m_SetTexture;
         SetTextureAsyncFn m_SetTextureAsync;
         SetTextureParamsFn m_SetTextureParams;
@@ -265,6 +277,8 @@ namespace dmGraphics
         GetPipelineStateFn m_GetPipelineState;
         IsContextFeatureSupportedFn m_IsContextFeatureSupported;
         IsAssetHandleValidFn m_IsAssetHandleValid;
+        InvalidateVertexBufferFn m_InvalidateVertexBuffer;
+        InvalidateIndexBufferFn m_InvalidateIndexBuffer;
 
         // Compute
         ReloadComputeProgramFn  m_ReloadComputeProgram;
@@ -313,6 +327,7 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewFragmentProgram); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewProgram); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteProgram); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateProgramHandle); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, ReloadVertexProgram); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, ReloadFragmentProgram); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteVertexProgram); \
@@ -357,6 +372,7 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsTextureFormatSupported); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewTexture); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteTexture); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateTexture); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetTexture); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetTextureAsync); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, SetTextureParams); \
@@ -385,7 +401,12 @@ namespace dmGraphics
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, IsAssetHandleValid); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewComputeProgram); \
         DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, NewProgramFromCompute); \
-        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteComputeProgram);
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, DeleteComputeProgram); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateVertexBuffer); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateIndexBuffer); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateVertexProgram); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateFragmentProgram); \
+        DM_REGISTER_GRAPHICS_FUNCTION(tbl, adapter_name, InvalidateComputeProgram);
 }
 
 #endif

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -834,6 +834,11 @@ namespace dmGraphics
         delete p;
     }
 
+    static void NullInvalidateComputeProgram(HComputeProgram prog)
+    {
+        (void)prog;
+    }
+
     static HProgram NullNewProgram(HContext context, HVertexProgram vertex_program, HFragmentProgram fragment_program)
     {
         ShaderProgram* vertex   = 0x0;
@@ -852,6 +857,11 @@ namespace dmGraphics
     static void NullDeleteProgram(HContext context, HProgram program)
     {
         delete (Program*) program;
+    }
+
+    static void NullInvalidateProgramHandle(HContext context, HProgram program)
+    {
+        (void)context; (void)program;
     }
 
     static HVertexProgram NullNewVertexProgram(HContext context, ShaderDesc::Shader* ddf)
@@ -904,6 +914,16 @@ namespace dmGraphics
         for(uint32_t i = 0; i < p->m_Uniforms.Size(); ++i)
             delete[] p->m_Uniforms[i].m_Name;
         delete p;
+    }
+
+    static void NullInvalidateVertexProgram(HVertexProgram prog)
+    {
+        (void)prog;
+    }
+
+    static void NullInvalidateFragmentProgram(HFragmentProgram prog)
+    {
+        (void)prog;
     }
 
     void SetOverrideShaderLanguage(HContext context, ShaderDesc::ShaderClass shader_class, ShaderDesc::Language language)
@@ -1475,6 +1495,11 @@ namespace dmGraphics
         }
     }
 
+    static void NullInvalidateTexture(HTexture texture)
+    {
+        (void)texture;
+    }
+
     static HandleResult NullGetTextureHandle(HTexture texture, void** out_handle)
     {
         *out_handle = 0x0;
@@ -1879,6 +1904,16 @@ namespace dmGraphics
             return GetAssetFromContainer<RenderTarget>(context->m_AssetHandleContainer, asset_handle) != 0;
         }
         return false;
+    }
+
+    static void NullInvalidateVertexBuffer(HVertexBufferRef buffer)
+    {
+        (void)buffer;
+    }
+    
+    static void NullInvalidateIndexBuffer(HIndexBufferRef buffer)
+    {
+        (void)buffer;
     }
 
     bool UnmapIndexBuffer(HContext context, HIndexBuffer buffer)

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1903,6 +1903,13 @@ static void LogFrameBufferError(GLenum status)
         delete program_ptr;
     }
 
+    static void OpenGLInvalidateProgramHandle(HContext context, HProgram program)
+    {
+        (void) context;
+        OpenGLProgram* program_ptr = (OpenGLProgram*) program;
+        program_ptr->m_Id = 0x0;
+    }
+
     // Tries to compile a shader (either a vertex or fragment) program.
     // We use this together with a temporary GLuint program to see if we it's
     // possible to compile a reloaded program.
@@ -2003,6 +2010,26 @@ static void LogFrameBufferError(GLenum status)
     static void OpenGLDeleteComputeProgram(HComputeProgram program)
     {
         OpenGLDeleteShader((OpenGLShader*) program);
+    }
+
+    static void InvalidateOpenGLShader(OpenGLShader* shader)
+    {
+        shader->m_Id = 0x0;
+    }
+
+    static void OpenGLInvalidateVertexProgram(HVertexProgram prog)
+    {
+        InvalidateOpenGLShader((OpenGLShader*) prog);
+    }
+
+    static void OpenGLInvalidateFragmentProgram(HFragmentProgram prog)
+    {
+        InvalidateOpenGLShader((OpenGLShader*) prog);
+    }
+
+    static void OpenGLInvalidateComputeProgram(HComputeProgram prog)
+    {
+        InvalidateOpenGLShader((OpenGLShader*) prog);
     }
 
     static ShaderDesc::Language OpenGLGetProgramLanguage(HProgram program)
@@ -2872,6 +2899,16 @@ static void LogFrameBufferError(GLenum status)
         else
         {
             OpenGLDeleteTextureAsync(texture);
+        }
+    }
+
+    static void OpenGLInvalidateTexture(HTexture texture)
+    {
+        assert(texture);
+        OpenGLTexture* tex = GetAssetFromContainer<OpenGLTexture>(g_Context->m_AssetHandleContainer, texture);
+        for (uint16_t idx = 0; idx < tex->m_NumTextureIds; ++idx)
+        {
+            tex->m_TextureIds[idx] = 0x0;
         }
     }
 
@@ -3818,6 +3855,16 @@ static void LogFrameBufferError(GLenum status)
             return GetAssetFromContainer<OpenGLRenderTarget>(context->m_AssetHandleContainer, asset_handle) != 0;
         }
         return false;
+    }
+
+    static void OpenGLInvalidateVertexBuffer(HVertexBufferRef buffer)
+    {
+        buffer = 0x0;
+    }
+
+    static void OpenGLInvalidateIndexBuffer(HIndexBufferRef buffer)
+    {
+        buffer = 0x0;
     }
 
     GLenum TEXTURE_UNIT_NAMES[32] =

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2522,6 +2522,11 @@ bail:
         delete program_ptr;
     }
 
+    static void VulkanInvalidateProgramHandle(HContext context, HProgram program)
+    {
+        (void)context; (void) program;
+    }
+
     static void DestroyShader(ShaderModule* shader)
     {
         if (!shader)
@@ -2575,6 +2580,16 @@ bail:
         ShaderModule* shader = (ShaderModule*) prog;
         DestroyShader(shader);
         delete shader;
+    }
+
+    static void VulkanInvalidateVertexProgram(HVertexProgram prog)
+    {
+        (void)prog;
+    }
+
+    static void VulkanInvalidateFragmentProgram(HFragmentProgram prog)
+    {
+        (void)prog;
     }
 
     static ShaderDesc::Language VulkanGetShaderProgramLanguage(HContext context, ShaderDesc::ShaderClass shader_class)
@@ -3465,6 +3480,11 @@ bail:
         g_VulkanContext->m_AssetHandleContainer.Release(texture);
     }
 
+    static void VulkanInvalidateTexture(HTexture texture)
+    {
+        (void)texture;
+    }
+
     static inline uint32_t GetOffsetFromMipmap(VulkanTexture* texture, uint8_t mipmap)
     {
         uint8_t bitspp  = GetTextureFormatBitsPerPixel(texture->m_GraphicsFormat);
@@ -4094,6 +4114,11 @@ bail:
         ShaderModule* shader = (ShaderModule*) prog;
         DestroyShader(shader);
         delete shader;
+    }
+
+    static void VulkanInvalidateComputeProgram(HComputeProgram prog)
+    {
+        (void)prog;
     }
 
     ///////////////////////////////////
@@ -4742,6 +4767,16 @@ bail:
             }
         }
         assert(0); // Should not happen
+    }
+
+    static void VulkanInvalidateVertexBuffer(HVertexBufferRef buffer)
+    {
+        (void)buffer;
+    }
+
+    static void VulkanInvalidateIndexBuffer(HIndexBufferRef buffer)
+    {
+        (void)buffer;
     }
 
     static GraphicsAdapterFunctionTable VulkanRegisterFunctionTable()

--- a/engine/render/src/js/library_render.js
+++ b/engine/render/src/js/library_render.js
@@ -1,0 +1,20 @@
+var LibraryRenderer = {
+    $dmRenderer: {
+        renderContext: null,
+        renderCallback: null,
+
+        rendererContextEvent: function(event_name) {
+            if (dmRenderer.renderCallback) {
+                var event_id = stringToUTF8OnStack(event_name);
+                {{{ makeDynCall('vii', 'dmRenderer.renderCallback') }}}(dmRenderer.renderContext, event_id);
+            }
+        }
+    },
+    setupCallbackJS: function(context, callback) {
+        dmRenderer.renderContext = context;
+        dmRenderer.renderCallback = callback;
+    }
+}
+
+autoAddDeps(LibraryRenderer, '$dmRenderer');
+addToLibrary(LibraryRenderer);

--- a/engine/render/src/platform/renderer_common.cpp
+++ b/engine/render/src/platform/renderer_common.cpp
@@ -1,0 +1,22 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "render/render_private.h"
+
+namespace dmRender
+{
+    void PlatformSetupContextEventCallback(void* context, ContextEventCallback callback)
+    {
+    }
+}

--- a/engine/render/src/platform/renderer_web.cpp
+++ b/engine/render/src/platform/renderer_web.cpp
@@ -1,0 +1,25 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "render/render_private.h"
+
+extern "C" void setupCallbackJS(void* context, dmRender::ContextEventCallback callback);
+
+namespace dmRender
+{
+    void PlatformSetupContextEventCallback(void* context, ContextEventCallback callback)
+    {
+        setupCallbackJS(context, callback);
+    }
+}

--- a/engine/render/src/render/buffer.cpp
+++ b/engine/render/src/render/buffer.cpp
@@ -72,6 +72,26 @@ namespace dmRender
         delete buffer;
     }
 
+    void InvalidateBufferedRenderBuffer(HBufferedRenderBuffer buffer)
+    {
+        if (!buffer)
+            return;
+        for (uint32_t i = 0; i < buffer->m_Buffers.Size(); ++i)
+        {
+            switch(buffer->m_Type)
+            {
+            case RENDER_BUFFER_TYPE_VERTEX_BUFFER:
+                dmGraphics::InvalidateVertexBuffer(/*(dmGraphics::HVertexBufferRef) */buffer->m_Buffers[i]);
+                break;
+            case RENDER_BUFFER_TYPE_INDEX_BUFFER:
+                dmGraphics::InvalidateIndexBuffer(/*(dmGraphics::HIndexBufferRef) */buffer->m_Buffers[i]);
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
     HRenderBuffer AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer)
     {
         if (!buffer)

--- a/engine/render/src/render/debug_renderer.cpp
+++ b/engine/render/src/render/debug_renderer.cpp
@@ -146,6 +146,21 @@ namespace dmRender
         dmGraphics::DeleteVertexDeclaration(debug_renderer.m_VertexDeclaration);
     }
 
+    void InvalidateDebugRenderer(HRenderContext context)
+    {
+        if (!context->m_DebugRenderer.m_RenderContext)
+            return;
+        DebugRenderer& debug_renderer = context->m_DebugRenderer;
+        dmResource::HFactory resource_factory = dmScript::GetResourceFactory(context->m_ScriptContext);
+        HMaterial material = debug_renderer.m_TypeData[DEBUG_RENDER_TYPE_FACE_3D].m_RenderObject.m_Material;
+        dmRender::InvalidateMaterial(debug_renderer.m_RenderContext, material);
+
+        material = debug_renderer.m_TypeData[DEBUG_RENDER_TYPE_FACE_2D].m_RenderObject.m_Material;
+        dmRender::InvalidateMaterial(debug_renderer.m_RenderContext, material);
+
+        dmGraphics::InvalidateVertexBuffer(debug_renderer.m_VertexBuffer);
+    }
+
     void ClearDebugRenderObjects(HRenderContext context)
     {
         if (!context->m_DebugRenderer.m_RenderContext)

--- a/engine/render/src/render/debug_renderer.h
+++ b/engine/render/src/render/debug_renderer.h
@@ -35,6 +35,8 @@ namespace dmRender
      */
     void FinalizeDebugRenderer(HRenderContext render_context);
 
+    void InvalidateDebugRenderer(HRenderContext context);
+
     void ClearDebugRenderObjects(HRenderContext render_context);
 
     void FlushDebug(HRenderContext render_context, uint32_t render_order);

--- a/engine/render/src/render/font_renderer.cpp
+++ b/engine/render/src/render/font_renderer.cpp
@@ -305,6 +305,11 @@ namespace dmRender
         delete font_map;
     }
 
+    void InvalidateFontMap(HFontMap font_map)
+    {
+        dmGraphics::InvalidateTexture(font_map->m_Texture);
+    }
+
     void SetFontMap(HFontMap font_map, FontMapParams& params)
     {
         const dmArray<Glyph>& glyphs = params.m_Glyphs;
@@ -477,6 +482,12 @@ namespace dmRender
         dmMemory::AlignedFree(text_context.m_ClientBuffer);
         dmGraphics::DeleteVertexBuffer(text_context.m_VertexBuffer);
         dmGraphics::DeleteVertexDeclaration(text_context.m_VertexDecl);
+    }
+
+    void InvalidateTextContext(HRenderContext render_context)
+    {
+        TextContext& text_context = render_context->m_TextContext;
+        dmGraphics::InvalidateVertexBuffer(text_context.m_VertexBuffer);
     }
 
     DrawTextParams::DrawTextParams()

--- a/engine/render/src/render/font_renderer.h
+++ b/engine/render/src/render/font_renderer.h
@@ -149,6 +149,12 @@ namespace dmRender
     void DeleteFontMap(HFontMap font_map);
 
     /**
+     * Invalidate texture handle in font map
+     * @param font_map Font map handle
+     */
+    void InvalidateFontMap(HFontMap font_map);
+
+    /**
      * Update the font map with the specified parameters. The parameters are consumed and should not be read after this call.
      * @param font_map Font map handle
      * @param params Parameters to update
@@ -178,6 +184,7 @@ namespace dmRender
 
     void InitializeTextContext(HRenderContext render_context, uint32_t max_characters, uint32_t max_batches);
     void FinalizeTextContext(HRenderContext render_context);
+    void InvalidateTextContext(HRenderContext render_context);
 
     const int MAX_FONT_RENDER_CONSTANTS = 16;
     /**

--- a/engine/render/src/render/material.cpp
+++ b/engine/render/src/render/material.cpp
@@ -206,6 +206,16 @@ namespace dmRender
         delete material;
     }
 
+    void InvalidateMaterial(dmRender::HRenderContext render_context, HMaterial material)
+    {
+        dmGraphics::HContext graphics_context = dmRender::GetGraphicsContext(render_context);
+        dmGraphics::InvalidateProgramHandle(graphics_context, material->m_Program);
+        dmGraphics::InvalidateVertexProgram(material->m_VertexProgram);
+        dmGraphics::InvalidateFragmentProgram(material->m_FragmentProgram);
+        //! TODO: replace with necessary call
+        // dmGraphics::DeleteVertexDeclaration(material->m_VertexDeclaration);
+    }
+
     void ApplyMaterialConstants(dmRender::HRenderContext render_context, HMaterial material, const RenderObject* ro)
     {
         const dmArray<RenderConstant>& constants = material->m_Constants;

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -119,6 +119,7 @@ namespace dmRender
         InitializeRenderScriptContext(context->m_RenderScriptContext, graphics_context, params.m_ScriptContext, params.m_CommandBufferSize);
         InitializeRenderScriptCameraContext(context, params.m_ScriptContext);
         context->m_ScriptWorld = dmScript::NewScriptWorld(context->m_ScriptContext);
+        context->m_CallbackInfo = 0x0;
 
         context->m_DebugRenderer.m_RenderContext = 0;
         if (params.m_VertexShaderDesc != 0 && params.m_VertexShaderDescSize != 0 &&
@@ -134,6 +135,8 @@ namespace dmRender
 
         context->m_MultiBufferingRequired = 0;
 
+        context->m_IsRenderPaused = 0;
+
         dmGraphics::AdapterFamily installed_adapter_family = dmGraphics::GetInstalledAdapterFamily();
         if (installed_adapter_family == dmGraphics::ADAPTER_FAMILY_VULKAN ||
             installed_adapter_family == dmGraphics::ADAPTER_FAMILY_VENDOR)
@@ -143,6 +146,8 @@ namespace dmRender
 
         context->m_RenderListDispatch.SetCapacity(255);
 
+        SetupContextEventCallback(context, &OnContextEvent);
+
         dmMessage::Result r = dmMessage::NewSocket(RENDER_SOCKET_NAME, &context->m_Socket);
         assert(r == dmMessage::RESULT_OK);
         return context;
@@ -151,6 +156,12 @@ namespace dmRender
     Result DeleteRenderContext(HRenderContext render_context, dmScript::HContext script_context)
     {
         if (render_context == 0x0) return RESULT_INVALID_CONTEXT;
+
+        if (render_context->m_CallbackInfo != 0x0)
+        {
+            dmScript::DestroyCallback(render_context->m_CallbackInfo);
+            render_context->m_CallbackInfo = 0x0;
+        }
 
         FinalizeRenderScriptContext(render_context->m_RenderScriptContext, script_context);
         FinalizeRenderScriptCameraContext(render_context);
@@ -1123,5 +1134,56 @@ namespace dmRender
         predicate->m_Tags[predicate->m_TagCount++] = tag;
         std::sort(predicate->m_Tags, predicate->m_Tags+predicate->m_TagCount);
         return RESULT_OK;
+    }
+
+    void SetupContextEventCallback(void* context, ContextEventCallback callback)
+    {
+        PlatformSetupContextEventCallback(context, callback);
+    }
+
+    void OnContextEvent(void* context, const char* event_name)
+    {
+        if (strcmp(event_name, "context_lost") == 0)
+        {
+            PauseRender(context);
+        }
+        RenderContext* render_context = (RenderContext*)context;
+        if (render_context->m_CallbackInfo != 0x0)
+        {
+            dmScript::LuaCallbackInfo* cbk = render_context->m_CallbackInfo;
+            if (!dmScript::IsCallbackValid(cbk))
+            {
+                return;
+            }
+            lua_State* L = dmScript::GetCallbackLuaContext(cbk);
+            DM_LUA_STACK_CHECK(L, 0);
+
+            if (!dmScript::SetupCallback(cbk))
+            {
+                return;
+            }
+            lua_pushstring(L, event_name);
+            int ret = dmScript::PCall(L, 2, 0);
+            (void)ret;
+            dmScript::TeardownCallback(cbk);
+        }
+    }
+
+    void PauseRender(void* context)
+    {
+        RenderContext* render_context = (RenderContext*)context;
+        render_context->m_IsRenderPaused = 1;
+    }
+
+    void ResumeRender(void* context)
+    {
+        RenderContext* render_context = (RenderContext*)context;
+        render_context->m_IsRenderPaused = 0;
+    }
+
+    bool IsRenderPaused(void* context)
+    {
+        RenderContext* render_context = (RenderContext*)context;
+        return render_context->m_IsRenderPaused;
     }
 }

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -1143,11 +1143,15 @@ namespace dmRender
 
     void OnContextEvent(void* context, const char* event_name)
     {
+        RenderContext* render_context = (RenderContext*)context;
         if (strcmp(event_name, "context_lost") == 0)
         {
             PauseRender(context);
+            dmResource::HFactory resource_factory = dmScript::GetResourceFactory(render_context->m_ScriptContext);
+            dmResource::InvalidateGraphicsResources(resource_factory);
+            InvalidateTextContext(render_context);
+            InvalidateDebugRenderer(render_context);
         }
-        RenderContext* render_context = (RenderContext*)context;
         if (render_context->m_CallbackInfo != 0x0)
         {
             dmScript::LuaCallbackInfo* cbk = render_context->m_CallbackInfo;

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -178,6 +178,10 @@ namespace dmRender
     Result DrawDebug3d(HRenderContext context, const FrustumOptions* frustum_options);
     Result DrawDebug2d(HRenderContext context);
 
+    void PauseRender(void* context);
+    void ResumeRender(void* context);
+    bool IsRenderPaused(void* context);
+
     /**
      * Render debug square. The upper left corner of the screen is (-1,-1) and the bottom right is (1,1).
      * @param context Render context handle

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -243,6 +243,7 @@ namespace dmRender
     // Material
     HMaterial                       NewMaterial(dmRender::HRenderContext render_context, dmGraphics::HVertexProgram vertex_program, dmGraphics::HFragmentProgram fragment_program);
     void                            DeleteMaterial(dmRender::HRenderContext render_context, HMaterial material);
+    void                            InvalidateMaterial(dmRender::HRenderContext render_context, HMaterial material);
     HSampler                        GetMaterialSampler(HMaterial material, uint32_t unit);
     dmhash_t                        GetMaterialSamplerNameHash(HMaterial material, uint32_t unit);
     uint32_t                        GetMaterialSamplerUnit(HMaterial material, dmhash_t name_hash);
@@ -337,6 +338,7 @@ namespace dmRender
      */
     HBufferedRenderBuffer           NewBufferedRenderBuffer(HRenderContext render_context, RenderBufferType type);
     void                            DeleteBufferedRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
+    void                            InvalidateBufferedRenderBuffer(HBufferedRenderBuffer buffer);
     HRenderBuffer                   AddRenderBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     HRenderBuffer                   GetBuffer(HRenderContext render_context, HBufferedRenderBuffer buffer);
     int32_t                         GetBufferIndex(HRenderContext render_context, HBufferedRenderBuffer buffer);

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -269,6 +269,7 @@ namespace dmRender
         RenderScriptContext         m_RenderScriptContext;
         dmArray<RenderObject*>      m_RenderObjects;
         dmScript::ScriptWorld*      m_ScriptWorld;
+        dmScript::LuaCallbackInfo*  m_CallbackInfo;
 
         dmArray<RenderListEntry>    m_RenderList;
         dmArray<RenderListDispatch> m_RenderListDispatch;
@@ -295,6 +296,7 @@ namespace dmRender
         uint32_t                    m_StencilBufferCleared          : 1;
         uint32_t                    m_MultiBufferingRequired        : 1;
         uint32_t                    m_CurrentRenderCameraUseFrustum : 1;
+        uint32_t                    m_IsRenderPaused                : 1;
     };
 
     struct BufferedRenderBuffer
@@ -355,12 +357,20 @@ namespace dmRender
     };
 
     typedef void (*RangeCallback)(void* ctx, uint32_t val, size_t start, size_t count);
+    typedef void (*ContextEventCallback)(void* ctx, const char* event_name);
 
     // Invokes the callback for each range. Two ranges are not guaranteed to preceed/succeed one another.
     void FindRenderListRanges(uint32_t* first, size_t offset, size_t size, RenderListEntry* entries, FindRangeComparator& comp, void* ctx, RangeCallback callback );
 
     bool FindTagListRange(RenderListRange* ranges, uint32_t num_ranges, uint32_t tag_list_key, RenderListRange& range);
 
+    /*
+    * Possible event_name values: "context_lost", "context_restored"
+    * See dmloader.js for event's name constants.
+    */
+    void OnContextEvent(void* context, const char* event_name);
+    void SetupContextEventCallback(void* context, ContextEventCallback callback);
+    void PlatformSetupContextEventCallback(void* context, ContextEventCallback callback);
 
     // ******************************************************************************************************
 

--- a/engine/render/src/wscript
+++ b/engine/render/src/wscript
@@ -10,11 +10,17 @@ def configure(cont):
     pass
 
 def build(bld):
+    sources = bld.path.ant_glob('render/*.cpp') + bld.path.parent.ant_glob('proto/render/*.proto')
+    if 'web' in bld.env.PLATFORM:
+        sources += ['platform/renderer_web.cpp']
+    else:
+        sources += ['platform/renderer_common.cpp']
+
     obj = bld.stlib(features        = 'cxx ddf',
                     includes        = ['.', '../build/proto'],
                     proto_gen_py    = True,
                     protoc_includes = '../proto',
-                    source          = bld.path.ant_glob('render/*.cpp') + bld.path.parent.ant_glob('proto/render/*.proto'),
+                    source          = sources,
                     target          = 'render')
 
     bld.recurse('test')
@@ -29,6 +35,9 @@ def build(bld):
     bld.install_files('${PREFIX}/share/proto/render', '../proto/render/material_ddf.proto')
     bld.install_files('${PREFIX}/share/proto/render', '../proto/render/render_ddf.proto')
     bld.install_files('${PREFIX}/share/proto/render', '../proto/render/font_ddf.proto')
+
+    if 'web' in bld.env.PLATFORM:
+        bld.install_files('${PREFIX}/lib/%s/js' % bld.env['PLATFORM'], 'js/library_render.js', postpone = False)
 
     apidoc_extract_task(bld, [
       '../proto/render/material_ddf.proto',

--- a/engine/resource/src/dmsdk/resource/resource.h
+++ b/engine/resource/src/dmsdk/resource/resource.h
@@ -256,6 +256,21 @@ namespace dmResource
      */
     typedef Result (*FResourceRecreate)(const ResourceRecreateParams& params);
 
+    /**
+     * Parameters to ResourceRenderContextLost callback.
+     */
+    struct ResourceRenderContextLostParams
+    {
+        /// Factory handle
+        HFactory m_Factory;
+        /// Resource context
+        void* m_Context;
+        /// Resource descriptor for resource to destroy
+        HResourceDescriptor m_Resource;
+    };
+
+    typedef Result (*FResourceRenderContextLost)(const ResourceRenderContextLostParams& params);
+
 
     /**
      * Register a resource type
@@ -267,6 +282,7 @@ namespace dmResource
      * @param post_create_function Post create function pointer
      * @param destroy_function Destroy function pointer
      * @param recreate_function Recreate function pointer. Optional, 0 if recreate is not supported.
+     * @param context_lost_function Render context lost function pointer. Optional, 0 if no need to react on render context lost.
      * @return RESULT_OK on success
      */
     Result RegisterType(HFactory factory,
@@ -276,7 +292,8 @@ namespace dmResource
                                FResourceCreate create_function,
                                FResourcePostCreate post_create_function,
                                FResourceDestroy destroy_function,
-                               FResourceRecreate recreate_function);
+                               FResourceRecreate recreate_function,
+                               FResourceRenderContextLost context_lost_function);
 
 
     /**
@@ -472,6 +489,14 @@ namespace dmResource
      * @param resource [type: void*] Resource pointer
      */
     void Release(HFactory factory, void* resource);
+
+    /*#
+     * Invalidate any graphics related resource. Resource not free.
+     * @name InvalidateGraphicsHandle
+     * @param factory [type: dmResource::HFactory] Factory handle
+     * @param resource [type: void*] Resource pointer
+     */
+    void InvalidateGraphicsHandle(HFactory factory, void* resource);
 
     /*#
      * Hint the preloader what to load before Create is called on the resource.

--- a/engine/resource/src/resource.h
+++ b/engine/resource/src/resource.h
@@ -385,6 +385,7 @@ namespace dmResource
      */
     struct IteratorResource
     {
+        void*    m_Resource;    // Resource struct
         dmhash_t m_Id;          // The name of the resource
         uint32_t m_SizeOnDisc;  // The size on disc (i.e. in the .darc file)
         uint32_t m_Size;        // in memory size, may be 0
@@ -410,6 +411,8 @@ namespace dmResource
     Result LoadResource(HFactory factory, const char* path, const char* original_name, void** buffer, uint32_t* resource_size);
     // load with own buffer
     Result LoadResourceFromBuffer(HFactory factory, const char* path, const char* original_name, uint32_t* resource_size, LoadBufferType* buffer);
+
+    void InvalidateGraphicsResources(HFactory factory);
 }
 
 #endif // RESOURCE_H

--- a/engine/resource/src/resource_private.h
+++ b/engine/resource/src/resource_private.h
@@ -44,14 +44,15 @@ namespace dmResource
         {
             memset(this, 0, sizeof(*this));
         }
-        dmhash_t            m_ExtensionHash;
-        const char*         m_Extension;
-        void*               m_Context;
-        FResourcePreload    m_PreloadFunction;
-        FResourceCreate     m_CreateFunction;
-        FResourcePostCreate m_PostCreateFunction;
-        FResourceDestroy    m_DestroyFunction;
-        FResourceRecreate   m_RecreateFunction;
+        dmhash_t                   m_ExtensionHash;
+        const char*                m_Extension;
+        void*                      m_Context;
+        FResourcePreload           m_PreloadFunction;
+        FResourceCreate            m_CreateFunction;
+        FResourcePostCreate        m_PostCreateFunction;
+        FResourceDestroy           m_DestroyFunction;
+        FResourceRecreate          m_RecreateFunction;
+        FResourceRenderContextLost m_RenderContextLostFunction;
     };
 
     struct SResourceDescriptor;

--- a/engine/script/src/script/sys_ddf.proto
+++ b/engine/script/src/script/sys_ddf.proto
@@ -233,3 +233,18 @@ message SetUpdateFrequency
 {
     required int32 frequency = 1;
 }
+
+/*# resume rendering
+ * Resume rendering.
+ * This message can only be sent to the designated `@system` socket.
+ *
+ * @message
+ * @name resume_rendering
+ * @examples
+ * <pre>
+ * msg.post("@system:", "resume_rendering")
+ * </pre>
+ */
+ message ResumeRendering
+ {
+ }


### PR DESCRIPTION
### Technical details
* Hook gl context events on JS side.
* Add `render.set_listener` API.
* Implement listener notification about gl context events.
* Add rendering pause if "context_lost" event occurred.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
