### PR TITLE
Make the ASCII character set optional in fonts

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -52,7 +52,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Set;
 
 import javax.imageio.ImageIO;
@@ -262,7 +262,7 @@ public class Fontc {
                 }
             }
         }
-        Set<Integer> deDup = new HashSet<Integer>(characters);
+        Set<Integer> deDup = new TreeSet<Integer>(characters);
         characters = new ArrayList<Integer>(deDup);
 
         if (fontDesc.getOutlineWidth() > 0.0f) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/font/Fontc.java
@@ -262,7 +262,6 @@ public class Fontc {
                 }
             }
         }
-        System.out.print("\ncharacters: "+characters+"\n");
         Set<Integer> deDup = new HashSet<Integer>(characters);
         characters = new ArrayList<Integer>(deDup);
 

--- a/editor/resources/templates/template.font
+++ b/editor/resources/templates/template.font
@@ -1,3 +1,4 @@
 font: "/builtins/fonts/vera_mo_bd.ttf"
 material: "/builtins/fonts/font.material"
 size: 15
+characters: " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"

--- a/editor/src/clj/editor/font.clj
+++ b/editor/src/clj/editor/font.clj
@@ -494,7 +494,7 @@
                                   :passes [pass/transparent]}))))
 
 (g/defnk produce-pb-msg [pb font material size antialias alpha outline-alpha outline-width
-                         shadow-alpha shadow-blur shadow-x shadow-y extra-characters output-format
+                         shadow-alpha shadow-blur shadow-x shadow-y characters output-format
                          all-chars cache-width cache-height render-mode]
   ;; The reason we use the originally loaded pb is to retain any default values
   ;; This is important for the saved file to not contain more data than it would
@@ -511,7 +511,7 @@
           :shadow-blur shadow-blur
           :shadow-x shadow-x
           :shadow-y shadow-y
-          :extra-characters extra-characters
+          :characters characters
           :output-format output-format
           :all-chars all-chars
           :cache-width cache-width
@@ -741,14 +741,23 @@
             (dynamic visible output-format-defold-or-distance-field?))
   (property shadow-y g/Num
             (dynamic visible output-format-defold-or-distance-field?))
-  (property extra-characters g/Str
-            (dynamic visible output-format-defold-or-distance-field?))
-  (property all-chars g/Bool
-            (dynamic visible output-format-defold-or-distance-field?))
   (property cache-width g/Int
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? cache-width)))
   (property cache-height g/Int
             (dynamic error (validation/prop-error-fnk :fatal validation/prop-negative? cache-height)))
+  (property characters g/Str (default (protobuf/default Font$FontDesc :characters))
+            (dynamic visible output-format-defold-or-distance-field?)
+            (dynamic read-only? (gu/passthrough all-chars))
+            (set (fn [evaluation-context self _old-value new-value]
+                   ;; It is illegal to have no characters in the font, but it is
+                   ;; also useful to be able to reset the field to the default
+                   ;; set of characters. If the user clears the field, we reset
+                   ;; to the printable ASCII characters.
+                   (when (and (= "" new-value)
+                              (properties/user-edit? self :characters evaluation-context))
+                     (g/set-property self :characters fontc/default-characters-string)))))
+  (property all-chars g/Bool
+            (dynamic visible output-format-defold-or-distance-field?))
 
   (property pb g/Any (dynamic visible (g/constantly false)))
 
@@ -798,6 +807,38 @@
                           (resource-fields prop) (workspace/resolve-resource resource))]]
         (g/set-property self prop value)))))
 
+(defn sanitize-font [{:keys [characters extra-characters] :as font-desc}]
+  {:pre [(map? font-desc)]} ; Font$FontDesc in map format.
+  ;; In a previous file format, we would always include all printable ASCII
+  ;; characters in the font, and the user could specify :extra-characters to
+  ;; include in addition to the ASCII characters.
+  ;; Now, we instead explicitly list the :characters to include, but default to
+  ;; the printable ASCII characters.
+  (let [explicit-characters
+        (if (pos? (count characters))
+          characters
+          fontc/default-characters-string)
+
+        distinct-extra-characters
+        (when (pos? (count extra-characters))
+          ;; We have extra-characters. Remove duplicates so we can add them to
+          ;; the characters field in the new file format.
+          (let [distinct-extra-characters
+                (into []
+                      (comp (remove (set explicit-characters))
+                            (distinct))
+                      extra-characters)]
+            (when (pos? (count distinct-extra-characters))
+              (String. (char-array distinct-extra-characters)))))
+
+        merged-characters
+        (cond-> explicit-characters
+                distinct-extra-characters (str distinct-extra-characters))]
+
+    (-> font-desc
+        (dissoc :extra-characters)
+        (assoc :characters merged-characters))))
+
 (defn register-resource-types [workspace]
   (concat
     (resource-node/register-ddf-resource-type workspace
@@ -807,6 +848,7 @@
       :node-type FontNode
       :ddf-type Font$FontDesc
       :load-fn load-font
+      :sanitize-fn sanitize-font
       :icon font-icon
       :icon-class :design
       :view-types [:scene :text])

--- a/editor/test/integration/save_data_test.clj
+++ b/editor/test/integration/save_data_test.clj
@@ -464,6 +464,10 @@
    {:default
     {"shape_type" :allowed-default}}
 
+   'dmRenderDDF.FontDesc
+   {:default
+    {"extra_characters" :deprecated}} ; Migration tested in integration.save-data-test/silent-migrations-test.
+
    'dmRenderDDF.MaterialDesc
    {:default
     {"textures" :deprecated}} ; Migration tested in integration.save-data-test/silent-migrations-test.
@@ -611,6 +615,11 @@
         (is (= [2.0 2.0 2.0] (g/node-value referenced-collection :scale)))
         (is (= [2.0 2.0 2.0] (g/node-value embedded-go :scale)))
         (is (= [2.0 2.0 2.0] (g/node-value referenced-go :scale)))))
+
+    (testing "font"
+      (let [extra-characters-font (project/get-resource-node project "/silently_migrated/extra_characters.font")]
+        (is (= " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~åäö"
+               (g/node-value extra-characters-font :characters)))))
 
     (testing "material"
       (let [legacy-textures-material (project/get-resource-node project "/silently_migrated/legacy_textures.material")]

--- a/editor/test/resources/save_data_project/checked.font
+++ b/editor/test/resources/save_data_project/checked.font
@@ -9,9 +9,9 @@ shadow_alpha: 0.3
 shadow_blur: 8
 shadow_x: 4.0
 shadow_y: -4.0
-extra_characters: "\303\245\303\244\303\266"
 output_format: TYPE_DISTANCE_FIELD
 all_chars: true
 cache_width: 2048
 cache_height: 2048
 render_mode: MODE_MULTI_LAYER
+characters: " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\303\245\303\244\303\266"

--- a/editor/test/resources/save_data_project/silently_migrated/extra_characters.font
+++ b/editor/test/resources/save_data_project/silently_migrated/extra_characters.font
@@ -1,0 +1,17 @@
+font: "/builtins/fonts/vera_mo_bd.ttf"
+material: "/builtins/fonts/font.material"
+size: 15
+antialias: 1
+alpha: 1.0
+outline_alpha: 0.0
+outline_width: 0.0
+shadow_alpha: 0.0
+shadow_blur: 0
+shadow_x: 0.0
+shadow_y: 0.0
+extra_characters: "\303\245\303\244\303\266"
+output_format: TYPE_BITMAP
+all_chars: false
+cache_width: 0
+cache_height: 0
+render_mode: MODE_SINGLE_LAYER

--- a/engine/render/proto/render/font_ddf.proto
+++ b/engine/render/proto/render/font_ddf.proto
@@ -32,13 +32,14 @@ message FontDesc
     optional uint32 shadow_blur = 9 [default = 0];
     optional float shadow_x = 10 [default = 0.0];
     optional float shadow_y = 11 [default = 0.0];
-    optional string extra_characters = 12 [default = ""];
+    optional string extra_characters = 12 [default = ""]; // Deprecated
     optional FontTextureFormat output_format = 13 [default = TYPE_BITMAP];
 
     optional bool all_chars = 14 [default = false];
     optional uint32 cache_width = 15 [default = 0];
     optional uint32 cache_height = 16 [default = 0];
     optional FontRenderMode render_mode = 17 [default = MODE_SINGLE_LAYER];
+    optional string characters = 18 [default = ""];
 }
 
 message GlyphBank


### PR DESCRIPTION
The `Extra Characters` field has been deprecated and replaced with a new field called `Characters`. This new field combines the default ASCII with any previously defined `Extra Characters`. Using this new field, developers can specify exactly which symbols the font should include, e.g. numbers only, etc.

Fix https://github.com/defold/defold/issues/8070
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
