### PR TITLE
Add imperative editor script API

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2501,10 +2501,7 @@ If you do not specifically require different script states, consider changing th
           platform (:platform-key last-bundle-options)]
       (bundle! main-stage tool-tab-pane changes-view build-errors-view project prefs platform last-bundle-options))))
 
-(def ^:private editor-extensions-allowed-commands-prefs-key
-  "editor-extensions/allowed-commands")
-
-(defn reload-extensions! [app-view project kind workspace changes-view prefs]
+(defn reload-extensions! [app-view project kind workspace changes-view]
   (extensions/reload!
     project kind
     :reload-resources! (fn reload-resources! []
@@ -2518,32 +2515,6 @@ If you do not specifically require different script states, consider changing th
                                                    (future/complete! f nil)
                                                    (future/fail! f (RuntimeException. "Reload failed")))))
                            f))
-    :can-execute? (fn can-execute? [[cmd-name :as command]]
-                    (let [allowed-commands (prefs/get-prefs prefs editor-extensions-allowed-commands-prefs-key #{})]
-                      (if (allowed-commands cmd-name)
-                        (future/completed true)
-                        (let [f (future/make)]
-                          (ui/run-later
-                            (let [allow (dialogs/make-confirmation-dialog
-                                          {:title "Allow executing shell command?"
-                                           :icon {:fx/type fxui/icon
-                                                  :type :icon/triangle-error
-                                                  :fill "#fa6731"}
-                                           :header "Extension wants to execute a shell command"
-                                           :content {:fx/type fxui/label
-                                                     :style-class "dialog-content-padding"
-                                                     :text (string/join " " command)}
-                                           :buttons [{:text "Abort Command"
-                                                      :cancel-button true
-                                                      :default-button true
-                                                      :result false}
-                                                     {:text "Allow"
-                                                      :variant :danger
-                                                      :result true}]})]
-                              (when allow
-                                (prefs/set-prefs prefs editor-extensions-allowed-commands-prefs-key (conj allowed-commands cmd-name)))
-                              (future/complete! f allow)))
-                          f))))
     :display-output! (fn display-output! [type string]
                        (let [[console-type prefix] (case type
                                                      :err [:extension-error "ERROR:EXT: "]
@@ -2562,7 +2533,7 @@ If you do not specifically require different script states, consider changing th
                                      (future/fail! f (Exception. "Save failed")))))
                f))))
 
-(defn- fetch-libraries [app-view workspace project changes-view prefs]
+(defn- fetch-libraries [app-view workspace project changes-view]
   (let [library-uris (project/project-dependencies project)
         hosts (into #{} (map url/strip-path) library-uris)]
     (if-let [first-unreachable-host (first-where (complement url/reachable?) hosts)]
@@ -2585,28 +2556,28 @@ If you do not specifically require different script states, consider changing th
                   (disk/async-reload! render-install-progress! workspace [] changes-view
                                       (fn [success]
                                         (when success
-                                          (reload-extensions! app-view project :library workspace changes-view prefs)))))))))))))
+                                          (reload-extensions! app-view project :library workspace changes-view)))))))))))))
 
 (handler/defhandler :add-dependency :global
   (enabled? [] (disk-availability/available?))
-  (run [selection app-view prefs workspace project changes-view user-data]
+  (run [selection app-view workspace project changes-view user-data]
        (let [game-project (project/get-resource-node project "/game.project")
              dependencies (game-project/get-setting game-project ["project" "dependencies"])
              dependency-uri (.toURI (URL. (:dep-url user-data)))]
          (when (not-any? (partial = dependency-uri) dependencies)
            (game-project/set-setting! game-project ["project" "dependencies"]
                                       (conj (vec dependencies) dependency-uri))
-           (fetch-libraries app-view workspace project changes-view prefs)))))
+           (fetch-libraries app-view workspace project changes-view)))))
 
 (handler/defhandler :fetch-libraries :global
   (enabled? [] (disk-availability/available?))
-  (run [app-view workspace project changes-view prefs]
-       (fetch-libraries app-view workspace project changes-view prefs)))
+  (run [app-view workspace project changes-view]
+       (fetch-libraries app-view workspace project changes-view)))
 
 (handler/defhandler :reload-extensions :global
   (enabled? [] (disk-availability/available?))
-  (run [app-view project workspace changes-view prefs]
-       (reload-extensions! app-view project :all workspace changes-view prefs)))
+  (run [app-view project workspace changes-view]
+       (reload-extensions! app-view project :all workspace changes-view)))
 
 (defn- ensure-exists-and-open-for-editing! [proj-path app-view changes-view prefs project]
   (let [workspace (project/workspace project)

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -210,7 +210,7 @@
                                                             console/url-prefix (console/make-request-handler console-view)})
                                    http-server/start!)]
       (ui/add-application-focused-callback! :main-stage app-view/handle-application-focused! app-view changes-view workspace prefs)
-      (app-view/reload-extensions! app-view project :all workspace changes-view prefs)
+      (app-view/reload-extensions! app-view project :all workspace changes-view)
 
       (when updater
         (let [update-link (.lookup root "#update-link")]

--- a/editor/src/clj/editor/boot_open_project.clj
+++ b/editor/src/clj/editor/boot_open_project.clj
@@ -210,7 +210,7 @@
                                                             console/url-prefix (console/make-request-handler console-view)})
                                    http-server/start!)]
       (ui/add-application-focused-callback! :main-stage app-view/handle-application-focused! app-view changes-view workspace prefs)
-      (app-view/reload-extensions! project :all workspace changes-view prefs)
+      (app-view/reload-extensions! app-view project :all workspace changes-view prefs)
 
       (when updater
         (let [update-link (.lookup root "#update-link")]

--- a/editor/src/clj/editor/editor_extensions.clj
+++ b/editor/src/clj/editor/editor_extensions.clj
@@ -46,8 +46,6 @@
 (defn- ext-state
   "Returns an extension state, a map with following keys:
     :reload-resources!     0-arg function used to reload resources
-    :can-execute?          1-arg function of command vector used to ask the user
-                           if it's okay to execute this command
     :display-output!       2-arg function used to display extension-related
                            output to the user, where args are:
                              type    output type, :err or :out
@@ -425,9 +423,6 @@
     :reload-resources!    0-arg function that asynchronously reloads the editor
                           resources, returns a CompletableFuture (that might
                           complete exceptionally if reload fails)
-    :can-execute?         1-arg function that takes in a command vector and asks
-                          the user if it's okay to execute this command. Returns
-                          a CompletableFuture that will resolve to boolean
     :display-output!      2-arg function used for displaying output in the
                           console, the args are:
                             type    output type, :out or :err
@@ -435,7 +430,7 @@
     :save!                0-arg function that asynchronously saves any unsaved
                           changes, returns CompletableFuture (that might
                           complete exceptionally if reload fails)"
-  [project kind & {:keys [reload-resources! can-execute? display-output! save!] :as opts}]
+  [project kind & {:keys [reload-resources! display-output! save!] :as opts}]
   (g/with-auto-evaluation-context evaluation-context
     (let [extensions (g/node-value project :editor-extensions evaluation-context)
           old-state (ext-state project evaluation-context)

--- a/editor/src/clj/editor/editor_extensions/actions.clj
+++ b/editor/src/clj/editor/editor_extensions/actions.clj
@@ -64,7 +64,15 @@
           (future/completed nil)
           future-fns))
 
-(defn- input-stream->console [input-stream display-output! type]
+(defn input-stream->console
+  "Pipe the input stream as text lines to the console output
+
+  Args
+    input-stream       the InputStream to consume
+    display-output!    2-arg function used to display extension-related output
+                       to the user
+    type               display-output!'s type argument, either :err or :out"
+  [input-stream display-output! type]
   (future
     (error-reporting/catch-all!
       (with-open [reader (io/reader input-stream)]

--- a/editor/src/clj/editor/editor_extensions/runtime.clj
+++ b/editor/src/clj/editor/editor_extensions/runtime.clj
@@ -50,7 +50,7 @@
             [dynamo.graph :as g]
             [editor.editor-extensions.vm :as vm]
             [editor.future :as future])
-  (:import [com.defold.editor.luart DefoldBaseLib DefoldCoroutine$Create DefoldCoroutine$Yield DefoldIoLib DefoldVarArgFn SearchPath]
+  (:import [com.defold.editor.luart DefoldBaseLib DefoldCoroutine$Create DefoldCoroutine$Yield DefoldIoLib DefoldUserdata DefoldVarArgFn SearchPath]
            [java.io File PrintStream Writer]
            [java.nio.charset StandardCharsets]
            [org.apache.commons.io.output WriterOutputStream]
@@ -202,8 +202,10 @@
 
 (defn wrap-userdata
   "Wraps the value into a LuaUserdata"
-  [x]
-  (vm/wrap-userdata x))
+  ([x]
+   (vm/wrap-userdata x))
+  ([x string-representation]
+   (DefoldUserdata. x string-representation)))
 
 (defn- writer->print-stream [^Writer writer]
   (-> writer

--- a/editor/src/clj/editor/editor_extensions/validation.clj
+++ b/editor/src/clj/editor/editor_extensions/validation.clj
@@ -111,6 +111,22 @@
           :opt-un [:editor.extensions.validation.language-server/watched_files]))
 (s/def ::language-servers (s/coll-of ::language-server))
 
+(defn- transaction-step? [x]
+  (= :transaction-step (:type (meta x))))
+
+(s/def ::transaction-steps (s/coll-of transaction-step? :min-count 1))
+
+(s/def :editor.extensions.validation.execute-options/reload_resources boolean?)
+(s/def :editor.extensions.validation.execute-options/out
+  #{"capture" "discard" "pipe"})
+(s/def :editor.extensions.validation.execute-options/err
+  #{"stdout" "discard" "pipe"})
+(s/def ::execute-command (s/coll-of string? :min-count 1))
+(s/def ::execute-options
+  (s/keys :opt-un [:editor.extensions.validation.execute-options/reload_resources
+                   :editor.extensions.validation.execute-options/out
+                   :editor.extensions.validation.execute-options/err]))
+
 (defn- ->lua-string
   "Convert Clojure data structure to a string representing equivalent Lua data structure"
   [x]
@@ -161,6 +177,7 @@
             node-id? "is not a node id"
             resource-path? "is not a resource path"
             map? "is not a table"
+            transaction-step? "is not a transaction step"
             nil))
 
         (set? pred)

--- a/editor/src/clj/editor/future.clj
+++ b/editor/src/clj/editor/future.clj
@@ -15,7 +15,7 @@
 (ns editor.future
   (:refer-clojure :exclude [future])
   (:import [java.util.concurrent CompletableFuture CompletionException]
-           [java.util.function Function]))
+           [java.util.function Function Supplier]))
 
 (set! *warn-on-reflection* true)
 
@@ -28,6 +28,14 @@
 (defn completed
   ^CompletableFuture [x]
   (CompletableFuture/completedFuture x))
+
+(defmacro supply-async [& body]
+  `(let [bindings# (get-thread-bindings)]
+     (CompletableFuture/supplyAsync
+       (reify Supplier
+         (get [~'_]
+           (with-bindings bindings#
+             ~@body))))))
 
 (defn wrap [x]
   (if (instance? CompletableFuture x)

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -360,11 +360,88 @@
                                     :doc "Resource path (starting with <code>/</code>) of a directory to delete"}]
                       :description "Delete a directory if it exists, and all existent child directories and files. Throws an error if the directory can't be deleted."
                       :examples "```\neditor.delete_directory(\"/assets/gen\")\n```"})]
-
+       [["editor"] (make-completion
+                     {:name "execute"
+                      :type :function
+                      :parameters [{:name "command"
+                                    :types ["string"]
+                                    :doc "Shell command name to execute"}
+                                   {:name "[...]"
+                                    :types ["string"]
+                                    :doc "Optional shell command arguments"}
+                                   {:name "[options]"
+                                    :types ["table"]
+                                    :doc "Optional options table. Supported entries:
+                                           <ul>
+                                             <li>
+                                               <span class=\"type\">boolean</span> <code>reload_resources</code>: make the editor reload the resources from disk after the command is executed, default <code>true</code>
+                                             </li>
+                                             <li>
+                                               <span class=\"type\">string</span> <code>out</code>: standard output mode, either:
+                                               <ul>
+                                                 <li>
+                                                   <code>\"pipe\"</code>: the output is piped to the editor console (this is the default behavior).
+                                                 </li>
+                                                 <li>
+                                                   <code>\"capture\"</code>: capture and return the output to the editor script with trailing newlines trimmed.
+                                                 </li>
+                                                 <li>
+                                                   <code>\"discard\"</code>: the output is discarded completely.
+                                                 </li>
+                                               </ul>
+                                             </li>
+                                             <li>
+                                               <span class=\"type\">string</span> <code>err</code>: standard error output mode, either:
+                                               <ul>
+                                                 <li>
+                                                   <code>\"pipe\"</code>: the error output is piped to the editor console (this is the default behavior).
+                                                 </li>
+                                                 <li>
+                                                   <code>\"stdout\"</code>: the error output is redirected to the standard output of the process.
+                                                 </li>
+                                                 <li>
+                                                   <code>\"discard\"</code>: the error output is discarded completely.
+                                                 </li>
+                                               </ul>
+                                             </li>
+                                           </ul>"}]
+                      :returnvalues [{:name "result"
+                                      :types ["nil" "string"]
+                                      :doc "If <code>out</code> option is set to <code>\"capture\"</code>, returns the output as string with trimmed trailing newlines. Otherwise, returns <code>nil</code>."}]
+                      :description "Execute a shell command. Any shell command arguments should be provided as separate argument strings to this function. If the exit code of the process is not zero, this function throws error. By default, the function returns `nil`, but it can be configured to capture the output of the shell command as string and return it — set `out` option to `\"capture\"` to do it.<br>By default, after this shell command is executed, the editor will reload resources from disk."
+                      :examples "Make a directory with spaces in it:\n```\neditor.execute(\"mkdir\", \"new dir\")\n```\nRead the git status:\n```\nlocal status = editor.execute(\"git\", \"status\", \"--porcelain\", {\n  reload_resources = false,\n  out = \"capture\"\n})\n```"})]
        [["editor"] (make-completion
                      {:name "platform"
                       :type :variable
                       :description "A `string`, either:\n- `\"x86_64-win32\"`\n- `\"x86_64-macos\"`\n- `\"arm64-macos\"`\n- `\"x86_64-linux\"`"})]
+       [["editor"] (make-completion
+                     {:name "save"
+                      :type :function
+                      :parameters []
+                      :description "Persist any unsaved changes to disk"})]
+       [["editor"] (make-completion
+                     {:name "transact"
+                      :type :function
+                      :parameters [{:name "txs"
+                                    :types ["transaction_step[]"]
+                                    :doc "An array of transaction steps created using <code>editor.tx.*</code> functions"}]
+                      :description "Change the editor state in a single, undoable transaction"})]
+       [["editor"] (make-completion
+                     {:name "tx"
+                      :type :module
+                      :description "The editor module that defines function for creating transaction steps for `editor.transact()` function."})]
+       [["editor" "tx"] (make-completion
+                          {:name "set"
+                           :type :function
+                           :parameters [node-param
+                                        property-param
+                                        {:name "value"
+                                         :types ["any"]
+                                         :doc "A new value for the property"}]
+                           :returnvalues [{:name "result"
+                                           :types ["transaction_step"]
+                                           :doc "A transaction step"}]
+                           :description "Create a transaction step that, when transacted using `editor.transact()`, will set the node's property to a supplied value"})]
        [["editor"] (make-completion
                      {:name "version"
                       :type :variable

--- a/editor/src/java/com/defold/editor/luart/DefoldUserdata.java
+++ b/editor/src/java/com/defold/editor/luart/DefoldUserdata.java
@@ -14,17 +14,21 @@
 
 package com.defold.editor.luart;
 
-import org.luaj.vm2.lib.jse.JseIoLib;
+import org.luaj.vm2.LuaUserdata;
 
-import java.io.IOException;
+import java.util.Objects;
 
-public class IoLib extends JseIoLib {
+public class DefoldUserdata extends LuaUserdata {
 
-    /**
-     * made public to avoid reflection from clojure
-     */
+    private final Object stringRepresentation;
+
+    public DefoldUserdata(Object obj, Object stringRepresentation) {
+        super(obj);
+        this.stringRepresentation = stringRepresentation;
+    }
+
     @Override
-    public File openFile(String s, boolean b, boolean b1, boolean b2, boolean b3) throws IOException {
-        return super.openFile(s, b, b1, b2, b3);
+    public String tojstring() {
+        return stringRepresentation + ": " + Integer.toHexString(Objects.hashCode(stringRepresentation));
     }
 }

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -13,13 +13,15 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns integration.editor-extensions-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
             [editor.editor-extensions :as extensions]
             [editor.editor-extensions.runtime :as rt]
             [editor.future :as future]
             [editor.graph-util :as gu]
             [editor.handler :as handler]
+            [editor.process :as process]
             [editor.ui :as ui]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
@@ -244,16 +246,29 @@
   (succeeding-selection [_] [])
   (alt-selection [_] []))
 
+(defn- make-reload-resources-fn [workspace]
+  (let [resource-sync (bound-fn* workspace/resource-sync!)]
+    (fn reload-resources! []
+      (resource-sync workspace)
+      (future/completed nil))))
+
+(defn- make-save-fn [project]
+  (let [save-project! (bound-fn* test-util/save-project!)]
+    (fn save! []
+      (save-project! project)
+      (future/completed nil))))
+
+(defn- can-execute? [_]
+  (future/completed true))
+
 (deftest editor-scripts-commands-test
   (test-util/with-loaded-project "test/resources/editor_extensions/commands_project"
-    (let [resource-sync (bound-fn* workspace/resource-sync!)
-          sprite-outline (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))]
+    (let [sprite-outline (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))]
       (extensions/reload! project :all
-                          :reload-resources! (fn test-reload-resources! []
-                                               (resource-sync workspace)
-                                               (future/completed nil))
-                          :can-execute? (constantly (future/completed true))
-                          :display-output! println)
+                          :reload-resources! (make-reload-resources-fn workspace)
+                          :can-execute? can-execute?
+                          :display-output! println
+                          :save! (make-save-fn project))
       (let [handler+context (handler/active
                               (:command (first (handler/realize-menu :editor.outline-view/context-menu-end)))
                               (handler/eval-contexts
@@ -274,14 +289,12 @@
 
 (deftest refresh-context-after-write-test
   (test-util/with-loaded-project "test/resources/editor_extensions/refresh_context_project"
-    (let [resource-sync (bound-fn* workspace/resource-sync!)
-          output (atom [])
+    (let [output (atom [])
           _ (extensions/reload! project :all
-                                :reload-resources! (fn test-reload-resources! []
-                                                     (resource-sync workspace)
-                                                     (future/completed nil))
-                                :can-execute? (constantly (future/completed true))
-                                :display-output! #(swap! output conj [%1 %2]))
+                                :reload-resources! (make-reload-resources-fn workspace)
+                                :can-execute? can-execute?
+                                :display-output! #(swap! output conj [%1 %2])
+                                :save! (make-save-fn project))
           handler+context (handler/active
                             (:command (first (handler/realize-menu :editor.asset-browser/context-menu-end)))
                             (handler/eval-contexts
@@ -297,3 +310,94 @@
       ;; capture in the test output.
       (is (= [[:out "old = Initial content, new = Another text!, reverted = Initial content"]]
              @output)))))
+
+(deftest execute-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/execute_test"
+    (let [output (atom [])
+          _ (extensions/reload! project :all
+                                :reload-resources! (make-reload-resources-fn workspace)
+                                :can-execute? can-execute?
+                                :display-output! #(swap! output conj [%1 %2])
+                                :save! (make-save-fn project))
+          handler+context (handler/active
+                            (:command (last (handler/realize-menu :editor.app-view/edit-end)))
+                            (handler/eval-contexts
+                              [(handler/->context :global {} (->StaticSelection []))]
+                              false)
+                            {})]
+      @(handler/run handler+context)
+      ;; see test.editor_script:
+      ;; first, it tries to execute `git bleh`, catches the error, then prints it.
+      ;; second, it captures the output of `git log --oneline --max-count=10` and
+      ;; prints the hashes.
+      (is (= (into [[:out "false\tCommand \"git bleh\" exited with code 1"]]
+                   (map (fn [line]
+                          [:out (re-find #"\w+" line)]))
+                   (string/split-lines
+                     (process/exec! "git" "log" "--oneline" "--max-count=10")))
+            @output)))))
+
+(deftest transact-test
+  (test-util/with-loaded-project "test/resources/editor_extensions/transact_test"
+    (let [output (atom [])
+          _ (extensions/reload! project :all
+                                :reload-resources! (make-reload-resources-fn workspace)
+                                :can-execute? can-execute?
+                                :display-output! #(swap! output conj [%1 %2])
+                                :save! (make-save-fn project))
+          node (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))
+          handler+context (handler/active
+                            (:command (first (handler/realize-menu :editor.outline-view/context-menu-end)))
+                            (handler/eval-contexts
+                              [(handler/->context :outline {} (->StaticSelection [node]))]
+                              false)
+                            {})
+          test-initial-state! (fn test-initial-state! []
+                                (is (= "properties" (test-util/prop node :id)))
+                                (is (= 0.0 (test-util/prop node :__num)))
+                                (is (= false (test-util/prop node :__boolean)))
+                                (is (nil? (test-util/prop node :__resource)))
+                                (is (= [0.0 0.0 0.0] (test-util/prop node :__vec3)))
+                                (is (= [0.0 0.0 0.0 0.0] (test-util/prop node :__vec4))))]
+
+      ;; initial state of the node
+      (test-initial-state!)
+
+      ;; see test.editor_script: it records old id, then transacts 6 properties
+      ;; at once, then prints new id and old id
+      @(handler/run handler+context)
+      (is (= [[:out "old id = properties, new id = My node id"]] @output))
+
+      ;; properties changed
+      (is (= "My node id" (test-util/prop node :id)))
+      (is (= 15.5 (test-util/prop node :__num)))
+      (is (= true (test-util/prop node :__boolean)))
+      (is (some? (test-util/prop node :__resource)))
+      (is (= [1 2 3] (test-util/prop node :__vec3)))
+      (is (= [1 2 3 4] (test-util/prop node :__vec4)))
+
+
+      ;; single undo
+      (g/undo! (g/node-id->graph-id project))
+
+      ;; all the changes should be reverted — a single transaction!
+      (test-initial-state!))))
+
+(test-util/with-loaded-project "test/resources/editor_extensions/save_test"
+  (let [output (atom [])
+        _ (extensions/reload! project :all
+                              :reload-resources! (make-reload-resources-fn workspace)
+                              :can-execute? can-execute?
+                              :display-output! #(swap! output conj [%1 %2])
+                              :save! (make-save-fn project))
+        handler+context (handler/active
+                          (:command (first (handler/realize-menu :editor.asset-browser/context-menu-end)))
+                          (handler/eval-contexts
+                            [(handler/->context :asset-browser {} (->StaticSelection []))]
+                            false)
+                          {})]
+    @(handler/run handler+context)
+    ;; see test.editor_script: it uses editor.transact() to set a file text, then reads
+    ;; the file text from file system, then saves, then reads it again.
+    (is (= [[:out "file read: before save = 'Initial text', after save = 'New text'"]]
+           @output))))

--- a/editor/test/integration/editor_extensions_test.clj
+++ b/editor/test/integration/editor_extensions_test.clj
@@ -258,15 +258,11 @@
       (save-project! project)
       (future/completed nil))))
 
-(defn- can-execute? [_]
-  (future/completed true))
-
 (deftest editor-scripts-commands-test
   (test-util/with-loaded-project "test/resources/editor_extensions/commands_project"
     (let [sprite-outline (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))]
       (extensions/reload! project :all
                           :reload-resources! (make-reload-resources-fn workspace)
-                          :can-execute? can-execute?
                           :display-output! println
                           :save! (make-save-fn project))
       (let [handler+context (handler/active
@@ -292,7 +288,6 @@
     (let [output (atom [])
           _ (extensions/reload! project :all
                                 :reload-resources! (make-reload-resources-fn workspace)
-                                :can-execute? can-execute?
                                 :display-output! #(swap! output conj [%1 %2])
                                 :save! (make-save-fn project))
           handler+context (handler/active
@@ -316,7 +311,6 @@
     (let [output (atom [])
           _ (extensions/reload! project :all
                                 :reload-resources! (make-reload-resources-fn workspace)
-                                :can-execute? can-execute?
                                 :display-output! #(swap! output conj [%1 %2])
                                 :save! (make-save-fn project))
           handler+context (handler/active
@@ -342,7 +336,6 @@
     (let [output (atom [])
           _ (extensions/reload! project :all
                                 :reload-resources! (make-reload-resources-fn workspace)
-                                :can-execute? can-execute?
                                 :display-output! #(swap! output conj [%1 %2])
                                 :save! (make-save-fn project))
           node (:node-id (test-util/outline (test-util/resource-node project "/main/main.collection") [0 0]))
@@ -376,7 +369,6 @@
       (is (= [1 2 3] (test-util/prop node :__vec3)))
       (is (= [1 2 3 4] (test-util/prop node :__vec4)))
 
-
       ;; single undo
       (g/undo! (g/node-id->graph-id project))
 
@@ -387,7 +379,6 @@
   (let [output (atom [])
         _ (extensions/reload! project :all
                               :reload-resources! (make-reload-resources-fn workspace)
-                              :can-execute? can-execute?
                               :display-output! #(swap! output conj [%1 %2])
                               :save! (make-save-fn project))
         handler+context (handler/active

--- a/editor/test/resources/editor_extensions/execute_test/.gitignore
+++ b/editor/test/resources/editor_extensions/execute_test/.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/execute_test/game.project
+++ b/editor/test/resources/editor_extensions/execute_test/game.project
@@ -1,0 +1,16 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = execute_test
+

--- a/editor/test/resources/editor_extensions/execute_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/execute_test/test.editor_script
@@ -1,0 +1,20 @@
+local M = {}
+
+function M.get_commands()
+    return {
+        {
+            label = "Test editor.execute()",
+            locations = {"Edit"},
+            run = function ()
+                print(pcall(editor.execute, "git", "bleh", { reload_resources = false, err = "discard" }))
+                local log = editor.execute("git", "log", "--oneline", "--max-count=10", {reload_resources = false, out = "capture"})
+                for line in log:gmatch("[^\r\n]+") do
+                    local sha = line:match("^(%S+)")
+                    print(sha)
+                end
+            end
+        }
+    }
+end
+
+return M

--- a/editor/test/resources/editor_extensions/save_test/.gitignore
+++ b/editor/test/resources/editor_extensions/save_test/.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/save_test/game.project
+++ b/editor/test/resources/editor_extensions/save_test/game.project
@@ -1,0 +1,16 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = save_test
+

--- a/editor/test/resources/editor_extensions/save_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/save_test/test.editor_script
@@ -1,0 +1,24 @@
+local M = {}
+
+function M.get_commands()
+    return {{
+        label = "Test",
+        locations = {"Assets"},
+        run = function ()
+            editor.transact { editor.tx.set("/test.txt", "text", "New text") }
+            local old_file = assert(io.open("test.txt", "r"))
+            local read_before_save = old_file:read("*a")
+            old_file:close()
+            editor.save()
+            local new_file = assert(io.open("test.txt", "r"))
+            local read_after_save = new_file:read("*a")
+            new_file:close()
+            -- cleanup
+            editor.transact { editor.tx.set("/test.txt", "text", read_before_save) }
+            editor.save()
+            print(("file read: before save = '%s', after save = '%s'"):format(read_before_save, read_after_save))
+        end
+    }}
+end
+
+return M

--- a/editor/test/resources/editor_extensions/save_test/test.txt
+++ b/editor/test/resources/editor_extensions/save_test/test.txt
@@ -1,0 +1,1 @@
+Initial text

--- a/editor/test/resources/editor_extensions/transact_test/.gitignore
+++ b/editor/test/resources/editor_extensions/transact_test/.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins

--- a/editor/test/resources/editor_extensions/transact_test/game.project
+++ b/editor/test/resources/editor_extensions/transact_test/game.project
@@ -1,0 +1,19 @@
+[bootstrap]
+main_collection = /main/main.collectionc
+
+[script]
+shared_state = 1
+
+[display]
+width = 960
+height = 640
+
+[android]
+input_method = HiddenInputField
+
+[project]
+title = transact_test
+
+[input]
+game_binding = /builtins/input/all.input_bindingc
+

--- a/editor/test/resources/editor_extensions/transact_test/main/main.collection
+++ b/editor/test/resources/editor_extensions/transact_test/main/main.collection
@@ -1,0 +1,39 @@
+name: "main"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"properties\"\n"
+  "  component: \"/main/properties.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "  property_decls {\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/editor/test/resources/editor_extensions/transact_test/main/properties.script
+++ b/editor/test/resources/editor_extensions/transact_test/main/properties.script
@@ -1,0 +1,5 @@
+go.property("num", 0)
+go.property("boolean", false)
+go.property("resource", resource.atlas())
+go.property("vec3", vmath.vector3())
+go.property("vec4", vmath.vector4())

--- a/editor/test/resources/editor_extensions/transact_test/test.editor_script
+++ b/editor/test/resources/editor_extensions/transact_test/test.editor_script
@@ -1,0 +1,25 @@
+local M = {}
+
+function M.get_commands()
+    return {{
+        label = "Transact",
+        locations = {"Outline"},
+        query = {selection = {type="outline", cardinality="one"}},
+        run = function (opts)
+            local node = opts.selection
+            local old_id = editor.get(node, "id")
+            editor.transact {
+                editor.tx.set(node, "id", "My node id"),
+                editor.tx.set(node, "__num", 15.5),
+                editor.tx.set(node, "__boolean", true),
+                editor.tx.set(node, "__resource", "/builtins/graphics/particle_blob.tilesource"),
+                editor.tx.set(node, "__vec3", {1, 2, 3}),
+                editor.tx.set(node, "__vec4", {1, 2, 3, 4})
+            }
+            local new_id = editor.get(node, "id")
+            print(("old id = %s, new id = %s"):format(old_id, new_id))
+        end
+    }}
+end
+
+return M


### PR DESCRIPTION
This changeset adds imperative editor script APIs:
1. `editor.transact(txs)`: similar to [`"set"` action](https://defold.com/manuals/editor-scripts/#undoable-actions) — modify the editor's in-memory state.
2. `editor.execute(cmd...)`: similar to [`"shell"` action](https://defold.com/manuals/editor-scripts/#non-undoable-actions) — execute a shell script.
3. `editor.save()`: persist all unsaved changes to disk.

Technical notes:
I'm currently working on updating the editor script manual.

Fixes #8427
