### PR TITLE
Only trigger mouse wheel up/down events if they're in the correct direction

### DIFF
--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -653,6 +653,10 @@ namespace dmInput
         }
         if (binding->m_MouseBinding != 0x0)
         {
+            bool is_wheel_offsets = false; // glfw 2.x
+            #if defined(DM_INPUT_USE_GLFW3)
+                is_wheel_offsets = true; // glfw 3, the wheel scroll is offsets
+            #endif
             MouseBinding* mouse_binding = binding->m_MouseBinding;
             dmHID::MousePacket* packet = &mouse_binding->m_Packet;
             dmHID::MousePacket* prev_packet = &mouse_binding->m_PreviousPacket;
@@ -671,13 +675,27 @@ namespace dmInput
                     switch (trigger.m_Input)
                     {
                     case dmInputDDF::MOUSE_WHEEL_UP:
-                        if (packet->m_Wheel > 0)
+                        if (is_wheel_offsets)
+                        {
+                            if (packet->m_Wheel > 0)
+                            {
+                                v = (float) (packet->m_Wheel - prev_packet->m_Wheel);
+                            }
+                        }
+                        else
                         {
                             v = (float) (packet->m_Wheel - prev_packet->m_Wheel);
                         }
                         break;
                     case dmInputDDF::MOUSE_WHEEL_DOWN:
-                        if (packet->m_Wheel < 0)
+                        if (is_wheel_offsets)
+                        {
+                            if (packet->m_Wheel < 0)
+                            {
+                                v = (float) -(packet->m_Wheel - prev_packet->m_Wheel);
+                            }
+                        }
+                        else
                         {
                             v = (float) -(packet->m_Wheel - prev_packet->m_Wheel);
                         }

--- a/engine/input/src/input.cpp
+++ b/engine/input/src/input.cpp
@@ -671,10 +671,16 @@ namespace dmInput
                     switch (trigger.m_Input)
                     {
                     case dmInputDDF::MOUSE_WHEEL_UP:
-                        v = (float) (packet->m_Wheel - prev_packet->m_Wheel);
+                        if (packet->m_Wheel > 0)
+                        {
+                            v = (float) (packet->m_Wheel - prev_packet->m_Wheel);
+                        }
                         break;
                     case dmInputDDF::MOUSE_WHEEL_DOWN:
-                        v = (float) -(packet->m_Wheel - prev_packet->m_Wheel);
+                        if (packet->m_Wheel < 0)
+                        {
+                            v = (float) -(packet->m_Wheel - prev_packet->m_Wheel);
+                        }
                         break;
                     default:
                         v = dmHID::GetMouseButton(packet, MOUSE_BUTTON_MAP[trigger.m_Input]) ? 1.0f : 0.0f;

--- a/engine/input/src/wscript
+++ b/engine/input/src/wscript
@@ -5,8 +5,14 @@ def configure(conf):
     pass
 
 def build(bld):
+
+    defines = []
+    if bld.env.PLATFORM in ['arm64-macos', 'x86_64-macos']:
+        defines = ['DM_INPUT_USE_GLFW3']
+
     lib = bld.stlib(features        = 'cxx c ddf',
                     includes        = '../proto .',
+                    defines         = defines,
                     target          = 'input',
                     source          = bld.path.ant_glob('input.cpp') + bld.path.parent.ant_glob('proto/input/*'),
                     proto_gen_py    = True,


### PR DESCRIPTION
Fixes https://github.com/defold/defold/issues/9129

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
