### PR TITLE
Editor: Default to internal code editor for .appmanifest files

### DIFF
--- a/editor/src/clj/editor/app_manifest.clj
+++ b/editor/src/clj/editor/app_manifest.clj
@@ -482,4 +482,5 @@
     :icon "icons/32/Icons_05-Project-info.png"
     :node-type AppManifestNode
     :view-types [:code :default]
+    :view-opts {:code {:use-custom-editor false}}
     :lazy-loaded true))

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2012,6 +2012,8 @@ If you do not specifically require different script states, consider changing th
               :header (format "Unable to open '%s', since it contains unrecognizable data. Could the project be missing a required extension?" (resource/proj-path resource))})
            false)
        (if-let [custom-editor (and (#{:code :text} (:id view-type))
+                                   (or (:selected-view-type opts)
+                                       (get-in resource-type [:view-opts (:id view-type) :use-custom-editor] true))
                                    (let [ed-pref (some->
                                                    (prefs/get-prefs prefs "code-custom-editor" "")
                                                    string/trim)]


### PR DESCRIPTION
Default to using the internal code editor and its accompanying generator UI for `.appmanifest` files.

Fixes #9120

### Technical changes
* The `:use-custom-editor` boolean setting in`:view-opts` controls whether or not a code resource will open with the user's configured Custom Code Editor by default. Defaults to `true`.

### Note to reviewers
This changes the behavior of selecting **Open** on, or double-clicking, an `.appmanifest` resource when the user has a Custom Code Editor configured.

The user can still open an `.appmanifest` in their Custom Code Editor by selecting **Open As... > Code**.

Selecting **Open As... > External Editor** will open it using the application associated with the `.appmanifest` file extension in the host OS. This will show an error dialog unless you have an editor associated with `.appmanifest` files. I found this confusing at first, but it is consistent with other file types.