### PR TITLE
Update transform for non-static collision objects affected by linear or angular velocity

### DIFF
--- a/engine/physics/src/physics/physics_2d.cpp
+++ b/engine/physics/src/physics/physics_2d.cpp
@@ -474,12 +474,12 @@ namespace dmPhysics
             world->m_ContactListener.SetStepWorldContext(&step_context);
             world->m_World.Step(dt, 10, 10);
             float inv_scale = world->m_Context->m_InvScale;
-            // Update transforms of dynamic bodies
+            // Update transforms of non-static bodies
             if (world->m_SetWorldTransformCallback)
             {
                 for (b2Body* body = world->m_World.GetBodyList(); body; body = body->GetNext())
                 {
-                    if (body->GetType() == b2_dynamicBody && body->IsActive())
+                    if (body->GetType() != b2_staticBody && body->IsActive())
                     {
                         Point3 position;
                         FromB2(body->GetPosition(), position, inv_scale);

--- a/engine/physics/src/physics/test/test_physics_2d.cpp
+++ b/engine/physics/src/physics/test/test_physics_2d.cpp
@@ -203,6 +203,63 @@ TYPED_TEST(PhysicsTest, UseBullet)
 }
 
 
+TYPED_TEST(PhysicsTest, SetLinearVelocity)
+{
+    const float vo_x = 0.5f;
+
+    VisualObject vo1;
+    vo1.m_Position = dmVMath::Point3(vo_x, 3.0f, 0.0f);
+    dmPhysics::CollisionObjectData data1;
+    data1.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_KINEMATIC;
+    data1.m_Mass = 0.0f;
+    data1.m_UserData = &vo1;
+    data1.m_Group = 1 << 3;
+    data1.m_Mask = 1 << 2;
+    typename TypeParam::CollisionShapeType shape1 = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, dmVMath::Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType kinematic_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data1, &shape1, 1u);
+    dmPhysics::SetLinearVelocity2D(TestFixture::m_Context, kinematic_co, dmVMath::Vector3(100.0f, 0.0f, 0.0f));
+
+    VisualObject vo2;
+    vo2.m_Position = dmVMath::Point3(vo_x, 3.0f, 0.0f);
+    dmPhysics::CollisionObjectData data2;
+    data2.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_DYNAMIC;
+    data2.m_Mass = 1.0f;
+    data2.m_UserData = &vo2;
+    data2.m_Group = 1 << 3;
+    data2.m_Mask = 1 << 2;
+    typename TypeParam::CollisionShapeType shape2 = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, dmVMath::Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType dynamic_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data2, &shape2, 1u);
+    dmPhysics::SetLinearVelocity2D(TestFixture::m_Context, dynamic_co, dmVMath::Vector3(100.0f, 0.0f, 0.0f));
+
+    VisualObject vo3;
+    vo3.m_Position = dmVMath::Point3(vo_x, 3.0f, 0.0f);
+    dmPhysics::CollisionObjectData data3;
+    data3.m_Type = dmPhysics::COLLISION_OBJECT_TYPE_STATIC;
+    data3.m_Mass = 0.0f;
+    data3.m_UserData = &vo3;
+    data3.m_Group = 1 << 3;
+    data3.m_Mask = 1 << 2;
+    typename TypeParam::CollisionShapeType shape3 = (*TestFixture::m_Test.m_NewBoxShapeFunc)(TestFixture::m_Context, dmVMath::Vector3(0.5f, 0.5f, 0.0f));
+    typename TypeParam::CollisionObjectType static_co = (*TestFixture::m_Test.m_NewCollisionObjectFunc)(TestFixture::m_World, data3, &shape3, 1u);
+    dmPhysics::SetLinearVelocity2D(TestFixture::m_Context, static_co, dmVMath::Vector3(100.0f, 0.0f, 0.0f));
+
+    for (uint32_t i = 0; i < 40; ++i)
+    {
+        (*TestFixture::m_Test.m_StepWorldFunc)(TestFixture::m_World, TestFixture::m_StepWorldContext);
+    }
+
+    ASSERT_NE(vo_x, vo1.m_Position.getX());
+    ASSERT_NE(vo_x, vo2.m_Position.getX());
+    ASSERT_NEAR(vo_x, vo3.m_Position.getX(), 0.01f);
+
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, kinematic_co);
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, dynamic_co);
+    (*TestFixture::m_Test.m_DeleteCollisionObjectFunc)(TestFixture::m_World, static_co);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape1);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape2);
+    (*TestFixture::m_Test.m_DeleteCollisionShapeFunc)(shape3);
+}
+
 TYPED_TEST(PhysicsTest, SetGridShapeHull)
 {
     int32_t rows = 1;


### PR DESCRIPTION
This change will make non-static collision objects move when a linear or angular force is applied.

Fixes #8101 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
