### PR TITLE
Clarify use of collectionproxy.get_resources()

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_collection_proxy.cpp
@@ -799,16 +799,18 @@ namespace dmGameSystem
 
     /*# return an indexed table of all the resources of a collection proxy
      *
-     * return an indexed table of resources for a collection proxy. Each
-     * entry is a hexadecimal string that represents the data of the specific
-     * resource. This representation corresponds with the filename for each
-     * individual resource that is exported when you bundle an application with
-     * LiveUpdate functionality.
+     * return an indexed table of resources for a collection proxy where the
+     * referenced collection has been excluded using LiveUpdate. Each entry is a
+     * hexadecimal string that represents the data of the specific resource.
+     * This representation corresponds with the filename for each individual
+     * resource that is exported when you bundle an application with LiveUpdate
+     * functionality.
      *
      * @namespace collectionproxy
      * @name collectionproxy.get_resources
      * @param collectionproxy [type:url] the collectionproxy to check for resources.
-     * @return resources [type:table] the resources
+     * @return resources [type:table] the resources, or an empty list if the
+     * collection was not excluded.
      *
      * @examples
      *


### PR DESCRIPTION
Clarifies that `collectionproxy.get_resources()` only returns resources if the collection has been excluded.

Closes #8909 