### PR TITLE
Fix issue where HTML5 build reports `Unknown` instead of compilation shader errors

### DIFF
--- a/engine/dlib/src/dlib/log.cpp
+++ b/engine/dlib/src/dlib/log.cpp
@@ -38,6 +38,9 @@
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
 
 namespace dmLog
 {
@@ -303,11 +306,16 @@ static void DoLogPlatform(LogSeverity severity, const char* output, int output_l
 #endif
 
 #ifdef __EMSCRIPTEN__
+
         //Emscripten maps stderr to console.error and stdout to console.log.
         if (severity == LOG_SEVERITY_ERROR || severity == LOG_SEVERITY_FATAL){
-            fwrite(output, 1, output_len, stderr);
+            EM_ASM_({
+                Module.printErr(UTF8ToString($0));
+            }, output);
         } else {
-            fwrite(output, 1, output_len, stdout);
+            EM_ASM_({
+                Module.print(UTF8ToString($0));
+            }, output);
         }
 #elif !defined(ANDROID)
         fwrite(output, 1, output_len, stderr);

--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -1807,8 +1807,8 @@ static void LogFrameBufferError(GLenum status)
             glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &logLength);
             if (logLength > 0)
             {
-                GLchar *log = (GLchar *)malloc(logLength);
-                glGetShaderInfoLog(shader_id, logLength, &logLength, log);
+                log_str = (GLchar *)malloc(logLength);
+                glGetShaderInfoLog(shader_id, logLength, &logLength, log_str);
             }
 #endif
             if (error_buffer)


### PR DESCRIPTION
Fixed the issue where the HTML5 bundle reports `Unknown` instead of shader compilation errors. Additionally, as part of this fix, multiline output has been added for errors in HTML5 bundles.

Fix https://github.com/defold/defold/issues/9146

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
