### PR TITLE
Add an adjustable limit for dynamic GUI textures

### DIFF
--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -2336,12 +2336,13 @@
       clipping/setup-states
       sort-scene)))
 
-(defn- ->scene-pb-msg [script-resource material-resource adjust-reference background-color max-nodes node-msgs layer-msgs font-msgs texture-msgs material-msgs layout-msgs particlefx-resource-msgs resource-msgs]
+(defn- ->scene-pb-msg [script-resource material-resource adjust-reference background-color max-nodes max-dynamic-textures node-msgs layer-msgs font-msgs texture-msgs material-msgs layout-msgs particlefx-resource-msgs resource-msgs]
   {:script (resource/resource->proj-path script-resource)
    :material (resource/resource->proj-path material-resource)
    :adjust-reference adjust-reference
    :background-color background-color
    :max-nodes max-nodes
+   :max-dynamic-textures max-dynamic-textures
    :nodes node-msgs
    :layers layer-msgs
    :fonts font-msgs
@@ -2351,8 +2352,8 @@
    :particlefxs particlefx-resource-msgs
    :resources resource-msgs})
 
-(g/defnk produce-pb-msg [script-resource material-resource adjust-reference background-color max-nodes node-msgs layer-msgs font-msgs texture-msgs material-msgs layout-msgs particlefx-resource-msgs resource-msgs]
-  (->scene-pb-msg script-resource material-resource adjust-reference background-color max-nodes node-msgs layer-msgs font-msgs texture-msgs material-msgs layout-msgs particlefx-resource-msgs resource-msgs))
+(g/defnk produce-pb-msg [script-resource material-resource adjust-reference background-color max-nodes max-dynamic-textures node-msgs layer-msgs font-msgs texture-msgs material-msgs layout-msgs particlefx-resource-msgs resource-msgs]
+  (->scene-pb-msg script-resource material-resource adjust-reference background-color max-nodes max-dynamic-textures node-msgs layer-msgs font-msgs texture-msgs material-msgs layout-msgs particlefx-resource-msgs resource-msgs))
 
 (defn- build-pb [resource dep-resources user-data]
   (let [def (:def user-data)
@@ -2561,6 +2562,7 @@
   (property max-nodes g/Int
             (dynamic error (g/fnk [_node-id max-nodes node-ids]
                              (validate-max-nodes _node-id max-nodes node-ids))))
+  (property max-dynamic-textures g/Int)
 
   (input script-resource resource/Resource)
 
@@ -2876,6 +2878,7 @@
       (g/set-property self :def def)
       (g/set-property self :background-color (:background-color scene))
       (g/set-property self :max-nodes (:max-nodes scene))
+      (g/set-property self :max-dynamic-textures (:max-dynamic-textures scene))
       (g/connect project :settings self :project-settings)
       (g/connect project :default-tex-params self :default-tex-params)
       (g/connect project :display-profiles self :display-profiles)

--- a/editor/test/resources/save_data_project/checked01.gui
+++ b/editor/test/resources/save_data_project/checked01.gui
@@ -553,3 +553,4 @@ materials {
   name: "second_material"
   material: "/checked.material"
 }
+max_dynamic_textures: 32

--- a/editor/test/resources/save_data_project/checked02.gui
+++ b/editor/test/resources/save_data_project/checked02.gui
@@ -743,3 +743,4 @@ materials {
   name: "referencing_material"
   material: "/checked.material"
 }
+max_dynamic_textures: 256

--- a/editor/test/resources/save_data_project/checked03.gui
+++ b/editor/test/resources/save_data_project/checked03.gui
@@ -1118,3 +1118,4 @@ materials {
   name: "second_material"
   material: "/checked.material"
 }
+max_dynamic_textures: 16

--- a/engine/gamesys/proto/gamesys/gui_ddf.proto
+++ b/engine/gamesys/proto/gamesys/gui_ddf.proto
@@ -215,20 +215,21 @@ message SceneDesc
         required string particlefx  = 2 [(resource)=true];
     }
 
-    required string          script           = 1 [(resource)=true];
-    repeated FontDesc        fonts            = 2;
-    repeated TextureDesc     textures         = 3;
-    optional dmMath.Vector4  background_color = 4;
-    repeated NodeDesc        nodes            = 6;
-    repeated LayerDesc       layers           = 7;
-    optional string          material         = 8 [(resource)=true, default="/builtins/materials/gui.material"];
-    repeated LayoutDesc      layouts          = 9;
-    optional AdjustReference adjust_reference = 10 [default = ADJUST_REFERENCE_LEGACY];
-    optional uint32          max_nodes        = 11 [default = 512];
-    repeated SpineSceneDesc  spine_scenes     = 12;
-    repeated ParticleFXDesc  particlefxs      = 13;
-    repeated ResourceDesc    resources        = 14;
-    repeated MaterialDesc    materials        = 15;
+    required string          script               = 1 [(resource)=true];
+    repeated FontDesc        fonts                = 2;
+    repeated TextureDesc     textures             = 3;
+    optional dmMath.Vector4  background_color     = 4;
+    repeated NodeDesc        nodes                = 6;
+    repeated LayerDesc       layers               = 7;
+    optional string          material             = 8 [(resource)=true, default="/builtins/materials/gui.material"];
+    repeated LayoutDesc      layouts              = 9;
+    optional AdjustReference adjust_reference     = 10 [default = ADJUST_REFERENCE_LEGACY];
+    optional uint32          max_nodes            = 11 [default = 512];
+    repeated SpineSceneDesc  spine_scenes         = 12;
+    repeated ParticleFXDesc  particlefxs          = 13;
+    repeated ResourceDesc    resources            = 14;
+    repeated MaterialDesc    materials            = 15;
+    optional uint32          max_dynamic_textures = 16 [default = 128];
 }
 
 /*# reports a layout change

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -774,6 +774,7 @@ namespace dmGameSystem
         scene_params.m_MaxNodes = scene_desc->m_MaxNodes;
         scene_params.m_UserData = gui_component;
         scene_params.m_MaxFonts = 64;
+        scene_params.m_MaxDynamicTextures = scene_desc->m_MaxDynamicTextures;
         scene_params.m_MaxTextures = 128;
         scene_params.m_MaxMaterials = 16;
         scene_params.m_MaxAnimations = gui_world->m_MaxAnimationCount;

--- a/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.go
+++ b/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.go
@@ -1,0 +1,4 @@
+components {
+  id: "gui"
+  component: "/gui/gui_max_dynamic_textures_256.gui"
+}

--- a/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.gui_script
+++ b/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures.gui_script
@@ -1,0 +1,51 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+--
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+--
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+MAX_DYNAMIC_TEXTURES = 256
+WIDTH = 4
+HEIGHT = 4
+
+function init(self)
+    self.test = 0
+end
+
+function test_create(self)
+    local t_data = string.char(0xff) .. string.char(0x80) .. string.char(0x10)
+    t_data = string.rep(t_data, WIDTH * HEIGHT)
+
+    for i=1,MAX_DYNAMIC_TEXTURES do
+        local ok, reason = gui.new_texture("texture_" .. i, WIDTH, HEIGHT, "rgb", t_data, false)
+        assert(ok)
+    end
+
+    local ok, reason = gui.new_texture("texture_outside_of_range", WIDTH, HEIGHT, "rgb", t_data, false)
+    assert(not ok)
+    assert(reason == gui.RESULT_OUT_OF_RESOURCES)
+end
+
+function test_delete(self)
+    for i=1,MAX_DYNAMIC_TEXTURES do
+        gui.delete_texture("texture_" .. i)
+    end
+end
+
+function update(self, dt)
+    if self.test == 0 then
+        test_create(self)
+    elseif self.test == 1 then
+        test_delete(self)
+    end
+    self.test = self.test + 1
+end
+

--- a/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures_256.gui
+++ b/engine/gamesys/src/gamesys/test/gui/gui_max_dynamic_textures_256.gui
@@ -1,0 +1,11 @@
+script: "/gui/gui_max_dynamic_textures.gui_script"
+background_color {
+  x: 0.0
+  y: 0.0
+  z: 0.0
+  w: 0.0
+}
+material: "/gui/gui.material"
+adjust_reference: ADJUST_REFERENCE_PARENT
+max_nodes: 512
+max_dynamic_textures: 256

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -20,6 +20,7 @@
 #include "../../../../render/src/render/font_renderer_private.h"
 #include "../../../../render/src/render/render_private.h"
 #include "../../../../resource/src/resource_private.h"
+#include "../../../../gui/src/gui_private.h"
 
 #include "gamesys/resources/res_material.h"
 #include "gamesys/resources/res_textureset.h"
@@ -1237,33 +1238,6 @@ TEST_F(CursorTest, GuiFlipbookCursor)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
-// Tests the animation done message/callback
-TEST_F(GuiTest, GuiFlipbookAnim)
-{
-    dmhash_t go_id = dmHashString64("/go");
-    dmhash_t gui_comp_id = dmHashString64("gui");
-    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/gui_flipbook_anim.goc", go_id, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
-    ASSERT_NE((void*)0x0, go);
-
-    dmMessage::URL msg_url;
-    dmMessage::ResetURL(&msg_url);
-    msg_url.m_Socket = dmGameObject::GetMessageSocket(m_Collection);
-    msg_url.m_Path = go_id;
-    msg_url.m_Fragment = gui_comp_id;
-
-    m_UpdateContext.m_DT = 1.0f;
-
-    bool tests_done = false;
-    WaitForTestsDone(100, true, &tests_done);
-
-    if (!tests_done)
-    {
-        dmLogError("The playback didn't finish");
-    }
-
-    ASSERT_TRUE(dmGameObject::Final(m_Collection));
-}
-
 TEST_P(CursorTest, Cursor)
 {
     const CursorTestParams& params = GetParam();
@@ -1308,12 +1282,38 @@ TEST_P(CursorTest, Cursor)
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
+// Tests the animation done message/callback
+TEST_F(GuiTest, GuiFlipbookAnim)
+{
+    dmhash_t go_id = dmHashString64("/go");
+    dmhash_t gui_comp_id = dmHashString64("gui");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/gui_flipbook_anim.goc", go_id, 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    dmMessage::URL msg_url;
+    dmMessage::ResetURL(&msg_url);
+    msg_url.m_Socket = dmGameObject::GetMessageSocket(m_Collection);
+    msg_url.m_Path = go_id;
+    msg_url.m_Fragment = gui_comp_id;
+
+    m_UpdateContext.m_DT = 1.0f;
+
+    bool tests_done = false;
+    WaitForTestsDone(100, true, &tests_done);
+
+    if (!tests_done)
+    {
+        dmLogError("The playback didn't finish");
+    }
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
 // Tests the different types of textures (atlas, texture, dynamic)
 // This test makes sure that we can use the correct resource pointers.
 TEST_F(GuiTest, TextureResources)
 {
     dmhash_t go_id = dmHashString64("/go");
-    dmGameSystem::InitializeScriptLibs(m_Scriptlibcontext);
 
     dmGameSystem::TextureSetResource* valid_atlas = 0;
     dmGameSystem::TextureResource* valid_texture = 0;
@@ -1391,6 +1391,43 @@ TEST_F(GuiTest, TextureResources)
         dmGraphics::HTexture texture_h = (dmGraphics::HTexture) texture_source;
         ASSERT_TRUE(dmGraphics::IsAssetHandleValid(m_GraphicsContext, texture_h));
     }
+
+    dmGameSystem::FinalizeScriptLibs(m_Scriptlibcontext);
+
+    ASSERT_TRUE(dmGameObject::Final(m_Collection));
+}
+
+// Tests creating and deleting dynamic textures
+TEST_F(GuiTest, MaxDynamictextures)
+{
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/gui/gui_max_dynamic_textures.goc", dmHashString64("/go"), 0, Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0x0, go);
+
+    uint32_t component_type_index        = dmGameObject::GetComponentTypeIndex(m_Collection, dmHashString64("guic"));
+    dmGameSystem::GuiWorld* gui_world    = (dmGameSystem::GuiWorld*) dmGameObject::GetWorld(m_Collection, component_type_index);
+    dmGameSystem::GuiComponent* gui_comp = gui_world->m_Components[0];
+
+    dmGui::Scene* scene = gui_comp->m_Scene;
+
+    ASSERT_EQ(256, scene->m_DynamicTextures.Capacity());
+    ASSERT_EQ(0, scene->m_DynamicTextures.Size());
+
+    // Test 1: create textures
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    ASSERT_EQ(256, scene->m_DynamicTextures.Size());
+
+    // Test 2: delete textures
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    // Trigger a render to finalize deletion of the textures
+    dmRender::RenderListBegin(m_RenderContext);
+    dmGameObject::Render(m_Collection);
+
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::DrawRenderList(m_RenderContext, 0x0, 0x0, 0x0);
+
+    ASSERT_EQ(0, scene->m_DynamicTextures.Size());
 
     dmGameSystem::FinalizeScriptLibs(m_Scriptlibcontext);
 

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -285,16 +285,17 @@ namespace dmGui
     {
         memset(params, 0, sizeof(*params));
         // The default max value for a scene is 512 (same as in gui_ddf.proto). Absolute max value is 2^INDEX_RANGE.
-        params->m_MaxNodes       = 512;
-        params->m_MaxAnimations  = 128;
-        params->m_MaxTextures    = 32;
-        params->m_MaxMaterials   = 8;
-        params->m_MaxFonts       = 4;
-        params->m_MaxParticlefxs = 128;
+        params->m_MaxNodes           = 512;
+        params->m_MaxAnimations      = 128;
+        params->m_MaxTextures        = 32;
+        params->m_MaxDynamicTextures = 32;
+        params->m_MaxMaterials       = 8;
+        params->m_MaxFonts           = 4;
+        params->m_MaxParticlefxs     = 128;
         // 256 is a hard cap for max layers, we use 8 bits in the render key (see LAYER_RANGE above)
-        params->m_MaxLayers       = 256;
-        params->m_AdjustReference = dmGui::ADJUST_REFERENCE_LEGACY;
-        params->m_ScriptWorld     = 0x0;
+        params->m_MaxLayers          = 256;
+        params->m_AdjustReference    = dmGui::ADJUST_REFERENCE_LEGACY;
+        params->m_ScriptWorld        = 0x0;
     }
 
     static void ResetScene(HScene scene) {
@@ -339,7 +340,7 @@ namespace dmGui
         scene->m_NodePool.SetCapacity(params->m_MaxNodes);
         scene->m_Animations.SetCapacity(params->m_MaxAnimations);
         scene->m_Textures.SetCapacity(params->m_MaxTextures*2, params->m_MaxTextures);
-        scene->m_DynamicTextures.SetCapacity(params->m_MaxTextures*2, params->m_MaxTextures);
+        scene->m_DynamicTextures.SetCapacity(params->m_MaxDynamicTextures*2, params->m_MaxDynamicTextures);
         scene->m_MaterialResources.SetCapacity(params->m_MaxMaterials*2, params->m_MaxMaterials);
         scene->m_Fonts.SetCapacity(params->m_MaxFonts*2, params->m_MaxFonts);
         scene->m_Particlefxs.SetCapacity(params->m_MaxParticlefxs*2, params->m_MaxParticlefxs);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -151,6 +151,7 @@ namespace dmGui
     {
         uint32_t m_MaxNodes;
         uint32_t m_MaxAnimations;
+        uint32_t m_MaxDynamicTextures;
         uint32_t m_MaxTextures;
         uint32_t m_MaxMaterials;
         uint32_t m_MaxFonts;


### PR DESCRIPTION
GUI components can now adjust the maximum number of dynamic textures that can be created in runtime.

Fixes #9092 