### PR TITLE
Ouput samplers to .computec resources

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/build.xml
@@ -93,6 +93,7 @@
             <classpath location="${bob.dir}/dist/bob.jar"/>
             <classpath location="${test.tmp.dir}/bob-tests.jar" />
 
+            <!--
             <batchtest>
                 <fileset dir="../com.dynamo.cr.bob.test/src">
                     <include name="**/*Test*.java" />
@@ -102,10 +103,12 @@
                     <exclude name="**/PropertiesTestUtil.java" />
                 </fileset>
             </batchtest>
+            -->
 
             <!-- How to test individual tests -->
             <!-- <test name="com.dynamo.bob.bundle.test.BundleHelperTest" haltonfailure="yes" /> -->
             <!-- <test name="com.dynamo.bob.pipeline.ShaderProgramBuilderTest" haltonfailure="yes" /> -->
+            <test name="com.dynamo.bob.pipeline.ComputeBuilderTest" haltonfailure="yes" />
         </junit>
     </target>
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/build.xml
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/build.xml
@@ -93,7 +93,6 @@
             <classpath location="${bob.dir}/dist/bob.jar"/>
             <classpath location="${test.tmp.dir}/bob-tests.jar" />
 
-            <!--
             <batchtest>
                 <fileset dir="../com.dynamo.cr.bob.test/src">
                     <include name="**/*Test*.java" />
@@ -103,12 +102,10 @@
                     <exclude name="**/PropertiesTestUtil.java" />
                 </fileset>
             </batchtest>
-            -->
 
             <!-- How to test individual tests -->
             <!-- <test name="com.dynamo.bob.bundle.test.BundleHelperTest" haltonfailure="yes" /> -->
             <!-- <test name="com.dynamo.bob.pipeline.ShaderProgramBuilderTest" haltonfailure="yes" /> -->
-            <test name="com.dynamo.bob.pipeline.ComputeBuilderTest" haltonfailure="yes" />
         </junit>
     </target>
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ComputeBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ComputeBuilderTest.java
@@ -1,0 +1,107 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dynamo.render.proto.Material.MaterialDesc;
+import com.dynamo.render.proto.Compute.ComputeDesc;
+import com.google.protobuf.Message;
+
+public class ComputeBuilderTest extends AbstractProtoBuilderTest {
+
+    @Before
+    public void setup() {
+        addTestFiles();
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+
+        addFile("/test.cp", "");
+
+        build("/test.cp", "");
+
+        StringBuilder src = new StringBuilder();
+        src.append("compute_program: \"/test.cp\"\n");
+
+        src.append("constants {\n");
+        src.append("  name: \"constant_one\"\n");
+        src.append("  type: CONSTANT_TYPE_USER\n");
+        src.append("  value {\n");
+        src.append("    x: 1.0\n");
+        src.append("    y: 0.0\n");
+        src.append("    z: 0.0\n");
+        src.append("    w: 0.0\n");
+        src.append("  }\n");
+        src.append("}\n");
+
+        src.append("constants {\n");
+        src.append("  name: \"constant_two\"\n");
+        src.append("  type: CONSTANT_TYPE_VIEWPROJ\n");
+        src.append("}\n");
+
+        src.append("samplers {\n");
+        src.append("  name: \"texture_in\"\n");
+        src.append("  wrap_u: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("  wrap_v: WRAP_MODE_CLAMP_TO_EDGE\n");
+        src.append("  filter_min: FILTER_MODE_MIN_LINEAR\n");
+        src.append("  filter_mag: FILTER_MODE_MAG_LINEAR\n");
+        src.append("}\n");
+
+        src.append("samplers {\n");
+        src.append("  name: \"texture_out\"\n");
+        src.append("  wrap_u: WRAP_MODE_REPEAT\n");
+        src.append("  wrap_v: WRAP_MODE_REPEAT\n");
+        src.append("  filter_min: FILTER_MODE_MIN_NEAREST\n");
+        src.append("  filter_mag: FILTER_MODE_MAG_NEAREST\n");
+        src.append("}\n");
+
+        ComputeDesc compute = (ComputeDesc) build("/test.compute", src.toString()).get(0);
+        assertEquals(2, compute.getSamplersCount());
+        assertEquals(2, compute.getConstantsCount());
+
+        List<MaterialDesc.Sampler> samplers = compute.getSamplersList();
+        List<MaterialDesc.Constant> constants = compute.getConstantsList();
+
+        assertEquals("texture_in", samplers.get(0).getName());
+        assertEquals(MaterialDesc.WrapMode.WRAP_MODE_CLAMP_TO_EDGE, samplers.get(0).getWrapU());
+        assertEquals(MaterialDesc.WrapMode.WRAP_MODE_CLAMP_TO_EDGE, samplers.get(0).getWrapV());
+        assertEquals(MaterialDesc.FilterModeMin.FILTER_MODE_MIN_LINEAR, samplers.get(0).getFilterMin());
+        assertEquals(MaterialDesc.FilterModeMag.FILTER_MODE_MAG_LINEAR, samplers.get(0).getFilterMag());
+
+        assertEquals("texture_out", samplers.get(1).getName());
+        assertEquals(MaterialDesc.WrapMode.WRAP_MODE_REPEAT, samplers.get(1).getWrapU());
+        assertEquals(MaterialDesc.WrapMode.WRAP_MODE_REPEAT, samplers.get(1).getWrapV());
+        assertEquals(MaterialDesc.FilterModeMin.FILTER_MODE_MIN_NEAREST, samplers.get(1).getFilterMin());
+        assertEquals(MaterialDesc.FilterModeMag.FILTER_MODE_MAG_NEAREST, samplers.get(1).getFilterMag());
+
+        float EPSILON = 0.0001f;
+
+        assertEquals("constant_one", constants.get(0).getName());
+        assertEquals(MaterialDesc.ConstantType.CONSTANT_TYPE_USER, constants.get(0).getType());
+        assertEquals(1.0, constants.get(0).getValue(0).getX(), EPSILON);
+        assertEquals(0.0, constants.get(0).getValue(0).getY(), EPSILON);
+        assertEquals(0.0, constants.get(0).getValue(0).getZ(), EPSILON);
+        assertEquals(0.0, constants.get(0).getValue(0).getW(), EPSILON);
+
+        assertEquals("constant_two", constants.get(1).getName());
+        assertEquals(MaterialDesc.ConstantType.CONSTANT_TYPE_VIEWPROJ, constants.get(1).getType());
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ParseUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ParseUtil.java
@@ -35,6 +35,7 @@ import com.dynamo.graphics.proto.Graphics;
 import com.dynamo.lua.proto.Lua.LuaModule;
 import com.dynamo.render.proto.Font;
 import com.dynamo.render.proto.Material;
+import com.dynamo.render.proto.Compute;
 import com.dynamo.render.proto.Render.RenderPrototypeDesc;
 import com.dynamo.rig.proto.Rig;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -217,6 +218,12 @@ public class ParseUtil {
             @Override
             public Message parse(byte[] content) throws InvalidProtocolBufferException {
                 return Material.MaterialDesc.parseFrom(content);
+            }
+        });
+        parseMap.put("computec", new IParser() {
+            @Override
+            public Message parse(byte[] content) throws InvalidProtocolBufferException {
+                return Compute.ComputeDesc.parseFrom(content);
             }
         });
         parseMap.put("renderc", new IParser() {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
@@ -41,7 +41,7 @@ import java.io.OutputStream;
 @ProtoParams(srcClass = ComputeDesc.class, messageClass = ComputeDesc.class)
 @BuilderParams(name = "Compute", inExts = {".compute"}, outExt = ".computec")
 public class ComputeBuilder extends Builder<Void>  {
-	@Override
+    @Override
     public Task<Void> create(IResource input) throws IOException, CompileExceptionError {
         TaskBuilder<Void> task = Task.<Void> newBuilder(this)
                 .setName(params.name())
@@ -105,7 +105,7 @@ public class ComputeBuilder extends Builder<Void>  {
             ComputeDesc.Builder computeBuilder = ComputeDesc.newBuilder();
             TextFormat.merge(reader, computeBuilder);
 
-        	computeBuilder.setComputeProgram(BuilderUtil.replaceExt(computeBuilder.getComputeProgram(), ".cp", ".cpc"));
+            computeBuilder.setComputeProgram(BuilderUtil.replaceExt(computeBuilder.getComputeProgram(), ".cp", ".cpc"));
 
             buildSamplers(computeBuilder);
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ComputeBuilder.java
@@ -1,0 +1,119 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.pipeline;
+
+import java.io.IOException;
+
+import com.google.protobuf.TextFormat;
+
+import com.dynamo.bob.Bob;
+import com.dynamo.bob.Builder;
+import com.dynamo.bob.BuilderParams;
+import com.dynamo.bob.CompileExceptionError;
+import com.dynamo.bob.Task;
+import com.dynamo.bob.Task.TaskBuilder;
+import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.ProtoParams;
+import com.dynamo.bob.util.MurmurHash;
+import com.dynamo.render.proto.Compute.ComputeDesc;
+import com.dynamo.render.proto.Material.MaterialDesc;
+
+// For tests
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.io.OutputStream;
+
+@ProtoParams(srcClass = ComputeDesc.class, messageClass = ComputeDesc.class)
+@BuilderParams(name = "Compute", inExts = {".compute"}, outExt = ".computec")
+public class ComputeBuilder extends Builder<Void>  {
+	@Override
+    public Task<Void> create(IResource input) throws IOException, CompileExceptionError {
+        TaskBuilder<Void> task = Task.<Void> newBuilder(this)
+                .setName(params.name())
+                .addInput(input)
+                .addOutput(input.changeExt(params.outExt()));
+
+        ComputeDesc.Builder computeBuilder = ComputeDesc.newBuilder();
+        ProtoUtil.merge(input, computeBuilder);
+
+        IResource computeProgramresource = this.project.getResource(computeBuilder.getComputeProgram()).changeExt(".cpc");
+        task.addInput(computeProgramresource);
+
+        for (MaterialDesc.Sampler sampler : computeBuilder.getSamplersList()) {
+            String texture = sampler.getTexture();
+            if (texture.isEmpty()) {
+                continue;
+            }
+
+            IResource res = BuilderUtil.checkResource(this.project, input, "texture", texture);
+            Task<?> embedTask = this.project.createTask(res);
+            if (embedTask == null) {
+                throw new CompileExceptionError(input, 0, String.format("Failed to create build task for component '%s'", res.getPath()));
+            }
+        }
+
+        return task.build();
+    }
+
+    private static void buildSamplers(ComputeDesc.Builder computeBuilder) throws CompileExceptionError {
+        for (int i=0; i < computeBuilder.getSamplersCount(); i++) {
+            MaterialDesc.Sampler sampler = computeBuilder.getSamplers(i);
+            computeBuilder.setSamplers(i, GraphicsUtil.buildSampler(sampler));
+        }
+    }
+
+    @Override
+    public void build(Task<Void> task) throws CompileExceptionError, IOException {
+        IResource res                        = task.input(0);
+        ComputeDesc.Builder computeBuilder = ComputeDesc.newBuilder();
+        ProtoUtil.merge(task.input(0), computeBuilder);
+
+        BuilderUtil.checkResource(this.project, res, "compute program", computeBuilder.getComputeProgram());
+        computeBuilder.setComputeProgram(BuilderUtil.replaceExt(computeBuilder.getComputeProgram(), ".cp", ".cpc"));
+
+        buildSamplers(computeBuilder);
+
+        ComputeDesc ComputeDesc = computeBuilder.build();
+        task.output(0).setContent(ComputeDesc.toByteArray());
+    }
+
+    // Running standalone:
+    // java -classpath $DYNAMO_HOME/share/java/bob-light.jar com.dynamo.bob.pipeline.computeBuilder <path-in.compute> <path-out.computec>
+    public static void main(String[] args) throws IOException, CompileExceptionError {
+
+        System.setProperty("java.awt.headless", "true");
+
+        Reader reader       = new BufferedReader(new FileReader(args[0]));
+        OutputStream output = new BufferedOutputStream(new FileOutputStream(args[1]));
+
+        try {
+            ComputeDesc.Builder computeBuilder = ComputeDesc.newBuilder();
+            TextFormat.merge(reader, computeBuilder);
+
+        	computeBuilder.setComputeProgram(BuilderUtil.replaceExt(computeBuilder.getComputeProgram(), ".cp", ".cpc"));
+
+            buildSamplers(computeBuilder);
+
+            ComputeDesc ComputeDesc = computeBuilder.build();
+            ComputeDesc.writeTo(output);
+        } finally {
+            reader.close();
+            output.close();
+        }
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GraphicsUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GraphicsUtil.java
@@ -17,6 +17,7 @@ package com.dynamo.bob.pipeline;
 import com.dynamo.bob.CompileExceptionError;
 import com.dynamo.bob.util.MurmurHash;
 import com.dynamo.graphics.proto.Graphics.VertexAttribute;
+import com.dynamo.render.proto.Material.MaterialDesc;
 import com.google.protobuf.ByteString;
 
 import java.nio.ByteBuffer;
@@ -192,5 +193,17 @@ public class GraphicsUtil {
         attributeBuilder.setNameHash(MurmurHash.hash64(sourceAttr.getName()));
         attributeBuilder.setBinaryValues(makeBinaryValues(sourceAttr, dataType, normalize));
         return attributeBuilder.build();
+    }
+
+    public static MaterialDesc.Sampler buildSampler(MaterialDesc.Sampler samplerIn) throws CompileExceptionError {
+        MaterialDesc.Sampler.Builder samplerBuilder = MaterialDesc.Sampler.newBuilder(samplerIn);
+        samplerBuilder.setNameHash(MurmurHash.hash64(samplerBuilder.getName()));
+
+        String texture = samplerIn.getTexture();
+        if (!texture.isEmpty()) {
+            samplerBuilder.setTexture(ProtoBuilders.replaceTextureName(texture));
+        }
+
+        return samplerBuilder.build();
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/MaterialBuilder.java
@@ -295,17 +295,8 @@ public class MaterialBuilder extends Builder<Void>  {
 
     private static void buildSamplers(MaterialDesc.Builder materialBuilder) throws CompileExceptionError {
         for (int i=0; i < materialBuilder.getSamplersCount(); i++) {
-            MaterialDesc.Sampler materialSampler = materialBuilder.getSamplers(i);
-
-            MaterialDesc.Sampler.Builder samplerBuilder = MaterialDesc.Sampler.newBuilder(materialSampler);
-            samplerBuilder.setNameHash(MurmurHash.hash64(samplerBuilder.getName()));
-
-            String texture = materialSampler.getTexture();
-            if (!texture.isEmpty()) {
-                samplerBuilder.setTexture(ProtoBuilders.replaceTextureName(texture));
-            }
-
-            materialBuilder.setSamplers(i, samplerBuilder.build());
+            MaterialDesc.Sampler sampler = materialBuilder.getSamplers(i);
+            materialBuilder.setSamplers(i, GraphicsUtil.buildSampler(sampler));
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ProtoBuilders.java
@@ -62,7 +62,6 @@ import com.dynamo.input.proto.Input.InputBinding;
 import com.dynamo.particle.proto.Particle.Emitter;
 import com.dynamo.particle.proto.Particle.Modifier;
 import com.dynamo.particle.proto.Particle.ParticleFX;
-import com.dynamo.render.proto.Compute.ComputeDesc;
 import com.dynamo.render.proto.Material.MaterialDesc;
 import com.dynamo.render.proto.Render.RenderPrototypeDesc;
 import com.dynamo.render.proto.Render.DisplayProfiles;
@@ -449,18 +448,6 @@ public class ProtoBuilders {
                 messageBuilder.addAllAttributes(spriteAttributeOverrides);
             }
 
-            return messageBuilder;
-        }
-    }
-
-    @ProtoParams(srcClass = ComputeDesc.class, messageClass = ComputeDesc.class)
-    @BuilderParams(name="ComputeProgram", inExts=".compute", outExt=".computec")
-    public static class ComputeProgramBuilder extends ProtoBuilder<ComputeDesc.Builder> {
-        @Override
-        protected ComputeDesc.Builder transform(Task<Void> task, IResource resource, ComputeDesc.Builder messageBuilder)
-                throws IOException, CompileExceptionError {
-            BuilderUtil.checkResource(this.project, resource, "compute program", messageBuilder.getComputeProgram());
-            messageBuilder.setComputeProgram(BuilderUtil.replaceExt(messageBuilder.getComputeProgram(), ".cp", ".cpc"));
             return messageBuilder;
         }
     }

--- a/engine/gamesys/src/gamesys/resources/res_compute.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_compute.cpp
@@ -139,14 +139,17 @@ namespace dmGameSystem
         ////////////////////////////////////////////////////////////
         for (uint32_t i = 0; i < dmRender::RenderObject::MAX_TEXTURE_COUNT; ++i)
         {
-            uint32_t unit = dmRender::GetComputeProgramSamplerUnit(resource->m_Program, resources->m_SamplerNames[i]);
-            if (unit == dmRender::INVALID_SAMPLER_UNIT)
+            if (resources->m_SamplerNames[i])
             {
-                continue;
+                uint32_t unit = dmRender::GetComputeProgramSamplerUnit(resource->m_Program, resources->m_SamplerNames[i]);
+                if (unit == dmRender::INVALID_SAMPLER_UNIT)
+                {
+                    continue;
+                }
+                resource->m_Textures[unit]     = resources->m_Textures[i];
+                resource->m_SamplerNames[unit] = resources->m_SamplerNames[i];
+                resource->m_NumTextures++;
             }
-            resource->m_Textures[unit]     = resources->m_Textures[i];
-            resource->m_SamplerNames[unit] = resources->m_SamplerNames[i];
-            resource->m_NumTextures++;
         }
     }
 

--- a/engine/gamesys/src/gamesys/test/shader/inputs.compute
+++ b/engine/gamesys/src/gamesys/test/shader/inputs.compute
@@ -79,3 +79,23 @@ constants {
     w: 116.0
   }
 }
+
+
+
+samplers {
+  name: "texture_b"
+  wrap_u: WRAP_MODE_REPEAT
+  wrap_v: WRAP_MODE_REPEAT
+  filter_min: FILTER_MODE_MIN_NEAREST
+  filter_mag: FILTER_MODE_MAG_NEAREST
+  max_anisotropy: 0.0
+}
+
+samplers {
+  name: "texture_c"
+  wrap_u: WRAP_MODE_CLAMP_TO_EDGE
+  wrap_v: WRAP_MODE_CLAMP_TO_EDGE
+  filter_min: FILTER_MODE_MIN_LINEAR
+  filter_mag: FILTER_MODE_MAG_LINEAR
+  max_anisotropy: 14.0
+}

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -5255,10 +5255,6 @@ TEST_F(ShaderTest, ComputeResource)
     dmGraphics::HProgram graphics_compute_program  = dmRender::GetComputeProgram(compute_program);
     ASSERT_EQ(7, dmGraphics::GetUniformCount(graphics_compute_program));
 
-    char buffer[128] = {};
-    dmGraphics::Type type;
-    int32_t size;
-
     dmRender::HConstant ca, cb, cc, cd;
     ASSERT_TRUE(dmRender::GetComputeProgramConstant(compute_program, dmHashString64("buffer_a"), ca));
     ASSERT_TRUE(dmRender::GetComputeProgramConstant(compute_program, dmHashString64("buffer_b"), cb));
@@ -5306,6 +5302,30 @@ TEST_F(ShaderTest, ComputeResource)
     ASSERT_NE(dmGraphics::INVALID_UNIFORM_LOCATION, la);
     ASSERT_NE(dmGraphics::INVALID_UNIFORM_LOCATION, lb);
     ASSERT_NE(dmGraphics::INVALID_UNIFORM_LOCATION, lc);
+
+    // Note: texture_a is a storage texture, so we only have two actual samplers here:
+    ASSERT_EQ(2, compute_program_res->m_NumTextures);
+
+    dmRender::Sampler* sampler_tex_b = dmRender::GetComputeProgramSampler(compute_program, 0);
+    dmRender::Sampler* sampler_tex_c = dmRender::GetComputeProgramSampler(compute_program, 1);
+
+    ASSERT_NE((dmRender::Sampler*) 0, sampler_tex_b);
+    ASSERT_EQ(dmHashString64("texture_b"),        sampler_tex_b->m_NameHash);
+    ASSERT_EQ(dmGraphics::TEXTURE_TYPE_2D,        sampler_tex_b->m_Type);
+    ASSERT_EQ(dmGraphics::TEXTURE_FILTER_NEAREST, sampler_tex_b->m_MinFilter);
+    ASSERT_EQ(dmGraphics::TEXTURE_FILTER_NEAREST, sampler_tex_b->m_MagFilter);
+    ASSERT_EQ(dmGraphics::TEXTURE_WRAP_REPEAT,    sampler_tex_b->m_UWrap);
+    ASSERT_EQ(dmGraphics::TEXTURE_WRAP_REPEAT,    sampler_tex_b->m_VWrap);
+    ASSERT_NEAR(0.0f, sampler_tex_b->m_MaxAnisotropy, EPSILON);
+
+    ASSERT_NE((dmRender::Sampler*) 0, sampler_tex_c);
+    ASSERT_EQ(dmHashString64("texture_c"),            sampler_tex_c->m_NameHash);
+    ASSERT_EQ(dmGraphics::TEXTURE_TYPE_2D,            sampler_tex_c->m_Type);
+    ASSERT_EQ(dmGraphics::TEXTURE_FILTER_LINEAR,      sampler_tex_c->m_MinFilter);
+    ASSERT_EQ(dmGraphics::TEXTURE_FILTER_LINEAR,      sampler_tex_c->m_MagFilter);
+    ASSERT_EQ(dmGraphics::TEXTURE_WRAP_CLAMP_TO_EDGE, sampler_tex_c->m_UWrap);
+    ASSERT_EQ(dmGraphics::TEXTURE_WRAP_CLAMP_TO_EDGE, sampler_tex_c->m_VWrap);
+    ASSERT_NEAR(14.0f, sampler_tex_c->m_MaxAnisotropy, EPSILON);
 
     dmResource::Release(m_Factory, (void*) compute_program_res);
 }

--- a/engine/gamesys/src/waf_gamesys.py
+++ b/engine/gamesys/src/waf_gamesys.py
@@ -366,10 +366,6 @@ def transform_sprite(task, msg):
         st.texture = transform_tilesource_name(st.texture)
     return msg
 
-def transform_compute(task, msg):
-    msg.compute_program = msg.compute_program.replace('.cp', '.cpc')
-    return msg
-
 def transform_tilegrid(task, msg):
     msg.tile_set = transform_tilesource_name(msg.tile_set)
     msg.material = msg.material.replace('.material', '.materialc')
@@ -525,7 +521,6 @@ proto_compile_task('tilegrid', 'tile_ddf_pb2', 'TileGrid', '.tilegrid', '.tilema
 proto_compile_task('tilemap', 'tile_ddf_pb2', 'TileGrid', '.tilemap', '.tilemapc', transform_tilegrid)
 proto_compile_task('sound', 'sound_ddf_pb2', 'SoundDesc', '.sound', '.soundc', transform_sound)
 proto_compile_task('display_profiles', 'render.render_ddf_pb2', 'render_ddf_pb2.DisplayProfiles', '.display_profiles', '.display_profilesc')
-proto_compile_task('compute', 'render.compute_ddf_pb2', 'compute_ddf_pb2.ComputeDesc', '.compute', '.computec', transform_compute)
 
 new_copy_task('project', '.project', '.projectc')
 
@@ -748,3 +743,19 @@ def material_file(self, node):
     obj_ext = '.materialc'
     out = node.change_ext(obj_ext)
     material.set_outputs(out)
+
+waflib.Task.task_factory('compute', '${JAVA} -classpath ${CLASSPATH} com.dynamo.bob.pipeline.ComputeBuilder ${SRC} ${TGT}',
+                      color='PINK',
+                      after='proto_gen_py',
+                      before='c cxx',
+                      shell=False)
+
+@extension('.compute')
+def compute_file(self, node):
+    classpath = [self.env['DYNAMO_HOME'] + '/share/java/bob-light.jar']
+    compute = self.create_task('compute')
+    compute.env['CLASSPATH'] = os.pathsep.join(classpath)
+    compute.set_inputs(node)
+    obj_ext = '.computec'
+    out = node.change_ext(obj_ext)
+    compute.set_outputs(out)

--- a/engine/render/src/render/compute.cpp
+++ b/engine/render/src/render/compute.cpp
@@ -104,6 +104,11 @@ namespace dmRender
         return GetProgramSamplerUnit(compute_program->m_Samplers, name_hash);
     }
 
+    HSampler GetComputeProgramSampler(HComputeProgram program, uint32_t unit)
+    {
+        return GetProgramSampler(program->m_Samplers, unit);
+    }
+
     dmGraphics::HComputeProgram GetComputeProgramShader(HComputeProgram program)
     {
         return program->m_Shader;

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -42,7 +42,7 @@ namespace dmRender
 
     typedef struct RenderTargetSetup*       HRenderTargetSetup;
     typedef uint64_t                        HRenderType;
-    typedef uint64_t                        HSampler;
+    typedef struct Sampler*                 HSampler;
     typedef struct RenderScript*            HRenderScript;
     typedef struct RenderScriptInstance*    HRenderScriptInstance;
     typedef struct Predicate*               HPredicate;
@@ -271,6 +271,7 @@ namespace dmRender
     // Compute
     HComputeProgram                 NewComputeProgram(HRenderContext render_context, dmGraphics::HComputeProgram shader);
     void                            DeleteComputeProgram(dmRender::HRenderContext render_context, HComputeProgram program);
+    HSampler                        GetComputeProgramSampler(HComputeProgram program, uint32_t unit);
     HRenderContext                  GetProgramRenderContext(HComputeProgram program);
     dmGraphics::HComputeProgram     GetComputeProgramShader(HComputeProgram program);
     dmGraphics::HProgram            GetComputeProgram(HComputeProgram program);


### PR DESCRIPTION
* Previously, bob.jar did not output any samplers from a .compute resource, whereas the editor did.
* Compute programs have their own ComputeBuilder.java now that is used in tests as well (and tested via bob tests)