### PR TITLE
Don't attempt to preload deprecated tile_set field

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_sprite.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_sprite.cpp
@@ -114,10 +114,12 @@ namespace dmGameSystem
                 dmResource::PreloadHint(params->m_HintInfo, ddf->m_Textures[i].m_Texture);
             }
         }
-        else
+
+        if (ddf->m_TileSet[0] != '\0')
         {
-            dmResource::PreloadHint(params->m_HintInfo, ddf->m_TileSet);
+            dmLogInfo("Using tilesets for sprites is deprecated. '%s' will not be loaded or used.", ddf->m_TileSet);
         }
+
         dmResource::PreloadHint(params->m_HintInfo, ddf->m_Material);
 
         *params->m_PreloadData = ddf;


### PR DESCRIPTION
Fixed an issue where loading a sprite resource with no texture samplers assigned incorrectly tries to load the tileset instead.

Fixes #9178 