### PR TITLE
Show an error if the wrong script type is used

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameObjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameObjectBuilder.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
 
+import com.dynamo.bob.util.BobNLS;
 import org.apache.commons.io.FilenameUtils;
 
 import com.dynamo.proto.DdfMath.Vector4;
@@ -237,6 +238,11 @@ public class GameObjectBuilder extends Builder<Void> {
             compStorage.add(ext);
             String inExt = "." + ext;
             String outExt = project.replaceExt(inExt);
+            if (ext.equals("gui_script") || ext.equals("render_script"))
+            {
+                throw new CompileExceptionError(resource, 0, BobNLS.bind(Messages.BuilderUtil_WRONG_RESOURCE_TYPE,
+                        new String[] { c, ext, "script" } ));
+            }
             c = BuilderUtil.replaceExt(c, inExt, outExt);
 
             PropertyDeclarations.Builder properties = PropertyDeclarations.newBuilder();

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GuiBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GuiBuilder.java
@@ -407,7 +407,7 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
             // transform and register scene external resources (if compiling)
             String scriptPath = sceneBuilder.getScript();
             String suffix = BuilderUtil.getSuffix(scriptPath);
-            if (!suffix.equals("gui_script"))
+            if (!suffix.isEmpty() && !suffix.equals("gui_script"))
             {
                  throw new CompileExceptionError(builder.project.getResource(input), 0, BobNLS.bind(Messages.BuilderUtil_WRONG_RESOURCE_TYPE,
                          new String[] { scriptPath, suffix, "gui_script" } ));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GuiBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GuiBuilder.java
@@ -405,7 +405,14 @@ public class GuiBuilder extends ProtoBuilder<SceneDesc.Builder> {
 
         if(builder != null) {
             // transform and register scene external resources (if compiling)
-            sceneBuilder.setScript(BuilderUtil.replaceExt(sceneBuilder.getScript(), ".gui_script", ".gui_scriptc"));
+            String scriptPath = sceneBuilder.getScript();
+            String suffix = BuilderUtil.getSuffix(scriptPath);
+            if (!suffix.equals("gui_script"))
+            {
+                 throw new CompileExceptionError(builder.project.getResource(input), 0, BobNLS.bind(Messages.BuilderUtil_WRONG_RESOURCE_TYPE,
+                         new String[] { scriptPath, suffix, "gui_script" } ));
+            }
+            sceneBuilder.setScript(BuilderUtil.replaceExt(scriptPath, ".gui_script", ".gui_scriptc"));
             sceneBuilder.setMaterial(BuilderUtil.replaceExt(sceneBuilder.getMaterial(), ".material", ".materialc"));
 
             for (FontDesc f : sceneBuilder.getFontsList()) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/Messages.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/Messages.java
@@ -22,6 +22,7 @@ public class Messages extends BobNLS {
     public static String BuilderUtil_EMPTY_RESOURCE;
     public static String BuilderUtil_MISSING_RESOURCE;
     public static String BuilderUtil_DUPLICATE_RESOURCE;
+    public static String BuilderUtil_WRONG_RESOURCE_TYPE;
 
     public static String GuiBuilder_MISSING_TEXTURE;
     public static String GuiBuilder_MISSING_MATERIAL;

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -290,6 +290,14 @@ public class ProtoBuilders {
         protected RenderPrototypeDesc.Builder transform(Task<Void> task, IResource resource, RenderPrototypeDesc.Builder messageBuilder)
                 throws IOException, CompileExceptionError {
 
+            String scriptPath = messageBuilder.getScript();
+            String suffix = BuilderUtil.getSuffix(scriptPath);
+            if (!suffix.isEmpty() && !suffix.equals("render_script"))
+            {
+                throw new CompileExceptionError(resource, 0, BobNLS.bind(Messages.BuilderUtil_WRONG_RESOURCE_TYPE,
+                        new String[] { scriptPath, suffix, "render_script" } ));
+            }
+
             BuilderUtil.checkResource(this.project, resource, "script", messageBuilder.getScript());
             messageBuilder.setScript(BuilderUtil.replaceExt(messageBuilder.getScript(), ".render_script", ".render_scriptc"));
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/messages.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/messages.properties
@@ -1,6 +1,7 @@
 BuilderUtil_EMPTY_RESOURCE=you must specify a {0}
 BuilderUtil_MISSING_RESOURCE=the {0} ''{1}'' can't be found
 BuilderUtil_DUPLICATE_RESOURCE=the resource ''{0}'' is duplicated
+BuilderUtil_WRONG_RESOURCE_TYPE= Wrong resource ''{0}''. It has resource type ''{1}'', but expected type is ''{2}''
 
 GuiBuilder_MISSING_TEXTURE=the texture ''{0}'' has not been added as a resource
 GuiBuilder_MISSING_MATERIAL=the material ''{0}'' has not been added as a resource

--- a/editor/src/clj/editor/game_object.clj
+++ b/editor/src/clj/editor/game_object.clj
@@ -141,11 +141,9 @@
                                (vec (distinct (concat display-order (:display-order source-properties))))))))
 
 (defn resource-path-error [_node-id source-resource]
-  (let [node-type (some-> source-resource resource/resource-type :node-type)]
     (or (validation/prop-error :fatal _node-id :path validation/prop-nil? source-resource "Path")
         (validation/prop-error :fatal _node-id :path validation/prop-resource-not-exists? source-resource "Path")
-        (and (= node-type editor.code.script/ScriptNode)
-             (validation/prop-error :fatal _node-id :script validation/prop-resource-ext? source-resource "script" "Path")))))
+        (validation/prop-error :fatal _node-id :script validation/prop-resource-comp? source-resource "Path")))
 
 (g/defnk produce-component-build-targets [_node-id build-resource ddf-message pose resource-property-build-targets source-build-targets]
   ;; Create a build-target for the referenced or embedded component. Also tag on

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -501,9 +501,13 @@
       (validation/prop-error :fatal node-id prop-kw (partial validation/prop-id-duplicate? id-counts) prop-value)))
 
 ;; SDK api
-(defn prop-resource-error [node-id prop-kw prop-value prop-name]
-  (or (validation/prop-error :fatal node-id prop-kw validation/prop-nil? prop-value prop-name)
+(defn prop-resource-error
+  ([node-id prop-kw prop-value prop-name]
+    (or (validation/prop-error :fatal node-id prop-kw validation/prop-nil? prop-value prop-name)
       (validation/prop-error :fatal node-id prop-kw validation/prop-resource-not-exists? prop-value prop-name)))
+  ([node-id prop-kw prop-value prop-name resource-ext]
+    (or (prop-resource-error node-id prop-kw prop-value prop-name)
+      (validation/prop-error :fatal node-id prop-kw validation/prop-resource-ext? prop-value resource-ext prop-name))))
 
 ;; SDK api
 (defn references-gui-resource? [evaluation-context node-id prop-kw gui-resource-name]
@@ -2470,7 +2474,7 @@
 
 (g/defnk produce-own-build-errors [_node-id material max-nodes node-ids script]
   (g/package-errors _node-id
-                    (when script (prop-resource-error _node-id :script script "Script"))
+                    (when script (prop-resource-error _node-id :script script "Script" "gui_script"))
                     (prop-resource-error _node-id :material material "Material")
                     (validate-max-nodes _node-id max-nodes node-ids)))
 
@@ -2500,7 +2504,7 @@
                      [:build-targets :dep-build-targets])))
             (dynamic error (g/fnk [_node-id script]
                              (when script
-                               (prop-resource-error _node-id :script script "Script"))))
+                               (prop-resource-error _node-id :script script "Script" "gui_script"))))
             (dynamic edit-type (g/fnk [] {:type resource/Resource
                                           :ext "gui_script"})))
 

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -503,11 +503,11 @@
 ;; SDK api
 (defn prop-resource-error
   ([node-id prop-kw prop-value prop-name]
-    (or (validation/prop-error :fatal node-id prop-kw validation/prop-nil? prop-value prop-name)
-      (validation/prop-error :fatal node-id prop-kw validation/prop-resource-not-exists? prop-value prop-name)))
+   (or (validation/prop-error :fatal node-id prop-kw validation/prop-nil? prop-value prop-name)
+       (validation/prop-error :fatal node-id prop-kw validation/prop-resource-not-exists? prop-value prop-name)))
   ([node-id prop-kw prop-value prop-name resource-ext]
-    (or (prop-resource-error node-id prop-kw prop-value prop-name)
-      (validation/prop-error :fatal node-id prop-kw validation/prop-resource-ext? prop-value resource-ext prop-name))))
+   (or (prop-resource-error node-id prop-kw prop-value prop-name)
+       (validation/prop-error :fatal node-id prop-kw validation/prop-resource-ext? prop-value resource-ext prop-name))))
 
 ;; SDK api
 (defn references-gui-resource? [evaluation-context node-id prop-kw gui-resource-name]

--- a/editor/src/clj/editor/render_pb.clj
+++ b/editor/src/clj/editor/render_pb.clj
@@ -118,7 +118,8 @@
 
 (defn- build-errors
   [_node-id script named-render-resources]
-  (when-let [errors (->> (into [(validation/prop-error :fatal _node-id :script validation/prop-resource-missing? script "Script")]
+  (when-let [errors (->> (into [(or (validation/prop-error :fatal _node-id :script validation/prop-resource-missing? script "Script")
+                                    (validation/prop-error :fatal _node-id :script validation/prop-resource-ext? script "render_script" "Script"))]
                                (for [{:keys [name path]} named-render-resources]
                                  (validation/prop-error :fatal _node-id :path validation/prop-resource-missing? path name)))
                          (remove nil?)

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -75,8 +75,10 @@
         (format "%s '%s' is not of type %s" name (resource/resource->proj-path v) (format-ext ext)))))
 
 (defn prop-resource-comp? [v name]
-  (let [resource-type (some-> v resource/resource-type)]
-    (when-not (contains? (:tags resource-type) :component)
+  (let [resource-type (some-> v resource/resource-type)
+        tags (:tags resource-type)]
+    (when-not (or (contains? tags :component)
+                  (contains? tags :embeddable))
       (format "Only components allowed for '%s'. '%s' is not a component." name (:ext resource-type)))))
 
 (defn prop-member-of? [v val-set message]

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -74,6 +74,11 @@
       (when-not (= (resource/type-ext v) ext)
         (format "%s '%s' is not of type %s" name (resource/resource->proj-path v) (format-ext ext)))))
 
+(defn prop-resource-comp? [v name]
+  (let [resource-type (some-> v resource/resource-type)]
+    (when-not (contains? (:tags resource-type) :component)
+      (format "Only components allowed for '%s'. '%s' is not a component." name (:ext resource-type)))))
+
 (defn prop-member-of? [v val-set message]
   (when (and val-set (not (val-set v)))
     message))

--- a/editor/src/clj/editor/validation.clj
+++ b/editor/src/clj/editor/validation.clj
@@ -74,7 +74,7 @@
       (when-not (= (resource/type-ext v) ext)
         (format "%s '%s' is not of type %s" name (resource/resource->proj-path v) (format-ext ext)))))
 
-(defn prop-resource-comp? [v name]
+(defn prop-resource-not-component? [v name]
   (let [resource-type (some-> v resource/resource-type)
         tags (:tags resource-type)]
     (when-not (or (contains? tags :component)


### PR DESCRIPTION
Fixed the issue where neither the editor nor bob reacts when the wrong script type is used, such as a `.script` file instead of a `*.gui_script` in `*.gui` etc.

Fix https://github.com/defold/defold/issues/8005
## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
