### PR TITLE
Better ux for tilemap editor

### DIFF
--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -177,9 +177,7 @@
      :height height
      :tiles tiles}))
 
-(def erase-brush (make-brush nil))
-
-(def ^:private empty-brush {:width 1 :height 1 :tiles [{:tile nil :h-flip false :v-flip false :rotate90 false}]})
+(def ^:private empty-brush (make-brush nil))
 
 (defn flip-brush-horizontally
   [brush]
@@ -864,7 +862,7 @@
 
 (def ^:private clamp-palette-mouse-offset (geom/clamper -0.5 0.5))
 
-(def ^:private select-mods #{:select-mode :cut-mode :erase-mode})
+(def ^:private select-modes #{:select-mode :cut-mode :erase-mode})
 
 (defn- make-palette-transform
   [tile-source-attributes viewport ^Vector3d cursor-screen-pos]
@@ -1153,7 +1151,7 @@
                         [{:world-transform (:world-transform active-layer-renderable)
                           :render-fn render-editor
                           :user-data {:cell current-tile
-                                      :brush (if (contains? select-mods cursor-mode)
+                                      :brush (if (contains? select-modes cursor-mode)
                                                empty-brush
                                                brush)
                                       :tile-dimensions tile-dimensions
@@ -1173,7 +1171,7 @@
                     [{:world-transform (:world-transform active-layer-renderable)
                       :render-fn render-editor
                       :user-data {:cell current-tile
-                                  :brush (if (contains? select-mods cursor-mode)
+                                  :brush (if (contains? select-modes cursor-mode)
                                            empty-brush
                                            brush)
                                   :color (case cursor-mode
@@ -1457,7 +1455,7 @@
   (run [selection user-data] (add-layer-handler (selection->tile-map selection))))
 
 (defn- erase-tool-handler [tool-controller]
-  (g/set-property! tool-controller :brush erase-brush))
+  (g/set-property! tool-controller :brush empty-brush))
 
 (defn- active-tile-map [app-view evaluation-context]
   (when-let [resource-node (g/node-value app-view :active-resource-node evaluation-context)]

--- a/editor/src/clj/editor/tile_map.clj
+++ b/editor/src/clj/editor/tile_map.clj
@@ -759,7 +759,7 @@
 (def color-shader (shader/make-shader ::color-shader pos-color-vert pos-color-frag))
 
 (def ^:private white-color (double-array (map #(/ % 255.0) [255 255 255])))
-(def ^:private blue-color (double-array (map #(/ % 255.0) [0 191 255]  )))
+(def ^:private blue-color (double-array (map #(/ % 255.0) [0 191 255])))
 (def ^:private red-color (double-array (map #(/ % 255.0) [255 0 0])))
 (def ^:private orange-color (double-array (map #(/ % 255.0) [255 140 0])))
 


### PR DESCRIPTION
I spited logic `op` from `cursor-mode` to be more flexible. It's still not perfect, but it is preparation work to make it great when we have Alt/Ctrl/Shirt events.

Also, I added color differentiation between mods to make sure selection mode is differed from paint mode