### PR TITLE
Delete render contants from CompRenderConstants

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_private.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_private.cpp
@@ -320,6 +320,15 @@ HComponentRenderConstants CreateRenderConstants()
 
 void DestroyRenderConstants(HComponentRenderConstants constants)
 {
+    uint32_t num_constants = constants->m_RenderConstants.Size();
+    for (uint32_t i = 0; i < num_constants; ++i)
+    {
+        if (constants->m_RenderConstants[i])
+        {
+            dmRender::DeleteConstant(constants->m_RenderConstants[i]);
+        }
+    }
+
     dmRender::DeleteNamedConstantBuffer(constants->m_ConstantBuffer);
     delete constants;
 }

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -1840,7 +1840,8 @@ namespace dmGameSystem
     static void CompSpriteSetConstantCallback(void* user_data, dmhash_t name_hash, int32_t value_index, uint32_t* element_index, const dmGameObject::PropertyVar& var)
     {
         SpriteComponent* component = (SpriteComponent*)user_data;
-        if (!component->m_RenderConstants) {
+        if (!component->m_RenderConstants)
+        {
             component->m_RenderConstants = dmGameSystem::CreateRenderConstants();
         }
         dmGameSystem::SetRenderConstant(component->m_RenderConstants, GetMaterial(component), name_hash, value_index, element_index, var);


### PR DESCRIPTION
Fixed a memory leak in the engine that happens when setting component constants via constant buffers.

Fixes #8884