### PR TITLE
Concat errors when creating shaders in runtime

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_compute_shader.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_compute_shader.cpp
@@ -14,6 +14,7 @@
 
 #include "res_compute_shader.h"
 #include <graphics/graphics.h>
+#include <dlib/log.h>
 
 namespace dmGameSystem
 {
@@ -24,9 +25,11 @@ namespace dmGameSystem
         {
             return dmResource::RESULT_FORMAT_ERROR;
         }
-        dmGraphics::HComputeProgram prog = dmGraphics::NewComputeProgram(context, shader);
+        char error_buffer[1024] = {};
+        dmGraphics::HComputeProgram prog = dmGraphics::NewComputeProgram(context, shader, error_buffer, sizeof(error_buffer));
         if (prog == 0)
         {
+            dmLogError("Failed to create compute program: %s", error_buffer);
             return dmResource::RESULT_FORMAT_ERROR;
         }
         *program = prog;

--- a/engine/gamesys/src/gamesys/resources/res_compute_shader.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_compute_shader.cpp
@@ -18,7 +18,7 @@
 
 namespace dmGameSystem
 {
-    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, dmGraphics::ShaderDesc* ddf, dmGraphics::HComputeProgram* program)
+    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, const char* filename, dmGraphics::ShaderDesc* ddf, dmGraphics::HComputeProgram* program)
     {
         dmGraphics::ShaderDesc::Shader* shader =  dmGraphics::GetShaderProgram(context, ddf);
         if (shader == 0x0)
@@ -29,7 +29,7 @@ namespace dmGameSystem
         dmGraphics::HComputeProgram prog = dmGraphics::NewComputeProgram(context, shader, error_buffer, sizeof(error_buffer));
         if (prog == 0)
         {
-            dmLogError("Failed to create compute program: %s", error_buffer);
+            dmLogError("Failed to create compute shader '%s': %s", filename, error_buffer);
             return dmResource::RESULT_FORMAT_ERROR;
         }
         *program = prog;
@@ -53,7 +53,7 @@ namespace dmGameSystem
     {
         dmGraphics::ShaderDesc* ddf         = (dmGraphics::ShaderDesc*) params->m_PreloadData;
         dmGraphics::HComputeProgram resource = 0x0;
-        dmResource::Result r                = AcquireResources((dmGraphics::HContext) params->m_Context, params->m_Factory, ddf, &resource);
+        dmResource::Result r                = AcquireResources((dmGraphics::HContext) params->m_Context, params->m_Factory, params->m_Filename, ddf, &resource);
         dmDDF::FreeMessage(ddf);
         if (r == dmResource::RESULT_OK)
         {

--- a/engine/gamesys/src/gamesys/resources/res_fragment_program.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_fragment_program.cpp
@@ -18,7 +18,7 @@
 
 namespace dmGameSystem
 {
-    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, dmGraphics::ShaderDesc* ddf, dmGraphics::HVertexProgram* program)
+    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, const char* filename, dmGraphics::ShaderDesc* ddf, dmGraphics::HVertexProgram* program)
     {
         dmGraphics::ShaderDesc::Shader* shader = dmGraphics::GetShaderProgram(context, ddf);
         if (shader == 0x0)
@@ -29,7 +29,7 @@ namespace dmGameSystem
         dmGraphics::HFragmentProgram prog = dmGraphics::NewFragmentProgram(context, shader, error_buffer, sizeof(error_buffer));
         if (prog == 0)
         {
-            dmLogError("Failed to create fragment program: %s", error_buffer);
+            dmLogError("Failed to create fragment program '%s': %s", filename, error_buffer);
             return dmResource::RESULT_FORMAT_ERROR;
         }
         *program = prog;
@@ -53,7 +53,7 @@ namespace dmGameSystem
     {
         dmGraphics::ShaderDesc* ddf = (dmGraphics::ShaderDesc*)params->m_PreloadData;
         dmGraphics::HVertexProgram resource = 0x0;
-        dmResource::Result r = AcquireResources((dmGraphics::HContext) params->m_Context, params->m_Factory, ddf, &resource);
+        dmResource::Result r = AcquireResources((dmGraphics::HContext) params->m_Context, params->m_Factory, params->m_Filename, ddf, &resource);
         if (r == dmResource::RESULT_OK)
         {
             dmResource::SetResource(params->m_Resource, (void*)resource);

--- a/engine/gamesys/src/gamesys/resources/res_fragment_program.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_fragment_program.cpp
@@ -14,6 +14,7 @@
 
 #include "res_fragment_program.h"
 #include <graphics/graphics.h>
+#include <dlib/log.h>
 
 namespace dmGameSystem
 {
@@ -24,9 +25,11 @@ namespace dmGameSystem
         {
             return dmResource::RESULT_FORMAT_ERROR;
         }
-        dmGraphics::HFragmentProgram prog = dmGraphics::NewFragmentProgram(context, shader);
+        char error_buffer[1024] = {};
+        dmGraphics::HFragmentProgram prog = dmGraphics::NewFragmentProgram(context, shader, error_buffer, sizeof(error_buffer));
         if (prog == 0)
         {
+            dmLogError("Failed to create fragment program: %s", error_buffer);
             return dmResource::RESULT_FORMAT_ERROR;
         }
         *program = prog;

--- a/engine/gamesys/src/gamesys/resources/res_vertex_program.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_vertex_program.cpp
@@ -19,7 +19,7 @@
 
 namespace dmGameSystem
 {
-    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, dmGraphics::ShaderDesc* ddf, dmGraphics::HVertexProgram* program)
+    static dmResource::Result AcquireResources(dmGraphics::HContext context, dmResource::HFactory factory, const char* filename, dmGraphics::ShaderDesc* ddf, dmGraphics::HVertexProgram* program)
     {
         dmGraphics::ShaderDesc::Shader* shader =  dmGraphics::GetShaderProgram(context, ddf);
         if (shader == 0x0)
@@ -31,7 +31,7 @@ namespace dmGameSystem
         dmGraphics::HVertexProgram prog = dmGraphics::NewVertexProgram(context, shader, error_buffer, sizeof(error_buffer));
         if (prog == 0)
         {
-            dmLogError("Failed to create vertex program: %s", error_buffer);
+            dmLogError("Failed to create vertex program '%s': %s", filename, error_buffer);
             return dmResource::RESULT_FORMAT_ERROR;
         }
         *program = prog;
@@ -55,7 +55,7 @@ namespace dmGameSystem
     {
         dmGraphics::ShaderDesc* ddf = (dmGraphics::ShaderDesc*)params->m_PreloadData;
         dmGraphics::HVertexProgram resource = 0x0;
-        dmResource::Result r = AcquireResources((dmGraphics::HContext) params->m_Context, params->m_Factory, ddf, &resource);
+        dmResource::Result r = AcquireResources((dmGraphics::HContext) params->m_Context, params->m_Factory, params->m_Filename, ddf, &resource);
         dmDDF::FreeMessage(ddf);
         if (r == dmResource::RESULT_OK)
         {

--- a/engine/gamesys/src/gamesys/resources/res_vertex_program.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_vertex_program.cpp
@@ -14,6 +14,8 @@
 
 #include "res_vertex_program.h"
 #include <graphics/graphics.h>
+#include <dlib/log.h>
+#include <dlib/dstrings.h>
 
 namespace dmGameSystem
 {
@@ -24,9 +26,12 @@ namespace dmGameSystem
         {
             return dmResource::RESULT_FORMAT_ERROR;
         }
-        dmGraphics::HVertexProgram prog = dmGraphics::NewVertexProgram(context, shader);
+
+        char error_buffer[1024] = {};
+        dmGraphics::HVertexProgram prog = dmGraphics::NewVertexProgram(context, shader, error_buffer, sizeof(error_buffer));
         if (prog == 0)
         {
+            dmLogError("Failed to create vertex program: %s", error_buffer);
             return dmResource::RESULT_FORMAT_ERROR;
         }
         *program = prog;

--- a/engine/graphics/src/graphics.cpp
+++ b/engine/graphics/src/graphics.cpp
@@ -1323,13 +1323,13 @@ namespace dmGraphics
     {
         g_functions.m_DispatchCompute(context, group_count_x, group_count_y, group_count_z);
     }
-    HVertexProgram NewVertexProgram(HContext context, ShaderDesc::Shader* ddf)
+    HVertexProgram NewVertexProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
-        return g_functions.m_NewVertexProgram(context, ddf);
+        return g_functions.m_NewVertexProgram(context, ddf, error_buffer, error_buffer_size);
     }
-    HFragmentProgram NewFragmentProgram(HContext context, ShaderDesc::Shader* ddf)
+    HFragmentProgram NewFragmentProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
-        return g_functions.m_NewFragmentProgram(context, ddf);
+        return g_functions.m_NewFragmentProgram(context, ddf, error_buffer, error_buffer_size);
     }
     HProgram NewProgram(HContext context, HVertexProgram vertex_program, HFragmentProgram fragment_program)
     {
@@ -1620,9 +1620,9 @@ namespace dmGraphics
         assert(asset_handle <= MAX_ASSET_HANDLE_VALUE);
         return g_functions.m_IsAssetHandleValid(context, asset_handle);
     }
-    HComputeProgram NewComputeProgram(HContext context, ShaderDesc::Shader* ddf)
+    HComputeProgram NewComputeProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
-        return g_functions.m_NewComputeProgram(context, ddf);
+        return g_functions.m_NewComputeProgram(context, ddf, error_buffer, error_buffer_size);
     }
     HProgram NewProgram(HContext context, HComputeProgram compute_program)
     {

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -539,9 +539,9 @@ namespace dmGraphics
     void DispatchCompute(HContext context, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
 
     // Shaders
-    HVertexProgram       NewVertexProgram(HContext context, ShaderDesc::Shader* ddf);
-    HFragmentProgram     NewFragmentProgram(HContext context, ShaderDesc::Shader* ddf);
-    HComputeProgram      NewComputeProgram(HContext context, ShaderDesc::Shader* ddf);
+    HVertexProgram       NewVertexProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size);
+    HFragmentProgram     NewFragmentProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size);
+    HComputeProgram      NewComputeProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size);
 
     HProgram             NewProgram(HContext context, HComputeProgram compute_program);
     HProgram             NewProgram(HContext context, HVertexProgram vertex_program, HFragmentProgram fragment_program);

--- a/engine/graphics/src/graphics_adapter.h
+++ b/engine/graphics/src/graphics_adapter.h
@@ -86,8 +86,8 @@ namespace dmGraphics
     typedef void (*DrawElementsFn)(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count, Type type, HIndexBuffer index_buffer);
     typedef void (*DrawFn)(HContext context, PrimitiveType prim_type, uint32_t first, uint32_t count);
     typedef void (*DispatchComputeFn)(HContext context, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
-    typedef HVertexProgram (*NewVertexProgramFn)(HContext context, ShaderDesc::Shader* ddf);
-    typedef HFragmentProgram (*NewFragmentProgramFn)(HContext context, ShaderDesc::Shader* ddf);
+    typedef HVertexProgram (*NewVertexProgramFn)(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size);
+    typedef HFragmentProgram (*NewFragmentProgramFn)(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size);
     typedef HProgram (*NewProgramFn)(HContext context, HVertexProgram vertex_program, HFragmentProgram fragment_program);
     typedef void (*DeleteProgramFn)(HContext context, HProgram program);
     typedef bool (*ReloadVertexProgramFn)(HVertexProgram prog, ShaderDesc::Shader* ddf);
@@ -159,7 +159,7 @@ namespace dmGraphics
     typedef uint32_t (*GetTextureUsageHintFlagsFn)(HTexture texture);
     typedef bool (*IsContextFeatureSupportedFn)(HContext context, ContextFeature feature);
     typedef bool (*IsAssetHandleValidFn)(HContext context, HAssetHandle asset_handle);
-    typedef HComputeProgram (*NewComputeProgramFn)(HContext context, ShaderDesc::Shader* ddf);
+    typedef HComputeProgram (*NewComputeProgramFn)(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size);
     typedef HProgram (*NewProgramFromComputeFn)(HContext context, HComputeProgram compute_program);
     typedef void (*DeleteComputeProgramFn)(HComputeProgram prog);
 

--- a/engine/graphics/src/null/graphics_null.cpp
+++ b/engine/graphics/src/null/graphics_null.cpp
@@ -826,7 +826,7 @@ namespace dmGraphics
         return p;
     }
 
-    static HComputeProgram NullNewComputeProgram(HContext context, ShaderDesc::Shader* ddf)
+    static HComputeProgram NullNewComputeProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
         return (HComputeProgram) NewShaderProgramFromDDF(ddf);
     }
@@ -865,12 +865,12 @@ namespace dmGraphics
         delete (Program*) program;
     }
 
-    static HVertexProgram NullNewVertexProgram(HContext context, ShaderDesc::Shader* ddf)
+    static HVertexProgram NullNewVertexProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
         return (HVertexProgram) NewShaderProgramFromDDF(ddf);
     }
 
-    static HFragmentProgram NullNewFragmentProgram(HContext context, ShaderDesc::Shader* ddf)
+    static HFragmentProgram NullNewFragmentProgram(HContext context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
         return (HFragmentProgram) NewShaderProgramFromDDF(ddf);
     }

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -305,8 +305,8 @@ struct SubPassTest : ITest
         fs_shader.m_Textures.m_Data  = &fs_input_color;
         fs_shader.m_Textures.m_Count = 1;
 
-        dmGraphics::HVertexProgram vs_program   = dmGraphics::NewVertexProgram(engine->m_GraphicsContext, &vs_shader);
-        dmGraphics::HFragmentProgram fs_program = dmGraphics::NewFragmentProgram(engine->m_GraphicsContext, &fs_shader);
+        dmGraphics::HVertexProgram vs_program   = dmGraphics::NewVertexProgram(engine->m_GraphicsContext, &vs_shader, 0, 0);
+        dmGraphics::HFragmentProgram fs_program = dmGraphics::NewFragmentProgram(engine->m_GraphicsContext, &fs_shader, 0, 0);
 
         m_ShaderProgram     = dmGraphics::NewProgram(engine->m_GraphicsContext, vs_program, fs_program);
         m_VertexDeclaration = dmGraphics::NewVertexDeclaration(engine->m_GraphicsContext, stream_declaration);
@@ -449,7 +449,7 @@ struct ComputeTest : ITest
         compute_shader.m_Types.m_Data           = &resource_type_info;
         compute_shader.m_Types.m_Count          = 1;
 
-        dmGraphics::HComputeProgram compute_program = dmGraphics::NewComputeProgram(engine->m_GraphicsContext, &compute_shader);
+        dmGraphics::HComputeProgram compute_program = dmGraphics::NewComputeProgram(engine->m_GraphicsContext, &compute_shader, 0, 0);
 
         m_Program = dmGraphics::NewProgram(engine->m_GraphicsContext, compute_program);
 
@@ -533,8 +533,8 @@ struct StorageBufferTest : ITest
         vs_shader.m_Inputs.m_Data  = m_VertexAttributes;
         vs_shader.m_Inputs.m_Count = sizeof(m_VertexAttributes) / sizeof(dmGraphics::ShaderDesc::ResourceBinding);
 
-        dmGraphics::HVertexProgram vs_program   = dmGraphics::NewVertexProgram(engine->m_GraphicsContext, &vs_shader);
-        dmGraphics::HFragmentProgram fs_program = dmGraphics::NewFragmentProgram(engine->m_GraphicsContext, &fs_shader);
+        dmGraphics::HVertexProgram vs_program   = dmGraphics::NewVertexProgram(engine->m_GraphicsContext, &vs_shader, 0, 0);
+        dmGraphics::HFragmentProgram fs_program = dmGraphics::NewFragmentProgram(engine->m_GraphicsContext, &fs_shader, 0, 0);
 
         m_Program = dmGraphics::NewProgram(engine->m_GraphicsContext, vs_program, fs_program);
 

--- a/engine/graphics/src/test/test_graphics.cpp
+++ b/engine/graphics/src/test/test_graphics.cpp
@@ -433,8 +433,8 @@ TEST_F(dmGraphicsTest, TestProgram)
     dmGraphics::ShaderDesc::Shader vs_shader = MakeDDFShader(dmGraphics::ShaderDesc::LANGUAGE_GLES_SM100, vertex_data, (uint32_t) strlen(vertex_data));
     dmGraphics::ShaderDesc::Shader fs_shader = MakeDDFShader(dmGraphics::ShaderDesc::LANGUAGE_GLES_SM100, fragment_data, (uint32_t) strlen(fragment_data));
 
-    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_Context, &vs_shader);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_Context, &fs_shader);
+    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_Context, &vs_shader, 0, 0);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_Context, &fs_shader, 0, 0);
 
     dmGraphics::HProgram program = dmGraphics::NewProgram(m_Context, vp, fp);
     ASSERT_EQ(4u, dmGraphics::GetUniformCount(program));
@@ -517,7 +517,7 @@ TEST_F(dmGraphicsTest, TestComputeProgram)
         "}\n";
 
     dmGraphics::ShaderDesc::Shader compute_shader = MakeDDFShader(dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM430, compute_data, (uint32_t) strlen(compute_data));
-    dmGraphics::HComputeProgram cp                = dmGraphics::NewComputeProgram(m_Context, &compute_shader);
+    dmGraphics::HComputeProgram cp                = dmGraphics::NewComputeProgram(m_Context, &compute_shader, 0, 0);
     dmGraphics::HProgram program                  = dmGraphics::NewProgram(m_Context, cp);
     ASSERT_EQ(1, dmGraphics::GetUniformCount(program));
     ASSERT_EQ(0, dmGraphics::GetUniformLocation(program, "my_uniform"));
@@ -560,8 +560,8 @@ TEST_F(dmGraphicsTest, TestVertexAttributesGL3)
     dmGraphics::ShaderDesc::Shader vs_shader = MakeDDFShader(dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM140, vertex_data, (uint32_t) strlen(vertex_data));
     dmGraphics::ShaderDesc::Shader fs_shader = MakeDDFShader(dmGraphics::ShaderDesc::LANGUAGE_GLSL_SM140, fragment_data, (uint32_t) strlen(fragment_data));
 
-    dmGraphics::HVertexProgram vp   = dmGraphics::NewVertexProgram(m_Context, &vs_shader);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_Context, &fs_shader);
+    dmGraphics::HVertexProgram vp   = dmGraphics::NewVertexProgram(m_Context, &vs_shader, 0, 0);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_Context, &fs_shader, 0, 0);
     dmGraphics::HProgram program    = dmGraphics::NewProgram(m_Context, vp, fp);
 
     uint32_t attribute_count = dmGraphics::GetAttributeCount(program);

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2337,19 +2337,19 @@ bail:
     {
         if (shader->m_ShaderMeta.m_UniformBuffers.Size() > context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorUniformBuffers)
         {
-            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of uniform buffers exceeded: vertex shader has %d buffers, but maximum is %d.",
+            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of uniform buffers exceeded: shader has %d buffers, but maximum is %d.",
                 shader->m_ShaderMeta.m_UniformBuffers.Size(), context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorUniformBuffers);
             return false;
         }
         else if (shader->m_ShaderMeta.m_StorageBuffers.Size() > context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorStorageBuffers)
         {
-            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of storage exceeded: vertex shader has %d buffer, but maximum is %d.",
+            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of storage exceeded: shader has %d buffer, but maximum is %d.",
                 shader->m_ShaderMeta.m_StorageBuffers.Size(), context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorStorageBuffers);
             return false;
         }
         else if (shader->m_ShaderMeta.m_Textures.Size() > context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorSamplers)
         {
-            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of texture samplers exceeded: vertex shader has %d samplers, but maximum is %d.",
+            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of texture samplers exceeded: shader has %d samplers, but maximum is %d.",
                 shader->m_ShaderMeta.m_Textures.Size(), context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorSamplers);
             return false;
         }

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2333,30 +2333,30 @@ bail:
         vkCmdDispatch(vk_command_buffer, group_count_x, group_count_y, group_count_z);
     }
 
-    static bool ValidateShaderModule(VulkanContext* context, ShaderModule* shader)
+    static bool ValidateShaderModule(VulkanContext* context, ShaderModule* shader, char* error_buffer, uint32_t error_buffer_size)
     {
         if (shader->m_ShaderMeta.m_UniformBuffers.Size() > context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorUniformBuffers)
         {
-            dmLogError("Maximum number of uniform buffers exceeded: vertex shader has %d buffers, but maximum is %d.",
+            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of uniform buffers exceeded: vertex shader has %d buffers, but maximum is %d.",
                 shader->m_ShaderMeta.m_UniformBuffers.Size(), context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorUniformBuffers);
             return false;
         }
         else if (shader->m_ShaderMeta.m_StorageBuffers.Size() > context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorStorageBuffers)
         {
-            dmLogError("Maximum number of storage exceeded: vertex shader has %d buffer, but maximum is %d.",
+            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of storage exceeded: vertex shader has %d buffer, but maximum is %d.",
                 shader->m_ShaderMeta.m_StorageBuffers.Size(), context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorStorageBuffers);
             return false;
         }
         else if (shader->m_ShaderMeta.m_Textures.Size() > context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorSamplers)
         {
-            dmLogError("Maximum number of texture samplers exceeded: vertex shader has %d samplers, but maximum is %d.",
+            dmSnPrintf(error_buffer, error_buffer_size, "Maximum number of texture samplers exceeded: vertex shader has %d samplers, but maximum is %d.",
                 shader->m_ShaderMeta.m_Textures.Size(), context->m_PhysicalDevice.m_Properties.limits.maxPerStageDescriptorSamplers);
             return false;
         }
         return true;
     }
 
-    static HVertexProgram VulkanNewVertexProgram(HContext _context, ShaderDesc::Shader* ddf)
+    static HVertexProgram VulkanNewVertexProgram(HContext _context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
         ShaderModule* shader = new ShaderModule;
         memset(shader, 0, sizeof(*shader));
@@ -2367,7 +2367,7 @@ bail:
 
         CreateShaderMeta(ddf, &shader->m_ShaderMeta);
 
-        if (!ValidateShaderModule(context, shader))
+        if (!ValidateShaderModule(context, shader, error_buffer, error_buffer_size))
         {
             DeleteVertexProgram((HVertexProgram) shader);
             return 0;
@@ -2376,7 +2376,7 @@ bail:
         return (HVertexProgram) shader;
     }
 
-    static HFragmentProgram VulkanNewFragmentProgram(HContext _context, ShaderDesc::Shader* ddf)
+    static HFragmentProgram VulkanNewFragmentProgram(HContext _context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
         ShaderModule* shader = new ShaderModule;
         memset(shader, 0, sizeof(*shader));
@@ -2387,7 +2387,7 @@ bail:
 
         CreateShaderMeta(ddf, &shader->m_ShaderMeta);
 
-        if (!ValidateShaderModule(context, shader))
+        if (!ValidateShaderModule(context, shader, error_buffer, error_buffer_size))
         {
             DeleteFragmentProgram((HFragmentProgram) shader);
             return 0;
@@ -4195,7 +4195,7 @@ bail:
         return false;
     }
 
-    static HComputeProgram VulkanNewComputeProgram(HContext _context, ShaderDesc::Shader* ddf)
+    static HComputeProgram VulkanNewComputeProgram(HContext _context, ShaderDesc::Shader* ddf, char* error_buffer, uint32_t error_buffer_size)
     {
         VulkanContext* context = (VulkanContext*) _context;
         ShaderModule* shader   = new ShaderModule;
@@ -4205,7 +4205,7 @@ bail:
         CHECK_VK_ERROR(res);
         CreateShaderMeta(ddf, &shader->m_ShaderMeta);
 
-        if (!ValidateShaderModule(context, shader))
+        if (!ValidateShaderModule(context, shader, error_buffer, error_buffer_size))
         {
             DeleteComputeProgram((HComputeProgram) shader);
             return 0;

--- a/engine/render/src/render/debug_renderer.cpp
+++ b/engine/render/src/render/debug_renderer.cpp
@@ -67,7 +67,7 @@ namespace dmRender
             else
             {
                 dmGraphics::ShaderDesc::Shader* shader =  dmGraphics::GetShaderProgram(render_context->m_GraphicsContext, shader_desc);
-                vertex_program = dmGraphics::NewVertexProgram(render_context->m_GraphicsContext, shader);
+                vertex_program = dmGraphics::NewVertexProgram(render_context->m_GraphicsContext, shader, 0, 0);
                 dmDDF::FreeMessage(shader_desc);
             }
         }
@@ -82,7 +82,7 @@ namespace dmRender
             else
             {
                 dmGraphics::ShaderDesc::Shader* shader =  dmGraphics::GetShaderProgram(render_context->m_GraphicsContext, shader_desc);
-                fragment_program = dmGraphics::NewFragmentProgram(render_context->m_GraphicsContext, shader);
+                fragment_program = dmGraphics::NewFragmentProgram(render_context->m_GraphicsContext, shader, 0, 0);
                 dmDDF::FreeMessage(shader_desc);
             }
         }

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -442,8 +442,8 @@ TEST_F(dmRenderTest, TestRenderListDrawState)
     dmRender::RenderListBegin(m_Context);
 
     dmGraphics::ShaderDesc::Shader shader = MakeDDFShader("foo", 3);
-    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader);
+    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader, 0, 0);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader, 0, 0);
     dmRender::HMaterial material = dmRender::NewMaterial(m_Context, vp, fp);
     dmhash_t tag = dmHashString64("tag");
     dmRender::SetMaterialTags(material, 1, &tag);
@@ -563,8 +563,8 @@ TEST_F(dmRenderTest, TestEnableTextureByHash)
     dmGraphics::ShaderDesc::Shader vs_shader = MakeDDFShader("foo", 3);
     dmGraphics::ShaderDesc::Shader fs_shader = MakeDDFShader(shader_src, strlen(shader_src));
 
-    dmGraphics::HVertexProgram vp   = dmGraphics::NewVertexProgram(m_GraphicsContext, &vs_shader);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fs_shader);
+    dmGraphics::HVertexProgram vp   = dmGraphics::NewVertexProgram(m_GraphicsContext, &vs_shader, 0, 0);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fs_shader, 0, 0);
     dmRender::HMaterial material    = dmRender::NewMaterial(m_Context, vp, fp);
 
     dmhash_t texture_sampler_1_hash = dmHashString64("texture_sampler_1");
@@ -717,8 +717,8 @@ TEST_F(dmRenderTest, TestEnableDisableContextTextures)
     dmGraphics::ShaderDesc::Shader vs_shader = MakeDDFShader("foo", 3);
     dmGraphics::ShaderDesc::Shader fs_shader = MakeDDFShader("foo", 3);
 
-    dmGraphics::HVertexProgram vp   = dmGraphics::NewVertexProgram(m_GraphicsContext, &vs_shader);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fs_shader);
+    dmGraphics::HVertexProgram vp   = dmGraphics::NewVertexProgram(m_GraphicsContext, &vs_shader, 0, 0);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fs_shader, 0, 0);
     dmRender::HMaterial material    = dmRender::NewMaterial(m_Context, vp, fp);
 
     dmhash_t tag = dmHashString64("tag");
@@ -832,8 +832,8 @@ TEST_F(dmRenderTest, TestDefaultSamplerFilters)
                              "uniform lowp sampler2D texture_sampler_3;\n";
 
     dmGraphics::ShaderDesc::Shader shader    = MakeDDFShader(shader_src, strlen(shader_src));
-    dmGraphics::HVertexProgram vp            = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader);
-    dmGraphics::HFragmentProgram fp          = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader);
+    dmGraphics::HVertexProgram vp            = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader, 0, 0);
+    dmGraphics::HFragmentProgram fp          = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader, 0, 0);
     dmRender::HMaterial material             = dmRender::NewMaterial(m_Context, vp, fp);
     dmRender::HMaterial material_no_samplers = dmRender::NewMaterial(m_Context, vp, fp);
 

--- a/engine/render/src/test/test_render_programs.cpp
+++ b/engine/render/src/test/test_render_programs.cpp
@@ -84,8 +84,8 @@ static inline dmGraphics::ShaderDesc::Shader MakeDDFShader(const char* data, uin
 TEST_F(dmRenderMaterialTest, TestTags)
 {
     dmGraphics::ShaderDesc::Shader shader = MakeDDFShader("foo", 3);
-    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader);
+    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader, 0, 0);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader, 0, 0);
     dmRender::HMaterial material = dmRender::NewMaterial(m_RenderContext, vp, fp);
 
     dmhash_t tags[] = {dmHashString64("tag1"), dmHashString64("tag2")};
@@ -102,10 +102,10 @@ TEST_F(dmRenderMaterialTest, TestMaterialConstants)
 {
     // create default material
     dmGraphics::ShaderDesc::Shader vp_shader = MakeDDFShader("uniform vec4 tint;\n", 19);
-    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader);
+    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader, 0, 0);
 
     dmGraphics::ShaderDesc::Shader fp_shader = MakeDDFShader("foo", 3);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader, 0, 0);
     dmRender::HMaterial material = dmRender::NewMaterial(m_RenderContext, vp, fp);
 
     // Constants buffer
@@ -146,10 +146,10 @@ TEST_F(dmRenderMaterialTest, TestMaterialVertexAttributes)
         attribute float attribute_three;\n";
 
     dmGraphics::ShaderDesc::Shader vp_shader = MakeDDFShader(vs_src, strlen(vs_src));
-    dmGraphics::HVertexProgram vp            = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader);
+    dmGraphics::HVertexProgram vp            = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader, 0, 0);
 
     dmGraphics::ShaderDesc::Shader fp_shader = MakeDDFShader("foo", 3);
-    dmGraphics::HFragmentProgram fp          = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader);
+    dmGraphics::HFragmentProgram fp          = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader, 0, 0);
     dmRender::HMaterial material             = dmRender::NewMaterial(m_RenderContext, vp, fp);
 
     const dmGraphics::VertexAttribute* attributes;
@@ -225,16 +225,16 @@ TEST_F(dmRenderMaterialTest, TestMaterialConstantsOverride)
 {
     // create default material
     dmGraphics::ShaderDesc::Shader vp_shader = MakeDDFShader("uniform vec4 tint;\n", 19);
-    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader);
+    dmGraphics::HVertexProgram vp = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader, 0, 0);
     dmGraphics::ShaderDesc::Shader fp_shader = MakeDDFShader("foo", 3);
-    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader);
+    dmGraphics::HFragmentProgram fp = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader, 0, 0);
     dmRender::HMaterial material = dmRender::NewMaterial(m_RenderContext, vp, fp);
     dmGraphics::HProgram program = dmRender::GetMaterialProgram(material);
 
     // create override material which contains tint, but at a different location
     vp_shader = MakeDDFShader("uniform vec4 dummy;\nuniform vec4 tint;\n", 40);
-    dmGraphics::HVertexProgram vp_ovr = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader);
-    dmGraphics::HFragmentProgram fp_ovr = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader);
+    dmGraphics::HVertexProgram vp_ovr = dmGraphics::NewVertexProgram(m_GraphicsContext, &vp_shader, 0, 0);
+    dmGraphics::HFragmentProgram fp_ovr = dmGraphics::NewFragmentProgram(m_GraphicsContext, &fp_shader, 0, 0);
     dmRender::HMaterial material_ovr = dmRender::NewMaterial(m_RenderContext, vp_ovr, fp_ovr);
     dmGraphics::HProgram program_ovr = dmRender::GetMaterialProgram(material_ovr);
 
@@ -312,11 +312,10 @@ TEST_F(dmRenderComputeTest, TestComputeConstants)
         "#version 430\n"
         "uniform vec4 tint_a;\n"
         "uniform vec4 tint_b;\n"
-        "uniform sampler2D texture_sampler;\n"
-        ;
+        "uniform sampler2D texture_sampler;\n";
 
     dmGraphics::ShaderDesc::Shader cp_shader  = MakeDDFShader(shader_src, strlen(shader_src));
-    dmGraphics::HComputeProgram cp            = dmGraphics::NewComputeProgram(m_GraphicsContext, &cp_shader);
+    dmGraphics::HComputeProgram cp            = dmGraphics::NewComputeProgram(m_GraphicsContext, &cp_shader, 0, 0);
     dmRender::HComputeProgram compute_program = dmRender::NewComputeProgram(m_RenderContext, cp);
     ASSERT_NE((dmRender::HComputeProgram) 0, compute_program);
 

--- a/engine/render/src/test/test_render_script.cpp
+++ b/engine/render/src/test/test_render_script.cpp
@@ -111,8 +111,8 @@ protected:
         shader_ddf.m_Source.m_Data  = (uint8_t*)"foo";
         shader_ddf.m_Source.m_Count = 3;
 
-        m_VertexProgram = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader_ddf);
-        m_FragmentProgram = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader_ddf);
+        m_VertexProgram = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader_ddf, 0, 0);
+        m_FragmentProgram = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader_ddf, 0, 0);
 
         m_FontMaterial = dmRender::NewMaterial(m_Context, m_VertexProgram, m_FragmentProgram);
         dmRender::SetFontMapMaterial(m_SystemFontMap, m_FontMaterial);
@@ -127,7 +127,7 @@ protected:
         compute_shader_ddf.m_Source.m_Data  = (uint8_t*) compute_program_src;
         compute_shader_ddf.m_Source.m_Count = strlen(compute_program_src);
 
-        m_ComputeProgram = dmGraphics::NewComputeProgram(m_GraphicsContext, &compute_shader_ddf);
+        m_ComputeProgram = dmGraphics::NewComputeProgram(m_GraphicsContext, &compute_shader_ddf, 0, 0);
     }
 
     virtual void TearDown()
@@ -1441,8 +1441,8 @@ TEST_F(dmRenderScriptTest, TestRenderResourceTable)
                              "uniform lowp sampler2D texture_sampler_3;\n";
 
     dmGraphics::ShaderDesc::Shader shader = MakeDDFShader(shader_src, strlen(shader_src));
-    dmGraphics::HVertexProgram vp         = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader);
-    dmGraphics::HFragmentProgram fp       = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader);
+    dmGraphics::HVertexProgram vp         = dmGraphics::NewVertexProgram(m_GraphicsContext, &shader, 0, 0);
+    dmGraphics::HFragmentProgram fp       = dmGraphics::NewFragmentProgram(m_GraphicsContext, &shader, 0, 0);
     dmRender::HMaterial material          = dmRender::NewMaterial(m_Context, vp, fp);
 
     /////////////////////////////


### PR DESCRIPTION
Shader errors now include the name of the shader and a concatenated error string when the graphics driver is unable to create it.

Fixes #9041
Fixes #8233 