### PR TITLE
Editor: Support viewing library resources in Custom Code Editor

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -2030,7 +2030,7 @@ If you do not specifically require different script states, consider changing th
                       (custom-code-editor-executable-path-preference prefs))))]
          (let [cursor-range (:cursor-range opts)
                arg-tmpl (string/trim (if cursor-range (prefs/get-prefs prefs "code-open-file-at-line" "{file}:{line}") (prefs/get-prefs prefs "code-open-file" "{file}")))
-               arg-sub (cond-> {:file (resource/abs-path resource)}
+               arg-sub (cond-> {:file (resource/externally-available-absolute-path resource)}
                                cursor-range (assoc :line (CursorRange->line-number cursor-range)))
                args (->> (string/split arg-tmpl #" ")
                          (map #(substitute-args % arg-sub)))]

--- a/editor/src/clj/editor/engine.clj
+++ b/editor/src/clj/editor/engine.clj
@@ -200,7 +200,7 @@
     (let [dmengine-entry (.getEntry zip-file entry-name)
           stream (.getInputStream zip-file dmengine-entry)]
       (io/copy stream engine-file)
-      (fs/set-executable! engine-file)
+      (fs/set-executable! engine-file true)
       engine-file)))
 
 (defn- zip-entries! [^ZipFile zipfile]
@@ -247,7 +247,7 @@
       (fs/delete-directory! engine-dir {:missing :ignore})
       (fs/create-directories! engine-dir)
       (unpack-build-zip! engine-archive engine-dir)
-      (fs/set-executable! engine-file)
+      (fs/set-executable! engine-file true)
       (copy-dmengine-dependencies! engine-dir extender-platform)
       engine-file)))
 

--- a/editor/src/clj/editor/fs.clj
+++ b/editor/src/clj/editor/fs.clj
@@ -76,11 +76,11 @@
 (defn same-file? [^File file1 ^File file2]
   (same-path? (.toPath file1) (.toPath file2)))
 
-(defn set-executable! ^File [^File target]
-  (.setExecutable target true))
+(defn set-executable! [^File target executable]
+  (.setExecutable target executable))
 
-(defn set-writable! ^File [^File target]
-  (.setWritable target true))
+(defn set-writable! [^File target writable]
+  (.setWritable target writable))
 
 (defn locked-file?
   "Returns true if we are unable to read from or write to the target location.
@@ -157,7 +157,7 @@
   [target & body]
   `(try ~@body
         (catch AccessDeniedException ~'_
-          (set-writable! ~target)
+          (set-writable! ~target true)
           ~@body)))
 
 ;; delete


### PR DESCRIPTION
It is now possible to view library resources with the configured Custom Code Editor.

Fixes #4964

### Technical changes
* Added boolean argument to `fs/set-executable!` and `fs/set-writable!`.