### PR TITLE
Show notification instead of exception when the editor can't be connected to debugger

### DIFF
--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1273,7 +1273,7 @@ If you do not specifically require different script states, consider changing th
                                  (when (or engine skip-engine)
                                    (when-let [target (launch-built-project! project engine project-directory prefs web-server true workspace)]
                                      (when (nil? (debug-view/current-session debug-view))
-                                       (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
+                                       (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0) workspace)))))))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
   (async-build! project
@@ -1288,7 +1288,7 @@ If you do not specifically require different script states, consider changing th
                              (when (handle-build-results! workspace render-build-error! build-results)
                                (let [target (targets/selected-target prefs)]
                                  (when (targets/controllable-target? target)
-                                   (debug-view/attach! debug-view project target (:artifacts build-results))))))))
+                                   (debug-view/attach! debug-view project target (:artifacts build-results) workspace)))))))
 
 (handler/defhandler :start-debugger :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.

--- a/editor/src/clj/editor/app_view.clj
+++ b/editor/src/clj/editor/app_view.clj
@@ -1273,7 +1273,7 @@ If you do not specifically require different script states, consider changing th
                                  (when (or engine skip-engine)
                                    (when-let [target (launch-built-project! project engine project-directory prefs web-server true workspace)]
                                      (when (nil? (debug-view/current-session debug-view))
-                                       (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0) workspace)))))))))
+                                       (debug-view/start-debugger! debug-view project (:address target "localhost") (:instance-index target 0))))))))))
 
 (defn- attach-debugger! [workspace project prefs debug-view render-build-error!]
   (async-build! project
@@ -1288,7 +1288,7 @@ If you do not specifically require different script states, consider changing th
                              (when (handle-build-results! workspace render-build-error! build-results)
                                (let [target (targets/selected-target prefs)]
                                  (when (targets/controllable-target? target)
-                                   (debug-view/attach! debug-view project target (:artifacts build-results) workspace)))))))
+                                   (debug-view/attach! debug-view project target (:artifacts build-results))))))))
 
 (handler/defhandler :start-debugger :global
   ;; NOTE: Shares a shortcut with :debug-view/continue.

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -506,7 +506,7 @@
                                           :suspension-state nil)
                          (state-changed! debug-view false)))
                      (fn [e]
-                          (show-connect-failed-info! target-address (+ mobdebug-port instance-index) e workspace))))
+                       (show-connect-failed-info! target-address (+ mobdebug-port instance-index) e workspace))))
 
 (defn current-session
   ([debug-view]

--- a/editor/src/clj/editor/debug_view.clj
+++ b/editor/src/clj/editor/debug_view.clj
@@ -30,6 +30,7 @@
             [editor.resource :as resource]
             [editor.targets :as targets]
             [editor.ui :as ui]
+            [editor.notifications :as notifications]
             [editor.workspace :as workspace]
             [service.log :as log])
   (:import [com.dynamo.lua.proto Lua$LuaModule]
@@ -473,38 +474,39 @@
 
 (def ^:private mobdebug-port 8172)
 
-(defn- show-connect-failed-dialog! [target-address port ^Exception exception]
-  (let [msg (str "Failed to attach debugger to " target-address ":" port ".\n"
-                 "Check that the game is running and is reachable over the network.\n")]
-    (log/error :msg msg :exception exception)
-    (dialogs/make-info-dialog
-      {:title "Attach Debugger Failed"
-       :icon :icon/triangle-error
-       :header msg
-       :content (.getMessage exception)})))
+(defn- show-connect-failed-info! [target-address port ^Exception exception workspace]
+  (ui/run-later
+    (let [msg (str "Failed to attach debugger to " target-address ":" port ".\n"
+                   "Check that the game is running and is reachable over the network.\n"
+                   "Error message:\n" (.getMessage exception))]
+      (log/error :msg msg :exception exception)
+      (notifications/show!
+        (workspace/notifications workspace)
+        {:type :error
+         :id ::debugger-connection-error
+         :text msg}))))
 
 (defn start-debugger!
-  [debug-view project target-address instance-index]
-  (try
-    (mobdebug/connect! target-address (+ mobdebug-port instance-index)
-                       (fn [debug-session]
-                         (ui/run-now
-                           (g/update-property! debug-view :debug-session
-                                               (fn [old new]
-                                                 (when old (mobdebug/close! old))
-                                                 new)
-                                               debug-session)
-                           (update-breakpoints! debug-session (g/node-value project :breakpoints))
-                           (mobdebug/run! debug-session (make-debugger-callbacks debug-view))
-                           (state-changed! debug-view true)))
-                       (fn [_debug-session]
-                         (ui/run-now
-                           (g/set-property! debug-view
-                                            :debug-session nil
-                                            :suspension-state nil)
-                           (state-changed! debug-view false))))
-    (catch Exception exception
-      (show-connect-failed-dialog! target-address (+ mobdebug-port instance-index) exception))))
+  [debug-view project target-address instance-index workspace]
+  (mobdebug/connect! target-address (+ mobdebug-port instance-index)
+                     (fn [debug-session]
+                       (ui/run-now
+                         (g/update-property! debug-view :debug-session
+                                             (fn [old new]
+                                               (when old (mobdebug/close! old))
+                                               new)
+                                             debug-session)
+                         (update-breakpoints! debug-session (g/node-value project :breakpoints))
+                         (mobdebug/run! debug-session (make-debugger-callbacks debug-view))
+                         (state-changed! debug-view true)))
+                     (fn [_debug-session]
+                       (ui/run-now
+                         (g/set-property! debug-view
+                                          :debug-session nil
+                                          :suspension-state nil)
+                         (state-changed! debug-view false)))
+                     (fn [e]
+                          (show-connect-failed-info! target-address (+ mobdebug-port instance-index) e workspace))))
 
 (defn current-session
   ([debug-view]
@@ -546,7 +548,7 @@
              (protobuf/bytes->map-with-defaults Lua$LuaModule))))
 
 (defn attach!
-  [debug-view project target build-artifacts]
+  [debug-view project target build-artifacts workspace]
   (let [target-address (:address target "localhost")
         target-port (+ mobdebug-port (:instance-index target 0))
         lua-module (built-lua-module build-artifacts debugger-init-script)]
@@ -555,10 +557,10 @@
                                (engine/run-script! target lua-module)
                                true
                                (catch Exception exception
-                                 (show-connect-failed-dialog! target-address target-port exception)
+                                 (show-connect-failed-info! target-address target-port exception workspace)
                                  false))]
       (when attach-successful?
-        (start-debugger! debug-view project target-address (:instance-index target 0))))))
+        (start-debugger! debug-view project target-address (:instance-index target 0) workspace)))))
 
 (defn detach!
   [debug-view]

--- a/editor/src/clj/editor/debugging/mobdebug.clj
+++ b/editor/src/clj/editor/debugging/mobdebug.clj
@@ -149,17 +149,20 @@
     (catch java.lang.Exception _ nil)))
 
 (defn connect!
-  [address port on-connected on-closed]
+  [address port on-connected on-closed on-error]
   (thread
-    (loop [retries 0]
-      (if-some [socket (try-connect! address port)]
-        (let [debug-session (make-debug-session socket on-closed)]
-          (on-connected debug-session))
-        (if (< retries 50)
-          (do (Thread/sleep 200) (recur (inc retries)))
-          (throw (ex-info (format "Failed to connect to debugger on %s:%d" address port)
-                          {:address address
-                           :port port})))))))
+    (try
+      (loop [retries 0]
+        (if-some [socket (try-connect! address port)]
+          (let [debug-session (make-debug-session socket on-closed)]
+            (on-connected debug-session))
+          (if (< retries 50)
+            (do (Thread/sleep 200) (recur (inc retries)))
+            (throw (ex-info (format "Failed to connect to debugger on %s:%d" address port)
+                            {:address address
+                             :port port})))))
+      (catch Exception e
+        (on-error e)))))
 
 (defn close!
   ([debug-session]

--- a/editor/src/clj/editor/debugging/mobdebug.clj
+++ b/editor/src/clj/editor/debugging/mobdebug.clj
@@ -158,7 +158,7 @@
             (on-connected debug-session))
           (if (< retries 50)
             (do (Thread/sleep 200) (recur (inc retries)))
-            (throw (ex-info (format "Failed to connect to debugger on %s:%d" address port)
+            (throw (ex-info (format "Failed to connect to debugger on %s:%d." address port)
                             {:address address
                              :port port})))))
       (catch Exception e


### PR DESCRIPTION
Inability to connect to the debugger is not the issue itself, so it shouldn't be reported as an reportable exception. Now it's a notification.

Fix https://github.com/defold/defold/issues/8885

## PR checklist

* [x] Code
	* [ ] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
