### PR TITLE
Fixed the order of layers in the dropdown menu

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -486,10 +486,13 @@
   (properties/->choicebox (sort (remove empty? coll))))
 
 ;; SDK api
-(defn optional-gui-resource-choicebox [coll]
+(defn optional-gui-resource-choicebox
   ;; The coll will contain a "" entry representing "No Selection". Remove this
   ;; before sorting the collection. We then provide the "" entry at the top.
-  (properties/->choicebox (cons "" (sort (remove empty? coll)))))
+  ([coll]
+   (optional-gui-resource-choicebox coll sort))
+  ([coll custom-sort-fn]
+   (properties/->choicebox (cons "" (custom-sort-fn (remove empty? coll))) false)))
 
 ;; SDK api
 (defn prop-unique-id-error [node-id prop-kw prop-value id-counts prop-name]
@@ -611,7 +614,8 @@
 
   (property layer g/Str
             (default "")
-            (dynamic edit-type (g/fnk [layer-names] (optional-gui-resource-choicebox layer-names)))
+            (dynamic edit-type (g/fnk [layer-names layer->index]
+                                 (optional-gui-resource-choicebox layer-names (partial sort-by layer->index))))
             (dynamic error (g/fnk [_node-id layer layer-names] (validate-layer true _node-id layer-names layer))))
   (output layer-index g/Any :cached
           (g/fnk [layer layer->index] (layer->index layer)))

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -599,9 +599,15 @@
 (defn round-vec-coarse [v]
   (mapv round-scalar-coarse v))
 
-(defn ->choicebox [vals]
-  {:type :choicebox
-   :options (mapv (juxt identity identity) (sort eutil/natural-order vals))})
+(defn ->choicebox
+  ([vals]
+   (->choicebox vals true))
+  ([vals apply-natural-sorting]
+   (let [sorted-vals (if apply-natural-sorting
+                       (sort eutil/natural-order vals)
+                       vals)]
+     {:type :choicebox
+      :options (mapv (juxt identity identity) sorted-vals)})))
 
 (defn ->pb-choicebox-raw [cls]
   (let [values (protobuf/enum-values cls)]

--- a/editor/src/clj/editor/properties.clj
+++ b/editor/src/clj/editor/properties.clj
@@ -602,8 +602,8 @@
 (defn ->choicebox
   ([vals]
    (->choicebox vals true))
-  ([vals apply-natural-sorting]
-   (let [sorted-vals (if apply-natural-sorting
+  ([vals apply-natural-sorting?]
+   (let [sorted-vals (if apply-natural-sorting?
                        (sort eutil/natural-order vals)
                        vals)]
      {:type :choicebox


### PR DESCRIPTION
Make the order of layers in the dropdown menu the same as specified in the outline panel.

Fix https://github.com/defold/defold/issues/8876
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
