### PR TITLE
Make sure user uses only one shape type in a Collision Object

### DIFF
--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -530,15 +530,15 @@
   (input project-settings g/Any)
 
   (property collision-shape resource/Resource
-          (value (gu/passthrough collision-shape-resource))
-          (set (fn [evaluation-context self old-value new-value]
-                 (project/resource-setter evaluation-context self old-value new-value
-                                          [:resource :collision-shape-resource]
-                                          [:build-targets :dep-build-targets])))
-          (dynamic edit-type (g/constantly {:type resource/Resource :ext #{"convexshape" "tilemap"}}))
-          (dynamic error (g/fnk [_node-id collision-shape shapes]
-                                (or (validation/prop-error :fatal _node-id :collision-shape validation/prop-resource-not-exists? collision-shape "Collision Shape")
-                                    (validation/prop-error :fatal _node-id :collision-shape validation/prop-collision-shape-conflict? shapes collision-shape)))))
+            (value (gu/passthrough collision-shape-resource))
+            (set (fn [evaluation-context self old-value new-value]
+                   (project/resource-setter evaluation-context self old-value new-value
+                                            [:resource :collision-shape-resource]
+                                            [:build-targets :dep-build-targets])))
+            (dynamic edit-type (g/constantly {:type resource/Resource :ext #{"convexshape" "tilemap"}}))
+            (dynamic error (g/fnk [_node-id collision-shape shapes]
+                             (or (validation/prop-error :fatal _node-id :collision-shape validation/prop-resource-not-exists? collision-shape "Collision Shape")
+                                 (validation/prop-error :fatal _node-id :collision-shape validation/prop-collision-shape-conflict? shapes collision-shape)))))
 
   (property type g/Any
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Physics$CollisionObjectType))))

--- a/editor/src/clj/editor/collision_object.clj
+++ b/editor/src/clj/editor/collision_object.clj
@@ -530,15 +530,15 @@
   (input project-settings g/Any)
 
   (property collision-shape resource/Resource
-           (value (gu/passthrough collision-shape-resource))
-           (set (fn [evaluation-context self old-value new-value]
-                  (project/resource-setter evaluation-context self old-value new-value
-                                           [:resource :collision-shape-resource]
-                                           [:build-targets :dep-build-targets])))
-           (dynamic edit-type (g/constantly {:type resource/Resource :ext #{"convexshape" "tilemap"}}))
-           (dynamic error (g/fnk [_node-id collision-shape shapes]
-                                 (or (validation/prop-error :fatal _node-id :collision-shape validation/prop-resource-not-exists? collision-shape "Collision Shape")
-                                     (validation/prop-error :fatal _node-id :collision-shape validation/prop-collision-shape-conflict? shapes collision-shape)))))
+          (value (gu/passthrough collision-shape-resource))
+          (set (fn [evaluation-context self old-value new-value]
+                 (project/resource-setter evaluation-context self old-value new-value
+                                          [:resource :collision-shape-resource]
+                                          [:build-targets :dep-build-targets])))
+          (dynamic edit-type (g/constantly {:type resource/Resource :ext #{"convexshape" "tilemap"}}))
+          (dynamic error (g/fnk [_node-id collision-shape shapes]
+                                (or (validation/prop-error :fatal _node-id :collision-shape validation/prop-resource-not-exists? collision-shape "Collision Shape")
+                                    (validation/prop-error :fatal _node-id :collision-shape validation/prop-collision-shape-conflict? shapes collision-shape)))))
 
   (property type g/Any
             (dynamic edit-type (g/constantly (properties/->pb-choicebox Physics$CollisionObjectType))))

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -93,6 +93,10 @@
     (when (not (<= min v max))
       (util/format* tmpl name min max))))
 
+(defn prop-collision-shape-conflict? [shapes collision-shape]
+  (when (and collision-shape (not (empty? shapes)))
+    "Cannot use both 'Collision Shape' and 'Shapes'. Please remove one of them."))
+
 (def prop-0-1? (partial prop-outside-range? [0.0 1.0]))
 
 (def prop-1-1? (partial prop-outside-range? [-1.0 1.0]))

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -95,7 +95,7 @@
 
 (defn prop-collision-shape-conflict? [shapes collision-shape]
   (when (and collision-shape (not (empty? shapes)))
-    "Cannot use both 'Collision Shape' and 'Shapes'. Please remove one of them."))
+    "Cannot combine embedded shapes with a referenced 'Collision Shape'. Please remove either."))
 
 (def prop-0-1? (partial prop-outside-range? [0.0 1.0]))
 


### PR DESCRIPTION
Show an error if the user uses both a Collision Shape based on a tilemap and a primitive shape in the same Collision Object.

Fix https://github.com/defold/defold/issues/8536
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
