### PR TITLE
Handle 'path' option in http.request for html5 implementation.

### DIFF
--- a/engine/gamesys/src/gamesys/scripts/script_http.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http.cpp
@@ -93,7 +93,7 @@ namespace dmGameSystem
      * @param [options] [type:table] optional table with request parameters. Supported entries:
      *
      * - [type:number] `timeout`: timeout in seconds
-     * - [type:string] `path`: path on disc where to download the file. Only overwrites the path if status is 200. [icon:attention] Not available in HTML5 build
+     * - [type:string] `path`: path on disc where to download the file. Only overwrites the path if status is 200. [icon:attention] Path should be absolute
      * - [type:boolean] `ignore_cache`: don't return cached data if we get a 304. [icon:attention] Not available in HTML5 build
      * - [type:boolean] `chunked_transfer`: use chunked transfer encoding for https requests larger than 16kb. Defaults to true. [icon:attention] Not available in HTML5 build
      *

--- a/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_http_js.cpp
@@ -53,6 +53,7 @@ namespace dmGameSystem
     {
         dmMessage::URL  m_Requester;
         void*           m_RequestData;
+        const char*     m_Path;
         int             m_Callback;
     };
 
@@ -98,6 +99,7 @@ namespace dmGameSystem
         resp.m_HeadersLength = headers_length;
         resp.m_Response = (uint64_t) response;
         resp.m_ResponseLength = response_length;
+        resp.m_Path = ctx->m_Path;
 
         resp.m_Headers = (uint64_t) malloc(headers_length);
         memcpy((void*) resp.m_Headers, headers, headers_length);
@@ -143,6 +145,7 @@ namespace dmGameSystem
         int top = lua_gettop(L);
 
         int callback = 0;
+        const char* path = 0;
         dmMessage::URL sender;
         if (dmScript::GetURL(L, &sender)) {
             RequestParams request_params;
@@ -205,6 +208,10 @@ namespace dmGameSystem
                     {
                         request_params.m_ReportProgress = lua_toboolean(L, -1);
                     }
+                    else if (strcmp(attr, "path") == 0)
+                    {
+                        path = luaL_checkstring(L, -1);
+                    }
                     lua_pop(L, 1);
                 }
                 lua_pop(L, 1);
@@ -214,6 +221,7 @@ namespace dmGameSystem
             ctx->m_Callback = callback;
             ctx->m_Requester = sender;
             ctx->m_RequestData = request_params.m_SendData;
+            ctx->m_Path = path;
 
             request_params.m_Args = ctx;
 


### PR DESCRIPTION
Add 'path' parameter handling for html5 implementation in `http.request` function.

Fixes #8234 

### Technical changes
Previously #8234 can appeared because of default value in `dmHttpDDF::HttpResponse::mPath`. Here is part of generated source file
```cpp
char DM_ALIGNED(4) dmHttpDDF_HttpResponse_path_DEFAULT_VALUE[] = "\x00";
dmDDF::FieldDescriptor dmHttpDDF_HttpResponse_FIELDS_DESCRIPTOR[] = 
{
    { "status", 1, 5, 2, 0x0, (uint32_t)DDF_OFFSET_OF(dmHttpDDF::HttpResponse, m_Status), 0x0, 0, 0},
    { "headers", 2, 4, 2, 0x0, (uint32_t)DDF_OFFSET_OF(dmHttpDDF::HttpResponse, m_Headers), 0x0, 0, 0},
    { "headers_length", 3, 13, 2, 0x0, (uint32_t)DDF_OFFSET_OF(dmHttpDDF::HttpResponse, m_HeadersLength), 0x0, 0, 0},
    { "response", 4, 4, 2, 0x0, (uint32_t)DDF_OFFSET_OF(dmHttpDDF::HttpResponse, m_Response), 0x0, 0, 0},
    { "response_length", 5, 13, 2, 0x0, (uint32_t)DDF_OFFSET_OF(dmHttpDDF::HttpResponse, m_ResponseLength), 0x0, 0, 0},
    { "path", 6, 9, 2, 0x0, (uint32_t)DDF_OFFSET_OF(dmHttpDDF::HttpResponse, m_Path), dmHttpDDF_HttpResponse_path_DEFAULT_VALUE, 0, 0},
};
```
As we see default value for `m_Path` field is empty string. When we try to rename `._httptmp` to `m_Path` we checked only pointer, not content.

I've added handling of `path` property for html5 implementation because emscripten can work with fopen/fwrite api (it simulates filesystem https://emscripten.org/docs/getting_started/Tutorial.html#using-files. In my example it looks like
```lua
	http.request("", "GET", function(self, id, response)
		pprint(id)
		pprint(response)
	end, {}, nil, { path = "/data/test1.bin"})
```
Result is
<img width="1728" alt="Screenshot 2024-05-11 at 12 26 08" src="https://github.com/defold/defold/assets/770105/71ecd808-66d2-4920-a5d5-8b614284b886">

<img width="565" alt="Screenshot 2024-05-11 at 12 26 28" src="https://github.com/defold/defold/assets/770105/25845dc8-3b80-4c8f-959b-1ba4cb3137cc">

⚠️ Pay attention that if `path` passed like './data/....' it doesn't work as expected. Path should be passed like '/data/....'.

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
