### PR TITLE
Fixed APK installation on device after bundling.

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -89,6 +89,7 @@
            [com.defold.editor Editor]
            [com.defold.editor UIUtil]
            [com.dynamo.bob Platform]
+           [com.dynamo.bob.bundle BundleHelper]
            [com.sun.javafx PlatformUtil]
            [com.sun.javafx.scene NodeHelper]
            [java.io BufferedReader File IOException OutputStream PipedInputStream PipedOutputStream PrintWriter]
@@ -2397,7 +2398,8 @@ If you do not specifically require different script states, consider changing th
     (let [game-project (project/get-resource-node project "/game.project" evaluation-context)
           package (game-project/get-setting game-project ["android" "package"] evaluation-context)
           project-title (game-project/get-setting game-project ["project" "title"] evaluation-context)
-          apk-path (io/file output-directory project-title (str project-title ".apk"))]
+          binary-name (BundleHelper/projectNameToBinaryName project-title)
+          apk-path (io/file output-directory binary-name (str binary-name ".apk"))]
       ;; Do the actual work asynchronously because adb commands are blocking.
       (future
         (error-reporting/catch-all!
@@ -2410,7 +2412,7 @@ If you do not specifically require different script states, consider changing th
                     _ (.println writer "Listing devices...")
                     device (or (first (adb/list-devices! adb-path))
                                (throw (ex-info "No devices are connected" {:adb adb-path})))]
-                (.println writer (format "Installing on '%s'..." (:label device)))
+                (.println writer (format "Installing `%s` on '%s'..." apk-path (:label device)))
                 (adb/install! adb-path device apk-path out)
                 (when launch
                   (.println writer (format "Launching %s..." package))


### PR DESCRIPTION
Make sure that the correct APK path is used when the editor installs the APK on a device.

Fix https://github.com/defold/defold/issues/8992
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
