### PR TITLE
Remove timer callback if timer freed prematurely

### DIFF
--- a/engine/script/src/script_timer.cpp
+++ b/engine/script/src/script_timer.cpp
@@ -166,6 +166,12 @@ namespace dmScript
         assert(timer_world != 0x0);
         assert(timer.m_IsAlive == 0);
 
+        LuaCallbackInfo* callback = (LuaCallbackInfo*) timer.m_UserData;
+        if (IsCallbackValid(callback))
+        {
+            DestroyCallback(callback);
+        }
+
         uint16_t lookup_index = GetLookupIndex(timer.m_Handle);
         uint16_t timer_index = timer_world->m_IndexLookup[lookup_index];
         timer_world->m_IndexPool.Push(lookup_index);


### PR DESCRIPTION
Fixed an issue where a timer was created with a callback and the timer was removed before it could complete. In this case, the lua reference to the timer callback was never released, causing a reference leak.

Fixes #8700