### PR TITLE
Add Enter/Esc controls for properties in the editor

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -160,7 +160,7 @@
                                       (properties/read-only? property))))
         cancel-fn update-prop-fn
         update-fn (fn [_]
-                    (if-let [v (field-expression/to-int (.getText text))]
+                    (when-let [v (field-expression/to-int (.getText text))]
                       (let [property (property-fn)]
                         (properties/set-values! property (repeat v))
                         (update-prop-fn nil))))]
@@ -300,9 +300,9 @@
                 cancel-fn (fn [_]
                             (let [property (property-fn)
                                   current-vals (properties/values property)]
-                              (update-ui-fn current-vals (properties/validation-message property)
-                                            (properties/read-only? property))
-                              ))
+                              (update-ui-fn current-vals
+                                            (properties/validation-message property)
+                                            (properties/read-only? property))))
                 update-fn (fn update-fn [_]
                             (let [property (property-fn)
                                   current-vals (properties/values property)
@@ -548,7 +548,7 @@
                                     (properties/validation-message property)
                                     (properties/read-only? property))))
         update-fn (fn [_]
-                      (properties/set-values! (property-fn) (repeat (.getText text))))]
+                    (properties/set-values! (property-fn) (repeat (.getText text))))]
     (customize! text update-fn cancel-fn)
     [text update-ui-fn]))
 

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -88,32 +88,17 @@
   (doto t
     (GridPane/setHgrow Priority/ALWAYS)
     (ui/on-action! update-fn)
+    (ui/on-cancel! cancel-fn)
     (ui/auto-commit! update-fn)
-    (select-all-on-click!)
-    (ui/bind-key! "Esc" (fn []
-                          (cancel-fn t)
-                          (when-let [parent (.getParent t)]
-                            (.requestFocus parent))))
-    (ui/bind-key! "Enter" (fn []
-                            (update-fn t)
-                            (if (zero? (.getLength (.getSelection t)))
-                              (.selectAll t)
-                              (.deselect t))))))
+    (select-all-on-click!)))
 
 (defmethod customize! TextArea [^TextArea t update-fn cancel-fn]
   (doto t
     (GridPane/setHgrow Priority/ALWAYS)
+    (ui/on-action! update-fn)
+    (ui/on-cancel! cancel-fn)
     (ui/auto-commit! update-fn)
-    (select-all-on-click!)
-    (ui/bind-key! "Shortcut+Enter" (fn []
-                                     (update-fn t)
-                                     (if (zero? (.getLength (.getSelection t)))
-                                       (.selectAll t)
-                                       (.deselect t))))
-    (ui/bind-key! "Esc" (fn []
-                          (cancel-fn t)
-                          (when-let [parent (.getParent t)]
-                            (.requestFocus parent))))))
+    (select-all-on-click!)))
 
 (defn- old-num->parse-num-fn [old-num]
   {:pre [(or (number? old-num) (nil? old-num))]}
@@ -561,8 +546,9 @@
                       (update-ui-fn (properties/values property)
                                     (properties/validation-message property)
                                     (properties/read-only? property))))
-        update-fn #(properties/set-values! (property-fn) (repeat (.getText text)))]
-    (customize! text (fn [_] (update-fn)) cancel-fn)
+        update-fn (fn [_]
+                      (properties/set-values! (property-fn) (repeat (.getText text))))]
+    (customize! text update-fn cancel-fn)
     [text update-ui-fn]))
 
 (defmethod create-property-control! :default [_ _ _]

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -197,8 +197,7 @@
                           old-num (coalesced-property->old-num property)]
                       (if-let [num (parse-num (.getText text-field) old-num)]
                         (properties/set-values! property (repeat num))
-                        (cancel-fn nil)
-                        )))]
+                        (cancel-fn nil))))]
     (customize! text-field update-fn cancel-fn)
     (when-let [style-class (script-property-type->style-class (:script-property-type edit-type))]
       (add-style-class! text-field style-class))

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -105,6 +105,11 @@
     (GridPane/setHgrow Priority/ALWAYS)
     (ui/auto-commit! update-fn)
     (select-all-on-click!)
+    (ui/bind-key! "Shortcut+Enter" (fn []
+                                     (update-fn t)
+                                     (if (zero? (.getLength (.getSelection t)))
+                                       (.selectAll t)
+                                       (.deselect t))))
     (ui/bind-key! "Esc" (fn []
                           (cancel-fn t)
                           (when-let [parent (.getParent t)]
@@ -558,7 +563,6 @@
                                     (properties/validation-message property)
                                     (properties/read-only? property))))
         update-fn #(properties/set-values! (property-fn) (repeat (.getText text)))]
-    (ui/bind-key! text "Shortcut+Enter" update-fn)
     (customize! text (fn [_] (update-fn)) cancel-fn)
     [text update-ui-fn]))
 

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -179,8 +179,9 @@
                                     (properties/read-only? property))))
         update-fn (fn update-fn [_]
                     (let [property (property-fn)
-                          old-num (coalesced-property->old-num property)]
-                      (if-let [num (parse-num (.getText text-field) old-num)]
+                          old-num (coalesced-property->old-num property)
+                          num (parse-num (.getText text-field) old-num)]
+                      (if (and num (not= num old-num))
                         (properties/set-values! property (repeat num))
                         (cancel-fn nil))))]
     (customize! text-field update-fn cancel-fn)
@@ -241,7 +242,7 @@
                                   current-vals (properties/values property)
                                   old-num (ffirst current-vals)
                                   num (parse-num (.getText text-field) old-num)]
-                              (if num
+                              (if (and num (not= num old-num))
                                 (properties/set-values! property (mapv #(assoc % index num) current-vals))
                                 (cancel-fn nil))))]
             (customize! text-field update-fn cancel-fn)

--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -100,11 +100,15 @@
                               (.selectAll t)
                               (.deselect t))))))
 
-(defmethod customize! TextArea [^TextArea t update-fn _]
+(defmethod customize! TextArea [^TextArea t update-fn cancel-fn]
   (doto t
     (GridPane/setHgrow Priority/ALWAYS)
     (ui/auto-commit! update-fn)
-    (select-all-on-click!)))
+    (select-all-on-click!)
+    (ui/bind-key! "Esc" (fn []
+                          (cancel-fn t)
+                          (when-let [parent (.getParent t)]
+                            (.requestFocus parent))))))
 
 (defn- old-num->parse-num-fn [old-num]
   {:pre [(or (number? old-num) (nil? old-num))]}

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -48,7 +48,7 @@
            [javafx.fxml FXMLLoader]
            [javafx.geometry Orientation Point2D]
            [javafx.scene Group Node Parent Scene]
-           [javafx.scene.control ButtonBase Cell CheckBox CheckMenuItem ChoiceBox ColorPicker ComboBox ComboBoxBase ContextMenu Control Label Labeled ListView Menu MenuBar MenuItem MultipleSelectionModel ProgressBar SelectionMode SelectionModel Separator SeparatorMenuItem Tab TableView TabPane TextField TextInputControl Toggle ToggleButton Tooltip TreeItem TreeTableView TreeView]
+           [javafx.scene.control ButtonBase Cell CheckBox CheckMenuItem ChoiceBox ColorPicker ComboBox ComboBoxBase ContextMenu Control Label Labeled ListView Menu MenuBar MenuItem MultipleSelectionModel ProgressBar SelectionMode SelectionModel Separator SeparatorMenuItem Tab TableView TabPane TextArea TextField TextInputControl Toggle ToggleButton Tooltip TreeItem TreeTableView TreeView]
            [javafx.scene.image Image ImageView]
            [javafx.scene.input Clipboard ContextMenuEvent DragEvent KeyCode KeyCombination KeyEvent MouseButton MouseEvent]
            [javafx.scene.layout AnchorPane HBox Pane]
@@ -107,6 +107,9 @@
 
 (defprotocol HasAction
   (on-action! [this fn]))
+
+(defprotocol Cancellable
+  (on-cancel! [this cancel-fn]))
 
 (defprotocol HasValue
   (value [this])
@@ -750,14 +753,43 @@
   (value [this] (.getValue this))
   (value! [this val] (with-on-edit-event-suppressed! this (.setValue this val))))
 
+(declare bind-key!)
+
 (extend-type TextField
   HasAction
-  (on-action! [node fn]
+  (on-action! [node update-fn]
     (.setOnAction node (event-handler e
                          ;; Clear the auto-commit flag. Further edits will re-apply it.
                          (when (user-data node ::auto-commit)
                            (user-data! node ::auto-commit false))
-                         (fn e)))))
+                         (if (zero? (.getLength (.getSelection node)))
+                           (.selectAll node)
+                           (.deselect node))
+                         (update-fn e))))
+  Cancellable
+  (on-cancel! [node cancel-fn]
+    (bind-key! node "Esc" (fn []
+                            (cancel-fn node)
+                            (when-let [parent (.getParent node)]
+                              (.requestFocus parent))))))
+
+(extend-type TextArea
+  HasAction
+  (on-action! [node update-fn]
+    (bind-key! node "Shortcut+Enter" (fn []
+                                         ;; Clear the auto-commit flag. Further edits will re-apply it.
+                                         (when (user-data node ::auto-commit)
+                                           (user-data! node ::auto-commit false))
+                                         (update-fn node)
+                                         (if (zero? (.getLength (.getSelection node)))
+                                           (.selectAll node)
+                                           (.deselect node)))))
+  Cancellable
+  (on-cancel! [node cancel-fn]
+    (bind-key! node "Esc" (fn []
+                            (cancel-fn node)
+                            (when-let [parent (.getParent node)]
+                              (.requestFocus parent))))))
 
 (extend-type Labeled
   Text


### PR DESCRIPTION
Now, if a property is selected, the `Esc` button cancels uncommitted changes and unselects the property; the `Enter` button commits changes and selects the value. If the value is selected, it then unselects it.

Fix https://github.com/defold/defold/issues/7941