### PR TITLE
Add `tilemap.get_tiles()` function

### DIFF
--- a/engine/engine/src/test/tile/coll.script
+++ b/engine/engine/src/test/tile/coll.script
@@ -52,10 +52,10 @@ function init(self)
 
     -- get_tiles
     local tiles = tilemap.get_tiles("#tilemap", "layer")
-    assert(tiles[0][-1] == 1)
+    assert(tiles[0][0] == 0)
     assert(tiles[0][1] == 0)
     assert(tiles[1][1] == 1)
-    assert(tiles[1][-1] == 0)
+    assert(tiles[-1][0] == 1)
 
     -- out of range
     tile = tilemap.get_tile("#tilemap", "layer", 2, 1)

--- a/engine/engine/src/test/tile/coll.script
+++ b/engine/engine/src/test/tile/coll.script
@@ -52,10 +52,10 @@ function init(self)
 
     -- get_tiles
     local tiles = tilemap.get_tiles("#tilemap", "layer")
-    assert(tiles[0][0] == 0)
+    assert(tiles[0][-1] == 1)
     assert(tiles[0][1] == 0)
     assert(tiles[1][1] == 1)
-    assert(tiles[-1][0] == 1)
+    assert(tiles[1][-1] == 0)
 
     -- out of range
     tile = tilemap.get_tile("#tilemap", "layer", 2, 1)

--- a/engine/engine/src/test/tile/coll.script
+++ b/engine/engine/src/test/tile/coll.script
@@ -50,6 +50,13 @@ function init(self)
     assert(tile_info.v_flip == false)
     assert(tile_info.h_flip == false)
 
+    -- get_tiles
+    local tiles = tilemap.get_tiles("#tilemap", "layer")
+    assert(tiles[0][-1] == 1)
+    assert(tiles[0][1] == 0)
+    assert(tiles[1][1] == 1)
+    assert(tiles[1][-1] == 0)
+
     -- out of range
     tile = tilemap.get_tile("#tilemap", "layer", 2, 1)
     assert(tile == nil)

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -469,7 +469,7 @@ namespace dmGameSystem
      * @name tilemap.get_tiles
      * @param url [type:string|hash|url] the tilemap
      * @param layer [type:string|hash] the name of the layer for the tiles
-     * @return tiles [type:table] a table of tables representing the layer
+     * @return tiles [type:table] a table of rows representing the layer
      * @examples
      *
      * ```lua

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -462,10 +462,10 @@ namespace dmGameSystem
 
     /*# get all the tiles from a layer in a tilemap
      * Retrieves all the tiles for the specified layer in the tilemap.
-     * It returns a table of columns where the keys are the
+     * It returns a table of rows where the keys are the
      * tile positions (see [ref:tilemap.get_bounds()]).
-     * You can iterate it using `tiles[x][y]`.
-     * 
+     * You can iterate it using `tiles[y][x]`.
+     *
      * @name tilemap.get_tiles
      * @param url [type:string|hash|url] the tilemap
      * @param layer [type:string|hash] the name of the layer for the tiles
@@ -474,13 +474,13 @@ namespace dmGameSystem
      *
      * ```lua
      * local mx, my, max_x, max_y = tilemap.get_bounds("#tilemap")
-     * local tbl = tilemap.get_tiles("#tilemap", "layer1")
+     * local tbl = tilemap.get_tiles("#tilemap", "layer")
      * local value, count = 0, 0
-     * for x = mx, mx + max_x - 1 do
-     *    for y = my, my + max_y - 1 do
-     *        value = tbl[x][y]
-     *       count = count + 1
-     *    end
+     * for y = my, my + max_y - 1 do
+     *     for x = mx, mx + max_x - 1 do
+     *         value = tbl[y][x]
+     *         count = count + 1
+     *     end
      * end
      * ```
      */
@@ -511,14 +511,14 @@ namespace dmGameSystem
         GetTileGridCellCoord(component, min_x, min_y, cell_x, cell_y);
 
         lua_newtable(L);
-        for (int ix = 0; ix < grid_w; ix++)
+        for (int iy = 0; iy < grid_h; iy++)
         {
-            lua_pushinteger(L, min_x + ix + 1);
+            lua_pushinteger(L, min_y + iy + 1);
             lua_newtable(L);
-            for (int iy = 0; iy < grid_h; iy++)
+            for (int ix = 0; ix < grid_w; ix++)
             {
                 uint16_t cell = GetTileGridTile(component, layer_index, cell_x + ix, cell_y + iy);
-                lua_pushinteger(L, min_y + iy + 1);
+                lua_pushinteger(L, min_x + ix + 1);
                 lua_pushinteger(L, cell);
                 lua_settable(L, -3);
             }

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -474,7 +474,7 @@ namespace dmGameSystem
      * ```lua
      *  local mx, my, max_x, max_y = tilemap.get_bounds("#tilemap")
      *  local tbl = tilemap.get_tiles("#1", "layer")
-     *  for y = my + max_y - 1, my, -1  do //starting top left corner
+     *  for y = my + max_y - 1, my, -1  do --starting top left corner
      *    local str = y.." \t"
      *    for x = mx, mx + max_x - 1 do
      *       str = str .. "\t".. tostring(tbl[y][x])

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -464,7 +464,7 @@ namespace dmGameSystem
      * Retrieves all the tiles for the specified layer in the tilemap.
      * It returns a table of rows where the keys are the
      * tile positions (see [ref:tilemap.get_bounds()]).
-     * You can iterate it using `tiles[y][x]`.
+     * You can iterate it using `tiles[row_index][column_index]`.
      *
      * @name tilemap.get_tiles
      * @param url [type:string|hash|url] the tilemap
@@ -473,12 +473,12 @@ namespace dmGameSystem
      * @examples
      *
      * ```lua
-     * local mx, my, max_x, max_y = tilemap.get_bounds("#tilemap")
-     * local tbl = tilemap.get_tiles("#tilemap", "layer")
-     * local value, count = 0, 0
-     * for y = my, my + max_y - 1 do
-     *     for x = mx, mx + max_x - 1 do
-     *         value = tbl[y][x]
+     * local left, bottom, columns_count, rows_count = tilemap.get_bounds("#tilemap")
+     * local tiles = tilemap.get_tiles("#tilemap", "layer")
+     * local tile, count = 0, 0
+     * for row_index = bottom, bottom + rows_count - 1 do
+     *     for column_index = left, left + columns_count - 1 do
+     *         tile = tiles[row_index][column_index]
      *         count = count + 1
      *     end
      * end

--- a/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
+++ b/engine/gamesys/src/gamesys/scripts/script_tilemap.cpp
@@ -462,9 +462,10 @@ namespace dmGameSystem
 
     /*# get all the tiles from a layer in a tilemap
      * Retrieves all the tiles for the specified layer in the tilemap.
-     * It returns a table of tables where the keys are the
+     * It returns a table of columns where the keys are the
      * tile positions (see [ref:tilemap.get_bounds()]).
-     *
+     * You can iterate it using `tiles[x][y]`.
+     * 
      * @name tilemap.get_tiles
      * @param url [type:string|hash|url] the tilemap
      * @param layer [type:string|hash] the name of the layer for the tiles
@@ -472,15 +473,15 @@ namespace dmGameSystem
      * @examples
      *
      * ```lua
-     *  local mx, my, max_x, max_y = tilemap.get_bounds("#tilemap")
-     *  local tbl = tilemap.get_tiles("#1", "layer")
-     *  for y = my + max_y - 1, my, -1  do --starting top left corner
-     *    local str = y.." \t"
-     *    for x = mx, mx + max_x - 1 do
-     *       str = str .. "\t".. tostring(tbl[y][x])
+     * local mx, my, max_x, max_y = tilemap.get_bounds("#tilemap")
+     * local tbl = tilemap.get_tiles("#tilemap", "layer1")
+     * local value, count = 0, 0
+     * for x = mx, mx + max_x - 1 do
+     *    for y = my, my + max_y - 1 do
+     *        value = tbl[x][y]
+     *       count = count + 1
      *    end
-     *    print(str)
-     *   end
+     * end
      * ```
      */
     static int TileMap_GetTiles(lua_State* L)
@@ -510,14 +511,14 @@ namespace dmGameSystem
         GetTileGridCellCoord(component, min_x, min_y, cell_x, cell_y);
 
         lua_newtable(L);
-        for (int iy = 0; iy < grid_h; iy++)
+        for (int ix = 0; ix < grid_w; ix++)
         {
-            lua_pushinteger(L, min_y + iy + 1);
+            lua_pushinteger(L, min_x + ix + 1);
             lua_newtable(L);
-            for (int ix = 0; ix < grid_w; ix++)
+            for (int iy = 0; iy < grid_h; iy++)
             {
                 uint16_t cell = GetTileGridTile(component, layer_index, cell_x + ix, cell_y + iy);
-                lua_pushinteger(L, min_x + ix + 1);
+                lua_pushinteger(L, min_y + iy + 1);
                 lua_pushinteger(L, cell);
                 lua_settable(L, -3);
             }


### PR DESCRIPTION
Added a new function `tilemap.get_tiles()` which returns a table of rows with all the tile indexes for the layer.

```lua
local left, bottom, columns_count, rows_count = tilemap.get_bounds("#tilemap")
local tiles = tilemap.get_tiles("#tilemap", "layer")
local tile, count = 0, 0
for row_index = bottom, bottom + rows_count - 1 do
	for column_index = left, left + columns_count - 1 do
		tile = tiles[row_index][column_index]
		count = count + 1
	end
end
```