### PR TITLE
Change sprite image by sampler hash

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -2108,10 +2108,6 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_IMAGE)
         {
-            /*
-            m_Key
-            m_HasKey
-            */
             dmhash_t sampler_name_hash = params.m_Options.m_HasKey ? params.m_Options.m_Key : 0;
             dmGameObject::PropertyResult res = AddOverrideTextureSet(dmGameObject::GetFactory(params.m_Instance), component, sampler_name_hash, params.m_Value.m_Hash);
             component->m_ReHash |= res == dmGameObject::PROPERTY_RESULT_OK;

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1060,7 +1060,7 @@ namespace dmGameSystem
         dmArray<float> scratch_pos;
 
         // The list of pointers to the scratch uvs
-        float* scratch_uv_ptrs[MAX_TEXTURE_COUNT];
+        float* scratch_uv_ptrs[MAX_TEXTURE_COUNT] = {};
 
         TexturesData textures = {};
         textures.m_NumTextures = GetNumTextures(first);
@@ -2074,9 +2074,11 @@ namespace dmGameSystem
         }
         else if (set_property == PROP_IMAGE)
         {
-            // TODO: use the sampler name as the key
-            // For now, we'll use hash("")==0 as the default sampler name
-            dmhash_t sampler_name_hash = 0;
+            /*
+            m_Key
+            m_HasKey
+            */
+            dmhash_t sampler_name_hash = params.m_Options.m_HasKey ? params.m_Options.m_Key : 0;
             dmGameObject::PropertyResult res = AddOverrideTextureSet(dmGameObject::GetFactory(params.m_Instance), component, sampler_name_hash, params.m_Value.m_Hash);
             component->m_ReHash |= res == dmGameObject::PROPERTY_RESULT_OK;
 

--- a/engine/gamesys/src/gamesys/test/atlas/valid_64x64.atlas
+++ b/engine/gamesys/src/gamesys/test/atlas/valid_64x64.atlas
@@ -1,0 +1,10 @@
+images {
+  image: "/texture/valid_png.png"
+  sprite_trim_mode: SPRITE_TRIM_MODE_OFF
+}
+margin: 0
+extrude_borders: 0
+inner_padding: 0
+max_page_width: 0
+max_page_height: 0
+rename_patterns: ""

--- a/engine/gamesys/src/gamesys/test/fragment_program/valid_two_samplers.fp
+++ b/engine/gamesys/src/gamesys/test/fragment_program/valid_two_samplers.fp
@@ -1,0 +1,13 @@
+
+uniform sampler2D tex0;
+uniform sampler2D tex1;
+
+varying vec2 var_texcoord0;
+varying vec2 var_texcoord1;
+
+void main()
+{
+    vec4 tex0_color = texture2D(tex0, var_texcoord0.st);
+    vec4 tex1_color = texture2D(tex1, var_texcoord1.st);
+    gl_FragColor = tex0_color * tex1_color;
+}

--- a/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.go
+++ b/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.go
@@ -1,0 +1,8 @@
+components {
+  id: "script"
+  component: "/sprite/image/get_set_image_by_hash.script"
+}
+components {
+  id: "sprite"
+  component: "/sprite/image/get_set_image_by_hash.sprite"
+}

--- a/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.material
+++ b/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.material
@@ -1,0 +1,19 @@
+name: "valid"
+vertex_program: "/vertex_program/valid.vp"
+fragment_program: "/fragment_program/valid_two_samplers.fp"
+
+samplers {
+  name: "tex0"
+  wrap_u: WRAP_MODE_CLAMP_TO_EDGE
+  wrap_v: WRAP_MODE_CLAMP_TO_EDGE
+  filter_min: FILTER_MODE_MIN_LINEAR
+  filter_mag: FILTER_MODE_MAG_LINEAR
+}
+
+samplers {
+  name: "tex1"
+  wrap_u: WRAP_MODE_CLAMP_TO_EDGE
+  wrap_v: WRAP_MODE_CLAMP_TO_EDGE
+  filter_min: FILTER_MODE_MIN_LINEAR
+  filter_mag: FILTER_MODE_MAG_LINEAR
+}

--- a/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.script
+++ b/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.script
@@ -1,0 +1,48 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+local function assert_error(func)
+    local r, err = pcall(func)
+    if not r then
+        print(err)
+    end
+    assert(not r)
+end
+
+function init(self)
+	local valid_atlas = hash("/atlas/valid.t.texturesetc")
+	local valid_atlas_64 = hash("/atlas/valid_64x64.t.texturesetc")
+
+	-- all of these should be the same initially.
+	local without_options = go.get("#sprite", "image")
+	local with_options_tex0 = go.get("#sprite", "image", { key = "tex0" })
+	local with_options_tex1 = go.get("#sprite", "image", { key = "tex1" })
+
+	assert(without_options == valid_atlas)
+	assert(without_options == with_options_tex0)
+	assert(without_options == with_options_tex1)
+
+	go.set("#sprite", "image", valid_atlas_64, { key = "tex1" })
+	assert(valid_atlas_64 == go.get("#sprite", "image", { key = "tex1" }))
+
+	go.set("#sprite", "image", valid_atlas_64)
+	assert(valid_atlas_64 == go.get("#sprite", "image"))
+
+	go.set("#sprite", "image", valid_atlas_64, { key = "tex0" })
+	assert(valid_atlas_64 == go.get("#sprite", "image", { key = "tex0" }))
+
+	-- error tests
+	assert_error(function() go.set("#sprite", "image", "missing_atlas") end)
+	assert_error(function() go.set("#sprite", "image", valid_atlas_64, { key = "missing_sampler" }) end)
+end

--- a/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.sprite
+++ b/engine/gamesys/src/gamesys/test/sprite/image/get_set_image_by_hash.sprite
@@ -1,0 +1,10 @@
+default_animation: "valid_png_128"
+material: "/sprite/image/get_set_image_by_hash.material"
+textures {
+  sampler: "tex0"
+  texture: "/atlas/valid.atlas"
+}
+textures {
+  sampler: "tex1"
+  texture: "/atlas/valid.atlas"
+}

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1078,8 +1078,6 @@ TEST_F(SpriteTest, GoDeletion)
 // Test that animation done event reaches either callback or onmessage
 TEST_F(SpriteTest, FlipbookAnim)
 {
-    dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
-
     // Spawn one go with a script that will initiate animations on the above sprites
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/sprite_flipbook_anim.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
@@ -1104,8 +1102,6 @@ TEST_F(SpriteTest, FlipbookAnim)
 
 TEST_F(SpriteTest, FrameCount)
 {
-    dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
-
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/frame_count/sprite_frame_count.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
@@ -1116,13 +1112,28 @@ TEST_F(SpriteTest, FrameCount)
 
 TEST_F(SpriteTest, GetSetSliceProperty)
 {
-    dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
-
     dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/sprite_slice9.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, go);
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+TEST_F(SpriteTest, GetSetImagesByHash)
+{
+    void* atlas=0;
+    dmResource::Result res = dmResource::Get(m_Factory, "/atlas/valid_64x64.t.texturesetc", &atlas);
+    ASSERT_EQ(dmResource::RESULT_OK, res);
+
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/image/get_set_image_by_hash.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    dmResource::Release(m_Factory, atlas);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
@@ -1289,8 +1300,6 @@ TEST_P(CursorTest, Cursor)
 TEST_F(GuiTest, TextureResources)
 {
     dmhash_t go_id = dmHashString64("/go");
-    dmhash_t gui_comp_id = dmHashString64("gui");
-
     dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
 
     dmGameSystem::TextureSetResource* valid_atlas = 0;

--- a/engine/gamesys/src/gamesys/test/test_gamesys.h
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.h
@@ -151,6 +151,8 @@ public:
         m_Scriptlibcontext.m_LuaState        = dmScript::GetLuaState(m_ScriptContext);
         m_Scriptlibcontext.m_GraphicsContext = m_GraphicsContext;
         m_Scriptlibcontext.m_ScriptContext   = m_ScriptContext;
+
+        dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
     }
     virtual ~ScriptBaseTest() {}
     dmGameSystem::ScriptLibContext m_Scriptlibcontext;

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -453,7 +453,7 @@ namespace dmGraphics
                 case dmGraphics::VertexAttribute::SEMANTIC_TYPE_TEXCOORD:
                 {
                     uint32_t unit = num_texcoords++;
-                    if (unit >= num_textures)
+                    if (unit >= num_textures || !uvs[unit])
                         unit = 0;
                     memcpy(write_ptr, uvs[unit] + vertex_index * 2, info.m_ValueByteSize);
                 } break;


### PR DESCRIPTION
Scripts can now change a sprite image by using a sampler hash:
`go.set("#sprite", "image", self.my_atlas_mask, { key = sampler_name })`

Or get the atlas from a specific sampler:
`go.get("#sprite", "image", { key = sampler_name })`

For example, this sprite is using a material that has two samplers, `tex0` and `tex1`:
<img width="468" alt="image" src="https://github.com/defold/defold/assets/169640/094c3064-090d-4fae-90e4-d8d6f79aa4d1">

To change the second atlas, pass "tex1" in as the key in the `go.set` call:
`go.set("/go1#sprite", "image", my_tex1_atlas, { key = "tex1" })`

To retrieve the atlas of the sampler, call:
`local my_tex1_atlas = go.get("/go1#sprite", "image", { key = "tex1" })`

Fixes #9046