### PR TITLE
Make sure that recursion is impossible when pasting a folder into its subfolders.

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -21,6 +21,7 @@
             [editor.disk-availability :as disk-availability]
             [editor.error-reporting :as error-reporting]
             [editor.fs :as fs]
+            [editor.notifications :as notifications]
             [editor.handler :as handler]
             [editor.icons :as icons]
             [editor.prefs :as prefs]
@@ -343,8 +344,19 @@
   (run [selection workspace asset-browser]
        (let [tree-view (g/node-value asset-browser :tree-view)
              resource (first selection)
-             src-files (.getFiles (Clipboard/getSystemClipboard))]
-         (paste! workspace resource src-files (partial select-files! workspace tree-view)))))
+             src-files (.getFiles (Clipboard/getSystemClipboard))
+             dest-path (resource/abs-path resource)]
+         (if-let [conflicting-file (some #(when (string/starts-with? dest-path (.getPath %)) %) src-files)]
+           (let [res-proj-path (resource/proj-path resource)
+                 dest-proj-path (resource/file->proj-path (workspace/project-path workspace) conflicting-file)]
+             (notifications/show!
+               (workspace/notifications workspace)
+               {:type :error
+                :id ::asset-circular-paste
+                :text (if (= res-proj-path dest-proj-path)
+                        (str "Cannot paste folder '" dest-proj-path "' into itself")
+                        (str "Cannot paste folder '" dest-proj-path "' into its subfolder '" res-proj-path "'"))}))
+           (paste! workspace resource src-files (partial select-files! workspace tree-view))))))
 
 (defn- moved-files
   [^File src-file ^File dest-file files]


### PR DESCRIPTION
Show an error if the user tries to paste a folder into its subfolders.

Fix https://github.com/defold/defold/issues/3910

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
