### PR TITLE
Allow pasting objects into itself

### DIFF
--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -345,11 +345,11 @@
        (let [tree-view (g/node-value asset-browser :tree-view)
              resource (first selection)
              src-files (.getFiles (Clipboard/getSystemClipboard))
-             dest-path (resource/abs-path resource)]
-         (if-let [conflicting-file (some #(when (and (.startsWith (.toPath (io/file dest-path))
-                                                                  (.toPath ^File %))
-                                                     (not= dest-path (.getPath ^File %)))
-                                            %)
+             dest-path (.toPath (io/file (resource/abs-path resource)))]
+         (if-let [conflicting-file (some #(let [src-path (.toPath ^File %)]
+                                            (when (and (.startsWith dest-path src-path)
+                                                       (not= dest-path src-path))
+                                              %))
                                          src-files)]
            (let [res-proj-path (resource/proj-path resource)
                  dest-proj-path (resource/file->proj-path (workspace/project-path workspace) conflicting-file)]

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -346,8 +346,8 @@
              resource (first selection)
              src-files (.getFiles (Clipboard/getSystemClipboard))
              dest-path (resource/abs-path resource)]
-         (if-let [conflicting-file (some #(when (and (.isDirectory ^File %)
-                                                     (string/starts-with? dest-path (.getPath ^File %))
+         (if-let [conflicting-file (some #(when (and (.startsWith (.toPath (io/file dest-path))
+                                                                  (.toPath %))
                                                      (not= dest-path (.getPath ^File %)))
                                             %)
                                          src-files)]

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -346,16 +346,17 @@
              resource (first selection)
              src-files (.getFiles (Clipboard/getSystemClipboard))
              dest-path (resource/abs-path resource)]
-         (if-let [conflicting-file (some #(when (string/starts-with? dest-path (.getPath ^File %)) %) src-files)]
+         (if-let [conflicting-file (some #(when (and (string/starts-with? dest-path (.getPath ^File %))
+                                                     (not= dest-path (.getPath ^File %)))
+                                            %)
+                                         src-files)]
            (let [res-proj-path (resource/proj-path resource)
                  dest-proj-path (resource/file->proj-path (workspace/project-path workspace) conflicting-file)]
              (notifications/show!
                (workspace/notifications workspace)
                {:type :error
                 :id ::asset-circular-paste
-                :text (if (= res-proj-path dest-proj-path)
-                        (str "Cannot paste folder '" dest-proj-path "' into itself")
-                        (str "Cannot paste folder '" dest-proj-path "' into its subfolder '" res-proj-path "'"))}))
+                :text (str "Cannot paste folder '" dest-proj-path "' into its subfolder '" res-proj-path "'")}))
            (paste! workspace resource src-files (partial select-files! workspace tree-view))))))
 
 (defn- moved-files

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -346,7 +346,8 @@
              resource (first selection)
              src-files (.getFiles (Clipboard/getSystemClipboard))
              dest-path (resource/abs-path resource)]
-         (if-let [conflicting-file (some #(when (and (string/starts-with? dest-path (.getPath ^File %))
+         (if-let [conflicting-file (some #(when (and (.isDirectory ^File %)
+                                                     (string/starts-with? dest-path (.getPath ^File %))
                                                      (not= dest-path (.getPath ^File %)))
                                             %)
                                          src-files)]

--- a/editor/src/clj/editor/asset_browser.clj
+++ b/editor/src/clj/editor/asset_browser.clj
@@ -347,7 +347,7 @@
              src-files (.getFiles (Clipboard/getSystemClipboard))
              dest-path (resource/abs-path resource)]
          (if-let [conflicting-file (some #(when (and (.startsWith (.toPath (io/file dest-path))
-                                                                  (.toPath %))
+                                                                  (.toPath ^File %))
                                                      (not= dest-path (.getPath ^File %)))
                                             %)
                                          src-files)]


### PR DESCRIPTION
We process pasting into itself later in this flow by renaming a new file/folder. So here I shouldn't check this case at all

Fix https://github.com/defold/defold/issues/9065
