### PR TITLE
Add child-seqs to outline nodes for copy+paste handling

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -425,7 +425,8 @@
         (g/set-property source :child-index next-index)
         (attach-gui-node node-tree target source type)))))
 
-(defn- gen-outline-node-tx-attach-fn
+;; SDK api
+(defn gen-outline-node-tx-attach-fn
   ([attach-fn]
    (gen-outline-node-tx-attach-fn attach-fn :names))
   ([attach-fn target-name-key]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -339,6 +339,7 @@
       (conj 1.0)))
 
 (declare get-registered-node-type-info get-registered-node-type-infos)
+(declare ^:private TextureNode)
 
 ;; /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -424,6 +425,17 @@
         (g/update-property source :id outline/resolve-id taken-ids)
         (g/set-property source :child-index next-index)
         (attach-gui-node node-tree target source type)))))
+
+(defn- gen-outline-node-tx-attach-fn
+  ([attach-fn]
+   (gen-outline-node-tx-attach-fn attach-fn :names))
+  ([attach-fn target-name-key]
+   (fn [target source]
+     (let [node-tree (node->gui-scene target)
+           taken-id-names (g/node-value target target-name-key)]
+       (concat
+         (g/update-property source :name outline/resolve-id taken-id-names)
+         (attach-fn node-tree target source))))))
 
 ;; Schema validation is disabled because it severely affects project load times.
 ;; You might want to enable these before making drastic changes to Gui nodes.
@@ -1710,7 +1722,8 @@
 (g/defnode LayerNode
   (inherits outline/OutlineNode)
   (property name g/Str
-            (dynamic error (g/fnk [_node-id name name-counts] (prop-unique-id-error _node-id :name name name-counts "Name")))
+            (dynamic error (g/fnk [_node-id name name-counts]
+                             (prop-unique-id-error _node-id :name name name-counts "Name")))
             (set (partial update-gui-resource-references :layer)))
   (property child-index g/Int (dynamic visible (g/constantly false)) (default 0))
   (input name-counts NameCounts)
@@ -2035,7 +2048,9 @@
   (output name-counts NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
-  (output node-outline outline/OutlineData :cached (gen-outline-fnk "Textures" "Textures" 1 false []))
+  (output node-outline outline/OutlineData :cached
+          (gen-outline-fnk "Textures" "Textures" 1 false [{:node-type TextureNode
+                                                           :tx-attach-fn (gen-outline-node-tx-attach-fn attach-texture)}]))
   (output add-handler-info g/Any
           (g/fnk [_node-id]
                  [_node-id "Textures..." texture-icon add-textures-handler {}])))
@@ -2074,7 +2089,9 @@
   (output name-counts NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
-  (output node-outline outline/OutlineData :cached (gen-outline-fnk "Materials" "Materials" 1 false []))
+  (output node-outline outline/OutlineData :cached
+          (gen-outline-fnk "Materials" "Materials" 1 false [{:node-type MaterialNode
+                                                             :tx-attach-fn (gen-outline-node-tx-attach-fn attach-material)}]))
   (output add-handler-info g/Any
           (g/fnk [_node-id]
             [_node-id "Materials..." material-icon add-materials-handler {}])))
@@ -2114,7 +2131,9 @@
   (output name-counts NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
-  (output node-outline outline/OutlineData :cached (gen-outline-fnk "Fonts" "Fonts" 2 false []))
+  (output node-outline outline/OutlineData :cached
+          (gen-outline-fnk "Fonts" "Fonts" 2 false [{:node-type FontNode
+                                                     :tx-attach-fn (gen-outline-node-tx-attach-fn attach-font)}]))
   (output add-handler-info g/Any
           (g/fnk [_node-id]
                  [_node-id "Fonts..." font-icon add-fonts-handler {}])))
@@ -2122,9 +2141,9 @@
 ;; //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 (defn- attach-layer
-  ([layers-node layer]
-   (attach-layer layers-node layer false))
-  ([layers-node layer internal?]
+  ([self layers-node layer]
+   (attach-layer self layers-node layer false))
+  ([_self layers-node layer internal?]
    (concat
     (g/connect layer :_node-id layers-node :nodes)
     (when (not internal?)
@@ -2138,9 +2157,10 @@
 
 (defn add-layer [project scene parent name child-index select-fn]
   (g/make-nodes (g/node-id->graph-id scene) [node [LayerNode :name name :child-index child-index]]
-                (attach-layer parent node)
-                (when select-fn
-                  (select-fn [node]))))
+    ;; Self is not used when attaching layers
+    (attach-layer nil parent node)
+    (when select-fn
+      (select-fn [node]))))
 
 (defn- add-layer-handler [project {:keys [scene parent]} select-fn]
   (let [name (outline/resolve-id "layer" (g/node-value parent :name-counts))
@@ -2150,6 +2170,14 @@
      (concat
       (g/operation-label "Add Layer")
       (add-layer project scene parent name next-index select-fn)))))
+
+;; Layers have a bit of different structure - there is no :names entry
+;; in the LayersNode node
+(defn- gen-layer-node-tx-attach-fn [target source]
+  (let [taken-id-names (g/node-value target :ordered-layer-names)]
+    (concat
+      (g/update-property source :name outline/resolve-id taken-id-names)
+      (attach-layer nil target source))))
 
 (g/defnode LayersNode
   (inherits core/Scope)
@@ -2169,7 +2197,9 @@
   (output layer->index g/Any :cached (g/fnk [ordered-layer-names]
                                        (zipmap ordered-layer-names (range))))
   (input child-indices NodeIndex :array)
-  (output node-outline outline/OutlineData :cached (gen-outline-fnk "Layers" "Layers" 3 true []))
+  (output node-outline outline/OutlineData :cached
+          (gen-outline-fnk "Layers" "Layers" 3 true [{:node-type LayerNode
+                                                      :tx-attach-fn (gen-outline-node-tx-attach-fn attach-layer :ordered-layer-names)}]))
   (output add-handler-info g/Any
           (g/fnk [_node-id]
                  [_node-id "Layer" layer-icon add-layer-handler {}])))
@@ -2209,7 +2239,11 @@
   (output name-counts NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
-  (output node-outline outline/OutlineData :cached (gen-outline-fnk "Layouts" "Layouts" 4 false []))
+  (output node-outline outline/OutlineData :cached
+          ;; Layouts don't have any child-reqs for the outline copy/pasting,
+          ;; since there is essentially only one node that _can_ be supported
+          ;; per "layout type".
+          (gen-outline-fnk "Layouts" "Layouts" 4 false []))
   (output add-handler-info g/Any
           (g/fnk [_node-id unused-display-profiles]
             (mapv #(vector _node-id % layout-icon add-layout-handler {:display-profile %})
@@ -2249,7 +2283,9 @@
   (output name-counts NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
-  (output node-outline outline/OutlineData :cached (gen-outline-fnk "Particle FX" "Particle FX" 5 false []))
+  (output node-outline outline/OutlineData :cached
+          (gen-outline-fnk "Particle FX" "Particle FX" 5 false [{:node-type ParticleFXResource
+                                                                 :tx-attach-fn (gen-outline-node-tx-attach-fn attach-particlefx-resource)}]))
   (output add-handler-info g/Any
           (g/fnk [_node-id]
                  [_node-id "Particle FX..." particlefx/particle-fx-icon add-particlefx-resources-handler {}])))
@@ -2916,7 +2952,7 @@
                     (g/connect layers-node :build-errors self :build-errors)
                     (g/connect layers-node :node-outline self :child-outlines)
                     (g/connect layers-node :add-handler-info self :handler-infos)
-                    (attach-layer layers-node no-layer true)
+                    (attach-layer self layers-node no-layer true)
                     (loop [[layer-desc & more] (:layers scene)
                            tx-data []
                            child-index 0]
@@ -2925,7 +2961,7 @@
                                                           [layer [LayerNode
                                                                   :name (:name layer-desc)
                                                                   :child-index child-index]]
-                                                          (attach-layer layers-node layer))]
+                                                          (attach-layer self layers-node layer))]
                           (recur more (conj tx-data layer-tx-data) (inc child-index)))
                         tx-data)))
       (g/make-nodes graph-id [node-tree NodeTree]

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -339,7 +339,6 @@
       (conj 1.0)))
 
 (declare get-registered-node-type-info get-registered-node-type-infos)
-(declare ^:private TextureNode)
 
 ;; /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1722,8 +1721,7 @@
 (g/defnode LayerNode
   (inherits outline/OutlineNode)
   (property name g/Str
-            (dynamic error (g/fnk [_node-id name name-counts]
-                             (prop-unique-id-error _node-id :name name name-counts "Name")))
+            (dynamic error (g/fnk [_node-id name name-counts] (prop-unique-id-error _node-id :name name name-counts "Name")))
             (set (partial update-gui-resource-references :layer)))
   (property child-index g/Int (dynamic visible (g/constantly false)) (default 0))
   (input name-counts NameCounts)
@@ -2143,6 +2141,7 @@
 (defn- attach-layer
   ([self layers-node layer]
    (attach-layer self layers-node layer false))
+  ;; Self is not used here but added to conform all attach-*** functions
   ([_self layers-node layer internal?]
    (concat
     (g/connect layer :_node-id layers-node :nodes)
@@ -2170,14 +2169,6 @@
      (concat
       (g/operation-label "Add Layer")
       (add-layer project scene parent name next-index select-fn)))))
-
-;; Layers have a bit of different structure - there is no :names entry
-;; in the LayersNode node
-(defn- gen-layer-node-tx-attach-fn [target source]
-  (let [taken-id-names (g/node-value target :ordered-layer-names)]
-    (concat
-      (g/update-property source :name outline/resolve-id taken-id-names)
-      (attach-layer nil target source))))
 
 (g/defnode LayersNode
   (inherits core/Scope)


### PR DESCRIPTION
The editor now has support for copy/paste/cut of all resources nodes in the outline view except for "layouts". Layouts are unique and only one of each type can exist in a GUI at any time.

Fixes #6682 