### PR TITLE
Editor: Ensure correct numeric types in settings-based file formats

### DIFF
--- a/editor/src/clj/editor/settings_core.clj
+++ b/editor/src/clj/editor/settings_core.clj
@@ -132,10 +132,12 @@
   (= raw "1"))
 
 (defmethod parse-setting-value :integer [_ raw]
+  ;; Parsed as 32-bit integer in the engine runtime.
   (Integer/parseInt raw))
 
 (defmethod parse-setting-value :number [_ raw]
-  (Double/parseDouble raw))
+  ;; Parsed as 32-bit float in the engine runtime.
+  (Float/parseFloat raw))
 
 (defmethod parse-setting-value :resource [_ raw]
   raw)
@@ -175,39 +177,51 @@
    :comma-separated-list []
    :string ""
    :boolean false
-   :integer 0
-   :number 0.0})
+   :integer (int 0) ; Parsed as 32-bit integer in the engine runtime.
+   :number (float 0.0)}) ; Parsed as 32-bit float in the engine runtime.
 
-(defn- add-type-defaults [meta-info]
-  (update-in meta-info [:settings]
-             (partial map (fn [setting] (update setting :default #(if (nil? %) (type-defaults (:type setting)) %))))))
+(defn- sanitize-default [default type]
+  (case type
+    :integer (int default) ; Parsed as 32-bit integer in the engine runtime.
+    :number (float default) ; Parsed as 32-bit float in the engine runtime.
+    default))
+
+(defn- ensure-type-defaults [meta-info]
+  (update meta-info :settings
+          (fn [settings]
+            (mapv (fn [{:keys [type] :as meta-setting}]
+                    (update meta-setting :default
+                            (fn [default]
+                              (if (some? default)
+                                (sanitize-default default type)
+                                (type-defaults type)))))
+                  settings))))
 
 (declare render-raw-setting-value)
 
 (defn- add-to-from-string [meta-info]
-  (update-in meta-info [:settings]
-             (fn [settings]
-               (map (fn [meta-setting]
-                      (if (contains? meta-setting :options)
-                        (assoc meta-setting
-                          :from-string #(parse-setting-value meta-setting %)
-                          :to-string #(render-raw-setting-value meta-setting %))
-                        meta-setting))
-                    settings))))
+  (update meta-info :settings
+          (fn [settings]
+            (mapv (fn [meta-setting]
+                    (if (contains? meta-setting :options)
+                      (assoc meta-setting
+                        :from-string #(parse-setting-value meta-setting %)
+                        :to-string #(render-raw-setting-value meta-setting %))
+                      meta-setting))
+                  settings))))
 
 (defn remove-to-from-string [meta-info]
-  (update-in meta-info [:settings]
-             (fn [settings]
-               (map (fn [meta-setting]
-                      (if (contains? meta-setting :options)
-                        (let [type (:type meta-setting)]
-                          (dissoc meta-setting :from-string :to-string))
-                        meta-setting))
-                    settings))))
+  (update meta-info :settings
+          (fn [settings]
+            (mapv (fn [meta-setting]
+                    (if (contains? meta-setting :options)
+                      (dissoc meta-setting :from-string :to-string)
+                      meta-setting))
+                  settings))))
 
 (defn finalize-meta-info [meta-info]
   (-> meta-info
-      add-type-defaults
+      ensure-type-defaults
       add-to-from-string))
 
 (defn load-meta-info [reader]


### PR DESCRIPTION
This PR ensures we always use 32-bit integer and floating point values for numeric settings inside settings-based file formats. Before this change, it was inconsistent, and editing an integer field would throw an exception due to a type mismatch between the default, read as a 64-bit `long` from an `.edn` file, and the parsed 32-bit `int` produced by the text field. The mismatch caused us to try to replace the `StringConverter` we configured for the default `long` value with a different `StringConverter` configured to handle `int` values for the edited field, which isn't allowed.

The change ensures we use 32-bit numbers throughout all interactions with settings files.

Fixes #9169