### PR TITLE
Frustrum culling for tilemap

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_tilegrid.cpp
@@ -655,11 +655,16 @@ namespace dmGameSystem
             int32_t row_count = (int32_t)resource->m_RowCount;
             int32_t min_x = resource->m_MinCellX + region_x * TILEGRID_REGION_SIZE;
             int32_t min_y = resource->m_MinCellY + region_y * TILEGRID_REGION_SIZE;
-            int32_t max_x = dmMath::Min(min_x + (int32_t)TILEGRID_REGION_SIZE, resource->m_MinCellX + column_count);
-            int32_t max_y = dmMath::Min(min_y + (int32_t)TILEGRID_REGION_SIZE, resource->m_MinCellY + row_count);
 
-            dmVMath::Vector3 min_corner = dmVMath::Vector3(min_x * tile_width, min_y * tile_height, 0.f);
-            dmVMath::Vector3 max_corner = dmVMath::Vector3(max_x * tile_width, max_y * tile_height, 0.f);
+            int32_t region_max_x = min_x + TILEGRID_REGION_SIZE;
+            int32_t tilemap_max_x = resource->m_MinCellX + column_count;
+            int32_t region_max_y = min_y + TILEGRID_REGION_SIZE;
+            int32_t tilemap_max_y = resource->m_MinCellY + row_count;
+            int32_t max_x = dmMath::Min(region_max_x, tilemap_max_x);
+            int32_t max_y = dmMath::Min(region_max_y, tilemap_max_y);
+
+            dmVMath::Vector3 min_corner = dmVMath::Vector3((float)(min_x * tile_width), (float)(min_y * tile_height), 0.f);
+            dmVMath::Vector3 max_corner = dmVMath::Vector3((float)(max_x * tile_width), (float)(max_y * tile_height), 0.f);
             bool intersect = dmIntersection::TestFrustumOBB(frustum, component->m_World, min_corner, max_corner);
             entry->m_Visibility = intersect ? dmRender::VISIBILITY_FULL : dmRender::VISIBILITY_NONE;
         }


### PR DESCRIPTION
Tilemaps are now included when doing frustum culling in `render.draw()`. Tilemaps are divided into 32x32 tile regions and culling is applied per region, not individual tiles.

Fixes #6938, #8744

### Technical changes
One render entry for tile map is tilemap region. So I check visibility for whole region, not for every tile. Region size now is 32x32 tiles. That's why id region partially outside of the camera frustrum - is will fully rendered.

Docs: https://github.com/defold/doc/pull/435

## PR checklist
* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
