### PR TITLE
Fix crash in GUI when atlas changes texture resource internally

### DIFF
--- a/engine/gamesys/src/dmsdk/gamesys/resources/res_gui.h
+++ b/engine/gamesys/src/dmsdk/gamesys/resources/res_gui.h
@@ -32,29 +32,27 @@ namespace dmParticle
 namespace dmGameSystem
 {
     struct MaterialResource;
-    struct TextureResource;
-    struct TextureSetResource;
 
     struct GuiSceneTextureSetResource
     {
-        TextureSetResource* m_TextureSet;
-        TextureResource*    m_Texture;
+        void*   m_Resource;
+        uint8_t m_ResourceIsTextureSet : 1;
     };
 
     struct GuiSceneResource
     {
-        dmGuiDDF::SceneDesc*            m_SceneDesc;
-        dmGui::HScript                  m_Script;
-        dmArray<dmRender::HFontMap>     m_FontMaps;
-        dmArray<dmhash_t>               m_FontMapPaths;
+        dmGuiDDF::SceneDesc*                m_SceneDesc;
+        dmGui::HScript                      m_Script;
+        dmArray<dmRender::HFontMap>         m_FontMaps;
+        dmArray<dmhash_t>                   m_FontMapPaths;
         dmArray<GuiSceneTextureSetResource> m_GuiTextureSets;
-        dmArray<dmParticle::HPrototype> m_ParticlePrototypes;
-        dmArray<MaterialResource*>      m_Materials;
-        const char*                     m_Path;
-        dmGui::HContext                 m_GuiContext;
-        MaterialResource*               m_Material;
-        dmHashTable64<void*>            m_Resources;
-        dmHashTable64<dmhash_t>         m_ResourceTypes;
+        dmArray<dmParticle::HPrototype>     m_ParticlePrototypes;
+        dmArray<MaterialResource*>          m_Materials;
+        const char*                         m_Path;
+        dmGui::HContext                     m_GuiContext;
+        MaterialResource*                   m_Material;
+        dmHashTable64<void*>                m_Resources;
+        dmHashTable64<dmhash_t>             m_ResourceTypes;
     };
 }
 

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -587,26 +587,35 @@ namespace dmGameSystem
 
         for (uint32_t i = 0; i < scene_resource->m_GuiTextureSets.Size(); ++i)
         {
-            const char* name                    = scene_desc->m_Textures[i].m_Name;
-            TextureResource* texture_res        = scene_resource->m_GuiTextureSets[i].m_Texture;
-            TextureSetResource* texture_set_res = scene_resource->m_GuiTextureSets[i].m_TextureSet;
-            dmGraphics::HTexture texture        = texture_res->m_Texture;
+            const char* name             = scene_desc->m_Textures[i].m_Name;
+            dmGraphics::HTexture texture = 0;
+            TextureResource* texture_res = 0;
 
             dmGui::HTextureSource texture_source;
             dmGui::NodeTextureType texture_source_type;
 
-            if (texture_set_res)
+            if (scene_resource->m_GuiTextureSets[i].m_TextureSet)
             {
+                TextureSetResource* texture_set_res = scene_resource->m_GuiTextureSets[i].m_TextureSet;
+                texture_res                         = texture_set_res->m_Texture;
+
                 texture_source_type = dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET;
                 texture_source      = (dmGui::HTextureSource) texture_set_res;
             }
             else
             {
                 texture_source_type = dmGui::NODE_TEXTURE_TYPE_TEXTURE;
-                texture_source      = (dmGui::HTextureSource) texture_res;
+                texture_source      = (dmGui::HTextureSource) scene_resource->m_GuiTextureSets[i].m_Texture;
+                texture_res         = scene_resource->m_GuiTextureSets[i].m_Texture;
             }
 
-            dmGui::Result r = dmGui::AddTexture(scene, dmHashString64(name), texture_source, texture_source_type, dmGraphics::GetOriginalTextureWidth(texture), dmGraphics::GetOriginalTextureHeight(texture));
+            texture = texture_res->m_Texture;
+            assert(texture != 0);
+
+            dmGui::Result r = dmGui::AddTexture(scene, dmHashString64(name),
+                texture_source, texture_source_type,
+                dmGraphics::GetOriginalTextureWidth(texture),
+                dmGraphics::GetOriginalTextureHeight(texture));
 
             if (r != dmGui::RESULT_OK) {
                 dmLogError("Unable to add texture '%s' to scene (%d)", name,  r);

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -594,9 +594,9 @@ namespace dmGameSystem
             dmGui::HTextureSource texture_source;
             dmGui::NodeTextureType texture_source_type;
 
-            if (scene_resource->m_GuiTextureSets[i].m_TextureSet)
+            if (scene_resource->m_GuiTextureSets[i].m_ResourceIsTextureSet)
             {
-                TextureSetResource* texture_set_res = scene_resource->m_GuiTextureSets[i].m_TextureSet;
+                TextureSetResource* texture_set_res = (TextureSetResource*) scene_resource->m_GuiTextureSets[i].m_Resource;
                 texture_res                         = texture_set_res->m_Texture;
 
                 texture_source_type = dmGui::NODE_TEXTURE_TYPE_TEXTURE_SET;
@@ -605,8 +605,8 @@ namespace dmGameSystem
             else
             {
                 texture_source_type = dmGui::NODE_TEXTURE_TYPE_TEXTURE;
-                texture_source      = (dmGui::HTextureSource) scene_resource->m_GuiTextureSets[i].m_Texture;
-                texture_res         = scene_resource->m_GuiTextureSets[i].m_Texture;
+                texture_source      = (dmGui::HTextureSource) scene_resource->m_GuiTextureSets[i].m_Resource;
+                texture_res         = (TextureResource*) scene_resource->m_GuiTextureSets[i].m_Resource;
             }
 
             texture = texture_res->m_Texture;

--- a/engine/gamesys/src/gamesys/resources/res_gui.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui.cpp
@@ -118,7 +118,7 @@ namespace dmGameSystem
         resource->m_GuiTextureSets.SetSize(0);
         for (uint32_t i = 0; i < resource->m_SceneDesc->m_Textures.m_Count; ++i)
         {
-            TextureSetResource* texture_set_resource;
+            void* texture_set_resource;
             dmResource::Result r = dmResource::Get(factory, resource->m_SceneDesc->m_Textures[i].m_Texture, (void**) &texture_set_resource);
             if (r != dmResource::RESULT_OK)
             {
@@ -132,17 +132,10 @@ namespace dmGameSystem
                 return r;
             }
 
-            GuiSceneTextureSetResource tsr;
-            if(resource_type != resource_type_textureset)
-            {
-                tsr.m_TextureSet = 0;
-                tsr.m_Texture = (TextureResource*) texture_set_resource;
-            }
-            else
-            {
-                tsr.m_TextureSet = texture_set_resource;
-                tsr.m_Texture    = texture_set_resource->m_Texture;
-            }
+            GuiSceneTextureSetResource tsr = {};
+            tsr.m_Resource                 = texture_set_resource;
+            tsr.m_ResourceIsTextureSet     = resource_type == resource_type_textureset;
+
             resource->m_GuiTextureSets.Push(tsr);
         }
 
@@ -185,10 +178,7 @@ namespace dmGameSystem
         }
         for (uint32_t j = 0; j < resource->m_GuiTextureSets.Size(); ++j)
         {
-            if(resource->m_GuiTextureSets[j].m_TextureSet)
-                dmResource::Release(factory, resource->m_GuiTextureSets[j].m_TextureSet);
-            else
-                dmResource::Release(factory, resource->m_GuiTextureSets[j].m_Texture);
+            dmResource::Release(factory, resource->m_GuiTextureSets[j].m_Resource);
         }
 
         resource->m_Resources.Iterate(HTReleaseResource, factory);


### PR DESCRIPTION
Fixed a crash where a call to resource.set_atlas(...) replaces the texture that was backing an atlas used in a GUI with a new texture resource. In this case, the engine was using the old texture resource pointer that was originally used in the atlas, whereas now we resolve the actual pointer being used instead.

Fixes #8786 