### PR TITLE
Add Defold YAML file types to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,11 @@
 *.tilemap linguist-language=text-proto
 *.tilesource linguist-language=text-proto
 
+# Defold YAML Files
+*.appmanifest linguist-language=YAML
+*.manifest linguist-language=YAML
+*.script_api linguist-language=YAML
+
 # Defold JSON Files
 *.buffer linguist-language=JSON
 


### PR DESCRIPTION
In gitattribute, set file types appmanifest, manifest, and script_api to use YAML linguist-language.

I have tested this in my own repo.

skip release notes