### PR TITLE
Migrate dynamic GUI textures to use resource system

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -75,9 +75,9 @@ namespace dmGameSystem
     static void UpdateCustomNodeCallback(void* context, dmGui::HScene scene, dmGui::HNode node, uint32_t custom_type, void* node_data, float dt);
     static const CompGuiNodeType* GetCompGuiCustomType(const CompGuiContext* gui_context, uint32_t custom_type);
 
-    static dmGui::HTextureSource NewTextureResourceCallback(dmGui::HScene scene, const dmhash_t path, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
-    static void                  DeleteTextureResourceCallback(dmGui::HScene scene, dmhash_t texture_hash, dmGui::HTextureSource texture_source);
-    static void                  SetTextureResourceCallback(dmGui::HScene scene, dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+    static dmGui::HTextureSource NewTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+    static void                  DeleteTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, dmGui::HTextureSource texture_source);
+    static void                  SetTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
 
     static inline dmRender::HMaterial GetNodeMaterial(void* material_res);
 
@@ -2274,7 +2274,7 @@ namespace dmGameSystem
         return (dmGui::HTextureSource) resource_out;
     }
 
-    static void DeleteTextureResourceCallback(dmGui::HScene scene, dmhash_t path_hash, dmGui::HTextureSource texture_source)
+    static void DeleteTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, dmGui::HTextureSource texture_source)
     {
         GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
         GuiSceneResource* resource = component->m_Resource;
@@ -2286,7 +2286,7 @@ namespace dmGameSystem
         ReleaseDynamicResource(dmGameObject::GetFactory(component->m_Instance), dmGameObject::GetCollection(component->m_Instance), resolved_path_hash);
     }
 
-    static void SetTextureResourceCallback(dmGui::HScene scene, dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)
+    static void SetTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)
     {
         GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
         GuiSceneResource* resource = component->m_Resource;
@@ -2472,10 +2472,6 @@ namespace dmGameSystem
 
         dmGui::RenderSceneParams rp;
         rp.m_RenderNodes = &RenderNodes;
-
-        //rp.m_NewTexture = &NewTexture;
-        //rp.m_DeleteTexture = &DeleteTexture;
-        //rp.m_SetTextureData = &SetTextureData;
 
         RenderGuiContext render_gui_context;
         render_gui_context.m_RenderContext = gui_context->m_RenderContext;

--- a/engine/gamesys/src/gamesys/components/comp_gui.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_gui.cpp
@@ -74,7 +74,10 @@ namespace dmGameSystem
     static void DestroyCustomNodeCallback(void* context, dmGui::HScene scene, dmGui::HNode node, uint32_t custom_type, void* node_data);
     static void UpdateCustomNodeCallback(void* context, dmGui::HScene scene, dmGui::HNode node, uint32_t custom_type, void* node_data, float dt);
     static const CompGuiNodeType* GetCompGuiCustomType(const CompGuiContext* gui_context, uint32_t custom_type);
-    static void DeleteTexture(dmGui::HScene scene, dmGui::HTextureSource texture_source, dmGui::NodeTextureType type, void* context);
+
+    static dmGui::HTextureSource NewTextureResourceCallback(dmGui::HScene scene, const dmhash_t path, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+    static void                  DeleteTextureResourceCallback(dmGui::HScene scene, dmhash_t texture_hash, dmGui::HTextureSource texture_source);
+    static void                  SetTextureResourceCallback(dmGui::HScene scene, dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
 
     static inline dmRender::HMaterial GetNodeMaterial(void* material_res);
 
@@ -936,6 +939,11 @@ namespace dmGameSystem
         scene_params.m_SetMaterialPropertyCallbackContext = gui_component;
         scene_params.m_DestroyRenderConstantsCallback = DestroyRenderConstantsCallback;
         scene_params.m_OnWindowResizeCallback = &OnWindowResizeCallback;
+
+        scene_params.m_NewTextureResourceCallback    = &NewTextureResourceCallback;
+        scene_params.m_DeleteTextureResourceCallback = &DeleteTextureResourceCallback;
+        scene_params.m_SetTextureResourceCallback    = &SetTextureResourceCallback;
+
         scene_params.m_ScriptWorld = gui_world->m_ScriptWorld;
         gui_component->m_Scene = dmGui::NewScene(scene_resource->m_GuiContext, &scene_params);
         dmGui::HScene scene = gui_component->m_Scene;
@@ -987,8 +995,7 @@ namespace dmGameSystem
         dmGui::Result result = dmGui::InitScene(gui_component->m_Scene);
         if (result != dmGui::RESULT_OK)
         {
-            // TODO: Translate result
-            dmLogError("Error when initializing gui component: %d.", result);
+            dmLogError("Error when initializing gui component: %s.", dmGui::GetResultLiteral(result));
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         gui_component->m_Initialized = 1;
@@ -998,11 +1005,10 @@ namespace dmGameSystem
     static dmGameObject::CreateResult CompGuiFinal(const dmGameObject::ComponentFinalParams& params)
     {
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
-        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene, &DeleteTexture);
+        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
         if (result != dmGui::RESULT_OK)
         {
-            // TODO: Translate result
-            dmLogError("Error when finalizing gui component: %d.", result);
+            dmLogError("Error when finalizing gui component: %s.", dmGui::GetResultLiteral(result));
             return dmGameObject::CREATE_RESULT_UNKNOWN_ERROR;
         }
         return dmGameObject::CREATE_RESULT_OK;
@@ -1108,10 +1114,6 @@ namespace dmGameSystem
         {
             TextureResource* texture_res = (TextureResource*) texture_source;
             return texture_res->m_Texture;
-        }
-        else if (texture_type == dmGui::NODE_TEXTURE_TYPE_DYNAMIC)
-        {
-            return (dmGraphics::HTexture) texture_source;
         }
         return 0;
     }
@@ -2218,7 +2220,8 @@ namespace dmGameSystem
         DM_PROPERTY_ADD_U32(rmtp_GuiVertexCount, gui_world->m_ClientVertexBuffer.Size());
     }
 
-    static dmGraphics::TextureFormat ToGraphicsFormat(dmImage::Type type) {
+    static dmGraphics::TextureFormat ToGraphicsFormat(dmImage::Type type)
+    {
         switch (type) {
             case dmImage::TYPE_RGB:
                 return dmGraphics::TEXTURE_FORMAT_RGB;
@@ -2235,51 +2238,82 @@ namespace dmGameSystem
         return (dmGraphics::TextureFormat) 0; // Never reached
     }
 
-    static dmGui::HTextureSource NewTexture(dmGui::HScene scene, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
+    static dmGui::HTextureSource NewTextureResourceCallback(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* data)
     {
-        RenderGuiContext* gui_context = (RenderGuiContext*) context;
-        dmGraphics::HContext gcontext = dmRender::GetGraphicsContext(gui_context->m_RenderContext);
+        GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
+        GuiSceneResource* resource = component->m_Resource;
 
-        dmGraphics::TextureCreationParams tcparams;
-        dmGraphics::TextureParams tparams;
+        char resource_path[dmResource::RESOURCE_PATH_MAX];
+        dmSnPrintf(resource_path, sizeof(resource_path), "%s/%llu.texturec", resource->m_Path, path_hash);
 
-        tcparams.m_Width = width;
-        tcparams.m_Height = height;
-        tcparams.m_OriginalWidth = width;
-        tcparams.m_OriginalHeight = height;
+        CreateTextureResourceParams params = {};
+        params.m_Path               = resource_path;
+        params.m_PathHash           = dmHashString64(resource_path);
+        params.m_Collection         = dmGameObject::GetCollection(component->m_Instance);
+        params.m_Type               = dmGraphics::TEXTURE_TYPE_2D;
+        params.m_Format             = ToGraphicsFormat(type);
+        params.m_TextureType        = GraphicsTextureTypeToImageType(params.m_Type);
+        params.m_TextureFormat      = GraphicsTextureFormatToImageFormat(params.m_Format);
+        params.m_CompressionType    = dmGraphics::TextureImage::COMPRESSION_TYPE_DEFAULT;
+        params.m_Buffer             = 0;
+        params.m_Data               = data;
+        params.m_Width              = width;
+        params.m_Height             = height;
+        params.m_MaxMipMaps         = 1;
+        params.m_TextureBpp         = dmGraphics::GetTextureFormatBitsPerPixel(params.m_Format);
+        params.m_UsageFlags         = dmGraphics::TEXTURE_USAGE_FLAG_SAMPLE;
 
-        tparams.m_Width = width;
-        tparams.m_Height = height;
-        tparams.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
-        tparams.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
-        tparams.m_Data = buffer;
-        tparams.m_DataSize = dmImage::BytesPerPixel(type) * width * height;
-        tparams.m_Format = ToGraphicsFormat(type);
-
-        dmGraphics::HTexture t =  dmGraphics::NewTexture(gcontext, tcparams);
-        dmGraphics::SetTexture(t, tparams);
-        return (dmGui::HTextureSource) t;
-    }
-
-    static void DeleteTexture(dmGui::HScene scene, dmGui::HTextureSource texture_source, dmGui::NodeTextureType type, void* context)
-    {
-        if (type == dmGui::NODE_TEXTURE_TYPE_DYNAMIC)
+        void* resource_out = 0;
+        dmResource::Result res = CreateTextureResource(dmGameObject::GetFactory(component->m_Instance), params, &resource_out);
+        if (res != dmResource::RESULT_OK)
         {
-            dmGraphics::DeleteTexture((dmGraphics::HTexture) texture_source);
+            dmLogError("Failed to create texture resource %s", resource_path);
+            return 0;
         }
+
+        return (dmGui::HTextureSource) resource_out;
     }
 
-    static void SetTextureData(dmGui::HScene scene, dmGui::HTextureSource texture_source, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
+    static void DeleteTextureResourceCallback(dmGui::HScene scene, dmhash_t path_hash, dmGui::HTextureSource texture_source)
     {
-        dmGraphics::TextureParams tparams;
-        tparams.m_Width = width;
-        tparams.m_Height = height;
-        tparams.m_MinFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
-        tparams.m_MagFilter = dmGraphics::TEXTURE_FILTER_LINEAR;
-        tparams.m_Data = buffer;
-        tparams.m_DataSize = dmImage::BytesPerPixel(type) * width * height;
-        tparams.m_Format = ToGraphicsFormat(type);
-        dmGraphics::SetTexture((dmGraphics::HTexture) texture_source, tparams);
+        GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
+        GuiSceneResource* resource = component->m_Resource;
+
+        char resource_path[dmResource::RESOURCE_PATH_MAX];
+        dmSnPrintf(resource_path, sizeof(resource_path), "%s/%llu.texturec", resource->m_Path, path_hash);
+
+        dmhash_t resolved_path_hash = dmHashString64(resource_path);
+        ReleaseDynamicResource(dmGameObject::GetFactory(component->m_Instance), dmGameObject::GetCollection(component->m_Instance), resolved_path_hash);
+    }
+
+    static void SetTextureResourceCallback(dmGui::HScene scene, dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)
+    {
+        GuiComponent* component = (GuiComponent*)dmGui::GetSceneUserData(scene);
+        GuiSceneResource* resource = component->m_Resource;
+
+        char resource_path[dmResource::RESOURCE_PATH_MAX];
+        dmSnPrintf(resource_path, sizeof(resource_path), "%s/%llu.texturec", resource->m_Path, path_hash);
+        dmhash_t resolved_path_hash = dmHashString64(resource_path);
+
+        SetTextureResourceParams params = {};
+        params.m_PathHash               = resolved_path_hash;
+        params.m_TextureType            = dmGraphics::TEXTURE_TYPE_2D;
+        params.m_TextureFormat          = ToGraphicsFormat(type);
+        params.m_CompressionType        = dmGraphics::TextureImage::COMPRESSION_TYPE_DEFAULT;
+        params.m_Data                   = buffer;
+        params.m_DataSize               = dmImage::BytesPerPixel(type) * width * height;
+        params.m_Width                  = width;
+        params.m_Height                 = height;
+        params.m_X                      = 0;
+        params.m_Y                      = 0;
+        params.m_MipMap                 = 0;
+        params.m_SubUpdate              = 0;
+
+        dmResource::Result res = SetTextureResource(dmGameObject::GetFactory(component->m_Instance), params);
+        if (res != dmResource::RESULT_OK)
+        {
+            dmLogError("Failed to set texture resource %s", dmHashReverseSafe64(resolved_path_hash));
+        }
     }
 
     static dmGui::FetchTextureSetAnimResult FetchTextureSetAnimCallback(dmGui::HTextureSource texture_source, dmhash_t animation, dmGui::TextureSetAnimDesc* out_data)
@@ -2438,9 +2472,10 @@ namespace dmGameSystem
 
         dmGui::RenderSceneParams rp;
         rp.m_RenderNodes = &RenderNodes;
-        rp.m_NewTexture = &NewTexture;
-        rp.m_DeleteTexture = &DeleteTexture;
-        rp.m_SetTextureData = &SetTextureData;
+
+        //rp.m_NewTexture = &NewTexture;
+        //rp.m_DeleteTexture = &DeleteTexture;
+        //rp.m_SetTextureData = &SetTextureData;
 
         RenderGuiContext render_gui_context;
         render_gui_context.m_RenderContext = gui_context->m_RenderContext;
@@ -2523,8 +2558,7 @@ namespace dmGameSystem
         dmGui::Result result = dmGui::DispatchMessage(gui_component->m_Scene, params.m_Message);
         if (result != dmGui::RESULT_OK)
         {
-            // TODO: Proper error message
-            LogMessageError(params.m_Message, "Error when dispatching message to gui scene: %d.", result);
+            LogMessageError(params.m_Message, "Error when dispatching message to gui scene: %s.", dmGui::GetResultLiteral(result));
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -2593,11 +2627,10 @@ namespace dmGameSystem
         GuiWorld* gui_world = (GuiWorld*)params.m_World;
         GuiSceneResource* scene_resource = (GuiSceneResource*) params.m_Resource;
         GuiComponent* gui_component = (GuiComponent*)*params.m_UserData;
-        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene, &DeleteTexture);
+        dmGui::Result result = dmGui::FinalScene(gui_component->m_Scene);
         if (result != dmGui::RESULT_OK)
         {
-            // TODO: Translate result
-            dmLogError("Error when finalizing gui component: %d.", result);
+            dmLogError("Error when finalizing gui component: %s.", dmGui::GetResultLiteral(result));
         }
         dmGui::ClearTextures(gui_component->m_Scene);
         dmGui::ClearFonts(gui_component->m_Scene);
@@ -2608,8 +2641,7 @@ namespace dmGameSystem
             result = dmGui::InitScene(gui_component->m_Scene);
             if (result != dmGui::RESULT_OK)
             {
-                // TODO: Translate result
-                dmLogError("Error when initializing gui component: %d.", result);
+                dmLogError("Error when initializing gui component: %s.", dmGui::GetResultLiteral(result));
             }
         }
         else

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -17,6 +17,7 @@
 
 #include <dlib/message.h>
 #include <dlib/object_pool.h>
+#include <dlib/buffer.h>
 
 #include <render/render.h>
 
@@ -129,6 +130,50 @@ namespace dmGameSystem
     dmGameObject::PropertyResult ClearMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index, dmhash_t name_hash);
     dmGameObject::PropertyResult SetMaterialAttribute(DynamicAttributePool& pool, uint32_t* dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, const dmGameObject::PropertyVar& var, CompGetMaterialAttributeCallback callback, void* callback_user_data);
     dmGameObject::PropertyResult GetMaterialAttribute(DynamicAttributePool& pool, uint32_t dynamic_attribute_index, dmRender::HMaterial material, dmhash_t name_hash, dmGameObject::PropertyDesc& out_desc, CompGetMaterialAttributeCallback callback, void* callback_user_data);
+
+    // gamesys_resource.cpp
+    struct CreateTextureResourceParams
+    {
+        const char*                               m_Path;
+        dmhash_t                                  m_PathHash;
+        dmGameObject::HCollection                 m_Collection;
+        dmGraphics::TextureType                   m_Type;
+        dmGraphics::TextureFormat                 m_Format;
+        dmGraphics::TextureImage::Type            m_TextureType;
+        dmGraphics::TextureImage::TextureFormat   m_TextureFormat;
+        dmGraphics::TextureImage::CompressionType m_CompressionType;
+        dmBuffer::HBuffer                         m_Buffer;
+        const void*                               m_Data;
+        uint32_t                                  m_Width;
+        uint32_t                                  m_Height;
+        uint32_t                                  m_MaxMipMaps;
+        uint32_t                                  m_TextureBpp;
+        uint32_t                                  m_UsageFlags;
+    };
+
+    struct SetTextureResourceParams
+    {
+        dmhash_t                                  m_PathHash;
+        dmGraphics::TextureType                   m_TextureType;
+        dmGraphics::TextureFormat                 m_TextureFormat;
+        dmGraphics::TextureImage::CompressionType m_CompressionType;
+        const void*                               m_Data;
+        size_t                                    m_DataSize;
+        uint32_t                                  m_Width;
+        uint32_t                                  m_Height;
+        uint32_t                                  m_X;
+        uint32_t                                  m_Y;
+        uint32_t                                  m_MipMap;
+        bool                                      m_SubUpdate;
+    };
+
+    dmGraphics::TextureImage::TextureFormat GraphicsTextureFormatToImageFormat(dmGraphics::TextureFormat textureformat);
+    dmGraphics::TextureImage::Type GraphicsTextureTypeToImageType(dmGraphics::TextureType texturetype);
+    void MakeTextureImage(CreateTextureResourceParams params, dmGraphics::TextureImage* texture_image);
+    void DestroyTextureImage(dmGraphics::TextureImage& texture_image, bool destroy_image_data);
+    dmResource::Result CreateTextureResource(dmResource::HFactory factory, const CreateTextureResourceParams& create_params, void** resource_out);
+    dmResource::Result SetTextureResource(dmResource::HFactory factory, const SetTextureResourceParams& params);
+    dmResource::Result ReleaseDynamicResource(dmResource::HFactory factory, dmGameObject::HCollection collection, dmhash_t path_hash);
 }
 
 #endif // DM_GAMESYS_PRIVER_H

--- a/engine/gamesys/src/gamesys/gamesys_resource.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_resource.cpp
@@ -1,0 +1,242 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "gamesys.h"
+#include "gamesys_private.h"
+
+#include "resources/res_texture.h"
+
+#include <graphics/graphics.h>
+
+namespace dmGameSystem
+{
+    void MakeTextureImage(CreateTextureResourceParams params, dmGraphics::TextureImage* texture_image)
+    {
+        uint32_t* mip_map_sizes              = new uint32_t[params.m_MaxMipMaps];
+        uint32_t* mip_map_offsets            = new uint32_t[params.m_MaxMipMaps];
+        uint32_t* mip_map_offsets_compressed = new uint32_t[1];
+        uint8_t layer_count                  = GetLayerCount(params.m_Type);
+
+        uint32_t data_size = 0;
+        uint16_t mm_width  = params.m_Width;
+        uint16_t mm_height = params.m_Height;
+        for (uint32_t i = 0; i < params.m_MaxMipMaps; ++i)
+        {
+            mip_map_sizes[i]    = dmMath::Max(mm_width, mm_height);
+            mip_map_offsets[i]  = (data_size / 8);
+            data_size          += mm_width * mm_height * params.m_TextureBpp * layer_count;
+            mm_width           /= 2;
+            mm_height          /= 2;
+        }
+        assert(data_size > 0);
+
+        data_size                *= layer_count;
+        uint32_t image_data_size  = data_size / 8; // bits -> bytes for compression formats
+        uint8_t* image_data       = 0;
+
+        if (params.m_Buffer)
+        {
+            uint8_t* data     = 0;
+            uint32_t datasize = 0;
+            dmBuffer::GetBytes(params.m_Buffer, (void**)&data, &datasize);
+            image_data      = data;
+            image_data_size = datasize;
+        }
+        else if (params.m_Data)
+        {
+            image_data = (uint8_t*) params.m_Data;
+        }
+        else
+        {
+            image_data = new uint8_t[image_data_size];
+            memset(image_data, 0, image_data_size);
+        }
+
+        // Note: Right now we only support creating compressed 2D textures with 1 mipmap,
+        //       so we only need a pointer here for the data offset.
+        mip_map_offsets_compressed[0] = image_data_size;
+
+        dmGraphics::TextureImage::Image* image = new dmGraphics::TextureImage::Image();
+        texture_image->m_Alternatives.m_Data   = image;
+        texture_image->m_Alternatives.m_Count  = 1;
+        texture_image->m_Type                  = params.m_TextureType;
+        texture_image->m_Count                 = layer_count;
+        texture_image->m_UsageFlags            = params.m_UsageFlags;
+
+        image->m_Width                = params.m_Width;
+        image->m_Height               = params.m_Height;
+        image->m_OriginalWidth        = params.m_Width;
+        image->m_OriginalHeight       = params.m_Height;
+        image->m_Format               = params.m_TextureFormat;
+        image->m_CompressionType      = params.m_CompressionType;
+        image->m_CompressionFlags     = 0;
+        image->m_Data.m_Data          = image_data;
+        image->m_Data.m_Count         = image_data_size;
+
+        image->m_MipMapOffset.m_Data  = mip_map_offsets;
+        image->m_MipMapOffset.m_Count = params.m_MaxMipMaps;
+        image->m_MipMapSize.m_Data    = mip_map_sizes;
+        image->m_MipMapSize.m_Count   = params.m_MaxMipMaps;
+        image->m_MipMapSizeCompressed.m_Data  = mip_map_offsets_compressed;
+        image->m_MipMapSizeCompressed.m_Count = 1;
+    }
+
+    void DestroyTextureImage(dmGraphics::TextureImage& texture_image, bool destroy_image_data)
+    {
+        for (int i = 0; i < texture_image.m_Alternatives.m_Count; ++i)
+        {
+            dmGraphics::TextureImage::Image& image = texture_image.m_Alternatives.m_Data[i];
+            delete[] image.m_MipMapOffset.m_Data;
+            delete[] image.m_MipMapSize.m_Data;
+            delete[] image.m_MipMapSizeCompressed.m_Data;
+            if (destroy_image_data)
+                delete[] image.m_Data.m_Data;
+        }
+        delete[] texture_image.m_Alternatives.m_Data;
+    }
+
+    dmGraphics::TextureImage::TextureFormat GraphicsTextureFormatToImageFormat(dmGraphics::TextureFormat textureformat)
+    {
+    #define GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(x) case dmGraphics::x: return dmGraphics::TextureImage::x
+        switch(textureformat)
+        {
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_LUMINANCE);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB_PVRTC_2BPPV1);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB_PVRTC_4BPPV1);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA_PVRTC_2BPPV1);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA_PVRTC_4BPPV1);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB_ETC1);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA_ETC2);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA_ASTC_4x4);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB_BC1);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA_BC3);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_R_BC4);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RG_BC5);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA_BC7);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB16F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGB32F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA16F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RGBA32F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_R16F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RG16F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_R32F);
+            GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE(TEXTURE_FORMAT_RG32F);
+        };
+    #undef GRAPHCIS_TO_TEXTURE_IMAGE_ENUM_CASE
+        return (dmGraphics::TextureImage::TextureFormat) -1;
+    }
+
+    dmGraphics::TextureImage::Type GraphicsTextureTypeToImageType(dmGraphics::TextureType texturetype)
+    {
+        switch(texturetype)
+        {
+            case dmGraphics::TEXTURE_TYPE_2D:       return dmGraphics::TextureImage::TYPE_2D;
+            case dmGraphics::TEXTURE_TYPE_2D_ARRAY: return dmGraphics::TextureImage::TYPE_2D_ARRAY;
+            case dmGraphics::TEXTURE_TYPE_CUBE_MAP: return dmGraphics::TextureImage::TYPE_CUBEMAP;
+            case dmGraphics::TEXTURE_TYPE_IMAGE_2D: return dmGraphics::TextureImage::TYPE_2D_IMAGE;
+            default: assert(0);
+        }
+        dmLogError("Unsupported texture type (%d)", texturetype);
+        return (dmGraphics::TextureImage::Type) -1;
+    }
+
+    dmResource::Result CreateTextureResource(dmResource::HFactory factory, const CreateTextureResourceParams& create_params, void** resource_out)
+    {
+        dmGraphics::TextureImage texture_image = {};
+        MakeTextureImage(create_params, &texture_image);
+
+        dmArray<uint8_t> ddf_buffer;
+        dmDDF::Result ddf_result = dmDDF::SaveMessageToArray(&texture_image, dmGraphics::TextureImage::m_DDFDescriptor, ddf_buffer);
+        assert(ddf_result == dmDDF::RESULT_OK);
+
+        void* resource = 0x0;
+        dmResource::Result res = dmResource::CreateResource(factory, create_params.m_Path, ddf_buffer.Begin(), ddf_buffer.Size(), &resource);
+
+        DestroyTextureImage(texture_image, create_params.m_Buffer == 0 && create_params.m_Data == 0);
+
+        if (res != dmResource::RESULT_OK)
+        {
+            return res;
+        }
+
+        assert(create_params.m_Collection);
+        dmGameObject::AddDynamicResourceHash(create_params.m_Collection, create_params.m_PathHash);
+        *resource_out = resource;
+        return dmResource::RESULT_OK;
+    }
+
+    dmResource::Result SetTextureResource(dmResource::HFactory factory, const SetTextureResourceParams& params)
+    {
+        // Note: We only support uploading a single mipmap for a single slice at a time
+        const uint32_t NUM_MIP_MAPS = 1;
+
+        dmGraphics::TextureImage::Image image  = {};
+        dmGraphics::TextureImage texture_image = {};
+        texture_image.m_Alternatives.m_Data    = &image;
+        texture_image.m_Alternatives.m_Count   = 1;
+        texture_image.m_Type                   = GraphicsTextureTypeToImageType(params.m_TextureType);
+        texture_image.m_Count                  = 1;
+
+        image.m_Width                = params.m_Width;
+        image.m_Height               = params.m_Height;
+        image.m_OriginalWidth        = params.m_Width;
+        image.m_OriginalHeight       = params.m_Height;
+        image.m_Format               = GraphicsTextureFormatToImageFormat(params.m_TextureFormat);
+        image.m_CompressionType      = params.m_CompressionType;
+        image.m_CompressionFlags     = 0;
+        image.m_Data.m_Data          = (uint8_t*) params.m_Data;
+        image.m_Data.m_Count         = params.m_DataSize;
+
+        // Note: When uploading cubemap faces on OpenGL, we expect that the "data size" is **per** slice
+        //       and not the entire data size of the buffer. For vulkan we don't look at this value but instead
+        //       calculate a slice size. Maybe we should do one or the other..
+        uint32_t mip_map_offsets             = 0;
+        uint32_t mip_map_sizes               = params.m_DataSize / GetLayerCount(params.m_TextureType);
+        image.m_MipMapOffset.m_Data          = &mip_map_offsets;
+        image.m_MipMapOffset.m_Count         = NUM_MIP_MAPS;
+        image.m_MipMapSize.m_Data            = &mip_map_sizes;
+        image.m_MipMapSize.m_Count           = NUM_MIP_MAPS;
+        image.m_MipMapSizeCompressed.m_Data  = &mip_map_sizes;
+        image.m_MipMapSizeCompressed.m_Count = NUM_MIP_MAPS;
+
+        ResTextureReCreateParams recreate_params;
+        recreate_params.m_TextureImage = &texture_image;
+
+        ResTextureUploadParams& upload_params = recreate_params.m_UploadParams;
+        upload_params.m_X                     = params.m_X;
+        upload_params.m_Y                     = params.m_Y;
+        upload_params.m_MipMap                = params.m_MipMap;
+        upload_params.m_SubUpdate             = params.m_SubUpdate;
+        upload_params.m_UploadSpecificMipmap  = 1;
+
+        return dmResource::SetResource(factory, params.m_PathHash, (void*) &recreate_params);
+    }
+
+    dmResource::Result ReleaseDynamicResource(dmResource::HFactory factory, dmGameObject::HCollection collection, dmhash_t path_hash)
+    {
+        HResourceDescriptor rd = dmResource::FindByHash(factory, path_hash);
+        if (!rd)
+        {
+            return dmResource::RESULT_RESOURCE_NOT_FOUND;
+        }
+
+        // This will remove the entry in the collections list of dynamically allocated resource (if it exists),
+        // but we do the actual release here since we allow releasing arbitrary resources now
+        dmGameObject::RemoveDynamicResourceHash(collection, path_hash);
+        dmResource::Release(factory, dmResource::GetResource(rd));
+        return dmResource::RESULT_OK;
+    }
+}

--- a/engine/gamesys/src/gamesys/resources/res_gui.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_gui.cpp
@@ -200,11 +200,11 @@ namespace dmGameSystem
         for (uint32_t i = 0; i < count; ++i)
         {
             dmGuiDDF::NodeDesc& node_desc = node_descs[i];
-            
+
             if (node_desc.m_SizeMode == dmGuiDDF::NodeDesc::SizeMode::SIZE_MODE_AUTO)
             {
                 dmVMath::Vector4& size = node_desc.m_Size;
-                
+
                 if (size.getX() == 0.0f)
                     size.setX(1.0f);
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1466,10 +1466,10 @@ TEST_F(GuiTest, TextureResources)
 
         dmGui::NodeTextureType texture_type;
         dmGui::HTextureSource texture_source = dmGui::GetNodeTexture(gui_comp->m_Scene, box3, &texture_type);
-        ASSERT_EQ(dmGui::NODE_TEXTURE_TYPE_DYNAMIC, texture_type);
+        ASSERT_EQ(dmGui::NODE_TEXTURE_TYPE_TEXTURE, texture_type);
 
-        dmGraphics::HTexture texture_h = (dmGraphics::HTexture) texture_source;
-        ASSERT_TRUE(dmGraphics::IsAssetHandleValid(m_GraphicsContext, texture_h));
+        dmGameSystem::TextureResource* texture_res = (dmGameSystem::TextureResource*) texture_source;
+        ASSERT_TRUE(dmGraphics::IsAssetHandleValid(m_GraphicsContext, texture_res->m_Texture));
     }
 
     dmGameSystem::FinalizeScriptLibs(m_Scriptlibcontext);

--- a/engine/graphics/src/graphics.h
+++ b/engine/graphics/src/graphics.h
@@ -707,6 +707,11 @@ namespace dmGraphics
                type == TYPE_IMAGE_2D;
     }
 
+    static inline uint32_t GetLayerCount(TextureType type)
+    {
+        return type == TEXTURE_TYPE_CUBE_MAP ? 6 : 1;
+    }
+
     /**
      * Get status of texture.
      *

--- a/engine/gui/src/dmsdk/gui/gui.h
+++ b/engine/gui/src/dmsdk/gui/gui.h
@@ -116,14 +116,12 @@ namespace dmGui
      * @member NODE_TEXTURE_TYPE_NONE
      * @member NODE_TEXTURE_TYPE_TEXTURE
      * @member NODE_TEXTURE_TYPE_TEXTURE_SET
-     * @member NODE_TEXTURE_TYPE_DYNAMIC
      */
     enum NodeTextureType
     {
         NODE_TEXTURE_TYPE_NONE,
         NODE_TEXTURE_TYPE_TEXTURE,
         NODE_TEXTURE_TYPE_TEXTURE_SET,
-        NODE_TEXTURE_TYPE_DYNAMIC
     };
 
     // NOTE: These enum values are duplicated in scene desc in gamesys (gui_ddf.proto)

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -140,6 +140,26 @@ namespace dmGui
         return 0;
     }
 
+    const char* GetResultLiteral(Result result)
+    {
+    #define GUI_RESULT_TO_STR_CASE(x) case x: return #x;
+        switch(result)
+        {
+            GUI_RESULT_TO_STR_CASE(RESULT_OK);
+            GUI_RESULT_TO_STR_CASE(RESULT_SYNTAX_ERROR);
+            GUI_RESULT_TO_STR_CASE(RESULT_SCRIPT_ERROR);
+            GUI_RESULT_TO_STR_CASE(RESULT_OUT_OF_RESOURCES);
+            GUI_RESULT_TO_STR_CASE(RESULT_RESOURCE_NOT_FOUND);
+            GUI_RESULT_TO_STR_CASE(RESULT_TEXTURE_ALREADY_EXISTS);
+            GUI_RESULT_TO_STR_CASE(RESULT_INVAL_ERROR);
+            GUI_RESULT_TO_STR_CASE(RESULT_INF_RECURSION);
+            GUI_RESULT_TO_STR_CASE(RESULT_DATA_ERROR);
+            GUI_RESULT_TO_STR_CASE(RESULT_WRONG_TYPE);
+        }
+        return "<unknown dmGui::Result>";
+    #undef GUI_RESULT_TO_STR_CASE
+    }
+
     TextMetrics::TextMetrics()
     {
         memset(this, 0, sizeof(TextMetrics));
@@ -370,6 +390,9 @@ namespace dmGui
         scene->m_SetMaterialPropertyCallbackContext = params->m_SetMaterialPropertyCallbackContext;
         scene->m_DestroyRenderConstantsCallback = params->m_DestroyRenderConstantsCallback;
         scene->m_OnWindowResizeCallback = params->m_OnWindowResizeCallback;
+        scene->m_NewTextureResourceCallback = params->m_NewTextureResourceCallback;
+        scene->m_DeleteTextureResourceCallback = params->m_DeleteTextureResourceCallback;
+        scene->m_SetTextureResourceCallback = params->m_SetTextureResourceCallback;
         scene->m_ScriptWorld = params->m_ScriptWorld;
 
         scene->m_Layers.Put(DEFAULT_LAYER, scene->m_NextLayerIndex++);
@@ -444,12 +467,13 @@ namespace dmGui
         return scene->m_UserData;
     }
 
-    Result AddTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
+    static Result AddTexture(HScene scene, dmHashTable64<TextureInfo>& info_array, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height, dmImage::Type image_type)
     {
-        if (scene->m_Textures.Full())
+        if (info_array.Full())
             return RESULT_OUT_OF_RESOURCES;
 
-        scene->m_Textures.Put(texture_name_hash, TextureInfo(texture_source, texture_type, original_width, original_height));
+        info_array.Put(texture_name_hash, TextureInfo(texture_source, texture_type, original_width, original_height, image_type));
+
         uint32_t n = scene->m_Nodes.Size();
         InternalNode* nodes = scene->m_Nodes.Begin();
         for (uint32_t i = 0; i < n; ++i)
@@ -463,9 +487,13 @@ namespace dmGui
         return RESULT_OK;
     }
 
-    void RemoveTexture(HScene scene, dmhash_t texture_name_hash)
+    Result AddTexture(HScene scene, dmhash_t texture_name_hash, HTextureSource texture_source, NodeTextureType texture_type, uint32_t original_width, uint32_t original_height)
     {
-        scene->m_Textures.Erase(texture_name_hash);
+        return AddTexture(scene, scene->m_Textures, texture_name_hash, texture_source, texture_type, original_width, original_height, (dmImage::Type) -1);
+    }
+
+    static void UnassignTexture(HScene scene, dmhash_t texture_name_hash)
+    {
         uint32_t n = scene->m_Nodes.Size();
         InternalNode* nodes = scene->m_Nodes.Begin();
         for (uint32_t i = 0; i < n; ++i)
@@ -482,6 +510,12 @@ namespace dmGui
                 node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
             }
         }
+    }
+
+    void RemoveTexture(HScene scene, dmhash_t texture_name_hash)
+    {
+        scene->m_Textures.Erase(texture_name_hash);
+        UnassignTexture(scene, texture_name_hash);
     }
 
     void ClearTextures(HScene scene)
@@ -536,130 +570,91 @@ namespace dmGui
         return true;
     }
 
-    static Result MakeDynamicTextureData(DynamicTexture* dynamic_texture, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
+    static void* MakeDynamicTextureData(uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
     {
-        assert(dynamic_texture->m_Buffer == 0x0);
-        dynamic_texture->m_Buffer = malloc(buffer_size);
+        void* data = malloc(buffer_size);
 
         if (flip)
         {
-            if (!CopyImageBufferFlipped(width, height, (uint8_t*)buffer, buffer_size, type, (uint8_t*)dynamic_texture->m_Buffer))
+            if (!CopyImageBufferFlipped(width, height, (uint8_t*)buffer, buffer_size, type, (uint8_t*) data))
             {
-                free(dynamic_texture->m_Buffer);
-                dynamic_texture->m_Buffer = 0;
-                return RESULT_DATA_ERROR;
+                free(data);
+                return 0;
             }
         }
         else
         {
-            memcpy(dynamic_texture->m_Buffer, buffer, buffer_size);
+            memcpy(data, buffer, buffer_size);
         }
-
-        dynamic_texture->m_Width  = width;
-        dynamic_texture->m_Height = height;
-        dynamic_texture->m_Type   = type;
-        return RESULT_OK;
+        return data;
     }
 
-    Result NewDynamicTexture(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
+    Result NewDynamicTexture(HScene scene, const dmhash_t path, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
     {
         uint32_t expected_buffer_size = width * height * dmImage::BytesPerPixel(type);
-        if (buffer_size != expected_buffer_size) {
+        if (buffer_size != expected_buffer_size)
+        {
             dmLogError("Invalid image buffer size. Expected %d, got %d", expected_buffer_size, buffer_size);
             return RESULT_INVAL_ERROR;
         }
 
-        if (DynamicTexture* t = scene->m_DynamicTextures.Get(texture_hash))
+        void* data = MakeDynamicTextureData(width, height, type, flip, buffer, buffer_size);
+        if (!data)
         {
-            if (t->m_Deleted)
-            {
-                t->m_Deleted = 0;
-                return MakeDynamicTextureData(t, width, height, type, flip, buffer, buffer_size);
-            }
-            else
-            {
-                return RESULT_TEXTURE_ALREADY_EXISTS;
-            }
+            return RESULT_DATA_ERROR;
         }
 
-        if (scene->m_DynamicTextures.Full()) {
-            return RESULT_OUT_OF_RESOURCES;
-        }
+        HTextureSource res = scene->m_NewTextureResourceCallback(scene, path, width, height, type, buffer);
+        free(data);
 
-        DynamicTexture t(0);
+        uint32_t buffer_size_mb = expected_buffer_size / 1024.0 / 1024.0;
+        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, buffer_size_mb);
 
-        Result res = MakeDynamicTextureData(&t, width, height, type, flip, buffer, buffer_size);
-        if (res != RESULT_OK)
-        {
-            return res;
-        }
-
-        scene->m_DynamicTextures.Put(texture_hash, t);
-
-        return RESULT_OK;
+        return AddTexture(scene, scene->m_DynamicTextures, path, res, NODE_TEXTURE_TYPE_TEXTURE, width, height, type);
     }
 
     Result DeleteDynamicTexture(HScene scene, const dmhash_t texture_hash)
     {
-        DynamicTexture* t = scene->m_DynamicTextures.Get(texture_hash);
-
-        if (!t) {
+        TextureInfo* t = scene->m_DynamicTextures.Get(texture_hash);
+        if (!t)
+        {
             return RESULT_RESOURCE_NOT_FOUND;
         }
-        t->m_Deleted = 1U;
 
-        if (t->m_Buffer) {
-            free(t->m_Buffer);
-            t->m_Buffer = 0;
-        }
+        uint32_t buffer_size_mb = t->m_OriginalWidth * t->m_OriginalHeight * dmImage::BytesPerPixel(t->m_ImageType);
+        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size_mb);
+
+        scene->m_DeleteTextureResourceCallback(scene, texture_hash, t->m_TextureSource);
+        scene->m_DynamicTextures.Erase(texture_hash);
+        UnassignTexture(scene, texture_hash);
 
         return RESULT_OK;
     }
 
     Result SetDynamicTextureData(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size)
     {
-        DynamicTexture*t = scene->m_DynamicTextures.Get(texture_hash);
-
-        if (!t) {
+        TextureInfo* t = scene->m_DynamicTextures.Get(texture_hash);
+        if (!t)
+        {
             return RESULT_RESOURCE_NOT_FOUND;
         }
 
-        if (t->m_Deleted) {
-            dmLogError("Can't set texture data for deleted texture");
-            return RESULT_INVAL_ERROR;
-        }
-
-        if (t->m_Buffer) {
-            free(t->m_Buffer);
-            t->m_Buffer = 0;
-        }
-
-        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - (buffer_size / 1024.0 / 1024.0));
-        return MakeDynamicTextureData(t, width, height, type, flip, buffer, buffer_size);
-    }
-
-    Result GetDynamicTextureData(HScene scene, const dmhash_t texture_hash, uint32_t* out_width, uint32_t* out_height, dmImage::Type* out_type, const void** out_buffer)
-    {
-        DynamicTexture*t = scene->m_DynamicTextures.Get(texture_hash);
-
-        if (!t) {
-            return RESULT_RESOURCE_NOT_FOUND;
-        }
-
-        if (t->m_Deleted) {
-            dmLogError("Can't get texture data for deleted texture");
-            return RESULT_INVAL_ERROR;
-        }
-
-        if (!t->m_Buffer) {
-            dmLogError("No texture data available for dynamic texture");
+        void* data = MakeDynamicTextureData(width, height, type, flip, buffer, buffer_size);
+        if (!data)
+        {
             return RESULT_DATA_ERROR;
         }
 
-        *out_width = t->m_Width;
-        *out_height = t->m_Height;
-        *out_type = t->m_Type;
-        *out_buffer = t->m_Buffer;
+        scene->m_SetTextureResourceCallback(scene, texture_hash, width, height, type, data);
+        free(data);
+
+        t->m_OriginalWidth  = width;
+        t->m_OriginalHeight = height;
+        t->m_ImageType      = type;
+
+        uint32_t buffer_size_orig_mb = t->m_OriginalWidth * t->m_OriginalHeight * dmImage::BytesPerPixel(t->m_ImageType);
+        uint32_t buffer_size_mb      = buffer_size / 1024.0 / 1024.0 - buffer_size_orig_mb;
+        DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size_mb);
 
         return RESULT_OK;
     }
@@ -1052,120 +1047,30 @@ namespace dmGui
         }
     }
 
-    struct UpdateDynamicTexturesParams
+    static void DeleteDynamicTextures(HScene scene)
     {
-        UpdateDynamicTexturesParams()
-        {
-            memset(this, 0, sizeof(*this));
-        }
-        HScene m_Scene;
-        void*  m_Context;
-        const RenderSceneParams* m_Params;
-        int    m_NewCount;
-    };
-
-    static void UpdateDynamicTextures(UpdateDynamicTexturesParams* params, const dmhash_t* key, DynamicTexture* texture)
-    {
-        dmGui::Scene* const scene = params->m_Scene;
-        void* const context = params->m_Context;
-
-        if (texture->m_Deleted) {
-            // handle might be null if the texture is created/destroyed in the same frame
-            if (texture->m_Handle) {
-                float buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024.0 / 1024.0;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
-                params->m_Params->m_DeleteTexture(scene, texture->m_Handle, NODE_TEXTURE_TYPE_DYNAMIC, context);
-            }
-            if (scene->m_DeletedDynamicTextures.Full()) {
-                scene->m_DeletedDynamicTextures.OffsetCapacity(16);
-            }
-            scene->m_DeletedDynamicTextures.Push(*key);
-        } else {
-            if (!texture->m_Handle && texture->m_Buffer) {
-                float buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024.0 / 1024.0;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, buffer_size);
-                texture->m_Handle = params->m_Params->m_NewTexture(scene, texture->m_Width, texture->m_Height, texture->m_Type, texture->m_Buffer, context);
-                params->m_NewCount++;
-                free(texture->m_Buffer);
-                texture->m_Buffer = 0;
-            } else if (texture->m_Handle && texture->m_Buffer) {
-                float buffer_size = texture->m_Width * texture->m_Height * dmImage::BytesPerPixel(texture->m_Type) / 1024.0 / 1024.0;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, buffer_size);
-                params->m_Params->m_SetTextureData(scene, texture->m_Handle, texture->m_Width, texture->m_Height, texture->m_Type, texture->m_Buffer, context);
-                free(texture->m_Buffer);
-                texture->m_Buffer = 0;
-            }
-        }
-    }
-
-    static void UpdateDynamicTextures(HScene scene, const RenderSceneParams& params, void* context)
-    {
-        UpdateDynamicTexturesParams p;
-        p.m_Scene = scene;
-        p.m_Context = context;
-        p.m_Params = &params;
-        scene->m_DeletedDynamicTextures.SetSize(0);
-        scene->m_DynamicTextures.Iterate(UpdateDynamicTextures, &p);
-
-        if (p.m_NewCount > 0) {
-            uint32_t n = scene->m_Nodes.Size();
-            InternalNode* nodes = scene->m_Nodes.Begin();
-            for (uint32_t j = 0; j < n; ++j) {
-                Node& node = nodes[j].m_Node;
-                if (DynamicTexture* texture = scene->m_DynamicTextures.Get(node.m_TextureHash)) {
-                    node.m_Texture = texture->m_Handle;
-                    node.m_TextureType = NODE_TEXTURE_TYPE_DYNAMIC;
-                }
-            }
-        }
-    }
-
-    static void DeleteDynamicTextures(HScene scene, DeleteTexture delete_texture)
-    {
-        dmHashTable64<DynamicTexture>::Iterator dynamic_textures_iter = scene->m_DynamicTextures.GetIterator();
+        dmHashTable64<TextureInfo>::Iterator dynamic_textures_iter = scene->m_DynamicTextures.GetIterator();
         while(dynamic_textures_iter.Next())
         {
-            const DynamicTexture texture = dynamic_textures_iter.GetValue();
-            if (texture.m_Buffer) {
-                free(texture.m_Buffer);
-            }
-            if (texture.m_Handle) {
-                float buffer_size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type) / 1024.0 / 1024.0;
-                DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
-                delete_texture(scene, texture.m_Handle, NODE_TEXTURE_TYPE_DYNAMIC, scene->m_Context);
-            }
+            const dmhash_t key = dynamic_textures_iter.GetKey();
+            const TextureInfo texture = dynamic_textures_iter.GetValue();
+            float buffer_size = texture.m_OriginalWidth * texture.m_OriginalHeight * dmImage::BytesPerPixel(texture.m_ImageType) / 1024.0 / 1024.0;
+            DM_PROPERTY_ADD_F32(rmtp_GuiDynamicTexturesSizeMb, - buffer_size);
+            scene->m_DeleteTextureResourceCallback(scene, key, texture.m_TextureSource);
         }
         scene->m_DynamicTextures.Clear();
     }
 
-    static void DeferredDeleteDynamicTextures(HScene scene, const RenderSceneParams& params, void* context)
-    {
-        for (uint32_t i = 0; i < scene->m_DeletedDynamicTextures.Size(); ++i) {
-            dmhash_t texture_hash = scene->m_DeletedDynamicTextures[i];
-            scene->m_DynamicTextures.Erase(texture_hash);
-
-            uint32_t n = scene->m_Nodes.Size();
-            InternalNode* nodes = scene->m_Nodes.Begin();
-            for (uint32_t j = 0; j < n; ++j) {
-                Node& node = nodes[j].m_Node;
-                if (node.m_TextureHash == texture_hash) {
-                    node.m_Texture = 0;
-                    node.m_TextureType = NODE_TEXTURE_TYPE_NONE;
-                    // Do not break here. Texture may be used multiple times.
-                }
-            }
-        }
-    }
-
     void IterateDynamicTextures(dmhash_t gui_res_id, HScene scene, FDynamicTextturesIterator callback, void* user_ctx)
     {
-        dmHashTable64<DynamicTexture>::Iterator dynamic_textures_iter = scene->m_DynamicTextures.GetIterator();
+        dmHashTable64<TextureInfo>::Iterator dynamic_textures_iter = scene->m_DynamicTextures.GetIterator();
         while(dynamic_textures_iter.Next())
         {
-            const DynamicTexture texture = dynamic_textures_iter.GetValue();
-            uint32_t size = texture.m_Width * texture.m_Height * dmImage::BytesPerPixel(texture.m_Type);
+            const TextureInfo texture = dynamic_textures_iter.GetValue();
+            uint32_t size = texture.m_OriginalWidth * texture.m_OriginalHeight * dmImage::BytesPerPixel(texture.m_ImageType);
             bool result = callback(gui_res_id, dynamic_textures_iter.GetKey(), size, user_ctx);
-            if (!result) {
+            if (!result)
+            {
                 break;
             }
         }
@@ -1458,9 +1363,6 @@ namespace dmGui
     void RenderScene(HScene scene, const RenderSceneParams& params, void* context)
     {
         Context* c = scene->m_Context;
-
-        UpdateDynamicTextures(scene, params, context);
-        DeferredDeleteDynamicTextures(scene, params, context);
 
         c->m_RenderNodes.SetSize(0);
         c->m_RenderTransforms.SetSize(0);
@@ -2134,7 +2036,7 @@ namespace dmGui
         return RunScript(scene, SCRIPT_FUNCTION_INIT, LUA_NOREF, 0x0);
     }
 
-    Result FinalScene(HScene scene, DeleteTexture delete_texture)
+    Result FinalScene(HScene scene)
     {
         Result result = RunScript(scene, SCRIPT_FUNCTION_FINAL, LUA_NOREF, 0x0);
 
@@ -2163,7 +2065,7 @@ namespace dmGui
         }
         scene->m_AliveParticlefxs.SetSize(0);
 
-        DeleteDynamicTextures(scene, delete_texture);
+        DeleteDynamicTextures(scene);
         ClearLayouts(scene);
         return result;
     }
@@ -3126,12 +3028,22 @@ namespace dmGui
         return SetNodeMaterial(scene, node, dmHashString64(material_id));
     }
 
+    static inline TextureInfo* GetTextureInfo(HScene scene, dmhash_t texture_id)
+    {
+        TextureInfo* texture_info = scene->m_Textures.Get(texture_id);
+        return texture_info ? texture_info : scene->m_DynamicTextures.Get(texture_id);
+    }
+
     Result SetNodeTexture(HScene scene, HNode node, dmhash_t texture_id)
     {
         InternalNode* n = GetNode(scene, node);
         if (n->m_Node.m_TextureType == NODE_TEXTURE_TYPE_TEXTURE_SET)
+        {
             CancelNodeFlipbookAnim(scene, node);
-        if (TextureInfo* texture_info = scene->m_Textures.Get(texture_id)) {
+        }
+
+        if (TextureInfo* texture_info = GetTextureInfo(scene, texture_id))
+        {
             n->m_Node.m_TextureHash = texture_id;
             n->m_Node.m_Texture = texture_info->m_TextureSource;
             n->m_Node.m_TextureType = texture_info->m_TextureSourceType;
@@ -3142,18 +3054,6 @@ namespace dmGui
             {
                 n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture_info->m_OriginalWidth;
                 n->m_Node.m_Properties[PROPERTY_SIZE][1] = texture_info->m_OriginalHeight;
-            }
-            return RESULT_OK;
-        } else if (DynamicTexture* texture = scene->m_DynamicTextures.Get(texture_id)) {
-            n->m_Node.m_TextureHash = texture_id;
-            n->m_Node.m_Texture = texture->m_Handle;
-            n->m_Node.m_TextureType = NODE_TEXTURE_TYPE_DYNAMIC;
-            if((n->m_Node.m_SizeMode != SIZE_MODE_MANUAL) &&
-                (n->m_Node.m_NodeType != NODE_TYPE_CUSTOM) &&
-                (n->m_Node.m_NodeType != NODE_TYPE_PARTICLEFX))
-            {
-                n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture->m_Width;
-                n->m_Node.m_Properties[PROPERTY_SIZE][1] = texture->m_Height;
             }
             return RESULT_OK;
         }
@@ -3644,11 +3544,6 @@ namespace dmGui
                     n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture_info->m_OriginalWidth;
                     n->m_Node.m_Properties[PROPERTY_SIZE][1] = texture_info->m_OriginalHeight;
                 }
-            }
-            else if (DynamicTexture* texture = scene->m_DynamicTextures.Get(n->m_Node.m_TextureHash))
-            {
-                n->m_Node.m_Properties[PROPERTY_SIZE][0] = texture->m_Width;
-                n->m_Node.m_Properties[PROPERTY_SIZE][1] = texture->m_Height;
             }
         }
     }

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -604,7 +604,7 @@ namespace dmGui
             return RESULT_DATA_ERROR;
         }
 
-        HTextureSource res = scene->m_NewTextureResourceCallback(scene, path, width, height, type, buffer);
+        HTextureSource res = scene->m_NewTextureResourceCallback(scene, path, width, height, type, data);
         free(data);
 
         uint32_t buffer_size_mb = expected_buffer_size / 1024.0 / 1024.0;

--- a/engine/gui/src/gui.cpp
+++ b/engine/gui/src/gui.cpp
@@ -636,7 +636,7 @@ namespace dmGui
         TextureInfo* t = scene->m_DynamicTextures.Get(texture_hash);
         if (!t)
         {
-            return RESULT_RESOURCE_NOT_FOUND;
+            return RESULT_INVAL_ERROR;
         }
 
         void* data = MakeDynamicTextureData(width, height, type, flip, buffer, buffer_size);

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -164,12 +164,12 @@ namespace dmGui
     /**
      * Callback to delete a texture resource
      */
-    typedef void (*DeleteTextureResourceCallback)(HScene scene, dmhash_t texture_hash, HTextureSource texture_source);
+    typedef void (*DeleteTextureResourceCallback)(HScene scene, const dmhash_t path_hash, HTextureSource texture_source);
 
     /**
      * Callback to set the data for a texture resource
      */
-    typedef void (*SetTextureResourceCallback)(HScene scene, HTextureSource texture, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+    typedef void (*SetTextureResourceCallback)(HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
 
     /**
      * Scene creation
@@ -768,9 +768,6 @@ namespace dmGui
      * @struct
      * @name RenderSceneParams
      * @member m_RenderNodes [type:RenderNodes] Callback to render nodes
-     * @member m_NewTexture [type:NewTexture] Callback to create a new texture
-     * @member m_DeleteTexture [type:DeleteTexture] Callback to delete a texture
-     * @member m_SetTextureData [type:SetTextureData] Callback to update texture data
      */
     struct RenderSceneParams
     {
@@ -779,10 +776,7 @@ namespace dmGui
             memset(this, 0, sizeof(*this));
         }
 
-        RenderNodes                 m_RenderNodes;
-        NewTexture                  m_NewTexture;
-        DeleteTexture               m_DeleteTexture;
-        SetTextureData              m_SetTextureData;
+        RenderNodes m_RenderNodes;
     };
 
     /** Renders a gui scene

--- a/engine/gui/src/gui.h
+++ b/engine/gui/src/gui.h
@@ -157,6 +157,21 @@ namespace dmGui
     typedef void (*DestroyRenderConstantsCallback)(void* render_constants);
 
     /**
+     * Callback to create a texture resource
+     */
+    typedef HTextureSource (*NewTextureResourceCallback)(HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+
+    /**
+     * Callback to delete a texture resource
+     */
+    typedef void (*DeleteTextureResourceCallback)(HScene scene, dmhash_t texture_hash, HTextureSource texture_source);
+
+    /**
+     * Callback to set the data for a texture resource
+     */
+    typedef void (*SetTextureResourceCallback)(HScene scene, HTextureSource texture, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+
+    /**
      * Scene creation
      */
     struct NewSceneParams;
@@ -174,24 +189,28 @@ namespace dmGui
         uint32_t m_MaxParticlefx;
         uint32_t m_MaxLayers;
 
-        dmParticle::HParticleContext m_ParticlefxContext;
-        void*                       m_UserData;
-        CreateCustomNodeCallback    m_CreateCustomNodeCallback;
-        DestroyCustomNodeCallback   m_DestroyCustomNodeCallback;
-        CloneCustomNodeCallback     m_CloneCustomNodeCallback;
-        UpdateCustomNodeCallback    m_UpdateCustomNodeCallback;
-        void*                       m_CreateCustomNodeCallbackContext;
-        GetResourceCallback         m_GetResourceCallback;
-        void*                       m_GetResourceCallbackContext;
-        GetMaterialPropertyCallback m_GetMaterialPropertyCallback;
-        void*                       m_GetMaterialPropertyCallbackContext;
-        SetMaterialPropertyCallback m_SetMaterialPropertyCallback;
-        void*                       m_SetMaterialPropertyCallbackContext;
+        dmParticle::HParticleContext   m_ParticlefxContext;
+        void*                          m_UserData;
+        CreateCustomNodeCallback       m_CreateCustomNodeCallback;
+        DestroyCustomNodeCallback      m_DestroyCustomNodeCallback;
+        CloneCustomNodeCallback        m_CloneCustomNodeCallback;
+        UpdateCustomNodeCallback       m_UpdateCustomNodeCallback;
+        void*                          m_CreateCustomNodeCallbackContext;
+        GetResourceCallback            m_GetResourceCallback;
+        void*                          m_GetResourceCallbackContext;
+        GetMaterialPropertyCallback    m_GetMaterialPropertyCallback;
+        void*                          m_GetMaterialPropertyCallbackContext;
+        SetMaterialPropertyCallback    m_SetMaterialPropertyCallback;
+        void*                          m_SetMaterialPropertyCallbackContext;
         DestroyRenderConstantsCallback m_DestroyRenderConstantsCallback;
-        FetchTextureSetAnimCallback m_FetchTextureSetAnimCallback;
-        OnWindowResizeCallback      m_OnWindowResizeCallback;
-        AdjustReference             m_AdjustReference;
-        dmScript::ScriptWorld*      m_ScriptWorld;
+        FetchTextureSetAnimCallback    m_FetchTextureSetAnimCallback;
+        OnWindowResizeCallback         m_OnWindowResizeCallback;
+        NewTextureResourceCallback     m_NewTextureResourceCallback;
+        DeleteTextureResourceCallback  m_DeleteTextureResourceCallback;
+        SetTextureResourceCallback     m_SetTextureResourceCallback;
+
+        AdjustReference                m_AdjustReference;
+        dmScript::ScriptWorld*         m_ScriptWorld;
 
         NewSceneParams()
         {
@@ -509,6 +528,8 @@ namespace dmGui
 
     AdjustReference GetSceneAdjustReference(HScene scene);
 
+    const char* GetResultLiteral(Result result);
+
     /**
      * Adds a texture and optional textureset with the specified name to the scene.
      * @note Any nodes connected to the same texture_name will also be connected to the new texture/textureset. This makes this function O(n), where n is #nodes.
@@ -557,7 +578,7 @@ namespace dmGui
      * @param buffer_size
      * @return
      */
-    Result NewDynamicTexture(HScene scene, const dmhash_t texture_hash, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size);
+    Result NewDynamicTexture(HScene scene, const dmhash_t path, uint32_t width, uint32_t height, dmImage::Type type, bool flip, const void* buffer, uint32_t buffer_size);
 
     /**
      * Delete dynamic texture
@@ -783,10 +804,9 @@ namespace dmGui
     /**
      * Run the final-function of the scene script.
      * @param scene Scene for which to run the script
-     * @param deleteTexture DeleteTexture Callback to delete a texture
      * @return RESULT_OK on success
      */
-    Result FinalScene(HScene scene, DeleteTexture delete_texture);
+    Result FinalScene(HScene scene);
 
     /**
      * Run the update-function of the scene script.

--- a/engine/gui/src/gui_null.cpp
+++ b/engine/gui/src/gui_null.cpp
@@ -325,7 +325,7 @@ namespace dmGui
         return RESULT_OK;
     }
 
-    Result FinalScene(HScene scene, DeleteTexture delete_texture)
+    Result FinalScene(HScene scene)
     {
         return RESULT_OK;
     }

--- a/engine/gui/src/gui_private.h
+++ b/engine/gui/src/gui_private.h
@@ -228,33 +228,19 @@ namespace dmGui
 
     struct TextureInfo
     {
-        TextureInfo(HTextureSource texture_source, NodeTextureType texture_source_type, uint32_t original_width, uint32_t original_height)
+        TextureInfo(HTextureSource texture_source, NodeTextureType texture_source_type, uint32_t original_width, uint32_t original_height, dmImage::Type image_type)
         : m_TextureSource(texture_source)
         , m_TextureSourceType(texture_source_type)
+        , m_ImageType(image_type)
         , m_OriginalWidth(original_width)
-        , m_OriginalHeight(original_height) {}
+        , m_OriginalHeight(original_height)
+        {}
 
         HTextureSource  m_TextureSource;
         NodeTextureType m_TextureSourceType;
+        dmImage::Type   m_ImageType;
         uint32_t        m_OriginalWidth : 16;
         uint32_t        m_OriginalHeight : 16;
-    };
-
-    struct DynamicTexture
-    {
-        DynamicTexture(HTextureSource handle)
-        {
-            memset(this, 0, sizeof(*this));
-            m_Handle = handle;
-            m_Type = (dmImage::Type) -1;
-        }
-        HTextureSource  m_Handle;
-        uint32_t        m_Created : 1;
-        uint32_t        m_Deleted : 1;
-        uint32_t        m_Width;
-        uint32_t        m_Height;
-        void*           m_Buffer;
-        dmImage::Type   m_Type;
     };
 
     struct ParticlefxComponent
@@ -270,53 +256,55 @@ namespace dmGui
 
     struct Scene
     {
-        int                     m_InstanceReference;
-        int                     m_DataReference;
-        int                     m_ContextTableReference;
-        Context*                m_Context;
-        Script*                 m_Script;
-        dmIndexPool16           m_NodePool;
-        dmArray<InternalNode>   m_Nodes;
-        dmArray<Animation>      m_Animations;
+        int                                   m_InstanceReference;
+        int                                   m_DataReference;
+        int                                   m_ContextTableReference;
+        Context*                              m_Context;
+        Script*                               m_Script;
+        dmIndexPool16                         m_NodePool;
+        dmArray<InternalNode>                 m_Nodes;
+        dmArray<Animation>                    m_Animations;
         dmHashTable<uintptr_t, dmhash_t>      m_ResourceToPath;
         dmHashTable64<void*>                  m_Fonts;
         dmHashTable64<TextureInfo>            m_Textures;
-        dmHashTable64<DynamicTexture>         m_DynamicTextures;
+        dmHashTable64<TextureInfo>            m_DynamicTextures;
         dmHashTable64<void*>                  m_MaterialResources;
         dmParticle::HParticleContext          m_ParticlefxContext;
         dmHashTable64<dmParticle::HPrototype> m_Particlefxs;
         dmArray<ParticlefxComponent>          m_AliveParticlefxs;
-        dmHashTable64<uint16_t> m_Layers;
-        dmArray<dmhash_t>       m_Layouts;
-        dmArray<void*>          m_LayoutsNodeDescs;
-        dmhash_t                m_LayoutId;
-        AdjustReference         m_AdjustReference;
-        dmArray<dmhash_t>       m_DeletedDynamicTextures;
-        void*                   m_DefaultFont;
-        void*                   m_UserData;
-        uint16_t                m_RenderHead;
-        uint16_t                m_RenderTail;
-        uint16_t                m_NextVersionNumber;
-        uint16_t                m_RenderOrder; // For the render-key
-        uint16_t                m_NextLayerIndex;
-        uint16_t                m_ResChanged : 1;
-        uint32_t                m_Width;
-        uint32_t                m_Height;
-        dmScript::ScriptWorld*  m_ScriptWorld;
-        CreateCustomNodeCallback    m_CreateCustomNodeCallback;
-        DestroyCustomNodeCallback   m_DestroyCustomNodeCallback;
-        CloneCustomNodeCallback     m_CloneCustomNodeCallback;
-        UpdateCustomNodeCallback    m_UpdateCustomNodeCallback;
-        void*                       m_CreateCustomNodeCallbackContext;
-        GetResourceCallback         m_GetResourceCallback;
-        void*                       m_GetResourceCallbackContext;
-        FetchTextureSetAnimCallback m_FetchTextureSetAnimCallback;
-        OnWindowResizeCallback      m_OnWindowResizeCallback;
-        GetMaterialPropertyCallback m_GetMaterialPropertyCallback;
-        void*                       m_GetMaterialPropertyCallbackContext;
-        SetMaterialPropertyCallback m_SetMaterialPropertyCallback;
-        void*                       m_SetMaterialPropertyCallbackContext;
-        DestroyRenderConstantsCallback m_DestroyRenderConstantsCallback;
+        dmHashTable64<uint16_t>               m_Layers;
+        dmArray<dmhash_t>                     m_Layouts;
+        dmArray<void*>                        m_LayoutsNodeDescs;
+        dmhash_t                              m_LayoutId;
+        AdjustReference                       m_AdjustReference;
+        void*                                 m_DefaultFont;
+        void*                                 m_UserData;
+        uint16_t                              m_RenderHead;
+        uint16_t                              m_RenderTail;
+        uint16_t                              m_NextVersionNumber;
+        uint16_t                              m_RenderOrder; // For the render-key
+        uint16_t                              m_NextLayerIndex;
+        uint16_t                              m_ResChanged : 1;
+        uint32_t                              m_Width;
+        uint32_t                              m_Height;
+        dmScript::ScriptWorld*                m_ScriptWorld;
+        CreateCustomNodeCallback              m_CreateCustomNodeCallback;
+        DestroyCustomNodeCallback             m_DestroyCustomNodeCallback;
+        CloneCustomNodeCallback               m_CloneCustomNodeCallback;
+        UpdateCustomNodeCallback              m_UpdateCustomNodeCallback;
+        void*                                 m_CreateCustomNodeCallbackContext;
+        GetResourceCallback                   m_GetResourceCallback;
+        void*                                 m_GetResourceCallbackContext;
+        FetchTextureSetAnimCallback           m_FetchTextureSetAnimCallback;
+        OnWindowResizeCallback                m_OnWindowResizeCallback;
+        GetMaterialPropertyCallback           m_GetMaterialPropertyCallback;
+        void*                                 m_GetMaterialPropertyCallbackContext;
+        SetMaterialPropertyCallback           m_SetMaterialPropertyCallback;
+        void*                                 m_SetMaterialPropertyCallbackContext;
+        DestroyRenderConstantsCallback        m_DestroyRenderConstantsCallback;
+        NewTextureResourceCallback            m_NewTextureResourceCallback;
+        DeleteTextureResourceCallback         m_DeleteTextureResourceCallback;
+        SetTextureResourceCallback            m_SetTextureResourceCallback;
     };
 
     InternalNode* GetNode(HScene scene, HNode node);

--- a/engine/gui/src/gui_script.cpp
+++ b/engine/gui/src/gui_script.cpp
@@ -2077,7 +2077,8 @@ namespace dmGui
         Scene* scene = GuiScriptInstance_Check(L);
 
         bool flip = false;
-        if (top > 5) {
+        if (top > 5)
+        {
             luaL_checktype(L, 6, LUA_TBOOLEAN);
             flip = (bool)lua_toboolean(L, 6);
         }
@@ -2090,13 +2091,18 @@ namespace dmGui
 
         dmImage::Type type = ToImageType(L, type_str);
         Result r = NewDynamicTexture(scene, name, width, height, type, flip, buffer, buffer_size);
-        if (r == RESULT_OK) {
+
+        if (r == RESULT_OK)
+        {
             lua_pushboolean(L, 1);
             lua_pushnil(L);
-        } else {
+        }
+        else
+        {
             lua_pushboolean(L, 0);
             lua_pushnumber(L, r);
         }
+
         assert(top + 2 == lua_gettop(L));
         return 2;
     }

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -84,6 +84,10 @@ static const float TEXT_GLYPH_WIDTH = 1.0f;
 static const float TEXT_MAX_ASCENT = 0.75f;
 static const float TEXT_MAX_DESCENT = 0.25f;
 
+static dmGui::HTextureSource DynamicNewTexture(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+static void DynamicDeleteTexture(dmGui::HScene scene, dmhash_t path_hash, dmGui::HTextureSource texture_source);
+static void DynamicSetTextureData(dmGui::HScene scene, dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer);
+
 
 static dmLuaDDF::LuaSource* LuaSourceFromStr(const char *str, int length = -1)
 {
@@ -146,25 +150,25 @@ public:
         m_Context->m_SceneTraversalCache.m_Data.SetCapacity(MAX_NODES);
         m_Context->m_SceneTraversalCache.m_Data.SetSize(MAX_NODES);
 
-        dmGui::NewSceneParams params;
+        dmGui::NewSceneParams params = {};
         params.m_MaxNodes = MAX_NODES;
         params.m_MaxAnimations = MAX_ANIMATIONS;
         params.m_UserData = this;
-
         params.m_MaxParticlefxs = MAX_PARTICLEFXS;
         params.m_MaxParticlefx = MAX_PARTICLEFX;
         params.m_ParticlefxContext = dmParticle::CreateContext(MAX_PARTICLEFX, MAX_PARTICLES);
         params.m_FetchTextureSetAnimCallback = FetchTextureSetAnimCallback;
         params.m_OnWindowResizeCallback = 0x0;
+        params.m_NewTextureResourceCallback    = DynamicNewTexture;
+        params.m_DeleteTextureResourceCallback = DynamicDeleteTexture;
+        params.m_SetTextureResourceCallback    = DynamicSetTextureData;
+
         m_Scene = dmGui::NewScene(m_Context, &params);
         dmGui::SetSceneResolution(m_Scene, 1, 1);
         m_Script = dmGui::NewScript(m_Context);
         dmGui::SetSceneScript(m_Scene, m_Script);
 
         m_RenderParams.m_RenderNodes = RenderNodes;
-        m_RenderParams.m_NewTexture = 0;
-        m_RenderParams.m_DeleteTexture = 0;
-        m_RenderParams.m_SetTextureData = 0;
     }
 
     static void RenderNodes(dmGui::HScene scene, const dmGui::RenderEntry* nodes, const dmVMath::Matrix4* node_transforms, const float* node_opacities,
@@ -627,18 +631,21 @@ TEST_F(dmGuiTest, TextureFontLayer)
     dmGui::DeleteNode(m_Scene, node, true);
 }
 
-static dmGui::HTextureSource DynamicNewTexture(dmGui::HScene scene, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
+static dmGui::HTextureSource DynamicNewTexture(dmGui::HScene scene, const dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)
 {
-    return (dmGui::HTextureSource) malloc(16);
+    uint32_t buffer_size = width * height * dmImage::BytesPerPixel(type);
+    void* p = malloc(buffer_size);
+    memcpy(p, buffer, buffer_size);
+    return (dmGui::HTextureSource) p;
 }
 
-static void DynamicDeleteTexture(dmGui::HScene scene, dmGui::HTextureSource texture_source, dmGui::NodeTextureType type, void* context)
+static void DynamicDeleteTexture(dmGui::HScene scene, dmhash_t path_hash, dmGui::HTextureSource texture_source)
 {
     assert(texture_source);
     free((void*) texture_source);
 }
 
-static void DynamicSetTextureData(dmGui::HScene scene, dmGui::HTextureSource texture_source, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer, void* context)
+static void DynamicSetTextureData(dmGui::HScene scene, dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)
 {
 }
 
@@ -661,9 +668,6 @@ TEST_F(dmGuiTest, DynamicTexture)
     uint32_t count = 0;
     dmGui::RenderSceneParams rp;
     rp.m_RenderNodes = DynamicRenderNodes;
-    rp.m_NewTexture = DynamicNewTexture;
-    rp.m_DeleteTexture = DynamicDeleteTexture;
-    rp.m_SetTextureData = DynamicSetTextureData;
 
     const int width = 2;
     const int height = 2;
@@ -762,37 +766,39 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
     r = dmGui::NewDynamicTexture(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGB, true, data_rgb, sizeof(data_rgb));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
+    dmGui::HTextureSource t1_res = dmGui::GetTexture(m_Scene, dmHashString64("t1"));
+
     // Get buffer, verify same as input but flipped
-    r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
-    ASSERT_EQ(r, dmGui::RESULT_OK);
-    ASSERT_EQ(width, out_width);
-    ASSERT_EQ(height, out_height);
-    ASSERT_EQ(dmImage::TYPE_RGB, out_type);
-    ASSERT_BUFFER(data_rgb_flip, out_buffer, width*height*3);
+    // r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
+    // ASSERT_EQ(r, dmGui::RESULT_OK);
+    // ASSERT_EQ(width, out_width);
+    // ASSERT_EQ(height, out_height);
+    // ASSERT_EQ(dmImage::TYPE_RGB, out_type);
+    // ASSERT_BUFFER(data_rgb_flip, out_buffer, width*height*3);
 
     // Upload RGBA data and flip
     r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGBA, true, data_rgba, sizeof(data_rgba));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Verify flipped result
-    r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
-    ASSERT_EQ(r, dmGui::RESULT_OK);
-    ASSERT_EQ(width, out_width);
-    ASSERT_EQ(height, out_height);
-    ASSERT_EQ(dmImage::TYPE_RGBA, out_type);
-    ASSERT_BUFFER(data_rgba_flip, out_buffer, width*height*4);
+    // r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
+    // ASSERT_EQ(r, dmGui::RESULT_OK);
+    // ASSERT_EQ(width, out_width);
+    // ASSERT_EQ(height, out_height);
+    // ASSERT_EQ(dmImage::TYPE_RGBA, out_type);
+    // ASSERT_BUFFER(data_rgba_flip, out_buffer, width*height*4);
 
     // Upload luminance data and flip
     r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_LUMINANCE, true, data_lum, sizeof(data_lum));
     ASSERT_EQ(r, dmGui::RESULT_OK);
 
     // Verify flipped result
-    r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
-    ASSERT_EQ(r, dmGui::RESULT_OK);
-    ASSERT_EQ(width, out_width);
-    ASSERT_EQ(height, out_height);
-    ASSERT_EQ(dmImage::TYPE_LUMINANCE, out_type);
-    ASSERT_BUFFER(data_lum_flip, out_buffer, width*height);
+    // r = dmGui::GetDynamicTextureData(m_Scene, dmHashString64("t1"), &out_width, &out_height, &out_type, (const void**)&out_buffer);
+    // ASSERT_EQ(r, dmGui::RESULT_OK);
+    // ASSERT_EQ(width, out_width);
+    // ASSERT_EQ(height, out_height);
+    // ASSERT_EQ(dmImage::TYPE_LUMINANCE, out_type);
+    // ASSERT_BUFFER(data_lum_flip, out_buffer, width*height);
 
     r = dmGui::DeleteDynamicTexture(m_Scene, dmHashString64("t1"));
     ASSERT_EQ(r, dmGui::RESULT_OK);
@@ -912,9 +918,6 @@ TEST_F(dmGuiTest, ScriptDynamicTexture)
 
     dmGui::RenderSceneParams rp;
     rp.m_RenderNodes = DynamicRenderNodes;
-    rp.m_NewTexture = DynamicNewTexture;
-    rp.m_DeleteTexture = DynamicDeleteTexture;
-    rp.m_SetTextureData = DynamicSetTextureData;
     dmGui::RenderScene(m_Scene, rp, this);
 }
 
@@ -1359,7 +1362,7 @@ TEST_F(dmGuiTest, ScriptAnimate)
 
     ASSERT_NEAR(dmGui::GetNodePosition(m_Scene, node).getX(), 1.0f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
     ASSERT_EQ(m_Scene->m_NodePool.Capacity(), m_Scene->m_NodePool.Remaining());
@@ -1410,7 +1413,7 @@ TEST_F(dmGuiTest, ScriptPlayback)
         dmGui::DeleteNode(m_Scene, node, true);
     }
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
     ASSERT_EQ(m_Scene->m_NodePool.Capacity(), m_Scene->m_NodePool.Remaining());
@@ -1443,7 +1446,7 @@ TEST_F(dmGuiTest, ScriptAnimatePreserveAlpha)
     ASSERT_NEAR(color.getX(), 1.0f, EPSILON);
     ASSERT_NEAR(color.getW(), 0.5f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -1476,7 +1479,7 @@ TEST_F(dmGuiTest, ScriptAnimateComponent)
     ASSERT_NEAR(color.getZ(), 0.9f, EPSILON);
     ASSERT_NEAR(color.getW(), 0.4f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -1590,7 +1593,7 @@ TEST_F(dmGuiTest, ScriptAnimateCancel1)
 
     ASSERT_NEAR(dmGui::GetNodeProperty(m_Scene, node, dmGui::PROPERTY_COLOR).getX(), 1.0f, EPSILON);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -1634,7 +1637,7 @@ TEST_F(dmGuiTest, ScriptAnimateCancel2)
     // We can't use epsilon here because of precision errors when the animation is canceled, so half precision (= twice the error)
     ASSERT_NEAR(dmGui::GetNodePosition(m_Scene, node).getX(), 5.0f, 2*EPSILON);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -2696,7 +2699,7 @@ TEST_F(dmGuiTest, ScriptErroneousReturnValues)
     bool consumed;
     r = dmGui::DispatchInput(m_Scene, &action, 1, &consumed);
     ASSERT_NE(dmGui::RESULT_OK, r);
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_NE(dmGui::RESULT_OK, r);
     dmGui::DeleteNode(m_Scene, node, true);
 }
@@ -4902,7 +4905,7 @@ TEST_F(dmGuiTest, KeepParticlefxOnNodeDeletion)
     dmGui::DeleteNode(m_Scene, node_text, false);
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::UpdateScene(m_Scene, 1.0f / 60.0f));
     ASSERT_EQ(1U, dmGui::GetParticlefxCount(m_Scene));
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -4935,7 +4938,7 @@ TEST_F(dmGuiTest, PlayNodeParticlefx)
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::PlayNodeParticlefx(m_Scene, node_box, 0));
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::PlayNodeParticlefx(m_Scene, node_pie, 0));
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::PlayNodeParticlefx(m_Scene, node_text, 0));
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -4964,7 +4967,7 @@ TEST_F(dmGuiTest, PlayNodeParticlefxInitialTransform)
     Vector3 pos = dmParticle::GetPosition(m_Scene->m_ParticlefxContext, n->m_Node.m_ParticleInstance);
     ASSERT_EQ(10, pos.getX());
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -4993,7 +4996,7 @@ TEST_F(dmGuiTest, PlayNodeParticlefxAdjustModeStretch)
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::PlayNodeParticlefx(m_Scene, node_pfx, 0));
     ASSERT_EQ(dmGui::ADJUST_MODE_FIT, (dmGui::AdjustMode)n->m_Node.m_AdjustMode);
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5019,7 +5022,7 @@ TEST_F(dmGuiTest, NewNodeParticlefx)
     ASSERT_EQ(dmGui::RESULT_OK, dmGui::SetNodeParticlefx(m_Scene, node_pfx, particlefx_id));
     ASSERT_EQ(dmGui::RESULT_RESOURCE_NOT_FOUND, dmGui::SetNodeParticlefx(m_Scene, node_pfx, particlefx_id_wrong));
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5083,7 +5086,7 @@ TEST_F(dmGuiTest, CallbackCalledCorrectNumTimes)
     dmGui::DeleteNode(m_Scene, node_pfx, true);
     dmGui::UpdateScene(m_Scene, dt);
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5115,7 +5118,7 @@ TEST_F(dmGuiTest, CallbackCalledSingleTimePerStateChange)
     dmGui::DeleteNode(m_Scene, node_pfx, true);
     dmGui::UpdateScene(m_Scene, dt);
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5149,7 +5152,7 @@ TEST_F(dmGuiTest, CallbackCalledMultipleEmitters)
     dmGui::DeleteNode(m_Scene, node_pfx, true);
     dmGui::UpdateScene(m_Scene, dt);
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5182,7 +5185,7 @@ TEST_F(dmGuiTest, StopNodeParticlefx)
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::StopNodeParticlefx(m_Scene, node_pie, false));
     ASSERT_EQ(dmGui::RESULT_WRONG_TYPE, dmGui::StopNodeParticlefx(m_Scene, node_text, false));
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5241,7 +5244,7 @@ TEST_F(dmGuiTest, StopNodeParticlefxMultiplePlaying)
 
     ASSERT_EQ(dmGui::GetParticlefxCount(m_Scene), 0);
 
-    dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    dmGui::FinalScene(m_Scene);
     UnloadParticlefxPrototype(prototype);
 }
 
@@ -5343,7 +5346,7 @@ TEST_F(dmGuiTest, InheritAlpha)
     r = dmGui::UpdateScene(m_Scene, 1.0f / 60.0f);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 
@@ -5441,7 +5444,7 @@ TEST_F(dmGuiTest, SetGetScreenPosition)
     Vector4 after_set = _GET_NODE_SCENE_POSITION(m_Scene, internal_node);
     ASSERT_EQ( before_set, after_set);
 
-    r = dmGui::FinalScene(m_Scene, &DynamicDeleteTexture);
+    r = dmGui::FinalScene(m_Scene);
     ASSERT_EQ(dmGui::RESULT_OK, r);
 }
 

--- a/engine/gui/src/test/test_gui.cpp
+++ b/engine/gui/src/test/test_gui.cpp
@@ -765,13 +765,12 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
 
     // Get buffer, verify same as input but flipped
     TestDynamicTexture* t1 = m_DynamicTextures.Get(dmHashString64("t1"));
-    uint8_t* t1_buffer = (uint8_t*) t1->m_Buffer;
 
     ASSERT_NE((TestDynamicTexture*) 0, t1);
     ASSERT_EQ(width, t1->m_Width);
     ASSERT_EQ(height, t1->m_Height);
     ASSERT_EQ(dmImage::TYPE_RGB, t1->m_Type);
-    ASSERT_BUFFER(data_rgb_flip, t1_buffer, width*height*3);
+    ASSERT_BUFFER(data_rgb_flip, (uint8_t*) t1->m_Buffer, width*height*3);
 
     // Upload RGBA data and flip
     r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_RGBA, true, data_rgba, sizeof(data_rgba));
@@ -781,7 +780,7 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
     ASSERT_EQ(width, t1->m_Width);
     ASSERT_EQ(height, t1->m_Height);
     ASSERT_EQ(dmImage::TYPE_RGBA, t1->m_Type);
-    ASSERT_BUFFER(data_rgba_flip, t1_buffer, width*height*4);
+    ASSERT_BUFFER(data_rgba_flip, (uint8_t*) t1->m_Buffer, width*height*4);
 
     // Upload luminance data and flip
     r = dmGui::SetDynamicTextureData(m_Scene, dmHashString64("t1"), width, height, dmImage::TYPE_LUMINANCE, true, data_lum, sizeof(data_lum));
@@ -791,7 +790,7 @@ TEST_F(dmGuiTest, DynamicTextureFlip)
     ASSERT_EQ(width, t1->m_Width);
     ASSERT_EQ(height, t1->m_Height);
     ASSERT_EQ(dmImage::TYPE_LUMINANCE, t1->m_Type);
-    ASSERT_BUFFER(data_lum_flip, t1_buffer, width*height);
+    ASSERT_BUFFER(data_lum_flip, (uint8_t*) t1->m_Buffer, width*height);
 
     r = dmGui::DeleteDynamicTexture(m_Scene, dmHashString64("t1"));
     ASSERT_EQ(r, dmGui::RESULT_OK);

--- a/engine/gui/src/test/test_gui_shared.h
+++ b/engine/gui/src/test/test_gui_shared.h
@@ -1,0 +1,135 @@
+// Copyright 2020-2024 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef DM_TEST_GUI_SHARED_H
+#define DM_TEST_GUI_SHARED_H
+
+#include <dlib/array.h>
+#include <dlib/hash.h>
+#include <dlib/image.h>
+
+#include <stdint.h>
+
+struct TestDynamicTexture
+{
+    dmhash_t      m_PathHash;
+    void*         m_Buffer;
+    dmImage::Type m_Type;
+    uint32_t      m_Width;
+    uint32_t      m_Height;
+};
+
+
+// This is just a wrapper around a list of TestDynamicTextures,
+// that will grow as needed. Empty slots are reused.
+// it could be rewritten to use a hash table, but it's just a
+// small test class so it doesn't really matter.
+class DynamicTextureContainer
+{
+public:
+    ~DynamicTextureContainer()
+    {
+        for (int i = 0; i < m_Textures.Size(); ++i)
+        {
+            if (!m_Textures[i])
+                continue;
+
+            if (m_Textures[i]->m_Buffer)
+            {
+                free(m_Textures[i]->m_Buffer);
+            }
+            delete m_Textures[i];
+        }
+    };
+
+    TestDynamicTexture* New(dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer) {
+        uint32_t buffer_size = width * height * dmImage::BytesPerPixel(type);
+        TestDynamicTexture* p = (TestDynamicTexture*) malloc(sizeof(TestDynamicTexture));
+        p->m_Width = width;
+        p->m_Height = height;
+        p->m_Buffer = (uint8_t*) malloc(buffer_size);
+        p->m_PathHash = path_hash;
+        p->m_Type = type;
+        memcpy(p->m_Buffer, buffer, buffer_size);
+
+        // reuse empty slots
+        for (int i = 0; i < m_Textures.Size(); ++i)
+        {
+            if (m_Textures[i] == 0)
+            {
+                m_Textures[i] = p;
+                return p;
+            }
+        }
+
+        // grow and store otherwise
+        if (m_Textures.Full())
+        {
+            m_Textures.OffsetCapacity(1);
+        }
+
+        m_Textures.Push(p);
+
+        return p;
+    }
+
+    void Delete(dmhash_t path_hash)
+    {
+        for (int i = 0; i < m_Textures.Size(); ++i)
+        {
+            if (m_Textures[i]->m_PathHash == path_hash)
+            {
+                free(m_Textures[i]->m_Buffer);
+                free(m_Textures[i]);
+                m_Textures[i] = 0;
+            }
+        }
+    }
+
+    void Set(dmhash_t path_hash, uint32_t width, uint32_t height, dmImage::Type type, const void* buffer)
+    {
+        for (int i = 0; i < m_Textures.Size(); ++i)
+        {
+            if (m_Textures[i]->m_PathHash == path_hash)
+            {
+                uint32_t buffer_size = width * height * dmImage::BytesPerPixel(type);
+                if (m_Textures[i]->m_Buffer)
+                {
+                    free(m_Textures[i]->m_Buffer);
+                    m_Textures[i]->m_Buffer = (uint8_t*) malloc(buffer_size);
+                }
+                m_Textures[i]->m_Width = width;
+                m_Textures[i]->m_Height = height;
+                m_Textures[i]->m_Type = type;
+                memcpy(m_Textures[i]->m_Buffer, buffer, buffer_size);
+            }
+        }
+    }
+
+    TestDynamicTexture* Get(dmhash_t path_hash)
+    {
+        for (int i = 0; i < m_Textures.Size(); ++i)
+        {
+            if (m_Textures[i] && m_Textures[i]->m_PathHash == path_hash)
+            {
+                return m_Textures[i];
+            }
+        }
+        return 0;
+    }
+
+    dmArray<TestDynamicTexture*> m_Textures;
+};
+
+#endif // DM_TEST_GUI_SHARED_H


### PR DESCRIPTION
Dynamic textures (created via `gui.new_texture`) are now managed by the resource system. There is no change in behaviour or function signature for how dynamic textures are managed, the biggest gain of this task is to remove GUI specific code in the engine and move some parts of the GUI system closer to the regular gameobject world, code wise.

Fixes #9093