### PR TITLE
Don't suggest completion popup unnecessarily

### DIFF
--- a/editor/src/clj/editor/code/script.clj
+++ b/editor/src/clj/editor/code/script.clj
@@ -59,6 +59,7 @@
                        :field #{"."}
                        :module #{"."}}
    :completion-trigger-characters #{"."}
+   :ignored-completion-trigger-characters #{"{" ","}
    :patterns [{:captures {1 {:name "keyword.control.lua"}
                           2 {:name "entity.name.function.scope.lua"}
                           3 {:name "entity.name.function.lua"}

--- a/editor/src/clj/editor/code/view.clj
+++ b/editor/src/clj/editor/code/view.clj
@@ -1028,7 +1028,12 @@
                        (g/set-property self :scroll-y new-scroll-y))))))
   (property completion-trigger-characters g/Any (default #{}) (dynamic visible (g/constantly false)))
   (output completion-trigger-characters g/Any :cached (g/fnk [completion-trigger-characters grammar]
-                                                        (into completion-trigger-characters (:completion-trigger-characters grammar))))
+                                                        (into #{}
+                                                              (comp
+                                                                cat
+                                                                (remove (:ignored-completion-trigger-characters grammar #{})))
+                                                              [completion-trigger-characters
+                                                               (:completion-trigger-characters grammar)])))
   (property diagnostics r/Regions (default []) (dynamic visible (g/constantly false)))
   (property document-width g/Num (default 0.0) (dynamic visible (g/constantly false)))
   (property color-scheme ColorScheme (dynamic visible (g/constantly false)))


### PR DESCRIPTION
The editor no longer shows the completion popup after typing `{` and `,`.

Fixes #8946
