### PR TITLE
Fix the last column size for the table view in the Editor.

### DIFF
--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -58,7 +58,7 @@
   (:import [java.io File]
            [javafx.event Event]
            [javafx.scene Node]
-           [javafx.scene.control Cell ComboBox ListView$EditEvent TableColumn$CellEditEvent TableView TableView$ResizeFeatures ListView]
+           [javafx.scene.control Cell ComboBox ListView$EditEvent TableColumn$CellEditEvent TableView TableColumn TableView$ResizeFeatures ListView]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.util StringConverter Callback]))
 
@@ -913,24 +913,23 @@
      :cell-value-factory (fn/partial table-cell-value-factory path)
      :cell-factory (fn/partial table-cell-factory column (dissoc edit :value))}))
 
-(defn custom-table-resize-policy []
+(def custom-table-resize-policy
   (reify Callback
     (call [_ resize-features]
       (let [^TableView$ResizeFeatures resize-features resize-features
-            resized-column (.getColumn resize-features)
+            ^TableColumn resized-column (.getColumn resize-features)
             delta (.getDelta resize-features)
-            table (.getTable resize-features)
+            ^TableView table (.getTable resize-features)
             columns (.getColumns table)
             total-width (.getWidth table)
-            last-column (last columns)]
+            ^TableColumn last-column (last columns)]
         (when resized-column
           (let [new-width (max (.getMinWidth resized-column) (+ (.getPrefWidth resized-column) delta))]
             (.setPrefWidth resized-column new-width)))
         (when (and last-column (not= resized-column last-column))
-          (let [used-width (reduce + (map #(.getWidth %) (butlast columns)))
+          (let [used-width (reduce + (map #(.getWidth ^TableColumn %) (butlast columns)))
                 remaining-width (- total-width used-width (* 2 (.size columns)))]
             (.setPrefWidth last-column (max (.getMinWidth last-column) remaining-width))))
-
         true))))
 
 (defmethod form-input-view :table [{:keys [value
@@ -983,7 +982,7 @@
                                                         9   ;; bottom scrollbar
                                                         (* line-height
                                                            (max 1 (count value))))
-                                        :column-resize-policy (custom-table-resize-policy)
+                                        :column-resize-policy custom-table-resize-policy
                                         :columns (mapv #(table-column % field)
                                                        columns)
                                         :items (into [] (map-indexed vector) value)

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -58,7 +58,7 @@
   (:import [java.io File]
            [javafx.event Event]
            [javafx.scene Node]
-           [javafx.scene.control Cell ComboBox ListView$EditEvent TableColumn$CellEditEvent TableView ListView]
+           [javafx.scene.control Cell ComboBox ListView$EditEvent TableColumn$CellEditEvent TableView TableView$ResizeFeatures ListView]
            [javafx.scene.input KeyCode KeyEvent]
            [javafx.util StringConverter Callback]))
 
@@ -915,20 +915,17 @@
 
 (defn custom-table-resize-policy []
   (reify Callback
-    (call [this resize-features]
-      (let [resized-column (.getColumn resize-features)
-            delta (.getDelta resize-features)]
-        (when resized-column
-          (let [new-width (max (.getMinWidth resized-column) (+ (.getPrefWidth resized-column) delta))]
-            (.setPrefWidth resized-column new-width))))
-
-      (let [resized-column (.getColumn resize-features)
+    (call [_ resize-features]
+      (let [^TableView$ResizeFeatures resize-features resize-features
+            resized-column (.getColumn resize-features)
+            delta (.getDelta resize-features)
             table (.getTable resize-features)
             columns (.getColumns table)
             total-width (.getWidth table)
             last-column (last columns)]
-
-        ;; Adjust the last column to fill the remaining space
+        (when resized-column
+          (let [new-width (max (.getMinWidth resized-column) (+ (.getPrefWidth resized-column) delta))]
+            (.setPrefWidth resized-column new-width)))
         (when (and last-column (not= resized-column last-column))
           (let [used-width (reduce + (map #(.getWidth %) (butlast columns)))
                 remaining-width (- total-width used-width (* 2 (.size columns)))]

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -60,7 +60,7 @@
            [javafx.scene Node]
            [javafx.scene.control Cell ComboBox ListView$EditEvent TableColumn$CellEditEvent TableView ListView]
            [javafx.scene.input KeyCode KeyEvent]
-           [javafx.util StringConverter]))
+           [javafx.util StringConverter Callback]))
 
 (set! *warn-on-reflection* true)
 
@@ -913,6 +913,29 @@
      :cell-value-factory (fn/partial table-cell-value-factory path)
      :cell-factory (fn/partial table-cell-factory column (dissoc edit :value))}))
 
+(defn custom-table-resize-policy []
+  (reify Callback
+    (call [this resize-features]
+      (let [resized-column (.getColumn resize-features)
+            delta (.getDelta resize-features)]
+        (when resized-column
+          (let [new-width (max (.getMinWidth resized-column) (+ (.getPrefWidth resized-column) delta))]
+            (.setPrefWidth resized-column new-width))))
+
+      (let [resized-column (.getColumn resize-features)
+            table (.getTable resize-features)
+            columns (.getColumns table)
+            total-width (.getWidth table)
+            last-column (last columns)]
+
+        ;; Adjust the last column to fill the remaining space
+        (when (and last-column (not= resized-column last-column))
+          (let [used-width (reduce + (map #(.getWidth %) (butlast columns)))
+                remaining-width (- total-width used-width (* 2 (.size columns)))]
+            (.setPrefWidth last-column (max (.getMinWidth last-column) remaining-width))))
+
+        true))))
+
 (defmethod form-input-view :table [{:keys [value
                                            on-value-changed
                                            columns
@@ -963,6 +986,7 @@
                                                         9   ;; bottom scrollbar
                                                         (* line-height
                                                            (max 1 (count value))))
+                                        :column-resize-policy (custom-table-resize-policy)
                                         :columns (mapv #(table-column % field)
                                                        columns)
                                         :items (into [] (map-indexed vector) value)


### PR DESCRIPTION
Fix the issue where the last column in a table has a minimum width size, making it hard to edit.

Fix https://github.com/defold/defold/issues/9063
## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
