### PR TITLE
Added engine.max_time_step config value

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/meta.properties
@@ -729,3 +729,6 @@ fixed_update_frequency.type = integer
 fixed_update_frequency.help = Enables some components to use a fixed frame rate. 0 means it's disabled. (Hz)
 fixed_update_frequency.default = 60
 
+max_time_step.type = number
+max_time_step.help = If the time step is too large, it will be capped to this max value
+max_time_step.default = 0.5

--- a/editor/resources/meta.edn
+++ b/editor/resources/meta.edn
@@ -78,6 +78,10 @@
    :help "enables some components to use a fixed frame rate. 0 means it's disabled. (Hz)",
    :default 60,
    :path ["engine" "fixed_update_frequency"]}
+  {:type :number,
+   :help "If the time step is too large, it will be capped to this max value (seconds)",
+   :default 0.5,
+   :path ["engine" "max_time_step"]}
   {:type :integer,
    :help
    "the width in pixels of the application window, 960 by default",

--- a/editor/test/resources/save_data_project/game.project
+++ b/editor/test/resources/save_data_project/game.project
@@ -180,6 +180,7 @@ max_tile_count = 1024
 [engine]
 run_while_iconified = 1
 fixed_update_frequency = 30
+max_time_step = 0.1
 
 [facebook]
 appid = com.defold.save-data-project

--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -951,12 +951,11 @@ namespace dmEngine
 #endif
 
         engine->m_FixedUpdateFrequency = dmConfigFile::GetInt(engine->m_Config, "engine.fixed_update_frequency", 60);
+        engine->m_MaxTimeStep = dmConfigFile::GetFloat(engine->m_Config, "engine.max_time_step", 0.5);
 
         dmGameSystem::OnWindowCreated(physical_width, physical_height);
 
-        engine->m_UpdateFrequency = dmConfigFile::GetInt(engine->m_Config, "display.update_frequency", 0);
-
-        SetUpdateFrequency(engine, engine->m_UpdateFrequency);
+        SetUpdateFrequency(engine, dmConfigFile::GetInt(engine->m_Config, "display.update_frequency", 0));
 
         const uint32_t max_resources = dmConfigFile::GetInt(engine->m_Config, dmResource::MAX_RESOURCES_KEY, 1024);
         dmResource::NewFactoryParams params;
@@ -1835,8 +1834,8 @@ bail:
         float frame_dt = (float)(frame_time / 1000000.0);
 
         // Never allow for large hitches
-        if (frame_dt > 0.5f) {
-            frame_dt = 0.5f;
+        if (frame_dt > engine->m_MaxTimeStep) {
+            frame_dt = engine->m_MaxTimeStep;
         }
 
         // Variable frame rate

--- a/engine/engine/src/engine_private.h
+++ b/engine/engine/src/engine_private.h
@@ -166,6 +166,7 @@ namespace dmEngine
         uint32_t                                    m_ClearColor;
         float                                       m_InvPhysicalWidth;
         float                                       m_InvPhysicalHeight;
+        float                                       m_MaxTimeStep;
 
         RecordData                                  m_RecordData;
     };


### PR DESCRIPTION
In case the engine timestep grows too large, it will be capped against this max value (default is 0.5 seconds)

Fixes https://github.com/defold/defold/issues/9252

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
