### PR TITLE
Allow disabling globals linting

### DIFF
--- a/editor/project.clj
+++ b/editor/project.clj
@@ -140,7 +140,7 @@
 
   ;; used by `pack` task
   :packing           {:pack-path "resources/_unpack"
-                      :lua-language-server-version "v1.7793"}
+                      :lua-language-server-version "v1.7795"}
 
   :codox             {:sources                   ["src/clj"]
                       :output-dir                "target/doc/api"

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -346,7 +346,7 @@
              resource (first selection)
              src-files (.getFiles (Clipboard/getSystemClipboard))
              dest-path (resource/abs-path resource)]
-         (if-let [conflicting-file (some #(when (string/starts-with? dest-path (.getPath %)) %) src-files)]
+         (if-let [conflicting-file (some #(when (string/starts-with? dest-path (.getPath ^File %)) %) src-files)]
            (let [res-proj-path (resource/proj-path resource)
                  dest-proj-path (resource/file->proj-path (workspace/project-path workspace) conflicting-file)]
              (notifications/show!


### PR DESCRIPTION
It's now possible to set or disable globals linting in `.luacheckrc`, e.g.:
```lua
globals = false -- disable all globals warnings
```

Fixes #9058