### PR TITLE
Fix issue when the first single value input into a property field right after the property reset may be lost

### DIFF
--- a/editor/src/clj/editor/properties_view.clj
+++ b/editor/src/clj/editor/properties_view.clj
@@ -663,7 +663,6 @@
                     (ui/add-styles! ["clear-button" "button-small"])
                     (ui/on-action! (fn [_]
                                      (properties/clear-override! (property-fn key))
-                                     (ui/suppress-auto-commit! control)
                                      (.requestFocus control))))
 
         label-box (let [box (GridPane.)]

--- a/editor/src/clj/editor/ui.clj
+++ b/editor/src/clj/editor/ui.clj
@@ -577,12 +577,7 @@
                                     (when (user-data node ::auto-commit)
                                       (commit-fn nil)))))
   (on-edit! node (fn [_old _new]
-                   (if (user-data node ::suppress-auto-commit)
-                     (user-data! node ::suppress-auto-commit false)
-                     (user-data! node ::auto-commit true)))))
-
-(defn suppress-auto-commit! [^Node node]
-  (user-data! node ::suppress-auto-commit true))
+                   (user-data! node ::auto-commit true))))
 
 (defn- clear-auto-commit! [^Node node]
   ;; Clear the auto-commit flag. You should call this whenever data has been


### PR DESCRIPTION
Fix the issue where a property value was reset and immediately replaced with a single input value, which would not be saved after the field is unfocused.

Fix https://github.com/defold/defold/issues/9182