### PR TITLE
Added the ability for tables to change their width in form view to improve material editing

### DIFF
--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -417,8 +417,6 @@
     {:fx/type fx.combo-box/lifecycle
      :style-class ["combo-box" "combo-box-base" "cljfx-form-combo-box"]
      :value value
-     :pref-width :use-computed-size
-     :min-width  small-max-width
      :on-value-changed on-value-changed
      :converter (proxy [StringConverter] []
                   (toString

--- a/editor/src/clj/editor/cljfx_form_view.clj
+++ b/editor/src/clj/editor/cljfx_form_view.clj
@@ -69,6 +69,10 @@
 
 (def ^:private cell-height (inc line-height))
 
+(def ^:private small-max-width 120)
+(def ^:private normal-max-width 400)
+(def ^:private large-max-width 1000)
+
 (g/defnk produce-form-view [renderer form-data ui-state]
   (renderer {:form-data form-data
              :ui-state ui-state})
@@ -252,6 +256,7 @@
 
 (defmethod form-input-view :string [{:keys [value on-value-changed]}]
   {:fx/type text-field
+   :max-width normal-max-width
    :text-formatter {:fx/type fx.text-formatter/lifecycle
                     :value-converter :default
                     :value value
@@ -277,12 +282,12 @@
 
 ;; region integer input
 
-(defmethod form-input-view :integer [{:keys [value on-value-changed] :as field}]
+(defmethod form-input-view :integer [{:keys [value on-value-changed custom-max-width] :as field}]
   (let [value (ensure-value value field)
         value-converter (number-string-converter value)]
     {:fx/type text-field
      :alignment :center-right
-     :max-width 80
+     :max-width (or custom-max-width small-max-width)
      :text-formatter {:fx/type fx.text-formatter/lifecycle
                       :value-converter value-converter
                       :value value
@@ -295,12 +300,12 @@
 
 ;; region number input
 
-(defmethod form-input-view :number [{:keys [value on-value-changed] :as field}]
+(defmethod form-input-view :number [{:keys [value on-value-changed custom-max-width] :as field}]
   (let [value (ensure-value value field)
         value-converter (number-string-converter value)]
     {:fx/type text-field
      :alignment :center-right
-     :max-width 80
+     :max-width (or custom-max-width small-max-width)
      :text-formatter {:fx/type fx.text-formatter/lifecycle
                       :value-converter value-converter
                       :value value
@@ -319,6 +324,7 @@
 
 (defmethod form-input-view :url [{:keys [value on-value-changed]}]
   {:fx/type text-field
+   :max-width normal-max-width
    :text-formatter {:fx/type fx.text-formatter/lifecycle
                     :value-converter uri-string-converter
                     :value value
@@ -353,6 +359,7 @@
                                      {:fx/type form-input-view
                                       :type :number
                                       :h-box/hgrow :always
+                                      :custom-max-width normal-max-width
                                       :value n
                                       :on-value-changed {:event-type :on-vec4-element-change
                                                          :on-value-changed on-value-changed
@@ -410,6 +417,8 @@
     {:fx/type fx.combo-box/lifecycle
      :style-class ["combo-box" "combo-box-base" "cljfx-form-combo-box"]
      :value value
+     :pref-width :use-computed-size
+     :min-width  small-max-width
      :on-value-changed on-value-changed
      :converter (proxy [StringConverter] []
                   (toString
@@ -603,6 +612,7 @@
                           :desc
                           {:fx/type fx.list-view/lifecycle
                            :style-class ["list-view" "cljfx-form-list-view"]
+                           :max-width normal-max-width
                            :items (into [] (map-indexed vector) value)
                            :editable true
                            :on-edit-start {:event-type :on-list-edit-start
@@ -661,6 +671,7 @@
                                    :or {value []}
                                    :as field}]
   (assoc field :fx/type list-input
+               :max-width normal-max-width
                :on-edited {:event-type :edit-list-item
                            :value value
                            :on-value-changed on-value-changed}
@@ -691,6 +702,7 @@
                                               resource-string-converter]}]
   {:fx/type fx.h-box/lifecycle
    :spacing 4
+   :max-width normal-max-width
    :children [{:fx/type text-field
                :h-box/hgrow :always
                :text-formatter {:fx/type fx.text-formatter/lifecycle
@@ -734,6 +746,7 @@
 (defmethod form-input-view :file [{:keys [on-value-changed value filter title in-project]}]
   {:fx/type fx.h-box/lifecycle
    :spacing 4
+   :max-width normal-max-width
    :children [{:fx/type text-field
                :h-box/hgrow :always
                :text-formatter {:fx/type fx.text-formatter/lifecycle
@@ -761,6 +774,7 @@
 (defmethod form-input-view :directory [{:keys [on-value-changed value title in-project]}]
   {:fx/type fx.h-box/lifecycle
    :spacing 4
+   :max-width normal-max-width
    :children [{:fx/type text-field
                :h-box/hgrow :always
                :text-formatter {:fx/type fx.text-formatter/lifecycle
@@ -876,6 +890,7 @@
       (-> column
           (assoc :fx/type cell-input-view
                  :value item
+                 :custom-max-width normal-max-width
                  :on-value-changed {:event-type :keep-table-edit
                                     :state-path state-path}
                  :on-cancel {:event-type :cancel-table-edit
@@ -1277,7 +1292,7 @@
                                                  {:fx/type fx.column-constraints/lifecycle
                                                   :hgrow :always
                                                   :min-width 200
-                                                  :max-width 400}]
+                                                  :max-width large-max-width}]
                             :children (first
                                         (reduce
                                           (fn [[acc row] field]


### PR DESCRIPTION
Fixed the issue where the table view in form view had a very small maximum width, making it difficult to edit materials and leaving most of the widescreen empty.

Fix https://github.com/defold/defold/issues/7622
Fix https://github.com/defold/defold/issues/6413

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
