### PR TITLE
Fix where a hash can be used as a regular string during concatenation in debug

### DIFF
--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -273,13 +273,14 @@ namespace dmScript
         return 1;
     }
 
-    static void PushStringHelper(dmAllocator* allocator, lua_State* L, int index)
+    static void PushStringHelper(lua_State* L, int index)
     {
         if (dmScript::IsHash(L, index))
         {
             char buffer[256];
             dmhash_t hash = *(dmhash_t*)lua_touserdata(L, index);
-            dmSnPrintf(buffer, sizeof(buffer), "[%s]", dmHashReverseSafe64Alloc(allocator, hash));
+            DM_HASH_REVERSE_MEM(hash_ctx, 256);
+            dmSnPrintf(buffer, sizeof(buffer), "[%s]", dmHashReverseSafe64Alloc(&hash_ctx, hash));
             lua_pushstring(L, buffer);
         }
         else
@@ -293,11 +294,8 @@ namespace dmScript
         // string .. hash
         // hash .. string
         // hash .. hash
-        DM_HASH_REVERSE_MEM(hash_ctx1, 256);
-        PushStringHelper(&hash_ctx1, L, 1);
-
-        DM_HASH_REVERSE_MEM(hash_ctx2, 256);
-        PushStringHelper(&hash_ctx2, L, 2);
+        PushStringHelper(L, 1);
+        PushStringHelper(L, 2);
 
         lua_concat(L, 2);
         return 1;

--- a/engine/script/src/script_hash.cpp
+++ b/engine/script/src/script_hash.cpp
@@ -266,21 +266,26 @@ namespace dmScript
         dmhash_t hash = CheckHash(L, 1);
         DM_HASH_REVERSE_MEM(hash_ctx, 64);
         const char* reverse = (const char*) dmHashReverseSafe64Alloc(&hash_ctx, hash);
-        char buffer[64];
+        char buffer[256];
         dmSnPrintf(buffer, sizeof(buffer), "%s: [%s]", SCRIPT_TYPE_NAME_HASH, reverse);
 
         lua_pushstring(L, buffer);
         return 1;
     }
 
-    static const char* GetStringHelper(dmAllocator* allocator, lua_State* L, int index)
+    static void PushStringHelper(dmAllocator* allocator, lua_State* L, int index)
     {
         if (dmScript::IsHash(L, index))
         {
+            char buffer[256];
             dmhash_t hash = *(dmhash_t*)lua_touserdata(L, index);
-            return dmHashReverseSafe64Alloc(allocator, hash);
+            dmSnPrintf(buffer, sizeof(buffer), "[%s]", dmHashReverseSafe64Alloc(allocator, hash));
+            lua_pushstring(L, buffer);
         }
-        return luaL_checkstring(L, index);
+        else
+        {
+            lua_pushstring(L, luaL_checkstring(L, index));
+        }
     }
 
     static int Script_concat(lua_State *L)
@@ -289,13 +294,11 @@ namespace dmScript
         // hash .. string
         // hash .. hash
         DM_HASH_REVERSE_MEM(hash_ctx1, 256);
-        const char* s1 = GetStringHelper(&hash_ctx1, L, 1);
+        PushStringHelper(&hash_ctx1, L, 1);
 
         DM_HASH_REVERSE_MEM(hash_ctx2, 256);
-        const char* s2 = GetStringHelper(&hash_ctx2, L, 2);
+        PushStringHelper(&hash_ctx2, L, 2);
 
-        lua_pushstring(L, s1);
-        lua_pushstring(L, s2);
         lua_concat(L, 2);
         return 1;
     }

--- a/engine/script/src/test/test_script_hash.cpp
+++ b/engine/script/src/test/test_script_hash.cpp
@@ -88,11 +88,11 @@ TEST_F(ScriptHashTest, TestHashUnknown)
         // string .. tostring(hash)
         "test('concat: ' .. tostring(test_hash), 'concat: hash: [<unknown:1234>]')\n"
         // string .. hash
-        "test('concat: ' .. test_hash,           'concat: <unknown:1234>')\n"
+        "test('concat: ' .. test_hash,           'concat: [<unknown:1234>]')\n"
         // hash .. string
-        "test(test_hash .. ' :concat',           '<unknown:1234> :concat')\n"
+        "test(test_hash .. ' :concat',           '[<unknown:1234>] :concat')\n"
         // hash .. hash
-        "test(test_hash .. test_hash,            '<unknown:1234><unknown:1234>')\n";
+        "test(test_hash .. test_hash,            '[<unknown:1234>][<unknown:1234>]')\n";
     ASSERT_TRUE(RunString(L, script));
 
     lua_getglobal(L, "test_fail");


### PR DESCRIPTION
Fix the issue where this construction produces a valid URL in debug:
```lua
local id = factory.create("#factory")
local broken_path = "main:"..id.."#sprite"
--- main:/go#sprite
```
Hash reverse strings don't exist in release build, and the fact that it works in debug may cause confusion.
With this fix, the result of concatenation can't be used as a valid URL:
```lua
--- main:[/go]#sprite
```

Fix https://github.com/defold/defold/issues/9084

## PR checklist

* [ ] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
