### PR TITLE
Add 'types' script module for checking Defold userdata types.

### DIFF
--- a/editor/src/clj/editor/app_manifest.clj
+++ b/editor/src/clj/editor/app_manifest.clj
@@ -325,6 +325,11 @@
       (exclude-libs-toggles all-platforms ["liveupdate"])
       (libs-toggles all-platforms ["liveupdate_null"]))))
 
+(def types-setting
+  (make-check-box-setting
+    (concat
+      (generic-contains-toggles all-platforms :excludeSymbols ["ScriptTypesExt"]))))
+
 (def basis-transcoder-setting
   (make-check-box-setting
     (concat
@@ -481,6 +486,10 @@
             (dynamic edit-type (g/constantly {:type g/Bool}))
             (value (setting-property-getter image-setting))
             (set (setting-property-setter image-setting)))
+  (property exclude-types g/Any
+            (dynamic edit-type (g/constantly {:type g/Bool}))
+            (value (setting-property-getter types-setting))
+            (set (setting-property-setter types-setting)))
   (property exclude-basis-transcoder g/Any
             (dynamic edit-type (g/constantly {:type g/Bool}))
             (value (setting-property-getter basis-transcoder-setting))

--- a/editor/src/clj/editor/lua.clj
+++ b/editor/src/clj/editor/lua.clj
@@ -35,7 +35,7 @@
    "html5" "http" "image" "io" "json" "label" "liveupdate" "math" "model" "msg"
    "os" "package" "particlefx" "physics" "profiler" "render" "resource"
    "socket" "sound" "sprite" "string" "sys" "table" "tilemap" "timer" "vmath"
-   "window" "zlib"])
+   "window" "zlib" "types"])
 
 (defn- sdoc-path [doc]
   (format "doc/%s_doc.sdoc" doc))

--- a/engine/docs/src/script_doc.py
+++ b/engine/docs/src/script_doc.py
@@ -501,7 +501,7 @@ def add_group_to_doc_dict(doc_dict):
         refdocgroups = [
             {
                 "group": "SYSTEM",
-                "namespaces": ["crash", "gui", "go", "graphics", "profiler", "render", "resource", "sys", "window", "engine", "physics", "b2d", "b2d.body"]
+                "namespaces": ["crash", "gui", "go", "graphics", "profiler", "render", "resource", "sys", "window", "engine", "physics", "b2d", "b2d.body", "types"]
             },
             {
                 "group": "COMPONENTS",

--- a/engine/engine/src/wscript
+++ b/engine/engine/src/wscript
@@ -62,7 +62,7 @@ def build(bld):
                              'ResourceProviderFile', 'ResourceProviderArchive', 'ResourceProviderArchiveMutable', 'ResourceProviderZip']
     component_type_symbols = ['ComponentTypeAnim', 'ComponentTypeScript', 'ComponentTypeGui', 'ComponentTypeMesh']
 
-    exported_symbols = ['DefaultSoundDevice', 'AudioDecoderWav', 'CrashExt', 'ProfilerExt', 'LiveUpdateExt', 'ScriptBox2DExt', 'ScriptImageExt', 'ScriptModelExt']
+    exported_symbols = ['DefaultSoundDevice', 'AudioDecoderWav', 'CrashExt', 'ProfilerExt', 'LiveUpdateExt', 'ScriptBox2DExt', 'ScriptImageExt', 'ScriptModelExt', 'ScriptTypesExt']
 
     # Add stb_vorbis and/or tremolo depending on platform
     if bld.env['PLATFORM'] in ('arm64-nx64', 'win32', 'x86_64-win32', 'js-web', 'wasm-web'):
@@ -195,7 +195,7 @@ def build(bld):
     obj = bld(
         features = 'c cxx cprogram apk web extract_symbols',
         use = 'RECORD_NULL GAMEOBJECT DDF LIVEUPDATE GAMESYS RESOURCE PHYSICS RENDER SOCKET SCRIPT LUA EXTENSION HID_NULL INPUT PARTICLE PLATFORM_NULL RIG GUI CRASH DLIB SOUND_NULL engine engine_service'.split() + graphics_lib.split() + profile_lib + additional_libs,
-        exported_symbols = ['ProfilerExt', 'LiveUpdateExt', 'GraphicsAdapterNull'] + resource_type_symbols + component_type_symbols,
+        exported_symbols = ['ProfilerExt', 'LiveUpdateExt', 'ScriptTypesExt', 'GraphicsAdapterNull'] + resource_type_symbols + component_type_symbols,
         web_libs = web_libs,
         includes = '../build ../proto . ..',
         proto_gen_py = True,

--- a/engine/script/src/script_types.cpp
+++ b/engine/script/src/script_types.cpp
@@ -1,0 +1,159 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <extension/extension.h>
+#include "script.h"
+
+extern "C"
+{
+#include <lua/lua.h>
+#include <lua/lauxlib.h>
+}
+
+#define LIB_NAME "types"
+
+namespace dmScript
+{
+    /*# Types API documentation
+     *
+     * Functions for checking Defold userdata types.
+     *
+     * @document
+     * @name Types
+     * @namespace types
+     */
+
+    /*# Check if passed type is vector.
+    *
+    * @name types.is_vector
+    * @param var [type:any] Variable to check type
+    * 
+    * @note 'vector3' and 'vector4' types is not a 'vector' type under the hood. 
+    * So if called `types.is_vector(vmath.vector3())` it returns 'false'
+    *
+    * @return result [type:boolean] True if passed type is vector
+    */
+    static int Types_IsVector(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsVector(L, 1));
+        return 1;
+    }
+
+    /*# Check if passed type is matrix4.
+    *
+    * @name types.is_matrix4
+    * @param var [type:any] Variable to check type
+    *
+    * @return result [type:boolean] True if passed type is matrix4
+    */
+    static int Types_IsMatrix4(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsMatrix4(L, 1));
+        return 1;
+    }
+
+    /*# Check if passed type is vector3.
+    *
+    * @name types.is_vector3
+    * @param var [type:any] Variable to check type
+    *
+    * @return result [type:boolean] True if passed type is vector3
+    */
+    static int Types_IsVector3(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsVector3(L, 1));
+        return 1;
+    }
+
+    /*# Check if passed type is vector4.
+    *
+    * @name types.is_vector4
+    * @param var [type:any] Variable to check type
+    *
+    * @return result [type:boolean] True if passed type is vector4
+    */
+    static int Types_IsVector4(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsVector4(L, 1));
+        return 1;
+    }
+
+    /*# Check if passed type is quaternion.
+    *
+    * @name types.is_quat
+    * @param var [type:any] Variable to check type
+    *
+    * @return result [type:boolean] True if passed type is quaternion
+    */
+    static int Types_IsQuat(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsQuat(L, 1));
+        return 1;
+    }
+
+    /*# Check if passed type is hash.
+    *
+    * @name types.is_hash
+    * @param var [type:any] Variable to check type
+    *
+    * @return result [type:boolean] True if passed type is hash
+    */
+    static int Types_IsHash(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsHash(L, 1));
+        return 1;
+    }
+
+    /*# Check if passed type is URL.
+    *
+    * @name types.is_url
+    * @param var [type:any] Variable to check type
+    *
+    * @return result [type:boolean] True if passed type is URL
+    */
+    static int Types_IsUrl(lua_State* L)
+    {
+        lua_pushboolean(L, dmScript::IsURL(L, 1));
+        return 1;
+    }
+
+    static const luaL_reg Types_methods[] =
+    {
+        { "is_vector", Types_IsVector },
+        { "is_matrix4", Types_IsMatrix4 },
+        { "is_vector3", Types_IsVector3 },
+        { "is_vector4", Types_IsVector4 },
+        { "is_quat", Types_IsQuat },
+        { "is_hash", Types_IsHash },
+        { "is_url", Types_IsUrl },
+        {0, 0}
+    };
+
+    static dmExtension::Result ScriptTypesInitialize(dmExtension::Params* params)
+    {
+        lua_State* L = params->m_L;
+        int top = lua_gettop(L);
+        luaL_register(L, LIB_NAME, Types_methods);
+        lua_pop(L, 1);
+        assert(top == lua_gettop(L));
+        return dmExtension::RESULT_OK;
+    }
+
+    static dmExtension::Result ScriptTypesFinalize(dmExtension::Params* params)
+    {
+        return dmExtension::RESULT_OK;
+    }
+}
+
+DM_DECLARE_EXTENSION(ScriptTypesExt, "ScriptTypes", 0, 0, dmScript::ScriptTypesInitialize, 0, 0, dmScript::ScriptTypesFinalize)

--- a/engine/script/src/test/test_script_types.cpp
+++ b/engine/script/src/test/test_script_types.cpp
@@ -1,0 +1,57 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "script.h"
+#include "test_script.h"
+
+#include <testmain/testmain.h>
+#include <dlib/log.h>
+
+class ScriptTypesTest : public dmScriptTest::ScriptTest
+{
+};
+
+TEST_F(ScriptTypesTest, TestTypes)
+{
+    int top = lua_gettop(L);
+
+    ASSERT_TRUE(RunFile(L, "test_types.luac"));
+
+    lua_getglobal(L, "functions");
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    lua_getfield(L, -1, "test_types");
+    ASSERT_EQ(LUA_TFUNCTION, lua_type(L, -1));
+    int result = dmScript::PCall(L, 0, LUA_MULTRET);
+    if (result == LUA_ERRRUN)
+    {
+        ASSERT_TRUE(false);
+    }
+    else
+    {
+        ASSERT_EQ(0, result);
+    }
+    lua_pop(L, 1);
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+extern "C" void dmExportedSymbols();
+
+int main(int argc, char **argv)
+{
+    dmExportedSymbols();
+    TestMainPlatformInit();
+    jc_test_init(&argc, argv);
+    return jc_test_run_all();
+}

--- a/engine/script/src/test/test_script_types_null.cpp
+++ b/engine/script/src/test/test_script_types_null.cpp
@@ -1,0 +1,57 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "script.h"
+#include "test_script.h"
+
+#include <testmain/testmain.h>
+#include <dlib/log.h>
+
+class ScriptTypesNullTest : public dmScriptTest::ScriptTest
+{
+};
+
+TEST_F(ScriptTypesNullTest, TestTypes)
+{
+    int top = lua_gettop(L);
+
+    ASSERT_TRUE(RunFile(L, "test_types.luac"));
+
+    lua_getglobal(L, "functions");
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    lua_getfield(L, -1, "test_excluded_types");
+    ASSERT_EQ(LUA_TFUNCTION, lua_type(L, -1));
+    int result = dmScript::PCall(L, 0, LUA_MULTRET);
+    if (result == LUA_ERRRUN)
+    {
+        ASSERT_TRUE(false);
+    }
+    else
+    {
+        ASSERT_EQ(0, result);
+    }
+    lua_pop(L, 1);
+
+    ASSERT_EQ(top, lua_gettop(L));
+}
+
+extern "C" void dmExportedSymbols();
+
+int main(int argc, char **argv)
+{
+    dmExportedSymbols();
+    TestMainPlatformInit();
+    jc_test_init(&argc, argv);
+    return jc_test_run_all();
+}

--- a/engine/script/src/test/test_types.lua
+++ b/engine/script/src/test/test_types.lua
@@ -1,0 +1,106 @@
+-- Copyright 2020-2024 The Defold Foundation
+-- Copyright 2014-2020 King
+-- Copyright 2009-2014 Ragnar Svensson, Christian Murray
+-- Licensed under the Defold License version 1.0 (the "License"); you may not use
+-- this file except in compliance with the License.
+-- 
+-- You may obtain a copy of the License, together with FAQs at
+-- https://www.defold.com/license
+-- 
+-- Unless required by applicable law or agreed to in writing, software distributed
+-- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+
+function test_types()
+    -- check urls
+    local empty_url = msg.url()
+    local url = msg.url("main_collection", "/hero", "right_hand")
+    local url_from_str = msg.url("main_collection:/hero2#left_hand")
+
+    assert(types.is_url(empty_url), "Variable should be url")
+    assert(types.is_url(url), "Variable should be url")
+    assert(types.is_url(url_from_str), "Variable should be url")
+
+    -- check vectors
+    local empty_vector = vmath.vector()
+    local vector = vmath.vector({ 1, 2, 4 })
+    local long_vector = vmath.vector({ 10, 14, 19, -20, -11, -2, 132 })
+
+    assert(types.is_vector(empty_vector), "Variable should be vector")
+    assert(types.is_vector(vector), "Variable should be vector")
+    assert(types.is_vector(long_vector), "Variable should be vector")
+
+    -- check vector3
+    local empty_vector3 = vmath.vector3()
+    local non_empty_vector3 = vmath.vector3(13, 14.5, -7)
+
+    assert(types.is_vector3(empty_vector3), "Variable should be vector3")
+    assert(types.is_vector3(non_empty_vector3), "Variable should be vector3")
+
+    -- check vector4
+    local empty_vector4 = vmath.vector4()
+    local non_empty_vector4 = vmath.vector4(33, -90, 34.2, 1.0)
+
+    assert(types.is_vector4(empty_vector4), "Variable should be vector4")
+    assert(types.is_vector4(non_empty_vector4), "Variable should be vector4")
+
+    -- check matrix
+    local identity_matrix = vmath.matrix4()
+    local non_empty_matrix = vmath.matrix4_translation(non_empty_vector3)
+
+    assert(types.is_matrix4(identity_matrix), "Variable should be matrix")
+    assert(types.is_matrix4(non_empty_matrix), "Variable should be matrix")
+
+    -- check quat
+    local empty_quat = vmath.quat()
+    local non_empty_quat = vmath.quat(1, 2, 3, 4)
+
+    assert(types.is_quat(empty_quat), "Variable should be quaternion")
+    assert(types.is_quat(non_empty_quat), "Variable should be quaternion")
+
+    -- check hash
+    local test_hash = hash("some_foo_text")
+
+    assert(types.is_hash(test_hash), "Variable should be hash")
+
+    -- check negative cases
+    assert(not types.is_vector(non_empty_vector3), "Variable shouldn't be vector")
+    assert(not types.is_vector(non_empty_vector4), "Variable shouldn't be vector")
+    assert(not types.is_vector3(non_empty_matrix), "Variable shouldn't be vector3")
+    assert(not types.is_hash(non_empty_quat), "Variable shouldn't be hash")
+    assert(not types.is_quat(non_empty_vector3), "Variable shouldn't be quaternion")
+    assert(not types.is_url(long_vector), "Variable shouldn't be url")
+    assert(not types.is_matrix4(test_hash), "Variable shouldn't be matrix")
+    assert(not types.is_vector4(identity_matrix), "Variable shouldn't be vector4")
+
+    -- check empty arg
+    assert(not types.is_vector(), "Empty arg is not vector")
+    assert(not types.is_vector(), "Empty arg is not vector")
+    assert(not types.is_vector3(), "Empty arg is not vector3")
+    assert(not types.is_hash(), "Empty arg is not hash")
+    assert(not types.is_quat(), "Empty arg is not quaternion")
+    assert(not types.is_url(), "Empty arg is not url")
+    assert(not types.is_matrix4(), "Empty arg is not matrix")
+    assert(not types.is_vector4(), "Empty arg is not vector4")
+
+    -- check nil
+    assert(not types.is_vector(nil), "Nil is not vector")
+    assert(not types.is_vector(nil), "Nil is not vector")
+    assert(not types.is_vector3(nil), "Nil is not vector3")
+    assert(not types.is_hash(nil), "Nil is not hash")
+    assert(not types.is_quat(nil), "Nil is not quaternion")
+    assert(not types.is_url(nil), "Nil is not url")
+    assert(not types.is_matrix4(nil), "Nil is not matrix")
+    assert(not types.is_vector4(nil), "Nil is not vector4")
+
+    print("Types test done")
+end
+
+function test_excluded_types()
+    -- check error when we exclude types script API
+    assert(not types, "'types' modules shouldn't exist")
+    print("Types null test done")
+end
+
+functions = { test_types = test_types, test_excluded_types = test_excluded_types }

--- a/engine/script/src/test/wscript
+++ b/engine/script/src/test/wscript
@@ -161,5 +161,23 @@ def build(bld):
                                        target = 'test_script_bitop',
                                        source = 'test_script_bitop.cpp test_bitop.lua'.split())
 
+    test_script_types = bld.program(features = flist,
+                                       includes = '..',
+                                       use = libs,
+                                       web_libs = web_libs,
+                                       exported_symbols = exported_symbols + ['ScriptTypesExt'],
+                                       proto_gen_py = True,
+                                       target = 'test_script_types',
+                                       source = 'test_script_types.cpp test_types.lua'.split())
+
+    test_script_types_null = bld.program(features = flist,
+                                       includes = '..',
+                                       use = libs,
+                                       web_libs = web_libs,
+                                       exported_symbols = exported_symbols,
+                                       proto_gen_py = True,
+                                       target = 'test_script_types_null',
+                                       source = 'test_script_types_null.cpp test_types.lua'.split())
+
     bld.install_files('${PREFIX}/include/script', 'test_script.h')
 

--- a/engine/script/src/wscript
+++ b/engine/script/src/wscript
@@ -65,6 +65,7 @@ def build(bld):
         'script_vmath.cpp',
         'script_zlib.cpp',
         'script_graphics.cpp',
+        'script_types.cpp',
         'luasocket/luasocket.doc_h',
         'script/sys_ddf.proto'])
 

--- a/share/extender/build_input.yml
+++ b/share/extender/build_input.yml
@@ -3,7 +3,7 @@ context:
     symbols: ["DefaultSoundDevice", "AudioDecoderWav", "CrashExt", "AudioDecoderStbVorbis", "ProfilerExt", "GraphicsAdapterOpenGL","LiveUpdateExt",
                 "ResourceTypeGameObject", "ResourceTypeCollection", "ResourceTypeScript", "ResourceTypeLua", "ResourceTypeAnim", "ResourceTypeAnimationSet", "ResourceTypeGui", "ResourceTypeGuiScript",
                 "ResourceProviderFile", "ResourceProviderArchive", "ResourceProviderArchiveMutable", "ResourceProviderZip", "ResourceProviderHttp",
-                "ComponentTypeScript", "ComponentTypeAnim", "ComponentTypeGui", "ComponentTypeMesh", "ScriptBox2DExt", "ScriptImageExt", "ScriptModelExt"]
+                "ComponentTypeScript", "ComponentTypeAnim", "ComponentTypeGui", "ComponentTypeMesh", "ScriptBox2DExt", "ScriptImageExt", "ScriptModelExt", "ScriptTypesExt"]
     allowedLibs: ["engine","engine_release","profile","profile_null","remotery","remotery_null","profilerext","profilerext_null","crashext","crashext_null","record","record_null","gameobject","ddf","resource","gamesys","gamesys_model","gamesys_rig","gamesys_model_null","gamesys_rig_null","rig_null","graphics","graphics_null","graphics_transcoder_null","graphics_transcoder_basisu","basis_transcoder","physics_2d","physics_3d","physics_null", "platform", "platform_vulkan", "platform_null", "BulletDynamics","BulletCollision","LinearMath","Box2D","render","script","luajit-5.1","extension","hid","hid_null","input","particle","rig","dlib","image","image_null","dmglfw","glfw3","gui","crashext","sound","sound_null","tremolo","vpx","liveupdate",
                   "libengine.lib","libengine_release.lib","libprofile.lib","libprofile_null.lib","libremotery.lib","libremotery_null.lib","libprofilerext.lib","libprofilerext_null.lib","libcrashext","libcrashext_null","librecord.lib","librecord_null.lib","libgameobject.lib","libddf.lib","libresource.lib","libgamesys.lib","libgamesys_model.lib","libgamesys_rig.lib","librig.lib","libgamesys_model_null.lib","libgamesys_rig_null.lib","librig_null.lib","libgraphics.lib","libgraphics_null.lib","libgraphics_transcoder_null.lib","libgraphics_transcoder_basisu.lib","libbasis_transcoder.lib","libphysics_2d.lib","libphysics_3d.lib","libphysics_null.lib","libBulletDynamics.lib","libBulletCollision.lib","libplatform.lib","libplatform_null.lib","libLinearMath.lib","libBox2D.lib","librender.lib",
                   "libscript.lib","libluajit.lib-5.1","libextension.lib","libhid.lib","libhid_null.lib","libinput.lib","libparticle.lib","librig.lib","libdlib.lib","libimage.lib","libimage_null.lib","libdmglfw.lib","libgui.lib","libcrashext.lib","libsound.lib","libsound_null.lib","libtremolo.lib","libvpx.lib","libliveupdate.lib",
@@ -11,7 +11,7 @@ context:
                   "script_box2d", "script_box2d_null", "libscript_box2d.lib", "libscript_box2d_null.lib"]
     allowedSymbols: ["DefaultSoundDevice", "NullSoundDevice", "AudioDecoderWav", "CrashExt", "AudioDecoderStbVorbis",
                     "ProfilerExt", "GraphicsAdapterOpenGL", "GraphicsAdapterVulkan", "GraphicsAdapterNull",
-                    "LiveUpdateExt", "ScriptBox2DExt", "ScriptImageExt", "ScriptModelExt"]
+                    "LiveUpdateExt", "ScriptBox2DExt", "ScriptImageExt", "ScriptModelExt", "ScriptTypesExt"]
     defines: ['DLIB_LOG_DOMAIN="{{extension_name_upper}}"']
 
 main: |


### PR DESCRIPTION
Changes added new Lua module '**types**' which contains utility function to check Defold userdata type like vector, vector3, matrix, quaternion, etc. Module can be excluded via AppManifest.

Usage example:
```lua
    local url = msg.url("main_collection", "/hero", "right_hand")
    print(types.is_url(url)) ----> true

    local long_vector = vmath.vector({ 10, 14, 19, -20, -11, -2, 132 })
    print(types.is_vector(long_vector)) --------> true

    local non_empty_vector3 = vmath.vector3(13, 14.5, -7)
    print(types.is_vector3(non_empty_vector3)) ------> true

    local non_empty_matrix = vmath.matrix4_translation(non_empty_vector3)
    print(types.is_matrix4(non_empty_matrix)) -----> true

    local non_empty_quat = vmath.quat(1, 2, 3, 4)
    print(types.is_quat(non_empty_quat)) ------> true

    local test_hash = hash("some_foo_text")
    print(types.is_hash(test_hash))  --- ---> true

    print(not types.is_vector(non_empty_vector3))   ------> false
    print(not types.is_vector(nil))   ------> false
    print(not types.is_vector3(non_empty_matrix))   ------> false
    print(not types.is_quat(non_empty_vector3))   ------> false
    print(not types.is_url(long_vector))   ------> false
    print(not types.is_matrix4(test_hash))   ------> false
```

Fixes #8071 

## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
