### PR TITLE
Make sure that multifield values applied right 

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -240,7 +240,7 @@
                 update-fn (fn update-fn [_]
                             (let [property (property-fn)
                                   current-vals (properties/values property)
-                                  old-num (ffirst current-vals)
+                                  old-num (get (get current-vals 0) index)
                                   num (parse-num (.getText text-field) old-num)]
                               (if (and num (not= num old-num))
                                 (properties/set-values! property (mapv #(assoc % index num) current-vals))

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -769,10 +769,11 @@
   (on-action! [node update-fn]
     (.setOnAction node (event-handler e
                          (clear-auto-commit! node)
-                         (update-fn e)
-                         (if (zero? (.getLength (.getSelection node)))
-                           (.selectAll node)
-                           (.deselect node)))))
+                         (let [length (.getLength (.getSelection node))]
+                           (update-fn e)
+                           (if (zero? length)
+                             (.selectAll node)
+                             (.deselect node))))))
   Cancellable
   (on-cancel! [node cancel-fn]
     (bind-key! node "Esc" (fn []
@@ -785,11 +786,12 @@
   HasAction
   (on-action! [node update-fn]
     (bind-key! node "Shortcut+Enter" (fn []
-                                         (clear-auto-commit! node)
+                                       (clear-auto-commit! node)
+                                       (let [length (.getLength (.getSelection node))]
                                          (update-fn node)
-                                         (if (zero? (.getLength (.getSelection node)))
+                                         (if (zero? length)
                                            (.selectAll node)
-                                           (.deselect node)))))
+                                           (.deselect node))))))
   Cancellable
   (on-cancel! [node cancel-fn]
     (bind-key! node "Esc" (fn []


### PR DESCRIPTION
I missed the fact that we always take the first value for the multifield input. That the reason that values which are equal to the first value can't be applied to the rest of fields.

Fix https://github.com/defold/defold/issues/9147