### PR TITLE
Make sure that build server url is trimmed

### DIFF
--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -150,11 +150,12 @@
 (defn get-build-server-url
   (^String [prefs project]
    (g/with-auto-evaluation-context evaluation-context
-     (get-build-server-url prefs project evaluation-context)))
+     (string/trim (get-build-server-url prefs project evaluation-context))))
   (^String [prefs project evaluation-context]
-   (or (not-empty (prefs/get-prefs prefs "extensions-server" ""))
-       (not-empty (shared-editor-settings/get-setting project ["extensions" "build_server"] evaluation-context))
-       defold-build-server-url)))
+   (string/trim
+     (or (not-empty (prefs/get-prefs prefs "extensions-server" ""))
+         (not-empty (shared-editor-settings/get-setting project ["extensions" "build_server"] evaluation-context))
+         defold-build-server-url))))
 
 (defn get-build-server-headers
   ^String [prefs]

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -150,7 +150,7 @@
 (defn get-build-server-url
   (^String [prefs project]
    (g/with-auto-evaluation-context evaluation-context
-     (string/trim (get-build-server-url prefs project evaluation-context))))
+     (get-build-server-url prefs project evaluation-context)))
   (^String [prefs project evaluation-context]
    (string/trim
      (or (not-empty (prefs/get-prefs prefs "extensions-server" ""))

--- a/editor/src/clj/editor/engine/native_extensions.clj
+++ b/editor/src/clj/editor/engine/native_extensions.clj
@@ -152,10 +152,9 @@
    (g/with-auto-evaluation-context evaluation-context
      (get-build-server-url prefs project evaluation-context)))
   (^String [prefs project evaluation-context]
-   (string/trim
-     (or (not-empty (prefs/get-prefs prefs "extensions-server" ""))
-         (not-empty (shared-editor-settings/get-setting project ["extensions" "build_server"] evaluation-context))
-         defold-build-server-url))))
+   (or (not-empty (string/trim (prefs/get-prefs prefs "extensions-server" ""))) ;; always trim because `get-prefs` does not return nil
+       (not-empty (some-> (shared-editor-settings/get-setting project ["extensions" "build_server"] evaluation-context) string/trim)) ;; use `some->` because `get-setting` may return nil
+       defold-build-server-url)))
 
 (defn get-build-server-headers
   ^String [prefs]


### PR DESCRIPTION
It's annoying when space in the beginning or in the end of URL prevents from building with:

>URISyntaxException: Illegal character in scheme name at index 0:  https://build.defold.com

 It happens from time to time for me and for ppl in community, I think it's easier just trim URL to make sure it's not an issue