### PR TITLE
Decorate editor build exceptions with error source

### DIFF
--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -886,12 +886,9 @@
        (update-cache-from-evaluation-context! ~ec))
      result#))
 
-(defn- do-node-value [node-id label evaluation-context]
-  (is/node-value @*the-system* node-id label evaluation-context))
-
 (defn node-value
   "Pull a value from a node's output, property or input, identified by `label`.
-  The value may be cached or it may be computed on demand. This is
+  The value may be cached, or it may be computed on demand. This is
   transparent to the caller.
 
   This uses the value of the node and its output at the time the
@@ -909,9 +906,12 @@
   `(node-value node-id :chained-output)`"
   ([node-id label]
    (with-auto-evaluation-context evaluation-context
-     (do-node-value node-id label evaluation-context)))
+     (node-value node-id label evaluation-context)))
   ([node-id label evaluation-context]
-   (do-node-value node-id label evaluation-context)))
+   (when (some? node-id)
+     (let [basis (:basis evaluation-context)
+           node (gt/node-by-id-at basis node-id)]
+       (in/node-value node label evaluation-context)))))
 
 (defn valid-node-value
   "Like the node-value function, but throws an exception if evaluation produced
@@ -920,7 +920,7 @@
    (with-auto-evaluation-context evaluation-context
      (valid-node-value node-id label evaluation-context)))
   ([node-id label evaluation-context]
-   (let [value (do-node-value node-id label evaluation-context)]
+   (let [value (node-value node-id label evaluation-context)]
      (if (error? value)
        (throw (ex-info "Evaluation produced an ErrorValue."
                        {:node-type-kw (node-type-kw (:basis evaluation-context) node-id)
@@ -928,16 +928,20 @@
                         :error value}))
        value))))
 
-(defn successful-node-value
+(defn maybe-node-value
   "Like the node-value function, but returns nil if evaluation produced an
-  ErrorValue."
+  ErrorValue or the label does not exist on the node."
   ([node-id label]
    (with-auto-evaluation-context evaluation-context
-     (successful-node-value node-id label evaluation-context)))
+     (maybe-node-value node-id label evaluation-context)))
   ([node-id label evaluation-context]
-   (let [value (do-node-value node-id label evaluation-context)]
-     (when-not (error? value)
-       value))))
+   (when (some? node-id)
+     (let [basis (:basis evaluation-context)
+           node (gt/node-by-id-at basis node-id)]
+       (when (some-> node gt/node-type (in/behavior label))
+         (let [value (in/node-value node label evaluation-context)]
+           (when-not (error? value)
+             value)))))))
 
 (defn graph-value
   "Returns the graph from the system given a graph-id and key.  It returns the graph at the point in time of the bais, if provided.

--- a/editor/src/clj/dynamo/graph.clj
+++ b/editor/src/clj/dynamo/graph.clj
@@ -928,6 +928,17 @@
                         :error value}))
        value))))
 
+(defn successful-node-value
+  "Like the node-value function, but returns nil if evaluation produced an
+  ErrorValue."
+  ([node-id label]
+   (with-auto-evaluation-context evaluation-context
+     (successful-node-value node-id label evaluation-context)))
+  ([node-id label evaluation-context]
+   (let [value (do-node-value node-id label evaluation-context)]
+     (when-not (error? value)
+       value))))
+
 (defn graph-value
   "Returns the graph from the system given a graph-id and key.  It returns the graph at the point in time of the bais, if provided.
   If the basis is not provided, it will take it from the current point of time in the system.

--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -95,7 +95,10 @@
                                     (g/map->error {:_node-id (build-target :node-id)
                                                    :_label :build-targets
                                                    :severity :fatal
-                                                   :message (str "Dependency cycle detected: " (string/join " -> " cycle))}))
+                                                   :message (format "Dependency cycle detected: %s."
+                                                                    (string/join " -> "
+                                                                                 (map #(str \' % \')
+                                                                                      cycle)))}))
                                   (let [deps (build-target :deps)
                                         dynamic-deps (build-target :dynamic-deps)
                                         resolved-deps

--- a/editor/src/clj/editor/build.clj
+++ b/editor/src/clj/editor/build.clj
@@ -169,7 +169,10 @@
         progress-tracer (project/make-progress-tracer :build-targets step-count progress-message-fn (progress/nest-render-progress render-progress! (progress/make "" 10) 5))
         evaluation-context-with-progress-trace (assoc evaluation-context :tracer progress-tracer)
         _ (doseq [node-id (rseq @steps)]
-            (g/node-value node-id :build-targets evaluation-context-with-progress-trace))
+            (try
+              (g/node-value node-id :build-targets evaluation-context-with-progress-trace)
+              (catch Throwable error
+                (throw (pipeline/decorate-build-exception error :compile node-id nil evaluation-context)))))
         #_#_#_#_
         prewarm-partitions (partition-all (max (quot step-count (+ (available-processors) 2)) 1000) (rseq @steps))
         _ (batched-pmap (fn [node-id] (g/node-value node-id :build-targets evaluation-context-with-progress-trace)) prewarm-partitions)
@@ -178,4 +181,4 @@
     (if (g/error? build-targets)
       {:error build-targets}
       (let [build-dir (workspace/build-path (project/workspace project evaluation-context))]
-        (pipeline/build! build-targets build-dir old-artifact-map (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5))))))
+        (pipeline/build! build-targets build-dir old-artifact-map evaluation-context (progress/nest-render-progress render-progress! (progress/make "" 10 5) 5))))))

--- a/editor/src/clj/editor/engine/build_errors.clj
+++ b/editor/src/clj/editor/engine/build_errors.clj
@@ -436,11 +436,11 @@
 
 (defn unsupported-platform-error [platform]
   (ex-info (str "Unsupported platform " platform)
-           {:type ::unsupported-platform-error
+           {:ex-type ::unsupported-platform-error
             :platform platform}))
 
 (defn unsupported-platform-error? [exception]
-  (= ::unsupported-platform-error (:type (ex-data exception))))
+  (= ::unsupported-platform-error (:ex-type (ex-data exception))))
 
 (defn unsupported-platform-error-causes [project evaluation-context]
   [(g/map->error
@@ -450,12 +450,12 @@
 
 (defn missing-resource-error [prop-name referenced-proj-path referencing-node-id]
   (ex-info (format "%s '%s' could not be found" prop-name referenced-proj-path)
-           {:type ::missing-resource-error
+           {:ex-type ::missing-resource-error
             :node-id referencing-node-id
             :proj-path referenced-proj-path}))
 
 (defn- missing-resource-error? [exception]
-  (= ::missing-resource-error (:type (ex-data exception))))
+  (= ::missing-resource-error (:ex-type (ex-data exception))))
 
 (defn- missing-resource-error-causes [^Throwable exception]
   [(g/map->error
@@ -464,10 +464,10 @@
       :severity :fatal})])
 
 (defn build-error [message log]
-  (ex-info message {:type ::build-error :log log}))
+  (ex-info message {:ex-type ::build-error :log log}))
 
 (defn build-error? [exception]
-  (= ::build-error (:type (ex-data exception))))
+  (= ::build-error (:ex-type (ex-data exception))))
 
 (defn- build-error-causes [project evaluation-context exception]
   (let [log (:log (ex-data exception))

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -61,15 +61,13 @@
                (str "embedded." (resource/ext resource))
                (resource/proj-path resource))))
          (when (in/inherits? node-type outline/OutlineNode)
-           (coll/not-empty (:label (g/successful-node-value node-id :node-outline evaluation-context))))
-         (when (g/has-output? node-type :name)
-           (let [name (g/successful-node-value node-id :name evaluation-context)]
-             (when (string? name)
-               (coll/not-empty name))))
-         (when (g/has-output? node-type :id)
-           (let [id (g/successful-node-value node-id :id evaluation-context)]
-             (when (string? id)
-               (coll/not-empty id))))
+           (coll/not-empty (:label (g/maybe-node-value node-id :node-outline evaluation-context))))
+         (let [name (g/maybe-node-value node-id :name evaluation-context)]
+           (when (string? name)
+             (coll/not-empty name)))
+         (let [id (g/maybe-node-value node-id :id evaluation-context)]
+           (when (string? id)
+             (coll/not-empty id)))
          (str (name (:k node-type)) \# node-id)))))
 
 (defn node-debug-label-path

--- a/editor/src/clj/editor/graph_util.clj
+++ b/editor/src/clj/editor/graph_util.clj
@@ -95,8 +95,7 @@
                                   (catch Exception _
                                     nil))
          owner-resource-node-type-kw (some->> owner-resource-node-id (g/node-type-kw basis))]
-     {:node-id node-id
-      :node-type-kw node-type-kw
+     {:node-type-kw node-type-kw
       :node-debug-label-path node-debug-label-path
       :owner-resource-node-id owner-resource-node-id
       :owner-resource-node-type-kw owner-resource-node-type-kw})))

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -1428,7 +1428,7 @@
 (defn- update-in-production [in-production endpoint]
   (if (contains? in-production endpoint)
     (throw (ex-info "Cycle detected on node"
-                    {:cause :cycle-detected
+                    {:ex-type :cycle-detected
                      :endpoint endpoint
                      :in-production in-production}))
     (conj in-production endpoint)))

--- a/editor/src/clj/internal/node.clj
+++ b/editor/src/clj/internal/node.clj
@@ -466,14 +466,11 @@
   gathering inputs to call a production function, invoke the function,
   return the result, meanwhile collecting stats on cache hits and
   misses (for later cache update) in the evaluation-context."
-  [node-id label evaluation-context]
+  [node label evaluation-context]
   (validate-evaluation-context evaluation-context)
-  (when (some? node-id)
-    (let [basis (:basis evaluation-context)
-          node (gt/node-by-id-at basis node-id)]
-      (gt/produce-value node label (apply-dry-run-cache evaluation-context)))))
+  (gt/produce-value node label (apply-dry-run-cache evaluation-context)))
 
-(defn node-property-value* [node label evaluation-context]
+(defn node-property-value [node label evaluation-context]
   (validate-evaluation-context evaluation-context)
   (let [node-type (gt/node-type node)]
     (when-let [behavior (property-behavior node-type label)]

--- a/editor/src/clj/internal/system.clj
+++ b/editor/src/clj/internal/system.clj
@@ -385,15 +385,6 @@
                   (update :cache c/cache-encache safe-cache-misses (:basis evaluation-context))))))
     system))
 
-(defn node-value
-  "Get a value, possibly cached, from a node. This is the entry point
-  to the \"plumbing\". If the value is cacheable and exists in the
-  cache, then return that value. Otherwise, produce the value by
-  gathering inputs to call a production function, invoke the function,
-  maybe cache the value that was produced, and return it."
-  [system node-id label evaluation-context]
-  (in/node-value node-id label evaluation-context))
-
 (defn user-data [system node-id key]
   (let [graph-id (gt/node-id->graph-id node-id)]
     (get-in (:user-data system) [graph-id node-id key])))

--- a/editor/src/clj/internal/transaction.clj
+++ b/editor/src/clj/internal/transaction.clj
@@ -625,7 +625,7 @@
       (let [;; Fetch the node value by either evaluating (value ...) for the property or looking in the node map
             ;; The context is intentionally bare, i.e. only :basis, for this reason
             evaluation-context (in/custom-evaluation-context {:basis basis :tx-data-context (:tx-data-context ctx)})
-            old-value (in/node-property-value* node property evaluation-context)
+            old-value (in/node-property-value node property evaluation-context)
             new-value (if inject-evaluation-context
                         (apply fn evaluation-context old-value args)
                         (apply fn old-value args))

--- a/editor/src/dev/dev.clj
+++ b/editor/src/dev/dev.clj
@@ -59,6 +59,7 @@
            [editor.gl.vertex2 VertexBuffer]
            [editor.resource FileResource MemoryResource ZipResource]
            [editor.types AABB]
+           [editor.workspace BuildResource]
            [internal.graph.types Arc Endpoint]
            [java.beans BeanInfo Introspector MethodDescriptor PropertyDescriptor]
            [java.io ByteArrayOutputStream]
@@ -1054,7 +1055,10 @@
                     (project-resource-pprint-handler [printer resource]
                       (object-data-pprint-handler nil project-resource->value printer resource))]
 
-              {(namespaced-class-symbol FileResource)
+              {(namespaced-class-symbol BuildResource)
+               project-resource-pprint-handler
+
+               (namespaced-class-symbol FileResource)
                project-resource-pprint-handler
 
                (namespaced-class-symbol MemoryResource)

--- a/editor/test/editor/pipeline_test.clj
+++ b/editor/test/editor/pipeline_test.clj
@@ -15,6 +15,7 @@
 (ns editor.pipeline-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
+            [dynamo.graph :as g]
             [editor.build :as build]
             [editor.build-target :as bt]
             [editor.defold-project :as project]
@@ -92,10 +93,13 @@
     (String. "UTF-8")))
 
 (defn- pipeline-build! [project build-targets]
-  (let [workspace (project/workspace project)
-        old-artifact-map (workspace/artifact-map workspace)
-        flat-build-targets (build/resolve-dependencies build-targets project)
-        build-results (pipeline/build! flat-build-targets (workspace/build-path workspace) old-artifact-map progress/null-render-progress!)]
+  (let [[workspace build-results]
+        (g/with-auto-evaluation-context evaluation-context
+          (let [workspace (project/workspace project evaluation-context)
+                old-artifact-map (workspace/artifact-map workspace)
+                flat-build-targets (build/resolve-dependencies build-targets project evaluation-context)
+                build-results (pipeline/build! flat-build-targets (workspace/build-path workspace) old-artifact-map evaluation-context progress/null-render-progress!)]
+            [workspace build-results]))]
     (when-not (contains? build-results :error)
       (workspace/artifact-map! workspace (:artifact-map build-results))
       (workspace/etags! workspace (:etags build-results)))

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -841,7 +841,7 @@
 (deftest build-process-detects-cyclic-lua-dependencies
   (with-loaded-project "test/resources/build_cyclic_lua_project"
     (g/with-auto-evaluation-context evaluation-context
-      (is (= "Dependency cycle detected: /main/1.lua -> /main/2.lua -> /main/1.lua"
+      (is (= "Dependency cycle detected: '/main/1.lua' -> '/main/2.lua' -> '/main/1.lua'."
              (->> (build/build-project! project
                                         (test-util/resource-node project "/game.project")
                                         evaluation-context

--- a/editor/test/internal/graph/graph_test.clj
+++ b/editor/test/internal/graph/graph_test.clj
@@ -13,15 +13,15 @@
 ;; specific language governing permissions and limitations under the License.
 
 (ns internal.graph.graph-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.core.cache :as cc]
+            [clojure.test :refer :all]
             [dynamo.graph :as g]
             [internal.graph :as ig]
-            [clojure.core.cache :as cc]
             [internal.graph.generator :as ggen]
             [internal.graph.types :as gt]
             [internal.node :as in]
             [schema.core :as s]
-            [support.test-support :refer [with-clean-system tx-nodes]]))
+            [support.test-support :refer [tx-nodes with-clean-system]]))
 
 (defn occurrences [coll]
   (vals (frequencies coll)))
@@ -123,7 +123,7 @@
   (property str-prop g/Str
             (value (g/fnk [str-in] str-in))
             (dynamic str-prop-dynamic (g/fnk [] 123)))
-  (input str-in g/Str)
+  (input str-in g/Str :cascade-delete)
   (output str-out g/Str :cached (g/fnk [str-in] str-in)))
 
 (deftest graph-override-cleanup
@@ -435,6 +435,76 @@
                   (is (= :internal.graph.graph-test/PassthroughNode (:node-type-kw ex-data)))
                   (is (= :str-out (:label ex-data)))
                   (is (= error-value (:error ex-data))))))))))))
+
+(deftest maybe-node-value
+  (with-clean-system
+    (let [check-valid-nodes!
+          (fn check-valid-nodes! [producer-node consumer-node]
+            (is (not (g/defective? producer-node)))
+            (is (not (g/defective? consumer-node)))
+            (testing "Declared property."
+              (is (= "initial" (g/maybe-node-value producer-node :val))))
+            (testing "Declared input."
+              (is (= "initial" (g/maybe-node-value consumer-node :str-in))))
+            (testing "Declared output."
+              (is (= "initial" (g/maybe-node-value consumer-node :str-out))))
+            (testing "Missing output."
+              (is (nil? (g/maybe-node-value producer-node :non-existing-label))))
+            (testing "Extern property."
+              (is (= producer-node (g/maybe-node-value producer-node :_node-id))))
+            (testing "Implicit :_properties."
+              (is (= "initial" (get-in (g/maybe-node-value producer-node :_properties) [:properties :val :value]))))
+            (testing "Implicit :_declared-properties."
+              (is (= "initial" (get-in (g/maybe-node-value producer-node :_declared-properties) [:properties :val :value])))))
+
+          check-defective-nodes!
+          (fn check-defective-nodes! [producer-node consumer-node]
+            (is (g/defective? producer-node))
+            (is (not (g/defective? consumer-node)))
+            (testing "Declared property."
+              (is (nil? (g/maybe-node-value producer-node :val))))
+            (testing "Declared input."
+              (is (nil? (g/maybe-node-value consumer-node :str-in))))
+            (testing "Declared output."
+              (is (nil? (g/maybe-node-value consumer-node :str-out))))
+            (testing "Missing output."
+              (is (nil? (g/maybe-node-value producer-node :non-existing-label))))
+            (testing "Extern property."
+              (is (= producer-node (g/maybe-node-value producer-node :_node-id))))
+            (testing "Implicit :_properties."
+              (is (nil? (g/maybe-node-value producer-node :_properties))))
+            (testing "Implicit :_declared-properties."
+              (is (= "initial" (get-in (g/maybe-node-value producer-node :_declared-properties) [:properties :val :value])))))
+
+          [producer-node consumer-node]
+          (tx-nodes
+            (g/make-nodes
+              world [producer-node (TestNode :val "initial")
+                     consumer-node PassthroughNode]
+              (g/connect producer-node :val consumer-node :str-in)))
+
+          [or-consumer-node or-producer-node]
+          (tx-nodes
+            (g/override consumer-node))]
+
+      (testing "Nil arguments."
+        (is (nil? (g/maybe-node-value nil nil)))
+        (is (nil? (g/maybe-node-value nil :_node-id)))
+        (is (nil? (g/maybe-node-value producer-node nil))))
+
+      (testing "Non-defective producer-node."
+        (testing "Original nodes."
+          (check-valid-nodes! producer-node consumer-node))
+        (testing "Override nodes."
+          (check-valid-nodes! or-producer-node or-consumer-node)))
+
+      (g/mark-defective! producer-node (g/error-fatal "bad"))
+
+      (testing "Defective producer-node."
+        (testing "Original nodes."
+          (check-defective-nodes! producer-node consumer-node))
+        (testing "Override nodes."
+          (check-defective-nodes! or-producer-node or-consumer-node))))))
 
 (deftest defective?-test
   (with-clean-system


### PR DESCRIPTION
Exceptions thrown from building the project in the editor will now contain information about the source of the error for diagnostic purposes.
