### PR TITLE
Editor: Unversion vcs.xml from .idea since it contains local settings

### DIFF
--- a/editor/.idea/.gitignore
+++ b/editor/.idea/.gitignore
@@ -6,6 +6,7 @@
 /**/tasks.xml
 /**/misc.xml
 /**/usage.statistics.xml
+/**/vcs.xml
 /**/dictionaries
 /**/shelf
 

--- a/editor/.idea/vcs.xml
+++ b/editor/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
### Technical changes
* This removes `vcs.xml` from the `.idea` directory and adds it into `.gitignore`, since it contains version-control-related settings derived from the local environment. Idea will re-write this file when you reopen and save the project. Having `vcs.xml` untracked lets users list additional `:source-paths` in `~/.lein/profiles.clj` without worrying about their VCS configuration.