### PR TITLE
Added ability to rotate and flip the brush when painting in tilemap.

### DIFF
--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -153,6 +153,7 @@
            ["Space" :show-palette]
            ["H" :flip-brush-horizontally]
            ["G" :rotate-brush-90-degrees]
+           ["V" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]
@@ -263,6 +264,7 @@
            ["Space" :show-palette]
            ["H" :flip-brush-horizontally]
            ["G" :rotate-brush-90-degrees]
+           ["V" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]
@@ -373,6 +375,7 @@
            ["Space" :show-palette]
            ["H" :flip-brush-horizontally]
            ["G" :rotate-brush-90-degrees]
+           ["V" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]})
@@ -401,8 +404,9 @@
     "F"         ; :frame-selection
     "R"         ; :scale-tool
     "W"         ; :move-tool
-    "H"         ; :flip-brush-horizontally]
     "G"         ; :rotate-brush-90-degrees
+    "H"         ; :flip-brush-horizontally
+    "V"         ; :flip-brush-vertically
     "Shift+A"   ; :add-secondary
     "Shift+E"}) ; :erase-tool
 

--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -151,6 +151,8 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
+           ["H" :flip-brush-horizontally]
+           ["G" :rotate-brush-90-degrees]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]
@@ -259,6 +261,8 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
+           ["H" :flip-brush-horizontally]
+           ["G" :rotate-brush-90-degrees]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]
@@ -367,6 +371,8 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
+           ["H" :flip-brush-horizontally]
+           ["G" :rotate-brush-90-degrees]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]})
@@ -395,6 +401,8 @@
     "F"         ; :frame-selection
     "R"         ; :scale-tool
     "W"         ; :move-tool
+    "H"         ; :flip-brush-horizontally]
+    "G"         ; :rotate-brush-90-degrees
     "Shift+A"   ; :add-secondary
     "Shift+E"}) ; :erase-tool
 

--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -151,9 +151,9 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
-           ["H" :flip-brush-horizontally]
-           ["G" :rotate-brush-90-degrees]
-           ["V" :flip-brush-vertically]
+           ["Z" :rotate-brush-90-degrees]
+           ["X" :flip-brush-horizontally]
+           ["Y" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]
@@ -262,9 +262,9 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
-           ["H" :flip-brush-horizontally]
-           ["G" :rotate-brush-90-degrees]
-           ["V" :flip-brush-vertically]
+           ["Z" :rotate-brush-90-degrees]
+           ["X" :flip-brush-horizontally]
+           ["Y" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]
@@ -373,9 +373,9 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
-           ["H" :flip-brush-horizontally]
-           ["G" :rotate-brush-90-degrees]
-           ["V" :flip-brush-vertically]
+           ["Z" :rotate-brush-90-degrees]
+           ["X" :flip-brush-horizontally]
+           ["Y" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
            ["W" :move-tool]]})
@@ -404,9 +404,9 @@
     "F"         ; :frame-selection
     "R"         ; :scale-tool
     "W"         ; :move-tool
-    "G"         ; :rotate-brush-90-degrees
-    "H"         ; :flip-brush-horizontally
-    "V"         ; :flip-brush-vertically
+    "Z"         ; :rotate-brush-90-degrees
+    "X"         ; :flip-brush-horizontally
+    "Y"         ; :flip-brush-vertically
     "Shift+A"   ; :add-secondary
     "Shift+E"}) ; :erase-tool
 

--- a/editor/src/clj/editor/keymap.clj
+++ b/editor/src/clj/editor/keymap.clj
@@ -151,12 +151,12 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
-           ["Z" :rotate-brush-90-degrees]
-           ["X" :flip-brush-horizontally]
-           ["Y" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
-           ["W" :move-tool]]
+           ["W" :move-tool]
+           ["X" :flip-brush-horizontally]
+           ["Y" :flip-brush-vertically]
+           ["Z" :rotate-brush-90-degrees]]
    :win32 [["A" :add]
            ["Alt+Down" :move-down]
            ["Alt+F9" :edit-breakpoint]
@@ -262,12 +262,12 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
-           ["Z" :rotate-brush-90-degrees]
-           ["X" :flip-brush-horizontally]
-           ["Y" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
-           ["W" :move-tool]]
+           ["W" :move-tool]
+           ["X" :flip-brush-horizontally]
+           ["Y" :flip-brush-vertically]
+           ["Z" :rotate-brush-90-degrees]]
    :linux [["A" :add]
            ["Alt+Down" :move-down]
            ["Alt+F9" :edit-breakpoint]
@@ -373,12 +373,12 @@
            ["Shift+Up" :up-major]
            ["Space" :scene-play]
            ["Space" :show-palette]
-           ["Z" :rotate-brush-90-degrees]
-           ["X" :flip-brush-horizontally]
-           ["Y" :flip-brush-vertically]
            ["Tab" :tab]
            ["Up" :up]
-           ["W" :move-tool]]})
+           ["W" :move-tool]
+           ["X" :flip-brush-horizontally]
+           ["Y" :flip-brush-vertically]
+           ["Z" :rotate-brush-90-degrees]]})
 
 (def default-host-key-bindings
   (platform->default-key-bindings (util/os)))
@@ -404,9 +404,9 @@
     "F"         ; :frame-selection
     "R"         ; :scale-tool
     "W"         ; :move-tool
-    "Z"         ; :rotate-brush-90-degrees
     "X"         ; :flip-brush-horizontally
     "Y"         ; :flip-brush-vertically
+    "Z"         ; :rotate-brush-90-degrees
     "Shift+A"   ; :add-secondary
     "Shift+E"}) ; :erase-tool
 

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -145,9 +145,9 @@
         ;; | 2 (010) - V   				| false | true  | false    | -> 3 (011) - H + V
         ;; | 3 (011) - H+V 				| true  | true  | false    | -> 2 (010) - V
         ;; | 4 (100) - 90° 				| false | false | true     | -> 6 (110) - V + R_90
-        ;; | 5 (101) - H+90° 		| true 	| false | true     | -> 7 (111) - H + V + R_90
-        ;; | 6 (110) - V+90° 		| false | true 	| true     | -> 4 (100) - R_90
-        ;; | 7 (111) - H+V+90° | true 	| true 	| true    	| -> 5 (101) - H + R_90
+        ;; | 5 (101) - H+90° 		  | true 	| false | true     | -> 7 (111) - H + V + R_90
+        ;; | 6 (110) - V+90° 		  | false | true 	| true     | -> 4 (100) - R_90
+        ;; | 7 (111) - H+V+90°    | true 	| true 	| true     | -> 5 (101) - H + R_90
         flipped-tiles (map (fn [tile]
                              (let [hflip (:h-flip tile)
                                    vflip (:v-flip tile)
@@ -156,14 +156,14 @@
                                                          (if vflip 2 0)
                                                          (if rotate90 4 0))
                                    new-state (case current-state
-                                               0 1  ; R_0 -> H
-                                               1 0  ; H -> R_0
-                                               2 3  ; V -> H + V
-                                               3 2  ; H + V -> V
-                                               4 6  ; R_90 -> V + R_90
-                                               5 7  ; H + R_90 -> H + V + R_90
-                                               6 4  ; V + R_90 -> R_90
-                                               7 5) ; H + V + R_90 -> H + R_90
+                                               0 1          ; R_0 -> H
+                                               1 0          ; H -> R_0
+                                               2 3          ; V -> H + V
+                                               3 2          ; H + V -> V
+                                               4 6          ; R_90 -> V + R_90
+                                               5 7          ; H + R_90 -> H + V + R_90
+                                               6 4          ; V + R_90 -> R_90
+                                               7 5)         ; H + V + R_90 -> H + R_90
                                    new-hflip (bit-test new-state 0)
                                    new-vflip (bit-test new-state 1)
                                    new-rotate90 (bit-test new-state 2)]
@@ -188,9 +188,9 @@
         ;; | 2 (010) - V   				| false | true  | false    | -> 6 (110) - V + R_90
         ;; | 3 (011) - H+V 				| true  | true  | false    | -> 7 (111) - H + V + R_90
         ;; | 4 (100) - 90° 				| false | false | true     | -> 3 (011) - H + V (180-degree rotation)
-        ;; | 5 (101) - H+90° 		| true 	| false | true     | -> 2 (010) - V
-        ;; | 6 (110) - V+90° 		| false | true 	| true     | -> 1 (001) - H
-        ;; | 7 (111) - H+V+90° | true 	| true 	| true    	| -> 0 (000) - R_0
+        ;; | 5 (101) - H+90° 		  | true 	| false | true     | -> 2 (010) - V
+        ;; | 6 (110) - V+90° 		  | false | true 	| true     | -> 1 (001) - H
+        ;; | 7 (111) - H+V+90°     | true 	| true 	| true   | -> 0 (000) - R_0
         rotated-tiles (map (fn [tile]
                              (let [hflip (:h-flip tile)
                                    vflip (:v-flip tile)
@@ -199,14 +199,14 @@
                                                          (if vflip 2 0)
                                                          (if rotate90 4 0))
                                    new-state (case current-state
-                                               0 4  ; R_0 -> R_90
-                                               1 5  ; H -> H + R_90
-                                               2 6  ; V -> V + R_90
-                                               3 7  ; H + V -> H + V + R_90
-                                               4 3  ; R_90 -> H + V (180-degree rotation)
-                                               5 2  ; H + R_90 -> V
-                                               6 1  ; V + R_90 -> H
-                                               7 0) ; H + V + R_90 -> R_0
+                                               0 4          ; R_0 -> R_90
+                                               1 5          ; H -> H + R_90
+                                               2 6          ; V -> V + R_90
+                                               3 7          ; H + V -> H + V + R_90
+                                               4 3          ; R_90 -> H + V (180-degree rotation)
+                                               5 2          ; H + R_90 -> V
+                                               6 1          ; V + R_90 -> H
+                                               7 0)         ; H + V + R_90 -> R_0
                                    new-hflip (bit-test new-state 0)
                                    new-vflip (bit-test new-state 1)
                                    new-rotate90 (bit-test new-state 2)]
@@ -220,6 +220,49 @@
     {:width (:width brush)
      :height (:height brush)
      :tiles rotated-tiles}))
+
+(defn flip-brush-vertically
+  [self]
+  (let [brush (g/node-value self :brush)
+        ;; Vertical Flip Mappings
+        ;; | current-state | hflip | vflip | rotate90 |
+        ;; | 0 (000) - 0°       | false | false | false    | -> 2 (010) - V
+        ;; | 1 (001) - H        | true  | false | false    | -> 3 (011) - H + V
+        ;; | 2 (010) - V        | false | true  | false    | -> 0 (000) - R_0
+        ;; | 3 (011) - H+V      | true  | true  | false    | -> 1 (001) - H
+        ;; | 4 (100) - 90°      | false | false | true     | -> 5 (101) - H + R_90
+        ;; | 5 (101) - H+90°    | true  | false | true     | -> 4 (100) - R_90
+        ;; | 6 (110) - V+90°    | false | true  | true     | -> 7 (111) - H + V + R_90
+        ;; | 7 (111) - H+V+90°  | true  | true  | true     | -> 6 (110) - V + R_90
+        flipped-tiles (map (fn [tile]
+                             (let [hflip (:h-flip tile)
+                                   vflip (:v-flip tile)
+                                   rotate90 (:rotate90 tile)
+                                   current-state (bit-or (if hflip 1 0)
+                                                         (if vflip 2 0)
+                                                         (if rotate90 4 0))
+                                   new-state (case current-state
+                                               0 2          ; R_0 -> V
+                                               1 3          ; H -> H + V
+                                               2 0          ; V -> R_0
+                                               3 1          ; H + V -> H
+                                               4 5          ; R_90 -> H + R_90
+                                               5 4          ; H + R_90 -> R_90
+                                               6 7          ; V + R_90 -> H + V + R_90
+                                               7 6)         ; H + V + R_90 -> V + R_90
+                                   new-hflip (bit-test new-state 0)
+                                   new-vflip (bit-test new-state 1)
+                                   new-rotate90 (bit-test new-state 2)]
+                               {:x (:x tile)
+                                :y (:y tile)
+                                :tile (:tile tile)
+                                :h-flip new-hflip
+                                :v-flip new-vflip
+                                :rotate90 new-rotate90}))
+                           (:tiles brush))]
+    {:width (:width brush)
+     :height (:height brush)
+     :tiles flipped-tiles}))
 
 ;;--------------------------------------------------------------------
 ;; rendering
@@ -1349,6 +1392,19 @@
              (g/node-value :tile-source-resource evaluation-context))))
   (run [app-view] (flip-brush-handler (-> (active-scene-view app-view) scene-view->tool-controller))))
 
+(defn flip-brush-vertically-handler [tool-controller]
+  (let [new-brush (flip-brush-vertically tool-controller)]
+    (g/set-property! tool-controller :brush new-brush)))
+
+(handler/defhandler :flip-brush-vertically :workbench
+  (active? [app-view evaluation-context]
+           (and (active-tile-map app-view evaluation-context)
+                (active-scene-view app-view evaluation-context)))
+  (enabled? [app-view selection evaluation-context]
+            (and (selection->layer selection)
+                 (-> (active-tile-map app-view evaluation-context)
+                     (g/node-value :tile-source-resource evaluation-context))))
+  (run [app-view] (flip-brush-vertically-handler (-> (active-scene-view app-view) scene-view->tool-controller))))
 
 (defn rotate-brush-handler [tool-controller]
   (let [new-brush (rotate-brush-90-degrees tool-controller)]
@@ -1371,6 +1427,8 @@
     :command :erase-tool}
    {:label "Flip Brush Horizontally"
     :command :flip-brush-horizontally}
+   {:label "Flip Brush Vertically"
+    :command :flip-brush-vertically}
    {:label "Rotate Brush 90 Degrees"
     :command :rotate-brush-90-degrees}])
 

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -136,9 +136,8 @@
 (def erase-brush (make-brush nil))
 
 (defn flip-brush-horizontally
-  [self]
-  (let [brush (g/node-value self :brush)
-        width (:width brush)
+  [brush]
+  (let [width (:width brush)
         height (:height brush)
         tiles (:tiles brush)
         ;; Horizontal Flip Mappings
@@ -186,9 +185,8 @@
      :tiles reordered-tiles}))
 
 (defn flip-brush-vertically
-  [self]
-  (let [brush (g/node-value self :brush)
-        width (:width brush)
+  [brush]
+  (let [width (:width brush)
         height (:height brush)
         tiles (:tiles brush)
         ;; Vertical Flip Mappings
@@ -235,9 +233,8 @@
      :tiles reordered-tiles}))
 
 (defn rotate-brush-90-degrees
-  [self]
-  (let [brush (g/node-value self :brush)
-        width (:width brush)
+  [brush]
+  (let [width (:width brush)
         height (:height brush)
         tiles (:tiles brush)
         ;; 90-degree Rotation Mappings
@@ -1401,7 +1398,8 @@
   (run [app-view] (tile-map-palette-handler (-> (active-scene-view app-view) scene-view->tool-controller))))
 
 (defn flip-brush-handler [tool-controller]
-  (let [new-brush (flip-brush-horizontally tool-controller)]
+  (let [brush (g/node-value tool-controller :brush)
+        new-brush (flip-brush-horizontally brush)]
     (g/set-property! tool-controller :brush new-brush)))
 
 (handler/defhandler :flip-brush-horizontally :workbench
@@ -1415,7 +1413,8 @@
   (run [app-view] (flip-brush-handler (-> (active-scene-view app-view) scene-view->tool-controller))))
 
 (defn flip-brush-vertically-handler [tool-controller]
-  (let [new-brush (flip-brush-vertically tool-controller)]
+  (let [brush (g/node-value tool-controller :brush)
+        new-brush (flip-brush-vertically brush)]
     (g/set-property! tool-controller :brush new-brush)))
 
 (handler/defhandler :flip-brush-vertically :workbench
@@ -1429,7 +1428,8 @@
   (run [app-view] (flip-brush-vertically-handler (-> (active-scene-view app-view) scene-view->tool-controller))))
 
 (defn rotate-brush-handler [tool-controller]
-  (let [new-brush (rotate-brush-90-degrees tool-controller)]
+  (let [brush (g/node-value tool-controller :brush)
+        new-brush (rotate-brush-90-degrees brush)]
     (g/set-property! tool-controller :brush new-brush)))
 
 (handler/defhandler :rotate-brush-90-degrees :workbench

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -1418,7 +1418,7 @@
                 (active-scene-view app-view evaluation-context)))
   (enabled? [app-view selection evaluation-context]
             (and (selection->layer selection)
-                 (-> (active-tile-map app-viyyyew evaluation-context)
+                 (-> (active-tile-map app-view evaluation-context)
                      (g/node-value :tile-source-resource evaluation-context))))
   (run [app-view] (transform-brush! app-view flip-brush-vertically)))
 

--- a/editor/test/integration/tile_map_test.clj
+++ b/editor/test/integration/tile_map_test.clj
@@ -73,3 +73,103 @@
                                 (take 128 (partition 2 (repeatedly #(rand-int 64)))))]
           (is (= (map val (sort-by key cell-map'))
                  (vals cell-map'))))))))
+
+(deftest tile-map-rotate-brush-90-degrees
+  ;; Initial brush:
+  ;; 1 2 3
+  ;; 4 5 6
+  (let [brush {:width 3 :height 2 :tiles [{:x 0 :y 0 :tile 1 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 1 :y 0 :tile 2 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 2 :y 0 :tile 3 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 0 :y 1 :tile 4 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 1 :y 1 :tile 5 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 2 :y 1 :tile 6 :h-flip false :v-flip false :rotate90 false}]}
+        rotated-brush (tile-map/rotate-brush-90-degrees brush)
+        rotated-brush-180 (tile-map/rotate-brush-90-degrees rotated-brush)
+        rotated-brush-270 (tile-map/rotate-brush-90-degrees rotated-brush-180)]
+    ;; After 90-degree rotation
+    ;; 3 6
+    ;; 2 5
+    ;; 1 4
+    (is (= 2 (:width rotated-brush)))
+    (is (= 3 (:height rotated-brush)))
+    (is (= [{:x 2, :y 0, :tile 3, :h-flip false, :v-flip false, :rotate90 true}
+            {:x 2, :y 1, :tile 6, :h-flip false, :v-flip false, :rotate90 true}
+            {:x 1, :y 0, :tile 2, :h-flip false, :v-flip false, :rotate90 true}
+            {:x 1, :y 1, :tile 5, :h-flip false, :v-flip false, :rotate90 true}
+            {:x 0, :y 0, :tile 1, :h-flip false, :v-flip false, :rotate90 true}
+            {:x 0, :y 1, :tile 4, :h-flip false, :v-flip false, :rotate90 true}]
+           (:tiles rotated-brush)))
+    ;; After 180-degree rotation
+    ;; 6 5 4
+    ;; 3 2 1
+    (is (= 3 (:width rotated-brush-180)))
+    (is (= 2 (:height rotated-brush-180)))
+    (is (= [{:x 2, :y 1, :tile 6, :h-flip true, :v-flip true, :rotate90 false}
+            {:x 1, :y 1, :tile 5, :h-flip true, :v-flip true, :rotate90 false}
+            {:x 0, :y 1, :tile 4, :h-flip true, :v-flip true, :rotate90 false}
+            {:x 2, :y 0, :tile 3, :h-flip true, :v-flip true, :rotate90 false}
+            {:x 1, :y 0, :tile 2, :h-flip true, :v-flip true, :rotate90 false}
+            {:x 0, :y 0, :tile 1, :h-flip true, :v-flip true, :rotate90 false}]
+           (:tiles rotated-brush-180)))
+    ;; After 270-degree rotation
+    ;; 4 1
+    ;; 5 2
+    ;; 6 3
+    (is (= 2 (:width rotated-brush-270)))
+    (is (= 3 (:height rotated-brush-270)))
+    (is (= [{:x 0, :y 1, :tile 4, :h-flip true, :v-flip true, :rotate90 true}
+            {:x 0, :y 0, :tile 1, :h-flip true, :v-flip true, :rotate90 true}
+            {:x 1, :y 1, :tile 5, :h-flip true, :v-flip true, :rotate90 true}
+            {:x 1, :y 0, :tile 2, :h-flip true, :v-flip true, :rotate90 true}
+            {:x 2, :y 1, :tile 6, :h-flip true, :v-flip true, :rotate90 true}
+            {:x 2, :y 0, :tile 3, :h-flip true, :v-flip true, :rotate90 true}]
+           (:tiles rotated-brush-270)))))
+
+(deftest tile-map-flip-brush-horizontally
+  ;; Initial brush:
+  ;; 1 2 3
+  ;; 4 5 6
+  (let [brush {:width 3 :height 2 :tiles [{:x 0 :y 0 :tile 1 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 1 :y 0 :tile 2 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 2 :y 0 :tile 3 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 0 :y 1 :tile 4 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 1 :y 1 :tile 5 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 2 :y 1 :tile 6 :h-flip false :v-flip false :rotate90 false}]}
+        flipped-brush (tile-map/flip-brush-horizontally brush)]
+    (is (= 3 (:width flipped-brush)))
+    (is (= 2 (:height flipped-brush)))
+    ;; After horizontal flip
+    ;; 3 2 1
+    ;; 6 5 4
+    (is (= [{:x 2 :y 0 :tile 3 :h-flip true :v-flip false :rotate90 false}
+            {:x 1 :y 0 :tile 2 :h-flip true :v-flip false :rotate90 false}
+            {:x 0 :y 0 :tile 1 :h-flip true :v-flip false :rotate90 false}
+            {:x 2 :y 1 :tile 6 :h-flip true :v-flip false :rotate90 false}
+            {:x 1 :y 1 :tile 5 :h-flip true :v-flip false :rotate90 false}
+            {:x 0 :y 1 :tile 4 :h-flip true :v-flip false :rotate90 false}]
+           (:tiles flipped-brush)))))
+
+(deftest tile-map-flip-brush-vertically
+  ;; Initial brush:
+  ;; 1 2 3
+  ;; 4 5 6
+  (let [brush {:width 3 :height 2 :tiles [{:x 0 :y 0 :tile 1 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 1 :y 0 :tile 2 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 2 :y 0 :tile 3 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 0 :y 1 :tile 4 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 1 :y 1 :tile 5 :h-flip false :v-flip false :rotate90 false}
+                                          {:x 2 :y 1 :tile 6 :h-flip false :v-flip false :rotate90 false}]}
+        flipped-brush (tile-map/flip-brush-vertically brush)]
+    (is (= 3 (:width flipped-brush)))
+    (is (= 2 (:height flipped-brush)))
+    ;; After vertical flip
+    ;; 4 5 6
+    ;; 1 2 3
+    (is (= [{:x 0 :y 1 :tile 4 :h-flip false :v-flip true :rotate90 false}
+            {:x 1 :y 1 :tile 5 :h-flip false :v-flip true :rotate90 false}
+            {:x 2 :y 1 :tile 6 :h-flip false :v-flip true :rotate90 false}
+            {:x 0 :y 0 :tile 1 :h-flip false :v-flip true :rotate90 false}
+            {:x 1 :y 0 :tile 2 :h-flip false :v-flip true :rotate90 false}
+            {:x 2 :y 0 :tile 3 :h-flip false :v-flip true :rotate90 false}]
+           (:tiles flipped-brush)))))


### PR DESCRIPTION
Now it's possible to flip and to rotate the brush when editing tile map using the following hotkeys:
* `X` - flip the brush horizontally
* `Y` - flip the brush vertically
* `Z` - rotate the brush 90° clockwise

Fix https://github.com/defold/defold/issues/3296
## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
