### PR TITLE
Fix various issues with slice9 and gui pivots

### DIFF
--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -51,7 +51,7 @@
             [util.murmur :as murmur])
   (:import [com.dynamo.bob.pipeline AtlasUtil ShaderUtil$Common ShaderUtil$VariantTextureArrayFallback]
            [com.dynamo.bob.textureset TextureSetGenerator$LayoutResult]
-           [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback Tile$SpriteTrimmingMode]
+           [com.dynamo.gamesys.proto AtlasProto$Atlas AtlasProto$AtlasAnimation AtlasProto$AtlasImage TextureSetProto$TextureSet Tile$Playback]
            [com.jogamp.opengl GL GL2]
            [editor.gl.vertex2 VertexBuffer]
            [editor.types AABB Animation Image]
@@ -149,19 +149,6 @@
     (.glVertex3d gl x1 y1 0)
     (.glVertex3d gl x1 y0 0)
     (.glEnd gl)))
-
-(defn render-image-outline
-  [^GL2 gl render-args renderables]
-  (doseq [renderable renderables]
-    (let [user-data (-> renderable :user-data)
-          page-offset-x (get-rect-page-offset (:layout-width user-data) (:page-index user-data))
-          color (colors/renderable-outline-color renderable)]
-      (render-rect gl (:rect user-data) color page-offset-x)))
-  (doseq [renderable renderables]
-    (let [user-data (-> renderable :user-data)
-          page-offset-x (get-rect-page-offset (:layout-width user-data) (:page-index user-data))]
-      (when (= (-> renderable :updatable :state :frame) (:order user-data))
-        (render-rect gl (:rect user-data) colors/defold-pink page-offset-x)))))
 
 (defn- renderables->outline-vertex-component-count
   [renderables]
@@ -289,7 +276,7 @@
             (dynamic read-only? (g/constantly true)))
 
   (property sprite-trim-mode g/Keyword (default (protobuf/default AtlasProto$AtlasImage :sprite-trim-mode))
-            (dynamic edit-type (g/constantly (properties/->pb-choicebox Tile$SpriteTrimmingMode))))
+            (dynamic edit-type (g/constantly texture-set-gen/sprite-trim-mode-edit-type)))
 
   (property image resource/Resource ; Required protobuf field.
             (value (gu/passthrough maybe-image-resource))

--- a/editor/src/clj/editor/geom.clj
+++ b/editor/src/clj/editor/geom.clj
@@ -32,9 +32,10 @@
 (def +& (lift-f1 +))
 (def -& (lift-f1 -))
 
-; -------------------------------------
-; 2D geometry
-; -------------------------------------
+;; -----------------------------------------------------------------------------
+;; 2D geometry
+;; -----------------------------------------------------------------------------
+
 (s/defn area :- double
   [r :- Rect]
   (if r
@@ -180,9 +181,9 @@
   [^Float fuv]
   (Geometry/toShortUV fuv))
 
-; -------------------------------------
-; Transformations
-; -------------------------------------
+;; -----------------------------------------------------------------------------
+;; Transformations
+;; -----------------------------------------------------------------------------
 
 (s/defn world-space [node :- {:world-transform Matrix4d s/Any s/Any} point :- Point3d]
   (let [p             (Point3d. point)
@@ -194,9 +195,10 @@
 (def ^Matrix3d Identity3d (doto (Matrix3d.) (.setIdentity)))
 (def ^Matrix4d Identity4d (doto (Matrix4d.) (.setIdentity)))
 
-; -------------------------------------
-; Matrix sloshing
-; -------------------------------------
+;; -----------------------------------------------------------------------------
+;; Matrix sloshing
+;; -----------------------------------------------------------------------------
+
 (defprotocol AsArray
   (^doubles as-array [this]))
 
@@ -242,9 +244,9 @@
   (doto (Matrix4d.)
     (.setIdentity)))
 
-; -------------------------------------
-; 3D geometry
-; -------------------------------------
+;; -----------------------------------------------------------------------------
+;; 3D geometry
+;; -----------------------------------------------------------------------------
 
 (defrecord DoubleRange [^double min ^double max])
 
@@ -481,10 +483,9 @@
                                (math/edge-normal near-br far-br)])]
     (types/->Frustum corners planes unique-edge-normals unique-face-normals)))
 
-; -------------------------------------
-; Primitive shapes as vertex arrays
-; -------------------------------------
-
+;; -----------------------------------------------------------------------------
+;; Primitive shapes as vertex arrays
+;; -----------------------------------------------------------------------------
 
 (s/defn unit-sphere-pos-nrm [lats longs]
   (for [lat-i (range lats)
@@ -606,3 +607,32 @@
              (.apply uv-trans p)
              [(.x p) (.y p)]) ps))
     ps))
+
+;; -----------------------------------------------------------------------------
+;; GUI Pivots
+;; -----------------------------------------------------------------------------
+
+(defn gui-pivot->h-align [gui-pivot]
+  (case gui-pivot
+    (:pivot-e :pivot-ne :pivot-se) :right
+    (:pivot-center :pivot-n :pivot-s) :center
+    (:pivot-w :pivot-nw :pivot-sw) :left))
+
+(defn gui-pivot->v-align [gui-pivot]
+  (case gui-pivot
+    (:pivot-ne :pivot-n :pivot-nw) :top
+    (:pivot-e :pivot-center :pivot-w) :middle
+    (:pivot-se :pivot-s :pivot-sw) :bottom))
+
+(defn gui-pivot-offset [gui-pivot size]
+  (let [h-align (gui-pivot->h-align gui-pivot)
+        v-align (gui-pivot->v-align gui-pivot)
+        xs (case h-align
+             :right -0.5
+             :center 0.0
+             :left 0.5)
+        ys (case v-align
+             :top -0.5
+             :middle 0.0
+             :bottom 0.5)]
+    (mapv * size [xs ys 0.0 0.0])))

--- a/editor/src/clj/editor/gui.clj
+++ b/editor/src/clj/editor/gui.clj
@@ -44,7 +44,6 @@
             [editor.resource-node :as resource-node]
             [editor.scene :as scene]
             [editor.scene-picking :as scene-picking]
-            [editor.slice9 :as slice9]
             [editor.texture-set :as texture-set]
             [editor.types :as types]
             [editor.util :as eutil]
@@ -1155,11 +1154,9 @@
   ;; Overloaded outputs
   (output node-msg g/Any :cached produce-box-node-msg)
   (output scene-renderable-user-data g/Any :cached
-          (g/fnk [pivot size color+alpha slice9 anim-data clipping-mode clipping-visible clipping-inverted]
+          (g/fnk [pivot size-mode size color+alpha slice9 anim-data clipping-mode clipping-visible clipping-inverted]
             (let [frame (get-in anim-data [:frames 0])
-                  vertex-data (if (and (:use-geometries frame))
-                                (texture-set/vertex-data frame)
-                                (slice9/vertex-data frame size slice9 pivot))
+                  vertex-data (texture-set/vertex-data frame size-mode size slice9 pivot)
                   user-data {:geom-data (:position-data vertex-data)
                              :line-data (:line-data vertex-data)
                              :uv-data (:uv-data vertex-data)

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -80,6 +80,16 @@
             (TextureSetGenerator/layoutImages layout inner-padding extrude-borders id->image))
           (.-layouts layout-result))))
 
+(def sprite-trim-mode-edit-type
+  ;; Excludes runtime-only values from the selectable options.
+  (let [selectable-value? (complement #{:sprite-trim-polygons})]
+    {:type :choicebox
+     :options (into []
+                    (keep (fn [[value opts]]
+                            (when (selectable-value? value)
+                              (pair value (:display-name opts)))))
+                    (protobuf/enum-values Tile$SpriteTrimmingMode))}))
+
 (defn- sprite-trim-mode->enum
   [sprite-trim-mode]
   (protobuf/val->pb-enum Tile$SpriteTrimmingMode sprite-trim-mode))

--- a/editor/src/clj/editor/texture_set.clj
+++ b/editor/src/clj/editor/texture_set.clj
@@ -15,9 +15,12 @@
 (ns editor.texture-set
   (:require [editor.camera :as camera]
             [editor.colors :as colors]
+            [editor.geom :as geom]
             [editor.gl :as gl]
             [editor.gl.shader :as shader]
-            [editor.gl.vertex2 :as vtx])
+            [editor.gl.vertex2 :as vtx]
+            [editor.slice9 :as slice9]
+            [util.coll :as coll])
   (:import [com.google.protobuf ByteString]
            [com.jogamp.opengl GL2]
            [editor.gl.vertex2 VertexBuffer]
@@ -25,15 +28,16 @@
            [javax.vecmath Matrix4d Point3d Vector3d]))
 
 (set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
 
-(def ^:const tex-coord-orders
-  [[0 1 2 3]   ; no flip
-   [1 0 3 2]   ; flip v
-   [3 2 1 0]   ; flip h
-   [2 3 0 1]]) ; flip vh
+(def ^:private tex-coord-orders
+  [(vector-of :long 0 1 2 3)   ; no flip
+   (vector-of :long 1 0 3 2)   ; flip v
+   (vector-of :long 3 2 1 0)   ; flip h
+   (vector-of :long 2 3 0 1)]) ; flip vh
 
 (defn- tex-coord-lookup
-  [flip-horizontal flip-vertical]
+  [^long flip-horizontal ^long flip-vertical]
   (nth tex-coord-orders (bit-xor flip-vertical
                                  (bit-shift-left flip-horizontal 1))))
 
@@ -45,19 +49,21 @@
 (defn- ->uv-quad
   [^long quad-index tex-coords tex-coord-order]
   (let [offset (* quad-index 4)]
-    (mapv #(->uv-vertex (+ offset %) tex-coords) tex-coord-order)))
+    (mapv (fn [^long tex-coord-index]
+            (->uv-vertex (+ offset tex-coord-index) tex-coords))
+          tex-coord-order)))
 
 (defn- ->tex-dim
-  [frame-index ^FloatBuffer tex-dims]
-  (let [offset (* frame-index 2)
-        width (.get tex-dims ^int (+ offset 0))
-        height (.get tex-dims ^int (+ offset 1))]
+  [^long frame-index ^FloatBuffer tex-dims]
+  (let [offset (int (* frame-index 2))
+        width (.get tex-dims offset)
+        height (.get tex-dims (inc offset))]
     {:width width :height height}))
 
 ;; anim data
 
 (defn- ->anim-frame
-  [frame-index page-index tex-coords tex-dims tex-coord-order]
+  [frame-index page-index tex-coords tex-coord-order tex-dims]
   (let [tex-coords-data (->uv-quad frame-index tex-coords tex-coord-order)
         {:keys [width height]} (->tex-dim frame-index tex-dims)]
     {:page-index page-index
@@ -67,14 +73,15 @@
 
 (defn- flat-array->2d-points [flat-array]
   (into []
-        (partition-all 2)
+        (coll/partition-all-primitives :double 2)
         flat-array))
 
 (defn- ->anim-frame-from-geometry
-  [page-index frame-geometry]
+  [frame-index page-index tex-coords tex-coord-order frame-geometry]
   {:page-index page-index
-   :tex-coords (flat-array->2d-points (:uvs frame-geometry))
+   :tex-coords (->uv-quad frame-index tex-coords tex-coord-order)
    :vertex-coords (flat-array->2d-points (:vertices frame-geometry))
+   :vertex-tex-coords (flat-array->2d-points (:uvs frame-geometry))
    :indices (:indices frame-geometry)
    :use-geometries true
    :width (:width frame-geometry)
@@ -82,13 +89,18 @@
 
 (defn- ->anim-data
   [{:keys [start end fps flip-horizontal flip-vertical playback]} tex-coords tex-dims uv-transforms frame-indices page-indices geometries use-geometries]
-  (let [frames (mapv (fn [i]
+  {:pre [(contains? #{nil 0 1} flip-horizontal)
+         (contains? #{nil 0 1} flip-vertical)]}
+  (let [tex-coord-order (tex-coord-lookup (or flip-horizontal 0) (or flip-vertical 0))
+        frames (mapv (fn [i]
                        (let [frame-index (frame-indices i)
                              page-index (page-indices frame-index)
                              frame-geometry (get geometries frame-index)]
-                         (if use-geometries
-                           (->anim-frame-from-geometry page-index frame-geometry)
-                           (->anim-frame frame-index page-index tex-coords tex-dims (tex-coord-lookup flip-horizontal flip-vertical)))))
+                         (if (and use-geometries
+                                  (not= :sprite-trim-mode-off
+                                        (:trim-mode frame-geometry)))
+                           (->anim-frame-from-geometry frame-index page-index tex-coords tex-coord-order frame-geometry)
+                           (->anim-frame frame-index page-index tex-coords tex-coord-order tex-dims))))
                      (range start end))]
     {:width (transduce (map :width) max 0 frames)
      :height (transduce (map :height) max 0 frames)
@@ -126,64 +138,91 @@
     (.transform world-transform p)
     (vector-of :double (.x p) (.y p) (.z p) 1.0 u v page-index)))
 
-(defn- animation-frame-corners [animation-frame]
-  (let [^double width (:width animation-frame)
-        ^double height (:height animation-frame)
-        x1 (* 0.5 width)
-        y1 (* 0.5 height)
-        x0 (- x1)
-        y0 (- y1)
+(defn- corner-points [[^double width ^double height :as size] pivot]
+  (let [[^double offset-x ^double offset-y] (geom/gui-pivot-offset pivot size)
+        half-width (* 0.5 width)
+        half-height (* 0.5 height)
+        x0 (+ (- half-width) offset-x)
+        y0 (+ (- half-height) offset-y)
+        x1 (+ half-width offset-x)
+        y1 (+ half-height offset-y)
         xynw (vector-of :double x0 y0 0.0 1.0)
         xyne (vector-of :double x1 y0 0.0 1.0)
         xysw (vector-of :double x0 y1 0.0 1.0)
         xyse (vector-of :double x1 y1 0.0 1.0)]
     [xynw xyne xysw xyse]))
 
-(defn position-data [animation-frame]
-  (if (:use-geometries animation-frame)
-    (let [^double width (:width animation-frame)
-          ^double height (:height animation-frame)
-          vertex-coords (:vertex-coords animation-frame)
-          indices (:indices animation-frame)]
-      (mapv (fn [i]
-              (let [p (get vertex-coords i)
-                    x (* width (get p 0))
-                    y (* height (get p 1))]
-                (vector-of :double x y 0.0 1.0)))
-            indices))
-    (let [corner-points (animation-frame-corners animation-frame)
-          xynw (get corner-points 0)
-          xyne (get corner-points 1)
-          xysw (get corner-points 2)
-          xyse (get corner-points 3)]
-      [xynw xyne xysw xyne xyse xysw])))
+(defn- corner-points->position-data [[xynw xyne xysw xyse]]
+  [xynw xyne xysw xyne xyse xysw])
 
-(defn uv-data [animation-frame]
-  (if (:use-geometries animation-frame)
-    (let [tex-coords (:tex-coords animation-frame)
-          indices (:indices animation-frame)]
-      (mapv (fn [i] (get tex-coords i)) indices))
-    (let [[uvnw uvsw uvse uvne] (:tex-coords animation-frame)]
-      [uvnw uvne uvsw uvne uvse uvsw])))
+(defn- corner-points->line-data [[xynw xyne xysw xyse]]
+  [xynw xyne xyne xyse xyse xysw xysw xynw])
 
-(defn- line-data [animation-frame]
-  (let [corner-points (animation-frame-corners animation-frame)
-        xynw (get corner-points 0)
-        xyne (get corner-points 1)
-        xysw (get corner-points 2)
-        xyse (get corner-points 3)]
-    [xynw xyne xyne xyse xyse xysw xysw xynw]))
+(defn- frame-vertex-data [animation-frame size pivot]
+  (let [use-geometries (:use-geometries animation-frame)
+        corner-points (corner-points size pivot)
+        line-data (corner-points->line-data corner-points)
 
-(defn vertex-data [animation-frame]
-  {:position-data (position-data animation-frame)
-   :uv-data (uv-data animation-frame)
-   :line-data (line-data animation-frame)})
+        position-data
+        (if use-geometries
+          (let [[^double width ^double height] size
+                [^double offset-x ^double offset-y] (geom/gui-pivot-offset pivot size)
+                vertex-coords (:vertex-coords animation-frame)
+                indices (:indices animation-frame)]
+            (mapv (fn [i]
+                    (let [[^double px ^double py] (vertex-coords i)
+                          x (+ (* width px) offset-x)
+                          y (+ (* height py) offset-y)]
+                      (vector-of :double x y 0.0 1.0)))
+                  indices))
+          (corner-points->position-data corner-points))
+
+        uv-data
+        (if use-geometries
+          (let [tex-coords (:vertex-tex-coords animation-frame)
+                indices (:indices animation-frame)]
+            (mapv tex-coords indices))
+          (let [[uvnw uvsw uvse uvne] (:tex-coords animation-frame)]
+            [uvnw uvne uvsw uvne uvse uvsw]))]
+
+    {:position-data position-data
+     :uv-data uv-data
+     :line-data line-data}))
+
+(def ^:private default-quad-uv-data
+  [(vector-of :double 0.0 0.0)
+   (vector-of :double 1.0 0.0)
+   (vector-of :double 0.0 1.0)
+   (vector-of :double 1.0 0.0)
+   (vector-of :double 1.0 1.0)
+   (vector-of :double 0.0 1.0)])
+
+(defn- quad-vertex-data [size pivot]
+  (let [corner-points (corner-points size pivot)
+        position-data (corner-points->position-data corner-points)
+        line-data (corner-points->line-data corner-points)]
+    {:position-data position-data
+     :uv-data default-quad-uv-data
+     :line-data line-data}))
+
+(defn vertex-data [animation-frame size-mode size slice9 pivot]
+  (-> (cond
+        (nil? animation-frame)
+        (quad-vertex-data size pivot)
+
+        (and (= :size-mode-manual size-mode)
+             (slice9/sliced? slice9))
+        (slice9/vertex-data animation-frame size slice9 pivot)
+
+        :else
+        (frame-vertex-data animation-frame size pivot))
+      (assoc :page-index (:page-index animation-frame 0))))
 
 
 ;; animation
 
 (defn- next-frame
-  [frame playback frame-time frame-count]
+  [frame playback frame-time ^long frame-count]
   (case playback
     :playback-none frame
 
@@ -191,20 +230,20 @@
     (mod frame-time frame-count)
 
     (:playback-once-backward :playback-loop-backward)
-    (- (dec frame-count) (mod frame-time frame-count))
+    (- (dec frame-count) (long (mod frame-time frame-count)))
 
     (:playback-once-pingpong :playback-loop-pingpong)
     ;; Unwrap to frame-count + (frame-count - 2)
     (let [pingpong-frame-count (max (- (* frame-count 2) 2) 1)
-          next-frame (mod frame-time pingpong-frame-count)]
+          next-frame (long (mod frame-time pingpong-frame-count))]
       (if (< next-frame frame-count)
         next-frame
         (- (dec frame-count) (- next-frame frame-count) 1)))))
 
 (defn step-animation
-  [{:keys [t frame] :as state} dt anim-data]
+  [{:keys [^double t frame] :as state} ^double dt anim-data]
   (let [t' (+ t dt)
-        time-per-frame (/ 1.0 (:fps anim-data))
+        time-per-frame (/ 1.0 (double (:fps anim-data)))
         frame-time (long (+ 0.5 (/ t' time-per-frame)))
         frame' (next-frame frame (:playback anim-data) frame-time (count (:frames anim-data)))]
     (assoc state :t t' :frame frame')))
@@ -222,12 +261,14 @@
 
 ;; rendering
 
-(def ^:const animation-preview-offset 40)
+(def ^:const animation-preview-offset 40.0)
 
-(defn animation-frame->vertex-pos-uv
+(defn- animation-frame->vertex-pos-uv
   [animation-frame world-transform]
-  (let [frame-vertex-data (vertex-data animation-frame)
-        page-index (:page-index animation-frame)]
+  (let [^double width (:width animation-frame)
+        ^double height (:height animation-frame)
+        frame-vertex-data (frame-vertex-data animation-frame width height)
+        page-index (:page-index animation-frame 0)]
     (mapv (fn [positions uvs]
             (let [x (get positions 0)
                   y (get positions 1)
@@ -255,26 +296,28 @@
       6)))
 
 (defn render-animation-overlay
-  [^GL2 gl render-args renderables n make-vbuf-fn shader]
-  (let [{:keys [pass camera viewport]} render-args
-        [sx sy sz] (camera/scale-factor camera viewport)
+  [^GL2 gl render-args renderables _renderable-count make-vbuf-fn shader]
+  (let [{:keys [camera viewport]} render-args
+        [^double sx ^double sy ^double sz] (camera/scale-factor camera viewport)
         scale-m (doto (Matrix4d.)
                   (.setIdentity)
-                  (.setM00 (/ 1 sx))
-                  (.setM11 (- (/ 1 sy))) ; flip
-                  (.setM22 (/ 1 sz))
-                  (.setM33 1))
-        world-pos (Vector3d. animation-preview-offset (- (:bottom viewport) animation-preview-offset) 0)]
+                  (.setM00 (/ 1.0 sx))
+                  (.setM11 (- (/ 1.0 sy))) ; flip
+                  (.setM22 (/ 1.0 sz))
+                  (.setM33 1.0))
+        world-pos (Vector3d. animation-preview-offset (- (double (:bottom viewport)) animation-preview-offset) 0.0)]
     (doseq [renderable renderables]
       (let [state (-> renderable :updatable :state)]
         (when-let [frame (:frame state)]
           (let [user-data (:user-data renderable)
                 anim-data (:anim-data user-data)
+                image-width (double (:width anim-data))
+                image-height (double (:height anim-data))
                 world-transform (doto (Matrix4d.)
                                   (.setIdentity)
-                                  (.setTranslation (Vector3d. (+ (.x world-pos)  (* 0.5 (/ 1 sx) (:width anim-data)))
-                                                              (- (.y world-pos) (* 0.5 (/ 1 sy) (:height anim-data)))
-                                                              0))
+                                  (.setTranslation (Vector3d. (+ (.x world-pos) (* 0.5 (/ 1.0 sx) image-width))
+                                                              (- (.y world-pos) (* 0.5 (/ 1.0 sy) image-height))
+                                                              0.0))
                                   (.mul scale-m))
                 vertex-count (anim-data->vertex-count anim-data frame)
                 vbuf (anim-data->vbuf anim-data frame world-transform make-vbuf-fn)]
@@ -283,8 +326,8 @@
                     gpu-texture (:gpu-texture user-data)
                     x0 (.x world-pos)
                     y0 (.y world-pos)
-                    x1 (+ x0 (* (/ 1 sx) (:width anim-data)))
-                    y1 (- y0 (* (/ 1 sy) (:height anim-data)))
+                    x1 (+ x0 (* (/ 1.0 sx) image-width))
+                    y1 (- y0 (* (/ 1.0 sy) image-height))
                     [cr cg cb ca] colors/outline-color
                     [xr xg xb xa] colors/scene-background]
                 (.glColor4d gl xr xg xb xa)

--- a/editor/src/clj/editor/tile_source.clj
+++ b/editor/src/clj/editor/tile_source.clj
@@ -46,7 +46,7 @@
             [editor.workspace :as workspace]
             [util.coll :as coll :refer [pair]]
             [util.digestable :as digestable])
-  (:import [com.dynamo.gamesys.proto TextureSetProto$TextureSet Tile$Animation Tile$ConvexHull Tile$Playback Tile$SpriteTrimmingMode Tile$TileSet]
+  (:import [com.dynamo.gamesys.proto TextureSetProto$TextureSet Tile$Animation Tile$ConvexHull Tile$Playback Tile$TileSet]
            [com.jogamp.opengl GL2]
            [editor.types AABB]
            [java.awt.image BufferedImage]
@@ -606,7 +606,7 @@
   (property original-convex-hulls g/Any ; No protobuf counterpart.
             (dynamic visible (g/constantly false)))
   (property sprite-trim-mode g/Keyword (default (protobuf/default Tile$TileSet :sprite-trim-mode))
-            (dynamic edit-type (g/constantly (properties/->pb-choicebox Tile$SpriteTrimmingMode))))
+            (dynamic edit-type (g/constantly texture-set-gen/sprite-trim-mode-edit-type)))
   (property tile->collision-group-node g/Any ; No protobuf counterpart.
             (dynamic visible (g/constantly false)))
 

--- a/editor/src/clj/editor/types.clj
+++ b/editor/src/clj/editor/types.clj
@@ -184,7 +184,8 @@
           :sprite-trim-mode-5
           :sprite-trim-mode-6
           :sprite-trim-mode-7
-          :sprite-trim-mode-8))
+          :sprite-trim-mode-8
+          :sprite-trim-polygons))
 
 (s/defrecord Image
   [path     :- s/Any


### PR DESCRIPTION
* The slice-9 setting will now be correctly visualized in the editor viewport in all scenarios.
* Gui pivot offsets are now correctly visualized in the editor viewport in all scenarios.
* You can no longer select "Polygons" as a Sprite Trim Mode for an atlas image, which would previously throw an exception.

Fixes #8826.
Fixes #9192.

---

Test Project: 
[dev-texture-vertex-data.zip](https://github.com/user-attachments/files/16565114/dev-texture-vertex-data.zip)
