### PR TITLE
Added the ability to select a tile region in the palette map as a brush.

### DIFF
--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -986,17 +986,19 @@
       (gl/gl-draw-arrays gl GL2/GL_QUADS 0 (count vbuf)))))
 
 (defn- render-palette-active
-  [^GL2 gl render-args tile-source-attributes palette-tile]
-  (when palette-tile
-    (let [n palette-tile
-          w (:width tile-source-attributes)
-          h (:height tile-source-attributes)
-          x (palette-x n (:tiles-per-row tile-source-attributes))
-          y (palette-y n (:tiles-per-row tile-source-attributes))
-          x0 (* x (+ tile-border-size w))
-          x1 (+ x0 w tile-border-size)
-          y0 (* y (+ tile-border-size h))
-          y1 (+ y0 h tile-border-size)
+  [^GL2 gl render-args tile-source-attributes start-tile end-tile]
+  (when (and start-tile end-tile)
+    (let [start-tile (min start-tile end-tile)
+          end-tile (max start-tile end-tile)
+          tiles-per-row (:tiles-per-row tile-source-attributes)
+          start-x (palette-x start-tile tiles-per-row)
+          start-y (palette-y start-tile tiles-per-row)
+          end-x (palette-x end-tile tiles-per-row)
+          end-y (palette-y end-tile tiles-per-row)
+          x0 (* (min start-x end-x) (+ (:width tile-source-attributes) tile-border-size))
+          x1 (+ (* (inc (max start-x end-x)) (:width tile-source-attributes)) (* (max start-x end-x) tile-border-size))
+          y0 (* (min start-y end-y) (+ (:height tile-source-attributes) tile-border-size))
+          y1 (+ (* (inc (max start-y end-y)) (:height tile-source-attributes)) (* (max start-y end-y) tile-border-size))
           vbuf (-> (->color-vtx 16)
                    ;; left edge
                    (color-vtx-put! x0 y0 0 1.0 1.0 1.0 1.0)
@@ -1037,14 +1039,14 @@
 (defn render-palette
   [^GL2 gl render-args renderables count]
   (let [user-data (:user-data (first renderables))
-        {:keys [viewport tile-source-attributes texture-set-data gpu-texture palette-transform palette-tile]} user-data]
+        {:keys [viewport tile-source-attributes texture-set-data gpu-texture palette-transform start-tile end-tile]} user-data]
     (render-palette-background gl viewport)
     (.glMatrixMode gl GL2/GL_MODELVIEW)
     (gl/gl-push-matrix gl
       (gl/gl-mult-matrix-4d gl palette-transform)
       (render-palette-tiles gl render-args tile-source-attributes texture-set-data gpu-texture)
       (render-palette-grid gl render-args tile-source-attributes)
-      (render-palette-active gl render-args tile-source-attributes palette-tile))))
+      (render-palette-active gl render-args tile-source-attributes (or start-tile end-tile) end-tile))))
 
 (defn render-editor-select-outline
   [^GL2 gl render-args renderables count]
@@ -1090,7 +1092,7 @@
       (render-brush-outline gl render-args renderables n))))
 
 (g/defnk produce-palette-renderables
-  [viewport tile-source-attributes texture-set-data gpu-texture palette-transform palette-tile]
+  [viewport tile-source-attributes texture-set-data gpu-texture palette-transform start-palette-tile palette-tile]
   {pass/overlay [{:world-transform (Matrix4d. geom/Identity4d)
                   :render-fn render-palette
                   :user-data {:viewport viewport
@@ -1098,7 +1100,8 @@
                               :texture-set-data texture-set-data
                               :gpu-texture gpu-texture
                               :palette-transform palette-transform
-                              :palette-tile palette-tile}}]})
+                              :start-tile start-palette-tile
+                              :end-tile palette-tile}}]})
 
 (g/defnk produce-editor-renderables
   [active-layer-renderable op op-select-start op-select-end current-tile tile-dimensions brush viewport texture-set-data gpu-texture]
@@ -1236,9 +1239,9 @@
   (let [^Point3d screen-pos (:screen-pos action)]
     (case (:type action)
       :mouse-pressed
-      (let [start-tile (g/node-value self :palette-tile evaluation-context)]
+      (do
         (g/transact
-          (g/set-property self :start-palette-tile start-tile))
+          (g/set-property self :start-palette-tile (g/node-value self :palette-tile evaluation-context)))
         true)
 
       :mouse-moved
@@ -1250,20 +1253,17 @@
       :mouse-released
       (let [start-tile (g/node-value self :start-palette-tile evaluation-context)
             end-tile (g/node-value self :palette-tile evaluation-context)]
-        (if (and start-tile end-tile) ; Ensure both start-tile and end-tile exist
-          (if (= start-tile end-tile)
-            (do
-              (g/transact
-                (concat
-                  (g/set-property self :brush (make-brush start-tile))
-                  (g/set-property self :mode :editor)))
-              true)
-            (do
-              (g/transact
-                (concat
-                  (g/set-property self :brush (make-brush-from-selection-in-palette start-tile end-tile (g/node-value self :tile-source-attributes evaluation-context)))
-                  (g/set-property self :mode :editor)))
-              true))
+        (if (and start-tile end-tile)
+          (do
+            (g/transact
+              (concat
+                (g/set-property self :brush
+                  (if (= start-tile end-tile)
+                    (make-brush start-tile)
+                    (make-brush-from-selection-in-palette start-tile end-tile (g/node-value self :tile-source-attributes evaluation-context))))
+                (g/set-property self :start-palette-tile nil)
+                (g/set-property self :mode :editor)))
+            true)
           false))
       false)))
 

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -1039,14 +1039,18 @@
 (defn render-palette
   [^GL2 gl render-args renderables count]
   (let [user-data (:user-data (first renderables))
-        {:keys [viewport tile-source-attributes texture-set-data gpu-texture palette-transform start-tile end-tile]} user-data]
+        {:keys [viewport tile-source-attributes texture-set-data gpu-texture palette-transform start-tile end-tile]} user-data
+        [start-tile end-tile] (if (and start-tile end-tile (<= start-tile end-tile))
+                                [start-tile end-tile]
+                                [end-tile (or start-tile end-tile)])]
     (render-palette-background gl viewport)
     (.glMatrixMode gl GL2/GL_MODELVIEW)
     (gl/gl-push-matrix gl
       (gl/gl-mult-matrix-4d gl palette-transform)
       (render-palette-tiles gl render-args tile-source-attributes texture-set-data gpu-texture)
       (render-palette-grid gl render-args tile-source-attributes)
-      (render-palette-active gl render-args tile-source-attributes (or start-tile end-tile) end-tile))))
+      (render-palette-active gl render-args tile-source-attributes start-tile end-tile))))
+
 
 (defn render-editor-select-outline
   [^GL2 gl render-args renderables count]


### PR DESCRIPTION
Now it is possible to select a few tiles in the palette as a brush.

https://github.com/defold/defold/assets/2209596/5e9d2bc1-405e-41c0-9548-d8d146b74779

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
