### PR TITLE
Fixed the issue where "Frame Selection" (F) doesn't work on multipage atlas.

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -231,8 +231,11 @@
   (let [path (resource/proj-path image-resource)
         rect (get image-path->rect path)
         editor-rect (atlas-rect->editor-rect rect)
-        aabb (geom/rect->aabb editor-rect)
-        [layout-width layout-height] layout-size]
+        [layout-width layout-height] layout-size
+        page-index (:page rect)
+        page-offset-x (get-rect-page-offset layout-width page-index)
+        adjusted-editor-rect (assoc editor-rect :x (+ (:x editor-rect) page-offset-x))
+        aabb (geom/rect->aabb adjusted-editor-rect)]
     {:node-id _node-id
      :aabb aabb
      :renderable {:render-fn render-image-outlines
@@ -242,7 +245,7 @@
                               :order order
                               :layout-width layout-width
                               :layout-height layout-height
-                              :page-index (:page rect)}
+                              :page-index page-index}
                   :passes [pass/outline]}
      :children [{:aabb aabb
                  :node-id _node-id


### PR DESCRIPTION
Fixed the issue where "Frame Selection" (F) doesn't work on a multipage atlas if an image is selected on any page except the first one.

Fix https://github.com/defold/defold/issues/8656

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
