### PR TITLE
Remove callback refs from sprite components

### DIFF
--- a/engine/gameobject/proto/gameobject/gameobject_ddf.proto
+++ b/engine/gameobject/proto/gameobject/gameobject_ddf.proto
@@ -134,16 +134,16 @@ message CollectionDesc
  *
  * Post this message to a game object instance to make that instance acquire the user input focus.
  *
- * User input is distributed by the engine to every instance that has 
+ * User input is distributed by the engine to every instance that has
  * requested it. The last instance to request focus will receive it first.
  * This means that the scripts in the instance will have first-hand-chance
- * at reacting on user input, possibly consuming it (by returning 
+ * at reacting on user input, possibly consuming it (by returning
  * <code>true</code> from <code>on_input</code>) so that no other instances
  * can react on it. The most common case is for a script to send this message
  * to itself when it needs to respond to user input.
  *
  * A script belonging to an instance which has the user input focus will
- * receive the input actions in its <code>on_input</code> callback function. 
+ * receive the input actions in its <code>on_input</code> callback function.
  * See [ref:on_input] for more information on how user input can be
  * handled.
  *
@@ -285,11 +285,17 @@ message Disable
 }
 
 
-// Script message wrapper for added typesafety
+// Internal engine script message wrapper for added typesafety
 message ScriptMessage
 {
     required uint64 descriptor_hash     = 1; // The descriptor name hash of the message
     required uint32 payload_size        = 2; // The payload ddf message. The payload will begin directly after this message
     optional uint32 function            = 3; // If 0, it will call the "on_message" function
     optional bool   unref_function      = 4; // unreference function after call
+}
+
+// Internal engine message for removing script references (typically used for callbacks)
+message ScriptUnrefMessage
+{
+    required uint32 reference = 1;
 }

--- a/engine/gameobject/src/dmsdk/gameobject/script.h
+++ b/engine/gameobject/src/dmsdk/gameobject/script.h
@@ -41,6 +41,17 @@ namespace dmGameObject
 
     Result PostScriptMessage(const dmDDF::Descriptor* descriptor, const uint8_t* payload, uint32_t payload_size, const dmMessage::URL* sender, const dmMessage::URL* receiver, int function_ref, bool unref_function_after_call);
 
+    /*# Sends an unref script message
+     * Sends a script message to unreference a script object
+     *
+     * @name dmScript::PostScriptUnrefMessage
+     * @param sender [type:dmMessage::Message*] The sender
+     * @param receiver [type:dmMessage::Message*] The receiver
+     * @param reference [type:int] The reference to remove
+     * @return success [type:Result] RESULT_OK if successful
+     */
+    Result PostScriptUnrefMessage(const dmMessage::URL* sender, const dmMessage::URL* receiver, int reference);
+
     /*# Sends a script message
      * Sends a script message. Wraps the message in a dmGameSystemDDF::ScriptMessage struct.
      * @name dmScript::PostDDF

--- a/engine/gameobject/src/gameobject/comp_script.cpp
+++ b/engine/gameobject/src/gameobject/comp_script.cpp
@@ -266,6 +266,25 @@ namespace dmGameObject
         return CompScriptUpdateInternal(params, SCRIPT_FUNCTION_FIXED_UPDATE, update_result);
     }
 
+    static UpdateResult HandleUnrefMessage(void* context, ScriptInstance* script_instance, int reference)
+    {
+        lua_State* L = GetLuaState(context);
+        DM_LUA_STACK_CHECK(L, 0);
+
+        lua_rawgeti(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
+        dmScript::SetInstance(L);
+
+        dmScript::ResolveInInstance(L, reference);
+        dmScript::UnrefInInstance(L, reference);
+
+        lua_pop(L, 1);
+
+        lua_pushnil(L);
+        dmScript::SetInstance(L);
+
+        return UPDATE_RESULT_OK;
+    }
+
     static UpdateResult HandleMessage(void* context, ScriptInstance* script_instance, dmMessage::Message* message, int function_ref, bool is_callback, bool deref_function_ref)
     {
         UpdateResult result = UPDATE_RESULT_OK;
@@ -277,7 +296,8 @@ namespace dmGameObject
         lua_rawgeti(L, LUA_REGISTRYINDEX, script_instance->m_InstanceReference);
         dmScript::SetInstance(L);
 
-        if (is_callback) {
+        if (is_callback)
+        {
             dmScript::ResolveInInstance(L, function_ref);
             if (!lua_isfunction(L, -1))
             {
@@ -412,6 +432,11 @@ namespace dmGameObject
                     deref_function_ref = false;
                     function_ref = script_instance->m_Script->m_FunctionReferences[SCRIPT_FUNCTION_ONMESSAGE];
                 }
+            }
+            else if (params.m_Message->m_Id == dmGameObjectDDF::ScriptUnrefMessage::m_DDFDescriptor->m_NameHash)
+            {
+                dmGameObjectDDF::ScriptUnrefMessage* unref_message = (dmGameObjectDDF::ScriptUnrefMessage*) params.m_Message->m_Data;
+                return HandleUnrefMessage(params.m_Context, script_instance, unref_message->m_Reference + LUA_NOREF);
             }
         }
 

--- a/engine/gameobject/src/gameobject/gameobject_script.cpp
+++ b/engine/gameobject/src/gameobject/gameobject_script.cpp
@@ -524,6 +524,27 @@ namespace dmGameObject
         return RESULT_OK;
     }
 
+    Result PostScriptUnrefMessage(const dmMessage::URL* sender, const dmMessage::URL* receiver, int reference)
+    {
+        dmGameObjectDDF::ScriptUnrefMessage msg = {};
+        msg.m_Reference = reference;
+
+        dmDDF::Descriptor* descriptor = dmGameObjectDDF::ScriptUnrefMessage::m_DDFDescriptor;
+        dmMessage::Result result = Post(sender, receiver, descriptor->m_NameHash, 0, 0, (uintptr_t)descriptor, &msg, sizeof(msg), 0);
+
+        if (dmMessage::RESULT_OK != result)
+        {
+            DM_HASH_REVERSE_MEM(hash_ctx, 512);
+            dmLogError("Failed to send message %s to %s:%s/%s",
+                dmHashReverseSafe64Alloc(&hash_ctx, descriptor->m_NameHash),
+                dmMessage::GetSocketName(receiver->m_Socket),
+                dmHashReverseSafe64Alloc(&hash_ctx, receiver->m_Path),
+                dmHashReverseSafe64Alloc(&hash_ctx, receiver->m_Fragment));
+            return RESULT_UNKNOWN_ERROR;
+        }
+        return RESULT_OK;
+    }
+
     static int CheckGoGetResult(lua_State* L, dmGameObject::PropertyResult result, const PropertyDesc& property_desc, dmhash_t property_id, dmGameObject::HInstance target_instance, const dmMessage::URL& target, const dmGameObject::PropertyOptions& property_options, bool index_requested)
     {
         DM_HASH_REVERSE_MEM(hash_ctx, 512);

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1519,7 +1519,10 @@ namespace dmGameSystem
                     message.m_CurrentTile = component->m_CurrentAnimationFrame + 1; // Engine has 0-based indices, scripts use 1-based
                     message.m_Id = component->m_CurrentAnimation;
 
-                    dmGameObject::Result go_result = dmGameObject::PostDDF(&message, &sender, &component->m_Listener, component->m_FunctionRef, false);
+                    // This is a 'done' callback, so we should tell the message system to remove the callback once it's been consumed
+                    dmGameObject::Result go_result = dmGameObject::PostDDF(&message, &sender, &component->m_Listener, component->m_FunctionRef, true);
+                    component->m_FunctionRef = 0;
+
                     dmMessage::ResetURL(&component->m_Listener);
                     if (go_result != dmGameObject::RESULT_OK)
                     {
@@ -1921,6 +1924,13 @@ namespace dmGameSystem
                 dmGameSystemDDF::PlayAnimation* ddf = (dmGameSystemDDF::PlayAnimation*)params.m_Message->m_Data;
                 if (PlayAnimation(component, ddf->m_Id, ddf->m_Offset, ddf->m_PlaybackRate))
                 {
+                    // Remove the currently assigned callback by sending an unref message
+                    if (component->m_FunctionRef)
+                    {
+                        dmMessage::URL sender = {};
+                        GetSender(component, &sender);
+                        dmGameObject::PostScriptUnrefMessage(&sender, &component->m_Listener, component->m_FunctionRef);
+                    }
                     component->m_Listener = params.m_Message->m_Sender;
                     component->m_FunctionRef = params.m_Message->m_UserData2;
                 }


### PR DESCRIPTION
Fixed an issue for sprite components where old callback references are not removed when issuing `sprite.play_flipbook` calls. 

Fixes #8123 