### PR TITLE
Delete dynamic attributes from sprites when deleting the instance

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -637,6 +637,8 @@ namespace dmGameSystem
 
         DeleteOverrides(factory, component);
 
+        FreeMaterialAttribute(sprite_world->m_DynamicVertexAttributePool, component->m_DynamicVertexAttributeIndex);
+
         sprite_world->m_Components.Free(index, true);
         return dmGameObject::CREATE_RESULT_OK;
     }
@@ -2264,5 +2266,10 @@ namespace dmGameSystem
         SpriteWorld* world = (SpriteWorld*) sprite_world;
         *vx_buffer = world->m_VertexBuffer;
         *ix_buffer = world->m_IndexBuffer;
+    }
+
+    void GetSpriteWorldDynamicAttributePool(void* sprite_world, DynamicAttributePool** pool_out)
+    {
+        *pool_out = &((SpriteWorld*) sprite_world)->m_DynamicVertexAttributePool;
     }
 }

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -442,6 +442,23 @@ namespace dmGameSystem
         }
     }
 
+    void FreeMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index)
+    {
+        if (dynamic_attribute_index == INVALID_DYNAMIC_ATTRIBUTE_INDEX)
+        {
+            return;
+        }
+
+        DynamicAttributeInfo& dynamic_info = pool.Get(dynamic_attribute_index);
+        if (dynamic_info.m_Infos)
+        {
+            assert(dynamic_info.m_NumInfos > 0);
+            free(dynamic_info.m_Infos);
+        }
+
+        pool.Free(dynamic_attribute_index, true);
+    }
+
     dmGameObject::PropertyResult ClearMaterialAttribute(
         DynamicAttributePool& pool,
         uint32_t              dynamic_attribute_index,

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -99,7 +99,7 @@ namespace dmGameSystem
 
     // Vertex attributes
     static const uint16_t INVALID_DYNAMIC_ATTRIBUTE_INDEX  = 0xFFFF;
-    static const uint8_t  DYNAMIC_ATTRIBUTE_INCREASE_COUNT = 1;
+    static const uint8_t  DYNAMIC_ATTRIBUTE_INCREASE_COUNT = 16;
 
     struct DynamicAttributeInfo
     {
@@ -125,6 +125,7 @@ namespace dmGameSystem
     void                         ConvertMaterialAttributeValuesToDataType(const DynamicAttributeInfo& info, uint32_t dynamic_attribute_index, const dmGraphics::VertexAttribute* attribute, uint8_t* value_ptr);
     void                         InitializeMaterialAttributeInfos(DynamicAttributePool& pool, uint32_t initial_capacity);
     void                         DestroyMaterialAttributeInfos(DynamicAttributePool& pool);
+    void                         FreeMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index);
     dmGameObject::PropertyResult ClearMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index, dmhash_t name_hash);
     dmGameObject::PropertyResult SetMaterialAttribute(DynamicAttributePool& pool, uint32_t* dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, CompGetMaterialAttributeCallback callback, void* callback_user_data);
     dmGameObject::PropertyResult GetMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, dmGameObject::PropertyDesc& out_desc, CompGetMaterialAttributeCallback callback, void* callback_user_data);

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_count.go
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_count.go
@@ -1,0 +1,13 @@
+components {
+  id: "script"
+  component: "/material/attributes_dynamic_count.script"
+}
+
+embedded_components {
+  id: "sprite"
+  type: "sprite"
+  data: "tile_set: \"/tile/flipbook.tilesource\"\n"
+  "default_animation: \"anim\"\n"
+  "material: \"/material/attributes_dynamic_go_animate.material\"\n"
+  "blend_mode: BLEND_MODE_ALPHA\n"
+}

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_count.script
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_count.script
@@ -1,0 +1,20 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+num_components = 0
+
+function init(self)
+	num_components = num_components + 1
+    go.set("#sprite", "custom_color", vmath.vector4(num_components))
+end

--- a/engine/gamesys/src/gamesys/test/material/attributes_dynamic_count_generated_0.sprite
+++ b/engine/gamesys/src/gamesys/test/material/attributes_dynamic_count_generated_0.sprite
@@ -1,0 +1,4 @@
+tile_set: "/tile/flipbook.tilesource"
+default_animation: "anim"
+material: "/material/attributes_dynamic_go_animate.material"
+blend_mode: BLEND_MODE_ALPHA


### PR DESCRIPTION
Fixed an issue where dynamically allocated vertex attributes were not correctly released from sprite components when the sprite component has been deleted.

Fixes #9061 